### PR TITLE
refactor: migrate pre-existing -700 status pills onto Theme.status_badge/1

### DIFF
--- a/lib/klass_hero_web/components/provider_components.ex
+++ b/lib/klass_hero_web/components/provider_components.ex
@@ -244,7 +244,8 @@ defmodule KlassHeroWeb.ProviderComponents do
     <div
       id="verification-status"
       class={[
-        "flex items-center gap-1.5 px-3 py-1.5 bg-green-100 text-green-700 text-xs font-medium",
+        "flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium",
+        Theme.status_badge(:available),
         Theme.rounded(:full)
       ]}
     >
@@ -259,7 +260,8 @@ defmodule KlassHeroWeb.ProviderComponents do
     <div
       id="verification-status"
       class={[
-        "flex items-center gap-1.5 px-3 py-1.5 bg-yellow-100 text-yellow-700 text-xs font-medium",
+        "flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium",
+        Theme.status_badge(:limited),
         Theme.rounded(:full)
       ]}
     >
@@ -274,7 +276,8 @@ defmodule KlassHeroWeb.ProviderComponents do
     <div
       id="verification-status"
       class={[
-        "flex items-center gap-1.5 px-3 py-1.5 bg-red-100 text-red-700 text-xs font-medium",
+        "flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium",
+        Theme.status_badge(:full),
         Theme.rounded(:full)
       ]}
     >
@@ -289,7 +292,8 @@ defmodule KlassHeroWeb.ProviderComponents do
     <div
       id="verification-status"
       class={[
-        "flex items-center gap-1.5 px-3 py-1.5 bg-hero-grey-100 text-hero-grey-500 text-xs font-medium",
+        "flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium",
+        Theme.status_badge(:neutral),
         Theme.rounded(:full)
       ]}
     >
@@ -307,27 +311,27 @@ defmodule KlassHeroWeb.ProviderComponents do
   attr :label, :string, required: true
 
   defp invitation_status_badge(assigns) do
-    {bg_class, text_class} = invitation_status_colors(assigns.status)
-    assigns = assign(assigns, bg_class: bg_class, text_class: text_class)
+    assigns = assign(assigns, :badge_class, invitation_status_badge_class(assigns.status))
 
     ~H"""
     <span class={[
       "shrink-0 px-2 py-0.5 text-xs font-medium",
       Theme.rounded(:full),
-      @bg_class,
-      @text_class
+      @badge_class
     ]}>
       {@label}
     </span>
     """
   end
 
-  defp invitation_status_colors(:pending), do: {"bg-yellow-100", "text-yellow-700"}
-  defp invitation_status_colors(:sent), do: {"bg-blue-100", "text-blue-700"}
-  defp invitation_status_colors(:accepted), do: {"bg-green-100", "text-green-700"}
-  defp invitation_status_colors(:failed), do: {"bg-red-100", "text-red-700"}
-  defp invitation_status_colors(:expired), do: {"bg-hero-grey-100", "text-hero-grey-600"}
-  defp invitation_status_colors(_), do: {"bg-hero-grey-100", "text-hero-grey-500"}
+  # `:sent` (was blue) folds into `:neutral` — the filled token drops blue for
+  # guaranteed WCAG AA contrast; the bordered `Theme.status/1` keeps `:info`.
+  defp invitation_status_badge_class(:pending), do: Theme.status_badge(:limited)
+  defp invitation_status_badge_class(:sent), do: Theme.status_badge(:neutral)
+  defp invitation_status_badge_class(:accepted), do: Theme.status_badge(:available)
+  defp invitation_status_badge_class(:failed), do: Theme.status_badge(:full)
+  defp invitation_status_badge_class(:expired), do: Theme.status_badge(:neutral)
+  defp invitation_status_badge_class(_), do: Theme.status_badge(:neutral)
 
   attr :icon, :string, required: true
   attr :label, :string, required: true
@@ -335,7 +339,8 @@ defmodule KlassHeroWeb.ProviderComponents do
   defp verification_badge(assigns) do
     ~H"""
     <div class={[
-      "flex items-center gap-1.5 px-3 py-1.5 bg-hero-grey-100 text-hero-grey-700 text-xs font-medium",
+      "flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium",
+      Theme.status_badge(:neutral),
       Theme.rounded(:full)
     ]}>
       <.icon name={@icon} class="w-4 h-4 text-green-600" />

--- a/lib/klass_hero_web/components/theme.ex
+++ b/lib/klass_hero_web/components/theme.ex
@@ -273,6 +273,24 @@ defmodule KlassHeroWeb.Theme do
   def status(:neutral), do: "bg-gray-50 border-gray-200 text-gray-700"
 
   @doc """
+  Returns filled (borderless) badge classes for a status pill: a tinted `-100`
+  background with `-800` text. The `-800` shade clears WCAG AA (≥4.5:1) on the
+  `-100` tint, unlike the lighter `-700`/`-600` pairings that drift below it.
+
+  Use for solid status badges (verification outcomes, document review). For the
+  bordered, lighter pill use `status/1`.
+
+  ## Examples
+
+      iex> Theme.status_badge(:available)
+      "bg-green-100 text-green-800"
+  """
+  def status_badge(:available), do: "bg-green-100 text-green-800"
+  def status_badge(:limited), do: "bg-yellow-100 text-yellow-800"
+  def status_badge(:full), do: "bg-red-100 text-red-800"
+  def status_badge(:neutral), do: "bg-hero-grey-100 text-hero-grey-800"
+
+  @doc """
   Returns width and height classes for icon sizing.
 
   ## Sizes

--- a/test/klass_hero_web/components/theme_test.exs
+++ b/test/klass_hero_web/components/theme_test.exs
@@ -1,0 +1,22 @@
+defmodule KlassHeroWeb.ThemeTest do
+  use ExUnit.Case, async: true
+
+  alias KlassHeroWeb.Theme
+
+  describe "status_badge/1" do
+    @cases [
+      {:available, "bg-green-100 text-green-800"},
+      {:limited, "bg-yellow-100 text-yellow-800"},
+      {:full, "bg-red-100 text-red-800"},
+      {:neutral, "bg-hero-grey-100 text-hero-grey-800"}
+    ]
+
+    test "returns AA-safe filled (-100/-800) classes for each bucket" do
+      for {bucket, expected} <- @cases do
+        assert Theme.status_badge(bucket) == expected,
+               "expected status_badge(#{inspect(bucket)}) to be #{inspect(expected)}, " <>
+                 "got #{inspect(Theme.status_badge(bucket))}"
+      end
+    end
+  end
+end

--- a/test/klass_hero_web/live/provider/dashboard_live_test.exs
+++ b/test/klass_hero_web/live/provider/dashboard_live_test.exs
@@ -171,6 +171,8 @@ defmodule KlassHeroWeb.Provider.DashboardLiveTest do
 
       assert has_element?(view, "#verification-status", "Verified")
       refute has_element?(view, "#verification-status", "Not Verified")
+      # locks the Theme.status_badge(:available) migration (AA-safe -800 shade)
+      assert has_element?(view, "#verification-status.text-green-800")
     end
   end
 


### PR DESCRIPTION
Closes #983

## Summary

Provider status pills hardcoded raw Tailwind literals at the lighter `-700` text shade — drifting from already-migrated identity/doc badges (`-800`), bypassing the design token, and measuring borderline for WCAG AA (`-700`-on-`-100` ~4.5:1; `-800` clears it comfortably).

This adds `Theme.status_badge/1` (filled, borderless, AA-safe `-100`/`-800` pairs, adjacent to the existing bordered `status/1`) and routes every filled status pill in `provider_components.ex` through it.

## Changes

- **`theme.ex`** — new `status_badge/1`: `:available` / `:limited` / `:full` / `:neutral` → `bg-*-100 text-*-800`.
- **`provider_components.ex`**
  - `verification_status_badge` — verified→`:available`, pending→`:limited`, rejected→`:full`, not-verified→`:neutral`.
  - `verification_badge` (grey doc label) → `:neutral` (matched the acceptance grep, so migrated too).
  - `invitation_status_badge` — 6 states onto the token; `invitation_status_colors` (`{bg, text}` tuple) collapsed into `invitation_status_badge_class` (single class string).
- **tests** — new `theme_test.exs` (first Theme test, tabular fold of the 4 buckets); class-lock assertion on `#verification-status` in `dashboard_live_test.exs`.

## Review focus

- **`:sent` blue → `:neutral`** is the one intentional on-screen color change. The filled token deliberately has no blue (traded for guaranteed AA contrast); the bordered `status/1` keeps `:info` for callers that need blue. Confirmed with the issue owner.
- Otherwise behaviour-safe: the only other shift is `-700`→`-800`. No existing test pinned the old literals.

## Test plan

- `mix precommit` → 3895 passed (compile `--warnings-as-errors`, format, `lint_typography`, full suite).
- `mix credo --strict` on changed files → no issues.
- Acceptance grep `bg-*-100 text-*-700|800` in `provider_components.ex` → clean.