### PR TITLE
docs: domain glossary, ADRs, and agent-skill config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,3 +275,17 @@ Rules:
 - If graphify-out/wiki/index.md exists, use it for broad navigation instead of raw source browsing.
 - Read graphify-out/GRAPH_REPORT.md only for broad architecture review or when query/path/explain do not surface enough context.
 - After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
+
+## Agent skills
+
+### Issue tracker
+
+Issues live in the `MaxPayne89/klass-hero` GitHub repo, managed via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Five canonical roles use their default label strings (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`); `wontfix` already exists in the repo. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -91,15 +91,52 @@ _Avoid_: Plan, Level, Membership
 ## Messaging
 
 **Conversation**:
-A messaging thread between **Users** (typically a **Parent** and a **Provider**).
+A messaging thread always anchored to a **Provider** (and optionally a **Program**). Comes in two kinds — a **Direct Conversation** or a **Broadcast** — and can be **Archived**, after which it is kept until a **Retention** deadline and then purged.
 _Avoid_: Thread, Chat, Channel
 
+**Direct Conversation** (`direct`):
+A thread between specific **Users** — typically a **Parent** and the **Provider**'s staff — whose membership is an explicit set of **Participants** who join and leave.
+_Avoid_: DM, Private message
+
+**Broadcast** (`program_broadcast`):
+A Provider's one-to-many announcement thread scoped to a single **Program**. At most one active Broadcast exists per Program. Its audience is *derived*, not hand-added: the **Parents**/guardians of the children **Enrolled** in that Program, plus the Program's assigned **Staff Members**. Recipients are not **Participants**.
+_Avoid_: Announcement, Bulletin, Newsletter, Channel
+
 **Message**:
-A single entry within a **Conversation**.
+A single entry within a **Conversation** (Direct or Broadcast). Usually typed by a **User**, but may instead be a **System Message**; it may carry **Attachments** (and a Message can be attachments-only, with no text). A sender may delete their own Message — a *soft* delete that hides it but keeps the row — distinct from the **Retention** purge that later hard-deletes the whole thread.
+
+**System Message**:
+A **Message** the platform generates rather than a person types — for example a marker recorded in a **Broadcast**. Shares the Message timeline but is not user-authored.
+_Avoid_: System Note (that risks colliding with **Session Note**), Notification, Event
+
+**Attachment**:
+A file attached to a **Message** — a photo or document with a filename, content type and size. Immutable once created; never edited. Deleted with its Message, and purged from storage when the **Conversation** passes its **Retention Period**.
+_Avoid_: Upload, File, Media, Document (that's a **Verification Document**, unrelated)
 
 **Participant** (Messaging):
-A **User**'s membership in a **Conversation** — tracks join/leave and read receipts. This is the *only* meaning of "Participant" in the system; it is **not** a child attending a Session.
-_Avoid_: using "Participant" for a child on a **Roster** (that's a **Participation Record**)
+A **User**'s membership in a **Direct Conversation** — tracks join/leave and read receipts. Applies to Direct Conversations only; a **Broadcast** has a derived audience, not Participants. This is the *only* meaning of "Participant" in the system; it is **not** a child attending a Session.
+_Avoid_: using "Participant" for a child on a **Roster** (that's a **Participation Record**), or for a **Broadcast** recipient
+
+**Archival**:
+The automatic retirement of a **Conversation** once its **Program** has ended (after a grace window). Archiving starts the **Retention Period**; it deletes nothing yet. A **Direct Conversation** with no Program is never archived — it lives indefinitely.
+_Avoid_: Delete, Close, Hide
+
+**Retention Period**:
+The window an archived **Conversation** (with its **Messages** and **Attachments**) is kept before being *purged* — a permanent hard delete, including attachment files in storage. Not recoverable. Distinct from the **Registration Period** on a Program.
+_Avoid_: Expiry, TTL; "purge" is the destructive end-state, not ordinary message deletion
+
+## Support Inbox
+
+A communication **channel** separate from in-app **Messaging** — external email handled by **Admins**, with no link to **Conversations**, **Parents** or **Providers**. Deliberately distinct; not merged with in-app messaging. "Support Inbox" is the canonical name; the code still says "Admin Inbox" / `emails` (`admin/emails`, `EmailsLive`) — a pending rename.
+_Avoid_: Admin Inbox, Emails (channel name), Tickets queue
+
+**Inbound Email**:
+An email received from outside the platform via the Resend webhook, triaged by an **Admin** (`unread → read → archived`). The sender is *any external party* — typically a prospect or a member of the public with a question, who need not be a platform **User**. This is why the channel shares no model with **Conversations** (which require Users). Body content is fetched asynchronously after the metadata arrives.
+_Avoid_: Message (in-app only), Ticket
+
+**Email Reply**:
+An **Admin**'s reply to an **Inbound Email**, sent from the admin dashboard (`sending → sent → failed`).
+_Avoid_: Message, Response
 
 ## Safeguarding & Feedback
 
@@ -185,3 +222,7 @@ Today **Subscription Tier** gates Parent and Provider capabilities through the S
 **"Participation" is overloaded across context, record, and consent.**
 The word names the Participation *context*, the **Participation Record** (roster row), and a `participation` **Consent** type.
 **Resolution:** Bare "participation" means attendance/roster only. The Consent type is being renamed `participation → activity_participation` so the word never also means consent.
+
+**The Support Inbox lives inside the Messaging context but shares no data with it.**
+**Inbound Email** / **Email Reply** (external email via Resend, Admin-operated) are co-located in Messaging yet share no rows or associations with in-app **Conversation**/**Message**. "Message" is in-app only; "Email" is the inbox only.
+**Resolution:** Keep them as distinct subsystems with no shared schema. The inbox stays co-located in Messaging for now; extracting it into its own **Support** bounded context is deferred until the inbox grows its own domain (assignment/SLA/richer status, or a second external channel). See ADR-0003.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,187 @@
+# Klass Hero
+
+The domain glossary for Klass Hero — a platform for afterschool activities, camps, and class trips that connects parents, providers, and instructors. This file defines the language we use; it is not a spec.
+
+## The Offering
+
+**Program**:
+A bookable offering a Provider lists for children to attend. Today a single `Program` entity serves all offering kinds, distinguished by a subject **Category**. It carries a recurring schedule (the days/times it meets) and a **Registration Period**.
+_Avoid_: Activity, Class, Course, Offering, Listing
+
+**Category**:
+The *subject* of a Program — what it is about. Current values: `sports`, `arts`, `music`, `education`, `life-skills`. This is one axis only and must not carry format/kind information.
+_Avoid_: Type, Kind, Tag
+
+**Registration Period**:
+The window during which parents may enrol in a Program. When unbounded, registration is "always open".
+_Avoid_: Enrolment window, Signup period, Booking window
+
+## Scheduling
+
+**Session**:
+A single dated occurrence of a Program (a date plus start/end time) that children attend and staff run. The Program attachment is implicit — we just say "Session", never "Program Session". Has its own lifecycle: `scheduled → in_progress → completed`, or `cancelled`.
+_Avoid_: Class, Meeting, Occurrence, Program Session; and never reuse "Session" for the authentication session
+
+## Enrollment & Attendance
+
+**Enrollment**:
+A child's signup to a **Program** — the program-level commitment, made once. Feeds the **Roster** of every Session in that Program. Parents "book" a Program; the record that results is an Enrollment.
+_Avoid_: Registration, Signup; and "Booking" as a domain *noun* ("Book" is fine as a front-of-house verb only — see flagged ambiguities)
+
+**Roster**:
+The set of children expected at a given **Session**, seeded from the Program's active **Enrollments**. A roster belongs to one Session.
+_Avoid_: Attendance list, Class list, Sign-in sheet
+
+**Participation Record**:
+One child's row on one Session's Roster, tracking presence through `registered → checked_in → checked_out`, or `absent`. `registered` here means "on the roster, not yet arrived" — it is not the **Enrollment**.
+_Avoid_: Attendance record, Booking
+
+**Attendance**:
+The act and result of checking a child in and out of a **Session** (the state changes recorded on a **Participation Record**).
+_Avoid_: Presence, Sign-in
+
+## Providers & Staff
+
+**Provider**:
+The business or organisation that lists **Programs** and employs **Staff Members**. Parents see the Provider as the entity behind a Program. Modelled as the `ProviderProfile` struct (DB table `providers`); "Provider" and "ProviderProfile" are the same thing — the profile *is* the provider, and `provider_id`/`provider_profile_id` point at it interchangeably.
+_Avoid_: Vendor, Merchant, Business, Partner, Organiser
+
+**Staff Member**:
+A person who works for a **Provider**. May be invited to claim a **User** account, may be assigned to one or more **Programs**, and carries a **Role**, qualifications and pay rate.
+_Avoid_: Employee, Team member, Worker
+
+**Instructor**:
+The lead **Staff Member** responsible for running a Program — the "boss" for that Program (or for a specific **Session**). Exactly one Instructor leads, even though several Staff Members may be assigned alongside them. In the Program Catalog this person also appears as a read-only display copy.
+_Avoid_: Teacher, Coach, Trainer (those are **Roles**, not the lead responsibility)
+
+**Role**:
+A **Staff Member**'s specific job title — freeform text such as "Coach" or "Teacher". Distinct from **Instructor**, which is the lead responsibility for a Program/Session, not a title.
+_Avoid_: Position, Title, Type
+
+**Program Staff Assignment**:
+The link recording that a **Staff Member** works on a **Program**. Many Staff Members may be assigned to one Program because a class can need several people.
+_Avoid_: Membership, Posting
+
+## Families & Accounts
+
+**User**:
+An authentication identity in the Accounts context — email, password, role. A person logs in as a User; their domain persona (**Parent**, **Staff Member**) lives in another context and links back by a correlation id, not a foreign key.
+_Avoid_: Account, Login, Member
+
+**Admin**:
+A platform operator (not a **Parent** or **Provider**) who reviews **Verification Documents** and **Incident Reports** and approves pending **Enrollments**. The reviewer behind `reviewed_by_id`.
+_Avoid_: Moderator, Superuser, Staff (Staff belongs to a Provider)
+
+**Parent**:
+The account-holding persona who manages **Children**, books **Programs**, and pays. A Parent is a **Guardian** who holds a **User** account.
+_Avoid_: Customer, Buyer, Family (Family is the context, not the person)
+
+**Guardian**:
+Any adult with a custodial relationship to a **Child**. A Child has one *or more* Guardians (e.g. two parents plus a grandparent); not every Guardian necessarily holds an account. Multiple guardians per child is intended, not incidental.
+_Avoid_: Parent (reserve that for the account-holding role), Caregiver, Custodian
+
+**Child**:
+A young person who attends **Programs**, belonging to one or more **Guardians**. The person a **Parent** enrols and a **Roster** tracks.
+_Avoid_: Kid, Student, Participant, Attendee
+
+**Subscription Tier** _(being removed — see flagged ambiguities)_:
+The plan a **Parent** (`explorer`, `active`) or **Provider** (`starter`, `professional`, `business_plus`) currently holds, gating capabilities (**Entitlements**) such as booking caps or the platform **Commission** rate. Slated for removal — do not build new behaviour on it.
+_Avoid_: Plan, Level, Membership
+
+## Messaging
+
+**Conversation**:
+A messaging thread between **Users** (typically a **Parent** and a **Provider**).
+_Avoid_: Thread, Chat, Channel
+
+**Message**:
+A single entry within a **Conversation**.
+
+**Participant** (Messaging):
+A **User**'s membership in a **Conversation** — tracks join/leave and read receipts. This is the *only* meaning of "Participant" in the system; it is **not** a child attending a Session.
+_Avoid_: using "Participant" for a child on a **Roster** (that's a **Participation Record**)
+
+## Safeguarding & Feedback
+
+**Incident Report**:
+A formal safeguarding/operational record of an event during a **Program** or a **Session** — injury, safety concern, property damage, policy violation, or a serious behavioural incident. Filed by a Provider's staff, severity-rated (`low`–`critical`), routed to admins, and never parent-approved.
+_Avoid_: Note, Complaint, unqualified "Report"
+
+**Session Note**:
+Routine per-child feedback from the **Instructor** about one **Child** at one **Session** (often positive, e.g. "very engaged today"). The **Parent** must approve it before it is shared; a rejected note can be revised. Attached to the child's **Participation Record**.
+_Avoid_: Behavioral Note (current code name, being retired), Feedback, Review, Comment
+
+## Trust & Compliance
+
+**Consent**:
+A **Guardian**'s recorded permission for a specific **Child** and a specific purpose — `photo_marketing`, `photo_social_media`, `medical`, `activity_participation` (currently `participation` in code — rename pending), or `provider_data_sharing`. Append-only for audit: re-granting or withdrawing adds a new record; the live state is the latest non-withdrawn one.
+_Avoid_: Permission, Agreement, Opt-in
+
+**Verification Document**:
+A document a **Provider** uploads for **Admin** review to establish trust — `business_registration`, `insurance_certificate`, `id_document`, `tax_certificate`. Lifecycle `pending → approved / rejected`.
+_Avoid_: Credential, Proof; "Certificate"/"Registration" name *document types*, not the concept
+
+## Parked (not modelled)
+
+**Referral**:
+Not a modelled concept yet. Only a code-format generator exists (`{FIRST_NAME}-{LOCATION}-{YEAR}`); there is no stored referral, claim, or reward. Parked — define this term only if/when the feature is built.
+
+## Example dialogue
+
+> **Dev:** A Parent just booked the Monday football class for two of their kids. What did we actually create?
+>
+> **Domain expert:** Two **Enrollments** — one per **Child** — against that **Program**. "Book" is just what the Parent does in the UI; the records are Enrollments.
+>
+> **Dev:** Both kids are the same Parent's, but I see three adults linked to one of them.
+>
+> **Domain expert:** Right — a **Child** can have several **Guardians**. Only the **Parent** (the Guardian with a **User** account) does the booking and pays, but the others are still Guardians.
+>
+> **Dev:** When does the football actually happen?
+>
+> **Domain expert:** Each occurrence is a **Session**. When a Session is created, its **Roster** is seeded from the Program's active Enrollments — one **Participation Record** per enrolled Child, starting as `registered`.
+>
+> **Dev:** And on the day?
+>
+> **Domain expert:** The **Instructor** — the **Staff Member** leading that Program — checks each child in and out. That's **Attendance**, recorded on the Participation Record. Other Staff Members can be assigned too if the class needs more hands.
+>
+> **Dev:** The Parent messaged the Provider about a pickup change — is that child now a "participant"?
+>
+> **Domain expert:** No. In that **Conversation** the Parent is a **Participant**. The child on the Roster is never called a participant — that word is messaging-only.
+
+## Flagged ambiguities
+
+**Offering kind is overloaded onto Category.**
+The persisted category list currently mixes two axes: *subject* (`sports`, `arts`, `music`, `education`, `life-skills`) and *format/kind* (`camps`, `workshops`). The `Program` moduledoc further describes it as "afterschool program, camp, or class trip" — but `afterschool` and `class trip` are not categories at all.
+**Resolution (direction, not yet built):** Afterschool programs, **Camps**, and **Class Trips** are considered *structurally different* offerings (e.g. multi-day vs recurring weekly, different booking/pricing rules) and are expected to become **distinct entities** down the line — not values of one enum. Until then, treat "Program" as the umbrella but do not encode kind into **Category**. When the split happens, **Category** stays subject-only.
+
+**Sessions are hand-created, not generated from the Program schedule.**
+A Program stores a recurring schedule (meeting days + meeting start/end times + a date range), but **Sessions** are today created manually one at a time, so those Program fields are merely *advertised* schedule and enforce nothing — the real schedule is the set of Sessions.
+**Resolution (direction, not yet built):** This is a design shortcoming. Since the Program already holds the data needed to derive its Sessions, Sessions *should* be generated from the Program's recurring schedule rather than entered by hand. Until then the duplication is accidental, not intentional.
+
+**"Instructor" does double duty.**
+The word names both a *responsibility* (the lead Staff Member running a Program/Session) and a *display snapshot* (the read-only copy of that person's name/headshot held in the Program Catalog). The snapshot is captured at Program creation, so it goes **stale** if the underlying Staff Member is renamed — the same denormalisation hazard as the `program_name` projection.
+**Resolution:** Keep "Instructor" for the lead responsibility. Treat the catalog copy as a derived display projection that must be refreshed from Provider data (via events), not hand-maintained.
+
+**Session-level staffing is not modelled.**
+A Staff Member (and a lead **Instructor**) can conceptually be assigned to a single **Session**, not just a whole **Program** — a class may need different people on different days. Today only `Program Staff Assignment` exists (Program-level); a Session has a child **Roster** but no staff assignment.
+**Resolution (direction, not yet built):** Session-level staff assignment is a recognised gap, not a decision to keep staffing Program-only.
+
+**"Participant" collides with "Participation".**
+Messaging's **Participant** is a conversation member (a **User**). The Participation context tracks children at **Sessions** through **Participation Record** and deliberately never uses the noun "Participant" for them.
+**Resolution:** "Participant" means *conversation member* only. A child attending a Session is a **Roster** entry / **Participation Record** — never a "participant".
+
+**"Booking" is a verb, not an entity.**
+"Book"/"Booking" lives almost entirely in the web/UI layer (front-of-house), while the domain records an **Enrollment**. They are the same concept under two names, not two concepts.
+**Resolution:** "Enrollment" is the only domain noun for the record. "Book"/"Booking" may appear in UI copy and route names but must never become a domain noun or a second entity (e.g. a multi-enrollment cart) unless that distinct concept is deliberately introduced and defined here.
+
+**"Behavioural" is overloaded; the feedback note should be a Session Note.**
+The per-child, parent-approved feedback entity is named `BehavioralNote` in code, but it is usually positive and collides with the `behavioral_issue` category on **Incident Report**.
+**Resolution:** Canonical term is **Session Note** for routine per-child feedback; reserve "behavioural" for the safeguarding-level `behavioral_issue` **Incident Report** category. A code rename `BehavioralNote → SessionNote` is pending.
+
+**Subscription tiers and the Entitlements service are being removed.**
+Today **Subscription Tier** gates Parent and Provider capabilities through the Shared **Entitlements** service, and the paid parent tier `:active` collides with the pervasive `active` lifecycle flag (`StaffMember.active`, `ProgramStaffAssignment.active?`, etc.).
+**Resolution (direction, not yet built):** Tiers are being dropped entirely. Once removed, the Entitlements service loses all functionality, the tier vocabulary (`explorer`/`active`/`starter`/`professional`/`business_plus`) retires, and the `:active` collision disappears on its own. Do not build new behaviour on tiers or Entitlements.
+
+**"Participation" is overloaded across context, record, and consent.**
+The word names the Participation *context*, the **Participation Record** (roster row), and a `participation` **Consent** type.
+**Resolution:** Bare "participation" means attendance/roster only. The Consent type is being renamed `participation → activity_participation` so the word never also means consent.

--- a/docs/adr/0001-cross-context-references-use-correlation-ids.md
+++ b/docs/adr/0001-cross-context-references-use-correlation-ids.md
@@ -1,0 +1,10 @@
+# Cross-context references use correlation IDs, not foreign keys
+
+Domain contexts reference identities owned by other contexts by storing a plain correlation id rather than a database foreign key — e.g. Family's `ParentProfile.identity_id` points at an Accounts `User` with no FK constraint.
+
+We accept losing database-level referential integrity across context boundaries in exchange for keeping each bounded context independently migratable, testable, and reasoned-about: a context's schema can change without a hard DB coupling to another context's tables. Integrity across the boundary is upheld by the application and events, not the database.
+
+## Consequences
+
+- A dangling correlation id is possible at the DB level; cleanup/consistency is an application concern (e.g. GDPR deletion flows must fan out across contexts).
+- Cross-context reads go through ACLs/projections, never SQL joins across context tables.

--- a/docs/adr/0002-program-catalog-holds-its-own-instructor-copy.md
+++ b/docs/adr/0002-program-catalog-holds-its-own-instructor-copy.md
@@ -1,0 +1,10 @@
+# Program Catalog holds its own Instructor copy (ACL snapshot)
+
+Program Catalog does not depend on the Provider context's richer `StaffMember` type. Each Program embeds an `Instructor` value object — a minimal `{id, name, headshot_url}` snapshot copied from Provider data at write time — acting as an Anti-Corruption Layer so Provider's model cannot leak into the catalog.
+
+The trade-off is staleness: the snapshot can drift if the underlying Staff Member is renamed or re-photographed. It must therefore be refreshed via events and treated as a derived display copy, not the authoritative record — the same denormalisation hazard as the projected `program_name`.
+
+## Consequences
+
+- Renames in Provider must propagate to the catalog snapshot through events, not be assumed live.
+- The catalog shows a single lead Instructor; the full assigned team lives in Provider's `ProgramStaffAssignment` and is not mirrored here.

--- a/docs/adr/0003-support-inbox-co-located-in-messaging.md
+++ b/docs/adr/0003-support-inbox-co-located-in-messaging.md
@@ -1,0 +1,24 @@
+# Support Inbox lives inside the Messaging context
+
+The Support Inbox — external email from the public, received via the Resend webhook and triaged by Admins — is implemented inside the Messaging bounded context (`lib/klass_hero/messaging/`), even though it shares no rows, associations, or use cases with in-app Conversations and Messages. Its `InboundEmail` and `EmailReply` entities reference only `users` (the Admin who reads or replies); they never touch `conversations` or `messages`.
+
+It is co-located rather than extracted because, at ~2 passive entities, a dedicated context buys nothing: a separate context module, Boundary declaration, DI wiring, and config envelope would all be overhead with no coupling to justify them. "Messaging" is the nearest existing home — both deal with communication — so the inbox was written there.
+
+The trade-off is conceptual honesty: a future reader sees email handling inside a context named for in-app conversations and reasonably asks why. The two subsystems are deliberately distinct channels with different actor populations — Conversations require platform Users, whereas an Inbound Email can come from any external party with no account — so the shared context is a co-location of convenience, not a domain relationship.
+
+## When to extract into a Support context
+
+Revisit the split when the inbox stops being two passive tables and grows its own domain. Concretely, any of:
+
+- Ticket-like workflow: assignment/ownership, SLA or escalation, or a status lifecycle richer than `unread → read → archived`.
+- A second external inbound channel (e.g. SMS, WhatsApp) joins email under the same triage surface.
+
+Extraction is **not** triggered by new actors: non-Admin users will never get an inbox — they communicate through in-app Messaging by design — so the Admin-only, public-inbound shape is permanent.
+
+Because the inbox is already fully decoupled (no shared schema or use case), the eventual move is close to mechanical: relocate the files, give the new context its own Boundary and config key, and point the `admin/emails` surface at it.
+
+## Consequences
+
+- The Messaging context's Boundary `deps` and public API carry inbox concerns that have nothing to do with Conversations; reviewers should not infer a relationship from the shared module.
+- The pending rename (`EmailsLive`/`admin/emails` → a Support-Inbox-named surface) and the context extraction are independent — the canonical name can be fixed without moving contexts.
+- No cross-context events flow from inbound mail today; if that need appears, treat it as an extraction signal, not as new wiring inside Messaging.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,33 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase. This repo is **single-context**.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root — the domain glossary.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-some-decision.md
+│   └── 0002-another-decision.md
+└── lib/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues in `MaxPayne89/klass-hero`. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,17 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+`wontfix` already exists in the repo's GitHub labels. The other four are created on first use (`gh label create <name>`) if absent.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
## Summary

- Add `CONTEXT.md` — a domain glossary capturing the ubiquitous language across all bounded contexts, with `_Avoid_` alias lists, a worked example dialogue, and 9 flagged ambiguities (each with a resolution or stated direction).
- Add two ADRs recording deliberate, non-obvious boundary decisions:
  - `0001` — cross-context references use correlation ids, not foreign keys
  - `0002` — Program Catalog holds its own Instructor ACL snapshot
- Add `docs/agents/` config (issue tracker = GitHub, triage labels, domain-doc consumer rules) used by the engineering skills, and reference it from a new `## Agent skills` block in `CLAUDE.md`.

## Review Focus

The glossary encodes several **language decisions** that should match product intent — worth a careful read:

- **Program** is today's umbrella; Camp / Class Trip are slated to become distinct entities (not enum values). See #922.
- **Booking** is front-of-house only; **Enrollment** is the sole domain noun.
- **Parent** = account-holding role; **Guardian** = relationship (many per child, intended).
- **Session Note** replaces "Behavioral Note" (#924); **Subscription Tier** + Entitlements are slated for removal (#925).
- Flagged ambiguities also point at #921 (generate sessions from schedule) and #923 (session-level staffing).

## Test Plan

- [x] Docs only — no code changed, so no test suite impact.
- [x] Confirm the language decisions in `CONTEXT.md` reflect product intent.
- [x] Confirm `docs/agents/` config (GitHub tracker, default triage labels, single-context layout) is correct.