### PR TITLE
refactor: replace raw programs query in conversation_summaries with facade read

### DIFF
--- a/lib/klass_hero/messaging/adapters/driven/projections/conversation_summaries.ex
+++ b/lib/klass_hero/messaging/adapters/driven/projections/conversation_summaries.ex
@@ -57,6 +57,7 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries 
   alias KlassHero.Messaging.Conversation
   alias KlassHero.Messaging.ConversationSummary
   alias KlassHero.Messaging.Message
+  alias KlassHero.ProgramCatalog
   alias KlassHero.Repo
   alias KlassHero.Shared.Domain.Events.IntegrationEvent
   alias KlassHero.Shared.Projection
@@ -650,7 +651,6 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries 
 
   defp fetch_user_names(_), do: %{}
 
-  # Cross-context raw-string query to sidestep Boundary isolation (#892 pattern, #685 tracks cleanup).
   defp fetch_program_names_for_broadcasts(conversations) do
     program_ids =
       for c <- conversations,
@@ -665,12 +665,7 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries 
   defp fetch_program_names([]), do: %{}
 
   defp fetch_program_names(program_ids) do
-    from(p in "programs",
-      where: p.id in type(^program_ids, {:array, :binary_id}),
-      select: {type(p.id, :binary_id), p.title}
-    )
-    |> Repo.all()
-    |> Map.new()
+    ProgramCatalog.get_titles(program_ids)
   end
 
   defp resolve_program_name("program_broadcast", program_id) when not is_nil(program_id) do

--- a/lib/klass_hero/program_catalog.ex
+++ b/lib/klass_hero/program_catalog.ex
@@ -164,6 +164,22 @@ defmodule KlassHero.ProgramCatalog do
     |> Repo.all()
   end
 
+  @doc """
+  Returns a map of `program_id => title` for the given ids (write model).
+
+  Unknown ids are omitted from the result. Used by other contexts (e.g. the
+  Messaging broadcast-summary projection) that need program titles without
+  reaching into the `programs` schema.
+  """
+  @spec get_titles([String.t()]) :: %{String.t() => String.t()}
+  def get_titles([]), do: %{}
+
+  def get_titles(program_ids) when is_list(program_ids) do
+    from(p in Program, where: p.id in ^program_ids, select: {p.id, p.title})
+    |> Repo.all()
+    |> Map.new()
+  end
+
   @doc "Returns an empty changeset for the program creation form."
   @spec new_program_changeset(map()) :: Ecto.Changeset.t()
   def new_program_changeset(attrs \\ %{}) do

--- a/test/klass_hero/program_catalog/get_titles_test.exs
+++ b/test/klass_hero/program_catalog/get_titles_test.exs
@@ -1,0 +1,35 @@
+defmodule KlassHero.ProgramCatalog.GetTitlesTest do
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+
+  alias KlassHero.ProgramCatalog
+
+  describe "get_titles/1" do
+    test "maps program ids to their titles" do
+      provider = insert(:provider_profile_schema)
+      p1 = insert(:program_schema, provider_id: provider.id, title: "Science Explorers")
+      p2 = insert(:program_schema, provider_id: provider.id, title: "Forest Friends")
+
+      assert ProgramCatalog.get_titles([p1.id, p2.id]) == %{
+               p1.id => "Science Explorers",
+               p2.id => "Forest Friends"
+             }
+    end
+
+    test "returns an empty map for an empty id list" do
+      assert ProgramCatalog.get_titles([]) == %{}
+    end
+
+    test "omits ids with no matching program" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id, title: "Science Explorers")
+      unknown_id = Ecto.UUID.generate()
+
+      result = ProgramCatalog.get_titles([program.id, unknown_id])
+
+      assert result[program.id] == "Science Explorers"
+      refute Map.has_key?(result, unknown_id)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`conversation_summaries.ex` resolved broadcast program names with a raw-string cross-context query against Program Catalog's `programs` table, hard-coding another context's table/column names across the boundary. This is the twin of the landed #992 fix — the same file already resolves user names via `Accounts.get_display_names/1`.

- Add `ProgramCatalog.get_titles/1` (a thin `%{id => title}` facade read, mirroring `Accounts.get_display_names/1`).
- Swap the projection's raw `from(p in "programs", ...)` for the facade call; drop the stale `#892 pattern, #685 tracks cleanup` comment.

Facade read is the blessed cross-context pattern (`.claude/rules/domain-architecture.md`); supersedes the obsolete pre-flatten #685 framing.

## Review Focus

- `program_catalog.ex` — new `get_titles/1` sits with the other write-model (`programs` table) reads. Routing through the `Program` schema drops the raw query's explicit `type(..., :binary_id)` casts (Ecto infers them).
- `conversation_summaries.ex` — behaviour-preserving; `get_titles([])` and unknown-id omission preserve the existing "unknown program → `program_name` nil" path.

## Test Plan

- New `get_titles_test.exs`: id→title map, `[]` → `%{}`, unknown ids omitted.
- Existing projection regression net (bootstrap, unknown-program-nil, conversation_created) stays green unchanged.
- `mix precommit` green (3928 passed).

Closes #1027