### PR TITLE
fix: replace stale provider tier pricing in home FAQ

### DIFF
--- a/lib/klass_hero_web/live/home_live.ex
+++ b/lib/klass_hero_web/live/home_live.ex
@@ -110,22 +110,14 @@ defmodule KlassHeroWeb.HomeLive do
           <li>{gettext("Private lessons and tutoring")}</li>
         </ul>
         <p class="font-semibold mb-1 text-hero-black">{gettext("Pricing:")}</p>
-        <ul class="list-disc list-inside mb-3 space-y-1">
-          <li>
-            {gettext(
-              "Starter: Free to join — no registration fees, no monthly subscriptions. 18% commission per booking, up to 2 active programs"
-            )}
-          </li>
-          <li>
-            {gettext("Professional: €19/month + 12% per booking. Up to 5 programs")}
-          </li>
-          <li>
-            {gettext("Business Plus: €49/month + 8% per booking. Unlimited programs and team seats")}
-          </li>
-        </ul>
+        <p class="mb-3">
+          {gettext(
+            "Joining Klass Hero costs nothing — unlimited programs, your whole team, all media, and direct parent messaging are included for everyone. A simple success-based fee on bookings made through the platform is coming; we'll share the details transparently before it launches."
+          )}
+        </p>
         <p class="mt-3">
           {gettext(
-            "All plans include: Profile page, booking system, payment processing, messaging, and marketing to Berlin families."
+            "Every provider gets: Profile page, booking system, payment processing, messaging, and marketing to Berlin families."
           )}
         </p>
       </.mk_faq_item>

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -3563,22 +3563,17 @@ msgstr "Konten"
 msgid "All Statuses"
 msgstr "Alle Status"
 
-#: lib/klass_hero_web/live/home_live.ex:150
+#: lib/klass_hero_web/live/home_live.ex:142
 #, elixir-autogen, elixir-format
 msgid "All payments processed securely through Stripe."
 msgstr "Alle Zahlungen werden sicher über Stripe abgewickelt."
-
-#: lib/klass_hero_web/live/home_live.ex:127
-#, elixir-autogen, elixir-format
-msgid "All plans include: Profile page, booking system, payment processing, messaging, and marketing to Berlin families."
-msgstr "Alle Pläne umfassen: Profilseite, Buchungssystem, Zahlungsabwicklung, Nachrichtenfunktion und Marketing für Berliner Familien."
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "An error occurred"
 msgstr "Ein Fehler ist aufgetreten"
 
-#: lib/klass_hero_web/live/home_live.ex:146
+#: lib/klass_hero_web/live/home_live.ex:138
 #, elixir-autogen, elixir-format
 msgid "Apple Pay / Google Pay"
 msgstr "Apple Pay / Google Pay"
@@ -3588,7 +3583,7 @@ msgstr "Apple Pay / Google Pay"
 msgid "Attendance corrected successfully"
 msgstr "Anwesenheit erfolgreich korrigiert"
 
-#: lib/klass_hero_web/live/home_live.ex:168
+#: lib/klass_hero_web/live/home_live.ex:160
 #, elixir-autogen, elixir-format
 msgid "Automatic fee calculation (no surprises)"
 msgstr "Automatische Gebührenberechnung (keine Überraschungen)"
@@ -3613,12 +3608,12 @@ msgstr "Buchungen"
 msgid "Camps and holiday programs"
 msgstr "Camps und Ferienprogramme"
 
-#: lib/klass_hero_web/live/home_live.ex:213
+#: lib/klass_hero_web/live/home_live.ex:205
 #, elixir-autogen, elixir-format
 msgid "Can I buy a gift voucher?"
 msgstr "Kann ich einen Geschenkgutschein kaufen?"
 
-#: lib/klass_hero_web/live/home_live.ex:191
+#: lib/klass_hero_web/live/home_live.ex:183
 #, elixir-autogen, elixir-format
 msgid "Can I change my booking date?"
 msgstr "Kann ich mein Buchungsdatum ändern?"
@@ -3677,7 +3672,7 @@ msgstr "Ausgecheckt"
 msgid "Child"
 msgstr "Kind"
 
-#: lib/klass_hero_web/live/home_live.ex:215
+#: lib/klass_hero_web/live/home_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Coming soon! Sign up for our newsletter to be notified when gift vouchers launch."
 msgstr "Demnächst verfügbar! Melden Sie sich für unseren Newsletter an, um benachrichtigt zu werden, sobald Geschenkgutscheine verfügbar sind."
@@ -3687,7 +3682,7 @@ msgstr "Demnächst verfügbar! Melden Sie sich für unseren Newsletter an, um be
 msgid "Completed"
 msgstr "Abgeschlossen"
 
-#: lib/klass_hero_web/live/home_live.ex:193
+#: lib/klass_hero_web/live/home_live.ex:185
 #, elixir-autogen, elixir-format
 msgid "Contact the provider directly (details in confirmation email). Most providers are flexible if you ask in advance."
 msgstr "Kontaktieren Sie den Anbieter direkt (Details in der Bestätigungs-E-Mail). Die meisten Anbieter sind flexibel, wenn Sie im Voraus fragen."
@@ -3704,22 +3699,22 @@ msgstr "Korrigieren"
 msgid "Could not start conversation. Please try again."
 msgstr "Unterhaltung konnte nicht gestartet werden. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/live/home_live.ex:145
+#: lib/klass_hero_web/live/home_live.ex:137
 #, elixir-autogen, elixir-format
 msgid "Credit/debit card (Visa, Mastercard, Amex)"
 msgstr "Kredit-/Debitkarte (Visa, Mastercard, Amex)"
 
-#: lib/klass_hero_web/live/home_live.ex:209
+#: lib/klass_hero_web/live/home_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Currently serving Berlin, with expansion to other German cities coming soon."
 msgstr "Derzeit verfügbar in Berlin, die Erweiterung auf weitere deutsche Städte folgt in Kürze."
 
-#: lib/klass_hero_web/live/home_live.ex:185
+#: lib/klass_hero_web/live/home_live.ex:177
 #, elixir-autogen, elixir-format
 msgid "Do I need an account to book?"
 msgstr "Benötige ich ein Konto, um zu buchen?"
 
-#: lib/klass_hero_web/live/home_live.ex:175
+#: lib/klass_hero_web/live/home_live.ex:167
 #, elixir-autogen, elixir-format
 msgid "Download monthly statements for taxes"
 msgstr "Monatliche Abrechnungen für die Steuer herunterladen"
@@ -3735,22 +3730,22 @@ msgstr "Anmeldung nicht bestätigt"
 msgid "Explain why this correction is needed..."
 msgstr "Erklären Sie, warum diese Korrektur nötig ist..."
 
-#: lib/klass_hero_web/live/home_live.ex:173
+#: lib/klass_hero_web/live/home_live.ex:165
 #, elixir-autogen, elixir-format
 msgid "Export participant lists anytime"
 msgstr "Teilnehmerlisten jederzeit exportieren"
 
-#: lib/klass_hero_web/live/home_live.ex:140
+#: lib/klass_hero_web/live/home_live.ex:132
 #, elixir-autogen, elixir-format
 msgid "Funds are immediately available in your Klass Hero account"
 msgstr "Guthaben ist sofort in Ihrem Klass Hero-Konto verfügbar"
 
-#: lib/klass_hero_web/live/home_live.ex:151
+#: lib/klass_hero_web/live/home_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "How You Get Paid:"
 msgstr "So werden Sie bezahlt:"
 
-#: lib/klass_hero_web/live/home_live.ex:133
+#: lib/klass_hero_web/live/home_live.ex:125
 #, elixir-autogen, elixir-format
 msgid "How does the booking system work?"
 msgstr "Wie funktioniert das Buchungssystem?"
@@ -3761,17 +3756,17 @@ msgstr "Wie funktioniert das Buchungssystem?"
 msgid "In Progress"
 msgstr "In Bearbeitung"
 
-#: lib/klass_hero_web/live/home_live.ex:154
+#: lib/klass_hero_web/live/home_live.ex:146
 #, elixir-autogen, elixir-format
 msgid "Instant availability: Funds are in your Klass Hero balance immediately after booking"
 msgstr "Sofortige Verfügbarkeit: Das Guthaben steht direkt nach der Buchung in Ihrem Klass Hero-Guthaben zur Verfügung"
 
-#: lib/klass_hero_web/live/home_live.ex:179
+#: lib/klass_hero_web/live/home_live.ex:171
 #, elixir-autogen, elixir-format
 msgid "Is Klass Hero free for parents to use?"
 msgstr "Ist die Nutzung von Klass Hero für Eltern kostenlos?"
 
-#: lib/klass_hero_web/live/home_live.ex:148
+#: lib/klass_hero_web/live/home_live.ex:140
 #, elixir-autogen, elixir-format
 msgid "Klarna (pay later options)"
 msgstr "Klarna (Optionen für spätere Zahlung)"
@@ -3797,7 +3792,7 @@ msgstr "Keine Änderung"
 msgid "No changes detected"
 msgstr "Keine Änderungen erkannt"
 
-#: lib/klass_hero_web/live/home_live.ex:166
+#: lib/klass_hero_web/live/home_live.ex:158
 #, elixir-autogen, elixir-format
 msgid "No chasing payments or sending invoices"
 msgstr "Kein Nachfassen bei Zahlungen oder Versenden von Rechnungen"
@@ -3808,7 +3803,7 @@ msgstr "Kein Nachfassen bei Zahlungen oder Versenden von Rechnungen"
 msgid "No enrolled parents"
 msgstr "Keine angemeldeten Eltern"
 
-#: lib/klass_hero_web/live/home_live.ex:167
+#: lib/klass_hero_web/live/home_live.ex:159
 #, elixir-autogen, elixir-format
 msgid "No risk of non-payment"
 msgstr "Kein Risiko von Zahlungsausfällen"
@@ -3820,7 +3815,7 @@ msgstr "Kein Risiko von Zahlungsausfällen"
 msgid "Notes"
 msgstr "Notizen"
 
-#: lib/klass_hero_web/live/home_live.ex:159
+#: lib/klass_hero_web/live/home_live.ex:151
 #, elixir-autogen, elixir-format
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr "Oder: Jederzeit eine Sofortauszahlung anfordern (mindestens 50 €)"
@@ -3831,27 +3826,27 @@ msgstr "Oder: Jederzeit eine Sofortauszahlung anfordern (mindestens 50 €)"
 msgid "Parent account not available"
 msgstr "Elternkonto nicht verfügbar"
 
-#: lib/klass_hero_web/live/home_live.ex:137
+#: lib/klass_hero_web/live/home_live.ex:129
 #, elixir-autogen, elixir-format
 msgid "Parent books and pays through Klass Hero (via Stripe)"
 msgstr "Eltern buchen und bezahlen über Klass Hero (via Stripe)"
 
-#: lib/klass_hero_web/live/home_live.ex:139
+#: lib/klass_hero_web/live/home_live.ex:131
 #, elixir-autogen, elixir-format
 msgid "Parent receives confirmation with your contact details"
 msgstr "Eltern erhalten eine Bestätigung mit Ihren Kontaktdaten"
 
-#: lib/klass_hero_web/live/home_live.ex:165
+#: lib/klass_hero_web/live/home_live.ex:157
 #, elixir-autogen, elixir-format
 msgid "Parents pay upfront when booking (reduces no-shows by 85%)"
 msgstr "Eltern zahlen bei der Buchung im Voraus (reduziert Nichterscheinen um 85 %)"
 
-#: lib/klass_hero_web/live/home_live.ex:143
+#: lib/klass_hero_web/live/home_live.ex:135
 #, elixir-autogen, elixir-format
 msgid "Payment Options for Parents:"
 msgstr "Zahlungsoptionen für Eltern:"
 
-#: lib/klass_hero_web/live/home_live.ex:160
+#: lib/klass_hero_web/live/home_live.ex:152
 #, elixir-autogen, elixir-format
 msgid "Platform fee automatically deducted when parent pays"
 msgstr "Plattformgebühr wird automatisch abgezogen, wenn Eltern bezahlen"
@@ -3872,7 +3867,7 @@ msgstr "Privatunterricht und Nachhilfe"
 msgid "Providers"
 msgstr "Anbieter"
 
-#: lib/klass_hero_web/live/home_live.ex:172
+#: lib/klass_hero_web/live/home_live.ex:164
 #, elixir-autogen, elixir-format
 msgid "Real-time dashboard shows all bookings and available balance"
 msgstr "Echtzeit-Dashboard zeigt alle Buchungen und das verfügbare Guthaben"
@@ -3892,7 +3887,7 @@ msgstr "Datensatz wurde von jemand anderem geändert. Bitte aktualisieren."
 msgid "Regular classes and courses (weekly/monthly)"
 msgstr "Regelmäßige Klassen und Kurse (wöchentlich/monatlich)"
 
-#: lib/klass_hero_web/live/home_live.ex:147
+#: lib/klass_hero_web/live/home_live.ex:139
 #, elixir-autogen, elixir-format
 msgid "SEPA direct debit"
 msgstr "SEPA-Lastschrift"
@@ -3907,12 +3902,12 @@ msgstr "Korrektur speichern"
 msgid "Scheduled"
 msgstr "Geplant"
 
-#: lib/klass_hero_web/live/home_live.ex:174
+#: lib/klass_hero_web/live/home_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "See payment history and upcoming payouts"
 msgstr "Zahlungsverlauf und bevorstehende Auszahlungen einsehen"
 
-#: lib/klass_hero_web/live/home_live.ex:134
+#: lib/klass_hero_web/live/home_live.ex:126
 #, elixir-autogen, elixir-format
 msgid "Simple and automated - we handle everything."
 msgstr "Einfach und automatisiert – wir kümmern uns um alles."
@@ -3922,7 +3917,7 @@ msgstr "Einfach und automatisiert – wir kümmern uns um alles."
 msgid "Staff Members"
 msgstr "Mitarbeiter"
 
-#: lib/klass_hero_web/live/home_live.ex:170
+#: lib/klass_hero_web/live/home_live.ex:162
 #, elixir-autogen, elixir-format
 msgid "Track Everything:"
 msgstr "Alles im Überblick:"
@@ -3933,7 +3928,7 @@ msgstr "Alles im Überblick:"
 msgid "Upgrade your plan to send messages."
 msgstr "Aktualisieren Sie Ihren Plan, um Nachrichten zu senden."
 
-#: lib/klass_hero_web/live/home_live.ex:158
+#: lib/klass_hero_web/live/home_live.ex:150
 #, elixir-autogen, elixir-format
 msgid "Weekly payouts: Transferred to your bank account every Friday"
 msgstr "Wöchentliche Auszahlungen: Jeden Freitag auf Ihr Bankkonto überwiesen"
@@ -3943,22 +3938,22 @@ msgstr "Wöchentliche Auszahlungen: Jeden Freitag auf Ihr Bankkonto überwiesen"
 msgid "What You Can List:"
 msgstr "Was Sie anbieten können:"
 
-#: lib/klass_hero_web/live/home_live.ex:199
+#: lib/klass_hero_web/live/home_live.ex:191
 #, elixir-autogen, elixir-format
 msgid "What if my child gets sick?"
 msgstr "Was ist, wenn mein Kind krank wird?"
 
-#: lib/klass_hero_web/live/home_live.ex:135
+#: lib/klass_hero_web/live/home_live.ex:127
 #, elixir-autogen, elixir-format
 msgid "When Someone Books:"
 msgstr "Wenn jemand bucht:"
 
-#: lib/klass_hero_web/live/home_live.ex:207
+#: lib/klass_hero_web/live/home_live.ex:199
 #, elixir-autogen, elixir-format
 msgid "Where is Klass Hero available?"
 msgstr "Wo ist Klass Hero verfügbar?"
 
-#: lib/klass_hero_web/live/home_live.ex:162
+#: lib/klass_hero_web/live/home_live.ex:154
 #, elixir-autogen, elixir-format
 msgid "Why This Works Better:"
 msgstr "Warum das besser funktioniert:"
@@ -3968,7 +3963,7 @@ msgstr "Warum das besser funktioniert:"
 msgid "Workshops and one-time events"
 msgstr "Workshops und einmalige Veranstaltungen"
 
-#: lib/klass_hero_web/live/home_live.ex:181
+#: lib/klass_hero_web/live/home_live.ex:173
 #, elixir-autogen, elixir-format
 msgid "Yes! Browsing and booking are completely free. No subscription, no booking fees."
 msgstr "Ja! Stöbern und Buchen sind völlig kostenlos. Kein Abonnement, keine Buchungsgebühren."
@@ -3978,22 +3973,22 @@ msgstr "Ja! Stöbern und Buchen sind völlig kostenlos. Kein Abonnement, keine B
 msgid "Yes! Register for free and start listing immediately."
 msgstr "Ja! Registrieren Sie sich kostenlos und beginnen Sie sofort damit, Ihre Programme zu listen."
 
-#: lib/klass_hero_web/live/home_live.ex:187
+#: lib/klass_hero_web/live/home_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "Yes, you need a free account to complete a booking and manage your reservations."
 msgstr "Ja, Sie benötigen ein kostenloses Konto, um eine Buchung abzuschließen und Ihre Reservierungen zu verwalten."
 
-#: lib/klass_hero_web/live/home_live.ex:141
+#: lib/klass_hero_web/live/home_live.ex:133
 #, elixir-autogen, elixir-format
 msgid "You deliver the program"
 msgstr "Sie führen das Programm durch"
 
-#: lib/klass_hero_web/live/home_live.ex:164
+#: lib/klass_hero_web/live/home_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "You get paid BEFORE delivering the program (no waiting)"
 msgstr "Sie werden bezahlt, BEVOR Sie das Programm durchführen (kein Warten)"
 
-#: lib/klass_hero_web/live/home_live.ex:138
+#: lib/klass_hero_web/live/home_live.ex:130
 #, elixir-autogen, elixir-format
 msgid "You receive instant email with booking details and parent contact info"
 msgstr "Sie erhalten sofort eine E-Mail mit den Buchungsdetails und den Kontaktdaten der Eltern"
@@ -5514,11 +5509,6 @@ msgstr "Für Pädagogen entwickelt, die unterrichten möchten, nicht ein Unterne
 msgid "Built-in trust"
 msgstr "Integriertes Vertrauen"
 
-#: lib/klass_hero_web/live/home_live.ex:123
-#, elixir-autogen, elixir-format
-msgid "Business Plus: €49/month + 8% per booking. Unlimited programs and team seats"
-msgstr "Business Plus: €49/Monat + 8% pro Buchung. Unbegrenzte Programme und Team-Plätze"
-
 #: lib/klass_hero_web/live/about_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "CFO"
@@ -5678,7 +5668,7 @@ msgstr "Einnahmenentwicklung"
 msgid "Edit program"
 msgstr "Programm bearbeiten"
 
-#: lib/klass_hero_web/live/home_live.ex:201
+#: lib/klass_hero_web/live/home_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "Email the provider and us (support@mail.klasshero.com) as soon as you can — we'll help you and the provider work it out."
 msgstr "Schreiben Sie dem Anbieter und uns (support@mail.klasshero.com) so schnell wie möglich eine E-Mail — wir helfen Ihnen und dem Anbieter, eine Lösung zu finden."
@@ -5953,6 +5943,7 @@ msgid "Join the team"
 msgstr "Treten Sie dem Team bei"
 
 #: lib/klass_hero_web/live/for_providers_live.ex:182
+#: lib/klass_hero_web/live/home_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "Joining Klass Hero costs nothing — unlimited programs, your whole team, all media, and direct parent messaging are included for everyone. A simple success-based fee on bookings made through the platform is coming; we'll share the details transparently before it launches."
 msgstr "Die Teilnahme an Klass Hero kostet nichts — unbegrenzte Programme, Ihr gesamtes Team, alle Medien und direkte Eltern-Kommunikation sind für alle inklusive. Eine einfache erfolgsbasierte Gebühr auf Buchungen über die Plattform kommt; wir teilen die Details transparent vor dem Start mit."
@@ -6344,11 +6335,6 @@ msgstr "Profi-Tipp"
 msgid "Process"
 msgstr "Prozess"
 
-#: lib/klass_hero_web/live/home_live.ex:120
-#, elixir-autogen, elixir-format
-msgid "Professional: €19/month + 12% per booking. Up to 5 programs"
-msgstr "Professional: 19 €/Monat + 12 % pro Buchung. Bis zu 5 Programme"
-
 #: lib/klass_hero_web/components/provider_layout_components.ex:101
 #, elixir-autogen, elixir-format
 msgid "Provider bottom navigation"
@@ -6581,11 +6567,6 @@ msgstr "Heute mit dem Unterrichten beginnen"
 #, elixir-autogen, elixir-format
 msgid "Start your own business"
 msgstr "Starten Sie Ihr eigenes Unternehmen"
-
-#: lib/klass_hero_web/live/home_live.ex:115
-#, elixir-autogen, elixir-format
-msgid "Starter: Free to join — no registration fees, no monthly subscriptions. 18% commission per booking, up to 2 active programs"
-msgstr "Starter: Kostenlose Anmeldung — keine Registrierungsgebühren, keine monatlichen Abos. 18 % Provision pro Buchung, bis zu 2 aktive Programme"
 
 #: lib/klass_hero_web/live/for_providers_live.ex:229
 #, elixir-autogen, elixir-format
@@ -7000,3 +6981,8 @@ msgstr "— eine Mutter mit über einem Jahrzehnt Erfahrung in Kindersicherheit 
 #, elixir-autogen, elixir-format
 msgid "You don't have permission to send broadcasts"
 msgstr "Sie haben keine Berechtigung, Rundnachrichten zu senden."
+
+#: lib/klass_hero_web/live/home_live.ex:119
+#, elixir-autogen, elixir-format
+msgid "Every provider gets: Profile page, booking system, payment processing, messaging, and marketing to Berlin families."
+msgstr "Jeder Anbieter erhält: Profilseite, Buchungssystem, Zahlungsabwicklung, Nachrichten und Marketing an Berliner Familien."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -3563,14 +3563,9 @@ msgstr ""
 msgid "All Statuses"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:150
+#: lib/klass_hero_web/live/home_live.ex:142
 #, elixir-autogen, elixir-format
 msgid "All payments processed securely through Stripe."
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:127
-#, elixir-autogen, elixir-format
-msgid "All plans include: Profile page, booking system, payment processing, messaging, and marketing to Berlin families."
 msgstr ""
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:261
@@ -3578,7 +3573,7 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:146
+#: lib/klass_hero_web/live/home_live.ex:138
 #, elixir-autogen, elixir-format
 msgid "Apple Pay / Google Pay"
 msgstr ""
@@ -3588,7 +3583,7 @@ msgstr ""
 msgid "Attendance corrected successfully"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:168
+#: lib/klass_hero_web/live/home_live.ex:160
 #, elixir-autogen, elixir-format
 msgid "Automatic fee calculation (no surprises)"
 msgstr ""
@@ -3613,12 +3608,12 @@ msgstr ""
 msgid "Camps and holiday programs"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:213
+#: lib/klass_hero_web/live/home_live.ex:205
 #, elixir-autogen, elixir-format
 msgid "Can I buy a gift voucher?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:191
+#: lib/klass_hero_web/live/home_live.ex:183
 #, elixir-autogen, elixir-format
 msgid "Can I change my booking date?"
 msgstr ""
@@ -3677,7 +3672,7 @@ msgstr ""
 msgid "Child"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:215
+#: lib/klass_hero_web/live/home_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Coming soon! Sign up for our newsletter to be notified when gift vouchers launch."
 msgstr ""
@@ -3687,7 +3682,7 @@ msgstr ""
 msgid "Completed"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:193
+#: lib/klass_hero_web/live/home_live.ex:185
 #, elixir-autogen, elixir-format
 msgid "Contact the provider directly (details in confirmation email). Most providers are flexible if you ask in advance."
 msgstr ""
@@ -3704,22 +3699,22 @@ msgstr ""
 msgid "Could not start conversation. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:145
+#: lib/klass_hero_web/live/home_live.ex:137
 #, elixir-autogen, elixir-format
 msgid "Credit/debit card (Visa, Mastercard, Amex)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:209
+#: lib/klass_hero_web/live/home_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Currently serving Berlin, with expansion to other German cities coming soon."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:185
+#: lib/klass_hero_web/live/home_live.ex:177
 #, elixir-autogen, elixir-format
 msgid "Do I need an account to book?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:175
+#: lib/klass_hero_web/live/home_live.ex:167
 #, elixir-autogen, elixir-format
 msgid "Download monthly statements for taxes"
 msgstr ""
@@ -3735,22 +3730,22 @@ msgstr ""
 msgid "Explain why this correction is needed..."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:173
+#: lib/klass_hero_web/live/home_live.ex:165
 #, elixir-autogen, elixir-format
 msgid "Export participant lists anytime"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:140
+#: lib/klass_hero_web/live/home_live.ex:132
 #, elixir-autogen, elixir-format
 msgid "Funds are immediately available in your Klass Hero account"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:151
+#: lib/klass_hero_web/live/home_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "How You Get Paid:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:133
+#: lib/klass_hero_web/live/home_live.ex:125
 #, elixir-autogen, elixir-format
 msgid "How does the booking system work?"
 msgstr ""
@@ -3761,17 +3756,17 @@ msgstr ""
 msgid "In Progress"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:154
+#: lib/klass_hero_web/live/home_live.ex:146
 #, elixir-autogen, elixir-format
 msgid "Instant availability: Funds are in your Klass Hero balance immediately after booking"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:179
+#: lib/klass_hero_web/live/home_live.ex:171
 #, elixir-autogen, elixir-format
 msgid "Is Klass Hero free for parents to use?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:148
+#: lib/klass_hero_web/live/home_live.ex:140
 #, elixir-autogen, elixir-format
 msgid "Klarna (pay later options)"
 msgstr ""
@@ -3797,7 +3792,7 @@ msgstr ""
 msgid "No changes detected"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:166
+#: lib/klass_hero_web/live/home_live.ex:158
 #, elixir-autogen, elixir-format
 msgid "No chasing payments or sending invoices"
 msgstr ""
@@ -3808,7 +3803,7 @@ msgstr ""
 msgid "No enrolled parents"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:167
+#: lib/klass_hero_web/live/home_live.ex:159
 #, elixir-autogen, elixir-format
 msgid "No risk of non-payment"
 msgstr ""
@@ -3820,7 +3815,7 @@ msgstr ""
 msgid "Notes"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:159
+#: lib/klass_hero_web/live/home_live.ex:151
 #, elixir-autogen, elixir-format
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
@@ -3831,27 +3826,27 @@ msgstr ""
 msgid "Parent account not available"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:137
+#: lib/klass_hero_web/live/home_live.ex:129
 #, elixir-autogen, elixir-format
 msgid "Parent books and pays through Klass Hero (via Stripe)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:139
+#: lib/klass_hero_web/live/home_live.ex:131
 #, elixir-autogen, elixir-format
 msgid "Parent receives confirmation with your contact details"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:165
+#: lib/klass_hero_web/live/home_live.ex:157
 #, elixir-autogen, elixir-format
 msgid "Parents pay upfront when booking (reduces no-shows by 85%)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:143
+#: lib/klass_hero_web/live/home_live.ex:135
 #, elixir-autogen, elixir-format
 msgid "Payment Options for Parents:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:160
+#: lib/klass_hero_web/live/home_live.ex:152
 #, elixir-autogen, elixir-format
 msgid "Platform fee automatically deducted when parent pays"
 msgstr ""
@@ -3872,7 +3867,7 @@ msgstr ""
 msgid "Providers"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:172
+#: lib/klass_hero_web/live/home_live.ex:164
 #, elixir-autogen, elixir-format
 msgid "Real-time dashboard shows all bookings and available balance"
 msgstr ""
@@ -3892,7 +3887,7 @@ msgstr ""
 msgid "Regular classes and courses (weekly/monthly)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:147
+#: lib/klass_hero_web/live/home_live.ex:139
 #, elixir-autogen, elixir-format
 msgid "SEPA direct debit"
 msgstr ""
@@ -3907,12 +3902,12 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:174
+#: lib/klass_hero_web/live/home_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "See payment history and upcoming payouts"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:134
+#: lib/klass_hero_web/live/home_live.ex:126
 #, elixir-autogen, elixir-format
 msgid "Simple and automated - we handle everything."
 msgstr ""
@@ -3922,7 +3917,7 @@ msgstr ""
 msgid "Staff Members"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:170
+#: lib/klass_hero_web/live/home_live.ex:162
 #, elixir-autogen, elixir-format
 msgid "Track Everything:"
 msgstr ""
@@ -3933,7 +3928,7 @@ msgstr ""
 msgid "Upgrade your plan to send messages."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:158
+#: lib/klass_hero_web/live/home_live.ex:150
 #, elixir-autogen, elixir-format
 msgid "Weekly payouts: Transferred to your bank account every Friday"
 msgstr ""
@@ -3943,22 +3938,22 @@ msgstr ""
 msgid "What You Can List:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:199
+#: lib/klass_hero_web/live/home_live.ex:191
 #, elixir-autogen, elixir-format
 msgid "What if my child gets sick?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:135
+#: lib/klass_hero_web/live/home_live.ex:127
 #, elixir-autogen, elixir-format
 msgid "When Someone Books:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:207
+#: lib/klass_hero_web/live/home_live.ex:199
 #, elixir-autogen, elixir-format
 msgid "Where is Klass Hero available?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:162
+#: lib/klass_hero_web/live/home_live.ex:154
 #, elixir-autogen, elixir-format
 msgid "Why This Works Better:"
 msgstr ""
@@ -3968,7 +3963,7 @@ msgstr ""
 msgid "Workshops and one-time events"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:181
+#: lib/klass_hero_web/live/home_live.ex:173
 #, elixir-autogen, elixir-format
 msgid "Yes! Browsing and booking are completely free. No subscription, no booking fees."
 msgstr ""
@@ -3978,22 +3973,22 @@ msgstr ""
 msgid "Yes! Register for free and start listing immediately."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:187
+#: lib/klass_hero_web/live/home_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "Yes, you need a free account to complete a booking and manage your reservations."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:141
+#: lib/klass_hero_web/live/home_live.ex:133
 #, elixir-autogen, elixir-format
 msgid "You deliver the program"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:164
+#: lib/klass_hero_web/live/home_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "You get paid BEFORE delivering the program (no waiting)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:138
+#: lib/klass_hero_web/live/home_live.ex:130
 #, elixir-autogen, elixir-format
 msgid "You receive instant email with booking details and parent contact info"
 msgstr ""
@@ -5514,11 +5509,6 @@ msgstr ""
 msgid "Built-in trust"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:123
-#, elixir-autogen, elixir-format
-msgid "Business Plus: €49/month + 8% per booking. Unlimited programs and team seats"
-msgstr ""
-
 #: lib/klass_hero_web/live/about_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "CFO"
@@ -5678,7 +5668,7 @@ msgstr ""
 msgid "Edit program"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:201
+#: lib/klass_hero_web/live/home_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "Email the provider and us (support@mail.klasshero.com) as soon as you can — we'll help you and the provider work it out."
 msgstr ""
@@ -5953,6 +5943,7 @@ msgid "Join the team"
 msgstr ""
 
 #: lib/klass_hero_web/live/for_providers_live.ex:182
+#: lib/klass_hero_web/live/home_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "Joining Klass Hero costs nothing — unlimited programs, your whole team, all media, and direct parent messaging are included for everyone. A simple success-based fee on bookings made through the platform is coming; we'll share the details transparently before it launches."
 msgstr ""
@@ -6344,11 +6335,6 @@ msgstr ""
 msgid "Process"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:120
-#, elixir-autogen, elixir-format
-msgid "Professional: €19/month + 12% per booking. Up to 5 programs"
-msgstr ""
-
 #: lib/klass_hero_web/components/provider_layout_components.ex:101
 #, elixir-autogen, elixir-format
 msgid "Provider bottom navigation"
@@ -6580,11 +6566,6 @@ msgstr ""
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "Start your own business"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:115
-#, elixir-autogen, elixir-format
-msgid "Starter: Free to join — no registration fees, no monthly subscriptions. 18% commission per booking, up to 2 active programs"
 msgstr ""
 
 #: lib/klass_hero_web/live/for_providers_live.ex:229
@@ -6999,4 +6980,9 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:27
 #, elixir-autogen, elixir-format
 msgid "You don't have permission to send broadcasts"
+msgstr ""
+
+#: lib/klass_hero_web/live/home_live.ex:119
+#, elixir-autogen, elixir-format
+msgid "Every provider gets: Profile page, booking system, payment processing, messaging, and marketing to Berlin families."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -3563,14 +3563,9 @@ msgstr ""
 msgid "All Statuses"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:150
+#: lib/klass_hero_web/live/home_live.ex:142
 #, elixir-autogen, elixir-format
 msgid "All payments processed securely through Stripe."
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:127
-#, elixir-autogen, elixir-format
-msgid "All plans include: Profile page, booking system, payment processing, messaging, and marketing to Berlin families."
 msgstr ""
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:261
@@ -3578,7 +3573,7 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:146
+#: lib/klass_hero_web/live/home_live.ex:138
 #, elixir-autogen, elixir-format
 msgid "Apple Pay / Google Pay"
 msgstr ""
@@ -3588,7 +3583,7 @@ msgstr ""
 msgid "Attendance corrected successfully"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:168
+#: lib/klass_hero_web/live/home_live.ex:160
 #, elixir-autogen, elixir-format
 msgid "Automatic fee calculation (no surprises)"
 msgstr ""
@@ -3613,12 +3608,12 @@ msgstr ""
 msgid "Camps and holiday programs"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:213
+#: lib/klass_hero_web/live/home_live.ex:205
 #, elixir-autogen, elixir-format
 msgid "Can I buy a gift voucher?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:191
+#: lib/klass_hero_web/live/home_live.ex:183
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Can I change my booking date?"
 msgstr ""
@@ -3677,7 +3672,7 @@ msgstr ""
 msgid "Child"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:215
+#: lib/klass_hero_web/live/home_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Coming soon! Sign up for our newsletter to be notified when gift vouchers launch."
 msgstr ""
@@ -3687,7 +3682,7 @@ msgstr ""
 msgid "Completed"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:193
+#: lib/klass_hero_web/live/home_live.ex:185
 #, elixir-autogen, elixir-format
 msgid "Contact the provider directly (details in confirmation email). Most providers are flexible if you ask in advance."
 msgstr ""
@@ -3704,22 +3699,22 @@ msgstr ""
 msgid "Could not start conversation. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:145
+#: lib/klass_hero_web/live/home_live.ex:137
 #, elixir-autogen, elixir-format
 msgid "Credit/debit card (Visa, Mastercard, Amex)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:209
+#: lib/klass_hero_web/live/home_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Currently serving Berlin, with expansion to other German cities coming soon."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:185
+#: lib/klass_hero_web/live/home_live.ex:177
 #, elixir-autogen, elixir-format
 msgid "Do I need an account to book?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:175
+#: lib/klass_hero_web/live/home_live.ex:167
 #, elixir-autogen, elixir-format
 msgid "Download monthly statements for taxes"
 msgstr ""
@@ -3735,22 +3730,22 @@ msgstr ""
 msgid "Explain why this correction is needed..."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:173
+#: lib/klass_hero_web/live/home_live.ex:165
 #, elixir-autogen, elixir-format
 msgid "Export participant lists anytime"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:140
+#: lib/klass_hero_web/live/home_live.ex:132
 #, elixir-autogen, elixir-format
 msgid "Funds are immediately available in your Klass Hero account"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:151
+#: lib/klass_hero_web/live/home_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "How You Get Paid:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:133
+#: lib/klass_hero_web/live/home_live.ex:125
 #, elixir-autogen, elixir-format
 msgid "How does the booking system work?"
 msgstr ""
@@ -3761,17 +3756,17 @@ msgstr ""
 msgid "In Progress"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:154
+#: lib/klass_hero_web/live/home_live.ex:146
 #, elixir-autogen, elixir-format
 msgid "Instant availability: Funds are in your Klass Hero balance immediately after booking"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:179
+#: lib/klass_hero_web/live/home_live.ex:171
 #, elixir-autogen, elixir-format
 msgid "Is Klass Hero free for parents to use?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:148
+#: lib/klass_hero_web/live/home_live.ex:140
 #, elixir-autogen, elixir-format
 msgid "Klarna (pay later options)"
 msgstr ""
@@ -3797,7 +3792,7 @@ msgstr ""
 msgid "No changes detected"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:166
+#: lib/klass_hero_web/live/home_live.ex:158
 #, elixir-autogen, elixir-format
 msgid "No chasing payments or sending invoices"
 msgstr ""
@@ -3808,7 +3803,7 @@ msgstr ""
 msgid "No enrolled parents"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:167
+#: lib/klass_hero_web/live/home_live.ex:159
 #, elixir-autogen, elixir-format
 msgid "No risk of non-payment"
 msgstr ""
@@ -3820,7 +3815,7 @@ msgstr ""
 msgid "Notes"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:159
+#: lib/klass_hero_web/live/home_live.ex:151
 #, elixir-autogen, elixir-format
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
@@ -3831,27 +3826,27 @@ msgstr ""
 msgid "Parent account not available"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:137
+#: lib/klass_hero_web/live/home_live.ex:129
 #, elixir-autogen, elixir-format
 msgid "Parent books and pays through Klass Hero (via Stripe)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:139
+#: lib/klass_hero_web/live/home_live.ex:131
 #, elixir-autogen, elixir-format
 msgid "Parent receives confirmation with your contact details"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:165
+#: lib/klass_hero_web/live/home_live.ex:157
 #, elixir-autogen, elixir-format
 msgid "Parents pay upfront when booking (reduces no-shows by 85%)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:143
+#: lib/klass_hero_web/live/home_live.ex:135
 #, elixir-autogen, elixir-format
 msgid "Payment Options for Parents:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:160
+#: lib/klass_hero_web/live/home_live.ex:152
 #, elixir-autogen, elixir-format
 msgid "Platform fee automatically deducted when parent pays"
 msgstr ""
@@ -3872,7 +3867,7 @@ msgstr ""
 msgid "Providers"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:172
+#: lib/klass_hero_web/live/home_live.ex:164
 #, elixir-autogen, elixir-format
 msgid "Real-time dashboard shows all bookings and available balance"
 msgstr ""
@@ -3892,7 +3887,7 @@ msgstr ""
 msgid "Regular classes and courses (weekly/monthly)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:147
+#: lib/klass_hero_web/live/home_live.ex:139
 #, elixir-autogen, elixir-format
 msgid "SEPA direct debit"
 msgstr ""
@@ -3907,12 +3902,12 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:174
+#: lib/klass_hero_web/live/home_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "See payment history and upcoming payouts"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:134
+#: lib/klass_hero_web/live/home_live.ex:126
 #, elixir-autogen, elixir-format
 msgid "Simple and automated - we handle everything."
 msgstr ""
@@ -3922,7 +3917,7 @@ msgstr ""
 msgid "Staff Members"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:170
+#: lib/klass_hero_web/live/home_live.ex:162
 #, elixir-autogen, elixir-format
 msgid "Track Everything:"
 msgstr ""
@@ -3933,7 +3928,7 @@ msgstr ""
 msgid "Upgrade your plan to send messages."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:158
+#: lib/klass_hero_web/live/home_live.ex:150
 #, elixir-autogen, elixir-format
 msgid "Weekly payouts: Transferred to your bank account every Friday"
 msgstr ""
@@ -3943,22 +3938,22 @@ msgstr ""
 msgid "What You Can List:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:199
+#: lib/klass_hero_web/live/home_live.ex:191
 #, elixir-autogen, elixir-format
 msgid "What if my child gets sick?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:135
+#: lib/klass_hero_web/live/home_live.ex:127
 #, elixir-autogen, elixir-format
 msgid "When Someone Books:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:207
+#: lib/klass_hero_web/live/home_live.ex:199
 #, elixir-autogen, elixir-format
 msgid "Where is Klass Hero available?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:162
+#: lib/klass_hero_web/live/home_live.ex:154
 #, elixir-autogen, elixir-format
 msgid "Why This Works Better:"
 msgstr ""
@@ -3968,7 +3963,7 @@ msgstr ""
 msgid "Workshops and one-time events"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:181
+#: lib/klass_hero_web/live/home_live.ex:173
 #, elixir-autogen, elixir-format
 msgid "Yes! Browsing and booking are completely free. No subscription, no booking fees."
 msgstr ""
@@ -3978,22 +3973,22 @@ msgstr ""
 msgid "Yes! Register for free and start listing immediately."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:187
+#: lib/klass_hero_web/live/home_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "Yes, you need a free account to complete a booking and manage your reservations."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:141
+#: lib/klass_hero_web/live/home_live.ex:133
 #, elixir-autogen, elixir-format
 msgid "You deliver the program"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:164
+#: lib/klass_hero_web/live/home_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "You get paid BEFORE delivering the program (no waiting)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:138
+#: lib/klass_hero_web/live/home_live.ex:130
 #, elixir-autogen, elixir-format
 msgid "You receive instant email with booking details and parent contact info"
 msgstr ""
@@ -5514,11 +5509,6 @@ msgstr ""
 msgid "Built-in trust"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:123
-#, elixir-autogen, elixir-format
-msgid "Business Plus: €49/month + 8% per booking. Unlimited programs and team seats"
-msgstr ""
-
 #: lib/klass_hero_web/live/about_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "CFO"
@@ -5678,7 +5668,7 @@ msgstr ""
 msgid "Edit program"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:201
+#: lib/klass_hero_web/live/home_live.ex:193
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Email the provider and us (support@mail.klasshero.com) as soon as you can — we'll help you and the provider work it out."
 msgstr ""
@@ -5953,6 +5943,7 @@ msgid "Join the team"
 msgstr ""
 
 #: lib/klass_hero_web/live/for_providers_live.ex:182
+#: lib/klass_hero_web/live/home_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "Joining Klass Hero costs nothing — unlimited programs, your whole team, all media, and direct parent messaging are included for everyone. A simple success-based fee on bookings made through the platform is coming; we'll share the details transparently before it launches."
 msgstr ""
@@ -6344,11 +6335,6 @@ msgstr ""
 msgid "Process"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:120
-#, elixir-autogen, elixir-format
-msgid "Professional: €19/month + 12% per booking. Up to 5 programs"
-msgstr ""
-
 #: lib/klass_hero_web/components/provider_layout_components.ex:101
 #, elixir-autogen, elixir-format
 msgid "Provider bottom navigation"
@@ -6580,11 +6566,6 @@ msgstr ""
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "Start your own business"
-msgstr ""
-
-#: lib/klass_hero_web/live/home_live.ex:115
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Starter: Free to join — no registration fees, no monthly subscriptions. 18% commission per booking, up to 2 active programs"
 msgstr ""
 
 #: lib/klass_hero_web/live/for_providers_live.ex:229
@@ -6999,4 +6980,9 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:27
 #, elixir-autogen, elixir-format
 msgid "You don't have permission to send broadcasts"
+msgstr ""
+
+#: lib/klass_hero_web/live/home_live.ex:119
+#, elixir-autogen, elixir-format
+msgid "Every provider gets: Profile page, booking system, payment processing, messaging, and marketing to Berlin families."
 msgstr ""


### PR DESCRIPTION
## Summary

The provider "Pricing:" FAQ on the home page (`home_live.ex`) still advertised the removed subscription-tier model — **Starter / Professional / Business Plus** with monthly fees, per-booking commissions, and program caps. All of that was deleted in the tier refactor (ADR-0004). The `/for-providers` page was already rewritten to the current "free to join, success-based fee coming" message, so the two pages contradicted each other and the home page advertised pricing that no longer exists.

## Changes

- Replace the three tier `<li>` bullets with the **exact `/for-providers` pricing sentence** — reusing its already-reviewed German translation rather than authoring fresh copy.
- Reword the "All plans include: …" line → "Every provider gets: …" (drops "plans", since tiers no longer exist).
- Gettext sync: 4 stale tier `msgid`s removed, 1 new benefits-line `msgid` added and translated to German.

## Review Focus

- Copy matches `for_providers_live.ex` `pricing_section/1` — single source of truth.
- German for the new benefits line (`de/LC_MESSAGES/default.po`).

## Test Plan

- `mix precommit` — 3892 passed, format + `lint_typography` + `lint_translations` clean.
- `home_live_test.exs` — 20 passed (renders the FAQ block).

Closes #1055