### PR TITLE
fix: guard critical-event payloads to JSON scalars (#1010)

### DIFF
--- a/lib/klass_hero/accounts.ex
+++ b/lib/klass_hero/accounts.ex
@@ -42,7 +42,7 @@ defmodule KlassHero.Accounts do
     |> Repo.insert()
     |> case do
       {:ok, user} ->
-        UserEvents.user_registered(user, %{registration_source: :web})
+        UserEvents.user_registered(user, %{registration_source: "web"})
         |> EventDispatchHelper.dispatch(__MODULE__)
 
         {:ok, user}
@@ -389,7 +389,7 @@ defmodule KlassHero.Accounts do
     |> update_user_and_delete_all_tokens()
     |> case do
       {:ok, {confirmed_user, tokens}} ->
-        UserEvents.user_confirmed(confirmed_user, %{confirmation_method: :magic_link})
+        UserEvents.user_confirmed(confirmed_user, %{confirmation_method: "magic_link"})
         |> EventDispatchHelper.dispatch(__MODULE__)
 
         {:ok, {confirmed_user, tokens}}

--- a/lib/klass_hero/accounts/domain/events/user_events.ex
+++ b/lib/klass_hero/accounts/domain/events/user_events.ex
@@ -42,7 +42,9 @@ defmodule KlassHero.Accounts.Domain.Events.UserEvents do
     base_payload = %{
       email: user.email,
       name: Map.get(user, :name),
-      confirmed_at: user.confirmed_at,
+      # Critical events serialize to jsonb; ISO8601 string keeps this a scalar
+      # so it round-trips with its type intact (see #1010).
+      confirmed_at: encode_timestamp(user.confirmed_at),
       intended_roles: Enum.map(Map.get(user, :intended_roles) || [], &Atom.to_string/1)
     }
 
@@ -119,6 +121,12 @@ defmodule KlassHero.Accounts.Domain.Events.UserEvents do
 
   defp validate_field!(_field, _value, :list_or_nil, _event_name), do: :ok
 
+  # Encodes a timestamp as an ISO8601 string so it stays a JSON scalar through
+  # critical-event serialization (see #1010). Accepts nil defensively — the
+  # confirmation validator already rejects a nil `confirmed_at` upstream.
+  defp encode_timestamp(%DateTime{} = timestamp), do: DateTime.to_iso8601(timestamp)
+  defp encode_timestamp(nil), do: nil
+
   defp validate_user_for_registration!(user) do
     validate_user!(user, :user_registered, [
       {:id, :required},
@@ -153,9 +161,11 @@ defmodule KlassHero.Accounts.Domain.Events.UserEvents do
       when is_binary(previous_email) and byte_size(previous_email) > 0 do
     validate_user_for_anonymization!(user)
 
+    # Critical events serialize to jsonb; carry the timestamp as an ISO8601
+    # string so it survives the round trip as a scalar (see #1010).
     base_payload = %{
       anonymized_email: Map.get(user, :email),
-      anonymized_at: DateTime.utc_now()
+      anonymized_at: DateTime.to_iso8601(DateTime.utc_now())
     }
 
     opts = Keyword.put_new(opts, :criticality, :critical)

--- a/lib/klass_hero/messaging/domain/events/messaging_integration_events.ex
+++ b/lib/klass_hero/messaging/domain/events/messaging_integration_events.ex
@@ -309,6 +309,8 @@ defmodule KlassHero.Messaging.Domain.Events.MessagingIntegrationEvents do
   def participant_added(conversation_id, %{participant_user_ids: [_ | _] = _ids, source: _source} = payload, opts)
       when is_binary(conversation_id) and byte_size(conversation_id) > 0 do
     base_payload = %{conversation_id: conversation_id}
+    # Critical payload must be a JSON scalar; the atom source is write-only (see #1010).
+    payload = Map.update!(payload, :source, &to_string/1)
     opts = Keyword.put_new(opts, :criticality, :critical)
 
     IntegrationEvent.new(
@@ -352,6 +354,8 @@ defmodule KlassHero.Messaging.Domain.Events.MessagingIntegrationEvents do
   def participant_removed(conversation_id, %{participant_user_ids: [_ | _] = _ids, source: _source} = payload, opts)
       when is_binary(conversation_id) and byte_size(conversation_id) > 0 do
     base_payload = %{conversation_id: conversation_id}
+    # Critical payload must be a JSON scalar; the atom source is write-only (see #1010).
+    payload = Map.update!(payload, :source, &to_string/1)
     opts = Keyword.put_new(opts, :criticality, :critical)
 
     IntegrationEvent.new(

--- a/lib/klass_hero/provider/domain/events/provider_integration_events.ex
+++ b/lib/klass_hero/provider/domain/events/provider_integration_events.ex
@@ -191,7 +191,7 @@ defmodule KlassHero.Provider.Domain.Events.ProviderIntegrationEvents do
       @incident_report_entity_type,
       incident_report_id,
       # Merge order: base_payload wins so callers cannot accidentally overwrite canonical IDs.
-      Map.merge(payload, base_payload),
+      Map.merge(scalarize_payload(payload), base_payload),
       opts
     )
   end
@@ -200,4 +200,18 @@ defmodule KlassHero.Provider.Domain.Events.ProviderIntegrationEvents do
     raise ArgumentError,
           "incident_reported/3 requires a non-empty incident_report_id string, got: #{inspect(incident_report_id)}"
   end
+
+  # Critical payloads serialize to jsonb, so category/severity atoms and the
+  # occurred_at DateTime must be encoded as JSON scalars (see #1010). All three
+  # are write-only over the integration channel (no registered handler). Only
+  # keys actually present are touched.
+  defp scalarize_payload(payload) do
+    payload
+    |> Map.replace_lazy(:category, &to_string/1)
+    |> Map.replace_lazy(:severity, &to_string/1)
+    |> Map.replace_lazy(:occurred_at, &encode_timestamp/1)
+  end
+
+  defp encode_timestamp(%DateTime{} = timestamp), do: DateTime.to_iso8601(timestamp)
+  defp encode_timestamp(other), do: other
 end

--- a/lib/klass_hero/shared/domain/events/domain_event.ex
+++ b/lib/klass_hero/shared/domain/events/domain_event.ex
@@ -16,6 +16,14 @@ defmodule KlassHero.Shared.Domain.Events.DomainEvent do
   Events can be marked with a criticality level via metadata:
   - `:critical` - Must not be lost (durable delivery via CriticalEventDispatcher + Oban)
   - `:normal` - Standard fire-and-forget (default)
+
+  ## Payload Constraint (critical events)
+
+  `:critical` event payloads are serialized to Oban's jsonb `args` for durable
+  delivery, so their values must be JSON scalars (string/number/boolean/nil),
+  nested freely in maps and lists. A `DateTime`, atom, or tuple value silently
+  loses its type across the round trip (see #1010); `new/5` raises on such
+  payloads. Encode timestamps as ISO8601 strings and enums as strings.
   """
 
   alias KlassHero.Shared.Domain.Events.EventMetadata
@@ -68,6 +76,7 @@ defmodule KlassHero.Shared.Domain.Events.DomainEvent do
   def new(event_type, aggregate_id, aggregate_type, payload, opts \\ []) do
     # DomainEvent includes :user_id in metadata (unlike IntegrationEvent) for audit/tracing.
     metadata = EventMetadata.build_metadata(opts, [:user_id])
+    EventMetadata.validate_critical_payload!(metadata.criticality, payload)
 
     %__MODULE__{
       event_id: EventMetadata.generate_event_id(),

--- a/lib/klass_hero/shared/domain/events/event_metadata.ex
+++ b/lib/klass_hero/shared/domain/events/event_metadata.ex
@@ -55,4 +55,70 @@ defmodule KlassHero.Shared.Domain.Events.EventMetadata do
       value -> Map.put(map, key, value)
     end
   end
+
+  @doc """
+  Raises if a `:critical` event carries a payload value that is not a JSON
+  scalar.
+
+  Critical events are serialized to Oban's jsonb `args` column for durable,
+  at-least-once delivery. Non-scalar payload *values* — a `%DateTime{}`, an
+  atom, a tuple — silently lose their type across the `serialize → jsonb →
+  deserialize` round trip (a `DateTime` comes back a string, an atom comes
+  back a string) with no error (see issue #1010). Guarding at construction
+  makes the failure loud at the publish site instead of latent three systems
+  downstream.
+
+  Nested maps and lists are allowed as *containers* — they are walked
+  recursively, and only their leaf values must be scalars.
+
+  Non-critical events dispatch in-memory only (never serialized), so they may
+  carry any term and are exempt.
+
+  Returns `:ok` or raises `ArgumentError`.
+  """
+  @spec validate_critical_payload!(criticality(), map()) :: :ok
+  def validate_critical_payload!(:critical, payload) when is_map(payload) do
+    scan_payload(payload, [])
+    :ok
+  end
+
+  def validate_critical_payload!(_criticality, _payload), do: :ok
+
+  # Containers recurse; the `not is_struct/1` guard keeps structs (which are
+  # maps) from being walked — they fall through to the leaf clause and get
+  # rejected there.
+  defp scan_payload(map, path) when is_map(map) and not is_struct(map) do
+    Enum.each(map, fn {key, value} -> scan_payload(value, [key | path]) end)
+  end
+
+  defp scan_payload(list, path) when is_list(list) do
+    list
+    |> Enum.with_index()
+    |> Enum.each(fn {value, index} -> scan_payload(value, [index | path]) end)
+  end
+
+  defp scan_payload(value, path) do
+    if !json_scalar?(value) do
+      location = path |> Enum.reverse() |> Enum.join(".")
+
+      raise ArgumentError,
+            "Critical event payload value at #{inspect(location)} is not a JSON scalar: " <>
+              "#{inspect(value)}. Critical payloads must carry only strings, numbers, " <>
+              "booleans, or nil (nested in maps/lists) so they survive jsonb serialization. " <>
+              "Encode DateTimes as ISO8601 strings and atoms as strings before publishing."
+    end
+  end
+
+  # A JSON scalar is a value that survives a jsonb round trip with its type
+  # intact: strings, numbers, booleans, and nil. `nil`/`true`/`false` are
+  # atoms but are allowed because they map to JSON null/true/false; every
+  # other atom is rejected, since restoring a bare atom value is precisely the
+  # type loss #1010 is about (hence the explicit clauses rather than a blanket
+  # `not is_atom/1`).
+  @spec json_scalar?(term()) :: boolean()
+  defp json_scalar?(value) when is_binary(value), do: true
+  defp json_scalar?(value) when is_number(value), do: true
+  defp json_scalar?(value) when is_boolean(value), do: true
+  defp json_scalar?(nil), do: true
+  defp json_scalar?(_value), do: false
 end

--- a/lib/klass_hero/shared/domain/events/integration_event.ex
+++ b/lib/klass_hero/shared/domain/events/integration_event.ex
@@ -101,6 +101,7 @@ defmodule KlassHero.Shared.Domain.Events.IntegrationEvent do
   def new(event_type, source_context, entity_type, entity_id, payload, opts \\ []) do
     metadata = EventMetadata.build_metadata(opts)
     version = Keyword.get(opts, :version, 1)
+    EventMetadata.validate_critical_payload!(metadata.criticality, payload)
 
     %__MODULE__{
       event_id: EventMetadata.generate_event_id(),

--- a/test/klass_hero/accounts/adapters/driving/events/event_handlers/promote_integration_events_test.exs
+++ b/test/klass_hero/accounts/adapters/driving/events/event_handlers/promote_integration_events_test.exs
@@ -57,7 +57,7 @@ defmodule KlassHero.Accounts.Adapters.Driving.Events.EventHandlers.PromoteIntegr
         DomainEvent.new(:user_anonymized, user_id, :user, %{
           anonymized_email: "deleted_#{user_id}@anonymized.local",
           previous_email: "old@example.com",
-          anonymized_at: DateTime.utc_now()
+          anonymized_at: DateTime.to_iso8601(DateTime.utc_now())
         })
 
       assert :ok = PromoteIntegrationEvents.handle(domain_event)
@@ -76,7 +76,7 @@ defmodule KlassHero.Accounts.Adapters.Driving.Events.EventHandlers.PromoteIntegr
         DomainEvent.new(:user_anonymized, user_id, :user, %{
           anonymized_email: "deleted_#{user_id}@anonymized.local",
           previous_email: "old@example.com",
-          anonymized_at: DateTime.utc_now()
+          anonymized_at: DateTime.to_iso8601(DateTime.utc_now())
         })
 
       TestIntegrationEventPublisher.configure_publish_error(:pubsub_down)
@@ -93,7 +93,7 @@ defmodule KlassHero.Accounts.Adapters.Driving.Events.EventHandlers.PromoteIntegr
         DomainEvent.new(:user_confirmed, user_id, :user, %{
           email: "test@example.com",
           name: "Test Provider",
-          confirmed_at: ~U[2024-01-01 12:00:00Z],
+          confirmed_at: DateTime.to_iso8601(~U[2024-01-01 12:00:00Z]),
           intended_roles: ["provider"]
         })
 
@@ -114,7 +114,7 @@ defmodule KlassHero.Accounts.Adapters.Driving.Events.EventHandlers.PromoteIntegr
         DomainEvent.new(:user_confirmed, user_id, :user, %{
           email: "test@example.com",
           name: "Test User",
-          confirmed_at: ~U[2024-01-01 12:00:00Z],
+          confirmed_at: DateTime.to_iso8601(~U[2024-01-01 12:00:00Z]),
           intended_roles: ["parent"]
         })
 

--- a/test/klass_hero/accounts/domain/events/accounts_integration_events_staff_test.exs
+++ b/test/klass_hero/accounts/domain/events/accounts_integration_events_staff_test.exs
@@ -105,12 +105,12 @@ defmodule KlassHero.Accounts.Domain.Events.AccountsIntegrationEventsStaffTest do
       event =
         AccountsIntegrationEvents.staff_invitation_failed(staff_member_id, %{
           provider_id: provider_id,
-          reason: :email_delivery_failed
+          reason: "email_delivery_failed"
         })
 
       assert event.payload.staff_member_id == staff_member_id
       assert event.payload.provider_id == provider_id
-      assert event.payload.reason == :email_delivery_failed
+      assert event.payload.reason == "email_delivery_failed"
     end
 
     test "base_payload staff_member_id wins over caller-supplied staff_member_id", %{

--- a/test/klass_hero/accounts/domain/events/accounts_integration_events_test.exs
+++ b/test/klass_hero/accounts/domain/events/accounts_integration_events_test.exs
@@ -24,10 +24,10 @@ defmodule KlassHero.Accounts.Domain.Events.AccountsIntegrationEventsTest do
     test "includes user_id in payload" do
       user_id = Ecto.UUID.generate()
 
-      event = AccountsIntegrationEvents.user_registered(user_id, %{registration_source: :web})
+      event = AccountsIntegrationEvents.user_registered(user_id, %{registration_source: "web"})
 
       assert event.payload.user_id == user_id
-      assert event.payload.registration_source == :web
+      assert event.payload.registration_source == "web"
     end
 
     test "base_payload user_id wins over caller-supplied user_id" do

--- a/test/klass_hero/accounts/domain/events/user_events_test.exs
+++ b/test/klass_hero/accounts/domain/events/user_events_test.exs
@@ -59,9 +59,9 @@ defmodule KlassHero.Accounts.Domain.Events.UserEventsTest do
     test "succeeds with valid user and custom payload" do
       user = %{id: 1, email: "test@example.com", name: "Test User"}
 
-      event = UserEvents.user_registered(user, %{source: :web})
+      event = UserEvents.user_registered(user, %{source: "web"})
 
-      assert event.payload.source == :web
+      assert event.payload.source == "web"
     end
 
     test "sets criticality to critical by default" do
@@ -175,7 +175,8 @@ defmodule KlassHero.Accounts.Domain.Events.UserEventsTest do
       assert event.aggregate_id == 1
       assert event.aggregate_type == :user
       assert event.payload.email == "test@example.com"
-      assert event.payload.confirmed_at == confirmed_at
+      # Critical payloads carry timestamps as ISO8601 strings (see #1010).
+      assert event.payload.confirmed_at == DateTime.to_iso8601(confirmed_at)
     end
 
     test "succeeds with valid user and custom payload" do

--- a/test/klass_hero/messaging/adapters/driving/events/event_handlers/promote_integration_events_test.exs
+++ b/test/klass_hero/messaging/adapters/driving/events/event_handlers/promote_integration_events_test.exs
@@ -240,7 +240,7 @@ defmodule KlassHero.Messaging.Adapters.Driving.Events.EventHandlers.PromoteInteg
       assert event.source_context == :messaging
       assert event.entity_type == :conversation
       assert event.payload.participant_user_ids == user_ids
-      assert event.payload.source == :initial_staff
+      assert event.payload.source == "initial_staff"
       assert IntegrationEvent.critical?(event)
     end
 
@@ -279,7 +279,7 @@ defmodule KlassHero.Messaging.Adapters.Driving.Events.EventHandlers.PromoteInteg
       assert event.source_context == :messaging
       assert event.entity_type == :conversation
       assert event.payload.participant_user_ids == user_ids
-      assert event.payload.source == :staff_unassignment
+      assert event.payload.source == "staff_unassignment"
       assert IntegrationEvent.critical?(event)
     end
 

--- a/test/klass_hero/messaging/adapters/driving/events/staff_assignment_handler_test.exs
+++ b/test/klass_hero/messaging/adapters/driving/events/staff_assignment_handler_test.exs
@@ -93,7 +93,7 @@ defmodule KlassHero.Messaging.Adapters.Driving.Events.StaffAssignmentHandlerTest
 
       assert Enum.all?(events, fn e ->
                e.payload.participant_user_ids == [staff_user.id] and
-                 e.payload.source == :later_assignment
+                 e.payload.source == "later_assignment"
              end)
     end
 
@@ -186,7 +186,7 @@ defmodule KlassHero.Messaging.Adapters.Driving.Events.StaffAssignmentHandlerTest
 
       assert Enum.all?(events, fn e ->
                e.payload.participant_user_ids == [staff_user.id] and
-                 e.payload.source == :staff_unassignment
+                 e.payload.source == "staff_unassignment"
              end)
     end
   end

--- a/test/klass_hero/messaging/broadcast_to_program_test.exs
+++ b/test/klass_hero/messaging/broadcast_to_program_test.exs
@@ -436,7 +436,7 @@ defmodule KlassHero.Messaging.BroadcastToProgramTest do
         get_published_integration_events()
         |> Enum.find(
           &match?(
-            %{event_type: :participant_added, payload: %{source: :broadcast_setup}},
+            %{event_type: :participant_added, payload: %{source: "broadcast_setup"}},
             &1
           )
         )
@@ -473,7 +473,7 @@ defmodule KlassHero.Messaging.BroadcastToProgramTest do
       refute Enum.any?(
                get_published_integration_events(),
                &match?(
-                 %{event_type: :participant_added, payload: %{source: :broadcast_setup}},
+                 %{event_type: :participant_added, payload: %{source: "broadcast_setup"}},
                  &1
                )
              ),
@@ -514,7 +514,7 @@ defmodule KlassHero.Messaging.BroadcastToProgramTest do
         get_published_integration_events()
         |> Enum.find(
           &match?(
-            %{event_type: :participant_added, payload: %{source: :broadcast_setup}},
+            %{event_type: :participant_added, payload: %{source: "broadcast_setup"}},
             &1
           )
         )
@@ -554,7 +554,7 @@ defmodule KlassHero.Messaging.BroadcastToProgramTest do
         get_published_integration_events()
         |> Enum.find(
           &match?(
-            %{event_type: :participant_added, payload: %{source: :broadcast_setup}},
+            %{event_type: :participant_added, payload: %{source: "broadcast_setup"}},
             &1
           )
         )

--- a/test/klass_hero/messaging/create_direct_conversation_test.exs
+++ b/test/klass_hero/messaging/create_direct_conversation_test.exs
@@ -164,7 +164,7 @@ defmodule KlassHero.Messaging.CreateDirectConversationTest do
       event = assert_integration_event_published(:participant_added)
       assert event.entity_id == conversation.id
       assert event.payload.participant_user_ids == [staff_user.id]
-      assert event.payload.source == :initial_staff
+      assert event.payload.source == "initial_staff"
     end
 
     test "post-commit dispatch contract: publish failure does NOT roll back the conversation" do

--- a/test/klass_hero/messaging/domain/events/messaging_integration_events_test.exs
+++ b/test/klass_hero/messaging/domain/events/messaging_integration_events_test.exs
@@ -337,7 +337,7 @@ defmodule KlassHero.Messaging.Domain.Events.MessagingIntegrationEventsTest do
 
       assert event.payload.conversation_id == real_id
       assert event.payload.participant_user_ids == [staff_id]
-      assert event.payload.source == :later_assignment
+      assert event.payload.source == "later_assignment"
       assert event.payload.extra == "data"
     end
 
@@ -433,7 +433,7 @@ defmodule KlassHero.Messaging.Domain.Events.MessagingIntegrationEventsTest do
 
       assert event.payload.conversation_id == real_id
       assert event.payload.participant_user_ids == [staff_id]
-      assert event.payload.source == :staff_unassignment
+      assert event.payload.source == "staff_unassignment"
       assert event.payload.extra == "data"
     end
 

--- a/test/klass_hero/provider/adapters/driving/events/event_handlers/promote_integration_events_test.exs
+++ b/test/klass_hero/provider/adapters/driving/events/event_handlers/promote_integration_events_test.exs
@@ -39,8 +39,8 @@ defmodule KlassHero.Provider.Adapters.Driving.Events.EventHandlers.PromoteIntegr
       assert event.entity_type == :incident_report
       assert event.payload.incident_report_id == incident_report_id
       assert event.payload.provider_id == provider_id
-      assert event.payload.category == :injury
-      assert event.payload.severity == :high
+      assert event.payload.category == "injury"
+      assert event.payload.severity == "high"
       assert event.payload.has_photo == true
     end
 

--- a/test/klass_hero/provider/domain/events/provider_integration_events_incident_test.exs
+++ b/test/klass_hero/provider/domain/events/provider_integration_events_incident_test.exs
@@ -41,8 +41,8 @@ defmodule KlassHero.Provider.Domain.Events.ProviderIntegrationEventsIncidentTest
 
       assert event.payload.incident_report_id == incident_report_id
       assert event.payload.provider_id == provider_id
-      assert event.payload.category == :injury
-      assert event.payload.severity == :high
+      assert event.payload.category == "injury"
+      assert event.payload.severity == "high"
     end
 
     test "base_payload incident_report_id wins over caller-supplied incident_report_id", %{

--- a/test/klass_hero/shared/domain/events/critical_payload_guard_test.exs
+++ b/test/klass_hero/shared/domain/events/critical_payload_guard_test.exs
@@ -1,0 +1,98 @@
+defmodule KlassHero.Shared.Domain.Events.CriticalPayloadGuardTest do
+  @moduledoc """
+  Guards that `:critical` event payloads carry only JSON scalars so they
+  survive jsonb serialization intact (see #1010). The guard lives in
+  `EventMetadata.validate_critical_payload!/2` and is invoked from both
+  `DomainEvent.new/5` and `IntegrationEvent.new/6`.
+  """
+  use ExUnit.Case, async: true
+
+  alias KlassHero.Shared.Domain.Events.DomainEvent
+  alias KlassHero.Shared.Domain.Events.IntegrationEvent
+
+  defp new_domain(payload, opts \\ [criticality: :critical]) do
+    DomainEvent.new(:test_event, "agg-1", :test, payload, opts)
+  end
+
+  defp new_integration(payload, opts \\ [criticality: :critical]) do
+    IntegrationEvent.new(:test_event, :test_ctx, :test, "id-1", payload, opts)
+  end
+
+  describe "critical events reject non-scalar payload values" do
+    test "raises on a DateTime payload value" do
+      assert_raise ArgumentError, ~r/not a JSON scalar/, fn ->
+        new_domain(%{happened_at: DateTime.utc_now()})
+      end
+    end
+
+    test "raises on a bare atom payload value" do
+      assert_raise ArgumentError, ~r/not a JSON scalar/, fn ->
+        new_domain(%{status: :pending})
+      end
+    end
+
+    test "raises on a tuple payload value" do
+      assert_raise ArgumentError, ~r/not a JSON scalar/, fn ->
+        new_domain(%{coord: {1, 2}})
+      end
+    end
+
+    test "raises on a non-scalar nested inside a map" do
+      assert_raise ArgumentError, ~r/not a JSON scalar/, fn ->
+        new_domain(%{outer: %{inner: :atom_value}})
+      end
+    end
+
+    test "raises on a non-scalar nested inside a list" do
+      assert_raise ArgumentError, ~r/not a JSON scalar/, fn ->
+        new_domain(%{items: ["ok", DateTime.utc_now()]})
+      end
+    end
+
+    test "error message names the offending path" do
+      error =
+        assert_raise ArgumentError, fn ->
+          new_domain(%{outer: %{when: DateTime.utc_now()}})
+        end
+
+      assert error.message =~ "outer.when"
+    end
+
+    test "applies to IntegrationEvent too" do
+      assert_raise ArgumentError, ~r/not a JSON scalar/, fn ->
+        new_integration(%{happened_at: DateTime.utc_now()})
+      end
+    end
+  end
+
+  describe "critical events accept JSON scalars and containers" do
+    test "allows strings, numbers, booleans, and nil" do
+      event = new_domain(%{name: "Alice", age: 7, ratio: 1.5, active: true, deleted: nil})
+      assert event.payload.name == "Alice"
+      assert event.payload.active == true
+      assert event.payload.deleted == nil
+    end
+
+    test "allows scalars nested in maps and lists" do
+      payload = %{address: %{city: "Berlin"}, tags: ["a", "b"], items: [%{n: 1}, %{n: 2}]}
+      event = new_domain(payload)
+      assert event.payload == payload
+    end
+
+    test "allows an empty payload" do
+      assert %DomainEvent{} = new_domain(%{})
+    end
+  end
+
+  describe "non-critical events are exempt" do
+    test "allows a DateTime payload value on a :normal event" do
+      event = new_domain(%{happened_at: ~U[2026-07-06 12:00:00Z]}, criticality: :normal)
+      assert %DateTime{} = event.payload.happened_at
+    end
+
+    test "defaults to :normal (exempt) when criticality is unset" do
+      event = DomainEvent.new(:test_event, "agg-1", :test, %{status: :pending})
+      assert event.payload.status == :pending
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`CriticalEventSerializer` round-trips every `:critical` event through Oban's jsonb `args`, but `deserialize/1` restores type only for top-level `occurred_at` and allowlisted metadata — **payload *values* fall through**. A payload `%DateTime{}` comes back a string and a payload atom comes back a string, silently (#1010).

This makes the "primitive types only" contract **executable**: `EventMetadata.validate_critical_payload!/2` (invoked from `DomainEvent.new`/`IntegrationEvent.new`) raises at construction if a `:critical` payload carries a non-scalar leaf. Nested maps/lists recurse; `nil`/`true`/`false` allowed, every other atom rejected; non-critical (in-memory PubSub) events are exempt.

Building the guard turned it into an audit — it surfaced **several live producers already emitting atom/DateTime payload values** (the issue's "no live producer" premise was incomplete). All are **write-only** (no consumer pattern-matches them — verified), so they are encoded as scalars at the point each event becomes `:critical`.

## Review focus

- **Design principle:** convert non-scalars where the event becomes critical. Accounts events are *directly* critical → fixed at the domain constructor / call site. Provider & Messaging events dispatch `:normal` and a promote-handler re-emits them as critical → fixed at the **integration** constructor. Mirrors the existing #1004 precedent in `promote_integration_events.ex` (staff branches already `Map.take`-drop the `assigned_at`/`unassigned_at` DateTimes).
- **`json_scalar?/1`** in `event_metadata.ex`: explicit clauses (not `not is_atom/1`) so `nil`/`true`/`false` stay allowed while other atoms are rejected — the atom case is the bug.
- **Remediated producers** (all write-only):
  - Accounts: `user_confirmed`/`user_anonymized` timestamps → ISO8601; `registration_source`/`confirmation_method` → strings
  - Messaging: `participant_added`/`participant_removed` `source` → string
  - Provider: `incident_reported` `category`/`severity` → strings, `occurred_at` → ISO8601
- **Serializer is unchanged** — Option 2 keeps it dumb; Option 1 (value-restoration pass) was rejected (ISO-heuristic foot-gun, couples shared infra to per-context payload shapes).

## Test plan

- New `test/klass_hero/shared/domain/events/critical_payload_guard_test.exs`: rejects DateTime/atom/tuple/nested non-scalars, accepts scalars + nested containers, non-critical exempt, error names the offending path.
- Updated integration-event assertions to expect scalars (domain-event assertions keep their in-memory atoms).
- `mix precommit` exit 0; `mix test` 3922 passed / 0 failed; `mix credo --strict` clean on changed files.

Closes #1010