### PR TITLE
fix: durable Oban delivery for provider staff-assignment events

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -15,6 +15,7 @@ alias KlassHero.Enrollment.Adapters.Driving.Events.InviteFamilyReadyHandler
 alias KlassHero.Family.Adapters.Driving.Events.FamilyEventHandler
 alias KlassHero.Family.Adapters.Driving.Events.InviteClaimedHandler
 alias KlassHero.Messaging.Adapters.Driving.Events.MessagingEventHandler
+alias KlassHero.Messaging.Adapters.Driving.Events.StaffAssignmentHandler
 alias KlassHero.Messaging.Adapters.Driving.Workers.MessageCleanupWorker
 alias KlassHero.Messaging.Adapters.Driving.Workers.RetentionPolicyWorker
 alias KlassHero.Provider.Adapters.Driving.Events.EventHandlers.StaffInvitationStatusHandler
@@ -121,6 +122,12 @@ config :klass_hero, :critical_event_handlers, %{
   ],
   "integration:provider:staff_member_invited" => [
     {StaffInvitationHandler, :handle_event}
+  ],
+  "integration:provider:staff_assigned_to_program" => [
+    {StaffAssignmentHandler, :handle_event}
+  ],
+  "integration:provider:staff_unassigned_from_program" => [
+    {StaffAssignmentHandler, :handle_event}
   ],
   "integration:accounts:staff_invitation_sent" => [
     {StaffInvitationStatusHandler, :handle_event}

--- a/lib/klass_hero/provider.ex
+++ b/lib/klass_hero/provider.ex
@@ -490,9 +490,11 @@ defmodule KlassHero.Provider do
     end
   end
 
-  # Non-critical fire-and-forget fan-out (no critical_event_handlers entry for
-  # these topics → PubSub-only, no Oban durability — preserved from the former
-  # AssignStaffToProgram/UnassignStaffFromProgram use cases).
+  # Dispatches the domain event on the Provider bus. PromoteIntegrationEvents
+  # then promotes it to a :critical integration event delivered belt-and-suspenders
+  # (PubSub + durable Oban via the critical_event_handlers registry for
+  # integration:provider:staff_(un)assigned_*; the event-id idempotency gate
+  # prevents double execution).
   defp dispatch_assignment_event(event), do: DomainEventBus.dispatch(__MODULE__, event)
 
   defp insert_program_staff_assignment(attrs) do

--- a/lib/klass_hero/provider/adapters/driving/events/event_handlers/promote_integration_events.ex
+++ b/lib/klass_hero/provider/adapters/driving/events/event_handlers/promote_integration_events.ex
@@ -12,16 +12,24 @@ defmodule KlassHero.Provider.Adapters.Driving.Events.EventHandlers.PromoteIntegr
   @spec handle(DomainEvent.t()) :: :ok | {:error, term()}
   # Messaging context needs to grant/revoke staff access to program broadcast conversations.
   def handle(%DomainEvent{event_type: :staff_assigned_to_program} = event) do
+    # assigned_at is intentionally dropped: no cross-context consumer reads it, and
+    # over durable Oban delivery a payload DateTime deserializes back to a string
+    # (CriticalEventSerializer does not re-parse payload values). Keep the contract lean.
+    payload = Map.take(event.payload, [:provider_id, :program_id, :staff_user_id])
+
     event.payload.staff_member_id
-    |> ProviderIntegrationEvents.staff_assigned_to_program(event.payload)
+    |> ProviderIntegrationEvents.staff_assigned_to_program(payload)
     |> IntegrationEventPublishing.publish_critical("staff_assigned_to_program",
       staff_member_id: event.payload.staff_member_id
     )
   end
 
   def handle(%DomainEvent{event_type: :staff_unassigned_from_program} = event) do
+    # unassigned_at dropped for the same reason as assigned_at above.
+    payload = Map.take(event.payload, [:provider_id, :program_id, :staff_user_id])
+
     event.payload.staff_member_id
-    |> ProviderIntegrationEvents.staff_unassigned_from_program(event.payload)
+    |> ProviderIntegrationEvents.staff_unassigned_from_program(payload)
     |> IntegrationEventPublishing.publish_critical("staff_unassigned_from_program",
       staff_member_id: event.payload.staff_member_id
     )

--- a/test/klass_hero/provider/adapters/driving/events/event_handlers/promote_integration_events_test.exs
+++ b/test/klass_hero/provider/adapters/driving/events/event_handlers/promote_integration_events_test.exs
@@ -87,4 +87,97 @@ defmodule KlassHero.Provider.Adapters.Driving.Events.EventHandlers.PromoteIntegr
       assert {:error, :pubsub_down} = PromoteIntegrationEvents.handle(domain_event)
     end
   end
+
+  describe "handle/1 — :staff_assigned_to_program" do
+    test "promotes to a critical integration event carrying the consumer-read fields" do
+      staff_member_id = Ecto.UUID.generate()
+      provider_id = Ecto.UUID.generate()
+      program_id = Ecto.UUID.generate()
+      staff_user_id = Ecto.UUID.generate()
+
+      domain_event =
+        DomainEvent.new(:staff_assigned_to_program, Ecto.UUID.generate(), :provider, %{
+          provider_id: provider_id,
+          program_id: program_id,
+          staff_member_id: staff_member_id,
+          staff_user_id: staff_user_id,
+          assigned_at: ~U[2026-07-04 10:00:00Z]
+        })
+
+      assert :ok = PromoteIntegrationEvents.handle(domain_event)
+
+      event = assert_integration_event_published(:staff_assigned_to_program)
+      assert event.source_context == :provider
+      assert event.entity_type == :staff_member
+      assert IntegrationEvent.critical?(event)
+      assert event.payload.staff_member_id == staff_member_id
+      assert event.payload.provider_id == provider_id
+      assert event.payload.program_id == program_id
+      assert event.payload.staff_user_id == staff_user_id
+    end
+
+    test "trims the assigned_at DateTime from the integration payload" do
+      # #1004: durable Oban delivery serializes the payload to jsonb; a DateTime
+      # would deserialize back to a string. No consumer reads assigned_at, so it
+      # must not cross the boundary.
+      domain_event =
+        DomainEvent.new(:staff_assigned_to_program, Ecto.UUID.generate(), :provider, %{
+          provider_id: Ecto.UUID.generate(),
+          program_id: Ecto.UUID.generate(),
+          staff_member_id: Ecto.UUID.generate(),
+          staff_user_id: Ecto.UUID.generate(),
+          assigned_at: ~U[2026-07-04 10:00:00Z]
+        })
+
+      assert :ok = PromoteIntegrationEvents.handle(domain_event)
+
+      event = assert_integration_event_published(:staff_assigned_to_program)
+      refute Map.has_key?(event.payload, :assigned_at)
+    end
+  end
+
+  describe "handle/1 — :staff_unassigned_from_program" do
+    test "promotes to a critical integration event carrying the consumer-read fields" do
+      staff_member_id = Ecto.UUID.generate()
+      provider_id = Ecto.UUID.generate()
+      program_id = Ecto.UUID.generate()
+      staff_user_id = Ecto.UUID.generate()
+
+      domain_event =
+        DomainEvent.new(:staff_unassigned_from_program, Ecto.UUID.generate(), :provider, %{
+          provider_id: provider_id,
+          program_id: program_id,
+          staff_member_id: staff_member_id,
+          staff_user_id: staff_user_id,
+          unassigned_at: ~U[2026-07-04 10:00:00Z]
+        })
+
+      assert :ok = PromoteIntegrationEvents.handle(domain_event)
+
+      event = assert_integration_event_published(:staff_unassigned_from_program)
+      assert event.source_context == :provider
+      assert event.entity_type == :staff_member
+      assert IntegrationEvent.critical?(event)
+      assert event.payload.staff_member_id == staff_member_id
+      assert event.payload.provider_id == provider_id
+      assert event.payload.program_id == program_id
+      assert event.payload.staff_user_id == staff_user_id
+    end
+
+    test "trims the unassigned_at DateTime from the integration payload" do
+      domain_event =
+        DomainEvent.new(:staff_unassigned_from_program, Ecto.UUID.generate(), :provider, %{
+          provider_id: Ecto.UUID.generate(),
+          program_id: Ecto.UUID.generate(),
+          staff_member_id: Ecto.UUID.generate(),
+          staff_user_id: Ecto.UUID.generate(),
+          unassigned_at: ~U[2026-07-04 10:00:00Z]
+        })
+
+      assert :ok = PromoteIntegrationEvents.handle(domain_event)
+
+      event = assert_integration_event_published(:staff_unassigned_from_program)
+      refute Map.has_key?(event.payload, :unassigned_at)
+    end
+  end
 end

--- a/test/klass_hero/provider/staff_assignment_durability_test.exs
+++ b/test/klass_hero/provider/staff_assignment_durability_test.exs
@@ -1,0 +1,102 @@
+defmodule KlassHero.Provider.StaffAssignmentDurabilityTest do
+  @moduledoc """
+  Regression coverage for #1004: the `staff_assigned_to_program` /
+  `staff_unassigned_from_program` integration events are built `:critical`, so
+  they must resolve to a durable Oban handler in the registry — and their
+  payload must survive the Oban `serialize → jsonb → deserialize` round trip.
+
+  These are the two pieces the fix adds:
+
+  1. **Wiring** — both topics resolve to Messaging's `StaffAssignmentHandler`
+     via the real `:critical_event_handlers` config (mirrors the "factory →
+     topic → registry" block in `critical_event_handler_registry_test.exs`).
+     The generic "critical event + registered handler ⇒ Oban job enqueued" step
+     is already proven by `pubsub_integration_event_publisher_test.exs`.
+
+  2. **Serialization safety** — the payload carries only string/UUID fields
+     (the `assigned_at`/`unassigned_at` `DateTime`s are trimmed at the promotion
+     boundary), so it round-trips through `CriticalEventSerializer` losslessly.
+  """
+  use ExUnit.Case, async: true
+
+  alias KlassHero.Messaging.Adapters.Driving.Events.StaffAssignmentHandler
+  alias KlassHero.Provider.Domain.Events.ProviderIntegrationEvents
+  alias KlassHero.Shared.Adapters.Driven.Events.CriticalEventHandlerRegistry
+  alias KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializer
+  alias KlassHero.Shared.Adapters.Driven.Events.PubSubIntegrationEventPublisher
+
+  @assigned_payload %{
+    provider_id: "prov-1",
+    program_id: "prog-1",
+    staff_user_id: "user-1"
+  }
+
+  describe "durable-delivery wiring: factory → topic → registry" do
+    test "staff_assigned_to_program resolves to the Messaging handler" do
+      event = ProviderIntegrationEvents.staff_assigned_to_program("staff-1", @assigned_payload)
+
+      assert PubSubIntegrationEventPublisher.derive_topic(event) ==
+               "integration:provider:staff_assigned_to_program"
+
+      assert CriticalEventHandlerRegistry.handlers_for("integration:provider:staff_assigned_to_program") == [
+               {StaffAssignmentHandler, :handle_event}
+             ]
+    end
+
+    test "staff_unassigned_from_program resolves to the Messaging handler" do
+      event = ProviderIntegrationEvents.staff_unassigned_from_program("staff-1", @assigned_payload)
+
+      assert PubSubIntegrationEventPublisher.derive_topic(event) ==
+               "integration:provider:staff_unassigned_from_program"
+
+      assert CriticalEventHandlerRegistry.handlers_for("integration:provider:staff_unassigned_from_program") == [
+               {StaffAssignmentHandler, :handle_event}
+             ]
+    end
+  end
+
+  describe "serialization safety: no DateTime in the integration payload" do
+    test "staff_assigned_to_program payload round-trips losslessly through the serializer" do
+      event = ProviderIntegrationEvents.staff_assigned_to_program("staff-1", @assigned_payload)
+
+      round_tripped =
+        event
+        |> CriticalEventSerializer.serialize()
+        |> jsonify()
+        |> CriticalEventSerializer.deserialize()
+
+      # Trimmed at the promotion boundary — no DateTime crosses the boundary.
+      refute Map.has_key?(round_tripped.payload, :assigned_at)
+
+      assert round_tripped.payload == %{
+               staff_member_id: "staff-1",
+               provider_id: "prov-1",
+               program_id: "prog-1",
+               staff_user_id: "user-1"
+             }
+    end
+
+    test "staff_unassigned_from_program payload round-trips losslessly through the serializer" do
+      event = ProviderIntegrationEvents.staff_unassigned_from_program("staff-1", @assigned_payload)
+
+      round_tripped =
+        event
+        |> CriticalEventSerializer.serialize()
+        |> jsonify()
+        |> CriticalEventSerializer.deserialize()
+
+      refute Map.has_key?(round_tripped.payload, :unassigned_at)
+
+      assert round_tripped.payload == %{
+               staff_member_id: "staff-1",
+               provider_id: "prov-1",
+               program_id: "prog-1",
+               staff_user_id: "user-1"
+             }
+    end
+  end
+
+  # Mirror the real Oban path: serialized args are stored as jsonb (string keys,
+  # JSON-encodable values only) before the worker deserializes them.
+  defp jsonify(args), do: args |> Jason.encode!() |> Jason.decode!()
+end


### PR DESCRIPTION
## Summary

`staff_assigned_to_program` / `staff_unassigned_from_program` integration events were built `criticality: :critical` but had **no** `critical_event_handlers` entry, so the flag was a no-op — `maybe_enqueue_critical_jobs` found no handler and enqueued zero Oban jobs. Delivery was PubSub-only. On the unassign path a lost broadcast (subscriber down, node restart mid-broadcast) could leave a removed staff member with lingering access to program broadcast conversations and **no durable retry**.

This wires both topics to Messaging's `StaffAssignmentHandler` (already idempotent + retry-safe), giving them the same belt-and-suspenders delivery as the sibling `staff_member_invited` (PubSub + durable Oban, with the event-id idempotency gate preventing double execution).

## Changes

- **`config/config.exs`** — register both `integration:provider:staff_(un)assigned_*` topics → `{StaffAssignmentHandler, :handle_event}`.
- **`promote_integration_events.ex`** — trim `assigned_at`/`unassigned_at` from the integration payload. Wiring to Oban activates payload serialization, and `CriticalEventSerializer` silently deserializes payload `DateTime`s back to strings; no consumer reads these fields, so they should not cross the boundary. They remain on the in-process domain event.
- **`provider.ex`** — fix the now-false "no Oban durability" comment.

The shared `CriticalEventSerializer` is intentionally left untouched (broad blast radius); its payload-`DateTime` gap is tracked separately in #1010.

## Review Focus

- Config wiring correctness — the `:critical` flag is inert without a matching registry key; that silent coupling is the whole bug.
- Payload trim vs. touching the shared serializer — is trimming at the promotion boundary the right call here? (See #1010 for the deferred serializer fix.)
- No second PubSub `EventSubscriber` added — the existing `messaging_staff_assignment_subscriber` stays as the PubSub half.

## Test Plan

- New: `test/klass_hero/provider/staff_assignment_durability_test.exs` — factory → topic → registry resolves to `StaffAssignmentHandler`; payload round-trips through the serializer with DateTimes trimmed.
- Extended: `promote_integration_events_test.exs` — staff assign/unassign promote to `:critical` and trim the DateTime.
- TDD: 4 red (2 wiring + 2 trim) → fix → 11 green. Regression: messaging consumer / registry / publisher (27 green). `mix precommit`: 3894 passed.
- No migration.

Closes #1004