### PR TITLE
fix: seed UI test staff user as staff-only (ADR-0005 follow-up)

### DIFF
--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -484,7 +484,11 @@ uitest_staff_user =
     email: "uitest-staff@example.com",
     hashed_password: hashed_pw,
     confirmed_at: now,
-    intended_roles: [:staff, :provider]
+    # Staff-only (ADR-0005): a staff member is no longer a provider. The stray
+    # :provider here (leftover :staff_provider conflation) gave this user a
+    # provider intent with no backing profile, dead-ending login on
+    # /provider/dashboard via role precedence.
+    intended_roles: [:staff]
   })
   |> Repo.insert!()
 


### PR DESCRIPTION
## Summary

Fixes a login dead-end for the `uitest-staff` seed user, found while test-driving the ADR-0005 branch (#973).

`seeds.exs` seeded `uitest-staff@example.com` with `intended_roles: [:staff, :provider]` — a leftover of the pre-ADR-0005 `:staff_provider` conflation — but created **no provider profile** for them (only a staff row at Wolf Musik Akademie). Post-ADR-0005, role-precedence routing sends a `:provider`-intent user to `/provider/dashboard`; with no profile, `require_provider` rejects them and bounces to home with *"You must have a provider profile to access this page."* The "Go to dashboard" button also points at `/provider/dashboard`, so it loops — the staff user can never reach their own `/staff/dashboard` via normal navigation.

Seeding them as `[:staff]` (their single real persona) fixes the landing. Verified: with the corrected role, the dashboard link resolves to `/staff/dashboard`.

## Deeper finding (follow-up, not fixed here)

The seed was only the trigger. The root robustness gap: `signed_in_path`/`dashboard_path` (`lib/klass_hero_web/user_auth.ex`, `role_routing.ex`) route off **raw `intended_roles`** rather than the **resolved scope**, so any dual-intent user missing the higher-precedence persona's backing record is stranded. This is the symmetric gap to #972 (durable `:staff` teardown): nothing tears down a dangling `:provider`, and routing doesn't defend against one. Worth a dedicated issue — routing should fall back to the next satisfiable persona (or route off `Scope.roles`).

## Test plan

- `mix ecto.reset` → log in as `uitest-staff@example.com` / `password` → lands on `/staff/dashboard` (was: bounced to `/`).
