### PR TITLE
refactor: remove dead RepositoryHelpers mapper-variant functions

### DIFF
--- a/lib/klass_hero/shared/adapters/driven/persistence/repository_helpers.ex
+++ b/lib/klass_hero/shared/adapters/driven/persistence/repository_helpers.ex
@@ -1,24 +1,21 @@
 defmodule KlassHero.Shared.Adapters.Driven.Persistence.RepositoryHelpers do
   @moduledoc """
-  Shared fetch-and-map helpers for repository adapters.
+  Two small conveniences shared by persistence-adapter code.
 
-  Each helper delegates domain mapping to a `mapper` module implementing
-  `to_domain/1`. None emit telemetry spans — callers wrap calls in their own
-  `span` so traces attribute to the repository, not this module.
+  The mapper-taking fetch-and-map variants were removed post-flatten (#986→#1002)
+  once every schema became its own domain struct. What remains is unrelated:
+
+    * `get_schema_by_uuid/2` — a UUID-safe `Repo.get` that returns
+      `{:error, :not_found}` for a malformed id instead of raising.
+    * `log_validation_error/2` — canonical changeset-failure logging.
+
+  Neither emits telemetry spans; callers wrap their own `span` so traces
+  attribute to the repository, not this module.
   """
 
   alias KlassHero.Repo
 
   require Logger
-
-  @doc "Fetches by primary key and maps to a domain struct. Raises on a malformed id."
-  @spec get_by_id(module(), term(), module()) :: {:ok, struct()} | {:error, :not_found}
-  def get_by_id(schema, id, mapper) do
-    case Repo.get(schema, id) do
-      nil -> {:error, :not_found}
-      record -> {:ok, mapper.to_domain(record)}
-    end
-  end
 
   @doc """
   Fetches a schema record by UUID primary key, returning `{:error, :not_found}`
@@ -38,24 +35,6 @@ defmodule KlassHero.Shared.Adapters.Driven.Persistence.RepositoryHelpers do
 
       :error ->
         {:error, :not_found}
-    end
-  end
-
-  @doc "UUID-safe `get_by_id/3`: maps to a domain struct, `:not_found` for a malformed id."
-  @spec get_by_uuid(module(), term(), module()) :: {:ok, struct()} | {:error, :not_found}
-  def get_by_uuid(schema, id, mapper) do
-    case get_schema_by_uuid(schema, id) do
-      {:ok, record} -> {:ok, mapper.to_domain(record)}
-      {:error, :not_found} -> {:error, :not_found}
-    end
-  end
-
-  @doc "Runs a single-row query and maps the result."
-  @spec fetch_one(Ecto.Queryable.t(), module()) :: {:ok, struct()} | {:error, :not_found}
-  def fetch_one(queryable, mapper) do
-    case Repo.one(queryable) do
-      nil -> {:error, :not_found}
-      record -> {:ok, mapper.to_domain(record)}
     end
   end
 

--- a/test/klass_hero/shared/adapters/driven/persistence/repository_helpers_test.exs
+++ b/test/klass_hero/shared/adapters/driven/persistence/repository_helpers_test.exs
@@ -1,41 +1,12 @@
-defmodule KlassHero.Shared.Adapters.Driven.Persistence.RepositoryHelpersTest.IdentityMapper do
-  @moduledoc """
-  Minimal schema→domain mapper for exercising `RepositoryHelpers`' mapper-taking
-  variants. Every context is now schema-as-struct (no `to_domain` mappers ship in
-  lib), so the "domain" struct is the schema itself — identity is the honest mapping.
-  """
-  def to_domain(struct), do: struct
-end
-
 defmodule KlassHero.Shared.Adapters.Driven.Persistence.RepositoryHelpersTest do
   use KlassHero.DataCase, async: true
 
-  import Ecto.Query
   import ExUnit.CaptureLog
 
   # RepositoryHelpers is generic infra; the choice of schema is incidental. We use
-  # the flattened Provider schema plus a local identity mapper (see IdentityMapper
-  # above) since no context ships a to_domain mapper post-flatten.
+  # the flattened Provider schema for the surviving helpers.
   alias KlassHero.Provider.ProviderProfile
   alias KlassHero.Shared.Adapters.Driven.Persistence.RepositoryHelpers
-  alias KlassHero.Shared.Adapters.Driven.Persistence.RepositoryHelpersTest.IdentityMapper
-
-  @mapper IdentityMapper
-
-  describe "get_by_id/3" do
-    test "returns {:ok, domain_struct} when record exists" do
-      profile = KlassHero.ProviderFixtures.provider_profile_fixture()
-
-      assert {:ok, domain} = RepositoryHelpers.get_by_id(ProviderProfile, profile.id, @mapper)
-      assert domain.id == profile.id
-      assert domain.business_name == profile.business_name
-    end
-
-    test "returns {:error, :not_found} when record does not exist" do
-      assert {:error, :not_found} =
-               RepositoryHelpers.get_by_id(ProviderProfile, Ecto.UUID.generate(), @mapper)
-    end
-  end
 
   describe "get_schema_by_uuid/2" do
     test "returns {:ok, schema} when record exists" do
@@ -52,36 +23,6 @@ defmodule KlassHero.Shared.Adapters.Driven.Persistence.RepositoryHelpersTest do
 
     test "returns {:error, :not_found} for a malformed UUID instead of crashing" do
       assert {:error, :not_found} = RepositoryHelpers.get_schema_by_uuid(ProviderProfile, "not-a-uuid")
-    end
-  end
-
-  describe "get_by_uuid/3" do
-    test "returns {:ok, domain_struct} when record exists" do
-      profile = KlassHero.ProviderFixtures.provider_profile_fixture()
-
-      assert {:ok, domain} = RepositoryHelpers.get_by_uuid(ProviderProfile, profile.id, @mapper)
-      assert domain.id == profile.id
-    end
-
-    test "returns {:error, :not_found} for a malformed UUID instead of crashing" do
-      assert {:error, :not_found} =
-               RepositoryHelpers.get_by_uuid(ProviderProfile, "not-a-uuid", @mapper)
-    end
-  end
-
-  describe "fetch_one/2" do
-    test "returns {:ok, domain_struct} for a query that matches one record" do
-      profile = KlassHero.ProviderFixtures.provider_profile_fixture()
-      query = from(p in ProviderProfile, where: p.id == ^profile.id)
-
-      assert {:ok, domain} = RepositoryHelpers.fetch_one(query, @mapper)
-      assert domain.id == profile.id
-    end
-
-    test "returns {:error, :not_found} when the query matches nothing" do
-      query = from(p in ProviderProfile, where: p.id == ^Ecto.UUID.generate())
-
-      assert {:error, :not_found} = RepositoryHelpers.fetch_one(query, @mapper)
     end
   end
 


### PR DESCRIPTION
## Summary

Deletes three structurally dead functions from `RepositoryHelpers`, left behind by the strangler flatten (#986→#1002). Each took a `mapper` module and called `mapper.to_domain/1`, but post-flatten every schema *is* its own domain struct — no context ships a `to_domain/1` mapper, so nothing could call them with a real mapper.

- `get_by_id/3`
- `get_by_uuid/3`
- `fetch_one/2`

#1002 had kept their tests green by repointing to a local `IdentityMapper` fake — the tell that a function only its own test can exercise is dead. This removes the functions, their vestigial `describe` blocks, and the `IdentityMapper`/`@mapper`/`import Ecto.Query` scaffolding, and rewrites the moduledoc to describe what actually remains.

**Kept (still live):** `get_schema_by_uuid/2` (Participation) and `log_validation_error/2` (Program Catalog).

## Review Focus

- `repository_helpers.ex` — the two surviving helpers are unrelated to the deleted mapper layer; moduledoc rewritten to say so.
- `mix compile --warnings-as-errors` returning `ok` is the proof of no remaining caller anywhere in `lib/` (actual reference graph, not grep).

## Test Plan

- [x] `mix compile --warnings-as-errors` → clean
- [x] `mix credo --strict` on the module → no issues
- [x] Helper test file → 4 passed (surviving `get_schema_by_uuid/2` + `log_validation_error/2` blocks untouched)
- [x] `mix precommit` → 3886 passed, 5 skipped (Participation + Program Catalog callers of the live helpers pass)

Closes #1005