### PR TITLE
fix: provider topbar emits duplicate <h1>s, breaking page heading outline

### DIFF
--- a/lib/klass_hero_web/components/provider_layout_components.ex
+++ b/lib/klass_hero_web/components/provider_layout_components.ex
@@ -207,7 +207,7 @@ defmodule KlassHeroWeb.ProviderLayoutComponents do
         </div>
         <div>
           <div class="flex items-center gap-2">
-            <h1 class={pv_topbar_title_classes()}>{@provider[:name]}</h1>
+            <span class={pv_topbar_title_classes()}>{@provider[:name]}</span>
             <.kh_pill :if={@provider[:verified?]} tone={:success}>
               <.icon name="hero-shield-check" class="w-3 h-3" /> {gettext("Verified")}
             </.kh_pill>
@@ -237,7 +237,7 @@ defmodule KlassHeroWeb.ProviderLayoutComponents do
         {String.first(@provider[:name] || "?") |> String.upcase()}
       </div>
       <div class="flex-1 min-w-0 flex items-center gap-1.5">
-        <h1 class={pv_topbar_mobile_title_classes()}>{@provider[:name]}</h1>
+        <span class={pv_topbar_mobile_title_classes()}>{@provider[:name]}</span>
         <.icon
           :if={@provider[:verified?]}
           name="hero-shield-check"

--- a/lib/klass_hero_web/live/provider/participation_live.html.heex
+++ b/lib/klass_hero_web/live/provider/participation_live.html.heex
@@ -12,6 +12,11 @@
   <.error_alert :if={assigns[:session_error]} errors={[@session_error]} />
 
   <%= if @session do %>
+    <.page_header class="mb-6" container_class="max-w-4xl mx-auto">
+      <:title>{Map.get(@session, :program_name, gettext("Session"))}</:title>
+      <:subtitle>{gettext("Participation")}</:subtitle>
+    </.page_header>
+
     <div class="mb-6">
       <.participation_card session={@session} role={:provider} />
     </div>

--- a/lib/klass_hero_web/live/staff/staff_participation_live.html.heex
+++ b/lib/klass_hero_web/live/staff/staff_participation_live.html.heex
@@ -12,6 +12,11 @@
   <.error_alert :if={assigns[:session_error]} errors={[@session_error]} />
 
   <%= if @session do %>
+    <.page_header class="mb-6" container_class="max-w-4xl mx-auto">
+      <:title>{Map.get(@session, :program_name, gettext("Session"))}</:title>
+      <:subtitle>{gettext("Participation")}</:subtitle>
+    </.page_header>
+
     <div class="mb-6">
       <.participation_card session={@session} role={:staff} />
     </div>

--- a/test/klass_hero_web/components/provider_layout_components_test.exs
+++ b/test/klass_hero_web/components/provider_layout_components_test.exs
@@ -74,6 +74,16 @@ defmodule KlassHeroWeb.ProviderLayoutComponentsTest do
 
       assert html =~ "New program"
     end
+
+    test "emits no <h1> — the page title owns the single document heading", %{} do
+      # Both desktop + mobile variants render in the same DOM, so the topbar
+      # must not contribute any <h1>; each provider page's LiveView supplies it.
+      html = render_pv_topbar(provider: %{name: "CodeKids Berlin", verified?: true})
+
+      refute html =~ "<h1"
+      # Provider name still renders (just not as a heading).
+      assert html =~ "CodeKids Berlin"
+    end
   end
 
   describe "pv_stat_card/1" do

--- a/test/klass_hero_web/live/provider/participation_live_test.exs
+++ b/test/klass_hero_web/live/provider/participation_live_test.exs
@@ -45,6 +45,28 @@ defmodule KlassHeroWeb.Provider.ParticipationLiveTest do
     end
   end
 
+  describe "document heading outline" do
+    setup [:create_session_with_child]
+
+    test "page renders exactly one <h1> (the page header owns it)", %{
+      conn: conn,
+      session: session
+    } do
+      {:ok, view, _html} = live(conn, ~p"/provider/participation/#{session.id}")
+
+      # Render after mount so @session is loaded (mount assigns it nil, then
+      # load_session_data/1 fills it). The page's single top-level heading is
+      # the <.page_header> title; the topbar no longer emits an <h1>. See #984.
+      html = render(view)
+
+      # Count opening <h1 tags across the whole page. There is no element/2
+      # equivalent for "exactly one of X", so we count tag openings directly.
+      h1_count = length(String.split(html, "<h1")) - 1
+
+      assert h1_count == 1
+    end
+  end
+
   describe "sidebar navigation" do
     setup [:create_session_with_child]
 

--- a/test/klass_hero_web/live/staff/staff_participation_live_test.exs
+++ b/test/klass_hero_web/live/staff/staff_participation_live_test.exs
@@ -103,6 +103,22 @@ defmodule KlassHeroWeb.Staff.StaffParticipationLiveTest do
       assert has_element?(view, "div", "Schmidt")
     end
 
+    test "page renders exactly one <h1> (the page header owns it)", %{
+      conn: conn,
+      session: session
+    } do
+      {:ok, view, _html} = live(conn, ~p"/staff/participation/#{session.id}")
+
+      # Render after mount so @session is loaded. The single top-level heading is
+      # the <.page_header> title; the shared provider_app topbar no longer emits
+      # an <h1>. See #984. No element/2 equivalent for "exactly one of X", so we
+      # count tag openings directly.
+      html = render(view)
+      h1_count = length(String.split(html, "<h1")) - 1
+
+      assert h1_count == 1
+    end
+
     test "check_in succeeds and shows flash", %{
       conn: conn,
       session: session,


### PR DESCRIPTION
## Summary

The provider topbar (shared `provider_app` layout chrome) rendered the provider name as an `<h1>` in **both** its desktop and mobile variants. Both variants live in the DOM at once (one hidden via responsive `display:none`), so every provider/staff page shipped multiple top-level headings — the two topbar name headings plus the page title. Multiple `<h1>`s (and a hidden duplicate) weaken the document outline for screen-reader users.

- Demote both topbar `<h1>`s → `<span>` (`pv_topbar_title_classes/0` / `pv_topbar_mobile_title_classes/0` unchanged → **zero visual change**).
- Removing the topbar `<h1>` exposed that **Participation** (provider + staff) had no content `<h1>` — they leaned on the topbar as their de-facto page heading. Added a `<.page_header>` with the session title to both so each page still renders exactly one `<h1>`.

## Review focus

- `provider_layout_components.ex` — the two-line `<h1>`→`<span>` swap.
- The two participation templates — new `<.page_header>` is the correct owner of each page's single heading (session `program_name`, guarded with the same `Map.get` default the card uses).

## Test plan

- `mix precommit` green (3898 tests).
- Component test asserts the topbar emits **no** `<h1>`.
- Provider + staff participation live tests assert **exactly one** `<h1>` per page (through the real router + layout).
- Browser: `/provider/messages` → 1 `<h1>` ("Messages"), topbar name renders as a `span`, visually identical.

## Out of scope (pre-existing, found while verifying)

`/provider/dashboard` throws `ArgumentError` for the seeded provider: a `verification_documents` row has `document_type = "safeguarding_certificate"`, a value the current `VerificationDocument` Ecto.Enum no longer allows. Unrelated to this change — happy to file a follow-up.

Closes #984