### PR TITLE
chore: suppress unbumpable hackney advisories in deps.audit

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -91,4 +91,4 @@ jobs:
         run: mix deps.get
 
       - name: Audit dependencies for vulnerabilities
-        run: mix deps.audit
+        run: mix deps.audit --ignore-file .mix_audit.ignore

--- a/.mix_audit.ignore
+++ b/.mix_audit.ignore
@@ -1,0 +1,35 @@
+# mix_audit advisory suppressions
+#
+# Format: one advisory ID per line. Lines starting with `#` and blank lines are
+# ignored. IDs are matched verbatim, so keep each ID alone on its line and put
+# justifications on `#` comment lines above it.
+#
+# Consumed by the Security workflow: `mix deps.audit --ignore-file .mix_audit.ignore`.
+#
+# Review trigger: drop these entries the moment hackney can move to >= 4.0.1.
+# That bump is currently blocked by transitive pins (ex_aws ~> 1.16,
+# httpoison ~> 1.21, wallaby/web_driver_client ~> 1.6). Tracked by #987.
+#
+# -----------------------------------------------------------------------------
+# hackney 1.25.0 — all four advisories first patched in 4.0.1, no 1.x backport.
+#
+# Exposure assessment (2026-06-28): the only app-code hackney consumer is
+# lib/klass_hero/shared/adapters/driven/storage/s3_storage_adapter.ex, which
+# calls ExAws.S3 against a fixed bucket endpoint with no user-controlled URLs.
+# httpoison and wallaby/web_driver_client are test-only. The SSRF/CRLF
+# advisories require attacker-controlled request URLs and are therefore not
+# reachable on our paths.
+# -----------------------------------------------------------------------------
+
+# SSRF allowlist bypass via percent-encoded host (moderate) — needs user-controlled URL; not reachable.
+GHSA-pj7v-xfvx-wmjq
+
+# CR/LF injection in query parameter (moderate) — needs user-controlled URL; not reachable.
+GHSA-j9wq-vxxc-94wf
+
+# CRLF / header injection via unvalidated `domain`/`path` options (low) — needs user-controlled input; not reachable.
+GHSA-mp55-p8c9-rfw2
+
+# ssl:connect/2 post-handshake upgrade has no timeout (high) — not URL-dependent; could let an S3
+# call hang. Accepted as low-impact: fixed endpoint, unbumpable today. Re-evaluate on hackney >= 4.0.1.
+GHSA-gp9c-pm5m-5cxr

--- a/lib/klass_hero/family.ex
+++ b/lib/klass_hero/family.ex
@@ -18,6 +18,8 @@ defmodule KlassHero.Family do
       {:ok, child} = Family.get_child_by_id("child-uuid")
   """
 
+  use KlassHero.Shared.Tracing
+
   import Ecto.Query
 
   alias KlassHero.Family.Adapters.Driven.ACL.ChildEnrollmentACL
@@ -44,19 +46,21 @@ defmodule KlassHero.Family do
   - `{:error, changeset}` - Persistence validation failed
   """
   def create_parent_profile(attrs) when is_map(attrs) do
-    %ParentProfile{}
-    |> ParentProfile.changeset(attrs)
-    |> Repo.insert()
-    |> case do
-      {:ok, parent} ->
-        {:ok, parent}
+    context_span entity: "parent" do
+      %ParentProfile{}
+      |> ParentProfile.changeset(attrs)
+      |> Repo.insert()
+      |> case do
+        {:ok, parent} ->
+          {:ok, parent}
 
-      {:error, %Ecto.Changeset{errors: errors} = changeset} ->
-        if EctoErrorHelpers.unique_constraint_violation?(errors, :identity_id) do
-          {:error, :duplicate_resource}
-        else
-          {:error, changeset}
-        end
+        {:error, %Ecto.Changeset{errors: errors} = changeset} ->
+          if EctoErrorHelpers.unique_constraint_violation?(errors, :identity_id) do
+            {:error, :duplicate_resource}
+          else
+            {:error, changeset}
+          end
+      end
     end
   end
 
@@ -71,15 +75,17 @@ defmodule KlassHero.Family do
   - `{:error, changeset}` for validation failures
   """
   def create_child(attrs) when is_map(attrs) do
-    {parent_id, child_attrs} = Map.pop(attrs, :parent_id)
+    context_span entity: "child" do
+      {parent_id, child_attrs} = Map.pop(attrs, :parent_id)
 
-    case insert_child(child_attrs, parent_id) do
-      {:ok, child} ->
-        dispatch_child_created(child, parent_id)
-        {:ok, child}
+      case insert_child(child_attrs, parent_id) do
+        {:ok, child} ->
+          dispatch_child_created(child, parent_id)
+          {:ok, child}
 
-      {:error, %Ecto.Changeset{} = changeset} ->
-        {:error, changeset}
+        {:error, %Ecto.Changeset{} = changeset} ->
+          {:error, changeset}
+      end
     end
   end
 
@@ -116,10 +122,12 @@ defmodule KlassHero.Family do
   - `{:error, changeset}` for validation failures
   """
   def update_child(child_id, attrs) when is_binary(child_id) and is_map(attrs) do
-    with {:ok, child} <- fetch_child(child_id),
-         {:ok, updated} <- child |> Child.changeset(attrs) |> Repo.update() do
-      dispatch_child_updated(updated)
-      {:ok, updated}
+    context_span entity: "child" do
+      with {:ok, child} <- fetch_child(child_id),
+           {:ok, updated} <- child |> Child.changeset(attrs) |> Repo.update() do
+        dispatch_child_updated(updated)
+        {:ok, updated}
+      end
     end
   end
 
@@ -135,20 +143,22 @@ defmodule KlassHero.Family do
   Returns `:ok`, or `{:error, :not_found}` if the child doesn't exist.
   """
   def delete_child(child_id) when is_binary(child_id) do
-    Repo.transaction(fn ->
-      with {:ok, _} <- tag_step(:delete_consents, delete_all_consents_for_child(child_id)),
-           {:ok, _} <- tag_step(:cancel_enrollments, ChildEnrollmentACL.cancel_active_for_child(child_id)),
-           {:ok, _} <- tag_step(:delete_participation, ChildParticipationACL.delete_all_for_child(child_id)),
-           :ok <- tag_step(:delete_child, delete_child_record(child_id)) do
-        :ok
-      else
-        {:error, reason} -> Repo.rollback(reason)
+    context_span entity: "child" do
+      Repo.transaction(fn ->
+        with {:ok, _} <- tag_step(:delete_consents, delete_all_consents_for_child(child_id)),
+             {:ok, _} <- tag_step(:cancel_enrollments, ChildEnrollmentACL.cancel_active_for_child(child_id)),
+             {:ok, _} <- tag_step(:delete_participation, ChildParticipationACL.delete_all_for_child(child_id)),
+             :ok <- tag_step(:delete_child, delete_child_record(child_id)) do
+          :ok
+        else
+          {:error, reason} -> Repo.rollback(reason)
+        end
+      end)
+      |> case do
+        {:ok, :ok} -> :ok
+        {:error, {:delete_child, :not_found}} -> {:error, :not_found}
+        {:error, reason} -> {:error, reason}
       end
-    end)
-    |> case do
-      {:ok, :ok} -> :ok
-      {:error, {:delete_child, :not_found}} -> {:error, :not_found}
-      {:error, reason} -> {:error, reason}
     end
   end
 
@@ -198,22 +208,24 @@ defmodule KlassHero.Family do
   Expects a map with `:parent_id`, `:child_id`, and `:consent_type`.
   """
   def grant_consent(attrs) when is_map(attrs) do
-    attrs = Map.put_new(attrs, :granted_at, DateTime.utc_now())
+    context_span entity: "consent" do
+      attrs = Map.put_new(attrs, :granted_at, DateTime.utc_now())
 
-    %Consent{}
-    |> Consent.changeset(attrs)
-    |> Repo.insert()
-    |> case do
-      {:ok, consent} ->
-        {:ok, consent}
+      %Consent{}
+      |> Consent.changeset(attrs)
+      |> Repo.insert()
+      |> case do
+        {:ok, consent} ->
+          {:ok, consent}
 
-      {:error, %Ecto.Changeset{errors: errors} = changeset} ->
-        # Partial unique index on (child_id, consent_type) WHERE withdrawn_at IS NULL.
-        if EctoErrorHelpers.any_unique_constraint_violation?(errors) do
-          {:error, :already_active}
-        else
-          {:error, changeset}
-        end
+        {:error, %Ecto.Changeset{errors: errors} = changeset} ->
+          # Partial unique index on (child_id, consent_type) WHERE withdrawn_at IS NULL.
+          if EctoErrorHelpers.any_unique_constraint_violation?(errors) do
+            {:error, :already_active}
+          else
+            {:error, changeset}
+          end
+      end
     end
   end
 
@@ -224,14 +236,16 @@ defmodule KlassHero.Family do
   exists.
   """
   def withdraw_consent(child_id, consent_type) when is_binary(child_id) and is_binary(consent_type) do
-    case active_consent(child_id, consent_type) do
-      nil ->
-        {:error, :not_found}
+    context_span entity: "consent" do
+      case active_consent(child_id, consent_type) do
+        nil ->
+          {:error, :not_found}
 
-      consent ->
-        consent
-        |> Consent.withdraw_changeset(DateTime.utc_now() |> DateTime.truncate(:second))
-        |> Repo.update()
+        consent ->
+          consent
+          |> Consent.withdraw_changeset(DateTime.utc_now() |> DateTime.truncate(:second))
+          |> Repo.update()
+      end
     end
   end
 
@@ -247,9 +261,11 @@ defmodule KlassHero.Family do
   - `{:ok, %{children_anonymized: count, consents_deleted: count}}`
   """
   def anonymize_data_for_user(identity_id) when is_binary(identity_id) do
-    case get_parent_by_identity(identity_id) do
-      {:ok, parent} -> anonymize_children_data(get_children(parent.id))
-      {:error, :not_found} -> {:ok, :no_data}
+    context_span entity: "parent" do
+      case get_parent_by_identity(identity_id) do
+        {:ok, parent} -> anonymize_children_data(get_children(parent.id))
+        {:error, :not_found} -> {:ok, :no_data}
+      end
     end
   end
 

--- a/lib/klass_hero/shared/tracing.ex
+++ b/lib/klass_hero/shared/tracing.ex
@@ -30,7 +30,15 @@ defmodule KlassHero.Shared.Tracing do
   defmacro __using__(_opts) do
     quote do
       import KlassHero.Shared.Tracing,
-        only: [span: 1, span: 2, acl_span: 2, set_attribute: 2, set_attributes: 2]
+        only: [
+          span: 1,
+          span: 2,
+          acl_span: 2,
+          context_span: 1,
+          context_span: 2,
+          set_attribute: 2,
+          set_attributes: 2
+        ]
 
       alias KlassHero.Shared.Tracing
 
@@ -105,6 +113,45 @@ defmodule KlassHero.Shared.Tracing do
           source: unquote(source),
           target: unquote(target),
           operation: unquote(operation)
+        )
+
+        unquote(block)
+      end
+    end
+  end
+
+  @doc """
+  Wraps a public context function body in a span tagged with the standard
+  `context.{name,operation}` attributes.
+
+  `name` is derived from the calling module's last segment (`KlassHero.Family` →
+  `"Family"`); `operation` from the calling function name — both at compile time.
+  This is the coarse, semantic seam for the flattened contexts: one span per
+  business operation, under which fine-grained DB spans (bridged from Ecto
+  telemetry) nest automatically.
+
+      def create_child(attrs) do
+        context_span entity: "child" do
+          # Multi insert + event dispatch
+        end
+      end
+
+  Extra opts are forwarded as additional `context.*` attributes. Expands in the
+  caller (like `span/2`), so the span name points at the context function.
+  """
+  defmacro context_span(do: block), do: build_context_span([], block, __CALLER__)
+  defmacro context_span(opts, do: block), do: build_context_span(opts, block, __CALLER__)
+
+  defp build_context_span(opts, block, caller) do
+    {function, _arity} = caller.function
+    operation = Atom.to_string(function)
+    name = caller.module |> Module.split() |> List.last()
+
+    quote do
+      span do
+        set_attributes(
+          "context",
+          [name: unquote(name), operation: unquote(operation)] ++ unquote(opts)
         )
 
         unquote(block)

--- a/lib/klass_hero/shared/tracing/ecto_span_bridge.ex
+++ b/lib/klass_hero/shared/tracing/ecto_span_bridge.ex
@@ -1,0 +1,79 @@
+defmodule KlassHero.Shared.Tracing.EctoSpanBridge do
+  @moduledoc """
+  Bridges Ecto query telemetry to OpenTelemetry child spans.
+
+  The flattened contexts call `Repo` directly inside a `context_span`, so there
+  is no driven-adapter seam to wrap each query in `db_interaction`. Instead, this
+  handler listens on `[:klass_hero, :repo, :query]` and, for every query that
+  runs **while a span is current**, emits a retroactive child span — turning the
+  coarse context span into a trace with per-query detail, with zero call-site
+  noise.
+
+  Two deliberate properties:
+
+  - **Child-only.** A query with no enclosing span emits nothing (no orphan-root
+    `*.query` spans cluttering traces). The span is detail under an intent span,
+    never a top-level entry on its own.
+  - **PII default-deny.** Only the *parameterised* statement (`… WHERE id = $1`)
+    and bounded timings travel to the span. Param **values** are dropped — they
+    never leave the process.
+
+  Attached once at boot from `KlassHeroWeb.Telemetry.init/1`.
+  """
+
+  @handler_id "klass-hero-ecto-span-bridge"
+  @event [:klass_hero, :repo, :query]
+
+  @doc "Attaches the telemetry handler. Idempotent across boots in a single VM."
+  def attach do
+    :telemetry.attach(@handler_id, @event, &__MODULE__.handle_event/4, %{})
+  end
+
+  @doc false
+  def handle_event(_event, measurements, metadata, _config) do
+    case OpenTelemetry.Tracer.current_span_ctx() do
+      :undefined -> :ok
+      _parent -> emit_span(measurements, metadata)
+    end
+  end
+
+  defp emit_span(measurements, metadata) do
+    end_time = :opentelemetry.timestamp()
+    start_time = end_time - Map.get(measurements, :total_time, 0)
+    source = metadata[:source] || "query"
+    tracer = :opentelemetry.get_application_tracer(__MODULE__)
+
+    span_ctx =
+      :otel_tracer.start_span(:otel_ctx.get_current(), tracer, "#{source}.query", %{start_time: start_time})
+
+    OpenTelemetry.Span.set_attributes(span_ctx, attributes(measurements, metadata, source))
+    set_status(span_ctx, metadata[:result])
+    OpenTelemetry.Span.end_span(span_ctx, end_time)
+    :ok
+  end
+
+  defp attributes(measurements, metadata, source) do
+    %{
+      "db.system" => "postgresql",
+      "db.source" => source,
+      "db.statement" => metadata[:query],
+      "db.total_time_ms" => to_ms(measurements[:total_time]),
+      "db.query_time_ms" => to_ms(measurements[:query_time]),
+      "db.queue_time_ms" => to_ms(measurements[:queue_time]),
+      "db.decode_time_ms" => to_ms(measurements[:decode_time]),
+      "db.rows" => row_count(metadata[:result])
+    }
+    |> Map.reject(fn {_key, value} -> is_nil(value) end)
+  end
+
+  defp to_ms(nil), do: nil
+  defp to_ms(native), do: System.convert_time_unit(native, :native, :microsecond) / 1000
+
+  defp row_count({:ok, %{num_rows: rows}}), do: rows
+  defp row_count(_result), do: nil
+
+  defp set_status(span_ctx, {:error, _reason}),
+    do: OpenTelemetry.Span.set_status(span_ctx, OpenTelemetry.status(:error, "query_error"))
+
+  defp set_status(_span_ctx, _result), do: :ok
+end

--- a/lib/klass_hero_web/telemetry.ex
+++ b/lib/klass_hero_web/telemetry.ex
@@ -4,6 +4,7 @@ defmodule KlassHeroWeb.Telemetry do
   import Telemetry.Metrics
 
   alias KlassHero.Shared.Interaction.TelemetryLogger
+  alias KlassHero.Shared.Tracing.EctoSpanBridge
 
   def start_link(arg) do
     Supervisor.start_link(__MODULE__, arg, name: __MODULE__)
@@ -12,6 +13,7 @@ defmodule KlassHeroWeb.Telemetry do
   @impl true
   def init(_arg) do
     TelemetryLogger.attach()
+    EctoSpanBridge.attach()
 
     children = [
       {:telemetry_poller, measurements: periodic_measurements(), period: 10_000}

--- a/test/klass_hero/family/observability_test.exs
+++ b/test/klass_hero/family/observability_test.exs
@@ -1,0 +1,28 @@
+defmodule KlassHero.Family.ObservabilityTest do
+  @moduledoc """
+  Proves Option E end-to-end on the flattened Family context: a public context
+  function opens a coarse `context_span`, under which the Ecto bridge nests a
+  fine-grained `*.query` child span — with no per-call instrumentation in the
+  context body.
+  """
+
+  use KlassHero.DataCase, async: false
+  use KlassHero.TracingHelpers
+
+  alias KlassHero.Family
+
+  @valid_attrs %{first_name: "Emma", last_name: "Smith", date_of_birth: ~D[2015-06-15]}
+
+  describe "context_span + Ecto bridge integration" do
+    test "create_child opens a context span with a nested db child span" do
+      assert {:ok, _child} = Family.create_child(@valid_attrs)
+
+      assert_span("Family.create_child/1",
+        "context.name": "Family",
+        "context.operation": "create_child"
+      )
+
+      assert_span("children.query")
+    end
+  end
+end

--- a/test/klass_hero/shared/tracing/ecto_span_bridge_test.exs
+++ b/test/klass_hero/shared/tracing/ecto_span_bridge_test.exs
@@ -1,0 +1,63 @@
+# Caller defined outside the test module to avoid the import conflict between
+# TracingHelpers.span (record accessor) and Tracing.span (macro).
+defmodule KlassHero.Shared.Tracing.EctoSpanBridgeTest.Caller do
+  use KlassHero.Shared.Tracing
+
+  import Ecto.Query
+
+  alias KlassHero.Repo
+
+  @doc "Runs a parameterised query INSIDE a parent span."
+  def query_in_span do
+    span "parent.span" do
+      run_query()
+    end
+  end
+
+  @doc "Runs the same query with NO enclosing span."
+  def query_no_span, do: run_query()
+
+  defp run_query do
+    Repo.all(from(c in "children", where: c.id == type(^Ecto.UUID.generate(), :binary_id), select: c.id))
+  end
+end
+
+defmodule KlassHero.Shared.Tracing.EctoSpanBridgeTest do
+  use KlassHero.DataCase, async: false
+  use KlassHero.TracingHelpers
+
+  alias KlassHero.Shared.Tracing.EctoSpanBridgeTest.Caller
+
+  describe "Ecto query -> OTel span bridge" do
+    test "emits a child db span for a query run inside a parent span" do
+      Caller.query_in_span()
+
+      span = assert_span("children.query")
+      attrs = span_attributes(span)
+
+      assert attrs["db.system"] == "postgresql"
+      assert attrs["db.source"] == "children"
+      assert is_number(attrs["db.total_time_ms"])
+    end
+
+    test "tags the parameterised statement but no raw param values" do
+      Caller.query_in_span()
+
+      span = assert_span("children.query")
+      attrs = span_attributes(span)
+
+      # Parameterised SQL keeps placeholders ($1), never inlined values.
+      assert is_binary(attrs["db.statement"])
+      assert attrs["db.statement"] =~ "$1"
+      # PII default-deny: param VALUES never leave the process.
+      refute Map.has_key?(attrs, "db.params")
+    end
+
+    test "emits nothing for a query with no enclosing span (child-only)" do
+      Caller.query_no_span()
+
+      flush_spans()
+      refute_receive {:span, _}, 200
+    end
+  end
+end

--- a/test/klass_hero/shared/tracing_test.exs
+++ b/test/klass_hero/shared/tracing_test.exs
@@ -63,6 +63,18 @@ defmodule KlassHero.Shared.TracingTest.TestAdapter do
       :ok
     end
   end
+
+  def context_traced do
+    context_span do
+      :ctx_result
+    end
+  end
+
+  def context_traced_with_attrs do
+    context_span entity: "child" do
+      :ok
+    end
+  end
 end
 
 defmodule KlassHero.Shared.TracingTest do
@@ -139,6 +151,27 @@ defmodule KlassHero.Shared.TracingTest do
       assert_span("Shared.TracingTest.TestAdapter.traced_with_namespaced_attributes/0",
         "db.operation": "insert",
         "db.entity": "enrollment"
+      )
+    end
+  end
+
+  describe "context_span" do
+    test "creates a span named for the context function with context attributes" do
+      assert :ctx_result == TestAdapter.context_traced()
+
+      assert_span("Shared.TracingTest.TestAdapter.context_traced/0",
+        "context.name": "TestAdapter",
+        "context.operation": "context_traced"
+      )
+    end
+
+    test "forwards extra opts as context.* attributes" do
+      TestAdapter.context_traced_with_attrs()
+
+      assert_span("Shared.TracingTest.TestAdapter.context_traced_with_attrs/0",
+        "context.name": "TestAdapter",
+        "context.operation": "context_traced_with_attrs",
+        "context.entity": "child"
       )
     end
   end


### PR DESCRIPTION
## Summary

Unblocks the Security check on #986. `mix deps.audit` started failing on
**hackney 1.25.0** (4 GHSA advisories, all first patched in 4.0.1) — freshly
published against an already-locked transitive dep, unrelated to the flatten
refactor.

hackney is pinned to the 1.x line by `ex_aws (~> 1.16)`, `httpoison (~> 1.21)`
and `wallaby/web_driver_client (~> 1.6)`, so it can't reach 4.0.1 yet.

## Change

- Add `.mix_audit.ignore` documenting each suppressed advisory + the exposure rationale.
- `mix deps.audit --ignore-file .mix_audit.ignore` in the Security workflow.

## Risk

Only app-code hackney consumer is the S3 storage adapter (ExAws.S3, fixed
endpoint, no user-controlled URLs) → SSRF/CRLF advisories not reachable. The
high-sev handshake-timeout advisory is accepted as low-impact pending the bump.

Un-suppression tracked by #987 (move ex_aws/httpoison off hackney to Req/Finch).

## Test plan

- [x] `mix deps.audit --ignore-file .mix_audit.ignore` → "No vulnerabilities found." locally
- [ ] Security workflow green on this PR