### PR TITLE
refactor: reconcile drifted gettext catalogs and add sync gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,9 @@ jobs:
       - name: Typography lint
         run: mix lint_typography
 
+      - name: Gettext catalog check (structure + DE completeness)
+        run: mix lint_translations
+
   test:
     name: Tests
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,7 @@ Router defines 5 `live_session` scopes with role-based access:
 
 **Presenters** in `lib/klass_hero_web/presenters/` transform domain models for templates.
 
-**Internationalization:** Gettext with English (`en`) and German (`de`) in `priv/gettext/`.
+**Internationalization:** Gettext with English (`en`, source/fallback) and German (`de`) in `priv/gettext/`. New `gettext(...)`/`dgettext(...)` calls must ship with a German translation in the **same PR** (or, for an intentional English passthrough, an entry with a reason in `priv/gettext/de/untranslated_allowlist.exs`). Enforced by `mix lint_translations` (in `precommit` and CI), which fails on stale `.pot` templates, empty `de` `msgstr`, or `fuzzy` entries. Run `mix gettext.extract && mix gettext.merge priv/gettext` after adding strings, then translate the new `de` entries.
 
 ## MCP Integration
 

--- a/lib/mix/tasks/lint_translations.ex
+++ b/lib/mix/tasks/lint_translations.ex
@@ -1,0 +1,143 @@
+defmodule Mix.Tasks.LintTranslations do
+  @shortdoc "Check gettext catalogs are in sync with source and DE translations are complete"
+  @moduledoc """
+  Two read-only checks (never writes `.po`/`.pot` files):
+
+    1. **Structure** — runs `mix gettext.extract --check-up-to-date`, which fails
+       if any `.pot` template would change (i.e. a `gettext(...)` call was
+       added/removed/moved in source without re-extracting).
+
+    2. **Completeness** — parses every non-default-locale `.po` file (currently
+       `de`) with `Expo.PO` and fails on any message that is untranslated
+       (empty `msgstr`) or still carries a `fuzzy` flag, unless its `msgid` is
+       listed in the per-domain allowlist.
+
+  The default locale (`en`) is intentionally excluded: it relies on Elixir's
+  msgid-fallback and is expected to be empty.
+
+  Intentional English passthroughs (e.g. brand names) are declared in the
+  allowlist file `priv/gettext/de/untranslated_allowlist.exs`.
+
+  ## Usage
+
+      mix lint_translations
+  """
+  use Mix.Task
+
+  alias Expo.Message.{Plural, Singular}
+
+  @gettext_dir "priv/gettext"
+  @allowlist_file "priv/gettext/de/untranslated_allowlist.exs"
+
+  @impl true
+  def run(_args) do
+    Mix.Task.run("app.config")
+
+    check_structure()
+    check_completeness()
+  end
+
+  # --- Check 1: .pot templates in sync with source ---------------------------
+
+  defp check_structure do
+    # Raises Mix.Error on drift; a clean run returns normally.
+    Mix.Task.run("gettext.extract", ["--check-up-to-date"])
+  end
+
+  # --- Check 2: DE catalogs complete and un-fuzzy ----------------------------
+
+  defp check_completeness do
+    locales = locales_to_check()
+    allowlist = load_allowlist()
+
+    violations =
+      for locale <- locales,
+          domain <- domains(),
+          violation <- check_domain(locale, domain, allowlist) do
+        violation
+      end
+
+    if violations == [] do
+      Mix.shell().info("Translation completeness check passed for: #{Enum.join(locales, ", ")}.")
+    else
+      report(violations)
+      Mix.raise("Translation check failed — #{length(violations)} untranslated/fuzzy msgid(s).")
+    end
+  end
+
+  # Real locales that require translations = configured locales minus the
+  # source/default locale. Derived from config so a 3rd locale is covered
+  # automatically without editing this task.
+  defp locales_to_check do
+    config = Application.fetch_env!(:klass_hero, KlassHeroWeb.Gettext)
+    Keyword.fetch!(config, :locales) -- [Keyword.fetch!(config, :default_locale)]
+  end
+
+  defp domains do
+    @gettext_dir
+    |> Path.join("*.pot")
+    |> Path.wildcard()
+    |> Enum.map(&Path.basename(&1, ".pot"))
+    |> Enum.sort()
+  end
+
+  defp check_domain(locale, domain, allowlist) do
+    path = Path.join([@gettext_dir, locale, "LC_MESSAGES", "#{domain}.po"])
+    allowed = Map.get(allowlist, domain, MapSet.new())
+
+    path
+    |> Expo.PO.parse_file!()
+    |> Map.fetch!(:messages)
+    |> Enum.reject(& &1.obsolete)
+    |> Enum.filter(&needs_translation?/1)
+    |> Enum.reject(&(msgid_of(&1) in allowed))
+    |> Enum.map(&{locale, domain, reason(&1), msgid_of(&1)})
+  end
+
+  # A message needs work if it is untranslated or fuzzy-flagged.
+  defp needs_translation?(message) do
+    empty?(message) or Expo.Message.has_flag?(message, "fuzzy")
+  end
+
+  # Singular: msgstr is one iodata string. Plural: msgstr is a map of
+  # plural-form index => iodata; every form must be non-empty.
+  defp empty?(%Singular{msgstr: msgstr}), do: blank?(msgstr)
+  defp empty?(%Plural{msgstr: forms}), do: Enum.any?(forms, fn {_i, v} -> blank?(v) end)
+
+  defp blank?(iodata), do: IO.iodata_to_binary(iodata) == ""
+
+  defp reason(message) do
+    cond do
+      empty?(message) and Expo.Message.has_flag?(message, "fuzzy") -> "empty+fuzzy"
+      empty?(message) -> "empty"
+      true -> "fuzzy"
+    end
+  end
+
+  defp msgid_of(message), do: IO.iodata_to_binary(message.msgid)
+
+  # --- Allowlist -------------------------------------------------------------
+
+  # File is an .exs term: %{"domain" => ["msgid", ...]}. Missing file => none.
+  defp load_allowlist do
+    if File.exists?(@allowlist_file) do
+      {allowlist, _bindings} = Code.eval_file(@allowlist_file)
+      Map.new(allowlist, fn {domain, msgids} -> {domain, MapSet.new(msgids)} end)
+    else
+      %{}
+    end
+  end
+
+  # --- Reporting -------------------------------------------------------------
+
+  defp report(violations) do
+    Mix.shell().error(
+      "Untranslated or fuzzy DE msgid(s) — add a translation (drop the fuzzy flag) " <>
+        "or list the msgid in #{@allowlist_file}:\n"
+    )
+
+    Enum.each(violations, fn {locale, domain, reason, msgid} ->
+      Mix.shell().error("  [#{locale}/#{domain}] (#{reason}) #{inspect(msgid)}")
+    end)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -78,6 +78,9 @@ defmodule KlassHero.MixProject do
       {:telemetry_metrics, "~> 1.0"},
       {:telemetry_poller, "~> 1.0"},
       {:gettext, "~> 1.0"},
+      # Direct dep (also transitive via gettext) so `mix lint_translations`'
+      # PO parsing can't break on a future gettext bump dropping expo.
+      {:expo, "~> 1.0"},
       {:nimble_csv, "~> 1.0"},
       {:jason, "~> 1.2"},
       {:dns_cluster, "~> 0.2.0"},
@@ -141,6 +144,7 @@ defmodule KlassHero.MixProject do
         "deps.unlock --unused",
         "format",
         "lint_typography",
+        "lint_translations",
         "cmd env MIX_ENV=test mix test"
       ]
     ]

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -12,1363 +12,1205 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: lib/klass_hero_web/components/layouts/app.html.heex:44
-#: lib/klass_hero_web/components/layouts/app.html.heex:210
+#: lib/klass_hero_web/components/layouts/app.html.heex:197
+#: lib/klass_hero_web/components/marketing_components.ex:193
+#: lib/klass_hero_web/components/marketing_components.ex:821
+#: lib/klass_hero_web/components/marketing_components.ex:910
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr "Über uns"
 
-#: lib/klass_hero_web/components/layouts.ex:39
-#: lib/klass_hero_web/components/layouts.ex:51
+#: lib/klass_hero_web/components/layouts.ex:34
+#: lib/klass_hero_web/components/layouts.ex:46
 #, elixir-autogen, elixir-format
 msgid "Attempting to reconnect"
 msgstr "Verbindung wird wiederhergestellt"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:247
+#: lib/klass_hero_web/live/user_live/settings.ex:172
 #, elixir-autogen, elixir-format
 msgid "Choose your preferred language for the interface"
 msgstr "Wählen Sie Ihre bevorzugte Sprache für die Benutzeroberfläche"
 
-#: lib/klass_hero_web/components/composite_components.ex:608
+#: lib/klass_hero_web/components/composite_components.ex:468
 #: lib/klass_hero_web/components/layouts/app.html.heex:52
-#: lib/klass_hero_web/components/layouts/app.html.heex:211
+#: lib/klass_hero_web/components/layouts/app.html.heex:198
+#: lib/klass_hero_web/components/marketing_components.ex:194
+#: lib/klass_hero_web/components/marketing_components.ex:822
+#: lib/klass_hero_web/components/marketing_components.ex:911
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr "Kontakt"
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:113
-#: lib/klass_hero_web/components/layouts/app.html.heex:138
-#: lib/klass_hero_web/components/layouts/app.html.heex:217
-#: lib/klass_hero_web/components/layouts/app.html.heex:253
-#: lib/klass_hero_web/components/provider_components.ex:357
-#: lib/klass_hero_web/live/dashboard_live.ex:58
+#: lib/klass_hero_web/components/layouts/app.html.heex:104
+#: lib/klass_hero_web/components/layouts/app.html.heex:129
+#: lib/klass_hero_web/components/layouts/app.html.heex:204
+#: lib/klass_hero_web/components/layouts/app.html.heex:229
+#: lib/klass_hero_web/components/provider_components.ex:366
+#: lib/klass_hero_web/components/ui_components.ex:268
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
 msgstr "Dashboard"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:406
+#: lib/klass_hero_web/live/user_live/settings.ex:263
 #, elixir-autogen, elixir-format
 msgid "Download My Data"
 msgstr "Meine Daten herunterladen"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:394
+#: lib/klass_hero_web/live/user_live/settings.ex:259
 #, elixir-autogen, elixir-format
 msgid "Download a copy of all your personal data"
 msgstr "Laden Sie eine Kopie aller Ihrer persönlichen Daten herunter"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:626
+#: lib/klass_hero_web/live/user_live/settings.ex:479
 #, elixir-autogen, elixir-format
 msgid "Failed to update language preference."
 msgstr "Spracheinstellung konnte nicht aktualisiert werden."
 
 #: lib/klass_hero_web/components/layouts/app.html.heex:28
-#: lib/klass_hero_web/components/layouts/app.html.heex:208
+#: lib/klass_hero_web/components/layouts/app.html.heex:195
+#: lib/klass_hero_web/components/marketing_components.ex:189
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr "Startseite"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:244
+#: lib/klass_hero_web/live/user_live/settings.ex:169
 #, elixir-autogen, elixir-format
 msgid "Language Preference"
 msgstr "Spracheinstellung"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:623
+#: lib/klass_hero_web/live/user_live/settings.ex:476
 #, elixir-autogen, elixir-format
 msgid "Language preference updated successfully."
 msgstr "Spracheinstellung erfolgreich aktualisiert."
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:167
-#: lib/klass_hero_web/components/layouts/app.html.heex:271
+#: lib/klass_hero_web/components/layouts/app.html.heex:158
+#: lib/klass_hero_web/components/layouts/app.html.heex:247
 #, elixir-autogen, elixir-format
 msgid "Login"
 msgstr "Anmelden"
 
-#: lib/klass_hero_web/components/composite_components.ex:602
-#: lib/klass_hero_web/components/composite_components.ex:619
+#: lib/klass_hero_web/components/composite_components.ex:462
+#: lib/klass_hero_web/components/composite_components.ex:484
 #: lib/klass_hero_web/components/layouts/app.html.heex:36
-#: lib/klass_hero_web/components/layouts/app.html.heex:209
+#: lib/klass_hero_web/components/layouts/app.html.heex:196
+#: lib/klass_hero_web/components/marketing_components.ex:190
 #, elixir-autogen, elixir-format
 msgid "Programs"
 msgstr "Programme"
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:122
-#: lib/klass_hero_web/components/layouts/app.html.heex:245
+#: lib/klass_hero_web/components/layouts/app.html.heex:113
+#: lib/klass_hero_web/components/layouts/app.html.heex:221
+#: lib/klass_hero_web/components/ui_components.ex:197
 #: lib/klass_hero_web/live/settings_live.ex:17
-#: lib/klass_hero_web/live/settings_live.ex:56
+#: lib/klass_hero_web/live/settings_live.ex:51
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr "Einstellungen"
 
 #: lib/klass_hero_web/components/layouts/admin.html.heex:20
-#: lib/klass_hero_web/components/layouts/app.html.heex:159
-#: lib/klass_hero_web/components/layouts/app.html.heex:265
-#: lib/klass_hero_web/live/settings_live.ex:285
+#: lib/klass_hero_web/components/layouts/app.html.heex:150
+#: lib/klass_hero_web/components/layouts/app.html.heex:241
+#: lib/klass_hero_web/live/settings_live.ex:238
 #, elixir-autogen, elixir-format
 msgid "Sign Out"
 msgstr "Abmelden"
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:173
-#: lib/klass_hero_web/components/layouts/app.html.heex:279
+#: lib/klass_hero_web/components/layouts/app.html.heex:164
+#: lib/klass_hero_web/components/layouts/app.html.heex:255
 #, elixir-autogen, elixir-format
 msgid "Sign Up"
 msgstr "Registrieren"
 
-#: lib/klass_hero_web/components/layouts.ex:46
+#: lib/klass_hero_web/components/layouts.ex:41
 #, elixir-autogen, elixir-format
 msgid "Something went wrong!"
 msgstr "Etwas ist schief gelaufen!"
 
-#: lib/klass_hero_web/components/layouts.ex:34
+#: lib/klass_hero_web/components/layouts.ex:29
 #, elixir-autogen, elixir-format
 msgid "We can't find the internet"
 msgstr "Keine Internetverbindung gefunden"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:391
+#: lib/klass_hero_web/live/user_live/settings.ex:257
 #, elixir-autogen, elixir-format
 msgid "Your Data"
 msgstr "Ihre Daten"
 
-#: lib/klass_hero_web/components/core_components.ex:69
-#: lib/klass_hero_web/components/provider_components.ex:1595
+#: lib/klass_hero_web/components/core_components.ex:67
+#: lib/klass_hero_web/components/provider_components.ex:1553
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr "schließen"
 
-#: lib/klass_hero_web/live/booking_live.ex:442
+#: lib/klass_hero_web/live/booking_live.ex:416
 #, elixir-autogen, elixir-format
 msgid "%{name} (Age %{age})"
 msgstr "%{name} (Alter %{age})"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:392
+#: lib/klass_hero_web/live/program_detail_live.ex:365
 #, elixir-autogen, elixir-format
 msgid "About This Program"
 msgstr "Über dieses Programm"
 
-#: lib/klass_hero_web/live/booking_live.ex:349
+#: lib/klass_hero_web/live/booking_live.ex:323
 #, elixir-autogen, elixir-format
 msgid "Activity Summary"
 msgstr "Aktivitätsübersicht"
 
-#: lib/klass_hero_web/live/booking_live.ex:455
+#: lib/klass_hero_web/live/booking_live.ex:429
 #, elixir-autogen, elixir-format
 msgid "Add another child"
 msgstr "Weiteres Kind hinzufügen"
 
-#: lib/klass_hero_web/live/booking_live.ex:390
+#: lib/klass_hero_web/live/booking_live.ex:364
 #, elixir-autogen, elixir-format
 msgid "Add another program"
 msgstr "Weiteres Programm hinzufügen"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:231
+#: lib/klass_hero_web/live/program_detail_live.ex:210
 #, elixir-autogen, elixir-format
 msgid "Ages %{range}"
 msgstr "Alter %{range}"
 
-#: lib/klass_hero_web/live/booking_live.ex:528
+#: lib/klass_hero_web/live/booking_live.ex:502
 #, elixir-autogen, elixir-format
 msgid "An invoice will be emailed to you after enrollment completion"
 msgstr "Nach Abschluss der Anmeldung erhalten Sie eine Rechnung per E-Mail"
 
-#: lib/klass_hero_web/live/booking_live.ex:472
+#: lib/klass_hero_web/live/booking_live.ex:446
 #, elixir-autogen, elixir-format
 msgid "Any allergies, medical conditions, or special instructions..."
 msgstr "Allergien, medizinische Bedingungen oder besondere Hinweise..."
 
-#: lib/klass_hero_web/live/home_live.ex:240
+#: lib/klass_hero_web/components/marketing_components.ex:491
 #, elixir-autogen, elixir-format
 msgid "Book camps, tutors, and workshops instantly. Our integrated planner helps you manage your child's busy life."
 msgstr "Buchen Sie Camps, Nachhilfe und Workshops sofort. Unser integrierter Planer hilft Ihnen, den vollen Terminkalender Ihres Kindes zu verwalten."
 
-#: lib/klass_hero_web/live/booking_live.ex:505
+#: lib/klass_hero_web/live/booking_live.ex:479
 #, elixir-autogen, elixir-format
 msgid "Cash / Bank Transfer"
 msgstr "Bar / Überweisung"
 
-#: lib/klass_hero_web/live/booking_live.ex:530
+#: lib/klass_hero_web/live/booking_live.ex:504
 #, elixir-autogen, elixir-format
 msgid "Cash/transfer payments will show as \"Pending\" until received"
 msgstr "Bar-/Überweisungszahlungen werden als \"Ausstehend\" angezeigt, bis sie eingegangen sind"
 
-#: lib/klass_hero_web/live/home_live.ex:248
+#: lib/klass_hero_web/components/marketing_components.ex:499
 #, elixir-autogen, elixir-format
 msgid "Community Focused"
 msgstr "Gemeinschaftsorientiert"
 
-#: lib/klass_hero_web/live/booking_live.ex:547
+#: lib/klass_hero_web/live/booking_live.ex:521
 #, elixir-autogen, elixir-format
 msgid "Complete Enrollment"
 msgstr "Anmeldung abschließen"
 
-#: lib/klass_hero_web/live/booking_live.ex:496
+#: lib/klass_hero_web/live/booking_live.ex:470
 #, elixir-autogen, elixir-format
 msgid "Credit Card"
 msgstr "Kreditkarte"
 
-#: lib/klass_hero_web/live/booking_live.ex:529
+#: lib/klass_hero_web/live/booking_live.ex:503
 #, elixir-autogen, elixir-format
 msgid "Credit card payments are processed immediately"
 msgstr "Kreditkartenzahlungen werden sofort verarbeitet"
 
-#: lib/klass_hero_web/live/booking_live.ex:381
+#: lib/klass_hero_web/live/booking_live.ex:355
 #, elixir-autogen, elixir-format
 msgid "Duration:"
 msgstr "Dauer:"
 
-#: lib/klass_hero_web/live/home_live.ex:238
+#: lib/klass_hero_web/components/marketing_components.ex:489
 #, elixir-autogen, elixir-format
 msgid "Easy Scheduling"
 msgstr "Einfache Terminplanung"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:551
+#: lib/klass_hero_web/live/program_detail_live.ex:468
 #, elixir-autogen, elixir-format
 msgid "Enroll Now - %{price}"
 msgstr "Jetzt anmelden - %{price}"
 
-#: lib/klass_hero_web/components/provider_components.ex:1386
-#: lib/klass_hero_web/live/booking_live.ex:344
+#: lib/klass_hero_web/components/provider_components.ex:1338
+#: lib/klass_hero_web/live/booking_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "Enrollment"
 msgstr "Anmeldung"
 
-#: lib/klass_hero_web/live/booking_live.ex:41
+#: lib/klass_hero_web/live/booking_live.ex:37
 #, elixir-autogen, elixir-format
 msgid "Enrollment - %{title}"
 msgstr "Anmeldung - %{title}"
 
-#: lib/klass_hero_web/live/booking_live.ex:217
+#: lib/klass_hero_web/live/booking_live.ex:199
 #, elixir-autogen, elixir-format
 msgid "Enrollment failed. Please try again or contact support."
 msgstr "Anmeldung fehlgeschlagen. Bitte versuchen Sie es erneut oder kontaktieren Sie den Support."
 
-#: lib/klass_hero_web/live/booking_live.ex:148
+#: lib/klass_hero_web/live/booking_live.ex:130
 #, elixir-autogen, elixir-format
 msgid "Enrollment successful! You'll receive a confirmation email shortly."
 msgstr "Anmeldung erfolgreich! Sie erhalten in Kürze eine Bestätigungs-E-Mail."
 
-#: lib/klass_hero_web/live/home_live.ex:230
+#: lib/klass_hero_web/components/marketing_components.ex:481
 #, elixir-autogen, elixir-format
 msgid "Every provider is rigorously vetted. We prioritize child safety above all else, giving parents peace of mind."
 msgstr "Jeder Anbieter wird sorgfältig geprüft. Wir stellen die Sicherheit der Kinder an erste Stelle und geben Eltern die nötige Sicherheit."
 
-#: lib/klass_hero_web/live/programs_live.ex:33
-#: lib/klass_hero_web/live/programs_live.ex:241
+#: lib/klass_hero_web/components/marketing_components.ex:952
+#: lib/klass_hero_web/live/programs_live.ex:34
 #, elixir-autogen, elixir-format
 msgid "Explore Programs"
 msgstr "Programme entdecken"
 
-#: lib/klass_hero_web/live/home_live.ex:168
-#, elixir-autogen, elixir-format
-msgid "Explore top-rated activities for your children"
-msgstr "Entdecken Sie erstklassige Aktivitäten für Ihre Kinder"
-
-#: lib/klass_hero_web/live/home_live.ex:165
+#: lib/klass_hero_web/components/marketing_components.ex:318
 #, elixir-autogen, elixir-format
 msgid "Featured Programs"
 msgstr "Empfohlene Programme"
 
-#: lib/klass_hero_web/live/programs_live.ex:192
+#: lib/klass_hero_web/live/programs_live.ex:220
 #, elixir-autogen, elixir-format
 msgid "Invalid pagination state. Please refresh the page."
 msgstr "Ungültiger Seitenstatus. Bitte laden Sie die Seite neu."
 
-#: lib/klass_hero_web/live/booking_live.ex:526
+#: lib/klass_hero_web/live/booking_live.ex:500
 #, elixir-autogen, elixir-format
 msgid "Invoice & Payment Confirmation"
 msgstr "Rechnung & Zahlungsbestätigung"
 
-#: lib/klass_hero_web/live/programs_live.ex:318
-#, elixir-autogen, elixir-format
-msgid "Load More Programs"
-msgstr "Mehr Programme laden"
-
-#: lib/klass_hero_web/live/programs_live.ex:315
+#: lib/klass_hero_web/live/programs_live.ex:360
 #, elixir-autogen, elixir-format
 msgid "Loading..."
 msgstr "Laden..."
 
-#: lib/klass_hero_web/live/program_detail_live.ex:432
+#: lib/klass_hero_web/live/program_detail_live.ex:405
 #, elixir-autogen, elixir-format
 msgid "Meet the Hero"
 msgid_plural "Meet the Heroes"
-msgstr[0] "Triff den Helden"
-msgstr[1] "Triff die Helden"
+msgstr[0] "Lernen Sie den Helden kennen"
+msgstr[1] "Lernen Sie die Helden kennen"
 
-#: lib/klass_hero_web/live/programs_live.ex:328
+#: lib/klass_hero_web/live/programs_live.ex:305
 #, elixir-autogen, elixir-format
 msgid "No programs found"
 msgstr "Keine Programme gefunden"
 
-#: lib/klass_hero_web/live/booking_live.ex:480
+#: lib/klass_hero_web/live/booking_live.ex:454
 #, elixir-autogen, elixir-format
 msgid "Optional: Include any important information we should know about your child."
 msgstr "Optional: Wichtige Informationen über Ihr Kind, die wir wissen sollten."
 
-#: lib/klass_hero_web/live/booking_live.ex:497
+#: lib/klass_hero_web/live/booking_live.ex:471
 #, elixir-autogen, elixir-format
 msgid "Pay securely with Visa, Mastercard, or other cards"
 msgstr "Sicher bezahlen mit Visa, Mastercard oder anderen Karten"
 
-#: lib/klass_hero_web/live/booking_live.ex:491
+#: lib/klass_hero_web/live/booking_live.ex:465
 #, elixir-autogen, elixir-format
 msgid "Payment Method"
 msgstr "Zahlungsmethode"
 
-#: lib/klass_hero_web/live/booking_live.ex:515
+#: lib/klass_hero_web/live/booking_live.ex:489
 #, elixir-autogen, elixir-format
 msgid "Payment Summary"
 msgstr "Zahlungsübersicht"
 
-#: lib/klass_hero_web/live/booking_live.ex:172
+#: lib/klass_hero_web/live/booking_live.ex:154
 #, elixir-autogen, elixir-format
 msgid "Payment information is invalid. Please check your details."
 msgstr "Zahlungsinformationen ungültig. Bitte überprüfen Sie Ihre Angaben."
 
-#: lib/klass_hero_web/live/booking_live.ex:176
+#: lib/klass_hero_web/live/booking_live.ex:158
 #, elixir-autogen, elixir-format
 msgid "Please select a child for enrollment."
 msgstr "Bitte wählen Sie ein Kind für die Anmeldung aus."
 
-#: lib/klass_hero_web/live/home_live.ex:21
+#: lib/klass_hero_web/live/home_live.ex:20
 #, elixir-autogen, elixir-format
 msgid "Klass Hero - Connecting Families with Trusted Youth Educators"
 msgstr "Klass Hero - Wir verbinden Familien mit vertrauenswürdigen Jugendpädagogen"
 
-#: lib/klass_hero_web/live/booking_live.ex:59
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:47
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:77
+#: lib/klass_hero_web/live/booking_live.ex:56
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:56
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:67
 #, elixir-autogen, elixir-format
 msgid "Program not found"
 msgstr "Programm nicht gefunden"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:74
+#: lib/klass_hero_web/live/program_detail_live.ex:72
 #, elixir-autogen, elixir-format
 msgid "Program not found. It may have been removed or is no longer available."
 msgstr "Programm nicht gefunden. Es wurde möglicherweise entfernt oder ist nicht mehr verfügbar."
 
-#: lib/klass_hero_web/live/about_live.ex:147
-#: lib/klass_hero_web/live/home_live.ex:228
+#: lib/klass_hero_web/components/marketing_components.ex:479
+#: lib/klass_hero_web/live/about_live.ex:19
 #, elixir-autogen, elixir-format
 msgid "Safety First"
 msgstr "Sicherheit zuerst"
 
-#: lib/klass_hero_web/live/home_live.ex:215
-#, elixir-autogen, elixir-format
-msgid "Safety, quality, and convenience for modern families."
-msgstr "Sicherheit, Qualität und Komfort für moderne Familien."
-
-#: lib/klass_hero_web/components/program_components.ex:35
-#: lib/klass_hero_web/live/programs_live.ex:246
+#: lib/klass_hero_web/components/program_components.ex:32
 #, elixir-autogen, elixir-format
 msgid "Search programs..."
 msgstr "Programme suchen..."
 
-#: lib/klass_hero_web/live/booking_live.ex:426
+#: lib/klass_hero_web/live/booking_live.ex:400
 #, elixir-autogen, elixir-format
 msgid "Select Child"
 msgstr "Kind auswählen"
 
-#: lib/klass_hero_web/live/booking_live.ex:436
+#: lib/klass_hero_web/live/booking_live.ex:410
 #, elixir-autogen, elixir-format
 msgid "Select a child"
 msgstr "Ein Kind auswählen"
 
-#: lib/klass_hero_web/live/booking_live.ex:69
+#: lib/klass_hero_web/live/booking_live.ex:66
 #, elixir-autogen, elixir-format
 msgid "Sorry, this program is currently full. Check back later for availability."
 msgstr "Dieses Programm ist derzeit ausgebucht. Bitte schauen Sie später wieder vorbei."
 
-#: lib/klass_hero_web/live/booking_live.ex:157
+#: lib/klass_hero_web/live/booking_live.ex:139
 #, elixir-autogen, elixir-format
 msgid "Sorry, this program is now full. Please choose another program."
 msgstr "Dieses Programm ist jetzt ausgebucht. Bitte wählen Sie ein anderes Programm."
 
-#: lib/klass_hero_web/live/booking_live.ex:465
+#: lib/klass_hero_web/live/booking_live.ex:439
 #, elixir-autogen, elixir-format
 msgid "Special Requirements"
 msgstr "Besondere Anforderungen"
 
-#: lib/klass_hero_web/live/booking_live.ex:374
+#: lib/klass_hero_web/live/booking_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "Total Price:"
 msgstr "Gesamtpreis:"
 
-#: lib/klass_hero_web/live/booking_live.ex:521
+#: lib/klass_hero_web/live/booking_live.ex:495
 #, elixir-autogen, elixir-format
 msgid "Total due today:"
 msgstr "Heute fällig:"
 
-#: lib/klass_hero_web/live/programs_live.ex:329
-#, elixir-autogen, elixir-format
-msgid "Try adjusting your search or filter criteria."
-msgstr "Versuchen Sie, Ihre Such- oder Filterkriterien anzupassen."
-
-#: lib/klass_hero_web/live/booking_live.ex:84
-#: lib/klass_hero_web/live/program_detail_live.ex:81
-#, elixir-autogen, elixir-format
-msgid "Unable to load program. Please try again later."
-msgstr "Programm konnte nicht geladen werden. Bitte versuchen Sie es später erneut."
-
-#: lib/klass_hero_web/live/home_live.ex:198
+#: lib/klass_hero_web/components/marketing_components.ex:337
 #, elixir-autogen, elixir-format
 msgid "View All Programs →"
 msgstr "Alle Programme ansehen →"
 
-#: lib/klass_hero_web/live/home_live.ex:212
-#, elixir-autogen, elixir-format
-msgid "Why Klass Hero?"
-msgstr "Warum Klass Hero Connect?"
-
-#: lib/klass_hero_web/live/program_detail_live.ex:243
+#: lib/klass_hero_web/live/program_detail_live.ex:222
 #, elixir-autogen, elixir-format
 msgid "✓ No hidden fees"
 msgstr "✓ Keine versteckten Gebühren"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:566
+#: lib/klass_hero_web/live/user_live/settings.ex:419
 #, elixir-autogen, elixir-format
 msgid "A link to confirm your email change has been sent to the new address."
 msgstr "Ein Bestätigungslink wurde an Ihre neue E-Mail-Adresse gesendet."
 
-#: lib/klass_hero_web/components/composite_components.ex:605
+#: lib/klass_hero_web/components/composite_components.ex:465
 #: lib/klass_hero_web/live/about_live.ex:10
 #, elixir-autogen, elixir-format
 msgid "About Us"
 msgstr "Über uns"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:17
-#, elixir-autogen, elixir-format
-msgid "Account Settings"
-msgstr "Kontoeinstellungen"
-
-#: lib/klass_hero_web/live/terms_of_service_live.ex:212
+#: lib/klass_hero_web/live/terms_of_service_live.ex:204
 #, elixir-autogen, elixir-format
 msgid "Account Termination"
 msgstr "Kontobeendigung"
 
-#: lib/klass_hero_web/live/contact_live.ex:81
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:247
+#: lib/klass_hero_web/live/contact_live.ex:79
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:254
 #, elixir-autogen, elixir-format
 msgid "Address"
 msgstr "Adresse"
 
-#: lib/klass_hero_web/live/terms_of_service_live.ex:23
+#: lib/klass_hero_web/live/terms_of_service_live.ex:27
 #, elixir-autogen, elixir-format
 msgid "Agreement to Terms"
 msgstr "Zustimmung zu den Bedingungen"
 
-#: lib/klass_hero_web/live/user_live/registration.ex:17
+#: lib/klass_hero_web/live/user_live/registration.ex:18
 #, elixir-autogen, elixir-format
 msgid "Already registered?"
 msgstr "Bereits registriert?"
 
-#: lib/klass_hero_web/live/user_live/registration.ex:159
+#: lib/klass_hero_web/live/user_live/registration.ex:148
 #, elixir-autogen, elixir-format
 msgid "An email was sent to %{email}, please access it to confirm your account."
 msgstr "Eine E-Mail wurde an %{email} gesendet. Bitte bestätigen Sie Ihr Konto über den Link."
 
-#: lib/klass_hero_web/live/contact_live.ex:151
+#: lib/klass_hero_web/live/contact_live.ex:91
 #, elixir-autogen, elixir-format
 msgid "Booking Support"
 msgstr "Buchungshilfe"
 
-#: lib/klass_hero_web/live/terms_of_service_live.ex:104
+#: lib/klass_hero_web/live/terms_of_service_live.ex:108
 #, elixir-autogen, elixir-format
 msgid "Cancellation & Refund Policy"
 msgstr "Stornierung & Rückerstattung"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:160
+#: lib/klass_hero_web/live/user_live/settings.ex:111
 #, elixir-autogen, elixir-format
 msgid "Change Email"
 msgstr "E-Mail ändern"
 
-#: lib/klass_hero_web/live/terms_of_service_live.ex:195
+#: lib/klass_hero_web/live/terms_of_service_live.ex:187
 #, elixir-autogen, elixir-format
 msgid "Changes to Terms"
 msgstr "Änderungen der Bedingungen"
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:201
+#: lib/klass_hero_web/live/privacy_policy_live.ex:205
 #, elixir-autogen, elixir-format
 msgid "Changes to This Policy"
 msgstr "Änderungen dieser Richtlinie"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:159
+#: lib/klass_hero_web/live/user_live/settings.ex:109
 #, elixir-autogen, elixir-format
 msgid "Changing..."
 msgstr "Wird geändert..."
 
-#: lib/klass_hero_web/live/contact_live.ex:253
-#, elixir-autogen, elixir-format
-msgid "Check out our FAQ section for answers to common questions."
-msgstr "Schauen Sie in unsere FAQ für Antworten auf häufige Fragen."
-
-#: lib/klass_hero_web/live/provider/participation_live.ex:70
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:70
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:39
 #, elixir-autogen, elixir-format
 msgid "Child checked in successfully"
 msgstr "Kind erfolgreich eingecheckt"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:133
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:133
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:72
 #, elixir-autogen, elixir-format
 msgid "Child checked out successfully"
 msgstr "Kind erfolgreich ausgecheckt"
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:149
+#: lib/klass_hero_web/live/privacy_policy_live.ex:153
 #, elixir-autogen, elixir-format
 msgid "Children's Privacy"
 msgstr "Datenschutz für Kinder"
 
-#: lib/klass_hero_web/live/contact_live.ex:100
-#, elixir-autogen, elixir-format
-msgid "Closed"
-msgstr "Geschlossen"
-
-#: lib/klass_hero_web/live/about_live.ex:193
+#: lib/klass_hero_web/live/about_live.ex:29
 #, elixir-autogen, elixir-format
 msgid "Community"
 msgstr "Gemeinschaft"
 
-#: lib/klass_hero_web/live/user_live/confirmation.ex:37
+#: lib/klass_hero_web/live/user_live/confirmation.ex:57
 #, elixir-autogen, elixir-format
 msgid "Confirm and log in only this time"
 msgstr "Bestätigen und nur diesmal anmelden"
 
-#: lib/klass_hero_web/live/user_live/confirmation.ex:31
+#: lib/klass_hero_web/live/user_live/confirmation.ex:48
 #, elixir-autogen, elixir-format
 msgid "Confirm and stay logged in"
 msgstr "Bestätigen und angemeldet bleiben"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:199
+#: lib/klass_hero_web/live/user_live/settings.ex:147
 #, elixir-autogen, elixir-format
 msgid "Confirm new password"
 msgstr "Neues Passwort bestätigen"
 
-#: lib/klass_hero_web/live/user_live/confirmation.ex:28
-#: lib/klass_hero_web/live/user_live/confirmation.ex:34
+#: lib/klass_hero_web/live/user_live/confirmation.ex:45
+#: lib/klass_hero_web/live/user_live/confirmation.ex:54
 #, elixir-autogen, elixir-format
 msgid "Confirming..."
 msgstr "Wird bestätigt..."
 
-#: lib/klass_hero_web/live/settings_live.ex:112
-#: lib/klass_hero_web/live/terms_of_service_live.ex:247
+#: lib/klass_hero_web/live/settings_live.ex:99
+#: lib/klass_hero_web/live/terms_of_service_live.ex:239
 #, elixir-autogen, elixir-format
 msgid "Contact Information"
 msgstr "Kontaktdaten"
 
-#: lib/klass_hero_web/components/composite_components.ex:808
-#: lib/klass_hero_web/live/contact_live.ex:15
-#: lib/klass_hero_web/live/contact_live.ex:112
-#: lib/klass_hero_web/live/privacy_policy_live.ex:217
-#: lib/klass_hero_web/live/trust_safety_live.ex:225
+#: lib/klass_hero_web/components/composite_components.ex:651
+#: lib/klass_hero_web/live/contact_live.ex:16
+#: lib/klass_hero_web/live/contact_live.ex:101
+#: lib/klass_hero_web/live/privacy_policy_live.ex:221
 #, elixir-autogen, elixir-format
 msgid "Contact Us"
 msgstr "Kontakt"
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:170
+#: lib/klass_hero_web/live/privacy_policy_live.ex:174
 #, elixir-autogen, elixir-format
 msgid "Cookies & Tracking"
 msgstr "Cookies & Tracking"
 
-#: lib/klass_hero_web/live/user_live/registration.ex:123
+#: lib/klass_hero_web/live/user_live/registration.ex:111
 #, elixir-autogen, elixir-format
 msgid "Create an account"
 msgstr "Konto erstellen"
 
-#: lib/klass_hero_web/live/user_live/registration.ex:80
+#: lib/klass_hero_web/live/user_live/registration.ex:91
 #, elixir-autogen, elixir-format
 msgid "Create and manage programs, activities, and services for families"
 msgstr "Programme, Aktivitäten und Dienstleistungen für Familien erstellen und verwalten"
 
-#: lib/klass_hero_web/live/user_live/registration.ex:120
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:73
+#: lib/klass_hero_web/live/user_live/registration.ex:109
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:81
 #, elixir-autogen, elixir-format
 msgid "Creating account..."
 msgstr "Konto wird erstellt..."
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:186
+#: lib/klass_hero_web/live/privacy_policy_live.ex:190
 #, elixir-autogen, elixir-format
 msgid "Data Retention"
 msgstr "Datenspeicherung"
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:132
+#: lib/klass_hero_web/live/privacy_policy_live.ex:136
 #, elixir-autogen, elixir-format
 msgid "Data Security"
 msgstr "Datensicherheit"
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:91
+#: lib/klass_hero_web/live/privacy_policy_live.ex:95
 #, elixir-autogen, elixir-format
 msgid "Data Sharing"
 msgstr "Datenweitergabe"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:422
+#: lib/klass_hero_web/live/user_live/settings.ex:278
 #, elixir-autogen, elixir-format
 msgid "Delete Account"
 msgstr "Konto löschen"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:447
+#: lib/klass_hero_web/live/user_live/settings.ex:310
 #, elixir-autogen, elixir-format
 msgid "Delete My Account"
 msgstr "Mein Konto löschen"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:445
+#: lib/klass_hero_web/live/user_live/settings.ex:300
 #, elixir-autogen, elixir-format
 msgid "Deleting..."
 msgstr "Wird gelöscht..."
 
-#: lib/klass_hero_web/live/user_live/settings.ex:286
+#: lib/klass_hero_web/live/user_live/settings.ex:209
 #, elixir-autogen, elixir-format
 msgid "Deutsch"
 msgstr "Deutsch"
 
-#: lib/klass_hero_web/live/terms_of_service_live.ex:230
+#: lib/klass_hero_web/live/terms_of_service_live.ex:222
 #, elixir-autogen, elixir-format
 msgid "Dispute Resolution"
 msgstr "Streitbeilegung"
 
-#: lib/klass_hero_web/live/user_live/login.ex:18
-#, elixir-autogen, elixir-format
-msgid "Don't have an account?"
-msgstr "Noch kein Konto?"
-
-#: lib/klass_hero_web/components/provider_components.ex:657
-#: lib/klass_hero_web/components/provider_components.ex:2104
-#: lib/klass_hero_web/components/provider_components.ex:2122
+#: lib/klass_hero_web/components/provider_components.ex:624
+#: lib/klass_hero_web/components/provider_components.ex:2050
+#: lib/klass_hero_web/components/provider_components.ex:2068
 #: lib/klass_hero_web/live/contact_live.ex:65
-#: lib/klass_hero_web/live/contact_live.ex:141
-#: lib/klass_hero_web/live/user_live/login.ex:49
-#: lib/klass_hero_web/live/user_live/login.ex:81
-#: lib/klass_hero_web/live/user_live/registration.ex:39
-#: lib/klass_hero_web/live/user_live/settings.ex:155
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:60
+#: lib/klass_hero_web/live/contact_live.ex:154
+#: lib/klass_hero_web/live/user_live/login.ex:60
+#: lib/klass_hero_web/live/user_live/login.ex:89
+#: lib/klass_hero_web/live/user_live/registration.ex:48
+#: lib/klass_hero_web/live/user_live/settings.ex:102
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:66
 #, elixir-autogen, elixir-format
 msgid "Email"
 msgstr "E-Mail"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:496
+#: lib/klass_hero_web/live/user_live/settings.ex:348
 #, elixir-autogen, elixir-format
 msgid "Email change link is invalid or it has expired."
 msgstr "Der Link zur E-Mail-Änderung ist ungültig oder abgelaufen."
 
-#: lib/klass_hero_web/live/user_live/settings.ex:493
+#: lib/klass_hero_web/live/user_live/settings.ex:345
 #, elixir-autogen, elixir-format
 msgid "Email changed successfully."
 msgstr "E-Mail erfolgreich geändert."
 
-#: lib/klass_hero_web/live/user_live/settings.ex:267
+#: lib/klass_hero_web/live/user_live/settings.ex:191
 #, elixir-autogen, elixir-format
 msgid "English"
 msgstr "Englisch"
 
-#: lib/klass_hero_web/live/user_live/registration.ex:60
+#: lib/klass_hero_web/live/user_live/registration.ex:71
 #, elixir-autogen, elixir-format
 msgid "Enroll children in programs"
 msgstr "Kinder für Programme anmelden"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:438
+#: lib/klass_hero_web/live/user_live/settings.ex:294
 #, elixir-autogen, elixir-format
 msgid "Enter your password to confirm"
 msgstr "Geben Sie Ihr Passwort zur Bestätigung ein"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:85
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:85
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:49
 #, elixir-autogen, elixir-format
 msgid "Failed to check in: %{reason}"
 msgstr "Einchecken fehlgeschlagen: %{reason}"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:150
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:150
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:84
 #, elixir-autogen, elixir-format
 msgid "Failed to check out: %{reason}"
 msgstr "Auschecken fehlgeschlagen: %{reason}"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:134
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:119
+#: lib/klass_hero_web/live/provider/sessions_live.ex:158
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:117
 #, elixir-autogen, elixir-format
 msgid "Failed to complete session: %{reason}"
 msgstr "Sitzung konnte nicht abgeschlossen werden: %{reason}"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:655
+#: lib/klass_hero_web/live/user_live/settings.ex:508
 #, elixir-autogen, elixir-format
 msgid "Failed to delete account. Please try again."
 msgstr "Konto konnte nicht gelöscht werden. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:399
-#: lib/klass_hero_web/live/provider/participation_live.ex:400
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:354
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:355
-#, elixir-autogen, elixir-format
-msgid "Failed to load session data"
-msgstr "Sitzungsdaten konnten nicht geladen werden"
-
-#: lib/klass_hero_web/live/provider/sessions_live.ex:111
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:90
+#: lib/klass_hero_web/live/provider/sessions_live.ex:135
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:88
 #, elixir-autogen, elixir-format
 msgid "Failed to start session: %{reason}"
 msgstr "Sitzung konnte nicht gestartet werden: %{reason}"
 
-#: lib/klass_hero_web/live/user_live/registration.ex:63
+#: lib/klass_hero_web/live/user_live/registration.ex:74
 #, elixir-autogen, elixir-format
 msgid "Find and book activities, camps, and classes for your children"
 msgstr "Aktivitäten, Camps und Kurse für Ihre Kinder finden und buchen"
 
-#: lib/klass_hero_web/live/contact_live.ex:149
+#: lib/klass_hero_web/live/contact_live.ex:89
 #, elixir-autogen, elixir-format
 msgid "General Inquiry"
 msgstr "Allgemeine Anfrage"
 
-#: lib/klass_hero_web/live/contact_live.ex:194
-#, elixir-autogen, elixir-format
-msgid "Get in Touch"
-msgstr "Kontaktieren Sie uns"
-
-#: lib/klass_hero_web/live/privacy_policy_live.ex:75
+#: lib/klass_hero_web/live/privacy_policy_live.ex:79
 #, elixir-autogen, elixir-format
 msgid "How We Use Your Information"
 msgstr "Wie wir Ihre Daten verwenden"
 
-#: lib/klass_hero_web/live/user_live/registration.ex:46
+#: lib/klass_hero_web/live/user_live/registration.ex:55
 #, elixir-autogen, elixir-format
 msgid "I want to..."
 msgstr "Ich möchte..."
 
-#: lib/klass_hero_web/live/user_live/login.ex:142
+#: lib/klass_hero_web/live/user_live/login.ex:170
 #, elixir-autogen, elixir-format
 msgid "If your email is in our system, you will receive instructions for logging in shortly."
 msgstr "Wenn Ihre E-Mail in unserem System ist, erhalten Sie in Kürze Anweisungen zum Anmelden."
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:34
+#: lib/klass_hero_web/live/privacy_policy_live.ex:38
 #, elixir-autogen, elixir-format
 msgid "Information We Collect"
 msgstr "Daten, die wir erheben"
 
-#: lib/klass_hero_web/live/contact_live.ex:152
+#: lib/klass_hero_web/live/contact_live.ex:92
 #, elixir-autogen, elixir-format
 msgid "Instructor Application"
 msgstr "Kursleiter-Bewerbung"
 
-#: lib/klass_hero_web/live/terms_of_service_live.ex:173
+#: lib/klass_hero_web/live/terms_of_service_live.ex:165
 #, elixir-autogen, elixir-format
 msgid "Intellectual Property"
 msgstr "Geistiges Eigentum"
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:23
+#: lib/klass_hero_web/live/privacy_policy_live.ex:27
 #, elixir-autogen, elixir-format
 msgid "Introduction"
 msgstr "Einleitung"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:89
-#: lib/klass_hero_web/live/provider/sessions_live.ex:336
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:66
+#: lib/klass_hero_web/live/provider/sessions_live.ex:113
+#: lib/klass_hero_web/live/provider/sessions_live.ex:348
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:64
 #, elixir-autogen, elixir-format
 msgid "Invalid date format"
 msgstr "Ungültiges Datumsformat"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:649
+#: lib/klass_hero_web/live/user_live/settings.ex:502
 #, elixir-autogen, elixir-format
 msgid "Invalid password."
 msgstr "Ungültiges Passwort."
 
-#: lib/klass_hero_web/live/user_live/confirmation.ex:62
+#: lib/klass_hero_web/live/user_live/confirmation.ex:92
 #, elixir-autogen, elixir-format
 msgid "Keep me logged in on this device"
 msgstr "Auf diesem Gerät angemeldet bleiben"
 
-#: lib/klass_hero_web/components/composite_components.ex:739
+#: lib/klass_hero_web/components/composite_components.ex:602
 #, elixir-autogen, elixir-format
 msgid "Last Updated:"
 msgstr "Zuletzt aktualisiert:"
 
-#: lib/klass_hero_web/live/terms_of_service_live.ex:151
+#: lib/klass_hero_web/live/terms_of_service_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "Limitation of Liability"
 msgstr "Haftungsbeschränkung"
 
-#: lib/klass_hero_web/live/user_live/confirmation.ex:53
-#: lib/klass_hero_web/live/user_live/registration.ex:19
+#: lib/klass_hero_web/live/user_live/confirmation.ex:80
+#: lib/klass_hero_web/live/user_live/registration.ex:23
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:96
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr "Anmelden"
 
-#: lib/klass_hero_web/live/user_live/login.ex:93
+#: lib/klass_hero_web/live/user_live/login.ex:113
 #, elixir-autogen, elixir-format
 msgid "Log in and stay logged in"
 msgstr "Anmelden und angemeldet bleiben"
 
-#: lib/klass_hero_web/live/user_live/login.ex:96
+#: lib/klass_hero_web/live/user_live/login.ex:116
 #, elixir-autogen, elixir-format
 msgid "Log in only this time"
 msgstr "Nur dieses Mal anmelden"
 
-#: lib/klass_hero_web/live/user_live/confirmation.ex:68
+#: lib/klass_hero_web/live/user_live/confirmation.ex:101
 #, elixir-autogen, elixir-format
 msgid "Log me in only this time"
 msgstr "Nur dieses Mal anmelden"
 
-#: lib/klass_hero_web/live/user_live/confirmation.ex:52
-#: lib/klass_hero_web/live/user_live/confirmation.ex:59
-#: lib/klass_hero_web/live/user_live/confirmation.ex:65
+#: lib/klass_hero_web/live/user_live/confirmation.ex:77
+#: lib/klass_hero_web/live/user_live/confirmation.ex:89
+#: lib/klass_hero_web/live/user_live/confirmation.ex:98
 #, elixir-autogen, elixir-format
 msgid "Logging in..."
 msgstr "Anmeldung läuft..."
 
-#: lib/klass_hero_web/live/contact_live.ex:250
-#, elixir-autogen, elixir-format
-msgid "Looking for Quick Answers?"
-msgstr "Suchen Sie schnelle Antworten?"
-
-#: lib/klass_hero_web/live/user_live/confirmation.ex:90
+#: lib/klass_hero_web/live/user_live/confirmation.ex:133
 #, elixir-autogen, elixir-format
 msgid "Magic link is invalid or it has expired."
 msgstr "Der Magic-Link ist ungültig oder abgelaufen."
 
-#: lib/klass_hero_web/live/contact_live.ex:162
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:158
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:194
+#: lib/klass_hero_web/live/contact_live.ex:170
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:178
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr "Nachricht"
 
-#: lib/klass_hero_web/live/contact_live.ex:173
+#: lib/klass_hero_web/live/contact_live.ex:129
 #, elixir-autogen, elixir-format
 msgid "Message sent successfully!"
 msgstr "Nachricht erfolgreich gesendet!"
 
-#: lib/klass_hero_web/live/contact_live.ex:98
-#, elixir-autogen, elixir-format
-msgid "Monday - Friday"
-msgstr "Montag - Freitag"
-
-#: lib/klass_hero_web/live/dashboard_live.ex:193
-#, elixir-autogen, elixir-format
-msgid "My Children"
-msgstr "Meine Kinder"
-
-#: lib/klass_hero_web/live/provider/sessions_live.ex:35
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:5
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:24
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:230
+#: lib/klass_hero_web/live/provider/sessions_live.ex:47
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:4
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:21
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "My Sessions"
 msgstr "Meine Sitzungen"
 
-#: lib/klass_hero_web/live/contact_live.ex:139
-#: lib/klass_hero_web/live/user_live/registration.ex:30
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:53
+#: lib/klass_hero_web/live/contact_live.ex:147
+#: lib/klass_hero_web/live/user_live/registration.ex:41
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:62
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr "Name"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:192
+#: lib/klass_hero_web/live/user_live/settings.ex:140
 #, elixir-autogen, elixir-format
 msgid "New password"
 msgstr "Neues Passwort"
 
-#: lib/klass_hero_web/live/user_live/registration.ex:77
+#: lib/klass_hero_web/live/user_live/registration.ex:88
 #, elixir-autogen, elixir-format
 msgid "Offer programs and services"
 msgstr "Programme und Dienstleistungen anbieten"
 
-#: lib/klass_hero_web/live/contact_live.ex:226
-#, elixir-autogen, elixir-format
-msgid "Office Hours"
-msgstr "Bürozeiten"
-
-#: lib/klass_hero_web/live/user_live/login.ex:105
+#: lib/klass_hero_web/live/user_live/login.ex:126
 #, elixir-autogen, elixir-format
 msgid "Or use magic link"
 msgstr "Oder Magic-Link verwenden"
 
-#: lib/klass_hero_web/live/user_live/login.ex:64
+#: lib/klass_hero_web/live/user_live/login.ex:74
 #, elixir-autogen, elixir-format
 msgid "Or use password"
 msgstr "Oder Passwort verwenden"
 
-#: lib/klass_hero_web/live/contact_live.ex:154
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:231
-#: lib/klass_hero_web/presenters/provider_presenter.ex:129
+#: lib/klass_hero_web/live/contact_live.ex:94
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:241
+#: lib/klass_hero_web/presenters/provider_presenter.ex:97
 #, elixir-autogen, elixir-format
 msgid "Other"
 msgstr "Sonstiges"
 
-#: lib/klass_hero_web/live/user_live/login.ex:89
-#: lib/klass_hero_web/live/user_live/settings.ex:170
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:68
+#: lib/klass_hero_web/live/user_live/login.ex:96
+#: lib/klass_hero_web/live/user_live/settings.ex:119
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:73
 #, elixir-autogen, elixir-format
 msgid "Password"
 msgstr "Passwort"
 
-#: lib/klass_hero_web/live/terms_of_service_live.ex:77
+#: lib/klass_hero_web/live/terms_of_service_live.ex:81
 #, elixir-autogen, elixir-format
 msgid "Payment Terms"
 msgstr "Zahlungsbedingungen"
 
-#: lib/klass_hero_web/live/contact_live.ex:73
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:232
+#: lib/klass_hero_web/live/contact_live.ex:72
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:239
 #, elixir-autogen, elixir-format
 msgid "Phone"
 msgstr "Telefon"
 
-#: lib/klass_hero_web/components/composite_components.ex:676
-#: lib/klass_hero_web/live/privacy_policy_live.ex:10
-#: lib/klass_hero_web/live/privacy_policy_live.ex:235
+#: lib/klass_hero_web/components/composite_components.ex:541
+#: lib/klass_hero_web/live/privacy_policy_live.ex:11
+#: lib/klass_hero_web/live/privacy_policy_live.ex:239
 #, elixir-autogen, elixir-format
 msgid "Privacy Policy"
 msgstr "Datenschutzerklärung"
 
-#: lib/klass_hero_web/live/terms_of_service_live.ex:56
+#: lib/klass_hero_web/live/terms_of_service_live.ex:60
 #, elixir-autogen, elixir-format
 msgid "Program Enrollment & Bookings"
 msgstr "Programm-Anmeldung & Buchungen"
 
-#: lib/klass_hero_web/live/contact_live.ex:150
+#: lib/klass_hero_web/live/contact_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "Program Question"
 msgstr "Programmfrage"
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:239
+#: lib/klass_hero_web/live/privacy_policy_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "Questions About Privacy?"
 msgstr "Fragen zum Datenschutz?"
 
-#: lib/klass_hero_web/live/terms_of_service_live.ex:272
+#: lib/klass_hero_web/live/terms_of_service_live.ex:264
 #, elixir-autogen, elixir-format
 msgid "Questions About These Terms?"
 msgstr "Fragen zu diesen Bedingungen?"
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:270
-#: lib/klass_hero_web/live/provider/participation_live.ex:60
-#: lib/klass_hero_web/live/provider/participation_live.ex:122
-#: lib/klass_hero_web/live/provider/participation_live.ex:269
-#: lib/klass_hero_web/live/provider/participation_live.ex:315
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:60
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:122
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:208
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:254
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:29
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:61
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:94
+#: lib/klass_hero_web/live/admin/sessions_live.ex:251
+#: lib/klass_hero_web/live/provider/participation_live.ex:176
+#: lib/klass_hero_web/live/provider/participation_live.ex:222
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:118
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:164
 #, elixir-autogen, elixir-format
 msgid "Record not found"
 msgstr "Eintrag nicht gefunden"
 
-#: lib/klass_hero_web/live/user_live/login.ex:22
+#: lib/klass_hero_web/live/user_live/login.ex:26
 #, elixir-autogen, elixir-format
 msgid "Register"
 msgstr "Registrieren"
 
-#: lib/klass_hero_web/live/user_live/registration.ex:15
-#, elixir-autogen, elixir-format
-msgid "Register for an account"
-msgstr "Konto registrieren"
-
-#: lib/klass_hero_web/live/contact_live.ex:99
-#, elixir-autogen, elixir-format
-msgid "Saturday"
-msgstr "Samstag"
-
-#: lib/klass_hero_web/live/user_live/settings.ex:203
+#: lib/klass_hero_web/live/user_live/settings.ex:151
 #, elixir-autogen, elixir-format
 msgid "Save Password"
 msgstr "Passwort speichern"
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:317
-#: lib/klass_hero_web/live/settings/children_live.ex:765
-#: lib/klass_hero_web/live/user_live/settings.ex:202
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:324
+#: lib/klass_hero_web/live/settings/children_live.ex:743
+#: lib/klass_hero_web/live/user_live/settings.ex:150
 #, elixir-autogen, elixir-format
 msgid "Saving..."
 msgstr "Speichern..."
 
-#: lib/klass_hero_web/live/contact_live.ex:147
-#, elixir-autogen, elixir-format
-msgid "Select a topic..."
-msgstr "Thema auswählen..."
-
-#: lib/klass_hero_web/live/user_live/registration.ex:48
+#: lib/klass_hero_web/live/user_live/registration.ex:58
 #, elixir-autogen, elixir-format
 msgid "Select one or both options"
 msgstr "Wählen Sie eine oder beide Optionen"
 
-#: lib/klass_hero_web/live/user_live/login.ex:55
-#, elixir-autogen, elixir-format
-msgid "Send Magic Link"
-msgstr "Magic-Link senden"
-
-#: lib/klass_hero_web/components/provider_components.ex:1802
-#: lib/klass_hero_web/components/provider_components.ex:1803
-#: lib/klass_hero_web/components/provider_components.ex:1842
-#: lib/klass_hero_web/live/contact_live.ex:184
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:290
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:291
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:329
+#: lib/klass_hero_web/components/provider_components.ex:1755
+#: lib/klass_hero_web/components/provider_components.ex:1756
+#: lib/klass_hero_web/components/provider_components.ex:1793
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:448
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:484
 #, elixir-autogen, elixir-format
 msgid "Send Message"
 msgstr "Nachricht senden"
 
-#: lib/klass_hero_web/live/contact_live.ex:128
-#, elixir-autogen, elixir-format
-msgid "Send us a Message"
-msgstr "Schreiben Sie uns eine Nachricht"
-
-#: lib/klass_hero_web/live/provider/sessions_live.ex:120
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:105
+#: lib/klass_hero_web/live/provider/sessions_live.ex:144
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:103
 #, elixir-autogen, elixir-format
 msgid "Session completed successfully"
 msgstr "Sitzung erfolgreich abgeschlossen"
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:69
-#: lib/klass_hero_web/live/admin/sessions_live.ex:75
-#: lib/klass_hero_web/live/provider/participation_live.ex:388
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:343
+#: lib/klass_hero_web/live/admin/sessions_live.ex:67
+#: lib/klass_hero_web/live/admin/sessions_live.ex:73
+#: lib/klass_hero_web/live/provider/participation_live.ex:270
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:229
 #, elixir-autogen, elixir-format
 msgid "Session not found"
 msgstr "Sitzung nicht gefunden"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:97
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:76
+#: lib/klass_hero_web/live/provider/sessions_live.ex:121
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:74
 #, elixir-autogen, elixir-format
 msgid "Session started successfully"
 msgstr "Sitzung erfolgreich gestartet"
 
-#: lib/klass_hero_web/live/contact_live.ex:146
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:144
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:180
+#: lib/klass_hero_web/live/contact_live.ex:162
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:164
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "Subject"
 msgstr "Betreff"
 
-#: lib/klass_hero_web/live/contact_live.ex:100
-#, elixir-autogen, elixir-format
-msgid "Sunday"
-msgstr "Sonntag"
-
-#: lib/klass_hero_web/components/composite_components.ex:747
+#: lib/klass_hero_web/components/composite_components.ex:610
 #, elixir-autogen, elixir-format
 msgid "Table of Contents"
 msgstr "Inhaltsverzeichnis"
 
-#: lib/klass_hero_web/live/contact_live.ex:153
+#: lib/klass_hero_web/live/contact_live.ex:93
 #, elixir-autogen, elixir-format
 msgid "Technical Issue"
 msgstr "Technisches Problem"
 
-#: lib/klass_hero_web/components/composite_components.ex:678
-#: lib/klass_hero_web/live/terms_of_service_live.ex:10
-#: lib/klass_hero_web/live/terms_of_service_live.ex:268
+#: lib/klass_hero_web/components/composite_components.ex:543
+#: lib/klass_hero_web/live/terms_of_service_live.ex:11
+#: lib/klass_hero_web/live/terms_of_service_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "Terms of Service"
 msgstr "Nutzungsbedingungen"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:425
+#: lib/klass_hero_web/live/user_live/settings.ex:281
 #, elixir-autogen, elixir-format
 msgid "This action cannot be undone. Your account data will be anonymized and you will be logged out."
 msgstr "Diese Aktion kann nicht rückgängig gemacht werden. Ihre Kontodaten werden anonymisiert und Sie werden abgemeldet."
 
-#: lib/klass_hero_web/live/user_live/confirmation.ex:74
+#: lib/klass_hero_web/live/user_live/confirmation.ex:110
 #, elixir-autogen, elixir-format
 msgid "Tip: If you prefer passwords, you can enable them in the user settings."
 msgstr "Tipp: Wenn Sie Passwörter bevorzugen, können Sie diese in den Benutzereinstellungen aktivieren."
 
-#: lib/klass_hero_web/live/user_live/login.ex:32
+#: lib/klass_hero_web/live/user_live/login.ex:40
 #, elixir-autogen, elixir-format
 msgid "To see sent emails, visit"
 msgstr "Um gesendete E-Mails zu sehen, besuchen Sie"
 
-#: lib/klass_hero_web/live/terms_of_service_live.ex:269
+#: lib/klass_hero_web/live/terms_of_service_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "Understanding our agreement with you"
 msgstr "Unsere Vereinbarung mit Ihnen verstehen"
 
-#: lib/klass_hero_web/live/terms_of_service_live.ex:34
+#: lib/klass_hero_web/live/terms_of_service_live.ex:38
 #, elixir-autogen, elixir-format
 msgid "User Accounts & Registration"
 msgstr "Benutzerkonten & Registrierung"
 
-#: lib/klass_hero_web/live/terms_of_service_live.ex:126
+#: lib/klass_hero_web/live/terms_of_service_live.ex:118
 #, elixir-autogen, elixir-format
 msgid "User Conduct & Responsibilities"
 msgstr "Nutzerverhalten & Verantwortlichkeiten"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:196
-#, elixir-autogen, elixir-format
-msgid "View All"
-msgstr "Alle Anzeigen"
-
-#: lib/klass_hero_web/live/contact_live.ex:256
-#, elixir-autogen, elixir-format
-msgid "Visit FAQ"
-msgstr "FAQ besuchen"
-
-#: lib/klass_hero_web/live/contact_live.ex:67
-#, elixir-autogen, elixir-format
-msgid "We respond within 24 hours"
-msgstr "Wir antworten innerhalb von 24 Stunden"
-
-#: lib/klass_hero_web/live/contact_live.ex:176
-#, elixir-autogen, elixir-format
-msgid "We'll get back to you within 24 hours."
-msgstr "Wir melden uns innerhalb von 24 Stunden bei Ihnen."
-
-#: lib/klass_hero_web/live/terms_of_service_live.ex:273
+#: lib/klass_hero_web/live/terms_of_service_live.ex:265
 #, elixir-autogen, elixir-format
 msgid "We're here to clarify any questions you may have."
 msgstr "Wir sind hier, um alle Ihre Fragen zu klären."
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:240
+#: lib/klass_hero_web/live/privacy_policy_live.ex:244
 #, elixir-autogen, elixir-format
 msgid "We're here to help with any privacy-related concerns."
 msgstr "Wir sind hier, um bei allen datenschutzbezogenen Fragen zu helfen."
 
-#: lib/klass_hero_web/live/contact_live.ex:115
-#, elixir-autogen, elixir-format
-msgid "We're here to help with any questions you may have"
-msgstr "Wir sind hier, um Ihnen bei allen Fragen zu helfen"
-
-#: lib/klass_hero_web/live/user_live/confirmation.ex:12
-#, elixir-autogen, elixir-format
-msgid "Welcome %{email}"
-msgstr "Willkommen %{email}"
-
-#: lib/klass_hero_web/live/user_live/login.ex:13
-#, elixir-autogen, elixir-format
-msgid "Welcome Back"
-msgstr "Willkommen zurück"
-
-#: lib/klass_hero_web/live/user_live/login.ex:30
+#: lib/klass_hero_web/live/user_live/login.ex:38
 #, elixir-autogen, elixir-format
 msgid "You are running the local mail adapter."
 msgstr "Sie verwenden den lokalen E-Mail-Adapter."
 
-#: lib/klass_hero_web/user_auth.ex:368
+#: lib/klass_hero_web/user_auth.ex:326
 #, elixir-autogen, elixir-format
 msgid "You must be authenticated to access this page."
 msgstr "Sie müssen angemeldet sein, um auf diese Seite zuzugreifen."
 
-#: lib/klass_hero_web/user_auth.ex:281
+#: lib/klass_hero_web/user_auth.ex:250
 #, elixir-autogen, elixir-format
 msgid "You must have a parent profile to access this page."
 msgstr "Sie müssen ein Eltern-Profil haben, um auf diese Seite zuzugreifen."
 
-#: lib/klass_hero_web/user_auth.ex:290
+#: lib/klass_hero_web/user_auth.ex:259
 #, elixir-autogen, elixir-format
 msgid "You must have a provider profile to access this page."
 msgstr "Sie müssen ein Anbieter-Profil haben, um auf diese Seite zuzugreifen."
 
-#: lib/klass_hero_web/user_auth.ex:251
-#: lib/klass_hero_web/user_auth.ex:417
+#: lib/klass_hero_web/user_auth.ex:220
+#: lib/klass_hero_web/user_auth.ex:363
 #, elixir-autogen, elixir-format
 msgid "You must log in to access this page."
 msgstr "Sie müssen sich anmelden, um auf diese Seite zuzugreifen."
 
-#: lib/klass_hero_web/user_auth.ex:268
+#: lib/klass_hero_web/user_auth.ex:237
 #, elixir-autogen, elixir-format
 msgid "You must re-authenticate to access this page."
 msgstr "Sie müssen sich erneut authentifizieren, um auf diese Seite zuzugreifen."
 
-#: lib/klass_hero_web/live/user_live/login.ex:16
+#: lib/klass_hero_web/live/user_live/login.ex:19
 #, elixir-autogen, elixir-format
 msgid "You need to reauthenticate to perform sensitive actions on your account."
 msgstr "Sie müssen sich erneut authentifizieren, um sensible Aktionen auf Ihrem Konto durchzuführen."
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:110
+#: lib/klass_hero_web/live/privacy_policy_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "Your Privacy Rights"
 msgstr "Ihre Datenschutzrechte"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:637
+#: lib/klass_hero_web/live/user_live/settings.ex:490
 #, elixir-autogen, elixir-format
 msgid "Your account has been deleted."
 msgstr "Ihr Konto wurde gelöscht."
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:236
+#: lib/klass_hero_web/live/privacy_policy_live.ex:240
 #, elixir-autogen, elixir-format
 msgid "Your privacy matters to us"
 msgstr "Ihre Privatsphäre ist uns wichtig"
 
-#: lib/klass_hero_web/live/user_live/login.ex:22
-#, elixir-autogen, elixir-format
-msgid "for an account now."
-msgstr "für ein Konto jetzt."
-
-#: lib/klass_hero_web/live/user_live/login.ex:32
+#: lib/klass_hero_web/live/user_live/login.ex:42
 #, elixir-autogen, elixir-format
 msgid "the mailbox page"
 msgstr "die Postfach-Seite"
 
-#: lib/klass_hero_web/live/user_live/registration.ex:21
-#, elixir-autogen, elixir-format
-msgid "to your account now."
-msgstr "zu Ihrem Konto jetzt."
-
-#: lib/klass_hero_web/components/composite_components.ex:622
+#: lib/klass_hero_web/components/composite_components.ex:487
 #, elixir-autogen, elixir-format
 msgid "Afterschool"
 msgstr "Nachmittagsbetreuung"
 
-#: lib/klass_hero_web/components/composite_components.ex:673
+#: lib/klass_hero_web/components/composite_components.ex:538
 #, elixir-autogen, elixir-format
 msgid "All rights reserved."
 msgstr "Alle Rechte vorbehalten."
 
-#: lib/klass_hero_web/components/composite_components.ex:594
+#: lib/klass_hero_web/components/composite_components.ex:454
 #, elixir-autogen, elixir-format
 msgid "Building the future of youth education by connecting communities."
 msgstr "Wir gestalten die Zukunft der Jugendbildung durch die Vernetzung von Gemeinschaften."
 
-#: lib/klass_hero_web/components/composite_components.ex:630
+#: lib/klass_hero_web/components/composite_components.ex:495
 #, elixir-autogen, elixir-format
 msgid "Class Trips"
 msgstr "Klassenfahrten"
 
-#: lib/klass_hero_web/components/composite_components.ex:639
+#: lib/klass_hero_web/components/composite_components.ex:504
 #, elixir-autogen, elixir-format
 msgid "Connect"
 msgstr "Verbinden"
 
-#: lib/klass_hero_web/components/composite_components.ex:633
+#: lib/klass_hero_web/components/composite_components.ex:498
 #, elixir-autogen, elixir-format
 msgid "Enrichment"
 msgstr "Bereicherung"
 
-#: lib/klass_hero_web/components/composite_components.ex:599
+#: lib/klass_hero_web/components/composite_components.ex:459
 #, elixir-autogen, elixir-format
 msgid "Quick Links"
 msgstr "Schnellzugriffe"
 
-#: lib/klass_hero_web/components/composite_components.ex:626
+#: lib/klass_hero_web/components/composite_components.ex:491
 #, elixir-autogen, elixir-format
 msgid "Summer Camps"
 msgstr "Sommercamps"
 
-#: lib/klass_hero_web/live/settings_live.ex:61
+#: lib/klass_hero_web/live/settings_live.ex:56
 #, elixir-autogen, elixir-format
 msgid "Account & Profile"
 msgstr "Konto & Profil"
 
-#: lib/klass_hero_web/live/settings_live.ex:76
+#: lib/klass_hero_web/live/settings_live.ex:69
 #, elixir-autogen, elixir-format
 msgid "Account preferences, password"
 msgstr "Kontoeinstellungen, Passwort"
 
-#: lib/klass_hero_web/live/settings_live.ex:106
+#: lib/klass_hero_web/live/settings_live.ex:95
 #, elixir-autogen, elixir-format
 msgid "Achievements and milestones"
 msgstr "Erfolge und Meilensteine"
 
-#: lib/klass_hero_web/live/settings_live.ex:186
+#: lib/klass_hero_web/live/settings_live.ex:159
 #, elixir-autogen, elixir-format
 msgid "Activity Permissions"
 msgstr "Aktivitätsberechtigungen"
 
-#: lib/klass_hero_web/live/settings_live.ex:156
+#: lib/klass_hero_web/live/settings_live.ex:135
 #, elixir-autogen, elixir-format
 msgid "Allergies & Dietary"
 msgstr "Allergien & Ernährung"
 
-#: lib/klass_hero_web/live/settings_live.ex:276
+#: lib/klass_hero_web/live/settings_live.ex:231
 #, elixir-autogen, elixir-format
 msgid "App Information"
 msgstr "App-Informationen"
 
-#: lib/klass_hero_web/live/settings_live.ex:226
+#: lib/klass_hero_web/live/settings_live.ex:191
 #, elixir-autogen, elixir-format
 msgid "Available credits and promo codes"
 msgstr "Verfügbare Guthaben und Aktionscodes"
 
-#: lib/klass_hero_web/live/settings_live.ex:136
+#: lib/klass_hero_web/live/settings_live.ex:119
 #, elixir-autogen, elixir-format
 msgid "Backup contacts for emergencies"
 msgstr "Backup-Kontakte für Notfälle"
 
-#: lib/klass_hero_web/live/settings_live.ex:208
+#: lib/klass_hero_web/live/settings_live.ex:177
 #, elixir-autogen, elixir-format
 msgid "Cards, bank accounts, billing info"
 msgstr "Karten, Bankkonten, Rechnungsinformationen"
 
 #: lib/klass_hero_web/live/settings/children_live.ex:23
-#: lib/klass_hero_web/live/settings/children_live.ex:367
-#: lib/klass_hero_web/live/settings_live.ex:88
-#: lib/klass_hero_web/live/user_live/settings.ex:48
-#: lib/klass_hero_web/live/user_live/settings.ex:347
+#: lib/klass_hero_web/live/settings/children_live.ex:348
+#: lib/klass_hero_web/live/settings_live.ex:79
+#: lib/klass_hero_web/live/user_live/settings.ex:235
 #, elixir-autogen, elixir-format
 msgid "Children Profiles"
 msgstr "Kinderprofile"
 
-#: lib/klass_hero_web/live/settings_live.ex:259
+#: lib/klass_hero_web/live/settings_live.ex:218
 #, elixir-autogen, elixir-format
 msgid "Common questions and guides"
 msgstr "Häufige Fragen und Anleitungen"
 
-#: lib/klass_hero_web/live/settings_live.ex:246
+#: lib/klass_hero_web/live/settings_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Communication Settings"
 msgstr "Kommunikationseinstellungen"
 
-#: lib/klass_hero_web/live/settings_live.ex:148
+#: lib/klass_hero_web/live/settings_live.ex:129
 #, elixir-autogen, elixir-format
 msgid "Conditions, medications, special needs"
 msgstr "Krankheiten, Medikamente, besondere Bedürfnisse"
 
-#: lib/klass_hero_web/live/settings_live.ex:267
+#: lib/klass_hero_web/live/settings_live.ex:224
 #, elixir-autogen, elixir-format
 msgid "Contact Support"
 msgstr "Support kontaktieren"
 
-#: lib/klass_hero_web/live/settings_live.ex:127
+#: lib/klass_hero_web/live/settings_live.ex:112
 #, elixir-autogen, elixir-format
 msgid "Contact info for both parents"
 msgstr "Kontaktinformationen beider Elternteile"
 
-#: lib/klass_hero_web/live/settings_live.ex:135
+#: lib/klass_hero_web/live/settings_live.ex:118
 #, elixir-autogen, elixir-format
 msgid "Emergency Contacts"
 msgstr "Notfallkontakte"
 
-#: lib/klass_hero_web/live/settings_live.ex:258
+#: lib/klass_hero_web/live/settings_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "FAQ & Help Center"
 msgstr "FAQ & Hilfezentrum"
 
-#: lib/klass_hero_web/live/settings_live.ex:225
+#: lib/klass_hero_web/live/settings_live.ex:190
 #, elixir-autogen, elixir-format
 msgid "Family Credits & Discounts"
 msgstr "Familienguthaben & Rabatte"
 
-#: lib/klass_hero_web/live/settings_live.ex:105
+#: lib/klass_hero_web/live/settings_live.ex:94
 #, elixir-autogen, elixir-format
 msgid "Family Progress"
 msgstr "Familienfortschritt"
 
-#: lib/klass_hero_web/live/settings_live.ex:157
+#: lib/klass_hero_web/live/settings_live.ex:136
 #, elixir-autogen, elixir-format
 msgid "Food allergies, dietary restrictions"
 msgstr "Nahrungsmittelallergien, Ernährungseinschränkungen"
 
-#: lib/klass_hero_web/live/settings_live.ex:268
+#: lib/klass_hero_web/live/settings_live.ex:225
 #, elixir-autogen, elixir-format
 msgid "Get help from our team"
 msgstr "Holen Sie sich Hilfe von unserem Team"
 
-#: lib/klass_hero_web/live/settings_live.ex:142
+#: lib/klass_hero_web/live/settings_live.ex:123
 #, elixir-autogen, elixir-format
 msgid "Health & Safety"
 msgstr "Gesundheit & Sicherheit"
 
-#: lib/klass_hero_web/live/settings_live.ex:166
+#: lib/klass_hero_web/live/settings_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "Health insurance details"
 msgstr "Krankenversicherungsdetails"
 
-#: lib/klass_hero_web/live/settings_live.ex:253
+#: lib/klass_hero_web/live/settings_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Help & Support"
 msgstr "Hilfe & Support"
 
-#: lib/klass_hero_web/live/settings_live.ex:117
+#: lib/klass_hero_web/live/settings_live.ex:104
 #, elixir-autogen, elixir-format
 msgid "Home Address"
 msgstr "Wohnadresse"
 
-#: lib/klass_hero_web/live/settings_live.ex:247
+#: lib/klass_hero_web/live/settings_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "How you want to be contacted"
 msgstr "Wie Sie kontaktiert werden möchten"
 
-#: lib/klass_hero_web/live/settings_live.ex:165
+#: lib/klass_hero_web/live/settings_live.ex:142
 #, elixir-autogen, elixir-format
 msgid "Insurance Information"
 msgstr "Versicherungsinformationen"
@@ -1378,129 +1220,128 @@ msgstr "Versicherungsinformationen"
 msgid "Invalid email or password"
 msgstr "Ungültige E-Mail oder Passwort"
 
-#: lib/klass_hero_web/live/settings_live.ex:286
+#: lib/klass_hero_web/live/settings_live.ex:239
 #, elixir-autogen, elixir-format
 msgid "Log out of your account"
 msgstr "Melden Sie sich von Ihrem Konto ab"
 
-#: lib/klass_hero_web/controllers/user_session_controller.ex:64
+#: lib/klass_hero_web/controllers/user_session_controller.ex:63
 #, elixir-autogen, elixir-format
 msgid "Logged out successfully."
 msgstr "Erfolgreich abgemeldet."
 
-#: lib/klass_hero_web/live/settings_live.ex:57
-#: lib/klass_hero_web/live/user_live/settings.ex:18
+#: lib/klass_hero_web/live/settings_live.ex:52
 #, elixir-autogen, elixir-format
 msgid "Manage your account and preferences"
 msgstr "Verwalten Sie Ihr Konto und Ihre Einstellungen"
 
-#: lib/klass_hero_web/live/settings_live.ex:178
+#: lib/klass_hero_web/live/settings_live.ex:153
 #, elixir-autogen, elixir-format
 msgid "Marketing and social media permissions"
 msgstr "Marketing- und Social-Media-Berechtigungen"
 
-#: lib/klass_hero_web/live/settings_live.ex:147
+#: lib/klass_hero_web/live/settings_live.ex:128
 #, elixir-autogen, elixir-format
 msgid "Medical Information"
 msgstr "Medizinische Informationen"
 
-#: lib/klass_hero_web/live/settings_live.ex:82
-#: lib/klass_hero_web/live/user_live/settings.ex:317
+#: lib/klass_hero_web/live/settings_live.ex:73
+#: lib/klass_hero_web/live/user_live/settings.ex:221
 #, elixir-autogen, elixir-format
 msgid "My Family"
 msgstr "Meine Familie"
 
-#: lib/klass_hero_web/live/settings_live.ex:96
+#: lib/klass_hero_web/live/settings_live.ex:87
 #, elixir-autogen, elixir-format
 msgid "My Schedule"
 msgstr "Mein Zeitplan"
 
-#: lib/klass_hero_web/live/settings_live.ex:67
+#: lib/klass_hero_web/live/settings_live.ex:62
 #, elixir-autogen, elixir-format
 msgid "Name, email, profile photo"
 msgstr "Name, E-Mail, Profilbild"
 
-#: lib/klass_hero_web/live/settings_live.ex:237
+#: lib/klass_hero_web/live/settings_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "Notification Preferences"
 msgstr "Benachrichtigungseinstellungen"
 
-#: lib/klass_hero_web/live/settings_live.ex:232
+#: lib/klass_hero_web/live/settings_live.ex:195
 #, elixir-autogen, elixir-format
 msgid "Notifications & Communication"
 msgstr "Benachrichtigungen & Kommunikation"
 
-#: lib/klass_hero_web/live/settings_live.ex:126
+#: lib/klass_hero_web/live/settings_live.ex:111
 #, elixir-autogen, elixir-format
 msgid "Parent/Guardian Details"
 msgstr "Eltern-/Erziehungsberechtigtendetails"
 
-#: lib/klass_hero_web/controllers/user_session_controller.ex:59
+#: lib/klass_hero_web/controllers/user_session_controller.ex:58
 #, elixir-autogen, elixir-format
 msgid "Password updated successfully!"
 msgstr "Passwort erfolgreich aktualisiert!"
 
-#: lib/klass_hero_web/live/settings_live.ex:217
+#: lib/klass_hero_web/live/settings_live.ex:184
 #, elixir-autogen, elixir-format
 msgid "Past payments and invoices"
 msgstr "Vergangene Zahlungen und Rechnungen"
 
-#: lib/klass_hero_web/live/settings_live.ex:202
+#: lib/klass_hero_web/live/settings_live.ex:171
 #, elixir-autogen, elixir-format
 msgid "Payment & Billing"
 msgstr "Zahlung & Abrechnung"
 
-#: lib/klass_hero_web/live/settings_live.ex:207
+#: lib/klass_hero_web/live/settings_live.ex:176
 #, elixir-autogen, elixir-format
 msgid "Payment Methods"
 msgstr "Zahlungsmethoden"
 
-#: lib/klass_hero_web/live/settings_live.ex:172
+#: lib/klass_hero_web/live/settings_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Permissions & Consents"
 msgstr "Berechtigungen & Einwilligungen"
 
-#: lib/klass_hero_web/live/settings_live.ex:177
+#: lib/klass_hero_web/live/settings_live.ex:152
 #, elixir-autogen, elixir-format
 msgid "Photo & Video Release"
 msgstr "Foto- & Videofreigabe"
 
-#: lib/klass_hero_web/live/settings_live.ex:118
+#: lib/klass_hero_web/live/settings_live.ex:105
 #, elixir-autogen, elixir-format
 msgid "Primary address and phone"
 msgstr "Hauptadresse und Telefon"
 
-#: lib/klass_hero_web/live/settings_live.ex:75
+#: lib/klass_hero_web/live/settings_live.ex:68
 #, elixir-autogen, elixir-format
 msgid "Privacy & Security"
 msgstr "Datenschutz & Sicherheit"
 
-#: lib/klass_hero_web/live/settings_live.ex:66
+#: lib/klass_hero_web/live/settings_live.ex:61
 #, elixir-autogen, elixir-format
 msgid "Profile Information"
 msgstr "Profilinformationen"
 
-#: lib/klass_hero_web/components/composite_components.ex:105
+#: lib/klass_hero_web/components/composite_components.ex:106
 #, elixir-autogen, elixir-format
 msgid "Progress"
 msgstr "Fortschritt"
 
-#: lib/klass_hero_web/live/settings_live.ex:238
+#: lib/klass_hero_web/live/settings_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Push, email, SMS settings"
 msgstr "Push-, E-Mail-, SMS-Einstellungen"
 
-#: lib/klass_hero_web/components/composite_components.ex:102
+#: lib/klass_hero_web/components/composite_components.ex:103
 #: lib/klass_hero_web/components/layouts/admin.html.heex:58
-#: lib/klass_hero_web/components/provider_components.ex:90
+#: lib/klass_hero_web/components/provider_components.ex:96
 #: lib/klass_hero_web/live/admin/sessions_live.ex:26
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:4
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:185
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:3
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "Sessions"
 msgstr "Sitzungen"
 
-#: lib/klass_hero_web/live/settings_live.ex:187
+#: lib/klass_hero_web/live/settings_live.ex:160
 #, elixir-autogen, elixir-format
 msgid "Swimming, field trips, group activities"
 msgstr "Schwimmen, Ausflüge, Gruppenaktivitäten"
@@ -1510,12 +1351,12 @@ msgstr "Schwimmen, Ausflüge, Gruppenaktivitäten"
 msgid "The link is invalid or it has expired."
 msgstr "Der Link ist ungültig oder abgelaufen."
 
-#: lib/klass_hero_web/live/settings_live.ex:216
+#: lib/klass_hero_web/live/settings_live.ex:183
 #, elixir-autogen, elixir-format
 msgid "Transaction History"
 msgstr "Transaktionsverlauf"
 
-#: lib/klass_hero_web/live/settings_live.ex:196
+#: lib/klass_hero_web/live/settings_live.ex:167
 #, elixir-autogen, elixir-format
 msgid "Updates, discounts, family credit"
 msgstr "Updates, Rabatte, Familienguthaben"
@@ -1525,12 +1366,12 @@ msgstr "Updates, Rabatte, Familienguthaben"
 msgid "User confirmed successfully."
 msgstr "Benutzer erfolgreich bestätigt."
 
-#: lib/klass_hero_web/live/settings_live.ex:277
+#: lib/klass_hero_web/live/settings_live.ex:232
 #, elixir-autogen, elixir-format
 msgid "Version, terms, privacy policy"
 msgstr "Version, Nutzungsbedingungen, Datenschutzrichtlinie"
 
-#: lib/klass_hero_web/live/settings_live.ex:97
+#: lib/klass_hero_web/live/settings_live.ex:88
 #, elixir-autogen, elixir-format
 msgid "View all family activities"
 msgstr "Alle Familienaktivitäten anzeigen"
@@ -1540,2701 +1381,2210 @@ msgstr "Alle Familienaktivitäten anzeigen"
 msgid "Welcome back!"
 msgstr "Willkommen zurück"
 
-#: lib/klass_hero_web/live/settings_live.ex:195
+#: lib/klass_hero_web/live/settings_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "WhatsApp Community"
 msgstr "WhatsApp-Community"
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:178
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:211
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Failed to load participation history"
 msgstr "Teilnahmeverlauf konnte nicht geladen werden"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:17
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:64
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:23
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:276
+#: lib/klass_hero_web/live/provider/participation_live.ex:26
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:60
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:29
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "Manage Participation"
 msgstr "Teilnahme verwalten"
 
 #: lib/klass_hero_web/live/parent/participation_history_live.ex:17
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:5
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "Participation History"
 msgstr "Teilnahmeübersicht"
 
-#: lib/klass_hero_web/live/home_live.ex:101
-#, elixir-autogen, elixir-format
-msgid " Find verified tutors, coaches, and camps near you."
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:101
-#, elixir-autogen, elixir-format
-msgid " youth education, sports, and recreational activities"
-msgstr ""
-
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:24
-#: lib/klass_hero_web/live/admin/verifications_live.ex:204
-#: lib/klass_hero_web/live/programs_live.ex:17
+#: lib/klass_hero_web/live/admin/verifications_live.ex:187
+#: lib/klass_hero_web/live/programs_live.ex:19
 #, elixir-autogen, elixir-format
 msgid "All"
-msgstr ""
+msgstr "Alle"
 
-#: lib/klass_hero_web/live/about_live.ex:150
-#, elixir-autogen, elixir-format
-msgid "All instructors are background-checked and verified"
-msgstr "Alle Lehrkräfte sind hintergrundgeprüft und verifiziert"
-
-#: lib/klass_hero_web/live/programs_live.ex:19
-#: lib/klass_hero_web/presenters/program_presenter.ex:366
+#: lib/klass_hero_web/live/programs_live.ex:21
+#: lib/klass_hero_web/presenters/program_presenter.ex:314
 #, elixir-autogen, elixir-format
 msgid "Arts"
-msgstr ""
+msgstr "Kunst"
 
-#: lib/klass_hero_web/live/about_live.ex:196
-#, elixir-autogen, elixir-format
-msgid "Building connections between families and local instructors"
-msgstr "Aufbau von Verbindungen zwischen Familien und lokalen Lehrkräften"
-
-#: lib/klass_hero_web/live/about_live.ex:113
+#: lib/klass_hero_web/live/about_live.ex:145
 #, elixir-autogen, elixir-format
 msgid "Built for Berlin Families"
 msgstr "Für Berliner Familien entwickelt"
 
-#: lib/klass_hero_web/live/programs_live.ex:23
+#: lib/klass_hero_web/live/programs_live.ex:25
 #, elixir-autogen, elixir-format
 msgid "Camps"
-msgstr ""
+msgstr "Camps"
 
-#: lib/klass_hero_web/live/home_live.ex:287
-#, elixir-autogen, elixir-format
-msgid "Create a Program"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:297
-#, elixir-autogen, elixir-format
-msgid "Deliver Quality"
-msgstr ""
-
-#: lib/klass_hero_web/live/programs_live.ex:242
-#, elixir-autogen, elixir-format
-msgid "Discover activities, camps, and classes for your child"
-msgstr ""
-
-#: lib/klass_hero_web/live/programs_live.ex:21
-#: lib/klass_hero_web/presenters/program_presenter.ex:367
+#: lib/klass_hero_web/live/programs_live.ex:23
+#: lib/klass_hero_web/presenters/program_presenter.ex:315
 #, elixir-autogen, elixir-format
 msgid "Education"
-msgstr ""
+msgstr "Bildung"
 
-#: lib/klass_hero_web/live/about_live.ex:213
-#, elixir-autogen, elixir-format
-msgid "Every instructor goes through rigorous screening to ensure the highest quality"
-msgstr "Jede Lehrkraft durchläuft eine strenge Überprüfung, um höchste Qualität zu gewährleisten"
-
-#: lib/klass_hero_web/live/home_live.ex:522
-#, elixir-autogen, elixir-format
-msgid "Everything you need to know about Klass Hero"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:209
-#, elixir-autogen, elixir-format
-msgid "For Families"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:265
+#: lib/klass_hero_web/components/composite_components.ex:472
+#: lib/klass_hero_web/components/marketing_components.ex:191
+#: lib/klass_hero_web/components/marketing_components.ex:537
+#: lib/klass_hero_web/components/marketing_components.ex:908
+#: lib/klass_hero_web/live/for_providers_live.ex:10
+#: lib/klass_hero_web/live/for_providers_live.ex:39
 #, elixir-autogen, elixir-format
 msgid "For Providers"
-msgstr ""
+msgstr "Für Anbieter"
 
-#: lib/klass_hero_web/live/home_live.ex:519
-#, elixir-autogen, elixir-format
-msgid "Frequently Asked Questions"
-msgstr ""
-
-#: lib/klass_hero_web/live/about_live.ex:121
+#: lib/klass_hero_web/live/about_live.ex:150
 #, elixir-autogen, elixir-format
 msgid "From sports to arts, technology to languages, we make it easy to discover enriching activities that fit your family's schedule and budget."
 msgstr "Von Sport über Kunst, Technologie bis Sprachen – wir machen es einfach, bereichernde Aktivitäten zu entdecken, die zu Zeitplan und Budget Ihrer Familie passen."
 
-#: lib/klass_hero_web/live/about_live.ex:292
-#, elixir-autogen, elixir-format
-msgid "GET STARTED TODAY"
-msgstr "HEUTE LOSLEGEN"
-
-#: lib/klass_hero_web/live/home_live.ex:307
+#: lib/klass_hero_web/components/marketing_components.ex:589
 #, elixir-autogen, elixir-format
 msgid "Get Paid & Grow"
-msgstr ""
+msgstr "Verdienen & Wachsen"
 
-#: lib/klass_hero_web/live/home_live.ex:269
-#, elixir-autogen, elixir-format
-msgid "How to Grow Your Youth Program: Let's Build Together."
-msgstr "Ihr Programm zum Wachsen bringen: Gemeinsam aufbauen."
-
-#: lib/klass_hero_web/live/home_live.ex:272
-#, elixir-autogen, elixir-format
-msgid "Join our community of passionate educators. Tools and support to help you succeed."
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:100
-#, elixir-autogen, elixir-format
-msgid "Klass Hero is Berlin's leading marketplace for"
-msgstr ""
-
-#: lib/klass_hero_web/live/programs_live.ex:22
+#: lib/klass_hero_web/live/programs_live.ex:24
 #, elixir-autogen, elixir-format
 msgid "Life Skills"
-msgstr ""
+msgstr "Lebenskompetenzen"
 
-#: lib/klass_hero_web/live/programs_live.ex:20
-#: lib/klass_hero_web/presenters/program_presenter.ex:369
+#: lib/klass_hero_web/live/programs_live.ex:22
+#: lib/klass_hero_web/presenters/program_presenter.ex:317
 #, elixir-autogen, elixir-format
 msgid "Music"
-msgstr ""
+msgstr "Musik"
 
-#: lib/klass_hero_web/live/about_live.ex:98
-#, elixir-autogen, elixir-format
-msgid "OUR MISSION"
-msgstr "UNSERE MISSION"
-
-#: lib/klass_hero_web/components/provider_components.ex:694
+#: lib/klass_hero_web/components/provider_components.ex:660
+#: lib/klass_hero_web/live/for_providers_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "Qualifications"
 msgstr "Qualifikationen"
 
-#: lib/klass_hero_web/live/about_live.ex:286
+#: lib/klass_hero_web/live/about_live.ex:206
 #, elixir-autogen, elixir-format
 msgid "Ready to join the movement?"
 msgstr "Bereit, Teil der Bewegung zu werden?"
 
-#: lib/klass_hero_web/live/home_live.ex:137
+#: lib/klass_hero_web/components/marketing_components.ex:986
 #, elixir-autogen, elixir-format
 msgid "Search"
-msgstr ""
+msgstr "Suche"
 
-#: lib/klass_hero_web/live/home_live.ex:309
-#, elixir-autogen, elixir-format
-msgid "Secure payments, insights into your business, and opportunities to expand your impact."
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:289
+#: lib/klass_hero_web/components/marketing_components.ex:573
 #, elixir-autogen, elixir-format
 msgid "Set up your teaching profile and list your programs in minutes. Share your expertise with families who need it."
-msgstr ""
+msgstr "Richten Sie Ihr Kursleiterprofil ein und veröffentlichen Sie Ihre Programme in wenigen Minuten. Teilen Sie Ihr Fachwissen mit Familien, die es brauchen."
 
-#: lib/klass_hero_web/live/programs_live.ex:18
-#: lib/klass_hero_web/presenters/program_presenter.ex:368
+#: lib/klass_hero_web/live/programs_live.ex:20
+#: lib/klass_hero_web/presenters/program_presenter.ex:316
 #, elixir-autogen, elixir-format
 msgid "Sports"
 msgstr "Sport"
 
-#: lib/klass_hero_web/components/marketing_components.ex:548
-#, elixir-autogen, elixir-format
-msgid "Are you an educator, coach, or artist?"
-msgstr "Bist du Pädagog:in, Coach oder Künstler:in?"
-
-#: lib/klass_hero_web/components/marketing_components.ex:553
-#, elixir-autogen, elixir-format
-msgid "Learn How to Become a Hero →"
-msgstr "Werde zum Hero →"
-
-#: lib/klass_hero_web/live/about_live.ex:173
-#, elixir-autogen, elixir-format
-msgid "Supporting local programs and eco-conscious practices"
-msgstr "Unterstützung lokaler Programme und umweltbewusster Praktiken"
-
-#: lib/klass_hero_web/live/about_live.ex:170
+#: lib/klass_hero_web/live/about_live.ex:24
 #, elixir-autogen, elixir-format
 msgid "Sustainability"
 msgstr "Nachhaltigkeit"
 
-#: lib/klass_hero_web/live/home_live.ex:299
-#, elixir-autogen, elixir-format
-msgid "Teach your passion with our tools for scheduling, communication, and progress tracking."
-msgstr ""
-
-#: lib/klass_hero_web/live/about_live.ex:101
-#, elixir-autogen, elixir-format
-msgid "To modernize how families discover and engage with children's programs in Berlin"
-msgstr "Die Art und Weise zu modernisieren, wie Familien Kinderprogramme in Berlin entdecken und nutzen"
-
-#: lib/klass_hero_web/live/home_live.ex:145
+#: lib/klass_hero_web/components/marketing_components.ex:269
 #, elixir-autogen, elixir-format
 msgid "Trending in Berlin:"
-msgstr ""
+msgstr "Beliebt in Berlin:"
 
-#: lib/klass_hero_web/live/about_live.ex:116
+#: lib/klass_hero_web/live/about_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "We understand the unique needs of Berlin's diverse families. Our platform connects you with vetted, high-quality programs that match your values and your children's interests."
 msgstr "Wir verstehen die einzigartigen Bedürfnisse der vielfältigen Familien Berlins. Unsere Plattform verbindet Sie mit geprüften, hochwertigen Programmen, die zu Ihren Werten und den Interessen Ihrer Kinder passen."
 
-#: lib/klass_hero_web/live/programs_live.ex:24
+#: lib/klass_hero_web/live/programs_live.ex:26
 #, elixir-autogen, elixir-format
 msgid "Workshops"
-msgstr ""
+msgstr "Workshops"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:215
-#: lib/klass_hero_web/live/settings/children_live.ex:396
-#: lib/klass_hero_web/live/settings/children_live.ex:418
-#: lib/klass_hero_web/live/settings/children_live.ex:640
-#: lib/klass_hero_web/live/settings/children_live.ex:774
+#: lib/klass_hero_web/live/settings/children_live.ex:377
+#: lib/klass_hero_web/live/settings/children_live.ex:399
+#: lib/klass_hero_web/live/settings/children_live.ex:618
+#: lib/klass_hero_web/live/settings/children_live.ex:752
 #, elixir-autogen, elixir-format
 msgid "Add Child"
 msgstr "Kind Hinzufügen"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:77
-#, elixir-autogen, elixir-format
-msgid "Almost there! One more to go!"
-msgstr "Fast geschafft! Noch eine Aktivität!"
-
-#: lib/klass_hero_web/live/dashboard_live.ex:76
-#, elixir-autogen, elixir-format
-msgid "Congratulations! Goal achieved!"
-msgstr "Glückwunsch! Ziel erreicht!"
-
-#: lib/klass_hero_web/components/composite_components.ex:332
-#, elixir-autogen, elixir-format
-msgid "Copy Code"
-msgstr "Code Kopieren"
-
-#: lib/klass_hero_web/components/composite_components.ex:265
-#, elixir-autogen, elixir-format
-msgid "Family Achievements"
-msgstr "Familien-Erfolge"
-
-#: lib/klass_hero_web/components/composite_components.ex:310
-#, elixir-autogen, elixir-format
-msgid "Friends Referred"
-msgstr "Freunde Eingeladen"
-
-#: lib/klass_hero_web/components/composite_components.ex:304
-#, elixir-autogen, elixir-format
-msgid "Invite friends and earn points!"
-msgstr "Freunde einladen und Punkte sammeln!"
-
-#: lib/klass_hero_web/components/composite_components.ex:314
-#, elixir-autogen, elixir-format
-msgid "Points Earned"
-msgstr "Punkte Verdient"
-
-#: lib/klass_hero_web/components/composite_components.ex:299
-#, elixir-autogen, elixir-format
-msgid "Refer & Earn"
-msgstr "Empfehlen & Verdienen"
-
-#: lib/klass_hero_web/components/composite_components.ex:348
-#, elixir-autogen, elixir-format
-msgid "Share Code"
-msgstr "Code Teilen"
-
-#: lib/klass_hero_web/components/composite_components.ex:185
+#: lib/klass_hero_web/components/composite_components.ex:186
 #, elixir-autogen, elixir-format
 msgid "Weekly Activity Goal"
 msgstr "Wöchentliches Aktivitätsziel"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:78
-#, elixir-autogen, elixir-format
-msgid "You're just getting started!"
-msgstr ""
-
-#: lib/klass_hero_web/live/dashboard_live.ex:79
-#, elixir-autogen, elixir-format
-msgid "You're doing great! Keep it up!"
-msgstr "Du machst das großartig! Weiter so!"
-
-#: lib/klass_hero_web/components/composite_components.ex:319
-#, elixir-autogen, elixir-format
-msgid "Your Referral Code"
-msgstr "Ihr Empfehlungscode"
-
-#: lib/klass_hero_web/components/composite_components.ex:194
+#: lib/klass_hero_web/components/composite_components.ex:195
 #, elixir-autogen, elixir-format
 msgid "activities completed"
 msgstr "Aktivitäten abgeschlossen"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:55
-#: lib/klass_hero_web/live/user_live/settings.ex:131
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/user_live/settings.ex:81
+#, elixir-autogen, elixir-format
 msgid "Account Security"
-msgstr "Kontoeinstellungen"
+msgstr "Kontosicherheit"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:237
+#: lib/klass_hero_web/live/user_live/settings.ex:164
 #, elixir-autogen, elixir-format
 msgid "Customize your experience"
 msgstr "Passen Sie Ihre Erfahrung an"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:414
+#: lib/klass_hero_web/live/user_live/settings.ex:271
 #, elixir-autogen, elixir-format
 msgid "Danger Zone"
 msgstr "Gefahrenzone"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:69
-#: lib/klass_hero_web/live/user_live/settings.ex:379
+#: lib/klass_hero_web/live/user_live/settings.ex:249
 #, elixir-autogen, elixir-format
 msgid "Data & Privacy"
 msgstr "Daten & Datenschutz"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:382
+#: lib/klass_hero_web/live/user_live/settings.ex:251
 #, elixir-autogen, elixir-format
 msgid "Download your data or delete your account"
 msgstr "Daten herunterladen oder Konto löschen"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:143
+#: lib/klass_hero_web/live/user_live/settings.ex:90
 #, elixir-autogen, elixir-format
 msgid "Email Address"
 msgstr "E-Mail-Adresse"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:134
+#: lib/klass_hero_web/live/user_live/settings.ex:83
 #, elixir-autogen, elixir-format
 msgid "Manage your email and password"
 msgstr "E-Mail und Passwort verwalten"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:101
+#: lib/klass_hero_web/live/user_live/settings.ex:70
 #, elixir-autogen, elixir-format
 msgid "Member since"
 msgstr "Mitglied seit"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:62
-#: lib/klass_hero_web/live/user_live/settings.ex:234
+#: lib/klass_hero_web/live/user_live/settings.ex:47
+#: lib/klass_hero_web/live/user_live/settings.ex:163
 #, elixir-autogen, elixir-format
 msgid "Preferences"
 msgstr "Einstellungen"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:41
+#: lib/klass_hero_web/live/user_live/settings.ex:34
 #, elixir-autogen, elixir-format
 msgid "Profile"
 msgstr "Profil"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:33
+#: lib/klass_hero_web/live/user_live/settings.ex:30
 #, elixir-autogen, elixir-format
 msgid "Quick Navigation"
 msgstr "Schnellnavigation"
 
-#: lib/klass_hero_web/components/provider_components.ex:1389
-#: lib/klass_hero_web/components/provider_components.ex:1775
-#: lib/klass_hero_web/components/provider_components.ex:2011
+#: lib/klass_hero_web/components/provider_components.ex:1341
+#: lib/klass_hero_web/components/provider_components.ex:1731
+#: lib/klass_hero_web/components/provider_components.ex:1957
 #, elixir-autogen, elixir-format
 msgid "Actions"
-msgstr ""
+msgstr "Aktionen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1485
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/components/provider_components.ex:1446
+#, elixir-autogen, elixir-format
 msgid "Active"
-msgstr "Aktive Familien"
+msgstr "Aktiv"
 
-#: lib/klass_hero_web/components/provider_components.ex:610
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1484
+#: lib/klass_hero_web/components/provider_components.ex:577
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1679
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
 msgstr "Teammitglied hinzufügen"
 
 #: lib/klass_hero_web/live/provider/dashboard_live.ex:82
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1728
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1934
 #, elixir-autogen, elixir-format
 msgid "All Staff"
 msgstr "Alle Mitarbeiter"
 
-#: lib/klass_hero_web/components/provider_components.ex:1380
+#: lib/klass_hero_web/components/provider_components.ex:1332
 #, elixir-autogen, elixir-format
 msgid "Assigned Staff"
 msgstr "Zugewiesenes Personal"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:359
-#: lib/klass_hero_web/live/program_detail_live.ex:575
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/program_detail_live.ex:332
+#: lib/klass_hero_web/live/program_detail_live.ex:492
+#, elixir-autogen, elixir-format
 msgid "Book Now"
-msgstr "Jetzt buchen - %{price}"
+msgstr "Jetzt buchen"
 
-#: lib/klass_hero_web/components/provider_components.ex:176
+#: lib/klass_hero_web/components/provider_components.ex:182
 #, elixir-autogen, elixir-format
 msgid "Business Profile"
 msgstr "Geschäftsprofil"
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:115
-#: lib/klass_hero_web/presenters/provider_presenter.ex:125
+#: lib/klass_hero_web/presenters/provider_presenter.ex:83
+#: lib/klass_hero_web/presenters/provider_presenter.ex:93
 #, elixir-autogen, elixir-format
 msgid "Business Registration"
 msgstr "Gewerbeanmeldung"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1467
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1656
 #, elixir-autogen, elixir-format
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr "Erstellen Sie Profile für Ihr Personal. Diese werden für Eltern sichtbar sein, wenn sie Programmen zugewiesen werden."
 
-#: lib/klass_hero_web/components/provider_components.ex:552
-#: lib/klass_hero_web/components/provider_components.ex:1457
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:49
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:76
-#: lib/klass_hero_web/live/settings/children_live.ex:467
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:49
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:76
+#: lib/klass_hero_web/components/provider_components.ex:515
+#: lib/klass_hero_web/components/provider_components.ex:1409
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:50
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:77
+#: lib/klass_hero_web/live/settings/children_live.ex:448
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:50
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:77
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: lib/klass_hero_web/components/provider_components.ex:194
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:170
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1297
+#: lib/klass_hero_web/components/provider_components.ex:200
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:172
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1427
 #, elixir-autogen, elixir-format
 msgid "Edit Profile"
 msgstr "Profil bearbeiten"
 
-#: lib/klass_hero_web/components/provider_components.ex:1487
+#: lib/klass_hero_web/components/provider_components.ex:1448
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr "Inaktiv"
 
-#: lib/klass_hero_web/components/provider_components.ex:83
+#: lib/klass_hero_web/components/provider_components.ex:89
 #, elixir-autogen, elixir-format
 msgid "My Programs"
 msgstr "Meine Programme"
 
-#: lib/klass_hero_web/components/provider_components.ex:418
-#: lib/klass_hero_web/components/provider_components.ex:870
+#: lib/klass_hero_web/components/provider_components.ex:392
+#: lib/klass_hero_web/components/provider_components.ex:835
 #, elixir-autogen, elixir-format
 msgid "New Program"
 msgstr "Neues Programm"
 
-#: lib/klass_hero_web/components/provider_components.ex:69
+#: lib/klass_hero_web/components/provider_components.ex:75
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr "Übersicht"
 
 #: lib/klass_hero_web/components/provider_components.ex:46
-#: lib/klass_hero_web/components/provider_components.ex:1486
-#: lib/klass_hero_web/components/provider_components.ex:2198
-#: lib/klass_hero_web/components/provider_components.ex:2218
-#: lib/klass_hero_web/live/admin/sessions_live.ex:318
-#: lib/klass_hero_web/live/admin/verifications_live.ex:209
+#: lib/klass_hero_web/components/provider_components.ex:1447
+#: lib/klass_hero_web/components/provider_components.ex:2144
+#: lib/klass_hero_web/components/provider_components.ex:2162
+#: lib/klass_hero_web/live/admin/sessions_live.ex:297
+#: lib/klass_hero_web/live/admin/verifications_live.ex:192
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr "Ausstehend"
 
-#: lib/klass_hero_web/components/provider_components.ex:1440
+#: lib/klass_hero_web/components/provider_components.ex:1392
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr "Vorschau"
 
-#: lib/klass_hero_web/components/provider_components.ex:1323
+#: lib/klass_hero_web/components/provider_components.ex:1275
 #, elixir-autogen, elixir-format
 msgid "Program Inventory"
 msgstr "Programmübersicht"
 
-#: lib/klass_hero_web/components/provider_components.ex:1377
+#: lib/klass_hero_web/components/provider_components.ex:1329
 #, elixir-autogen, elixir-format
 msgid "Program Name"
 msgstr "Programmname"
 
-#: lib/klass_hero_web/components/provider_components.ex:383
-#, elixir-autogen, elixir-format
-msgid "Program Slots"
-msgstr "Programmplätze"
-
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:91
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:88
 #, elixir-autogen, elixir-format
 msgid "Provider Dashboard"
 msgstr "Anbieter-Dashboard"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:372
+#: lib/klass_hero_web/live/program_detail_live.ex:345
 #, elixir-autogen, elixir-format
 msgid "Save for Later"
 msgstr "Für später speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:1335
+#: lib/klass_hero_web/components/provider_components.ex:1287
 #, elixir-autogen, elixir-format
 msgid "Search by name..."
 msgstr "Nach Namen suchen..."
 
-#: lib/klass_hero_web/components/provider_components.ex:1383
-#: lib/klass_hero_web/components/provider_components.ex:1714
-#: lib/klass_hero_web/components/provider_components.ex:1769
-#: lib/klass_hero_web/components/provider_components.ex:2008
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:73
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:158
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:201
+#: lib/klass_hero_web/components/provider_components.ex:1335
+#: lib/klass_hero_web/components/provider_components.ex:1670
+#: lib/klass_hero_web/components/provider_components.ex:1725
+#: lib/klass_hero_web/components/provider_components.ex:1954
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr "Status"
 
-#: lib/klass_hero_web/components/provider_components.ex:76
+#: lib/klass_hero_web/components/provider_components.ex:82
 #, elixir-autogen, elixir-format
 msgid "Team & Profiles"
 msgstr "Team & Profile"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1464
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1653
 #, elixir-autogen, elixir-format
 msgid "Team & Provider Profiles"
 msgstr "Team- & Anbieterprofile"
 
-#: lib/klass_hero_web/components/provider_components.ex:179
+#: lib/klass_hero_web/components/provider_components.ex:185
 #, elixir-autogen, elixir-format
 msgid "This is your main business identity. Verification is required to list programs."
 msgstr "Dies ist Ihre Hauptgeschäftsidentität. Eine Verifizierung ist erforderlich, um Programme anzubieten."
 
-#: lib/klass_hero_web/components/provider_components.ex:1413
-#: lib/klass_hero_web/components/provider_components.ex:1729
+#: lib/klass_hero_web/components/provider_components.ex:1365
+#: lib/klass_hero_web/components/provider_components.ex:1685
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr "Nicht zugewiesen"
 
-#: lib/klass_hero_web/components/messaging_components.ex:53
+#: lib/klass_hero_web/components/messaging_components.ex:728
 #: lib/klass_hero_web/components/provider_components.ex:49
-#: lib/klass_hero_web/components/provider_components.ex:1488
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:277
+#: lib/klass_hero_web/components/provider_components.ex:1449
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:434
+#: lib/klass_hero_web/presenters/provider_presenter.ex:99
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr "Unbekannt"
 
-#: lib/klass_hero_web/components/provider_components.ex:375
+#: lib/klass_hero_web/components/provider_components.ex:377
 #, elixir-autogen, elixir-format
 msgid "Verified Business"
 msgstr "Verifiziertes Unternehmen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1451
+#: lib/klass_hero_web/components/provider_components.ex:1403
 #, elixir-autogen, elixir-format
 msgid "View Roster"
 msgstr "Teilnehmerliste"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:449
+#: lib/klass_hero_web/live/settings/children_live.ex:430
 #, elixir-autogen, elixir-format
 msgid "%{age} years old"
 msgstr "%{age} Jahre alt"
 
-#: lib/klass_hero_web/components/messaging_components.ex:664
+#: lib/klass_hero_web/components/messaging_components.ex:738
 #, elixir-autogen, elixir-format
 msgid "%{n}m ago"
-msgstr ""
+msgstr "vor %{n} Min."
 
-#: lib/klass_hero_web/live/dashboard_live.ex:240
-#, elixir-autogen, elixir-format
-msgid "%{remaining} remaining"
-msgstr ""
-
-#: lib/klass_hero_web/live/settings/children_live.ex:404
+#: lib/klass_hero_web/live/settings/children_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "Add your first child to get started with activities and programs."
 msgstr "Fügen Sie Ihr erstes Kind hinzu, um mit Aktivitäten und Programmen zu beginnen."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:519
-#: lib/klass_hero_web/live/settings/children_live.ex:715
+#: lib/klass_hero_web/live/settings/children_live.ex:499
+#: lib/klass_hero_web/live/settings/children_live.ex:693
 #, elixir-autogen, elixir-format
 msgid "Allergies"
 msgstr "Allergien"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:742
+#: lib/klass_hero_web/live/settings/children_live.ex:720
 #, elixir-autogen, elixir-format
 msgid "Allow activity providers to access this child's profile information for program participation."
 msgstr "Aktivitätsanbietern Zugriff auf die Profilinformationen dieses Kindes für die Programmteilnahme erlauben."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:223
+#: lib/klass_hero_web/live/settings/children_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred. Please try again."
 msgstr "Ein unerwarteter Fehler ist aufgetreten. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:723
+#: lib/klass_hero_web/live/settings/children_live.ex:701
 #, elixir-autogen, elixir-format
 msgid "Any special accommodations or support needs..."
 msgstr "Besondere Bedürfnisse oder Unterstützungsbedarf..."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:382
+#: lib/klass_hero_web/live/settings/children_live.ex:363
 #, elixir-autogen, elixir-format
 msgid "Back to Settings"
 msgstr "Zurück zu Einstellungen"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:185
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:183
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:107
 #, elixir-autogen, elixir-format
 msgid "Behavioral note submitted for review"
 msgstr "Verhaltensnotiz zur Überprüfung eingereicht"
 
-#: lib/klass_hero_web/components/messaging_components.ex:147
+#: lib/klass_hero_web/components/messaging_components.ex:150
 #, elixir-autogen, elixir-format
 msgid "Broadcast"
-msgstr ""
+msgstr "Rundnachricht"
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:78
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:126
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:98
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "Broadcast sent to %{count} parents"
-msgstr ""
+msgstr "Rundnachricht an %{count} Eltern gesendet"
 
-#: lib/klass_hero_web/components/participation_components.ex:436
-#: lib/klass_hero_web/components/participation_components.ex:627
-#: lib/klass_hero_web/components/participation_components.ex:715
-#: lib/klass_hero_web/components/provider_components.ex:829
-#: lib/klass_hero_web/components/provider_components.ex:1239
-#: lib/klass_hero_web/components/provider_components.ex:1946
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:247
-#: lib/klass_hero_web/live/admin/verifications_live.ex:424
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:116
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:197
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:346
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:191
-#: lib/klass_hero_web/live/settings/children_live.ex:600
-#: lib/klass_hero_web/live/settings/children_live.ex:760
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:224
+#: lib/klass_hero_web/components/participation_components.ex:417
+#: lib/klass_hero_web/components/participation_components.ex:607
+#: lib/klass_hero_web/components/participation_components.ex:693
+#: lib/klass_hero_web/components/provider_components.ex:794
+#: lib/klass_hero_web/components/provider_components.ex:1191
+#: lib/klass_hero_web/components/provider_components.ex:1896
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
+#: lib/klass_hero_web/live/admin/verifications_live.ex:407
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:219
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:356
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:186
+#: lib/klass_hero_web/live/settings/children_live.ex:579
+#: lib/klass_hero_web/live/settings/children_live.ex:738
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:225
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:307
+#: lib/klass_hero_web/live/settings/children_live.ex:293
 #, elixir-autogen, elixir-format
 msgid "Child added successfully."
 msgstr "Kind erfolgreich hinzugefügt."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:309
+#: lib/klass_hero_web/live/settings/children_live.ex:295
 #, elixir-autogen, elixir-format
 msgid "Child added, but consent update failed. Please try again."
 msgstr "Kind hinzugefügt, aber Einwilligungsaktualisierung fehlgeschlagen. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:89
-#: lib/klass_hero_web/live/settings/children_live.ex:186
+#: lib/klass_hero_web/live/settings/children_live.ex:87
+#: lib/klass_hero_web/live/settings/children_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "Child not found."
 msgstr "Kind nicht gefunden."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:179
+#: lib/klass_hero_web/live/settings/children_live.ex:172
 #, elixir-autogen, elixir-format
 msgid "Child removed successfully."
 msgstr "Kind erfolgreich entfernt."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:311
+#: lib/klass_hero_web/live/settings/children_live.ex:297
 #, elixir-autogen, elixir-format
 msgid "Child updated successfully."
 msgstr "Kind erfolgreich aktualisiert."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:313
+#: lib/klass_hero_web/live/settings/children_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "Child updated, but consent update failed. Please try again."
 msgstr "Kind aktualisiert, aber Einwilligungsaktualisierung fehlgeschlagen. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:354
+#: lib/klass_hero_web/live/dashboard_live.ex:169
+#: lib/klass_hero_web/live/messaging_live_helper.ex:343
 #, elixir-autogen, elixir-format
 msgid "Conversation"
-msgstr ""
+msgstr "Unterhaltung"
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:164
+#: lib/klass_hero_web/live/messaging_live_helper.ex:172
 #, elixir-autogen, elixir-format
 msgid "Conversation not found"
-msgstr ""
+msgstr "Unterhaltung nicht gefunden"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:195
+#: lib/klass_hero_web/live/settings/children_live.ex:188
 #, elixir-autogen, elixir-format
 msgid "Could not remove child. Please try again."
 msgstr "Kind konnte nicht entfernt werden. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:497
+#: lib/klass_hero_web/live/settings/children_live.ex:477
 #, elixir-autogen, elixir-format
 msgid "Data sharing consent"
 msgstr "Einwilligung zur Datenweitergabe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2085
-#: lib/klass_hero_web/live/settings/children_live.ex:679
+#: lib/klass_hero_web/components/provider_components.ex:2031
+#: lib/klass_hero_web/live/settings/children_live.ex:657
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr "Geburtsdatum"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:481
+#: lib/klass_hero_web/live/settings/children_live.ex:462
 #, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr "Löschen"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:642
+#: lib/klass_hero_web/live/settings/children_live.ex:620
 #, elixir-autogen, elixir-format
 msgid "Edit Child"
 msgstr "Kind bearbeiten"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:508
-#: lib/klass_hero_web/live/settings/children_live.ex:708
+#: lib/klass_hero_web/live/settings/children_live.ex:488
+#: lib/klass_hero_web/live/settings/children_live.ex:686
 #, elixir-autogen, elixir-format
 msgid "Emergency contact"
 msgstr "Notfallkontakt"
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:66
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:61
 #, elixir-autogen, elixir-format
 msgid "Failed to approve note"
 msgstr "Notiz konnte nicht genehmigt werden"
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:227
-#, elixir-autogen, elixir-format
-msgid "Failed to load pending notes"
-msgstr "Ausstehende Notizen konnten nicht geladen werden"
-
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:117
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:112
 #, elixir-autogen, elixir-format
 msgid "Failed to reject note"
 msgstr "Notiz konnte nicht abgelehnt werden"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:261
+#: lib/klass_hero_web/live/provider/participation_live.ex:168
 #, elixir-autogen, elixir-format
 msgid "Failed to resubmit note"
 msgstr "Notiz konnte nicht erneut eingereicht werden"
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:100
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:121
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:146
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Failed to send broadcast"
-msgstr "Sitzungsdaten konnten nicht geladen werden"
+msgstr "Rundnachricht konnte nicht gesendet werden"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:202
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:200
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:124
 #, elixir-autogen, elixir-format
 msgid "Failed to submit note"
 msgstr "Notiz konnte nicht eingereicht werden"
 
-#: lib/klass_hero_web/components/provider_components.ex:2079
-#: lib/klass_hero_web/components/provider_components.ex:2108
-#: lib/klass_hero_web/components/provider_components.ex:2124
-#: lib/klass_hero_web/live/settings/children_live.ex:665
+#: lib/klass_hero_web/components/provider_components.ex:2025
+#: lib/klass_hero_web/components/provider_components.ex:2054
+#: lib/klass_hero_web/components/provider_components.ex:2070
+#: lib/klass_hero_web/live/settings/children_live.ex:643
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr "Vorname"
 
-#: lib/klass_hero_web/components/provider_components.ex:2080
-#: lib/klass_hero_web/components/provider_components.ex:2109
-#: lib/klass_hero_web/components/provider_components.ex:2125
-#: lib/klass_hero_web/live/settings/children_live.ex:671
+#: lib/klass_hero_web/components/provider_components.ex:2026
+#: lib/klass_hero_web/components/provider_components.ex:2055
+#: lib/klass_hero_web/components/provider_components.ex:2071
+#: lib/klass_hero_web/live/settings/children_live.ex:649
 #, elixir-autogen, elixir-format
 msgid "Last name"
 msgstr "Nachname"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:716
+#: lib/klass_hero_web/live/settings/children_live.ex:694
 #, elixir-autogen, elixir-format
 msgid "List any known allergies..."
 msgstr "Bekannte Allergien auflisten..."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:368
+#: lib/klass_hero_web/live/settings/children_live.ex:349
 #, elixir-autogen, elixir-format
 msgid "Manage your children's information and consents"
 msgstr "Informationen und Einwilligungen Ihrer Kinder verwalten"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:320
+#: lib/klass_hero_web/live/user_live/settings.ex:223
 #, elixir-autogen, elixir-format
 msgid "Manage your children's profiles"
-msgstr ""
+msgstr "Verwalten Sie die Profile Ihrer Kinder"
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:64
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:109
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:79
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:94
 #, elixir-autogen, elixir-format
 msgid "Message content is required"
-msgstr ""
+msgstr "Nachrichteninhalt ist erforderlich"
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:236
-#: lib/klass_hero_web/components/messaging_components.ex:434
-#: lib/klass_hero_web/components/messaging_components.ex:457
-#: lib/klass_hero_web/live/messaging_live_helper.ex:301
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Messages"
-msgstr "Nachricht"
-
-#: lib/klass_hero_web/live/dashboard_live.ex:229
+#: lib/klass_hero_web/components/layouts/app.html.heex:212
+#: lib/klass_hero_web/components/messaging_components.ex:494
+#: lib/klass_hero_web/components/messaging_components.ex:517
+#: lib/klass_hero_web/live/messages_live/index.ex:19
+#: lib/klass_hero_web/live/messaging_live_helper.ex:295
 #, elixir-autogen, elixir-format
-msgid "Monthly Booking Usage"
-msgstr ""
+msgid "Messages"
+msgstr "Nachrichten"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:403
-#: lib/klass_hero_web/presenters/child_presenter.ex:96
+#: lib/klass_hero_web/live/settings/children_live.ex:384
+#: lib/klass_hero_web/presenters/child_presenter.ex:57
 #, elixir-autogen, elixir-format
 msgid "No children yet"
 msgstr "Noch keine Kinder"
 
-#: lib/klass_hero_web/components/messaging_components.ex:399
+#: lib/klass_hero_web/components/messaging_components.ex:464
 #, elixir-autogen, elixir-format
 msgid "No conversations yet"
-msgstr ""
+msgstr "Noch keine Unterhaltungen"
 
-#: lib/klass_hero_web/components/messaging_components.ex:368
-#: lib/klass_hero_web/components/messaging_components.ex:674
-#: lib/klass_hero_web/components/messaging_components.ex:685
+#: lib/klass_hero_web/components/messaging_components.ex:433
+#: lib/klass_hero_web/components/messaging_components.ex:748
+#: lib/klass_hero_web/components/messaging_components.ex:759
 #, elixir-autogen, elixir-format
 msgid "No messages yet"
-msgstr ""
+msgstr "Noch keine Nachrichten"
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:92
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:134
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:106
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "No parents are enrolled in this program"
-msgstr ""
+msgstr "Für dieses Programm sind keine Eltern angemeldet"
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:57
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:52
 #, elixir-autogen, elixir-format
 msgid "Note approved"
 msgstr "Notiz genehmigt"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:191
-#: lib/klass_hero_web/live/provider/participation_live.ex:253
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:189
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:113
+#: lib/klass_hero_web/live/provider/participation_live.ex:160
 #, elixir-autogen, elixir-format
 msgid "Note content cannot be blank"
 msgstr "Notizinhalt darf nicht leer sein"
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:106
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:101
 #, elixir-autogen, elixir-format
 msgid "Note rejected"
 msgstr "Notiz abgelehnt"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:247
+#: lib/klass_hero_web/live/provider/participation_live.ex:154
 #, elixir-autogen, elixir-format
 msgid "Note resubmitted for review"
 msgstr "Notiz erneut zur Überprüfung eingereicht"
 
-#: lib/klass_hero_web/components/messaging_components.ex:663
+#: lib/klass_hero_web/components/messaging_components.ex:737
 #, elixir-autogen, elixir-format
 msgid "Now"
-msgstr ""
+msgstr "Jetzt"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:709
+#: lib/klass_hero_web/live/settings/children_live.ex:687
 #, elixir-autogen, elixir-format
 msgid "Phone number or name"
 msgstr "Telefonnummer oder Name"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:218
+#: lib/klass_hero_web/live/settings/children_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "Please check the form for errors."
 msgstr "Bitte überprüfen Sie das Formular auf Fehler."
 
-#: lib/klass_hero_web/live/booking_live.ex:191
+#: lib/klass_hero_web/live/booking_live.ex:173
 #, elixir-autogen, elixir-format
 msgid "Please complete your profile before making a booking."
-msgstr ""
+msgstr "Bitte vervollständigen Sie Ihr Profil, bevor Sie eine Buchung vornehmen."
 
-#: lib/klass_hero_web/live/user_live/settings.ex:575
+#: lib/klass_hero_web/live/user_live/settings.ex:428
 #, elixir-autogen, elixir-format
 msgid "Please re-authenticate to change your email."
-msgstr ""
+msgstr "Bitte authentifizieren Sie sich erneut, um Ihre E-Mail-Adresse zu ändern."
 
-#: lib/klass_hero_web/live/user_live/settings.ex:607
+#: lib/klass_hero_web/live/user_live/settings.ex:460
 #, elixir-autogen, elixir-format
 msgid "Please re-authenticate to change your password."
-msgstr ""
+msgstr "Bitte authentifizieren Sie sich erneut, um Ihr Passwort zu ändern."
 
-#: lib/klass_hero_web/live/user_live/settings.ex:643
+#: lib/klass_hero_web/live/user_live/settings.ex:496
 #, elixir-autogen, elixir-format
 msgid "Please re-authenticate to delete your account."
-msgstr ""
+msgstr "Bitte authentifizieren Sie sich erneut, um Ihr Konto zu löschen."
 
 #: lib/klass_hero_web/live/settings/children_live.ex:36
 #, elixir-autogen, elixir-format
 msgid "Please set up your parent profile to manage children."
 msgstr "Bitte richten Sie Ihr Elternprofil ein, um Kinder zu verwalten."
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:350
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/components/messaging_components.ex:721
+#: lib/klass_hero_web/live/messaging_live_helper.ex:339
+#, elixir-autogen, elixir-format
 msgid "Program Broadcast"
-msgstr "Programmplätze"
+msgstr "Programm-Rundnachricht"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:739
+#: lib/klass_hero_web/live/settings/children_live.ex:717
 #, elixir-autogen, elixir-format
 msgid "Provider data sharing consent"
 msgstr "Einwilligung zur Datenweitergabe an Anbieter"
 
-#: lib/klass_hero_web/components/provider_components.ex:814
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1397
-#: lib/klass_hero_web/live/settings/children_live.ex:776
+#: lib/klass_hero_web/components/provider_components.ex:779
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1524
+#: lib/klass_hero_web/live/settings/children_live.ex:754
 #, elixir-autogen, elixir-format
 msgid "Save Changes"
 msgstr "Änderungen speichern"
 
-#: lib/klass_hero_web/live/home_live.ex:129
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Search for programs..."
-msgstr "Programme suchen..."
-
-#: lib/klass_hero_web/components/provider_components.ex:1573
-#: lib/klass_hero_web/components/provider_components.ex:1574
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:37
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:128
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:227
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:60
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:164
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:237
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:231
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:232
+#: lib/klass_hero_web/components/provider_components.ex:1531
+#: lib/klass_hero_web/components/provider_components.ex:1532
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:40
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:148
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:249
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:44
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:163
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:238
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:393
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:394
 #, elixir-autogen, elixir-format
 msgid "Send Broadcast"
-msgstr ""
+msgstr "Rundnachricht senden"
 
-#: lib/klass_hero_web/components/messaging_components.ex:371
+#: lib/klass_hero_web/components/messaging_components.ex:436
 #, elixir-autogen, elixir-format
 msgid "Send a message to start the conversation"
-msgstr ""
+msgstr "Senden Sie eine Nachricht, um die Unterhaltung zu beginnen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2179
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:226
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:236
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/components/provider_components.ex:2125
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:248
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:237
+#, elixir-autogen, elixir-format
 msgid "Sending..."
-msgstr "Ausstehend"
+msgstr "Wird gesendet..."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:530
-#: lib/klass_hero_web/live/settings/children_live.ex:722
+#: lib/klass_hero_web/live/settings/children_live.ex:510
+#: lib/klass_hero_web/live/settings/children_live.ex:700
 #, elixir-autogen, elixir-format
 msgid "Support needs"
 msgstr "Unterstützungsbedarf"
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:185
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:212
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:207
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "This message will be sent to all parents with active enrollments in this program."
-msgstr ""
+msgstr "Diese Nachricht wird an alle Eltern mit aktiven Anmeldungen in diesem Programm gesendet."
 
-#: lib/klass_hero_web/components/messaging_components.ex:322
+#: lib/klass_hero_web/components/messaging_components.ex:387
 #, elixir-autogen, elixir-format
 msgid "Type a message..."
-msgstr ""
+msgstr "Nachricht eingeben..."
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:419
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:374
+#: lib/klass_hero_web/live/provider/participation_live.ex:290
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:249
 #, elixir-autogen, elixir-format
 msgid "Unable to refresh roster. Please reload."
 msgstr "Teilnehmerliste konnte nicht aktualisiert werden. Bitte laden Sie die Seite neu."
 
-#: lib/klass_hero_web/live/booking_live.ex:418
-#: lib/klass_hero_web/live/dashboard_live.ex:250
+#: lib/klass_hero_web/components/parent_components.ex:589
+#: lib/klass_hero_web/live/booking_live.ex:392
 #, elixir-autogen, elixir-format
 msgid "Upgrade"
-msgstr ""
+msgstr "Upgrade"
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:165
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:201
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:185
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "Write your message to all enrolled parents..."
-msgstr ""
+msgstr "Schreiben Sie Ihre Nachricht an alle angemeldeten Eltern..."
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:194
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:192
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:116
 #, elixir-autogen, elixir-format
 msgid "You already submitted a note for this record"
 msgstr "Sie haben bereits eine Notiz für diesen Eintrag eingereicht"
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:170
+#: lib/klass_hero_web/live/messaging_live_helper.ex:178
 #, elixir-autogen, elixir-format
 msgid "You don't have access to this conversation"
-msgstr ""
+msgstr "Sie haben keinen Zugriff auf diese Unterhaltung"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:142
+#: lib/klass_hero_web/live/settings/children_live.ex:137
 #, elixir-autogen, elixir-format
 msgid "You don't have permission to delete this child."
 msgstr "Sie haben keine Berechtigung, dieses Kind zu löschen."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:83
+#: lib/klass_hero_web/live/settings/children_live.ex:81
 #, elixir-autogen, elixir-format
 msgid "You don't have permission to edit this child."
 msgstr "Sie haben keine Berechtigung, dieses Kind zu bearbeiten."
 
-#: lib/klass_hero_web/live/booking_live.ex:405
+#: lib/klass_hero_web/live/booking_live.ex:379
 #, elixir-autogen, elixir-format
 msgid "You have %{remaining} of %{total} bookings remaining this month."
-msgstr ""
+msgstr "Sie haben noch %{remaining} von %{total} Buchungen in diesem Monat übrig."
 
-#: lib/klass_hero_web/live/dashboard_live.ex:234
+#: lib/klass_hero_web/components/parent_components.ex:579
 #, elixir-autogen, elixir-format
 msgid "You have used %{used} of %{cap} bookings this month."
-msgstr ""
+msgstr "Sie haben %{used} von %{cap} Buchungen in diesem Monat genutzt."
 
-#: lib/klass_hero_web/live/booking_live.ex:183
+#: lib/klass_hero_web/live/booking_live.ex:165
 #, elixir-autogen, elixir-format
 msgid "You've reached your monthly booking limit. Upgrade to Active tier for unlimited bookings."
-msgstr ""
+msgstr "Sie haben Ihr monatliches Buchungslimit erreicht. Upgraden Sie auf die Stufe Aktiv für unbegrenzte Buchungen."
 
-#: lib/klass_hero_web/live/booking_live.ex:399
+#: lib/klass_hero_web/live/booking_live.ex:373
 #, elixir-autogen, elixir-format
 msgid "Your Booking Plan"
-msgstr ""
+msgstr "Ihr Buchungsplan"
 
-#: lib/klass_hero_web/components/messaging_components.ex:408
+#: lib/klass_hero_web/components/messaging_components.ex:473
 #, elixir-autogen, elixir-format
 msgid "Your conversations with parents will appear here"
-msgstr ""
+msgstr "Ihre Unterhaltungen mit Eltern werden hier angezeigt"
 
-#: lib/klass_hero_web/components/messaging_components.ex:410
+#: lib/klass_hero_web/components/messaging_components.ex:475
 #, elixir-autogen, elixir-format
 msgid "Your conversations with providers will appear here"
-msgstr ""
+msgstr "Ihre Unterhaltungen mit Anbietern werden hier angezeigt"
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:25
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:86
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:29
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:28
 #, elixir-autogen, elixir-format
 msgid "Your subscription tier doesn't support broadcasts"
-msgstr ""
+msgstr "Ihre Abonnementstufe unterstützt keine Rundnachrichten"
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:152
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:188
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:172
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:187
 #, elixir-autogen, elixir-format
 msgid "e.g., Important Update"
-msgstr ""
+msgstr "z. B. Wichtiges Update"
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:144
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:180
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:164
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "optional"
-msgstr ""
+msgstr "optional"
 
-#: lib/klass_hero_web/live/booking_live.ex:411
-#: lib/klass_hero_web/live/dashboard_live.ex:243
+#: lib/klass_hero_web/components/parent_components.ex:595
+#: lib/klass_hero_web/live/booking_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "tier"
-msgstr ""
+msgstr "Stufe"
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:192
+#: lib/klass_hero_web/live/admin/verifications_live.ex:175
 #, elixir-autogen, elixir-format
 msgid "%{count} document"
 msgid_plural "%{count} documents"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%{count} Dokument"
+msgstr[1] "%{count} Dokumente"
 
-#: lib/klass_hero_web/components/program_components.ex:575
-#: lib/klass_hero_web/components/program_components.ex:583
+#: lib/klass_hero_web/components/program_components.ex:574
+#: lib/klass_hero_web/components/program_components.ex:582
 #, elixir-autogen, elixir-format
 msgid "%{count} month"
 msgid_plural "%{count} months"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%{count} Monat"
+msgstr[1] "%{count} Monate"
 
-#: lib/klass_hero_web/components/program_components.ex:571
-#: lib/klass_hero_web/components/program_components.ex:582
+#: lib/klass_hero_web/components/program_components.ex:570
+#: lib/klass_hero_web/components/program_components.ex:581
 #, elixir-autogen, elixir-format
 msgid "%{count} year"
 msgid_plural "%{count} years"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%{count} Jahr"
+msgstr[1] "%{count} Jahre"
 
-#: lib/klass_hero_web/components/program_components.ex:596
+#: lib/klass_hero_web/components/program_components.ex:592
 #, elixir-autogen, elixir-format
 msgid "%{gender} only"
-msgstr ""
+msgstr "Nur %{gender}"
 
-#: lib/klass_hero_web/components/provider_components.ex:277
+#: lib/klass_hero_web/components/provider_components.ex:285
 #, elixir-autogen, elixir-format
 msgid "Action Required"
-msgstr ""
+msgstr "Aktion erforderlich"
 
-#: lib/klass_hero_web/components/provider_components.ex:816
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/components/provider_components.ex:781
+#, elixir-autogen, elixir-format
 msgid "Add Member"
-msgstr "Teammitglied hinzufügen"
+msgstr "Mitglied hinzufügen"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1506
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1703
 #, elixir-autogen, elixir-format
 msgid "Add your first staff member to get started!"
-msgstr ""
+msgstr "Fügen Sie Ihren ersten Mitarbeiter hinzu, um loszulegen!"
 
-#: lib/klass_hero_web/components/program_components.ex:555
+#: lib/klass_hero_web/components/program_components.ex:556
 #, elixir-autogen, elixir-format
 msgid "Ages %{min} to %{max}"
-msgstr ""
+msgstr "Alter %{min} bis %{max}"
 
-#: lib/klass_hero_web/components/program_components.ex:559
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/components/program_components.ex:560
+#, elixir-autogen, elixir-format
 msgid "Ages %{min}+"
-msgstr "Alter %{range}"
+msgstr "Alter %{min}+"
 
-#: lib/klass_hero_web/components/provider_components.ex:1099
+#: lib/klass_hero_web/components/provider_components.ex:1054
 #, elixir-autogen, elixir-format
 msgid "Allowed Genders"
-msgstr ""
+msgstr "Zulässige Geschlechter"
 
-#: lib/klass_hero_web/components/provider_components.ex:2263
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/components/provider_components.ex:2184
+#, elixir-autogen, elixir-format
 msgid "An unexpected error occurred during import."
-msgstr "Ein unerwarteter Fehler ist aufgetreten. Bitte versuchen Sie es erneut."
+msgstr "Beim Import ist ein unerwarteter Fehler aufgetreten."
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:384
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:57
+#: lib/klass_hero_web/components/provider_layout_components.ex:564
+#: lib/klass_hero_web/live/admin/verifications_live.ex:367
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "Approve"
 msgstr "Genehmigen"
 
-#: lib/klass_hero_web/components/participation_components.ex:832
+#: lib/klass_hero_web/components/participation_components.ex:802
 #: lib/klass_hero_web/components/provider_components.ex:47
-#: lib/klass_hero_web/live/admin/sessions_live.ex:315
-#: lib/klass_hero_web/live/admin/verifications_live.ex:214
+#: lib/klass_hero_web/live/admin/sessions_live.ex:294
+#: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Approved"
 msgstr "Genehmigt"
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:380
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/admin/verifications_live.ex:363
+#, elixir-autogen, elixir-format
 msgid "Are you sure you want to approve this document?"
-msgstr "Möchten Sie dieses Kind wirklich entfernen?"
+msgstr "Möchten Sie dieses Dokument wirklich genehmigen?"
 
-#: lib/klass_hero_web/components/provider_components.ex:572
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/components/provider_components.ex:535
+#, elixir-autogen, elixir-format
 msgid "Are you sure you want to remove this team member?"
-msgstr "Möchten Sie dieses Kind wirklich entfernen?"
+msgstr "Möchten Sie dieses Teammitglied wirklich entfernen?"
 
-#: lib/klass_hero_web/live/home_live.ex:493
+#: lib/klass_hero_web/components/marketing_components.ex:641
 #, elixir-autogen, elixir-format
 msgid "As fathers and partners of teachers in Berlin, we saw and heard firsthand how hard it is to find, book, and manage quality youth activities outside the classroom. Klass Hero is the complete platform connecting Berlin families and schools with trusted, vetted activity providers — offering safe, supervised, and enriching experiences across sports, arts, tutoring, and more. We verify every provider, structure every booking, and support every step — so parents know their child is in good hands, and providers can focus on what they do best: inspiring kids."
-msgstr ""
+msgstr "Als Väter und Partner von Lehrkräften in Berlin haben wir aus erster Hand erlebt, wie schwer es ist, hochwertige außerschulische Aktivitäten für Kinder zu finden, zu buchen und zu organisieren. Klass Hero ist die umfassende Plattform, die Berliner Familien und Schulen mit vertrauenswürdigen, geprüften Anbietern verbindet — und bietet sichere, betreute und bereichernde Erlebnisse in den Bereichen Sport, Kunst, Nachhilfe und mehr. Wir überprüfen jeden Anbieter, strukturieren jede Buchung und unterstützen bei jedem Schritt — damit Eltern wissen, dass ihr Kind in guten Händen ist, und Anbieter sich auf das konzentrieren können, was sie am besten können: Kinder zu begeistern."
 
-#: lib/klass_hero_web/components/provider_components.ex:1223
+#: lib/klass_hero_web/components/provider_components.ex:1175
 #, elixir-autogen, elixir-format
 msgid "Assign Instructor"
-msgstr ""
+msgstr "Kursleiter zuweisen"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1293
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:253
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:190
-#: lib/klass_hero_web/live/provider/subscription_live.ex:100
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1423
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:263
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Back to Dashboard"
-msgstr ""
+msgstr "Zurück zum Dashboard"
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:298
+#: lib/klass_hero_web/live/admin/verifications_live.ex:281
 #, elixir-autogen, elixir-format
 msgid "Back to verifications"
-msgstr ""
+msgstr "Zurück zu den Verifizierungen"
 
-#: lib/klass_hero_web/live/home_live.ex:108
-#, elixir-autogen, elixir-format
-msgid "Berlin's leading network for tutors, coaches, and camp providers!"
-msgstr ""
-
-#: lib/klass_hero_web/components/provider_components.ex:665
+#: lib/klass_hero_web/components/provider_components.ex:633
 #, elixir-autogen, elixir-format
 msgid "Bio"
-msgstr ""
+msgstr "Biografie"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:285
+#: lib/klass_hero_web/live/dashboard_live.ex:373
 #, elixir-autogen, elixir-format
 msgid "Book a Program"
-msgstr ""
+msgstr "Programm buchen"
 
-#: lib/klass_hero_web/components/provider_components.ex:666
+#: lib/klass_hero_web/components/provider_components.ex:634
 #, elixir-autogen, elixir-format
 msgid "Brief description of experience and specialties..."
-msgstr ""
+msgstr "Kurze Beschreibung der Erfahrung und Spezialgebiete..."
 
-#: lib/klass_hero_web/live/about_live.ex:250
-#, elixir-autogen, elixir-format
-msgid "Built by Parents and Educators for More Learning Opportunities"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:490
+#: lib/klass_hero_web/components/marketing_components.ex:638
 #, elixir-autogen, elixir-format
 msgid "Built by Parents to Empower Educators."
-msgstr ""
+msgstr "Von Eltern entwickelt, um Pädagogen zu stärken."
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:313
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/admin/verifications_live.ex:296
+#, elixir-autogen, elixir-format
 msgid "Business"
-msgstr "Business-Plan"
+msgstr "Business"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1315
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1444
+#, elixir-autogen, elixir-format
 msgid "Business Description"
-msgstr "Gewerbeanmeldung"
+msgstr "Geschäftsbeschreibung"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1302
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1431
 #, elixir-autogen, elixir-format
 msgid "Business Information"
-msgstr ""
+msgstr "Geschäftsinformationen"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1323
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:280
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1451
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "Business Logo"
-msgstr ""
+msgstr "Firmenlogo"
 
-#: lib/klass_hero_web/components/provider_components.ex:900
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:296
+#: lib/klass_hero_web/components/provider_components.ex:865
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "Category"
 msgstr "Kategorie"
 
-#: lib/klass_hero_web/components/provider_components.ex:1046
+#: lib/klass_hero_web/components/provider_components.ex:1003
 #, elixir-autogen, elixir-format
 msgid "Check eligibility at"
-msgstr ""
+msgstr "Berechtigung prüfen unter"
 
-#: lib/klass_hero_web/components/provider_components.ex:1766
-#: lib/klass_hero_web/components/provider_components.ex:2002
+#: lib/klass_hero_web/components/provider_components.ex:1722
+#: lib/klass_hero_web/components/provider_components.ex:1948
 #, elixir-autogen, elixir-format
 msgid "Child Name"
-msgstr ""
+msgstr "Name des Kindes"
 
 #: lib/klass_hero_web/components/booking_components.ex:181
 #, elixir-autogen, elixir-format
 msgid "Child does not meet program requirements"
-msgstr ""
+msgstr "Kind erfüllt die Programmanforderungen nicht"
 
 #: lib/klass_hero_web/components/booking_components.ex:171
 #, elixir-autogen, elixir-format
 msgid "Child meets all program requirements"
-msgstr ""
+msgstr "Kind erfüllt alle Programmanforderungen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1211
+#: lib/klass_hero_web/components/provider_components.ex:1164
 #, elixir-autogen, elixir-format
 msgid "Choose Image"
-msgstr ""
+msgstr "Bild auswählen"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1377
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1504
 #, elixir-autogen, elixir-format
 msgid "Choose Logo"
-msgstr ""
+msgstr "Logo auswählen"
 
-#: lib/klass_hero_web/components/provider_components.ex:793
+#: lib/klass_hero_web/components/provider_components.ex:758
 #, elixir-autogen, elixir-format
 msgid "Choose Photo"
-msgstr ""
+msgstr "Foto auswählen"
 
-#: lib/klass_hero_web/components/provider_components.ex:902
+#: lib/klass_hero_web/components/provider_components.ex:867
 #, elixir-autogen, elixir-format
 msgid "Choose a category"
-msgstr ""
+msgstr "Kategorie auswählen"
 
-#: lib/klass_hero_web/components/provider_components.ex:433
+#: lib/klass_hero_web/components/provider_components.ex:404
 #, elixir-autogen, elixir-format
 msgid "Complete business verification to create programs."
-msgstr ""
+msgstr "Schließen Sie die Geschäftsverifizierung ab, um Programme zu erstellen."
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:413
+#: lib/klass_hero_web/live/admin/verifications_live.ex:396
 #, elixir-autogen, elixir-format
 msgid "Confirm rejection"
-msgstr ""
+msgstr "Ablehnung bestätigen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2199
+#: lib/klass_hero_web/components/provider_components.ex:2145
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
-msgstr ""
+msgstr "Bestätigt"
 
-#: lib/klass_hero_web/components/messaging_components.ex:737
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Contact Provider"
-msgstr ""
-
-#: lib/klass_hero_web/live/admin/verifications_live.ex:57
+#: lib/klass_hero_web/components/messaging_components.ex:811
 #, elixir-autogen, elixir-format
-msgid "Could not load verification documents."
-msgstr ""
+msgid "Contact Provider"
+msgstr "Anbieter kontaktieren"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:751
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:789
 #, elixir-autogen, elixir-format
 msgid "Could not read the uploaded file."
-msgstr ""
+msgstr "Die hochgeladene Datei konnte nicht gelesen werden."
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:708
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:716
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:757
 #, elixir-autogen, elixir-format
 msgid "Could not remove invite."
-msgstr ""
+msgstr "Einladung konnte nicht entfernt werden."
 
-#: lib/klass_hero_web/components/provider_components.ex:1167
+#: lib/klass_hero_web/components/provider_components.ex:1120
 #, elixir-autogen, elixir-format
 msgid "Cover Image"
-msgstr ""
+msgstr "Titelbild"
 
-#: lib/klass_hero_web/components/provider_components.ex:1039
+#: lib/klass_hero_web/components/provider_components.ex:997
 #, elixir-autogen, elixir-format
 msgid "Define age, gender, or grade restrictions for eligible participants."
-msgstr ""
+msgstr "Legen Sie Alters-, Geschlechts- oder Klassenstufenbeschränkungen für teilnahmeberechtigte Teilnehmer fest."
 
-#: lib/klass_hero_web/components/provider_components.ex:1159
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/components/provider_components.ex:1113
+#, elixir-autogen, elixir-format
 msgid "Describe your program..."
-msgstr "Programme suchen..."
+msgstr "Beschreiben Sie Ihr Programm..."
 
-#: lib/klass_hero_web/components/provider_components.ex:1158
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:313
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:221
+#: lib/klass_hero_web/components/provider_components.ex:1112
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:323
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:228
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr "Beschreibung"
 
-#: lib/klass_hero_web/components/program_components.ex:603
-#: lib/klass_hero_web/components/provider_components.ex:1110
-#: lib/klass_hero_web/live/settings/children_live.ex:692
+#: lib/klass_hero_web/components/program_components.ex:694
+#: lib/klass_hero_web/components/provider_components.ex:1065
+#: lib/klass_hero_web/live/settings/children_live.ex:670
 #, elixir-autogen, elixir-format
 msgid "Diverse"
-msgstr ""
+msgstr "Divers"
 
-#: lib/klass_hero_web/components/provider_components.ex:2368
+#: lib/klass_hero_web/components/provider_components.ex:2281
 #, elixir-autogen, elixir-format
 msgid "Document Type"
-msgstr ""
+msgstr "Dokumenttyp"
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:117
+#: lib/klass_hero_web/live/admin/verifications_live.ex:100
 #, elixir-autogen, elixir-format
 msgid "Document approved successfully."
-msgstr ""
+msgstr "Dokument erfolgreich genehmigt."
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:120
-#: lib/klass_hero_web/live/admin/verifications_live.ex:160
+#: lib/klass_hero_web/live/admin/verifications_live.ex:103
+#: lib/klass_hero_web/live/admin/verifications_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "Document has already been reviewed."
-msgstr ""
+msgstr "Dokument wurde bereits überprüft."
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:344
-#: lib/klass_hero_web/live/admin/verifications_live.ex:484
-#: lib/klass_hero_web/live/admin/verifications_live.ex:496
+#: lib/klass_hero_web/live/admin/verifications_live.ex:327
+#: lib/klass_hero_web/live/admin/verifications_live.ex:463
+#: lib/klass_hero_web/live/admin/verifications_live.ex:475
 #, elixir-autogen, elixir-format
 msgid "Document preview"
-msgstr ""
+msgstr "Dokumentvorschau"
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:154
+#: lib/klass_hero_web/live/admin/verifications_live.ex:137
 #, elixir-autogen, elixir-format
 msgid "Document rejected."
-msgstr ""
+msgstr "Dokument abgelehnt."
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:467
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:533
 #, elixir-autogen, elixir-format
 msgid "Document uploaded successfully."
-msgstr ""
+msgstr "Dokument erfolgreich hochgeladen."
 
-#: lib/klass_hero_web/components/provider_components.ex:1966
+#: lib/klass_hero_web/components/provider_components.ex:1915
 #, elixir-autogen, elixir-format
 msgid "Download Template"
-msgstr ""
+msgstr "Vorlage herunterladen"
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:357
+#: lib/klass_hero_web/live/admin/verifications_live.ex:340
 #, elixir-autogen, elixir-format
 msgid "Download document"
-msgstr ""
+msgstr "Dokument herunterladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:868
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/components/provider_components.ex:833
+#, elixir-autogen, elixir-format
 msgid "Edit Program"
-msgstr "Programme"
+msgstr "Programm bearbeiten"
 
-#: lib/klass_hero_web/components/provider_components.ex:608
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/components/provider_components.ex:575
+#, elixir-autogen, elixir-format
 msgid "Edit Team Member"
-msgstr "Teammitglied hinzufügen"
+msgstr "Teammitglied bearbeiten"
 
-#: lib/klass_hero_web/components/provider_components.ex:981
+#: lib/klass_hero_web/components/provider_components.ex:942
 #, elixir-autogen, elixir-format
 msgid "End Date"
-msgstr ""
+msgstr "Enddatum"
 
-#: lib/klass_hero_web/components/provider_components.ex:967
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:166
+#: lib/klass_hero_web/components/provider_components.ex:929
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:161
 #, elixir-autogen, elixir-format
 msgid "End Time"
-msgstr ""
+msgstr "Endzeit"
 
-#: lib/klass_hero_web/components/provider_components.ex:1772
-#: lib/klass_hero_web/components/provider_components.ex:2221
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/components/provider_components.ex:1728
+#: lib/klass_hero_web/components/provider_components.ex:2165
+#: lib/klass_hero_web/components/provider_layout_components.ex:554
+#, elixir-autogen, elixir-format
 msgid "Enrolled"
-msgstr "Anmeldung"
+msgstr "Angemeldet"
 
-#: lib/klass_hero_web/components/provider_components.ex:1620
+#: lib/klass_hero_web/components/provider_components.ex:1577
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
-msgstr ""
+msgstr "Angemeldet (%{count})"
 
-#: lib/klass_hero_web/components/provider_components.ex:1011
+#: lib/klass_hero_web/components/provider_components.ex:970
 #, elixir-autogen, elixir-format
 msgid "Enrollment Capacity (optional)"
-msgstr ""
+msgstr "Anmeldekapazität (optional)"
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:405
+#: lib/klass_hero_web/live/admin/verifications_live.ex:388
 #, elixir-autogen, elixir-format
 msgid "Explain why this document is being rejected..."
-msgstr ""
+msgstr "Erklären Sie, warum dieses Dokument abgelehnt wird..."
 
-#: lib/klass_hero_web/components/provider_components.ex:2222
-#: lib/klass_hero_web/live/admin/emails_live.ex:220
+#: lib/klass_hero_web/components/provider_components.ex:2166
+#: lib/klass_hero_web/live/admin/emails_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Failed"
 msgstr "Fehlgeschlagen"
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:134
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/admin/verifications_live.ex:117
+#, elixir-autogen, elixir-format
 msgid "Failed to approve document."
-msgstr "Notiz konnte nicht genehmigt werden"
+msgstr "Dokument konnte nicht genehmigt werden."
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:174
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/admin/verifications_live.ex:157
+#, elixir-autogen, elixir-format
 msgid "Failed to reject document."
-msgstr "Notiz konnte nicht abgelehnt werden"
+msgstr "Dokument konnte nicht abgelehnt werden."
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:690
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:739
+#, elixir-autogen, elixir-format
 msgid "Failed to resend invite."
-msgstr "Notiz konnte nicht abgelehnt werden"
+msgstr "Einladung konnte nicht erneut gesendet werden."
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:476
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:542
+#, elixir-autogen, elixir-format
 msgid "Failed to upload document."
-msgstr "Sitzungsdaten konnten nicht geladen werden"
+msgstr "Dokument konnte nicht hochgeladen werden."
 
-#: lib/klass_hero_web/live/dashboard_live.ex:266
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/dashboard_live.ex:354
+#, elixir-autogen, elixir-format
 msgid "Family Programs"
-msgstr "Familienfortschritt"
+msgstr "Familienprogramme"
 
-#: lib/klass_hero_web/components/program_components.ex:601
-#: lib/klass_hero_web/components/provider_components.ex:1109
-#: lib/klass_hero_web/live/settings/children_live.ex:691
+#: lib/klass_hero_web/components/program_components.ex:692
+#: lib/klass_hero_web/components/provider_components.ex:1064
+#: lib/klass_hero_web/live/settings/children_live.ex:669
 #, elixir-autogen, elixir-format
 msgid "Female"
-msgstr ""
+msgstr "Weiblich"
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:317
+#: lib/klass_hero_web/live/admin/verifications_live.ex:300
 #, elixir-autogen, elixir-format
 msgid "File"
-msgstr ""
+msgstr "Datei"
 
-#: lib/klass_hero_web/components/provider_components.ex:2301
+#: lib/klass_hero_web/components/provider_components.ex:2216
 #, elixir-autogen, elixir-format
 msgid "File is too large."
-msgstr ""
+msgstr "Die Datei ist zu groß."
 
-#: lib/klass_hero_web/components/provider_components.ex:2303
+#: lib/klass_hero_web/components/provider_components.ex:2218
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
-msgstr ""
+msgstr "Dateityp wird nicht akzeptiert."
 
-#: lib/klass_hero_web/components/provider_components.ex:695
+#: lib/klass_hero_web/components/provider_components.ex:661
 #, elixir-autogen, elixir-format
 msgid "First Aid, UEFA B License, Child Care Cert"
-msgstr ""
+msgstr "Erste Hilfe, UEFA-B-Lizenz, Kinderbetreuungszertifikat"
 
-#: lib/klass_hero_web/components/provider_components.ex:636
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/components/provider_components.ex:603
+#, elixir-autogen, elixir-format
 msgid "First Name"
 msgstr "Vorname"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:687
+#: lib/klass_hero_web/live/settings/children_live.ex:665
 #, elixir-autogen, elixir-format
 msgid "Gender"
-msgstr ""
+msgstr "Geschlecht"
 
-#: lib/klass_hero_web/components/program_components.ex:610
+#: lib/klass_hero_web/components/program_components.ex:701
 #, elixir-autogen, elixir-format
 msgid "Grade %{grade}"
-msgstr ""
+msgstr "Klassenstufe %{grade}"
 
-#: lib/klass_hero_web/components/program_components.ex:618
+#: lib/klass_hero_web/components/program_components.ex:709
 #, elixir-autogen, elixir-format
 msgid "Grade %{min}+"
-msgstr ""
+msgstr "Klassenstufe %{min}+"
 
-#: lib/klass_hero_web/components/program_components.ex:614
+#: lib/klass_hero_web/components/program_components.ex:705
 #, elixir-autogen, elixir-format
 msgid "Grades %{min} – %{max}"
-msgstr ""
+msgstr "Klassenstufen %{min} – %{max}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2005
+#: lib/klass_hero_web/components/provider_components.ex:1951
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
-msgstr ""
+msgstr "E-Mail des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:757
+#: lib/klass_hero_web/components/provider_components.ex:722
 #, elixir-autogen, elixir-format
 msgid "Headshot Photo"
-msgstr ""
+msgstr "Porträtfoto"
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:127
+#: lib/klass_hero_web/presenters/provider_presenter.ex:95
 #, elixir-autogen, elixir-format
 msgid "ID Document"
-msgstr ""
+msgstr "Ausweisdokument"
 
-#: lib/klass_hero_web/components/provider_components.ex:1938
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/components/provider_components.ex:1888
+#, elixir-autogen, elixir-format
 msgid "Import"
-msgstr "Wichtig:"
+msgstr "Importieren"
 
-#: lib/klass_hero_web/components/provider_components.ex:1979
+#: lib/klass_hero_web/presenters/provider_presenter.ex:94
 #, elixir-autogen, elixir-format
-msgid "Import failed"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:760
-#, elixir-autogen, elixir-format
-msgid "Imported %{count} families."
-msgstr ""
-
-#: lib/klass_hero_web/live/about_live.ex:261
-#, elixir-autogen, elixir-format
-msgid "In 2025, Shane connected with his friend Max Pergl, a full-stack developer who shared a unique perspective. Both Shane and Max are partners of teachers who wanted to extend their expertise beyond the classroom, offering more to the community, but without the time to manage bookings, payments, and compliance on their own."
-msgstr ""
-
-#: lib/klass_hero_web/presenters/provider_presenter.ex:126
-#, elixir-autogen, elixir-format, fuzzy
 msgid "Insurance Certificate"
-msgstr "Versicherung"
+msgstr "Versicherungsnachweis"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:705
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:754
 #, elixir-autogen, elixir-format
 msgid "Invite not found."
-msgstr ""
+msgstr "Einladung nicht gefunden."
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:702
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:751
 #, elixir-autogen, elixir-format
 msgid "Invite removed."
-msgstr ""
+msgstr "Einladung entfernt."
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:679
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:728
 #, elixir-autogen, elixir-format
 msgid "Invite resent successfully."
-msgstr ""
+msgstr "Einladung erfolgreich erneut gesendet."
 
-#: lib/klass_hero_web/components/provider_components.ex:1637
+#: lib/klass_hero_web/components/provider_components.ex:1594
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
-msgstr ""
+msgstr "Einladungen (%{count})"
 
-#: lib/klass_hero_web/components/provider_components.ex:796
+#: lib/klass_hero_web/components/provider_components.ex:761
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 1MB."
-msgstr ""
+msgstr "JPG, PNG oder WebP. Max. 1 MB."
 
-#: lib/klass_hero_web/components/provider_components.ex:1214
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1380
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:297
+#: lib/klass_hero_web/components/provider_components.ex:1167
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1507
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:304
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 2MB."
-msgstr ""
+msgstr "JPG, PNG oder WebP. Max. 2 MB."
 
-#: lib/klass_hero_web/live/about_live.ex:266
+#: lib/klass_hero_web/live/about_live.ex:189
 #, elixir-autogen, elixir-format
 msgid "Klass Hero was built to solve exactly that. A comprehensive operational platform that empowers educators to spend less time on paperwork and more time inspiring children."
-msgstr ""
+msgstr "Klass Hero wurde genau dafür entwickelt. Eine umfassende Betriebsplattform, die es Pädagogen ermöglicht, weniger Zeit mit Papierkram zu verbringen und mehr Zeit damit, Kinder zu inspirieren."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:701
+#: lib/klass_hero_web/live/settings/children_live.ex:679
 #, elixir-autogen, elixir-format
 msgid "Klasse %{n}"
-msgstr ""
+msgstr "Klasse %{n}"
 
-#: lib/klass_hero_web/live/about_live.ex:271
+#: lib/klass_hero_web/components/provider_components.ex:609
 #, elixir-autogen, elixir-format
-msgid "Konstantin Pergl, Max's brother, joined as CFO, bringing the financial rigour and strategic planning needed to navigate the German market and ensure long-term stability for every provider on the platform."
-msgstr ""
-
-#: lib/klass_hero_web/components/provider_components.ex:642
-#, elixir-autogen, elixir-format, fuzzy
 msgid "Last Name"
 msgstr "Nachname"
 
-#: lib/klass_hero_web/components/provider_components.ex:992
+#: lib/klass_hero_web/components/provider_components.ex:952
 #, elixir-autogen, elixir-format
 msgid "Leave blank for open registration at any time."
-msgstr ""
+msgstr "Leer lassen für eine jederzeit offene Anmeldung."
+
+#: lib/klass_hero_web/components/provider_components.ex:1057
+#, elixir-autogen, elixir-format
+msgid "Leave unchecked to allow all genders."
+msgstr "Nicht markiert lassen, um alle Geschlechter zuzulassen."
+
+#: lib/klass_hero_web/components/provider_components.ex:885
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:167
+#, elixir-autogen, elixir-format
+msgid "Location"
+msgstr "Ort"
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:460
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:77
+#, elixir-autogen, elixir-format
+msgid "Logo upload failed. Please try again."
+msgstr "Logo-Upload fehlgeschlagen. Bitte versuchen Sie es erneut."
+
+#: lib/klass_hero_web/components/program_components.ex:693
+#: lib/klass_hero_web/components/provider_components.ex:1063
+#: lib/klass_hero_web/live/settings/children_live.ex:668
+#, elixir-autogen, elixir-format
+msgid "Male"
+msgstr "Männlich"
+
+#: lib/klass_hero_web/components/provider_components.ex:1047
+#, elixir-autogen, elixir-format
+msgid "Maximum Age (months)"
+msgstr "Höchstalter (Monate)"
+
+#: lib/klass_hero_web/components/provider_components.ex:985
+#, elixir-autogen, elixir-format
+msgid "Maximum Enrollment"
+msgstr "Maximale Anmeldekapazität"
 
 #: lib/klass_hero_web/components/provider_components.ex:1102
 #, elixir-autogen, elixir-format
-msgid "Leave unchecked to allow all genders."
-msgstr ""
-
-#: lib/klass_hero_web/components/provider_components.ex:920
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:172
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Location"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:394
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:73
-#, elixir-autogen, elixir-format
-msgid "Logo upload failed. Please try again."
-msgstr ""
-
-#: lib/klass_hero_web/components/program_components.ex:602
-#: lib/klass_hero_web/components/provider_components.ex:1108
-#: lib/klass_hero_web/live/settings/children_live.ex:690
-#, elixir-autogen, elixir-format
-msgid "Male"
-msgstr ""
-
-#: lib/klass_hero_web/components/provider_components.ex:1091
-#, elixir-autogen, elixir-format
-msgid "Maximum Age (months)"
-msgstr ""
-
-#: lib/klass_hero_web/components/provider_components.ex:1026
-#, elixir-autogen, elixir-format
-msgid "Maximum Enrollment"
-msgstr ""
-
-#: lib/klass_hero_web/components/provider_components.ex:1148
-#, elixir-autogen, elixir-format
 msgid "Maximum Grade"
-msgstr ""
+msgstr "Höchste Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:931
+#: lib/klass_hero_web/components/provider_components.ex:894
 #, elixir-autogen, elixir-format
 msgid "Meeting Days"
-msgstr ""
+msgstr "Wochentage"
 
-#: lib/klass_hero_web/components/provider_components.ex:1085
+#: lib/klass_hero_web/components/provider_components.ex:1041
 #, elixir-autogen, elixir-format
 msgid "Minimum Age (months)"
-msgstr ""
+msgstr "Mindestalter (Monate)"
 
-#: lib/klass_hero_web/components/provider_components.ex:1020
+#: lib/klass_hero_web/components/provider_components.ex:979
 #, elixir-autogen, elixir-format
 msgid "Minimum Enrollment"
-msgstr ""
+msgstr "Minimale Anmeldekapazität"
 
-#: lib/klass_hero_web/components/provider_components.ex:1141
+#: lib/klass_hero_web/components/provider_components.ex:1095
 #, elixir-autogen, elixir-format
 msgid "Minimum Grade"
-msgstr ""
+msgstr "Niedrigste Klassenstufe"
 
-#: lib/klass_hero_web/live/contact_live.ex:75
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Mon-Fri, 9am-6pm CET"
-msgstr "Mo-Fr, 9-17 Uhr"
-
-#: lib/klass_hero_web/live/admin/verifications_live.ex:522
+#: lib/klass_hero_web/live/admin/verifications_live.ex:496
 #, elixir-autogen, elixir-format
 msgid "No approved documents."
-msgstr ""
+msgstr "Keine genehmigten Dokumente."
 
-#: lib/klass_hero_web/components/provider_components.ex:2329
+#: lib/klass_hero_web/components/provider_components.ex:2243
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
-msgstr ""
+msgstr "Noch keine Dokumente hochgeladen."
 
-#: lib/klass_hero_web/components/provider_components.ex:1759
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:269
+#: lib/klass_hero_web/components/provider_components.ex:1715
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
-msgstr ""
+msgstr "Noch keine Anmeldungen."
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:747
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:785
 #, elixir-autogen, elixir-format
 msgid "No file selected."
-msgstr ""
+msgstr "Keine Datei ausgewählt."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:700
+#: lib/klass_hero_web/live/settings/children_live.ex:678
 #, elixir-autogen, elixir-format
 msgid "No grade"
-msgstr ""
+msgstr "Keine Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:1992
+#: lib/klass_hero_web/components/provider_components.ex:1939
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
-msgstr ""
+msgstr "Noch keine Einladungen. Laden Sie eine CSV-Datei hoch, um Familien einzuladen."
 
-#: lib/klass_hero_web/components/provider_components.ex:1150
+#: lib/klass_hero_web/components/provider_components.ex:1104
 #, elixir-autogen, elixir-format
 msgid "No maximum"
-msgstr ""
+msgstr "Kein Maximum"
 
-#: lib/klass_hero_web/components/provider_components.ex:1143
+#: lib/klass_hero_web/components/provider_components.ex:1097
 #, elixir-autogen, elixir-format
 msgid "No minimum"
-msgstr ""
+msgstr "Kein Minimum"
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:521
+#: lib/klass_hero_web/live/admin/verifications_live.ex:495
 #, elixir-autogen, elixir-format
 msgid "No pending documents to review."
-msgstr ""
+msgstr "Keine ausstehenden Dokumente zur Überprüfung."
 
-#: lib/klass_hero_web/live/dashboard_live.ex:274
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/dashboard_live.ex:362
+#, elixir-autogen, elixir-format
 msgid "No programs booked yet"
-msgstr "Keine Programme gefunden"
+msgstr "Noch keine Programme gebucht"
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:523
+#: lib/klass_hero_web/live/admin/verifications_live.ex:497
 #, elixir-autogen, elixir-format
 msgid "No rejected documents."
-msgstr ""
+msgstr "Keine abgelehnten Dokumente."
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1505
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1702
 #, elixir-autogen, elixir-format
 msgid "No team members yet"
-msgstr ""
+msgstr "Noch keine Teammitglieder"
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:520
-#: lib/klass_hero_web/live/admin/verifications_live.ex:524
+#: lib/klass_hero_web/live/admin/verifications_live.ex:494
+#: lib/klass_hero_web/live/admin/verifications_live.ex:498
 #, elixir-autogen, elixir-format
 msgid "No verification documents found."
-msgstr ""
+msgstr "Keine Verifizierungsdokumente gefunden."
 
-#: lib/klass_hero_web/components/provider_components.ex:1225
+#: lib/klass_hero_web/components/provider_components.ex:1177
 #, elixir-autogen, elixir-format
 msgid "None (optional)"
-msgstr ""
+msgstr "Keine (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:292
+#: lib/klass_hero_web/components/provider_components.ex:301
 #, elixir-autogen, elixir-format
 msgid "Not Verified"
-msgstr ""
+msgstr "Nicht verifiziert"
 
-#: lib/klass_hero_web/components/program_components.ex:604
-#: lib/klass_hero_web/components/provider_components.ex:1111
-#: lib/klass_hero_web/live/settings/children_live.ex:689
+#: lib/klass_hero_web/components/program_components.ex:695
+#: lib/klass_hero_web/components/provider_components.ex:1066
+#: lib/klass_hero_web/live/settings/children_live.ex:667
 #, elixir-autogen, elixir-format
 msgid "Not specified"
-msgstr ""
+msgstr "Nicht angegeben"
 
-#: lib/klass_hero_web/live/home_live.ex:488
+#: lib/klass_hero_web/components/marketing_components.ex:635
 #, elixir-autogen, elixir-format
 msgid "Our Story"
-msgstr ""
+msgstr "Unsere Geschichte"
 
-#: lib/klass_hero_web/components/provider_components.ex:2405
+#: lib/klass_hero_web/components/provider_components.ex:2318
 #, elixir-autogen, elixir-format
 msgid "PDF, JPG or PNG. Max 10MB."
-msgstr ""
+msgstr "PDF, JPG oder PNG. Max. 10 MB."
 
-#: lib/klass_hero_web/components/program_components.ex:527
+#: lib/klass_hero_web/components/program_components.ex:519
 #, elixir-autogen, elixir-format
 msgid "Participant Requirements"
-msgstr ""
+msgstr "Teilnahmevoraussetzungen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1036
+#: lib/klass_hero_web/components/provider_components.ex:994
 #, elixir-autogen, elixir-format
 msgid "Participant Restrictions (optional)"
-msgstr ""
+msgstr "Teilnahmebeschränkungen (optional)"
 
-#: lib/klass_hero_web/components/participation_components.ex:831
-#: lib/klass_hero_web/components/provider_components.ex:262
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/components/participation_components.ex:801
+#: lib/klass_hero_web/components/provider_components.ex:269
+#, elixir-autogen, elixir-format
 msgid "Pending Review"
-msgstr "Ausstehend"
+msgstr "Ausstehende Überprüfung"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:413
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:975
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1036
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1071
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1143
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:479
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1025
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1083
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1114
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1165
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1270
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:99
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:103
 #, elixir-autogen, elixir-format
 msgid "Please fix the errors below."
 msgstr "Bitte korrigieren Sie die Fehler unten."
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:157
+#: lib/klass_hero_web/live/admin/verifications_live.ex:140
 #, elixir-autogen, elixir-format
 msgid "Please provide a rejection reason."
-msgstr ""
+msgstr "Bitte geben Sie einen Ablehnungsgrund an."
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:507
+#: lib/klass_hero_web/live/admin/verifications_live.ex:485
 #, elixir-autogen, elixir-format
 msgid "Preview not available for this file type."
-msgstr ""
+msgstr "Vorschau für diesen Dateityp nicht verfügbar."
 
-#: lib/klass_hero_web/components/provider_components.ex:911
+#: lib/klass_hero_web/components/provider_components.ex:876
 #, elixir-autogen, elixir-format
 msgid "Price (EUR)"
-msgstr ""
+msgstr "Preis (EUR)"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:409
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:475
+#, elixir-autogen, elixir-format
 msgid "Profile updated successfully."
-msgstr "Kind erfolgreich aktualisiert."
+msgstr "Profil erfolgreich aktualisiert."
 
-#: lib/klass_hero_web/components/provider_components.ex:1075
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/components/provider_components.ex:1032
+#, elixir-autogen, elixir-format
 msgid "Program Start"
-msgstr "Programmplätze"
+msgstr "Programmbeginn"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:2069
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:2262
+#, elixir-autogen, elixir-format
 msgid "Program created successfully."
-msgstr "Benutzer erfolgreich bestätigt."
+msgstr "Programm erfolgreich erstellt."
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:2076
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:2269
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
-msgstr ""
+msgstr "Programm erstellt, aber die Anmeldekapazität konnte nicht gespeichert werden. Bearbeiten Sie das Programm, um es erneut zu versuchen."
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:533
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:571
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:574
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1011
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:595
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:631
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:634
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1058
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:53
+#, elixir-autogen, elixir-format
 msgid "Program not found."
-msgstr "Programm nicht gefunden"
+msgstr "Programm nicht gefunden."
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1000
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1047
+#, elixir-autogen, elixir-format
 msgid "Program updated successfully."
-msgstr "Kind erfolgreich aktualisiert."
+msgstr "Programm erfolgreich aktualisiert."
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:418
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:34
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:484
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:32
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:27
 #, elixir-autogen, elixir-format
 msgid "Provider profile not found."
 msgstr "Anbieterprofil nicht gefunden."
 
-#: lib/klass_hero_web/live/home_live.ex:508
+#: lib/klass_hero_web/components/marketing_components.ex:648
 #, elixir-autogen, elixir-format
 msgid "Read our founding story →"
-msgstr ""
+msgstr "Lesen Sie unsere Gründungsgeschichte →"
 
-#: lib/klass_hero_web/components/participation_components.ex:809
-#: lib/klass_hero_web/components/provider_components.ex:2220
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:204
+#: lib/klass_hero_web/components/participation_components.ex:781
+#: lib/klass_hero_web/components/provider_components.ex:2164
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Registered"
 msgstr "Registriert"
 
-#: lib/klass_hero_web/components/provider_components.ex:1062
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/components/provider_components.ex:1019
+#, elixir-autogen, elixir-format
 msgid "Registration"
-msgstr "Anmeldegebühr:"
+msgstr "Anmeldung"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:187
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/program_detail_live.ex:166
+#, elixir-autogen, elixir-format
 msgid "Registration Closed"
-msgstr "Anmeldegebühr:"
+msgstr "Anmeldung geschlossen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1003
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/components/provider_components.ex:963
+#, elixir-autogen, elixir-format
 msgid "Registration Closes"
-msgstr "Anmeldegebühr:"
+msgstr "Anmeldeschluss"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:185
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/program_detail_live.ex:164
+#, elixir-autogen, elixir-format
 msgid "Registration Not Open Yet"
-msgstr "Anmeldegebühr:"
+msgstr "Anmeldung noch nicht geöffnet"
 
-#: lib/klass_hero_web/components/provider_components.ex:998
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/components/provider_components.ex:958
+#, elixir-autogen, elixir-format
 msgid "Registration Opens"
-msgstr "Anmeldegebühr:"
+msgstr "Anmeldebeginn"
 
-#: lib/klass_hero_web/components/provider_components.ex:989
+#: lib/klass_hero_web/components/provider_components.ex:949
 #, elixir-autogen, elixir-format
 msgid "Registration Period (optional)"
-msgstr ""
+msgstr "Anmeldezeitraum (optional)"
 
-#: lib/klass_hero_web/live/booking_live.ex:164
+#: lib/klass_hero_web/live/booking_live.ex:146
 #, elixir-autogen, elixir-format
 msgid "Registration has closed for this program."
-msgstr ""
+msgstr "Die Anmeldung für dieses Programm ist geschlossen."
 
-#: lib/klass_hero_web/live/program_detail_live.ex:159
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/program_detail_live.ex:138
+#, elixir-autogen, elixir-format
 msgid "Registration is closed"
-msgstr "Anmeldegebühr:"
+msgstr "Anmeldung geschlossen"
 
-#: lib/klass_hero_web/live/booking_live.ex:78
+#: lib/klass_hero_web/live/booking_live.ex:75
 #, elixir-autogen, elixir-format
 msgid "Registration is not currently open for this program."
-msgstr ""
+msgstr "Die Anmeldung für dieses Programm ist derzeit nicht geöffnet."
 
-#: lib/klass_hero_web/live/program_detail_live.ex:99
+#: lib/klass_hero_web/live/program_detail_live.ex:88
 #, elixir-autogen, elixir-format
 msgid "Registration is not open for this program."
-msgstr ""
+msgstr "Die Anmeldung für dieses Programm ist nicht geöffnet."
 
-#: lib/klass_hero_web/live/program_detail_live.ex:155
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/program_detail_live.ex:134
+#, elixir-autogen, elixir-format
 msgid "Registration opens %{date}"
-msgstr "Anmeldegebühr:"
+msgstr "Anmeldung öffnet am %{date}"
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:392
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:71
+#: lib/klass_hero_web/live/admin/verifications_live.ex:375
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:67
 #, elixir-autogen, elixir-format
 msgid "Reject"
 msgstr "Ablehnen"
 
-#: lib/klass_hero_web/components/participation_components.ex:833
+#: lib/klass_hero_web/components/participation_components.ex:803
 #: lib/klass_hero_web/components/provider_components.ex:48
-#: lib/klass_hero_web/live/admin/verifications_live.ex:219
+#: lib/klass_hero_web/live/admin/verifications_live.ex:202
 #, elixir-autogen, elixir-format
 msgid "Rejected"
 msgstr "Abgelehnt"
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:335
-#: lib/klass_hero_web/live/admin/verifications_live.ex:402
+#: lib/klass_hero_web/live/admin/verifications_live.ex:318
+#: lib/klass_hero_web/live/admin/verifications_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "Rejection reason"
-msgstr ""
+msgstr "Ablehnungsgrund"
 
-#: lib/klass_hero_web/components/provider_components.ex:779
-#: lib/klass_hero_web/components/provider_components.ex:1190
-#: lib/klass_hero_web/components/provider_components.ex:2040
-#: lib/klass_hero_web/components/provider_components.ex:2424
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1356
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:311
+#: lib/klass_hero_web/components/provider_components.ex:744
+#: lib/klass_hero_web/components/provider_components.ex:1143
+#: lib/klass_hero_web/components/provider_components.ex:1986
+#: lib/klass_hero_web/components/provider_components.ex:2337
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1483
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "Remove"
-msgstr ""
+msgstr "Entfernen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2033
+#: lib/klass_hero_web/components/provider_components.ex:1979
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
-msgstr ""
+msgstr "Einladung erneut senden"
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:326
+#: lib/klass_hero_web/live/admin/verifications_live.ex:309
 #, elixir-autogen, elixir-format
 msgid "Reviewed"
-msgstr ""
+msgstr "Überprüft"
 
-#: lib/klass_hero_web/components/provider_components.ex:651
+#: lib/klass_hero_web/components/provider_components.ex:618
 #, elixir-autogen, elixir-format
 msgid "Role"
-msgstr ""
+msgstr "Rolle"
 
-#: lib/klass_hero_web/components/provider_components.ex:1563
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:224
+#: lib/klass_hero_web/components/provider_components.ex:1523
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:386
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
-msgstr ""
+msgstr "Teilnehmerliste: %{name}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2230
-#: lib/klass_hero_web/components/provider_components.ex:2242
-#: lib/klass_hero_web/components/provider_components.ex:2253
+#: lib/klass_hero_web/components/provider_components.ex:1204
 #, elixir-autogen, elixir-format
-msgid "Row %{row}: %{msg}"
-msgstr ""
-
-#: lib/klass_hero_web/components/provider_components.ex:1252
-#, elixir-autogen, elixir-format, fuzzy
 msgid "Save Program"
-msgstr "Neues Programm"
+msgstr "Programm speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:927
+#: lib/klass_hero_web/components/provider_components.ex:891
 #, elixir-autogen, elixir-format
 msgid "Schedule (optional)"
-msgstr ""
+msgstr "Zeitplan (optional)"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:226
+#: lib/klass_hero_web/live/program_detail_live.ex:205
 #, elixir-autogen, elixir-format
 msgid "Schedule TBD"
-msgstr ""
+msgstr "Zeitplan noch offen"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:699
+#: lib/klass_hero_web/live/settings/children_live.ex:677
 #, elixir-autogen, elixir-format
 msgid "School Grade (optional)"
-msgstr ""
+msgstr "Klassenstufe (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2402
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/components/provider_components.ex:2315
+#, elixir-autogen, elixir-format
 msgid "Select File"
-msgstr "Kind auswählen"
+msgstr "Datei auswählen"
 
-#: lib/klass_hero_web/live/booking_live.ex:136
-#: lib/klass_hero_web/live/booking_live.ex:201
+#: lib/klass_hero_web/live/booking_live.ex:118
+#: lib/klass_hero_web/live/booking_live.ex:183
 #, elixir-autogen, elixir-format
 msgid "Selected child does not meet the program requirements."
-msgstr ""
+msgstr "Das ausgewählte Kind erfüllt die Programmanforderungen nicht."
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:965
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1026
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1015
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1073
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
-msgstr ""
+msgstr "Der ausgewählte Kursleiter konnte nicht gefunden werden. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2219
-#: lib/klass_hero_web/live/admin/emails_live.ex:219
+#: lib/klass_hero_web/components/provider_components.ex:2163
+#: lib/klass_hero_web/live/admin/emails_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Sent"
 msgstr "Gesendet"
 
-#: lib/klass_hero_web/components/provider_components.ex:699
+#: lib/klass_hero_web/components/provider_components.ex:665
 #, elixir-autogen, elixir-format
 msgid "Separate multiple qualifications with commas"
-msgstr ""
+msgstr "Trennen Sie mehrere Qualifikationen durch Kommas"
 
-#: lib/klass_hero_web/components/provider_components.ex:1014
+#: lib/klass_hero_web/components/provider_components.ex:973
 #, elixir-autogen, elixir-format
 msgid "Set minimum and maximum enrollment for this program."
-msgstr ""
+msgstr "Legen Sie die minimale und maximale Anmeldekapazität für dieses Programm fest."
 
-#: lib/klass_hero_web/live/about_live.ex:256
-#, elixir-autogen, elixir-format
-msgid "Shane spent over a decade as a coach and youth activity provider in Berlin, building Prime Youth, a community of providers, schools, and parents dedicated to giving children the best possible experiences. But one pattern kept emerging: the administrative burden of managing bookings, payments, and compliance was getting in everyone's way. Shane saw the problem from every angle. That experience became the foundation for Klass Hero."
-msgstr ""
-
-#: lib/klass_hero_web/components/provider_components.ex:672
+#: lib/klass_hero_web/components/provider_components.ex:639
 #, elixir-autogen, elixir-format
 msgid "Specialties"
-msgstr ""
+msgstr "Spezialisierungen"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1149
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1276
 #, elixir-autogen, elixir-format
 msgid "Staff member no longer exists."
-msgstr ""
+msgstr "Der Mitarbeiter existiert nicht mehr."
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:272
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:333
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:349
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:343
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:403
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:419
 #, elixir-autogen, elixir-format
 msgid "Staff member not found."
-msgstr ""
+msgstr "Mitarbeiter nicht gefunden."
 
-#: lib/klass_hero_web/components/provider_components.ex:976
+#: lib/klass_hero_web/components/provider_components.ex:937
 #, elixir-autogen, elixir-format
 msgid "Start Date"
-msgstr ""
+msgstr "Startdatum"
 
-#: lib/klass_hero_web/components/provider_components.ex:962
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:165
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/components/provider_components.ex:924
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:160
+#, elixir-autogen, elixir-format
 msgid "Start Time"
-msgstr ""
+msgstr "Startzeit"
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:321
+#: lib/klass_hero_web/live/admin/verifications_live.ex:304
 #, elixir-autogen, elixir-format
 msgid "Submitted"
-msgstr ""
+msgstr "Eingereicht"
 
-#: lib/klass_hero_web/live/booking_live.ex:383
+#: lib/klass_hero_web/live/booking_live.ex:357
 #, elixir-autogen, elixir-format
 msgid "TBD"
-msgstr ""
+msgstr "Noch offen"
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:128
+#: lib/klass_hero_web/presenters/provider_presenter.ex:96
 #, elixir-autogen, elixir-format
 msgid "Tax Certificate"
-msgstr ""
+msgstr "Steuerbescheinigung"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1091
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1218
 #, elixir-autogen, elixir-format
 msgid "Team member added, but headshot upload failed."
-msgstr ""
+msgstr "Teammitglied hinzugefügt, aber der Upload des Profilfotos ist fehlgeschlagen."
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1092
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1219
 #, elixir-autogen, elixir-format
 msgid "Team member added."
-msgstr ""
+msgstr "Teammitglied hinzugefügt."
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:330
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:400
 #, elixir-autogen, elixir-format
 msgid "Team member removed."
-msgstr ""
+msgstr "Teammitglied entfernt."
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1115
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1242
 #, elixir-autogen, elixir-format
 msgid "Team member updated, but headshot upload failed."
-msgstr ""
+msgstr "Teammitglied aktualisiert, aber der Upload des Profilfotos ist fehlgeschlagen."
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1116
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1243
 #, elixir-autogen, elixir-format
 msgid "Team member updated."
-msgstr ""
+msgstr "Teammitglied aktualisiert."
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1316
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1445
 #, elixir-autogen, elixir-format
 msgid "Tell parents about your organization..."
-msgstr ""
+msgstr "Erzählen Sie Eltern von Ihrer Organisation..."
 
-#: lib/klass_hero_web/live/about_live.ex:247
+#: lib/klass_hero_web/live/about_live.ex:170
 #, elixir-autogen, elixir-format
 msgid "The Klass Hero Story"
-msgstr ""
+msgstr "Die Geschichte von Klass Hero"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:682
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:731
 #, elixir-autogen, elixir-format
 msgid "This invite cannot be resent."
-msgstr ""
+msgstr "Diese Einladung kann nicht erneut gesendet werden."
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1018
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1065
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
-msgstr ""
+msgstr "Dieses Programm wurde von jemand anderem geändert. Bitte schließen Sie es und versuchen Sie es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:893
+#: lib/klass_hero_web/components/provider_components.ex:858
 #, elixir-autogen, elixir-format
 msgid "Title"
-msgstr ""
+msgstr "Titel"
 
-#: lib/klass_hero_web/live/about_live.ex:276
-#, elixir-autogen, elixir-format
-msgid "To lead trust and quality, Laurie Camargo, a mother with over a decade of experience in child safety and quality assurance, will join to architect our Safety-First Verification engine, ensuring every Hero meets the highest standards before working with families."
-msgstr ""
-
-#: lib/klass_hero_web/components/provider_components.ex:2302
+#: lib/klass_hero_web/components/provider_components.ex:2217
 #, elixir-autogen, elixir-format
 msgid "Too many files."
-msgstr ""
+msgstr "Zu viele Dateien."
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:367
+#: lib/klass_hero_web/live/admin/verifications_live.ex:350
 #, elixir-autogen, elixir-format
 msgid "Unable to load document preview."
-msgstr ""
+msgstr "Die Dokumentvorschau konnte nicht geladen werden."
 
-#: lib/klass_hero_web/components/program_components.ex:563
+#: lib/klass_hero_web/components/program_components.ex:564
 #, elixir-autogen, elixir-format
 msgid "Up to %{max}"
-msgstr ""
+msgstr "Bis zu %{max}"
 
-#: lib/klass_hero_web/components/program_components.ex:622
+#: lib/klass_hero_web/components/program_components.ex:713
 #, elixir-autogen, elixir-format
 msgid "Up to Grade %{max}"
-msgstr ""
+msgstr "Bis Klassenstufe %{max}"
 
-#: lib/klass_hero_web/components/provider_components.ex:1923
+#: lib/klass_hero_web/components/provider_components.ex:1874
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
-msgstr ""
+msgstr "CSV hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2448
+#: lib/klass_hero_web/components/provider_components.ex:2361
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
-msgstr ""
+msgstr "Dokument hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2357
+#: lib/klass_hero_web/components/provider_components.ex:2270
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
-msgstr ""
+msgstr "Neues Dokument hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2323
+#: lib/klass_hero_web/components/provider_components.ex:2238
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
-msgstr ""
+msgstr "Laden Sie Dokumente hoch, um Ihr Unternehmen zu verifizieren. Die Dokumente werden von unserem Team überprüft."
 
-#: lib/klass_hero_web/components/provider_components.ex:2304
+#: lib/klass_hero_web/components/provider_components.ex:2219
 #, elixir-autogen, elixir-format
 msgid "Upload error."
-msgstr ""
+msgstr "Upload-Fehler."
 
-#: lib/klass_hero_web/components/provider_components.ex:2320
+#: lib/klass_hero_web/components/provider_components.ex:2235
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
-msgstr ""
+msgstr "Verifizierungsdokumente"
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:71
-#: lib/klass_hero_web/live/admin/verifications_live.ex:93
-#: lib/klass_hero_web/live/admin/verifications_live.ex:125
-#: lib/klass_hero_web/live/admin/verifications_live.ex:165
+#: lib/klass_hero_web/live/admin/verifications_live.ex:57
+#: lib/klass_hero_web/live/admin/verifications_live.ex:79
+#: lib/klass_hero_web/live/admin/verifications_live.ex:108
+#: lib/klass_hero_web/live/admin/verifications_live.ex:148
 #, elixir-autogen, elixir-format
 msgid "Verification document not found."
-msgstr ""
+msgstr "Verifizierungsdokument nicht gefunden."
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:147
-#: lib/klass_hero_web/components/layouts/app.html.heex:256
+#: lib/klass_hero_web/components/layouts/app.html.heex:138
+#: lib/klass_hero_web/components/layouts/app.html.heex:232
+#: lib/klass_hero_web/components/ui_components.ex:271
 #: lib/klass_hero_web/live/admin/verifications_live.ex:40
-#: lib/klass_hero_web/live/admin/verifications_live.ex:50
-#: lib/klass_hero_web/live/admin/verifications_live.ex:189
+#: lib/klass_hero_web/live/admin/verifications_live.ex:172
 #, elixir-autogen, elixir-format
 msgid "Verifications"
-msgstr ""
+msgstr "Verifizierungen"
 
-#: lib/klass_hero_web/components/provider_components.ex:247
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/components/provider_components.ex:253
+#: lib/klass_hero_web/components/provider_layout_components.ex:212
+#, elixir-autogen, elixir-format
 msgid "Verified"
-msgstr "Verifiziertes Unternehmen"
+msgstr "Verifiziert"
 
-#: lib/klass_hero_web/live/about_live.ex:126
+#: lib/klass_hero_web/live/about_live.ex:155
 #, elixir-autogen, elixir-format
 msgid "We are Klass Hero — parents, brothers, and partners of educators — building the infrastructure that helps every child learn and thrive."
-msgstr ""
+msgstr "Wir sind Klass Hero — Eltern, Brüder und Partner von Pädagogen — und bauen die Infrastruktur auf, die jedem Kind hilft, zu lernen und zu wachsen."
 
-#: lib/klass_hero_web/user_auth.ex:315
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/user_auth.ex:280
+#, elixir-autogen, elixir-format
 msgid "You don't have access to that page."
-msgstr ""
+msgstr "Sie haben keinen Zugriff auf diese Seite."
 
-#: lib/klass_hero_web/components/provider_components.ex:652
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/components/provider_components.ex:619
+#, elixir-autogen, elixir-format
 msgid "e.g. Head Coach"
-msgstr "Cheftrainer"
+msgstr "z. B. Cheftrainer"
 
-#: lib/klass_hero_web/components/provider_components.ex:643
+#: lib/klass_hero_web/components/provider_components.ex:610
 #, elixir-autogen, elixir-format
 msgid "e.g. Johnson"
-msgstr ""
+msgstr "z. B. Johnson"
 
-#: lib/klass_hero_web/components/provider_components.ex:637
+#: lib/klass_hero_web/components/provider_components.ex:604
 #, elixir-autogen, elixir-format
 msgid "e.g. Mike"
-msgstr ""
+msgstr "z. B. Mike"
 
-#: lib/klass_hero_web/components/provider_components.ex:658
+#: lib/klass_hero_web/components/provider_components.ex:625
 #, elixir-autogen, elixir-format
 msgid "e.g. mike@example.com"
-msgstr ""
+msgstr "z. B. mike@example.com"
 
-#: lib/klass_hero_web/components/provider_components.ex:894
+#: lib/klass_hero_web/components/provider_components.ex:859
 #, elixir-autogen, elixir-format
 msgid "e.g., Art Adventures"
-msgstr ""
+msgstr "z. B. Art Adventures"
 
-#: lib/klass_hero_web/components/provider_components.ex:921
+#: lib/klass_hero_web/components/provider_components.ex:886
 #, elixir-autogen, elixir-format
 msgid "e.g., Community Center, Main St"
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:150
-#, elixir-autogen, elixir-format
-msgid "%{media_types} media"
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:39
-#, elixir-autogen, elixir-format
-msgid "%{name} Plan"
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:132
-#, elixir-autogen, elixir-format
-msgid "%{percent}% commission"
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:128
-#, elixir-autogen, elixir-format, fuzzy
-msgid "1 program"
-msgid_plural "%{count} programs"
-msgstr[0] "Programme"
-msgstr[1] "Programme"
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:159
-#: lib/klass_hero_web/presenters/tier_presenter.ex:160
-#, elixir-autogen, elixir-format
-msgid "1 team seat"
-msgid_plural "%{count} team seats"
-msgstr[0] ""
-msgstr[1] ""
+msgstr "z. B. Gemeindezentrum, Hauptstraße"
 
 #: lib/klass_hero_web/live/about_live.ex:71
-#: lib/klass_hero_web/live/trust_safety_live.ex:53
-#, elixir-autogen, elixir-format
-msgid "All Heroes must hold or complete a recognized child safeguarding course, ensuring up-to-date knowledge."
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:146
-#, elixir-autogen, elixir-format
-msgid "All media types"
-msgstr ""
-
-#: lib/klass_hero_web/live/about_live.ex:25
-#: lib/klass_hero_web/live/trust_safety_live.ex:23
-#, elixir-autogen, elixir-format
-msgid "All providers must be 18 years or older, ensuring legal accountability and professional responsibility."
-msgstr ""
-
-#: lib/klass_hero_web/live/trust_safety_live.ex:234
-#, elixir-autogen, elixir-format
-msgid "And at Klass Hero, both come standard."
-msgstr ""
-
-#: lib/klass_hero_web/live/about_live.ex:61
-#: lib/klass_hero_web/live/trust_safety_live.ex:47
-#, elixir-autogen, elixir-format
-msgid "Applicants complete a video screening to assess communication skills and alignment with our values."
-msgstr ""
-
-#: lib/klass_hero_web/live/trust_safety_live.ex:102
-#, elixir-autogen, elixir-format
-msgid "At Klass Hero, trust isn't a feature — it's the foundation of everything we do. Our platform is built to connect families, schools, and organizations with qualified, vetted, and safety-verified educators and activity providers."
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:154
-#, elixir-autogen, elixir-format
-msgid "Avatar"
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:135
-#, elixir-autogen, elixir-format
-msgid "Avatar media only"
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:35
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Business Plus"
-msgstr "Business-Plan"
-
-#: lib/klass_hero_web/live/about_live.ex:69
 #: lib/klass_hero_web/live/trust_safety_live.ex:51
 #, elixir-autogen, elixir-format
-msgid "Child Safeguarding Training"
-msgstr ""
+msgid "All Heroes must hold or complete a recognized child safeguarding course, ensuring up-to-date knowledge."
+msgstr "Alle Heroes müssen einen anerkannten Kinderschutzkurs absolviert haben oder absolvieren, um stets aktuelles Wissen sicherzustellen."
 
-#: lib/klass_hero_web/live/provider/subscription_live.ex:106
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Choose the plan that fits your business needs."
-msgstr ""
-
-#: lib/klass_hero_web/live/user_live/registration.ex:92
+#: lib/klass_hero_web/live/about_live.ex:41
+#: lib/klass_hero_web/live/trust_safety_live.ex:21
 #, elixir-autogen, elixir-format
-msgid "Choose your plan"
-msgstr ""
+msgid "All providers must be 18 years or older, ensuring legal accountability and professional responsibility."
+msgstr "Alle Anbieter müssen mindestens 18 Jahre alt sein, um rechtliche Verantwortlichkeit und professionelle Verlässlichkeit zu gewährleisten."
 
-#: lib/klass_hero_web/live/about_live.ex:81
-#: lib/klass_hero_web/live/trust_safety_live.ex:59
+#: lib/klass_hero_web/live/trust_safety_live.ex:161
+#, elixir-autogen, elixir-format
+msgid "And at Klass Hero, both come standard."
+msgstr "Und bei Klass Hero sind beide selbstverständlich."
+
+#: lib/klass_hero_web/live/about_live.ex:65
+#: lib/klass_hero_web/live/trust_safety_live.ex:45
+#, elixir-autogen, elixir-format
+msgid "Applicants complete a video screening to assess communication skills and alignment with our values."
+msgstr "Bewerber absolvieren ein Video-Screening, um Kommunikationsfähigkeiten und die Übereinstimmung mit unseren Werten zu beurteilen."
+
+#: lib/klass_hero_web/live/about_live.ex:69
+#: lib/klass_hero_web/live/trust_safety_live.ex:49
+#, elixir-autogen, elixir-format
+msgid "Child Safeguarding Training"
+msgstr "Kinderschutzschulung"
+
+#: lib/klass_hero_web/live/about_live.ex:77
+#: lib/klass_hero_web/live/trust_safety_live.ex:57
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
-msgstr ""
+msgstr "Vereinbarung zu Community-Standards"
 
-#: lib/klass_hero_web/live/provider/subscription_live.ex:83
-#, elixir-autogen, elixir-format
-msgid "Could not change subscription tier"
-msgstr ""
-
-#: lib/klass_hero_web/live/trust_safety_live.ex:73
+#: lib/klass_hero_web/live/trust_safety_live.ex:71
 #, elixir-autogen, elixir-format
 msgid "Create long-term trust across our community"
-msgstr ""
+msgstr "Langfristiges Vertrauen in unserer Community aufbauen"
 
-#: lib/klass_hero_web/live/provider/subscription_live.ex:126
-#: lib/klass_hero_web/live/provider/subscription_live.ex:166
-#, elixir-autogen, elixir-format
-msgid "Current Plan"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1440
-#, elixir-autogen, elixir-format
-msgid "Current Plan: %{plan}"
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:75
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Direct messaging"
-msgstr ""
-
-#: lib/klass_hero_web/live/about_live.ex:49
-#: lib/klass_hero_web/live/trust_safety_live.ex:39
-#, elixir-autogen, elixir-format
-msgid "Each provider submits an extended police background check, confirming their eligibility to work safely with minors."
-msgstr ""
-
-#: lib/klass_hero_web/live/trust_safety_live.ex:80
-#, elixir-autogen, elixir-format
-msgid "Enforcing platform standards and guidelines"
-msgstr ""
-
-#: lib/klass_hero_web/live/trust_safety_live.ex:157
-#, elixir-autogen, elixir-format
-msgid "Every educator and enrichment professional on Klass Hero completes a 6-step verification process before being approved."
-msgstr ""
-
-#: lib/klass_hero_web/live/about_live.ex:83
-#: lib/klass_hero_web/live/trust_safety_live.ex:61
-#, elixir-autogen, elixir-format
-msgid "Every provider agrees to follow our Community Guidelines, defining expectations around professionalism."
-msgstr ""
-
-#: lib/klass_hero_web/live/about_live.ex:35
-#: lib/klass_hero_web/live/trust_safety_live.ex:29
-#, elixir-autogen, elixir-format
-msgid "Experience Validation"
-msgstr ""
-
-#: lib/klass_hero_web/live/about_live.ex:47
+#: lib/klass_hero_web/live/about_live.ex:57
 #: lib/klass_hero_web/live/trust_safety_live.ex:37
 #, elixir-autogen, elixir-format
+msgid "Each provider submits an extended police background check, confirming their eligibility to work safely with minors."
+msgstr "Jeder Anbieter reicht ein erweitertes polizeiliches Führungszeugnis ein, das seine Eignung bestätigt, sicher mit Minderjährigen zu arbeiten."
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:78
+#, elixir-autogen, elixir-format
+msgid "Enforcing platform standards and guidelines"
+msgstr "Durchsetzung von Plattformstandards und -richtlinien"
+
+#: lib/klass_hero_web/live/about_live.ex:79
+#: lib/klass_hero_web/live/trust_safety_live.ex:59
+#, elixir-autogen, elixir-format
+msgid "Every provider agrees to follow our Community Guidelines, defining expectations around professionalism."
+msgstr "Jeder Anbieter verpflichtet sich, unsere Community-Richtlinien einzuhalten, die die Erwartungen an Professionalität festlegen."
+
+#: lib/klass_hero_web/live/about_live.ex:47
+#: lib/klass_hero_web/live/trust_safety_live.ex:27
+#, elixir-autogen, elixir-format
+msgid "Experience Validation"
+msgstr "Erfahrungsprüfung"
+
+#: lib/klass_hero_web/live/about_live.ex:55
+#: lib/klass_hero_web/live/trust_safety_live.ex:35
+#, elixir-autogen, elixir-format
 msgid "Extended Background Checks"
-msgstr ""
+msgstr "Erweiterte Führungszeugnisprüfungen"
 
-#: lib/klass_hero_web/presenters/tier_presenter.ex:45
-#, elixir-autogen, elixir-format
-msgid "For established providers"
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:44
-#, elixir-autogen, elixir-format
-msgid "For growing businesses"
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:49
-#, elixir-autogen, elixir-format
-msgid "Free"
-msgstr ""
-
-#: lib/klass_hero_web/live/trust_safety_live.ex:136
+#: lib/klass_hero_web/live/trust_safety_live.ex:120
 #, elixir-autogen, elixir-format
 msgid "From academic tutoring to sports, arts, and enrichment programs, every provider on Klass Hero is carefully reviewed to ensure they meet our high standards for child safety, professionalism, and educational quality."
-msgstr ""
+msgstr "Von akademischer Nachhilfe über Sport und Kunst bis hin zu Förderprogrammen wird jeder Anbieter auf Klass Hero sorgfältig geprüft, um sicherzustellen, dass er unseren hohen Standards für Kindersicherheit, Professionalität und pädagogische Qualität entspricht."
 
-#: lib/klass_hero_web/presenters/tier_presenter.ex:155
-#, elixir-autogen, elixir-format
-msgid "Gallery"
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:43
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Get started for free"
-msgstr "Kostenlos starten"
-
-#: lib/klass_hero_web/live/trust_safety_live.ex:214
-#, elixir-autogen, elixir-format
-msgid "Have Questions?"
-msgstr ""
-
-#: lib/klass_hero_web/live/trust_safety_live.ex:154
+#: lib/klass_hero_web/components/marketing_components.ex:1428
 #, elixir-autogen, elixir-format
 msgid "How We Verify Providers"
-msgstr ""
+msgstr "Wie wir Anbieter verifizieren"
 
-#: lib/klass_hero_web/live/about_live.ex:23
-#: lib/klass_hero_web/live/trust_safety_live.ex:21
+#: lib/klass_hero_web/live/about_live.ex:39
+#: lib/klass_hero_web/live/trust_safety_live.ex:19
 #, elixir-autogen, elixir-format
 msgid "Identity & Age Verification"
 msgstr "Identitäts- und Altersverifizierung"
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:217
+#: lib/klass_hero_web/live/trust_safety_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "If you'd like to learn more about our Trust & Safety standards or provider verification process, we're happy to help."
-msgstr ""
+msgstr "Wenn Sie mehr über unsere Trust-&-Safety-Standards oder den Verifizierungsprozess für Anbieter erfahren möchten, helfen wir Ihnen gerne weiter."
 
-#: lib/klass_hero_web/live/provider/subscription_live.ex:74
-#: lib/klass_hero_web/live/provider/subscription_live.ex:87
+#: lib/klass_hero_web/live/trust_safety_live.ex:77
 #, elixir-autogen, elixir-format
-msgid "Invalid subscription tier"
-msgstr ""
+msgid "Monitoring provider activity and feedback"
+msgstr "Überwachung der Anbieteraktivität und des Feedbacks"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1450
+#: lib/klass_hero_web/live/booking_live.ex:480
 #, elixir-autogen, elixir-format
-msgid "Manage Plan →"
-msgstr ""
+msgid "Pay by cash or direct bank transfer"
+msgstr "Zahlung per Bargeld oder Banküberweisung"
+
+#: lib/klass_hero_web/live/booking_live.ex:491
+#, elixir-autogen, elixir-format
+msgid "Program fee:"
+msgstr "Programmgebühr:"
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:2106
+#, elixir-autogen, elixir-format
+msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
+msgstr "Programm gespeichert, aber der Upload des Titelbilds ist fehlgeschlagen. Sie können es erneut hochladen, indem Sie das Programm bearbeiten."
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:68
+#, elixir-autogen, elixir-format
+msgid "Protect children and families"
+msgstr "Kinder und Familien schützen"
+
+#: lib/klass_hero_web/live/about_live.ex:49
+#: lib/klass_hero_web/live/trust_safety_live.ex:29
+#, elixir-autogen, elixir-format
+msgid "Providers must demonstrate at least one year of experience working with children in their area of expertise."
+msgstr "Anbieter müssen mindestens ein Jahr Erfahrung in der Arbeit mit Kindern in ihrem Fachgebiet nachweisen."
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:146
+#, elixir-autogen, elixir-format
+msgid "Providers who fail to uphold our expectations may be suspended or removed from the platform."
+msgstr "Anbieter, die unseren Erwartungen nicht gerecht werden, können gesperrt oder von der Plattform entfernt werden."
 
 #: lib/klass_hero_web/live/trust_safety_live.ex:79
 #, elixir-autogen, elixir-format
-msgid "Monitoring provider activity and feedback"
-msgstr ""
+msgid "Reviewing concerns or reports promptly and seriously"
+msgstr "Bedenken oder Meldungen zügig und gewissenhaft prüfen"
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:184
+#: lib/klass_hero_web/live/booking_live.ex:207
 #, elixir-autogen, elixir-format
-msgid "Ongoing Quality & Accountability"
-msgstr ""
+msgid "Something went wrong. Please try again or contact support."
+msgstr "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut oder kontaktieren Sie den Support."
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:114
+#: lib/klass_hero_web/live/trust_safety_live.ex:69
 #, elixir-autogen, elixir-format
-msgid "Our Commitment to Child Safety"
-msgstr ""
+msgid "Support schools and institutions with reliable providers"
+msgstr "Schulen und Einrichtungen mit zuverlässigen Anbietern unterstützen"
 
-#: lib/klass_hero_web/live/booking_live.ex:506
+#: lib/klass_hero_web/live/trust_safety_live.ex:80
 #, elixir-autogen, elixir-format
-msgid "Pay by cash or direct bank transfer"
-msgstr ""
+msgid "Taking action when standards are not met"
+msgstr "Bei Nichteinhaltung von Standards Maßnahmen ergreifen"
 
-#: lib/klass_hero_web/presenters/tier_presenter.ex:34
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Professional"
-msgstr ""
-
-#: lib/klass_hero_web/live/booking_live.ex:517
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Program fee:"
-msgstr "Programmname"
-
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1913
+#: lib/klass_hero_web/live/booking_live.ex:191
 #, elixir-autogen, elixir-format
-msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
-msgstr ""
+msgid "This child is already enrolled in this program."
+msgstr "Dieses Kind ist bereits für dieses Programm angemeldet."
 
-#: lib/klass_hero_web/presenters/tier_presenter.ex:76
+#: lib/klass_hero_web/components/composite_components.ex:477
+#: lib/klass_hero_web/components/composite_components.ex:546
+#: lib/klass_hero_web/components/layouts/app.html.heex:60
+#: lib/klass_hero_web/components/layouts/app.html.heex:199
+#: lib/klass_hero_web/components/marketing_components.ex:192
+#: lib/klass_hero_web/components/marketing_components.ex:805
+#: lib/klass_hero_web/components/marketing_components.ex:909
+#: lib/klass_hero_web/live/for_providers_live.ex:136
+#: lib/klass_hero_web/live/trust_safety_live.ex:10
 #, elixir-autogen, elixir-format
-msgid "Promotional content"
-msgstr ""
+msgid "Trust & Safety"
+msgstr "Vertrauen & Sicherheit"
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:140
+#, elixir-autogen, elixir-format
+msgid "Trust doesn't stop at onboarding. Klass Hero continuously works to maintain a safe and high-quality ecosystem by:"
+msgstr "Vertrauen endet nicht beim Onboarding. Klass Hero arbeitet kontinuierlich daran, ein sicheres und hochwertiges Ökosystem zu erhalten, indem es:"
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:160
+#, elixir-autogen, elixir-format
+msgid "Trust is earned. Safety is non-negotiable."
+msgstr "Vertrauen muss man sich verdienen. Sicherheit ist nicht verhandelbar."
 
 #: lib/klass_hero_web/live/trust_safety_live.ex:70
 #, elixir-autogen, elixir-format
-msgid "Protect children and families"
-msgstr ""
-
-#: lib/klass_hero_web/live/about_live.ex:37
-#: lib/klass_hero_web/live/trust_safety_live.ex:31
-#, elixir-autogen, elixir-format
-msgid "Providers must demonstrate at least one year of experience working with children in their area of expertise."
-msgstr ""
-
-#: lib/klass_hero_web/live/trust_safety_live.ex:203
-#, elixir-autogen, elixir-format
-msgid "Providers who fail to uphold our expectations may be suspended or removed from the platform."
-msgstr ""
-
-#: lib/klass_hero_web/live/trust_safety_live.ex:81
-#, elixir-autogen, elixir-format
-msgid "Reviewing concerns or reports promptly and seriously"
-msgstr ""
-
-#: lib/klass_hero_web/live/booking_live.ex:225
-#, elixir-autogen, elixir-format
-msgid "Something went wrong. Please try again or contact support."
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:33
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Starter"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/subscription_live.ex:46
-#, elixir-autogen, elixir-format
-msgid "Subscription"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/subscription_live.ex:103
-#, elixir-autogen, elixir-format
-msgid "Subscription Plans"
-msgstr ""
-
-#: lib/klass_hero_web/live/trust_safety_live.ex:71
-#, elixir-autogen, elixir-format
-msgid "Support schools and institutions with reliable providers"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/subscription_live.ex:175
-#, elixir-autogen, elixir-format
-msgid "Switch to %{plan}"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/subscription_live.ex:67
-#, elixir-autogen, elixir-format
-msgid "Switched to %{plan}"
-msgstr ""
-
-#: lib/klass_hero_web/live/trust_safety_live.ex:99
-#, elixir-autogen, elixir-format
-msgid "TRUST & SAFETY"
-msgstr ""
-
-#: lib/klass_hero_web/live/trust_safety_live.ex:82
-#, elixir-autogen, elixir-format
-msgid "Taking action when standards are not met"
-msgstr ""
-
-#: lib/klass_hero_web/live/booking_live.ex:209
-#, elixir-autogen, elixir-format
-msgid "This child is already enrolled in this program."
-msgstr ""
-
-#: lib/klass_hero_web/components/composite_components.ex:612
-#: lib/klass_hero_web/components/composite_components.ex:681
-#: lib/klass_hero_web/components/layouts/app.html.heex:60
-#: lib/klass_hero_web/components/layouts/app.html.heex:212
-#: lib/klass_hero_web/live/trust_safety_live.ex:12
-#, elixir-autogen, elixir-format
-msgid "Trust & Safety"
-msgstr ""
-
-#: lib/klass_hero_web/live/trust_safety_live.ex:187
-#, elixir-autogen, elixir-format
-msgid "Trust doesn't stop at onboarding. Klass Hero continuously works to maintain a safe and high-quality ecosystem by:"
-msgstr ""
-
-#: lib/klass_hero_web/live/trust_safety_live.ex:231
-#, elixir-autogen, elixir-format
-msgid "Trust is earned. Safety is non-negotiable."
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:127
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Unlimited programs"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1443
-#, elixir-autogen, elixir-format
-msgid "Upgrade your plan to unlock more features"
-msgstr ""
-
-#: lib/klass_hero_web/live/trust_safety_live.ex:72
-#, elixir-autogen, elixir-format
 msgid "Uphold professional and ethical teaching practices"
-msgstr ""
+msgstr "Professionelle und ethische Lehrpraktiken einhalten"
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:133
+#: lib/klass_hero_web/components/marketing_components.ex:1387
 #, elixir-autogen, elixir-format
 msgid "Vetted with Care"
-msgstr ""
+msgstr "Mit Sorgfalt geprüft"
 
-#: lib/klass_hero_web/presenters/tier_presenter.ex:156
-#, elixir-autogen, elixir-format
-msgid "Video"
-msgstr ""
-
-#: lib/klass_hero_web/live/about_live.ex:59
-#: lib/klass_hero_web/live/trust_safety_live.ex:45
+#: lib/klass_hero_web/live/about_live.ex:63
+#: lib/klass_hero_web/live/trust_safety_live.ex:43
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
-msgstr ""
+msgstr "Video-Überprüfung"
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:117
-#, elixir-autogen, elixir-format
-msgid "We believe that children thrive best in environments that are safe, respectful, and professionally led. That's why Klass Hero applies a multi-layered safety and verification framework before any provider can offer sessions on our platform."
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/subscription_live.ex:71
-#, elixir-autogen, elixir-format
-msgid "You are already on this plan"
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:55
-#, elixir-autogen, elixir-format
-msgid "forever"
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:56
-#: lib/klass_hero_web/presenters/tier_presenter.ex:57
-#, elixir-autogen, elixir-format
-msgid "month"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:532
+#: lib/klass_hero_web/live/home_live.ex:94
 #, elixir-autogen, elixir-format
 msgid "Every provider completes identity and age verification, experience validation, an extended background check, video screening, child safeguarding training, and agreement to our Community Guidelines before being approved."
-msgstr ""
+msgstr "Jeder Anbieter durchläuft vor der Freigabe eine Identitäts- und Altersprüfung, eine Erfahrungsvalidierung, eine erweiterte Hintergrundüberprüfung, eine Video-Überprüfung, eine Schulung zum Kinderschutz und die Zustimmung zu unseren Community-Richtlinien."
 
-#: lib/klass_hero_web/live/home_live.ex:530
+#: lib/klass_hero_web/live/home_live.ex:91
 #, elixir-autogen, elixir-format
 msgid "How does the 6-step provider vetting process work?"
-msgstr ""
+msgstr "Wie funktioniert der 6-stufige Anbieter-Prüfprozess?"
 
-#: lib/klass_hero_web/live/about_live.ex:210
+#: lib/klass_hero_web/live/about_live.ex:163
 #, elixir-autogen, elixir-format
 msgid "Our 6-Step Vetting Process"
 msgstr "Unser 6-Schritte-Überprüfungsverfahren"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:139
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/settings/children_live.ex:134
+#, elixir-autogen, elixir-format
 msgid "Could not check enrollments. Please try again."
-msgstr "Kind konnte nicht entfernt werden. Bitte versuchen Sie es erneut."
+msgstr "Anmeldungen konnten nicht überprüft werden. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:613
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/settings/children_live.ex:592
+#, elixir-autogen, elixir-format
 msgid "Remove Child"
-msgstr ""
+msgstr "Kind entfernen"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:567
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/settings/children_live.ex:546
+#, elixir-autogen, elixir-format
 msgid "Remove Child?"
-msgstr ""
+msgstr "Kind entfernen?"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:585
+#: lib/klass_hero_web/live/settings/children_live.ex:564
 #, elixir-autogen, elixir-format
 msgid "Their enrollments will be cancelled. This action cannot be undone."
-msgstr ""
+msgstr "Die Anmeldungen des Kindes werden storniert. Diese Aktion kann nicht rückgängig gemacht werden."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:572
+#: lib/klass_hero_web/live/settings/children_live.ex:551
 #, elixir-autogen, elixir-format
 msgid "This child is currently enrolled in the following programs:"
-msgstr ""
+msgstr "Dieses Kind ist derzeit für folgende Programme angemeldet:"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:152
+#: lib/klass_hero_web/live/settings/children_live.ex:145
 #, elixir-autogen, elixir-format
 msgid "This deletion request has expired. Please try again."
-msgstr ""
+msgstr "Diese Löschanfrage ist abgelaufen. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/live/home_live.ex:669
-#, elixir-autogen, elixir-format
-msgid "1st cancellation (90 days): Warning only"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:670
-#, elixir-autogen, elixir-format
-msgid "2nd cancellation: €50 penalty"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:648
-#, elixir-autogen, elixir-format
-msgid "3-7 days before: Usually 75% refund (you keep 25%)"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:671
-#, elixir-autogen, elixir-format
-msgid "3rd cancellation: €100 penalty + 14-day suspension"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:672
-#, elixir-autogen, elixir-format
-msgid "4+ cancellations: Account termination"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:647
-#, elixir-autogen, elixir-format
-msgid "7+ days before: Usually full refund (you keep nothing)"
-msgstr ""
-
-#: lib/klass_hero_web/live/admin/sessions_live.ex:268
+#: lib/klass_hero_web/live/admin/sessions_live.ex:249
 #, elixir-autogen, elixir-format
 msgid "A reason is required for corrections"
 msgstr "Ein Grund für die Korrektur ist erforderlich"
 
-#: lib/klass_hero_web/components/participation_components.ex:815
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:207
+#: lib/klass_hero_web/components/participation_components.ex:787
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:201
 #, elixir-autogen, elixir-format
 msgid "Absent"
 msgstr "Abwesend"
@@ -4242,49 +3592,49 @@ msgstr "Abwesend"
 #: lib/klass_hero_web/components/layouts/admin.html.heex:28
 #, elixir-autogen, elixir-format
 msgid "Accounts"
-msgstr ""
+msgstr "Konten"
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:79
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "All Statuses"
 msgstr "Alle Status"
 
-#: lib/klass_hero_web/live/home_live.ex:605
+#: lib/klass_hero_web/live/home_live.ex:150
 #, elixir-autogen, elixir-format
 msgid "All payments processed securely through Stripe."
-msgstr ""
+msgstr "Alle Zahlungen werden sicher über Stripe abgewickelt."
 
-#: lib/klass_hero_web/live/home_live.ex:577
+#: lib/klass_hero_web/live/home_live.ex:127
 #, elixir-autogen, elixir-format
 msgid "All plans include: Profile page, booking system, payment processing, messaging, and marketing to Berlin families."
-msgstr ""
+msgstr "Alle Pläne umfassen: Profilseite, Buchungssystem, Zahlungsabwicklung, Nachrichtenfunktion und Marketing für Berliner Familien."
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:280
+#: lib/klass_hero_web/live/admin/sessions_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "An error occurred"
 msgstr "Ein Fehler ist aufgetreten"
 
-#: lib/klass_hero_web/live/home_live.ex:601
+#: lib/klass_hero_web/live/home_live.ex:146
 #, elixir-autogen, elixir-format
 msgid "Apple Pay / Google Pay"
-msgstr ""
+msgstr "Apple Pay / Google Pay"
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:189
+#: lib/klass_hero_web/live/admin/sessions_live.ex:177
 #, elixir-autogen, elixir-format
 msgid "Attendance corrected successfully"
 msgstr "Anwesenheit erfolgreich korrigiert"
 
-#: lib/klass_hero_web/live/home_live.ex:623
+#: lib/klass_hero_web/live/home_live.ex:168
 #, elixir-autogen, elixir-format
 msgid "Automatic fee calculation (no surprises)"
-msgstr ""
+msgstr "Automatische Gebührenberechnung (keine Überraschungen)"
 
 #: lib/klass_hero_web/components/layouts/admin.html.heex:16
 #, elixir-autogen, elixir-format
 msgid "Back to App"
-msgstr ""
+msgstr "Zurück zur App"
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:132
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:127
 #, elixir-autogen, elixir-format
 msgid "Back to sessions"
 msgstr "Zurück zu Sitzungen"
@@ -4292,257 +3642,177 @@ msgstr "Zurück zu Sitzungen"
 #: lib/klass_hero_web/components/layouts/admin.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Bookings"
-msgstr ""
+msgstr "Buchungen"
 
-#: lib/klass_hero_web/live/home_live.ex:573
-#, elixir-autogen, elixir-format
-msgid "Business Account: You keep €901 (€60 commission + €39 monthly fee)"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:563
-#, elixir-autogen, elixir-format
-msgid "Business Account: €39/month + 6% per booking (for providers/teams earning €600+/month)"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:546
+#: lib/klass_hero_web/live/home_live.ex:108
 #, elixir-autogen, elixir-format
 msgid "Camps and holiday programs"
-msgstr ""
+msgstr "Camps und Ferienprogramme"
 
-#: lib/klass_hero_web/live/home_live.ex:765
+#: lib/klass_hero_web/live/home_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "Can I buy a gift voucher?"
-msgstr ""
+msgstr "Kann ich einen Geschenkgutschein kaufen?"
 
-#: lib/klass_hero_web/live/home_live.ex:719
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Can I change my booking date?"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:739
+#: lib/klass_hero_web/live/home_live.ex:191
 #, elixir-autogen, elixir-format
-msgid "Can I get a refund if the provider cancels?"
-msgstr ""
+msgid "Can I change my booking date?"
+msgstr "Kann ich mein Buchungsdatum ändern?"
 
-#: lib/klass_hero_web/live/home_live.ex:540
+#: lib/klass_hero_web/live/home_live.ex:102
 #, elixir-autogen, elixir-format
 msgid "Can I list my programs on Klass Hero and what does it cost?"
-msgstr ""
+msgstr "Kann ich meine Programme auf Klass Hero listen und was kostet das?"
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:274
+#: lib/klass_hero_web/live/admin/sessions_live.ex:255
 #, elixir-autogen, elixir-format
 msgid "Cannot check out without a check-in"
 msgstr "Auschecken ohne Einchecken nicht möglich"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:654
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:96
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:703
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
-msgstr ""
+msgstr "Diesem Elternteil kann keine Nachricht gesendet werden."
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:159
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:153
 #, elixir-autogen, elixir-format
 msgid "Check-in"
 msgstr "Einchecken"
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:211
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "Check-in time"
 msgstr "Eincheckzeit"
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:160
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:154
 #, elixir-autogen, elixir-format
 msgid "Check-out"
 msgstr "Auschecken"
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:220
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:214
 #, elixir-autogen, elixir-format
 msgid "Check-out time"
 msgstr "Auscheckzeit"
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:297
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:205
+#: lib/klass_hero_web/live/admin/sessions_live.ex:276
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "Checked In"
 msgstr "Eingecheckt"
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:298
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:206
+#: lib/klass_hero_web/live/admin/sessions_live.ex:277
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:200
 #, elixir-autogen, elixir-format
 msgid "Checked Out"
 msgstr "Ausgecheckt"
 
-#: lib/klass_hero_web/components/provider_components.ex:2076
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:157
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/components/provider_components.ex:2022
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
+#, elixir-autogen, elixir-format
 msgid "Child"
 msgstr "Kind"
 
-#: lib/klass_hero_web/live/home_live.ex:638
-#, elixir-autogen, elixir-format
-msgid "Clear policies protect everyone."
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:767
+#: lib/klass_hero_web/live/home_live.ex:215
 #, elixir-autogen, elixir-format
 msgid "Coming soon! Sign up for our newsletter to be notified when gift vouchers launch."
-msgstr ""
+msgstr "Demnächst verfügbar! Melden Sie sich für unseren Newsletter an, um benachrichtigt zu werden, sobald Geschenkgutscheine verfügbar sind."
 
-#: lib/klass_hero_web/components/participation_components.ex:812
+#: lib/klass_hero_web/components/participation_components.ex:784
 #, elixir-autogen, elixir-format
 msgid "Completed"
 msgstr "Abgeschlossen"
 
-#: lib/klass_hero_web/live/home_live.ex:658
-#, elixir-autogen, elixir-format
-msgid "Contact all booked parents immediately and offer alternative dates. Include us in CC/BCC (support@mail.klasshero.com)."
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:721
+#: lib/klass_hero_web/live/home_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "Contact the provider directly (details in confirmation email). Most providers are flexible if you ask in advance."
-msgstr ""
+msgstr "Kontaktieren Sie den Anbieter direkt (Details in der Bestätigungs-E-Mail). Die meisten Anbieter sind flexibel, wenn Sie im Voraus fragen."
 
-#: lib/klass_hero_web/live/home_live.ex:641
-#, elixir-autogen, elixir-format
-msgid "Contact them immediately - often you can find an alternative date. Include us in CC/BCC (support@mail.klasshero.com) so we're informed."
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:747
-#, elixir-autogen, elixir-format
-msgid "Contact us immediately at support@mail.klasshero.com or call +49 (0) 152 2426 0416. You'll receive 100% refund + family credit, and the provider faces serious penalties."
-msgstr ""
-
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:184
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:178
 #, elixir-autogen, elixir-format
 msgid "Correct"
 msgstr "Korrigieren"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:177
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:651
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:124
+#: lib/klass_hero_web/live/dashboard_live.ex:280
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:700
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Could not start conversation. Please try again."
-msgstr ""
+msgstr "Unterhaltung konnte nicht gestartet werden. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/live/home_live.ex:600
+#: lib/klass_hero_web/live/home_live.ex:145
 #, elixir-autogen, elixir-format
 msgid "Credit/debit card (Visa, Mastercard, Amex)"
-msgstr ""
+msgstr "Kredit-/Debitkarte (Visa, Mastercard, Amex)"
 
-#: lib/klass_hero_web/live/home_live.ex:757
+#: lib/klass_hero_web/live/home_live.ex:209
 #, elixir-autogen, elixir-format
 msgid "Currently serving Berlin, with expansion to other German cities coming soon."
-msgstr ""
+msgstr "Derzeit verfügbar in Berlin, die Erweiterung auf weitere deutsche Städte folgt in Kürze."
 
-#: lib/klass_hero_web/live/home_live.ex:677
-#, elixir-autogen, elixir-format
-msgid "Death in family"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:709
+#: lib/klass_hero_web/live/home_live.ex:185
 #, elixir-autogen, elixir-format
 msgid "Do I need an account to book?"
-msgstr ""
+msgstr "Benötige ich ein Konto, um zu buchen?"
 
-#: lib/klass_hero_web/live/home_live.ex:630
+#: lib/klass_hero_web/live/home_live.ex:175
 #, elixir-autogen, elixir-format
 msgid "Download monthly statements for taxes"
-msgstr ""
+msgstr "Monatliche Abrechnungen für die Steuer herunterladen"
 
-#: lib/klass_hero_web/live/home_live.ex:731
+#: lib/klass_hero_web/components/provider_components.ex:1792
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:483
 #, elixir-autogen, elixir-format
-msgid "Email the provider and us (support@mail.klasshero.com) immediately. You may qualify for full refund."
-msgstr ""
-
-#: lib/klass_hero_web/components/provider_components.ex:1841
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:328
-#, elixir-autogen, elixir-format, fuzzy
 msgid "Enrollment not confirmed"
-msgstr "Anmeldung"
+msgstr "Anmeldung nicht bestätigt"
 
-#: lib/klass_hero_web/live/home_live.ex:568
-#, elixir-autogen, elixir-format
-msgid "Example: If you earn €1,000 in bookings"
-msgstr ""
-
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:237
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:231
 #, elixir-autogen, elixir-format
 msgid "Explain why this correction is needed..."
 msgstr "Erklären Sie, warum diese Korrektur nötig ist..."
 
-#: lib/klass_hero_web/live/home_live.ex:628
+#: lib/klass_hero_web/live/home_live.ex:173
 #, elixir-autogen, elixir-format
 msgid "Export participant lists anytime"
-msgstr ""
+msgstr "Teilnehmerlisten jederzeit exportieren"
 
-#: lib/klass_hero_web/live/home_live.ex:595
+#: lib/klass_hero_web/live/home_live.ex:140
 #, elixir-autogen, elixir-format
 msgid "Funds are immediately available in your Klass Hero account"
-msgstr ""
+msgstr "Guthaben ist sofort in Ihrem Klass Hero-Konto verfügbar"
 
-#: lib/klass_hero_web/live/home_live.ex:679
-#, elixir-autogen, elixir-format
-msgid "Government closure"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:606
+#: lib/klass_hero_web/live/home_live.ex:151
 #, elixir-autogen, elixir-format
 msgid "How You Get Paid:"
-msgstr ""
+msgstr "So werden Sie bezahlt:"
 
-#: lib/klass_hero_web/live/home_live.ex:585
+#: lib/klass_hero_web/live/home_live.ex:133
 #, elixir-autogen, elixir-format
 msgid "How does the booking system work?"
-msgstr ""
+msgstr "Wie funktioniert das Buchungssystem?"
 
-#: lib/klass_hero_web/live/home_live.ex:639
-#, elixir-autogen, elixir-format
-msgid "If Parent Cancels:"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:656
-#, elixir-autogen, elixir-format
-msgid "If You Must Cancel:"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:683
-#, elixir-autogen, elixir-format
-msgid "If you fail to show up without prior notice:"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:685
-#, elixir-autogen, elixir-format
-msgid "Immediate account suspension"
-msgstr ""
-
-#: lib/klass_hero_web/components/participation_components.ex:811
-#: lib/klass_hero_web/live/admin/sessions_live.ex:296
+#: lib/klass_hero_web/components/participation_components.ex:783
+#: lib/klass_hero_web/live/admin/sessions_live.ex:275
 #, elixir-autogen, elixir-format
 msgid "In Progress"
 msgstr "In Bearbeitung"
 
-#: lib/klass_hero_web/live/home_live.ex:609
+#: lib/klass_hero_web/live/home_live.ex:154
 #, elixir-autogen, elixir-format
 msgid "Instant availability: Funds are in your Klass Hero balance immediately after booking"
-msgstr ""
+msgstr "Sofortige Verfügbarkeit: Das Guthaben steht direkt nach der Buchung in Ihrem Klass Hero-Guthaben zur Verfügung"
 
-#: lib/klass_hero_web/live/home_live.ex:699
+#: lib/klass_hero_web/live/home_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "Is Klass Hero free for parents to use?"
-msgstr ""
+msgstr "Ist die Nutzung von Klass Hero für Eltern kostenlos?"
 
-#: lib/klass_hero_web/live/home_live.ex:691
-#, elixir-autogen, elixir-format
-msgid "Keep your reliability high - parents can see your cancellation rate on your profile."
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:603
+#: lib/klass_hero_web/live/home_live.ex:148
 #, elixir-autogen, elixir-format
 msgid "Klarna (pay later options)"
-msgstr ""
+msgstr "Klarna (Optionen für spätere Zahlung)"
 
-#: lib/klass_hero_web/components/composite_components.ex:592
+#: lib/klass_hero_web/components/composite_components.ex:452
 #: lib/klass_hero_web/components/layouts/admin.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Klass Hero"
@@ -4551,558 +3821,448 @@ msgstr "Klass Hero"
 #: lib/klass_hero_web/components/layouts/admin.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Klass Hero Admin"
-msgstr ""
+msgstr "Klass Hero Admin"
 
-#: lib/klass_hero_web/live/home_live.ex:649
-#, elixir-autogen, elixir-format
-msgid "Less than 3 days: Usually 25-50% refund (you keep 50-75%)"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:676
-#, elixir-autogen, elixir-format
-msgid "Medical emergency"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:680
-#, elixir-autogen, elixir-format
-msgid "Minimum enrollment not met (camps only - notify 14 days before)"
-msgstr ""
-
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:203
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:197
 #, elixir-autogen, elixir-format
 msgid "No change"
 msgstr "Keine Änderung"
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:269
+#: lib/klass_hero_web/live/admin/sessions_live.ex:250
 #, elixir-autogen, elixir-format
 msgid "No changes detected"
 msgstr "Keine Änderungen erkannt"
 
-#: lib/klass_hero_web/live/home_live.ex:621
+#: lib/klass_hero_web/live/home_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "No chasing payments or sending invoices"
-msgstr ""
+msgstr "Kein Nachfassen bei Zahlungen oder Versenden von Rechnungen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1588
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:248
-#, elixir-autogen, elixir-format, fuzzy
-msgid "No enrolled parents"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:674
+#: lib/klass_hero_web/components/provider_components.ex:1546
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:407
 #, elixir-autogen, elixir-format
-msgid "No penalties for legitimate reasons:"
-msgstr ""
+msgid "No enrolled parents"
+msgstr "Keine angemeldeten Eltern"
 
-#: lib/klass_hero_web/live/home_live.ex:622
+#: lib/klass_hero_web/live/home_live.ex:167
 #, elixir-autogen, elixir-format
 msgid "No risk of non-payment"
-msgstr ""
+msgstr "Kein Risiko von Zahlungsausfällen"
 
-#: lib/klass_hero_web/components/participation_components.ex:836
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:161
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:178
+#: lib/klass_hero_web/components/participation_components.ex:806
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:155
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "Notes"
 msgstr "Notizen"
 
-#: lib/klass_hero_web/live/home_live.ex:614
+#: lib/klass_hero_web/live/home_live.ex:159
 #, elixir-autogen, elixir-format
 msgid "Or: Request instant payout anytime (minimum €50)"
-msgstr ""
+msgstr "Oder: Jederzeit eine Sofortauszahlung anfordern (mindestens 50 €)"
 
-#: lib/klass_hero_web/components/provider_components.ex:1840
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:327
+#: lib/klass_hero_web/components/provider_components.ex:1791
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
-msgstr ""
+msgstr "Elternkonto nicht verfügbar"
 
-#: lib/klass_hero_web/live/home_live.ex:590
+#: lib/klass_hero_web/live/home_live.ex:137
 #, elixir-autogen, elixir-format
 msgid "Parent books and pays through Klass Hero (via Stripe)"
-msgstr ""
+msgstr "Eltern buchen und bezahlen über Klass Hero (via Stripe)"
 
-#: lib/klass_hero_web/live/home_live.ex:687
-#, elixir-autogen, elixir-format
-msgid "Parent gets 100% refund + family credit"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:594
+#: lib/klass_hero_web/live/home_live.ex:139
 #, elixir-autogen, elixir-format
 msgid "Parent receives confirmation with your contact details"
-msgstr ""
+msgstr "Eltern erhalten eine Bestätigung mit Ihren Kontaktdaten"
 
-#: lib/klass_hero_web/live/home_live.ex:620
+#: lib/klass_hero_web/live/home_live.ex:165
 #, elixir-autogen, elixir-format
 msgid "Parents pay upfront when booking (reduces no-shows by 85%)"
-msgstr ""
+msgstr "Eltern zahlen bei der Buchung im Voraus (reduziert Nichterscheinen um 85 %)"
 
-#: lib/klass_hero_web/live/home_live.ex:598
+#: lib/klass_hero_web/live/home_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "Payment Options for Parents:"
-msgstr ""
+msgstr "Zahlungsoptionen für Eltern:"
 
-#: lib/klass_hero_web/live/home_live.ex:688
-#, elixir-autogen, elixir-format
-msgid "Permanent ban if no valid emergency"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:615
+#: lib/klass_hero_web/live/home_live.ex:160
 #, elixir-autogen, elixir-format
 msgid "Platform fee automatically deducted when parent pays"
-msgstr ""
+msgstr "Plattformgebühr wird automatisch abgezogen, wenn Eltern bezahlen"
 
-#: lib/klass_hero_web/live/home_live.ex:550
+#: lib/klass_hero_web/live/home_live.ex:112
 #, elixir-autogen, elixir-format
 msgid "Pricing:"
-msgstr ""
+msgstr "Preise:"
 
-#: lib/klass_hero_web/live/home_live.ex:548
+#: lib/klass_hero_web/live/home_live.ex:110
 #, elixir-autogen, elixir-format
 msgid "Private lessons and tutoring"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:558
-#, elixir-autogen, elixir-format
-msgid "Professional: More tools and opportunities for €9/month + 12% per booking (only when you get bookings)"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:571
-#, elixir-autogen, elixir-format
-msgid "Professional: You keep €871 (€120 commission + €9 monthly fee)"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:667
-#, elixir-autogen, elixir-format
-msgid "Provider Cancellation Penalties:"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:682
-#, elixir-autogen, elixir-format
-msgid "Provider No-Show:"
-msgstr ""
+msgstr "Privatunterricht und Nachhilfe"
 
 #: lib/klass_hero_web/components/layouts/admin.html.heex:31
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/components/marketing_components.ex:810
+#, elixir-autogen, elixir-format
 msgid "Providers"
-msgstr "Anbieter-Dashboard"
+msgstr "Anbieter"
 
-#: lib/klass_hero_web/live/home_live.ex:627
+#: lib/klass_hero_web/live/home_live.ex:172
 #, elixir-autogen, elixir-format
 msgid "Real-time dashboard shows all bookings and available balance"
-msgstr ""
+msgstr "Echtzeit-Dashboard zeigt alle Buchungen und das verfügbare Guthaben"
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:231
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:225
 #, elixir-autogen, elixir-format
 msgid "Reason for correction"
 msgstr "Grund für die Korrektur"
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:272
+#: lib/klass_hero_web/live/admin/sessions_live.ex:253
 #, elixir-autogen, elixir-format
 msgid "Record was modified by someone else. Please refresh."
 msgstr "Datensatz wurde von jemand anderem geändert. Bitte aktualisieren."
 
-#: lib/klass_hero_web/live/home_live.ex:645
-#, elixir-autogen, elixir-format
-msgid "Refunds are automatic based on our cancellation policy:"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:545
+#: lib/klass_hero_web/live/home_live.ex:107
 #, elixir-autogen, elixir-format
 msgid "Regular classes and courses (weekly/monthly)"
-msgstr ""
+msgstr "Regelmäßige Klassen und Kurse (wöchentlich/monatlich)"
 
-#: lib/klass_hero_web/live/home_live.ex:602
+#: lib/klass_hero_web/live/home_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "SEPA direct debit"
-msgstr ""
+msgstr "SEPA-Lastschrift"
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:250
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:244
 #, elixir-autogen, elixir-format
 msgid "Save Correction"
 msgstr "Korrektur speichern"
 
-#: lib/klass_hero_web/components/participation_components.ex:810
+#: lib/klass_hero_web/components/participation_components.ex:782
 #, elixir-autogen, elixir-format
 msgid "Scheduled"
 msgstr "Geplant"
 
-#: lib/klass_hero_web/live/home_live.ex:629
+#: lib/klass_hero_web/live/home_live.ex:174
 #, elixir-autogen, elixir-format
 msgid "See payment history and upcoming payouts"
-msgstr ""
+msgstr "Zahlungsverlauf und bevorstehende Auszahlungen einsehen"
 
-#: lib/klass_hero_web/live/home_live.ex:678
-#, elixir-autogen, elixir-format
-msgid "Severe weather"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:587
+#: lib/klass_hero_web/live/home_live.ex:134
 #, elixir-autogen, elixir-format
 msgid "Simple and automated - we handle everything."
-msgstr ""
+msgstr "Einfach und automatisiert – wir kümmern uns um alles."
 
 #: lib/klass_hero_web/components/layouts/admin.html.heex:36
 #, elixir-autogen, elixir-format
 msgid "Staff Members"
-msgstr ""
+msgstr "Mitarbeiter"
 
-#: lib/klass_hero_web/live/home_live.ex:553
-#, elixir-autogen, elixir-format
-msgid "Starter: Free to join — no registration fees, no monthly subscriptions. 20% commission per booking"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:570
-#, elixir-autogen, elixir-format
-msgid "Starter: You keep €800 (€200 commission)"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:652
-#, elixir-autogen, elixir-format
-msgid "Stripe processes all refunds - funds returned to parent's original payment method within 5-10 business days. Any amounts you keep remain in your balance."
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:625
+#: lib/klass_hero_web/live/home_live.ex:170
 #, elixir-autogen, elixir-format
 msgid "Track Everything:"
-msgstr ""
+msgstr "Alles im Überblick:"
 
-#: lib/klass_hero_web/components/provider_components.ex:1836
-#, elixir-autogen, elixir-format
-msgid "Upgrade to Professional to message parents"
-msgstr ""
-
-#: lib/klass_hero_web/live/dashboard_live.ex:164
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:648
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:93
+#: lib/klass_hero_web/live/dashboard_live.ex:267
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:144
 #, elixir-autogen, elixir-format
 msgid "Upgrade your plan to send messages."
-msgstr ""
+msgstr "Aktualisieren Sie Ihren Plan, um Nachrichten zu senden."
 
-#: lib/klass_hero_web/live/home_live.ex:613
+#: lib/klass_hero_web/live/home_live.ex:158
 #, elixir-autogen, elixir-format
 msgid "Weekly payouts: Transferred to your bank account every Friday"
-msgstr ""
+msgstr "Wöchentliche Auszahlungen: Jeden Freitag auf Ihr Bankkonto überwiesen"
 
-#: lib/klass_hero_web/live/home_live.ex:543
+#: lib/klass_hero_web/live/home_live.ex:105
 #, elixir-autogen, elixir-format
 msgid "What You Can List:"
-msgstr ""
+msgstr "Was Sie anbieten können:"
 
-#: lib/klass_hero_web/live/home_live.ex:636
-#, elixir-autogen, elixir-format
-msgid "What happens if a parent cancels or I need to cancel?"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:729
+#: lib/klass_hero_web/live/home_live.ex:199
 #, elixir-autogen, elixir-format
 msgid "What if my child gets sick?"
-msgstr ""
+msgstr "Was ist, wenn mein Kind krank wird?"
 
-#: lib/klass_hero_web/live/home_live.ex:745
-#, elixir-autogen, elixir-format
-msgid "What if the provider doesn't show up?"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:588
+#: lib/klass_hero_web/live/home_live.ex:135
 #, elixir-autogen, elixir-format
 msgid "When Someone Books:"
-msgstr ""
+msgstr "Wenn jemand bucht:"
 
-#: lib/klass_hero_web/live/home_live.ex:663
-#, elixir-autogen, elixir-format
-msgid "When you cancel, parents get 100% refund automatically. The amount is deducted from your next payout."
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:755
+#: lib/klass_hero_web/live/home_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Where is Klass Hero available?"
-msgstr ""
+msgstr "Wo ist Klass Hero verfügbar?"
 
-#: lib/klass_hero_web/live/home_live.ex:617
+#: lib/klass_hero_web/live/home_live.ex:162
 #, elixir-autogen, elixir-format
 msgid "Why This Works Better:"
-msgstr ""
+msgstr "Warum das besser funktioniert:"
 
-#: lib/klass_hero_web/live/home_live.ex:547
+#: lib/klass_hero_web/live/home_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "Workshops and one-time events"
-msgstr ""
+msgstr "Workshops und einmalige Veranstaltungen"
 
-#: lib/klass_hero_web/live/home_live.ex:701
+#: lib/klass_hero_web/live/home_live.ex:181
 #, elixir-autogen, elixir-format
 msgid "Yes! Browsing and booking are completely free. No subscription, no booking fees."
-msgstr ""
+msgstr "Ja! Stöbern und Buchen sind völlig kostenlos. Kein Abonnement, keine Buchungsgebühren."
 
-#: lib/klass_hero_web/live/home_live.ex:542
+#: lib/klass_hero_web/live/home_live.ex:104
 #, elixir-autogen, elixir-format
 msgid "Yes! Register for free and start listing immediately."
-msgstr ""
+msgstr "Ja! Registrieren Sie sich kostenlos und beginnen Sie sofort damit, Ihre Programme zu listen."
 
-#: lib/klass_hero_web/live/home_live.ex:740
-#, elixir-autogen, elixir-format
-msgid "Yes, always 100% refund if provider cancels. No exceptions."
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:711
+#: lib/klass_hero_web/live/home_live.ex:187
 #, elixir-autogen, elixir-format
 msgid "Yes, you need a free account to complete a booking and manage your reservations."
-msgstr ""
+msgstr "Ja, Sie benötigen ein kostenloses Konto, um eine Buchung abzuschließen und Ihre Reservierungen zu verwalten."
 
-#: lib/klass_hero_web/live/home_live.ex:596
+#: lib/klass_hero_web/live/home_live.ex:141
 #, elixir-autogen, elixir-format
 msgid "You deliver the program"
-msgstr ""
+msgstr "Sie führen das Programm durch"
 
-#: lib/klass_hero_web/live/home_live.ex:619
+#: lib/klass_hero_web/live/home_live.ex:164
 #, elixir-autogen, elixir-format
 msgid "You get paid BEFORE delivering the program (no waiting)"
-msgstr ""
+msgstr "Sie werden bezahlt, BEVOR Sie das Programm durchführen (kein Warten)"
 
-#: lib/klass_hero_web/live/home_live.ex:592
+#: lib/klass_hero_web/live/home_live.ex:138
 #, elixir-autogen, elixir-format
 msgid "You receive instant email with booking details and parent contact info"
-msgstr ""
+msgstr "Sie erhalten sofort eine E-Mail mit den Buchungsdetails und den Kontaktdaten der Eltern"
 
-#: lib/klass_hero_web/live/home_live.ex:686
-#, elixir-autogen, elixir-format
-msgid "€200 penalty (deducted from balance or invoiced)"
-msgstr ""
-
-#: lib/klass_hero_web/components/participation_components.ex:78
+#: lib/klass_hero_web/components/participation_components.ex:73
 #, elixir-autogen, elixir-format
 msgid "%{checked_in} / %{capacity} checked in"
 msgstr "%{checked_in} / %{capacity} eingecheckt"
 
-#: lib/klass_hero_web/components/participation_components.ex:322
+#: lib/klass_hero_web/components/participation_components.ex:311
 #, elixir-autogen, elixir-format
 msgid "%{checked_in} / %{total} checked in"
 msgstr "%{checked_in} / %{total} eingecheckt"
 
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:9
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "%{count} unread"
-msgstr ""
+msgstr "%{count} ungelesen"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:356
+#: lib/klass_hero_web/live/provider/sessions_live.ex:366
 #, elixir-autogen, elixir-format
 msgid "A session already exists at this time"
-msgstr ""
+msgstr "Zu dieser Zeit existiert bereits eine Sitzung"
 
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:152
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:196
 #, elixir-autogen, elixir-format
 msgid "Account created! Check your email to confirm and log in."
-msgstr ""
+msgstr "Konto erstellt! Überprüfen Sie Ihre E-Mails, um zu bestätigen und sich anzumelden."
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:112
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:112
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:111
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:111
 #, elixir-autogen, elixir-format
 msgid "Add Note"
 msgstr "Notiz hinzufügen"
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:129
-#: lib/klass_hero_web/components/layouts/app.html.heex:249
+#: lib/klass_hero_web/components/layouts/app.html.heex:120
+#: lib/klass_hero_web/components/layouts/app.html.heex:225
+#: lib/klass_hero_web/components/ui_components.ex:264
 #, elixir-autogen, elixir-format
 msgid "Admin"
 msgstr "Admin"
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:27
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:25
+#, elixir-autogen, elixir-format
 msgid "All programs"
-msgstr "Programme"
+msgstr "Alle Programme"
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:15
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:13
+#, elixir-autogen, elixir-format
 msgid "All providers"
-msgstr "Anbieter-Dashboard"
+msgstr "Alle Anbieter"
 
-#: lib/klass_hero_web/components/participation_components.ex:735
+#: lib/klass_hero_web/components/participation_components.ex:713
 #, elixir-autogen, elixir-format
 msgid "Allergies: %{details}"
 msgstr "Allergien: %{details}"
 
-#: lib/klass_hero_web/components/participation_components.ex:233
+#: lib/klass_hero_web/components/participation_components.ex:224
 #, elixir-autogen, elixir-format
 msgid "Any important notes about today's session..."
 msgstr "Wichtige Notizen zur heutigen Sitzung..."
 
-#: lib/klass_hero_web/live/admin/emails_live.html.heex:124
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/admin/emails_live.html.heex:122
+#, elixir-autogen, elixir-format
 msgid "Archive"
-msgstr "Aktive Familien"
+msgstr "Archiv"
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:215
+#: lib/klass_hero_web/live/admin/emails_live.ex:207
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:57
 #, elixir-autogen, elixir-format
 msgid "Archived"
 msgstr "Archiviert"
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:158
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:321
 #, elixir-autogen, elixir-format
 msgid "Assigned Programs"
-msgstr ""
+msgstr "Zugewiesene Programme"
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:9
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:9
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:8
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Back to Sessions"
 msgstr "Zurück zu Sitzungen"
 
-#: lib/klass_hero_web/live/admin/emails_live.html.heex:107
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/admin/emails_live.html.heex:105
+#, elixir-autogen, elixir-format
 msgid "Back to emails"
-msgstr "Zurück zu Einstellungen"
+msgstr "Zurück zu E-Mails"
 
-#: lib/klass_hero_web/components/participation_components.ex:515
+#: lib/klass_hero_web/components/participation_components.ex:495
 #, elixir-autogen, elixir-format
 msgid "Behavioral Note"
 msgstr "Verhaltensnotiz"
 
-#: lib/klass_hero_web/components/messaging_components.ex:628
+#: lib/klass_hero_web/components/messaging_components.ex:688
 #, elixir-autogen, elixir-format
 msgid "Broadcast messages are one-way"
-msgstr ""
+msgstr "Broadcast-Nachrichten sind einseitig"
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:91
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:91
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:92
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:92
 #, elixir-autogen, elixir-format
 msgid "Check In"
 msgstr "Einchecken"
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:276
+#: lib/klass_hero_web/live/admin/sessions_live.ex:257
 #, elixir-autogen, elixir-format
 msgid "Check-in time must be before check-out time"
-msgstr ""
+msgstr "Die Eincheckzeit muss vor der Auscheckzeit liegen"
 
-#: lib/klass_hero_web/components/participation_components.ex:367
+#: lib/klass_hero_web/components/participation_components.ex:352
 #, elixir-autogen, elixir-format
 msgid "Check-in:"
 msgstr "Einchecken:"
 
-#: lib/klass_hero_web/components/participation_components.ex:407
+#: lib/klass_hero_web/components/participation_components.ex:389
 #, elixir-autogen, elixir-format
 msgid "Check-out notes (optional)"
 msgstr "Auschecken-Notizen (optional)"
 
-#: lib/klass_hero_web/components/participation_components.ex:373
+#: lib/klass_hero_web/components/participation_components.ex:358
 #, elixir-autogen, elixir-format
 msgid "Check-out:"
 msgstr "Auschecken:"
 
-#: lib/klass_hero_web/components/participation_components.ex:217
+#: lib/klass_hero_web/components/participation_components.ex:209
 #, elixir-autogen, elixir-format
 msgid "Checked in at %{time}"
 msgstr "Eingecheckt um %{time}"
 
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:174
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Checked in:"
 msgstr "Eingecheckt:"
 
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:184
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:175
 #, elixir-autogen, elixir-format
 msgid "Checked out:"
 msgstr "Ausgecheckt:"
 
-#: lib/klass_hero_web/live/admin/components/searchable_select.ex:86
+#: lib/klass_hero_web/live/admin/components/searchable_select.ex:80
 #, elixir-autogen, elixir-format
 msgid "Clear selection"
-msgstr ""
+msgstr "Auswahl aufheben"
 
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:76
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:202
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:83
 #, elixir-autogen, elixir-format
 msgid "Complete Registration"
-msgstr ""
+msgstr "Registrierung abschließen"
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:75
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:287
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:71
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:271
 #, elixir-autogen, elixir-format
 msgid "Complete Session"
 msgstr "Sitzung abschließen"
 
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:42
-#, elixir-autogen, elixir-format
-msgid "Complete Your Registration"
-msgstr ""
-
-#: lib/klass_hero_web/components/participation_components.ex:423
+#: lib/klass_hero_web/components/participation_components.ex:404
 #, elixir-autogen, elixir-format
 msgid "Confirm Check Out"
 msgstr "Auschecken bestätigen"
 
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:103
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "Confirm Rejection"
 msgstr "Ablehnung bestätigen"
 
 #: lib/klass_hero_web/components/layouts/admin.html.heex:44
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Consents"
-msgstr "Verbinden"
+msgstr "Einwilligungen"
 
-#: lib/klass_hero_web/live/admin/emails_live.html.heex:90
+#: lib/klass_hero_web/live/admin/emails_live.html.heex:88
 #, elixir-autogen, elixir-format
 msgid "Content fetch failed"
 msgstr "Inhaltsabruf fehlgeschlagen"
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:125
+#: lib/klass_hero_web/live/admin/emails_live.ex:119
 #, elixir-autogen, elixir-format
 msgid "Content fetch retrying..."
-msgstr ""
+msgstr "Inhalt wird erneut abgerufen..."
 
-#: lib/klass_hero_web/live/admin/emails_live.html.heex:144
+#: lib/klass_hero_web/live/admin/emails_live.html.heex:142
 #, elixir-autogen, elixir-format
 msgid "Content is being fetched..."
-msgstr ""
+msgstr "Inhalt wird abgerufen..."
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:240
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/messaging_live_helper.ex:239
+#, elixir-autogen, elixir-format
 msgid "Could not start private conversation"
-msgstr ""
+msgstr "Private Unterhaltung konnte nicht gestartet werden"
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:17
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:135
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:200
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:18
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:130
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:195
 #, elixir-autogen, elixir-format
 msgid "Create Session"
-msgstr ""
+msgstr "Sitzung erstellen"
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:162
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "Date"
-msgstr ""
+msgstr "Datum"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:330
-#: lib/klass_hero_web/live/provider/sessions_live.ex:331
+#: lib/klass_hero_web/live/provider/sessions_live.ex:342
+#: lib/klass_hero_web/live/provider/sessions_live.ex:343
 #, elixir-autogen, elixir-format
 msgid "Date is required"
-msgstr ""
+msgstr "Datum ist erforderlich"
 
-#: lib/klass_hero_web/components/participation_components.ex:408
+#: lib/klass_hero_web/components/participation_components.ex:390
 #, elixir-autogen, elixir-format
 msgid "E.g., picked up by parent, gave medication reminder..."
 msgstr "Z.B. von Eltern abgeholt, Medikamentenerinnerung gegeben..."
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:144
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:140
 #, elixir-autogen, elixir-format
 msgid "Edit & Resubmit"
 msgstr "Bearbeiten & erneut einreichen"
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:142
+#: lib/klass_hero_web/live/admin/emails_live.ex:136
 #, elixir-autogen, elixir-format
 msgid "Email archived"
-msgstr ""
+msgstr "E-Mail archiviert"
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:162
+#: lib/klass_hero_web/live/admin/emails_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "Email marked as unread"
-msgstr ""
+msgstr "E-Mail als ungelesen markiert"
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:70
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/admin/emails_live.ex:66
+#, elixir-autogen, elixir-format
 msgid "Email not found"
-msgstr "Kind nicht gefunden."
+msgstr "E-Mail nicht gefunden"
 
 #: lib/klass_hero_web/components/layouts/admin.html.heex:49
 #: lib/klass_hero_web/live/admin/emails_live.ex:21
@@ -5112,131 +4272,125 @@ msgstr "Kind nicht gefunden."
 msgid "Emails"
 msgstr "E-Mails"
 
-#: lib/klass_hero_web/components/participation_components.ex:747
+#: lib/klass_hero_web/components/participation_components.ex:725
 #, elixir-autogen, elixir-format
 msgid "Emergency: %{details}"
 msgstr "Notfall: %{details}"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:355
+#: lib/klass_hero_web/live/provider/sessions_live.ex:365
 #, elixir-autogen, elixir-format
 msgid "End time must be after start time"
-msgstr ""
+msgstr "Die Endzeit muss nach der Startzeit liegen"
 
-#: lib/klass_hero_web/components/participation_components.ex:816
+#: lib/klass_hero_web/components/participation_components.ex:788
 #, elixir-autogen, elixir-format
 msgid "Expected"
 msgstr "Erwartet"
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:145
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/admin/emails_live.ex:139
+#, elixir-autogen, elixir-format
 msgid "Failed to archive email"
-msgstr "Notiz konnte nicht genehmigt werden"
+msgstr "E-Mail konnte nicht archiviert werden"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:290
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/provider/sessions_live.ex:302
+#, elixir-autogen, elixir-format
 msgid "Failed to create session: %{reason}"
-msgstr "Sitzung konnte nicht gestartet werden: %{reason}"
+msgstr "Sitzung konnte nicht erstellt werden: %{reason}"
 
-#: lib/klass_hero_web/live/admin/emails_live.html.heex:148
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/admin/emails_live.html.heex:146
+#, elixir-autogen, elixir-format
 msgid "Failed to fetch email content."
-msgstr "Notiz konnte nicht abgelehnt werden"
+msgstr "E-Mail-Inhalt konnte nicht abgerufen werden."
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:165
+#: lib/klass_hero_web/live/admin/emails_live.ex:159
 #, elixir-autogen, elixir-format
 msgid "Failed to mark email as unread"
-msgstr ""
+msgstr "E-Mail konnte nicht als ungelesen markiert werden"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:365
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:435
+#, elixir-autogen, elixir-format
 msgid "Failed to resend invitation. Please try again."
-msgstr "Notiz konnte nicht abgelehnt werden"
+msgstr "Einladung konnte nicht erneut gesendet werden. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:128
+#: lib/klass_hero_web/live/admin/emails_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "Failed to schedule retry"
-msgstr ""
+msgstr "Wiederholung konnte nicht geplant werden"
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:109
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/admin/emails_live.ex:103
+#, elixir-autogen, elixir-format
 msgid "Failed to send reply"
-msgstr ""
+msgstr "Antwort konnte nicht gesendet werden"
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:39
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:36
 #, elixir-autogen, elixir-format
 msgid "From"
-msgstr ""
+msgstr "Von"
 
-#: lib/klass_hero_web/live/admin/emails_live.html.heex:114
+#: lib/klass_hero_web/live/admin/emails_live.html.heex:112
 #, elixir-autogen, elixir-format
 msgid "From:"
-msgstr ""
+msgstr "Von:"
 
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:24
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:36
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:22
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:34
 #, elixir-autogen, elixir-format
 msgid "Go to Home"
-msgstr ""
+msgstr "Zur Startseite"
 
-#: lib/klass_hero_web/components/participation_components.ex:351
+#: lib/klass_hero_web/components/participation_components.ex:337
 #, elixir-autogen, elixir-format
 msgid "In: %{time}"
 msgstr "Ein: %{time}"
 
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:18
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:17
 #, elixir-autogen, elixir-format
 msgid "Invalid Invitation"
-msgstr ""
+msgstr "Ungültige Einladung"
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:278
-#: lib/klass_hero_web/live/provider/sessions_live.ex:351
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/admin/sessions_live.ex:259
+#: lib/klass_hero_web/live/provider/sessions_live.ex:361
+#, elixir-autogen, elixir-format
 msgid "Invalid time format"
-msgstr "Ungültiges Datumsformat"
+msgstr "Ungültiges Zeitformat"
 
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:30
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:81
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:27
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:107
 #, elixir-autogen, elixir-format
 msgid "Invitation Expired"
-msgstr ""
+msgstr "Einladung abgelaufen"
 
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:79
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:105
 #, elixir-autogen, elixir-format
 msgid "Invitation Failed"
-msgstr ""
+msgstr "Einladung fehlgeschlagen"
 
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:77
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:103
 #, elixir-autogen, elixir-format
 msgid "Invitation Pending"
-msgstr ""
+msgstr "Einladung ausstehend"
 
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:78
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:104
 #, elixir-autogen, elixir-format
 msgid "Invitation Sent"
-msgstr ""
+msgstr "Einladung gesendet"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:346
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:416
+#, elixir-autogen, elixir-format
 msgid "Invitation resent successfully."
-msgstr ""
+msgstr "Einladung erfolgreich erneut gesendet."
 
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:80
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:106
 #, elixir-autogen, elixir-format
 msgid "Joined"
-msgstr ""
+msgstr "Beigetreten"
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:15
-#: lib/klass_hero_web/components/layouts/app.html.heex:202
-#, elixir-autogen, elixir-format
-msgid "Klass Hero Logo"
-msgstr "Klass Hero Logo"
-
-#: lib/klass_hero_web/live/admin/emails_live.html.heex:160
+#: lib/klass_hero_web/live/admin/emails_live.html.heex:158
 #, elixir-autogen, elixir-format
 msgid "Load images"
-msgstr ""
+msgstr "Bilder laden"
 
-#: lib/klass_hero_web/components/participation_components.ex:71
+#: lib/klass_hero_web/components/participation_components.ex:66
 #, elixir-autogen, elixir-format
 msgid "Location TBD"
 msgstr "Ort noch offen"
@@ -5246,1010 +4400,2644 @@ msgstr "Ort noch offen"
 msgid "Manage your scheduled sessions and attendance"
 msgstr "Verwalten Sie Ihre geplanten Sitzungen und die Anwesenheit"
 
-#: lib/klass_hero_web/live/admin/emails_live.html.heex:132
+#: lib/klass_hero_web/live/admin/emails_live.html.heex:130
 #, elixir-autogen, elixir-format
 msgid "Mark Unread"
-msgstr ""
+msgstr "Als ungelesen markieren"
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:181
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:176
 #, elixir-autogen, elixir-format
 msgid "Max Capacity"
-msgstr ""
+msgstr "Maximale Kapazität"
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:89
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:301
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:85
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:285
 #, elixir-autogen, elixir-format
 msgid "No actions available"
 msgstr "Keine Aktionen verfügbar"
 
-#: lib/klass_hero_web/components/participation_components.ex:454
+#: lib/klass_hero_web/components/participation_components.ex:434
 #, elixir-autogen, elixir-format
 msgid "No children enrolled in this session"
 msgstr "Keine Kinder in dieser Sitzung angemeldet"
 
-#: lib/klass_hero_web/live/admin/emails_live.html.heex:64
+#: lib/klass_hero_web/live/admin/emails_live.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "No emails found."
-msgstr ""
+msgstr "Keine E-Mails gefunden."
 
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:202
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "No participation records yet"
 msgstr "Noch keine Teilnahmeeinträge"
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:162
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:325
+#, elixir-autogen, elixir-format
 msgid "No programs assigned yet."
-msgstr "Keine Programme gefunden"
+msgstr "Noch keine Programme zugewiesen."
 
-#: lib/klass_hero_web/live/admin/components/searchable_select.ex:113
+#: lib/klass_hero_web/live/admin/components/searchable_select.ex:107
 #, elixir-autogen, elixir-format
 msgid "No results"
-msgstr ""
+msgstr "Keine Ergebnisse"
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:91
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "No sessions found for the selected filters."
-msgstr ""
+msgstr "Keine Sitzungen für die ausgewählten Filter gefunden."
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:104
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:316
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:100
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:300
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled"
 msgstr "Keine Sitzungen geplant"
 
-#: lib/klass_hero_web/components/participation_components.ex:654
+#: lib/klass_hero_web/components/participation_components.ex:634
 #, elixir-autogen, elixir-format
 msgid "Note:"
 msgstr "Notiz:"
 
-#: lib/klass_hero_web/components/participation_components.ex:516
+#: lib/klass_hero_web/components/participation_components.ex:496
 #, elixir-autogen, elixir-format
 msgid "Observation about the child's participation..."
 msgstr "Beobachtung zur Teilnahme des Kindes..."
 
-#: lib/klass_hero_web/components/participation_components.ex:357
+#: lib/klass_hero_web/components/participation_components.ex:343
 #, elixir-autogen, elixir-format
 msgid "Out: %{time}"
 msgstr "Aus: %{time}"
 
-#: lib/klass_hero_web/components/participation_components.ex:179
+#: lib/klass_hero_web/components/participation_components.ex:172
 #, elixir-autogen, elixir-format
 msgid "Participation Check-In"
 msgstr "Teilnahme-Einchecken"
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:25
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:25
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:26
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "Participation Management"
 msgstr "Teilnahmeverwaltung"
 
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:17
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Pending Reviews"
 msgstr "Ausstehende Überprüfungen"
 
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:90
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Please explain why you're rejecting this note..."
 msgstr "Bitte erklären Sie, warum Sie diese Notiz ablehnen..."
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:358
+#: lib/klass_hero_web/live/provider/sessions_live.ex:368
 #, elixir-autogen, elixir-format
 msgid "Please fill in all required fields"
-msgstr ""
+msgstr "Bitte füllen Sie alle erforderlichen Felder aus"
 
-#: lib/klass_hero_web/components/composite_components.ex:571
+#: lib/klass_hero_web/components/composite_components.ex:431
 #, elixir-autogen, elixir-format
 msgid "Post"
 msgstr "Absenden"
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:26
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:143
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:612
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:287
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:156
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:24
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:666
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:297
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr "Programm"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:153
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/provider/sessions_live.ex:177
+#, elixir-autogen, elixir-format
 msgid "Program is required"
-msgstr "Programme"
+msgstr "Programm ist erforderlich"
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:14
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/components/provider_layout_components.ex:74
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:12
+#, elixir-autogen, elixir-format
 msgid "Provider"
-msgstr "Anbieter-Dashboard"
+msgstr "Anbieter"
 
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:35
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:32
 #, elixir-autogen, elixir-format
 msgid "Provider observation"
 msgstr "Beobachtung des Anbieters"
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:214
+#: lib/klass_hero_web/live/admin/emails_live.ex:206
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "Read"
 msgstr "Gelesen"
 
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:89
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "Reason for rejection (optional)"
 msgstr "Grund für die Ablehnung (optional)"
 
-#: lib/klass_hero_web/live/admin/emails_live.html.heex:201
+#: lib/klass_hero_web/live/admin/emails_live.html.heex:197
 #, elixir-autogen, elixir-format
 msgid "Reply"
-msgstr ""
+msgstr "Antworten"
 
-#: lib/klass_hero_web/components/messaging_components.ex:639
+#: lib/klass_hero_web/components/messaging_components.ex:699
 #, elixir-autogen, elixir-format
 msgid "Reply privately"
-msgstr ""
+msgstr "Privat antworten"
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:247
+#: lib/klass_hero_web/live/messaging_live_helper.ex:246
 #, elixir-autogen, elixir-format
 msgid "Reply privately is only available for broadcast messages"
-msgstr ""
+msgstr "Privates Antworten ist nur für Broadcast-Nachrichten verfügbar"
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:106
+#: lib/klass_hero_web/live/admin/emails_live.ex:100
 #, elixir-autogen, elixir-format
 msgid "Reply sent successfully"
-msgstr ""
+msgstr "Antwort erfolgreich gesendet"
 
-#: lib/klass_hero_web/components/provider_components.ex:566
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/components/provider_components.ex:529
+#, elixir-autogen, elixir-format
 msgid "Resend"
-msgstr ""
+msgstr "Erneut senden"
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:65
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:62
 #, elixir-autogen, elixir-format
 msgid "Reset to today"
-msgstr ""
+msgstr "Auf heute zurücksetzen"
 
-#: lib/klass_hero_web/components/participation_components.ex:547
+#: lib/klass_hero_web/components/participation_components.ex:527
 #, elixir-autogen, elixir-format
 msgid "Resubmit Note"
 msgstr "Notiz erneut einreichen"
 
-#: lib/klass_hero_web/live/admin/emails_live.html.heex:150
+#: lib/klass_hero_web/live/admin/emails_live.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "Retry"
-msgstr ""
+msgstr "Erneut versuchen"
 
-#: lib/klass_hero_web/components/participation_components.ex:545
+#: lib/klass_hero_web/components/participation_components.ex:525
 #, elixir-autogen, elixir-format
 msgid "Revised Note"
 msgstr "Überarbeitete Notiz"
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:157
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:152
+#, elixir-autogen, elixir-format
 msgid "Select a program..."
-msgstr "Thema auswählen..."
+msgstr "Programm auswählen..."
 
-#: lib/klass_hero_web/live/admin/emails_live.html.heex:211
+#: lib/klass_hero_web/live/admin/emails_live.html.heex:207
 #, elixir-autogen, elixir-format
 msgid "Send Reply"
-msgstr ""
+msgstr "Antwort senden"
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:218
+#: lib/klass_hero_web/live/admin/emails_live.ex:210
 #, elixir-autogen, elixir-format
 msgid "Sending"
 msgstr "Wird gesendet"
 
-#: lib/klass_hero_web/components/participation_components.ex:58
+#: lib/klass_hero_web/components/participation_components.ex:54
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:16
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:16
 #, elixir-autogen, elixir-format
 msgid "Session"
 msgstr "Sitzung"
 
-#: lib/klass_hero_web/components/participation_components.ex:232
+#: lib/klass_hero_web/components/participation_components.ex:223
 #, elixir-autogen, elixir-format
 msgid "Session Notes (optional)"
 msgstr "Sitzungsnotizen (optional)"
 
-#: lib/klass_hero_web/components/participation_components.ex:188
-#: lib/klass_hero_web/components/participation_components.ex:319
+#: lib/klass_hero_web/components/participation_components.ex:180
+#: lib/klass_hero_web/components/participation_components.ex:308
 #, elixir-autogen, elixir-format
 msgid "Session Roster"
 msgstr "Teilnehmerliste"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:270
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/provider/sessions_live.ex:284
+#, elixir-autogen, elixir-format
 msgid "Session created successfully"
-msgstr "Sitzung erfolgreich gestartet"
+msgstr "Sitzung erfolgreich erstellt"
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:27
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:30
 #, elixir-autogen, elixir-format
 msgid "Staff Dashboard"
-msgstr ""
+msgstr "Mitarbeiter-Dashboard"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1078
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1121
 #, elixir-autogen, elixir-format
 msgid "Staff member created, but the invitation could not be sent. Try resending from the team list."
-msgstr ""
+msgstr "Mitarbeiter wurde erstellt, aber die Einladung konnte nicht gesendet werden. Versuchen Sie es erneut über die Team-Liste."
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:53
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:265
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:49
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:249
 #, elixir-autogen, elixir-format
 msgid "Start Session"
 msgstr "Sitzung starten"
 
-#: lib/klass_hero_web/components/participation_components.ex:517
+#: lib/klass_hero_web/components/participation_components.ex:497
 #, elixir-autogen, elixir-format
 msgid "Submit Note"
 msgstr "Notiz absenden"
 
-#: lib/klass_hero_web/components/participation_components.ex:248
+#: lib/klass_hero_web/components/participation_components.ex:238
 #, elixir-autogen, elixir-format
 msgid "Submit Participation"
 msgstr "Teilnahme bestätigen"
 
-#: lib/klass_hero_web/components/participation_components.ex:741
+#: lib/klass_hero_web/components/participation_components.ex:719
 #, elixir-autogen, elixir-format
 msgid "Support: %{details}"
 msgstr "Unterstützung: %{details}"
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:49
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:55
 #, elixir-autogen, elixir-format
 msgid "The business associated with your account could not be found."
-msgstr ""
+msgstr "Das mit Ihrem Konto verknüpfte Unternehmen konnte nicht gefunden werden."
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:356
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "This invitation cannot be resent in its current state."
-msgstr ""
+msgstr "Diese Einladung kann in ihrem aktuellen Status nicht erneut gesendet werden."
 
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:32
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:29
 #, elixir-autogen, elixir-format
 msgid "This invitation has expired. Please ask your business to resend it."
-msgstr ""
+msgstr "Diese Einladung ist abgelaufen. Bitten Sie Ihr Unternehmen, sie erneut zu senden."
 
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:20
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:18
 #, elixir-autogen, elixir-format
 msgid "This invitation link is invalid or has already been used."
-msgstr ""
+msgstr "Dieser Einladungslink ist ungültig oder wurde bereits verwendet."
 
-#: lib/klass_hero_web/controllers/invite_claim_controller.ex:57
+#: lib/klass_hero_web/controllers/invite_claim_controller.ex:50
 #, elixir-autogen, elixir-format
 msgid "This invite has already been used."
 msgstr "Diese Einladung wurde bereits verwendet."
 
-#: lib/klass_hero_web/controllers/invite_claim_controller.ex:52
+#: lib/klass_hero_web/controllers/invite_claim_controller.ex:45
 #, elixir-autogen, elixir-format
 msgid "This invite link is invalid or has expired."
 msgstr "Dieser Einladungslink ist ungültig oder abgelaufen."
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:340
-#: lib/klass_hero_web/live/provider/sessions_live.ex:341
+#: lib/klass_hero_web/live/provider/sessions_live.ex:352
+#: lib/klass_hero_web/live/provider/sessions_live.ex:353
 #, elixir-autogen, elixir-format
 msgid "Time is required"
-msgstr ""
+msgstr "Uhrzeit ist erforderlich"
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:51
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:48
 #, elixir-autogen, elixir-format
 msgid "To"
-msgstr ""
+msgstr "An"
 
-#: lib/klass_hero_web/live/admin/emails_live.html.heex:206
+#: lib/klass_hero_web/live/admin/emails_live.html.heex:202
 #, elixir-autogen, elixir-format
 msgid "Type your reply..."
-msgstr ""
+msgstr "Ihre Antwort eingeben..."
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:160
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:72
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:95
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:124
+#: lib/klass_hero_web/live/provider/sessions_live.ex:181
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:123
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:93
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "Unauthorized"
-msgstr ""
+msgstr "Nicht autorisiert"
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:213
+#: lib/klass_hero_web/components/parent_components.ex:481
+#: lib/klass_hero_web/live/admin/emails_live.ex:205
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:35
 #, elixir-autogen, elixir-format
 msgid "Unread"
 msgstr "Ungelesen"
 
-#: lib/klass_hero_web/components/participation_components.ex:546
+#: lib/klass_hero_web/components/participation_components.ex:526
 #, elixir-autogen, elixir-format
 msgid "Update your observation..."
 msgstr "Aktualisieren Sie Ihre Beobachtung..."
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:460
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:744
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:526
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:782
 #, elixir-autogen, elixir-format
 msgid "Upload connection lost. Please try again."
-msgstr ""
+msgstr "Upload-Verbindung unterbrochen. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:86
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:298
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:82
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "View Participation"
 msgstr "Teilnahme anzeigen"
 
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:6
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "View your children's participation records"
 msgstr "Sehen Sie die Teilnahmeeinträge Ihrer Kinder ein"
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:137
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:214
+#, elixir-autogen, elixir-format
 msgid "Welcome, %{name}"
-msgstr "Willkommen %{email}"
+msgstr "Willkommen, %{name}"
 
-#: lib/klass_hero_web/components/composite_components.ex:563
+#: lib/klass_hero_web/components/composite_components.ex:423
 #, elixir-autogen, elixir-format
 msgid "Write a comment..."
 msgstr "Kommentar schreiben..."
 
-#: lib/klass_hero_web/controllers/invite_claim_controller.ex:44
+#: lib/klass_hero_web/controllers/invite_claim_controller.ex:37
 #, elixir-autogen, elixir-format
 msgid "You already have an account. Log in to see your new enrollment."
 msgstr "Sie haben bereits ein Konto. Melden Sie sich an, um Ihre neue Anmeldung zu sehen."
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:107
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:319
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:103
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:303
 #, elixir-autogen, elixir-format
 msgid "You have no sessions scheduled for %{date}"
 msgstr "Sie haben keine Sitzungen geplant für %{date}"
 
-#: lib/klass_hero_web/user_auth.ex:299
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/user_auth.ex:268
+#, elixir-autogen, elixir-format
 msgid "You must be a staff member to access this page."
-msgstr "Sie müssen angemeldet sein, um auf diese Seite zuzugreifen."
+msgstr "Sie müssen Mitarbeiter sein, um auf diese Seite zuzugreifen."
 
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:44
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:43
 #, elixir-autogen, elixir-format
 msgid "You've been invited to join a team on Klass Hero."
-msgstr ""
+msgstr "Sie wurden eingeladen, einem Team bei Klass Hero beizutreten."
 
-#: lib/klass_hero_web/controllers/invite_claim_controller.ex:32
+#: lib/klass_hero_web/controllers/invite_claim_controller.ex:29
 #, elixir-autogen, elixir-format
 msgid "Your account has been created! Set up your password in settings."
 msgstr "Ihr Konto wurde erstellt! Richten Sie Ihr Passwort in den Einstellungen ein."
 
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:205
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:195
 #, elixir-autogen, elixir-format
 msgid "Your children's participation will appear here"
 msgstr "Die Teilnahme Ihrer Kinder wird hier angezeigt"
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:200
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:363
 #, elixir-autogen, elixir-format
 msgid "Roster"
-msgstr ""
+msgstr "Teilnehmerliste"
 
-#: lib/klass_hero_web/components/provider_components.ex:393
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Team Members"
-msgstr "Teammitglied hinzufügen"
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:158
+#: lib/klass_hero_web/live/for_providers_live.ex:417
 #, elixir-autogen, elixir-format
 msgid "Unlimited team seats"
-msgstr ""
+msgstr "Unbegrenzte Team-Plätze"
 
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:231
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:218
 #, elixir-autogen, elixir-format
 msgid "View and manage your assigned sessions"
-msgstr ""
+msgstr "Ihre zugewiesenen Sitzungen anzeigen und verwalten"
 
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:70
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:332
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:60
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:218
 #, elixir-autogen, elixir-format
 msgid "You are not assigned to this program"
-msgstr ""
+msgstr "Sie sind diesem Programm nicht zugewiesen"
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:233
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:240
 #, elixir-autogen, elixir-format
 msgid "+1234567890"
-msgstr ""
+msgstr "+1234567890"
 
-#: lib/klass_hero_web/components/composite_components.ex:852
+#: lib/klass_hero_web/components/composite_components.ex:692
 #, elixir-autogen, elixir-format
 msgid "About the Provider"
-msgstr ""
+msgstr "Über den Anbieter"
 
-#: lib/klass_hero_web/live/home_live.ex:250
+#: lib/klass_hero_web/components/marketing_components.ex:501
 #, elixir-autogen, elixir-format
 msgid "Built for the Berlin international community. Integrated secure encrypted messaging to connect with local families and trusted educators nearby."
 msgstr "Entwickelt für die internationale Berliner Gemeinschaft. Integriertes sicheres verschlüsseltes Messaging, um sich mit lokalen Familien und vertrauenswürdigen Pädagogen in Ihrer Nähe zu verbinden."
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:214
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:221
+#, elixir-autogen, elixir-format
 msgid "Business Name"
-msgstr "Business-Plan"
+msgstr "Unternehmensname"
 
-#: lib/klass_hero_web/components/participation_components.ex:817
+#: lib/klass_hero_web/components/participation_components.ex:789
 #, elixir-autogen, elixir-format
 msgid "Cancelled"
 msgstr "Abgesagt"
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:253
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:260
+#, elixir-autogen, elixir-format
 msgid "Categories"
-msgstr ""
+msgstr "Kategorien"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1273
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:318
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1407
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:325
+#, elixir-autogen, elixir-format
 msgid "Complete Profile"
-msgstr "Anmeldung abschließen"
+msgstr "Profil vervollständigen"
 
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:40
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Complete Your Profile"
-msgstr ""
+msgstr "Vervollständigen Sie Ihr Profil"
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:195
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:202
 #, elixir-autogen, elixir-format
 msgid "Complete Your Provider Profile"
-msgstr ""
+msgstr "Vervollständigen Sie Ihr Anbieterprofil"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1256
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1390
 #, elixir-autogen, elixir-format
 msgid "Complete your provider profile"
-msgstr ""
+msgstr "Vervollständigen Sie Ihr Anbieterprofil"
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:294
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:301
 #, elixir-autogen, elixir-format
 msgid "Drag and drop or click to upload"
-msgstr ""
+msgstr "Ziehen und ablegen oder klicken zum Hochladen"
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:504
+#: lib/klass_hero_web/live/messaging_live_helper.ex:481
 #, elixir-autogen, elixir-format
 msgid "Failed to upload files. Please try again."
-msgstr ""
+msgstr "Hochladen der Dateien fehlgeschlagen. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/components/messaging_components.ex:689
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/components/messaging_components.ex:763
+#, elixir-autogen, elixir-format
 msgid "File is too large (max %{mb} MB)"
-msgstr ""
+msgstr "Datei ist zu groß (max. %{mb} MB)"
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:502
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/messaging_live_helper.ex:479
+#, elixir-autogen, elixir-format
 msgid "File is too large (max %{mb} MB)."
-msgstr ""
+msgstr "Datei ist zu groß (max. %{mb} MB)."
 
-#: lib/klass_hero_web/components/messaging_components.ex:692
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/components/messaging_components.ex:766
+#, elixir-autogen, elixir-format
 msgid "File type not accepted (images only)"
-msgstr ""
+msgstr "Dateityp nicht akzeptiert (nur Bilder)"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1259
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1393
 #, elixir-autogen, elixir-format
 msgid "Fill in your business details so parents can find you. Your profile will be reviewed by Klass Hero before going live."
-msgstr ""
+msgstr "Geben Sie Ihre Unternehmensdaten ein, damit Eltern Sie finden können. Ihr Profil wird von Klass Hero geprüft, bevor es veröffentlicht wird."
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:198
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:205
 #, elixir-autogen, elixir-format
 msgid "Fill in your business details. Your profile will be reviewed by Klass Hero before going live."
-msgstr ""
+msgstr "Geben Sie Ihre Unternehmensdaten ein. Ihr Profil wird von Klass Hero geprüft, bevor es veröffentlicht wird."
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:152
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:263
 #, elixir-autogen, elixir-format
 msgid "Manage your business"
-msgstr ""
+msgstr "Ihr Unternehmen verwalten"
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:499
+#: lib/klass_hero_web/live/messaging_live_helper.ex:476
 #, elixir-autogen, elixir-format
 msgid "Only images are accepted (JPG, PNG, GIF, WebP)."
-msgstr ""
+msgstr "Nur Bilder werden akzeptiert (JPG, PNG, GIF, WebP)."
 
-#: lib/klass_hero_web/components/messaging_components.ex:677
-#: lib/klass_hero_web/components/messaging_components.ex:681
+#: lib/klass_hero_web/components/messaging_components.ex:751
+#: lib/klass_hero_web/components/messaging_components.ex:755
 #, elixir-autogen, elixir-format
 msgid "Photo"
-msgstr ""
+msgstr "Foto"
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:494
+#: lib/klass_hero_web/live/messaging_live_helper.ex:471
 #, elixir-autogen, elixir-format
 msgid "Please enter a message or attach a photo."
-msgstr ""
+msgstr "Bitte geben Sie eine Nachricht ein oder fügen Sie ein Foto hinzu."
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:91
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:95
 #, elixir-autogen, elixir-format
 msgid "Profile completed! Klass Hero will review your profile shortly."
-msgstr ""
+msgstr "Profil vervollständigt! Klass Hero wird Ihr Profil in Kürze prüfen."
 
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:36
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:31
+#, elixir-autogen, elixir-format
 msgid "Provider not found"
-msgstr "Programm nicht gefunden"
+msgstr "Anbieter nicht gefunden"
 
 #: lib/klass_hero_web/components/messaging_components.ex:276
+#: lib/klass_hero_web/components/messaging_components.ex:344
 #, elixir-autogen, elixir-format
 msgid "Remove attachment"
-msgstr ""
+msgstr "Anhang entfernen"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1422
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Sessions Completed"
-msgstr "Sitzungen"
-
-#: lib/klass_hero_web/live/messaging_live_helper.ex:505
+#: lib/klass_hero_web/live/messaging_live_helper.ex:482
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:132
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:136
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:103
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:47
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:88
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:107
+#, elixir-autogen, elixir-format
 msgid "Something went wrong. Please try again."
-msgstr ""
+msgstr "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:223
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:230
+#, elixir-autogen, elixir-format
 msgid "Tell parents about your organization and what makes you unique..."
-msgstr ""
+msgstr "Erzählen Sie Eltern von Ihrer Organisation und was Sie einzigartig macht..."
 
-#: lib/klass_hero_web/components/messaging_components.ex:696
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/components/messaging_components.ex:770
+#, elixir-autogen, elixir-format
 msgid "Too many files (max %{max})"
-msgstr ""
+msgstr "Zu viele Dateien (max. %{max})"
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:497
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/messaging_live_helper.ex:474
+#, elixir-autogen, elixir-format
 msgid "Too many files (max %{max})."
-msgstr ""
+msgstr "Zu viele Dateien (max. %{max})."
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:323
+#: lib/klass_hero_web/components/messaging_components.ex:774
 #, elixir-autogen, elixir-format
-msgid "Upgrade plan to message parents"
-msgstr ""
-
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:247
-#, elixir-autogen, elixir-format
-msgid "Upgrade plan to send broadcasts"
-msgstr ""
-
-#: lib/klass_hero_web/components/messaging_components.ex:700
-#, elixir-autogen, elixir-format, fuzzy
 msgid "Upload error"
-msgstr ""
+msgstr "Upload-Fehler"
 
-#: lib/klass_hero_web/components/messaging_components.ex:699
+#: lib/klass_hero_web/components/messaging_components.ex:773
 #, elixir-autogen, elixir-format
 msgid "Upload failed"
-msgstr ""
+msgstr "Hochladen fehlgeschlagen"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1184
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1309
 #, elixir-autogen, elixir-format
 msgid "View your assignments"
-msgstr ""
+msgstr "Ihre Zuweisungen anzeigen"
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:239
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "Website"
-msgstr ""
+msgstr "Website"
 
-#: lib/klass_hero_web/components/provider_components.ex:435
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:957
-#, elixir-autogen, elixir-format
-msgid "You've reached your program limit. Upgrade your plan to add more programs."
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:248
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:255
 #, elixir-autogen, elixir-format
 msgid "Your business address"
-msgstr ""
+msgstr "Ihre Geschäftsadresse"
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:215
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:222
 #, elixir-autogen, elixir-format
 msgid "Your business or organization name"
-msgstr ""
+msgstr "Name Ihres Unternehmens oder Ihrer Organisation"
 
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:29
 #, elixir-autogen, elixir-format
 msgid "Your profile is already complete."
-msgstr ""
+msgstr "Ihr Profil ist bereits vollständig."
 
-#: lib/klass_hero_web/components/messaging_components.ex:89
-#: lib/klass_hero_web/live/messaging_live_helper.ex:338
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/components/messaging_components.ex:92
+#: lib/klass_hero_web/live/messaging_live_helper.ex:327
+#, elixir-autogen, elixir-format
 msgid "for"
-msgstr ""
+msgstr "für"
 
-#: lib/klass_hero_web/components/provider_components.ex:1711
+#: lib/klass_hero_web/components/provider_components.ex:1667
 #, elixir-autogen, elixir-format
 msgid "Assigned staff"
 msgstr "Zugewiesenes Personal"
 
-#: lib/klass_hero_web/components/provider_components.ex:1713
+#: lib/klass_hero_web/components/provider_components.ex:1669
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr "Anwesenheit"
 
-#: lib/klass_hero_web/components/provider_components.ex:1695
+#: lib/klass_hero_web/components/provider_components.ex:1651
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr "Schließen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1712
+#: lib/klass_hero_web/components/provider_components.ex:1668
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr "Vertretung"
 
-#: lib/klass_hero_web/components/provider_components.ex:1710
+#: lib/klass_hero_web/components/provider_components.ex:1666
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr "Datum / Uhrzeit"
 
-#: lib/klass_hero_web/components/provider_components.ex:1704
+#: lib/klass_hero_web/components/provider_components.ex:1660
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled yet."
 msgstr "Noch keine Sessions geplant."
 
-#: lib/klass_hero_web/components/provider_components.ex:1693
+#: lib/klass_hero_web/components/provider_components.ex:1649
 #, elixir-autogen, elixir-format
 msgid "Sessions — %{title}"
 msgstr "Sessions — %{title}"
 
-#: lib/klass_hero_web/components/provider_components.ex:1444
+#: lib/klass_hero_web/components/provider_components.ex:1396
 #, elixir-autogen, elixir-format
 msgid "View sessions"
 msgstr "Sessions anzeigen"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:800
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:873
 #, elixir-autogen, elixir-format
 msgid "Create a program before inviting participants."
-msgstr "Erstelle zuerst ein Programm, bevor du Teilnehmer einlädst."
+msgstr "Erstellen Sie zuerst ein Programm, bevor Sie Teilnehmer einladen."
 
-#: lib/klass_hero_web/components/participation_components.ex:814
+#: lib/klass_hero_web/components/participation_components.ex:786
 #, elixir-autogen, elixir-format
 msgid "Departed"
-msgstr ""
+msgstr "Abgereist"
 
-#: lib/klass_hero_web/components/participation_components.ex:835
+#: lib/klass_hero_web/components/participation_components.ex:805
 #, elixir-autogen, elixir-format
 msgid "Departure notes"
-msgstr ""
+msgstr "Notizen zur Abreise"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:318
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:257
+#: lib/klass_hero_web/live/provider/participation_live.ex:225
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:167
 #, elixir-autogen, elixir-format
 msgid "Departure time is not a valid date and time"
-msgstr ""
+msgstr "Abreisezeit ist kein gültiges Datum oder keine gültige Uhrzeit"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:329
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:268
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/live/provider/participation_live.ex:236
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:178
+#, elixir-autogen, elixir-format
 msgid "Failed to update record"
-msgstr "Sitzungsdaten konnten nicht geladen werden"
+msgstr "Aktualisieren des Datensatzes fehlgeschlagen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2140
+#: lib/klass_hero_web/components/provider_components.ex:2086
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr "Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:1863
+#: lib/klass_hero_web/components/provider_components.ex:1814
 #, elixir-autogen, elixir-format
 msgid "Invite mode"
 msgstr "Einladungsmodus"
 
-#: lib/klass_hero_web/components/provider_components.ex:1882
+#: lib/klass_hero_web/components/provider_components.ex:1833
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr "Einzelperson einladen"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:796
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:869
 #, elixir-autogen, elixir-format
 msgid "Invite sent."
 msgstr "Einladung verschickt."
 
-#: lib/klass_hero_web/components/participation_components.ex:600
+#: lib/klass_hero_web/components/participation_components.ex:580
 #, elixir-autogen, elixir-format
 msgid "Leave blank to keep this child marked as present."
-msgstr ""
+msgstr "Leer lassen, um dieses Kind als anwesend markiert zu lassen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2153
+#: lib/klass_hero_web/components/provider_components.ex:2099
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr "Gesundheit & Einwilligungen (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2159
+#: lib/klass_hero_web/components/provider_components.ex:2105
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr "Gesundheitliche Besonderheiten"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:321
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:260
+#: lib/klass_hero_web/live/provider/participation_live.ex:228
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:170
 #, elixir-autogen, elixir-format
 msgid "Nothing to update"
-msgstr ""
+msgstr "Nichts zu aktualisieren"
 
-#: lib/klass_hero_web/components/provider_components.ex:2161
+#: lib/klass_hero_web/components/provider_components.ex:2107
 #, elixir-autogen, elixir-format
 msgid "Nut allergy"
 msgstr "Nussallergie"
 
-#: lib/klass_hero_web/components/provider_components.ex:2165
+#: lib/klass_hero_web/components/provider_components.ex:2111
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr "Fotos dürfen in Marketingmaterialien verwendet werden"
 
-#: lib/klass_hero_web/components/provider_components.ex:2170
+#: lib/klass_hero_web/components/provider_components.ex:2116
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr "Fotos dürfen in sozialen Medien erscheinen"
 
-#: lib/klass_hero_web/components/participation_components.ex:813
+#: lib/klass_hero_web/components/participation_components.ex:785
 #, elixir-autogen, elixir-format
 msgid "Present"
-msgstr ""
+msgstr "Anwesend"
 
-#: lib/klass_hero_web/components/provider_components.ex:2097
+#: lib/klass_hero_web/components/provider_components.ex:2043
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr "Hauptansprechpartner"
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:61
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:61
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:62
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:62
 #, elixir-autogen, elixir-format
 msgid "Record departure"
-msgstr ""
+msgstr "Abreise erfassen"
 
-#: lib/klass_hero_web/components/participation_components.ex:597
+#: lib/klass_hero_web/components/participation_components.ex:577
 #, elixir-autogen, elixir-format
 msgid "Record departure time (optional)"
-msgstr ""
+msgstr "Abreisezeit erfassen (optional)"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:309
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:248
+#: lib/klass_hero_web/live/provider/participation_live.ex:216
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:158
 #, elixir-autogen, elixir-format
 msgid "Record updated"
-msgstr ""
+msgstr "Datensatz aktualisiert"
 
-#: lib/klass_hero_web/components/participation_components.ex:614
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/components/participation_components.ex:594
+#, elixir-autogen, elixir-format
 msgid "Save changes"
 msgstr "Änderungen speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:2134
+#: lib/klass_hero_web/components/provider_components.ex:2080
 #, elixir-autogen, elixir-format
 msgid "School (optional)"
 msgstr "Schule (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2144
+#: lib/klass_hero_web/components/provider_components.ex:2090
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr "Schulname"
 
-#: lib/klass_hero_web/components/provider_components.ex:2118
+#: lib/klass_hero_web/components/provider_components.ex:2064
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr "Zweiter Ansprechpartner (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2187
+#: lib/klass_hero_web/components/provider_components.ex:2133
 #, elixir-autogen, elixir-format
 msgid "Send invite"
 msgstr "Einladung senden"
 
-#: lib/klass_hero_web/components/participation_components.ex:589
+#: lib/klass_hero_web/components/participation_components.ex:569
 #, elixir-autogen, elixir-format
 msgid "Update the note for this child (e.g. clarify what happened)"
-msgstr ""
+msgstr "Aktualisieren Sie die Notiz für dieses Kind (z. B. um zu klären, was passiert ist)"
 
-#: lib/klass_hero_web/components/provider_components.ex:1900
+#: lib/klass_hero_web/components/provider_components.ex:1851
 #, elixir-autogen, elixir-format
 msgid "Upload a list"
 msgstr "Liste hochladen"
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:807
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:880
 #, elixir-autogen, elixir-format
 msgid "An invite for this child and program already exists."
 msgstr "Für dieses Kind und Programm existiert bereits eine Einladung."
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:227
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:237
 #, elixir-autogen, elixir-format
 msgid "Behavioral Issue"
 msgstr "Verhaltensproblem"
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:240
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:250
 #, elixir-autogen, elixir-format
 msgid "Critical"
 msgstr "Kritisch"
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:280
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:290
 #, elixir-autogen, elixir-format
 msgid "Date & time"
 msgstr "Datum & Uhrzeit"
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:330
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:340
 #, elixir-autogen, elixir-format
 msgid "Drop a photo here or click to browse"
 msgstr "Foto hierher ziehen oder klicken zum Auswählen"
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:239
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:249
 #, elixir-autogen, elixir-format
 msgid "High"
 msgstr "Hoch"
 
-#: lib/klass_hero_web/components/provider_components.ex:726
+#: lib/klass_hero_web/components/provider_components.ex:692
 #, elixir-autogen, elixir-format
 msgid "Hourly"
-msgstr ""
+msgstr "Stündlich"
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:121
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:115
 #, elixir-autogen, elixir-format
 msgid "Incident report submitted."
 msgstr "Vorfallsbericht wurde eingereicht."
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:228
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:238
 #, elixir-autogen, elixir-format
 msgid "Injury"
 msgstr "Verletzung"
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:237
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:247
 #, elixir-autogen, elixir-format
 msgid "Low"
 msgstr "Niedrig"
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:238
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:248
 #, elixir-autogen, elixir-format
 msgid "Medium"
 msgstr "Mittel"
 
-#: lib/klass_hero_web/components/provider_components.ex:716
+#: lib/klass_hero_web/components/provider_components.ex:682
 #, elixir-autogen, elixir-format
 msgid "None"
-msgstr ""
+msgstr "Keine"
 
-#: lib/klass_hero_web/components/provider_components.ex:705
+#: lib/klass_hero_web/components/provider_components.ex:671
 #, elixir-autogen, elixir-format
 msgid "Pay Rate"
-msgstr ""
+msgstr "Vergütung"
 
-#: lib/klass_hero_web/components/provider_components.ex:537
+#: lib/klass_hero_web/components/provider_components.ex:500
 #, elixir-autogen, elixir-format
 msgid "Pay rate"
-msgstr ""
+msgstr "Vergütung"
 
-#: lib/klass_hero_web/components/provider_components.ex:736
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/components/provider_components.ex:702
+#, elixir-autogen, elixir-format
 msgid "Per Session"
-msgstr "Sitzung"
+msgstr "Pro Sitzung"
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:320
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:330
 #, elixir-autogen, elixir-format
 msgid "Photo (optional)"
 msgstr "Foto (optional)"
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:230
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:240
 #, elixir-autogen, elixir-format
 msgid "Policy Violation"
 msgstr "Richtlinienverstoß"
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:64
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:63
 #, elixir-autogen, elixir-format
 msgid "Program or session not found."
 msgstr "Programm oder Session nicht gefunden."
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:229
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:239
 #, elixir-autogen, elixir-format
 msgid "Property Damage"
 msgstr "Sachschaden"
 
-#: lib/klass_hero_web/components/provider_components.ex:1467
+#: lib/klass_hero_web/components/provider_components.ex:1419
 #, elixir-autogen, elixir-format
 msgid "Report Incident"
 msgstr "Vorfall melden"
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:47
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:258
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:45
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "Report an Incident"
 msgstr "Vorfall melden"
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:226
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:236
 #, elixir-autogen, elixir-format
 msgid "Safety Concern"
 msgstr "Sicherheitsbedenken"
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:298
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "Select a category"
 msgstr "Kategorie auswählen"
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:289
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "Select a program"
 msgstr "Programm auswählen"
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:305
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:315
 #, elixir-autogen, elixir-format
 msgid "Severity"
 msgstr "Schweregrad"
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:264
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:274
 #, elixir-autogen, elixir-format
 msgid "Submit a report about an incident during a program or session. All fields are confidential."
 msgstr "Melden Sie einen Vorfall während eines Programms oder einer Session. Alle Angaben werden vertraulich behandelt."
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:355
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:365
 #, elixir-autogen, elixir-format
 msgid "Submit report"
 msgstr "Bericht absenden"
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:144
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:221
 #, elixir-autogen, elixir-format
 msgid "Your pay rate"
-msgstr ""
+msgstr "Ihre Vergütung"
 
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:73
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:99
 #, elixir-autogen, elixir-format
 msgid "hour"
-msgstr ""
+msgstr "Stunde"
 
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:74
-#, elixir-autogen, elixir-format, fuzzy
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:100
+#, elixir-autogen, elixir-format
 msgid "session"
 msgstr "Sitzung"
 
-#: lib/klass_hero_web/helpers/greeting.ex
+#: lib/klass_hero_web/helpers/greeting.ex:53
 #, elixir-autogen, elixir-format
 msgid "Good morning"
 msgstr "Guten Morgen"
 
-#: lib/klass_hero_web/helpers/greeting.ex
+#: lib/klass_hero_web/helpers/greeting.ex:54
 #, elixir-autogen, elixir-format
 msgid "Good afternoon"
 msgstr "Guten Tag"
 
-#: lib/klass_hero_web/helpers/greeting.ex
+#: lib/klass_hero_web/helpers/greeting.ex:55
 #, elixir-autogen, elixir-format
 msgid "Good evening"
 msgstr "Guten Abend"
 
-#: lib/klass_hero_web/live/dashboard_live.ex
+#: lib/klass_hero_web/live/dashboard_live.ex:60
 #, elixir-autogen, elixir-format
 msgid "Your week with the kids"
 msgstr "Ihre Woche mit den Kindern"
 
-#: lib/klass_hero_web/components/marketing_components.ex
+#: lib/klass_hero_web/components/marketing_components.ex:91
+#: lib/klass_hero_web/components/marketing_components.ex:159
 #, elixir-autogen, elixir-format
 msgid "Go to dashboard"
 msgstr "Zum Dashboard"
 
-#: lib/klass_hero_web/live/for_providers_live.ex
-msgid "Free to join"
-msgstr "Kostenlos beitreten"
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:825
+#, elixir-autogen, elixir-format
+msgid "%{count} row could not be processed."
+msgid_plural "%{count} rows could not be processed."
+msgstr[0] "%{count} Zeile konnte nicht verarbeitet werden."
+msgstr[1] "%{count} Zeilen konnten nicht verarbeitet werden."
 
-#: lib/klass_hero_web/live/for_providers_live.ex
-msgid "Every feature included. No subscription, no setup fees."
-msgstr "Alle Funktionen inklusive. Kein Abo, keine Einrichtungsgebühren."
+#: lib/klass_hero_web/components/parent_components.ex:411
+#, elixir-autogen, elixir-format
+msgid "%{done} of %{goal} sessions attended"
+msgstr "%{done} von %{goal} Sitzungen besucht"
 
-#: lib/klass_hero_web/live/for_providers_live.ex
-msgid "We earn when you earn"
-msgstr "Wir verdienen, wenn Sie verdienen"
+#: lib/klass_hero_web/live/about_live.ex:195
+#, elixir-autogen, elixir-format
+msgid ", Max's brother, joined as CFO, bringing the financial rigour and strategic planning needed to navigate the German market and ensure long-term stability for every provider on the platform. To lead trust and quality,"
+msgstr ", Max' Bruder, kam als CFO dazu und brachte die finanzielle Sorgfalt und strategische Planung mit, die nötig sind, um den deutschen Markt zu meistern und langfristige Stabilität für jeden Anbieter auf der Plattform zu gewährleisten. Um Vertrauen und Qualität zu führen,"
 
-#: lib/klass_hero_web/live/for_providers_live.ex
-msgid "Joining Klass Hero costs nothing — unlimited programs, your whole team, all media, and direct parent messaging are included for everyone. A simple success-based fee on bookings made through the platform is coming; we'll share the details transparently before it launches."
-msgstr "Die Teilnahme an Klass Hero kostet nichts — unbegrenzte Programme, Ihr gesamtes Team, alle Medien und direkte Eltern-Kommunikation sind für alle inklusive. Eine einfache erfolgsbasierte Gebühr auf Buchungen über die Plattform kommt; wir teilen die Details transparent vor dem Start mit."
+#: lib/klass_hero_web/live/about_live.ex:184
+#, elixir-autogen, elixir-format
+msgid ", a full-stack developer who shared a unique perspective. Both Shane and Max are partners of teachers who wanted to extend their expertise beyond the classroom — but without the time to manage the operational side on their own."
+msgstr ", ein Full-Stack-Entwickler, der eine besondere Perspektive einbrachte. Sowohl Shane als auch Max sind Partner von Lehrkräften, die ihre Expertise über den Unterricht hinaus erweitern wollten — jedoch ohne die Zeit, die operative Seite selbst zu verwalten."
 
-#: lib/klass_hero_web/live/for_providers_live.ex
-msgid "Unlimited programs and locations"
-msgstr "Unbegrenzte Programme und Standorte"
+#: lib/klass_hero_web/components/marketing_components.ex:958
+#, elixir-autogen, elixir-format
+msgid ", camps & classes for your child"
+msgstr ", Camps & Kurse für Ihr Kind"
 
-#: lib/klass_hero_web/live/for_providers_live.ex
+#: lib/klass_hero_web/live/for_providers_live.ex:345
+#, elixir-autogen, elixir-format
+msgid "18+, government-ID verified before listing."
+msgstr "18+, amtlicher Ausweis vor Veröffentlichung verifiziert."
+
+#: lib/klass_hero_web/live/about_live.ex:93
+#, elixir-autogen, elixir-format
+msgid "A decade-plus coaching and running youth activity programs in Berlin. Built Prime Youth before founding Klass Hero."
+msgstr "Über zehn Jahre Erfahrung im Coaching und der Leitung von Jugendförderprogrammen in Berlin. Gründete Prime Youth, bevor er Klass Hero ins Leben rief."
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:529
+#, elixir-autogen, elixir-format
+msgid "Accept"
+msgstr "Akzeptieren"
+
+#: lib/klass_hero_web/live/user_live/settings.ex:15
+#: lib/klass_hero_web/live/user_live/settings.ex:17
+#, elixir-autogen, elixir-format
+msgid "Account"
+msgstr "Konto"
+
+#: lib/klass_hero_web/components/parent_components.ex:89
+#, elixir-autogen, elixir-format
+msgid "Account settings"
+msgstr "Kontoeinstellungen"
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1565
+#, elixir-autogen, elixir-format
+msgid "Across all programs"
+msgstr "Über alle Programme hinweg"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:380
+#, elixir-autogen, elixir-format
+msgid "Active policy required to teach."
+msgstr "Aktive Versicherungspolice erforderlich, um zu unterrichten."
+
+#: lib/klass_hero_web/live/dashboard_live.ex:300
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1555
+#, elixir-autogen, elixir-format
+msgid "Active programs"
+msgstr "Aktive Programme"
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:93
+#, elixir-autogen, elixir-format
+msgid "Add 3+ photos to boost bookings by ~40%."
+msgstr "Fügen Sie 3+ Fotos hinzu, um Buchungen um ~40% zu steigern."
+
+#: lib/klass_hero_web/components/parent_components.ex:290
+#, elixir-autogen, elixir-format
+msgid "Add a child"
+msgstr "Ein Kind hinzufügen"
+
+#: lib/klass_hero_web/components/marketing_components.ex:321
+#, elixir-autogen, elixir-format
+msgid "Afterschool Adventures Await"
+msgstr "Nachmittagsabenteuer erwarten Sie"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:344
+#, elixir-autogen, elixir-format
+msgid "Age & Identity"
+msgstr "Alter & Identität"
+
+#: lib/klass_hero_web/live/about_live.ex:20
+#, elixir-autogen, elixir-format
+msgid "All instructors are background-checked and verified."
+msgstr "Alle Lehrkräfte sind hintergrundgeprüft und verifiziert."
+
+#: lib/klass_hero_web/components/marketing_components.ex:548
+#, elixir-autogen, elixir-format
+msgid "Are you an educator, coach, or artist?"
+msgstr "Sind Sie Pädagog:in, Coach oder Künstler:in?"
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:104
+#, elixir-autogen, elixir-format
+msgid "At Klass Hero, trust isn't a feature — it's the foundation of everything we do. We connect families, schools, and organizations with qualified, vetted, and safety-verified educators."
+msgstr "Bei Klass Hero ist Vertrauen kein Feature — es ist das Fundament von allem, was wir tun. Wir verbinden Familien, Schulen und Organisationen mit qualifizierten, geprüften und sicherheitsverifizierten Pädagogen."
+
+#: lib/klass_hero_web/components/messaging_components.ex:294
+#, elixir-autogen, elixir-format
+msgid "Attach photo"
+msgstr "Foto anhängen"
+
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:68
+#, elixir-autogen, elixir-format
+msgid "Back to Programs"
+msgstr "Zurück zu den Programmen"
+
+#: lib/klass_hero_web/components/marketing_components.ex:890
+#: lib/klass_hero_web/components/marketing_components.ex:900
+#, elixir-autogen, elixir-format
+msgid "Become a Hero"
+msgstr "Werden Sie ein Hero"
+
+#: lib/klass_hero_web/components/marketing_components.ex:858
+#, elixir-autogen, elixir-format
+msgid "Become a Hero →"
+msgstr "Werden Sie ein Hero →"
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:314
+#, elixir-autogen, elixir-format
+msgid "Become a provider"
+msgstr "Anbieter werden"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:303
+#, elixir-autogen, elixir-format
+msgid "Berlin parents come to Klass Hero looking for trusted programs. You focus on teaching — we handle the funnel."
+msgstr "Berliner Eltern kommen zu Klass Hero auf der Suche nach vertrauenswürdigen Programmen. Sie konzentrieren sich aufs Unterrichten — wir übernehmen die Akquise."
+
+#: lib/klass_hero_web/components/marketing_components.ex:226
+#, elixir-autogen, elixir-format
+msgid "Berlin's #1 network for youth educators"
+msgstr "Berlins Nr. 1-Netzwerk für Jugendpädagogen"
+
+#: lib/klass_hero_web/components/marketing_components.ex:240
+#, elixir-autogen, elixir-format
+msgid "Berlin's leading network for tutors, coaches, and camp providers — every one verified by our team."
+msgstr "Berlins führendes Netzwerk für Nachhilfelehrer, Trainer und Camp-Anbieter — jeder Einzelne von unserem Team verifiziert."
+
+#: lib/klass_hero_web/components/marketing_components.ex:794
+#, elixir-autogen, elixir-format
+msgid "Berlin's network for trusted youth educators. Built by parents, for parents."
+msgstr "Berlins Netzwerk für vertrauenswürdige Jugendpädagogen. Von Eltern für Eltern entwickelt."
+
+#: lib/klass_hero_web/live/for_providers_live.ex:328
+#, elixir-autogen, elixir-format
+msgid "Better parent relationships"
+msgstr "Bessere Beziehungen zu Eltern"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:311
+#, elixir-autogen, elixir-format
+msgid "Bookings, rosters, schedules, attendance, parent comms — all in one place. No more spreadsheets."
+msgstr "Buchungen, Teilnehmerlisten, Zeitpläne, Anwesenheit, Elternkommunikation — alles an einem Ort. Keine Tabellenkalkulationen mehr."
+
+#: lib/klass_hero_web/live/about_live.ex:111
+#, elixir-autogen, elixir-format
+msgid "Brings the financial rigour and strategic planning needed for the German market and long-term provider stability."
+msgstr "Bringt die finanzielle Sorgfalt und strategische Planung mit, die für den deutschen Markt und langfristige Stabilität der Anbieter nötig sind."
+
+#: lib/klass_hero_web/components/marketing_components.ex:803
+#: lib/klass_hero_web/components/marketing_components.ex:907
+#, elixir-autogen, elixir-format
+msgid "Browse Programs"
+msgstr "Programme durchsuchen"
+
+#: lib/klass_hero_web/components/marketing_components.ex:868
+#: lib/klass_hero_web/components/marketing_components.ex:878
+#: lib/klass_hero_web/components/marketing_components.ex:888
+#: lib/klass_hero_web/components/marketing_components.ex:898
+#, elixir-autogen, elixir-format
+msgid "Browse Programs →"
+msgstr "Programme durchsuchen →"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:391
+#, elixir-autogen, elixir-format
+msgid "Build a listing in under 10 minutes. Schedule, capacity, photos, age range — done."
+msgstr "Erstellen Sie ein Angebot in unter 10 Minuten. Zeitplan, Kapazität, Fotos, Altersbereich — fertig."
+
+#: lib/klass_hero_web/live/about_live.ex:30
+#, elixir-autogen, elixir-format
+msgid "Building connections between families and local instructors."
+msgstr "Aufbau von Verbindungen zwischen Familien und lokalen Lehrkräften."
+
+#: lib/klass_hero_web/live/about_live.ex:171
+#, elixir-autogen, elixir-format
+msgid "Built by parents and educators for more learning opportunities."
+msgstr "Von Eltern und Pädagogen entwickelt, für mehr Lernmöglichkeiten."
+
+#: lib/klass_hero_web/live/about_live.ex:144
+#, elixir-autogen, elixir-format
+msgid "Built for Berlin"
+msgstr "Für Berlin entwickelt"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:74
+#, elixir-autogen, elixir-format
+msgid "Built for educators who want to teach, not run a business"
+msgstr "Für Pädagogen entwickelt, die unterrichten möchten, nicht ein Unternehmen führen"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:323
+#, elixir-autogen, elixir-format
+msgid "Built-in trust"
+msgstr "Integriertes Vertrauen"
+
+#: lib/klass_hero_web/live/home_live.ex:123
+#, elixir-autogen, elixir-format
+msgid "Business Plus: €49/month + 8% per booking. Unlimited programs and team seats"
+msgstr "Business Plus: €49/Monat + 8% pro Buchung. Unbegrenzte Programme und Team-Plätze"
+
+#: lib/klass_hero_web/live/about_live.ex:109
+#, elixir-autogen, elixir-format
+msgid "CFO"
+msgstr "CFO"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:455
+#, elixir-autogen, elixir-format
+msgid "Can I run programs at multiple locations?"
+msgstr "Kann ich Programme an mehreren Standorten anbieten?"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:279
+#, elixir-autogen, elixir-format
+msgid "Cancel anytime"
+msgstr "Jederzeit kündbar"
+
+#: lib/klass_hero_web/live/contact_live.ex:209
+#, elixir-autogen, elixir-format
+msgid "Check our FAQ — most questions are answered there."
+msgstr "Schauen Sie in unsere FAQ — die meisten Fragen werden dort beantwortet."
+
+#: lib/klass_hero_web/live/user_live/settings.ex:37
+#, elixir-autogen, elixir-format
+msgid "Children"
+msgstr "Kinder"
+
+#: lib/klass_hero_web/components/marketing_components.ex:1245
+#, elixir-autogen, elixir-format
+msgid "Clear filters"
+msgstr "Filter zurücksetzen"
+
+#: lib/klass_hero_web/live/user_live/confirmation.ex:18
+#, elixir-autogen, elixir-format
+msgid "Click below to log in."
+msgstr "Klicken Sie unten, um sich anzumelden."
+
+#: lib/klass_hero_web/live/about_live.ex:100
+#, elixir-autogen, elixir-format
+msgid "Co-founder & CTO"
+msgstr "Mitgründer & CTO"
+
+#: lib/klass_hero_web/components/parent_components.ex:143
+#: lib/klass_hero_web/components/parent_components.ex:322
+#: lib/klass_hero_web/components/provider_layout_components.ex:147
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1573
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1581
+#, elixir-autogen, elixir-format
+msgid "Coming soon"
+msgstr "Demnächst verfügbar"
+
+#: lib/klass_hero_web/components/parent_components.ex:414
+#, elixir-autogen, elixir-format
+msgid "Coming soon — track your family's weekly attendance."
+msgstr "Demnächst verfügbar — verfolgen Sie die wöchentliche Anwesenheit Ihrer Familie."
+
+#: lib/klass_hero_web/live/provider/messages_live/index.ex:19
+#, elixir-autogen, elixir-format
+msgid "Comms"
+msgstr "Kommunikation"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:374
+#, elixir-autogen, elixir-format
+msgid "Community Standards"
+msgstr "Gemeinschaftsstandards"
+
+#: lib/klass_hero_web/components/marketing_components.ex:819
+#, elixir-autogen, elixir-format
+msgid "Company"
+msgstr "Unternehmen"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:397
+#, elixir-autogen, elixir-format
+msgid "Complete Hero verification. We handle background checks, references and screening."
+msgstr "Schließen Sie die Hero-Verifizierung ab. Wir kümmern uns um Hintergrundüberprüfungen, Referenzen und Screening."
+
+#: lib/klass_hero_web/live/user_live/confirmation.ex:11
+#, elixir-autogen, elixir-format
+msgid "Confirm"
+msgstr "Bestätigen"
+
+#: lib/klass_hero_web/live/user_live/confirmation.ex:20
+#, elixir-autogen, elixir-format
+msgid "Confirm your account to finish signing up."
+msgstr "Bestätigen Sie Ihr Konto, um die Registrierung abzuschließen."
+
+#: lib/klass_hero_web/components/marketing_components.ex:232
+#, elixir-autogen, elixir-format
+msgid "Connecting Families with"
+msgstr "Familien verbinden mit"
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:165
+#, elixir-autogen, elixir-format
+msgid "Contact Us →"
+msgstr "Kontakt →"
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1173
+#, elixir-autogen, elixir-format
+msgid "Could not add you to the team. Please try again."
+msgstr "Sie konnten nicht zum Team hinzugefügt werden. Bitte versuchen Sie es erneut."
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:226
+#, elixir-autogen, elixir-format
+msgid "Could not link your account. Please try again."
+msgstr "Ihr Konto konnte nicht verknüpft werden. Bitte versuchen Sie es erneut."
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:176
+#, elixir-autogen, elixir-format
+msgid "Could not set up your provider profile. Please try again."
+msgstr "Ihr Anbieterprofil konnte nicht eingerichtet werden. Bitte versuchen Sie es erneut."
+
+#: lib/klass_hero_web/live/user_live/registration.ex:14
+#, elixir-autogen, elixir-format
+msgid "Create your"
+msgstr "Erstellen Sie Ihr"
+
+#: lib/klass_hero_web/live/user_live/settings.ex:52
+#, elixir-autogen, elixir-format
+msgid "Data & privacy"
+msgstr "Daten & Datenschutz"
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:521
+#, elixir-autogen, elixir-format
+msgid "Decline"
+msgstr "Ablehnen"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:370
+#, elixir-autogen, elixir-format
+msgid "Degrees, certs, and references reviewed."
+msgstr "Abschlüsse, Zertifikate und Referenzen werden geprüft."
+
+#: lib/klass_hero_web/live/for_providers_live.ex:418
+#, elixir-autogen, elixir-format
 msgid "Direct messaging and broadcasts"
 msgstr "Direktnachrichten und Rundnachrichten"
 
-#: lib/klass_hero_web/live/for_providers_live.ex
-msgid "Secure payments, invoicing, and VAT handling"
-msgstr "Sichere Zahlungen, Rechnungsstellung und Umsatzsteuer-Abwicklung"
+#: lib/klass_hero_web/live/for_providers_live.ex:330
+#, elixir-autogen, elixir-format
+msgid "Direct messaging, broadcast announcements, incident reports. Keep parents informed, automatically."
+msgstr "Direktnachrichten, Rundschreiben, Vorfallberichte. Halten Sie Eltern automatisch auf dem Laufenden."
 
-#: lib/klass_hero_web/live/for_providers_live.ex
-msgid "The Klass Hero verified badge"
-msgstr "Das Klass-Hero-Verifizierungssiegel"
+#: lib/klass_hero_web/components/marketing_components.ex:956
+#, elixir-autogen, elixir-format
+msgid "Discover"
+msgstr "Entdecken"
 
-#: lib/klass_hero_web/live/for_providers_live.ex
-msgid "Start for free"
-msgstr "Kostenlos starten"
+#: lib/klass_hero_web/components/provider_layout_components.ex:347
+#, elixir-autogen, elixir-format
+msgid "Earnings tracking is coming soon."
+msgstr "Die Einnahmenverfolgung kommt bald."
 
-#: lib/klass_hero_web/live/for_providers_live.ex
+#: lib/klass_hero_web/components/provider_layout_components.ex:337
+#, elixir-autogen, elixir-format
+msgid "Earnings trend"
+msgstr "Einnahmenentwicklung"
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:405
+#, elixir-autogen, elixir-format
+msgid "Edit program"
+msgstr "Programm bearbeiten"
+
+#: lib/klass_hero_web/live/home_live.ex:201
+#, elixir-autogen, elixir-format
+msgid "Email the provider and us (support@mail.klasshero.com) as soon as you can — we'll help you and the provider work it out."
+msgstr "Schreiben Sie dem Anbieter und uns (support@mail.klasshero.com) so schnell wie möglich eine E-Mail — wir helfen Ihnen und dem Anbieter, eine Lösung zu finden."
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1561
+#, elixir-autogen, elixir-format
+msgid "Enrolled kids"
+msgstr "Angemeldete Kinder"
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:281
+#, elixir-autogen, elixir-format
+msgid "Enrollment approved"
+msgstr "Anmeldung genehmigt"
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:289
+#, elixir-autogen, elixir-format
+msgid "Enrollment is not pending"
+msgstr "Anmeldung ist nicht ausstehend"
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:293
+#, elixir-autogen, elixir-format
+msgid "Enrollment not found"
+msgstr "Anmeldung nicht gefunden"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:355
+#, elixir-autogen, elixir-format
+msgid "Erweitertes Führungszeugnis (extended background check), refreshed annually."
+msgstr "Erweitertes Führungszeugnis (erweiterte Hintergrundüberprüfung), jährlich aktualisiert."
+
+#: lib/klass_hero_web/live/for_providers_live.ex:141
+#, elixir-autogen, elixir-format
+msgid "Every Hero clears the same checks. Here's what that means."
+msgstr "Jeder Hero durchläuft dieselben Prüfungen. Hier erfahren Sie, was das bedeutet."
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:118
+#, elixir-autogen, elixir-format
+msgid "Every Hero, carefully reviewed."
+msgstr "Jeder Hero, sorgfältig geprüft."
+
+#: lib/klass_hero_web/live/about_live.ex:164
+#, elixir-autogen, elixir-format
+msgid "Every Hero. Every step."
+msgstr "Jeder Hero. Jeder Schritt."
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:130
+#, elixir-autogen, elixir-format
+msgid "Every educator and enrichment professional completes a 6-step verification process before being approved."
+msgstr "Jede Lehrkraft und jede pädagogische Fachkraft durchläuft vor der Genehmigung ein 6-stufiges Prüfverfahren."
+
+#: lib/klass_hero_web/live/for_providers_live.ex:172
+#, elixir-autogen, elixir-format
+msgid "Every feature included. No subscription, no setup fees."
+msgstr "Alle Funktionen inklusive. Kein Abo, keine Einrichtungsgebühren."
+
+#: lib/klass_hero_web/components/marketing_components.ex:472
+#, elixir-autogen, elixir-format
+msgid "Everything parents need, nothing they don't"
+msgstr "Alles, was Eltern brauchen – nichts, was sie nicht brauchen"
+
+#: lib/klass_hero_web/live/home_live.ex:88
+#, elixir-autogen, elixir-format
+msgid "Everything you need to know about Klass Hero."
+msgstr "Alles, was Sie über Klass Hero wissen müssen."
+
+#: lib/klass_hero_web/live/for_providers_live.ex:354
+#, elixir-autogen, elixir-format
+msgid "Extended Police Check"
+msgstr "Erweitertes Führungszeugnis"
+
+#: lib/klass_hero_web/components/marketing_components.ex:676
+#: lib/klass_hero_web/live/for_providers_live.ex:213
+#, elixir-autogen, elixir-format
+msgid "FAQ"
+msgstr "FAQ"
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:302
+#, elixir-autogen, elixir-format
+msgid "Failed to approve"
+msgstr "Genehmigung fehlgeschlagen"
+
+#: lib/klass_hero_web/components/marketing_components.ex:801
+#, elixir-autogen, elixir-format
+msgid "Families"
+msgstr "Familien"
+
+#: lib/klass_hero_web/components/marketing_components.ex:260
+#, elixir-autogen, elixir-format
+msgid "Find Programs"
+msgstr "Programme finden"
+
+#: lib/klass_hero_web/components/marketing_components.ex:764
+#, elixir-autogen, elixir-format
+msgid "Footer mobile"
+msgstr "Fußzeile (mobil)"
+
+#: lib/klass_hero_web/live/about_live.ex:91
+#, elixir-autogen, elixir-format
+msgid "Founder & CEO"
+msgstr "Gründer & CEO"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:169
+#, elixir-autogen, elixir-format
+msgid "Free to join"
+msgstr "Kostenlos beitreten"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:275
+#, elixir-autogen, elixir-format
+msgid "Free to start"
+msgstr "Kostenloser Einstieg"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:105
+#, elixir-autogen, elixir-format
+msgid "From listing to first payout in under a week"
+msgstr "Vom Eintrag bis zur ersten Auszahlung in weniger als einer Woche"
+
+#: lib/klass_hero_web/live/about_live.ex:102
+#, elixir-autogen, elixir-format
+msgid "Full-stack developer. Partner of a teacher who saw the gap between great educators and good infrastructure."
+msgstr "Full-Stack-Entwickler. Partner einer Lehrerin, die die Lücke zwischen großartigen Pädagogen und guter Infrastruktur erkannte."
+
+#: lib/klass_hero_web/components/marketing_components.ex:580
+#, elixir-autogen, elixir-format
+msgid "Get Bookings"
+msgstr "Buchungen erhalten"
+
+#: lib/klass_hero_web/live/about_live.ex:211
+#, elixir-autogen, elixir-format
+msgid "Get Started Today →"
+msgstr "Jetzt loslegen →"
+
+#: lib/klass_hero_web/live/contact_live.ex:189
+#, elixir-autogen, elixir-format
+msgid "Get in touch"
+msgstr "Kontaktieren Sie uns"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:408
+#, elixir-autogen, elixir-format
+msgid "Get paid weekly"
+msgstr "Wöchentlich bezahlt werden"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:396
+#, elixir-autogen, elixir-format
+msgid "Get verified"
+msgstr "Lassen Sie sich verifizieren"
+
+#: lib/klass_hero_web/components/marketing_components.ex:1099
+#, elixir-autogen, elixir-format
+msgid "Grid"
+msgstr "Raster"
+
+#: lib/klass_hero_web/components/marketing_components.ex:324
+#, elixir-autogen, elixir-format
+msgid "Hand-picked programs this week across Berlin."
+msgstr "Handverlesene Programme diese Woche in ganz Berlin."
+
+#: lib/klass_hero_web/components/marketing_components.ex:962
+#, elixir-autogen, elixir-format
+msgid "Hand-picked, vetted programs across Berlin — filter by category, age, or schedule."
+msgstr "Handverlesene, geprüfte Programme in ganz Berlin — filtern Sie nach Kategorie, Alter oder Zeitplan."
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:154
+#, elixir-autogen, elixir-format
+msgid "Have questions?"
+msgstr "Haben Sie Fragen?"
+
+#: lib/klass_hero_web/live/about_live.ex:118
+#, elixir-autogen, elixir-format
+msgid "Head of Trust & Quality (joining)"
+msgstr "Leitung Vertrauen & Qualität (kommt bald dazu)"
+
+#: lib/klass_hero_web/components/marketing_components.ex:814
+#: lib/klass_hero_web/components/marketing_components.ex:912
+#, elixir-autogen, elixir-format
+msgid "Help Center"
+msgstr "Hilfezentrum"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:441
+#, elixir-autogen, elixir-format
+msgid "How and when do I get paid?"
+msgstr "Wie und wann werde ich bezahlt?"
+
+#: lib/klass_hero_web/components/marketing_components.ex:804
+#, elixir-autogen, elixir-format
+msgid "How it Works"
+msgstr "So funktioniert's"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:103
+#, elixir-autogen, elixir-format
+msgid "How it works"
+msgstr "So funktioniert's"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:427
+#, elixir-autogen, elixir-format
+msgid "How much does Klass Hero cost?"
+msgstr "Wie viel kostet Klass Hero?"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:434
+#, elixir-autogen, elixir-format
+msgid "How quickly can I start accepting bookings?"
+msgstr "Wie schnell kann ich Buchungen annehmen?"
+
+#: lib/klass_hero_web/components/marketing_components.ex:540
+#, elixir-autogen, elixir-format
+msgid "How to Grow Your Youth Program"
+msgstr "So bringen Sie Ihr Jugendprogramm zum Wachsen"
+
+#: lib/klass_hero_web/components/marketing_components.ex:870
+#, elixir-autogen, elixir-format
+msgid "How we vet providers"
+msgstr "Wie wir Anbieter überprüfen"
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1670
+#, elixir-autogen, elixir-format
+msgid "I'll be teaching"
+msgstr "Ich werde unterrichten"
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:800
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:822
+#, elixir-autogen, elixir-format
+msgid "Imported %{count} family."
+msgid_plural "Imported %{count} families."
+msgstr[0] "%{count} Familie importiert."
+msgstr[1] "%{count} Familien importiert."
+
+#: lib/klass_hero_web/live/about_live.ex:182
+#, elixir-autogen, elixir-format
+msgid "In 2025, Shane connected with his friend"
+msgstr "2025 tat sich Shane mit seinem Freund zusammen"
+
+#: lib/klass_hero_web/components/provider_components.ex:1428
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:42
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:73
+#, elixir-autogen, elixir-format
+msgid "Incident Reports"
+msgstr "Vorfallberichte"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:334
+#, elixir-autogen, elixir-format
+msgid "Insights that matter"
+msgstr "Erkenntnisse, die zählen"
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:16
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:26
+#, elixir-autogen, elixir-format
+msgid "Invitation"
+msgstr "Einladung"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:450
+#, elixir-autogen, elixir-format
+msgid "It's the Hero standard: identity & age verification, experience validation, extended police background check (Erweitertes Führungszeugnis), video interview, child safeguarding training, and signing our community standards. See the Trust & Safety page for the full breakdown."
+msgstr "Das ist der Hero-Standard: Identitäts- und Altersprüfung, Erfahrungsnachweis, erweiterte polizeiliche Führungszeugnisprüfung (Erweitertes Führungszeugnis), Videointerview, Schulung zum Kinderschutz und Unterzeichnung unserer Gemeinschaftsstandards. Die vollständige Übersicht finden Sie auf der Seite „Vertrauen & Sicherheit“."
+
+#: lib/klass_hero_web/live/for_providers_live.ex:262
+#, elixir-autogen, elixir-format
+msgid "Join Berlin's growing network of trusted educators. Free to list. No setup fees."
+msgstr "Werden Sie Teil von Berlins wachsendem Netzwerk vertrauenswürdiger Pädagogen. Kostenlos eintragen. Keine Einrichtungsgebühren."
+
+#: lib/klass_hero_web/components/marketing_components.ex:543
+#, elixir-autogen, elixir-format
+msgid "Join Berlin's trusted network of educators. We handle payments, scheduling, and discovery — you focus on teaching."
+msgstr "Werden Sie Teil von Berlins vertrauenswürdigem Netzwerk von Pädagogen. Wir kümmern uns um Zahlungen, Terminplanung und Sichtbarkeit — Sie konzentrieren sich aufs Unterrichten."
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:40
+#, elixir-autogen, elixir-format
+msgid "Join the"
+msgstr "Werden Sie Teil der"
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:38
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:268
+#, elixir-autogen, elixir-format
+msgid "Join the team"
+msgstr "Treten Sie dem Team bei"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:182
+#, elixir-autogen, elixir-format
+msgid "Joining Klass Hero costs nothing — unlimited programs, your whole team, all media, and direct parent messaging are included for everyone. A simple success-based fee on bookings made through the platform is coming; we'll share the details transparently before it launches."
+msgstr "Die Teilnahme an Klass Hero kostet nichts — unbegrenzte Programme, Ihr gesamtes Team, alle Medien und direkte Eltern-Kommunikation sind für alle inklusive. Eine einfache erfolgsbasierte Gebühr auf Buchungen über die Plattform kommt; wir teilen die Details transparent vor dem Start mit."
+
+#: lib/klass_hero_web/live/for_providers_live.ex:429
+#, elixir-autogen, elixir-format
 msgid "Joining is free — every feature is included for all providers, with no subscription or setup fees. A success-based fee on bookings made through the platform is planned; we'll announce the details transparently before it launches."
 msgstr "Die Teilnahme ist kostenlos — alle Funktionen sind für alle Anbieter inklusive, ohne Abo oder Einrichtungsgebühren. Eine erfolgsbasierte Gebühr auf Buchungen über die Plattform ist geplant; wir geben die Details transparent vor dem Start bekannt."
 
-#: lib/klass_hero_web/live/for_providers_live.ex
+#: lib/klass_hero_web/components/parent_components.ex:261
+#, elixir-autogen, elixir-format
+msgid "Kid picker"
+msgstr "Kinderauswahl"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:48
+#, elixir-autogen, elixir-format
+msgid "Klass Hero is the operational backbone for Berlin's youth educators. We handle bookings, payments, and discovery — you focus on what you do best."
+msgstr "Klass Hero ist das operative Rückgrat für Berlins Jugendpädagogen. Wir kümmern uns um Buchungen, Zahlungen und Sichtbarkeit — Sie konzentrieren sich auf das, was Sie am besten können."
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:338
+#, elixir-autogen, elixir-format
+msgid "Last 8 weeks"
+msgstr "Letzte 8 Wochen"
+
+#: lib/klass_hero_web/presenters/hero_cards_presenter.ex:38
+#, elixir-autogen, elixir-format
+msgid "Lead Instructor"
+msgstr "Leitender Kursleiter"
+
+#: lib/klass_hero_web/components/marketing_components.ex:553
+#, elixir-autogen, elixir-format
+msgid "Learn How to Become a Hero →"
+msgstr "Werde zum Hero →"
+
+#: lib/klass_hero_web/components/marketing_components.ex:860
+#, elixir-autogen, elixir-format
+msgid "Learn how vetting works"
+msgstr "Erfahren Sie, wie die Überprüfung funktioniert"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:309
+#, elixir-autogen, elixir-format
+msgid "Less admin, more teaching"
+msgstr "Weniger Verwaltung, mehr Unterrichten"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:379
+#, elixir-autogen, elixir-format
+msgid "Liability Insurance"
+msgstr "Haftpflichtversicherung"
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:113
+#, elixir-autogen, elixir-format
+msgid "Link my account"
+msgstr "Mein Konto verknüpfen"
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:103
+#, elixir-autogen, elixir-format
+msgid "Link this invitation to your account %{email}."
+msgstr "Verknüpfen Sie diese Einladung mit Ihrem Konto %{email}."
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:111
+#, elixir-autogen, elixir-format
+msgid "Linking..."
+msgstr "Wird verknüpft..."
+
+#: lib/klass_hero_web/components/marketing_components.ex:1115
+#, elixir-autogen, elixir-format
+msgid "List"
+msgstr "Liste"
+
+#: lib/klass_hero_web/components/marketing_components.ex:571
+#, elixir-autogen, elixir-format
+msgid "List Your Program"
+msgstr "Ihr Programm eintragen"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:390
+#, elixir-autogen, elixir-format
+msgid "List your program"
+msgstr "Ihr Programm eintragen"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:360
+#, elixir-autogen, elixir-format
+msgid "Live video screen with our safeguarding lead."
+msgstr "Live-Video-Screening mit unserer Kinderschutzbeauftragten."
+
+#: lib/klass_hero_web/live/programs_live.ex:362
+#, elixir-autogen, elixir-format
+msgid "Load more programs"
+msgstr "Weitere Programme laden"
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:52
+#, elixir-autogen, elixir-format
+msgid "Loading your invitation…"
+msgstr "Ihre Einladung wird geladen…"
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:92
+#, elixir-autogen, elixir-format
+msgid "Log in, then reopen this invitation to join the team."
+msgstr "Melden Sie sich an und öffnen Sie diese Einladung erneut, um dem Team beizutreten."
+
+#: lib/klass_hero_web/components/ui_components.ex:207
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:129
+#, elixir-autogen, elixir-format
+msgid "Log out"
+msgstr "Abmelden"
+
+#: lib/klass_hero_web/components/marketing_components.ex:867
+#, elixir-autogen, elixir-format
+msgid "Looking for programs for your child?"
+msgstr "Suchen Sie Programme für Ihr Kind?"
+
+#: lib/klass_hero_web/live/contact_live.ex:206
+#, elixir-autogen, elixir-format
+msgid "Looking for quick answers?"
+msgstr "Suchen Sie schnelle Antworten?"
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1597
+#, elixir-autogen, elixir-format
+msgid "Manage"
+msgstr "Verwalten"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:44
+#, elixir-autogen, elixir-format
+msgid "Manage less."
+msgstr "Weniger verwalten."
+
+#: lib/klass_hero_web/live/user_live/settings.ex:20
+#, elixir-autogen, elixir-format
+msgid "Manage your account, preferences, and privacy in one place."
+msgstr "Verwalten Sie Ihr Konto, Ihre Einstellungen und Ihren Datenschutz an einem Ort."
+
+#: lib/klass_hero_web/live/for_providers_live.ex:365
+#, elixir-autogen, elixir-format
+msgid "Mandatory child-protection course before going live."
+msgstr "Verpflichtender Kinderschutzkurs vor der Freischaltung."
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:472
+#, elixir-autogen, elixir-format
+msgid "Mark absent"
+msgstr "Als abwesend markieren"
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:445
+#, elixir-autogen, elixir-format
+msgid "Mark all present"
+msgstr "Alle als anwesend markieren"
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:472
+#, elixir-autogen, elixir-format
+msgid "Mark present"
+msgstr "Als anwesend markieren"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:350
+#, elixir-autogen, elixir-format
+msgid "Minimum one year working with children, validated."
+msgstr "Mindestens ein Jahr Erfahrung in der Arbeit mit Kindern, nachgewiesen."
+
+#: lib/klass_hero_web/components/marketing_components.ex:135
+#, elixir-autogen, elixir-format
+msgid "Mobile primary"
+msgstr "Primäre mobile Navigation"
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:342
+#, elixir-autogen, elixir-format
+msgid "Month"
+msgstr "Monat"
+
+#: lib/klass_hero_web/components/parent_components.ex:577
+#, elixir-autogen, elixir-format
+msgid "Monthly booking usage"
+msgstr "Monatliche Buchungsnutzung"
+
+#: lib/klass_hero_web/live/about_live.ex:120
+#, elixir-autogen, elixir-format
+msgid "Mother and child-safety specialist with 10+ years in quality assurance. Architecting our Safety-First Verification engine."
+msgstr "Mutter und Kindersicherheitsspezialistin mit über 10 Jahren Erfahrung in der Qualitätssicherung. Verantwortlich für die Konzeption unserer Safety-First-Verifizierungs-Engine."
+
+#: lib/klass_hero_web/live/dashboard_live.ex:157
+#, elixir-autogen, elixir-format
+msgid "New conversation"
+msgstr "Neue Unterhaltung"
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:226
+#, elixir-autogen, elixir-format
+msgid "New program"
+msgstr "Neues Programm"
+
+#: lib/klass_hero_web/components/marketing_components.ex:1126
+#, elixir-autogen, elixir-format
+msgid "Newest"
+msgstr "Neueste"
+
+#: lib/klass_hero_web/components/parent_components.ex:532
+#, elixir-autogen, elixir-format
+msgid "Next"
+msgstr "Weiter"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:283
+#, elixir-autogen, elixir-format
+msgid "No credit card required"
+msgstr "Keine Kreditkarte erforderlich"
+
+#: lib/klass_hero_web/components/marketing_components.ex:352
+#, elixir-autogen, elixir-format
+msgid "No featured programs available right now. Check back soon."
+msgstr "Derzeit keine empfohlenen Programme verfügbar. Schauen Sie bald wieder vorbei."
+
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:115
+#, elixir-autogen, elixir-format
+msgid "No incident reports yet"
+msgstr "Noch keine Vorfallberichte"
+
+#: lib/klass_hero_web/components/parent_components.ex:456
+#, elixir-autogen, elixir-format
+msgid "No messages yet."
+msgstr "Noch keine Nachrichten."
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1631
+#, elixir-autogen, elixir-format
+msgid "No pending enrollments right now."
+msgstr "Derzeit keine ausstehenden Anmeldungen."
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1616
+#, elixir-autogen, elixir-format
+msgid "No pending requests right now."
+msgstr "Derzeit keine ausstehenden Anfragen."
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1601
+#, elixir-autogen, elixir-format
+msgid "No programs yet — add your first one from the Programs tab."
+msgstr "Noch keine Programme — fügen Sie Ihr erstes über den Tab „Programme“ hinzu."
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:449
+#, elixir-autogen, elixir-format
+msgid "No registered children for this session."
+msgstr "Keine Kinder in dieser Sitzung angemeldet."
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:809
+#, elixir-autogen, elixir-format
+msgid "No rows imported. %{count} row could not be processed."
+msgid_plural "No rows imported. %{count} rows could not be processed."
+msgstr[0] "Keine Zeilen importiert. %{count} Zeile konnte nicht verarbeitet werden."
+msgstr[1] "Keine Zeilen importiert. %{count} Zeilen konnten nicht verarbeitet werden."
+
+#: lib/klass_hero_web/live/dashboard_live.ex:340
+#, elixir-autogen, elixir-format
+msgid "No upcoming sessions in the next few weeks."
+msgstr "Keine bevorstehenden Sitzungen in den nächsten Wochen."
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:284
+#, elixir-autogen, elixir-format
+msgid "Not allowed to approve this enrollment"
+msgstr "Nicht berechtigt, diese Anmeldung zu genehmigen"
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:297
+#, elixir-autogen, elixir-format
+msgid "Not now"
+msgstr "Nicht jetzt"
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:303
+#, elixir-autogen, elixir-format
+msgid "Offer your own programs on Klass Hero — alongside your work for %{business}."
+msgstr "Bieten Sie Ihre eigenen Programme auf Klass Hero an — zusätzlich zu Ihrer Arbeit für %{business}."
+
+#: lib/klass_hero_web/live/for_providers_live.ex:436
+#, elixir-autogen, elixir-format
+msgid "Once your listing is live and you've completed Hero verification (typically 3–5 business days), parents can book immediately. Most providers receive their first inquiry within the first week."
+msgstr "Sobald Ihr Eintrag live ist und Sie die Hero-Verifizierung abgeschlossen haben (in der Regel 3–5 Werktage), können Eltern sofort buchen. Die meisten Anbieter erhalten ihre erste Anfrage innerhalb der ersten Woche."
+
+#: lib/klass_hero_web/components/marketing_components.ex:1476
+#, elixir-autogen, elixir-format
+msgid "Ongoing Quality"
+msgstr "Laufende Qualität"
+
+#: lib/klass_hero_web/components/parent_components.ex:538
+#, elixir-autogen, elixir-format
+msgid "Open"
+msgstr "Offen"
+
+#: lib/klass_hero_web/components/ui_components.ex:157
+#, elixir-autogen, elixir-format
+msgid "Open account menu"
+msgstr "Kontomenü öffnen"
+
+#: lib/klass_hero_web/components/parent_components.ex:452
+#, elixir-autogen, elixir-format
+msgid "Open inbox"
+msgstr "Posteingang öffnen"
+
+#: lib/klass_hero_web/components/marketing_components.ex:110
+#, elixir-autogen, elixir-format
+msgid "Open menu"
+msgstr "Menü öffnen"
+
+#: lib/klass_hero_web/components/marketing_components.ex:1366
+#, elixir-autogen, elixir-format
+msgid "Our Commitment"
+msgstr "Unser Engagement"
+
+#: lib/klass_hero_web/live/about_live.ex:130
+#, elixir-autogen, elixir-format
+msgid "Our Mission"
+msgstr "Unsere Mission"
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:111
+#, elixir-autogen, elixir-format
+msgid "Our commitment to child safety"
+msgstr "Unser Engagement für die Sicherheit von Kindern"
+
+#: lib/klass_hero_web/components/parent_components.ex:105
+#, elixir-autogen, elixir-format
+msgid "Parent bottom navigation"
+msgstr "Eltern-Navigation (unten)"
+
+#: lib/klass_hero_web/components/parent_components.ex:75
+#, elixir-autogen, elixir-format
+msgid "Parent navigation"
+msgstr "Elternnavigation"
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:456
+#, elixir-autogen, elixir-format
+msgid "Parent: %{name}"
+msgstr "Elternteil: %{name}"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:403
+#, elixir-autogen, elixir-format
+msgid "Parents discover you on Klass Hero. Approve manually or auto-accept — your call."
+msgstr "Eltern entdecken Sie auf Klass Hero. Genehmigen Sie manuell oder automatisch — Sie entscheiden."
+
+#: lib/klass_hero_web/components/marketing_components.ex:582
+#, elixir-autogen, elixir-format
+msgid "Parents find you through Klass Hero. Approve or auto-accept bookings with secure messaging built in."
+msgstr "Eltern finden Sie über Klass Hero. Genehmigen Sie Buchungen manuell oder automatisch — inklusive sicherer Nachrichtenfunktion."
+
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:17
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:17
+#, elixir-autogen, elixir-format
+msgid "Participation"
+msgstr "Teilnahme"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:359
+#, elixir-autogen, elixir-format
+msgid "Pedagogical Interview"
+msgstr "Pädagogisches Interview"
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1610
+#, elixir-autogen, elixir-format
+msgid "Pending booking requests"
+msgstr "Ausstehende Buchungsanfragen"
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1625
+#, elixir-autogen, elixir-format
+msgid "Pending enrollments"
+msgstr "Ausstehende Anmeldungen"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:315
+#, elixir-autogen, elixir-format
+msgid "Predictable income"
+msgstr "Planbares Einkommen"
+
+#: lib/klass_hero_web/components/marketing_components.ex:1128
+#, elixir-autogen, elixir-format
+msgid "Price: high to low"
+msgstr "Preis: hoch zu niedrig"
+
+#: lib/klass_hero_web/components/marketing_components.ex:1127
+#, elixir-autogen, elixir-format
+msgid "Price: low to high"
+msgstr "Preis: niedrig zu hoch"
+
+#: lib/klass_hero_web/components/marketing_components.ex:813
+#: lib/klass_hero_web/live/for_providers_live.ex:167
+#, elixir-autogen, elixir-format
+msgid "Pricing"
+msgstr "Preise"
+
+#: lib/klass_hero_web/components/marketing_components.ex:65
+#, elixir-autogen, elixir-format
+msgid "Primary"
+msgstr "Primär"
+
+#: lib/klass_hero_web/components/marketing_components.ex:776
+#: lib/klass_hero_web/components/marketing_components.ex:823
+#: lib/klass_hero_web/live/privacy_policy_live.ex:238
+#, elixir-autogen, elixir-format
+msgid "Privacy"
+msgstr "Datenschutz"
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:90
+#, elixir-autogen, elixir-format
+msgid "Pro tip"
+msgstr "Profi-Tipp"
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:87
+#, elixir-autogen, elixir-format
+msgid "Process"
+msgstr "Prozess"
+
+#: lib/klass_hero_web/live/home_live.ex:120
+#, elixir-autogen, elixir-format
+msgid "Professional: €19/month + 12% per booking. Up to 5 programs"
+msgstr "Professional: 19 €/Monat + 12 % pro Buchung. Bis zu 5 Programme"
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:101
+#, elixir-autogen, elixir-format
+msgid "Provider bottom navigation"
+msgstr "Anbieter-Navigation unten"
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:77
+#, elixir-autogen, elixir-format
+msgid "Provider navigation"
+msgstr "Anbieter-Navigation"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:215
+#, elixir-autogen, elixir-format
+msgid "Provider questions, answered"
+msgstr "Fragen von Anbietern, beantwortet"
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:138
+#, elixir-autogen, elixir-format
+msgid "Quality & accountability — always on."
+msgstr "Qualität & Verantwortung — jederzeit aktiv."
+
+#: lib/klass_hero_web/live/contact_live.ex:107
+#, elixir-autogen, elixir-format
+msgid "Questions about programs, bookings, or becoming a Hero — we read every message."
+msgstr "Fragen zu Programmen, Buchungen oder wie Sie ein Hero werden — wir lesen jede Nachricht."
+
+#: lib/klass_hero_web/components/marketing_components.ex:679
+#, elixir-autogen, elixir-format
+msgid "Questions, answered."
+msgstr "Fragen, beantwortet."
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1576
+#, elixir-autogen, elixir-format
+msgid "Rating"
+msgstr "Bewertung"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:259
+#, elixir-autogen, elixir-format
+msgid "Ready to be a Hero?"
+msgstr "Bereit, ein Hero zu werden?"
+
+#: lib/klass_hero_web/components/marketing_components.ex:877
+#: lib/klass_hero_web/components/marketing_components.ex:897
+#, elixir-autogen, elixir-format
+msgid "Ready to find your child's next adventure?"
+msgstr "Bereit, das nächste Abenteuer für Ihr Kind zu finden?"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:402
+#, elixir-autogen, elixir-format
+msgid "Receive bookings"
+msgstr "Buchungen erhalten"
+
+#: lib/klass_hero_web/components/parent_components.ex:450
+#, elixir-autogen, elixir-format
+msgid "Recent messages"
+msgstr "Neueste Nachrichten"
+
+#: lib/klass_hero_web/components/marketing_components.ex:1125
+#: lib/klass_hero_web/components/marketing_components.ex:1137
+#, elixir-autogen, elixir-format
+msgid "Recommended"
+msgstr "Empfohlen"
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:91
+#, elixir-autogen, elixir-format
+msgid "Reporting"
+msgstr "Berichte"
+
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:118
+#, elixir-autogen, elixir-format
+msgid "Reports filed for this program will appear here."
+msgstr "Für dieses Programm eingereichte Berichte werden hier angezeigt."
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1568
+#, elixir-autogen, elixir-format
+msgid "Revenue (this week)"
+msgstr "Umsatz (diese Woche)"
+
+#: lib/klass_hero_web/live/about_live.ex:165
+#, elixir-autogen, elixir-format
+msgid "Rigorous screening so families never wonder who's leading the room."
+msgstr "Strenge Überprüfung, damit Familien immer wissen, wer die Gruppe leitet."
+
+#: lib/klass_hero_web/components/provider_components.ex:2172
+#, elixir-autogen, elixir-format
+msgid "Row %{row}"
+msgstr "Zeile %{row}"
+
+#: lib/klass_hero_web/components/provider_components.ex:2172
+#, elixir-autogen, elixir-format
+msgid "Row —"
+msgstr "Zeile —"
+
+#: lib/klass_hero_web/components/provider_components.ex:1927
+#, elixir-autogen, elixir-format
+msgid "Rows with errors"
+msgstr "Zeilen mit Fehlern"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:364
+#, elixir-autogen, elixir-format
+msgid "Safeguarding Training"
+msgstr "Kinderschutzschulung"
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:101
+#, elixir-autogen, elixir-format
+msgid "Safety"
+msgstr "Sicherheit"
+
+#: lib/klass_hero_web/components/marketing_components.ex:982
+#, elixir-autogen, elixir-format
+msgid "Search programs, providers, neighborhoods..."
+msgstr "Programme, Anbieter, Stadtteile durchsuchen..."
+
+#: lib/klass_hero_web/components/marketing_components.ex:255
+#, elixir-autogen, elixir-format
+msgid "Search: coding, football, art..."
+msgstr "Suche: Programmieren, Fußball, Kunst..."
+
+#: lib/klass_hero_web/live/for_providers_live.ex:409
+#, elixir-autogen, elixir-format
+msgid "Secure SEPA payouts every Monday. Invoices and VAT handled automatically."
+msgstr "Sichere SEPA-Auszahlungen jeden Montag. Rechnungen und Mehrwertsteuer werden automatisch abgewickelt."
+
+#: lib/klass_hero_web/live/for_providers_live.ex:419
+#, elixir-autogen, elixir-format
+msgid "Secure payments, invoicing, and VAT handling"
+msgstr "Sichere Zahlungen, Rechnungsstellung und Umsatzsteuer-Abwicklung"
+
+#: lib/klass_hero_web/components/marketing_components.ex:591
+#, elixir-autogen, elixir-format
+msgid "Secure weekly payouts. Insights into your business and opportunities to expand your impact."
+msgstr "Sichere wöchentliche Auszahlungen. Einblicke in Ihr Geschäft und Möglichkeiten, Ihre Wirkung auszubauen."
+
+#: lib/klass_hero_web/live/user_live/settings.ex:42
+#, elixir-autogen, elixir-format
+msgid "Security"
+msgstr "Sicherheit"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:57
+#, elixir-autogen, elixir-format
+msgid "See pricing"
+msgstr "Preise ansehen"
+
+#: lib/klass_hero_web/components/marketing_components.ex:562
+#, elixir-autogen, elixir-format
+msgid "See provider plans"
+msgstr "Anbieter-Tarife ansehen"
+
+#: lib/klass_hero_web/live/contact_live.ex:163
+#, elixir-autogen, elixir-format
+msgid "Select a topic…"
+msgstr "Thema auswählen…"
+
+#: lib/klass_hero_web/live/contact_live.ex:181
+#, elixir-autogen, elixir-format
+msgid "Send Message →"
+msgstr "Nachricht senden →"
+
+#: lib/klass_hero_web/live/user_live/login.ex:65
+#, elixir-autogen, elixir-format
+msgid "Send magic link"
+msgstr "Magic-Link senden"
+
+#: lib/klass_hero_web/live/contact_live.ex:116
+#, elixir-autogen, elixir-format
+msgid "Send us a message"
+msgstr "Schreiben Sie uns eine Nachricht"
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:286
+#, elixir-autogen, elixir-format
+msgid "Setting up..."
+msgstr "Wird eingerichtet..."
+
+#: lib/klass_hero_web/components/marketing_components.ex:95
+#: lib/klass_hero_web/components/marketing_components.ex:167
+#: lib/klass_hero_web/live/user_live/login.ex:12
+#, elixir-autogen, elixir-format
+msgid "Sign in"
+msgstr "Anmelden"
+
+#: lib/klass_hero_web/live/user_live/login.ex:21
+#, elixir-autogen, elixir-format
+msgid "Sign in to continue. Don't have an account?"
+msgstr "Melden Sie sich an, um fortzufahren. Sie haben noch kein Konto?"
+
+#: lib/klass_hero_web/components/marketing_components.ex:98
+#: lib/klass_hero_web/components/marketing_components.ex:172
+#: lib/klass_hero_web/live/user_live/registration.ex:12
+#, elixir-autogen, elixir-format
+msgid "Sign up"
+msgstr "Registrieren"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:375
+#, elixir-autogen, elixir-format
+msgid "Signed agreement on conduct and quality bar."
+msgstr "Unterzeichnete Vereinbarung zu Verhalten und Qualitätsstandards."
+
+#: lib/klass_hero_web/components/marketing_components.ex:154
+#: lib/klass_hero_web/components/ui_components.ex:193
+#, elixir-autogen, elixir-format
+msgid "Signed in as"
+msgstr "Angemeldet als"
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:128
+#, elixir-autogen, elixir-format
+msgid "Six checks. No shortcuts."
+msgstr "Sechs Prüfungen. Keine Abkürzungen."
+
+#: lib/klass_hero_web/components/marketing_components.ex:1052
+#, elixir-autogen, elixir-format
+msgid "Sort:"
+msgstr "Sortieren:"
+
+#: lib/klass_hero_web/components/marketing_components.ex:812
+#, elixir-autogen, elixir-format
+msgid "Start Teaching"
+msgstr "Unterrichten beginnen"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:198
+#, elixir-autogen, elixir-format
+msgid "Start for free"
+msgstr "Kostenlos starten"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:54
+#: lib/klass_hero_web/live/for_providers_live.ex:266
+#, elixir-autogen, elixir-format
+msgid "Start teaching today"
+msgstr "Heute mit dem Unterrichten beginnen"
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:269
+#, elixir-autogen, elixir-format
+msgid "Start your own business"
+msgstr "Starten Sie Ihr eigenes Unternehmen"
+
+#: lib/klass_hero_web/live/home_live.ex:115
+#, elixir-autogen, elixir-format
+msgid "Starter: Free to join — no registration fees, no monthly subscriptions. 18% commission per booking, up to 2 active programs"
+msgstr "Starter: Kostenlose Anmeldung — keine Registrierungsgebühren, keine monatlichen Abos. 18 % Provision pro Buchung, bis zu 2 aktive Programme"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:229
+#, elixir-autogen, elixir-format
+msgid "Still curious?"
+msgstr "Noch neugierig?"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:301
+#, elixir-autogen, elixir-format
+msgid "Stop chasing leads"
+msgstr "Hören Sie auf, Leads hinterherzujagen"
+
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:98
+#, elixir-autogen, elixir-format
+msgid "Submitted by"
+msgstr "Eingereicht von"
+
+#: lib/klass_hero_web/live/about_live.ex:25
+#, elixir-autogen, elixir-format
+msgid "Supporting local programs and eco-conscious practices."
+msgstr "Unterstützung lokaler Programme und umweltbewusster Praktiken."
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:229
+#, elixir-autogen, elixir-format
+msgid "Switch business"
+msgstr "Unternehmen wechseln"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:240
+#, elixir-autogen, elixir-format
+msgid "Talk to our team →"
+msgstr "Sprechen Sie mit unserem Team →"
+
+#: lib/klass_hero_web/components/marketing_components.ex:880
+#: lib/klass_hero_web/live/about_live.ex:215
+#: lib/klass_hero_web/live/for_providers_live.ex:269
+#, elixir-autogen, elixir-format
+msgid "Talk to us"
+msgstr "Sprechen Sie mit uns"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:42
+#, elixir-autogen, elixir-format
+msgid "Teach more."
+msgstr "Mehr unterrichten."
+
+#: lib/klass_hero_web/live/for_providers_live.ex:349
+#, elixir-autogen, elixir-format
+msgid "Teaching Experience"
+msgstr "Unterrichtserfahrung"
+
+#: lib/klass_hero_web/components/marketing_components.ex:857
+#, elixir-autogen, elixir-format
+msgid "Teaching kids is your thing? Join as a Hero."
+msgstr "Unterrichten von Kindern ist Ihr Ding? Werden Sie ein Hero."
+
+#: lib/klass_hero_web/live/contact_live.ex:119
+#, elixir-autogen, elixir-format
+msgid "Tell us a bit about what you need — we'll route you to the right person."
+msgstr "Erzählen Sie uns kurz, was Sie brauchen — wir leiten Sie an die richtige Person weiter."
+
+#: lib/klass_hero_web/components/marketing_components.ex:777
+#: lib/klass_hero_web/components/marketing_components.ex:824
+#: lib/klass_hero_web/live/terms_of_service_live.ex:259
+#, elixir-autogen, elixir-format
+msgid "Terms"
+msgstr "Nutzungsbedingungen"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:420
+#, elixir-autogen, elixir-format
+msgid "The Klass Hero verified badge"
+msgstr "Das Klass-Hero-Verifizierungssiegel"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:324
+#, elixir-autogen, elixir-format
+msgid "The Klass Hero verified badge gets you more inquiries — parents trust vetted providers."
+msgstr "Das verifizierte Klass Hero-Abzeichen bringt Ihnen mehr Anfragen — Eltern vertrauen geprüften Anbietern."
+
+#: lib/klass_hero_web/live/for_providers_live.ex:138
+#, elixir-autogen, elixir-format
+msgid "The bar to teach on Klass Hero"
+msgstr "Der Maßstab für das Unterrichten auf Klass Hero"
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:119
+#, elixir-autogen, elixir-format
+msgid "This invitation is for %{invite}."
+msgstr "Diese Einladung ist für %{invite} bestimmt."
+
+#: lib/klass_hero_web/components/parent_components.ex:408
+#, elixir-autogen, elixir-format
+msgid "This week"
+msgstr "Diese Woche"
+
+#: lib/klass_hero_web/live/about_live.ex:132
+#, elixir-autogen, elixir-format
+msgid "To modernize how Berlin"
+msgstr "Um zu modernisieren, wie Berlin"
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:435
+#, elixir-autogen, elixir-format
+msgid "Today's check-ins"
+msgstr "Heutige Check-ins"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:335
+#, elixir-autogen, elixir-format
+msgid "Track signups, retention, no-shows, and revenue. Identify what's working and double down."
+msgstr "Verfolgen Sie Anmeldungen, Bindung, Nichterscheinen und Umsatz. Erkennen Sie, was funktioniert, und bauen Sie darauf auf."
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:100
+#, elixir-autogen, elixir-format
+msgid "Trust &"
+msgstr "Vertrauen &"
+
+#: lib/klass_hero_web/components/marketing_components.ex:234
+#, elixir-autogen, elixir-format
+msgid "Trusted Heroes"
+msgstr "Vertrauenswürdige Heroes"
+
+#: lib/klass_hero_web/live/programs_live.ex:307
+#, elixir-autogen, elixir-format
+msgid "Try adjusting your search or filter criteria — there's plenty more in Berlin."
+msgstr "Versuchen Sie, Ihre Such- oder Filterkriterien anzupassen — in Berlin gibt es noch viel mehr."
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:512
+#, elixir-autogen, elixir-format
+msgid "Unknown parent"
+msgstr "Unbekannter Elternteil"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:416
+#, elixir-autogen, elixir-format
+msgid "Unlimited programs and locations"
+msgstr "Unbegrenzte Programme und Standorte"
+
+#: lib/klass_hero_web/live/dashboard_live.ex:312
+#, elixir-autogen, elixir-format
+msgid "Unread messages"
+msgstr "Ungelesene Nachrichten"
+
+#: lib/klass_hero_web/live/dashboard_live.ex:331
+#, elixir-autogen, elixir-format
+msgid "Upcoming sessions"
+msgstr "Anstehende Sitzungen"
+
+#: lib/klass_hero_web/live/dashboard_live.ex:306
+#, elixir-autogen, elixir-format
+msgid "Upcoming this week"
+msgstr "Diese Woche anstehend"
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:86
+#, elixir-autogen, elixir-format
+msgid "Vetted"
+msgstr "Geprüft"
+
+#: lib/klass_hero_web/components/marketing_components.ex:1212
+#, elixir-autogen, elixir-format
+msgid "View"
+msgstr "Ansehen"
+
+#: lib/klass_hero_web/live/dashboard_live.ex:336
+#, elixir-autogen, elixir-format
+msgid "View all"
+msgstr "Alle anzeigen"
+
+#: lib/klass_hero_web/components/marketing_components.ex:431
+#, elixir-autogen, elixir-format
+msgid "View →"
+msgstr "Ansehen →"
+
+#: lib/klass_hero_web/live/contact_live.ex:221
+#, elixir-autogen, elixir-format
+msgid "Visit FAQ →"
+msgstr "FAQ besuchen →"
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:113
+#, elixir-autogen, elixir-format
+msgid "We believe children thrive best in environments that are safe, respectful, and professionally led. That's why Klass Hero applies a multi-layered safety and verification framework before any provider can offer sessions on our platform."
+msgstr "Wir glauben, dass Kinder in einem sicheren, respektvollen und professionell geleiteten Umfeld am besten gedeihen. Deshalb wendet Klass Hero ein mehrschichtiges Sicherheits- und Verifizierungssystem an, bevor ein Anbieter Sitzungen auf unserer Plattform anbieten kann."
+
+#: lib/klass_hero_web/live/for_providers_live.ex:179
+#, elixir-autogen, elixir-format
+msgid "We earn when you earn"
+msgstr "Wir verdienen, wenn Sie verdienen"
+
+#: lib/klass_hero_web/live/contact_live.ex:178
+#, elixir-autogen, elixir-format
+msgid "We never share your details."
+msgstr "Wir geben Ihre Daten niemals weiter."
+
+#: lib/klass_hero_web/live/for_providers_live.ex:443
+#, elixir-autogen, elixir-format
+msgid "We use SEPA bank transfers, paid out every Monday for the previous week's completed sessions. You'll receive an automatic invoice for each payout, and VAT is handled per-booking."
+msgstr "Wir nutzen SEPA-Überweisungen, die jeden Montag für die abgeschlossenen Sitzungen der Vorwoche ausgezahlt werden. Sie erhalten für jede Auszahlung automatisch eine Rechnung, und die Mehrwertsteuer wird pro Buchung abgewickelt."
+
+#: lib/klass_hero_web/live/contact_live.ex:103
+#, elixir-autogen, elixir-format
+msgid "We're here to"
+msgstr "Wir sind hier, um zu"
+
+#: lib/klass_hero_web/live/about_live.ex:137
+#, elixir-autogen, elixir-format
+msgid "We're parents, brothers, and partners of educators — building the infrastructure that helps every child learn and thrive."
+msgstr "Wir sind Eltern, Brüder und Partner von Pädagogen — wir bauen die Infrastruktur auf, die jedem Kind hilft, zu lernen und sich zu entfalten."
+
+#: lib/klass_hero_web/live/contact_live.ex:132
+#, elixir-autogen, elixir-format
+msgid "We've got it — we'll be in touch."
+msgstr "Alles klar — wir melden uns bei Ihnen."
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:341
+#, elixir-autogen, elixir-format
+msgid "Week"
+msgstr "Woche"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:317
+#, elixir-autogen, elixir-format
+msgid "Weekly SEPA payouts, automatic VAT handling, transparent fees. Plan your business around real numbers."
+msgstr "Wöchentliche SEPA-Auszahlungen, automatische Mehrwertsteuerabwicklung, transparente Gebühren. Planen Sie Ihr Geschäft anhand echter Zahlen."
+
+#: lib/klass_hero_web/components/parent_components.ex:409
+#, elixir-autogen, elixir-format
+msgid "Weekly adventure goal"
+msgstr "Wöchentliches Abenteuerziel"
+
+#: lib/klass_hero_web/live/user_live/confirmation.ex:13
+#: lib/klass_hero_web/live/user_live/login.ex:14
+#, elixir-autogen, elixir-format
+msgid "Welcome"
+msgstr "Willkommen"
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:72
+#, elixir-autogen, elixir-format
+msgid "Welcome aboard! Let's set up your business profile."
+msgstr "Willkommen an Bord! Lassen Sie uns Ihr Geschäftsprofil einrichten."
+
+#: lib/klass_hero_web/live/contact_live.ex:171
+#, elixir-autogen, elixir-format
+msgid "What's on your mind?"
+msgstr "Was beschäftigt Sie?"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:448
+#, elixir-autogen, elixir-format
+msgid "What's the verification process like?"
+msgstr "Wie läuft der Verifizierungsprozess ab?"
+
+#: lib/klass_hero_web/components/marketing_components.ex:887
+#, elixir-autogen, elixir-format
+msgid "While you're here — explore programs."
+msgstr "Wo Sie schon mal hier sind — entdecken Sie Programme."
+
+#: lib/klass_hero_web/components/marketing_components.ex:469
+#: lib/klass_hero_web/live/for_providers_live.ex:72
+#, elixir-autogen, elixir-format
+msgid "Why Klass Hero"
+msgstr "Warum Klass Hero"
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:343
+#, elixir-autogen, elixir-format
+msgid "Year"
+msgstr "Jahr"
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:288
+#, elixir-autogen, elixir-format
+msgid "Yes, become a provider"
+msgstr "Ja, Anbieter werden"
+
+#: lib/klass_hero_web/live/for_providers_live.ex:457
+#, elixir-autogen, elixir-format
 msgid "Yes. You can run unlimited programs, each with its own schedule and venue, and add as many team members as you need to delegate management across instructors."
 msgstr "Ja. Sie können unbegrenzt viele Programme mit jeweils eigenem Zeitplan und Veranstaltungsort betreiben und beliebig viele Teammitglieder hinzufügen, um die Verwaltung auf Ihre Kursleitungen zu verteilen."
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:80
+#, elixir-autogen, elixir-format
+msgid "You already have a provider profile."
+msgstr "Sie haben bereits ein Anbieterprofil."
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:89
+#, elixir-autogen, elixir-format
+msgid "You already have an account for %{email}."
+msgstr "Sie haben bereits ein Konto für %{email}."
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:274
+#, elixir-autogen, elixir-format
+msgid "You'll get your own provider profile to fill in, and your account will open on your business dashboard from now on. You stay on %{business}'s team."
+msgstr "Sie erhalten Ihr eigenes Anbieterprofil zum Ausfüllen, und Ihr Konto öffnet sich ab sofort auf Ihrem Geschäfts-Dashboard. Sie bleiben im Team von %{business}."
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1153
+#, elixir-autogen, elixir-format
+msgid "You're already on your team."
+msgstr "Sie sind bereits in Ihrem Team."
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:122
+#, elixir-autogen, elixir-format
+msgid "You're logged in as %{current}. Log into the matching account to accept."
+msgstr "Sie sind als %{current} angemeldet. Melden Sie sich mit dem passenden Konto an, um anzunehmen."
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:167
+#, elixir-autogen, elixir-format
+msgid "You're no longer on that team."
+msgstr "Sie sind nicht mehr in diesem Team."
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:213
+#, elixir-autogen, elixir-format
+msgid "You're now part of the team."
+msgstr "Sie sind jetzt Teil des Teams."
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1201
+#, elixir-autogen, elixir-format
+msgid "You're on the team — you can now be assigned to programs."
+msgstr "Sie sind im Team — Sie können nun Programmen zugewiesen werden."
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1200
+#, elixir-autogen, elixir-format
+msgid "You're on the team, but the headshot upload failed."
+msgstr "Sie sind im Team, aber der Upload des Profilfotos ist fehlgeschlagen."
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1592
+#, elixir-autogen, elixir-format
+msgid "Your top programs"
+msgstr "Ihre Top-Programme"
+
+#: lib/klass_hero_web/live/user_live/registration.ex:15
+#, elixir-autogen, elixir-format
+msgid "account"
+msgstr "Konto"
+
+#: lib/klass_hero_web/components/parent_components.ex:283
+#, elixir-autogen, elixir-format
+msgid "active"
+msgstr "Aktiv"
+
+#: lib/klass_hero_web/components/marketing_components.ex:957
+#, elixir-autogen, elixir-format
+msgid "activities"
+msgstr "Aktivitäten"
+
+#: lib/klass_hero_web/live/user_live/login.ex:15
+#, elixir-autogen, elixir-format
+msgid "back"
+msgstr "Zurück"
+
+#: lib/klass_hero_web/components/parent_components.ex:424
+#, elixir-autogen, elixir-format
+msgid "complete"
+msgstr "Abgeschlossen"
+
+#: lib/klass_hero_web/live/about_live.ex:134
+#, elixir-autogen, elixir-format
+msgid "discover & engage with children's programs"
+msgstr "Kinderprogramme entdecken und nutzen"
+
+#: lib/klass_hero_web/live/about_live.ex:133
+#, elixir-autogen, elixir-format
+msgid "families"
+msgstr "Familien"
+
+#: lib/klass_hero_web/components/marketing_components.ex:236
+#, elixir-autogen, elixir-format
+msgid "for Our Youth"
+msgstr "für unsere Jugend"
+
+#: lib/klass_hero_web/live/contact_live.ex:104
+#, elixir-autogen, elixir-format
+msgid "help"
+msgstr "Hilfe"
+
+#: lib/klass_hero_web/components/marketing_components.ex:1040
+#, elixir-autogen, elixir-format
+msgid "in"
+msgstr "in"
+
+#: lib/klass_hero_web/components/marketing_components.ex:1044
+#, elixir-autogen, elixir-format
+msgid "matching"
+msgstr "Passend"
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1612
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1627
+#, elixir-autogen, elixir-format
+msgid "pending"
+msgstr "Ausstehend"
+
+#: lib/klass_hero_web/components/marketing_components.ex:1038
+#, elixir-autogen, elixir-format
+msgid "program"
+msgid_plural "programs"
+msgstr[0] "Programm"
+msgstr[1] "Programme"
+
+#: lib/klass_hero_web/components/parent_components.ex:595
+#, elixir-autogen, elixir-format
+msgid "remaining"
+msgstr "Verbleibend"
+
+#: lib/klass_hero_web/live/user_live/settings.ex:18
+#, elixir-autogen, elixir-format
+msgid "settings"
+msgstr "Einstellungen"
+
+#: lib/klass_hero_web/live/about_live.ex:177
+#, elixir-autogen, elixir-format
+msgid "spent over a decade as a coach and youth activity provider in Berlin, building Prime Youth — a community of providers, schools, and parents dedicated to giving children the best possible experiences. But one pattern kept emerging: the administrative burden of managing bookings, payments, and compliance was getting in everyone's way."
+msgstr "verbrachte über ein Jahrzehnt als Trainer und Anbieter von Freizeitaktivitäten für Kinder in Berlin und baute Prime Youth auf — eine Gemeinschaft aus Anbietern, Schulen und Eltern, die sich dafür einsetzt, Kindern die bestmöglichen Erlebnisse zu bieten. Doch ein Muster zeigte sich immer wieder: Der administrative Aufwand für die Verwaltung von Buchungen, Zahlungen und Compliance stand allen im Weg."
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:41
+#, elixir-autogen, elixir-format
+msgid "team"
+msgstr "Team"
+
+#: lib/klass_hero_web/components/parent_components.ex:426
+#, elixir-autogen, elixir-format
+msgid "to go"
+msgstr "übrig"
+
+#: lib/klass_hero_web/live/about_live.ex:199
+#, elixir-autogen, elixir-format
+msgid "— a mother with over a decade of experience in child safety and quality assurance — will join to architect our Safety-First Verification engine."
+msgstr "— eine Mutter mit über einem Jahrzehnt Erfahrung in Kindersicherheit und Qualitätssicherung — wird sich uns anschließen, um unsere Safety-First Verification Engine zu konzipieren."

--- a/priv/gettext/de/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/de/LC_MESSAGES/enrollment.po
@@ -11,62 +11,62 @@ msgstr ""
 "Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:2278
+#: lib/klass_hero_web/components/provider_components.ex:2193
 #, elixir-autogen, elixir-format
 msgid "Child first name"
-msgstr ""
+msgstr "Vorname des Kindes"
 
-#: lib/klass_hero_web/components/provider_components.ex:2279
+#: lib/klass_hero_web/components/provider_components.ex:2194
 #, elixir-autogen, elixir-format
 msgid "Child last name"
-msgstr ""
+msgstr "Nachname des Kindes"
 
-#: lib/klass_hero_web/components/provider_components.ex:2280
+#: lib/klass_hero_web/components/provider_components.ex:2195
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
-msgstr ""
+msgstr "Geburtsdatum"
 
-#: lib/klass_hero_web/components/provider_components.ex:2291
+#: lib/klass_hero_web/components/provider_components.ex:2206
 #, elixir-autogen, elixir-format
 msgid "Grade"
-msgstr ""
+msgstr "Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2281
+#: lib/klass_hero_web/components/provider_components.ex:2196
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
-msgstr ""
+msgstr "E-Mail des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2282
+#: lib/klass_hero_web/components/provider_components.ex:2197
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
-msgstr ""
+msgstr "Vorname des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2283
+#: lib/klass_hero_web/components/provider_components.ex:2198
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
-msgstr ""
+msgstr "Nachname des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2290
+#: lib/klass_hero_web/components/provider_components.ex:2205
 #, elixir-autogen, elixir-format
 msgid "Program"
-msgstr ""
+msgstr "Programm"
 
-#: lib/klass_hero_web/components/provider_components.ex:2292
+#: lib/klass_hero_web/components/provider_components.ex:2207
 #, elixir-autogen, elixir-format
 msgid "School"
-msgstr ""
+msgstr "Schule"
 
-#: lib/klass_hero_web/components/provider_components.ex:2284
+#: lib/klass_hero_web/components/provider_components.ex:2199
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
-msgstr ""
+msgstr "E-Mail des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2286
+#: lib/klass_hero_web/components/provider_components.ex:2201
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
-msgstr ""
+msgstr "Vorname des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2288
+#: lib/klass_hero_web/components/provider_components.ex:2203
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
-msgstr ""
+msgstr "Nachname des zweiten Erziehungsberechtigten"

--- a/priv/gettext/de/untranslated_allowlist.exs
+++ b/priv/gettext/de/untranslated_allowlist.exs
@@ -1,0 +1,15 @@
+# Msgids intentionally left untranslated in the German (de) catalog — they fall
+# back to the English source string. Read by `mix lint_translations`, which would
+# otherwise fail the build on an empty/fuzzy German `msgstr`.
+#
+# Every entry MUST have a one-line comment explaining WHY it stays English, so a
+# reviewer can sanity-check it from the diff alone. Keep this list small: prefer a
+# real translation over an allowlist entry. Keys are gettext text domains.
+%{
+  "default" => [
+    # Brand name — never translated in any market.
+    "Klass Hero"
+  ],
+  "enrollment" => [],
+  "errors" => []
+}

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -12,1363 +12,1205 @@ msgid ""
 msgstr ""
 
 #: lib/klass_hero_web/components/layouts/app.html.heex:44
-#: lib/klass_hero_web/components/layouts/app.html.heex:210
+#: lib/klass_hero_web/components/layouts/app.html.heex:197
+#: lib/klass_hero_web/components/marketing_components.ex:193
+#: lib/klass_hero_web/components/marketing_components.ex:821
+#: lib/klass_hero_web/components/marketing_components.ex:910
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts.ex:39
-#: lib/klass_hero_web/components/layouts.ex:51
+#: lib/klass_hero_web/components/layouts.ex:34
+#: lib/klass_hero_web/components/layouts.ex:46
 #, elixir-autogen, elixir-format
 msgid "Attempting to reconnect"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:247
+#: lib/klass_hero_web/live/user_live/settings.ex:172
 #, elixir-autogen, elixir-format
 msgid "Choose your preferred language for the interface"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:608
+#: lib/klass_hero_web/components/composite_components.ex:468
 #: lib/klass_hero_web/components/layouts/app.html.heex:52
-#: lib/klass_hero_web/components/layouts/app.html.heex:211
+#: lib/klass_hero_web/components/layouts/app.html.heex:198
+#: lib/klass_hero_web/components/marketing_components.ex:194
+#: lib/klass_hero_web/components/marketing_components.ex:822
+#: lib/klass_hero_web/components/marketing_components.ex:911
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:113
-#: lib/klass_hero_web/components/layouts/app.html.heex:138
-#: lib/klass_hero_web/components/layouts/app.html.heex:217
-#: lib/klass_hero_web/components/layouts/app.html.heex:253
-#: lib/klass_hero_web/components/provider_components.ex:357
-#: lib/klass_hero_web/live/dashboard_live.ex:58
+#: lib/klass_hero_web/components/layouts/app.html.heex:104
+#: lib/klass_hero_web/components/layouts/app.html.heex:129
+#: lib/klass_hero_web/components/layouts/app.html.heex:204
+#: lib/klass_hero_web/components/layouts/app.html.heex:229
+#: lib/klass_hero_web/components/provider_components.ex:366
+#: lib/klass_hero_web/components/ui_components.ex:268
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:406
+#: lib/klass_hero_web/live/user_live/settings.ex:263
 #, elixir-autogen, elixir-format
 msgid "Download My Data"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:394
+#: lib/klass_hero_web/live/user_live/settings.ex:259
 #, elixir-autogen, elixir-format
 msgid "Download a copy of all your personal data"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:626
+#: lib/klass_hero_web/live/user_live/settings.ex:479
 #, elixir-autogen, elixir-format
 msgid "Failed to update language preference."
 msgstr ""
 
 #: lib/klass_hero_web/components/layouts/app.html.heex:28
-#: lib/klass_hero_web/components/layouts/app.html.heex:208
+#: lib/klass_hero_web/components/layouts/app.html.heex:195
+#: lib/klass_hero_web/components/marketing_components.ex:189
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:244
+#: lib/klass_hero_web/live/user_live/settings.ex:169
 #, elixir-autogen, elixir-format
 msgid "Language Preference"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:623
+#: lib/klass_hero_web/live/user_live/settings.ex:476
 #, elixir-autogen, elixir-format
 msgid "Language preference updated successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:167
-#: lib/klass_hero_web/components/layouts/app.html.heex:271
+#: lib/klass_hero_web/components/layouts/app.html.heex:158
+#: lib/klass_hero_web/components/layouts/app.html.heex:247
 #, elixir-autogen, elixir-format
 msgid "Login"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:602
-#: lib/klass_hero_web/components/composite_components.ex:619
+#: lib/klass_hero_web/components/composite_components.ex:462
+#: lib/klass_hero_web/components/composite_components.ex:484
 #: lib/klass_hero_web/components/layouts/app.html.heex:36
-#: lib/klass_hero_web/components/layouts/app.html.heex:209
+#: lib/klass_hero_web/components/layouts/app.html.heex:196
+#: lib/klass_hero_web/components/marketing_components.ex:190
 #, elixir-autogen, elixir-format
 msgid "Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:122
-#: lib/klass_hero_web/components/layouts/app.html.heex:245
+#: lib/klass_hero_web/components/layouts/app.html.heex:113
+#: lib/klass_hero_web/components/layouts/app.html.heex:221
+#: lib/klass_hero_web/components/ui_components.ex:197
 #: lib/klass_hero_web/live/settings_live.ex:17
-#: lib/klass_hero_web/live/settings_live.ex:56
+#: lib/klass_hero_web/live/settings_live.ex:51
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr ""
 
 #: lib/klass_hero_web/components/layouts/admin.html.heex:20
-#: lib/klass_hero_web/components/layouts/app.html.heex:159
-#: lib/klass_hero_web/components/layouts/app.html.heex:265
-#: lib/klass_hero_web/live/settings_live.ex:285
+#: lib/klass_hero_web/components/layouts/app.html.heex:150
+#: lib/klass_hero_web/components/layouts/app.html.heex:241
+#: lib/klass_hero_web/live/settings_live.ex:238
 #, elixir-autogen, elixir-format
 msgid "Sign Out"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:173
-#: lib/klass_hero_web/components/layouts/app.html.heex:279
+#: lib/klass_hero_web/components/layouts/app.html.heex:164
+#: lib/klass_hero_web/components/layouts/app.html.heex:255
 #, elixir-autogen, elixir-format
 msgid "Sign Up"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts.ex:46
+#: lib/klass_hero_web/components/layouts.ex:41
 #, elixir-autogen, elixir-format
 msgid "Something went wrong!"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts.ex:34
+#: lib/klass_hero_web/components/layouts.ex:29
 #, elixir-autogen, elixir-format
 msgid "We can't find the internet"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:391
+#: lib/klass_hero_web/live/user_live/settings.ex:257
 #, elixir-autogen, elixir-format
 msgid "Your Data"
 msgstr ""
 
-#: lib/klass_hero_web/components/core_components.ex:69
-#: lib/klass_hero_web/components/provider_components.ex:1595
+#: lib/klass_hero_web/components/core_components.ex:67
+#: lib/klass_hero_web/components/provider_components.ex:1553
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:442
+#: lib/klass_hero_web/live/booking_live.ex:416
 #, elixir-autogen, elixir-format
 msgid "%{name} (Age %{age})"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:392
+#: lib/klass_hero_web/live/program_detail_live.ex:365
 #, elixir-autogen, elixir-format
 msgid "About This Program"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:349
+#: lib/klass_hero_web/live/booking_live.ex:323
 #, elixir-autogen, elixir-format
 msgid "Activity Summary"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:455
+#: lib/klass_hero_web/live/booking_live.ex:429
 #, elixir-autogen, elixir-format
 msgid "Add another child"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:390
+#: lib/klass_hero_web/live/booking_live.ex:364
 #, elixir-autogen, elixir-format
 msgid "Add another program"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:231
+#: lib/klass_hero_web/live/program_detail_live.ex:210
 #, elixir-autogen, elixir-format
 msgid "Ages %{range}"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:528
+#: lib/klass_hero_web/live/booking_live.ex:502
 #, elixir-autogen, elixir-format
 msgid "An invoice will be emailed to you after enrollment completion"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:472
+#: lib/klass_hero_web/live/booking_live.ex:446
 #, elixir-autogen, elixir-format
 msgid "Any allergies, medical conditions, or special instructions..."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:240
+#: lib/klass_hero_web/components/marketing_components.ex:491
 #, elixir-autogen, elixir-format
 msgid "Book camps, tutors, and workshops instantly. Our integrated planner helps you manage your child's busy life."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:505
+#: lib/klass_hero_web/live/booking_live.ex:479
 #, elixir-autogen, elixir-format
 msgid "Cash / Bank Transfer"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:530
+#: lib/klass_hero_web/live/booking_live.ex:504
 #, elixir-autogen, elixir-format
 msgid "Cash/transfer payments will show as \"Pending\" until received"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:248
+#: lib/klass_hero_web/components/marketing_components.ex:499
 #, elixir-autogen, elixir-format
 msgid "Community Focused"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:547
+#: lib/klass_hero_web/live/booking_live.ex:521
 #, elixir-autogen, elixir-format
 msgid "Complete Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:496
+#: lib/klass_hero_web/live/booking_live.ex:470
 #, elixir-autogen, elixir-format
 msgid "Credit Card"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:529
+#: lib/klass_hero_web/live/booking_live.ex:503
 #, elixir-autogen, elixir-format
 msgid "Credit card payments are processed immediately"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:381
+#: lib/klass_hero_web/live/booking_live.ex:355
 #, elixir-autogen, elixir-format
 msgid "Duration:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:238
+#: lib/klass_hero_web/components/marketing_components.ex:489
 #, elixir-autogen, elixir-format
 msgid "Easy Scheduling"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:551
+#: lib/klass_hero_web/live/program_detail_live.ex:468
 #, elixir-autogen, elixir-format
 msgid "Enroll Now - %{price}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1386
-#: lib/klass_hero_web/live/booking_live.ex:344
+#: lib/klass_hero_web/components/provider_components.ex:1338
+#: lib/klass_hero_web/live/booking_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:41
+#: lib/klass_hero_web/live/booking_live.ex:37
 #, elixir-autogen, elixir-format
 msgid "Enrollment - %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:217
+#: lib/klass_hero_web/live/booking_live.ex:199
 #, elixir-autogen, elixir-format
 msgid "Enrollment failed. Please try again or contact support."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:148
+#: lib/klass_hero_web/live/booking_live.ex:130
 #, elixir-autogen, elixir-format
 msgid "Enrollment successful! You'll receive a confirmation email shortly."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:230
+#: lib/klass_hero_web/components/marketing_components.ex:481
 #, elixir-autogen, elixir-format
 msgid "Every provider is rigorously vetted. We prioritize child safety above all else, giving parents peace of mind."
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:33
-#: lib/klass_hero_web/live/programs_live.ex:241
+#: lib/klass_hero_web/components/marketing_components.ex:952
+#: lib/klass_hero_web/live/programs_live.ex:34
 #, elixir-autogen, elixir-format
 msgid "Explore Programs"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:168
-#, elixir-autogen, elixir-format
-msgid "Explore top-rated activities for your children"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:165
+#: lib/klass_hero_web/components/marketing_components.ex:318
 #, elixir-autogen, elixir-format
 msgid "Featured Programs"
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:192
+#: lib/klass_hero_web/live/programs_live.ex:220
 #, elixir-autogen, elixir-format
 msgid "Invalid pagination state. Please refresh the page."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:526
+#: lib/klass_hero_web/live/booking_live.ex:500
 #, elixir-autogen, elixir-format
 msgid "Invoice & Payment Confirmation"
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:318
-#, elixir-autogen, elixir-format
-msgid "Load More Programs"
-msgstr ""
-
-#: lib/klass_hero_web/live/programs_live.ex:315
+#: lib/klass_hero_web/live/programs_live.ex:360
 #, elixir-autogen, elixir-format
 msgid "Loading..."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:432
+#: lib/klass_hero_web/live/program_detail_live.ex:405
 #, elixir-autogen, elixir-format
 msgid "Meet the Hero"
 msgid_plural "Meet the Heroes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/live/programs_live.ex:328
+#: lib/klass_hero_web/live/programs_live.ex:305
 #, elixir-autogen, elixir-format
 msgid "No programs found"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:480
+#: lib/klass_hero_web/live/booking_live.ex:454
 #, elixir-autogen, elixir-format
 msgid "Optional: Include any important information we should know about your child."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:497
+#: lib/klass_hero_web/live/booking_live.ex:471
 #, elixir-autogen, elixir-format
 msgid "Pay securely with Visa, Mastercard, or other cards"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:491
+#: lib/klass_hero_web/live/booking_live.ex:465
 #, elixir-autogen, elixir-format
 msgid "Payment Method"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:515
+#: lib/klass_hero_web/live/booking_live.ex:489
 #, elixir-autogen, elixir-format
 msgid "Payment Summary"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:172
+#: lib/klass_hero_web/live/booking_live.ex:154
 #, elixir-autogen, elixir-format
 msgid "Payment information is invalid. Please check your details."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:176
+#: lib/klass_hero_web/live/booking_live.ex:158
 #, elixir-autogen, elixir-format
 msgid "Please select a child for enrollment."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:21
+#: lib/klass_hero_web/live/home_live.ex:20
 #, elixir-autogen, elixir-format
 msgid "Klass Hero - Connecting Families with Trusted Youth Educators"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:59
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:47
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:77
+#: lib/klass_hero_web/live/booking_live.ex:56
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:56
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:67
 #, elixir-autogen, elixir-format
 msgid "Program not found"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:74
+#: lib/klass_hero_web/live/program_detail_live.ex:72
 #, elixir-autogen, elixir-format
 msgid "Program not found. It may have been removed or is no longer available."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:147
-#: lib/klass_hero_web/live/home_live.ex:228
+#: lib/klass_hero_web/components/marketing_components.ex:479
+#: lib/klass_hero_web/live/about_live.ex:19
 #, elixir-autogen, elixir-format
 msgid "Safety First"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:215
-#, elixir-autogen, elixir-format
-msgid "Safety, quality, and convenience for modern families."
-msgstr ""
-
-#: lib/klass_hero_web/components/program_components.ex:35
-#: lib/klass_hero_web/live/programs_live.ex:246
+#: lib/klass_hero_web/components/program_components.ex:32
 #, elixir-autogen, elixir-format
 msgid "Search programs..."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:426
+#: lib/klass_hero_web/live/booking_live.ex:400
 #, elixir-autogen, elixir-format
 msgid "Select Child"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:436
+#: lib/klass_hero_web/live/booking_live.ex:410
 #, elixir-autogen, elixir-format
 msgid "Select a child"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:69
+#: lib/klass_hero_web/live/booking_live.ex:66
 #, elixir-autogen, elixir-format
 msgid "Sorry, this program is currently full. Check back later for availability."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:157
+#: lib/klass_hero_web/live/booking_live.ex:139
 #, elixir-autogen, elixir-format
 msgid "Sorry, this program is now full. Please choose another program."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:465
+#: lib/klass_hero_web/live/booking_live.ex:439
 #, elixir-autogen, elixir-format
 msgid "Special Requirements"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:374
+#: lib/klass_hero_web/live/booking_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "Total Price:"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:521
+#: lib/klass_hero_web/live/booking_live.ex:495
 #, elixir-autogen, elixir-format
 msgid "Total due today:"
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:329
-#, elixir-autogen, elixir-format
-msgid "Try adjusting your search or filter criteria."
-msgstr ""
-
-#: lib/klass_hero_web/live/booking_live.ex:84
-#: lib/klass_hero_web/live/program_detail_live.ex:81
-#, elixir-autogen, elixir-format
-msgid "Unable to load program. Please try again later."
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:198
+#: lib/klass_hero_web/components/marketing_components.ex:337
 #, elixir-autogen, elixir-format
 msgid "View All Programs →"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:212
-#, elixir-autogen, elixir-format
-msgid "Why Klass Hero?"
-msgstr ""
-
-#: lib/klass_hero_web/live/program_detail_live.ex:243
+#: lib/klass_hero_web/live/program_detail_live.ex:222
 #, elixir-autogen, elixir-format
 msgid "✓ No hidden fees"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:566
+#: lib/klass_hero_web/live/user_live/settings.ex:419
 #, elixir-autogen, elixir-format
 msgid "A link to confirm your email change has been sent to the new address."
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:605
+#: lib/klass_hero_web/components/composite_components.ex:465
 #: lib/klass_hero_web/live/about_live.ex:10
 #, elixir-autogen, elixir-format
 msgid "About Us"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:17
-#, elixir-autogen, elixir-format
-msgid "Account Settings"
-msgstr ""
-
-#: lib/klass_hero_web/live/terms_of_service_live.ex:212
+#: lib/klass_hero_web/live/terms_of_service_live.ex:204
 #, elixir-autogen, elixir-format
 msgid "Account Termination"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:81
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:247
+#: lib/klass_hero_web/live/contact_live.ex:79
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:254
 #, elixir-autogen, elixir-format
 msgid "Address"
 msgstr ""
 
-#: lib/klass_hero_web/live/terms_of_service_live.ex:23
+#: lib/klass_hero_web/live/terms_of_service_live.ex:27
 #, elixir-autogen, elixir-format
 msgid "Agreement to Terms"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/registration.ex:17
+#: lib/klass_hero_web/live/user_live/registration.ex:18
 #, elixir-autogen, elixir-format
 msgid "Already registered?"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/registration.ex:159
+#: lib/klass_hero_web/live/user_live/registration.ex:148
 #, elixir-autogen, elixir-format
 msgid "An email was sent to %{email}, please access it to confirm your account."
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:151
+#: lib/klass_hero_web/live/contact_live.ex:91
 #, elixir-autogen, elixir-format
 msgid "Booking Support"
 msgstr ""
 
-#: lib/klass_hero_web/live/terms_of_service_live.ex:104
+#: lib/klass_hero_web/live/terms_of_service_live.ex:108
 #, elixir-autogen, elixir-format
 msgid "Cancellation & Refund Policy"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:160
+#: lib/klass_hero_web/live/user_live/settings.ex:111
 #, elixir-autogen, elixir-format
 msgid "Change Email"
 msgstr ""
 
-#: lib/klass_hero_web/live/terms_of_service_live.ex:195
+#: lib/klass_hero_web/live/terms_of_service_live.ex:187
 #, elixir-autogen, elixir-format
 msgid "Changes to Terms"
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:201
+#: lib/klass_hero_web/live/privacy_policy_live.ex:205
 #, elixir-autogen, elixir-format
 msgid "Changes to This Policy"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:159
+#: lib/klass_hero_web/live/user_live/settings.ex:109
 #, elixir-autogen, elixir-format
 msgid "Changing..."
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:253
-#, elixir-autogen, elixir-format
-msgid "Check out our FAQ section for answers to common questions."
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/participation_live.ex:70
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:70
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:39
 #, elixir-autogen, elixir-format
 msgid "Child checked in successfully"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:133
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:133
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:72
 #, elixir-autogen, elixir-format
 msgid "Child checked out successfully"
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:149
+#: lib/klass_hero_web/live/privacy_policy_live.ex:153
 #, elixir-autogen, elixir-format
 msgid "Children's Privacy"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:100
-#, elixir-autogen, elixir-format
-msgid "Closed"
-msgstr ""
-
-#: lib/klass_hero_web/live/about_live.ex:193
+#: lib/klass_hero_web/live/about_live.ex:29
 #, elixir-autogen, elixir-format
 msgid "Community"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/confirmation.ex:37
+#: lib/klass_hero_web/live/user_live/confirmation.ex:57
 #, elixir-autogen, elixir-format
 msgid "Confirm and log in only this time"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/confirmation.ex:31
+#: lib/klass_hero_web/live/user_live/confirmation.ex:48
 #, elixir-autogen, elixir-format
 msgid "Confirm and stay logged in"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:199
+#: lib/klass_hero_web/live/user_live/settings.ex:147
 #, elixir-autogen, elixir-format
 msgid "Confirm new password"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/confirmation.ex:28
-#: lib/klass_hero_web/live/user_live/confirmation.ex:34
+#: lib/klass_hero_web/live/user_live/confirmation.ex:45
+#: lib/klass_hero_web/live/user_live/confirmation.ex:54
 #, elixir-autogen, elixir-format
 msgid "Confirming..."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:112
-#: lib/klass_hero_web/live/terms_of_service_live.ex:247
+#: lib/klass_hero_web/live/settings_live.ex:99
+#: lib/klass_hero_web/live/terms_of_service_live.ex:239
 #, elixir-autogen, elixir-format
 msgid "Contact Information"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:808
-#: lib/klass_hero_web/live/contact_live.ex:15
-#: lib/klass_hero_web/live/contact_live.ex:112
-#: lib/klass_hero_web/live/privacy_policy_live.ex:217
-#: lib/klass_hero_web/live/trust_safety_live.ex:225
+#: lib/klass_hero_web/components/composite_components.ex:651
+#: lib/klass_hero_web/live/contact_live.ex:16
+#: lib/klass_hero_web/live/contact_live.ex:101
+#: lib/klass_hero_web/live/privacy_policy_live.ex:221
 #, elixir-autogen, elixir-format
 msgid "Contact Us"
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:170
+#: lib/klass_hero_web/live/privacy_policy_live.ex:174
 #, elixir-autogen, elixir-format
 msgid "Cookies & Tracking"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/registration.ex:123
+#: lib/klass_hero_web/live/user_live/registration.ex:111
 #, elixir-autogen, elixir-format
 msgid "Create an account"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/registration.ex:80
+#: lib/klass_hero_web/live/user_live/registration.ex:91
 #, elixir-autogen, elixir-format
 msgid "Create and manage programs, activities, and services for families"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/registration.ex:120
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:73
+#: lib/klass_hero_web/live/user_live/registration.ex:109
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:81
 #, elixir-autogen, elixir-format
 msgid "Creating account..."
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:186
+#: lib/klass_hero_web/live/privacy_policy_live.ex:190
 #, elixir-autogen, elixir-format
 msgid "Data Retention"
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:132
+#: lib/klass_hero_web/live/privacy_policy_live.ex:136
 #, elixir-autogen, elixir-format
 msgid "Data Security"
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:91
+#: lib/klass_hero_web/live/privacy_policy_live.ex:95
 #, elixir-autogen, elixir-format
 msgid "Data Sharing"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:422
+#: lib/klass_hero_web/live/user_live/settings.ex:278
 #, elixir-autogen, elixir-format
 msgid "Delete Account"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:447
+#: lib/klass_hero_web/live/user_live/settings.ex:310
 #, elixir-autogen, elixir-format
 msgid "Delete My Account"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:445
+#: lib/klass_hero_web/live/user_live/settings.ex:300
 #, elixir-autogen, elixir-format
 msgid "Deleting..."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:286
+#: lib/klass_hero_web/live/user_live/settings.ex:209
 #, elixir-autogen, elixir-format
 msgid "Deutsch"
 msgstr ""
 
-#: lib/klass_hero_web/live/terms_of_service_live.ex:230
+#: lib/klass_hero_web/live/terms_of_service_live.ex:222
 #, elixir-autogen, elixir-format
 msgid "Dispute Resolution"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:18
-#, elixir-autogen, elixir-format
-msgid "Don't have an account?"
-msgstr ""
-
-#: lib/klass_hero_web/components/provider_components.ex:657
-#: lib/klass_hero_web/components/provider_components.ex:2104
-#: lib/klass_hero_web/components/provider_components.ex:2122
+#: lib/klass_hero_web/components/provider_components.ex:624
+#: lib/klass_hero_web/components/provider_components.ex:2050
+#: lib/klass_hero_web/components/provider_components.ex:2068
 #: lib/klass_hero_web/live/contact_live.ex:65
-#: lib/klass_hero_web/live/contact_live.ex:141
-#: lib/klass_hero_web/live/user_live/login.ex:49
-#: lib/klass_hero_web/live/user_live/login.ex:81
-#: lib/klass_hero_web/live/user_live/registration.ex:39
-#: lib/klass_hero_web/live/user_live/settings.ex:155
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:60
+#: lib/klass_hero_web/live/contact_live.ex:154
+#: lib/klass_hero_web/live/user_live/login.ex:60
+#: lib/klass_hero_web/live/user_live/login.ex:89
+#: lib/klass_hero_web/live/user_live/registration.ex:48
+#: lib/klass_hero_web/live/user_live/settings.ex:102
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:66
 #, elixir-autogen, elixir-format
 msgid "Email"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:496
+#: lib/klass_hero_web/live/user_live/settings.ex:348
 #, elixir-autogen, elixir-format
 msgid "Email change link is invalid or it has expired."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:493
+#: lib/klass_hero_web/live/user_live/settings.ex:345
 #, elixir-autogen, elixir-format
 msgid "Email changed successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:267
+#: lib/klass_hero_web/live/user_live/settings.ex:191
 #, elixir-autogen, elixir-format
 msgid "English"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/registration.ex:60
+#: lib/klass_hero_web/live/user_live/registration.ex:71
 #, elixir-autogen, elixir-format
 msgid "Enroll children in programs"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:438
+#: lib/klass_hero_web/live/user_live/settings.ex:294
 #, elixir-autogen, elixir-format
 msgid "Enter your password to confirm"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:85
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:85
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:49
 #, elixir-autogen, elixir-format
 msgid "Failed to check in: %{reason}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:150
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:150
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:84
 #, elixir-autogen, elixir-format
 msgid "Failed to check out: %{reason}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:134
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:119
+#: lib/klass_hero_web/live/provider/sessions_live.ex:158
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:117
 #, elixir-autogen, elixir-format
 msgid "Failed to complete session: %{reason}"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:655
+#: lib/klass_hero_web/live/user_live/settings.ex:508
 #, elixir-autogen, elixir-format
 msgid "Failed to delete account. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:399
-#: lib/klass_hero_web/live/provider/participation_live.ex:400
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:354
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:355
-#, elixir-autogen, elixir-format
-msgid "Failed to load session data"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/sessions_live.ex:111
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:90
+#: lib/klass_hero_web/live/provider/sessions_live.ex:135
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:88
 #, elixir-autogen, elixir-format
 msgid "Failed to start session: %{reason}"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/registration.ex:63
+#: lib/klass_hero_web/live/user_live/registration.ex:74
 #, elixir-autogen, elixir-format
 msgid "Find and book activities, camps, and classes for your children"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:149
+#: lib/klass_hero_web/live/contact_live.ex:89
 #, elixir-autogen, elixir-format
 msgid "General Inquiry"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:194
-#, elixir-autogen, elixir-format
-msgid "Get in Touch"
-msgstr ""
-
-#: lib/klass_hero_web/live/privacy_policy_live.ex:75
+#: lib/klass_hero_web/live/privacy_policy_live.ex:79
 #, elixir-autogen, elixir-format
 msgid "How We Use Your Information"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/registration.ex:46
+#: lib/klass_hero_web/live/user_live/registration.ex:55
 #, elixir-autogen, elixir-format
 msgid "I want to..."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:142
+#: lib/klass_hero_web/live/user_live/login.ex:170
 #, elixir-autogen, elixir-format
 msgid "If your email is in our system, you will receive instructions for logging in shortly."
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:34
+#: lib/klass_hero_web/live/privacy_policy_live.ex:38
 #, elixir-autogen, elixir-format
 msgid "Information We Collect"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:152
+#: lib/klass_hero_web/live/contact_live.ex:92
 #, elixir-autogen, elixir-format
 msgid "Instructor Application"
 msgstr ""
 
-#: lib/klass_hero_web/live/terms_of_service_live.ex:173
+#: lib/klass_hero_web/live/terms_of_service_live.ex:165
 #, elixir-autogen, elixir-format
 msgid "Intellectual Property"
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:23
+#: lib/klass_hero_web/live/privacy_policy_live.ex:27
 #, elixir-autogen, elixir-format
 msgid "Introduction"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:89
-#: lib/klass_hero_web/live/provider/sessions_live.ex:336
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:66
+#: lib/klass_hero_web/live/provider/sessions_live.ex:113
+#: lib/klass_hero_web/live/provider/sessions_live.ex:348
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:64
 #, elixir-autogen, elixir-format
 msgid "Invalid date format"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:649
+#: lib/klass_hero_web/live/user_live/settings.ex:502
 #, elixir-autogen, elixir-format
 msgid "Invalid password."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/confirmation.ex:62
+#: lib/klass_hero_web/live/user_live/confirmation.ex:92
 #, elixir-autogen, elixir-format
 msgid "Keep me logged in on this device"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:739
+#: lib/klass_hero_web/components/composite_components.ex:602
 #, elixir-autogen, elixir-format
 msgid "Last Updated:"
 msgstr ""
 
-#: lib/klass_hero_web/live/terms_of_service_live.ex:151
+#: lib/klass_hero_web/live/terms_of_service_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "Limitation of Liability"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/confirmation.ex:53
-#: lib/klass_hero_web/live/user_live/registration.ex:19
+#: lib/klass_hero_web/live/user_live/confirmation.ex:80
+#: lib/klass_hero_web/live/user_live/registration.ex:23
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:96
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:93
+#: lib/klass_hero_web/live/user_live/login.ex:113
 #, elixir-autogen, elixir-format
 msgid "Log in and stay logged in"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:96
+#: lib/klass_hero_web/live/user_live/login.ex:116
 #, elixir-autogen, elixir-format
 msgid "Log in only this time"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/confirmation.ex:68
+#: lib/klass_hero_web/live/user_live/confirmation.ex:101
 #, elixir-autogen, elixir-format
 msgid "Log me in only this time"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/confirmation.ex:52
-#: lib/klass_hero_web/live/user_live/confirmation.ex:59
-#: lib/klass_hero_web/live/user_live/confirmation.ex:65
+#: lib/klass_hero_web/live/user_live/confirmation.ex:77
+#: lib/klass_hero_web/live/user_live/confirmation.ex:89
+#: lib/klass_hero_web/live/user_live/confirmation.ex:98
 #, elixir-autogen, elixir-format
 msgid "Logging in..."
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:250
-#, elixir-autogen, elixir-format
-msgid "Looking for Quick Answers?"
-msgstr ""
-
-#: lib/klass_hero_web/live/user_live/confirmation.ex:90
+#: lib/klass_hero_web/live/user_live/confirmation.ex:133
 #, elixir-autogen, elixir-format
 msgid "Magic link is invalid or it has expired."
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:162
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:158
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:194
+#: lib/klass_hero_web/live/contact_live.ex:170
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:178
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:173
+#: lib/klass_hero_web/live/contact_live.ex:129
 #, elixir-autogen, elixir-format
 msgid "Message sent successfully!"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:98
-#, elixir-autogen, elixir-format
-msgid "Monday - Friday"
-msgstr ""
-
-#: lib/klass_hero_web/live/dashboard_live.ex:193
-#, elixir-autogen, elixir-format
-msgid "My Children"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/sessions_live.ex:35
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:5
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:24
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:230
+#: lib/klass_hero_web/live/provider/sessions_live.ex:47
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:4
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:21
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "My Sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:139
-#: lib/klass_hero_web/live/user_live/registration.ex:30
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:53
+#: lib/klass_hero_web/live/contact_live.ex:147
+#: lib/klass_hero_web/live/user_live/registration.ex:41
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:62
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:192
+#: lib/klass_hero_web/live/user_live/settings.ex:140
 #, elixir-autogen, elixir-format
 msgid "New password"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/registration.ex:77
+#: lib/klass_hero_web/live/user_live/registration.ex:88
 #, elixir-autogen, elixir-format
 msgid "Offer programs and services"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:226
-#, elixir-autogen, elixir-format
-msgid "Office Hours"
-msgstr ""
-
-#: lib/klass_hero_web/live/user_live/login.ex:105
+#: lib/klass_hero_web/live/user_live/login.ex:126
 #, elixir-autogen, elixir-format
 msgid "Or use magic link"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:64
+#: lib/klass_hero_web/live/user_live/login.ex:74
 #, elixir-autogen, elixir-format
 msgid "Or use password"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:154
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:231
-#: lib/klass_hero_web/presenters/provider_presenter.ex:129
+#: lib/klass_hero_web/live/contact_live.ex:94
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:241
+#: lib/klass_hero_web/presenters/provider_presenter.ex:97
 #, elixir-autogen, elixir-format
 msgid "Other"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:89
-#: lib/klass_hero_web/live/user_live/settings.ex:170
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:68
+#: lib/klass_hero_web/live/user_live/login.ex:96
+#: lib/klass_hero_web/live/user_live/settings.ex:119
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:73
 #, elixir-autogen, elixir-format
 msgid "Password"
 msgstr ""
 
-#: lib/klass_hero_web/live/terms_of_service_live.ex:77
+#: lib/klass_hero_web/live/terms_of_service_live.ex:81
 #, elixir-autogen, elixir-format
 msgid "Payment Terms"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:73
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:232
+#: lib/klass_hero_web/live/contact_live.ex:72
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:239
 #, elixir-autogen, elixir-format
 msgid "Phone"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:676
-#: lib/klass_hero_web/live/privacy_policy_live.ex:10
-#: lib/klass_hero_web/live/privacy_policy_live.ex:235
+#: lib/klass_hero_web/components/composite_components.ex:541
+#: lib/klass_hero_web/live/privacy_policy_live.ex:11
+#: lib/klass_hero_web/live/privacy_policy_live.ex:239
 #, elixir-autogen, elixir-format
 msgid "Privacy Policy"
 msgstr ""
 
-#: lib/klass_hero_web/live/terms_of_service_live.ex:56
+#: lib/klass_hero_web/live/terms_of_service_live.ex:60
 #, elixir-autogen, elixir-format
 msgid "Program Enrollment & Bookings"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:150
+#: lib/klass_hero_web/live/contact_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "Program Question"
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:239
+#: lib/klass_hero_web/live/privacy_policy_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "Questions About Privacy?"
 msgstr ""
 
-#: lib/klass_hero_web/live/terms_of_service_live.ex:272
+#: lib/klass_hero_web/live/terms_of_service_live.ex:264
 #, elixir-autogen, elixir-format
 msgid "Questions About These Terms?"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:270
-#: lib/klass_hero_web/live/provider/participation_live.ex:60
-#: lib/klass_hero_web/live/provider/participation_live.ex:122
-#: lib/klass_hero_web/live/provider/participation_live.ex:269
-#: lib/klass_hero_web/live/provider/participation_live.ex:315
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:60
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:122
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:208
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:254
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:29
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:61
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:94
+#: lib/klass_hero_web/live/admin/sessions_live.ex:251
+#: lib/klass_hero_web/live/provider/participation_live.ex:176
+#: lib/klass_hero_web/live/provider/participation_live.ex:222
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:118
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:164
 #, elixir-autogen, elixir-format
 msgid "Record not found"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:22
+#: lib/klass_hero_web/live/user_live/login.ex:26
 #, elixir-autogen, elixir-format
 msgid "Register"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/registration.ex:15
-#, elixir-autogen, elixir-format
-msgid "Register for an account"
-msgstr ""
-
-#: lib/klass_hero_web/live/contact_live.ex:99
-#, elixir-autogen, elixir-format
-msgid "Saturday"
-msgstr ""
-
-#: lib/klass_hero_web/live/user_live/settings.ex:203
+#: lib/klass_hero_web/live/user_live/settings.ex:151
 #, elixir-autogen, elixir-format
 msgid "Save Password"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:317
-#: lib/klass_hero_web/live/settings/children_live.ex:765
-#: lib/klass_hero_web/live/user_live/settings.ex:202
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:324
+#: lib/klass_hero_web/live/settings/children_live.ex:743
+#: lib/klass_hero_web/live/user_live/settings.ex:150
 #, elixir-autogen, elixir-format
 msgid "Saving..."
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:147
-#, elixir-autogen, elixir-format
-msgid "Select a topic..."
-msgstr ""
-
-#: lib/klass_hero_web/live/user_live/registration.ex:48
+#: lib/klass_hero_web/live/user_live/registration.ex:58
 #, elixir-autogen, elixir-format
 msgid "Select one or both options"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:55
-#, elixir-autogen, elixir-format
-msgid "Send Magic Link"
-msgstr ""
-
-#: lib/klass_hero_web/components/provider_components.ex:1802
-#: lib/klass_hero_web/components/provider_components.ex:1803
-#: lib/klass_hero_web/components/provider_components.ex:1842
-#: lib/klass_hero_web/live/contact_live.ex:184
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:290
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:291
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:329
+#: lib/klass_hero_web/components/provider_components.ex:1755
+#: lib/klass_hero_web/components/provider_components.ex:1756
+#: lib/klass_hero_web/components/provider_components.ex:1793
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:448
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:484
 #, elixir-autogen, elixir-format
 msgid "Send Message"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:128
-#, elixir-autogen, elixir-format
-msgid "Send us a Message"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/sessions_live.ex:120
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:105
+#: lib/klass_hero_web/live/provider/sessions_live.ex:144
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:103
 #, elixir-autogen, elixir-format
 msgid "Session completed successfully"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:69
-#: lib/klass_hero_web/live/admin/sessions_live.ex:75
-#: lib/klass_hero_web/live/provider/participation_live.ex:388
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:343
+#: lib/klass_hero_web/live/admin/sessions_live.ex:67
+#: lib/klass_hero_web/live/admin/sessions_live.ex:73
+#: lib/klass_hero_web/live/provider/participation_live.ex:270
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:229
 #, elixir-autogen, elixir-format
 msgid "Session not found"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:97
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:76
+#: lib/klass_hero_web/live/provider/sessions_live.ex:121
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:74
 #, elixir-autogen, elixir-format
 msgid "Session started successfully"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:146
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:144
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:180
+#: lib/klass_hero_web/live/contact_live.ex:162
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:164
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "Subject"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:100
-#, elixir-autogen, elixir-format
-msgid "Sunday"
-msgstr ""
-
-#: lib/klass_hero_web/components/composite_components.ex:747
+#: lib/klass_hero_web/components/composite_components.ex:610
 #, elixir-autogen, elixir-format
 msgid "Table of Contents"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:153
+#: lib/klass_hero_web/live/contact_live.ex:93
 #, elixir-autogen, elixir-format
 msgid "Technical Issue"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:678
-#: lib/klass_hero_web/live/terms_of_service_live.ex:10
-#: lib/klass_hero_web/live/terms_of_service_live.ex:268
+#: lib/klass_hero_web/components/composite_components.ex:543
+#: lib/klass_hero_web/live/terms_of_service_live.ex:11
+#: lib/klass_hero_web/live/terms_of_service_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "Terms of Service"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:425
+#: lib/klass_hero_web/live/user_live/settings.ex:281
 #, elixir-autogen, elixir-format
 msgid "This action cannot be undone. Your account data will be anonymized and you will be logged out."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/confirmation.ex:74
+#: lib/klass_hero_web/live/user_live/confirmation.ex:110
 #, elixir-autogen, elixir-format
 msgid "Tip: If you prefer passwords, you can enable them in the user settings."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:32
+#: lib/klass_hero_web/live/user_live/login.ex:40
 #, elixir-autogen, elixir-format
 msgid "To see sent emails, visit"
 msgstr ""
 
-#: lib/klass_hero_web/live/terms_of_service_live.ex:269
+#: lib/klass_hero_web/live/terms_of_service_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "Understanding our agreement with you"
 msgstr ""
 
-#: lib/klass_hero_web/live/terms_of_service_live.ex:34
+#: lib/klass_hero_web/live/terms_of_service_live.ex:38
 #, elixir-autogen, elixir-format
 msgid "User Accounts & Registration"
 msgstr ""
 
-#: lib/klass_hero_web/live/terms_of_service_live.ex:126
+#: lib/klass_hero_web/live/terms_of_service_live.ex:118
 #, elixir-autogen, elixir-format
 msgid "User Conduct & Responsibilities"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:196
-#, elixir-autogen, elixir-format
-msgid "View All"
-msgstr ""
-
-#: lib/klass_hero_web/live/contact_live.ex:256
-#, elixir-autogen, elixir-format
-msgid "Visit FAQ"
-msgstr ""
-
-#: lib/klass_hero_web/live/contact_live.ex:67
-#, elixir-autogen, elixir-format
-msgid "We respond within 24 hours"
-msgstr ""
-
-#: lib/klass_hero_web/live/contact_live.ex:176
-#, elixir-autogen, elixir-format
-msgid "We'll get back to you within 24 hours."
-msgstr ""
-
-#: lib/klass_hero_web/live/terms_of_service_live.ex:273
+#: lib/klass_hero_web/live/terms_of_service_live.ex:265
 #, elixir-autogen, elixir-format
 msgid "We're here to clarify any questions you may have."
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:240
+#: lib/klass_hero_web/live/privacy_policy_live.ex:244
 #, elixir-autogen, elixir-format
 msgid "We're here to help with any privacy-related concerns."
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:115
-#, elixir-autogen, elixir-format
-msgid "We're here to help with any questions you may have"
-msgstr ""
-
-#: lib/klass_hero_web/live/user_live/confirmation.ex:12
-#, elixir-autogen, elixir-format
-msgid "Welcome %{email}"
-msgstr ""
-
-#: lib/klass_hero_web/live/user_live/login.ex:13
-#, elixir-autogen, elixir-format
-msgid "Welcome Back"
-msgstr ""
-
-#: lib/klass_hero_web/live/user_live/login.ex:30
+#: lib/klass_hero_web/live/user_live/login.ex:38
 #, elixir-autogen, elixir-format
 msgid "You are running the local mail adapter."
 msgstr ""
 
-#: lib/klass_hero_web/user_auth.ex:368
+#: lib/klass_hero_web/user_auth.ex:326
 #, elixir-autogen, elixir-format
 msgid "You must be authenticated to access this page."
 msgstr ""
 
-#: lib/klass_hero_web/user_auth.ex:281
+#: lib/klass_hero_web/user_auth.ex:250
 #, elixir-autogen, elixir-format
 msgid "You must have a parent profile to access this page."
 msgstr ""
 
-#: lib/klass_hero_web/user_auth.ex:290
+#: lib/klass_hero_web/user_auth.ex:259
 #, elixir-autogen, elixir-format
 msgid "You must have a provider profile to access this page."
 msgstr ""
 
-#: lib/klass_hero_web/user_auth.ex:251
-#: lib/klass_hero_web/user_auth.ex:417
+#: lib/klass_hero_web/user_auth.ex:220
+#: lib/klass_hero_web/user_auth.ex:363
 #, elixir-autogen, elixir-format
 msgid "You must log in to access this page."
 msgstr ""
 
-#: lib/klass_hero_web/user_auth.ex:268
+#: lib/klass_hero_web/user_auth.ex:237
 #, elixir-autogen, elixir-format
 msgid "You must re-authenticate to access this page."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:16
+#: lib/klass_hero_web/live/user_live/login.ex:19
 #, elixir-autogen, elixir-format
 msgid "You need to reauthenticate to perform sensitive actions on your account."
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:110
+#: lib/klass_hero_web/live/privacy_policy_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "Your Privacy Rights"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:637
+#: lib/klass_hero_web/live/user_live/settings.ex:490
 #, elixir-autogen, elixir-format
 msgid "Your account has been deleted."
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:236
+#: lib/klass_hero_web/live/privacy_policy_live.ex:240
 #, elixir-autogen, elixir-format
 msgid "Your privacy matters to us"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:22
-#, elixir-autogen, elixir-format
-msgid "for an account now."
-msgstr ""
-
-#: lib/klass_hero_web/live/user_live/login.ex:32
+#: lib/klass_hero_web/live/user_live/login.ex:42
 #, elixir-autogen, elixir-format
 msgid "the mailbox page"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/registration.ex:21
-#, elixir-autogen, elixir-format
-msgid "to your account now."
-msgstr ""
-
-#: lib/klass_hero_web/components/composite_components.ex:622
+#: lib/klass_hero_web/components/composite_components.ex:487
 #, elixir-autogen, elixir-format
 msgid "Afterschool"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:673
+#: lib/klass_hero_web/components/composite_components.ex:538
 #, elixir-autogen, elixir-format
 msgid "All rights reserved."
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:594
+#: lib/klass_hero_web/components/composite_components.ex:454
 #, elixir-autogen, elixir-format
 msgid "Building the future of youth education by connecting communities."
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:630
+#: lib/klass_hero_web/components/composite_components.ex:495
 #, elixir-autogen, elixir-format
 msgid "Class Trips"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:639
+#: lib/klass_hero_web/components/composite_components.ex:504
 #, elixir-autogen, elixir-format
 msgid "Connect"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:633
+#: lib/klass_hero_web/components/composite_components.ex:498
 #, elixir-autogen, elixir-format
 msgid "Enrichment"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:599
+#: lib/klass_hero_web/components/composite_components.ex:459
 #, elixir-autogen, elixir-format
 msgid "Quick Links"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:626
+#: lib/klass_hero_web/components/composite_components.ex:491
 #, elixir-autogen, elixir-format
 msgid "Summer Camps"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:61
+#: lib/klass_hero_web/live/settings_live.ex:56
 #, elixir-autogen, elixir-format
 msgid "Account & Profile"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:76
+#: lib/klass_hero_web/live/settings_live.ex:69
 #, elixir-autogen, elixir-format
 msgid "Account preferences, password"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:106
+#: lib/klass_hero_web/live/settings_live.ex:95
 #, elixir-autogen, elixir-format
 msgid "Achievements and milestones"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:186
+#: lib/klass_hero_web/live/settings_live.ex:159
 #, elixir-autogen, elixir-format
 msgid "Activity Permissions"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:156
+#: lib/klass_hero_web/live/settings_live.ex:135
 #, elixir-autogen, elixir-format
 msgid "Allergies & Dietary"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:276
+#: lib/klass_hero_web/live/settings_live.ex:231
 #, elixir-autogen, elixir-format
 msgid "App Information"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:226
+#: lib/klass_hero_web/live/settings_live.ex:191
 #, elixir-autogen, elixir-format
 msgid "Available credits and promo codes"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:136
+#: lib/klass_hero_web/live/settings_live.ex:119
 #, elixir-autogen, elixir-format
 msgid "Backup contacts for emergencies"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:208
+#: lib/klass_hero_web/live/settings_live.ex:177
 #, elixir-autogen, elixir-format
 msgid "Cards, bank accounts, billing info"
 msgstr ""
 
 #: lib/klass_hero_web/live/settings/children_live.ex:23
-#: lib/klass_hero_web/live/settings/children_live.ex:367
-#: lib/klass_hero_web/live/settings_live.ex:88
-#: lib/klass_hero_web/live/user_live/settings.ex:48
-#: lib/klass_hero_web/live/user_live/settings.ex:347
+#: lib/klass_hero_web/live/settings/children_live.ex:348
+#: lib/klass_hero_web/live/settings_live.ex:79
+#: lib/klass_hero_web/live/user_live/settings.ex:235
 #, elixir-autogen, elixir-format
 msgid "Children Profiles"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:259
+#: lib/klass_hero_web/live/settings_live.ex:218
 #, elixir-autogen, elixir-format
 msgid "Common questions and guides"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:246
+#: lib/klass_hero_web/live/settings_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Communication Settings"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:148
+#: lib/klass_hero_web/live/settings_live.ex:129
 #, elixir-autogen, elixir-format
 msgid "Conditions, medications, special needs"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:267
+#: lib/klass_hero_web/live/settings_live.ex:224
 #, elixir-autogen, elixir-format
 msgid "Contact Support"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:127
+#: lib/klass_hero_web/live/settings_live.ex:112
 #, elixir-autogen, elixir-format
 msgid "Contact info for both parents"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:135
+#: lib/klass_hero_web/live/settings_live.ex:118
 #, elixir-autogen, elixir-format
 msgid "Emergency Contacts"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:258
+#: lib/klass_hero_web/live/settings_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "FAQ & Help Center"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:225
+#: lib/klass_hero_web/live/settings_live.ex:190
 #, elixir-autogen, elixir-format
 msgid "Family Credits & Discounts"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:105
+#: lib/klass_hero_web/live/settings_live.ex:94
 #, elixir-autogen, elixir-format
 msgid "Family Progress"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:157
+#: lib/klass_hero_web/live/settings_live.ex:136
 #, elixir-autogen, elixir-format
 msgid "Food allergies, dietary restrictions"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:268
+#: lib/klass_hero_web/live/settings_live.ex:225
 #, elixir-autogen, elixir-format
 msgid "Get help from our team"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:142
+#: lib/klass_hero_web/live/settings_live.ex:123
 #, elixir-autogen, elixir-format
 msgid "Health & Safety"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:166
+#: lib/klass_hero_web/live/settings_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "Health insurance details"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:253
+#: lib/klass_hero_web/live/settings_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Help & Support"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:117
+#: lib/klass_hero_web/live/settings_live.ex:104
 #, elixir-autogen, elixir-format
 msgid "Home Address"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:247
+#: lib/klass_hero_web/live/settings_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "How you want to be contacted"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:165
+#: lib/klass_hero_web/live/settings_live.ex:142
 #, elixir-autogen, elixir-format
 msgid "Insurance Information"
 msgstr ""
@@ -1378,129 +1220,128 @@ msgstr ""
 msgid "Invalid email or password"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:286
+#: lib/klass_hero_web/live/settings_live.ex:239
 #, elixir-autogen, elixir-format
 msgid "Log out of your account"
 msgstr ""
 
-#: lib/klass_hero_web/controllers/user_session_controller.ex:64
+#: lib/klass_hero_web/controllers/user_session_controller.ex:63
 #, elixir-autogen, elixir-format
 msgid "Logged out successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:57
-#: lib/klass_hero_web/live/user_live/settings.ex:18
+#: lib/klass_hero_web/live/settings_live.ex:52
 #, elixir-autogen, elixir-format
 msgid "Manage your account and preferences"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:178
+#: lib/klass_hero_web/live/settings_live.ex:153
 #, elixir-autogen, elixir-format
 msgid "Marketing and social media permissions"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:147
+#: lib/klass_hero_web/live/settings_live.ex:128
 #, elixir-autogen, elixir-format
 msgid "Medical Information"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:82
-#: lib/klass_hero_web/live/user_live/settings.ex:317
+#: lib/klass_hero_web/live/settings_live.ex:73
+#: lib/klass_hero_web/live/user_live/settings.ex:221
 #, elixir-autogen, elixir-format
 msgid "My Family"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:96
+#: lib/klass_hero_web/live/settings_live.ex:87
 #, elixir-autogen, elixir-format
 msgid "My Schedule"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:67
+#: lib/klass_hero_web/live/settings_live.ex:62
 #, elixir-autogen, elixir-format
 msgid "Name, email, profile photo"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:237
+#: lib/klass_hero_web/live/settings_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "Notification Preferences"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:232
+#: lib/klass_hero_web/live/settings_live.ex:195
 #, elixir-autogen, elixir-format
 msgid "Notifications & Communication"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:126
+#: lib/klass_hero_web/live/settings_live.ex:111
 #, elixir-autogen, elixir-format
 msgid "Parent/Guardian Details"
 msgstr ""
 
-#: lib/klass_hero_web/controllers/user_session_controller.ex:59
+#: lib/klass_hero_web/controllers/user_session_controller.ex:58
 #, elixir-autogen, elixir-format
 msgid "Password updated successfully!"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:217
+#: lib/klass_hero_web/live/settings_live.ex:184
 #, elixir-autogen, elixir-format
 msgid "Past payments and invoices"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:202
+#: lib/klass_hero_web/live/settings_live.ex:171
 #, elixir-autogen, elixir-format
 msgid "Payment & Billing"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:207
+#: lib/klass_hero_web/live/settings_live.ex:176
 #, elixir-autogen, elixir-format
 msgid "Payment Methods"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:172
+#: lib/klass_hero_web/live/settings_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Permissions & Consents"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:177
+#: lib/klass_hero_web/live/settings_live.ex:152
 #, elixir-autogen, elixir-format
 msgid "Photo & Video Release"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:118
+#: lib/klass_hero_web/live/settings_live.ex:105
 #, elixir-autogen, elixir-format
 msgid "Primary address and phone"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:75
+#: lib/klass_hero_web/live/settings_live.ex:68
 #, elixir-autogen, elixir-format
 msgid "Privacy & Security"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:66
+#: lib/klass_hero_web/live/settings_live.ex:61
 #, elixir-autogen, elixir-format
 msgid "Profile Information"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:105
+#: lib/klass_hero_web/components/composite_components.ex:106
 #, elixir-autogen, elixir-format
 msgid "Progress"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:238
+#: lib/klass_hero_web/live/settings_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Push, email, SMS settings"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:102
+#: lib/klass_hero_web/components/composite_components.ex:103
 #: lib/klass_hero_web/components/layouts/admin.html.heex:58
-#: lib/klass_hero_web/components/provider_components.ex:90
+#: lib/klass_hero_web/components/provider_components.ex:96
 #: lib/klass_hero_web/live/admin/sessions_live.ex:26
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:4
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:185
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:3
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "Sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:187
+#: lib/klass_hero_web/live/settings_live.ex:160
 #, elixir-autogen, elixir-format
 msgid "Swimming, field trips, group activities"
 msgstr ""
@@ -1510,12 +1351,12 @@ msgstr ""
 msgid "The link is invalid or it has expired."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:216
+#: lib/klass_hero_web/live/settings_live.ex:183
 #, elixir-autogen, elixir-format
 msgid "Transaction History"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:196
+#: lib/klass_hero_web/live/settings_live.ex:167
 #, elixir-autogen, elixir-format
 msgid "Updates, discounts, family credit"
 msgstr ""
@@ -1525,12 +1366,12 @@ msgstr ""
 msgid "User confirmed successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:277
+#: lib/klass_hero_web/live/settings_live.ex:232
 #, elixir-autogen, elixir-format
 msgid "Version, terms, privacy policy"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:97
+#: lib/klass_hero_web/live/settings_live.ex:88
 #, elixir-autogen, elixir-format
 msgid "View all family activities"
 msgstr ""
@@ -1540,873 +1381,690 @@ msgstr ""
 msgid "Welcome back!"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:195
+#: lib/klass_hero_web/live/settings_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "WhatsApp Community"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:178
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:211
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Failed to load participation history"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:17
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:64
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:23
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:276
+#: lib/klass_hero_web/live/provider/participation_live.ex:26
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:60
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:29
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "Manage Participation"
 msgstr ""
 
 #: lib/klass_hero_web/live/parent/participation_history_live.ex:17
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:5
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "Participation History"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:101
-#, elixir-autogen, elixir-format
-msgid " Find verified tutors, coaches, and camps near you."
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:101
-#, elixir-autogen, elixir-format
-msgid " youth education, sports, and recreational activities"
-msgstr ""
-
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:24
-#: lib/klass_hero_web/live/admin/verifications_live.ex:204
-#: lib/klass_hero_web/live/programs_live.ex:17
+#: lib/klass_hero_web/live/admin/verifications_live.ex:187
+#: lib/klass_hero_web/live/programs_live.ex:19
 #, elixir-autogen, elixir-format
 msgid "All"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:150
-#, elixir-autogen, elixir-format
-msgid "All instructors are background-checked and verified"
-msgstr ""
-
-#: lib/klass_hero_web/live/programs_live.ex:19
-#: lib/klass_hero_web/presenters/program_presenter.ex:366
+#: lib/klass_hero_web/live/programs_live.ex:21
+#: lib/klass_hero_web/presenters/program_presenter.ex:314
 #, elixir-autogen, elixir-format
 msgid "Arts"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:196
-#, elixir-autogen, elixir-format
-msgid "Building connections between families and local instructors"
-msgstr ""
-
-#: lib/klass_hero_web/live/about_live.ex:113
+#: lib/klass_hero_web/live/about_live.ex:145
 #, elixir-autogen, elixir-format
 msgid "Built for Berlin Families"
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:23
+#: lib/klass_hero_web/live/programs_live.ex:25
 #, elixir-autogen, elixir-format
 msgid "Camps"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:287
-#, elixir-autogen, elixir-format
-msgid "Create a Program"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:297
-#, elixir-autogen, elixir-format
-msgid "Deliver Quality"
-msgstr ""
-
-#: lib/klass_hero_web/live/programs_live.ex:242
-#, elixir-autogen, elixir-format
-msgid "Discover activities, camps, and classes for your child"
-msgstr ""
-
-#: lib/klass_hero_web/live/programs_live.ex:21
-#: lib/klass_hero_web/presenters/program_presenter.ex:367
+#: lib/klass_hero_web/live/programs_live.ex:23
+#: lib/klass_hero_web/presenters/program_presenter.ex:315
 #, elixir-autogen, elixir-format
 msgid "Education"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:213
-#, elixir-autogen, elixir-format
-msgid "Every instructor goes through rigorous screening to ensure the highest quality"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:522
-#, elixir-autogen, elixir-format
-msgid "Everything you need to know about Klass Hero"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:209
-#, elixir-autogen, elixir-format
-msgid "For Families"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:265
+#: lib/klass_hero_web/components/composite_components.ex:472
+#: lib/klass_hero_web/components/marketing_components.ex:191
+#: lib/klass_hero_web/components/marketing_components.ex:537
+#: lib/klass_hero_web/components/marketing_components.ex:908
+#: lib/klass_hero_web/live/for_providers_live.ex:10
+#: lib/klass_hero_web/live/for_providers_live.ex:39
 #, elixir-autogen, elixir-format
 msgid "For Providers"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:519
-#, elixir-autogen, elixir-format
-msgid "Frequently Asked Questions"
-msgstr ""
-
-#: lib/klass_hero_web/live/about_live.ex:121
+#: lib/klass_hero_web/live/about_live.ex:150
 #, elixir-autogen, elixir-format
 msgid "From sports to arts, technology to languages, we make it easy to discover enriching activities that fit your family's schedule and budget."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:292
-#, elixir-autogen, elixir-format
-msgid "GET STARTED TODAY"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:307
+#: lib/klass_hero_web/components/marketing_components.ex:589
 #, elixir-autogen, elixir-format
 msgid "Get Paid & Grow"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:269
-#, elixir-autogen, elixir-format
-msgid "How to Grow Your Youth Program: Let's Build Together."
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:272
-#, elixir-autogen, elixir-format
-msgid "Join our community of passionate educators. Tools and support to help you succeed."
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:100
-#, elixir-autogen, elixir-format
-msgid "Klass Hero is Berlin's leading marketplace for"
-msgstr ""
-
-#: lib/klass_hero_web/live/programs_live.ex:22
+#: lib/klass_hero_web/live/programs_live.ex:24
 #, elixir-autogen, elixir-format
 msgid "Life Skills"
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:20
-#: lib/klass_hero_web/presenters/program_presenter.ex:369
+#: lib/klass_hero_web/live/programs_live.ex:22
+#: lib/klass_hero_web/presenters/program_presenter.ex:317
 #, elixir-autogen, elixir-format
 msgid "Music"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:98
-#, elixir-autogen, elixir-format
-msgid "OUR MISSION"
-msgstr ""
-
-#: lib/klass_hero_web/components/provider_components.ex:694
+#: lib/klass_hero_web/components/provider_components.ex:660
+#: lib/klass_hero_web/live/for_providers_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "Qualifications"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:286
+#: lib/klass_hero_web/live/about_live.ex:206
 #, elixir-autogen, elixir-format
 msgid "Ready to join the movement?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:137
+#: lib/klass_hero_web/components/marketing_components.ex:986
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:309
-#, elixir-autogen, elixir-format
-msgid "Secure payments, insights into your business, and opportunities to expand your impact."
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:289
+#: lib/klass_hero_web/components/marketing_components.ex:573
 #, elixir-autogen, elixir-format
 msgid "Set up your teaching profile and list your programs in minutes. Share your expertise with families who need it."
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:18
-#: lib/klass_hero_web/presenters/program_presenter.ex:368
+#: lib/klass_hero_web/live/programs_live.ex:20
+#: lib/klass_hero_web/presenters/program_presenter.ex:316
 #, elixir-autogen, elixir-format
 msgid "Sports"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:325
-#, elixir-autogen, elixir-format
-msgid "Start Teaching Today →"
-msgstr ""
-
-#: lib/klass_hero_web/live/about_live.ex:173
-#, elixir-autogen, elixir-format
-msgid "Supporting local programs and eco-conscious practices"
-msgstr ""
-
-#: lib/klass_hero_web/live/about_live.ex:170
+#: lib/klass_hero_web/live/about_live.ex:24
 #, elixir-autogen, elixir-format
 msgid "Sustainability"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:299
-#, elixir-autogen, elixir-format
-msgid "Teach your passion with our tools for scheduling, communication, and progress tracking."
-msgstr ""
-
-#: lib/klass_hero_web/live/about_live.ex:101
-#, elixir-autogen, elixir-format
-msgid "To modernize how families discover and engage with children's programs in Berlin"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:145
+#: lib/klass_hero_web/components/marketing_components.ex:269
 #, elixir-autogen, elixir-format
 msgid "Trending in Berlin:"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:116
+#: lib/klass_hero_web/live/about_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "We understand the unique needs of Berlin's diverse families. Our platform connects you with vetted, high-quality programs that match your values and your children's interests."
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:24
+#: lib/klass_hero_web/live/programs_live.ex:26
 #, elixir-autogen, elixir-format
 msgid "Workshops"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:215
-#: lib/klass_hero_web/live/settings/children_live.ex:396
-#: lib/klass_hero_web/live/settings/children_live.ex:418
-#: lib/klass_hero_web/live/settings/children_live.ex:640
-#: lib/klass_hero_web/live/settings/children_live.ex:774
+#: lib/klass_hero_web/live/settings/children_live.ex:377
+#: lib/klass_hero_web/live/settings/children_live.ex:399
+#: lib/klass_hero_web/live/settings/children_live.ex:618
+#: lib/klass_hero_web/live/settings/children_live.ex:752
 #, elixir-autogen, elixir-format
 msgid "Add Child"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:77
-#, elixir-autogen, elixir-format
-msgid "Almost there! One more to go!"
-msgstr ""
-
-#: lib/klass_hero_web/live/dashboard_live.ex:76
-#, elixir-autogen, elixir-format
-msgid "Congratulations! Goal achieved!"
-msgstr ""
-
-#: lib/klass_hero_web/components/composite_components.ex:332
-#, elixir-autogen, elixir-format
-msgid "Copy Code"
-msgstr ""
-
-#: lib/klass_hero_web/components/composite_components.ex:265
-#, elixir-autogen, elixir-format
-msgid "Family Achievements"
-msgstr ""
-
-#: lib/klass_hero_web/components/composite_components.ex:310
-#, elixir-autogen, elixir-format
-msgid "Friends Referred"
-msgstr ""
-
-#: lib/klass_hero_web/components/composite_components.ex:304
-#, elixir-autogen, elixir-format
-msgid "Invite friends and earn points!"
-msgstr ""
-
-#: lib/klass_hero_web/components/composite_components.ex:314
-#, elixir-autogen, elixir-format
-msgid "Points Earned"
-msgstr ""
-
-#: lib/klass_hero_web/components/composite_components.ex:299
-#, elixir-autogen, elixir-format
-msgid "Refer & Earn"
-msgstr ""
-
-#: lib/klass_hero_web/components/composite_components.ex:348
-#, elixir-autogen, elixir-format
-msgid "Share Code"
-msgstr ""
-
-#: lib/klass_hero_web/components/composite_components.ex:185
+#: lib/klass_hero_web/components/composite_components.ex:186
 #, elixir-autogen, elixir-format
 msgid "Weekly Activity Goal"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:78
-#, elixir-autogen, elixir-format
-msgid "You're just getting started!"
-msgstr ""
-
-#: lib/klass_hero_web/live/dashboard_live.ex:79
-#, elixir-autogen, elixir-format
-msgid "You're doing great! Keep it up!"
-msgstr ""
-
-#: lib/klass_hero_web/components/composite_components.ex:319
-#, elixir-autogen, elixir-format
-msgid "Your Referral Code"
-msgstr ""
-
-#: lib/klass_hero_web/components/composite_components.ex:194
+#: lib/klass_hero_web/components/composite_components.ex:195
 #, elixir-autogen, elixir-format
 msgid "activities completed"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:55
-#: lib/klass_hero_web/live/user_live/settings.ex:131
+#: lib/klass_hero_web/live/user_live/settings.ex:81
 #, elixir-autogen, elixir-format
 msgid "Account Security"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:237
+#: lib/klass_hero_web/live/user_live/settings.ex:164
 #, elixir-autogen, elixir-format
 msgid "Customize your experience"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:414
+#: lib/klass_hero_web/live/user_live/settings.ex:271
 #, elixir-autogen, elixir-format
 msgid "Danger Zone"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:69
-#: lib/klass_hero_web/live/user_live/settings.ex:379
+#: lib/klass_hero_web/live/user_live/settings.ex:249
 #, elixir-autogen, elixir-format
 msgid "Data & Privacy"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:382
+#: lib/klass_hero_web/live/user_live/settings.ex:251
 #, elixir-autogen, elixir-format
 msgid "Download your data or delete your account"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:143
+#: lib/klass_hero_web/live/user_live/settings.ex:90
 #, elixir-autogen, elixir-format
 msgid "Email Address"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:134
+#: lib/klass_hero_web/live/user_live/settings.ex:83
 #, elixir-autogen, elixir-format
 msgid "Manage your email and password"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:101
+#: lib/klass_hero_web/live/user_live/settings.ex:70
 #, elixir-autogen, elixir-format
 msgid "Member since"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:62
-#: lib/klass_hero_web/live/user_live/settings.ex:234
+#: lib/klass_hero_web/live/user_live/settings.ex:47
+#: lib/klass_hero_web/live/user_live/settings.ex:163
 #, elixir-autogen, elixir-format
 msgid "Preferences"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:41
+#: lib/klass_hero_web/live/user_live/settings.ex:34
 #, elixir-autogen, elixir-format
 msgid "Profile"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:33
+#: lib/klass_hero_web/live/user_live/settings.ex:30
 #, elixir-autogen, elixir-format
 msgid "Quick Navigation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1389
-#: lib/klass_hero_web/components/provider_components.ex:1775
-#: lib/klass_hero_web/components/provider_components.ex:2011
+#: lib/klass_hero_web/components/provider_components.ex:1341
+#: lib/klass_hero_web/components/provider_components.ex:1731
+#: lib/klass_hero_web/components/provider_components.ex:1957
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1485
+#: lib/klass_hero_web/components/provider_components.ex:1446
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:610
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1484
+#: lib/klass_hero_web/components/provider_components.ex:577
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1679
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/dashboard_live.ex:82
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1728
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1934
 #, elixir-autogen, elixir-format
 msgid "All Staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1380
+#: lib/klass_hero_web/components/provider_components.ex:1332
 #, elixir-autogen, elixir-format
 msgid "Assigned Staff"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:359
-#: lib/klass_hero_web/live/program_detail_live.ex:575
+#: lib/klass_hero_web/live/program_detail_live.ex:332
+#: lib/klass_hero_web/live/program_detail_live.ex:492
 #, elixir-autogen, elixir-format
 msgid "Book Now"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:176
+#: lib/klass_hero_web/components/provider_components.ex:182
 #, elixir-autogen, elixir-format
 msgid "Business Profile"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:115
-#: lib/klass_hero_web/presenters/provider_presenter.ex:125
+#: lib/klass_hero_web/presenters/provider_presenter.ex:83
+#: lib/klass_hero_web/presenters/provider_presenter.ex:93
 #, elixir-autogen, elixir-format
 msgid "Business Registration"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1467
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1656
 #, elixir-autogen, elixir-format
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:552
-#: lib/klass_hero_web/components/provider_components.ex:1457
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:49
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:76
-#: lib/klass_hero_web/live/settings/children_live.ex:467
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:49
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:76
+#: lib/klass_hero_web/components/provider_components.ex:515
+#: lib/klass_hero_web/components/provider_components.ex:1409
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:50
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:77
+#: lib/klass_hero_web/live/settings/children_live.ex:448
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:50
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:77
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:194
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:170
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1297
+#: lib/klass_hero_web/components/provider_components.ex:200
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:172
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1427
 #, elixir-autogen, elixir-format
 msgid "Edit Profile"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1487
+#: lib/klass_hero_web/components/provider_components.ex:1448
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:83
+#: lib/klass_hero_web/components/provider_components.ex:89
 #, elixir-autogen, elixir-format
 msgid "My Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:418
-#: lib/klass_hero_web/components/provider_components.ex:870
+#: lib/klass_hero_web/components/provider_components.ex:392
+#: lib/klass_hero_web/components/provider_components.ex:835
 #, elixir-autogen, elixir-format
 msgid "New Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:69
+#: lib/klass_hero_web/components/provider_components.ex:75
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:46
-#: lib/klass_hero_web/components/provider_components.ex:1486
-#: lib/klass_hero_web/components/provider_components.ex:2198
-#: lib/klass_hero_web/components/provider_components.ex:2218
-#: lib/klass_hero_web/live/admin/sessions_live.ex:318
-#: lib/klass_hero_web/live/admin/verifications_live.ex:209
+#: lib/klass_hero_web/components/provider_components.ex:1447
+#: lib/klass_hero_web/components/provider_components.ex:2144
+#: lib/klass_hero_web/components/provider_components.ex:2162
+#: lib/klass_hero_web/live/admin/sessions_live.ex:297
+#: lib/klass_hero_web/live/admin/verifications_live.ex:192
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1440
+#: lib/klass_hero_web/components/provider_components.ex:1392
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1323
+#: lib/klass_hero_web/components/provider_components.ex:1275
 #, elixir-autogen, elixir-format
 msgid "Program Inventory"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1377
+#: lib/klass_hero_web/components/provider_components.ex:1329
 #, elixir-autogen, elixir-format
 msgid "Program Name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:383
-#, elixir-autogen, elixir-format
-msgid "Program Slots"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:91
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:88
 #, elixir-autogen, elixir-format
 msgid "Provider Dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:372
+#: lib/klass_hero_web/live/program_detail_live.ex:345
 #, elixir-autogen, elixir-format
 msgid "Save for Later"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1335
+#: lib/klass_hero_web/components/provider_components.ex:1287
 #, elixir-autogen, elixir-format
 msgid "Search by name..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1383
-#: lib/klass_hero_web/components/provider_components.ex:1714
-#: lib/klass_hero_web/components/provider_components.ex:1769
-#: lib/klass_hero_web/components/provider_components.ex:2008
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:73
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:158
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:201
+#: lib/klass_hero_web/components/provider_components.ex:1335
+#: lib/klass_hero_web/components/provider_components.ex:1670
+#: lib/klass_hero_web/components/provider_components.ex:1725
+#: lib/klass_hero_web/components/provider_components.ex:1954
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:76
+#: lib/klass_hero_web/components/provider_components.ex:82
 #, elixir-autogen, elixir-format
 msgid "Team & Profiles"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1464
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1653
 #, elixir-autogen, elixir-format
 msgid "Team & Provider Profiles"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:179
+#: lib/klass_hero_web/components/provider_components.ex:185
 #, elixir-autogen, elixir-format
 msgid "This is your main business identity. Verification is required to list programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1413
-#: lib/klass_hero_web/components/provider_components.ex:1729
+#: lib/klass_hero_web/components/provider_components.ex:1365
+#: lib/klass_hero_web/components/provider_components.ex:1685
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:53
+#: lib/klass_hero_web/components/messaging_components.ex:728
 #: lib/klass_hero_web/components/provider_components.ex:49
-#: lib/klass_hero_web/components/provider_components.ex:1488
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:277
+#: lib/klass_hero_web/components/provider_components.ex:1449
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:434
+#: lib/klass_hero_web/presenters/provider_presenter.ex:99
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:375
+#: lib/klass_hero_web/components/provider_components.ex:377
 #, elixir-autogen, elixir-format
 msgid "Verified Business"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1451
+#: lib/klass_hero_web/components/provider_components.ex:1403
 #, elixir-autogen, elixir-format
 msgid "View Roster"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:449
+#: lib/klass_hero_web/live/settings/children_live.ex:430
 #, elixir-autogen, elixir-format
 msgid "%{age} years old"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:664
+#: lib/klass_hero_web/components/messaging_components.ex:738
 #, elixir-autogen, elixir-format
 msgid "%{n}m ago"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:240
-#, elixir-autogen, elixir-format
-msgid "%{remaining} remaining"
-msgstr ""
-
-#: lib/klass_hero_web/live/settings/children_live.ex:404
+#: lib/klass_hero_web/live/settings/children_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "Add your first child to get started with activities and programs."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:519
-#: lib/klass_hero_web/live/settings/children_live.ex:715
+#: lib/klass_hero_web/live/settings/children_live.ex:499
+#: lib/klass_hero_web/live/settings/children_live.ex:693
 #, elixir-autogen, elixir-format
 msgid "Allergies"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:742
+#: lib/klass_hero_web/live/settings/children_live.ex:720
 #, elixir-autogen, elixir-format
 msgid "Allow activity providers to access this child's profile information for program participation."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:223
+#: lib/klass_hero_web/live/settings/children_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:723
+#: lib/klass_hero_web/live/settings/children_live.ex:701
 #, elixir-autogen, elixir-format
 msgid "Any special accommodations or support needs..."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:382
+#: lib/klass_hero_web/live/settings/children_live.ex:363
 #, elixir-autogen, elixir-format
 msgid "Back to Settings"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:185
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:183
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:107
 #, elixir-autogen, elixir-format
 msgid "Behavioral note submitted for review"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:147
+#: lib/klass_hero_web/components/messaging_components.ex:150
 #, elixir-autogen, elixir-format
 msgid "Broadcast"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:78
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:126
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:98
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "Broadcast sent to %{count} parents"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:436
-#: lib/klass_hero_web/components/participation_components.ex:627
-#: lib/klass_hero_web/components/participation_components.ex:715
-#: lib/klass_hero_web/components/provider_components.ex:829
-#: lib/klass_hero_web/components/provider_components.ex:1239
-#: lib/klass_hero_web/components/provider_components.ex:1946
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:247
-#: lib/klass_hero_web/live/admin/verifications_live.ex:424
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:116
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:197
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:346
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:191
-#: lib/klass_hero_web/live/settings/children_live.ex:600
-#: lib/klass_hero_web/live/settings/children_live.ex:760
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:224
+#: lib/klass_hero_web/components/participation_components.ex:417
+#: lib/klass_hero_web/components/participation_components.ex:607
+#: lib/klass_hero_web/components/participation_components.ex:693
+#: lib/klass_hero_web/components/provider_components.ex:794
+#: lib/klass_hero_web/components/provider_components.ex:1191
+#: lib/klass_hero_web/components/provider_components.ex:1896
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
+#: lib/klass_hero_web/live/admin/verifications_live.ex:407
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:219
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:356
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:186
+#: lib/klass_hero_web/live/settings/children_live.ex:579
+#: lib/klass_hero_web/live/settings/children_live.ex:738
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:225
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:307
+#: lib/klass_hero_web/live/settings/children_live.ex:293
 #, elixir-autogen, elixir-format
 msgid "Child added successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:309
+#: lib/klass_hero_web/live/settings/children_live.ex:295
 #, elixir-autogen, elixir-format
 msgid "Child added, but consent update failed. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:89
-#: lib/klass_hero_web/live/settings/children_live.ex:186
+#: lib/klass_hero_web/live/settings/children_live.ex:87
+#: lib/klass_hero_web/live/settings/children_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "Child not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:179
+#: lib/klass_hero_web/live/settings/children_live.ex:172
 #, elixir-autogen, elixir-format
 msgid "Child removed successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:311
+#: lib/klass_hero_web/live/settings/children_live.ex:297
 #, elixir-autogen, elixir-format
 msgid "Child updated successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:313
+#: lib/klass_hero_web/live/settings/children_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "Child updated, but consent update failed. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:354
+#: lib/klass_hero_web/live/dashboard_live.ex:169
+#: lib/klass_hero_web/live/messaging_live_helper.ex:343
 #, elixir-autogen, elixir-format
 msgid "Conversation"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:164
+#: lib/klass_hero_web/live/messaging_live_helper.ex:172
 #, elixir-autogen, elixir-format
 msgid "Conversation not found"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:195
+#: lib/klass_hero_web/live/settings/children_live.ex:188
 #, elixir-autogen, elixir-format
 msgid "Could not remove child. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:497
+#: lib/klass_hero_web/live/settings/children_live.ex:477
 #, elixir-autogen, elixir-format
 msgid "Data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2085
-#: lib/klass_hero_web/live/settings/children_live.ex:679
+#: lib/klass_hero_web/components/provider_components.ex:2031
+#: lib/klass_hero_web/live/settings/children_live.ex:657
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:481
+#: lib/klass_hero_web/live/settings/children_live.ex:462
 #, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:642
+#: lib/klass_hero_web/live/settings/children_live.ex:620
 #, elixir-autogen, elixir-format
 msgid "Edit Child"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:508
-#: lib/klass_hero_web/live/settings/children_live.ex:708
+#: lib/klass_hero_web/live/settings/children_live.ex:488
+#: lib/klass_hero_web/live/settings/children_live.ex:686
 #, elixir-autogen, elixir-format
 msgid "Emergency contact"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:66
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:61
 #, elixir-autogen, elixir-format
 msgid "Failed to approve note"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:227
-#, elixir-autogen, elixir-format
-msgid "Failed to load pending notes"
-msgstr ""
-
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:117
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:112
 #, elixir-autogen, elixir-format
 msgid "Failed to reject note"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:261
+#: lib/klass_hero_web/live/provider/participation_live.ex:168
 #, elixir-autogen, elixir-format
 msgid "Failed to resubmit note"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:100
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:121
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:146
 #, elixir-autogen, elixir-format
 msgid "Failed to send broadcast"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:202
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:200
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:124
 #, elixir-autogen, elixir-format
 msgid "Failed to submit note"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2079
-#: lib/klass_hero_web/components/provider_components.ex:2108
-#: lib/klass_hero_web/components/provider_components.ex:2124
-#: lib/klass_hero_web/live/settings/children_live.ex:665
+#: lib/klass_hero_web/components/provider_components.ex:2025
+#: lib/klass_hero_web/components/provider_components.ex:2054
+#: lib/klass_hero_web/components/provider_components.ex:2070
+#: lib/klass_hero_web/live/settings/children_live.ex:643
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2080
-#: lib/klass_hero_web/components/provider_components.ex:2109
-#: lib/klass_hero_web/components/provider_components.ex:2125
-#: lib/klass_hero_web/live/settings/children_live.ex:671
+#: lib/klass_hero_web/components/provider_components.ex:2026
+#: lib/klass_hero_web/components/provider_components.ex:2055
+#: lib/klass_hero_web/components/provider_components.ex:2071
+#: lib/klass_hero_web/live/settings/children_live.ex:649
 #, elixir-autogen, elixir-format
 msgid "Last name"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:716
+#: lib/klass_hero_web/live/settings/children_live.ex:694
 #, elixir-autogen, elixir-format
 msgid "List any known allergies..."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:368
+#: lib/klass_hero_web/live/settings/children_live.ex:349
 #, elixir-autogen, elixir-format
 msgid "Manage your children's information and consents"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:320
+#: lib/klass_hero_web/live/user_live/settings.ex:223
 #, elixir-autogen, elixir-format
 msgid "Manage your children's profiles"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:64
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:109
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:79
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:94
 #, elixir-autogen, elixir-format
 msgid "Message content is required"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:236
-#: lib/klass_hero_web/components/messaging_components.ex:434
-#: lib/klass_hero_web/components/messaging_components.ex:457
-#: lib/klass_hero_web/live/messaging_live_helper.ex:301
+#: lib/klass_hero_web/components/layouts/app.html.heex:212
+#: lib/klass_hero_web/components/messaging_components.ex:494
+#: lib/klass_hero_web/components/messaging_components.ex:517
+#: lib/klass_hero_web/live/messages_live/index.ex:19
+#: lib/klass_hero_web/live/messaging_live_helper.ex:295
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:229
-#, elixir-autogen, elixir-format
-msgid "Monthly Booking Usage"
-msgstr ""
-
-#: lib/klass_hero_web/live/settings/children_live.ex:403
-#: lib/klass_hero_web/presenters/child_presenter.ex:96
+#: lib/klass_hero_web/live/settings/children_live.ex:384
+#: lib/klass_hero_web/presenters/child_presenter.ex:57
 #, elixir-autogen, elixir-format
 msgid "No children yet"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:399
+#: lib/klass_hero_web/components/messaging_components.ex:464
 #, elixir-autogen, elixir-format
 msgid "No conversations yet"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:368
-#: lib/klass_hero_web/components/messaging_components.ex:674
-#: lib/klass_hero_web/components/messaging_components.ex:685
+#: lib/klass_hero_web/components/messaging_components.ex:433
+#: lib/klass_hero_web/components/messaging_components.ex:748
+#: lib/klass_hero_web/components/messaging_components.ex:759
 #, elixir-autogen, elixir-format
 msgid "No messages yet"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:92
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:134
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:106
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "No parents are enrolled in this program"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:57
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:52
 #, elixir-autogen, elixir-format
 msgid "Note approved"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:191
-#: lib/klass_hero_web/live/provider/participation_live.ex:253
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:189
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:113
+#: lib/klass_hero_web/live/provider/participation_live.ex:160
 #, elixir-autogen, elixir-format
 msgid "Note content cannot be blank"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:106
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:101
 #, elixir-autogen, elixir-format
 msgid "Note rejected"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:247
+#: lib/klass_hero_web/live/provider/participation_live.ex:154
 #, elixir-autogen, elixir-format
 msgid "Note resubmitted for review"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:663
+#: lib/klass_hero_web/components/messaging_components.ex:737
 #, elixir-autogen, elixir-format
 msgid "Now"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:709
+#: lib/klass_hero_web/live/settings/children_live.ex:687
 #, elixir-autogen, elixir-format
 msgid "Phone number or name"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:218
+#: lib/klass_hero_web/live/settings/children_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "Please check the form for errors."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:191
+#: lib/klass_hero_web/live/booking_live.ex:173
 #, elixir-autogen, elixir-format
 msgid "Please complete your profile before making a booking."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:575
+#: lib/klass_hero_web/live/user_live/settings.ex:428
 #, elixir-autogen, elixir-format
 msgid "Please re-authenticate to change your email."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:607
+#: lib/klass_hero_web/live/user_live/settings.ex:460
 #, elixir-autogen, elixir-format
 msgid "Please re-authenticate to change your password."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:643
+#: lib/klass_hero_web/live/user_live/settings.ex:496
 #, elixir-autogen, elixir-format
 msgid "Please re-authenticate to delete your account."
 msgstr ""
@@ -2416,339 +2074,322 @@ msgstr ""
 msgid "Please set up your parent profile to manage children."
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:350
+#: lib/klass_hero_web/components/messaging_components.ex:721
+#: lib/klass_hero_web/live/messaging_live_helper.ex:339
 #, elixir-autogen, elixir-format
 msgid "Program Broadcast"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:739
+#: lib/klass_hero_web/live/settings/children_live.ex:717
 #, elixir-autogen, elixir-format
 msgid "Provider data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:814
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1397
-#: lib/klass_hero_web/live/settings/children_live.ex:776
+#: lib/klass_hero_web/components/provider_components.ex:779
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1524
+#: lib/klass_hero_web/live/settings/children_live.ex:754
 #, elixir-autogen, elixir-format
 msgid "Save Changes"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:129
-#, elixir-autogen, elixir-format
-msgid "Search for programs..."
-msgstr ""
-
-#: lib/klass_hero_web/components/provider_components.ex:1573
-#: lib/klass_hero_web/components/provider_components.ex:1574
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:37
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:128
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:227
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:60
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:164
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:237
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:231
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:232
+#: lib/klass_hero_web/components/provider_components.ex:1531
+#: lib/klass_hero_web/components/provider_components.ex:1532
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:40
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:148
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:249
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:44
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:163
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:238
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:393
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:394
 #, elixir-autogen, elixir-format
 msgid "Send Broadcast"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:371
+#: lib/klass_hero_web/components/messaging_components.ex:436
 #, elixir-autogen, elixir-format
 msgid "Send a message to start the conversation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2179
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:226
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:236
+#: lib/klass_hero_web/components/provider_components.ex:2125
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:248
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:237
 #, elixir-autogen, elixir-format
 msgid "Sending..."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:530
-#: lib/klass_hero_web/live/settings/children_live.ex:722
+#: lib/klass_hero_web/live/settings/children_live.ex:510
+#: lib/klass_hero_web/live/settings/children_live.ex:700
 #, elixir-autogen, elixir-format
 msgid "Support needs"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:185
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:212
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:207
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "This message will be sent to all parents with active enrollments in this program."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:322
+#: lib/klass_hero_web/components/messaging_components.ex:387
 #, elixir-autogen, elixir-format
 msgid "Type a message..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:419
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:374
+#: lib/klass_hero_web/live/provider/participation_live.ex:290
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:249
 #, elixir-autogen, elixir-format
 msgid "Unable to refresh roster. Please reload."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:418
-#: lib/klass_hero_web/live/dashboard_live.ex:250
+#: lib/klass_hero_web/components/parent_components.ex:589
+#: lib/klass_hero_web/live/booking_live.ex:392
 #, elixir-autogen, elixir-format
 msgid "Upgrade"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:165
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:201
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:185
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "Write your message to all enrolled parents..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:194
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:192
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:116
 #, elixir-autogen, elixir-format
 msgid "You already submitted a note for this record"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:170
+#: lib/klass_hero_web/live/messaging_live_helper.ex:178
 #, elixir-autogen, elixir-format
 msgid "You don't have access to this conversation"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:142
+#: lib/klass_hero_web/live/settings/children_live.ex:137
 #, elixir-autogen, elixir-format
 msgid "You don't have permission to delete this child."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:83
+#: lib/klass_hero_web/live/settings/children_live.ex:81
 #, elixir-autogen, elixir-format
 msgid "You don't have permission to edit this child."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:405
+#: lib/klass_hero_web/live/booking_live.ex:379
 #, elixir-autogen, elixir-format
 msgid "You have %{remaining} of %{total} bookings remaining this month."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:234
+#: lib/klass_hero_web/components/parent_components.ex:579
 #, elixir-autogen, elixir-format
 msgid "You have used %{used} of %{cap} bookings this month."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:183
+#: lib/klass_hero_web/live/booking_live.ex:165
 #, elixir-autogen, elixir-format
 msgid "You've reached your monthly booking limit. Upgrade to Active tier for unlimited bookings."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:399
+#: lib/klass_hero_web/live/booking_live.ex:373
 #, elixir-autogen, elixir-format
 msgid "Your Booking Plan"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:408
+#: lib/klass_hero_web/components/messaging_components.ex:473
 #, elixir-autogen, elixir-format
 msgid "Your conversations with parents will appear here"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:410
+#: lib/klass_hero_web/components/messaging_components.ex:475
 #, elixir-autogen, elixir-format
 msgid "Your conversations with providers will appear here"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:25
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:86
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:29
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:28
 #, elixir-autogen, elixir-format
 msgid "Your subscription tier doesn't support broadcasts"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:152
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:188
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:172
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:187
 #, elixir-autogen, elixir-format
 msgid "e.g., Important Update"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:144
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:180
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:164
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "optional"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:411
-#: lib/klass_hero_web/live/dashboard_live.ex:243
+#: lib/klass_hero_web/components/parent_components.ex:595
+#: lib/klass_hero_web/live/booking_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "tier"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:192
+#: lib/klass_hero_web/live/admin/verifications_live.ex:175
 #, elixir-autogen, elixir-format
 msgid "%{count} document"
 msgid_plural "%{count} documents"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/components/program_components.ex:575
-#: lib/klass_hero_web/components/program_components.ex:583
+#: lib/klass_hero_web/components/program_components.ex:574
+#: lib/klass_hero_web/components/program_components.ex:582
 #, elixir-autogen, elixir-format
 msgid "%{count} month"
 msgid_plural "%{count} months"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/components/program_components.ex:571
-#: lib/klass_hero_web/components/program_components.ex:582
+#: lib/klass_hero_web/components/program_components.ex:570
+#: lib/klass_hero_web/components/program_components.ex:581
 #, elixir-autogen, elixir-format
 msgid "%{count} year"
 msgid_plural "%{count} years"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/components/program_components.ex:596
+#: lib/klass_hero_web/components/program_components.ex:592
 #, elixir-autogen, elixir-format
 msgid "%{gender} only"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:277
+#: lib/klass_hero_web/components/provider_components.ex:285
 #, elixir-autogen, elixir-format
 msgid "Action Required"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:816
+#: lib/klass_hero_web/components/provider_components.ex:781
 #, elixir-autogen, elixir-format
 msgid "Add Member"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1506
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1703
 #, elixir-autogen, elixir-format
 msgid "Add your first staff member to get started!"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:555
+#: lib/klass_hero_web/components/program_components.ex:556
 #, elixir-autogen, elixir-format
 msgid "Ages %{min} to %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:559
+#: lib/klass_hero_web/components/program_components.ex:560
 #, elixir-autogen, elixir-format
 msgid "Ages %{min}+"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1099
+#: lib/klass_hero_web/components/provider_components.ex:1054
 #, elixir-autogen, elixir-format
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2263
+#: lib/klass_hero_web/components/provider_components.ex:2184
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred during import."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:384
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:57
+#: lib/klass_hero_web/components/provider_layout_components.ex:564
+#: lib/klass_hero_web/live/admin/verifications_live.ex:367
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "Approve"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:832
+#: lib/klass_hero_web/components/participation_components.ex:802
 #: lib/klass_hero_web/components/provider_components.ex:47
-#: lib/klass_hero_web/live/admin/sessions_live.ex:315
-#: lib/klass_hero_web/live/admin/verifications_live.ex:214
+#: lib/klass_hero_web/live/admin/sessions_live.ex:294
+#: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Approved"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:380
+#: lib/klass_hero_web/live/admin/verifications_live.ex:363
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to approve this document?"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:572
+#: lib/klass_hero_web/components/provider_components.ex:535
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to remove this team member?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:493
+#: lib/klass_hero_web/components/marketing_components.ex:641
 #, elixir-autogen, elixir-format
 msgid "As fathers and partners of teachers in Berlin, we saw and heard firsthand how hard it is to find, book, and manage quality youth activities outside the classroom. Klass Hero is the complete platform connecting Berlin families and schools with trusted, vetted activity providers — offering safe, supervised, and enriching experiences across sports, arts, tutoring, and more. We verify every provider, structure every booking, and support every step — so parents know their child is in good hands, and providers can focus on what they do best: inspiring kids."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1223
+#: lib/klass_hero_web/components/provider_components.ex:1175
 #, elixir-autogen, elixir-format
 msgid "Assign Instructor"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1293
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:253
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:190
-#: lib/klass_hero_web/live/provider/subscription_live.ex:100
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1423
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:263
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Back to Dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:298
+#: lib/klass_hero_web/live/admin/verifications_live.ex:281
 #, elixir-autogen, elixir-format
 msgid "Back to verifications"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:108
-#, elixir-autogen, elixir-format
-msgid "Berlin's leading network for tutors, coaches, and camp providers!"
-msgstr ""
-
-#: lib/klass_hero_web/components/provider_components.ex:665
+#: lib/klass_hero_web/components/provider_components.ex:633
 #, elixir-autogen, elixir-format
 msgid "Bio"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:285
+#: lib/klass_hero_web/live/dashboard_live.ex:373
 #, elixir-autogen, elixir-format
 msgid "Book a Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:666
+#: lib/klass_hero_web/components/provider_components.ex:634
 #, elixir-autogen, elixir-format
 msgid "Brief description of experience and specialties..."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:250
-#, elixir-autogen, elixir-format
-msgid "Built by Parents and Educators for More Learning Opportunities"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:490
+#: lib/klass_hero_web/components/marketing_components.ex:638
 #, elixir-autogen, elixir-format
 msgid "Built by Parents to Empower Educators."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:313
+#: lib/klass_hero_web/live/admin/verifications_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "Business"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1315
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1444
 #, elixir-autogen, elixir-format
 msgid "Business Description"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1302
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1431
 #, elixir-autogen, elixir-format
 msgid "Business Information"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1323
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:280
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1451
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "Business Logo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:900
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:296
+#: lib/klass_hero_web/components/provider_components.ex:865
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "Category"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1046
+#: lib/klass_hero_web/components/provider_components.ex:1003
 #, elixir-autogen, elixir-format
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1766
-#: lib/klass_hero_web/components/provider_components.ex:2002
+#: lib/klass_hero_web/components/provider_components.ex:1722
+#: lib/klass_hero_web/components/provider_components.ex:1948
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2763,1473 +2404,1187 @@ msgstr ""
 msgid "Child meets all program requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1211
+#: lib/klass_hero_web/components/provider_components.ex:1164
 #, elixir-autogen, elixir-format
 msgid "Choose Image"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1377
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1504
 #, elixir-autogen, elixir-format
 msgid "Choose Logo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:793
+#: lib/klass_hero_web/components/provider_components.ex:758
 #, elixir-autogen, elixir-format
 msgid "Choose Photo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:902
+#: lib/klass_hero_web/components/provider_components.ex:867
 #, elixir-autogen, elixir-format
 msgid "Choose a category"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:433
+#: lib/klass_hero_web/components/provider_components.ex:404
 #, elixir-autogen, elixir-format
 msgid "Complete business verification to create programs."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:413
+#: lib/klass_hero_web/live/admin/verifications_live.ex:396
 #, elixir-autogen, elixir-format
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2199
+#: lib/klass_hero_web/components/provider_components.ex:2145
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:737
+#: lib/klass_hero_web/components/messaging_components.ex:811
 #, elixir-autogen, elixir-format
 msgid "Contact Provider"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:57
-#, elixir-autogen, elixir-format
-msgid "Could not load verification documents."
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:751
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:789
 #, elixir-autogen, elixir-format
 msgid "Could not read the uploaded file."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:708
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:716
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:757
 #, elixir-autogen, elixir-format
 msgid "Could not remove invite."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1167
+#: lib/klass_hero_web/components/provider_components.ex:1120
 #, elixir-autogen, elixir-format
 msgid "Cover Image"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1039
+#: lib/klass_hero_web/components/provider_components.ex:997
 #, elixir-autogen, elixir-format
 msgid "Define age, gender, or grade restrictions for eligible participants."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1159
+#: lib/klass_hero_web/components/provider_components.ex:1113
 #, elixir-autogen, elixir-format
 msgid "Describe your program..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1158
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:313
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:221
+#: lib/klass_hero_web/components/provider_components.ex:1112
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:323
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:228
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:603
-#: lib/klass_hero_web/components/provider_components.ex:1110
-#: lib/klass_hero_web/live/settings/children_live.ex:692
+#: lib/klass_hero_web/components/program_components.ex:694
+#: lib/klass_hero_web/components/provider_components.ex:1065
+#: lib/klass_hero_web/live/settings/children_live.ex:670
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2368
+#: lib/klass_hero_web/components/provider_components.ex:2281
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:117
+#: lib/klass_hero_web/live/admin/verifications_live.ex:100
 #, elixir-autogen, elixir-format
 msgid "Document approved successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:120
-#: lib/klass_hero_web/live/admin/verifications_live.ex:160
+#: lib/klass_hero_web/live/admin/verifications_live.ex:103
+#: lib/klass_hero_web/live/admin/verifications_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "Document has already been reviewed."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:344
-#: lib/klass_hero_web/live/admin/verifications_live.ex:484
-#: lib/klass_hero_web/live/admin/verifications_live.ex:496
+#: lib/klass_hero_web/live/admin/verifications_live.ex:327
+#: lib/klass_hero_web/live/admin/verifications_live.ex:463
+#: lib/klass_hero_web/live/admin/verifications_live.ex:475
 #, elixir-autogen, elixir-format
 msgid "Document preview"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:154
+#: lib/klass_hero_web/live/admin/verifications_live.ex:137
 #, elixir-autogen, elixir-format
 msgid "Document rejected."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:467
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:533
 #, elixir-autogen, elixir-format
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1966
+#: lib/klass_hero_web/components/provider_components.ex:1915
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:357
+#: lib/klass_hero_web/live/admin/verifications_live.ex:340
 #, elixir-autogen, elixir-format
 msgid "Download document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:868
+#: lib/klass_hero_web/components/provider_components.ex:833
 #, elixir-autogen, elixir-format
 msgid "Edit Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:608
+#: lib/klass_hero_web/components/provider_components.ex:575
 #, elixir-autogen, elixir-format
 msgid "Edit Team Member"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:981
+#: lib/klass_hero_web/components/provider_components.ex:942
 #, elixir-autogen, elixir-format
 msgid "End Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:967
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:166
+#: lib/klass_hero_web/components/provider_components.ex:929
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:161
 #, elixir-autogen, elixir-format
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1772
-#: lib/klass_hero_web/components/provider_components.ex:2221
+#: lib/klass_hero_web/components/provider_components.ex:1728
+#: lib/klass_hero_web/components/provider_components.ex:2165
+#: lib/klass_hero_web/components/provider_layout_components.ex:554
 #, elixir-autogen, elixir-format
 msgid "Enrolled"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1620
+#: lib/klass_hero_web/components/provider_components.ex:1577
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1011
+#: lib/klass_hero_web/components/provider_components.ex:970
 #, elixir-autogen, elixir-format
 msgid "Enrollment Capacity (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:405
+#: lib/klass_hero_web/live/admin/verifications_live.ex:388
 #, elixir-autogen, elixir-format
 msgid "Explain why this document is being rejected..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2222
-#: lib/klass_hero_web/live/admin/emails_live.ex:220
+#: lib/klass_hero_web/components/provider_components.ex:2166
+#: lib/klass_hero_web/live/admin/emails_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Failed"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:134
+#: lib/klass_hero_web/live/admin/verifications_live.ex:117
 #, elixir-autogen, elixir-format
 msgid "Failed to approve document."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:174
+#: lib/klass_hero_web/live/admin/verifications_live.ex:157
 #, elixir-autogen, elixir-format
 msgid "Failed to reject document."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:690
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:739
 #, elixir-autogen, elixir-format
 msgid "Failed to resend invite."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:476
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:542
 #, elixir-autogen, elixir-format
 msgid "Failed to upload document."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:266
+#: lib/klass_hero_web/live/dashboard_live.ex:354
 #, elixir-autogen, elixir-format
 msgid "Family Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:601
-#: lib/klass_hero_web/components/provider_components.ex:1109
-#: lib/klass_hero_web/live/settings/children_live.ex:691
+#: lib/klass_hero_web/components/program_components.ex:692
+#: lib/klass_hero_web/components/provider_components.ex:1064
+#: lib/klass_hero_web/live/settings/children_live.ex:669
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:317
+#: lib/klass_hero_web/live/admin/verifications_live.ex:300
 #, elixir-autogen, elixir-format
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2301
+#: lib/klass_hero_web/components/provider_components.ex:2216
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2303
+#: lib/klass_hero_web/components/provider_components.ex:2218
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:695
+#: lib/klass_hero_web/components/provider_components.ex:661
 #, elixir-autogen, elixir-format
 msgid "First Aid, UEFA B License, Child Care Cert"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:636
+#: lib/klass_hero_web/components/provider_components.ex:603
 #, elixir-autogen, elixir-format
 msgid "First Name"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:687
+#: lib/klass_hero_web/live/settings/children_live.ex:665
 #, elixir-autogen, elixir-format
 msgid "Gender"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:610
+#: lib/klass_hero_web/components/program_components.ex:701
 #, elixir-autogen, elixir-format
 msgid "Grade %{grade}"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:618
+#: lib/klass_hero_web/components/program_components.ex:709
 #, elixir-autogen, elixir-format
 msgid "Grade %{min}+"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:614
+#: lib/klass_hero_web/components/program_components.ex:705
 #, elixir-autogen, elixir-format
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2005
+#: lib/klass_hero_web/components/provider_components.ex:1951
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:757
+#: lib/klass_hero_web/components/provider_components.ex:722
 #, elixir-autogen, elixir-format
 msgid "Headshot Photo"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:127
+#: lib/klass_hero_web/presenters/provider_presenter.ex:95
 #, elixir-autogen, elixir-format
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1938
+#: lib/klass_hero_web/components/provider_components.ex:1888
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1979
-#, elixir-autogen, elixir-format
-msgid "Import failed"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:760
-#, elixir-autogen, elixir-format
-msgid "Imported %{count} families."
-msgstr ""
-
-#: lib/klass_hero_web/live/about_live.ex:261
-#, elixir-autogen, elixir-format
-msgid "In 2025, Shane connected with his friend Max Pergl, a full-stack developer who shared a unique perspective. Both Shane and Max are partners of teachers who wanted to extend their expertise beyond the classroom, offering more to the community, but without the time to manage bookings, payments, and compliance on their own."
-msgstr ""
-
-#: lib/klass_hero_web/presenters/provider_presenter.ex:126
+#: lib/klass_hero_web/presenters/provider_presenter.ex:94
 #, elixir-autogen, elixir-format
 msgid "Insurance Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:705
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:754
 #, elixir-autogen, elixir-format
 msgid "Invite not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:702
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:751
 #, elixir-autogen, elixir-format
 msgid "Invite removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:679
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:728
 #, elixir-autogen, elixir-format
 msgid "Invite resent successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1637
+#: lib/klass_hero_web/components/provider_components.ex:1594
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:796
+#: lib/klass_hero_web/components/provider_components.ex:761
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 1MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1214
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1380
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:297
+#: lib/klass_hero_web/components/provider_components.ex:1167
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1507
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:304
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 2MB."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:266
+#: lib/klass_hero_web/live/about_live.ex:189
 #, elixir-autogen, elixir-format
 msgid "Klass Hero was built to solve exactly that. A comprehensive operational platform that empowers educators to spend less time on paperwork and more time inspiring children."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:701
+#: lib/klass_hero_web/live/settings/children_live.ex:679
 #, elixir-autogen, elixir-format
 msgid "Klasse %{n}"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:271
-#, elixir-autogen, elixir-format
-msgid "Konstantin Pergl, Max's brother, joined as CFO, bringing the financial rigour and strategic planning needed to navigate the German market and ensure long-term stability for every provider on the platform."
-msgstr ""
-
-#: lib/klass_hero_web/components/provider_components.ex:642
+#: lib/klass_hero_web/components/provider_components.ex:609
 #, elixir-autogen, elixir-format
 msgid "Last Name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:992
+#: lib/klass_hero_web/components/provider_components.ex:952
 #, elixir-autogen, elixir-format
 msgid "Leave blank for open registration at any time."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1102
+#: lib/klass_hero_web/components/provider_components.ex:1057
 #, elixir-autogen, elixir-format
 msgid "Leave unchecked to allow all genders."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:920
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:172
+#: lib/klass_hero_web/components/provider_components.ex:885
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Location"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:394
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:73
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:460
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:77
 #, elixir-autogen, elixir-format
 msgid "Logo upload failed. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:602
-#: lib/klass_hero_web/components/provider_components.ex:1108
-#: lib/klass_hero_web/live/settings/children_live.ex:690
+#: lib/klass_hero_web/components/program_components.ex:693
+#: lib/klass_hero_web/components/provider_components.ex:1063
+#: lib/klass_hero_web/live/settings/children_live.ex:668
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1091
+#: lib/klass_hero_web/components/provider_components.ex:1047
 #, elixir-autogen, elixir-format
 msgid "Maximum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1026
+#: lib/klass_hero_web/components/provider_components.ex:985
 #, elixir-autogen, elixir-format
 msgid "Maximum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1148
+#: lib/klass_hero_web/components/provider_components.ex:1102
 #, elixir-autogen, elixir-format
 msgid "Maximum Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:931
+#: lib/klass_hero_web/components/provider_components.ex:894
 #, elixir-autogen, elixir-format
 msgid "Meeting Days"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1085
+#: lib/klass_hero_web/components/provider_components.ex:1041
 #, elixir-autogen, elixir-format
 msgid "Minimum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1020
+#: lib/klass_hero_web/components/provider_components.ex:979
 #, elixir-autogen, elixir-format
 msgid "Minimum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1141
+#: lib/klass_hero_web/components/provider_components.ex:1095
 #, elixir-autogen, elixir-format
 msgid "Minimum Grade"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:75
-#, elixir-autogen, elixir-format
-msgid "Mon-Fri, 9am-6pm CET"
-msgstr ""
-
-#: lib/klass_hero_web/live/admin/verifications_live.ex:522
+#: lib/klass_hero_web/live/admin/verifications_live.ex:496
 #, elixir-autogen, elixir-format
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2329
+#: lib/klass_hero_web/components/provider_components.ex:2243
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1759
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:269
+#: lib/klass_hero_web/components/provider_components.ex:1715
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:747
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:785
 #, elixir-autogen, elixir-format
 msgid "No file selected."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:700
+#: lib/klass_hero_web/live/settings/children_live.ex:678
 #, elixir-autogen, elixir-format
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1992
+#: lib/klass_hero_web/components/provider_components.ex:1939
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1150
+#: lib/klass_hero_web/components/provider_components.ex:1104
 #, elixir-autogen, elixir-format
 msgid "No maximum"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1143
+#: lib/klass_hero_web/components/provider_components.ex:1097
 #, elixir-autogen, elixir-format
 msgid "No minimum"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:521
+#: lib/klass_hero_web/live/admin/verifications_live.ex:495
 #, elixir-autogen, elixir-format
 msgid "No pending documents to review."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:274
+#: lib/klass_hero_web/live/dashboard_live.ex:362
 #, elixir-autogen, elixir-format
 msgid "No programs booked yet"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:523
+#: lib/klass_hero_web/live/admin/verifications_live.ex:497
 #, elixir-autogen, elixir-format
 msgid "No rejected documents."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1505
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1702
 #, elixir-autogen, elixir-format
 msgid "No team members yet"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:520
-#: lib/klass_hero_web/live/admin/verifications_live.ex:524
+#: lib/klass_hero_web/live/admin/verifications_live.ex:494
+#: lib/klass_hero_web/live/admin/verifications_live.ex:498
 #, elixir-autogen, elixir-format
 msgid "No verification documents found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1225
+#: lib/klass_hero_web/components/provider_components.ex:1177
 #, elixir-autogen, elixir-format
 msgid "None (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:292
+#: lib/klass_hero_web/components/provider_components.ex:301
 #, elixir-autogen, elixir-format
 msgid "Not Verified"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:604
-#: lib/klass_hero_web/components/provider_components.ex:1111
-#: lib/klass_hero_web/live/settings/children_live.ex:689
+#: lib/klass_hero_web/components/program_components.ex:695
+#: lib/klass_hero_web/components/provider_components.ex:1066
+#: lib/klass_hero_web/live/settings/children_live.ex:667
 #, elixir-autogen, elixir-format
 msgid "Not specified"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:488
+#: lib/klass_hero_web/components/marketing_components.ex:635
 #, elixir-autogen, elixir-format
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2405
+#: lib/klass_hero_web/components/provider_components.ex:2318
 #, elixir-autogen, elixir-format
 msgid "PDF, JPG or PNG. Max 10MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:527
+#: lib/klass_hero_web/components/program_components.ex:519
 #, elixir-autogen, elixir-format
 msgid "Participant Requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1036
+#: lib/klass_hero_web/components/provider_components.ex:994
 #, elixir-autogen, elixir-format
 msgid "Participant Restrictions (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:831
-#: lib/klass_hero_web/components/provider_components.ex:262
+#: lib/klass_hero_web/components/participation_components.ex:801
+#: lib/klass_hero_web/components/provider_components.ex:269
 #, elixir-autogen, elixir-format
 msgid "Pending Review"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:413
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:975
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1036
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1071
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1143
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:479
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1025
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1083
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1114
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1165
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1270
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:99
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:103
 #, elixir-autogen, elixir-format
 msgid "Please fix the errors below."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:157
+#: lib/klass_hero_web/live/admin/verifications_live.ex:140
 #, elixir-autogen, elixir-format
 msgid "Please provide a rejection reason."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:507
+#: lib/klass_hero_web/live/admin/verifications_live.ex:485
 #, elixir-autogen, elixir-format
 msgid "Preview not available for this file type."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:911
+#: lib/klass_hero_web/components/provider_components.ex:876
 #, elixir-autogen, elixir-format
 msgid "Price (EUR)"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:409
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:475
 #, elixir-autogen, elixir-format
 msgid "Profile updated successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1075
+#: lib/klass_hero_web/components/provider_components.ex:1032
 #, elixir-autogen, elixir-format
 msgid "Program Start"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:2069
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:2262
 #, elixir-autogen, elixir-format
 msgid "Program created successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:2076
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:2269
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:533
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:571
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:574
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1011
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:595
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:631
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:634
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1058
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:53
 #, elixir-autogen, elixir-format
 msgid "Program not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1000
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1047
 #, elixir-autogen, elixir-format
 msgid "Program updated successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:418
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:34
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:484
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:32
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:27
 #, elixir-autogen, elixir-format
 msgid "Provider profile not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:508
+#: lib/klass_hero_web/components/marketing_components.ex:648
 #, elixir-autogen, elixir-format
 msgid "Read our founding story →"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:809
-#: lib/klass_hero_web/components/provider_components.ex:2220
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:204
+#: lib/klass_hero_web/components/participation_components.ex:781
+#: lib/klass_hero_web/components/provider_components.ex:2164
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Registered"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1062
+#: lib/klass_hero_web/components/provider_components.ex:1019
 #, elixir-autogen, elixir-format
 msgid "Registration"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:187
+#: lib/klass_hero_web/live/program_detail_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Registration Closed"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1003
+#: lib/klass_hero_web/components/provider_components.ex:963
 #, elixir-autogen, elixir-format
 msgid "Registration Closes"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:185
+#: lib/klass_hero_web/live/program_detail_live.ex:164
 #, elixir-autogen, elixir-format
 msgid "Registration Not Open Yet"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:998
+#: lib/klass_hero_web/components/provider_components.ex:958
 #, elixir-autogen, elixir-format
 msgid "Registration Opens"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:989
+#: lib/klass_hero_web/components/provider_components.ex:949
 #, elixir-autogen, elixir-format
 msgid "Registration Period (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:164
+#: lib/klass_hero_web/live/booking_live.ex:146
 #, elixir-autogen, elixir-format
 msgid "Registration has closed for this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:159
+#: lib/klass_hero_web/live/program_detail_live.ex:138
 #, elixir-autogen, elixir-format
 msgid "Registration is closed"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:78
+#: lib/klass_hero_web/live/booking_live.ex:75
 #, elixir-autogen, elixir-format
 msgid "Registration is not currently open for this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:99
+#: lib/klass_hero_web/live/program_detail_live.ex:88
 #, elixir-autogen, elixir-format
 msgid "Registration is not open for this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:155
+#: lib/klass_hero_web/live/program_detail_live.ex:134
 #, elixir-autogen, elixir-format
 msgid "Registration opens %{date}"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:392
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:71
+#: lib/klass_hero_web/live/admin/verifications_live.ex:375
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:67
 #, elixir-autogen, elixir-format
 msgid "Reject"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:833
+#: lib/klass_hero_web/components/participation_components.ex:803
 #: lib/klass_hero_web/components/provider_components.ex:48
-#: lib/klass_hero_web/live/admin/verifications_live.ex:219
+#: lib/klass_hero_web/live/admin/verifications_live.ex:202
 #, elixir-autogen, elixir-format
 msgid "Rejected"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:335
-#: lib/klass_hero_web/live/admin/verifications_live.ex:402
+#: lib/klass_hero_web/live/admin/verifications_live.ex:318
+#: lib/klass_hero_web/live/admin/verifications_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "Rejection reason"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:779
-#: lib/klass_hero_web/components/provider_components.ex:1190
-#: lib/klass_hero_web/components/provider_components.ex:2040
-#: lib/klass_hero_web/components/provider_components.ex:2424
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1356
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:311
+#: lib/klass_hero_web/components/provider_components.ex:744
+#: lib/klass_hero_web/components/provider_components.ex:1143
+#: lib/klass_hero_web/components/provider_components.ex:1986
+#: lib/klass_hero_web/components/provider_components.ex:2337
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1483
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2033
+#: lib/klass_hero_web/components/provider_components.ex:1979
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:326
+#: lib/klass_hero_web/live/admin/verifications_live.ex:309
 #, elixir-autogen, elixir-format
 msgid "Reviewed"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:651
+#: lib/klass_hero_web/components/provider_components.ex:618
 #, elixir-autogen, elixir-format
 msgid "Role"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1563
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:224
+#: lib/klass_hero_web/components/provider_components.ex:1523
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:386
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2230
-#: lib/klass_hero_web/components/provider_components.ex:2242
-#: lib/klass_hero_web/components/provider_components.ex:2253
-#, elixir-autogen, elixir-format
-msgid "Row %{row}: %{msg}"
-msgstr ""
-
-#: lib/klass_hero_web/components/provider_components.ex:1252
+#: lib/klass_hero_web/components/provider_components.ex:1204
 #, elixir-autogen, elixir-format
 msgid "Save Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:927
+#: lib/klass_hero_web/components/provider_components.ex:891
 #, elixir-autogen, elixir-format
 msgid "Schedule (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:226
+#: lib/klass_hero_web/live/program_detail_live.ex:205
 #, elixir-autogen, elixir-format
 msgid "Schedule TBD"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:699
+#: lib/klass_hero_web/live/settings/children_live.ex:677
 #, elixir-autogen, elixir-format
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2402
+#: lib/klass_hero_web/components/provider_components.ex:2315
 #, elixir-autogen, elixir-format
 msgid "Select File"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:136
-#: lib/klass_hero_web/live/booking_live.ex:201
+#: lib/klass_hero_web/live/booking_live.ex:118
+#: lib/klass_hero_web/live/booking_live.ex:183
 #, elixir-autogen, elixir-format
 msgid "Selected child does not meet the program requirements."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:965
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1026
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1015
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1073
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2219
-#: lib/klass_hero_web/live/admin/emails_live.ex:219
+#: lib/klass_hero_web/components/provider_components.ex:2163
+#: lib/klass_hero_web/live/admin/emails_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Sent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:699
+#: lib/klass_hero_web/components/provider_components.ex:665
 #, elixir-autogen, elixir-format
 msgid "Separate multiple qualifications with commas"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1014
+#: lib/klass_hero_web/components/provider_components.ex:973
 #, elixir-autogen, elixir-format
 msgid "Set minimum and maximum enrollment for this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:256
-#, elixir-autogen, elixir-format
-msgid "Shane spent over a decade as a coach and youth activity provider in Berlin, building Prime Youth, a community of providers, schools, and parents dedicated to giving children the best possible experiences. But one pattern kept emerging: the administrative burden of managing bookings, payments, and compliance was getting in everyone's way. Shane saw the problem from every angle. That experience became the foundation for Klass Hero."
-msgstr ""
-
-#: lib/klass_hero_web/components/provider_components.ex:672
+#: lib/klass_hero_web/components/provider_components.ex:639
 #, elixir-autogen, elixir-format
 msgid "Specialties"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1149
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1276
 #, elixir-autogen, elixir-format
 msgid "Staff member no longer exists."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:272
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:333
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:349
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:343
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:403
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:419
 #, elixir-autogen, elixir-format
 msgid "Staff member not found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:976
+#: lib/klass_hero_web/components/provider_components.ex:937
 #, elixir-autogen, elixir-format
 msgid "Start Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:962
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:165
+#: lib/klass_hero_web/components/provider_components.ex:924
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:160
 #, elixir-autogen, elixir-format
 msgid "Start Time"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:321
+#: lib/klass_hero_web/live/admin/verifications_live.ex:304
 #, elixir-autogen, elixir-format
 msgid "Submitted"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:383
+#: lib/klass_hero_web/live/booking_live.ex:357
 #, elixir-autogen, elixir-format
 msgid "TBD"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:128
+#: lib/klass_hero_web/presenters/provider_presenter.ex:96
 #, elixir-autogen, elixir-format
 msgid "Tax Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1091
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1218
 #, elixir-autogen, elixir-format
 msgid "Team member added, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1092
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1219
 #, elixir-autogen, elixir-format
 msgid "Team member added."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:330
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:400
 #, elixir-autogen, elixir-format
 msgid "Team member removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1115
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1242
 #, elixir-autogen, elixir-format
 msgid "Team member updated, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1116
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1243
 #, elixir-autogen, elixir-format
 msgid "Team member updated."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1316
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1445
 #, elixir-autogen, elixir-format
 msgid "Tell parents about your organization..."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:247
+#: lib/klass_hero_web/live/about_live.ex:170
 #, elixir-autogen, elixir-format
 msgid "The Klass Hero Story"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:682
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:731
 #, elixir-autogen, elixir-format
 msgid "This invite cannot be resent."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1018
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1065
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:893
+#: lib/klass_hero_web/components/provider_components.ex:858
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:276
-#, elixir-autogen, elixir-format
-msgid "To lead trust and quality, Laurie Camargo, a mother with over a decade of experience in child safety and quality assurance, will join to architect our Safety-First Verification engine, ensuring every Hero meets the highest standards before working with families."
-msgstr ""
-
-#: lib/klass_hero_web/components/provider_components.ex:2302
+#: lib/klass_hero_web/components/provider_components.ex:2217
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:367
+#: lib/klass_hero_web/live/admin/verifications_live.ex:350
 #, elixir-autogen, elixir-format
 msgid "Unable to load document preview."
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:563
+#: lib/klass_hero_web/components/program_components.ex:564
 #, elixir-autogen, elixir-format
 msgid "Up to %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:622
+#: lib/klass_hero_web/components/program_components.ex:713
 #, elixir-autogen, elixir-format
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1923
+#: lib/klass_hero_web/components/provider_components.ex:1874
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2448
+#: lib/klass_hero_web/components/provider_components.ex:2361
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2357
+#: lib/klass_hero_web/components/provider_components.ex:2270
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2323
+#: lib/klass_hero_web/components/provider_components.ex:2238
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2304
+#: lib/klass_hero_web/components/provider_components.ex:2219
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2320
+#: lib/klass_hero_web/components/provider_components.ex:2235
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:71
-#: lib/klass_hero_web/live/admin/verifications_live.ex:93
-#: lib/klass_hero_web/live/admin/verifications_live.ex:125
-#: lib/klass_hero_web/live/admin/verifications_live.ex:165
+#: lib/klass_hero_web/live/admin/verifications_live.ex:57
+#: lib/klass_hero_web/live/admin/verifications_live.ex:79
+#: lib/klass_hero_web/live/admin/verifications_live.ex:108
+#: lib/klass_hero_web/live/admin/verifications_live.ex:148
 #, elixir-autogen, elixir-format
 msgid "Verification document not found."
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:147
-#: lib/klass_hero_web/components/layouts/app.html.heex:256
+#: lib/klass_hero_web/components/layouts/app.html.heex:138
+#: lib/klass_hero_web/components/layouts/app.html.heex:232
+#: lib/klass_hero_web/components/ui_components.ex:271
 #: lib/klass_hero_web/live/admin/verifications_live.ex:40
-#: lib/klass_hero_web/live/admin/verifications_live.ex:50
-#: lib/klass_hero_web/live/admin/verifications_live.ex:189
+#: lib/klass_hero_web/live/admin/verifications_live.ex:172
 #, elixir-autogen, elixir-format
 msgid "Verifications"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:247
+#: lib/klass_hero_web/components/provider_components.ex:253
+#: lib/klass_hero_web/components/provider_layout_components.ex:212
 #, elixir-autogen, elixir-format
 msgid "Verified"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:126
+#: lib/klass_hero_web/live/about_live.ex:155
 #, elixir-autogen, elixir-format
 msgid "We are Klass Hero — parents, brothers, and partners of educators — building the infrastructure that helps every child learn and thrive."
 msgstr ""
 
-#: lib/klass_hero_web/user_auth.ex:315
+#: lib/klass_hero_web/user_auth.ex:280
 #, elixir-autogen, elixir-format
 msgid "You don't have access to that page."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:652
+#: lib/klass_hero_web/components/provider_components.ex:619
 #, elixir-autogen, elixir-format
 msgid "e.g. Head Coach"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:643
+#: lib/klass_hero_web/components/provider_components.ex:610
 #, elixir-autogen, elixir-format
 msgid "e.g. Johnson"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:637
+#: lib/klass_hero_web/components/provider_components.ex:604
 #, elixir-autogen, elixir-format
 msgid "e.g. Mike"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:658
+#: lib/klass_hero_web/components/provider_components.ex:625
 #, elixir-autogen, elixir-format
 msgid "e.g. mike@example.com"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:894
+#: lib/klass_hero_web/components/provider_components.ex:859
 #, elixir-autogen, elixir-format
 msgid "e.g., Art Adventures"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:921
+#: lib/klass_hero_web/components/provider_components.ex:886
 #, elixir-autogen, elixir-format
 msgid "e.g., Community Center, Main St"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/tier_presenter.ex:150
-#, elixir-autogen, elixir-format
-msgid "%{media_types} media"
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:39
-#, elixir-autogen, elixir-format
-msgid "%{name} Plan"
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:132
-#, elixir-autogen, elixir-format
-msgid "%{percent}% commission"
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:128
-#, elixir-autogen, elixir-format
-msgid "1 program"
-msgid_plural "%{count} programs"
-msgstr[0] ""
-msgstr[1] ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:159
-#: lib/klass_hero_web/presenters/tier_presenter.ex:160
-#, elixir-autogen, elixir-format
-msgid "1 team seat"
-msgid_plural "%{count} team seats"
-msgstr[0] ""
-msgstr[1] ""
-
 #: lib/klass_hero_web/live/about_live.ex:71
-#: lib/klass_hero_web/live/trust_safety_live.ex:53
+#: lib/klass_hero_web/live/trust_safety_live.ex:51
 #, elixir-autogen, elixir-format
 msgid "All Heroes must hold or complete a recognized child safeguarding course, ensuring up-to-date knowledge."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/tier_presenter.ex:146
-#, elixir-autogen, elixir-format
-msgid "All media types"
-msgstr ""
-
-#: lib/klass_hero_web/live/about_live.ex:25
-#: lib/klass_hero_web/live/trust_safety_live.ex:23
+#: lib/klass_hero_web/live/about_live.ex:41
+#: lib/klass_hero_web/live/trust_safety_live.ex:21
 #, elixir-autogen, elixir-format
 msgid "All providers must be 18 years or older, ensuring legal accountability and professional responsibility."
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:234
+#: lib/klass_hero_web/live/trust_safety_live.ex:161
 #, elixir-autogen, elixir-format
 msgid "And at Klass Hero, both come standard."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:61
-#: lib/klass_hero_web/live/trust_safety_live.ex:47
+#: lib/klass_hero_web/live/about_live.ex:65
+#: lib/klass_hero_web/live/trust_safety_live.ex:45
 #, elixir-autogen, elixir-format
 msgid "Applicants complete a video screening to assess communication skills and alignment with our values."
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:102
-#, elixir-autogen, elixir-format
-msgid "At Klass Hero, trust isn't a feature — it's the foundation of everything we do. Our platform is built to connect families, schools, and organizations with qualified, vetted, and safety-verified educators and activity providers."
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:154
-#, elixir-autogen, elixir-format
-msgid "Avatar"
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:135
-#, elixir-autogen, elixir-format
-msgid "Avatar media only"
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:35
-#, elixir-autogen, elixir-format
-msgid "Business Plus"
-msgstr ""
-
 #: lib/klass_hero_web/live/about_live.ex:69
-#: lib/klass_hero_web/live/trust_safety_live.ex:51
+#: lib/klass_hero_web/live/trust_safety_live.ex:49
 #, elixir-autogen, elixir-format
 msgid "Child Safeguarding Training"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/subscription_live.ex:106
-#, elixir-autogen, elixir-format
-msgid "Choose the plan that fits your business needs."
-msgstr ""
-
-#: lib/klass_hero_web/live/user_live/registration.ex:92
-#, elixir-autogen, elixir-format
-msgid "Choose your plan"
-msgstr ""
-
-#: lib/klass_hero_web/live/about_live.ex:81
-#: lib/klass_hero_web/live/trust_safety_live.ex:59
+#: lib/klass_hero_web/live/about_live.ex:77
+#: lib/klass_hero_web/live/trust_safety_live.ex:57
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/subscription_live.ex:83
-#, elixir-autogen, elixir-format
-msgid "Could not change subscription tier"
-msgstr ""
-
-#: lib/klass_hero_web/live/trust_safety_live.ex:73
+#: lib/klass_hero_web/live/trust_safety_live.ex:71
 #, elixir-autogen, elixir-format
 msgid "Create long-term trust across our community"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/subscription_live.ex:126
-#: lib/klass_hero_web/live/provider/subscription_live.ex:166
-#, elixir-autogen, elixir-format
-msgid "Current Plan"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1440
-#, elixir-autogen, elixir-format
-msgid "Current Plan: %{plan}"
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:75
-#, elixir-autogen, elixir-format
-msgid "Direct messaging"
-msgstr ""
-
-#: lib/klass_hero_web/live/about_live.ex:49
-#: lib/klass_hero_web/live/trust_safety_live.ex:39
+#: lib/klass_hero_web/live/about_live.ex:57
+#: lib/klass_hero_web/live/trust_safety_live.ex:37
 #, elixir-autogen, elixir-format
 msgid "Each provider submits an extended police background check, confirming their eligibility to work safely with minors."
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:80
+#: lib/klass_hero_web/live/trust_safety_live.ex:78
 #, elixir-autogen, elixir-format
 msgid "Enforcing platform standards and guidelines"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:157
-#, elixir-autogen, elixir-format
-msgid "Every educator and enrichment professional on Klass Hero completes a 6-step verification process before being approved."
-msgstr ""
-
-#: lib/klass_hero_web/live/about_live.ex:83
-#: lib/klass_hero_web/live/trust_safety_live.ex:61
+#: lib/klass_hero_web/live/about_live.ex:79
+#: lib/klass_hero_web/live/trust_safety_live.ex:59
 #, elixir-autogen, elixir-format
 msgid "Every provider agrees to follow our Community Guidelines, defining expectations around professionalism."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:35
-#: lib/klass_hero_web/live/trust_safety_live.ex:29
+#: lib/klass_hero_web/live/about_live.ex:47
+#: lib/klass_hero_web/live/trust_safety_live.ex:27
 #, elixir-autogen, elixir-format
 msgid "Experience Validation"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:47
-#: lib/klass_hero_web/live/trust_safety_live.ex:37
+#: lib/klass_hero_web/live/about_live.ex:55
+#: lib/klass_hero_web/live/trust_safety_live.ex:35
 #, elixir-autogen, elixir-format
 msgid "Extended Background Checks"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/tier_presenter.ex:45
-#, elixir-autogen, elixir-format
-msgid "For established providers"
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:44
-#, elixir-autogen, elixir-format
-msgid "For growing businesses"
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:49
-#, elixir-autogen, elixir-format
-msgid "Free"
-msgstr ""
-
-#: lib/klass_hero_web/live/trust_safety_live.ex:136
+#: lib/klass_hero_web/live/trust_safety_live.ex:120
 #, elixir-autogen, elixir-format
 msgid "From academic tutoring to sports, arts, and enrichment programs, every provider on Klass Hero is carefully reviewed to ensure they meet our high standards for child safety, professionalism, and educational quality."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/tier_presenter.ex:155
-#, elixir-autogen, elixir-format
-msgid "Gallery"
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:43
-#, elixir-autogen, elixir-format
-msgid "Get started for free"
-msgstr ""
-
-#: lib/klass_hero_web/live/trust_safety_live.ex:214
-#, elixir-autogen, elixir-format
-msgid "Have Questions?"
-msgstr ""
-
-#: lib/klass_hero_web/live/trust_safety_live.ex:154
+#: lib/klass_hero_web/components/marketing_components.ex:1428
 #, elixir-autogen, elixir-format
 msgid "How We Verify Providers"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:23
-#: lib/klass_hero_web/live/trust_safety_live.ex:21
+#: lib/klass_hero_web/live/about_live.ex:39
+#: lib/klass_hero_web/live/trust_safety_live.ex:19
 #, elixir-autogen, elixir-format
 msgid "Identity & Age Verification"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:217
+#: lib/klass_hero_web/live/trust_safety_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "If you'd like to learn more about our Trust & Safety standards or provider verification process, we're happy to help."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/subscription_live.ex:74
-#: lib/klass_hero_web/live/provider/subscription_live.ex:87
-#, elixir-autogen, elixir-format
-msgid "Invalid subscription tier"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1450
-#, elixir-autogen, elixir-format
-msgid "Manage Plan →"
-msgstr ""
-
-#: lib/klass_hero_web/live/trust_safety_live.ex:79
+#: lib/klass_hero_web/live/trust_safety_live.ex:77
 #, elixir-autogen, elixir-format
 msgid "Monitoring provider activity and feedback"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:184
-#, elixir-autogen, elixir-format
-msgid "Ongoing Quality & Accountability"
-msgstr ""
-
-#: lib/klass_hero_web/live/trust_safety_live.ex:114
-#, elixir-autogen, elixir-format
-msgid "Our Commitment to Child Safety"
-msgstr ""
-
-#: lib/klass_hero_web/live/booking_live.ex:506
+#: lib/klass_hero_web/live/booking_live.ex:480
 #, elixir-autogen, elixir-format
 msgid "Pay by cash or direct bank transfer"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/tier_presenter.ex:34
-#, elixir-autogen, elixir-format
-msgid "Professional"
-msgstr ""
-
-#: lib/klass_hero_web/live/booking_live.ex:517
+#: lib/klass_hero_web/live/booking_live.ex:491
 #, elixir-autogen, elixir-format
 msgid "Program fee:"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1913
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:2106
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/tier_presenter.ex:76
-#, elixir-autogen, elixir-format
-msgid "Promotional content"
-msgstr ""
-
-#: lib/klass_hero_web/live/trust_safety_live.ex:70
+#: lib/klass_hero_web/live/trust_safety_live.ex:68
 #, elixir-autogen, elixir-format
 msgid "Protect children and families"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:37
-#: lib/klass_hero_web/live/trust_safety_live.ex:31
+#: lib/klass_hero_web/live/about_live.ex:49
+#: lib/klass_hero_web/live/trust_safety_live.ex:29
 #, elixir-autogen, elixir-format
 msgid "Providers must demonstrate at least one year of experience working with children in their area of expertise."
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:203
+#: lib/klass_hero_web/live/trust_safety_live.ex:146
 #, elixir-autogen, elixir-format
 msgid "Providers who fail to uphold our expectations may be suspended or removed from the platform."
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:81
+#: lib/klass_hero_web/live/trust_safety_live.ex:79
 #, elixir-autogen, elixir-format
 msgid "Reviewing concerns or reports promptly and seriously"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:225
+#: lib/klass_hero_web/live/booking_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Please try again or contact support."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/tier_presenter.ex:33
-#, elixir-autogen, elixir-format
-msgid "Starter"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/subscription_live.ex:46
-#, elixir-autogen, elixir-format
-msgid "Subscription"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/subscription_live.ex:103
-#, elixir-autogen, elixir-format
-msgid "Subscription Plans"
-msgstr ""
-
-#: lib/klass_hero_web/live/trust_safety_live.ex:71
+#: lib/klass_hero_web/live/trust_safety_live.ex:69
 #, elixir-autogen, elixir-format
 msgid "Support schools and institutions with reliable providers"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/subscription_live.ex:175
-#, elixir-autogen, elixir-format
-msgid "Switch to %{plan}"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/subscription_live.ex:67
-#, elixir-autogen, elixir-format
-msgid "Switched to %{plan}"
-msgstr ""
-
-#: lib/klass_hero_web/live/trust_safety_live.ex:99
-#, elixir-autogen, elixir-format
-msgid "TRUST & SAFETY"
-msgstr ""
-
-#: lib/klass_hero_web/live/trust_safety_live.ex:82
+#: lib/klass_hero_web/live/trust_safety_live.ex:80
 #, elixir-autogen, elixir-format
 msgid "Taking action when standards are not met"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:209
+#: lib/klass_hero_web/live/booking_live.ex:191
 #, elixir-autogen, elixir-format
 msgid "This child is already enrolled in this program."
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:612
-#: lib/klass_hero_web/components/composite_components.ex:681
+#: lib/klass_hero_web/components/composite_components.ex:477
+#: lib/klass_hero_web/components/composite_components.ex:546
 #: lib/klass_hero_web/components/layouts/app.html.heex:60
-#: lib/klass_hero_web/components/layouts/app.html.heex:212
-#: lib/klass_hero_web/live/trust_safety_live.ex:12
+#: lib/klass_hero_web/components/layouts/app.html.heex:199
+#: lib/klass_hero_web/components/marketing_components.ex:192
+#: lib/klass_hero_web/components/marketing_components.ex:805
+#: lib/klass_hero_web/components/marketing_components.ex:909
+#: lib/klass_hero_web/live/for_providers_live.ex:136
+#: lib/klass_hero_web/live/trust_safety_live.ex:10
 #, elixir-autogen, elixir-format
 msgid "Trust & Safety"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:187
+#: lib/klass_hero_web/live/trust_safety_live.ex:140
 #, elixir-autogen, elixir-format
 msgid "Trust doesn't stop at onboarding. Klass Hero continuously works to maintain a safe and high-quality ecosystem by:"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:231
+#: lib/klass_hero_web/live/trust_safety_live.ex:160
 #, elixir-autogen, elixir-format
 msgid "Trust is earned. Safety is non-negotiable."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/tier_presenter.ex:127
-#, elixir-autogen, elixir-format
-msgid "Unlimited programs"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1443
-#, elixir-autogen, elixir-format
-msgid "Upgrade your plan to unlock more features"
-msgstr ""
-
-#: lib/klass_hero_web/live/trust_safety_live.ex:72
+#: lib/klass_hero_web/live/trust_safety_live.ex:70
 #, elixir-autogen, elixir-format
 msgid "Uphold professional and ethical teaching practices"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:133
+#: lib/klass_hero_web/components/marketing_components.ex:1387
 #, elixir-autogen, elixir-format
 msgid "Vetted with Care"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/tier_presenter.ex:156
-#, elixir-autogen, elixir-format
-msgid "Video"
-msgstr ""
-
-#: lib/klass_hero_web/live/about_live.ex:59
-#: lib/klass_hero_web/live/trust_safety_live.ex:45
+#: lib/klass_hero_web/live/about_live.ex:63
+#: lib/klass_hero_web/live/trust_safety_live.ex:43
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:117
-#, elixir-autogen, elixir-format
-msgid "We believe that children thrive best in environments that are safe, respectful, and professionally led. That's why Klass Hero applies a multi-layered safety and verification framework before any provider can offer sessions on our platform."
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/subscription_live.ex:71
-#, elixir-autogen, elixir-format
-msgid "You are already on this plan"
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:55
-#, elixir-autogen, elixir-format
-msgid "forever"
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:56
-#: lib/klass_hero_web/presenters/tier_presenter.ex:57
-#, elixir-autogen, elixir-format
-msgid "month"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:532
+#: lib/klass_hero_web/live/home_live.ex:94
 #, elixir-autogen, elixir-format
 msgid "Every provider completes identity and age verification, experience validation, an extended background check, video screening, child safeguarding training, and agreement to our Community Guidelines before being approved."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:530
+#: lib/klass_hero_web/live/home_live.ex:91
 #, elixir-autogen, elixir-format
 msgid "How does the 6-step provider vetting process work?"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:210
+#: lib/klass_hero_web/live/about_live.ex:163
 #, elixir-autogen, elixir-format
 msgid "Our 6-Step Vetting Process"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:139
+#: lib/klass_hero_web/live/settings/children_live.ex:134
 #, elixir-autogen, elixir-format
 msgid "Could not check enrollments. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:613
+#: lib/klass_hero_web/live/settings/children_live.ex:592
 #, elixir-autogen, elixir-format
 msgid "Remove Child"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:567
+#: lib/klass_hero_web/live/settings/children_live.ex:546
 #, elixir-autogen, elixir-format
 msgid "Remove Child?"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:585
+#: lib/klass_hero_web/live/settings/children_live.ex:564
 #, elixir-autogen, elixir-format
 msgid "Their enrollments will be cancelled. This action cannot be undone."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:572
+#: lib/klass_hero_web/live/settings/children_live.ex:551
 #, elixir-autogen, elixir-format
 msgid "This child is currently enrolled in the following programs:"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:152
+#: lib/klass_hero_web/live/settings/children_live.ex:145
 #, elixir-autogen, elixir-format
 msgid "This deletion request has expired. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:669
-#, elixir-autogen, elixir-format
-msgid "1st cancellation (90 days): Warning only"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:670
-#, elixir-autogen, elixir-format
-msgid "2nd cancellation: €50 penalty"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:648
-#, elixir-autogen, elixir-format
-msgid "3-7 days before: Usually 75% refund (you keep 25%)"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:671
-#, elixir-autogen, elixir-format
-msgid "3rd cancellation: €100 penalty + 14-day suspension"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:672
-#, elixir-autogen, elixir-format
-msgid "4+ cancellations: Account termination"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:647
-#, elixir-autogen, elixir-format
-msgid "7+ days before: Usually full refund (you keep nothing)"
-msgstr ""
-
-#: lib/klass_hero_web/live/admin/sessions_live.ex:268
+#: lib/klass_hero_web/live/admin/sessions_live.ex:249
 #, elixir-autogen, elixir-format
 msgid "A reason is required for corrections"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:815
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:207
+#: lib/klass_hero_web/components/participation_components.ex:787
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:201
 #, elixir-autogen, elixir-format
 msgid "Absent"
 msgstr ""
@@ -4239,37 +3594,37 @@ msgstr ""
 msgid "Accounts"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:79
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "All Statuses"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:605
+#: lib/klass_hero_web/live/home_live.ex:150
 #, elixir-autogen, elixir-format
 msgid "All payments processed securely through Stripe."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:577
+#: lib/klass_hero_web/live/home_live.ex:127
 #, elixir-autogen, elixir-format
 msgid "All plans include: Profile page, booking system, payment processing, messaging, and marketing to Berlin families."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:280
+#: lib/klass_hero_web/live/admin/sessions_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "An error occurred"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:601
+#: lib/klass_hero_web/live/home_live.ex:146
 #, elixir-autogen, elixir-format
 msgid "Apple Pay / Google Pay"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:189
+#: lib/klass_hero_web/live/admin/sessions_live.ex:177
 #, elixir-autogen, elixir-format
 msgid "Attendance corrected successfully"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:623
+#: lib/klass_hero_web/live/home_live.ex:168
 #, elixir-autogen, elixir-format
 msgid "Automatic fee calculation (no surprises)"
 msgstr ""
@@ -4279,7 +3634,7 @@ msgstr ""
 msgid "Back to App"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:132
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:127
 #, elixir-autogen, elixir-format
 msgid "Back to sessions"
 msgstr ""
@@ -4289,255 +3644,175 @@ msgstr ""
 msgid "Bookings"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:573
-#, elixir-autogen, elixir-format
-msgid "Business Account: You keep €901 (€60 commission + €39 monthly fee)"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:563
-#, elixir-autogen, elixir-format
-msgid "Business Account: €39/month + 6% per booking (for providers/teams earning €600+/month)"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:546
+#: lib/klass_hero_web/live/home_live.ex:108
 #, elixir-autogen, elixir-format
 msgid "Camps and holiday programs"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:765
+#: lib/klass_hero_web/live/home_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "Can I buy a gift voucher?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:719
+#: lib/klass_hero_web/live/home_live.ex:191
 #, elixir-autogen, elixir-format
 msgid "Can I change my booking date?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:739
-#, elixir-autogen, elixir-format
-msgid "Can I get a refund if the provider cancels?"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:540
+#: lib/klass_hero_web/live/home_live.ex:102
 #, elixir-autogen, elixir-format
 msgid "Can I list my programs on Klass Hero and what does it cost?"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:274
+#: lib/klass_hero_web/live/admin/sessions_live.ex:255
 #, elixir-autogen, elixir-format
 msgid "Cannot check out without a check-in"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:654
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:96
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:703
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:159
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:153
 #, elixir-autogen, elixir-format
 msgid "Check-in"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:211
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "Check-in time"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:160
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:154
 #, elixir-autogen, elixir-format
 msgid "Check-out"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:220
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:214
 #, elixir-autogen, elixir-format
 msgid "Check-out time"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:297
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:205
+#: lib/klass_hero_web/live/admin/sessions_live.ex:276
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "Checked In"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:298
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:206
+#: lib/klass_hero_web/live/admin/sessions_live.ex:277
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:200
 #, elixir-autogen, elixir-format
 msgid "Checked Out"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2076
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:157
+#: lib/klass_hero_web/components/provider_components.ex:2022
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Child"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:638
-#, elixir-autogen, elixir-format
-msgid "Clear policies protect everyone."
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:767
+#: lib/klass_hero_web/live/home_live.ex:215
 #, elixir-autogen, elixir-format
 msgid "Coming soon! Sign up for our newsletter to be notified when gift vouchers launch."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:812
+#: lib/klass_hero_web/components/participation_components.ex:784
 #, elixir-autogen, elixir-format
 msgid "Completed"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:658
-#, elixir-autogen, elixir-format
-msgid "Contact all booked parents immediately and offer alternative dates. Include us in CC/BCC (support@mail.klasshero.com)."
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:721
+#: lib/klass_hero_web/live/home_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "Contact the provider directly (details in confirmation email). Most providers are flexible if you ask in advance."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:641
-#, elixir-autogen, elixir-format
-msgid "Contact them immediately - often you can find an alternative date. Include us in CC/BCC (support@mail.klasshero.com) so we're informed."
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:747
-#, elixir-autogen, elixir-format
-msgid "Contact us immediately at support@mail.klasshero.com or call +49 (0) 152 2426 0416. You'll receive 100% refund + family credit, and the provider faces serious penalties."
-msgstr ""
-
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:184
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:178
 #, elixir-autogen, elixir-format
 msgid "Correct"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:177
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:651
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:124
+#: lib/klass_hero_web/live/dashboard_live.ex:280
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:700
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Could not start conversation. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:600
+#: lib/klass_hero_web/live/home_live.ex:145
 #, elixir-autogen, elixir-format
 msgid "Credit/debit card (Visa, Mastercard, Amex)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:757
+#: lib/klass_hero_web/live/home_live.ex:209
 #, elixir-autogen, elixir-format
 msgid "Currently serving Berlin, with expansion to other German cities coming soon."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:677
-#, elixir-autogen, elixir-format
-msgid "Death in family"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:709
+#: lib/klass_hero_web/live/home_live.ex:185
 #, elixir-autogen, elixir-format
 msgid "Do I need an account to book?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:630
+#: lib/klass_hero_web/live/home_live.ex:175
 #, elixir-autogen, elixir-format
 msgid "Download monthly statements for taxes"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:731
-#, elixir-autogen, elixir-format
-msgid "Email the provider and us (support@mail.klasshero.com) immediately. You may qualify for full refund."
-msgstr ""
-
-#: lib/klass_hero_web/components/provider_components.ex:1841
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:328
+#: lib/klass_hero_web/components/provider_components.ex:1792
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "Enrollment not confirmed"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:568
-#, elixir-autogen, elixir-format
-msgid "Example: If you earn €1,000 in bookings"
-msgstr ""
-
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:237
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:231
 #, elixir-autogen, elixir-format
 msgid "Explain why this correction is needed..."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:628
+#: lib/klass_hero_web/live/home_live.ex:173
 #, elixir-autogen, elixir-format
 msgid "Export participant lists anytime"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:595
+#: lib/klass_hero_web/live/home_live.ex:140
 #, elixir-autogen, elixir-format
 msgid "Funds are immediately available in your Klass Hero account"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:679
-#, elixir-autogen, elixir-format
-msgid "Government closure"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:606
+#: lib/klass_hero_web/live/home_live.ex:151
 #, elixir-autogen, elixir-format
 msgid "How You Get Paid:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:585
+#: lib/klass_hero_web/live/home_live.ex:133
 #, elixir-autogen, elixir-format
 msgid "How does the booking system work?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:639
-#, elixir-autogen, elixir-format
-msgid "If Parent Cancels:"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:656
-#, elixir-autogen, elixir-format
-msgid "If You Must Cancel:"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:683
-#, elixir-autogen, elixir-format
-msgid "If you fail to show up without prior notice:"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:685
-#, elixir-autogen, elixir-format
-msgid "Immediate account suspension"
-msgstr ""
-
-#: lib/klass_hero_web/components/participation_components.ex:811
-#: lib/klass_hero_web/live/admin/sessions_live.ex:296
+#: lib/klass_hero_web/components/participation_components.ex:783
+#: lib/klass_hero_web/live/admin/sessions_live.ex:275
 #, elixir-autogen, elixir-format
 msgid "In Progress"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:609
+#: lib/klass_hero_web/live/home_live.ex:154
 #, elixir-autogen, elixir-format
 msgid "Instant availability: Funds are in your Klass Hero balance immediately after booking"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:699
+#: lib/klass_hero_web/live/home_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "Is Klass Hero free for parents to use?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:691
-#, elixir-autogen, elixir-format
-msgid "Keep your reliability high - parents can see your cancellation rate on your profile."
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:603
+#: lib/klass_hero_web/live/home_live.ex:148
 #, elixir-autogen, elixir-format
 msgid "Klarna (pay later options)"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:592
+#: lib/klass_hero_web/components/composite_components.ex:452
 #: lib/klass_hero_web/components/layouts/admin.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Klass Hero"
@@ -4548,191 +3823,132 @@ msgstr ""
 msgid "Klass Hero Admin"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:649
-#, elixir-autogen, elixir-format
-msgid "Less than 3 days: Usually 25-50% refund (you keep 50-75%)"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:676
-#, elixir-autogen, elixir-format
-msgid "Medical emergency"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:680
-#, elixir-autogen, elixir-format
-msgid "Minimum enrollment not met (camps only - notify 14 days before)"
-msgstr ""
-
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:203
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:197
 #, elixir-autogen, elixir-format
 msgid "No change"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:269
+#: lib/klass_hero_web/live/admin/sessions_live.ex:250
 #, elixir-autogen, elixir-format
 msgid "No changes detected"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:621
+#: lib/klass_hero_web/live/home_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "No chasing payments or sending invoices"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1588
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:248
+#: lib/klass_hero_web/components/provider_components.ex:1546
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:407
 #, elixir-autogen, elixir-format
 msgid "No enrolled parents"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:674
-#, elixir-autogen, elixir-format
-msgid "No penalties for legitimate reasons:"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:622
+#: lib/klass_hero_web/live/home_live.ex:167
 #, elixir-autogen, elixir-format
 msgid "No risk of non-payment"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:836
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:161
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:178
+#: lib/klass_hero_web/components/participation_components.ex:806
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:155
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "Notes"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:614
+#: lib/klass_hero_web/live/home_live.ex:159
 #, elixir-autogen, elixir-format
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1840
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:327
+#: lib/klass_hero_web/components/provider_components.ex:1791
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:590
+#: lib/klass_hero_web/live/home_live.ex:137
 #, elixir-autogen, elixir-format
 msgid "Parent books and pays through Klass Hero (via Stripe)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:687
-#, elixir-autogen, elixir-format
-msgid "Parent gets 100% refund + family credit"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:594
+#: lib/klass_hero_web/live/home_live.ex:139
 #, elixir-autogen, elixir-format
 msgid "Parent receives confirmation with your contact details"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:620
+#: lib/klass_hero_web/live/home_live.ex:165
 #, elixir-autogen, elixir-format
 msgid "Parents pay upfront when booking (reduces no-shows by 85%)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:598
+#: lib/klass_hero_web/live/home_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "Payment Options for Parents:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:688
-#, elixir-autogen, elixir-format
-msgid "Permanent ban if no valid emergency"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:615
+#: lib/klass_hero_web/live/home_live.ex:160
 #, elixir-autogen, elixir-format
 msgid "Platform fee automatically deducted when parent pays"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:550
+#: lib/klass_hero_web/live/home_live.ex:112
 #, elixir-autogen, elixir-format
 msgid "Pricing:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:548
+#: lib/klass_hero_web/live/home_live.ex:110
 #, elixir-autogen, elixir-format
 msgid "Private lessons and tutoring"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:558
-#, elixir-autogen, elixir-format
-msgid "Professional: More tools and opportunities for €9/month + 12% per booking (only when you get bookings)"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:571
-#, elixir-autogen, elixir-format
-msgid "Professional: You keep €871 (€120 commission + €9 monthly fee)"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:667
-#, elixir-autogen, elixir-format
-msgid "Provider Cancellation Penalties:"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:682
-#, elixir-autogen, elixir-format
-msgid "Provider No-Show:"
-msgstr ""
-
 #: lib/klass_hero_web/components/layouts/admin.html.heex:31
+#: lib/klass_hero_web/components/marketing_components.ex:810
 #, elixir-autogen, elixir-format
 msgid "Providers"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:627
+#: lib/klass_hero_web/live/home_live.ex:172
 #, elixir-autogen, elixir-format
 msgid "Real-time dashboard shows all bookings and available balance"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:231
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:225
 #, elixir-autogen, elixir-format
 msgid "Reason for correction"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:272
+#: lib/klass_hero_web/live/admin/sessions_live.ex:253
 #, elixir-autogen, elixir-format
 msgid "Record was modified by someone else. Please refresh."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:645
-#, elixir-autogen, elixir-format
-msgid "Refunds are automatic based on our cancellation policy:"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:545
+#: lib/klass_hero_web/live/home_live.ex:107
 #, elixir-autogen, elixir-format
 msgid "Regular classes and courses (weekly/monthly)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:602
+#: lib/klass_hero_web/live/home_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "SEPA direct debit"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:250
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:244
 #, elixir-autogen, elixir-format
 msgid "Save Correction"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:810
+#: lib/klass_hero_web/components/participation_components.ex:782
 #, elixir-autogen, elixir-format
 msgid "Scheduled"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:629
+#: lib/klass_hero_web/live/home_live.ex:174
 #, elixir-autogen, elixir-format
 msgid "See payment history and upcoming payouts"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:678
-#, elixir-autogen, elixir-format
-msgid "Severe weather"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:587
+#: lib/klass_hero_web/live/home_live.ex:134
 #, elixir-autogen, elixir-format
 msgid "Simple and automated - we handle everything."
 msgstr ""
@@ -4742,134 +3958,88 @@ msgstr ""
 msgid "Staff Members"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:553
-#, elixir-autogen, elixir-format
-msgid "Starter: Free to join — no registration fees, no monthly subscriptions. 20% commission per booking"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:570
-#, elixir-autogen, elixir-format
-msgid "Starter: You keep €800 (€200 commission)"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:652
-#, elixir-autogen, elixir-format
-msgid "Stripe processes all refunds - funds returned to parent's original payment method within 5-10 business days. Any amounts you keep remain in your balance."
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:625
+#: lib/klass_hero_web/live/home_live.ex:170
 #, elixir-autogen, elixir-format
 msgid "Track Everything:"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1836
-#, elixir-autogen, elixir-format
-msgid "Upgrade to Professional to message parents"
-msgstr ""
-
-#: lib/klass_hero_web/live/dashboard_live.ex:164
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:648
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:93
+#: lib/klass_hero_web/live/dashboard_live.ex:267
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:144
 #, elixir-autogen, elixir-format
 msgid "Upgrade your plan to send messages."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:613
+#: lib/klass_hero_web/live/home_live.ex:158
 #, elixir-autogen, elixir-format
 msgid "Weekly payouts: Transferred to your bank account every Friday"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:543
+#: lib/klass_hero_web/live/home_live.ex:105
 #, elixir-autogen, elixir-format
 msgid "What You Can List:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:636
-#, elixir-autogen, elixir-format
-msgid "What happens if a parent cancels or I need to cancel?"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:729
+#: lib/klass_hero_web/live/home_live.ex:199
 #, elixir-autogen, elixir-format
 msgid "What if my child gets sick?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:745
-#, elixir-autogen, elixir-format
-msgid "What if the provider doesn't show up?"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:588
+#: lib/klass_hero_web/live/home_live.ex:135
 #, elixir-autogen, elixir-format
 msgid "When Someone Books:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:663
-#, elixir-autogen, elixir-format
-msgid "When you cancel, parents get 100% refund automatically. The amount is deducted from your next payout."
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:755
+#: lib/klass_hero_web/live/home_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Where is Klass Hero available?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:617
+#: lib/klass_hero_web/live/home_live.ex:162
 #, elixir-autogen, elixir-format
 msgid "Why This Works Better:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:547
+#: lib/klass_hero_web/live/home_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "Workshops and one-time events"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:701
+#: lib/klass_hero_web/live/home_live.ex:181
 #, elixir-autogen, elixir-format
 msgid "Yes! Browsing and booking are completely free. No subscription, no booking fees."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:542
+#: lib/klass_hero_web/live/home_live.ex:104
 #, elixir-autogen, elixir-format
 msgid "Yes! Register for free and start listing immediately."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:740
-#, elixir-autogen, elixir-format
-msgid "Yes, always 100% refund if provider cancels. No exceptions."
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:711
+#: lib/klass_hero_web/live/home_live.ex:187
 #, elixir-autogen, elixir-format
 msgid "Yes, you need a free account to complete a booking and manage your reservations."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:596
+#: lib/klass_hero_web/live/home_live.ex:141
 #, elixir-autogen, elixir-format
 msgid "You deliver the program"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:619
+#: lib/klass_hero_web/live/home_live.ex:164
 #, elixir-autogen, elixir-format
 msgid "You get paid BEFORE delivering the program (no waiting)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:592
+#: lib/klass_hero_web/live/home_live.ex:138
 #, elixir-autogen, elixir-format
 msgid "You receive instant email with booking details and parent contact info"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:686
-#, elixir-autogen, elixir-format
-msgid "€200 penalty (deducted from balance or invoiced)"
-msgstr ""
-
-#: lib/klass_hero_web/components/participation_components.ex:78
+#: lib/klass_hero_web/components/participation_components.ex:73
 #, elixir-autogen, elixir-format
 msgid "%{checked_in} / %{capacity} checked in"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:322
+#: lib/klass_hero_web/components/participation_components.ex:311
 #, elixir-autogen, elixir-format
 msgid "%{checked_in} / %{total} checked in"
 msgstr ""
@@ -4879,154 +4049,149 @@ msgstr ""
 msgid "%{count} unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:356
+#: lib/klass_hero_web/live/provider/sessions_live.ex:366
 #, elixir-autogen, elixir-format
 msgid "A session already exists at this time"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:152
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:196
 #, elixir-autogen, elixir-format
 msgid "Account created! Check your email to confirm and log in."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:112
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:112
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:111
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:111
 #, elixir-autogen, elixir-format
 msgid "Add Note"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:129
-#: lib/klass_hero_web/components/layouts/app.html.heex:249
+#: lib/klass_hero_web/components/layouts/app.html.heex:120
+#: lib/klass_hero_web/components/layouts/app.html.heex:225
+#: lib/klass_hero_web/components/ui_components.ex:264
 #, elixir-autogen, elixir-format
 msgid "Admin"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:27
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:25
 #, elixir-autogen, elixir-format
 msgid "All programs"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:15
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "All providers"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:735
+#: lib/klass_hero_web/components/participation_components.ex:713
 #, elixir-autogen, elixir-format
 msgid "Allergies: %{details}"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:233
+#: lib/klass_hero_web/components/participation_components.ex:224
 #, elixir-autogen, elixir-format
 msgid "Any important notes about today's session..."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.html.heex:124
+#: lib/klass_hero_web/live/admin/emails_live.html.heex:122
 #, elixir-autogen, elixir-format
 msgid "Archive"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:215
+#: lib/klass_hero_web/live/admin/emails_live.ex:207
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:57
 #, elixir-autogen, elixir-format
 msgid "Archived"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:158
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:321
 #, elixir-autogen, elixir-format
 msgid "Assigned Programs"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:9
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:9
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:8
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Back to Sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.html.heex:107
+#: lib/klass_hero_web/live/admin/emails_live.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Back to emails"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:515
+#: lib/klass_hero_web/components/participation_components.ex:495
 #, elixir-autogen, elixir-format
 msgid "Behavioral Note"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:628
+#: lib/klass_hero_web/components/messaging_components.ex:688
 #, elixir-autogen, elixir-format
 msgid "Broadcast messages are one-way"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:91
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:91
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:92
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:92
 #, elixir-autogen, elixir-format
 msgid "Check In"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:276
+#: lib/klass_hero_web/live/admin/sessions_live.ex:257
 #, elixir-autogen, elixir-format
 msgid "Check-in time must be before check-out time"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:367
+#: lib/klass_hero_web/components/participation_components.ex:352
 #, elixir-autogen, elixir-format
 msgid "Check-in:"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:407
+#: lib/klass_hero_web/components/participation_components.ex:389
 #, elixir-autogen, elixir-format
 msgid "Check-out notes (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:373
+#: lib/klass_hero_web/components/participation_components.ex:358
 #, elixir-autogen, elixir-format
 msgid "Check-out:"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:217
+#: lib/klass_hero_web/components/participation_components.ex:209
 #, elixir-autogen, elixir-format
 msgid "Checked in at %{time}"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:174
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Checked in:"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:184
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:175
 #, elixir-autogen, elixir-format
 msgid "Checked out:"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/components/searchable_select.ex:86
+#: lib/klass_hero_web/live/admin/components/searchable_select.ex:80
 #, elixir-autogen, elixir-format
 msgid "Clear selection"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:76
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:202
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:83
 #, elixir-autogen, elixir-format
 msgid "Complete Registration"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:75
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:287
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:71
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:271
 #, elixir-autogen, elixir-format
 msgid "Complete Session"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:42
-#, elixir-autogen, elixir-format
-msgid "Complete Your Registration"
-msgstr ""
-
-#: lib/klass_hero_web/components/participation_components.ex:423
+#: lib/klass_hero_web/components/participation_components.ex:404
 #, elixir-autogen, elixir-format
 msgid "Confirm Check Out"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:103
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:98
 #, elixir-autogen, elixir-format
 msgid "Confirm Rejection"
 msgstr ""
@@ -5036,65 +4201,65 @@ msgstr ""
 msgid "Consents"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.html.heex:90
+#: lib/klass_hero_web/live/admin/emails_live.html.heex:88
 #, elixir-autogen, elixir-format
 msgid "Content fetch failed"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:125
+#: lib/klass_hero_web/live/admin/emails_live.ex:119
 #, elixir-autogen, elixir-format
 msgid "Content fetch retrying..."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.html.heex:144
+#: lib/klass_hero_web/live/admin/emails_live.html.heex:142
 #, elixir-autogen, elixir-format
 msgid "Content is being fetched..."
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:240
+#: lib/klass_hero_web/live/messaging_live_helper.ex:239
 #, elixir-autogen, elixir-format
 msgid "Could not start private conversation"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:17
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:135
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:200
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:18
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:130
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:195
 #, elixir-autogen, elixir-format
 msgid "Create Session"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:162
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:330
-#: lib/klass_hero_web/live/provider/sessions_live.ex:331
+#: lib/klass_hero_web/live/provider/sessions_live.ex:342
+#: lib/klass_hero_web/live/provider/sessions_live.ex:343
 #, elixir-autogen, elixir-format
 msgid "Date is required"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:408
+#: lib/klass_hero_web/components/participation_components.ex:390
 #, elixir-autogen, elixir-format
 msgid "E.g., picked up by parent, gave medication reminder..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:144
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:140
 #, elixir-autogen, elixir-format
 msgid "Edit & Resubmit"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:142
+#: lib/klass_hero_web/live/admin/emails_live.ex:136
 #, elixir-autogen, elixir-format
 msgid "Email archived"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:162
+#: lib/klass_hero_web/live/admin/emails_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "Email marked as unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:70
+#: lib/klass_hero_web/live/admin/emails_live.ex:66
 #, elixir-autogen, elixir-format
 msgid "Email not found"
 msgstr ""
@@ -5107,131 +4272,125 @@ msgstr ""
 msgid "Emails"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:747
+#: lib/klass_hero_web/components/participation_components.ex:725
 #, elixir-autogen, elixir-format
 msgid "Emergency: %{details}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:355
+#: lib/klass_hero_web/live/provider/sessions_live.ex:365
 #, elixir-autogen, elixir-format
 msgid "End time must be after start time"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:816
+#: lib/klass_hero_web/components/participation_components.ex:788
 #, elixir-autogen, elixir-format
 msgid "Expected"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:145
+#: lib/klass_hero_web/live/admin/emails_live.ex:139
 #, elixir-autogen, elixir-format
 msgid "Failed to archive email"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:290
+#: lib/klass_hero_web/live/provider/sessions_live.ex:302
 #, elixir-autogen, elixir-format
 msgid "Failed to create session: %{reason}"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.html.heex:148
+#: lib/klass_hero_web/live/admin/emails_live.html.heex:146
 #, elixir-autogen, elixir-format
 msgid "Failed to fetch email content."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:165
+#: lib/klass_hero_web/live/admin/emails_live.ex:159
 #, elixir-autogen, elixir-format
 msgid "Failed to mark email as unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:365
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:435
 #, elixir-autogen, elixir-format
 msgid "Failed to resend invitation. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:128
+#: lib/klass_hero_web/live/admin/emails_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "Failed to schedule retry"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:109
+#: lib/klass_hero_web/live/admin/emails_live.ex:103
 #, elixir-autogen, elixir-format
 msgid "Failed to send reply"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:39
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:36
 #, elixir-autogen, elixir-format
 msgid "From"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.html.heex:114
+#: lib/klass_hero_web/live/admin/emails_live.html.heex:112
 #, elixir-autogen, elixir-format
 msgid "From:"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:24
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:36
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:22
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:34
 #, elixir-autogen, elixir-format
 msgid "Go to Home"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:351
+#: lib/klass_hero_web/components/participation_components.ex:337
 #, elixir-autogen, elixir-format
 msgid "In: %{time}"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:18
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:17
 #, elixir-autogen, elixir-format
 msgid "Invalid Invitation"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:278
-#: lib/klass_hero_web/live/provider/sessions_live.ex:351
+#: lib/klass_hero_web/live/admin/sessions_live.ex:259
+#: lib/klass_hero_web/live/provider/sessions_live.ex:361
 #, elixir-autogen, elixir-format
 msgid "Invalid time format"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:30
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:81
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:27
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:107
 #, elixir-autogen, elixir-format
 msgid "Invitation Expired"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:79
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:105
 #, elixir-autogen, elixir-format
 msgid "Invitation Failed"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:77
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:103
 #, elixir-autogen, elixir-format
 msgid "Invitation Pending"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:78
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:104
 #, elixir-autogen, elixir-format
 msgid "Invitation Sent"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:346
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:416
 #, elixir-autogen, elixir-format
 msgid "Invitation resent successfully."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:80
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:106
 #, elixir-autogen, elixir-format
 msgid "Joined"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:15
-#: lib/klass_hero_web/components/layouts/app.html.heex:202
-#, elixir-autogen, elixir-format
-msgid "Klass Hero Logo"
-msgstr ""
-
-#: lib/klass_hero_web/live/admin/emails_live.html.heex:160
+#: lib/klass_hero_web/live/admin/emails_live.html.heex:158
 #, elixir-autogen, elixir-format
 msgid "Load images"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:71
+#: lib/klass_hero_web/components/participation_components.ex:66
 #, elixir-autogen, elixir-format
 msgid "Location TBD"
 msgstr ""
@@ -5241,432 +4400,431 @@ msgstr ""
 msgid "Manage your scheduled sessions and attendance"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.html.heex:132
+#: lib/klass_hero_web/live/admin/emails_live.html.heex:130
 #, elixir-autogen, elixir-format
 msgid "Mark Unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:181
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:176
 #, elixir-autogen, elixir-format
 msgid "Max Capacity"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:89
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:301
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:85
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:285
 #, elixir-autogen, elixir-format
 msgid "No actions available"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:454
+#: lib/klass_hero_web/components/participation_components.ex:434
 #, elixir-autogen, elixir-format
 msgid "No children enrolled in this session"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.html.heex:64
+#: lib/klass_hero_web/live/admin/emails_live.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "No emails found."
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:202
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "No participation records yet"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:162
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:325
 #, elixir-autogen, elixir-format
 msgid "No programs assigned yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/components/searchable_select.ex:113
+#: lib/klass_hero_web/live/admin/components/searchable_select.ex:107
 #, elixir-autogen, elixir-format
 msgid "No results"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:91
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "No sessions found for the selected filters."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:104
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:316
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:100
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:300
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:654
+#: lib/klass_hero_web/components/participation_components.ex:634
 #, elixir-autogen, elixir-format
 msgid "Note:"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:516
+#: lib/klass_hero_web/components/participation_components.ex:496
 #, elixir-autogen, elixir-format
 msgid "Observation about the child's participation..."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:357
+#: lib/klass_hero_web/components/participation_components.ex:343
 #, elixir-autogen, elixir-format
 msgid "Out: %{time}"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:179
+#: lib/klass_hero_web/components/participation_components.ex:172
 #, elixir-autogen, elixir-format
 msgid "Participation Check-In"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:25
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:25
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:26
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "Participation Management"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:17
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Pending Reviews"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:90
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Please explain why you're rejecting this note..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:358
+#: lib/klass_hero_web/live/provider/sessions_live.ex:368
 #, elixir-autogen, elixir-format
 msgid "Please fill in all required fields"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:571
+#: lib/klass_hero_web/components/composite_components.ex:431
 #, elixir-autogen, elixir-format
 msgid "Post"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:26
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:143
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:612
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:287
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:156
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:24
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:666
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:297
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:153
+#: lib/klass_hero_web/live/provider/sessions_live.ex:177
 #, elixir-autogen, elixir-format
 msgid "Program is required"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:14
+#: lib/klass_hero_web/components/provider_layout_components.ex:74
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:12
 #, elixir-autogen, elixir-format
 msgid "Provider"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:35
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:32
 #, elixir-autogen, elixir-format
 msgid "Provider observation"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:214
+#: lib/klass_hero_web/live/admin/emails_live.ex:206
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "Read"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:89
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "Reason for rejection (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.html.heex:201
+#: lib/klass_hero_web/live/admin/emails_live.html.heex:197
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:639
+#: lib/klass_hero_web/components/messaging_components.ex:699
 #, elixir-autogen, elixir-format
 msgid "Reply privately"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:247
+#: lib/klass_hero_web/live/messaging_live_helper.ex:246
 #, elixir-autogen, elixir-format
 msgid "Reply privately is only available for broadcast messages"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:106
+#: lib/klass_hero_web/live/admin/emails_live.ex:100
 #, elixir-autogen, elixir-format
 msgid "Reply sent successfully"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:566
+#: lib/klass_hero_web/components/provider_components.ex:529
 #, elixir-autogen, elixir-format
 msgid "Resend"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:65
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:62
 #, elixir-autogen, elixir-format
 msgid "Reset to today"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:547
+#: lib/klass_hero_web/components/participation_components.ex:527
 #, elixir-autogen, elixir-format
 msgid "Resubmit Note"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.html.heex:150
+#: lib/klass_hero_web/live/admin/emails_live.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "Retry"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:545
+#: lib/klass_hero_web/components/participation_components.ex:525
 #, elixir-autogen, elixir-format
 msgid "Revised Note"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:157
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:152
 #, elixir-autogen, elixir-format
 msgid "Select a program..."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.html.heex:211
+#: lib/klass_hero_web/live/admin/emails_live.html.heex:207
 #, elixir-autogen, elixir-format
 msgid "Send Reply"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:218
+#: lib/klass_hero_web/live/admin/emails_live.ex:210
 #, elixir-autogen, elixir-format
 msgid "Sending"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:58
+#: lib/klass_hero_web/components/participation_components.ex:54
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:16
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:16
 #, elixir-autogen, elixir-format
 msgid "Session"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:232
+#: lib/klass_hero_web/components/participation_components.ex:223
 #, elixir-autogen, elixir-format
 msgid "Session Notes (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:188
-#: lib/klass_hero_web/components/participation_components.ex:319
+#: lib/klass_hero_web/components/participation_components.ex:180
+#: lib/klass_hero_web/components/participation_components.ex:308
 #, elixir-autogen, elixir-format
 msgid "Session Roster"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:270
+#: lib/klass_hero_web/live/provider/sessions_live.ex:284
 #, elixir-autogen, elixir-format
 msgid "Session created successfully"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:27
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:30
 #, elixir-autogen, elixir-format
 msgid "Staff Dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1078
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1121
 #, elixir-autogen, elixir-format
 msgid "Staff member created, but the invitation could not be sent. Try resending from the team list."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:53
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:265
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:49
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:249
 #, elixir-autogen, elixir-format
 msgid "Start Session"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:517
+#: lib/klass_hero_web/components/participation_components.ex:497
 #, elixir-autogen, elixir-format
 msgid "Submit Note"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:248
+#: lib/klass_hero_web/components/participation_components.ex:238
 #, elixir-autogen, elixir-format
 msgid "Submit Participation"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:741
+#: lib/klass_hero_web/components/participation_components.ex:719
 #, elixir-autogen, elixir-format
 msgid "Support: %{details}"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:49
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:55
 #, elixir-autogen, elixir-format
 msgid "The business associated with your account could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:356
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "This invitation cannot be resent in its current state."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:32
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:29
 #, elixir-autogen, elixir-format
 msgid "This invitation has expired. Please ask your business to resend it."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:20
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:18
 #, elixir-autogen, elixir-format
 msgid "This invitation link is invalid or has already been used."
 msgstr ""
 
-#: lib/klass_hero_web/controllers/invite_claim_controller.ex:57
+#: lib/klass_hero_web/controllers/invite_claim_controller.ex:50
 #, elixir-autogen, elixir-format
 msgid "This invite has already been used."
 msgstr ""
 
-#: lib/klass_hero_web/controllers/invite_claim_controller.ex:52
+#: lib/klass_hero_web/controllers/invite_claim_controller.ex:45
 #, elixir-autogen, elixir-format
 msgid "This invite link is invalid or has expired."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:340
-#: lib/klass_hero_web/live/provider/sessions_live.ex:341
+#: lib/klass_hero_web/live/provider/sessions_live.ex:352
+#: lib/klass_hero_web/live/provider/sessions_live.ex:353
 #, elixir-autogen, elixir-format
 msgid "Time is required"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:51
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:48
 #, elixir-autogen, elixir-format
 msgid "To"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.html.heex:206
+#: lib/klass_hero_web/live/admin/emails_live.html.heex:202
 #, elixir-autogen, elixir-format
 msgid "Type your reply..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:160
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:72
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:95
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:124
+#: lib/klass_hero_web/live/provider/sessions_live.ex:181
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:123
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:93
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "Unauthorized"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:213
+#: lib/klass_hero_web/components/parent_components.ex:481
+#: lib/klass_hero_web/live/admin/emails_live.ex:205
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:35
 #, elixir-autogen, elixir-format
 msgid "Unread"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:546
+#: lib/klass_hero_web/components/participation_components.ex:526
 #, elixir-autogen, elixir-format
 msgid "Update your observation..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:460
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:744
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:526
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:782
 #, elixir-autogen, elixir-format
 msgid "Upload connection lost. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:86
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:298
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:82
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "View Participation"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:6
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "View your children's participation records"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:137
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:214
 #, elixir-autogen, elixir-format
 msgid "Welcome, %{name}"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:563
+#: lib/klass_hero_web/components/composite_components.ex:423
 #, elixir-autogen, elixir-format
 msgid "Write a comment..."
 msgstr ""
 
-#: lib/klass_hero_web/controllers/invite_claim_controller.ex:44
+#: lib/klass_hero_web/controllers/invite_claim_controller.ex:37
 #, elixir-autogen, elixir-format
 msgid "You already have an account. Log in to see your new enrollment."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:107
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:319
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:103
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:303
 #, elixir-autogen, elixir-format
 msgid "You have no sessions scheduled for %{date}"
 msgstr ""
 
-#: lib/klass_hero_web/user_auth.ex:299
+#: lib/klass_hero_web/user_auth.ex:268
 #, elixir-autogen, elixir-format
 msgid "You must be a staff member to access this page."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:44
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:43
 #, elixir-autogen, elixir-format
 msgid "You've been invited to join a team on Klass Hero."
 msgstr ""
 
-#: lib/klass_hero_web/controllers/invite_claim_controller.ex:32
+#: lib/klass_hero_web/controllers/invite_claim_controller.ex:29
 #, elixir-autogen, elixir-format
 msgid "Your account has been created! Set up your password in settings."
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:205
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:195
 #, elixir-autogen, elixir-format
 msgid "Your children's participation will appear here"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:200
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:363
 #, elixir-autogen, elixir-format
 msgid "Roster"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:393
-#, elixir-autogen, elixir-format
-msgid "Team Members"
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:158
+#: lib/klass_hero_web/live/for_providers_live.ex:417
 #, elixir-autogen, elixir-format
 msgid "Unlimited team seats"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:231
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:218
 #, elixir-autogen, elixir-format
 msgid "View and manage your assigned sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:70
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:332
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:60
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:218
 #, elixir-autogen, elixir-format
 msgid "You are not assigned to this program"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:233
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:240
 #, elixir-autogen, elixir-format
 msgid "+1234567890"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:852
+#: lib/klass_hero_web/components/composite_components.ex:692
 #, elixir-autogen, elixir-format
 msgid "About the Provider"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:250
+#: lib/klass_hero_web/components/marketing_components.ex:501
 #, elixir-autogen, elixir-format
 msgid "Built for the Berlin international community. Integrated secure encrypted messaging to connect with local families and trusted educators nearby."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:214
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:221
 #, elixir-autogen, elixir-format
 msgid "Business Name"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:817
+#: lib/klass_hero_web/components/participation_components.ex:789
 #, elixir-autogen, elixir-format
 msgid "Cancelled"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:253
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "Categories"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1273
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:318
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1407
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:325
 #, elixir-autogen, elixir-format
 msgid "Complete Profile"
 msgstr ""
@@ -5676,159 +4834,136 @@ msgstr ""
 msgid "Complete Your Profile"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:195
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:202
 #, elixir-autogen, elixir-format
 msgid "Complete Your Provider Profile"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1256
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1390
 #, elixir-autogen, elixir-format
 msgid "Complete your provider profile"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:294
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:301
 #, elixir-autogen, elixir-format
 msgid "Drag and drop or click to upload"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:504
+#: lib/klass_hero_web/live/messaging_live_helper.ex:481
 #, elixir-autogen, elixir-format
 msgid "Failed to upload files. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:689
+#: lib/klass_hero_web/components/messaging_components.ex:763
 #, elixir-autogen, elixir-format
 msgid "File is too large (max %{mb} MB)"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:502
+#: lib/klass_hero_web/live/messaging_live_helper.ex:479
 #, elixir-autogen, elixir-format
 msgid "File is too large (max %{mb} MB)."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:692
+#: lib/klass_hero_web/components/messaging_components.ex:766
 #, elixir-autogen, elixir-format
 msgid "File type not accepted (images only)"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1259
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1393
 #, elixir-autogen, elixir-format
 msgid "Fill in your business details so parents can find you. Your profile will be reviewed by Klass Hero before going live."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:198
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:205
 #, elixir-autogen, elixir-format
 msgid "Fill in your business details. Your profile will be reviewed by Klass Hero before going live."
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:152
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:263
 #, elixir-autogen, elixir-format
 msgid "Manage your business"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:499
+#: lib/klass_hero_web/live/messaging_live_helper.ex:476
 #, elixir-autogen, elixir-format
 msgid "Only images are accepted (JPG, PNG, GIF, WebP)."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:677
-#: lib/klass_hero_web/components/messaging_components.ex:681
+#: lib/klass_hero_web/components/messaging_components.ex:751
+#: lib/klass_hero_web/components/messaging_components.ex:755
 #, elixir-autogen, elixir-format
 msgid "Photo"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:494
+#: lib/klass_hero_web/live/messaging_live_helper.ex:471
 #, elixir-autogen, elixir-format
 msgid "Please enter a message or attach a photo."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:91
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:95
 #, elixir-autogen, elixir-format
 msgid "Profile completed! Klass Hero will review your profile shortly."
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:36
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:31
 #, elixir-autogen, elixir-format
 msgid "Provider not found"
 msgstr ""
 
 #: lib/klass_hero_web/components/messaging_components.ex:276
+#: lib/klass_hero_web/components/messaging_components.ex:344
 #, elixir-autogen, elixir-format
 msgid "Remove attachment"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1422
-#, elixir-autogen, elixir-format
-msgid "Sessions Completed"
-msgstr ""
-
-#: lib/klass_hero_web/live/messaging_live_helper.ex:505
+#: lib/klass_hero_web/live/messaging_live_helper.ex:482
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:132
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:136
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:103
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:47
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:88
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:107
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:223
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:230
 #, elixir-autogen, elixir-format
 msgid "Tell parents about your organization and what makes you unique..."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:696
+#: lib/klass_hero_web/components/messaging_components.ex:770
 #, elixir-autogen, elixir-format
 msgid "Too many files (max %{max})"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:497
+#: lib/klass_hero_web/live/messaging_live_helper.ex:474
 #, elixir-autogen, elixir-format
 msgid "Too many files (max %{max})."
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:323
-#, elixir-autogen, elixir-format
-msgid "Upgrade plan to message parents"
-msgstr ""
-
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:247
-#, elixir-autogen, elixir-format
-msgid "Upgrade plan to send broadcasts"
-msgstr ""
-
-#: lib/klass_hero_web/components/messaging_components.ex:700
+#: lib/klass_hero_web/components/messaging_components.ex:774
 #, elixir-autogen, elixir-format
 msgid "Upload error"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:699
+#: lib/klass_hero_web/components/messaging_components.ex:773
 #, elixir-autogen, elixir-format
 msgid "Upload failed"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1184
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1309
 #, elixir-autogen, elixir-format
 msgid "View your assignments"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:239
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "Website"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:435
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:957
-#, elixir-autogen, elixir-format
-msgid "You've reached your program limit. Upgrade your plan to add more programs."
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:248
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:255
 #, elixir-autogen, elixir-format
 msgid "Your business address"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:215
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:222
 #, elixir-autogen, elixir-format
 msgid "Your business or organization name"
 msgstr ""
@@ -5838,369 +4973,2071 @@ msgstr ""
 msgid "Your profile is already complete."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:89
-#: lib/klass_hero_web/live/messaging_live_helper.ex:338
+#: lib/klass_hero_web/components/messaging_components.ex:92
+#: lib/klass_hero_web/live/messaging_live_helper.ex:327
 #, elixir-autogen, elixir-format
 msgid "for"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1711
+#: lib/klass_hero_web/components/provider_components.ex:1667
 #, elixir-autogen, elixir-format
 msgid "Assigned staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1713
+#: lib/klass_hero_web/components/provider_components.ex:1669
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1695
+#: lib/klass_hero_web/components/provider_components.ex:1651
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1712
+#: lib/klass_hero_web/components/provider_components.ex:1668
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1710
+#: lib/klass_hero_web/components/provider_components.ex:1666
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1704
+#: lib/klass_hero_web/components/provider_components.ex:1660
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1693
+#: lib/klass_hero_web/components/provider_components.ex:1649
 #, elixir-autogen, elixir-format
 msgid "Sessions — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1444
+#: lib/klass_hero_web/components/provider_components.ex:1396
 #, elixir-autogen, elixir-format
 msgid "View sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:800
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:873
 #, elixir-autogen, elixir-format
 msgid "Create a program before inviting participants."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:814
+#: lib/klass_hero_web/components/participation_components.ex:786
 #, elixir-autogen, elixir-format
 msgid "Departed"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:835
+#: lib/klass_hero_web/components/participation_components.ex:805
 #, elixir-autogen, elixir-format
 msgid "Departure notes"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:318
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:257
+#: lib/klass_hero_web/live/provider/participation_live.ex:225
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:167
 #, elixir-autogen, elixir-format
 msgid "Departure time is not a valid date and time"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:329
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:268
+#: lib/klass_hero_web/live/provider/participation_live.ex:236
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:178
 #, elixir-autogen, elixir-format
 msgid "Failed to update record"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2140
+#: lib/klass_hero_web/components/provider_components.ex:2086
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1863
+#: lib/klass_hero_web/components/provider_components.ex:1814
 #, elixir-autogen, elixir-format
 msgid "Invite mode"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1882
+#: lib/klass_hero_web/components/provider_components.ex:1833
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:796
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:869
 #, elixir-autogen, elixir-format
 msgid "Invite sent."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:600
+#: lib/klass_hero_web/components/participation_components.ex:580
 #, elixir-autogen, elixir-format
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2153
+#: lib/klass_hero_web/components/provider_components.ex:2099
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2159
+#: lib/klass_hero_web/components/provider_components.ex:2105
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:321
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:260
+#: lib/klass_hero_web/live/provider/participation_live.ex:228
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:170
 #, elixir-autogen, elixir-format
 msgid "Nothing to update"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2161
+#: lib/klass_hero_web/components/provider_components.ex:2107
 #, elixir-autogen, elixir-format
 msgid "Nut allergy"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2165
+#: lib/klass_hero_web/components/provider_components.ex:2111
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2170
+#: lib/klass_hero_web/components/provider_components.ex:2116
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:813
+#: lib/klass_hero_web/components/participation_components.ex:785
 #, elixir-autogen, elixir-format
 msgid "Present"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2097
+#: lib/klass_hero_web/components/provider_components.ex:2043
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:61
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:61
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:62
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:62
 #, elixir-autogen, elixir-format
 msgid "Record departure"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:597
+#: lib/klass_hero_web/components/participation_components.ex:577
 #, elixir-autogen, elixir-format
 msgid "Record departure time (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:309
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:248
+#: lib/klass_hero_web/live/provider/participation_live.ex:216
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:158
 #, elixir-autogen, elixir-format
 msgid "Record updated"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:614
+#: lib/klass_hero_web/components/participation_components.ex:594
 #, elixir-autogen, elixir-format
 msgid "Save changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2134
+#: lib/klass_hero_web/components/provider_components.ex:2080
 #, elixir-autogen, elixir-format
 msgid "School (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2144
+#: lib/klass_hero_web/components/provider_components.ex:2090
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2118
+#: lib/klass_hero_web/components/provider_components.ex:2064
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2187
+#: lib/klass_hero_web/components/provider_components.ex:2133
 #, elixir-autogen, elixir-format
 msgid "Send invite"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:589
+#: lib/klass_hero_web/components/participation_components.ex:569
 #, elixir-autogen, elixir-format
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1900
+#: lib/klass_hero_web/components/provider_components.ex:1851
 #, elixir-autogen, elixir-format
 msgid "Upload a list"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:807
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:880
 #, elixir-autogen, elixir-format
 msgid "An invite for this child and program already exists."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:227
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:237
 #, elixir-autogen, elixir-format
 msgid "Behavioral Issue"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:240
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:250
 #, elixir-autogen, elixir-format
 msgid "Critical"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:280
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:290
 #, elixir-autogen, elixir-format
 msgid "Date & time"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:330
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:340
 #, elixir-autogen, elixir-format
 msgid "Drop a photo here or click to browse"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:239
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:249
 #, elixir-autogen, elixir-format
 msgid "High"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:726
+#: lib/klass_hero_web/components/provider_components.ex:692
 #, elixir-autogen, elixir-format
 msgid "Hourly"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:121
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:115
 #, elixir-autogen, elixir-format
 msgid "Incident report submitted."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:228
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:238
 #, elixir-autogen, elixir-format
 msgid "Injury"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:237
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:247
 #, elixir-autogen, elixir-format
 msgid "Low"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:238
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:248
 #, elixir-autogen, elixir-format
 msgid "Medium"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:716
+#: lib/klass_hero_web/components/provider_components.ex:682
 #, elixir-autogen, elixir-format
 msgid "None"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:705
+#: lib/klass_hero_web/components/provider_components.ex:671
 #, elixir-autogen, elixir-format
 msgid "Pay Rate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:537
+#: lib/klass_hero_web/components/provider_components.ex:500
 #, elixir-autogen, elixir-format
 msgid "Pay rate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:736
+#: lib/klass_hero_web/components/provider_components.ex:702
 #, elixir-autogen, elixir-format
 msgid "Per Session"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:320
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:330
 #, elixir-autogen, elixir-format
 msgid "Photo (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:230
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:240
 #, elixir-autogen, elixir-format
 msgid "Policy Violation"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:64
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:63
 #, elixir-autogen, elixir-format
 msgid "Program or session not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:229
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:239
 #, elixir-autogen, elixir-format
 msgid "Property Damage"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1467
+#: lib/klass_hero_web/components/provider_components.ex:1419
 #, elixir-autogen, elixir-format
 msgid "Report Incident"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:47
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:258
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:45
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "Report an Incident"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:226
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:236
 #, elixir-autogen, elixir-format
 msgid "Safety Concern"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:298
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "Select a category"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:289
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "Select a program"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:305
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:315
 #, elixir-autogen, elixir-format
 msgid "Severity"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:264
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:274
 #, elixir-autogen, elixir-format
 msgid "Submit a report about an incident during a program or session. All fields are confidential."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:355
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:365
 #, elixir-autogen, elixir-format
 msgid "Submit report"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:144
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:221
 #, elixir-autogen, elixir-format
 msgid "Your pay rate"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:73
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:99
 #, elixir-autogen, elixir-format
 msgid "hour"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:74
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:100
 #, elixir-autogen, elixir-format
 msgid "session"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/greeting.ex
+#: lib/klass_hero_web/helpers/greeting.ex:53
 #, elixir-autogen, elixir-format
 msgid "Good morning"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/greeting.ex
+#: lib/klass_hero_web/helpers/greeting.ex:54
 #, elixir-autogen, elixir-format
 msgid "Good afternoon"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/greeting.ex
+#: lib/klass_hero_web/helpers/greeting.ex:55
 #, elixir-autogen, elixir-format
 msgid "Good evening"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex
+#: lib/klass_hero_web/live/dashboard_live.ex:60
 #, elixir-autogen, elixir-format
 msgid "Your week with the kids"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex
+#: lib/klass_hero_web/components/marketing_components.ex:91
+#: lib/klass_hero_web/components/marketing_components.ex:159
 #, elixir-autogen, elixir-format
 msgid "Go to dashboard"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:825
+#, elixir-autogen, elixir-format
+msgid "%{count} row could not be processed."
+msgid_plural "%{count} rows could not be processed."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/klass_hero_web/components/parent_components.ex:411
+#, elixir-autogen, elixir-format
+msgid "%{done} of %{goal} sessions attended"
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:195
+#, elixir-autogen, elixir-format
+msgid ", Max's brother, joined as CFO, bringing the financial rigour and strategic planning needed to navigate the German market and ensure long-term stability for every provider on the platform. To lead trust and quality,"
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:184
+#, elixir-autogen, elixir-format
+msgid ", a full-stack developer who shared a unique perspective. Both Shane and Max are partners of teachers who wanted to extend their expertise beyond the classroom — but without the time to manage the operational side on their own."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:958
+#, elixir-autogen, elixir-format
+msgid ", camps & classes for your child"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:345
+#, elixir-autogen, elixir-format
+msgid "18+, government-ID verified before listing."
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:93
+#, elixir-autogen, elixir-format
+msgid "A decade-plus coaching and running youth activity programs in Berlin. Built Prime Youth before founding Klass Hero."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:529
+#, elixir-autogen, elixir-format
+msgid "Accept"
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/settings.ex:15
+#: lib/klass_hero_web/live/user_live/settings.ex:17
+#, elixir-autogen, elixir-format
+msgid "Account"
+msgstr ""
+
+#: lib/klass_hero_web/components/parent_components.ex:89
+#, elixir-autogen, elixir-format
+msgid "Account settings"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1565
+#, elixir-autogen, elixir-format
+msgid "Across all programs"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:380
+#, elixir-autogen, elixir-format
+msgid "Active policy required to teach."
+msgstr ""
+
+#: lib/klass_hero_web/live/dashboard_live.ex:300
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1555
+#, elixir-autogen, elixir-format
+msgid "Active programs"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:93
+#, elixir-autogen, elixir-format
+msgid "Add 3+ photos to boost bookings by ~40%."
+msgstr ""
+
+#: lib/klass_hero_web/components/parent_components.ex:290
+#, elixir-autogen, elixir-format
+msgid "Add a child"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:321
+#, elixir-autogen, elixir-format
+msgid "Afterschool Adventures Await"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:344
+#, elixir-autogen, elixir-format
+msgid "Age & Identity"
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:20
+#, elixir-autogen, elixir-format
+msgid "All instructors are background-checked and verified."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:548
+#, elixir-autogen, elixir-format
+msgid "Are you an educator, coach, or artist?"
+msgstr ""
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:104
+#, elixir-autogen, elixir-format
+msgid "At Klass Hero, trust isn't a feature — it's the foundation of everything we do. We connect families, schools, and organizations with qualified, vetted, and safety-verified educators."
+msgstr ""
+
+#: lib/klass_hero_web/components/messaging_components.ex:294
+#, elixir-autogen, elixir-format
+msgid "Attach photo"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:68
+#, elixir-autogen, elixir-format
+msgid "Back to Programs"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:890
+#: lib/klass_hero_web/components/marketing_components.ex:900
+#, elixir-autogen, elixir-format
+msgid "Become a Hero"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:858
+#, elixir-autogen, elixir-format
+msgid "Become a Hero →"
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:314
+#, elixir-autogen, elixir-format
+msgid "Become a provider"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:303
+#, elixir-autogen, elixir-format
+msgid "Berlin parents come to Klass Hero looking for trusted programs. You focus on teaching — we handle the funnel."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:226
+#, elixir-autogen, elixir-format
+msgid "Berlin's #1 network for youth educators"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:240
+#, elixir-autogen, elixir-format
+msgid "Berlin's leading network for tutors, coaches, and camp providers — every one verified by our team."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:794
+#, elixir-autogen, elixir-format
+msgid "Berlin's network for trusted youth educators. Built by parents, for parents."
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:328
+#, elixir-autogen, elixir-format
+msgid "Better parent relationships"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:311
+#, elixir-autogen, elixir-format
+msgid "Bookings, rosters, schedules, attendance, parent comms — all in one place. No more spreadsheets."
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:111
+#, elixir-autogen, elixir-format
+msgid "Brings the financial rigour and strategic planning needed for the German market and long-term provider stability."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:803
+#: lib/klass_hero_web/components/marketing_components.ex:907
+#, elixir-autogen, elixir-format
+msgid "Browse Programs"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:868
+#: lib/klass_hero_web/components/marketing_components.ex:878
+#: lib/klass_hero_web/components/marketing_components.ex:888
+#: lib/klass_hero_web/components/marketing_components.ex:898
+#, elixir-autogen, elixir-format
+msgid "Browse Programs →"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:391
+#, elixir-autogen, elixir-format
+msgid "Build a listing in under 10 minutes. Schedule, capacity, photos, age range — done."
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:30
+#, elixir-autogen, elixir-format
+msgid "Building connections between families and local instructors."
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:171
+#, elixir-autogen, elixir-format
+msgid "Built by parents and educators for more learning opportunities."
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:144
+#, elixir-autogen, elixir-format
+msgid "Built for Berlin"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:74
+#, elixir-autogen, elixir-format
+msgid "Built for educators who want to teach, not run a business"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:323
+#, elixir-autogen, elixir-format
+msgid "Built-in trust"
+msgstr ""
+
+#: lib/klass_hero_web/live/home_live.ex:123
+#, elixir-autogen, elixir-format
+msgid "Business Plus: €49/month + 8% per booking. Unlimited programs and team seats"
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:109
+#, elixir-autogen, elixir-format
+msgid "CFO"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:455
+#, elixir-autogen, elixir-format
+msgid "Can I run programs at multiple locations?"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:279
+#, elixir-autogen, elixir-format
+msgid "Cancel anytime"
+msgstr ""
+
+#: lib/klass_hero_web/live/contact_live.ex:209
+#, elixir-autogen, elixir-format
+msgid "Check our FAQ — most questions are answered there."
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/settings.ex:37
+#, elixir-autogen, elixir-format
+msgid "Children"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:1245
+#, elixir-autogen, elixir-format
+msgid "Clear filters"
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/confirmation.ex:18
+#, elixir-autogen, elixir-format
+msgid "Click below to log in."
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:100
+#, elixir-autogen, elixir-format
+msgid "Co-founder & CTO"
+msgstr ""
+
+#: lib/klass_hero_web/components/parent_components.ex:143
+#: lib/klass_hero_web/components/parent_components.ex:322
+#: lib/klass_hero_web/components/provider_layout_components.ex:147
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1573
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1581
+#, elixir-autogen, elixir-format
+msgid "Coming soon"
+msgstr ""
+
+#: lib/klass_hero_web/components/parent_components.ex:414
+#, elixir-autogen, elixir-format
+msgid "Coming soon — track your family's weekly attendance."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/messages_live/index.ex:19
+#, elixir-autogen, elixir-format
+msgid "Comms"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:374
+#, elixir-autogen, elixir-format
+msgid "Community Standards"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:819
+#, elixir-autogen, elixir-format
+msgid "Company"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:397
+#, elixir-autogen, elixir-format
+msgid "Complete Hero verification. We handle background checks, references and screening."
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/confirmation.ex:11
+#, elixir-autogen, elixir-format
+msgid "Confirm"
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/confirmation.ex:20
+#, elixir-autogen, elixir-format
+msgid "Confirm your account to finish signing up."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:232
+#, elixir-autogen, elixir-format
+msgid "Connecting Families with"
+msgstr ""
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:165
+#, elixir-autogen, elixir-format
+msgid "Contact Us →"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1173
+#, elixir-autogen, elixir-format
+msgid "Could not add you to the team. Please try again."
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:226
+#, elixir-autogen, elixir-format
+msgid "Could not link your account. Please try again."
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:176
+#, elixir-autogen, elixir-format
+msgid "Could not set up your provider profile. Please try again."
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/registration.ex:14
+#, elixir-autogen, elixir-format
+msgid "Create your"
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/settings.ex:52
+#, elixir-autogen, elixir-format
+msgid "Data & privacy"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:521
+#, elixir-autogen, elixir-format
+msgid "Decline"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:370
+#, elixir-autogen, elixir-format
+msgid "Degrees, certs, and references reviewed."
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:418
+#, elixir-autogen, elixir-format
+msgid "Direct messaging and broadcasts"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:330
+#, elixir-autogen, elixir-format
+msgid "Direct messaging, broadcast announcements, incident reports. Keep parents informed, automatically."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:956
+#, elixir-autogen, elixir-format
+msgid "Discover"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:347
+#, elixir-autogen, elixir-format
+msgid "Earnings tracking is coming soon."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:337
+#, elixir-autogen, elixir-format
+msgid "Earnings trend"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:405
+#, elixir-autogen, elixir-format
+msgid "Edit program"
+msgstr ""
+
+#: lib/klass_hero_web/live/home_live.ex:201
+#, elixir-autogen, elixir-format
+msgid "Email the provider and us (support@mail.klasshero.com) as soon as you can — we'll help you and the provider work it out."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1561
+#, elixir-autogen, elixir-format
+msgid "Enrolled kids"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:281
+#, elixir-autogen, elixir-format
+msgid "Enrollment approved"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:289
+#, elixir-autogen, elixir-format
+msgid "Enrollment is not pending"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:293
+#, elixir-autogen, elixir-format
+msgid "Enrollment not found"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:355
+#, elixir-autogen, elixir-format
+msgid "Erweitertes Führungszeugnis (extended background check), refreshed annually."
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:141
+#, elixir-autogen, elixir-format
+msgid "Every Hero clears the same checks. Here's what that means."
+msgstr ""
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:118
+#, elixir-autogen, elixir-format
+msgid "Every Hero, carefully reviewed."
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:164
+#, elixir-autogen, elixir-format
+msgid "Every Hero. Every step."
+msgstr ""
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:130
+#, elixir-autogen, elixir-format
+msgid "Every educator and enrichment professional completes a 6-step verification process before being approved."
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:172
+#, elixir-autogen, elixir-format
+msgid "Every feature included. No subscription, no setup fees."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:472
+#, elixir-autogen, elixir-format
+msgid "Everything parents need, nothing they don't"
+msgstr ""
+
+#: lib/klass_hero_web/live/home_live.ex:88
+#, elixir-autogen, elixir-format
+msgid "Everything you need to know about Klass Hero."
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:354
+#, elixir-autogen, elixir-format
+msgid "Extended Police Check"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:676
+#: lib/klass_hero_web/live/for_providers_live.ex:213
+#, elixir-autogen, elixir-format
+msgid "FAQ"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:302
+#, elixir-autogen, elixir-format
+msgid "Failed to approve"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:801
+#, elixir-autogen, elixir-format
+msgid "Families"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:260
+#, elixir-autogen, elixir-format
+msgid "Find Programs"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:764
+#, elixir-autogen, elixir-format
+msgid "Footer mobile"
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:91
+#, elixir-autogen, elixir-format
+msgid "Founder & CEO"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:169
+#, elixir-autogen, elixir-format
+msgid "Free to join"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:275
+#, elixir-autogen, elixir-format
+msgid "Free to start"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:105
+#, elixir-autogen, elixir-format
+msgid "From listing to first payout in under a week"
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:102
+#, elixir-autogen, elixir-format
+msgid "Full-stack developer. Partner of a teacher who saw the gap between great educators and good infrastructure."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:580
+#, elixir-autogen, elixir-format
+msgid "Get Bookings"
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:211
+#, elixir-autogen, elixir-format
+msgid "Get Started Today →"
+msgstr ""
+
+#: lib/klass_hero_web/live/contact_live.ex:189
+#, elixir-autogen, elixir-format
+msgid "Get in touch"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:408
+#, elixir-autogen, elixir-format
+msgid "Get paid weekly"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:396
+#, elixir-autogen, elixir-format
+msgid "Get verified"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:1099
+#, elixir-autogen, elixir-format
+msgid "Grid"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:324
+#, elixir-autogen, elixir-format
+msgid "Hand-picked programs this week across Berlin."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:962
+#, elixir-autogen, elixir-format
+msgid "Hand-picked, vetted programs across Berlin — filter by category, age, or schedule."
+msgstr ""
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:154
+#, elixir-autogen, elixir-format
+msgid "Have questions?"
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:118
+#, elixir-autogen, elixir-format
+msgid "Head of Trust & Quality (joining)"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:814
+#: lib/klass_hero_web/components/marketing_components.ex:912
+#, elixir-autogen, elixir-format
+msgid "Help Center"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:441
+#, elixir-autogen, elixir-format
+msgid "How and when do I get paid?"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:804
+#, elixir-autogen, elixir-format
+msgid "How it Works"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:103
+#, elixir-autogen, elixir-format
+msgid "How it works"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:427
+#, elixir-autogen, elixir-format
+msgid "How much does Klass Hero cost?"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:434
+#, elixir-autogen, elixir-format
+msgid "How quickly can I start accepting bookings?"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:540
+#, elixir-autogen, elixir-format
+msgid "How to Grow Your Youth Program"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:870
+#, elixir-autogen, elixir-format
+msgid "How we vet providers"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1670
+#, elixir-autogen, elixir-format
+msgid "I'll be teaching"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:800
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:822
+#, elixir-autogen, elixir-format
+msgid "Imported %{count} family."
+msgid_plural "Imported %{count} families."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/klass_hero_web/live/about_live.ex:182
+#, elixir-autogen, elixir-format
+msgid "In 2025, Shane connected with his friend"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1428
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:42
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:73
+#, elixir-autogen, elixir-format
+msgid "Incident Reports"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:334
+#, elixir-autogen, elixir-format
+msgid "Insights that matter"
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:16
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:26
+#, elixir-autogen, elixir-format
+msgid "Invitation"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:450
+#, elixir-autogen, elixir-format
+msgid "It's the Hero standard: identity & age verification, experience validation, extended police background check (Erweitertes Führungszeugnis), video interview, child safeguarding training, and signing our community standards. See the Trust & Safety page for the full breakdown."
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:262
+#, elixir-autogen, elixir-format
+msgid "Join Berlin's growing network of trusted educators. Free to list. No setup fees."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:543
+#, elixir-autogen, elixir-format
+msgid "Join Berlin's trusted network of educators. We handle payments, scheduling, and discovery — you focus on teaching."
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:40
+#, elixir-autogen, elixir-format
+msgid "Join the"
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:38
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:268
+#, elixir-autogen, elixir-format
+msgid "Join the team"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:182
+#, elixir-autogen, elixir-format
+msgid "Joining Klass Hero costs nothing — unlimited programs, your whole team, all media, and direct parent messaging are included for everyone. A simple success-based fee on bookings made through the platform is coming; we'll share the details transparently before it launches."
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:429
+#, elixir-autogen, elixir-format
+msgid "Joining is free — every feature is included for all providers, with no subscription or setup fees. A success-based fee on bookings made through the platform is planned; we'll announce the details transparently before it launches."
+msgstr ""
+
+#: lib/klass_hero_web/components/parent_components.ex:261
+#, elixir-autogen, elixir-format
+msgid "Kid picker"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:48
+#, elixir-autogen, elixir-format
+msgid "Klass Hero is the operational backbone for Berlin's youth educators. We handle bookings, payments, and discovery — you focus on what you do best."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:338
+#, elixir-autogen, elixir-format
+msgid "Last 8 weeks"
+msgstr ""
+
+#: lib/klass_hero_web/presenters/hero_cards_presenter.ex:38
+#, elixir-autogen, elixir-format
+msgid "Lead Instructor"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:553
+#, elixir-autogen, elixir-format
+msgid "Learn How to Become a Hero →"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:860
+#, elixir-autogen, elixir-format
+msgid "Learn how vetting works"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:309
+#, elixir-autogen, elixir-format
+msgid "Less admin, more teaching"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:379
+#, elixir-autogen, elixir-format
+msgid "Liability Insurance"
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:113
+#, elixir-autogen, elixir-format
+msgid "Link my account"
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:103
+#, elixir-autogen, elixir-format
+msgid "Link this invitation to your account %{email}."
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:111
+#, elixir-autogen, elixir-format
+msgid "Linking..."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:1115
+#, elixir-autogen, elixir-format
+msgid "List"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:571
+#, elixir-autogen, elixir-format
+msgid "List Your Program"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:390
+#, elixir-autogen, elixir-format
+msgid "List your program"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:360
+#, elixir-autogen, elixir-format
+msgid "Live video screen with our safeguarding lead."
+msgstr ""
+
+#: lib/klass_hero_web/live/programs_live.ex:362
+#, elixir-autogen, elixir-format
+msgid "Load more programs"
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:52
+#, elixir-autogen, elixir-format
+msgid "Loading your invitation…"
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:92
+#, elixir-autogen, elixir-format
+msgid "Log in, then reopen this invitation to join the team."
+msgstr ""
+
+#: lib/klass_hero_web/components/ui_components.ex:207
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:129
+#, elixir-autogen, elixir-format
+msgid "Log out"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:867
+#, elixir-autogen, elixir-format
+msgid "Looking for programs for your child?"
+msgstr ""
+
+#: lib/klass_hero_web/live/contact_live.ex:206
+#, elixir-autogen, elixir-format
+msgid "Looking for quick answers?"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1597
+#, elixir-autogen, elixir-format
+msgid "Manage"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:44
+#, elixir-autogen, elixir-format
+msgid "Manage less."
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/settings.ex:20
+#, elixir-autogen, elixir-format
+msgid "Manage your account, preferences, and privacy in one place."
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:365
+#, elixir-autogen, elixir-format
+msgid "Mandatory child-protection course before going live."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:472
+#, elixir-autogen, elixir-format
+msgid "Mark absent"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:445
+#, elixir-autogen, elixir-format
+msgid "Mark all present"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:472
+#, elixir-autogen, elixir-format
+msgid "Mark present"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:350
+#, elixir-autogen, elixir-format
+msgid "Minimum one year working with children, validated."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:135
+#, elixir-autogen, elixir-format
+msgid "Mobile primary"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:342
+#, elixir-autogen, elixir-format
+msgid "Month"
+msgstr ""
+
+#: lib/klass_hero_web/components/parent_components.ex:577
+#, elixir-autogen, elixir-format
+msgid "Monthly booking usage"
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:120
+#, elixir-autogen, elixir-format
+msgid "Mother and child-safety specialist with 10+ years in quality assurance. Architecting our Safety-First Verification engine."
+msgstr ""
+
+#: lib/klass_hero_web/live/dashboard_live.ex:157
+#, elixir-autogen, elixir-format
+msgid "New conversation"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:226
+#, elixir-autogen, elixir-format
+msgid "New program"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:1126
+#, elixir-autogen, elixir-format
+msgid "Newest"
+msgstr ""
+
+#: lib/klass_hero_web/components/parent_components.ex:532
+#, elixir-autogen, elixir-format
+msgid "Next"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:283
+#, elixir-autogen, elixir-format
+msgid "No credit card required"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:352
+#, elixir-autogen, elixir-format
+msgid "No featured programs available right now. Check back soon."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:115
+#, elixir-autogen, elixir-format
+msgid "No incident reports yet"
+msgstr ""
+
+#: lib/klass_hero_web/components/parent_components.ex:456
+#, elixir-autogen, elixir-format
+msgid "No messages yet."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1631
+#, elixir-autogen, elixir-format
+msgid "No pending enrollments right now."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1616
+#, elixir-autogen, elixir-format
+msgid "No pending requests right now."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1601
+#, elixir-autogen, elixir-format
+msgid "No programs yet — add your first one from the Programs tab."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:449
+#, elixir-autogen, elixir-format
+msgid "No registered children for this session."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:809
+#, elixir-autogen, elixir-format
+msgid "No rows imported. %{count} row could not be processed."
+msgid_plural "No rows imported. %{count} rows could not be processed."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/klass_hero_web/live/dashboard_live.ex:340
+#, elixir-autogen, elixir-format
+msgid "No upcoming sessions in the next few weeks."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:284
+#, elixir-autogen, elixir-format
+msgid "Not allowed to approve this enrollment"
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:297
+#, elixir-autogen, elixir-format
+msgid "Not now"
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:303
+#, elixir-autogen, elixir-format
+msgid "Offer your own programs on Klass Hero — alongside your work for %{business}."
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:436
+#, elixir-autogen, elixir-format
+msgid "Once your listing is live and you've completed Hero verification (typically 3–5 business days), parents can book immediately. Most providers receive their first inquiry within the first week."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:1476
+#, elixir-autogen, elixir-format
+msgid "Ongoing Quality"
+msgstr ""
+
+#: lib/klass_hero_web/components/parent_components.ex:538
+#, elixir-autogen, elixir-format
+msgid "Open"
+msgstr ""
+
+#: lib/klass_hero_web/components/ui_components.ex:157
+#, elixir-autogen, elixir-format
+msgid "Open account menu"
+msgstr ""
+
+#: lib/klass_hero_web/components/parent_components.ex:452
+#, elixir-autogen, elixir-format
+msgid "Open inbox"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:110
+#, elixir-autogen, elixir-format
+msgid "Open menu"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:1366
+#, elixir-autogen, elixir-format
+msgid "Our Commitment"
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:130
+#, elixir-autogen, elixir-format
+msgid "Our Mission"
+msgstr ""
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:111
+#, elixir-autogen, elixir-format
+msgid "Our commitment to child safety"
+msgstr ""
+
+#: lib/klass_hero_web/components/parent_components.ex:105
+#, elixir-autogen, elixir-format
+msgid "Parent bottom navigation"
+msgstr ""
+
+#: lib/klass_hero_web/components/parent_components.ex:75
+#, elixir-autogen, elixir-format
+msgid "Parent navigation"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:456
+#, elixir-autogen, elixir-format
+msgid "Parent: %{name}"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:403
+#, elixir-autogen, elixir-format
+msgid "Parents discover you on Klass Hero. Approve manually or auto-accept — your call."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:582
+#, elixir-autogen, elixir-format
+msgid "Parents find you through Klass Hero. Approve or auto-accept bookings with secure messaging built in."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:17
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:17
+#, elixir-autogen, elixir-format
+msgid "Participation"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:359
+#, elixir-autogen, elixir-format
+msgid "Pedagogical Interview"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1610
+#, elixir-autogen, elixir-format
+msgid "Pending booking requests"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1625
+#, elixir-autogen, elixir-format
+msgid "Pending enrollments"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:315
+#, elixir-autogen, elixir-format
+msgid "Predictable income"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:1128
+#, elixir-autogen, elixir-format
+msgid "Price: high to low"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:1127
+#, elixir-autogen, elixir-format
+msgid "Price: low to high"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:813
+#: lib/klass_hero_web/live/for_providers_live.ex:167
+#, elixir-autogen, elixir-format
+msgid "Pricing"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:65
+#, elixir-autogen, elixir-format
+msgid "Primary"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:776
+#: lib/klass_hero_web/components/marketing_components.ex:823
+#: lib/klass_hero_web/live/privacy_policy_live.ex:238
+#, elixir-autogen, elixir-format
+msgid "Privacy"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:90
+#, elixir-autogen, elixir-format
+msgid "Pro tip"
+msgstr ""
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:87
+#, elixir-autogen, elixir-format
+msgid "Process"
+msgstr ""
+
+#: lib/klass_hero_web/live/home_live.ex:120
+#, elixir-autogen, elixir-format
+msgid "Professional: €19/month + 12% per booking. Up to 5 programs"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:101
+#, elixir-autogen, elixir-format
+msgid "Provider bottom navigation"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:77
+#, elixir-autogen, elixir-format
+msgid "Provider navigation"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:215
+#, elixir-autogen, elixir-format
+msgid "Provider questions, answered"
+msgstr ""
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:138
+#, elixir-autogen, elixir-format
+msgid "Quality & accountability — always on."
+msgstr ""
+
+#: lib/klass_hero_web/live/contact_live.ex:107
+#, elixir-autogen, elixir-format
+msgid "Questions about programs, bookings, or becoming a Hero — we read every message."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:679
+#, elixir-autogen, elixir-format
+msgid "Questions, answered."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1576
+#, elixir-autogen, elixir-format
+msgid "Rating"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:259
+#, elixir-autogen, elixir-format
+msgid "Ready to be a Hero?"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:877
+#: lib/klass_hero_web/components/marketing_components.ex:897
+#, elixir-autogen, elixir-format
+msgid "Ready to find your child's next adventure?"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:402
+#, elixir-autogen, elixir-format
+msgid "Receive bookings"
+msgstr ""
+
+#: lib/klass_hero_web/components/parent_components.ex:450
+#, elixir-autogen, elixir-format
+msgid "Recent messages"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:1125
+#: lib/klass_hero_web/components/marketing_components.ex:1137
+#, elixir-autogen, elixir-format
+msgid "Recommended"
+msgstr ""
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:91
+#, elixir-autogen, elixir-format
+msgid "Reporting"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:118
+#, elixir-autogen, elixir-format
+msgid "Reports filed for this program will appear here."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1568
+#, elixir-autogen, elixir-format
+msgid "Revenue (this week)"
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:165
+#, elixir-autogen, elixir-format
+msgid "Rigorous screening so families never wonder who's leading the room."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2172
+#, elixir-autogen, elixir-format
+msgid "Row %{row}"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2172
+#, elixir-autogen, elixir-format
+msgid "Row —"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1927
+#, elixir-autogen, elixir-format
+msgid "Rows with errors"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:364
+#, elixir-autogen, elixir-format
+msgid "Safeguarding Training"
+msgstr ""
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:101
+#, elixir-autogen, elixir-format
+msgid "Safety"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:982
+#, elixir-autogen, elixir-format
+msgid "Search programs, providers, neighborhoods..."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:255
+#, elixir-autogen, elixir-format
+msgid "Search: coding, football, art..."
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:409
+#, elixir-autogen, elixir-format
+msgid "Secure SEPA payouts every Monday. Invoices and VAT handled automatically."
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:419
+#, elixir-autogen, elixir-format
+msgid "Secure payments, invoicing, and VAT handling"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:591
+#, elixir-autogen, elixir-format
+msgid "Secure weekly payouts. Insights into your business and opportunities to expand your impact."
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/settings.ex:42
+#, elixir-autogen, elixir-format
+msgid "Security"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:57
+#, elixir-autogen, elixir-format
+msgid "See pricing"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:562
+#, elixir-autogen, elixir-format
+msgid "See provider plans"
+msgstr ""
+
+#: lib/klass_hero_web/live/contact_live.ex:163
+#, elixir-autogen, elixir-format
+msgid "Select a topic…"
+msgstr ""
+
+#: lib/klass_hero_web/live/contact_live.ex:181
+#, elixir-autogen, elixir-format
+msgid "Send Message →"
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/login.ex:65
+#, elixir-autogen, elixir-format
+msgid "Send magic link"
+msgstr ""
+
+#: lib/klass_hero_web/live/contact_live.ex:116
+#, elixir-autogen, elixir-format
+msgid "Send us a message"
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:286
+#, elixir-autogen, elixir-format
+msgid "Setting up..."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:95
+#: lib/klass_hero_web/components/marketing_components.ex:167
+#: lib/klass_hero_web/live/user_live/login.ex:12
+#, elixir-autogen, elixir-format
+msgid "Sign in"
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/login.ex:21
+#, elixir-autogen, elixir-format
+msgid "Sign in to continue. Don't have an account?"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:98
+#: lib/klass_hero_web/components/marketing_components.ex:172
+#: lib/klass_hero_web/live/user_live/registration.ex:12
+#, elixir-autogen, elixir-format
+msgid "Sign up"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:375
+#, elixir-autogen, elixir-format
+msgid "Signed agreement on conduct and quality bar."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:154
+#: lib/klass_hero_web/components/ui_components.ex:193
+#, elixir-autogen, elixir-format
+msgid "Signed in as"
+msgstr ""
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:128
+#, elixir-autogen, elixir-format
+msgid "Six checks. No shortcuts."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:1052
+#, elixir-autogen, elixir-format
+msgid "Sort:"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:812
+#, elixir-autogen, elixir-format
+msgid "Start Teaching"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:198
+#, elixir-autogen, elixir-format
+msgid "Start for free"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:54
+#: lib/klass_hero_web/live/for_providers_live.ex:266
+#, elixir-autogen, elixir-format
+msgid "Start teaching today"
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:269
+#, elixir-autogen, elixir-format
+msgid "Start your own business"
+msgstr ""
+
+#: lib/klass_hero_web/live/home_live.ex:115
+#, elixir-autogen, elixir-format
+msgid "Starter: Free to join — no registration fees, no monthly subscriptions. 18% commission per booking, up to 2 active programs"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:229
+#, elixir-autogen, elixir-format
+msgid "Still curious?"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:301
+#, elixir-autogen, elixir-format
+msgid "Stop chasing leads"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:98
+#, elixir-autogen, elixir-format
+msgid "Submitted by"
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:25
+#, elixir-autogen, elixir-format
+msgid "Supporting local programs and eco-conscious practices."
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:229
+#, elixir-autogen, elixir-format
+msgid "Switch business"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:240
+#, elixir-autogen, elixir-format
+msgid "Talk to our team →"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:880
+#: lib/klass_hero_web/live/about_live.ex:215
+#: lib/klass_hero_web/live/for_providers_live.ex:269
+#, elixir-autogen, elixir-format
+msgid "Talk to us"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:42
+#, elixir-autogen, elixir-format
+msgid "Teach more."
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:349
+#, elixir-autogen, elixir-format
+msgid "Teaching Experience"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:857
+#, elixir-autogen, elixir-format
+msgid "Teaching kids is your thing? Join as a Hero."
+msgstr ""
+
+#: lib/klass_hero_web/live/contact_live.ex:119
+#, elixir-autogen, elixir-format
+msgid "Tell us a bit about what you need — we'll route you to the right person."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:777
+#: lib/klass_hero_web/components/marketing_components.ex:824
+#: lib/klass_hero_web/live/terms_of_service_live.ex:259
+#, elixir-autogen, elixir-format
+msgid "Terms"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:420
+#, elixir-autogen, elixir-format
+msgid "The Klass Hero verified badge"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:324
+#, elixir-autogen, elixir-format
+msgid "The Klass Hero verified badge gets you more inquiries — parents trust vetted providers."
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:138
+#, elixir-autogen, elixir-format
+msgid "The bar to teach on Klass Hero"
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:119
+#, elixir-autogen, elixir-format
+msgid "This invitation is for %{invite}."
+msgstr ""
+
+#: lib/klass_hero_web/components/parent_components.ex:408
+#, elixir-autogen, elixir-format
+msgid "This week"
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:132
+#, elixir-autogen, elixir-format
+msgid "To modernize how Berlin"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:435
+#, elixir-autogen, elixir-format
+msgid "Today's check-ins"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:335
+#, elixir-autogen, elixir-format
+msgid "Track signups, retention, no-shows, and revenue. Identify what's working and double down."
+msgstr ""
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:100
+#, elixir-autogen, elixir-format
+msgid "Trust &"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:234
+#, elixir-autogen, elixir-format
+msgid "Trusted Heroes"
+msgstr ""
+
+#: lib/klass_hero_web/live/programs_live.ex:307
+#, elixir-autogen, elixir-format
+msgid "Try adjusting your search or filter criteria — there's plenty more in Berlin."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:512
+#, elixir-autogen, elixir-format
+msgid "Unknown parent"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:416
+#, elixir-autogen, elixir-format
+msgid "Unlimited programs and locations"
+msgstr ""
+
+#: lib/klass_hero_web/live/dashboard_live.ex:312
+#, elixir-autogen, elixir-format
+msgid "Unread messages"
+msgstr ""
+
+#: lib/klass_hero_web/live/dashboard_live.ex:331
+#, elixir-autogen, elixir-format
+msgid "Upcoming sessions"
+msgstr ""
+
+#: lib/klass_hero_web/live/dashboard_live.ex:306
+#, elixir-autogen, elixir-format
+msgid "Upcoming this week"
+msgstr ""
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:86
+#, elixir-autogen, elixir-format
+msgid "Vetted"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:1212
+#, elixir-autogen, elixir-format
+msgid "View"
+msgstr ""
+
+#: lib/klass_hero_web/live/dashboard_live.ex:336
+#, elixir-autogen, elixir-format
+msgid "View all"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:431
+#, elixir-autogen, elixir-format
+msgid "View →"
+msgstr ""
+
+#: lib/klass_hero_web/live/contact_live.ex:221
+#, elixir-autogen, elixir-format
+msgid "Visit FAQ →"
+msgstr ""
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:113
+#, elixir-autogen, elixir-format
+msgid "We believe children thrive best in environments that are safe, respectful, and professionally led. That's why Klass Hero applies a multi-layered safety and verification framework before any provider can offer sessions on our platform."
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:179
+#, elixir-autogen, elixir-format
+msgid "We earn when you earn"
+msgstr ""
+
+#: lib/klass_hero_web/live/contact_live.ex:178
+#, elixir-autogen, elixir-format
+msgid "We never share your details."
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:443
+#, elixir-autogen, elixir-format
+msgid "We use SEPA bank transfers, paid out every Monday for the previous week's completed sessions. You'll receive an automatic invoice for each payout, and VAT is handled per-booking."
+msgstr ""
+
+#: lib/klass_hero_web/live/contact_live.ex:103
+#, elixir-autogen, elixir-format
+msgid "We're here to"
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:137
+#, elixir-autogen, elixir-format
+msgid "We're parents, brothers, and partners of educators — building the infrastructure that helps every child learn and thrive."
+msgstr ""
+
+#: lib/klass_hero_web/live/contact_live.ex:132
+#, elixir-autogen, elixir-format
+msgid "We've got it — we'll be in touch."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:341
+#, elixir-autogen, elixir-format
+msgid "Week"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:317
+#, elixir-autogen, elixir-format
+msgid "Weekly SEPA payouts, automatic VAT handling, transparent fees. Plan your business around real numbers."
+msgstr ""
+
+#: lib/klass_hero_web/components/parent_components.ex:409
+#, elixir-autogen, elixir-format
+msgid "Weekly adventure goal"
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/confirmation.ex:13
+#: lib/klass_hero_web/live/user_live/login.ex:14
+#, elixir-autogen, elixir-format
+msgid "Welcome"
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:72
+#, elixir-autogen, elixir-format
+msgid "Welcome aboard! Let's set up your business profile."
+msgstr ""
+
+#: lib/klass_hero_web/live/contact_live.ex:171
+#, elixir-autogen, elixir-format
+msgid "What's on your mind?"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:448
+#, elixir-autogen, elixir-format
+msgid "What's the verification process like?"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:887
+#, elixir-autogen, elixir-format
+msgid "While you're here — explore programs."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:469
+#: lib/klass_hero_web/live/for_providers_live.ex:72
+#, elixir-autogen, elixir-format
+msgid "Why Klass Hero"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:343
+#, elixir-autogen, elixir-format
+msgid "Year"
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:288
+#, elixir-autogen, elixir-format
+msgid "Yes, become a provider"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:457
+#, elixir-autogen, elixir-format
+msgid "Yes. You can run unlimited programs, each with its own schedule and venue, and add as many team members as you need to delegate management across instructors."
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:80
+#, elixir-autogen, elixir-format
+msgid "You already have a provider profile."
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:89
+#, elixir-autogen, elixir-format
+msgid "You already have an account for %{email}."
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:274
+#, elixir-autogen, elixir-format
+msgid "You'll get your own provider profile to fill in, and your account will open on your business dashboard from now on. You stay on %{business}'s team."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1153
+#, elixir-autogen, elixir-format
+msgid "You're already on your team."
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:122
+#, elixir-autogen, elixir-format
+msgid "You're logged in as %{current}. Log into the matching account to accept."
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:167
+#, elixir-autogen, elixir-format
+msgid "You're no longer on that team."
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:213
+#, elixir-autogen, elixir-format
+msgid "You're now part of the team."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1201
+#, elixir-autogen, elixir-format
+msgid "You're on the team — you can now be assigned to programs."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1200
+#, elixir-autogen, elixir-format
+msgid "You're on the team, but the headshot upload failed."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1592
+#, elixir-autogen, elixir-format
+msgid "Your top programs"
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/registration.ex:15
+#, elixir-autogen, elixir-format
+msgid "account"
+msgstr ""
+
+#: lib/klass_hero_web/components/parent_components.ex:283
+#, elixir-autogen, elixir-format
+msgid "active"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:957
+#, elixir-autogen, elixir-format
+msgid "activities"
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/login.ex:15
+#, elixir-autogen, elixir-format
+msgid "back"
+msgstr ""
+
+#: lib/klass_hero_web/components/parent_components.ex:424
+#, elixir-autogen, elixir-format
+msgid "complete"
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:134
+#, elixir-autogen, elixir-format
+msgid "discover & engage with children's programs"
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:133
+#, elixir-autogen, elixir-format
+msgid "families"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:236
+#, elixir-autogen, elixir-format
+msgid "for Our Youth"
+msgstr ""
+
+#: lib/klass_hero_web/live/contact_live.ex:104
+#, elixir-autogen, elixir-format
+msgid "help"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:1040
+#, elixir-autogen, elixir-format
+msgid "in"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:1044
+#, elixir-autogen, elixir-format
+msgid "matching"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1612
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1627
+#, elixir-autogen, elixir-format
+msgid "pending"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:1038
+#, elixir-autogen, elixir-format
+msgid "program"
+msgid_plural "programs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/klass_hero_web/components/parent_components.ex:595
+#, elixir-autogen, elixir-format
+msgid "remaining"
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/settings.ex:18
+#, elixir-autogen, elixir-format
+msgid "settings"
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:177
+#, elixir-autogen, elixir-format
+msgid "spent over a decade as a coach and youth activity provider in Berlin, building Prime Youth — a community of providers, schools, and parents dedicated to giving children the best possible experiences. But one pattern kept emerging: the administrative burden of managing bookings, payments, and compliance was getting in everyone's way."
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:41
+#, elixir-autogen, elixir-format
+msgid "team"
+msgstr ""
+
+#: lib/klass_hero_web/components/parent_components.ex:426
+#, elixir-autogen, elixir-format
+msgid "to go"
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:199
+#, elixir-autogen, elixir-format
+msgid "— a mother with over a decade of experience in child safety and quality assurance — will join to architect our Safety-First Verification engine."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -12,1363 +12,1205 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: lib/klass_hero_web/components/layouts/app.html.heex:44
-#: lib/klass_hero_web/components/layouts/app.html.heex:210
+#: lib/klass_hero_web/components/layouts/app.html.heex:197
+#: lib/klass_hero_web/components/marketing_components.ex:193
+#: lib/klass_hero_web/components/marketing_components.ex:821
+#: lib/klass_hero_web/components/marketing_components.ex:910
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts.ex:39
-#: lib/klass_hero_web/components/layouts.ex:51
+#: lib/klass_hero_web/components/layouts.ex:34
+#: lib/klass_hero_web/components/layouts.ex:46
 #, elixir-autogen, elixir-format
 msgid "Attempting to reconnect"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:247
+#: lib/klass_hero_web/live/user_live/settings.ex:172
 #, elixir-autogen, elixir-format
 msgid "Choose your preferred language for the interface"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:608
+#: lib/klass_hero_web/components/composite_components.ex:468
 #: lib/klass_hero_web/components/layouts/app.html.heex:52
-#: lib/klass_hero_web/components/layouts/app.html.heex:211
+#: lib/klass_hero_web/components/layouts/app.html.heex:198
+#: lib/klass_hero_web/components/marketing_components.ex:194
+#: lib/klass_hero_web/components/marketing_components.ex:822
+#: lib/klass_hero_web/components/marketing_components.ex:911
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:113
-#: lib/klass_hero_web/components/layouts/app.html.heex:138
-#: lib/klass_hero_web/components/layouts/app.html.heex:217
-#: lib/klass_hero_web/components/layouts/app.html.heex:253
-#: lib/klass_hero_web/components/provider_components.ex:357
-#: lib/klass_hero_web/live/dashboard_live.ex:58
+#: lib/klass_hero_web/components/layouts/app.html.heex:104
+#: lib/klass_hero_web/components/layouts/app.html.heex:129
+#: lib/klass_hero_web/components/layouts/app.html.heex:204
+#: lib/klass_hero_web/components/layouts/app.html.heex:229
+#: lib/klass_hero_web/components/provider_components.ex:366
+#: lib/klass_hero_web/components/ui_components.ex:268
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:406
+#: lib/klass_hero_web/live/user_live/settings.ex:263
 #, elixir-autogen, elixir-format
 msgid "Download My Data"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:394
+#: lib/klass_hero_web/live/user_live/settings.ex:259
 #, elixir-autogen, elixir-format
 msgid "Download a copy of all your personal data"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:626
+#: lib/klass_hero_web/live/user_live/settings.ex:479
 #, elixir-autogen, elixir-format
 msgid "Failed to update language preference."
 msgstr ""
 
 #: lib/klass_hero_web/components/layouts/app.html.heex:28
-#: lib/klass_hero_web/components/layouts/app.html.heex:208
+#: lib/klass_hero_web/components/layouts/app.html.heex:195
+#: lib/klass_hero_web/components/marketing_components.ex:189
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:244
+#: lib/klass_hero_web/live/user_live/settings.ex:169
 #, elixir-autogen, elixir-format
 msgid "Language Preference"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:623
+#: lib/klass_hero_web/live/user_live/settings.ex:476
 #, elixir-autogen, elixir-format
 msgid "Language preference updated successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:167
-#: lib/klass_hero_web/components/layouts/app.html.heex:271
+#: lib/klass_hero_web/components/layouts/app.html.heex:158
+#: lib/klass_hero_web/components/layouts/app.html.heex:247
 #, elixir-autogen, elixir-format
 msgid "Login"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:602
-#: lib/klass_hero_web/components/composite_components.ex:619
+#: lib/klass_hero_web/components/composite_components.ex:462
+#: lib/klass_hero_web/components/composite_components.ex:484
 #: lib/klass_hero_web/components/layouts/app.html.heex:36
-#: lib/klass_hero_web/components/layouts/app.html.heex:209
+#: lib/klass_hero_web/components/layouts/app.html.heex:196
+#: lib/klass_hero_web/components/marketing_components.ex:190
 #, elixir-autogen, elixir-format
 msgid "Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:122
-#: lib/klass_hero_web/components/layouts/app.html.heex:245
+#: lib/klass_hero_web/components/layouts/app.html.heex:113
+#: lib/klass_hero_web/components/layouts/app.html.heex:221
+#: lib/klass_hero_web/components/ui_components.ex:197
 #: lib/klass_hero_web/live/settings_live.ex:17
-#: lib/klass_hero_web/live/settings_live.ex:56
+#: lib/klass_hero_web/live/settings_live.ex:51
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr ""
 
 #: lib/klass_hero_web/components/layouts/admin.html.heex:20
-#: lib/klass_hero_web/components/layouts/app.html.heex:159
-#: lib/klass_hero_web/components/layouts/app.html.heex:265
-#: lib/klass_hero_web/live/settings_live.ex:285
+#: lib/klass_hero_web/components/layouts/app.html.heex:150
+#: lib/klass_hero_web/components/layouts/app.html.heex:241
+#: lib/klass_hero_web/live/settings_live.ex:238
 #, elixir-autogen, elixir-format
 msgid "Sign Out"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:173
-#: lib/klass_hero_web/components/layouts/app.html.heex:279
+#: lib/klass_hero_web/components/layouts/app.html.heex:164
+#: lib/klass_hero_web/components/layouts/app.html.heex:255
 #, elixir-autogen, elixir-format
 msgid "Sign Up"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts.ex:46
+#: lib/klass_hero_web/components/layouts.ex:41
 #, elixir-autogen, elixir-format
 msgid "Something went wrong!"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts.ex:34
+#: lib/klass_hero_web/components/layouts.ex:29
 #, elixir-autogen, elixir-format
 msgid "We can't find the internet"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:391
+#: lib/klass_hero_web/live/user_live/settings.ex:257
 #, elixir-autogen, elixir-format
 msgid "Your Data"
 msgstr ""
 
-#: lib/klass_hero_web/components/core_components.ex:69
-#: lib/klass_hero_web/components/provider_components.ex:1595
+#: lib/klass_hero_web/components/core_components.ex:67
+#: lib/klass_hero_web/components/provider_components.ex:1553
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:442
+#: lib/klass_hero_web/live/booking_live.ex:416
 #, elixir-autogen, elixir-format
 msgid "%{name} (Age %{age})"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:392
+#: lib/klass_hero_web/live/program_detail_live.ex:365
 #, elixir-autogen, elixir-format
 msgid "About This Program"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:349
+#: lib/klass_hero_web/live/booking_live.ex:323
 #, elixir-autogen, elixir-format
 msgid "Activity Summary"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:455
+#: lib/klass_hero_web/live/booking_live.ex:429
 #, elixir-autogen, elixir-format
 msgid "Add another child"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:390
+#: lib/klass_hero_web/live/booking_live.ex:364
 #, elixir-autogen, elixir-format
 msgid "Add another program"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:231
+#: lib/klass_hero_web/live/program_detail_live.ex:210
 #, elixir-autogen, elixir-format
 msgid "Ages %{range}"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:528
+#: lib/klass_hero_web/live/booking_live.ex:502
 #, elixir-autogen, elixir-format
 msgid "An invoice will be emailed to you after enrollment completion"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:472
+#: lib/klass_hero_web/live/booking_live.ex:446
 #, elixir-autogen, elixir-format
 msgid "Any allergies, medical conditions, or special instructions..."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:240
+#: lib/klass_hero_web/components/marketing_components.ex:491
 #, elixir-autogen, elixir-format
 msgid "Book camps, tutors, and workshops instantly. Our integrated planner helps you manage your child's busy life."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:505
+#: lib/klass_hero_web/live/booking_live.ex:479
 #, elixir-autogen, elixir-format
 msgid "Cash / Bank Transfer"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:530
+#: lib/klass_hero_web/live/booking_live.ex:504
 #, elixir-autogen, elixir-format
 msgid "Cash/transfer payments will show as \"Pending\" until received"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:248
+#: lib/klass_hero_web/components/marketing_components.ex:499
 #, elixir-autogen, elixir-format
 msgid "Community Focused"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:547
+#: lib/klass_hero_web/live/booking_live.ex:521
 #, elixir-autogen, elixir-format
 msgid "Complete Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:496
+#: lib/klass_hero_web/live/booking_live.ex:470
 #, elixir-autogen, elixir-format
 msgid "Credit Card"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:529
+#: lib/klass_hero_web/live/booking_live.ex:503
 #, elixir-autogen, elixir-format
 msgid "Credit card payments are processed immediately"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:381
+#: lib/klass_hero_web/live/booking_live.ex:355
 #, elixir-autogen, elixir-format
 msgid "Duration:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:238
+#: lib/klass_hero_web/components/marketing_components.ex:489
 #, elixir-autogen, elixir-format
 msgid "Easy Scheduling"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:551
+#: lib/klass_hero_web/live/program_detail_live.ex:468
 #, elixir-autogen, elixir-format
 msgid "Enroll Now - %{price}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1386
-#: lib/klass_hero_web/live/booking_live.ex:344
+#: lib/klass_hero_web/components/provider_components.ex:1338
+#: lib/klass_hero_web/live/booking_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:41
+#: lib/klass_hero_web/live/booking_live.ex:37
 #, elixir-autogen, elixir-format
 msgid "Enrollment - %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:217
+#: lib/klass_hero_web/live/booking_live.ex:199
 #, elixir-autogen, elixir-format
 msgid "Enrollment failed. Please try again or contact support."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:148
+#: lib/klass_hero_web/live/booking_live.ex:130
 #, elixir-autogen, elixir-format
 msgid "Enrollment successful! You'll receive a confirmation email shortly."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:230
+#: lib/klass_hero_web/components/marketing_components.ex:481
 #, elixir-autogen, elixir-format
 msgid "Every provider is rigorously vetted. We prioritize child safety above all else, giving parents peace of mind."
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:33
-#: lib/klass_hero_web/live/programs_live.ex:241
+#: lib/klass_hero_web/components/marketing_components.ex:952
+#: lib/klass_hero_web/live/programs_live.ex:34
 #, elixir-autogen, elixir-format
 msgid "Explore Programs"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:168
-#, elixir-autogen, elixir-format
-msgid "Explore top-rated activities for your children"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:165
+#: lib/klass_hero_web/components/marketing_components.ex:318
 #, elixir-autogen, elixir-format
 msgid "Featured Programs"
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:192
+#: lib/klass_hero_web/live/programs_live.ex:220
 #, elixir-autogen, elixir-format
 msgid "Invalid pagination state. Please refresh the page."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:526
+#: lib/klass_hero_web/live/booking_live.ex:500
 #, elixir-autogen, elixir-format
 msgid "Invoice & Payment Confirmation"
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:318
-#, elixir-autogen, elixir-format
-msgid "Load More Programs"
-msgstr ""
-
-#: lib/klass_hero_web/live/programs_live.ex:315
+#: lib/klass_hero_web/live/programs_live.ex:360
 #, elixir-autogen, elixir-format
 msgid "Loading..."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:432
+#: lib/klass_hero_web/live/program_detail_live.ex:405
 #, elixir-autogen, elixir-format
 msgid "Meet the Hero"
 msgid_plural "Meet the Heroes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/live/programs_live.ex:328
+#: lib/klass_hero_web/live/programs_live.ex:305
 #, elixir-autogen, elixir-format
 msgid "No programs found"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:480
+#: lib/klass_hero_web/live/booking_live.ex:454
 #, elixir-autogen, elixir-format
 msgid "Optional: Include any important information we should know about your child."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:497
+#: lib/klass_hero_web/live/booking_live.ex:471
 #, elixir-autogen, elixir-format
 msgid "Pay securely with Visa, Mastercard, or other cards"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:491
+#: lib/klass_hero_web/live/booking_live.ex:465
 #, elixir-autogen, elixir-format
 msgid "Payment Method"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:515
+#: lib/klass_hero_web/live/booking_live.ex:489
 #, elixir-autogen, elixir-format
 msgid "Payment Summary"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:172
+#: lib/klass_hero_web/live/booking_live.ex:154
 #, elixir-autogen, elixir-format
 msgid "Payment information is invalid. Please check your details."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:176
+#: lib/klass_hero_web/live/booking_live.ex:158
 #, elixir-autogen, elixir-format
 msgid "Please select a child for enrollment."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:21
+#: lib/klass_hero_web/live/home_live.ex:20
 #, elixir-autogen, elixir-format
 msgid "Klass Hero - Connecting Families with Trusted Youth Educators"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:59
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:47
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:77
+#: lib/klass_hero_web/live/booking_live.ex:56
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:56
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:67
 #, elixir-autogen, elixir-format
 msgid "Program not found"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:74
+#: lib/klass_hero_web/live/program_detail_live.ex:72
 #, elixir-autogen, elixir-format
 msgid "Program not found. It may have been removed or is no longer available."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:147
-#: lib/klass_hero_web/live/home_live.ex:228
+#: lib/klass_hero_web/components/marketing_components.ex:479
+#: lib/klass_hero_web/live/about_live.ex:19
 #, elixir-autogen, elixir-format
 msgid "Safety First"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:215
-#, elixir-autogen, elixir-format
-msgid "Safety, quality, and convenience for modern families."
-msgstr ""
-
-#: lib/klass_hero_web/components/program_components.ex:35
-#: lib/klass_hero_web/live/programs_live.ex:246
+#: lib/klass_hero_web/components/program_components.ex:32
 #, elixir-autogen, elixir-format
 msgid "Search programs..."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:426
+#: lib/klass_hero_web/live/booking_live.ex:400
 #, elixir-autogen, elixir-format
 msgid "Select Child"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:436
+#: lib/klass_hero_web/live/booking_live.ex:410
 #, elixir-autogen, elixir-format
 msgid "Select a child"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:69
+#: lib/klass_hero_web/live/booking_live.ex:66
 #, elixir-autogen, elixir-format
 msgid "Sorry, this program is currently full. Check back later for availability."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:157
+#: lib/klass_hero_web/live/booking_live.ex:139
 #, elixir-autogen, elixir-format
 msgid "Sorry, this program is now full. Please choose another program."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:465
+#: lib/klass_hero_web/live/booking_live.ex:439
 #, elixir-autogen, elixir-format
 msgid "Special Requirements"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:374
+#: lib/klass_hero_web/live/booking_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "Total Price:"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:521
+#: lib/klass_hero_web/live/booking_live.ex:495
 #, elixir-autogen, elixir-format
 msgid "Total due today:"
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:329
-#, elixir-autogen, elixir-format
-msgid "Try adjusting your search or filter criteria."
-msgstr ""
-
-#: lib/klass_hero_web/live/booking_live.ex:84
-#: lib/klass_hero_web/live/program_detail_live.ex:81
-#, elixir-autogen, elixir-format
-msgid "Unable to load program. Please try again later."
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:198
+#: lib/klass_hero_web/components/marketing_components.ex:337
 #, elixir-autogen, elixir-format
 msgid "View All Programs →"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:212
-#, elixir-autogen, elixir-format
-msgid "Why Klass Hero?"
-msgstr ""
-
-#: lib/klass_hero_web/live/program_detail_live.ex:243
+#: lib/klass_hero_web/live/program_detail_live.ex:222
 #, elixir-autogen, elixir-format
 msgid "✓ No hidden fees"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:566
+#: lib/klass_hero_web/live/user_live/settings.ex:419
 #, elixir-autogen, elixir-format
 msgid "A link to confirm your email change has been sent to the new address."
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:605
+#: lib/klass_hero_web/components/composite_components.ex:465
 #: lib/klass_hero_web/live/about_live.ex:10
 #, elixir-autogen, elixir-format, fuzzy
 msgid "About Us"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:17
-#, elixir-autogen, elixir-format
-msgid "Account Settings"
-msgstr ""
-
-#: lib/klass_hero_web/live/terms_of_service_live.ex:212
+#: lib/klass_hero_web/live/terms_of_service_live.ex:204
 #, elixir-autogen, elixir-format
 msgid "Account Termination"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:81
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:247
+#: lib/klass_hero_web/live/contact_live.ex:79
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:254
 #, elixir-autogen, elixir-format
 msgid "Address"
 msgstr ""
 
-#: lib/klass_hero_web/live/terms_of_service_live.ex:23
+#: lib/klass_hero_web/live/terms_of_service_live.ex:27
 #, elixir-autogen, elixir-format
 msgid "Agreement to Terms"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/registration.ex:17
+#: lib/klass_hero_web/live/user_live/registration.ex:18
 #, elixir-autogen, elixir-format
 msgid "Already registered?"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/registration.ex:159
+#: lib/klass_hero_web/live/user_live/registration.ex:148
 #, elixir-autogen, elixir-format
 msgid "An email was sent to %{email}, please access it to confirm your account."
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:151
+#: lib/klass_hero_web/live/contact_live.ex:91
 #, elixir-autogen, elixir-format
 msgid "Booking Support"
 msgstr ""
 
-#: lib/klass_hero_web/live/terms_of_service_live.ex:104
+#: lib/klass_hero_web/live/terms_of_service_live.ex:108
 #, elixir-autogen, elixir-format
 msgid "Cancellation & Refund Policy"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:160
+#: lib/klass_hero_web/live/user_live/settings.ex:111
 #, elixir-autogen, elixir-format
 msgid "Change Email"
 msgstr ""
 
-#: lib/klass_hero_web/live/terms_of_service_live.ex:195
+#: lib/klass_hero_web/live/terms_of_service_live.ex:187
 #, elixir-autogen, elixir-format
 msgid "Changes to Terms"
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:201
+#: lib/klass_hero_web/live/privacy_policy_live.ex:205
 #, elixir-autogen, elixir-format
 msgid "Changes to This Policy"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:159
+#: lib/klass_hero_web/live/user_live/settings.ex:109
 #, elixir-autogen, elixir-format
 msgid "Changing..."
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:253
-#, elixir-autogen, elixir-format
-msgid "Check out our FAQ section for answers to common questions."
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/participation_live.ex:70
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:70
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:39
 #, elixir-autogen, elixir-format
 msgid "Child checked in successfully"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:133
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:133
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:72
 #, elixir-autogen, elixir-format
 msgid "Child checked out successfully"
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:149
+#: lib/klass_hero_web/live/privacy_policy_live.ex:153
 #, elixir-autogen, elixir-format
 msgid "Children's Privacy"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:100
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Closed"
-msgstr ""
-
-#: lib/klass_hero_web/live/about_live.ex:193
+#: lib/klass_hero_web/live/about_live.ex:29
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Community"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/confirmation.ex:37
+#: lib/klass_hero_web/live/user_live/confirmation.ex:57
 #, elixir-autogen, elixir-format
 msgid "Confirm and log in only this time"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/confirmation.ex:31
+#: lib/klass_hero_web/live/user_live/confirmation.ex:48
 #, elixir-autogen, elixir-format
 msgid "Confirm and stay logged in"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:199
+#: lib/klass_hero_web/live/user_live/settings.ex:147
 #, elixir-autogen, elixir-format
 msgid "Confirm new password"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/confirmation.ex:28
-#: lib/klass_hero_web/live/user_live/confirmation.ex:34
+#: lib/klass_hero_web/live/user_live/confirmation.ex:45
+#: lib/klass_hero_web/live/user_live/confirmation.ex:54
 #, elixir-autogen, elixir-format
 msgid "Confirming..."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:112
-#: lib/klass_hero_web/live/terms_of_service_live.ex:247
+#: lib/klass_hero_web/live/settings_live.ex:99
+#: lib/klass_hero_web/live/terms_of_service_live.ex:239
 #, elixir-autogen, elixir-format
 msgid "Contact Information"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:808
-#: lib/klass_hero_web/live/contact_live.ex:15
-#: lib/klass_hero_web/live/contact_live.ex:112
-#: lib/klass_hero_web/live/privacy_policy_live.ex:217
-#: lib/klass_hero_web/live/trust_safety_live.ex:225
+#: lib/klass_hero_web/components/composite_components.ex:651
+#: lib/klass_hero_web/live/contact_live.ex:16
+#: lib/klass_hero_web/live/contact_live.ex:101
+#: lib/klass_hero_web/live/privacy_policy_live.ex:221
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Contact Us"
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:170
+#: lib/klass_hero_web/live/privacy_policy_live.ex:174
 #, elixir-autogen, elixir-format
 msgid "Cookies & Tracking"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/registration.ex:123
+#: lib/klass_hero_web/live/user_live/registration.ex:111
 #, elixir-autogen, elixir-format
 msgid "Create an account"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/registration.ex:80
+#: lib/klass_hero_web/live/user_live/registration.ex:91
 #, elixir-autogen, elixir-format
 msgid "Create and manage programs, activities, and services for families"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/registration.ex:120
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:73
+#: lib/klass_hero_web/live/user_live/registration.ex:109
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:81
 #, elixir-autogen, elixir-format
 msgid "Creating account..."
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:186
+#: lib/klass_hero_web/live/privacy_policy_live.ex:190
 #, elixir-autogen, elixir-format
 msgid "Data Retention"
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:132
+#: lib/klass_hero_web/live/privacy_policy_live.ex:136
 #, elixir-autogen, elixir-format
 msgid "Data Security"
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:91
+#: lib/klass_hero_web/live/privacy_policy_live.ex:95
 #, elixir-autogen, elixir-format
 msgid "Data Sharing"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:422
+#: lib/klass_hero_web/live/user_live/settings.ex:278
 #, elixir-autogen, elixir-format
 msgid "Delete Account"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:447
+#: lib/klass_hero_web/live/user_live/settings.ex:310
 #, elixir-autogen, elixir-format
 msgid "Delete My Account"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:445
+#: lib/klass_hero_web/live/user_live/settings.ex:300
 #, elixir-autogen, elixir-format
 msgid "Deleting..."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:286
+#: lib/klass_hero_web/live/user_live/settings.ex:209
 #, elixir-autogen, elixir-format
 msgid "Deutsch"
 msgstr ""
 
-#: lib/klass_hero_web/live/terms_of_service_live.ex:230
+#: lib/klass_hero_web/live/terms_of_service_live.ex:222
 #, elixir-autogen, elixir-format
 msgid "Dispute Resolution"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:18
-#, elixir-autogen, elixir-format
-msgid "Don't have an account?"
-msgstr ""
-
-#: lib/klass_hero_web/components/provider_components.ex:657
-#: lib/klass_hero_web/components/provider_components.ex:2104
-#: lib/klass_hero_web/components/provider_components.ex:2122
+#: lib/klass_hero_web/components/provider_components.ex:624
+#: lib/klass_hero_web/components/provider_components.ex:2050
+#: lib/klass_hero_web/components/provider_components.ex:2068
 #: lib/klass_hero_web/live/contact_live.ex:65
-#: lib/klass_hero_web/live/contact_live.ex:141
-#: lib/klass_hero_web/live/user_live/login.ex:49
-#: lib/klass_hero_web/live/user_live/login.ex:81
-#: lib/klass_hero_web/live/user_live/registration.ex:39
-#: lib/klass_hero_web/live/user_live/settings.ex:155
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:60
+#: lib/klass_hero_web/live/contact_live.ex:154
+#: lib/klass_hero_web/live/user_live/login.ex:60
+#: lib/klass_hero_web/live/user_live/login.ex:89
+#: lib/klass_hero_web/live/user_live/registration.ex:48
+#: lib/klass_hero_web/live/user_live/settings.ex:102
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:66
 #, elixir-autogen, elixir-format
 msgid "Email"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:496
+#: lib/klass_hero_web/live/user_live/settings.ex:348
 #, elixir-autogen, elixir-format
 msgid "Email change link is invalid or it has expired."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:493
+#: lib/klass_hero_web/live/user_live/settings.ex:345
 #, elixir-autogen, elixir-format
 msgid "Email changed successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:267
+#: lib/klass_hero_web/live/user_live/settings.ex:191
 #, elixir-autogen, elixir-format
 msgid "English"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/registration.ex:60
+#: lib/klass_hero_web/live/user_live/registration.ex:71
 #, elixir-autogen, elixir-format
 msgid "Enroll children in programs"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:438
+#: lib/klass_hero_web/live/user_live/settings.ex:294
 #, elixir-autogen, elixir-format
 msgid "Enter your password to confirm"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:85
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:85
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:49
 #, elixir-autogen, elixir-format
 msgid "Failed to check in: %{reason}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:150
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:150
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:84
 #, elixir-autogen, elixir-format
 msgid "Failed to check out: %{reason}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:134
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:119
+#: lib/klass_hero_web/live/provider/sessions_live.ex:158
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:117
 #, elixir-autogen, elixir-format
 msgid "Failed to complete session: %{reason}"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:655
+#: lib/klass_hero_web/live/user_live/settings.ex:508
 #, elixir-autogen, elixir-format
 msgid "Failed to delete account. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:399
-#: lib/klass_hero_web/live/provider/participation_live.ex:400
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:354
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:355
-#, elixir-autogen, elixir-format
-msgid "Failed to load session data"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/sessions_live.ex:111
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:90
+#: lib/klass_hero_web/live/provider/sessions_live.ex:135
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:88
 #, elixir-autogen, elixir-format
 msgid "Failed to start session: %{reason}"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/registration.ex:63
+#: lib/klass_hero_web/live/user_live/registration.ex:74
 #, elixir-autogen, elixir-format
 msgid "Find and book activities, camps, and classes for your children"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:149
+#: lib/klass_hero_web/live/contact_live.ex:89
 #, elixir-autogen, elixir-format
 msgid "General Inquiry"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:194
-#, elixir-autogen, elixir-format
-msgid "Get in Touch"
-msgstr ""
-
-#: lib/klass_hero_web/live/privacy_policy_live.ex:75
+#: lib/klass_hero_web/live/privacy_policy_live.ex:79
 #, elixir-autogen, elixir-format
 msgid "How We Use Your Information"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/registration.ex:46
+#: lib/klass_hero_web/live/user_live/registration.ex:55
 #, elixir-autogen, elixir-format
 msgid "I want to..."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:142
+#: lib/klass_hero_web/live/user_live/login.ex:170
 #, elixir-autogen, elixir-format
 msgid "If your email is in our system, you will receive instructions for logging in shortly."
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:34
+#: lib/klass_hero_web/live/privacy_policy_live.ex:38
 #, elixir-autogen, elixir-format
 msgid "Information We Collect"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:152
+#: lib/klass_hero_web/live/contact_live.ex:92
 #, elixir-autogen, elixir-format
 msgid "Instructor Application"
 msgstr ""
 
-#: lib/klass_hero_web/live/terms_of_service_live.ex:173
+#: lib/klass_hero_web/live/terms_of_service_live.ex:165
 #, elixir-autogen, elixir-format
 msgid "Intellectual Property"
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:23
+#: lib/klass_hero_web/live/privacy_policy_live.ex:27
 #, elixir-autogen, elixir-format
 msgid "Introduction"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:89
-#: lib/klass_hero_web/live/provider/sessions_live.ex:336
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:66
+#: lib/klass_hero_web/live/provider/sessions_live.ex:113
+#: lib/klass_hero_web/live/provider/sessions_live.ex:348
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:64
 #, elixir-autogen, elixir-format
 msgid "Invalid date format"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:649
+#: lib/klass_hero_web/live/user_live/settings.ex:502
 #, elixir-autogen, elixir-format
 msgid "Invalid password."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/confirmation.ex:62
+#: lib/klass_hero_web/live/user_live/confirmation.ex:92
 #, elixir-autogen, elixir-format
 msgid "Keep me logged in on this device"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:739
+#: lib/klass_hero_web/components/composite_components.ex:602
 #, elixir-autogen, elixir-format
 msgid "Last Updated:"
 msgstr ""
 
-#: lib/klass_hero_web/live/terms_of_service_live.ex:151
+#: lib/klass_hero_web/live/terms_of_service_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "Limitation of Liability"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/confirmation.ex:53
-#: lib/klass_hero_web/live/user_live/registration.ex:19
+#: lib/klass_hero_web/live/user_live/confirmation.ex:80
+#: lib/klass_hero_web/live/user_live/registration.ex:23
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:96
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Log in"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:93
+#: lib/klass_hero_web/live/user_live/login.ex:113
 #, elixir-autogen, elixir-format
 msgid "Log in and stay logged in"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:96
+#: lib/klass_hero_web/live/user_live/login.ex:116
 #, elixir-autogen, elixir-format
 msgid "Log in only this time"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/confirmation.ex:68
+#: lib/klass_hero_web/live/user_live/confirmation.ex:101
 #, elixir-autogen, elixir-format
 msgid "Log me in only this time"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/confirmation.ex:52
-#: lib/klass_hero_web/live/user_live/confirmation.ex:59
-#: lib/klass_hero_web/live/user_live/confirmation.ex:65
+#: lib/klass_hero_web/live/user_live/confirmation.ex:77
+#: lib/klass_hero_web/live/user_live/confirmation.ex:89
+#: lib/klass_hero_web/live/user_live/confirmation.ex:98
 #, elixir-autogen, elixir-format
 msgid "Logging in..."
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:250
-#, elixir-autogen, elixir-format
-msgid "Looking for Quick Answers?"
-msgstr ""
-
-#: lib/klass_hero_web/live/user_live/confirmation.ex:90
+#: lib/klass_hero_web/live/user_live/confirmation.ex:133
 #, elixir-autogen, elixir-format
 msgid "Magic link is invalid or it has expired."
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:162
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:158
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:194
+#: lib/klass_hero_web/live/contact_live.ex:170
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:178
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:173
+#: lib/klass_hero_web/live/contact_live.ex:129
 #, elixir-autogen, elixir-format
 msgid "Message sent successfully!"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:98
-#, elixir-autogen, elixir-format
-msgid "Monday - Friday"
-msgstr ""
-
-#: lib/klass_hero_web/live/dashboard_live.ex:193
-#, elixir-autogen, elixir-format
-msgid "My Children"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/sessions_live.ex:35
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:5
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:24
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:230
+#: lib/klass_hero_web/live/provider/sessions_live.ex:47
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:4
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:21
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "My Sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:139
-#: lib/klass_hero_web/live/user_live/registration.ex:30
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:53
+#: lib/klass_hero_web/live/contact_live.ex:147
+#: lib/klass_hero_web/live/user_live/registration.ex:41
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:62
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:192
+#: lib/klass_hero_web/live/user_live/settings.ex:140
 #, elixir-autogen, elixir-format
 msgid "New password"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/registration.ex:77
+#: lib/klass_hero_web/live/user_live/registration.ex:88
 #, elixir-autogen, elixir-format
 msgid "Offer programs and services"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:226
-#, elixir-autogen, elixir-format
-msgid "Office Hours"
-msgstr ""
-
-#: lib/klass_hero_web/live/user_live/login.ex:105
+#: lib/klass_hero_web/live/user_live/login.ex:126
 #, elixir-autogen, elixir-format
 msgid "Or use magic link"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:64
+#: lib/klass_hero_web/live/user_live/login.ex:74
 #, elixir-autogen, elixir-format
 msgid "Or use password"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:154
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:231
-#: lib/klass_hero_web/presenters/provider_presenter.ex:129
+#: lib/klass_hero_web/live/contact_live.ex:94
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:241
+#: lib/klass_hero_web/presenters/provider_presenter.ex:97
 #, elixir-autogen, elixir-format
 msgid "Other"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:89
-#: lib/klass_hero_web/live/user_live/settings.ex:170
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:68
+#: lib/klass_hero_web/live/user_live/login.ex:96
+#: lib/klass_hero_web/live/user_live/settings.ex:119
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:73
 #, elixir-autogen, elixir-format
 msgid "Password"
 msgstr ""
 
-#: lib/klass_hero_web/live/terms_of_service_live.ex:77
+#: lib/klass_hero_web/live/terms_of_service_live.ex:81
 #, elixir-autogen, elixir-format
 msgid "Payment Terms"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:73
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:232
+#: lib/klass_hero_web/live/contact_live.ex:72
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:239
 #, elixir-autogen, elixir-format
 msgid "Phone"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:676
-#: lib/klass_hero_web/live/privacy_policy_live.ex:10
-#: lib/klass_hero_web/live/privacy_policy_live.ex:235
+#: lib/klass_hero_web/components/composite_components.ex:541
+#: lib/klass_hero_web/live/privacy_policy_live.ex:11
+#: lib/klass_hero_web/live/privacy_policy_live.ex:239
 #, elixir-autogen, elixir-format
 msgid "Privacy Policy"
 msgstr ""
 
-#: lib/klass_hero_web/live/terms_of_service_live.ex:56
+#: lib/klass_hero_web/live/terms_of_service_live.ex:60
 #, elixir-autogen, elixir-format
 msgid "Program Enrollment & Bookings"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:150
+#: lib/klass_hero_web/live/contact_live.ex:90
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program Question"
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:239
+#: lib/klass_hero_web/live/privacy_policy_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "Questions About Privacy?"
 msgstr ""
 
-#: lib/klass_hero_web/live/terms_of_service_live.ex:272
+#: lib/klass_hero_web/live/terms_of_service_live.ex:264
 #, elixir-autogen, elixir-format
 msgid "Questions About These Terms?"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:270
-#: lib/klass_hero_web/live/provider/participation_live.ex:60
-#: lib/klass_hero_web/live/provider/participation_live.ex:122
-#: lib/klass_hero_web/live/provider/participation_live.ex:269
-#: lib/klass_hero_web/live/provider/participation_live.ex:315
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:60
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:122
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:208
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:254
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:29
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:61
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:94
+#: lib/klass_hero_web/live/admin/sessions_live.ex:251
+#: lib/klass_hero_web/live/provider/participation_live.ex:176
+#: lib/klass_hero_web/live/provider/participation_live.ex:222
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:118
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:164
 #, elixir-autogen, elixir-format
 msgid "Record not found"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:22
+#: lib/klass_hero_web/live/user_live/login.ex:26
 #, elixir-autogen, elixir-format
 msgid "Register"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/registration.ex:15
-#, elixir-autogen, elixir-format
-msgid "Register for an account"
-msgstr ""
-
-#: lib/klass_hero_web/live/contact_live.ex:99
-#, elixir-autogen, elixir-format
-msgid "Saturday"
-msgstr ""
-
-#: lib/klass_hero_web/live/user_live/settings.ex:203
+#: lib/klass_hero_web/live/user_live/settings.ex:151
 #, elixir-autogen, elixir-format
 msgid "Save Password"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:317
-#: lib/klass_hero_web/live/settings/children_live.ex:765
-#: lib/klass_hero_web/live/user_live/settings.ex:202
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:324
+#: lib/klass_hero_web/live/settings/children_live.ex:743
+#: lib/klass_hero_web/live/user_live/settings.ex:150
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Saving..."
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:147
-#, elixir-autogen, elixir-format
-msgid "Select a topic..."
-msgstr ""
-
-#: lib/klass_hero_web/live/user_live/registration.ex:48
+#: lib/klass_hero_web/live/user_live/registration.ex:58
 #, elixir-autogen, elixir-format
 msgid "Select one or both options"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:55
-#, elixir-autogen, elixir-format
-msgid "Send Magic Link"
-msgstr ""
-
-#: lib/klass_hero_web/components/provider_components.ex:1802
-#: lib/klass_hero_web/components/provider_components.ex:1803
-#: lib/klass_hero_web/components/provider_components.ex:1842
-#: lib/klass_hero_web/live/contact_live.ex:184
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:290
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:291
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:329
+#: lib/klass_hero_web/components/provider_components.ex:1755
+#: lib/klass_hero_web/components/provider_components.ex:1756
+#: lib/klass_hero_web/components/provider_components.ex:1793
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:448
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:484
 #, elixir-autogen, elixir-format
 msgid "Send Message"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:128
-#, elixir-autogen, elixir-format
-msgid "Send us a Message"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/sessions_live.ex:120
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:105
+#: lib/klass_hero_web/live/provider/sessions_live.ex:144
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:103
 #, elixir-autogen, elixir-format
 msgid "Session completed successfully"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:69
-#: lib/klass_hero_web/live/admin/sessions_live.ex:75
-#: lib/klass_hero_web/live/provider/participation_live.ex:388
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:343
+#: lib/klass_hero_web/live/admin/sessions_live.ex:67
+#: lib/klass_hero_web/live/admin/sessions_live.ex:73
+#: lib/klass_hero_web/live/provider/participation_live.ex:270
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:229
 #, elixir-autogen, elixir-format
 msgid "Session not found"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:97
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:76
+#: lib/klass_hero_web/live/provider/sessions_live.ex:121
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:74
 #, elixir-autogen, elixir-format
 msgid "Session started successfully"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:146
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:144
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:180
+#: lib/klass_hero_web/live/contact_live.ex:162
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:164
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "Subject"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:100
-#, elixir-autogen, elixir-format
-msgid "Sunday"
-msgstr ""
-
-#: lib/klass_hero_web/components/composite_components.ex:747
+#: lib/klass_hero_web/components/composite_components.ex:610
 #, elixir-autogen, elixir-format
 msgid "Table of Contents"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:153
+#: lib/klass_hero_web/live/contact_live.ex:93
 #, elixir-autogen, elixir-format
 msgid "Technical Issue"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:678
-#: lib/klass_hero_web/live/terms_of_service_live.ex:10
-#: lib/klass_hero_web/live/terms_of_service_live.ex:268
+#: lib/klass_hero_web/components/composite_components.ex:543
+#: lib/klass_hero_web/live/terms_of_service_live.ex:11
+#: lib/klass_hero_web/live/terms_of_service_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "Terms of Service"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:425
+#: lib/klass_hero_web/live/user_live/settings.ex:281
 #, elixir-autogen, elixir-format
 msgid "This action cannot be undone. Your account data will be anonymized and you will be logged out."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/confirmation.ex:74
+#: lib/klass_hero_web/live/user_live/confirmation.ex:110
 #, elixir-autogen, elixir-format
 msgid "Tip: If you prefer passwords, you can enable them in the user settings."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:32
+#: lib/klass_hero_web/live/user_live/login.ex:40
 #, elixir-autogen, elixir-format
 msgid "To see sent emails, visit"
 msgstr ""
 
-#: lib/klass_hero_web/live/terms_of_service_live.ex:269
+#: lib/klass_hero_web/live/terms_of_service_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "Understanding our agreement with you"
 msgstr ""
 
-#: lib/klass_hero_web/live/terms_of_service_live.ex:34
+#: lib/klass_hero_web/live/terms_of_service_live.ex:38
 #, elixir-autogen, elixir-format
 msgid "User Accounts & Registration"
 msgstr ""
 
-#: lib/klass_hero_web/live/terms_of_service_live.ex:126
+#: lib/klass_hero_web/live/terms_of_service_live.ex:118
 #, elixir-autogen, elixir-format
 msgid "User Conduct & Responsibilities"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:196
-#, elixir-autogen, elixir-format, fuzzy
-msgid "View All"
-msgstr ""
-
-#: lib/klass_hero_web/live/contact_live.ex:256
-#, elixir-autogen, elixir-format
-msgid "Visit FAQ"
-msgstr ""
-
-#: lib/klass_hero_web/live/contact_live.ex:67
-#, elixir-autogen, elixir-format
-msgid "We respond within 24 hours"
-msgstr ""
-
-#: lib/klass_hero_web/live/contact_live.ex:176
-#, elixir-autogen, elixir-format
-msgid "We'll get back to you within 24 hours."
-msgstr ""
-
-#: lib/klass_hero_web/live/terms_of_service_live.ex:273
+#: lib/klass_hero_web/live/terms_of_service_live.ex:265
 #, elixir-autogen, elixir-format
 msgid "We're here to clarify any questions you may have."
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:240
+#: lib/klass_hero_web/live/privacy_policy_live.ex:244
 #, elixir-autogen, elixir-format
 msgid "We're here to help with any privacy-related concerns."
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:115
-#, elixir-autogen, elixir-format
-msgid "We're here to help with any questions you may have"
-msgstr ""
-
-#: lib/klass_hero_web/live/user_live/confirmation.ex:12
-#, elixir-autogen, elixir-format
-msgid "Welcome %{email}"
-msgstr ""
-
-#: lib/klass_hero_web/live/user_live/login.ex:13
-#, elixir-autogen, elixir-format
-msgid "Welcome Back"
-msgstr ""
-
-#: lib/klass_hero_web/live/user_live/login.ex:30
+#: lib/klass_hero_web/live/user_live/login.ex:38
 #, elixir-autogen, elixir-format
 msgid "You are running the local mail adapter."
 msgstr ""
 
-#: lib/klass_hero_web/user_auth.ex:368
+#: lib/klass_hero_web/user_auth.ex:326
 #, elixir-autogen, elixir-format
 msgid "You must be authenticated to access this page."
 msgstr ""
 
-#: lib/klass_hero_web/user_auth.ex:281
+#: lib/klass_hero_web/user_auth.ex:250
 #, elixir-autogen, elixir-format
 msgid "You must have a parent profile to access this page."
 msgstr ""
 
-#: lib/klass_hero_web/user_auth.ex:290
+#: lib/klass_hero_web/user_auth.ex:259
 #, elixir-autogen, elixir-format
 msgid "You must have a provider profile to access this page."
 msgstr ""
 
-#: lib/klass_hero_web/user_auth.ex:251
-#: lib/klass_hero_web/user_auth.ex:417
+#: lib/klass_hero_web/user_auth.ex:220
+#: lib/klass_hero_web/user_auth.ex:363
 #, elixir-autogen, elixir-format
 msgid "You must log in to access this page."
 msgstr ""
 
-#: lib/klass_hero_web/user_auth.ex:268
+#: lib/klass_hero_web/user_auth.ex:237
 #, elixir-autogen, elixir-format
 msgid "You must re-authenticate to access this page."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:16
+#: lib/klass_hero_web/live/user_live/login.ex:19
 #, elixir-autogen, elixir-format
 msgid "You need to reauthenticate to perform sensitive actions on your account."
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:110
+#: lib/klass_hero_web/live/privacy_policy_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "Your Privacy Rights"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:637
+#: lib/klass_hero_web/live/user_live/settings.ex:490
 #, elixir-autogen, elixir-format
 msgid "Your account has been deleted."
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:236
+#: lib/klass_hero_web/live/privacy_policy_live.ex:240
 #, elixir-autogen, elixir-format
 msgid "Your privacy matters to us"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/login.ex:22
-#, elixir-autogen, elixir-format
-msgid "for an account now."
-msgstr ""
-
-#: lib/klass_hero_web/live/user_live/login.ex:32
+#: lib/klass_hero_web/live/user_live/login.ex:42
 #, elixir-autogen, elixir-format
 msgid "the mailbox page"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/registration.ex:21
-#, elixir-autogen, elixir-format
-msgid "to your account now."
-msgstr ""
-
-#: lib/klass_hero_web/components/composite_components.ex:622
+#: lib/klass_hero_web/components/composite_components.ex:487
 #, elixir-autogen, elixir-format
 msgid "Afterschool"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:673
+#: lib/klass_hero_web/components/composite_components.ex:538
 #, elixir-autogen, elixir-format
 msgid "All rights reserved."
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:594
+#: lib/klass_hero_web/components/composite_components.ex:454
 #, elixir-autogen, elixir-format
 msgid "Building the future of youth education by connecting communities."
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:630
+#: lib/klass_hero_web/components/composite_components.ex:495
 #, elixir-autogen, elixir-format
 msgid "Class Trips"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:639
+#: lib/klass_hero_web/components/composite_components.ex:504
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Connect"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:633
+#: lib/klass_hero_web/components/composite_components.ex:498
 #, elixir-autogen, elixir-format
 msgid "Enrichment"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:599
+#: lib/klass_hero_web/components/composite_components.ex:459
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Quick Links"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:626
+#: lib/klass_hero_web/components/composite_components.ex:491
 #, elixir-autogen, elixir-format
 msgid "Summer Camps"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:61
+#: lib/klass_hero_web/live/settings_live.ex:56
 #, elixir-autogen, elixir-format
 msgid "Account & Profile"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:76
+#: lib/klass_hero_web/live/settings_live.ex:69
 #, elixir-autogen, elixir-format
 msgid "Account preferences, password"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:106
+#: lib/klass_hero_web/live/settings_live.ex:95
 #, elixir-autogen, elixir-format
 msgid "Achievements and milestones"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:186
+#: lib/klass_hero_web/live/settings_live.ex:159
 #, elixir-autogen, elixir-format
 msgid "Activity Permissions"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:156
+#: lib/klass_hero_web/live/settings_live.ex:135
 #, elixir-autogen, elixir-format
 msgid "Allergies & Dietary"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:276
+#: lib/klass_hero_web/live/settings_live.ex:231
 #, elixir-autogen, elixir-format
 msgid "App Information"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:226
+#: lib/klass_hero_web/live/settings_live.ex:191
 #, elixir-autogen, elixir-format
 msgid "Available credits and promo codes"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:136
+#: lib/klass_hero_web/live/settings_live.ex:119
 #, elixir-autogen, elixir-format
 msgid "Backup contacts for emergencies"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:208
+#: lib/klass_hero_web/live/settings_live.ex:177
 #, elixir-autogen, elixir-format
 msgid "Cards, bank accounts, billing info"
 msgstr ""
 
 #: lib/klass_hero_web/live/settings/children_live.ex:23
-#: lib/klass_hero_web/live/settings/children_live.ex:367
-#: lib/klass_hero_web/live/settings_live.ex:88
-#: lib/klass_hero_web/live/user_live/settings.ex:48
-#: lib/klass_hero_web/live/user_live/settings.ex:347
+#: lib/klass_hero_web/live/settings/children_live.ex:348
+#: lib/klass_hero_web/live/settings_live.ex:79
+#: lib/klass_hero_web/live/user_live/settings.ex:235
 #, elixir-autogen, elixir-format
 msgid "Children Profiles"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:259
+#: lib/klass_hero_web/live/settings_live.ex:218
 #, elixir-autogen, elixir-format
 msgid "Common questions and guides"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:246
+#: lib/klass_hero_web/live/settings_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Communication Settings"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:148
+#: lib/klass_hero_web/live/settings_live.ex:129
 #, elixir-autogen, elixir-format
 msgid "Conditions, medications, special needs"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:267
+#: lib/klass_hero_web/live/settings_live.ex:224
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Contact Support"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:127
+#: lib/klass_hero_web/live/settings_live.ex:112
 #, elixir-autogen, elixir-format
 msgid "Contact info for both parents"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:135
+#: lib/klass_hero_web/live/settings_live.ex:118
 #, elixir-autogen, elixir-format
 msgid "Emergency Contacts"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:258
+#: lib/klass_hero_web/live/settings_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "FAQ & Help Center"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:225
+#: lib/klass_hero_web/live/settings_live.ex:190
 #, elixir-autogen, elixir-format
 msgid "Family Credits & Discounts"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:105
+#: lib/klass_hero_web/live/settings_live.ex:94
 #, elixir-autogen, elixir-format
 msgid "Family Progress"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:157
+#: lib/klass_hero_web/live/settings_live.ex:136
 #, elixir-autogen, elixir-format
 msgid "Food allergies, dietary restrictions"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:268
+#: lib/klass_hero_web/live/settings_live.ex:225
 #, elixir-autogen, elixir-format
 msgid "Get help from our team"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:142
+#: lib/klass_hero_web/live/settings_live.ex:123
 #, elixir-autogen, elixir-format
 msgid "Health & Safety"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:166
+#: lib/klass_hero_web/live/settings_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "Health insurance details"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:253
+#: lib/klass_hero_web/live/settings_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Help & Support"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:117
+#: lib/klass_hero_web/live/settings_live.ex:104
 #, elixir-autogen, elixir-format
 msgid "Home Address"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:247
+#: lib/klass_hero_web/live/settings_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "How you want to be contacted"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:165
+#: lib/klass_hero_web/live/settings_live.ex:142
 #, elixir-autogen, elixir-format
 msgid "Insurance Information"
 msgstr ""
@@ -1378,129 +1220,128 @@ msgstr ""
 msgid "Invalid email or password"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:286
+#: lib/klass_hero_web/live/settings_live.ex:239
 #, elixir-autogen, elixir-format
 msgid "Log out of your account"
 msgstr ""
 
-#: lib/klass_hero_web/controllers/user_session_controller.ex:64
+#: lib/klass_hero_web/controllers/user_session_controller.ex:63
 #, elixir-autogen, elixir-format
 msgid "Logged out successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:57
-#: lib/klass_hero_web/live/user_live/settings.ex:18
+#: lib/klass_hero_web/live/settings_live.ex:52
 #, elixir-autogen, elixir-format
 msgid "Manage your account and preferences"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:178
+#: lib/klass_hero_web/live/settings_live.ex:153
 #, elixir-autogen, elixir-format
 msgid "Marketing and social media permissions"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:147
+#: lib/klass_hero_web/live/settings_live.ex:128
 #, elixir-autogen, elixir-format
 msgid "Medical Information"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:82
-#: lib/klass_hero_web/live/user_live/settings.ex:317
+#: lib/klass_hero_web/live/settings_live.ex:73
+#: lib/klass_hero_web/live/user_live/settings.ex:221
 #, elixir-autogen, elixir-format
 msgid "My Family"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:96
+#: lib/klass_hero_web/live/settings_live.ex:87
 #, elixir-autogen, elixir-format, fuzzy
 msgid "My Schedule"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:67
+#: lib/klass_hero_web/live/settings_live.ex:62
 #, elixir-autogen, elixir-format
 msgid "Name, email, profile photo"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:237
+#: lib/klass_hero_web/live/settings_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "Notification Preferences"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:232
+#: lib/klass_hero_web/live/settings_live.ex:195
 #, elixir-autogen, elixir-format
 msgid "Notifications & Communication"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:126
+#: lib/klass_hero_web/live/settings_live.ex:111
 #, elixir-autogen, elixir-format
 msgid "Parent/Guardian Details"
 msgstr ""
 
-#: lib/klass_hero_web/controllers/user_session_controller.ex:59
+#: lib/klass_hero_web/controllers/user_session_controller.ex:58
 #, elixir-autogen, elixir-format
 msgid "Password updated successfully!"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:217
+#: lib/klass_hero_web/live/settings_live.ex:184
 #, elixir-autogen, elixir-format
 msgid "Past payments and invoices"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:202
+#: lib/klass_hero_web/live/settings_live.ex:171
 #, elixir-autogen, elixir-format
 msgid "Payment & Billing"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:207
+#: lib/klass_hero_web/live/settings_live.ex:176
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Payment Methods"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:172
+#: lib/klass_hero_web/live/settings_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Permissions & Consents"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:177
+#: lib/klass_hero_web/live/settings_live.ex:152
 #, elixir-autogen, elixir-format
 msgid "Photo & Video Release"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:118
+#: lib/klass_hero_web/live/settings_live.ex:105
 #, elixir-autogen, elixir-format
 msgid "Primary address and phone"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:75
+#: lib/klass_hero_web/live/settings_live.ex:68
 #, elixir-autogen, elixir-format
 msgid "Privacy & Security"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:66
+#: lib/klass_hero_web/live/settings_live.ex:61
 #, elixir-autogen, elixir-format
 msgid "Profile Information"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:105
+#: lib/klass_hero_web/components/composite_components.ex:106
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Progress"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:238
+#: lib/klass_hero_web/live/settings_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Push, email, SMS settings"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:102
+#: lib/klass_hero_web/components/composite_components.ex:103
 #: lib/klass_hero_web/components/layouts/admin.html.heex:58
-#: lib/klass_hero_web/components/provider_components.ex:90
+#: lib/klass_hero_web/components/provider_components.ex:96
 #: lib/klass_hero_web/live/admin/sessions_live.ex:26
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:4
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:185
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:3
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:348
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:187
+#: lib/klass_hero_web/live/settings_live.ex:160
 #, elixir-autogen, elixir-format
 msgid "Swimming, field trips, group activities"
 msgstr ""
@@ -1510,12 +1351,12 @@ msgstr ""
 msgid "The link is invalid or it has expired."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:216
+#: lib/klass_hero_web/live/settings_live.ex:183
 #, elixir-autogen, elixir-format
 msgid "Transaction History"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:196
+#: lib/klass_hero_web/live/settings_live.ex:167
 #, elixir-autogen, elixir-format
 msgid "Updates, discounts, family credit"
 msgstr ""
@@ -1525,12 +1366,12 @@ msgstr ""
 msgid "User confirmed successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:277
+#: lib/klass_hero_web/live/settings_live.ex:232
 #, elixir-autogen, elixir-format
 msgid "Version, terms, privacy policy"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:97
+#: lib/klass_hero_web/live/settings_live.ex:88
 #, elixir-autogen, elixir-format
 msgid "View all family activities"
 msgstr ""
@@ -1540,878 +1381,690 @@ msgstr ""
 msgid "Welcome back!"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings_live.ex:195
+#: lib/klass_hero_web/live/settings_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "WhatsApp Community"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:178
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:211
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:166
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to load participation history"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:17
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:64
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:23
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:276
+#: lib/klass_hero_web/live/provider/participation_live.ex:26
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:60
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:29
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "Manage Participation"
 msgstr ""
 
 #: lib/klass_hero_web/live/parent/participation_history_live.ex:17
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:5
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "Participation History"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:101
-#, elixir-autogen, elixir-format
-msgid " Find verified tutors, coaches, and camps near you."
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:101
-#, elixir-autogen, elixir-format
-msgid " youth education, sports, and recreational activities"
-msgstr ""
-
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:24
-#: lib/klass_hero_web/live/admin/verifications_live.ex:204
-#: lib/klass_hero_web/live/programs_live.ex:17
+#: lib/klass_hero_web/live/admin/verifications_live.ex:187
+#: lib/klass_hero_web/live/programs_live.ex:19
 #, elixir-autogen, elixir-format
 msgid "All"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:150
-#, elixir-autogen, elixir-format
-msgid "All instructors are background-checked and verified"
-msgstr ""
-
-#: lib/klass_hero_web/live/programs_live.ex:19
-#: lib/klass_hero_web/presenters/program_presenter.ex:366
+#: lib/klass_hero_web/live/programs_live.ex:21
+#: lib/klass_hero_web/presenters/program_presenter.ex:314
 #, elixir-autogen, elixir-format
 msgid "Arts"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:196
-#, elixir-autogen, elixir-format
-msgid "Building connections between families and local instructors"
-msgstr ""
-
-#: lib/klass_hero_web/live/about_live.ex:113
+#: lib/klass_hero_web/live/about_live.ex:145
 #, elixir-autogen, elixir-format
 msgid "Built for Berlin Families"
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:23
+#: lib/klass_hero_web/live/programs_live.ex:25
 #, elixir-autogen, elixir-format
 msgid "Camps"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:287
-#, elixir-autogen, elixir-format
-msgid "Create a Program"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:297
-#, elixir-autogen, elixir-format
-msgid "Deliver Quality"
-msgstr ""
-
-#: lib/klass_hero_web/live/programs_live.ex:242
-#, elixir-autogen, elixir-format
-msgid "Discover activities, camps, and classes for your child"
-msgstr ""
-
-#: lib/klass_hero_web/live/programs_live.ex:21
-#: lib/klass_hero_web/presenters/program_presenter.ex:367
+#: lib/klass_hero_web/live/programs_live.ex:23
+#: lib/klass_hero_web/presenters/program_presenter.ex:315
 #, elixir-autogen, elixir-format
 msgid "Education"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:213
-#, elixir-autogen, elixir-format
-msgid "Every instructor goes through rigorous screening to ensure the highest quality"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:522
-#, elixir-autogen, elixir-format
-msgid "Everything you need to know about Klass Hero"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:209
-#, elixir-autogen, elixir-format
-msgid "For Families"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:265
+#: lib/klass_hero_web/components/composite_components.ex:472
+#: lib/klass_hero_web/components/marketing_components.ex:191
+#: lib/klass_hero_web/components/marketing_components.ex:537
+#: lib/klass_hero_web/components/marketing_components.ex:908
+#: lib/klass_hero_web/live/for_providers_live.ex:10
+#: lib/klass_hero_web/live/for_providers_live.ex:39
 #, elixir-autogen, elixir-format
 msgid "For Providers"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:519
-#, elixir-autogen, elixir-format
-msgid "Frequently Asked Questions"
-msgstr ""
-
-#: lib/klass_hero_web/live/about_live.ex:121
+#: lib/klass_hero_web/live/about_live.ex:150
 #, elixir-autogen, elixir-format
 msgid "From sports to arts, technology to languages, we make it easy to discover enriching activities that fit your family's schedule and budget."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:292
-#, elixir-autogen, elixir-format
-msgid "GET STARTED TODAY"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:307
+#: lib/klass_hero_web/components/marketing_components.ex:589
 #, elixir-autogen, elixir-format
 msgid "Get Paid & Grow"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:269
-#, elixir-autogen, elixir-format
-msgid "How to Grow Your Youth Program: Let's Build Together."
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:272
-#, elixir-autogen, elixir-format
-msgid "Join our community of passionate educators. Tools and support to help you succeed."
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:100
-#, elixir-autogen, elixir-format
-msgid "Klass Hero is Berlin's leading marketplace for"
-msgstr ""
-
-#: lib/klass_hero_web/live/programs_live.ex:22
+#: lib/klass_hero_web/live/programs_live.ex:24
 #, elixir-autogen, elixir-format
 msgid "Life Skills"
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:20
-#: lib/klass_hero_web/presenters/program_presenter.ex:369
+#: lib/klass_hero_web/live/programs_live.ex:22
+#: lib/klass_hero_web/presenters/program_presenter.ex:317
 #, elixir-autogen, elixir-format
 msgid "Music"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:98
-#, elixir-autogen, elixir-format
-msgid "OUR MISSION"
-msgstr ""
-
-#: lib/klass_hero_web/components/provider_components.ex:694
+#: lib/klass_hero_web/components/provider_components.ex:660
+#: lib/klass_hero_web/live/for_providers_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "Qualifications"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:286
+#: lib/klass_hero_web/live/about_live.ex:206
 #, elixir-autogen, elixir-format
 msgid "Ready to join the movement?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:137
+#: lib/klass_hero_web/components/marketing_components.ex:986
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:309
-#, elixir-autogen, elixir-format
-msgid "Secure payments, insights into your business, and opportunities to expand your impact."
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:289
+#: lib/klass_hero_web/components/marketing_components.ex:573
 #, elixir-autogen, elixir-format
 msgid "Set up your teaching profile and list your programs in minutes. Share your expertise with families who need it."
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:18
-#: lib/klass_hero_web/presenters/program_presenter.ex:368
+#: lib/klass_hero_web/live/programs_live.ex:20
+#: lib/klass_hero_web/presenters/program_presenter.ex:316
 #, elixir-autogen, elixir-format
 msgid "Sports"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:548
-#, elixir-autogen, elixir-format
-msgid "Are you an educator, coach, or artist?"
-msgstr ""
-
-#: lib/klass_hero_web/components/marketing_components.ex:553
-#, elixir-autogen, elixir-format
-msgid "Learn How to Become a Hero →"
-msgstr ""
-
-#: lib/klass_hero_web/live/about_live.ex:173
-#, elixir-autogen, elixir-format
-msgid "Supporting local programs and eco-conscious practices"
-msgstr ""
-
-#: lib/klass_hero_web/live/about_live.ex:170
+#: lib/klass_hero_web/live/about_live.ex:24
 #, elixir-autogen, elixir-format
 msgid "Sustainability"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:299
-#, elixir-autogen, elixir-format
-msgid "Teach your passion with our tools for scheduling, communication, and progress tracking."
-msgstr ""
-
-#: lib/klass_hero_web/live/about_live.ex:101
-#, elixir-autogen, elixir-format
-msgid "To modernize how families discover and engage with children's programs in Berlin"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:145
+#: lib/klass_hero_web/components/marketing_components.ex:269
 #, elixir-autogen, elixir-format
 msgid "Trending in Berlin:"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:116
+#: lib/klass_hero_web/live/about_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "We understand the unique needs of Berlin's diverse families. Our platform connects you with vetted, high-quality programs that match your values and your children's interests."
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:24
+#: lib/klass_hero_web/live/programs_live.ex:26
 #, elixir-autogen, elixir-format
 msgid "Workshops"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:215
-#: lib/klass_hero_web/live/settings/children_live.ex:396
-#: lib/klass_hero_web/live/settings/children_live.ex:418
-#: lib/klass_hero_web/live/settings/children_live.ex:640
-#: lib/klass_hero_web/live/settings/children_live.ex:774
+#: lib/klass_hero_web/live/settings/children_live.ex:377
+#: lib/klass_hero_web/live/settings/children_live.ex:399
+#: lib/klass_hero_web/live/settings/children_live.ex:618
+#: lib/klass_hero_web/live/settings/children_live.ex:752
 #, elixir-autogen, elixir-format
 msgid "Add Child"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:77
-#, elixir-autogen, elixir-format
-msgid "Almost there! One more to go!"
-msgstr ""
-
-#: lib/klass_hero_web/live/dashboard_live.ex:76
-#, elixir-autogen, elixir-format
-msgid "Congratulations! Goal achieved!"
-msgstr ""
-
-#: lib/klass_hero_web/components/composite_components.ex:332
-#, elixir-autogen, elixir-format
-msgid "Copy Code"
-msgstr ""
-
-#: lib/klass_hero_web/components/composite_components.ex:265
-#, elixir-autogen, elixir-format
-msgid "Family Achievements"
-msgstr ""
-
-#: lib/klass_hero_web/components/composite_components.ex:310
-#, elixir-autogen, elixir-format
-msgid "Friends Referred"
-msgstr ""
-
-#: lib/klass_hero_web/components/composite_components.ex:304
-#, elixir-autogen, elixir-format
-msgid "Invite friends and earn points!"
-msgstr ""
-
-#: lib/klass_hero_web/components/composite_components.ex:314
-#, elixir-autogen, elixir-format
-msgid "Points Earned"
-msgstr ""
-
-#: lib/klass_hero_web/components/composite_components.ex:299
-#, elixir-autogen, elixir-format
-msgid "Refer & Earn"
-msgstr ""
-
-#: lib/klass_hero_web/components/composite_components.ex:348
-#, elixir-autogen, elixir-format
-msgid "Share Code"
-msgstr ""
-
-#: lib/klass_hero_web/components/composite_components.ex:185
+#: lib/klass_hero_web/components/composite_components.ex:186
 #, elixir-autogen, elixir-format
 msgid "Weekly Activity Goal"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:78
-#, elixir-autogen, elixir-format
-msgid "You're just getting started!"
-msgstr ""
-
-#: lib/klass_hero_web/live/dashboard_live.ex:79
-#, elixir-autogen, elixir-format
-msgid "You're doing great! Keep it up!"
-msgstr ""
-
-#: lib/klass_hero_web/components/composite_components.ex:319
-#, elixir-autogen, elixir-format
-msgid "Your Referral Code"
-msgstr ""
-
-#: lib/klass_hero_web/components/composite_components.ex:194
+#: lib/klass_hero_web/components/composite_components.ex:195
 #, elixir-autogen, elixir-format
 msgid "activities completed"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:55
-#: lib/klass_hero_web/live/user_live/settings.ex:131
+#: lib/klass_hero_web/live/user_live/settings.ex:81
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Account Security"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:237
+#: lib/klass_hero_web/live/user_live/settings.ex:164
 #, elixir-autogen, elixir-format
 msgid "Customize your experience"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:414
+#: lib/klass_hero_web/live/user_live/settings.ex:271
 #, elixir-autogen, elixir-format
 msgid "Danger Zone"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:69
-#: lib/klass_hero_web/live/user_live/settings.ex:379
+#: lib/klass_hero_web/live/user_live/settings.ex:249
 #, elixir-autogen, elixir-format
 msgid "Data & Privacy"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:382
+#: lib/klass_hero_web/live/user_live/settings.ex:251
 #, elixir-autogen, elixir-format
 msgid "Download your data or delete your account"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:143
+#: lib/klass_hero_web/live/user_live/settings.ex:90
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Email Address"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:134
+#: lib/klass_hero_web/live/user_live/settings.ex:83
 #, elixir-autogen, elixir-format
 msgid "Manage your email and password"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:101
+#: lib/klass_hero_web/live/user_live/settings.ex:70
 #, elixir-autogen, elixir-format
 msgid "Member since"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:62
-#: lib/klass_hero_web/live/user_live/settings.ex:234
+#: lib/klass_hero_web/live/user_live/settings.ex:47
+#: lib/klass_hero_web/live/user_live/settings.ex:163
 #, elixir-autogen, elixir-format
 msgid "Preferences"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:41
+#: lib/klass_hero_web/live/user_live/settings.ex:34
 #, elixir-autogen, elixir-format
 msgid "Profile"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:33
+#: lib/klass_hero_web/live/user_live/settings.ex:30
 #, elixir-autogen, elixir-format
 msgid "Quick Navigation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1389
-#: lib/klass_hero_web/components/provider_components.ex:1775
-#: lib/klass_hero_web/components/provider_components.ex:2011
+#: lib/klass_hero_web/components/provider_components.ex:1341
+#: lib/klass_hero_web/components/provider_components.ex:1731
+#: lib/klass_hero_web/components/provider_components.ex:1957
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1485
+#: lib/klass_hero_web/components/provider_components.ex:1446
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Active"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:610
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1484
+#: lib/klass_hero_web/components/provider_components.ex:577
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1679
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/dashboard_live.ex:82
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1728
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1934
 #, elixir-autogen, elixir-format
 msgid "All Staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1380
+#: lib/klass_hero_web/components/provider_components.ex:1332
 #, elixir-autogen, elixir-format
 msgid "Assigned Staff"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:359
-#: lib/klass_hero_web/live/program_detail_live.ex:575
+#: lib/klass_hero_web/live/program_detail_live.ex:332
+#: lib/klass_hero_web/live/program_detail_live.ex:492
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Book Now"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:176
+#: lib/klass_hero_web/components/provider_components.ex:182
 #, elixir-autogen, elixir-format
 msgid "Business Profile"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:115
-#: lib/klass_hero_web/presenters/provider_presenter.ex:125
+#: lib/klass_hero_web/presenters/provider_presenter.ex:83
+#: lib/klass_hero_web/presenters/provider_presenter.ex:93
 #, elixir-autogen, elixir-format
 msgid "Business Registration"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1467
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1656
 #, elixir-autogen, elixir-format
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:552
-#: lib/klass_hero_web/components/provider_components.ex:1457
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:49
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:76
-#: lib/klass_hero_web/live/settings/children_live.ex:467
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:49
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:76
+#: lib/klass_hero_web/components/provider_components.ex:515
+#: lib/klass_hero_web/components/provider_components.ex:1409
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:50
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:77
+#: lib/klass_hero_web/live/settings/children_live.ex:448
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:50
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:77
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:194
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:170
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1297
+#: lib/klass_hero_web/components/provider_components.ex:200
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:172
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1427
 #, elixir-autogen, elixir-format
 msgid "Edit Profile"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1487
+#: lib/klass_hero_web/components/provider_components.ex:1448
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:83
+#: lib/klass_hero_web/components/provider_components.ex:89
 #, elixir-autogen, elixir-format, fuzzy
 msgid "My Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:418
-#: lib/klass_hero_web/components/provider_components.ex:870
+#: lib/klass_hero_web/components/provider_components.ex:392
+#: lib/klass_hero_web/components/provider_components.ex:835
 #, elixir-autogen, elixir-format, fuzzy
 msgid "New Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:69
+#: lib/klass_hero_web/components/provider_components.ex:75
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:46
-#: lib/klass_hero_web/components/provider_components.ex:1486
-#: lib/klass_hero_web/components/provider_components.ex:2198
-#: lib/klass_hero_web/components/provider_components.ex:2218
-#: lib/klass_hero_web/live/admin/sessions_live.ex:318
-#: lib/klass_hero_web/live/admin/verifications_live.ex:209
+#: lib/klass_hero_web/components/provider_components.ex:1447
+#: lib/klass_hero_web/components/provider_components.ex:2144
+#: lib/klass_hero_web/components/provider_components.ex:2162
+#: lib/klass_hero_web/live/admin/sessions_live.ex:297
+#: lib/klass_hero_web/live/admin/verifications_live.ex:192
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1440
+#: lib/klass_hero_web/components/provider_components.ex:1392
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1323
+#: lib/klass_hero_web/components/provider_components.ex:1275
 #, elixir-autogen, elixir-format
 msgid "Program Inventory"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1377
+#: lib/klass_hero_web/components/provider_components.ex:1329
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program Name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:383
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Program Slots"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:91
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:88
 #, elixir-autogen, elixir-format
 msgid "Provider Dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:372
+#: lib/klass_hero_web/live/program_detail_live.ex:345
 #, elixir-autogen, elixir-format
 msgid "Save for Later"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1335
+#: lib/klass_hero_web/components/provider_components.ex:1287
 #, elixir-autogen, elixir-format
 msgid "Search by name..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1383
-#: lib/klass_hero_web/components/provider_components.ex:1714
-#: lib/klass_hero_web/components/provider_components.ex:1769
-#: lib/klass_hero_web/components/provider_components.ex:2008
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:73
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:158
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:201
+#: lib/klass_hero_web/components/provider_components.ex:1335
+#: lib/klass_hero_web/components/provider_components.ex:1670
+#: lib/klass_hero_web/components/provider_components.ex:1725
+#: lib/klass_hero_web/components/provider_components.ex:1954
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:76
+#: lib/klass_hero_web/components/provider_components.ex:82
 #, elixir-autogen, elixir-format
 msgid "Team & Profiles"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1464
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1653
 #, elixir-autogen, elixir-format
 msgid "Team & Provider Profiles"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:179
+#: lib/klass_hero_web/components/provider_components.ex:185
 #, elixir-autogen, elixir-format
 msgid "This is your main business identity. Verification is required to list programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1413
-#: lib/klass_hero_web/components/provider_components.ex:1729
+#: lib/klass_hero_web/components/provider_components.ex:1365
+#: lib/klass_hero_web/components/provider_components.ex:1685
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:53
+#: lib/klass_hero_web/components/messaging_components.ex:728
 #: lib/klass_hero_web/components/provider_components.ex:49
-#: lib/klass_hero_web/components/provider_components.ex:1488
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:277
+#: lib/klass_hero_web/components/provider_components.ex:1449
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:434
+#: lib/klass_hero_web/presenters/provider_presenter.ex:99
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:375
+#: lib/klass_hero_web/components/provider_components.ex:377
 #, elixir-autogen, elixir-format
 msgid "Verified Business"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1451
+#: lib/klass_hero_web/components/provider_components.ex:1403
 #, elixir-autogen, elixir-format
 msgid "View Roster"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:449
+#: lib/klass_hero_web/live/settings/children_live.ex:430
 #, elixir-autogen, elixir-format
 msgid "%{age} years old"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:664
+#: lib/klass_hero_web/components/messaging_components.ex:738
 #, elixir-autogen, elixir-format
 msgid "%{n}m ago"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:240
-#, elixir-autogen, elixir-format
-msgid "%{remaining} remaining"
-msgstr ""
-
-#: lib/klass_hero_web/live/settings/children_live.ex:404
+#: lib/klass_hero_web/live/settings/children_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "Add your first child to get started with activities and programs."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:519
-#: lib/klass_hero_web/live/settings/children_live.ex:715
+#: lib/klass_hero_web/live/settings/children_live.ex:499
+#: lib/klass_hero_web/live/settings/children_live.ex:693
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Allergies"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:742
+#: lib/klass_hero_web/live/settings/children_live.ex:720
 #, elixir-autogen, elixir-format
 msgid "Allow activity providers to access this child's profile information for program participation."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:223
+#: lib/klass_hero_web/live/settings/children_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:723
+#: lib/klass_hero_web/live/settings/children_live.ex:701
 #, elixir-autogen, elixir-format
 msgid "Any special accommodations or support needs..."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:382
+#: lib/klass_hero_web/live/settings/children_live.ex:363
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Back to Settings"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:185
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:183
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:107
 #, elixir-autogen, elixir-format
 msgid "Behavioral note submitted for review"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:147
+#: lib/klass_hero_web/components/messaging_components.ex:150
 #, elixir-autogen, elixir-format
 msgid "Broadcast"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:78
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:126
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:98
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "Broadcast sent to %{count} parents"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:436
-#: lib/klass_hero_web/components/participation_components.ex:627
-#: lib/klass_hero_web/components/participation_components.ex:715
-#: lib/klass_hero_web/components/provider_components.ex:829
-#: lib/klass_hero_web/components/provider_components.ex:1239
-#: lib/klass_hero_web/components/provider_components.ex:1946
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:247
-#: lib/klass_hero_web/live/admin/verifications_live.ex:424
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:116
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:197
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:346
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:191
-#: lib/klass_hero_web/live/settings/children_live.ex:600
-#: lib/klass_hero_web/live/settings/children_live.ex:760
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:224
+#: lib/klass_hero_web/components/participation_components.ex:417
+#: lib/klass_hero_web/components/participation_components.ex:607
+#: lib/klass_hero_web/components/participation_components.ex:693
+#: lib/klass_hero_web/components/provider_components.ex:794
+#: lib/klass_hero_web/components/provider_components.ex:1191
+#: lib/klass_hero_web/components/provider_components.ex:1896
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
+#: lib/klass_hero_web/live/admin/verifications_live.ex:407
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:219
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:356
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:186
+#: lib/klass_hero_web/live/settings/children_live.ex:579
+#: lib/klass_hero_web/live/settings/children_live.ex:738
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:225
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:307
+#: lib/klass_hero_web/live/settings/children_live.ex:293
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Child added successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:309
+#: lib/klass_hero_web/live/settings/children_live.ex:295
 #, elixir-autogen, elixir-format
 msgid "Child added, but consent update failed. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:89
-#: lib/klass_hero_web/live/settings/children_live.ex:186
+#: lib/klass_hero_web/live/settings/children_live.ex:87
+#: lib/klass_hero_web/live/settings/children_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "Child not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:179
+#: lib/klass_hero_web/live/settings/children_live.ex:172
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Child removed successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:311
+#: lib/klass_hero_web/live/settings/children_live.ex:297
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Child updated successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:313
+#: lib/klass_hero_web/live/settings/children_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "Child updated, but consent update failed. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:354
+#: lib/klass_hero_web/live/dashboard_live.ex:169
+#: lib/klass_hero_web/live/messaging_live_helper.ex:343
 #, elixir-autogen, elixir-format
 msgid "Conversation"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:164
+#: lib/klass_hero_web/live/messaging_live_helper.ex:172
 #, elixir-autogen, elixir-format
 msgid "Conversation not found"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:195
+#: lib/klass_hero_web/live/settings/children_live.ex:188
 #, elixir-autogen, elixir-format
 msgid "Could not remove child. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:497
+#: lib/klass_hero_web/live/settings/children_live.ex:477
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2085
-#: lib/klass_hero_web/live/settings/children_live.ex:679
+#: lib/klass_hero_web/components/provider_components.ex:2031
+#: lib/klass_hero_web/live/settings/children_live.ex:657
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:481
+#: lib/klass_hero_web/live/settings/children_live.ex:462
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Delete"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:642
+#: lib/klass_hero_web/live/settings/children_live.ex:620
 #, elixir-autogen, elixir-format
 msgid "Edit Child"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:508
-#: lib/klass_hero_web/live/settings/children_live.ex:708
+#: lib/klass_hero_web/live/settings/children_live.ex:488
+#: lib/klass_hero_web/live/settings/children_live.ex:686
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Emergency contact"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:66
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:61
 #, elixir-autogen, elixir-format
 msgid "Failed to approve note"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:227
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Failed to load pending notes"
-msgstr ""
-
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:117
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:112
 #, elixir-autogen, elixir-format
 msgid "Failed to reject note"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:261
+#: lib/klass_hero_web/live/provider/participation_live.ex:168
 #, elixir-autogen, elixir-format
 msgid "Failed to resubmit note"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:100
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:121
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:146
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to send broadcast"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:202
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:200
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:124
 #, elixir-autogen, elixir-format
 msgid "Failed to submit note"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2079
-#: lib/klass_hero_web/components/provider_components.ex:2108
-#: lib/klass_hero_web/components/provider_components.ex:2124
-#: lib/klass_hero_web/live/settings/children_live.ex:665
+#: lib/klass_hero_web/components/provider_components.ex:2025
+#: lib/klass_hero_web/components/provider_components.ex:2054
+#: lib/klass_hero_web/components/provider_components.ex:2070
+#: lib/klass_hero_web/live/settings/children_live.ex:643
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2080
-#: lib/klass_hero_web/components/provider_components.ex:2109
-#: lib/klass_hero_web/components/provider_components.ex:2125
-#: lib/klass_hero_web/live/settings/children_live.ex:671
+#: lib/klass_hero_web/components/provider_components.ex:2026
+#: lib/klass_hero_web/components/provider_components.ex:2055
+#: lib/klass_hero_web/components/provider_components.ex:2071
+#: lib/klass_hero_web/live/settings/children_live.ex:649
 #, elixir-autogen, elixir-format
 msgid "Last name"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:716
+#: lib/klass_hero_web/live/settings/children_live.ex:694
 #, elixir-autogen, elixir-format
 msgid "List any known allergies..."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:368
+#: lib/klass_hero_web/live/settings/children_live.ex:349
 #, elixir-autogen, elixir-format
 msgid "Manage your children's information and consents"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:320
+#: lib/klass_hero_web/live/user_live/settings.ex:223
 #, elixir-autogen, elixir-format
 msgid "Manage your children's profiles"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:64
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:109
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:79
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:94
 #, elixir-autogen, elixir-format
 msgid "Message content is required"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:236
-#: lib/klass_hero_web/components/messaging_components.ex:434
-#: lib/klass_hero_web/components/messaging_components.ex:457
-#: lib/klass_hero_web/live/messaging_live_helper.ex:301
+#: lib/klass_hero_web/components/layouts/app.html.heex:212
+#: lib/klass_hero_web/components/messaging_components.ex:494
+#: lib/klass_hero_web/components/messaging_components.ex:517
+#: lib/klass_hero_web/live/messages_live/index.ex:19
+#: lib/klass_hero_web/live/messaging_live_helper.ex:295
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Messages"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:229
-#, elixir-autogen, elixir-format
-msgid "Monthly Booking Usage"
-msgstr ""
-
-#: lib/klass_hero_web/live/settings/children_live.ex:403
-#: lib/klass_hero_web/presenters/child_presenter.ex:96
+#: lib/klass_hero_web/live/settings/children_live.ex:384
+#: lib/klass_hero_web/presenters/child_presenter.ex:57
 #, elixir-autogen, elixir-format
 msgid "No children yet"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:399
+#: lib/klass_hero_web/components/messaging_components.ex:464
 #, elixir-autogen, elixir-format
 msgid "No conversations yet"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:368
-#: lib/klass_hero_web/components/messaging_components.ex:674
-#: lib/klass_hero_web/components/messaging_components.ex:685
+#: lib/klass_hero_web/components/messaging_components.ex:433
+#: lib/klass_hero_web/components/messaging_components.ex:748
+#: lib/klass_hero_web/components/messaging_components.ex:759
 #, elixir-autogen, elixir-format
 msgid "No messages yet"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:92
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:134
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:106
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "No parents are enrolled in this program"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:57
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:52
 #, elixir-autogen, elixir-format
 msgid "Note approved"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:191
-#: lib/klass_hero_web/live/provider/participation_live.ex:253
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:189
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:113
+#: lib/klass_hero_web/live/provider/participation_live.ex:160
 #, elixir-autogen, elixir-format
 msgid "Note content cannot be blank"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:106
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:101
 #, elixir-autogen, elixir-format
 msgid "Note rejected"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:247
+#: lib/klass_hero_web/live/provider/participation_live.ex:154
 #, elixir-autogen, elixir-format
 msgid "Note resubmitted for review"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:663
+#: lib/klass_hero_web/components/messaging_components.ex:737
 #, elixir-autogen, elixir-format
 msgid "Now"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:709
+#: lib/klass_hero_web/live/settings/children_live.ex:687
 #, elixir-autogen, elixir-format
 msgid "Phone number or name"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:218
+#: lib/klass_hero_web/live/settings/children_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "Please check the form for errors."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:191
+#: lib/klass_hero_web/live/booking_live.ex:173
 #, elixir-autogen, elixir-format
 msgid "Please complete your profile before making a booking."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:575
+#: lib/klass_hero_web/live/user_live/settings.ex:428
 #, elixir-autogen, elixir-format
 msgid "Please re-authenticate to change your email."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:607
+#: lib/klass_hero_web/live/user_live/settings.ex:460
 #, elixir-autogen, elixir-format
 msgid "Please re-authenticate to change your password."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:643
+#: lib/klass_hero_web/live/user_live/settings.ex:496
 #, elixir-autogen, elixir-format
 msgid "Please re-authenticate to delete your account."
 msgstr ""
@@ -2421,339 +2074,322 @@ msgstr ""
 msgid "Please set up your parent profile to manage children."
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:350
+#: lib/klass_hero_web/components/messaging_components.ex:721
+#: lib/klass_hero_web/live/messaging_live_helper.ex:339
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program Broadcast"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:739
+#: lib/klass_hero_web/live/settings/children_live.ex:717
 #, elixir-autogen, elixir-format
 msgid "Provider data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:814
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1397
-#: lib/klass_hero_web/live/settings/children_live.ex:776
+#: lib/klass_hero_web/components/provider_components.ex:779
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1524
+#: lib/klass_hero_web/live/settings/children_live.ex:754
 #, elixir-autogen, elixir-format
 msgid "Save Changes"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:129
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Search for programs..."
-msgstr ""
-
-#: lib/klass_hero_web/components/provider_components.ex:1573
-#: lib/klass_hero_web/components/provider_components.ex:1574
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:37
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:128
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:227
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:60
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:164
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:237
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:231
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:232
+#: lib/klass_hero_web/components/provider_components.ex:1531
+#: lib/klass_hero_web/components/provider_components.ex:1532
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:40
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:148
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:249
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:44
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:163
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:238
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:393
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:394
 #, elixir-autogen, elixir-format
 msgid "Send Broadcast"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:371
+#: lib/klass_hero_web/components/messaging_components.ex:436
 #, elixir-autogen, elixir-format
 msgid "Send a message to start the conversation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2179
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:226
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:236
+#: lib/klass_hero_web/components/provider_components.ex:2125
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:248
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:237
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sending..."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:530
-#: lib/klass_hero_web/live/settings/children_live.ex:722
+#: lib/klass_hero_web/live/settings/children_live.ex:510
+#: lib/klass_hero_web/live/settings/children_live.ex:700
 #, elixir-autogen, elixir-format
 msgid "Support needs"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:185
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:212
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:207
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "This message will be sent to all parents with active enrollments in this program."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:322
+#: lib/klass_hero_web/components/messaging_components.ex:387
 #, elixir-autogen, elixir-format
 msgid "Type a message..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:419
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:374
+#: lib/klass_hero_web/live/provider/participation_live.ex:290
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:249
 #, elixir-autogen, elixir-format
 msgid "Unable to refresh roster. Please reload."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:418
-#: lib/klass_hero_web/live/dashboard_live.ex:250
+#: lib/klass_hero_web/components/parent_components.ex:589
+#: lib/klass_hero_web/live/booking_live.ex:392
 #, elixir-autogen, elixir-format
 msgid "Upgrade"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:165
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:201
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:185
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "Write your message to all enrolled parents..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:194
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:192
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:116
 #, elixir-autogen, elixir-format
 msgid "You already submitted a note for this record"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:170
+#: lib/klass_hero_web/live/messaging_live_helper.ex:178
 #, elixir-autogen, elixir-format
 msgid "You don't have access to this conversation"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:142
+#: lib/klass_hero_web/live/settings/children_live.ex:137
 #, elixir-autogen, elixir-format
 msgid "You don't have permission to delete this child."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:83
+#: lib/klass_hero_web/live/settings/children_live.ex:81
 #, elixir-autogen, elixir-format
 msgid "You don't have permission to edit this child."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:405
+#: lib/klass_hero_web/live/booking_live.ex:379
 #, elixir-autogen, elixir-format
 msgid "You have %{remaining} of %{total} bookings remaining this month."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:234
+#: lib/klass_hero_web/components/parent_components.ex:579
 #, elixir-autogen, elixir-format
 msgid "You have used %{used} of %{cap} bookings this month."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:183
+#: lib/klass_hero_web/live/booking_live.ex:165
 #, elixir-autogen, elixir-format
 msgid "You've reached your monthly booking limit. Upgrade to Active tier for unlimited bookings."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:399
+#: lib/klass_hero_web/live/booking_live.ex:373
 #, elixir-autogen, elixir-format
 msgid "Your Booking Plan"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:408
+#: lib/klass_hero_web/components/messaging_components.ex:473
 #, elixir-autogen, elixir-format
 msgid "Your conversations with parents will appear here"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:410
+#: lib/klass_hero_web/components/messaging_components.ex:475
 #, elixir-autogen, elixir-format
 msgid "Your conversations with providers will appear here"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:25
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:86
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:29
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:28
 #, elixir-autogen, elixir-format
 msgid "Your subscription tier doesn't support broadcasts"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:152
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:188
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:172
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:187
 #, elixir-autogen, elixir-format
 msgid "e.g., Important Update"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:144
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:180
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:164
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "optional"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:411
-#: lib/klass_hero_web/live/dashboard_live.ex:243
+#: lib/klass_hero_web/components/parent_components.ex:595
+#: lib/klass_hero_web/live/booking_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "tier"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:192
+#: lib/klass_hero_web/live/admin/verifications_live.ex:175
 #, elixir-autogen, elixir-format
 msgid "%{count} document"
 msgid_plural "%{count} documents"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/components/program_components.ex:575
-#: lib/klass_hero_web/components/program_components.ex:583
+#: lib/klass_hero_web/components/program_components.ex:574
+#: lib/klass_hero_web/components/program_components.ex:582
 #, elixir-autogen, elixir-format
 msgid "%{count} month"
 msgid_plural "%{count} months"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/components/program_components.ex:571
-#: lib/klass_hero_web/components/program_components.ex:582
+#: lib/klass_hero_web/components/program_components.ex:570
+#: lib/klass_hero_web/components/program_components.ex:581
 #, elixir-autogen, elixir-format
 msgid "%{count} year"
 msgid_plural "%{count} years"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/components/program_components.ex:596
+#: lib/klass_hero_web/components/program_components.ex:592
 #, elixir-autogen, elixir-format
 msgid "%{gender} only"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:277
+#: lib/klass_hero_web/components/provider_components.ex:285
 #, elixir-autogen, elixir-format
 msgid "Action Required"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:816
+#: lib/klass_hero_web/components/provider_components.ex:781
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add Member"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1506
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1703
 #, elixir-autogen, elixir-format
 msgid "Add your first staff member to get started!"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:555
+#: lib/klass_hero_web/components/program_components.ex:556
 #, elixir-autogen, elixir-format
 msgid "Ages %{min} to %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:559
+#: lib/klass_hero_web/components/program_components.ex:560
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Ages %{min}+"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1099
+#: lib/klass_hero_web/components/provider_components.ex:1054
 #, elixir-autogen, elixir-format
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2263
+#: lib/klass_hero_web/components/provider_components.ex:2184
 #, elixir-autogen, elixir-format, fuzzy
 msgid "An unexpected error occurred during import."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:384
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:57
+#: lib/klass_hero_web/components/provider_layout_components.ex:564
+#: lib/klass_hero_web/live/admin/verifications_live.ex:367
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "Approve"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:832
+#: lib/klass_hero_web/components/participation_components.ex:802
 #: lib/klass_hero_web/components/provider_components.ex:47
-#: lib/klass_hero_web/live/admin/sessions_live.ex:315
-#: lib/klass_hero_web/live/admin/verifications_live.ex:214
+#: lib/klass_hero_web/live/admin/sessions_live.ex:294
+#: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Approved"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:380
+#: lib/klass_hero_web/live/admin/verifications_live.ex:363
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Are you sure you want to approve this document?"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:572
+#: lib/klass_hero_web/components/provider_components.ex:535
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Are you sure you want to remove this team member?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:493
+#: lib/klass_hero_web/components/marketing_components.ex:641
 #, elixir-autogen, elixir-format
 msgid "As fathers and partners of teachers in Berlin, we saw and heard firsthand how hard it is to find, book, and manage quality youth activities outside the classroom. Klass Hero is the complete platform connecting Berlin families and schools with trusted, vetted activity providers — offering safe, supervised, and enriching experiences across sports, arts, tutoring, and more. We verify every provider, structure every booking, and support every step — so parents know their child is in good hands, and providers can focus on what they do best: inspiring kids."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1223
+#: lib/klass_hero_web/components/provider_components.ex:1175
 #, elixir-autogen, elixir-format
 msgid "Assign Instructor"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1293
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:253
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:190
-#: lib/klass_hero_web/live/provider/subscription_live.ex:100
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1423
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:263
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Back to Dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:298
+#: lib/klass_hero_web/live/admin/verifications_live.ex:281
 #, elixir-autogen, elixir-format
 msgid "Back to verifications"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:108
-#, elixir-autogen, elixir-format
-msgid "Berlin's leading network for tutors, coaches, and camp providers!"
-msgstr ""
-
-#: lib/klass_hero_web/components/provider_components.ex:665
+#: lib/klass_hero_web/components/provider_components.ex:633
 #, elixir-autogen, elixir-format
 msgid "Bio"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:285
+#: lib/klass_hero_web/live/dashboard_live.ex:373
 #, elixir-autogen, elixir-format
 msgid "Book a Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:666
+#: lib/klass_hero_web/components/provider_components.ex:634
 #, elixir-autogen, elixir-format
 msgid "Brief description of experience and specialties..."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:250
-#, elixir-autogen, elixir-format
-msgid "Built by Parents and Educators for More Learning Opportunities"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:490
+#: lib/klass_hero_web/components/marketing_components.ex:638
 #, elixir-autogen, elixir-format
 msgid "Built by Parents to Empower Educators."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:313
+#: lib/klass_hero_web/live/admin/verifications_live.ex:296
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Business"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1315
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1444
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Business Description"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1302
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1431
 #, elixir-autogen, elixir-format
 msgid "Business Information"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1323
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:280
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1451
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "Business Logo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:900
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:296
+#: lib/klass_hero_web/components/provider_components.ex:865
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "Category"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1046
+#: lib/klass_hero_web/components/provider_components.ex:1003
 #, elixir-autogen, elixir-format
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1766
-#: lib/klass_hero_web/components/provider_components.ex:2002
+#: lib/klass_hero_web/components/provider_components.ex:1722
+#: lib/klass_hero_web/components/provider_components.ex:1948
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2768,1473 +2404,1187 @@ msgstr ""
 msgid "Child meets all program requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1211
+#: lib/klass_hero_web/components/provider_components.ex:1164
 #, elixir-autogen, elixir-format
 msgid "Choose Image"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1377
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1504
 #, elixir-autogen, elixir-format
 msgid "Choose Logo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:793
+#: lib/klass_hero_web/components/provider_components.ex:758
 #, elixir-autogen, elixir-format
 msgid "Choose Photo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:902
+#: lib/klass_hero_web/components/provider_components.ex:867
 #, elixir-autogen, elixir-format
 msgid "Choose a category"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:433
+#: lib/klass_hero_web/components/provider_components.ex:404
 #, elixir-autogen, elixir-format
 msgid "Complete business verification to create programs."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:413
+#: lib/klass_hero_web/live/admin/verifications_live.ex:396
 #, elixir-autogen, elixir-format
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2199
+#: lib/klass_hero_web/components/provider_components.ex:2145
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:737
+#: lib/klass_hero_web/components/messaging_components.ex:811
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Contact Provider"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:57
-#, elixir-autogen, elixir-format
-msgid "Could not load verification documents."
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:751
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:789
 #, elixir-autogen, elixir-format
 msgid "Could not read the uploaded file."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:708
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:716
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:757
 #, elixir-autogen, elixir-format
 msgid "Could not remove invite."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1167
+#: lib/klass_hero_web/components/provider_components.ex:1120
 #, elixir-autogen, elixir-format
 msgid "Cover Image"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1039
+#: lib/klass_hero_web/components/provider_components.ex:997
 #, elixir-autogen, elixir-format
 msgid "Define age, gender, or grade restrictions for eligible participants."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1159
+#: lib/klass_hero_web/components/provider_components.ex:1113
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Describe your program..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1158
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:313
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:221
+#: lib/klass_hero_web/components/provider_components.ex:1112
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:323
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:228
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:603
-#: lib/klass_hero_web/components/provider_components.ex:1110
-#: lib/klass_hero_web/live/settings/children_live.ex:692
+#: lib/klass_hero_web/components/program_components.ex:694
+#: lib/klass_hero_web/components/provider_components.ex:1065
+#: lib/klass_hero_web/live/settings/children_live.ex:670
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2368
+#: lib/klass_hero_web/components/provider_components.ex:2281
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:117
+#: lib/klass_hero_web/live/admin/verifications_live.ex:100
 #, elixir-autogen, elixir-format
 msgid "Document approved successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:120
-#: lib/klass_hero_web/live/admin/verifications_live.ex:160
+#: lib/klass_hero_web/live/admin/verifications_live.ex:103
+#: lib/klass_hero_web/live/admin/verifications_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "Document has already been reviewed."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:344
-#: lib/klass_hero_web/live/admin/verifications_live.ex:484
-#: lib/klass_hero_web/live/admin/verifications_live.ex:496
+#: lib/klass_hero_web/live/admin/verifications_live.ex:327
+#: lib/klass_hero_web/live/admin/verifications_live.ex:463
+#: lib/klass_hero_web/live/admin/verifications_live.ex:475
 #, elixir-autogen, elixir-format
 msgid "Document preview"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:154
+#: lib/klass_hero_web/live/admin/verifications_live.ex:137
 #, elixir-autogen, elixir-format
 msgid "Document rejected."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:467
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:533
 #, elixir-autogen, elixir-format
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1966
+#: lib/klass_hero_web/components/provider_components.ex:1915
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:357
+#: lib/klass_hero_web/live/admin/verifications_live.ex:340
 #, elixir-autogen, elixir-format
 msgid "Download document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:868
+#: lib/klass_hero_web/components/provider_components.ex:833
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:608
+#: lib/klass_hero_web/components/provider_components.ex:575
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit Team Member"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:981
+#: lib/klass_hero_web/components/provider_components.ex:942
 #, elixir-autogen, elixir-format
 msgid "End Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:967
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:166
+#: lib/klass_hero_web/components/provider_components.ex:929
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:161
 #, elixir-autogen, elixir-format
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1772
-#: lib/klass_hero_web/components/provider_components.ex:2221
+#: lib/klass_hero_web/components/provider_components.ex:1728
+#: lib/klass_hero_web/components/provider_components.ex:2165
+#: lib/klass_hero_web/components/provider_layout_components.ex:554
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrolled"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1620
+#: lib/klass_hero_web/components/provider_components.ex:1577
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1011
+#: lib/klass_hero_web/components/provider_components.ex:970
 #, elixir-autogen, elixir-format
 msgid "Enrollment Capacity (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:405
+#: lib/klass_hero_web/live/admin/verifications_live.ex:388
 #, elixir-autogen, elixir-format
 msgid "Explain why this document is being rejected..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2222
-#: lib/klass_hero_web/live/admin/emails_live.ex:220
+#: lib/klass_hero_web/components/provider_components.ex:2166
+#: lib/klass_hero_web/live/admin/emails_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Failed"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:134
+#: lib/klass_hero_web/live/admin/verifications_live.ex:117
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to approve document."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:174
+#: lib/klass_hero_web/live/admin/verifications_live.ex:157
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to reject document."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:690
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:739
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to resend invite."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:476
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:542
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to upload document."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:266
+#: lib/klass_hero_web/live/dashboard_live.ex:354
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Family Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:601
-#: lib/klass_hero_web/components/provider_components.ex:1109
-#: lib/klass_hero_web/live/settings/children_live.ex:691
+#: lib/klass_hero_web/components/program_components.ex:692
+#: lib/klass_hero_web/components/provider_components.ex:1064
+#: lib/klass_hero_web/live/settings/children_live.ex:669
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:317
+#: lib/klass_hero_web/live/admin/verifications_live.ex:300
 #, elixir-autogen, elixir-format
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2301
+#: lib/klass_hero_web/components/provider_components.ex:2216
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2303
+#: lib/klass_hero_web/components/provider_components.ex:2218
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:695
+#: lib/klass_hero_web/components/provider_components.ex:661
 #, elixir-autogen, elixir-format
 msgid "First Aid, UEFA B License, Child Care Cert"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:636
+#: lib/klass_hero_web/components/provider_components.ex:603
 #, elixir-autogen, elixir-format, fuzzy
 msgid "First Name"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:687
+#: lib/klass_hero_web/live/settings/children_live.ex:665
 #, elixir-autogen, elixir-format
 msgid "Gender"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:610
+#: lib/klass_hero_web/components/program_components.ex:701
 #, elixir-autogen, elixir-format
 msgid "Grade %{grade}"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:618
+#: lib/klass_hero_web/components/program_components.ex:709
 #, elixir-autogen, elixir-format
 msgid "Grade %{min}+"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:614
+#: lib/klass_hero_web/components/program_components.ex:705
 #, elixir-autogen, elixir-format
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2005
+#: lib/klass_hero_web/components/provider_components.ex:1951
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:757
+#: lib/klass_hero_web/components/provider_components.ex:722
 #, elixir-autogen, elixir-format
 msgid "Headshot Photo"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:127
+#: lib/klass_hero_web/presenters/provider_presenter.ex:95
 #, elixir-autogen, elixir-format
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1938
+#: lib/klass_hero_web/components/provider_components.ex:1888
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1979
-#, elixir-autogen, elixir-format
-msgid "Import failed"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:760
-#, elixir-autogen, elixir-format
-msgid "Imported %{count} families."
-msgstr ""
-
-#: lib/klass_hero_web/live/about_live.ex:261
-#, elixir-autogen, elixir-format
-msgid "In 2025, Shane connected with his friend Max Pergl, a full-stack developer who shared a unique perspective. Both Shane and Max are partners of teachers who wanted to extend their expertise beyond the classroom, offering more to the community, but without the time to manage bookings, payments, and compliance on their own."
-msgstr ""
-
-#: lib/klass_hero_web/presenters/provider_presenter.ex:126
+#: lib/klass_hero_web/presenters/provider_presenter.ex:94
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Insurance Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:705
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:754
 #, elixir-autogen, elixir-format
 msgid "Invite not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:702
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:751
 #, elixir-autogen, elixir-format
 msgid "Invite removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:679
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:728
 #, elixir-autogen, elixir-format
 msgid "Invite resent successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1637
+#: lib/klass_hero_web/components/provider_components.ex:1594
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:796
+#: lib/klass_hero_web/components/provider_components.ex:761
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 1MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1214
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1380
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:297
+#: lib/klass_hero_web/components/provider_components.ex:1167
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1507
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:304
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 2MB."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:266
+#: lib/klass_hero_web/live/about_live.ex:189
 #, elixir-autogen, elixir-format
 msgid "Klass Hero was built to solve exactly that. A comprehensive operational platform that empowers educators to spend less time on paperwork and more time inspiring children."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:701
+#: lib/klass_hero_web/live/settings/children_live.ex:679
 #, elixir-autogen, elixir-format
 msgid "Klasse %{n}"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:271
-#, elixir-autogen, elixir-format
-msgid "Konstantin Pergl, Max's brother, joined as CFO, bringing the financial rigour and strategic planning needed to navigate the German market and ensure long-term stability for every provider on the platform."
-msgstr ""
-
-#: lib/klass_hero_web/components/provider_components.ex:642
+#: lib/klass_hero_web/components/provider_components.ex:609
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Last Name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:992
+#: lib/klass_hero_web/components/provider_components.ex:952
 #, elixir-autogen, elixir-format
 msgid "Leave blank for open registration at any time."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1102
+#: lib/klass_hero_web/components/provider_components.ex:1057
 #, elixir-autogen, elixir-format
 msgid "Leave unchecked to allow all genders."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:920
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:172
+#: lib/klass_hero_web/components/provider_components.ex:885
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:167
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Location"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:394
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:73
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:460
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:77
 #, elixir-autogen, elixir-format
 msgid "Logo upload failed. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:602
-#: lib/klass_hero_web/components/provider_components.ex:1108
-#: lib/klass_hero_web/live/settings/children_live.ex:690
+#: lib/klass_hero_web/components/program_components.ex:693
+#: lib/klass_hero_web/components/provider_components.ex:1063
+#: lib/klass_hero_web/live/settings/children_live.ex:668
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1091
+#: lib/klass_hero_web/components/provider_components.ex:1047
 #, elixir-autogen, elixir-format
 msgid "Maximum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1026
+#: lib/klass_hero_web/components/provider_components.ex:985
 #, elixir-autogen, elixir-format
 msgid "Maximum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1148
+#: lib/klass_hero_web/components/provider_components.ex:1102
 #, elixir-autogen, elixir-format
 msgid "Maximum Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:931
+#: lib/klass_hero_web/components/provider_components.ex:894
 #, elixir-autogen, elixir-format
 msgid "Meeting Days"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1085
+#: lib/klass_hero_web/components/provider_components.ex:1041
 #, elixir-autogen, elixir-format
 msgid "Minimum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1020
+#: lib/klass_hero_web/components/provider_components.ex:979
 #, elixir-autogen, elixir-format
 msgid "Minimum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1141
+#: lib/klass_hero_web/components/provider_components.ex:1095
 #, elixir-autogen, elixir-format
 msgid "Minimum Grade"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:75
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Mon-Fri, 9am-6pm CET"
-msgstr ""
-
-#: lib/klass_hero_web/live/admin/verifications_live.ex:522
+#: lib/klass_hero_web/live/admin/verifications_live.ex:496
 #, elixir-autogen, elixir-format
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2329
+#: lib/klass_hero_web/components/provider_components.ex:2243
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1759
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:269
+#: lib/klass_hero_web/components/provider_components.ex:1715
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:747
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:785
 #, elixir-autogen, elixir-format
 msgid "No file selected."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:700
+#: lib/klass_hero_web/live/settings/children_live.ex:678
 #, elixir-autogen, elixir-format
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1992
+#: lib/klass_hero_web/components/provider_components.ex:1939
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1150
+#: lib/klass_hero_web/components/provider_components.ex:1104
 #, elixir-autogen, elixir-format
 msgid "No maximum"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1143
+#: lib/klass_hero_web/components/provider_components.ex:1097
 #, elixir-autogen, elixir-format
 msgid "No minimum"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:521
+#: lib/klass_hero_web/live/admin/verifications_live.ex:495
 #, elixir-autogen, elixir-format
 msgid "No pending documents to review."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:274
+#: lib/klass_hero_web/live/dashboard_live.ex:362
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No programs booked yet"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:523
+#: lib/klass_hero_web/live/admin/verifications_live.ex:497
 #, elixir-autogen, elixir-format
 msgid "No rejected documents."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1505
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1702
 #, elixir-autogen, elixir-format
 msgid "No team members yet"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:520
-#: lib/klass_hero_web/live/admin/verifications_live.ex:524
+#: lib/klass_hero_web/live/admin/verifications_live.ex:494
+#: lib/klass_hero_web/live/admin/verifications_live.ex:498
 #, elixir-autogen, elixir-format
 msgid "No verification documents found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1225
+#: lib/klass_hero_web/components/provider_components.ex:1177
 #, elixir-autogen, elixir-format
 msgid "None (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:292
+#: lib/klass_hero_web/components/provider_components.ex:301
 #, elixir-autogen, elixir-format
 msgid "Not Verified"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:604
-#: lib/klass_hero_web/components/provider_components.ex:1111
-#: lib/klass_hero_web/live/settings/children_live.ex:689
+#: lib/klass_hero_web/components/program_components.ex:695
+#: lib/klass_hero_web/components/provider_components.ex:1066
+#: lib/klass_hero_web/live/settings/children_live.ex:667
 #, elixir-autogen, elixir-format
 msgid "Not specified"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:488
+#: lib/klass_hero_web/components/marketing_components.ex:635
 #, elixir-autogen, elixir-format
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2405
+#: lib/klass_hero_web/components/provider_components.ex:2318
 #, elixir-autogen, elixir-format
 msgid "PDF, JPG or PNG. Max 10MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:527
+#: lib/klass_hero_web/components/program_components.ex:519
 #, elixir-autogen, elixir-format
 msgid "Participant Requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1036
+#: lib/klass_hero_web/components/provider_components.ex:994
 #, elixir-autogen, elixir-format
 msgid "Participant Restrictions (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:831
-#: lib/klass_hero_web/components/provider_components.ex:262
+#: lib/klass_hero_web/components/participation_components.ex:801
+#: lib/klass_hero_web/components/provider_components.ex:269
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Pending Review"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:413
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:975
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1036
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1071
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1143
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:479
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1025
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1083
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1114
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1165
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1270
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:99
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:103
 #, elixir-autogen, elixir-format
 msgid "Please fix the errors below."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:157
+#: lib/klass_hero_web/live/admin/verifications_live.ex:140
 #, elixir-autogen, elixir-format
 msgid "Please provide a rejection reason."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:507
+#: lib/klass_hero_web/live/admin/verifications_live.ex:485
 #, elixir-autogen, elixir-format
 msgid "Preview not available for this file type."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:911
+#: lib/klass_hero_web/components/provider_components.ex:876
 #, elixir-autogen, elixir-format
 msgid "Price (EUR)"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:409
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:475
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Profile updated successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1075
+#: lib/klass_hero_web/components/provider_components.ex:1032
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program Start"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:2069
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:2262
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program created successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:2076
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:2269
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:533
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:571
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:574
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1011
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:595
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:631
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:634
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1058
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:53
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1000
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1047
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program updated successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:418
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:34
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:484
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:32
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:27
 #, elixir-autogen, elixir-format
 msgid "Provider profile not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:508
+#: lib/klass_hero_web/components/marketing_components.ex:648
 #, elixir-autogen, elixir-format
 msgid "Read our founding story →"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:809
-#: lib/klass_hero_web/components/provider_components.ex:2220
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:204
+#: lib/klass_hero_web/components/participation_components.ex:781
+#: lib/klass_hero_web/components/provider_components.ex:2164
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registered"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1062
+#: lib/klass_hero_web/components/provider_components.ex:1019
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:187
+#: lib/klass_hero_web/live/program_detail_live.ex:166
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration Closed"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1003
+#: lib/klass_hero_web/components/provider_components.ex:963
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration Closes"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:185
+#: lib/klass_hero_web/live/program_detail_live.ex:164
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration Not Open Yet"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:998
+#: lib/klass_hero_web/components/provider_components.ex:958
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration Opens"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:989
+#: lib/klass_hero_web/components/provider_components.ex:949
 #, elixir-autogen, elixir-format
 msgid "Registration Period (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:164
+#: lib/klass_hero_web/live/booking_live.ex:146
 #, elixir-autogen, elixir-format
 msgid "Registration has closed for this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:159
+#: lib/klass_hero_web/live/program_detail_live.ex:138
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration is closed"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:78
+#: lib/klass_hero_web/live/booking_live.ex:75
 #, elixir-autogen, elixir-format
 msgid "Registration is not currently open for this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:99
+#: lib/klass_hero_web/live/program_detail_live.ex:88
 #, elixir-autogen, elixir-format
 msgid "Registration is not open for this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:155
+#: lib/klass_hero_web/live/program_detail_live.ex:134
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration opens %{date}"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:392
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:71
+#: lib/klass_hero_web/live/admin/verifications_live.ex:375
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:67
 #, elixir-autogen, elixir-format
 msgid "Reject"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:833
+#: lib/klass_hero_web/components/participation_components.ex:803
 #: lib/klass_hero_web/components/provider_components.ex:48
-#: lib/klass_hero_web/live/admin/verifications_live.ex:219
+#: lib/klass_hero_web/live/admin/verifications_live.ex:202
 #, elixir-autogen, elixir-format
 msgid "Rejected"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:335
-#: lib/klass_hero_web/live/admin/verifications_live.ex:402
+#: lib/klass_hero_web/live/admin/verifications_live.ex:318
+#: lib/klass_hero_web/live/admin/verifications_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "Rejection reason"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:779
-#: lib/klass_hero_web/components/provider_components.ex:1190
-#: lib/klass_hero_web/components/provider_components.ex:2040
-#: lib/klass_hero_web/components/provider_components.ex:2424
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1356
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:311
+#: lib/klass_hero_web/components/provider_components.ex:744
+#: lib/klass_hero_web/components/provider_components.ex:1143
+#: lib/klass_hero_web/components/provider_components.ex:1986
+#: lib/klass_hero_web/components/provider_components.ex:2337
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1483
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2033
+#: lib/klass_hero_web/components/provider_components.ex:1979
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:326
+#: lib/klass_hero_web/live/admin/verifications_live.ex:309
 #, elixir-autogen, elixir-format
 msgid "Reviewed"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:651
+#: lib/klass_hero_web/components/provider_components.ex:618
 #, elixir-autogen, elixir-format
 msgid "Role"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1563
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:224
+#: lib/klass_hero_web/components/provider_components.ex:1523
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:386
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2230
-#: lib/klass_hero_web/components/provider_components.ex:2242
-#: lib/klass_hero_web/components/provider_components.ex:2253
-#, elixir-autogen, elixir-format
-msgid "Row %{row}: %{msg}"
-msgstr ""
-
-#: lib/klass_hero_web/components/provider_components.ex:1252
+#: lib/klass_hero_web/components/provider_components.ex:1204
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Save Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:927
+#: lib/klass_hero_web/components/provider_components.ex:891
 #, elixir-autogen, elixir-format
 msgid "Schedule (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:226
+#: lib/klass_hero_web/live/program_detail_live.ex:205
 #, elixir-autogen, elixir-format
 msgid "Schedule TBD"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:699
+#: lib/klass_hero_web/live/settings/children_live.ex:677
 #, elixir-autogen, elixir-format
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2402
+#: lib/klass_hero_web/components/provider_components.ex:2315
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select File"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:136
-#: lib/klass_hero_web/live/booking_live.ex:201
+#: lib/klass_hero_web/live/booking_live.ex:118
+#: lib/klass_hero_web/live/booking_live.ex:183
 #, elixir-autogen, elixir-format
 msgid "Selected child does not meet the program requirements."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:965
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1026
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1015
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1073
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2219
-#: lib/klass_hero_web/live/admin/emails_live.ex:219
+#: lib/klass_hero_web/components/provider_components.ex:2163
+#: lib/klass_hero_web/live/admin/emails_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Sent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:699
+#: lib/klass_hero_web/components/provider_components.ex:665
 #, elixir-autogen, elixir-format
 msgid "Separate multiple qualifications with commas"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1014
+#: lib/klass_hero_web/components/provider_components.ex:973
 #, elixir-autogen, elixir-format
 msgid "Set minimum and maximum enrollment for this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:256
-#, elixir-autogen, elixir-format
-msgid "Shane spent over a decade as a coach and youth activity provider in Berlin, building Prime Youth, a community of providers, schools, and parents dedicated to giving children the best possible experiences. But one pattern kept emerging: the administrative burden of managing bookings, payments, and compliance was getting in everyone's way. Shane saw the problem from every angle. That experience became the foundation for Klass Hero."
-msgstr ""
-
-#: lib/klass_hero_web/components/provider_components.ex:672
+#: lib/klass_hero_web/components/provider_components.ex:639
 #, elixir-autogen, elixir-format
 msgid "Specialties"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1149
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1276
 #, elixir-autogen, elixir-format
 msgid "Staff member no longer exists."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:272
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:333
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:349
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:343
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:403
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:419
 #, elixir-autogen, elixir-format
 msgid "Staff member not found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:976
+#: lib/klass_hero_web/components/provider_components.ex:937
 #, elixir-autogen, elixir-format
 msgid "Start Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:962
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:165
+#: lib/klass_hero_web/components/provider_components.ex:924
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:160
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Start Time"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:321
+#: lib/klass_hero_web/live/admin/verifications_live.ex:304
 #, elixir-autogen, elixir-format
 msgid "Submitted"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:383
+#: lib/klass_hero_web/live/booking_live.ex:357
 #, elixir-autogen, elixir-format
 msgid "TBD"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:128
+#: lib/klass_hero_web/presenters/provider_presenter.ex:96
 #, elixir-autogen, elixir-format
 msgid "Tax Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1091
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1218
 #, elixir-autogen, elixir-format
 msgid "Team member added, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1092
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1219
 #, elixir-autogen, elixir-format
 msgid "Team member added."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:330
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:400
 #, elixir-autogen, elixir-format
 msgid "Team member removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1115
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1242
 #, elixir-autogen, elixir-format
 msgid "Team member updated, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1116
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1243
 #, elixir-autogen, elixir-format
 msgid "Team member updated."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1316
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1445
 #, elixir-autogen, elixir-format
 msgid "Tell parents about your organization..."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:247
+#: lib/klass_hero_web/live/about_live.ex:170
 #, elixir-autogen, elixir-format
 msgid "The Klass Hero Story"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:682
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:731
 #, elixir-autogen, elixir-format
 msgid "This invite cannot be resent."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1018
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1065
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:893
+#: lib/klass_hero_web/components/provider_components.ex:858
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:276
-#, elixir-autogen, elixir-format
-msgid "To lead trust and quality, Laurie Camargo, a mother with over a decade of experience in child safety and quality assurance, will join to architect our Safety-First Verification engine, ensuring every Hero meets the highest standards before working with families."
-msgstr ""
-
-#: lib/klass_hero_web/components/provider_components.ex:2302
+#: lib/klass_hero_web/components/provider_components.ex:2217
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:367
+#: lib/klass_hero_web/live/admin/verifications_live.ex:350
 #, elixir-autogen, elixir-format
 msgid "Unable to load document preview."
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:563
+#: lib/klass_hero_web/components/program_components.ex:564
 #, elixir-autogen, elixir-format
 msgid "Up to %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:622
+#: lib/klass_hero_web/components/program_components.ex:713
 #, elixir-autogen, elixir-format
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1923
+#: lib/klass_hero_web/components/provider_components.ex:1874
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2448
+#: lib/klass_hero_web/components/provider_components.ex:2361
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2357
+#: lib/klass_hero_web/components/provider_components.ex:2270
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2323
+#: lib/klass_hero_web/components/provider_components.ex:2238
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2304
+#: lib/klass_hero_web/components/provider_components.ex:2219
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2320
+#: lib/klass_hero_web/components/provider_components.ex:2235
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/verifications_live.ex:71
-#: lib/klass_hero_web/live/admin/verifications_live.ex:93
-#: lib/klass_hero_web/live/admin/verifications_live.ex:125
-#: lib/klass_hero_web/live/admin/verifications_live.ex:165
+#: lib/klass_hero_web/live/admin/verifications_live.ex:57
+#: lib/klass_hero_web/live/admin/verifications_live.ex:79
+#: lib/klass_hero_web/live/admin/verifications_live.ex:108
+#: lib/klass_hero_web/live/admin/verifications_live.ex:148
 #, elixir-autogen, elixir-format
 msgid "Verification document not found."
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:147
-#: lib/klass_hero_web/components/layouts/app.html.heex:256
+#: lib/klass_hero_web/components/layouts/app.html.heex:138
+#: lib/klass_hero_web/components/layouts/app.html.heex:232
+#: lib/klass_hero_web/components/ui_components.ex:271
 #: lib/klass_hero_web/live/admin/verifications_live.ex:40
-#: lib/klass_hero_web/live/admin/verifications_live.ex:50
-#: lib/klass_hero_web/live/admin/verifications_live.ex:189
+#: lib/klass_hero_web/live/admin/verifications_live.ex:172
 #, elixir-autogen, elixir-format
 msgid "Verifications"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:247
+#: lib/klass_hero_web/components/provider_components.ex:253
+#: lib/klass_hero_web/components/provider_layout_components.ex:212
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Verified"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:126
+#: lib/klass_hero_web/live/about_live.ex:155
 #, elixir-autogen, elixir-format
 msgid "We are Klass Hero — parents, brothers, and partners of educators — building the infrastructure that helps every child learn and thrive."
 msgstr ""
 
-#: lib/klass_hero_web/user_auth.ex:315
+#: lib/klass_hero_web/user_auth.ex:280
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You don't have access to that page."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:652
+#: lib/klass_hero_web/components/provider_components.ex:619
 #, elixir-autogen, elixir-format, fuzzy
 msgid "e.g. Head Coach"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:643
+#: lib/klass_hero_web/components/provider_components.ex:610
 #, elixir-autogen, elixir-format
 msgid "e.g. Johnson"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:637
+#: lib/klass_hero_web/components/provider_components.ex:604
 #, elixir-autogen, elixir-format
 msgid "e.g. Mike"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:658
+#: lib/klass_hero_web/components/provider_components.ex:625
 #, elixir-autogen, elixir-format
 msgid "e.g. mike@example.com"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:894
+#: lib/klass_hero_web/components/provider_components.ex:859
 #, elixir-autogen, elixir-format
 msgid "e.g., Art Adventures"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:921
+#: lib/klass_hero_web/components/provider_components.ex:886
 #, elixir-autogen, elixir-format
 msgid "e.g., Community Center, Main St"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/tier_presenter.ex:150
-#, elixir-autogen, elixir-format
-msgid "%{media_types} media"
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:39
-#, elixir-autogen, elixir-format
-msgid "%{name} Plan"
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:132
-#, elixir-autogen, elixir-format
-msgid "%{percent}% commission"
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:128
-#, elixir-autogen, elixir-format, fuzzy
-msgid "1 program"
-msgid_plural "%{count} programs"
-msgstr[0] ""
-msgstr[1] ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:159
-#: lib/klass_hero_web/presenters/tier_presenter.ex:160
-#, elixir-autogen, elixir-format
-msgid "1 team seat"
-msgid_plural "%{count} team seats"
-msgstr[0] ""
-msgstr[1] ""
-
 #: lib/klass_hero_web/live/about_live.ex:71
-#: lib/klass_hero_web/live/trust_safety_live.ex:53
+#: lib/klass_hero_web/live/trust_safety_live.ex:51
 #, elixir-autogen, elixir-format
 msgid "All Heroes must hold or complete a recognized child safeguarding course, ensuring up-to-date knowledge."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/tier_presenter.ex:146
-#, elixir-autogen, elixir-format
-msgid "All media types"
-msgstr ""
-
-#: lib/klass_hero_web/live/about_live.ex:25
-#: lib/klass_hero_web/live/trust_safety_live.ex:23
+#: lib/klass_hero_web/live/about_live.ex:41
+#: lib/klass_hero_web/live/trust_safety_live.ex:21
 #, elixir-autogen, elixir-format
 msgid "All providers must be 18 years or older, ensuring legal accountability and professional responsibility."
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:234
+#: lib/klass_hero_web/live/trust_safety_live.ex:161
 #, elixir-autogen, elixir-format
 msgid "And at Klass Hero, both come standard."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:61
-#: lib/klass_hero_web/live/trust_safety_live.ex:47
+#: lib/klass_hero_web/live/about_live.ex:65
+#: lib/klass_hero_web/live/trust_safety_live.ex:45
 #, elixir-autogen, elixir-format
 msgid "Applicants complete a video screening to assess communication skills and alignment with our values."
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:102
-#, elixir-autogen, elixir-format
-msgid "At Klass Hero, trust isn't a feature — it's the foundation of everything we do. Our platform is built to connect families, schools, and organizations with qualified, vetted, and safety-verified educators and activity providers."
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:154
-#, elixir-autogen, elixir-format
-msgid "Avatar"
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:135
-#, elixir-autogen, elixir-format
-msgid "Avatar media only"
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:35
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Business Plus"
-msgstr ""
-
 #: lib/klass_hero_web/live/about_live.ex:69
-#: lib/klass_hero_web/live/trust_safety_live.ex:51
+#: lib/klass_hero_web/live/trust_safety_live.ex:49
 #, elixir-autogen, elixir-format
 msgid "Child Safeguarding Training"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/subscription_live.ex:106
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Choose the plan that fits your business needs."
-msgstr ""
-
-#: lib/klass_hero_web/live/user_live/registration.ex:92
-#, elixir-autogen, elixir-format
-msgid "Choose your plan"
-msgstr ""
-
-#: lib/klass_hero_web/live/about_live.ex:81
-#: lib/klass_hero_web/live/trust_safety_live.ex:59
+#: lib/klass_hero_web/live/about_live.ex:77
+#: lib/klass_hero_web/live/trust_safety_live.ex:57
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/subscription_live.ex:83
-#, elixir-autogen, elixir-format
-msgid "Could not change subscription tier"
-msgstr ""
-
-#: lib/klass_hero_web/live/trust_safety_live.ex:73
+#: lib/klass_hero_web/live/trust_safety_live.ex:71
 #, elixir-autogen, elixir-format
 msgid "Create long-term trust across our community"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/subscription_live.ex:126
-#: lib/klass_hero_web/live/provider/subscription_live.ex:166
-#, elixir-autogen, elixir-format
-msgid "Current Plan"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1440
-#, elixir-autogen, elixir-format
-msgid "Current Plan: %{plan}"
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:75
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Direct messaging"
-msgstr ""
-
-#: lib/klass_hero_web/live/about_live.ex:49
-#: lib/klass_hero_web/live/trust_safety_live.ex:39
+#: lib/klass_hero_web/live/about_live.ex:57
+#: lib/klass_hero_web/live/trust_safety_live.ex:37
 #, elixir-autogen, elixir-format
 msgid "Each provider submits an extended police background check, confirming their eligibility to work safely with minors."
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:80
+#: lib/klass_hero_web/live/trust_safety_live.ex:78
 #, elixir-autogen, elixir-format
 msgid "Enforcing platform standards and guidelines"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:157
-#, elixir-autogen, elixir-format
-msgid "Every educator and enrichment professional on Klass Hero completes a 6-step verification process before being approved."
-msgstr ""
-
-#: lib/klass_hero_web/live/about_live.ex:83
-#: lib/klass_hero_web/live/trust_safety_live.ex:61
+#: lib/klass_hero_web/live/about_live.ex:79
+#: lib/klass_hero_web/live/trust_safety_live.ex:59
 #, elixir-autogen, elixir-format
 msgid "Every provider agrees to follow our Community Guidelines, defining expectations around professionalism."
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:35
-#: lib/klass_hero_web/live/trust_safety_live.ex:29
+#: lib/klass_hero_web/live/about_live.ex:47
+#: lib/klass_hero_web/live/trust_safety_live.ex:27
 #, elixir-autogen, elixir-format
 msgid "Experience Validation"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:47
-#: lib/klass_hero_web/live/trust_safety_live.ex:37
+#: lib/klass_hero_web/live/about_live.ex:55
+#: lib/klass_hero_web/live/trust_safety_live.ex:35
 #, elixir-autogen, elixir-format
 msgid "Extended Background Checks"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/tier_presenter.ex:45
-#, elixir-autogen, elixir-format
-msgid "For established providers"
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:44
-#, elixir-autogen, elixir-format
-msgid "For growing businesses"
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:49
-#, elixir-autogen, elixir-format
-msgid "Free"
-msgstr ""
-
-#: lib/klass_hero_web/live/trust_safety_live.ex:136
+#: lib/klass_hero_web/live/trust_safety_live.ex:120
 #, elixir-autogen, elixir-format
 msgid "From academic tutoring to sports, arts, and enrichment programs, every provider on Klass Hero is carefully reviewed to ensure they meet our high standards for child safety, professionalism, and educational quality."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/tier_presenter.ex:155
-#, elixir-autogen, elixir-format
-msgid "Gallery"
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:43
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Get started for free"
-msgstr ""
-
-#: lib/klass_hero_web/live/trust_safety_live.ex:214
-#, elixir-autogen, elixir-format
-msgid "Have Questions?"
-msgstr ""
-
-#: lib/klass_hero_web/live/trust_safety_live.ex:154
+#: lib/klass_hero_web/components/marketing_components.ex:1428
 #, elixir-autogen, elixir-format
 msgid "How We Verify Providers"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:23
-#: lib/klass_hero_web/live/trust_safety_live.ex:21
+#: lib/klass_hero_web/live/about_live.ex:39
+#: lib/klass_hero_web/live/trust_safety_live.ex:19
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Identity & Age Verification"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:217
+#: lib/klass_hero_web/live/trust_safety_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "If you'd like to learn more about our Trust & Safety standards or provider verification process, we're happy to help."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/subscription_live.ex:74
-#: lib/klass_hero_web/live/provider/subscription_live.ex:87
-#, elixir-autogen, elixir-format
-msgid "Invalid subscription tier"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1450
-#, elixir-autogen, elixir-format
-msgid "Manage Plan →"
-msgstr ""
-
-#: lib/klass_hero_web/live/trust_safety_live.ex:79
+#: lib/klass_hero_web/live/trust_safety_live.ex:77
 #, elixir-autogen, elixir-format
 msgid "Monitoring provider activity and feedback"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:184
-#, elixir-autogen, elixir-format
-msgid "Ongoing Quality & Accountability"
-msgstr ""
-
-#: lib/klass_hero_web/live/trust_safety_live.ex:114
-#, elixir-autogen, elixir-format
-msgid "Our Commitment to Child Safety"
-msgstr ""
-
-#: lib/klass_hero_web/live/booking_live.ex:506
+#: lib/klass_hero_web/live/booking_live.ex:480
 #, elixir-autogen, elixir-format
 msgid "Pay by cash or direct bank transfer"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/tier_presenter.ex:34
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Professional"
-msgstr ""
-
-#: lib/klass_hero_web/live/booking_live.ex:517
+#: lib/klass_hero_web/live/booking_live.ex:491
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program fee:"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1913
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:2106
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/tier_presenter.ex:76
-#, elixir-autogen, elixir-format
-msgid "Promotional content"
-msgstr ""
-
-#: lib/klass_hero_web/live/trust_safety_live.ex:70
+#: lib/klass_hero_web/live/trust_safety_live.ex:68
 #, elixir-autogen, elixir-format
 msgid "Protect children and families"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:37
-#: lib/klass_hero_web/live/trust_safety_live.ex:31
+#: lib/klass_hero_web/live/about_live.ex:49
+#: lib/klass_hero_web/live/trust_safety_live.ex:29
 #, elixir-autogen, elixir-format
 msgid "Providers must demonstrate at least one year of experience working with children in their area of expertise."
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:203
+#: lib/klass_hero_web/live/trust_safety_live.ex:146
 #, elixir-autogen, elixir-format
 msgid "Providers who fail to uphold our expectations may be suspended or removed from the platform."
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:81
+#: lib/klass_hero_web/live/trust_safety_live.ex:79
 #, elixir-autogen, elixir-format
 msgid "Reviewing concerns or reports promptly and seriously"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:225
+#: lib/klass_hero_web/live/booking_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Please try again or contact support."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/tier_presenter.ex:33
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Starter"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/subscription_live.ex:46
-#, elixir-autogen, elixir-format
-msgid "Subscription"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/subscription_live.ex:103
-#, elixir-autogen, elixir-format
-msgid "Subscription Plans"
-msgstr ""
-
-#: lib/klass_hero_web/live/trust_safety_live.ex:71
+#: lib/klass_hero_web/live/trust_safety_live.ex:69
 #, elixir-autogen, elixir-format
 msgid "Support schools and institutions with reliable providers"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/subscription_live.ex:175
-#, elixir-autogen, elixir-format
-msgid "Switch to %{plan}"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/subscription_live.ex:67
-#, elixir-autogen, elixir-format
-msgid "Switched to %{plan}"
-msgstr ""
-
-#: lib/klass_hero_web/live/trust_safety_live.ex:99
-#, elixir-autogen, elixir-format
-msgid "TRUST & SAFETY"
-msgstr ""
-
-#: lib/klass_hero_web/live/trust_safety_live.ex:82
+#: lib/klass_hero_web/live/trust_safety_live.ex:80
 #, elixir-autogen, elixir-format
 msgid "Taking action when standards are not met"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:209
+#: lib/klass_hero_web/live/booking_live.ex:191
 #, elixir-autogen, elixir-format
 msgid "This child is already enrolled in this program."
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:612
-#: lib/klass_hero_web/components/composite_components.ex:681
+#: lib/klass_hero_web/components/composite_components.ex:477
+#: lib/klass_hero_web/components/composite_components.ex:546
 #: lib/klass_hero_web/components/layouts/app.html.heex:60
-#: lib/klass_hero_web/components/layouts/app.html.heex:212
-#: lib/klass_hero_web/live/trust_safety_live.ex:12
+#: lib/klass_hero_web/components/layouts/app.html.heex:199
+#: lib/klass_hero_web/components/marketing_components.ex:192
+#: lib/klass_hero_web/components/marketing_components.ex:805
+#: lib/klass_hero_web/components/marketing_components.ex:909
+#: lib/klass_hero_web/live/for_providers_live.ex:136
+#: lib/klass_hero_web/live/trust_safety_live.ex:10
 #, elixir-autogen, elixir-format
 msgid "Trust & Safety"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:187
+#: lib/klass_hero_web/live/trust_safety_live.ex:140
 #, elixir-autogen, elixir-format
 msgid "Trust doesn't stop at onboarding. Klass Hero continuously works to maintain a safe and high-quality ecosystem by:"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:231
+#: lib/klass_hero_web/live/trust_safety_live.ex:160
 #, elixir-autogen, elixir-format
 msgid "Trust is earned. Safety is non-negotiable."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/tier_presenter.ex:127
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Unlimited programs"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1443
-#, elixir-autogen, elixir-format
-msgid "Upgrade your plan to unlock more features"
-msgstr ""
-
-#: lib/klass_hero_web/live/trust_safety_live.ex:72
+#: lib/klass_hero_web/live/trust_safety_live.ex:70
 #, elixir-autogen, elixir-format
 msgid "Uphold professional and ethical teaching practices"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:133
+#: lib/klass_hero_web/components/marketing_components.ex:1387
 #, elixir-autogen, elixir-format
 msgid "Vetted with Care"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/tier_presenter.ex:156
-#, elixir-autogen, elixir-format
-msgid "Video"
-msgstr ""
-
-#: lib/klass_hero_web/live/about_live.ex:59
-#: lib/klass_hero_web/live/trust_safety_live.ex:45
+#: lib/klass_hero_web/live/about_live.ex:63
+#: lib/klass_hero_web/live/trust_safety_live.ex:43
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr ""
 
-#: lib/klass_hero_web/live/trust_safety_live.ex:117
-#, elixir-autogen, elixir-format
-msgid "We believe that children thrive best in environments that are safe, respectful, and professionally led. That's why Klass Hero applies a multi-layered safety and verification framework before any provider can offer sessions on our platform."
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/subscription_live.ex:71
-#, elixir-autogen, elixir-format
-msgid "You are already on this plan"
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:55
-#, elixir-autogen, elixir-format
-msgid "forever"
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:56
-#: lib/klass_hero_web/presenters/tier_presenter.ex:57
-#, elixir-autogen, elixir-format
-msgid "month"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:532
+#: lib/klass_hero_web/live/home_live.ex:94
 #, elixir-autogen, elixir-format
 msgid "Every provider completes identity and age verification, experience validation, an extended background check, video screening, child safeguarding training, and agreement to our Community Guidelines before being approved."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:530
+#: lib/klass_hero_web/live/home_live.ex:91
 #, elixir-autogen, elixir-format
 msgid "How does the 6-step provider vetting process work?"
 msgstr ""
 
-#: lib/klass_hero_web/live/about_live.ex:210
+#: lib/klass_hero_web/live/about_live.ex:163
 #, elixir-autogen, elixir-format
 msgid "Our 6-Step Vetting Process"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:139
+#: lib/klass_hero_web/live/settings/children_live.ex:134
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Could not check enrollments. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:613
+#: lib/klass_hero_web/live/settings/children_live.ex:592
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove Child"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:567
+#: lib/klass_hero_web/live/settings/children_live.ex:546
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove Child?"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:585
+#: lib/klass_hero_web/live/settings/children_live.ex:564
 #, elixir-autogen, elixir-format
 msgid "Their enrollments will be cancelled. This action cannot be undone."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:572
+#: lib/klass_hero_web/live/settings/children_live.ex:551
 #, elixir-autogen, elixir-format
 msgid "This child is currently enrolled in the following programs:"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:152
+#: lib/klass_hero_web/live/settings/children_live.ex:145
 #, elixir-autogen, elixir-format
 msgid "This deletion request has expired. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:669
-#, elixir-autogen, elixir-format
-msgid "1st cancellation (90 days): Warning only"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:670
-#, elixir-autogen, elixir-format
-msgid "2nd cancellation: €50 penalty"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:648
-#, elixir-autogen, elixir-format
-msgid "3-7 days before: Usually 75% refund (you keep 25%)"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:671
-#, elixir-autogen, elixir-format
-msgid "3rd cancellation: €100 penalty + 14-day suspension"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:672
-#, elixir-autogen, elixir-format
-msgid "4+ cancellations: Account termination"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:647
-#, elixir-autogen, elixir-format
-msgid "7+ days before: Usually full refund (you keep nothing)"
-msgstr ""
-
-#: lib/klass_hero_web/live/admin/sessions_live.ex:268
+#: lib/klass_hero_web/live/admin/sessions_live.ex:249
 #, elixir-autogen, elixir-format
 msgid "A reason is required for corrections"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:815
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:207
+#: lib/klass_hero_web/components/participation_components.ex:787
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:201
 #, elixir-autogen, elixir-format
 msgid "Absent"
 msgstr ""
@@ -4244,37 +3594,37 @@ msgstr ""
 msgid "Accounts"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:79
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:76
 #, elixir-autogen, elixir-format, fuzzy
 msgid "All Statuses"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:605
+#: lib/klass_hero_web/live/home_live.ex:150
 #, elixir-autogen, elixir-format
 msgid "All payments processed securely through Stripe."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:577
+#: lib/klass_hero_web/live/home_live.ex:127
 #, elixir-autogen, elixir-format
 msgid "All plans include: Profile page, booking system, payment processing, messaging, and marketing to Berlin families."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:280
+#: lib/klass_hero_web/live/admin/sessions_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "An error occurred"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:601
+#: lib/klass_hero_web/live/home_live.ex:146
 #, elixir-autogen, elixir-format
 msgid "Apple Pay / Google Pay"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:189
+#: lib/klass_hero_web/live/admin/sessions_live.ex:177
 #, elixir-autogen, elixir-format
 msgid "Attendance corrected successfully"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:623
+#: lib/klass_hero_web/live/home_live.ex:168
 #, elixir-autogen, elixir-format
 msgid "Automatic fee calculation (no surprises)"
 msgstr ""
@@ -4284,7 +3634,7 @@ msgstr ""
 msgid "Back to App"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:132
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:127
 #, elixir-autogen, elixir-format
 msgid "Back to sessions"
 msgstr ""
@@ -4294,255 +3644,175 @@ msgstr ""
 msgid "Bookings"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:573
-#, elixir-autogen, elixir-format
-msgid "Business Account: You keep €901 (€60 commission + €39 monthly fee)"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:563
-#, elixir-autogen, elixir-format
-msgid "Business Account: €39/month + 6% per booking (for providers/teams earning €600+/month)"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:546
+#: lib/klass_hero_web/live/home_live.ex:108
 #, elixir-autogen, elixir-format
 msgid "Camps and holiday programs"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:765
+#: lib/klass_hero_web/live/home_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "Can I buy a gift voucher?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:719
+#: lib/klass_hero_web/live/home_live.ex:191
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Can I change my booking date?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:739
-#, elixir-autogen, elixir-format
-msgid "Can I get a refund if the provider cancels?"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:540
+#: lib/klass_hero_web/live/home_live.ex:102
 #, elixir-autogen, elixir-format
 msgid "Can I list my programs on Klass Hero and what does it cost?"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:274
+#: lib/klass_hero_web/live/admin/sessions_live.ex:255
 #, elixir-autogen, elixir-format
 msgid "Cannot check out without a check-in"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:654
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:96
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:703
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:159
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:153
 #, elixir-autogen, elixir-format
 msgid "Check-in"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:211
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "Check-in time"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:160
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:154
 #, elixir-autogen, elixir-format
 msgid "Check-out"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:220
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:214
 #, elixir-autogen, elixir-format
 msgid "Check-out time"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:297
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:205
+#: lib/klass_hero_web/live/admin/sessions_live.ex:276
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "Checked In"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:298
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:206
+#: lib/klass_hero_web/live/admin/sessions_live.ex:277
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:200
 #, elixir-autogen, elixir-format
 msgid "Checked Out"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2076
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:157
+#: lib/klass_hero_web/components/provider_components.ex:2022
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Child"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:638
-#, elixir-autogen, elixir-format
-msgid "Clear policies protect everyone."
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:767
+#: lib/klass_hero_web/live/home_live.ex:215
 #, elixir-autogen, elixir-format
 msgid "Coming soon! Sign up for our newsletter to be notified when gift vouchers launch."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:812
+#: lib/klass_hero_web/components/participation_components.ex:784
 #, elixir-autogen, elixir-format
 msgid "Completed"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:658
-#, elixir-autogen, elixir-format
-msgid "Contact all booked parents immediately and offer alternative dates. Include us in CC/BCC (support@mail.klasshero.com)."
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:721
+#: lib/klass_hero_web/live/home_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "Contact the provider directly (details in confirmation email). Most providers are flexible if you ask in advance."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:641
-#, elixir-autogen, elixir-format
-msgid "Contact them immediately - often you can find an alternative date. Include us in CC/BCC (support@mail.klasshero.com) so we're informed."
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:747
-#, elixir-autogen, elixir-format
-msgid "Contact us immediately at support@mail.klasshero.com or call +49 (0) 152 2426 0416. You'll receive 100% refund + family credit, and the provider faces serious penalties."
-msgstr ""
-
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:184
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:178
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Correct"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:177
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:651
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:124
+#: lib/klass_hero_web/live/dashboard_live.ex:280
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:700
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Could not start conversation. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:600
+#: lib/klass_hero_web/live/home_live.ex:145
 #, elixir-autogen, elixir-format
 msgid "Credit/debit card (Visa, Mastercard, Amex)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:757
+#: lib/klass_hero_web/live/home_live.ex:209
 #, elixir-autogen, elixir-format
 msgid "Currently serving Berlin, with expansion to other German cities coming soon."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:677
-#, elixir-autogen, elixir-format
-msgid "Death in family"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:709
+#: lib/klass_hero_web/live/home_live.ex:185
 #, elixir-autogen, elixir-format
 msgid "Do I need an account to book?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:630
+#: lib/klass_hero_web/live/home_live.ex:175
 #, elixir-autogen, elixir-format
 msgid "Download monthly statements for taxes"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:731
-#, elixir-autogen, elixir-format
-msgid "Email the provider and us (support@mail.klasshero.com) immediately. You may qualify for full refund."
-msgstr ""
-
-#: lib/klass_hero_web/components/provider_components.ex:1841
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:328
+#: lib/klass_hero_web/components/provider_components.ex:1792
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:483
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrollment not confirmed"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:568
-#, elixir-autogen, elixir-format
-msgid "Example: If you earn €1,000 in bookings"
-msgstr ""
-
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:237
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:231
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Explain why this correction is needed..."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:628
+#: lib/klass_hero_web/live/home_live.ex:173
 #, elixir-autogen, elixir-format
 msgid "Export participant lists anytime"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:595
+#: lib/klass_hero_web/live/home_live.ex:140
 #, elixir-autogen, elixir-format
 msgid "Funds are immediately available in your Klass Hero account"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:679
-#, elixir-autogen, elixir-format
-msgid "Government closure"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:606
+#: lib/klass_hero_web/live/home_live.ex:151
 #, elixir-autogen, elixir-format
 msgid "How You Get Paid:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:585
+#: lib/klass_hero_web/live/home_live.ex:133
 #, elixir-autogen, elixir-format
 msgid "How does the booking system work?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:639
-#, elixir-autogen, elixir-format
-msgid "If Parent Cancels:"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:656
-#, elixir-autogen, elixir-format
-msgid "If You Must Cancel:"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:683
-#, elixir-autogen, elixir-format
-msgid "If you fail to show up without prior notice:"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:685
-#, elixir-autogen, elixir-format
-msgid "Immediate account suspension"
-msgstr ""
-
-#: lib/klass_hero_web/components/participation_components.ex:811
-#: lib/klass_hero_web/live/admin/sessions_live.ex:296
+#: lib/klass_hero_web/components/participation_components.ex:783
+#: lib/klass_hero_web/live/admin/sessions_live.ex:275
 #, elixir-autogen, elixir-format, fuzzy
 msgid "In Progress"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:609
+#: lib/klass_hero_web/live/home_live.ex:154
 #, elixir-autogen, elixir-format
 msgid "Instant availability: Funds are in your Klass Hero balance immediately after booking"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:699
+#: lib/klass_hero_web/live/home_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "Is Klass Hero free for parents to use?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:691
-#, elixir-autogen, elixir-format
-msgid "Keep your reliability high - parents can see your cancellation rate on your profile."
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:603
+#: lib/klass_hero_web/live/home_live.ex:148
 #, elixir-autogen, elixir-format
 msgid "Klarna (pay later options)"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:592
+#: lib/klass_hero_web/components/composite_components.ex:452
 #: lib/klass_hero_web/components/layouts/admin.html.heex:5
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Klass Hero"
@@ -4553,191 +3823,132 @@ msgstr ""
 msgid "Klass Hero Admin"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:649
-#, elixir-autogen, elixir-format
-msgid "Less than 3 days: Usually 25-50% refund (you keep 50-75%)"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:676
-#, elixir-autogen, elixir-format
-msgid "Medical emergency"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:680
-#, elixir-autogen, elixir-format
-msgid "Minimum enrollment not met (camps only - notify 14 days before)"
-msgstr ""
-
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:203
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:197
 #, elixir-autogen, elixir-format
 msgid "No change"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:269
+#: lib/klass_hero_web/live/admin/sessions_live.ex:250
 #, elixir-autogen, elixir-format
 msgid "No changes detected"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:621
+#: lib/klass_hero_web/live/home_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "No chasing payments or sending invoices"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1588
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:248
+#: lib/klass_hero_web/components/provider_components.ex:1546
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:407
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No enrolled parents"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:674
-#, elixir-autogen, elixir-format
-msgid "No penalties for legitimate reasons:"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:622
+#: lib/klass_hero_web/live/home_live.ex:167
 #, elixir-autogen, elixir-format
 msgid "No risk of non-payment"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:836
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:161
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:178
+#: lib/klass_hero_web/components/participation_components.ex:806
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:155
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:173
 #, elixir-autogen, elixir-format
 msgid "Notes"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:614
+#: lib/klass_hero_web/live/home_live.ex:159
 #, elixir-autogen, elixir-format
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1840
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:327
+#: lib/klass_hero_web/components/provider_components.ex:1791
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:590
+#: lib/klass_hero_web/live/home_live.ex:137
 #, elixir-autogen, elixir-format
 msgid "Parent books and pays through Klass Hero (via Stripe)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:687
-#, elixir-autogen, elixir-format
-msgid "Parent gets 100% refund + family credit"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:594
+#: lib/klass_hero_web/live/home_live.ex:139
 #, elixir-autogen, elixir-format
 msgid "Parent receives confirmation with your contact details"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:620
+#: lib/klass_hero_web/live/home_live.ex:165
 #, elixir-autogen, elixir-format
 msgid "Parents pay upfront when booking (reduces no-shows by 85%)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:598
+#: lib/klass_hero_web/live/home_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "Payment Options for Parents:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:688
-#, elixir-autogen, elixir-format
-msgid "Permanent ban if no valid emergency"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:615
+#: lib/klass_hero_web/live/home_live.ex:160
 #, elixir-autogen, elixir-format
 msgid "Platform fee automatically deducted when parent pays"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:550
+#: lib/klass_hero_web/live/home_live.ex:112
 #, elixir-autogen, elixir-format
 msgid "Pricing:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:548
+#: lib/klass_hero_web/live/home_live.ex:110
 #, elixir-autogen, elixir-format
 msgid "Private lessons and tutoring"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:558
-#, elixir-autogen, elixir-format
-msgid "Professional: More tools and opportunities for €9/month + 12% per booking (only when you get bookings)"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:571
-#, elixir-autogen, elixir-format
-msgid "Professional: You keep €871 (€120 commission + €9 monthly fee)"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:667
-#, elixir-autogen, elixir-format
-msgid "Provider Cancellation Penalties:"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:682
-#, elixir-autogen, elixir-format
-msgid "Provider No-Show:"
-msgstr ""
-
 #: lib/klass_hero_web/components/layouts/admin.html.heex:31
+#: lib/klass_hero_web/components/marketing_components.ex:810
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Providers"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:627
+#: lib/klass_hero_web/live/home_live.ex:172
 #, elixir-autogen, elixir-format
 msgid "Real-time dashboard shows all bookings and available balance"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:231
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:225
 #, elixir-autogen, elixir-format
 msgid "Reason for correction"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:272
+#: lib/klass_hero_web/live/admin/sessions_live.ex:253
 #, elixir-autogen, elixir-format
 msgid "Record was modified by someone else. Please refresh."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:645
-#, elixir-autogen, elixir-format
-msgid "Refunds are automatic based on our cancellation policy:"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:545
+#: lib/klass_hero_web/live/home_live.ex:107
 #, elixir-autogen, elixir-format
 msgid "Regular classes and courses (weekly/monthly)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:602
+#: lib/klass_hero_web/live/home_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "SEPA direct debit"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:250
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:244
 #, elixir-autogen, elixir-format
 msgid "Save Correction"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:810
+#: lib/klass_hero_web/components/participation_components.ex:782
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Scheduled"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:629
+#: lib/klass_hero_web/live/home_live.ex:174
 #, elixir-autogen, elixir-format
 msgid "See payment history and upcoming payouts"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:678
-#, elixir-autogen, elixir-format
-msgid "Severe weather"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:587
+#: lib/klass_hero_web/live/home_live.ex:134
 #, elixir-autogen, elixir-format
 msgid "Simple and automated - we handle everything."
 msgstr ""
@@ -4747,134 +3958,88 @@ msgstr ""
 msgid "Staff Members"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:553
-#, elixir-autogen, elixir-format
-msgid "Starter: Free to join — no registration fees, no monthly subscriptions. 20% commission per booking"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:570
-#, elixir-autogen, elixir-format
-msgid "Starter: You keep €800 (€200 commission)"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:652
-#, elixir-autogen, elixir-format
-msgid "Stripe processes all refunds - funds returned to parent's original payment method within 5-10 business days. Any amounts you keep remain in your balance."
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:625
+#: lib/klass_hero_web/live/home_live.ex:170
 #, elixir-autogen, elixir-format
 msgid "Track Everything:"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1836
-#, elixir-autogen, elixir-format
-msgid "Upgrade to Professional to message parents"
-msgstr ""
-
-#: lib/klass_hero_web/live/dashboard_live.ex:164
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:648
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:93
+#: lib/klass_hero_web/live/dashboard_live.ex:267
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:144
 #, elixir-autogen, elixir-format
 msgid "Upgrade your plan to send messages."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:613
+#: lib/klass_hero_web/live/home_live.ex:158
 #, elixir-autogen, elixir-format
 msgid "Weekly payouts: Transferred to your bank account every Friday"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:543
+#: lib/klass_hero_web/live/home_live.ex:105
 #, elixir-autogen, elixir-format
 msgid "What You Can List:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:636
-#, elixir-autogen, elixir-format
-msgid "What happens if a parent cancels or I need to cancel?"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:729
+#: lib/klass_hero_web/live/home_live.ex:199
 #, elixir-autogen, elixir-format
 msgid "What if my child gets sick?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:745
-#, elixir-autogen, elixir-format
-msgid "What if the provider doesn't show up?"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:588
+#: lib/klass_hero_web/live/home_live.ex:135
 #, elixir-autogen, elixir-format
 msgid "When Someone Books:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:663
-#, elixir-autogen, elixir-format
-msgid "When you cancel, parents get 100% refund automatically. The amount is deducted from your next payout."
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:755
+#: lib/klass_hero_web/live/home_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Where is Klass Hero available?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:617
+#: lib/klass_hero_web/live/home_live.ex:162
 #, elixir-autogen, elixir-format
 msgid "Why This Works Better:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:547
+#: lib/klass_hero_web/live/home_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "Workshops and one-time events"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:701
+#: lib/klass_hero_web/live/home_live.ex:181
 #, elixir-autogen, elixir-format
 msgid "Yes! Browsing and booking are completely free. No subscription, no booking fees."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:542
+#: lib/klass_hero_web/live/home_live.ex:104
 #, elixir-autogen, elixir-format
 msgid "Yes! Register for free and start listing immediately."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:740
-#, elixir-autogen, elixir-format
-msgid "Yes, always 100% refund if provider cancels. No exceptions."
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:711
+#: lib/klass_hero_web/live/home_live.ex:187
 #, elixir-autogen, elixir-format
 msgid "Yes, you need a free account to complete a booking and manage your reservations."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:596
+#: lib/klass_hero_web/live/home_live.ex:141
 #, elixir-autogen, elixir-format
 msgid "You deliver the program"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:619
+#: lib/klass_hero_web/live/home_live.ex:164
 #, elixir-autogen, elixir-format
 msgid "You get paid BEFORE delivering the program (no waiting)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:592
+#: lib/klass_hero_web/live/home_live.ex:138
 #, elixir-autogen, elixir-format
 msgid "You receive instant email with booking details and parent contact info"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:686
-#, elixir-autogen, elixir-format
-msgid "€200 penalty (deducted from balance or invoiced)"
-msgstr ""
-
-#: lib/klass_hero_web/components/participation_components.ex:78
+#: lib/klass_hero_web/components/participation_components.ex:73
 #, elixir-autogen, elixir-format
 msgid "%{checked_in} / %{capacity} checked in"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:322
+#: lib/klass_hero_web/components/participation_components.ex:311
 #, elixir-autogen, elixir-format
 msgid "%{checked_in} / %{total} checked in"
 msgstr ""
@@ -4884,154 +4049,149 @@ msgstr ""
 msgid "%{count} unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:356
+#: lib/klass_hero_web/live/provider/sessions_live.ex:366
 #, elixir-autogen, elixir-format
 msgid "A session already exists at this time"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:152
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:196
 #, elixir-autogen, elixir-format
 msgid "Account created! Check your email to confirm and log in."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:112
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:112
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:111
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:111
 #, elixir-autogen, elixir-format
 msgid "Add Note"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:129
-#: lib/klass_hero_web/components/layouts/app.html.heex:249
+#: lib/klass_hero_web/components/layouts/app.html.heex:120
+#: lib/klass_hero_web/components/layouts/app.html.heex:225
+#: lib/klass_hero_web/components/ui_components.ex:264
 #, elixir-autogen, elixir-format
 msgid "Admin"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:27
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:25
 #, elixir-autogen, elixir-format, fuzzy
 msgid "All programs"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:15
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:13
 #, elixir-autogen, elixir-format, fuzzy
 msgid "All providers"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:735
+#: lib/klass_hero_web/components/participation_components.ex:713
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Allergies: %{details}"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:233
+#: lib/klass_hero_web/components/participation_components.ex:224
 #, elixir-autogen, elixir-format
 msgid "Any important notes about today's session..."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.html.heex:124
+#: lib/klass_hero_web/live/admin/emails_live.html.heex:122
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Archive"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:215
+#: lib/klass_hero_web/live/admin/emails_live.ex:207
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:57
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Archived"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:158
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:321
 #, elixir-autogen, elixir-format
 msgid "Assigned Programs"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:9
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:9
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:8
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:8
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Back to Sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.html.heex:107
+#: lib/klass_hero_web/live/admin/emails_live.html.heex:105
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Back to emails"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:515
+#: lib/klass_hero_web/components/participation_components.ex:495
 #, elixir-autogen, elixir-format
 msgid "Behavioral Note"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:628
+#: lib/klass_hero_web/components/messaging_components.ex:688
 #, elixir-autogen, elixir-format
 msgid "Broadcast messages are one-way"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:91
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:91
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:92
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:92
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Check In"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:276
+#: lib/klass_hero_web/live/admin/sessions_live.ex:257
 #, elixir-autogen, elixir-format
 msgid "Check-in time must be before check-out time"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:367
+#: lib/klass_hero_web/components/participation_components.ex:352
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Check-in:"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:407
+#: lib/klass_hero_web/components/participation_components.ex:389
 #, elixir-autogen, elixir-format
 msgid "Check-out notes (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:373
+#: lib/klass_hero_web/components/participation_components.ex:358
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Check-out:"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:217
+#: lib/klass_hero_web/components/participation_components.ex:209
 #, elixir-autogen, elixir-format
 msgid "Checked in at %{time}"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:174
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:165
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Checked in:"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:184
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:175
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Checked out:"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/components/searchable_select.ex:86
+#: lib/klass_hero_web/live/admin/components/searchable_select.ex:80
 #, elixir-autogen, elixir-format
 msgid "Clear selection"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:76
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:202
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:83
 #, elixir-autogen, elixir-format
 msgid "Complete Registration"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:75
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:287
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:71
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:271
 #, elixir-autogen, elixir-format
 msgid "Complete Session"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:42
-#, elixir-autogen, elixir-format
-msgid "Complete Your Registration"
-msgstr ""
-
-#: lib/klass_hero_web/components/participation_components.ex:423
+#: lib/klass_hero_web/components/participation_components.ex:404
 #, elixir-autogen, elixir-format
 msgid "Confirm Check Out"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:103
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:98
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Confirm Rejection"
 msgstr ""
@@ -5041,65 +4201,65 @@ msgstr ""
 msgid "Consents"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.html.heex:90
+#: lib/klass_hero_web/live/admin/emails_live.html.heex:88
 #, elixir-autogen, elixir-format
 msgid "Content fetch failed"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:125
+#: lib/klass_hero_web/live/admin/emails_live.ex:119
 #, elixir-autogen, elixir-format
 msgid "Content fetch retrying..."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.html.heex:144
+#: lib/klass_hero_web/live/admin/emails_live.html.heex:142
 #, elixir-autogen, elixir-format
 msgid "Content is being fetched..."
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:240
+#: lib/klass_hero_web/live/messaging_live_helper.ex:239
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Could not start private conversation"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:17
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:135
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:200
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:18
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:130
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:195
 #, elixir-autogen, elixir-format
 msgid "Create Session"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:162
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:330
-#: lib/klass_hero_web/live/provider/sessions_live.ex:331
+#: lib/klass_hero_web/live/provider/sessions_live.ex:342
+#: lib/klass_hero_web/live/provider/sessions_live.ex:343
 #, elixir-autogen, elixir-format
 msgid "Date is required"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:408
+#: lib/klass_hero_web/components/participation_components.ex:390
 #, elixir-autogen, elixir-format
 msgid "E.g., picked up by parent, gave medication reminder..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:144
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:140
 #, elixir-autogen, elixir-format
 msgid "Edit & Resubmit"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:142
+#: lib/klass_hero_web/live/admin/emails_live.ex:136
 #, elixir-autogen, elixir-format
 msgid "Email archived"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:162
+#: lib/klass_hero_web/live/admin/emails_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "Email marked as unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:70
+#: lib/klass_hero_web/live/admin/emails_live.ex:66
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Email not found"
 msgstr ""
@@ -5112,131 +4272,125 @@ msgstr ""
 msgid "Emails"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:747
+#: lib/klass_hero_web/components/participation_components.ex:725
 #, elixir-autogen, elixir-format
 msgid "Emergency: %{details}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:355
+#: lib/klass_hero_web/live/provider/sessions_live.ex:365
 #, elixir-autogen, elixir-format
 msgid "End time must be after start time"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:816
+#: lib/klass_hero_web/components/participation_components.ex:788
 #, elixir-autogen, elixir-format
 msgid "Expected"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:145
+#: lib/klass_hero_web/live/admin/emails_live.ex:139
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to archive email"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:290
+#: lib/klass_hero_web/live/provider/sessions_live.ex:302
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to create session: %{reason}"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.html.heex:148
+#: lib/klass_hero_web/live/admin/emails_live.html.heex:146
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to fetch email content."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:165
+#: lib/klass_hero_web/live/admin/emails_live.ex:159
 #, elixir-autogen, elixir-format
 msgid "Failed to mark email as unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:365
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:435
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to resend invitation. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:128
+#: lib/klass_hero_web/live/admin/emails_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "Failed to schedule retry"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:109
+#: lib/klass_hero_web/live/admin/emails_live.ex:103
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to send reply"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:39
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:36
 #, elixir-autogen, elixir-format
 msgid "From"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.html.heex:114
+#: lib/klass_hero_web/live/admin/emails_live.html.heex:112
 #, elixir-autogen, elixir-format
 msgid "From:"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:24
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:36
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:22
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:34
 #, elixir-autogen, elixir-format
 msgid "Go to Home"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:351
+#: lib/klass_hero_web/components/participation_components.ex:337
 #, elixir-autogen, elixir-format
 msgid "In: %{time}"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:18
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:17
 #, elixir-autogen, elixir-format
 msgid "Invalid Invitation"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:278
-#: lib/klass_hero_web/live/provider/sessions_live.ex:351
+#: lib/klass_hero_web/live/admin/sessions_live.ex:259
+#: lib/klass_hero_web/live/provider/sessions_live.ex:361
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invalid time format"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:30
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:81
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:27
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:107
 #, elixir-autogen, elixir-format
 msgid "Invitation Expired"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:79
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:105
 #, elixir-autogen, elixir-format
 msgid "Invitation Failed"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:77
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:103
 #, elixir-autogen, elixir-format
 msgid "Invitation Pending"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:78
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:104
 #, elixir-autogen, elixir-format
 msgid "Invitation Sent"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:346
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:416
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invitation resent successfully."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:80
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:106
 #, elixir-autogen, elixir-format
 msgid "Joined"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/app.html.heex:15
-#: lib/klass_hero_web/components/layouts/app.html.heex:202
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Klass Hero Logo"
-msgstr ""
-
-#: lib/klass_hero_web/live/admin/emails_live.html.heex:160
+#: lib/klass_hero_web/live/admin/emails_live.html.heex:158
 #, elixir-autogen, elixir-format
 msgid "Load images"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:71
+#: lib/klass_hero_web/components/participation_components.ex:66
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Location TBD"
 msgstr ""
@@ -5246,432 +4400,431 @@ msgstr ""
 msgid "Manage your scheduled sessions and attendance"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.html.heex:132
+#: lib/klass_hero_web/live/admin/emails_live.html.heex:130
 #, elixir-autogen, elixir-format
 msgid "Mark Unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:181
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:176
 #, elixir-autogen, elixir-format
 msgid "Max Capacity"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:89
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:301
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:85
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:285
 #, elixir-autogen, elixir-format
 msgid "No actions available"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:454
+#: lib/klass_hero_web/components/participation_components.ex:434
 #, elixir-autogen, elixir-format
 msgid "No children enrolled in this session"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.html.heex:64
+#: lib/klass_hero_web/live/admin/emails_live.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "No emails found."
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:202
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "No participation records yet"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:162
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:325
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No programs assigned yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/components/searchable_select.ex:113
+#: lib/klass_hero_web/live/admin/components/searchable_select.ex:107
 #, elixir-autogen, elixir-format
 msgid "No results"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:91
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "No sessions found for the selected filters."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:104
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:316
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:100
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:300
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:654
+#: lib/klass_hero_web/components/participation_components.ex:634
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Note:"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:516
+#: lib/klass_hero_web/components/participation_components.ex:496
 #, elixir-autogen, elixir-format
 msgid "Observation about the child's participation..."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:357
+#: lib/klass_hero_web/components/participation_components.ex:343
 #, elixir-autogen, elixir-format
 msgid "Out: %{time}"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:179
+#: lib/klass_hero_web/components/participation_components.ex:172
 #, elixir-autogen, elixir-format
 msgid "Participation Check-In"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:25
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:25
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:26
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:26
 #, elixir-autogen, elixir-format
 msgid "Participation Management"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:17
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:14
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Pending Reviews"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:90
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Please explain why you're rejecting this note..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:358
+#: lib/klass_hero_web/live/provider/sessions_live.ex:368
 #, elixir-autogen, elixir-format
 msgid "Please fill in all required fields"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:571
+#: lib/klass_hero_web/components/composite_components.ex:431
 #, elixir-autogen, elixir-format
 msgid "Post"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:26
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:143
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:612
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:287
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:156
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:24
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:666
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:297
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:153
+#: lib/klass_hero_web/live/provider/sessions_live.ex:177
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program is required"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:14
+#: lib/klass_hero_web/components/provider_layout_components.ex:74
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:12
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Provider"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:35
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:32
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Provider observation"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:214
+#: lib/klass_hero_web/live/admin/emails_live.ex:206
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "Read"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:89
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:84
 #, elixir-autogen, elixir-format
 msgid "Reason for rejection (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.html.heex:201
+#: lib/klass_hero_web/live/admin/emails_live.html.heex:197
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:639
+#: lib/klass_hero_web/components/messaging_components.ex:699
 #, elixir-autogen, elixir-format
 msgid "Reply privately"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:247
+#: lib/klass_hero_web/live/messaging_live_helper.ex:246
 #, elixir-autogen, elixir-format
 msgid "Reply privately is only available for broadcast messages"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:106
+#: lib/klass_hero_web/live/admin/emails_live.ex:100
 #, elixir-autogen, elixir-format
 msgid "Reply sent successfully"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:566
+#: lib/klass_hero_web/components/provider_components.ex:529
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Resend"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:65
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:62
 #, elixir-autogen, elixir-format
 msgid "Reset to today"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:547
+#: lib/klass_hero_web/components/participation_components.ex:527
 #, elixir-autogen, elixir-format
 msgid "Resubmit Note"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.html.heex:150
+#: lib/klass_hero_web/live/admin/emails_live.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "Retry"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:545
+#: lib/klass_hero_web/components/participation_components.ex:525
 #, elixir-autogen, elixir-format
 msgid "Revised Note"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:157
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:152
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select a program..."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.html.heex:211
+#: lib/klass_hero_web/live/admin/emails_live.html.heex:207
 #, elixir-autogen, elixir-format
 msgid "Send Reply"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:218
+#: lib/klass_hero_web/live/admin/emails_live.ex:210
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sending"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:58
+#: lib/klass_hero_web/components/participation_components.ex:54
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:16
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:16
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Session"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:232
+#: lib/klass_hero_web/components/participation_components.ex:223
 #, elixir-autogen, elixir-format
 msgid "Session Notes (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:188
-#: lib/klass_hero_web/components/participation_components.ex:319
+#: lib/klass_hero_web/components/participation_components.ex:180
+#: lib/klass_hero_web/components/participation_components.ex:308
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Session Roster"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:270
+#: lib/klass_hero_web/live/provider/sessions_live.ex:284
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Session created successfully"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:27
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:30
 #, elixir-autogen, elixir-format
 msgid "Staff Dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1078
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1121
 #, elixir-autogen, elixir-format
 msgid "Staff member created, but the invitation could not be sent. Try resending from the team list."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:53
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:265
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:49
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:249
 #, elixir-autogen, elixir-format
 msgid "Start Session"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:517
+#: lib/klass_hero_web/components/participation_components.ex:497
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Submit Note"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:248
+#: lib/klass_hero_web/components/participation_components.ex:238
 #, elixir-autogen, elixir-format
 msgid "Submit Participation"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:741
+#: lib/klass_hero_web/components/participation_components.ex:719
 #, elixir-autogen, elixir-format
 msgid "Support: %{details}"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:49
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:55
 #, elixir-autogen, elixir-format
 msgid "The business associated with your account could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:356
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "This invitation cannot be resent in its current state."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:32
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:29
 #, elixir-autogen, elixir-format
 msgid "This invitation has expired. Please ask your business to resend it."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:20
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:18
 #, elixir-autogen, elixir-format
 msgid "This invitation link is invalid or has already been used."
 msgstr ""
 
-#: lib/klass_hero_web/controllers/invite_claim_controller.ex:57
+#: lib/klass_hero_web/controllers/invite_claim_controller.ex:50
 #, elixir-autogen, elixir-format
 msgid "This invite has already been used."
 msgstr ""
 
-#: lib/klass_hero_web/controllers/invite_claim_controller.ex:52
+#: lib/klass_hero_web/controllers/invite_claim_controller.ex:45
 #, elixir-autogen, elixir-format, fuzzy
 msgid "This invite link is invalid or has expired."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:340
-#: lib/klass_hero_web/live/provider/sessions_live.ex:341
+#: lib/klass_hero_web/live/provider/sessions_live.ex:352
+#: lib/klass_hero_web/live/provider/sessions_live.ex:353
 #, elixir-autogen, elixir-format
 msgid "Time is required"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.html.heex:51
+#: lib/klass_hero_web/live/admin/sessions_live.html.heex:48
 #, elixir-autogen, elixir-format
 msgid "To"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.html.heex:206
+#: lib/klass_hero_web/live/admin/emails_live.html.heex:202
 #, elixir-autogen, elixir-format
 msgid "Type your reply..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:160
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:72
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:95
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:124
+#: lib/klass_hero_web/live/provider/sessions_live.ex:181
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:123
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:93
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "Unauthorized"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:213
+#: lib/klass_hero_web/components/parent_components.ex:481
+#: lib/klass_hero_web/live/admin/emails_live.ex:205
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:35
 #, elixir-autogen, elixir-format
 msgid "Unread"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:546
+#: lib/klass_hero_web/components/participation_components.ex:526
 #, elixir-autogen, elixir-format
 msgid "Update your observation..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:460
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:744
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:526
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:782
 #, elixir-autogen, elixir-format
 msgid "Upload connection lost. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:86
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:298
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:82
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "View Participation"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:6
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "View your children's participation records"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:137
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:214
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Welcome, %{name}"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:563
+#: lib/klass_hero_web/components/composite_components.ex:423
 #, elixir-autogen, elixir-format
 msgid "Write a comment..."
 msgstr ""
 
-#: lib/klass_hero_web/controllers/invite_claim_controller.ex:44
+#: lib/klass_hero_web/controllers/invite_claim_controller.ex:37
 #, elixir-autogen, elixir-format
 msgid "You already have an account. Log in to see your new enrollment."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:107
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:319
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:103
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:303
 #, elixir-autogen, elixir-format
 msgid "You have no sessions scheduled for %{date}"
 msgstr ""
 
-#: lib/klass_hero_web/user_auth.ex:299
+#: lib/klass_hero_web/user_auth.ex:268
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You must be a staff member to access this page."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:44
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:43
 #, elixir-autogen, elixir-format
 msgid "You've been invited to join a team on Klass Hero."
 msgstr ""
 
-#: lib/klass_hero_web/controllers/invite_claim_controller.ex:32
+#: lib/klass_hero_web/controllers/invite_claim_controller.ex:29
 #, elixir-autogen, elixir-format
 msgid "Your account has been created! Set up your password in settings."
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:205
+#: lib/klass_hero_web/live/parent/participation_history_live.html.heex:195
 #, elixir-autogen, elixir-format
 msgid "Your children's participation will appear here"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:200
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:363
 #, elixir-autogen, elixir-format
 msgid "Roster"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:393
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Team Members"
-msgstr ""
-
-#: lib/klass_hero_web/presenters/tier_presenter.ex:158
+#: lib/klass_hero_web/live/for_providers_live.ex:417
 #, elixir-autogen, elixir-format
 msgid "Unlimited team seats"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:231
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:218
 #, elixir-autogen, elixir-format
 msgid "View and manage your assigned sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:70
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:332
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:60
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:218
 #, elixir-autogen, elixir-format
 msgid "You are not assigned to this program"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:233
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:240
 #, elixir-autogen, elixir-format
 msgid "+1234567890"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:852
+#: lib/klass_hero_web/components/composite_components.ex:692
 #, elixir-autogen, elixir-format
 msgid "About the Provider"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:250
+#: lib/klass_hero_web/components/marketing_components.ex:501
 #, elixir-autogen, elixir-format
 msgid "Built for the Berlin international community. Integrated secure encrypted messaging to connect with local families and trusted educators nearby."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:214
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:221
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Business Name"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:817
+#: lib/klass_hero_web/components/participation_components.ex:789
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cancelled"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:253
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:260
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Categories"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1273
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:318
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1407
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:325
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Complete Profile"
 msgstr ""
@@ -5681,159 +4834,136 @@ msgstr ""
 msgid "Complete Your Profile"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:195
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:202
 #, elixir-autogen, elixir-format
 msgid "Complete Your Provider Profile"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1256
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1390
 #, elixir-autogen, elixir-format
 msgid "Complete your provider profile"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:294
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:301
 #, elixir-autogen, elixir-format
 msgid "Drag and drop or click to upload"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:504
+#: lib/klass_hero_web/live/messaging_live_helper.ex:481
 #, elixir-autogen, elixir-format
 msgid "Failed to upload files. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:689
+#: lib/klass_hero_web/components/messaging_components.ex:763
 #, elixir-autogen, elixir-format, fuzzy
 msgid "File is too large (max %{mb} MB)"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:502
+#: lib/klass_hero_web/live/messaging_live_helper.ex:479
 #, elixir-autogen, elixir-format, fuzzy
 msgid "File is too large (max %{mb} MB)."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:692
+#: lib/klass_hero_web/components/messaging_components.ex:766
 #, elixir-autogen, elixir-format, fuzzy
 msgid "File type not accepted (images only)"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1259
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1393
 #, elixir-autogen, elixir-format
 msgid "Fill in your business details so parents can find you. Your profile will be reviewed by Klass Hero before going live."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:198
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:205
 #, elixir-autogen, elixir-format
 msgid "Fill in your business details. Your profile will be reviewed by Klass Hero before going live."
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:152
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:263
 #, elixir-autogen, elixir-format
 msgid "Manage your business"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:499
+#: lib/klass_hero_web/live/messaging_live_helper.ex:476
 #, elixir-autogen, elixir-format
 msgid "Only images are accepted (JPG, PNG, GIF, WebP)."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:677
-#: lib/klass_hero_web/components/messaging_components.ex:681
+#: lib/klass_hero_web/components/messaging_components.ex:751
+#: lib/klass_hero_web/components/messaging_components.ex:755
 #, elixir-autogen, elixir-format
 msgid "Photo"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:494
+#: lib/klass_hero_web/live/messaging_live_helper.ex:471
 #, elixir-autogen, elixir-format
 msgid "Please enter a message or attach a photo."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:91
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:95
 #, elixir-autogen, elixir-format
 msgid "Profile completed! Klass Hero will review your profile shortly."
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:36
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:31
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Provider not found"
 msgstr ""
 
 #: lib/klass_hero_web/components/messaging_components.ex:276
+#: lib/klass_hero_web/components/messaging_components.ex:344
 #, elixir-autogen, elixir-format
 msgid "Remove attachment"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1422
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Sessions Completed"
-msgstr ""
-
-#: lib/klass_hero_web/live/messaging_live_helper.ex:505
+#: lib/klass_hero_web/live/messaging_live_helper.ex:482
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:132
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:136
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:103
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:47
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:88
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:107
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Something went wrong. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:223
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:230
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Tell parents about your organization and what makes you unique..."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:696
+#: lib/klass_hero_web/components/messaging_components.ex:770
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Too many files (max %{max})"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:497
+#: lib/klass_hero_web/live/messaging_live_helper.ex:474
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Too many files (max %{max})."
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:323
-#, elixir-autogen, elixir-format
-msgid "Upgrade plan to message parents"
-msgstr ""
-
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:247
-#, elixir-autogen, elixir-format
-msgid "Upgrade plan to send broadcasts"
-msgstr ""
-
-#: lib/klass_hero_web/components/messaging_components.ex:700
+#: lib/klass_hero_web/components/messaging_components.ex:774
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload error"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:699
+#: lib/klass_hero_web/components/messaging_components.ex:773
 #, elixir-autogen, elixir-format
 msgid "Upload failed"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:1184
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1309
 #, elixir-autogen, elixir-format
 msgid "View your assignments"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:239
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "Website"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:435
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:957
-#, elixir-autogen, elixir-format
-msgid "You've reached your program limit. Upgrade your plan to add more programs."
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:248
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:255
 #, elixir-autogen, elixir-format
 msgid "Your business address"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:215
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:222
 #, elixir-autogen, elixir-format
 msgid "Your business or organization name"
 msgstr ""
@@ -5843,369 +4973,2071 @@ msgstr ""
 msgid "Your profile is already complete."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:89
-#: lib/klass_hero_web/live/messaging_live_helper.ex:338
+#: lib/klass_hero_web/components/messaging_components.ex:92
+#: lib/klass_hero_web/live/messaging_live_helper.ex:327
 #, elixir-autogen, elixir-format, fuzzy
 msgid "for"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1711
+#: lib/klass_hero_web/components/provider_components.ex:1667
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assigned staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1713
+#: lib/klass_hero_web/components/provider_components.ex:1669
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1695
+#: lib/klass_hero_web/components/provider_components.ex:1651
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Close"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1712
+#: lib/klass_hero_web/components/provider_components.ex:1668
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1710
+#: lib/klass_hero_web/components/provider_components.ex:1666
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1704
+#: lib/klass_hero_web/components/provider_components.ex:1660
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No sessions scheduled yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1693
+#: lib/klass_hero_web/components/provider_components.ex:1649
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sessions — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1444
+#: lib/klass_hero_web/components/provider_components.ex:1396
 #, elixir-autogen, elixir-format
 msgid "View sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:800
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:873
 #, elixir-autogen, elixir-format
 msgid "Create a program before inviting participants."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:814
+#: lib/klass_hero_web/components/participation_components.ex:786
 #, elixir-autogen, elixir-format
 msgid "Departed"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:835
+#: lib/klass_hero_web/components/participation_components.ex:805
 #, elixir-autogen, elixir-format
 msgid "Departure notes"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:318
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:257
+#: lib/klass_hero_web/live/provider/participation_live.ex:225
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:167
 #, elixir-autogen, elixir-format
 msgid "Departure time is not a valid date and time"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:329
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:268
+#: lib/klass_hero_web/live/provider/participation_live.ex:236
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:178
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to update record"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2140
+#: lib/klass_hero_web/components/provider_components.ex:2086
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1863
+#: lib/klass_hero_web/components/provider_components.ex:1814
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invite mode"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1882
+#: lib/klass_hero_web/components/provider_components.ex:1833
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:796
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:869
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invite sent."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:600
+#: lib/klass_hero_web/components/participation_components.ex:580
 #, elixir-autogen, elixir-format
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2153
+#: lib/klass_hero_web/components/provider_components.ex:2099
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2159
+#: lib/klass_hero_web/components/provider_components.ex:2105
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:321
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:260
+#: lib/klass_hero_web/live/provider/participation_live.ex:228
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:170
 #, elixir-autogen, elixir-format
 msgid "Nothing to update"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2161
+#: lib/klass_hero_web/components/provider_components.ex:2107
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nut allergy"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2165
+#: lib/klass_hero_web/components/provider_components.ex:2111
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2170
+#: lib/klass_hero_web/components/provider_components.ex:2116
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:813
+#: lib/klass_hero_web/components/participation_components.ex:785
 #, elixir-autogen, elixir-format
 msgid "Present"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2097
+#: lib/klass_hero_web/components/provider_components.ex:2043
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:61
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:61
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:62
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:62
 #, elixir-autogen, elixir-format
 msgid "Record departure"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:597
+#: lib/klass_hero_web/components/participation_components.ex:577
 #, elixir-autogen, elixir-format
 msgid "Record departure time (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:309
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:248
+#: lib/klass_hero_web/live/provider/participation_live.ex:216
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:158
 #, elixir-autogen, elixir-format
 msgid "Record updated"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:614
+#: lib/klass_hero_web/components/participation_components.ex:594
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Save changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2134
+#: lib/klass_hero_web/components/provider_components.ex:2080
 #, elixir-autogen, elixir-format, fuzzy
 msgid "School (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2144
+#: lib/klass_hero_web/components/provider_components.ex:2090
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2118
+#: lib/klass_hero_web/components/provider_components.ex:2064
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2187
+#: lib/klass_hero_web/components/provider_components.ex:2133
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Send invite"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:589
+#: lib/klass_hero_web/components/participation_components.ex:569
 #, elixir-autogen, elixir-format
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1900
+#: lib/klass_hero_web/components/provider_components.ex:1851
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload a list"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/dashboard_live.ex:807
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:880
 #, elixir-autogen, elixir-format
 msgid "An invite for this child and program already exists."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:227
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:237
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Behavioral Issue"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:240
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:250
 #, elixir-autogen, elixir-format
 msgid "Critical"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:280
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:290
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Date & time"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:330
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:340
 #, elixir-autogen, elixir-format
 msgid "Drop a photo here or click to browse"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:239
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:249
 #, elixir-autogen, elixir-format
 msgid "High"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:726
+#: lib/klass_hero_web/components/provider_components.ex:692
 #, elixir-autogen, elixir-format
 msgid "Hourly"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:121
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:115
 #, elixir-autogen, elixir-format
 msgid "Incident report submitted."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:228
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:238
 #, elixir-autogen, elixir-format
 msgid "Injury"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:237
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:247
 #, elixir-autogen, elixir-format
 msgid "Low"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:238
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:248
 #, elixir-autogen, elixir-format
 msgid "Medium"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:716
+#: lib/klass_hero_web/components/provider_components.ex:682
 #, elixir-autogen, elixir-format
 msgid "None"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:705
+#: lib/klass_hero_web/components/provider_components.ex:671
 #, elixir-autogen, elixir-format
 msgid "Pay Rate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:537
+#: lib/klass_hero_web/components/provider_components.ex:500
 #, elixir-autogen, elixir-format
 msgid "Pay rate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:736
+#: lib/klass_hero_web/components/provider_components.ex:702
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Per Session"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:320
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:330
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Photo (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:230
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:240
 #, elixir-autogen, elixir-format
 msgid "Policy Violation"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:64
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:63
 #, elixir-autogen, elixir-format
 msgid "Program or session not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:229
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:239
 #, elixir-autogen, elixir-format
 msgid "Property Damage"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1467
+#: lib/klass_hero_web/components/provider_components.ex:1419
 #, elixir-autogen, elixir-format
 msgid "Report Incident"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:47
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:258
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:45
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "Report an Incident"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:226
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:236
 #, elixir-autogen, elixir-format
 msgid "Safety Concern"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:298
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "Select a category"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:289
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:299
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select a program"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:305
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:315
 #, elixir-autogen, elixir-format
 msgid "Severity"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:264
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:274
 #, elixir-autogen, elixir-format
 msgid "Submit a report about an incident during a program or session. All fields are confidential."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_report_live.ex:355
+#: lib/klass_hero_web/live/provider/incident_report_live.ex:365
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Submit report"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:144
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:221
 #, elixir-autogen, elixir-format
 msgid "Your pay rate"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:73
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:99
 #, elixir-autogen, elixir-format
 msgid "hour"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:74
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:100
 #, elixir-autogen, elixir-format, fuzzy
 msgid "session"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/greeting.ex
+#: lib/klass_hero_web/helpers/greeting.ex:53
 #, elixir-autogen, elixir-format
 msgid "Good morning"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/greeting.ex
+#: lib/klass_hero_web/helpers/greeting.ex:54
 #, elixir-autogen, elixir-format
 msgid "Good afternoon"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/greeting.ex
+#: lib/klass_hero_web/helpers/greeting.ex:55
 #, elixir-autogen, elixir-format
 msgid "Good evening"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex
+#: lib/klass_hero_web/live/dashboard_live.ex:60
 #, elixir-autogen, elixir-format
 msgid "Your week with the kids"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex
+#: lib/klass_hero_web/components/marketing_components.ex:91
+#: lib/klass_hero_web/components/marketing_components.ex:159
 #, elixir-autogen, elixir-format
 msgid "Go to dashboard"
-msgstr "Go to dashboard"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:825
+#, elixir-autogen, elixir-format
+msgid "%{count} row could not be processed."
+msgid_plural "%{count} rows could not be processed."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/klass_hero_web/components/parent_components.ex:411
+#, elixir-autogen, elixir-format
+msgid "%{done} of %{goal} sessions attended"
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:195
+#, elixir-autogen, elixir-format, fuzzy
+msgid ", Max's brother, joined as CFO, bringing the financial rigour and strategic planning needed to navigate the German market and ensure long-term stability for every provider on the platform. To lead trust and quality,"
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:184
+#, elixir-autogen, elixir-format
+msgid ", a full-stack developer who shared a unique perspective. Both Shane and Max are partners of teachers who wanted to extend their expertise beyond the classroom — but without the time to manage the operational side on their own."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:958
+#, elixir-autogen, elixir-format
+msgid ", camps & classes for your child"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:345
+#, elixir-autogen, elixir-format
+msgid "18+, government-ID verified before listing."
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:93
+#, elixir-autogen, elixir-format
+msgid "A decade-plus coaching and running youth activity programs in Berlin. Built Prime Youth before founding Klass Hero."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:529
+#, elixir-autogen, elixir-format
+msgid "Accept"
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/settings.ex:15
+#: lib/klass_hero_web/live/user_live/settings.ex:17
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Account"
+msgstr ""
+
+#: lib/klass_hero_web/components/parent_components.ex:89
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Account settings"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1565
+#, elixir-autogen, elixir-format
+msgid "Across all programs"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:380
+#, elixir-autogen, elixir-format
+msgid "Active policy required to teach."
+msgstr ""
+
+#: lib/klass_hero_web/live/dashboard_live.ex:300
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1555
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Active programs"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:93
+#, elixir-autogen, elixir-format
+msgid "Add 3+ photos to boost bookings by ~40%."
+msgstr ""
+
+#: lib/klass_hero_web/components/parent_components.ex:290
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Add a child"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:321
+#, elixir-autogen, elixir-format
+msgid "Afterschool Adventures Await"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:344
+#, elixir-autogen, elixir-format
+msgid "Age & Identity"
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:20
+#, elixir-autogen, elixir-format, fuzzy
+msgid "All instructors are background-checked and verified."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:548
+#, elixir-autogen, elixir-format
+msgid "Are you an educator, coach, or artist?"
+msgstr ""
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:104
+#, elixir-autogen, elixir-format, fuzzy
+msgid "At Klass Hero, trust isn't a feature — it's the foundation of everything we do. We connect families, schools, and organizations with qualified, vetted, and safety-verified educators."
+msgstr ""
+
+#: lib/klass_hero_web/components/messaging_components.ex:294
+#, elixir-autogen, elixir-format
+msgid "Attach photo"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:68
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Back to Programs"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:890
+#: lib/klass_hero_web/components/marketing_components.ex:900
+#, elixir-autogen, elixir-format
+msgid "Become a Hero"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:858
+#, elixir-autogen, elixir-format
+msgid "Become a Hero →"
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:314
+#, elixir-autogen, elixir-format
+msgid "Become a provider"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:303
+#, elixir-autogen, elixir-format
+msgid "Berlin parents come to Klass Hero looking for trusted programs. You focus on teaching — we handle the funnel."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:226
+#, elixir-autogen, elixir-format
+msgid "Berlin's #1 network for youth educators"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:240
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Berlin's leading network for tutors, coaches, and camp providers — every one verified by our team."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:794
+#, elixir-autogen, elixir-format
+msgid "Berlin's network for trusted youth educators. Built by parents, for parents."
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:328
+#, elixir-autogen, elixir-format
+msgid "Better parent relationships"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:311
+#, elixir-autogen, elixir-format
+msgid "Bookings, rosters, schedules, attendance, parent comms — all in one place. No more spreadsheets."
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:111
+#, elixir-autogen, elixir-format
+msgid "Brings the financial rigour and strategic planning needed for the German market and long-term provider stability."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:803
+#: lib/klass_hero_web/components/marketing_components.ex:907
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Browse Programs"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:868
+#: lib/klass_hero_web/components/marketing_components.ex:878
+#: lib/klass_hero_web/components/marketing_components.ex:888
+#: lib/klass_hero_web/components/marketing_components.ex:898
+#, elixir-autogen, elixir-format
+msgid "Browse Programs →"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:391
+#, elixir-autogen, elixir-format
+msgid "Build a listing in under 10 minutes. Schedule, capacity, photos, age range — done."
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:30
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Building connections between families and local instructors."
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:171
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Built by parents and educators for more learning opportunities."
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:144
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Built for Berlin"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:74
+#, elixir-autogen, elixir-format
+msgid "Built for educators who want to teach, not run a business"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:323
+#, elixir-autogen, elixir-format
+msgid "Built-in trust"
+msgstr ""
+
+#: lib/klass_hero_web/live/home_live.ex:123
+#, elixir-autogen, elixir-format
+msgid "Business Plus: €49/month + 8% per booking. Unlimited programs and team seats"
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:109
+#, elixir-autogen, elixir-format
+msgid "CFO"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:455
+#, elixir-autogen, elixir-format
+msgid "Can I run programs at multiple locations?"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:279
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Cancel anytime"
+msgstr ""
+
+#: lib/klass_hero_web/live/contact_live.ex:209
+#, elixir-autogen, elixir-format
+msgid "Check our FAQ — most questions are answered there."
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/settings.ex:37
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Children"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:1245
+#, elixir-autogen, elixir-format
+msgid "Clear filters"
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/confirmation.ex:18
+#, elixir-autogen, elixir-format
+msgid "Click below to log in."
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:100
+#, elixir-autogen, elixir-format
+msgid "Co-founder & CTO"
+msgstr ""
+
+#: lib/klass_hero_web/components/parent_components.ex:143
+#: lib/klass_hero_web/components/parent_components.ex:322
+#: lib/klass_hero_web/components/provider_layout_components.ex:147
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1573
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1581
+#, elixir-autogen, elixir-format
+msgid "Coming soon"
+msgstr ""
+
+#: lib/klass_hero_web/components/parent_components.ex:414
+#, elixir-autogen, elixir-format
+msgid "Coming soon — track your family's weekly attendance."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/messages_live/index.ex:19
+#, elixir-autogen, elixir-format
+msgid "Comms"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:374
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Community Standards"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:819
+#, elixir-autogen, elixir-format
+msgid "Company"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:397
+#, elixir-autogen, elixir-format
+msgid "Complete Hero verification. We handle background checks, references and screening."
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/confirmation.ex:11
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Confirm"
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/confirmation.ex:20
+#, elixir-autogen, elixir-format
+msgid "Confirm your account to finish signing up."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:232
+#, elixir-autogen, elixir-format
+msgid "Connecting Families with"
+msgstr ""
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:165
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Contact Us →"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1173
+#, elixir-autogen, elixir-format
+msgid "Could not add you to the team. Please try again."
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:226
+#, elixir-autogen, elixir-format
+msgid "Could not link your account. Please try again."
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:176
+#, elixir-autogen, elixir-format
+msgid "Could not set up your provider profile. Please try again."
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/registration.ex:14
+#, elixir-autogen, elixir-format
+msgid "Create your"
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/settings.ex:52
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Data & privacy"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:521
+#, elixir-autogen, elixir-format
+msgid "Decline"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:370
+#, elixir-autogen, elixir-format
+msgid "Degrees, certs, and references reviewed."
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:418
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Direct messaging and broadcasts"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:330
+#, elixir-autogen, elixir-format
+msgid "Direct messaging, broadcast announcements, incident reports. Keep parents informed, automatically."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:956
+#, elixir-autogen, elixir-format
+msgid "Discover"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:347
+#, elixir-autogen, elixir-format
+msgid "Earnings tracking is coming soon."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:337
+#, elixir-autogen, elixir-format
+msgid "Earnings trend"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:405
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Edit program"
+msgstr ""
+
+#: lib/klass_hero_web/live/home_live.ex:201
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Email the provider and us (support@mail.klasshero.com) as soon as you can — we'll help you and the provider work it out."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1561
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Enrolled kids"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:281
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Enrollment approved"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:289
+#, elixir-autogen, elixir-format
+msgid "Enrollment is not pending"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:293
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Enrollment not found"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:355
+#, elixir-autogen, elixir-format
+msgid "Erweitertes Führungszeugnis (extended background check), refreshed annually."
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:141
+#, elixir-autogen, elixir-format
+msgid "Every Hero clears the same checks. Here's what that means."
+msgstr ""
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:118
+#, elixir-autogen, elixir-format
+msgid "Every Hero, carefully reviewed."
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:164
+#, elixir-autogen, elixir-format
+msgid "Every Hero. Every step."
+msgstr ""
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:130
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Every educator and enrichment professional completes a 6-step verification process before being approved."
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:172
+#, elixir-autogen, elixir-format
+msgid "Every feature included. No subscription, no setup fees."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:472
+#, elixir-autogen, elixir-format
+msgid "Everything parents need, nothing they don't"
+msgstr ""
+
+#: lib/klass_hero_web/live/home_live.ex:88
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Everything you need to know about Klass Hero."
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:354
+#, elixir-autogen, elixir-format
+msgid "Extended Police Check"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:676
+#: lib/klass_hero_web/live/for_providers_live.ex:213
+#, elixir-autogen, elixir-format
+msgid "FAQ"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:302
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Failed to approve"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:801
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Families"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:260
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Find Programs"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:764
+#, elixir-autogen, elixir-format
+msgid "Footer mobile"
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:91
+#, elixir-autogen, elixir-format
+msgid "Founder & CEO"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:169
+#, elixir-autogen, elixir-format
+msgid "Free to join"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:275
+#, elixir-autogen, elixir-format
+msgid "Free to start"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:105
+#, elixir-autogen, elixir-format
+msgid "From listing to first payout in under a week"
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:102
+#, elixir-autogen, elixir-format
+msgid "Full-stack developer. Partner of a teacher who saw the gap between great educators and good infrastructure."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:580
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Get Bookings"
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:211
+#, elixir-autogen, elixir-format
+msgid "Get Started Today →"
+msgstr ""
+
+#: lib/klass_hero_web/live/contact_live.ex:189
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Get in touch"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:408
+#, elixir-autogen, elixir-format
+msgid "Get paid weekly"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:396
+#, elixir-autogen, elixir-format
+msgid "Get verified"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:1099
+#, elixir-autogen, elixir-format
+msgid "Grid"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:324
+#, elixir-autogen, elixir-format
+msgid "Hand-picked programs this week across Berlin."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:962
+#, elixir-autogen, elixir-format
+msgid "Hand-picked, vetted programs across Berlin — filter by category, age, or schedule."
+msgstr ""
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:154
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Have questions?"
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:118
+#, elixir-autogen, elixir-format
+msgid "Head of Trust & Quality (joining)"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:814
+#: lib/klass_hero_web/components/marketing_components.ex:912
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Help Center"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:441
+#, elixir-autogen, elixir-format
+msgid "How and when do I get paid?"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:804
+#, elixir-autogen, elixir-format
+msgid "How it Works"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:103
+#, elixir-autogen, elixir-format
+msgid "How it works"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:427
+#, elixir-autogen, elixir-format
+msgid "How much does Klass Hero cost?"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:434
+#, elixir-autogen, elixir-format
+msgid "How quickly can I start accepting bookings?"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:540
+#, elixir-autogen, elixir-format, fuzzy
+msgid "How to Grow Your Youth Program"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:870
+#, elixir-autogen, elixir-format
+msgid "How we vet providers"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1670
+#, elixir-autogen, elixir-format
+msgid "I'll be teaching"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:800
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:822
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Imported %{count} family."
+msgid_plural "Imported %{count} families."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/klass_hero_web/live/about_live.ex:182
+#, elixir-autogen, elixir-format
+msgid "In 2025, Shane connected with his friend"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1428
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:42
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:73
+#, elixir-autogen, elixir-format
+msgid "Incident Reports"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:334
+#, elixir-autogen, elixir-format
+msgid "Insights that matter"
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:16
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:26
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Invitation"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:450
+#, elixir-autogen, elixir-format
+msgid "It's the Hero standard: identity & age verification, experience validation, extended police background check (Erweitertes Führungszeugnis), video interview, child safeguarding training, and signing our community standards. See the Trust & Safety page for the full breakdown."
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:262
+#, elixir-autogen, elixir-format
+msgid "Join Berlin's growing network of trusted educators. Free to list. No setup fees."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:543
+#, elixir-autogen, elixir-format
+msgid "Join Berlin's trusted network of educators. We handle payments, scheduling, and discovery — you focus on teaching."
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:40
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Join the"
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:38
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:268
+#, elixir-autogen, elixir-format
+msgid "Join the team"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:182
+#, elixir-autogen, elixir-format
+msgid "Joining Klass Hero costs nothing — unlimited programs, your whole team, all media, and direct parent messaging are included for everyone. A simple success-based fee on bookings made through the platform is coming; we'll share the details transparently before it launches."
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:429
+#, elixir-autogen, elixir-format
+msgid "Joining is free — every feature is included for all providers, with no subscription or setup fees. A success-based fee on bookings made through the platform is planned; we'll announce the details transparently before it launches."
+msgstr ""
+
+#: lib/klass_hero_web/components/parent_components.ex:261
+#, elixir-autogen, elixir-format
+msgid "Kid picker"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:48
+#, elixir-autogen, elixir-format
+msgid "Klass Hero is the operational backbone for Berlin's youth educators. We handle bookings, payments, and discovery — you focus on what you do best."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:338
+#, elixir-autogen, elixir-format
+msgid "Last 8 weeks"
+msgstr ""
+
+#: lib/klass_hero_web/presenters/hero_cards_presenter.ex:38
+#, elixir-autogen, elixir-format
+msgid "Lead Instructor"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:553
+#, elixir-autogen, elixir-format
+msgid "Learn How to Become a Hero →"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:860
+#, elixir-autogen, elixir-format
+msgid "Learn how vetting works"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:309
+#, elixir-autogen, elixir-format
+msgid "Less admin, more teaching"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:379
+#, elixir-autogen, elixir-format
+msgid "Liability Insurance"
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:113
+#, elixir-autogen, elixir-format
+msgid "Link my account"
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:103
+#, elixir-autogen, elixir-format
+msgid "Link this invitation to your account %{email}."
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:111
+#, elixir-autogen, elixir-format
+msgid "Linking..."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:1115
+#, elixir-autogen, elixir-format
+msgid "List"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:571
+#, elixir-autogen, elixir-format
+msgid "List Your Program"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:390
+#, elixir-autogen, elixir-format
+msgid "List your program"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:360
+#, elixir-autogen, elixir-format
+msgid "Live video screen with our safeguarding lead."
+msgstr ""
+
+#: lib/klass_hero_web/live/programs_live.ex:362
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Load more programs"
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:52
+#, elixir-autogen, elixir-format
+msgid "Loading your invitation…"
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:92
+#, elixir-autogen, elixir-format
+msgid "Log in, then reopen this invitation to join the team."
+msgstr ""
+
+#: lib/klass_hero_web/components/ui_components.ex:207
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:129
+#, elixir-autogen, elixir-format
+msgid "Log out"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:867
+#, elixir-autogen, elixir-format
+msgid "Looking for programs for your child?"
+msgstr ""
+
+#: lib/klass_hero_web/live/contact_live.ex:206
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Looking for quick answers?"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1597
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Manage"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:44
+#, elixir-autogen, elixir-format
+msgid "Manage less."
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/settings.ex:20
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Manage your account, preferences, and privacy in one place."
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:365
+#, elixir-autogen, elixir-format
+msgid "Mandatory child-protection course before going live."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:472
+#, elixir-autogen, elixir-format
+msgid "Mark absent"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:445
+#, elixir-autogen, elixir-format
+msgid "Mark all present"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:472
+#, elixir-autogen, elixir-format
+msgid "Mark present"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:350
+#, elixir-autogen, elixir-format
+msgid "Minimum one year working with children, validated."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:135
+#, elixir-autogen, elixir-format
+msgid "Mobile primary"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:342
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Month"
+msgstr ""
+
+#: lib/klass_hero_web/components/parent_components.ex:577
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Monthly booking usage"
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:120
+#, elixir-autogen, elixir-format
+msgid "Mother and child-safety specialist with 10+ years in quality assurance. Architecting our Safety-First Verification engine."
+msgstr ""
+
+#: lib/klass_hero_web/live/dashboard_live.ex:157
+#, elixir-autogen, elixir-format, fuzzy
+msgid "New conversation"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:226
+#, elixir-autogen, elixir-format, fuzzy
+msgid "New program"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:1126
+#, elixir-autogen, elixir-format
+msgid "Newest"
+msgstr ""
+
+#: lib/klass_hero_web/components/parent_components.ex:532
+#, elixir-autogen, elixir-format
+msgid "Next"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:283
+#, elixir-autogen, elixir-format
+msgid "No credit card required"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:352
+#, elixir-autogen, elixir-format
+msgid "No featured programs available right now. Check back soon."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:115
+#, elixir-autogen, elixir-format
+msgid "No incident reports yet"
+msgstr ""
+
+#: lib/klass_hero_web/components/parent_components.ex:456
+#, elixir-autogen, elixir-format, fuzzy
+msgid "No messages yet."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1631
+#, elixir-autogen, elixir-format
+msgid "No pending enrollments right now."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1616
+#, elixir-autogen, elixir-format, fuzzy
+msgid "No pending requests right now."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1601
+#, elixir-autogen, elixir-format
+msgid "No programs yet — add your first one from the Programs tab."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:449
+#, elixir-autogen, elixir-format, fuzzy
+msgid "No registered children for this session."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:809
+#, elixir-autogen, elixir-format
+msgid "No rows imported. %{count} row could not be processed."
+msgid_plural "No rows imported. %{count} rows could not be processed."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/klass_hero_web/live/dashboard_live.ex:340
+#, elixir-autogen, elixir-format
+msgid "No upcoming sessions in the next few weeks."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:284
+#, elixir-autogen, elixir-format
+msgid "Not allowed to approve this enrollment"
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:297
+#, elixir-autogen, elixir-format
+msgid "Not now"
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:303
+#, elixir-autogen, elixir-format
+msgid "Offer your own programs on Klass Hero — alongside your work for %{business}."
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:436
+#, elixir-autogen, elixir-format
+msgid "Once your listing is live and you've completed Hero verification (typically 3–5 business days), parents can book immediately. Most providers receive their first inquiry within the first week."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:1476
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Ongoing Quality"
+msgstr ""
+
+#: lib/klass_hero_web/components/parent_components.ex:538
+#, elixir-autogen, elixir-format
+msgid "Open"
+msgstr ""
+
+#: lib/klass_hero_web/components/ui_components.ex:157
+#, elixir-autogen, elixir-format
+msgid "Open account menu"
+msgstr ""
+
+#: lib/klass_hero_web/components/parent_components.ex:452
+#, elixir-autogen, elixir-format
+msgid "Open inbox"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:110
+#, elixir-autogen, elixir-format
+msgid "Open menu"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:1366
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Our Commitment"
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:130
+#, elixir-autogen, elixir-format
+msgid "Our Mission"
+msgstr ""
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:111
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Our commitment to child safety"
+msgstr ""
+
+#: lib/klass_hero_web/components/parent_components.ex:105
+#, elixir-autogen, elixir-format
+msgid "Parent bottom navigation"
+msgstr ""
+
+#: lib/klass_hero_web/components/parent_components.ex:75
+#, elixir-autogen, elixir-format
+msgid "Parent navigation"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:456
+#, elixir-autogen, elixir-format
+msgid "Parent: %{name}"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:403
+#, elixir-autogen, elixir-format
+msgid "Parents discover you on Klass Hero. Approve manually or auto-accept — your call."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:582
+#, elixir-autogen, elixir-format
+msgid "Parents find you through Klass Hero. Approve or auto-accept bookings with secure messaging built in."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:17
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:17
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Participation"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:359
+#, elixir-autogen, elixir-format
+msgid "Pedagogical Interview"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1610
+#, elixir-autogen, elixir-format
+msgid "Pending booking requests"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1625
+#, elixir-autogen, elixir-format
+msgid "Pending enrollments"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:315
+#, elixir-autogen, elixir-format
+msgid "Predictable income"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:1128
+#, elixir-autogen, elixir-format
+msgid "Price: high to low"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:1127
+#, elixir-autogen, elixir-format
+msgid "Price: low to high"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:813
+#: lib/klass_hero_web/live/for_providers_live.ex:167
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Pricing"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:65
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Primary"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:776
+#: lib/klass_hero_web/components/marketing_components.ex:823
+#: lib/klass_hero_web/live/privacy_policy_live.ex:238
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Privacy"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:90
+#, elixir-autogen, elixir-format
+msgid "Pro tip"
+msgstr ""
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:87
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Process"
+msgstr ""
+
+#: lib/klass_hero_web/live/home_live.ex:120
+#, elixir-autogen, elixir-format
+msgid "Professional: €19/month + 12% per booking. Up to 5 programs"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:101
+#, elixir-autogen, elixir-format
+msgid "Provider bottom navigation"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:77
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Provider navigation"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:215
+#, elixir-autogen, elixir-format
+msgid "Provider questions, answered"
+msgstr ""
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:138
+#, elixir-autogen, elixir-format
+msgid "Quality & accountability — always on."
+msgstr ""
+
+#: lib/klass_hero_web/live/contact_live.ex:107
+#, elixir-autogen, elixir-format
+msgid "Questions about programs, bookings, or becoming a Hero — we read every message."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:679
+#, elixir-autogen, elixir-format
+msgid "Questions, answered."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1576
+#, elixir-autogen, elixir-format
+msgid "Rating"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:259
+#, elixir-autogen, elixir-format
+msgid "Ready to be a Hero?"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:877
+#: lib/klass_hero_web/components/marketing_components.ex:897
+#, elixir-autogen, elixir-format
+msgid "Ready to find your child's next adventure?"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:402
+#, elixir-autogen, elixir-format
+msgid "Receive bookings"
+msgstr ""
+
+#: lib/klass_hero_web/components/parent_components.ex:450
+#, elixir-autogen, elixir-format
+msgid "Recent messages"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:1125
+#: lib/klass_hero_web/components/marketing_components.ex:1137
+#, elixir-autogen, elixir-format
+msgid "Recommended"
+msgstr ""
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:91
+#, elixir-autogen, elixir-format
+msgid "Reporting"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:118
+#, elixir-autogen, elixir-format
+msgid "Reports filed for this program will appear here."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1568
+#, elixir-autogen, elixir-format
+msgid "Revenue (this week)"
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:165
+#, elixir-autogen, elixir-format
+msgid "Rigorous screening so families never wonder who's leading the room."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2172
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Row %{row}"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2172
+#, elixir-autogen, elixir-format
+msgid "Row —"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1927
+#, elixir-autogen, elixir-format
+msgid "Rows with errors"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:364
+#, elixir-autogen, elixir-format
+msgid "Safeguarding Training"
+msgstr ""
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:101
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Safety"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:982
+#, elixir-autogen, elixir-format
+msgid "Search programs, providers, neighborhoods..."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:255
+#, elixir-autogen, elixir-format
+msgid "Search: coding, football, art..."
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:409
+#, elixir-autogen, elixir-format
+msgid "Secure SEPA payouts every Monday. Invoices and VAT handled automatically."
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:419
+#, elixir-autogen, elixir-format
+msgid "Secure payments, invoicing, and VAT handling"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:591
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Secure weekly payouts. Insights into your business and opportunities to expand your impact."
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/settings.ex:42
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Security"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:57
+#, elixir-autogen, elixir-format
+msgid "See pricing"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:562
+#, elixir-autogen, elixir-format
+msgid "See provider plans"
+msgstr ""
+
+#: lib/klass_hero_web/live/contact_live.ex:163
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Select a topic…"
+msgstr ""
+
+#: lib/klass_hero_web/live/contact_live.ex:181
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Send Message →"
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/login.ex:65
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Send magic link"
+msgstr ""
+
+#: lib/klass_hero_web/live/contact_live.ex:116
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Send us a message"
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:286
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Setting up..."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:95
+#: lib/klass_hero_web/components/marketing_components.ex:167
+#: lib/klass_hero_web/live/user_live/login.ex:12
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Sign in"
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/login.ex:21
+#, elixir-autogen, elixir-format
+msgid "Sign in to continue. Don't have an account?"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:98
+#: lib/klass_hero_web/components/marketing_components.ex:172
+#: lib/klass_hero_web/live/user_live/registration.ex:12
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Sign up"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:375
+#, elixir-autogen, elixir-format
+msgid "Signed agreement on conduct and quality bar."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:154
+#: lib/klass_hero_web/components/ui_components.ex:193
+#, elixir-autogen, elixir-format
+msgid "Signed in as"
+msgstr ""
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:128
+#, elixir-autogen, elixir-format
+msgid "Six checks. No shortcuts."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:1052
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Sort:"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:812
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Start Teaching"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:198
+#, elixir-autogen, elixir-format
+msgid "Start for free"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:54
+#: lib/klass_hero_web/live/for_providers_live.ex:266
+#, elixir-autogen, elixir-format
+msgid "Start teaching today"
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:269
+#, elixir-autogen, elixir-format
+msgid "Start your own business"
+msgstr ""
+
+#: lib/klass_hero_web/live/home_live.ex:115
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Starter: Free to join — no registration fees, no monthly subscriptions. 18% commission per booking, up to 2 active programs"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:229
+#, elixir-autogen, elixir-format
+msgid "Still curious?"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:301
+#, elixir-autogen, elixir-format
+msgid "Stop chasing leads"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:98
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Submitted by"
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:25
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Supporting local programs and eco-conscious practices."
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:229
+#, elixir-autogen, elixir-format
+msgid "Switch business"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:240
+#, elixir-autogen, elixir-format
+msgid "Talk to our team →"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:880
+#: lib/klass_hero_web/live/about_live.ex:215
+#: lib/klass_hero_web/live/for_providers_live.ex:269
+#, elixir-autogen, elixir-format
+msgid "Talk to us"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:42
+#, elixir-autogen, elixir-format
+msgid "Teach more."
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:349
+#, elixir-autogen, elixir-format
+msgid "Teaching Experience"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:857
+#, elixir-autogen, elixir-format
+msgid "Teaching kids is your thing? Join as a Hero."
+msgstr ""
+
+#: lib/klass_hero_web/live/contact_live.ex:119
+#, elixir-autogen, elixir-format
+msgid "Tell us a bit about what you need — we'll route you to the right person."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:777
+#: lib/klass_hero_web/components/marketing_components.ex:824
+#: lib/klass_hero_web/live/terms_of_service_live.ex:259
+#, elixir-autogen, elixir-format
+msgid "Terms"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:420
+#, elixir-autogen, elixir-format
+msgid "The Klass Hero verified badge"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:324
+#, elixir-autogen, elixir-format
+msgid "The Klass Hero verified badge gets you more inquiries — parents trust vetted providers."
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:138
+#, elixir-autogen, elixir-format
+msgid "The bar to teach on Klass Hero"
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:119
+#, elixir-autogen, elixir-format
+msgid "This invitation is for %{invite}."
+msgstr ""
+
+#: lib/klass_hero_web/components/parent_components.ex:408
+#, elixir-autogen, elixir-format
+msgid "This week"
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:132
+#, elixir-autogen, elixir-format
+msgid "To modernize how Berlin"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:435
+#, elixir-autogen, elixir-format
+msgid "Today's check-ins"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:335
+#, elixir-autogen, elixir-format
+msgid "Track signups, retention, no-shows, and revenue. Identify what's working and double down."
+msgstr ""
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:100
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Trust &"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:234
+#, elixir-autogen, elixir-format
+msgid "Trusted Heroes"
+msgstr ""
+
+#: lib/klass_hero_web/live/programs_live.ex:307
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Try adjusting your search or filter criteria — there's plenty more in Berlin."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:512
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Unknown parent"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:416
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Unlimited programs and locations"
+msgstr ""
+
+#: lib/klass_hero_web/live/dashboard_live.ex:312
+#, elixir-autogen, elixir-format
+msgid "Unread messages"
+msgstr ""
+
+#: lib/klass_hero_web/live/dashboard_live.ex:331
+#, elixir-autogen, elixir-format
+msgid "Upcoming sessions"
+msgstr ""
+
+#: lib/klass_hero_web/live/dashboard_live.ex:306
+#, elixir-autogen, elixir-format
+msgid "Upcoming this week"
+msgstr ""
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:86
+#, elixir-autogen, elixir-format
+msgid "Vetted"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:1212
+#, elixir-autogen, elixir-format, fuzzy
+msgid "View"
+msgstr ""
+
+#: lib/klass_hero_web/live/dashboard_live.ex:336
+#, elixir-autogen, elixir-format, fuzzy
+msgid "View all"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:431
+#, elixir-autogen, elixir-format, fuzzy
+msgid "View →"
+msgstr ""
+
+#: lib/klass_hero_web/live/contact_live.ex:221
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Visit FAQ →"
+msgstr ""
+
+#: lib/klass_hero_web/live/trust_safety_live.ex:113
+#, elixir-autogen, elixir-format, fuzzy
+msgid "We believe children thrive best in environments that are safe, respectful, and professionally led. That's why Klass Hero applies a multi-layered safety and verification framework before any provider can offer sessions on our platform."
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:179
+#, elixir-autogen, elixir-format
+msgid "We earn when you earn"
+msgstr ""
+
+#: lib/klass_hero_web/live/contact_live.ex:178
+#, elixir-autogen, elixir-format
+msgid "We never share your details."
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:443
+#, elixir-autogen, elixir-format
+msgid "We use SEPA bank transfers, paid out every Monday for the previous week's completed sessions. You'll receive an automatic invoice for each payout, and VAT is handled per-booking."
+msgstr ""
+
+#: lib/klass_hero_web/live/contact_live.ex:103
+#, elixir-autogen, elixir-format
+msgid "We're here to"
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:137
+#, elixir-autogen, elixir-format, fuzzy
+msgid "We're parents, brothers, and partners of educators — building the infrastructure that helps every child learn and thrive."
+msgstr ""
+
+#: lib/klass_hero_web/live/contact_live.ex:132
+#, elixir-autogen, elixir-format
+msgid "We've got it — we'll be in touch."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:341
+#, elixir-autogen, elixir-format
+msgid "Week"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:317
+#, elixir-autogen, elixir-format
+msgid "Weekly SEPA payouts, automatic VAT handling, transparent fees. Plan your business around real numbers."
+msgstr ""
+
+#: lib/klass_hero_web/components/parent_components.ex:409
+#, elixir-autogen, elixir-format
+msgid "Weekly adventure goal"
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/confirmation.ex:13
+#: lib/klass_hero_web/live/user_live/login.ex:14
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Welcome"
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:72
+#, elixir-autogen, elixir-format
+msgid "Welcome aboard! Let's set up your business profile."
+msgstr ""
+
+#: lib/klass_hero_web/live/contact_live.ex:171
+#, elixir-autogen, elixir-format
+msgid "What's on your mind?"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:448
+#, elixir-autogen, elixir-format
+msgid "What's the verification process like?"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:887
+#, elixir-autogen, elixir-format
+msgid "While you're here — explore programs."
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:469
+#: lib/klass_hero_web/live/for_providers_live.ex:72
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Why Klass Hero"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_layout_components.ex:343
+#, elixir-autogen, elixir-format
+msgid "Year"
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:288
+#, elixir-autogen, elixir-format
+msgid "Yes, become a provider"
+msgstr ""
+
+#: lib/klass_hero_web/live/for_providers_live.ex:457
+#, elixir-autogen, elixir-format
+msgid "Yes. You can run unlimited programs, each with its own schedule and venue, and add as many team members as you need to delegate management across instructors."
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:80
+#, elixir-autogen, elixir-format
+msgid "You already have a provider profile."
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:89
+#, elixir-autogen, elixir-format
+msgid "You already have an account for %{email}."
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:274
+#, elixir-autogen, elixir-format
+msgid "You'll get your own provider profile to fill in, and your account will open on your business dashboard from now on. You stay on %{business}'s team."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1153
+#, elixir-autogen, elixir-format
+msgid "You're already on your team."
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:122
+#, elixir-autogen, elixir-format
+msgid "You're logged in as %{current}. Log into the matching account to accept."
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:167
+#, elixir-autogen, elixir-format
+msgid "You're no longer on that team."
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:213
+#, elixir-autogen, elixir-format
+msgid "You're now part of the team."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1201
+#, elixir-autogen, elixir-format
+msgid "You're on the team — you can now be assigned to programs."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1200
+#, elixir-autogen, elixir-format
+msgid "You're on the team, but the headshot upload failed."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1592
+#, elixir-autogen, elixir-format
+msgid "Your top programs"
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/registration.ex:15
+#, elixir-autogen, elixir-format, fuzzy
+msgid "account"
+msgstr ""
+
+#: lib/klass_hero_web/components/parent_components.ex:283
+#, elixir-autogen, elixir-format, fuzzy
+msgid "active"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:957
+#, elixir-autogen, elixir-format, fuzzy
+msgid "activities"
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/login.ex:15
+#, elixir-autogen, elixir-format
+msgid "back"
+msgstr ""
+
+#: lib/klass_hero_web/components/parent_components.ex:424
+#, elixir-autogen, elixir-format, fuzzy
+msgid "complete"
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:134
+#, elixir-autogen, elixir-format
+msgid "discover & engage with children's programs"
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:133
+#, elixir-autogen, elixir-format, fuzzy
+msgid "families"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:236
+#, elixir-autogen, elixir-format
+msgid "for Our Youth"
+msgstr ""
+
+#: lib/klass_hero_web/live/contact_live.ex:104
+#, elixir-autogen, elixir-format
+msgid "help"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:1040
+#, elixir-autogen, elixir-format
+msgid "in"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:1044
+#, elixir-autogen, elixir-format
+msgid "matching"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1612
+#: lib/klass_hero_web/live/provider/dashboard_live.ex:1627
+#, elixir-autogen, elixir-format, fuzzy
+msgid "pending"
+msgstr ""
+
+#: lib/klass_hero_web/components/marketing_components.ex:1038
+#, elixir-autogen, elixir-format, fuzzy
+msgid "program"
+msgid_plural "programs"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/klass_hero_web/components/parent_components.ex:595
+#, elixir-autogen, elixir-format, fuzzy
+msgid "remaining"
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/settings.ex:18
+#, elixir-autogen, elixir-format, fuzzy
+msgid "settings"
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:177
+#, elixir-autogen, elixir-format
+msgid "spent over a decade as a coach and youth activity provider in Berlin, building Prime Youth — a community of providers, schools, and parents dedicated to giving children the best possible experiences. But one pattern kept emerging: the administrative burden of managing bookings, payments, and compliance was getting in everyone's way."
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:41
+#, elixir-autogen, elixir-format
+msgid "team"
+msgstr ""
+
+#: lib/klass_hero_web/components/parent_components.ex:426
+#, elixir-autogen, elixir-format
+msgid "to go"
+msgstr ""
+
+#: lib/klass_hero_web/live/about_live.ex:199
+#, elixir-autogen, elixir-format
+msgid "— a mother with over a decade of experience in child safety and quality assurance — will join to architect our Safety-First Verification engine."
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/en/LC_MESSAGES/enrollment.po
@@ -11,62 +11,62 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:2278
+#: lib/klass_hero_web/components/provider_components.ex:2193
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2279
+#: lib/klass_hero_web/components/provider_components.ex:2194
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2280
+#: lib/klass_hero_web/components/provider_components.ex:2195
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2291
+#: lib/klass_hero_web/components/provider_components.ex:2206
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2281
+#: lib/klass_hero_web/components/provider_components.ex:2196
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2282
+#: lib/klass_hero_web/components/provider_components.ex:2197
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2283
+#: lib/klass_hero_web/components/provider_components.ex:2198
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2290
+#: lib/klass_hero_web/components/provider_components.ex:2205
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2292
+#: lib/klass_hero_web/components/provider_components.ex:2207
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2284
+#: lib/klass_hero_web/components/provider_components.ex:2199
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2286
+#: lib/klass_hero_web/components/provider_components.ex:2201
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2288
+#: lib/klass_hero_web/components/provider_components.ex:2203
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""

--- a/priv/gettext/enrollment.pot
+++ b/priv/gettext/enrollment.pot
@@ -11,62 +11,62 @@
 msgid ""
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2278
+#: lib/klass_hero_web/components/provider_components.ex:2193
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2279
+#: lib/klass_hero_web/components/provider_components.ex:2194
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2280
+#: lib/klass_hero_web/components/provider_components.ex:2195
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2291
+#: lib/klass_hero_web/components/provider_components.ex:2206
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2281
+#: lib/klass_hero_web/components/provider_components.ex:2196
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2282
+#: lib/klass_hero_web/components/provider_components.ex:2197
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2283
+#: lib/klass_hero_web/components/provider_components.ex:2198
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2290
+#: lib/klass_hero_web/components/provider_components.ex:2205
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2292
+#: lib/klass_hero_web/components/provider_components.ex:2207
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2284
+#: lib/klass_hero_web/components/provider_components.ex:2199
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2286
+#: lib/klass_hero_web/components/provider_components.ex:2201
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2288
+#: lib/klass_hero_web/components/provider_components.ex:2203
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""


### PR DESCRIPTION
## Summary

Closes #876. Reconciles the drifted gettext catalogs with source and adds a strict sync gate so drift can't silently reaccumulate.

**Two commits:**
1. `chore(i18n): reconcile gettext catalogs and translate DE` — regenerate `default.pot`/`enrollment.pot` from source, then fill **all** German translations (formal *Sie*) and clear every `fuzzy` entry. ~815 DE strings across `default` + `enrollment`.
2. `feat(i18n): enforce gettext catalog sync with mix lint_translations` — new mix task wired into `precommit` + CI.

### Why the diff is large
`mix gettext.extract` surfaced ~225 source strings that were in the code but **never** in the catalog — the drift hid new strings, not just stale ones. Most of the +9k/-6.9k `.po` diff is mechanical reflow from the extract/merge plus the translation fills.

### Notable fixes
- **4 runtime bombs**: fuzzy entries whose `msgstr` carried `%{...}` placeholders absent from the `msgid` (`"Book Now"` → `"Jetzt buchen - %{price}"` etc.) — these would raise via `Gettext.Interpolation`. Now corrected.
- Normalized 3 stray informal `du`-form strings to formal `Sie`.
- `errors` domain left untouched (already 100% translated, hand-ordered) — merged per-domain to avoid reformatting it.

## Review focus
The translation diff is bulk mechanical — **don't read all ~815 strings**. Focus on:
- `lib/mix/tasks/lint_translations.ex` — the gate (structure via `--check-up-to-date`, completeness + fuzzy via Expo, allowlist escape hatch).
- `priv/gettext/de/untranslated_allowlist.exs` — the passthrough mechanism.
- `mix.exs` / `.github/workflows/ci.yml` / `CLAUDE.md` — wiring + the new contributor requirement.
- Spot-check a handful of DE translations for tone.

## Test plan
- `mix lint_translations` — passes (0 empty, 0 fuzzy, structure in sync).
- Negative test: blanking a `msgstr` makes the gate fail naming the exact `[de/default] (empty) "Login"` — restores clean.
- `mix precommit` — green, **3928 passed** (on an isolated test DB partition).
- Runtime render check (`de` locale): `Login`→`Anmelden`, `Welcome, %{name}`→`Willkommen, Max` (interpolation binds, no crash), enrollment `dgettext` + plural forms all render.

> **Note for merge:** going forward, every PR adding a `gettext(...)` call must ship its DE translation (or an allowlist entry) in the same PR — enforced by the new gate. This is a deliberate reversal of the previous "rely on English fallback" stance.
