### PR TITLE
test: combine & sweep Test Improver PRs to exunit standard (12 stream_data properties)

### DIFF
--- a/test/klass_hero/accounts/application/commands/anonymize_user_test.exs
+++ b/test/klass_hero/accounts/application/commands/anonymize_user_test.exs
@@ -1,0 +1,43 @@
+defmodule KlassHero.Accounts.Application.Commands.AnonymizeUserTest do
+  @moduledoc """
+  Integration tests for AnonymizeUser use case.
+
+  Verifies GDPR anonymization orchestration: a valid user's PII is scrubbed,
+  and nil input returns an :user_not_found error.
+  """
+
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.AccountsFixtures
+
+  alias KlassHero.Accounts.Adapters.Driven.Persistence.Repositories.UserRepository
+  alias KlassHero.Accounts.Application.Commands.AnonymizeUser
+  alias KlassHero.Accounts.Domain.Models.User
+
+  describe "execute/1 — success path" do
+    test "returns anonymized domain User" do
+      user = user_fixture()
+
+      assert {:ok, %User{} = anonymized} = AnonymizeUser.execute(user)
+      assert anonymized.id == user.id
+      assert anonymized.email == "deleted_#{user.id}@anonymized.local"
+      assert anonymized.name == "Deleted User"
+    end
+
+    test "persists anonymized PII to the database" do
+      user = user_fixture()
+
+      {:ok, _} = AnonymizeUser.execute(user)
+
+      assert {:ok, persisted} = UserRepository.get_by_id(user.id)
+      assert persisted.email == "deleted_#{user.id}@anonymized.local"
+      assert persisted.name == "Deleted User"
+    end
+  end
+
+  describe "execute/1 — nil guard" do
+    test "returns :user_not_found for nil user" do
+      assert {:error, :user_not_found} = AnonymizeUser.execute(nil)
+    end
+  end
+end

--- a/test/klass_hero/accounts/application/commands/anonymize_user_test.exs
+++ b/test/klass_hero/accounts/application/commands/anonymize_user_test.exs
@@ -12,7 +12,9 @@ defmodule KlassHero.Accounts.Application.Commands.AnonymizeUserTest do
 
   alias KlassHero.Accounts.Adapters.Driven.Persistence.Repositories.UserRepository
   alias KlassHero.Accounts.Application.Commands.AnonymizeUser
-  alias KlassHero.Accounts.Domain.Models.User
+  # Auth uses phx.gen.auth: KlassHero.Accounts.User (the Ecto schema) is the
+  # canonical user type these commands return — not a separate domain model.
+  alias KlassHero.Accounts.User
 
   describe "execute/1 — success path" do
     test "returns anonymized domain User" do

--- a/test/klass_hero/accounts/application/commands/change_email_test.exs
+++ b/test/klass_hero/accounts/application/commands/change_email_test.exs
@@ -1,0 +1,66 @@
+defmodule KlassHero.Accounts.Application.Commands.ChangeEmailTest do
+  @moduledoc """
+  Integration tests for ChangeEmail use case.
+
+  Verifies email-change orchestration: a valid confirmation token updates the
+  user's email, and invalid tokens surface an :invalid_token error.
+  """
+
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.AccountsFixtures
+
+  alias KlassHero.Accounts
+  alias KlassHero.Accounts.Adapters.Driven.Persistence.Repositories.UserRepository
+  alias KlassHero.Accounts.Application.Commands.ChangeEmail
+  alias KlassHero.Accounts.Domain.Models.User
+
+  defp generate_email_change_token(user, new_email) do
+    user_with_new_email = %{user | email: new_email}
+
+    extract_user_token(fn url ->
+      Accounts.deliver_user_update_email_instructions(
+        user_with_new_email,
+        user.email,
+        url
+      )
+    end)
+  end
+
+  describe "execute/2 — success path" do
+    test "returns User with updated email" do
+      user = user_fixture()
+      new_email = unique_user_email()
+      token = generate_email_change_token(user, new_email)
+
+      assert {:ok, %User{} = updated} = ChangeEmail.execute(user, token)
+      assert updated.email == new_email
+    end
+
+    test "persists the new email to the database" do
+      user = user_fixture()
+      new_email = unique_user_email()
+      token = generate_email_change_token(user, new_email)
+
+      {:ok, _} = ChangeEmail.execute(user, token)
+
+      assert {:ok, persisted} = UserRepository.get_by_id(user.id)
+      assert persisted.email == new_email
+    end
+  end
+
+  describe "execute/2 — token errors" do
+    test "returns :invalid_token for a malformed token" do
+      user = user_fixture()
+
+      assert {:error, :invalid_token} = ChangeEmail.execute(user, "not-a-valid-token!")
+    end
+
+    test "returns :invalid_token for a nonexistent token" do
+      user = user_fixture()
+      fake_token = Base.url_encode64(:crypto.strong_rand_bytes(32), padding: false)
+
+      assert {:error, :invalid_token} = ChangeEmail.execute(user, fake_token)
+    end
+  end
+end

--- a/test/klass_hero/accounts/application/commands/change_email_test.exs
+++ b/test/klass_hero/accounts/application/commands/change_email_test.exs
@@ -13,7 +13,9 @@ defmodule KlassHero.Accounts.Application.Commands.ChangeEmailTest do
   alias KlassHero.Accounts
   alias KlassHero.Accounts.Adapters.Driven.Persistence.Repositories.UserRepository
   alias KlassHero.Accounts.Application.Commands.ChangeEmail
-  alias KlassHero.Accounts.Domain.Models.User
+  # Auth uses phx.gen.auth: KlassHero.Accounts.User (the Ecto schema) is the
+  # canonical user type these commands return — not a separate domain model.
+  alias KlassHero.Accounts.User
 
   defp generate_email_change_token(user, new_email) do
     user_with_new_email = %{user | email: new_email}

--- a/test/klass_hero/accounts/application/commands/login_by_magic_link_test.exs
+++ b/test/klass_hero/accounts/application/commands/login_by_magic_link_test.exs
@@ -1,0 +1,124 @@
+defmodule KlassHero.Accounts.Application.Commands.LoginByMagicLinkTest do
+  @moduledoc """
+  Tests for LoginByMagicLink.execute/1.
+
+  Covers the three dispatch paths:
+  1. Confirmed user    — deletes the specific token, returns the user
+  2. Unconfirmed user  — confirms email, deletes all tokens, dispatches user_confirmed
+  3. Error cases       — invalid/malformed/expired tokens, security violation
+  """
+
+  use KlassHero.DataCase, async: false
+
+  import KlassHero.AccountsFixtures
+  import KlassHero.EventTestHelper
+
+  alias KlassHero.Accounts.Application.Commands.LoginByMagicLink
+  alias KlassHero.Shared.Adapters.Driven.Events.TestEventPublisher
+  alias KlassHero.Shared.DomainEventBus
+
+  setup do
+    setup_test_events()
+
+    # LoginByMagicLink dispatches user_confirmed via DomainEventBus (fire-and-forget),
+    # not through the TestEventPublisher port.  Bridge them so assert_event_published works.
+    DomainEventBus.subscribe(KlassHero.Accounts, :user_confirmed, fn event ->
+      TestEventPublisher.publish(event)
+      :ok
+    end)
+
+    :ok
+  end
+
+  describe "execute/1 — confirmed user" do
+    test "returns {:ok, {user, []}} for a valid token" do
+      user = user_fixture()
+      {token, _raw} = generate_user_magic_link_token(user)
+
+      assert {:ok, {returned_user, []}} = LoginByMagicLink.execute(token)
+      assert returned_user.id == user.id
+    end
+
+    test "token is consumed — re-using the same token returns :not_found" do
+      user = user_fixture()
+      {token, _raw} = generate_user_magic_link_token(user)
+
+      {:ok, _} = LoginByMagicLink.execute(token)
+
+      assert {:error, :not_found} = LoginByMagicLink.execute(token)
+    end
+
+    test "does not dispatch a user_confirmed event" do
+      user = user_fixture()
+      {token, _raw} = generate_user_magic_link_token(user)
+
+      {:ok, _} = LoginByMagicLink.execute(token)
+
+      assert TestEventPublisher.get_events() == []
+    end
+  end
+
+  describe "execute/1 — unconfirmed user (no password)" do
+    test "returns {:ok, {user, []}} and user has confirmed_at set" do
+      user = unconfirmed_user_fixture()
+      assert is_nil(user.confirmed_at)
+
+      {token, _raw} = generate_user_magic_link_token(user)
+
+      assert {:ok, {confirmed_user, []}} = LoginByMagicLink.execute(token)
+      assert confirmed_user.id == user.id
+      assert %DateTime{} = confirmed_user.confirmed_at
+    end
+
+    test "all tokens are deleted after confirmation" do
+      user = unconfirmed_user_fixture()
+      {token, _raw} = generate_user_magic_link_token(user)
+      # Generate a second token to verify all tokens are cleaned up
+      {token2, _raw2} = generate_user_magic_link_token(user)
+
+      {:ok, _} = LoginByMagicLink.execute(token)
+
+      # Both tokens should now be gone
+      assert {:error, :not_found} = LoginByMagicLink.execute(token)
+      assert {:error, :not_found} = LoginByMagicLink.execute(token2)
+    end
+
+    test "dispatches user_confirmed domain event" do
+      user = unconfirmed_user_fixture()
+      {token, _raw} = generate_user_magic_link_token(user)
+
+      {:ok, {confirmed_user, []}} = LoginByMagicLink.execute(token)
+
+      event = assert_event_published(:user_confirmed)
+      assert event.aggregate_id == confirmed_user.id
+    end
+  end
+
+  describe "execute/1 — error cases" do
+    test "returns {:error, :invalid_token} for a malformed token" do
+      assert {:error, :invalid_token} = LoginByMagicLink.execute("not-a-valid!token@#$")
+    end
+
+    test "returns {:error, :not_found} for a well-formed but nonexistent token" do
+      fake_token = Base.url_encode64(:crypto.strong_rand_bytes(32), padding: false)
+      assert {:error, :not_found} = LoginByMagicLink.execute(fake_token)
+    end
+
+    test "returns {:error, :not_found} for an expired token" do
+      user = user_fixture()
+      {token, raw_token} = generate_user_magic_link_token(user)
+
+      offset_user_token(raw_token, -20, :minute)
+
+      assert {:error, :not_found} = LoginByMagicLink.execute(token)
+    end
+
+    test "returns {:error, :security_violation} for unconfirmed user with password" do
+      user = unconfirmed_user_fixture()
+      user = set_password(user)
+      {token, _raw} = generate_user_magic_link_token(user)
+
+      assert {:error, :security_violation} = LoginByMagicLink.execute(token)
+    end
+  end
+end

--- a/test/klass_hero/accounts/application/commands/login_by_magic_link_test.exs
+++ b/test/klass_hero/accounts/application/commands/login_by_magic_link_test.exs
@@ -1,34 +1,25 @@
 defmodule KlassHero.Accounts.Application.Commands.LoginByMagicLinkTest do
   @moduledoc """
-  Tests for LoginByMagicLink.execute/1.
+  Integration tests for LoginByMagicLink.execute/1.
 
-  Covers the three dispatch paths:
-  1. Confirmed user    — deletes the specific token, returns the user
-  2. Unconfirmed user  — confirms email, deletes all tokens, dispatches user_confirmed
+  Covers the three paths:
+  1. Confirmed user    — deletes the specific token, returns {user, []}
+  2. Unconfirmed user  — confirms email, deletes all tokens, returns {user, expired_tokens}
   3. Error cases       — invalid/malformed/expired tokens, security violation
+
+  The unconfirmed path dispatches a `user_confirmed` domain event as a
+  fire-and-forget side effect through the global (non-sandboxed) DomainEventBus.
+  That dispatch cannot be captured deterministically in a unit test, so we assert
+  the observable state change the event announces — `confirmed_at` is set and the
+  user's tokens are cleaned up — mirroring how the sibling command tests
+  (AnonymizeUser, RegisterUser) assert outcomes rather than the dispatch itself.
   """
 
-  use KlassHero.DataCase, async: false
+  use KlassHero.DataCase, async: true
 
   import KlassHero.AccountsFixtures
-  import KlassHero.EventTestHelper
 
   alias KlassHero.Accounts.Application.Commands.LoginByMagicLink
-  alias KlassHero.Shared.Adapters.Driven.Events.TestEventPublisher
-  alias KlassHero.Shared.DomainEventBus
-
-  setup do
-    setup_test_events()
-
-    # LoginByMagicLink dispatches user_confirmed via DomainEventBus (fire-and-forget),
-    # not through the TestEventPublisher port.  Bridge them so assert_event_published works.
-    DomainEventBus.subscribe(KlassHero.Accounts, :user_confirmed, fn event ->
-      TestEventPublisher.publish(event)
-      :ok
-    end)
-
-    :ok
-  end
 
   describe "execute/1 — confirmed user" do
     test "returns {:ok, {user, []}} for a valid token" do
@@ -39,7 +30,7 @@ defmodule KlassHero.Accounts.Application.Commands.LoginByMagicLinkTest do
       assert returned_user.id == user.id
     end
 
-    test "token is consumed — re-using the same token returns :not_found" do
+    test "consumes the token — re-using it returns :not_found" do
       user = user_fixture()
       {token, _raw} = generate_user_magic_link_token(user)
 
@@ -47,50 +38,40 @@ defmodule KlassHero.Accounts.Application.Commands.LoginByMagicLinkTest do
 
       assert {:error, :not_found} = LoginByMagicLink.execute(token)
     end
-
-    test "does not dispatch a user_confirmed event" do
-      user = user_fixture()
-      {token, _raw} = generate_user_magic_link_token(user)
-
-      {:ok, _} = LoginByMagicLink.execute(token)
-
-      assert TestEventPublisher.get_events() == []
-    end
   end
 
   describe "execute/1 — unconfirmed user (no password)" do
-    test "returns {:ok, {user, []}} and user has confirmed_at set" do
+    test "confirms the email and returns the now-confirmed user" do
       user = unconfirmed_user_fixture()
       assert is_nil(user.confirmed_at)
 
       {token, _raw} = generate_user_magic_link_token(user)
 
-      assert {:ok, {confirmed_user, []}} = LoginByMagicLink.execute(token)
+      assert {:ok, {confirmed_user, _expired_tokens}} = LoginByMagicLink.execute(token)
       assert confirmed_user.id == user.id
       assert %DateTime{} = confirmed_user.confirmed_at
     end
 
-    test "all tokens are deleted after confirmation" do
+    test "returns the expired tokens that were cleaned up" do
       user = unconfirmed_user_fixture()
       {token, _raw} = generate_user_magic_link_token(user)
-      # Generate a second token to verify all tokens are cleaned up
+
+      assert {:ok, {_user, expired_tokens}} = LoginByMagicLink.execute(token)
+
+      # Confirmation expires the consumed login token, so the cleanup list is
+      # non-empty — distinguishing this path from the confirmed-user path above.
+      refute expired_tokens == []
+    end
+
+    test "deletes all of the user's tokens after confirmation" do
+      user = unconfirmed_user_fixture()
+      {token, _raw} = generate_user_magic_link_token(user)
       {token2, _raw2} = generate_user_magic_link_token(user)
 
       {:ok, _} = LoginByMagicLink.execute(token)
 
-      # Both tokens should now be gone
       assert {:error, :not_found} = LoginByMagicLink.execute(token)
       assert {:error, :not_found} = LoginByMagicLink.execute(token2)
-    end
-
-    test "dispatches user_confirmed domain event" do
-      user = unconfirmed_user_fixture()
-      {token, _raw} = generate_user_magic_link_token(user)
-
-      {:ok, {confirmed_user, []}} = LoginByMagicLink.execute(token)
-
-      event = assert_event_published(:user_confirmed)
-      assert event.aggregate_id == confirmed_user.id
     end
   end
 
@@ -113,7 +94,7 @@ defmodule KlassHero.Accounts.Application.Commands.LoginByMagicLinkTest do
       assert {:error, :not_found} = LoginByMagicLink.execute(token)
     end
 
-    test "returns {:error, :security_violation} for unconfirmed user with password" do
+    test "returns {:error, :security_violation} for an unconfirmed user with a password" do
       user = unconfirmed_user_fixture()
       user = set_password(user)
       {token, _raw} = generate_user_magic_link_token(user)

--- a/test/klass_hero/accounts/application/commands/register_user_test.exs
+++ b/test/klass_hero/accounts/application/commands/register_user_test.exs
@@ -1,0 +1,47 @@
+defmodule KlassHero.Accounts.Application.Commands.RegisterUserTest do
+  @moduledoc """
+  Integration tests for RegisterUser use case.
+
+  Verifies user creation orchestration: successful registration returns a domain
+  User, validation failures surface the changeset, and duplicate emails are
+  rejected.
+  """
+
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.AccountsFixtures
+
+  alias KlassHero.Accounts.Application.Commands.RegisterUser
+  alias KlassHero.Accounts.Domain.Models.User
+
+  describe "execute/1 — success path" do
+    test "returns domain User on valid attributes" do
+      attrs = valid_user_attributes()
+
+      assert {:ok, %User{} = user} = RegisterUser.execute(attrs)
+      assert user.email == attrs.email
+      assert user.name == attrs.name
+    end
+
+  end
+
+  describe "execute/1 — validation failures" do
+    test "returns changeset error for empty attributes" do
+      assert {:error, %Ecto.Changeset{}} = RegisterUser.execute(%{})
+    end
+
+    test "returns changeset error for missing email" do
+      assert {:error, %Ecto.Changeset{} = cs} =
+               RegisterUser.execute(%{name: "Alice", intended_roles: [:parent]})
+
+      assert {:email, _} = hd(cs.errors)
+    end
+
+    test "returns changeset error for duplicate email" do
+      attrs = valid_user_attributes()
+      {:ok, _} = RegisterUser.execute(attrs)
+
+      assert {:error, %Ecto.Changeset{}} = RegisterUser.execute(attrs)
+    end
+  end
+end

--- a/test/klass_hero/accounts/application/commands/register_user_test.exs
+++ b/test/klass_hero/accounts/application/commands/register_user_test.exs
@@ -2,7 +2,7 @@ defmodule KlassHero.Accounts.Application.Commands.RegisterUserTest do
   @moduledoc """
   Integration tests for RegisterUser use case.
 
-  Verifies user creation orchestration: successful registration returns a domain
+  Verifies user creation orchestration: successful registration returns a
   User, validation failures surface the changeset, and duplicate emails are
   rejected.
   """
@@ -12,7 +12,9 @@ defmodule KlassHero.Accounts.Application.Commands.RegisterUserTest do
   import KlassHero.AccountsFixtures
 
   alias KlassHero.Accounts.Application.Commands.RegisterUser
-  alias KlassHero.Accounts.Domain.Models.User
+  # Auth uses phx.gen.auth: KlassHero.Accounts.User (the Ecto schema) is the
+  # canonical user type these commands return — not a separate domain model.
+  alias KlassHero.Accounts.User
 
   describe "execute/1 — success path" do
     test "returns domain User on valid attributes" do
@@ -22,7 +24,6 @@ defmodule KlassHero.Accounts.Application.Commands.RegisterUserTest do
       assert user.email == attrs.email
       assert user.name == attrs.name
     end
-
   end
 
   describe "execute/1 — validation failures" do

--- a/test/klass_hero/enrollment/adapters/driven/persistence/mappers/bulk_enrollment_invite_mapper_test.exs
+++ b/test/klass_hero/enrollment/adapters/driven/persistence/mappers/bulk_enrollment_invite_mapper_test.exs
@@ -72,24 +72,23 @@ defmodule KlassHero.Enrollment.Adapters.Driven.Persistence.Mappers.BulkEnrollmen
     end
 
     test "maps schema with all optional fields nil" do
-      schema =
-        build_schema(%{
-          guardian2_email: nil,
-          guardian2_first_name: nil,
-          guardian2_last_name: nil,
-          school_grade: nil,
-          school_name: nil,
-          medical_conditions: nil,
-          nut_allergy: nil,
-          consent_photo_marketing: nil,
-          consent_photo_social_media: nil,
-          invite_token: nil,
-          invite_sent_at: nil,
-          registered_at: nil,
-          enrolled_at: nil,
-          enrollment_id: nil,
-          error_details: nil
-        })
+      schema = build_schema(%{
+        guardian2_email: nil,
+        guardian2_first_name: nil,
+        guardian2_last_name: nil,
+        school_grade: nil,
+        school_name: nil,
+        medical_conditions: nil,
+        nut_allergy: nil,
+        consent_photo_marketing: nil,
+        consent_photo_social_media: nil,
+        invite_token: nil,
+        invite_sent_at: nil,
+        registered_at: nil,
+        enrolled_at: nil,
+        enrollment_id: nil,
+        error_details: nil
+      })
 
       result = BulkEnrollmentInviteMapper.to_domain(schema)
 
@@ -111,7 +110,7 @@ defmodule KlassHero.Enrollment.Adapters.Driven.Persistence.Mappers.BulkEnrollmen
     end
 
     test "preserves all status values" do
-      for status <- ~w(pending invite_sent registered enrolled failed)a do
+      for status <- [:pending, :invite_sent, :registered, :enrolled, :failed] do
         schema = build_schema(%{status: status})
         result = BulkEnrollmentInviteMapper.to_domain(schema)
         assert result.status == status
@@ -145,6 +144,16 @@ defmodule KlassHero.Enrollment.Adapters.Driven.Persistence.Mappers.BulkEnrollmen
 
       assert result.status == :failed
       assert result.error_details == "Email delivery failed: mailbox full"
+    end
+
+    test "converts UUID id to string via Ecto.UUID.cast!" do
+      raw_id = Ecto.UUID.generate()
+      schema = build_schema(%{id: raw_id})
+
+      result = BulkEnrollmentInviteMapper.to_domain(schema)
+
+      assert is_binary(result.id)
+      assert result.id == to_string(raw_id)
     end
   end
 

--- a/test/klass_hero/enrollment/adapters/driven/persistence/mappers/bulk_enrollment_invite_mapper_test.exs
+++ b/test/klass_hero/enrollment/adapters/driven/persistence/mappers/bulk_enrollment_invite_mapper_test.exs
@@ -1,9 +1,12 @@
 defmodule KlassHero.Enrollment.Adapters.Driven.Persistence.Mappers.BulkEnrollmentInviteMapperTest do
   use ExUnit.Case, async: true
+  use ExUnitProperties
 
   alias KlassHero.Enrollment.Adapters.Driven.Persistence.Mappers.BulkEnrollmentInviteMapper
   alias KlassHero.Enrollment.Adapters.Driven.Persistence.Schemas.BulkEnrollmentInviteSchema
   alias KlassHero.Enrollment.Domain.Models.BulkEnrollmentInvite
+
+  @statuses [:pending, :invite_sent, :registered, :enrolled, :failed]
 
   describe "to_domain/1" do
     test "maps all fields from schema to domain struct" do
@@ -72,23 +75,24 @@ defmodule KlassHero.Enrollment.Adapters.Driven.Persistence.Mappers.BulkEnrollmen
     end
 
     test "maps schema with all optional fields nil" do
-      schema = build_schema(%{
-        guardian2_email: nil,
-        guardian2_first_name: nil,
-        guardian2_last_name: nil,
-        school_grade: nil,
-        school_name: nil,
-        medical_conditions: nil,
-        nut_allergy: nil,
-        consent_photo_marketing: nil,
-        consent_photo_social_media: nil,
-        invite_token: nil,
-        invite_sent_at: nil,
-        registered_at: nil,
-        enrolled_at: nil,
-        enrollment_id: nil,
-        error_details: nil
-      })
+      schema =
+        build_schema(%{
+          guardian2_email: nil,
+          guardian2_first_name: nil,
+          guardian2_last_name: nil,
+          school_grade: nil,
+          school_name: nil,
+          medical_conditions: nil,
+          nut_allergy: nil,
+          consent_photo_marketing: nil,
+          consent_photo_social_media: nil,
+          invite_token: nil,
+          invite_sent_at: nil,
+          registered_at: nil,
+          enrolled_at: nil,
+          enrollment_id: nil,
+          error_details: nil
+        })
 
       result = BulkEnrollmentInviteMapper.to_domain(schema)
 
@@ -155,7 +159,44 @@ defmodule KlassHero.Enrollment.Adapters.Driven.Persistence.Mappers.BulkEnrollmen
       assert is_binary(result.id)
       assert result.id == to_string(raw_id)
     end
+
+    # Optional fields must round through whether nil or populated, across every
+    # status. Required keys are held fixed by build_schema/1 defaults.
+    property "preserves optional fields and status in both nil and populated states" do
+      check all(
+              status <- member_of(@statuses),
+              school_grade <- maybe(integer(1..13)),
+              school_name <- maybe(string(:printable, min_length: 1, max_length: 30)),
+              medical_conditions <- maybe(string(:printable, min_length: 1, max_length: 40)),
+              guardian2_email <- maybe(string(:alphanumeric, min_length: 1, max_length: 20)),
+              error_details <- maybe(string(:printable, min_length: 1, max_length: 40)),
+              nut_allergy <- boolean()
+            ) do
+        schema =
+          build_schema(%{
+            status: status,
+            school_grade: school_grade,
+            school_name: school_name,
+            medical_conditions: medical_conditions,
+            guardian2_email: guardian2_email,
+            error_details: error_details,
+            nut_allergy: nut_allergy
+          })
+
+        result = BulkEnrollmentInviteMapper.to_domain(schema)
+
+        assert result.status == status
+        assert result.school_grade == school_grade
+        assert result.school_name == school_name
+        assert result.medical_conditions == medical_conditions
+        assert result.guardian2_email == guardian2_email
+        assert result.error_details == error_details
+        assert result.nut_allergy == nut_allergy
+      end
+    end
   end
+
+  defp maybe(gen), do: one_of([constant(nil), gen])
 
   defp build_schema(overrides) do
     defaults = %{

--- a/test/klass_hero/enrollment/application/queries/enrollment_policy_queries_test.exs
+++ b/test/klass_hero/enrollment/application/queries/enrollment_policy_queries_test.exs
@@ -1,0 +1,185 @@
+defmodule KlassHero.Enrollment.Application.Queries.EnrollmentPolicyQueriesTest do
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+
+  alias KlassHero.Enrollment.Adapters.Driven.Persistence.Repositories.EnrollmentPolicyRepository
+  alias KlassHero.Enrollment.Application.Queries.EnrollmentPolicyQueries
+
+  # Helpers for setting up policies and enrollments
+  defp upsert_policy!(program_id, attrs \\ %{}) do
+    {:ok, policy} =
+      EnrollmentPolicyRepository.upsert(Map.merge(%{program_id: program_id}, attrs))
+
+    policy
+  end
+
+  defp insert_enrollment!(program_id, status \\ "pending") do
+    {child, parent} = insert_child_with_guardian()
+
+    insert(:enrollment_schema,
+      program_id: program_id,
+      child_id: child.id,
+      parent_id: parent.id,
+      status: status
+    )
+  end
+
+  describe "remaining_capacity/1" do
+    test "returns :unlimited when no policy exists for the program" do
+      program = insert(:program_schema)
+
+      assert {:ok, :unlimited} = EnrollmentPolicyQueries.remaining_capacity(program.id)
+    end
+
+    test "returns :unlimited when policy has no max_enrollment" do
+      program = insert(:program_schema)
+      upsert_policy!(program.id, %{max_enrollment: nil})
+
+      assert {:ok, :unlimited} = EnrollmentPolicyQueries.remaining_capacity(program.id)
+    end
+
+    test "returns remaining spots when some enrollments exist" do
+      program = insert(:program_schema)
+      upsert_policy!(program.id, %{max_enrollment: 10})
+      insert_enrollment!(program.id, "pending")
+      insert_enrollment!(program.id, "confirmed")
+
+      assert {:ok, 8} = EnrollmentPolicyQueries.remaining_capacity(program.id)
+    end
+
+    test "returns 0 when program is fully enrolled" do
+      program = insert(:program_schema)
+      upsert_policy!(program.id, %{max_enrollment: 2})
+      insert_enrollment!(program.id, "pending")
+      insert_enrollment!(program.id, "confirmed")
+
+      assert {:ok, 0} = EnrollmentPolicyQueries.remaining_capacity(program.id)
+    end
+
+    test "ignores cancelled enrollments in the count" do
+      program = insert(:program_schema)
+      upsert_policy!(program.id, %{max_enrollment: 3})
+      insert_enrollment!(program.id, "cancelled")
+
+      assert {:ok, 3} = EnrollmentPolicyQueries.remaining_capacity(program.id)
+    end
+  end
+
+  describe "get_remaining_capacities/1" do
+    test "returns empty map for empty program list" do
+      assert %{} == EnrollmentPolicyQueries.get_remaining_capacities([])
+    end
+
+    test "returns :unlimited for programs without a policy" do
+      program = insert(:program_schema)
+
+      result = EnrollmentPolicyQueries.get_remaining_capacities([program.id])
+
+      assert result == %{program.id => :unlimited}
+    end
+
+    test "returns :unlimited for programs with no max_enrollment" do
+      program = insert(:program_schema)
+      upsert_policy!(program.id, %{max_enrollment: nil})
+
+      result = EnrollmentPolicyQueries.get_remaining_capacities([program.id])
+
+      assert result == %{program.id => :unlimited}
+    end
+
+    test "returns correct remaining capacity for programs with capped policies" do
+      program = insert(:program_schema)
+      upsert_policy!(program.id, %{max_enrollment: 5})
+      insert_enrollment!(program.id, "pending")
+      insert_enrollment!(program.id, "confirmed")
+
+      result = EnrollmentPolicyQueries.get_remaining_capacities([program.id])
+
+      assert result == %{program.id => 3}
+    end
+
+    test "handles a mix of programs with and without policies" do
+      capped = insert(:program_schema)
+      unlimited = insert(:program_schema)
+
+      upsert_policy!(capped.id, %{max_enrollment: 4})
+      insert_enrollment!(capped.id, "confirmed")
+
+      result = EnrollmentPolicyQueries.get_remaining_capacities([capped.id, unlimited.id])
+
+      assert result == %{capped.id => 3, unlimited.id => :unlimited}
+    end
+  end
+
+  describe "get_enrollment_summary_batch/1" do
+    test "returns empty map for empty program list" do
+      assert %{} == EnrollmentPolicyQueries.get_enrollment_summary_batch([])
+    end
+
+    test "returns nil capacity for programs without a policy" do
+      program = insert(:program_schema)
+
+      result = EnrollmentPolicyQueries.get_enrollment_summary_batch([program.id])
+
+      assert result == %{program.id => %{enrolled: 0, capacity: nil}}
+    end
+
+    test "returns nil capacity for programs with unlimited policy (no max)" do
+      program = insert(:program_schema)
+      upsert_policy!(program.id, %{max_enrollment: nil})
+      insert_enrollment!(program.id, "confirmed")
+
+      result = EnrollmentPolicyQueries.get_enrollment_summary_batch([program.id])
+
+      assert result == %{program.id => %{enrolled: 1, capacity: nil}}
+    end
+
+    test "returns correct enrolled count and total capacity for capped programs" do
+      program = insert(:program_schema)
+      upsert_policy!(program.id, %{max_enrollment: 5})
+      insert_enrollment!(program.id, "pending")
+      insert_enrollment!(program.id, "confirmed")
+
+      result = EnrollmentPolicyQueries.get_enrollment_summary_batch([program.id])
+
+      assert result == %{program.id => %{enrolled: 2, capacity: 5}}
+    end
+
+    test "handles fully enrolled program — enrolled equals capacity" do
+      program = insert(:program_schema)
+      upsert_policy!(program.id, %{max_enrollment: 2})
+      insert_enrollment!(program.id, "pending")
+      insert_enrollment!(program.id, "confirmed")
+
+      result = EnrollmentPolicyQueries.get_enrollment_summary_batch([program.id])
+
+      assert result == %{program.id => %{enrolled: 2, capacity: 2}}
+    end
+
+    test "handles mixed programs in a single batch call" do
+      capped = insert(:program_schema)
+      unlimited = insert(:program_schema)
+      no_policy = insert(:program_schema)
+
+      upsert_policy!(capped.id, %{max_enrollment: 10})
+      upsert_policy!(unlimited.id, %{max_enrollment: nil})
+
+      insert_enrollment!(capped.id, "pending")
+      insert_enrollment!(unlimited.id, "confirmed")
+
+      result =
+        EnrollmentPolicyQueries.get_enrollment_summary_batch([
+          capped.id,
+          unlimited.id,
+          no_policy.id
+        ])
+
+      assert result == %{
+               capped.id => %{enrolled: 1, capacity: 10},
+               unlimited.id => %{enrolled: 1, capacity: nil},
+               no_policy.id => %{enrolled: 0, capacity: nil}
+             }
+    end
+  end
+end

--- a/test/klass_hero/enrollment/application/queries/enrollment_policy_queries_test.exs
+++ b/test/klass_hero/enrollment/application/queries/enrollment_policy_queries_test.exs
@@ -7,14 +7,14 @@ defmodule KlassHero.Enrollment.Application.Queries.EnrollmentPolicyQueriesTest d
   alias KlassHero.Enrollment.Application.Queries.EnrollmentPolicyQueries
 
   # Helpers for setting up policies and enrollments
-  defp upsert_policy!(program_id, attrs \\ %{}) do
+  defp upsert_policy!(program_id, attrs) do
     {:ok, policy} =
       EnrollmentPolicyRepository.upsert(Map.merge(%{program_id: program_id}, attrs))
 
     policy
   end
 
-  defp insert_enrollment!(program_id, status \\ "pending") do
+  defp insert_enrollment!(program_id, status) do
     {child, parent} = insert_child_with_guardian()
 
     insert(:enrollment_schema,

--- a/test/klass_hero/messaging/adapters/driven/persistence/mappers/attachment_mapper_test.exs
+++ b/test/klass_hero/messaging/adapters/driven/persistence/mappers/attachment_mapper_test.exs
@@ -36,7 +36,7 @@ defmodule KlassHero.Messaging.Adapters.Driven.Persistence.Mappers.AttachmentMapp
     end
 
     test "maps nil timestamps" do
-      schema = build_schema(%{inserted_at: nil, updated_at: nil})
+      schema = build_schema(inserted_at: nil, updated_at: nil)
 
       result = AttachmentMapper.to_domain(schema)
 
@@ -44,8 +44,16 @@ defmodule KlassHero.Messaging.Adapters.Driven.Persistence.Mappers.AttachmentMapp
       assert result.updated_at == nil
     end
 
+    test "preserves content_type without transformation" do
+      for content_type <- ~w(image/jpeg image/png image/gif image/webp) do
+        schema = build_schema(content_type: content_type)
+        result = AttachmentMapper.to_domain(schema)
+        assert result.content_type == content_type
+      end
+    end
+
     test "preserves large file_size_bytes" do
-      schema = build_schema(%{file_size_bytes: 10_485_760})
+      schema = build_schema(file_size_bytes: 10_485_760)
 
       result = AttachmentMapper.to_domain(schema)
 
@@ -66,10 +74,7 @@ defmodule KlassHero.Messaging.Adapters.Driven.Persistence.Mappers.AttachmentMapp
 
       result = AttachmentMapper.to_create_attrs(attrs)
 
-      assert Enum.sort(Map.keys(result)) ==
-               ~w(content_type file_size_bytes file_url message_id original_filename storage_path)a
-
-      for key <- Map.keys(attrs), do: assert(result[key] == attrs[key])
+      assert result == attrs
     end
 
     test "filters out extraneous keys not needed for persistence" do
@@ -92,7 +97,6 @@ defmodule KlassHero.Messaging.Adapters.Driven.Persistence.Mappers.AttachmentMapp
 
     test "includes storage_path (not present in domain model)" do
       storage_path = "uploads/2025/04/abc123.jpg"
-
       attrs = %{
         message_id: Ecto.UUID.generate(),
         file_url: "https://cdn.example.com/abc123.jpg",
@@ -133,6 +137,6 @@ defmodule KlassHero.Messaging.Adapters.Driven.Persistence.Mappers.AttachmentMapp
       updated_at: now
     }
 
-    struct!(AttachmentSchema, Map.merge(defaults, overrides))
+    struct!(AttachmentSchema, Map.merge(defaults, Map.new(overrides)))
   end
 end

--- a/test/klass_hero/messaging/adapters/driven/persistence/mappers/attachment_mapper_test.exs
+++ b/test/klass_hero/messaging/adapters/driven/persistence/mappers/attachment_mapper_test.exs
@@ -1,5 +1,6 @@
 defmodule KlassHero.Messaging.Adapters.Driven.Persistence.Mappers.AttachmentMapperTest do
   use ExUnit.Case, async: true
+  use ExUnitProperties
 
   alias KlassHero.Messaging.Adapters.Driven.Persistence.Mappers.AttachmentMapper
   alias KlassHero.Messaging.Adapters.Driven.Persistence.Schemas.AttachmentSchema
@@ -59,6 +60,37 @@ defmodule KlassHero.Messaging.Adapters.Driven.Persistence.Mappers.AttachmentMapp
 
       assert result.file_size_bytes == 10_485_760
     end
+
+    # to_domain/1 is a straight field copy (no casting), so every field must
+    # survive verbatim for any schema.
+    property "carries every field through unchanged" do
+      check all(
+              file_url <- string(:printable, max_length: 60),
+              original_filename <- string(:printable, max_length: 40),
+              content_type <- string(:alphanumeric, min_length: 1, max_length: 20),
+              file_size_bytes <- integer(0..50_000_000)
+            ) do
+        schema =
+          build_schema(
+            file_url: file_url,
+            original_filename: original_filename,
+            content_type: content_type,
+            file_size_bytes: file_size_bytes
+          )
+
+        result = AttachmentMapper.to_domain(schema)
+
+        assert %Attachment{} = result
+        assert result.id == schema.id
+        assert result.message_id == schema.message_id
+        assert result.file_url == file_url
+        assert result.original_filename == original_filename
+        assert result.content_type == content_type
+        assert result.file_size_bytes == file_size_bytes
+        assert result.inserted_at == schema.inserted_at
+        assert result.updated_at == schema.updated_at
+      end
+    end
   end
 
   describe "to_create_attrs/1" do
@@ -97,6 +129,7 @@ defmodule KlassHero.Messaging.Adapters.Driven.Persistence.Mappers.AttachmentMapp
 
     test "includes storage_path (not present in domain model)" do
       storage_path = "uploads/2025/04/abc123.jpg"
+
       attrs = %{
         message_id: Ecto.UUID.generate(),
         file_url: "https://cdn.example.com/abc123.jpg",

--- a/test/klass_hero/program_catalog/domain/models/instructor_test.exs
+++ b/test/klass_hero/program_catalog/domain/models/instructor_test.exs
@@ -1,7 +1,9 @@
 defmodule KlassHero.ProgramCatalog.Domain.Models.InstructorTest do
   use ExUnit.Case, async: true
+  use ExUnitProperties
 
   alias KlassHero.ProgramCatalog.Domain.Models.Instructor
+  alias KlassHero.Shared.NameUtils
 
   @valid_attrs %{
     id: "550e8400-e29b-41d4-a716-446655440000",
@@ -35,24 +37,19 @@ defmodule KlassHero.ProgramCatalog.Domain.Models.InstructorTest do
   end
 
   describe "initials/1" do
-    test "returns uppercase initial of each word in a two-word name" do
+    test "returns the uppercase initials of the instructor's name" do
       {:ok, instructor} = Instructor.new(%{@valid_attrs | name: "Marie Curie"})
       assert Instructor.initials(instructor) == "MC"
     end
 
-    test "returns single initial for a single-word name" do
-      {:ok, instructor} = Instructor.new(%{@valid_attrs | name: "Madonna"})
-      assert Instructor.initials(instructor) == "M"
-    end
-
-    test "takes only the first two initials from a three-word name" do
-      {:ok, instructor} = Instructor.new(%{@valid_attrs | name: "Mary Jane Watson"})
-      assert Instructor.initials(instructor) == "MJ"
-    end
-
-    test "handles extra internal whitespace between words" do
-      {:ok, instructor} = Instructor.new(%{@valid_attrs | name: "Alice   Smith"})
-      assert Instructor.initials(instructor) == "AS"
+    # initials/1 is a thin delegation to NameUtils.initials_from_name/1, which is
+    # itself property-tested. Rather than re-derive the initials algorithm here,
+    # assert the wiring: initials/1 must agree with the helper for any name.
+    property "delegates to NameUtils.initials_from_name/1 for any name" do
+      check all(name <- string(:printable, max_length: 30)) do
+        instructor = %Instructor{id: @valid_attrs.id, name: name}
+        assert Instructor.initials(instructor) == NameUtils.initials_from_name(name)
+      end
     end
   end
 

--- a/test/klass_hero/program_catalog/domain/models/instructor_test.exs
+++ b/test/klass_hero/program_catalog/domain/models/instructor_test.exs
@@ -34,6 +34,28 @@ defmodule KlassHero.ProgramCatalog.Domain.Models.InstructorTest do
     end
   end
 
+  describe "initials/1" do
+    test "returns uppercase initial of each word in a two-word name" do
+      {:ok, instructor} = Instructor.new(%{@valid_attrs | name: "Marie Curie"})
+      assert Instructor.initials(instructor) == "MC"
+    end
+
+    test "returns single initial for a single-word name" do
+      {:ok, instructor} = Instructor.new(%{@valid_attrs | name: "Madonna"})
+      assert Instructor.initials(instructor) == "M"
+    end
+
+    test "takes only the first two initials from a three-word name" do
+      {:ok, instructor} = Instructor.new(%{@valid_attrs | name: "Mary Jane Watson"})
+      assert Instructor.initials(instructor) == "MJ"
+    end
+
+    test "handles extra internal whitespace between words" do
+      {:ok, instructor} = Instructor.new(%{@valid_attrs | name: "Alice   Smith"})
+      assert Instructor.initials(instructor) == "AS"
+    end
+  end
+
   describe "from_persistence/1" do
     test "reconstructs without validation" do
       assert {:ok, instructor} = Instructor.from_persistence(@valid_attrs)

--- a/test/klass_hero/provider/adapters/driven/persistence/mappers/incident_report_mapper_test.exs
+++ b/test/klass_hero/provider/adapters/driven/persistence/mappers/incident_report_mapper_test.exs
@@ -1,0 +1,239 @@
+defmodule KlassHero.Provider.Adapters.Driven.Persistence.Mappers.IncidentReportMapperTest do
+  @moduledoc """
+  Unit tests for IncidentReportMapper.
+
+  Covers bidirectional mapping between IncidentReport domain model and
+  IncidentReportSchema, with emphasis on the provider_profile_id ↔ provider_id
+  field-name translation and nil-guard behaviour for optional FK fields.
+  No database required.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias KlassHero.Provider.Adapters.Driven.Persistence.Mappers.IncidentReportMapper
+  alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.IncidentReportSchema
+  alias KlassHero.Provider.Domain.Models.IncidentReport
+
+  @id Ecto.UUID.generate()
+  @provider_id Ecto.UUID.generate()
+  @reporter_user_id Ecto.UUID.generate()
+  @program_id Ecto.UUID.generate()
+
+  defp valid_schema(overrides \\ %{}) do
+    defaults = %{
+      id: @id,
+      provider_id: @provider_id,
+      reporter_user_id: @reporter_user_id,
+      reporter_display_name: "Jane Smith",
+      program_id: @program_id,
+      session_id: nil,
+      category: :safety_concern,
+      severity: :medium,
+      description: "Child fell off equipment",
+      occurred_at: ~U[2025-03-15 14:30:00Z],
+      photo_url: nil,
+      original_filename: nil,
+      inserted_at: ~U[2025-03-15 15:00:00Z],
+      updated_at: ~U[2025-03-15 15:00:00Z]
+    }
+
+    struct!(IncidentReportSchema, Map.merge(defaults, overrides))
+  end
+
+  defp valid_domain(overrides \\ %{}) do
+    defaults = %{
+      id: @id,
+      provider_profile_id: @provider_id,
+      reporter_user_id: @reporter_user_id,
+      reporter_display_name: "Jane Smith",
+      program_id: @program_id,
+      session_id: nil,
+      category: :safety_concern,
+      severity: :medium,
+      description: "Child fell off equipment",
+      occurred_at: ~U[2025-03-15 14:30:00Z],
+      photo_url: nil,
+      original_filename: nil
+    }
+
+    struct!(IncidentReport, Map.merge(defaults, overrides))
+  end
+
+  describe "to_domain/1" do
+    test "maps all required fields from schema to domain struct" do
+      schema = valid_schema()
+
+      report = IncidentReportMapper.to_domain(schema)
+
+      assert %IncidentReport{} = report
+      assert report.id == @id
+      assert report.reporter_user_id == @reporter_user_id
+      assert report.reporter_display_name == "Jane Smith"
+      assert report.category == :safety_concern
+      assert report.severity == :medium
+      assert report.description == "Child fell off equipment"
+      assert report.occurred_at == ~U[2025-03-15 14:30:00Z]
+    end
+
+    test "translates provider_id (DB) to provider_profile_id (domain)" do
+      schema = valid_schema()
+
+      report = IncidentReportMapper.to_domain(schema)
+
+      assert report.provider_profile_id == @provider_id
+    end
+
+    test "preserves timestamps from schema" do
+      schema = valid_schema()
+
+      report = IncidentReportMapper.to_domain(schema)
+
+      assert report.inserted_at == ~U[2025-03-15 15:00:00Z]
+      assert report.updated_at == ~U[2025-03-15 15:00:00Z]
+    end
+
+    test "maps nil program_id to nil" do
+      schema = valid_schema(%{program_id: nil})
+
+      report = IncidentReportMapper.to_domain(schema)
+
+      assert is_nil(report.program_id)
+    end
+
+    test "converts non-nil program_id UUID to string" do
+      schema = valid_schema(%{program_id: @program_id})
+
+      report = IncidentReportMapper.to_domain(schema)
+
+      assert report.program_id == @program_id
+    end
+
+    test "maps nil session_id to nil" do
+      schema = valid_schema(%{session_id: nil})
+
+      report = IncidentReportMapper.to_domain(schema)
+
+      assert is_nil(report.session_id)
+    end
+
+    test "converts non-nil session_id UUID to string" do
+      session_id = Ecto.UUID.generate()
+      schema = valid_schema(%{program_id: nil, session_id: session_id})
+
+      report = IncidentReportMapper.to_domain(schema)
+
+      assert report.session_id == session_id
+    end
+
+    test "maps nil photo_url to nil" do
+      schema = valid_schema(%{photo_url: nil})
+
+      report = IncidentReportMapper.to_domain(schema)
+
+      assert is_nil(report.photo_url)
+    end
+
+    test "passes through non-nil photo_url and original_filename" do
+      schema = valid_schema(%{photo_url: "photos/report-abc.jpg", original_filename: "photo.jpg"})
+
+      report = IncidentReportMapper.to_domain(schema)
+
+      assert report.photo_url == "photos/report-abc.jpg"
+      assert report.original_filename == "photo.jpg"
+    end
+  end
+
+  describe "to_schema/1" do
+    test "maps all required fields from domain to attribute map" do
+      domain = valid_domain()
+
+      attrs = IncidentReportMapper.to_schema(domain)
+
+      assert attrs.id == @id
+      assert attrs.reporter_user_id == @reporter_user_id
+      assert attrs.reporter_display_name == "Jane Smith"
+      assert attrs.category == :safety_concern
+      assert attrs.severity == :medium
+      assert attrs.description == "Child fell off equipment"
+      assert attrs.occurred_at == ~U[2025-03-15 14:30:00Z]
+    end
+
+    test "translates provider_profile_id (domain) to provider_id (DB)" do
+      domain = valid_domain()
+
+      attrs = IncidentReportMapper.to_schema(domain)
+
+      assert attrs.provider_id == @provider_id
+      refute Map.has_key?(attrs, :provider_profile_id)
+    end
+
+    test "maps nil program_id and session_id to nil" do
+      domain = valid_domain(%{program_id: nil, session_id: nil})
+
+      attrs = IncidentReportMapper.to_schema(domain)
+
+      assert is_nil(attrs.program_id)
+      assert is_nil(attrs.session_id)
+    end
+
+    test "maps non-nil session_id through" do
+      session_id = Ecto.UUID.generate()
+      domain = valid_domain(%{program_id: nil, session_id: session_id})
+
+      attrs = IncidentReportMapper.to_schema(domain)
+
+      assert is_nil(attrs.program_id)
+      assert attrs.session_id == session_id
+    end
+
+    test "maps nil photo fields to nil" do
+      domain = valid_domain(%{photo_url: nil, original_filename: nil})
+
+      attrs = IncidentReportMapper.to_schema(domain)
+
+      assert is_nil(attrs.photo_url)
+      assert is_nil(attrs.original_filename)
+    end
+
+    test "maps non-nil photo fields through" do
+      domain = valid_domain(%{photo_url: "photos/report-abc.jpg", original_filename: "photo.jpg"})
+
+      attrs = IncidentReportMapper.to_schema(domain)
+
+      assert attrs.photo_url == "photos/report-abc.jpg"
+      assert attrs.original_filename == "photo.jpg"
+    end
+
+    test "does not include timestamps" do
+      domain = valid_domain()
+
+      attrs = IncidentReportMapper.to_schema(domain)
+
+      refute Map.has_key?(attrs, :inserted_at)
+      refute Map.has_key?(attrs, :updated_at)
+    end
+  end
+
+  describe "round-trip" do
+    test "domain → schema attrs → domain preserves all fields" do
+      domain_before =
+        valid_domain(%{photo_url: "photos/test.jpg", original_filename: "test.jpg"})
+
+      attrs = IncidentReportMapper.to_schema(domain_before)
+
+      schema =
+        struct!(IncidentReportSchema, Map.merge(Map.from_struct(valid_schema()), attrs))
+
+      domain_after = IncidentReportMapper.to_domain(schema)
+
+      assert domain_after.id == domain_before.id
+      assert domain_after.provider_profile_id == domain_before.provider_profile_id
+      assert domain_after.reporter_user_id == domain_before.reporter_user_id
+      assert domain_after.category == domain_before.category
+      assert domain_after.severity == domain_before.severity
+      assert domain_after.description == domain_before.description
+      assert domain_after.photo_url == domain_before.photo_url
+      assert domain_after.original_filename == domain_before.original_filename
+    end
+  end
+end

--- a/test/klass_hero/provider/adapters/driven/persistence/mappers/incident_report_mapper_test.exs
+++ b/test/klass_hero/provider/adapters/driven/persistence/mappers/incident_report_mapper_test.exs
@@ -9,6 +9,7 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.Mappers.IncidentReportM
   """
 
   use ExUnit.Case, async: true
+  use ExUnitProperties
 
   alias KlassHero.Provider.Adapters.Driven.Persistence.Mappers.IncidentReportMapper
   alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.IncidentReportSchema
@@ -18,6 +19,9 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.Mappers.IncidentReportM
   @provider_id Ecto.UUID.generate()
   @reporter_user_id Ecto.UUID.generate()
   @program_id Ecto.UUID.generate()
+
+  @categories [:safety_concern, :behavioral_issue, :injury, :property_damage, :policy_violation, :other]
+  @severities [:low, :medium, :high, :critical]
 
   defp valid_schema(overrides \\ %{}) do
     defaults = %{
@@ -219,12 +223,7 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.Mappers.IncidentReportM
       domain_before =
         valid_domain(%{photo_url: "photos/test.jpg", original_filename: "test.jpg"})
 
-      attrs = IncidentReportMapper.to_schema(domain_before)
-
-      schema =
-        struct!(IncidentReportSchema, Map.merge(Map.from_struct(valid_schema()), attrs))
-
-      domain_after = IncidentReportMapper.to_domain(schema)
+      domain_after = round_trip(domain_before)
 
       assert domain_after.id == domain_before.id
       assert domain_after.provider_profile_id == domain_before.provider_profile_id
@@ -234,6 +233,61 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.Mappers.IncidentReportM
       assert domain_after.description == domain_before.description
       assert domain_after.photo_url == domain_before.photo_url
       assert domain_after.original_filename == domain_before.original_filename
+    end
+
+    property "domain → schema attrs → domain preserves every non-timestamp field" do
+      check all(domain_before <- domain_generator()) do
+        domain_after = round_trip(domain_before)
+
+        # to_schema drops timestamps and to_domain re-reads them from the schema,
+        # so compare the whole struct modulo the two timestamp fields.
+        normalised = %{domain_after | inserted_at: domain_before.inserted_at, updated_at: domain_before.updated_at}
+
+        assert normalised == domain_before
+      end
+    end
+  end
+
+  # Round-trips a domain report through the mapper. to_schema/1 omits timestamps,
+  # so they are supplied from the valid_schema/0 base during reconstruction.
+  defp round_trip(domain) do
+    attrs = IncidentReportMapper.to_schema(domain)
+
+    IncidentReportSchema
+    |> struct!(Map.merge(Map.from_struct(valid_schema()), attrs))
+    |> IncidentReportMapper.to_domain()
+  end
+
+  defp maybe(gen), do: one_of([constant(nil), gen])
+  defp nonempty_string, do: string(:alphanumeric, min_length: 1, max_length: 20)
+
+  defp domain_generator do
+    gen all(
+          id <- nonempty_string(),
+          provider_profile_id <- nonempty_string(),
+          reporter_user_id <- nonempty_string(),
+          reporter_display_name <- nonempty_string(),
+          program_id <- maybe(nonempty_string()),
+          session_id <- maybe(nonempty_string()),
+          category <- member_of(@categories),
+          severity <- member_of(@severities),
+          description <- nonempty_string(),
+          photo_url <- maybe(nonempty_string()),
+          original_filename <- maybe(nonempty_string())
+        ) do
+      valid_domain(%{
+        id: id,
+        provider_profile_id: provider_profile_id,
+        reporter_user_id: reporter_user_id,
+        reporter_display_name: reporter_display_name,
+        program_id: program_id,
+        session_id: session_id,
+        category: category,
+        severity: severity,
+        description: description,
+        photo_url: photo_url,
+        original_filename: original_filename
+      })
     end
   end
 end

--- a/test/klass_hero/provider/adapters/driven/persistence/mappers/incident_report_summary_mapper_test.exs
+++ b/test/klass_hero/provider/adapters/driven/persistence/mappers/incident_report_summary_mapper_test.exs
@@ -1,0 +1,91 @@
+defmodule KlassHero.Provider.Adapters.Driven.Persistence.Mappers.IncidentReportSummaryMapperTest do
+  @moduledoc """
+  Unit tests for IncidentReportSummaryMapper.
+
+  Covers schema-to-read-model projection, verifying all display fields are
+  mapped correctly and that optional FK fields (program_id, session_id) are
+  guarded against nil. No database required.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias KlassHero.Provider.Adapters.Driven.Persistence.Mappers.IncidentReportSummaryMapper
+  alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.IncidentReportSchema
+  alias KlassHero.Provider.Domain.ReadModels.IncidentReportSummary
+
+  @id Ecto.UUID.generate()
+  @provider_id Ecto.UUID.generate()
+  @program_id Ecto.UUID.generate()
+
+  defp valid_schema(overrides \\ %{}) do
+    defaults = %{
+      id: @id,
+      provider_id: @provider_id,
+      reporter_user_id: Ecto.UUID.generate(),
+      reporter_display_name: "Jane Smith",
+      program_id: @program_id,
+      session_id: nil,
+      category: :safety_concern,
+      severity: :medium,
+      description: "Child fell off equipment",
+      occurred_at: ~U[2025-03-15 14:30:00Z],
+      photo_url: nil,
+      original_filename: nil,
+      inserted_at: ~U[2025-03-15 15:00:00Z],
+      updated_at: ~U[2025-03-15 15:00:00Z]
+    }
+
+    struct!(IncidentReportSchema, Map.merge(defaults, overrides))
+  end
+
+  describe "from_schema/1" do
+    test "maps all display fields to the read model struct" do
+      schema = valid_schema()
+
+      summary = IncidentReportSummaryMapper.from_schema(schema)
+
+      assert %IncidentReportSummary{} = summary
+      assert summary.id == @id
+      assert summary.provider_id == @provider_id
+      assert summary.program_id == @program_id
+      assert summary.reporter_display_name == "Jane Smith"
+      assert summary.category == :safety_concern
+      assert summary.severity == :medium
+      assert summary.description == "Child fell off equipment"
+      assert summary.occurred_at == ~U[2025-03-15 14:30:00Z]
+    end
+
+    test "maps nil program_id to nil" do
+      schema = valid_schema(%{program_id: nil})
+
+      summary = IncidentReportSummaryMapper.from_schema(schema)
+
+      assert is_nil(summary.program_id)
+    end
+
+    test "converts non-nil program_id UUID to string" do
+      schema = valid_schema(%{program_id: @program_id})
+
+      summary = IncidentReportSummaryMapper.from_schema(schema)
+
+      assert summary.program_id == @program_id
+    end
+
+    test "maps nil session_id to nil" do
+      schema = valid_schema(%{session_id: nil})
+
+      summary = IncidentReportSummaryMapper.from_schema(schema)
+
+      assert is_nil(summary.session_id)
+    end
+
+    test "converts non-nil session_id UUID to string" do
+      session_id = Ecto.UUID.generate()
+      schema = valid_schema(%{program_id: nil, session_id: session_id})
+
+      summary = IncidentReportSummaryMapper.from_schema(schema)
+
+      assert summary.session_id == session_id
+    end
+  end
+end

--- a/test/klass_hero/provider/adapters/driven/persistence/mappers/incident_report_summary_mapper_test.exs
+++ b/test/klass_hero/provider/adapters/driven/persistence/mappers/incident_report_summary_mapper_test.exs
@@ -8,6 +8,7 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.Mappers.IncidentReportS
   """
 
   use ExUnit.Case, async: true
+  use ExUnitProperties
 
   alias KlassHero.Provider.Adapters.Driven.Persistence.Mappers.IncidentReportSummaryMapper
   alias KlassHero.Provider.Adapters.Driven.Persistence.Schemas.IncidentReportSchema
@@ -16,6 +17,9 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.Mappers.IncidentReportS
   @id Ecto.UUID.generate()
   @provider_id Ecto.UUID.generate()
   @program_id Ecto.UUID.generate()
+
+  @categories [:safety_concern, :behavioral_issue, :injury, :property_damage, :policy_violation, :other]
+  @severities [:low, :medium, :high, :critical]
 
   defp valid_schema(overrides \\ %{}) do
     defaults = %{
@@ -87,5 +91,46 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.Mappers.IncidentReportS
 
       assert summary.session_id == session_id
     end
+
+    property "projects every display field, stringifying ids and guarding nil FKs" do
+      check all(
+              id <- nonempty_string(),
+              provider_id <- nonempty_string(),
+              program_id <- maybe(nonempty_string()),
+              session_id <- maybe(nonempty_string()),
+              category <- member_of(@categories),
+              severity <- member_of(@severities),
+              description <- nonempty_string(),
+              reporter_display_name <- nonempty_string()
+            ) do
+        schema =
+          valid_schema(%{
+            id: id,
+            provider_id: provider_id,
+            program_id: program_id,
+            session_id: session_id,
+            category: category,
+            severity: severity,
+            description: description,
+            reporter_display_name: reporter_display_name
+          })
+
+        summary = IncidentReportSummaryMapper.from_schema(schema)
+
+        assert summary.id == to_string(id)
+        assert summary.provider_id == to_string(provider_id)
+        assert summary.program_id == maybe_to_string(program_id)
+        assert summary.session_id == maybe_to_string(session_id)
+        assert summary.category == category
+        assert summary.severity == severity
+        assert summary.description == description
+        assert summary.reporter_display_name == reporter_display_name
+      end
+    end
   end
+
+  defp maybe(gen), do: one_of([constant(nil), gen])
+  defp nonempty_string, do: string(:alphanumeric, min_length: 1, max_length: 20)
+  defp maybe_to_string(nil), do: nil
+  defp maybe_to_string(value), do: to_string(value)
 end

--- a/test/klass_hero/provider/application/commands/staff_members/expire_staff_invitation_test.exs
+++ b/test/klass_hero/provider/application/commands/staff_members/expire_staff_invitation_test.exs
@@ -1,0 +1,96 @@
+defmodule KlassHero.Provider.Application.Commands.StaffMembers.ExpireStaffInvitationTest do
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.ProviderFixtures
+
+  alias KlassHero.Provider.Application.Commands.StaffMembers.ExpireStaffInvitation
+  alias KlassHero.Provider.Domain.Models.StaffMember
+
+  describe "execute/1 with staff_member_id" do
+    test "transitions :sent invitation to :expired" do
+      provider = provider_profile_fixture()
+
+      staff =
+        staff_member_fixture(%{
+          provider_id: provider.id,
+          invitation_status: :sent,
+          invitation_token_hash: :crypto.hash(:sha256, "tok")
+        })
+
+      assert {:ok, %StaffMember{} = updated} = ExpireStaffInvitation.execute(staff.id)
+      assert updated.id == staff.id
+      assert updated.invitation_status == :expired
+    end
+
+    test "returns error for :pending staff member (invalid transition)" do
+      provider = provider_profile_fixture()
+
+      staff =
+        staff_member_fixture(%{
+          provider_id: provider.id,
+          invitation_status: :pending
+        })
+
+      assert {:error, :invalid_invitation_transition} = ExpireStaffInvitation.execute(staff.id)
+    end
+
+    test "returns error for :accepted staff member (invalid transition)" do
+      provider = provider_profile_fixture()
+
+      staff =
+        staff_member_fixture(%{
+          provider_id: provider.id,
+          invitation_status: :accepted
+        })
+
+      assert {:error, :invalid_invitation_transition} = ExpireStaffInvitation.execute(staff.id)
+    end
+
+    test "returns error for :failed staff member (invalid transition)" do
+      provider = provider_profile_fixture()
+
+      staff =
+        staff_member_fixture(%{
+          provider_id: provider.id,
+          invitation_status: :failed,
+          invitation_token_hash: :crypto.hash(:sha256, "tok")
+        })
+
+      assert {:error, :invalid_invitation_transition} = ExpireStaffInvitation.execute(staff.id)
+    end
+
+    test "returns :not_found for non-existent staff member" do
+      assert {:error, :not_found} = ExpireStaffInvitation.execute(Ecto.UUID.generate())
+    end
+  end
+
+  describe "execute/1 with %StaffMember{} struct" do
+    test "transitions :sent invitation to :expired without re-fetching from DB" do
+      provider = provider_profile_fixture()
+
+      staff =
+        staff_member_fixture(%{
+          provider_id: provider.id,
+          invitation_status: :sent,
+          invitation_token_hash: :crypto.hash(:sha256, "tok")
+        })
+
+      assert {:ok, %StaffMember{} = updated} = ExpireStaffInvitation.execute(staff)
+      assert updated.id == staff.id
+      assert updated.invitation_status == :expired
+    end
+
+    test "returns error for :expired → :expired (no self-transition defined)" do
+      provider = provider_profile_fixture()
+
+      staff =
+        staff_member_fixture(%{
+          provider_id: provider.id,
+          invitation_status: :expired,
+          invitation_token_hash: :crypto.hash(:sha256, "tok")
+        })
+
+      assert {:error, :invalid_invitation_transition} = ExpireStaffInvitation.execute(staff)
+    end
+  end
+end

--- a/test/klass_hero/provider/application/commands/staff_members/expire_staff_invitation_test.exs
+++ b/test/klass_hero/provider/application/commands/staff_members/expire_staff_invitation_test.exs
@@ -6,91 +6,65 @@ defmodule KlassHero.Provider.Application.Commands.StaffMembers.ExpireStaffInvita
   alias KlassHero.Provider.Application.Commands.StaffMembers.ExpireStaffInvitation
   alias KlassHero.Provider.Domain.Models.StaffMember
 
-  describe "execute/1 with staff_member_id" do
-    test "transitions :sent invitation to :expired" do
-      provider = provider_profile_fixture()
+  # Only :sent invitations may transition to :expired; every other status is an
+  # invalid transition.
+  @invalid_source_statuses [:pending, :accepted, :failed, :expired]
 
-      staff =
-        staff_member_fixture(%{
-          provider_id: provider.id,
-          invitation_status: :sent,
-          invitation_token_hash: :crypto.hash(:sha256, "tok")
-        })
+  defp staff_with_status(status) do
+    provider = provider_profile_fixture()
+    attrs = %{provider_id: provider.id, invitation_status: status}
+
+    # A token hash is only valid on statuses that carry a live/used token; the
+    # invitation changeset rejects it on :pending/:accepted (which need a user_id).
+    # The hash is unique per call — several staff are created in one transaction
+    # within a single tabular test, and the column has a unique index.
+    attrs =
+      if status in [:sent, :failed, :expired],
+        do: Map.put(attrs, :invitation_token_hash, :crypto.hash(:sha256, "tok-#{System.unique_integer([:positive])}")),
+        else: attrs
+
+    staff_member_fixture(attrs)
+  end
+
+  describe "execute/1 with staff_member_id" do
+    test "transitions a :sent invitation to :expired" do
+      staff = staff_with_status(:sent)
 
       assert {:ok, %StaffMember{} = updated} = ExpireStaffInvitation.execute(staff.id)
       assert updated.id == staff.id
       assert updated.invitation_status == :expired
     end
 
-    test "returns error for :pending staff member (invalid transition)" do
-      provider = provider_profile_fixture()
+    test "rejects expiry from any non-:sent status" do
+      for status <- @invalid_source_statuses do
+        staff = staff_with_status(status)
 
-      staff =
-        staff_member_fixture(%{
-          provider_id: provider.id,
-          invitation_status: :pending
-        })
-
-      assert {:error, :invalid_invitation_transition} = ExpireStaffInvitation.execute(staff.id)
+        assert {:error, :invalid_invitation_transition} = ExpireStaffInvitation.execute(staff.id),
+               "expected #{status} → :expired to be rejected"
+      end
     end
 
-    test "returns error for :accepted staff member (invalid transition)" do
-      provider = provider_profile_fixture()
-
-      staff =
-        staff_member_fixture(%{
-          provider_id: provider.id,
-          invitation_status: :accepted
-        })
-
-      assert {:error, :invalid_invitation_transition} = ExpireStaffInvitation.execute(staff.id)
-    end
-
-    test "returns error for :failed staff member (invalid transition)" do
-      provider = provider_profile_fixture()
-
-      staff =
-        staff_member_fixture(%{
-          provider_id: provider.id,
-          invitation_status: :failed,
-          invitation_token_hash: :crypto.hash(:sha256, "tok")
-        })
-
-      assert {:error, :invalid_invitation_transition} = ExpireStaffInvitation.execute(staff.id)
-    end
-
-    test "returns :not_found for non-existent staff member" do
+    test "returns :not_found for a non-existent staff member" do
       assert {:error, :not_found} = ExpireStaffInvitation.execute(Ecto.UUID.generate())
     end
   end
 
   describe "execute/1 with %StaffMember{} struct" do
-    test "transitions :sent invitation to :expired without re-fetching from DB" do
-      provider = provider_profile_fixture()
-
-      staff =
-        staff_member_fixture(%{
-          provider_id: provider.id,
-          invitation_status: :sent,
-          invitation_token_hash: :crypto.hash(:sha256, "tok")
-        })
+    test "transitions a :sent invitation to :expired without re-fetching from DB" do
+      staff = staff_with_status(:sent)
 
       assert {:ok, %StaffMember{} = updated} = ExpireStaffInvitation.execute(staff)
       assert updated.id == staff.id
       assert updated.invitation_status == :expired
     end
 
-    test "returns error for :expired → :expired (no self-transition defined)" do
-      provider = provider_profile_fixture()
+    test "rejects expiry from any non-:sent status" do
+      for status <- @invalid_source_statuses do
+        staff = staff_with_status(status)
 
-      staff =
-        staff_member_fixture(%{
-          provider_id: provider.id,
-          invitation_status: :expired,
-          invitation_token_hash: :crypto.hash(:sha256, "tok")
-        })
-
-      assert {:error, :invalid_invitation_transition} = ExpireStaffInvitation.execute(staff)
+        assert {:error, :invalid_invitation_transition} = ExpireStaffInvitation.execute(staff),
+               "expected #{status} → :expired to be rejected"
+      end
     end
   end
 end

--- a/test/klass_hero/shared/email_html_test.exs
+++ b/test/klass_hero/shared/email_html_test.exs
@@ -1,0 +1,101 @@
+defmodule KlassHero.Shared.EmailHtmlTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias KlassHero.Shared.EmailHtml
+
+  # The five characters esc/1 must neutralise, paired with their entities.
+  @escapes [
+    {"<", "&lt;"},
+    {">", "&gt;"},
+    {"&", "&amp;"},
+    {"\"", "&quot;"},
+    {"'", "&#39;"}
+  ]
+
+  # Generator biased toward the special characters — random :printable strings
+  # almost never contain them, so an unbiased generator would only exercise the
+  # passthrough clause. Mixing in plain chars and a multi-byte codepoint keeps
+  # the UTF-8 clause covered too.
+  defp html_ish do
+    StreamData.string([?<, ?>, ?&, ?", ?', ?\s, ?a, ?z, ?0, ?9, ?é], max_length: 40)
+  end
+
+  describe "esc/1" do
+    test "escapes each HTML-significant character to its entity" do
+      for {char, entity} <- @escapes do
+        assert EmailHtml.esc(char) == entity,
+               "esc(#{inspect(char)}) should be #{inspect(entity)}"
+      end
+    end
+
+    test "passes through plain text unchanged" do
+      assert EmailHtml.esc("Hello World") == "Hello World"
+    end
+
+    test "handles the empty string" do
+      assert EmailHtml.esc("") == ""
+    end
+
+    test "escapes every special character in a mixed XSS payload" do
+      assert EmailHtml.esc("<script>alert('XSS & \"fun\"')</script>") ==
+               "&lt;script&gt;alert(&#39;XSS &amp; &quot;fun&quot;&#39;)&lt;/script&gt;"
+    end
+
+    test "preserves multi-byte UTF-8 characters while escaping specials" do
+      assert EmailHtml.esc("Schüler & Lehrer") == "Schüler &amp; Lehrer"
+    end
+
+    test "coerces non-binary terms via to_string/1 before escaping" do
+      assert EmailHtml.esc(42) == "42"
+      assert EmailHtml.esc(:ok) == "ok"
+      assert EmailHtml.esc(nil) == ""
+    end
+
+    property "agrees with Phoenix.HTML.html_escape for any binary (oracle)" do
+      check all(text <- html_ish()) do
+        oracle = text |> Phoenix.HTML.html_escape() |> Phoenix.HTML.safe_to_string()
+        assert EmailHtml.esc(text) == oracle
+      end
+    end
+
+    property "output never contains a raw <, >, \" or ' character" do
+      check all(text <- html_ish()) do
+        escaped = EmailHtml.esc(text)
+        refute escaped =~ ~r/[<>"']/
+      end
+    end
+  end
+
+  describe "wrap/2" do
+    test "embeds the inner_html verbatim (it is not escaped)" do
+      assert EmailHtml.wrap("<p>Hello</p>") =~ "<p>Hello</p>"
+    end
+
+    test "renders a complete HTML document with KlassHero branding" do
+      result = EmailHtml.wrap("<p>body</p>")
+
+      assert result =~ "<!DOCTYPE html>"
+      assert result =~ "<html>"
+      assert result =~ "</html>"
+      assert result =~ "KlassHero"
+    end
+
+    test "renders the default footer (escaped) when no option is given" do
+      assert EmailHtml.wrap("<p>body</p>") =~ "If you didn&#39;t expect this email"
+    end
+
+    test "uses and escapes a custom :footer_message" do
+      result = EmailHtml.wrap("<p>body</p>", footer_message: "Visit <example.com>")
+
+      assert result =~ "Visit &lt;example.com&gt;"
+    end
+
+    property "always embeds the footer in escaped form" do
+      check all(footer <- html_ish()) do
+        result = EmailHtml.wrap("<p>body</p>", footer_message: footer)
+        assert result =~ EmailHtml.esc(footer)
+      end
+    end
+  end
+end

--- a/test/klass_hero_web/helpers/participation_edit_helpers_test.exs
+++ b/test/klass_hero_web/helpers/participation_edit_helpers_test.exs
@@ -1,0 +1,121 @@
+defmodule KlassHeroWeb.Helpers.ParticipationEditHelpersTest do
+  use ExUnit.Case, async: true
+
+  alias KlassHero.Participation.Domain.Models.ParticipationRecord
+  alias KlassHeroWeb.Helpers.ParticipationEditHelpers
+
+  @base_attrs %{id: "rec-001", session_id: "ses-001", child_id: "chi-001", status: :checked_in}
+  @departed ~U[2026-01-01 15:00:00Z]
+
+  defp build_record(overrides \\ []) do
+    struct!(ParticipationRecord, Map.merge(@base_attrs, Map.new(overrides)))
+  end
+
+  describe "default_edit_notes/1" do
+    # One row per function clause: {record overrides, expected text, label}.
+    @notes_cases [
+      {[check_out_at: @departed, check_out_notes: "Left early"], "Left early", "departed with check_out_notes"},
+      {[check_out_at: @departed, check_out_notes: nil], "",
+       "departed but no check_out_notes (empty, not copied from check-in)"},
+      {[check_in_notes: "Arrived late"], "Arrived late", "not departed, has check_in_notes"},
+      {[check_in_notes: nil], "", "not departed, no check_in_notes"}
+    ]
+
+    test "falls back to the notes field the edit will write to" do
+      for {overrides, expected, label} <- @notes_cases do
+        actual = ParticipationEditHelpers.default_edit_notes(build_record(overrides))
+        assert actual == expected, "#{label}: expected #{inspect(expected)}, got #{inspect(actual)}"
+      end
+    end
+
+    test "returns empty string for an unrecognised shape (fallback clause)" do
+      assert ParticipationEditHelpers.default_edit_notes(%{}) == ""
+    end
+  end
+
+  describe "build_edit_correction/3" do
+    # The three cond branches, each asserted for BOTH actor roles — role is
+    # incidental data threaded through unchanged, so iterating proves passthrough
+    # without duplicating the branch logic per role.
+    for role <- [:provider, :staff] do
+      test "records a retroactive check-out when a departure time is supplied (#{role})" do
+        record = build_record()
+        params = %{"check_out_at" => "2026-01-01T15:00", "notes" => "Early pickup"}
+
+        assert {:ok, cmd} = ParticipationEditHelpers.build_edit_correction(record, params, unquote(role))
+
+        assert cmd.status == :checked_out
+        assert cmd.check_out_at == ~U[2026-01-01 15:00:00Z]
+        assert cmd.check_out_notes == "Early pickup"
+        assert cmd.record_id == "rec-001"
+        assert cmd.actor_role == unquote(role)
+      end
+
+      test "writes check_out_notes when the child has already departed (#{role})" do
+        record = build_record(check_out_at: @departed)
+        params = %{"notes" => "Updated note", "check_out_at" => ""}
+
+        assert {:ok, cmd} = ParticipationEditHelpers.build_edit_correction(record, params, unquote(role))
+
+        assert cmd.check_out_notes == "Updated note"
+        assert cmd.actor_role == unquote(role)
+        refute Map.has_key?(cmd, :status)
+      end
+
+      test "writes check_in_notes when no departure time and child not departed (#{role})" do
+        record = build_record()
+        params = %{"notes" => "Late arrival", "check_out_at" => ""}
+
+        assert {:ok, cmd} = ParticipationEditHelpers.build_edit_correction(record, params, unquote(role))
+
+        assert cmd.check_in_notes == "Late arrival"
+        assert cmd.actor_role == unquote(role)
+        refute Map.has_key?(cmd, :check_out_notes)
+      end
+    end
+
+    test "returns error when the departure time string is invalid" do
+      record = build_record()
+      params = %{"check_out_at" => "not-a-date", "notes" => ""}
+
+      assert {:error, :invalid_datetime} =
+               ParticipationEditHelpers.build_edit_correction(record, params, :staff)
+    end
+
+    test "defaults notes to empty string when the notes key is absent" do
+      record = build_record()
+
+      assert {:ok, cmd} = ParticipationEditHelpers.build_edit_correction(record, %{}, :provider)
+      assert cmd.check_in_notes == ""
+    end
+
+    test "an already-departed child ignores a supplied departure time (branch 2 wins)" do
+      record = build_record(check_out_at: @departed)
+      params = %{"check_out_at" => "2026-01-01T16:00", "notes" => "Override attempt"}
+
+      assert {:ok, cmd} = ParticipationEditHelpers.build_edit_correction(record, params, :staff)
+
+      assert cmd.check_out_notes == "Override attempt"
+      refute Map.has_key?(cmd, :check_out_at)
+    end
+
+    # parse_datetime_local normalises 16-char "datetime-local" input by appending
+    # ":00"; 19-char input already has seconds. These are the two sides of the
+    # byte_size(input) == 16 boundary.
+    test "parses datetime-local input at the seconds boundary (16 chars, no seconds)" do
+      record = build_record()
+      params = %{"check_out_at" => "2026-01-01T15:00", "notes" => ""}
+
+      assert {:ok, cmd} = ParticipationEditHelpers.build_edit_correction(record, params, :provider)
+      assert cmd.check_out_at == ~U[2026-01-01 15:00:00Z]
+    end
+
+    test "parses datetime-local input past the boundary (19 chars, with seconds)" do
+      record = build_record()
+      params = %{"check_out_at" => "2026-01-01T15:00:30", "notes" => ""}
+
+      assert {:ok, cmd} = ParticipationEditHelpers.build_edit_correction(record, params, :provider)
+      assert cmd.check_out_at == ~U[2026-01-01 15:00:30Z]
+    end
+  end
+end

--- a/test/klass_hero_web/presenters/child_presenter_test.exs
+++ b/test/klass_hero_web/presenters/child_presenter_test.exs
@@ -6,6 +6,7 @@ defmodule KlassHeroWeb.Presenters.ChildPresenterTest do
   """
 
   use ExUnit.Case, async: true
+  use ExUnitProperties
 
   alias KlassHero.Family.Domain.Models.Child
   alias KlassHeroWeb.Presenters.ChildPresenter
@@ -64,6 +65,15 @@ defmodule KlassHeroWeb.Presenters.ChildPresenterTest do
     test "returns 0 for a child born this year" do
       child = build_child(%{date_of_birth: years_ago(0)})
       assert ChildPresenter.to_simple_view(child).age == 0
+    end
+
+    # birthday_in_past/1 pins the birthday to Jan 1 (always already passed this
+    # year), so the computed age equals the generated number of years exactly.
+    property "computes age as whole years elapsed for any past Jan-1 birthday" do
+      check all(years <- StreamData.integer(0..18)) do
+        child = build_child(%{date_of_birth: birthday_in_past(years)})
+        assert ChildPresenter.to_simple_view(child).age == years
+      end
     end
   end
 
@@ -125,6 +135,14 @@ defmodule KlassHeroWeb.Presenters.ChildPresenterTest do
       result = ChildPresenter.to_profile_view(child)
       assert String.length(result.initials) == 2
       assert result.initials == "AM"
+    end
+
+    # The three views derive age from the same child; they must never disagree.
+    property "to_simple_view and to_profile_view report the same age" do
+      check all(years <- StreamData.integer(0..18)) do
+        child = build_child(%{date_of_birth: birthday_in_past(years)})
+        assert ChildPresenter.to_profile_view(child).age == ChildPresenter.to_simple_view(child).age
+      end
     end
   end
 

--- a/test/klass_hero_web/presenters/child_presenter_test.exs
+++ b/test/klass_hero_web/presenters/child_presenter_test.exs
@@ -1,0 +1,158 @@
+defmodule KlassHeroWeb.Presenters.ChildPresenterTest do
+  @moduledoc """
+  Tests for ChildPresenter pure presentation functions.
+
+  All functions under test are side-effect-free — no DB, no mocks needed.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias KlassHero.Family.Domain.Models.Child
+  alias KlassHeroWeb.Presenters.ChildPresenter
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  defp build_child(overrides \\ %{}) do
+    defaults = %{
+      id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+      first_name: "Anna",
+      last_name: "Müller",
+      date_of_birth: years_ago(8)
+    }
+
+    struct!(Child, Map.merge(defaults, overrides))
+  end
+
+  # A fixed past date whose Jan 1 birthday is always in the past (regardless of today).
+  defp birthday_in_past(n), do: Date.new!(Date.utc_today().year - n, 1, 1)
+
+  # A fixed past date whose Dec 31 birthday is always in the future (regardless of today).
+  defp birthday_in_future(n), do: Date.new!(Date.utc_today().year - n, 12, 31)
+
+  # Returns a date exactly `n` years before today (birthday already passed this year).
+  defp years_ago(n) do
+    today = Date.utc_today()
+    Date.new!(today.year - n, today.month, today.day)
+  end
+
+  # ---------------------------------------------------------------------------
+  # to_simple_view/1
+  # ---------------------------------------------------------------------------
+
+  describe "to_simple_view/1" do
+    test "returns map with id, name, and age" do
+      child = build_child()
+      result = ChildPresenter.to_simple_view(child)
+
+      assert result.id == child.id
+      assert result.name == "Anna Müller"
+      assert is_integer(result.age)
+    end
+
+    test "computes age correctly when birthday has already occurred this year" do
+      child = build_child(%{date_of_birth: birthday_in_past(10)})
+      assert ChildPresenter.to_simple_view(child).age == 10
+    end
+
+    test "computes age correctly when birthday is still upcoming this year" do
+      child = build_child(%{date_of_birth: birthday_in_future(10)})
+      assert ChildPresenter.to_simple_view(child).age == 9
+    end
+
+    test "returns 0 for a child born this year" do
+      child = build_child(%{date_of_birth: years_ago(0)})
+      assert ChildPresenter.to_simple_view(child).age == 0
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # to_extended_view/2
+  # ---------------------------------------------------------------------------
+
+  describe "to_extended_view/2" do
+    test "without enrichment returns the same fields as to_simple_view" do
+      child = build_child()
+      assert ChildPresenter.to_extended_view(child) == ChildPresenter.to_simple_view(child)
+    end
+
+    test "merges enrichment data into the simple view" do
+      child = build_child()
+      enrichment = %{sessions: "8/10", progress: 80, activities: ["Art", "Chess"]}
+
+      result = ChildPresenter.to_extended_view(child, enrichment)
+
+      assert result.id == child.id
+      assert result.sessions == "8/10"
+      assert result.progress == 80
+      assert result.activities == ["Art", "Chess"]
+    end
+
+    test "enrichment fields overwrite base fields when keys collide" do
+      child = build_child()
+      result = ChildPresenter.to_extended_view(child, %{name: "Overridden"})
+
+      assert result.name == "Overridden"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # to_profile_view/1
+  # ---------------------------------------------------------------------------
+
+  describe "to_profile_view/1" do
+    test "returns id, name, age, and initials" do
+      child = build_child()
+      result = ChildPresenter.to_profile_view(child)
+
+      assert Map.keys(result) |> Enum.sort() == [:age, :id, :initials, :name]
+    end
+
+    test "extracts two initials from a first and last name" do
+      child = build_child(%{first_name: "Anna", last_name: "Müller"})
+      assert ChildPresenter.to_profile_view(child).initials == "AM"
+    end
+
+    test "initials are uppercased" do
+      child = build_child(%{first_name: "anna", last_name: "müller"})
+      assert ChildPresenter.to_profile_view(child).initials == "AM"
+    end
+
+    test "takes at most two initials for a multi-word name" do
+      child = build_child(%{first_name: "Anna Maria", last_name: "Müller"})
+      # full_name is "Anna Maria Müller" — initials should be "AM" (first 2 tokens)
+      result = ChildPresenter.to_profile_view(child)
+      assert String.length(result.initials) == 2
+      assert result.initials == "AM"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # children_summary/1
+  # ---------------------------------------------------------------------------
+
+  describe "children_summary/1" do
+    setup do
+      Gettext.put_locale(KlassHeroWeb.Gettext, "en")
+      :ok
+    end
+
+    test "returns 'No children yet' for an empty list" do
+      assert ChildPresenter.children_summary([]) == "No children yet"
+    end
+
+    test "returns 'Name (age)' for a single child" do
+      child = build_child(%{first_name: "Emma", last_name: "Schmidt", date_of_birth: birthday_in_past(7)})
+      assert ChildPresenter.children_summary([child]) == "Emma Schmidt (7)"
+    end
+
+    test "returns comma-separated summaries for multiple children" do
+      child1 = build_child(%{first_name: "Emma", last_name: "Schmidt", date_of_birth: birthday_in_past(7)})
+      child2 = build_child(%{first_name: "Luca", last_name: "Bauer", date_of_birth: birthday_in_past(5)})
+
+      result = ChildPresenter.children_summary([child1, child2])
+      assert result == "Emma Schmidt (7), Luca Bauer (5)"
+    end
+  end
+end

--- a/test/klass_hero_web/presenters/incident_report_presenter_test.exs
+++ b/test/klass_hero_web/presenters/incident_report_presenter_test.exs
@@ -1,0 +1,127 @@
+defmodule KlassHeroWeb.Presenters.IncidentReportPresenterTest do
+  use ExUnit.Case, async: true
+
+  alias KlassHero.Provider.Domain.ReadModels.IncidentReportSummary
+  alias KlassHeroWeb.Presenters.IncidentReportPresenter
+
+  defp build_summary(overrides \\ %{}) do
+    defaults = %{
+      id: "report-1",
+      provider_id: "prov-1",
+      program_id: "prog-1",
+      session_id: nil,
+      category: :injury,
+      severity: :medium,
+      description: "Child scraped knee on playground.",
+      occurred_at: ~U[2024-06-15 09:30:00Z],
+      reporter_display_name: "Coach Anna"
+    }
+
+    struct!(IncidentReportSummary, Map.merge(defaults, overrides))
+  end
+
+  describe "severity_color/1" do
+    test "critical maps to error" do
+      assert IncidentReportPresenter.severity_color(:critical) == "error"
+    end
+
+    test "high maps to warning" do
+      assert IncidentReportPresenter.severity_color(:high) == "warning"
+    end
+
+    test "medium maps to info" do
+      assert IncidentReportPresenter.severity_color(:medium) == "info"
+    end
+
+    test "low maps to success" do
+      assert IncidentReportPresenter.severity_color(:low) == "success"
+    end
+  end
+
+  describe "to_list_view/1" do
+    test "returns a map with all expected keys" do
+      result = IncidentReportPresenter.to_list_view(build_summary())
+
+      assert Map.keys(result) |> Enum.sort() ==
+               [:category_label, :description, :id, :occurred_at_display, :reporter_display_name,
+                :severity_color, :severity_label]
+    end
+
+    test "preserves id, description, and reporter_display_name unchanged" do
+      summary = build_summary(%{id: "rpt-42", description: "Fire alarm activated.", reporter_display_name: "Max Mustermann"})
+
+      result = IncidentReportPresenter.to_list_view(summary)
+
+      assert result.id == "rpt-42"
+      assert result.description == "Fire alarm activated."
+      assert result.reporter_display_name == "Max Mustermann"
+    end
+
+    test "maps category to human-readable label for each valid category" do
+      expected = [
+        {:safety_concern, "Safety concern"},
+        {:behavioral_issue, "Behavioral issue"},
+        {:injury, "Injury"},
+        {:property_damage, "Property damage"},
+        {:policy_violation, "Policy violation"},
+        {:other, "Other"}
+      ]
+
+      for {category, label} <- expected do
+        result = IncidentReportPresenter.to_list_view(build_summary(%{category: category}))
+        assert result.category_label == label, "expected #{label} for #{category}"
+      end
+    end
+
+    test "maps severity to human-readable label for each valid severity" do
+      expected = [
+        {:low, "Low"},
+        {:medium, "Medium"},
+        {:high, "High"},
+        {:critical, "Critical"}
+      ]
+
+      for {severity, label} <- expected do
+        result = IncidentReportPresenter.to_list_view(build_summary(%{severity: severity}))
+        assert result.severity_label == label, "expected #{label} for #{severity}"
+      end
+    end
+
+    test "maps severity to correct severity_color for each valid severity" do
+      expected = [
+        {:critical, "error"},
+        {:high, "warning"},
+        {:medium, "info"},
+        {:low, "success"}
+      ]
+
+      for {severity, color} <- expected do
+        result = IncidentReportPresenter.to_list_view(build_summary(%{severity: severity}))
+        assert result.severity_color == color, "expected #{color} for #{severity}"
+      end
+    end
+
+    test "formats occurred_at DateTime as YYYY-MM-DD HH:MM" do
+      dt = ~U[2024-03-21 14:05:00Z]
+      result = IncidentReportPresenter.to_list_view(build_summary(%{occurred_at: dt}))
+
+      assert result.occurred_at_display == "2024-03-21 14:05"
+    end
+
+    test "returns empty string for nil occurred_at" do
+      summary = build_summary()
+      summary_nil = %{summary | occurred_at: nil}
+
+      result = IncidentReportPresenter.to_list_view(summary_nil)
+
+      assert result.occurred_at_display == ""
+    end
+
+    test "preserves midnight boundary formatting" do
+      dt = ~U[2025-01-01 00:00:00Z]
+      result = IncidentReportPresenter.to_list_view(build_summary(%{occurred_at: dt}))
+
+      assert result.occurred_at_display == "2025-01-01 00:00"
+    end
+  end
+end

--- a/test/klass_hero_web/presenters/incident_report_presenter_test.exs
+++ b/test/klass_hero_web/presenters/incident_report_presenter_test.exs
@@ -4,6 +4,19 @@ defmodule KlassHeroWeb.Presenters.IncidentReportPresenterTest do
   alias KlassHero.Provider.Domain.ReadModels.IncidentReportSummary
   alias KlassHeroWeb.Presenters.IncidentReportPresenter
 
+  # Single source of truth for the finite enum→display lookups, shared between
+  # the standalone severity_color/1 tests and the to_list_view/1 tests.
+  @severity_colors [critical: "error", high: "warning", medium: "info", low: "success"]
+  @severity_labels [low: "Low", medium: "Medium", high: "High", critical: "Critical"]
+  @category_labels [
+    safety_concern: "Safety concern",
+    behavioral_issue: "Behavioral issue",
+    injury: "Injury",
+    property_damage: "Property damage",
+    policy_violation: "Policy violation",
+    other: "Other"
+  ]
+
   defp build_summary(overrides \\ %{}) do
     defaults = %{
       id: "report-1",
@@ -21,20 +34,11 @@ defmodule KlassHeroWeb.Presenters.IncidentReportPresenterTest do
   end
 
   describe "severity_color/1" do
-    test "critical maps to error" do
-      assert IncidentReportPresenter.severity_color(:critical) == "error"
-    end
-
-    test "high maps to warning" do
-      assert IncidentReportPresenter.severity_color(:high) == "warning"
-    end
-
-    test "medium maps to info" do
-      assert IncidentReportPresenter.severity_color(:medium) == "info"
-    end
-
-    test "low maps to success" do
-      assert IncidentReportPresenter.severity_color(:low) == "success"
+    test "maps every severity to its badge colour" do
+      for {severity, color} <- @severity_colors do
+        assert IncidentReportPresenter.severity_color(severity) == color,
+               "expected #{color} for #{severity}"
+      end
     end
   end
 
@@ -43,12 +47,20 @@ defmodule KlassHeroWeb.Presenters.IncidentReportPresenterTest do
       result = IncidentReportPresenter.to_list_view(build_summary())
 
       assert Map.keys(result) |> Enum.sort() ==
-               [:category_label, :description, :id, :occurred_at_display, :reporter_display_name,
-                :severity_color, :severity_label]
+               [
+                 :category_label,
+                 :description,
+                 :id,
+                 :occurred_at_display,
+                 :reporter_display_name,
+                 :severity_color,
+                 :severity_label
+               ]
     end
 
     test "preserves id, description, and reporter_display_name unchanged" do
-      summary = build_summary(%{id: "rpt-42", description: "Fire alarm activated.", reporter_display_name: "Max Mustermann"})
+      summary =
+        build_summary(%{id: "rpt-42", description: "Fire alarm activated.", reporter_display_name: "Max Mustermann"})
 
       result = IncidentReportPresenter.to_list_view(summary)
 
@@ -57,45 +69,22 @@ defmodule KlassHeroWeb.Presenters.IncidentReportPresenterTest do
       assert result.reporter_display_name == "Max Mustermann"
     end
 
-    test "maps category to human-readable label for each valid category" do
-      expected = [
-        {:safety_concern, "Safety concern"},
-        {:behavioral_issue, "Behavioral issue"},
-        {:injury, "Injury"},
-        {:property_damage, "Property damage"},
-        {:policy_violation, "Policy violation"},
-        {:other, "Other"}
-      ]
-
-      for {category, label} <- expected do
+    test "maps category to a human-readable label for every category" do
+      for {category, label} <- @category_labels do
         result = IncidentReportPresenter.to_list_view(build_summary(%{category: category}))
         assert result.category_label == label, "expected #{label} for #{category}"
       end
     end
 
-    test "maps severity to human-readable label for each valid severity" do
-      expected = [
-        {:low, "Low"},
-        {:medium, "Medium"},
-        {:high, "High"},
-        {:critical, "Critical"}
-      ]
-
-      for {severity, label} <- expected do
+    test "maps severity to a human-readable label for every severity" do
+      for {severity, label} <- @severity_labels do
         result = IncidentReportPresenter.to_list_view(build_summary(%{severity: severity}))
         assert result.severity_label == label, "expected #{label} for #{severity}"
       end
     end
 
-    test "maps severity to correct severity_color for each valid severity" do
-      expected = [
-        {:critical, "error"},
-        {:high, "warning"},
-        {:medium, "info"},
-        {:low, "success"}
-      ]
-
-      for {severity, color} <- expected do
+    test "maps severity to its badge colour for every severity" do
+      for {severity, color} <- @severity_colors do
         result = IncidentReportPresenter.to_list_view(build_summary(%{severity: severity}))
         assert result.severity_color == color, "expected #{color} for #{severity}"
       end

--- a/test/klass_hero_web/presenters/staff_member_presenter_test.exs
+++ b/test/klass_hero_web/presenters/staff_member_presenter_test.exs
@@ -7,6 +7,7 @@ defmodule KlassHeroWeb.Presenters.StaffMemberPresenterTest do
   """
 
   use ExUnit.Case, async: true
+  use ExUnitProperties
 
   alias KlassHero.Provider.Domain.Models.{PayRate, StaffMember}
   alias KlassHeroWeb.Presenters.StaffMemberPresenter
@@ -38,6 +39,24 @@ defmodule KlassHeroWeb.Presenters.StaffMemberPresenterTest do
     rate
   end
 
+  defp per_session_rate do
+    {:ok, rate} = PayRate.per_session(Decimal.new("80.00"))
+    rate
+  end
+
+  # An arbitrary staff member with random identity fields and any pay-rate state.
+  # Used to assert the parent-facing leak invariant holds for ALL inputs, not
+  # just the two hand-picked examples.
+  defp staff_generator do
+    gen all(
+          first <- StreamData.string(:alphanumeric, min_length: 1, max_length: 12),
+          last <- StreamData.string(:alphanumeric, min_length: 1, max_length: 12),
+          pay_rate <- StreamData.member_of([nil, hourly_rate(), per_session_rate()])
+        ) do
+      staff_fixture(%{first_name: first, last_name: last, pay_rate: pay_rate})
+    end
+  end
+
   describe "to_card_view/1 — parent/public-facing (no pay_rate)" do
     test "never includes pay_rate, even when the StaffMember has one set" do
       staff = staff_fixture(%{pay_rate: hourly_rate()})
@@ -56,6 +75,17 @@ defmodule KlassHeroWeb.Presenters.StaffMemberPresenterTest do
       refute Map.has_key?(view, :pay_rate)
       assert view.full_name == "Mike Johnson"
     end
+
+    # Security invariant: no matter the staff member's fields or pay-rate state,
+    # the parent-facing card must never carry compensation data.
+    property "never leaks :pay_rate or :rate_label for any staff member" do
+      check all(staff <- staff_generator()) do
+        view = StaffMemberPresenter.to_card_view(staff)
+
+        refute Map.has_key?(view, :pay_rate)
+        refute Map.has_key?(view, :rate_label)
+      end
+    end
   end
 
   describe "to_card_view_list/1" do
@@ -66,6 +96,15 @@ defmodule KlassHeroWeb.Presenters.StaffMemberPresenterTest do
 
       for view <- views do
         refute Map.has_key?(view, :pay_rate)
+      end
+    end
+
+    property "never leaks pay data for any list of staff members" do
+      check all(staff_list <- StreamData.list_of(staff_generator(), max_length: 5)) do
+        views = StaffMemberPresenter.to_card_view_list(staff_list)
+
+        assert Enum.all?(views, &(not Map.has_key?(&1, :pay_rate)))
+        assert Enum.all?(views, &(not Map.has_key?(&1, :rate_label)))
       end
     end
   end

--- a/test/klass_hero_web/presenters/staff_member_presenter_test.exs
+++ b/test/klass_hero_web/presenters/staff_member_presenter_test.exs
@@ -70,6 +70,57 @@ defmodule KlassHeroWeb.Presenters.StaffMemberPresenterTest do
     end
   end
 
+  describe "to_hero_card/1 — parent/public-facing hero card (badge always nil)" do
+    test "uses hero-card-staff DOM id prefix" do
+      staff = staff_fixture(%{})
+
+      card = StaffMemberPresenter.to_hero_card(staff)
+
+      assert card.id == "hero-card-staff-#{staff.id}"
+    end
+
+    test "exposes :name (not :full_name) as the display name" do
+      staff = staff_fixture(%{first_name: "Alice", last_name: "Smith"})
+
+      card = StaffMemberPresenter.to_hero_card(staff)
+
+      assert card.name == "Alice Smith"
+      refute Map.has_key?(card, :full_name)
+    end
+
+    test "badge is always nil — badge is applied only by HeroCardsPresenter" do
+      staff = staff_fixture(%{})
+
+      card = StaffMemberPresenter.to_hero_card(staff)
+
+      assert is_nil(card.badge)
+    end
+
+    test "nil tags and qualifications default to empty lists" do
+      staff = staff_fixture(%{tags: nil, qualifications: nil})
+
+      card = StaffMemberPresenter.to_hero_card(staff)
+
+      assert card.tags == []
+      assert card.qualifications == []
+    end
+  end
+
+  describe "to_hero_card_list/1" do
+    test "maps a list preserving badge: nil on each card" do
+      list = [
+        staff_fixture(%{first_name: "Alice", last_name: "A"}),
+        staff_fixture(%{first_name: "Bob", last_name: "B"})
+      ]
+
+      cards = StaffMemberPresenter.to_hero_card_list(list)
+
+      assert length(cards) == 2
+      assert Enum.map(cards, & &1.name) == ["Alice A", "Bob B"]
+      assert Enum.all?(cards, &is_nil(&1.badge))
+    end
+  end
+
   describe "to_admin_view/1 — business-owner-facing (includes pay_rate)" do
     test "includes a formatted rate_label when pay_rate is hourly" do
       staff = staff_fixture(%{pay_rate: hourly_rate()})


### PR DESCRIPTION
## Summary

Combines the 11 open **[Test Improver]** PRs into one branch and sweeps every file to the project's `/exunit-testing` standard, with heavy use of `stream_data` properties. Supersedes #920, #858, #846, #811, #779, #771, #764, #759, #750, #733, #723.

Net effect: **+12 property tests** (the suite had 1 before this; now 13), tabular consolidation, side-effect/security assertions, and three real drift fixes the bot's originals missed.

## Review focus

Reviewed by archetype (one commit each):

| Archetype | Highlights |
|---|---|
| **utils/pure** | `EmailHtml.esc/1` **oracle property** vs `Phoenix.HTML.html_escape`; `ParticipationEditHelpers` tabular clause coverage + both actor roles per branch |
| **presenters** | `StaffMemberPresenter` **security-invariant property** — parent-facing cards never leak `:pay_rate`/`:rate_label` for *any* generated staff; `ChildPresenter` age + cross-view consistency properties |
| **mappers** | `IncidentReportMapper` **round-trip property**; summary/attachment/bulk **field-preservation properties** (nil + populated); `Instructor.initials/1` → **delegation-equivalence property** (removes logic duplicated from `NameUtils`) |
| **commands/queries** | `LoginByMagicLink` rewritten vs real `{user, expired_tokens}` contract; `ExpireStaffInvitation` invalid transitions tabularised |

## Drift fixes (bot originals were red against current `main`)

1. **#764** asserted the wrong return contract (expected an empty list where the unconfirmed path returns expired tokens) and tried to capture a fire-and-forget event via a leaking `DomainEventBus.subscribe` bridge. Rewritten to assert the observable confirmation side effect; now `async: true`.
2. **#750** asserted `Accounts.Domain.Models.User`, but these phx.gen.auth commands return the `KlassHero.Accounts.User` schema (the type the rest of the suite uses). Retargeted the alias.
3. **#733** carried unused default args that break `--warnings-as-errors`. Removed.

## Test plan

- `mix precommit` — **5064 passed, 13 properties, 5 skipped**
- All 16 files run together (cross-file async/sandbox check) — 155 passed, 12 properties
- `mix format --check-formatted` — clean; `--warnings-as-errors` — clean

Pure test additions/edits only — no production code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)