### PR TITLE
refactor: route Enrollment parent reads through the Family ACL

### DIFF
--- a/lib/klass_hero/enrollment.ex
+++ b/lib/klass_hero/enrollment.ex
@@ -29,7 +29,6 @@ defmodule KlassHero.Enrollment do
   alias KlassHero.Enrollment.ParticipantPolicyForm
   alias KlassHero.Enrollment.SingleInviteForm
   alias KlassHero.Family
-  alias KlassHero.Family.ParentProfile
   alias KlassHero.Repo
   alias KlassHero.Shared.Adapters.Driven.Persistence.EctoErrorHelpers
   alias KlassHero.Shared.EventDispatchHelper
@@ -575,10 +574,11 @@ defmodule KlassHero.Enrollment do
     EnrollmentQueries.base()
     |> EnrollmentQueries.by_program(program_id)
     |> EnrollmentQueries.active_only()
-    |> join(:inner, [e], p in ParentProfile, on: e.parent_id == p.id)
-    |> select([e, p], p.identity_id)
+    |> select([e], e.parent_id)
     |> distinct(true)
     |> Repo.all()
+    |> ParentInfoACL.get_parents_by_ids()
+    |> Enum.map(& &1.identity_id)
   end
 
   @doc """
@@ -588,12 +588,17 @@ defmodule KlassHero.Enrollment do
   """
   @spec enrolled?(String.t(), String.t()) :: boolean()
   def enrolled?(program_id, identity_id) when is_binary(program_id) and is_binary(identity_id) do
-    EnrollmentQueries.base()
-    |> EnrollmentQueries.by_program(program_id)
-    |> EnrollmentQueries.active_only()
-    |> join(:inner, [e], p in ParentProfile, on: e.parent_id == p.id)
-    |> where([e, p], p.identity_id == ^identity_id)
-    |> Repo.exists?()
+    case ParentInfoACL.resolve_identity_id(identity_id) do
+      nil ->
+        false
+
+      parent_id ->
+        EnrollmentQueries.base()
+        |> EnrollmentQueries.by_program(program_id)
+        |> EnrollmentQueries.active_only()
+        |> where([e], e.parent_id == ^parent_id)
+        |> Repo.exists?()
+    end
   end
 
   # Creates an enrollment with an atomic capacity check. Locks the enrollment policy row

--- a/lib/klass_hero/enrollment/adapters/driven/acl/parent_info_acl.ex
+++ b/lib/klass_hero/enrollment/adapters/driven/acl/parent_info_acl.ex
@@ -26,4 +26,17 @@ defmodule KlassHero.Enrollment.Adapters.Driven.ACL.ParentInfoACL do
       end)
     end
   end
+
+  @doc """
+  Resolves a Family parent's identity_id to their parent_id, or nil when no
+  parent profile exists for the identity.
+  """
+  def resolve_identity_id(identity_id) when is_binary(identity_id) do
+    acl_span source: "enrollment", target: "family" do
+      case Family.get_parent_by_identity(identity_id) do
+        {:ok, parent} -> parent.id
+        {:error, :not_found} -> nil
+      end
+    end
+  end
 end

--- a/test/klass_hero/enrollment/adapters/driven/acl/parent_info_acl_test.exs
+++ b/test/klass_hero/enrollment/adapters/driven/acl/parent_info_acl_test.exs
@@ -36,4 +36,16 @@ defmodule KlassHero.Enrollment.Adapters.Driven.ACL.ParentInfoACLTest do
       assert hd(result).id == to_string(parent.id)
     end
   end
+
+  describe "resolve_identity_id/1" do
+    test "returns the parent_id for a known identity_id" do
+      parent = insert(:parent_profile_schema)
+
+      assert ParentInfoACL.resolve_identity_id(parent.identity_id) == to_string(parent.id)
+    end
+
+    test "returns nil when no parent profile exists for the identity_id" do
+      assert ParentInfoACL.resolve_identity_id(Ecto.UUID.generate()) == nil
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`KlassHero.Enrollment` joined directly against `Family.ParentProfile` (Family's schema/table) from inside two functions, coupling Enrollment to Family's internal table shape — a Family column/PK rename would break Enrollment silently, with no compiler signal. Violated the cross-context boundary convention.

Both call sites now read through `ParentInfoACL` (Family facade) instead of a raw join:

- `list_enrolled_identity_ids/1` — selects distinct `parent_id`s from its own schema, maps them via `ParentInfoACL.get_parents_by_ids/1`.
- `enrolled?/2` — resolves `identity_id -> parent_id` via a new `ParentInfoACL.resolve_identity_id/1` (facade-backed, `acl_span`-wrapped), then queries only Enrollment's own `enrollments` table.

Drops the now-dead `alias KlassHero.Family.ParentProfile`.

Closes #1046.

## Review Focus

- **Behaviour preservation.** An FK (`enrollments_parent_id_fkey`) guarantees every `parent_id` resolves to a `ParentProfile`, so the inner-join "drop rows without a profile" branch was unreachable — the ACL route returns the identical set. No signature/return-shape change (`[identity_id]`, `boolean`).
- **`enrolled?/2` now issues 2 queries** (resolve identity, then `exists?`) vs 1 before. Not a hot path.
- **ACL route vs direct facade** — `resolve_identity_id/1` was added to `ParentInfoACL` (rather than calling `Family.get_parent_by_identity/1` inline) to keep every Family read funneled through one ACL and pick up tracing.

## Test Plan

- Existing suites `list_enrolled_identity_ids_test.exs` (7) + `check_enrollment_test.exs` (6) stay green — the safety net.
- +2 new tests for `ParentInfoACL.resolve_identity_id/1` (known identity → parent_id; unknown → nil).
- `mix precommit`: 3865 passed, 0 failures.
- `boundary-checker` (changed files): 5/5 pass, 0 new violations, #1046 resolved.

## Follow-up

The Enrollment schema still has `belongs_to :parent, ParentProfile` / `belongs_to :child, Child` — a compile-time reference to Family's schema modules. Deeper, pre-existing coupling; tracked separately.