### PR TITLE
refactor: flatten Family.ProcessInviteClaim to context root

### DIFF
--- a/lib/klass_hero/family/adapters/driving/workers/process_invite_claim_worker.ex
+++ b/lib/klass_hero/family/adapters/driving/workers/process_invite_claim_worker.ex
@@ -12,7 +12,7 @@ defmodule KlassHero.Family.Adapters.Driving.Workers.ProcessInviteClaimWorker do
     queue: :family,
     max_attempts: 3
 
-  alias KlassHero.Family.Application.Commands.Invites.ProcessInviteClaim
+  alias KlassHero.Family.ProcessInviteClaim
 
   @impl true
   def execute(%Oban.Job{args: args}) do

--- a/lib/klass_hero/family/process_invite_claim.ex
+++ b/lib/klass_hero/family/process_invite_claim.ex
@@ -1,4 +1,4 @@
-defmodule KlassHero.Family.Application.Commands.Invites.ProcessInviteClaim do
+defmodule KlassHero.Family.ProcessInviteClaim do
   @moduledoc """
   Use case for processing an invite claim into a family unit.
 

--- a/test/klass_hero/family/process_invite_claim_test.exs
+++ b/test/klass_hero/family/process_invite_claim_test.exs
@@ -1,10 +1,10 @@
-defmodule KlassHero.Family.Application.Commands.Invites.ProcessInviteClaimTest do
+defmodule KlassHero.Family.ProcessInviteClaimTest do
   use KlassHero.DataCase, async: true
 
   import KlassHero.AccountsFixtures
 
   alias KlassHero.Family
-  alias KlassHero.Family.Application.Commands.Invites.ProcessInviteClaim
+  alias KlassHero.Family.ProcessInviteClaim
 
   defp valid_attrs(user_id, overrides \\ %{}) do
     Map.merge(


### PR DESCRIPTION
## Summary

Moves the last DDD-namespaced straggler in the Family context to the context root, completing the #986 Family flatten. Pure relocation — **no logic change**.

- `KlassHero.Family.Application.Commands.Invites.ProcessInviteClaim` → `KlassHero.Family.ProcessInviteClaim`
- `lib/klass_hero/family/application/commands/invites/process_invite_claim.ex` → `lib/klass_hero/family/process_invite_claim.ex` (`git mv`, history preserved)
- Update the sole caller (`ProcessInviteClaimWorker`) alias
- Move + rename the test to mirror the live module (per #1017 — test moves *with* the lib module, never renamed alone)
- Delete the now-empty `family/application/` trees (lib + test)

The `InviteClaimedHandler` moduledoc needed no edit — it references the bare `ProcessInviteClaim`, which stays valid.

## Review Focus

- Nothing under `lib/klass_hero/family/application/` or `test/klass_hero/family/application/` remains
- `grep -rn "Family.Application" lib test` returns nothing
- No behaviour change — only module moniker + file location

## Test Plan

- Moved test: 9/9 pass
- `mix compile --warnings-as-errors`: clean
- Full suite: 3909/3910 (the single failure is a pre-existing async span-leak flake in `EctoSpanBridgeTest`, unrelated to this change — passes in isolation)

Closes #1019