### PR TITLE
fix: drop Enrollment schema's belongs_to into Family (#1052)

### DIFF
--- a/lib/klass_hero/enrollment/enrollment.ex
+++ b/lib/klass_hero/enrollment/enrollment.ex
@@ -18,8 +18,6 @@ defmodule KlassHero.Enrollment.Enrollment do
 
   import Ecto.Changeset
 
-  alias KlassHero.Family.Child
-  alias KlassHero.Family.ParentProfile
   alias KlassHero.ProgramCatalog.Program
 
   @primary_key {:id, :binary_id, autogenerate: true}
@@ -31,8 +29,8 @@ defmodule KlassHero.Enrollment.Enrollment do
 
   schema "enrollments" do
     belongs_to :program, Program
-    belongs_to :child, Child
-    belongs_to :parent, ParentProfile
+    field :child_id, :binary_id
+    field :parent_id, :binary_id
 
     field :status, Ecto.Enum, values: [:pending, :confirmed, :completed, :cancelled]
     field :enrolled_at, :utc_datetime

--- a/lib/klass_hero_web/live/admin/booking_live.ex
+++ b/lib/klass_hero_web/live/admin/booking_live.ex
@@ -73,31 +73,6 @@ defmodule KlassHeroWeb.Admin.BookingLive do
         orderable: true,
         only: [:index, :show]
       },
-      child: %{
-        module: BelongsTo,
-        label: "Child",
-        display_field: :first_name,
-        searchable: true,
-        only: [:index, :show],
-        render: fn assigns ->
-          ~H"""
-          <span>
-            <%= if @value do %>
-              {@value.first_name} {@value.last_name}
-            <% else %>
-              <span class="text-gray-400 italic">Deleted</span>
-            <% end %>
-          </span>
-          """
-        end
-      },
-      parent: %{
-        module: BelongsTo,
-        label: "Parent",
-        display_field: :display_name,
-        searchable: true,
-        only: [:index, :show]
-      },
       status: %{
         module: Text,
         label: "Status",


### PR DESCRIPTION
## Summary

Severs the compile-time coupling from the Enrollment schema into Family's internal schema modules. `enrollment/enrollment.ex` declared `belongs_to :child, Family.Child` and `belongs_to :parent, Family.ParentProfile`, aliasing another context's schemas beyond the documented `Accounts.User` exception. This is the **schema-level root cause** of the query-level coupling fixed in #1046 — same violation, deeper layer.

Both associations are converted to plain `field :child_id/:parent_id, :binary_id`. The FK columns and `foreign_key_constraint` checks are unchanged, and the Enrollment facade already reads all Family data through ACLs (`ChildInfoACL`, `ParentInfoACL`, `ParticipantDetailsACL`), consuming `child_id`/`parent_id` as plain fields everywhere.

## Review focus

- **No migration.** `belongs_to` and `field :.., :binary_id` map to the identical `enrollments.child_id`/`parent_id` columns.
- **One hidden consumer removed.** The admin Backpex booking view (`admin/booking_live.ex`) rendered Child/Parent columns via `Backpex.Fields.BelongsTo`, which internally preloads the association — invisible to a `Repo.preload`/`assoc` grep. Those two read-only columns are dropped (Backpex admin is slated for removal; only doc-approval/mailing views are being kept). The `Program` column stays.
- The `belongs_to :program, Program` (ProgramCatalog) is intentionally left in scope — #1052 targets only the Family aliases.

## Test plan

- `mix precommit` — full suite green (**3892 passed**, 0 failures).
- Enrollment context suite unchanged (439) — the test factory already builds via `child_id`/`parent_id`, not the association.
- 4 previously-failing `Admin.BookingLiveTest` render crashes resolved by dropping the columns; no test assertions changed.
- `boundary-checker` on `enrollment.ex`: 5/5 clean, Enrollment→Family schema coupling gone, type-coherent (both FKs `:binary_id`).

Closes #1052

🤖 Generated with [Claude Code](https://claude.com/claude-code)