### PR TITLE
fix: isolate tracing tests from cross-test span leakage

### DIFF
--- a/test/klass_hero/shared/tracing/context_test.exs
+++ b/test/klass_hero/shared/tracing/context_test.exs
@@ -103,21 +103,8 @@ defmodule KlassHero.Shared.Tracing.ContextTest do
   alias KlassHero.Shared.Tracing.Context
   alias KlassHero.Shared.Tracing.ContextTest.Helpers
 
-  # Drain leftover spans between tests. Uses a short 10ms timeout so it can
-  # collect any in-flight span messages before returning when the mailbox is empty.
-  setup do
-    flush_spans()
-    drain_span_mailbox()
-    :ok
-  end
-
-  defp drain_span_mailbox do
-    receive do
-      {:span, _} -> drain_span_mailbox()
-    after
-      10 -> :ok
-    end
-  end
+  # Span isolation (flush + drain between tests) is provided by the shared
+  # `use KlassHero.TracingHelpers` setup.
 
   describe "inject/0 and attach/1" do
     test "roundtrips trace context across processes" do

--- a/test/klass_hero/shared/tracing/ecto_span_bridge_test.exs
+++ b/test/klass_hero/shared/tracing/ecto_span_bridge_test.exs
@@ -56,9 +56,10 @@ defmodule KlassHero.Shared.Tracing.EctoSpanBridgeTest do
     test "emits nothing for a query with no enclosing span (child-only)" do
       Caller.query_no_span()
 
-      # Scope to this query's own span name — the OTel exporter is process-global,
-      # so an unrelated span (e.g. a concurrent auth "users.query") can land in the
-      # mailbox; a bare `refute_receive {:span, _}` would wrongly match it.
+      # The shared TracingHelpers setup flushes + drains the mailbox before this
+      # test runs, so no earlier test's buffered "children.query" span can leak in
+      # (the batch exporter is process-global). Scoping to the name is then a
+      # belt-and-braces guard against a differently-named span.
       refute_span("children.query")
     end
   end

--- a/test/klass_hero/shared/tracing/live_view_hook_test.exs
+++ b/test/klass_hero/shared/tracing/live_view_hook_test.exs
@@ -6,21 +6,8 @@ defmodule KlassHero.Shared.Tracing.LiveViewHookTest do
   alias KlassHeroWeb.Provider.ProgramLive.Index
   alias Phoenix.LiveView.Socket
 
-  # Drain leftover spans between tests. Waits up to 10ms for any pending
-  # span messages before returning once the mailbox is empty.
-  setup do
-    flush_spans()
-    drain_span_mailbox()
-    :ok
-  end
-
-  defp drain_span_mailbox do
-    receive do
-      {:span, _} -> drain_span_mailbox()
-    after
-      10 -> :ok
-    end
-  end
+  # Span isolation (flush + drain between tests) is provided by the shared
+  # `use KlassHero.TracingHelpers` setup.
 
   # Asserts no span with the given name was exported. Ignores unrelated spans
   # from the global OTel exporter to avoid flaky failures.

--- a/test/klass_hero/shared/tracing/plug_test.exs
+++ b/test/klass_hero/shared/tracing/plug_test.exs
@@ -7,21 +7,8 @@ defmodule KlassHero.Shared.Tracing.PlugTest do
 
   alias KlassHero.Shared.Tracing.Plug, as: TracingPlug
 
-  # Drain leftover spans between tests. Waits up to 10ms for any in-flight
-  # span messages, then returns once the mailbox is empty.
-  setup do
-    flush_spans()
-    drain_span_mailbox()
-    :ok
-  end
-
-  defp drain_span_mailbox do
-    receive do
-      {:span, _} -> drain_span_mailbox()
-    after
-      10 -> :ok
-    end
-  end
+  # Span isolation (flush + drain between tests) is provided by the shared
+  # `use KlassHero.TracingHelpers` setup.
 
   defp run_plug(conn) do
     opts = TracingPlug.init([])

--- a/test/klass_hero/shared/tracing/traced_worker_test.exs
+++ b/test/klass_hero/shared/tracing/traced_worker_test.exs
@@ -18,21 +18,8 @@ defmodule KlassHero.Shared.Tracing.TracedWorkerTest do
 
   alias KlassHero.Shared.Tracing.TracedWorker
 
-  # Drain leftover spans between tests. Waits briefly for any in-flight
-  # span messages, then returns once the mailbox appears empty.
-  setup do
-    flush_spans()
-    drain_span_mailbox()
-    :ok
-  end
-
-  defp drain_span_mailbox do
-    receive do
-      {:span, _} -> drain_span_mailbox()
-    after
-      10 -> :ok
-    end
-  end
+  # Span isolation (flush + drain between tests) is provided by the shared
+  # `use KlassHero.TracingHelpers` setup.
 
   defp build_job(attrs \\ %{}) do
     defaults = %Oban.Job{

--- a/test/support/tracing_helpers.ex
+++ b/test/support/tracing_helpers.ex
@@ -26,6 +26,13 @@ defmodule KlassHero.TracingHelpers do
 
       setup do
         :otel_batch_processor.set_exporter(:otel_exporter_pid, self())
+        # Clear spans buffered by earlier tests before this test's code runs.
+        # The batch exporter is process-global and flushes late, so a prior
+        # test's span (matched by name in refute_span/1) can otherwise leak
+        # into this process's mailbox. Draining must happen here, before the
+        # code under test — draining after would consume a genuine span too.
+        flush_spans()
+        drain_span_mailbox()
         :ok
       end
     end
@@ -37,6 +44,20 @@ defmodule KlassHero.TracingHelpers do
   """
   def flush_spans do
     :otel_tracer_provider.force_flush()
+  end
+
+  @doc """
+  Drains any leftover `{:span, _}` messages from the current process mailbox.
+  Waits briefly for in-flight span messages, then returns once the mailbox is
+  quiet. Pair with `flush_spans/0` in setup to isolate a test from spans
+  buffered by earlier tests (the batch exporter is process-global).
+  """
+  def drain_span_mailbox do
+    receive do
+      {:span, _} -> drain_span_mailbox()
+    after
+      10 -> :ok
+    end
   end
 
   @doc """


### PR DESCRIPTION
## Summary

Fixes the flaky `EctoSpanBridgeTest` "emits nothing for a query with no enclosing span (child-only)" (#1035).

The test's `refute_span("children.query")` matched a **prior** test's span left buffered in the process-global OTel batch exporter and flushed late into this test's mailbox. `async: false` prevents concurrency but not **buffer carryover** between tests. The span name is table-derived (`<table>.query`) so it's not unique to the test — any test querying `children` (e.g. `Family.get_children`) emits a same-named span.

## Fix

The `flush_spans() + drain_span_mailbox()` isolation pattern was already copy-pasted into **four** tracing test files (`traced_worker`, `plug`, `live_view_hook`, `context`) — but `ecto_span_bridge_test` lacked it. This promotes the pattern into the shared `TracingHelpers.__using__` setup so **every** tracing test starts residue-free, and deletes all four local copies.

Key mechanic: the drain runs in **setup**, before code-under-test. Draining *after* the action would consume a genuinely-emitted span and silently pass a broken assertion.

## Review focus

- `test/support/tracing_helpers.ex` — new public `drain_span_mailbox/0` + setup wiring.
- Four test files lose their local drain copy; `refute_span/1` interface unchanged.

## Test plan

- `mix test test/klass_hero/shared/tracing/` — 42 passed, zero warnings.
- `mix precommit` — 3925 passed, `--warnings-as-errors` clean (guards the import/`defp` collision that would otherwise slip in).
- Looped the full suite 3× with distinct seeds — no `Unexpectedly received message {:span, ...}`, all green.

Closes #1035