### PR TITLE
chore: replace commit-check hook with async per-file credo/format/test/typography hooks

### DIFF
--- a/.claude/hooks/credo.sh
+++ b/.claude/hooks/credo.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# PostToolUse(Edit|Write) hook: run credo --strict on the edited Elixir file.
+# asyncRewake contract: exit 2 (with output on stderr) wakes the session; exit 0 is silent.
+set -uo pipefail
+
+FILE=$(cat | tr -d '\000-\037' | jq -r '.tool_input.file_path // empty')
+
+[[ -n "$FILE" ]] || exit 0
+[[ "$FILE" =~ \.(ex|exs)$ ]] || exit 0
+[[ -f "$FILE" ]] || exit 0
+
+OUT=$(mix credo --strict "$FILE" 2>&1)
+STATUS=$?
+
+if [[ $STATUS -ne 0 ]]; then
+  echo "mix credo --strict flagged ${FILE}:" >&2
+  echo "$OUT" >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/hooks/format.sh
+++ b/.claude/hooks/format.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# PostToolUse(Edit|Write) hook: auto-format the edited Elixir/HEEx file.
+# asyncRewake contract: exit 2 (with a message on stderr) wakes the session;
+# exit 0 is silent. We only wake when the file was actually reformatted.
+set -uo pipefail
+
+# Read the hook payload. Strip raw control bytes (U+0000–U+001F) before jq —
+# tool_response can carry unescaped ANSI/bell bytes that break strict jq parsing.
+FILE=$(cat | tr -d '\000-\037' | jq -r '.tool_input.file_path // empty')
+
+[[ -n "$FILE" ]] || exit 0
+[[ "$FILE" =~ \.(ex|exs|heex)$ ]] || exit 0
+[[ -f "$FILE" ]] || exit 0
+
+# Already formatted? Nothing to do.
+if mix format --check-formatted "$FILE" >/dev/null 2>&1; then
+  exit 0
+fi
+
+if mix format "$FILE" >/dev/null 2>&1; then
+  echo "mix format reformatted ${FILE} — re-read it before making further edits." >&2
+  exit 2
+fi
+
+# Format itself errored (syntax error etc.) — stay silent; credo/compile will surface it.
+exit 0

--- a/.claude/hooks/lint_typography.sh
+++ b/.claude/hooks/lint_typography.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# PostToolUse(Edit|Write) hook: run typography lint when a HEEx template changes.
+# asyncRewake contract: exit 2 (with output on stderr) wakes the session; exit 0 is silent.
+set -uo pipefail
+
+FILE=$(cat | tr -d '\000-\037' | jq -r '.tool_input.file_path // empty')
+
+[[ -n "$FILE" ]] || exit 0
+[[ "$FILE" =~ \.html\.heex$ ]] || exit 0
+[[ -f "$FILE" ]] || exit 0
+
+OUT=$(mix lint_typography 2>&1)
+STATUS=$?
+
+if [[ $STATUS -ne 0 ]]; then
+  echo "mix lint_typography flagged a typography violation (edited ${FILE}):" >&2
+  echo "$OUT" >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/hooks/tests.sh
+++ b/.claude/hooks/tests.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# PostToolUse(Edit|Write) hook: run the test file(s) relevant to the edited file.
+# asyncRewake contract: exit 2 (with output on stderr) wakes the session; exit 0 is silent.
+#
+# Target derivation (exact 1:1 path-swap only):
+#   lib/<rel>/<name>.ex        -> test/<rel>/<name>_test.exs
+#   lib/<rel>/<name>.html.heex -> test/<rel>/<name>_test.exs
+#   test/<rel>/<name>_test.exs -> itself
+# No matching test file -> silent (exit 0).
+#
+# A stem-prefix glob was tried and rejected: filename prefixes can't tell a
+# qualifier ("child" -> "child_guardian") from a sibling module, so it both
+# over-matched (running unrelated tests) and under-matched the multi-file
+# LiveViews it was meant to catch. 1:1 is the only unambiguous mapping.
+set -uo pipefail
+
+FILE=$(cat | tr -d '\000-\037' | jq -r '.tool_input.file_path // empty')
+[[ -n "$FILE" ]] || exit 0
+
+# Make the path repo-relative (hook payload paths are absolute; cwd is the project root).
+REL="${FILE#"$PWD"/}"
+
+declare -a PATHS=()
+
+if [[ "$REL" == test/*_test.exs ]]; then
+  # Editing a test directly — run it.
+  [[ -f "$REL" ]] && PATHS+=("$REL")
+elif [[ "$REL" == lib/* ]]; then
+  STEM="${REL#lib/}"
+  case "$STEM" in
+    *.html.heex) BASE="${STEM%.html.heex}" ;;
+    *.ex)        BASE="${STEM%.ex}" ;;
+    *)           exit 0 ;;
+  esac
+  DIR="test/$(dirname "$BASE")"
+  NAME="$(basename "$BASE")"
+  PRIMARY="${DIR}/${NAME}_test.exs"
+  [[ -f "$PRIMARY" ]] && PATHS+=("$PRIMARY")
+else
+  exit 0
+fi
+
+[[ ${#PATHS[@]} -gt 0 ]] || exit 0
+
+# CI=true skips the Docker test.setup branch in the repo's test alias (assumes Postgres is up).
+OUT=$(CI=true mix test "${PATHS[@]}" --max-failures 5 2>&1)
+STATUS=$?
+[[ $STATUS -eq 0 ]] && exit 0
+
+# Couldn't run (Postgres down / DB unreachable) is not a test failure — stay silent.
+if echo "$OUT" | grep -qiE 'could not connect|connection refused|DBConnection\.ConnectionError|no such (file|database)'; then
+  exit 0
+fi
+
+echo "Tests failed for ${REL} (${PATHS[*]}):" >&2
+echo "$OUT" >&2
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "FILE=$(cat | jq -r '.tool_input.file_path // empty') && [[ \"$FILE\" =~ \\.(ex|exs)$ ]] && mix format \"$FILE\" || true"
+            "command": ".claude/hooks/format.sh",
+            "asyncRewake": true
           }
         ]
       },
@@ -15,7 +16,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "FILE=$(cat | jq -r '.tool_input.file_path // empty') && [[ \"$FILE\" =~ \\.(ex|exs)$ ]] && mix credo \"$FILE\" --strict --mute-exit-status || true"
+            "command": ".claude/hooks/credo.sh",
+            "asyncRewake": true
           }
         ]
       },
@@ -24,7 +26,18 @@
         "hooks": [
           {
             "type": "command",
-            "command": "FILE=$(cat | jq -r '.tool_input.file_path // empty') && [[ \"$FILE\" =~ \\.html\\.heex$ ]] && mix lint_typography || true"
+            "command": ".claude/hooks/tests.sh",
+            "asyncRewake": true
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/lint_typography.sh",
+            "asyncRewake": true
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,15 +27,6 @@
             "command": "FILE=$(cat | jq -r '.tool_input.file_path // empty') && [[ \"$FILE\" =~ \\.html\\.heex$ ]] && mix lint_typography || true"
           }
         ]
-      },
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "INPUT=$(cat) && CMD=$(echo \"$INPUT\" | jq -r '.tool_input.command // empty') && if echo \"$CMD\" | grep -q 'git commit'; then git log -1 --pretty=%s | grep -qE '^(feat|fix|chore|docs|refactor|test|ci|perf)(\\(.+\\))?:' || (echo 'ERROR: Commit message must follow semantic conventions (feat:/fix:/chore:/docs:/refactor:/test:/ci:/perf:)' && exit 1); fi"
-          }
-        ]
       }
     ]
   }


### PR DESCRIPTION
## Summary

Overhauls the project's `.claude/settings.json` hooks in two steps.

**1. Remove the noisy post-hoc semantic-commit hook.** It ran `jq` over the entire `PostToolUse` payload (which bundles `tool_response.stdout`); unescaped control bytes from command output (ANSI/bell/esc) broke strict `jq`, spamming `PostToolUse:Bash hook error / jq: parse error: ... control characters ... must be escaped` on nearly every command. It was post-hoc (the commit already ran; `exit 1` can't undo it) and redundant with CI's conventional-commit check on PR titles.

**2. Add async, non-blocking per-file quality hooks** (`.claude/hooks/*.sh`, wired with `asyncRewake: true`). Each runs in the background on every edited/created file and only wakes the session (exit 2 + output) when it finds something to act on; clean runs are silent.

| Script | Runs on | Wakes session when |
|---|---|---|
| `format.sh` | `.ex` `.exs` `.heex` | file was reformatted (re-read it) |
| `credo.sh` | `.ex` `.exs` | `mix credo --strict` finds issues |
| `tests.sh` | `lib/**` + `*_test.exs` | the module's 1:1 `_test.exs` fails |
| `lint_typography.sh` | `.html.heex` | `mix lint_typography` violation |

Notes:
- All scripts strip raw control bytes (`tr -d '\000-\037'`) before `jq` — fixes the parse-error class at the source.
- `tests.sh` maps `lib/<rel>/<name>.ex` → `test/<rel>/<name>_test.exs` (exact 1:1 only — a stem-prefix glob was tried and rejected because filename prefixes can't distinguish a qualifier like `child`→`child_guardian` from a sibling module). Uses `CI=true` to skip the Docker `test.setup` alias branch, and stays silent if Postgres is unreachable (can't-run ≠ failure).
- Replaces the previously-blocking format/credo/lint hooks; nothing blocks the turn anymore.

## Test plan

- Script logic validated by piping crafted payloads (incl. a raw-control-byte payload that no longer breaks `jq`) with a stubbed `mix` to confirm path selection and `CI=true` propagation; `bash -n` clean; `mix format --check-formatted` single-file invocation verified live.
- Post-merge + session restart: edit an `.ex` with a credo violation / failing test and confirm the session is woken with the output; a clean edit stays silent; a colored-output Bash command no longer logs a hook error.