### PR TITLE
refactor: mirror provider test tree to post-#1003 sub-domain layout

### DIFF
--- a/test/klass_hero/provider/assignments/assign_staff_to_program_test.exs
+++ b/test/klass_hero/provider/assignments/assign_staff_to_program_test.exs
@@ -1,4 +1,4 @@
-defmodule KlassHero.Provider.AssignStaffToProgramTest do
+defmodule KlassHero.Provider.Assignments.AssignStaffToProgramTest do
   use KlassHero.DataCase, async: true
 
   import KlassHero.Factory

--- a/test/klass_hero/provider/assignments/list_staff_assigned_programs_test.exs
+++ b/test/klass_hero/provider/assignments/list_staff_assigned_programs_test.exs
@@ -1,4 +1,4 @@
-defmodule KlassHero.Provider.Application.Queries.StaffMembers.ListStaffAssignedProgramsTest do
+defmodule KlassHero.Provider.Assignments.ListStaffAssignedProgramsTest do
   use KlassHero.DataCase, async: true
 
   import KlassHero.ProviderFixtures

--- a/test/klass_hero/provider/assignments/unassign_staff_from_program_test.exs
+++ b/test/klass_hero/provider/assignments/unassign_staff_from_program_test.exs
@@ -1,4 +1,4 @@
-defmodule KlassHero.Provider.UnassignStaffFromProgramTest do
+defmodule KlassHero.Provider.Assignments.UnassignStaffFromProgramTest do
   use KlassHero.DataCase, async: true
 
   import KlassHero.Factory

--- a/test/klass_hero/provider/incidents/incident_report_queries_test.exs
+++ b/test/klass_hero/provider/incidents/incident_report_queries_test.exs
@@ -1,4 +1,4 @@
-defmodule KlassHero.Provider.Application.Queries.IncidentReportQueriesTest do
+defmodule KlassHero.Provider.Incidents.IncidentReportQueriesTest do
   use KlassHero.DataCase, async: true
 
   import KlassHero.AccountsFixtures

--- a/test/klass_hero/provider/incidents/notify_incident_reported_test.exs
+++ b/test/klass_hero/provider/incidents/notify_incident_reported_test.exs
@@ -1,4 +1,4 @@
-defmodule KlassHero.Provider.Application.Commands.Incident.NotifyIncidentReportedTest do
+defmodule KlassHero.Provider.Incidents.NotifyIncidentReportedTest do
   @moduledoc """
   Tests for the NotifyIncidentReported use case.
 

--- a/test/klass_hero/provider/incidents/submit_incident_report_test.exs
+++ b/test/klass_hero/provider/incidents/submit_incident_report_test.exs
@@ -1,4 +1,4 @@
-defmodule KlassHero.Provider.SubmitIncidentReportTest do
+defmodule KlassHero.Provider.Incidents.SubmitIncidentReportTest do
   use KlassHero.DataCase, async: false
   use Mimic
 

--- a/test/klass_hero/provider/profiles/complete_provider_profile_test.exs
+++ b/test/klass_hero/provider/profiles/complete_provider_profile_test.exs
@@ -1,4 +1,4 @@
-defmodule KlassHero.Provider.Application.Commands.Providers.CompleteProviderProfileTest do
+defmodule KlassHero.Provider.Profiles.CompleteProviderProfileTest do
   use KlassHero.DataCase, async: true
 
   alias KlassHero.Provider

--- a/test/klass_hero/provider/profiles/create_provider_profile_test.exs
+++ b/test/klass_hero/provider/profiles/create_provider_profile_test.exs
@@ -1,4 +1,4 @@
-defmodule KlassHero.Provider.Application.Commands.Providers.CreateProviderProfileTest do
+defmodule KlassHero.Provider.Profiles.CreateProviderProfileTest do
   @moduledoc """
   Integration tests for CreateProviderProfile use case.
 

--- a/test/klass_hero/provider/profiles/provider_verification_test.exs
+++ b/test/klass_hero/provider/profiles/provider_verification_test.exs
@@ -1,4 +1,4 @@
-defmodule KlassHero.Provider.Application.Commands.Providers.ProviderVerificationTest do
+defmodule KlassHero.Provider.Profiles.ProviderVerificationTest do
   @moduledoc """
   Tests for provider verification use cases.
 

--- a/test/klass_hero/provider/profiles/update_provider_profile_test.exs
+++ b/test/klass_hero/provider/profiles/update_provider_profile_test.exs
@@ -1,4 +1,4 @@
-defmodule KlassHero.Provider.Application.Commands.Providers.UpdateProviderProfileTest do
+defmodule KlassHero.Provider.Profiles.UpdateProviderProfileTest do
   use KlassHero.DataCase, async: true
 
   alias KlassHero.Provider

--- a/test/klass_hero/provider/staff/accept_staff_invitation_test.exs
+++ b/test/klass_hero/provider/staff/accept_staff_invitation_test.exs
@@ -1,4 +1,4 @@
-defmodule KlassHero.Provider.Application.Commands.StaffMembers.AcceptStaffInvitationTest do
+defmodule KlassHero.Provider.Staff.AcceptStaffInvitationTest do
   use KlassHero.DataCase, async: true
 
   import KlassHero.AccountsFixtures

--- a/test/klass_hero/provider/staff/create_self_staff_member_test.exs
+++ b/test/klass_hero/provider/staff/create_self_staff_member_test.exs
@@ -1,4 +1,4 @@
-defmodule KlassHero.Provider.Application.Commands.StaffMembers.CreateSelfStaffMemberTest do
+defmodule KlassHero.Provider.Staff.CreateSelfStaffMemberTest do
   use KlassHero.DataCase, async: true
 
   import KlassHero.AccountsFixtures

--- a/test/klass_hero/provider/staff/create_staff_member_invitation_test.exs
+++ b/test/klass_hero/provider/staff/create_staff_member_invitation_test.exs
@@ -1,4 +1,4 @@
-defmodule KlassHero.Provider.Application.Commands.StaffMembers.CreateStaffMemberInvitationTest do
+defmodule KlassHero.Provider.Staff.CreateStaffMemberInvitationTest do
   use KlassHero.DataCase, async: true
 
   import KlassHero.EventTestHelper

--- a/test/klass_hero/provider/staff/create_staff_member_test.exs
+++ b/test/klass_hero/provider/staff/create_staff_member_test.exs
@@ -1,4 +1,4 @@
-defmodule KlassHero.Provider.Application.Commands.StaffMembers.CreateStaffMemberTest do
+defmodule KlassHero.Provider.Staff.CreateStaffMemberTest do
   use KlassHero.DataCase, async: true
 
   alias KlassHero.Provider

--- a/test/klass_hero/provider/staff/delete_staff_member_test.exs
+++ b/test/klass_hero/provider/staff/delete_staff_member_test.exs
@@ -1,4 +1,4 @@
-defmodule KlassHero.Provider.Application.Commands.StaffMembers.DeleteStaffMemberTest do
+defmodule KlassHero.Provider.Staff.DeleteStaffMemberTest do
   use KlassHero.DataCase, async: true
 
   alias KlassHero.Provider

--- a/test/klass_hero/provider/staff/expire_staff_invitation_test.exs
+++ b/test/klass_hero/provider/staff/expire_staff_invitation_test.exs
@@ -1,4 +1,4 @@
-defmodule KlassHero.Provider.Application.Commands.StaffMembers.ExpireStaffInvitationTest do
+defmodule KlassHero.Provider.Staff.ExpireStaffInvitationTest do
   use KlassHero.DataCase, async: true
 
   import KlassHero.ProviderFixtures

--- a/test/klass_hero/provider/staff/resend_staff_invitation_test.exs
+++ b/test/klass_hero/provider/staff/resend_staff_invitation_test.exs
@@ -1,4 +1,4 @@
-defmodule KlassHero.Provider.Application.Commands.StaffMembers.ResendStaffInvitationTest do
+defmodule KlassHero.Provider.Staff.ResendStaffInvitationTest do
   use KlassHero.DataCase, async: true
 
   import KlassHero.EventTestHelper

--- a/test/klass_hero/provider/staff/select_staff_context_test.exs
+++ b/test/klass_hero/provider/staff/select_staff_context_test.exs
@@ -1,4 +1,4 @@
-defmodule KlassHero.Provider.Application.Commands.StaffMembers.SelectStaffContextTest do
+defmodule KlassHero.Provider.Staff.SelectStaffContextTest do
   @moduledoc """
   Tests for Provider.select_staff_context/2 (#969 staff-context switcher):
   remembering which employment a multi-employer staff user works in.

--- a/test/klass_hero/provider/staff/update_staff_member_test.exs
+++ b/test/klass_hero/provider/staff/update_staff_member_test.exs
@@ -1,4 +1,4 @@
-defmodule KlassHero.Provider.Application.Commands.StaffMembers.UpdateStaffMemberTest do
+defmodule KlassHero.Provider.Staff.UpdateStaffMemberTest do
   use KlassHero.DataCase, async: true
 
   alias KlassHero.Provider

--- a/test/klass_hero/provider/verification/auto_verify_integration_test.exs
+++ b/test/klass_hero/provider/verification/auto_verify_integration_test.exs
@@ -1,4 +1,4 @@
-defmodule KlassHero.Provider.Application.Commands.Verification.AutoVerifyIntegrationTest do
+defmodule KlassHero.Provider.Verification.AutoVerifyIntegrationTest do
   @moduledoc """
   Integration test for the full flow: approve all docs -> provider verified.
   Reject a doc -> provider unverified.

--- a/test/klass_hero/provider/verification/document_review_test.exs
+++ b/test/klass_hero/provider/verification/document_review_test.exs
@@ -1,4 +1,4 @@
-defmodule KlassHero.Provider.Application.Commands.Verification.DocumentReviewTest do
+defmodule KlassHero.Provider.Verification.DocumentReviewTest do
   use KlassHero.DataCase, async: false
 
   import KlassHero.EventTestHelper

--- a/test/klass_hero/provider/verification/get_verification_document_preview_test.exs
+++ b/test/klass_hero/provider/verification/get_verification_document_preview_test.exs
@@ -1,4 +1,4 @@
-defmodule KlassHero.Provider.Application.Queries.Verification.GetVerificationDocumentPreviewTest do
+defmodule KlassHero.Provider.Verification.GetVerificationDocumentPreviewTest do
   use KlassHero.DataCase, async: true
 
   alias KlassHero.Factory

--- a/test/klass_hero/provider/verification/submit_verification_document_test.exs
+++ b/test/klass_hero/provider/verification/submit_verification_document_test.exs
@@ -1,4 +1,4 @@
-defmodule KlassHero.Provider.Application.Commands.Verification.SubmitVerificationDocumentTest do
+defmodule KlassHero.Provider.Verification.SubmitVerificationDocumentTest do
   use KlassHero.DataCase, async: true
 
   alias KlassHero.ProviderFixtures


### PR DESCRIPTION
## Summary

Retires the last pre-flatten DDD naming in the Provider test tree. PR #1012 (closes #1003) split `KlassHero.Provider` into six sub-domain modules behind a frozen facade; the lib side reflects that, the tests did not. This moves the 23 files under `test/klass_hero/provider/application/**` into sub-domain dirs and renames their modules `KlassHero.Provider.Application.*` → `KlassHero.Provider.<SubDomain>.<UseCase>Test`.

Cosmetic only — test bodies are untouched (they already drive the `KlassHero.Provider` facade, not the deleted `Application.*` lib modules). All 23 land as `git mv` + a one-line `defmodule` edit, so history follows through.

## Review Focus

- **Sub-domain assignment is by facade delegation target, not old dir.** This re-sorts three tests out of the old `staff_members/` dir into `assignments/` — `assign_staff_to_program`, `unassign_staff_from_program`, `list_staff_assigned_programs` — because the facade delegates those to `Provider.Assignments`, not `Provider.Staff`.
- Empty `application/` tree deleted.

## Test Plan

- [x] `mix test test/klass_hero/provider/` green
- [x] `grep -rn "Provider.Application" lib test` → empty
- [x] `find test/klass_hero/provider/application -type f` → gone
- [x] `mix precommit` clean (3894 passed)

Closes #1013