### PR TITLE
refactor: flatten Enrollment.ParticipantPolicyForm to context root (#1020)

### DIFF
--- a/lib/klass_hero/enrollment.ex
+++ b/lib/klass_hero/enrollment.ex
@@ -17,7 +17,6 @@ defmodule KlassHero.Enrollment do
   alias KlassHero.Enrollment.Adapters.Driven.ACL.ProgramScheduleACL
   alias KlassHero.Enrollment.Adapters.Driven.Persistence.Queries.EnrollmentQueries
   alias KlassHero.Enrollment.Adapters.Driving.Events.EventHandlers.NotifyLiveViews
-  alias KlassHero.Enrollment.Application.ParticipantPolicyForm
   alias KlassHero.Enrollment.BulkEnrollmentInvite
   alias KlassHero.Enrollment.ClaimInvite
   alias KlassHero.Enrollment.Domain.Events.EnrollmentEvents
@@ -27,6 +26,7 @@ defmodule KlassHero.Enrollment do
   alias KlassHero.Enrollment.ImportEnrollmentCsv
   alias KlassHero.Enrollment.InviteSingleParticipant
   alias KlassHero.Enrollment.ParticipantPolicy
+  alias KlassHero.Enrollment.ParticipantPolicyForm
   alias KlassHero.Enrollment.SingleInviteForm
   alias KlassHero.Family
   alias KlassHero.Family.ParentProfile

--- a/lib/klass_hero/enrollment/participant_policy_form.ex
+++ b/lib/klass_hero/enrollment/participant_policy_form.ex
@@ -1,4 +1,4 @@
-defmodule KlassHero.Enrollment.Application.ParticipantPolicyForm do
+defmodule KlassHero.Enrollment.ParticipantPolicyForm do
   @moduledoc """
   Schemaless form for participant policy validation.
 

--- a/test/klass_hero/enrollment/participant_policy_form_test.exs
+++ b/test/klass_hero/enrollment/participant_policy_form_test.exs
@@ -1,7 +1,7 @@
-defmodule KlassHero.Enrollment.Application.ParticipantPolicyFormTest do
+defmodule KlassHero.Enrollment.ParticipantPolicyFormTest do
   use ExUnit.Case, async: true
 
-  alias KlassHero.Enrollment.Application.ParticipantPolicyForm
+  alias KlassHero.Enrollment.ParticipantPolicyForm
 
   describe "changeset/2 — valid inputs" do
     test "accepts all fields with valid values" do


### PR DESCRIPTION
## Summary

Flattens Enrollment's last pre-flatten DDD straggler. `ParticipantPolicyForm` was the sole file under `lib/klass_hero/enrollment/application/`; every other Enrollment module already sits flat at the context root. Same pattern as participation PR #1017.

Namespace-only move, no logic change:

- `lib/klass_hero/enrollment/application/participant_policy_form.ex` → `lib/klass_hero/enrollment/participant_policy_form.ex`
- Module `KlassHero.Enrollment.Application.ParticipantPolicyForm` → `KlassHero.Enrollment.ParticipantPolicyForm`
- Caller alias updated in `lib/klass_hero/enrollment.ex`
- Test moved + renamed to mirror
- Emptied `application/` dirs removed (lib + test)

## Review Focus

Pure rename. `git mv` preserves blame; the diff is 4 line changes across 3 files.

## Test Plan

- `grep -rn "Enrollment.Application" lib test` → empty
- No files remain under `.../enrollment/application/`
- `mix test test/klass_hero/enrollment/participant_policy_form_test.exs` → 32 passed
- `mix precommit` → green (3910 passed)

Closes #1020

🤖 Generated with [Claude Code](https://claude.com/claude-code)