### PR TITLE
fix: add provider-ownership (IDOR) guards to dashboard mutations

### DIFF
--- a/lib/klass_hero/accounts.ex
+++ b/lib/klass_hero/accounts.ex
@@ -152,15 +152,21 @@ defmodule KlassHero.Accounts do
 
   Returns `{:ok, %StaffMember{}}` (the deleted row) or `{:error, :not_found}`.
   """
-  @spec remove_staff_member(String.t()) :: {:ok, StaffMember.t()} | {:error, :not_found}
-  def remove_staff_member(staff_id) when is_binary(staff_id) do
+  @spec remove_staff_member(String.t(), String.t()) ::
+          {:ok, StaffMember.t()} | {:error, :not_found}
+  def remove_staff_member(provider_id, staff_id) when is_binary(provider_id) and is_binary(staff_id) do
     context_span entity: "user" do
       Repo.transaction(fn ->
-        with {:ok, staff} <- Provider.get_staff_member(staff_id),
+        # Ownership guard (IDOR): a staff row owned by another provider is
+        # indistinguishable from a missing one — both roll back :not_found so an
+        # attacker can't probe existence, and no foreign row/role is touched.
+        with {:ok, %StaffMember{provider_id: ^provider_id} = staff} <-
+               Provider.get_staff_member(staff_id),
              :ok <- Provider.delete_staff_member(staff_id),
              :ok <- maybe_revoke_staff_role(staff) do
           staff
         else
+          {:ok, %StaffMember{}} -> Repo.rollback(:not_found)
           {:error, reason} -> Repo.rollback(reason)
         end
       end)

--- a/lib/klass_hero/program_catalog.ex
+++ b/lib/klass_hero/program_catalog.ex
@@ -88,15 +88,21 @@ defmodule KlassHero.ProgramCatalog do
   - `{:error, :stale_data}` if a concurrent modification was detected
   - `{:error, Ecto.Changeset.t()}` on validation failure
   """
-  @spec update_program(String.t(), map()) ::
+  @spec update_program(String.t(), String.t(), map()) ::
           {:ok, Program.t()} | {:error, :not_found | :stale_data | Ecto.Changeset.t()}
-  def update_program(id, changes) when is_binary(id) and is_map(changes) do
+  def update_program(provider_id, id, changes) when is_binary(provider_id) and is_binary(id) and is_map(changes) do
     context_span entity: "program" do
       attrs = flatten_instructor_attrs(changes)
 
+      # Ownership guard (IDOR): a program owned by another provider is
+      # indistinguishable from a missing one — both return :not_found so an
+      # attacker can't probe for existence by enumerating ids.
       case fetch_program(id) do
-        nil -> {:error, :not_found}
-        current -> do_update_program(current, attrs, Program.load_value_objects(current))
+        %Program{provider_id: ^provider_id} = current ->
+          do_update_program(current, attrs, Program.load_value_objects(current))
+
+        _nil_or_foreign ->
+          {:error, :not_found}
       end
     end
   end

--- a/lib/klass_hero/provider.ex
+++ b/lib/klass_hero/provider.ex
@@ -129,7 +129,7 @@ defmodule KlassHero.Provider do
   defdelegate create_staff_member(attrs), to: Staff
 
   @doc "Updates an existing staff member."
-  defdelegate update_staff_member(staff_id, attrs), to: Staff
+  defdelegate update_staff_member(provider_id, staff_id, attrs), to: Staff
 
   @doc "Deletes a staff member by ID."
   defdelegate delete_staff_member(staff_id), to: Staff

--- a/lib/klass_hero/provider/staff.ex
+++ b/lib/klass_hero/provider/staff.ex
@@ -90,17 +90,24 @@ defmodule KlassHero.Provider.Staff do
     end
   end
 
-  @doc "Updates an existing staff member."
-  def update_staff_member(staff_id, attrs) when is_binary(staff_id) and is_map(attrs) do
+  @doc """
+  Updates an existing staff member owned by `provider_id`.
+
+  A staff member owned by another provider is indistinguishable from a missing
+  one — both return `{:error, :not_found}` (IDOR guard, no existence leak).
+  """
+  def update_staff_member(provider_id, staff_id, attrs)
+      when is_binary(provider_id) and is_binary(staff_id) and is_map(attrs) do
     context_span entity: "staff_member" do
       attrs = Map.take(attrs, @staff_updatable_fields)
 
-      with {:ok, existing} <- get_staff_member(staff_id),
+      with {:ok, %StaffMember{provider_id: ^provider_id} = existing} <- get_staff_member(staff_id),
            merged = Map.merge(Map.from_struct(existing), attrs),
            {:ok, _validated} <- StaffMember.new(merged),
            {:ok, persisted} <- persist_staff_update(existing, attrs) do
         {:ok, persisted}
       else
+        {:ok, %StaffMember{}} -> {:error, :not_found}
         result -> CommandResult.wrap_validation_errors(result)
       end
     end

--- a/lib/klass_hero_web/live/provider/programs_live.ex
+++ b/lib/klass_hero_web/live/provider/programs_live.ex
@@ -120,20 +120,33 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
 
   @impl true
   def handle_event("edit_program", %{"id" => program_id}, socket) do
-    case ProgramCatalog.get_program_by_id(program_id) do
-      {:ok, program} ->
-        changeset = ProgramCatalog.new_program_changeset(program_to_form_params(program))
+    provider_id = socket.assigns.current_scope.provider.id
 
-        {:noreply,
-         socket
-         |> assign(
-           show_program_form: true,
-           editing_program_id: program_id,
-           program_form: to_form(changeset, as: :program_schema),
-           enrollment_form: load_enrollment_policy_form(program_id),
-           participant_policy_form: load_participant_policy_form(program_id),
-           instructor_options: build_instructor_options(socket.assigns.current_scope.provider.id)
-         )}
+    # Verify ownership before loading into the form — program_id is untrusted
+    # client input (IDOR guard). The shared getter is unscoped (7 callers), so the
+    # guard lives here, mirroring view_roster.
+    with {:ok, program} <- ProgramCatalog.get_program_by_id(program_id),
+         true <- program.provider_id == provider_id do
+      changeset = ProgramCatalog.new_program_changeset(program_to_form_params(program))
+
+      {:noreply,
+       socket
+       |> assign(
+         show_program_form: true,
+         editing_program_id: program_id,
+         program_form: to_form(changeset, as: :program_schema),
+         enrollment_form: load_enrollment_policy_form(program_id),
+         participant_policy_form: load_participant_policy_form(program_id),
+         instructor_options: build_instructor_options(provider_id)
+       )}
+    else
+      false ->
+        Logger.warning("[ProgramsLive] Unauthorized program edit attempt",
+          program_id: program_id,
+          provider_id: provider_id
+        )
+
+        {:noreply, put_flash(socket, :error, gettext("Program not found."))}
 
       {:error, :not_found} ->
         {:noreply, put_flash(socket, :error, gettext("Program not found."))}
@@ -574,9 +587,10 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
     program_params = all_params["program_schema"] || %{}
     enrollment_params = all_params["enrollment_policy"] || %{}
     participant_policy_params = all_params["participant_policy"] || %{}
+    provider_id = socket.assigns.current_scope.provider.id
 
     with {:ok, attrs} <- maybe_add_instructor(attrs, program_params["instructor_id"], socket),
-         {:ok, updated} <- ProgramCatalog.update_program(program_id, attrs) do
+         {:ok, updated} <- ProgramCatalog.update_program(provider_id, program_id, attrs) do
       policy_result = maybe_set_enrollment_policy(program_id, enrollment_params)
       set_participant_policy_on_update(program_id, participant_policy_params)
 

--- a/lib/klass_hero_web/live/provider/team_live.ex
+++ b/lib/klass_hero_web/live/provider/team_live.ex
@@ -79,14 +79,26 @@ defmodule KlassHeroWeb.Provider.TeamLive do
 
   @impl true
   def handle_event("edit_member", %{"id" => staff_id}, socket) do
-    case Provider.get_staff_member(staff_id) do
-      {:ok, staff} ->
-        changeset = Provider.change_staff_member(staff)
+    provider_id = socket.assigns.current_scope.provider.id
 
-        {:noreply,
-         socket
-         |> assign(show_staff_form: true, editing_staff_id: staff_id, self_staffing?: false)
-         |> assign(staff_form: to_form(changeset, as: :staff_member_schema))}
+    # Verify ownership before loading into the form — staff_id is untrusted client
+    # input (IDOR guard). The shared getter is unscoped, so the guard lives here.
+    with {:ok, staff} <- Provider.get_staff_member(staff_id),
+         true <- staff.provider_id == provider_id do
+      changeset = Provider.change_staff_member(staff)
+
+      {:noreply,
+       socket
+       |> assign(show_staff_form: true, editing_staff_id: staff_id, self_staffing?: false)
+       |> assign(staff_form: to_form(changeset, as: :staff_member_schema))}
+    else
+      false ->
+        Logger.warning("[TeamLive] Unauthorized staff edit attempt",
+          staff_member_id: staff_id,
+          provider_id: provider_id
+        )
+
+        {:noreply, put_flash(socket, :error, gettext("Staff member not found."))}
 
       {:error, :not_found} ->
         {:noreply, put_flash(socket, :error, gettext("Staff member not found."))}
@@ -101,6 +113,7 @@ defmodule KlassHeroWeb.Provider.TeamLive do
   @impl true
   def handle_event("validate_staff", %{"staff_member_schema" => params}, socket) do
     params = normalize_staff_form_params(params)
+    provider_id = socket.assigns.current_scope.provider.id
 
     changeset =
       case socket.assigns.editing_staff_id do
@@ -108,12 +121,14 @@ defmodule KlassHeroWeb.Provider.TeamLive do
           Provider.new_staff_member_changeset(params)
 
         staff_id ->
-          # Member may have been deleted between form open and keystroke; fall back to new changeset.
+          # Member may have been deleted between form open and keystroke — fall back
+          # to a new changeset. Ownership is re-checked here too (defence in depth):
+          # a foreign row must never rehydrate into the form via a crafted event.
           case Provider.get_staff_member(staff_id) do
-            {:ok, staff} ->
+            {:ok, %{provider_id: ^provider_id} = staff} ->
               Provider.change_staff_member(staff, params)
 
-            {:error, :not_found} ->
+            _not_found_or_foreign ->
               Provider.new_staff_member_changeset(params)
           end
       end
@@ -136,9 +151,12 @@ defmodule KlassHeroWeb.Provider.TeamLive do
 
   @impl true
   def handle_event("delete_member", %{"id" => staff_id}, socket) do
+    provider_id = socket.assigns.current_scope.provider.id
+
     # Accounts orchestrates: it deletes the Provider row AND durably drops :staff
-    # when no other active linked row remains (#972), atomically.
-    case Accounts.remove_staff_member(staff_id) do
+    # when no other active linked row remains (#972), atomically. It also enforces
+    # provider ownership — a foreign staff_id comes back as :not_found.
+    case Accounts.remove_staff_member(provider_id, staff_id) do
       {:ok, deleted} ->
         {:noreply,
          socket
@@ -149,6 +167,13 @@ defmodule KlassHeroWeb.Provider.TeamLive do
          |> put_flash(:info, gettext("Team member removed."))}
 
       {:error, :not_found} ->
+        # Foreign id is indistinguishable from a genuine miss here — log the
+        # attempt so an enumeration attack is visible (IDOR guard).
+        Logger.warning("[TeamLive] Staff delete returned not_found",
+          staff_member_id: staff_id,
+          provider_id: provider_id
+        )
+
         {:noreply, put_flash(socket, :error, gettext("Staff member not found."))}
     end
   end
@@ -341,12 +366,14 @@ defmodule KlassHeroWeb.Provider.TeamLive do
   end
 
   defp save_existing_staff(socket, params, staff_id, headshot_result) do
+    provider_id = socket.assigns.current_scope.provider.id
+
     {headshot_status, attrs} =
       params
       |> atomize_staff_params()
       |> maybe_add_headshot(headshot_result)
 
-    case Provider.update_staff_member(staff_id, attrs) do
+    case Provider.update_staff_member(provider_id, staff_id, attrs) do
       {:ok, staff} ->
         view = StaffMemberPresenter.to_admin_view(staff)
 
@@ -365,14 +392,26 @@ defmodule KlassHeroWeb.Provider.TeamLive do
       {:error, {:validation_error, _errors}} ->
         handle_staff_validation_error(socket, staff_id, params)
 
+      # Ownership mismatch or a row deleted mid-edit both surface as :not_found —
+      # an atom, not a changeset, so it must not fall through to the clause below
+      # (to_form(:not_found, ...) would raise). Mirrors handle_staff_validation_error.
+      {:error, :not_found} ->
+        {:noreply,
+         socket
+         |> assign(show_staff_form: false, editing_staff_id: nil)
+         |> put_flash(:error, gettext("Staff member no longer exists."))}
+
       {:error, changeset} ->
         {:noreply, assign(socket, staff_form: to_form(changeset, as: :staff_member_schema))}
     end
   end
 
   defp handle_staff_validation_error(socket, staff_id, params) do
+    provider_id = socket.assigns.current_scope.provider.id
+
+    # Ownership re-checked (defence in depth): a foreign row is treated as gone.
     case Provider.get_staff_member(staff_id) do
-      {:ok, staff} ->
+      {:ok, %{provider_id: ^provider_id} = staff} ->
         changeset =
           Provider.change_staff_member(staff, normalize_staff_form_params(params))
           |> Map.put(:action, :validate)
@@ -382,7 +421,7 @@ defmodule KlassHeroWeb.Provider.TeamLive do
          |> assign(staff_form: to_form(changeset, as: :staff_member_schema))
          |> put_flash(:error, gettext("Please fix the errors below."))}
 
-      {:error, :not_found} ->
+      _not_found_or_foreign ->
         {:noreply,
          socket
          |> assign(show_staff_form: false, editing_staff_id: nil)

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -1599,7 +1599,7 @@ msgid "Active"
 msgstr "Aktiv"
 
 #: lib/klass_hero_web/components/provider_components.ex:577
-#: lib/klass_hero_web/live/provider/team_live.ex:505
+#: lib/klass_hero_web/live/provider/team_live.ex:544
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
 msgstr "Teammitglied hinzufügen"
@@ -1631,7 +1631,7 @@ msgstr "Geschäftsprofil"
 msgid "Business Registration"
 msgstr "Gewerbeanmeldung"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:482
+#: lib/klass_hero_web/live/provider/team_live.ex:521
 #, elixir-autogen, elixir-format
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr "Erstellen Sie Profile für Ihr Personal. Diese werden für Eltern sichtbar sein, wenn sie Programmen zugewiesen werden."
@@ -1733,7 +1733,7 @@ msgstr "Status"
 msgid "Team & Profiles"
 msgstr "Team & Profile"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:479
+#: lib/klass_hero_web/live/provider/team_live.ex:518
 #, elixir-autogen, elixir-format
 msgid "Team & Provider Profiles"
 msgstr "Team- & Anbieterprofile"
@@ -2228,7 +2228,7 @@ msgstr "Aktion erforderlich"
 msgid "Add Member"
 msgstr "Mitglied hinzufügen"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:529
+#: lib/klass_hero_web/live/provider/team_live.ex:568
 #, elixir-autogen, elixir-format
 msgid "Add your first staff member to get started!"
 msgstr "Fügen Sie Ihren ersten Mitarbeiter hinzu, um loszulegen!"
@@ -2408,12 +2408,12 @@ msgstr "Bestätigt"
 msgid "Contact Provider"
 msgstr "Anbieter kontaktieren"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:333
+#: lib/klass_hero_web/live/provider/programs_live.ex:346
 #, elixir-autogen, elixir-format
 msgid "Could not read the uploaded file."
 msgstr "Die hochgeladene Datei konnte nicht gelesen werden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:301
+#: lib/klass_hero_web/live/provider/programs_live.ex:314
 #, elixir-autogen, elixir-format
 msgid "Could not remove invite."
 msgstr "Einladung konnte nicht entfernt werden."
@@ -2549,7 +2549,7 @@ msgstr "Dokument konnte nicht genehmigt werden."
 msgid "Failed to reject document."
 msgstr "Dokument konnte nicht abgelehnt werden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:283
+#: lib/klass_hero_web/live/provider/programs_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "Failed to resend invite."
 msgstr "Einladung konnte nicht erneut gesendet werden."
@@ -2641,17 +2641,17 @@ msgstr "Importieren"
 msgid "Insurance Certificate"
 msgstr "Versicherungsnachweis"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:298
+#: lib/klass_hero_web/live/provider/programs_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "Invite not found."
 msgstr "Einladung nicht gefunden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:295
+#: lib/klass_hero_web/live/provider/programs_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "Invite removed."
 msgstr "Einladung entfernt."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:272
+#: lib/klass_hero_web/live/provider/programs_live.ex:285
 #, elixir-autogen, elixir-format
 msgid "Invite resent successfully."
 msgstr "Einladung erfolgreich erneut gesendet."
@@ -2768,7 +2768,7 @@ msgstr "Noch keine Dokumente hochgeladen."
 msgid "No enrollments yet."
 msgstr "Noch keine Anmeldungen."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:329
+#: lib/klass_hero_web/live/provider/programs_live.ex:342
 #, elixir-autogen, elixir-format
 msgid "No file selected."
 msgstr "Keine Datei ausgewählt."
@@ -2808,7 +2808,7 @@ msgstr "Noch keine Programme gebucht"
 msgid "No rejected documents."
 msgstr "Keine abgelehnten Dokumente."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:528
+#: lib/klass_hero_web/live/provider/team_live.ex:567
 #, elixir-autogen, elixir-format
 msgid "No team members yet"
 msgstr "Noch keine Teammitglieder"
@@ -2866,11 +2866,11 @@ msgstr "Ausstehende Überprüfung"
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:103
-#: lib/klass_hero_web/live/provider/programs_live.ex:569
-#: lib/klass_hero_web/live/provider/programs_live.ex:627
-#: lib/klass_hero_web/live/provider/team_live.ex:227
-#: lib/klass_hero_web/live/provider/team_live.ex:278
-#: lib/klass_hero_web/live/provider/team_live.ex:383
+#: lib/klass_hero_web/live/provider/programs_live.ex:582
+#: lib/klass_hero_web/live/provider/programs_live.ex:641
+#: lib/klass_hero_web/live/provider/team_live.ex:252
+#: lib/klass_hero_web/live/provider/team_live.ex:303
+#: lib/klass_hero_web/live/provider/team_live.ex:422
 #, elixir-autogen, elixir-format
 msgid "Please fix the errors below."
 msgstr "Bitte korrigieren Sie die Fehler unten."
@@ -2900,26 +2900,27 @@ msgstr "Profil erfolgreich aktualisiert."
 msgid "Program Start"
 msgstr "Programmbeginn"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:861
+#: lib/klass_hero_web/live/provider/programs_live.ex:875
 #, elixir-autogen, elixir-format
 msgid "Program created successfully."
 msgstr "Programm erfolgreich erstellt."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:868
+#: lib/klass_hero_web/live/provider/programs_live.ex:882
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr "Programm erstellt, aber die Anmeldekapazität konnte nicht gespeichert werden. Bearbeiten Sie das Programm, um es erneut zu versuchen."
 
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:53
-#: lib/klass_hero_web/live/provider/programs_live.ex:139
-#: lib/klass_hero_web/live/provider/programs_live.ex:175
-#: lib/klass_hero_web/live/provider/programs_live.ex:178
-#: lib/klass_hero_web/live/provider/programs_live.ex:602
+#: lib/klass_hero_web/live/provider/programs_live.ex:149
+#: lib/klass_hero_web/live/provider/programs_live.ex:152
+#: lib/klass_hero_web/live/provider/programs_live.ex:188
+#: lib/klass_hero_web/live/provider/programs_live.ex:191
+#: lib/klass_hero_web/live/provider/programs_live.ex:616
 #, elixir-autogen, elixir-format
 msgid "Program not found."
 msgstr "Programm nicht gefunden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:591
+#: lib/klass_hero_web/live/provider/programs_live.ex:605
 #, elixir-autogen, elixir-format
 msgid "Program updated successfully."
 msgstr "Programm erfolgreich aktualisiert."
@@ -3079,8 +3080,8 @@ msgstr "Datei auswählen"
 msgid "Selected child does not meet the program requirements."
 msgstr "Das ausgewählte Kind erfüllt die Programmanforderungen nicht."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:559
-#: lib/klass_hero_web/live/provider/programs_live.ex:617
+#: lib/klass_hero_web/live/provider/programs_live.ex:572
+#: lib/klass_hero_web/live/provider/programs_live.ex:631
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr "Der ausgewählte Kursleiter konnte nicht gefunden werden. Bitte versuchen Sie es erneut."
@@ -3106,14 +3107,16 @@ msgstr "Legen Sie die minimale und maximale Anmeldekapazität für dieses Progra
 msgid "Specialties"
 msgstr "Spezialisierungen"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:389
+#: lib/klass_hero_web/live/provider/team_live.ex:402
+#: lib/klass_hero_web/live/provider/team_live.ex:428
 #, elixir-autogen, elixir-format
 msgid "Staff member no longer exists."
 msgstr "Der Mitarbeiter existiert nicht mehr."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:92
-#: lib/klass_hero_web/live/provider/team_live.ex:152
-#: lib/klass_hero_web/live/provider/team_live.ex:168
+#: lib/klass_hero_web/live/provider/team_live.ex:101
+#: lib/klass_hero_web/live/provider/team_live.ex:104
+#: lib/klass_hero_web/live/provider/team_live.ex:177
+#: lib/klass_hero_web/live/provider/team_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "Staff member not found."
 msgstr "Mitarbeiter nicht gefunden."
@@ -3144,27 +3147,27 @@ msgstr "Noch offen"
 msgid "Tax Certificate"
 msgstr "Steuerbescheinigung"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:331
+#: lib/klass_hero_web/live/provider/team_live.ex:356
 #, elixir-autogen, elixir-format
 msgid "Team member added, but headshot upload failed."
 msgstr "Teammitglied hinzugefügt, aber der Upload des Profilfotos ist fehlgeschlagen."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:332
+#: lib/klass_hero_web/live/provider/team_live.ex:357
 #, elixir-autogen, elixir-format
 msgid "Team member added."
 msgstr "Teammitglied hinzugefügt."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:149
+#: lib/klass_hero_web/live/provider/team_live.ex:167
 #, elixir-autogen, elixir-format
 msgid "Team member removed."
 msgstr "Teammitglied entfernt."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:355
+#: lib/klass_hero_web/live/provider/team_live.ex:382
 #, elixir-autogen, elixir-format
 msgid "Team member updated, but headshot upload failed."
 msgstr "Teammitglied aktualisiert, aber der Upload des Profilfotos ist fehlgeschlagen."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:356
+#: lib/klass_hero_web/live/provider/team_live.ex:383
 #, elixir-autogen, elixir-format
 msgid "Team member updated."
 msgstr "Teammitglied aktualisiert."
@@ -3179,12 +3182,12 @@ msgstr "Erzählen Sie Eltern von Ihrer Organisation..."
 msgid "The Klass Hero Story"
 msgstr "Die Geschichte von Klass Hero"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:275
+#: lib/klass_hero_web/live/provider/programs_live.ex:288
 #, elixir-autogen, elixir-format
 msgid "This invite cannot be resent."
 msgstr "Diese Einladung kann nicht erneut gesendet werden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:609
+#: lib/klass_hero_web/live/provider/programs_live.ex:623
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr "Dieses Programm wurde von jemand anderem geändert. Bitte schließen Sie es und versuchen Sie es erneut."
@@ -3412,7 +3415,7 @@ msgstr "Zahlung per Bargeld oder Banküberweisung"
 msgid "Program fee:"
 msgstr "Programmgebühr:"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:709
+#: lib/klass_hero_web/live/provider/programs_live.ex:723
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr "Programm gespeichert, aber der Upload des Titelbilds ist fehlgeschlagen. Sie können es erneut hochladen, indem Sie das Programm bearbeiten."
@@ -3628,7 +3631,7 @@ msgstr "Kann ich meine Programme auf Klass Hero listen und was kostet das?"
 msgid "Cannot check out without a check-in"
 msgstr "Auschecken ohne Einchecken nicht möglich"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:247
+#: lib/klass_hero_web/live/provider/programs_live.ex:260
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:146
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
@@ -3693,7 +3696,7 @@ msgid "Correct"
 msgstr "Korrigieren"
 
 #: lib/klass_hero_web/live/dashboard_live.ex:258
-#: lib/klass_hero_web/live/provider/programs_live.ex:244
+#: lib/klass_hero_web/live/provider/programs_live.ex:257
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "Could not start conversation. Please try again."
@@ -4266,7 +4269,7 @@ msgstr "E-Mail-Inhalt konnte nicht abgerufen werden."
 msgid "Failed to mark email as unread"
 msgstr "E-Mail konnte nicht als ungelesen markiert werden"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:184
+#: lib/klass_hero_web/live/provider/team_live.ex:209
 #, elixir-autogen, elixir-format
 msgid "Failed to resend invitation. Please try again."
 msgstr "Einladung konnte nicht erneut gesendet werden. Bitte versuchen Sie es erneut."
@@ -4334,7 +4337,7 @@ msgstr "Einladung ausstehend"
 msgid "Invitation Sent"
 msgstr "Einladung gesendet"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:165
+#: lib/klass_hero_web/live/provider/team_live.ex:190
 #, elixir-autogen, elixir-format
 msgid "Invitation resent successfully."
 msgstr "Einladung erfolgreich erneut gesendet."
@@ -4460,7 +4463,7 @@ msgstr "Absenden"
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:24
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
-#: lib/klass_hero_web/live/provider/programs_live.ex:210
+#: lib/klass_hero_web/live/provider/programs_live.ex:223
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Program"
@@ -4581,7 +4584,7 @@ msgstr "Sitzung erfolgreich erstellt"
 msgid "Staff Dashboard"
 msgstr "Mitarbeiter-Dashboard"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:234
+#: lib/klass_hero_web/live/provider/team_live.ex:259
 #, elixir-autogen, elixir-format
 msgid "Staff member created, but the invitation could not be sent. Try resending from the team list."
 msgstr "Mitarbeiter wurde erstellt, aber die Einladung konnte nicht gesendet werden. Versuchen Sie es erneut über die Team-Liste."
@@ -4612,7 +4615,7 @@ msgstr "Unterstützung: %{details}"
 msgid "The business associated with your account could not be found."
 msgstr "Das mit Ihrem Konto verknüpfte Unternehmen konnte nicht gefunden werden."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:175
+#: lib/klass_hero_web/live/provider/team_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "This invitation cannot be resent in its current state."
 msgstr "Diese Einladung kann in ihrem aktuellen Status nicht erneut gesendet werden."
@@ -4674,7 +4677,7 @@ msgid "Update your observation..."
 msgstr "Aktualisieren Sie Ihre Beobachtung..."
 
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:138
-#: lib/klass_hero_web/live/provider/programs_live.ex:326
+#: lib/klass_hero_web/live/provider/programs_live.ex:339
 #, elixir-autogen, elixir-format
 msgid "Upload connection lost. Please try again."
 msgstr "Upload-Verbindung unterbrochen. Bitte versuchen Sie es erneut."
@@ -4978,7 +4981,7 @@ msgstr "Sessions — %{title}"
 msgid "View sessions"
 msgstr "Sessions anzeigen"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:417
+#: lib/klass_hero_web/live/provider/programs_live.ex:430
 #, elixir-autogen, elixir-format
 msgid "Create a program before inviting participants."
 msgstr "Erstellen Sie zuerst ein Programm, bevor Sie Teilnehmer einladen."
@@ -5020,7 +5023,7 @@ msgstr "Einladungsmodus"
 msgid "Invite one person"
 msgstr "Einzelperson einladen"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:413
+#: lib/klass_hero_web/live/provider/programs_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "Invite sent."
 msgstr "Einladung verschickt."
@@ -5123,7 +5126,7 @@ msgstr "Aktualisieren Sie die Notiz für dieses Kind (z. B. um zu klären, was p
 msgid "Upload a list"
 msgstr "Liste hochladen"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:424
+#: lib/klass_hero_web/live/provider/programs_live.ex:437
 #, elixir-autogen, elixir-format
 msgid "An invite for this child and program already exists."
 msgstr "Für dieses Kind und Programm existiert bereits eine Einladung."
@@ -5300,7 +5303,7 @@ msgstr "Ihre Woche mit den Kindern"
 msgid "Go to dashboard"
 msgstr "Zum Dashboard"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:369
+#: lib/klass_hero_web/live/provider/programs_live.ex:382
 #, elixir-autogen, elixir-format
 msgid "%{count} row could not be processed."
 msgid_plural "%{count} rows could not be processed."
@@ -5603,7 +5606,7 @@ msgstr "Familien verbinden mit"
 msgid "Contact Us →"
 msgstr "Kontakt →"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:286
+#: lib/klass_hero_web/live/provider/team_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "Could not add you to the team. Please try again."
 msgstr "Sie konnten nicht zum Team hinzugefügt werden. Bitte versuchen Sie es erneut."
@@ -5880,13 +5883,13 @@ msgstr "So bringen Sie Ihr Jugendprogramm zum Wachsen"
 msgid "How we vet providers"
 msgstr "Wie wir Anbieter überprüfen"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:496
+#: lib/klass_hero_web/live/provider/team_live.ex:535
 #, elixir-autogen, elixir-format
 msgid "I'll be teaching"
 msgstr "Ich werde unterrichten"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:344
-#: lib/klass_hero_web/live/provider/programs_live.ex:366
+#: lib/klass_hero_web/live/provider/programs_live.ex:357
+#: lib/klass_hero_web/live/provider/programs_live.ex:379
 #, elixir-autogen, elixir-format
 msgid "Imported %{count} family."
 msgid_plural "Imported %{count} families."
@@ -6174,7 +6177,7 @@ msgstr "Noch keine Programme — fügen Sie Ihr erstes über den Tab „Programm
 msgid "No registered children for this session."
 msgstr "Keine Kinder in dieser Sitzung angemeldet."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:353
+#: lib/klass_hero_web/live/provider/programs_live.ex:366
 #, elixir-autogen, elixir-format
 msgid "No rows imported. %{count} row could not be processed."
 msgid_plural "No rows imported. %{count} rows could not be processed."
@@ -6849,7 +6852,7 @@ msgstr "Sie haben bereits ein Konto für %{email}."
 msgid "You'll get your own provider profile to fill in, and your account will open on your business dashboard from now on. You stay on %{business}'s team."
 msgstr "Sie erhalten Ihr eigenes Anbieterprofil zum Ausfüllen, und Ihr Konto öffnet sich ab sofort auf Ihrem Geschäfts-Dashboard. Sie bleiben im Team von %{business}."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:266
+#: lib/klass_hero_web/live/provider/team_live.ex:291
 #, elixir-autogen, elixir-format
 msgid "You're already on your team."
 msgstr "Sie sind bereits in Ihrem Team."
@@ -6869,12 +6872,12 @@ msgstr "Sie sind nicht mehr in diesem Team."
 msgid "You're now part of the team."
 msgstr "Sie sind jetzt Teil des Teams."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:314
+#: lib/klass_hero_web/live/provider/team_live.ex:339
 #, elixir-autogen, elixir-format
 msgid "You're on the team — you can now be assigned to programs."
 msgstr "Sie sind im Team — Sie können nun Programmen zugewiesen werden."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:313
+#: lib/klass_hero_web/live/provider/team_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "You're on the team, but the headshot upload failed."
 msgstr "Sie sind im Team, aber der Upload des Profilfotos ist fehlgeschlagen."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -1599,7 +1599,7 @@ msgid "Active"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:577
-#: lib/klass_hero_web/live/provider/team_live.ex:505
+#: lib/klass_hero_web/live/provider/team_live.ex:544
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
 msgstr ""
@@ -1631,7 +1631,7 @@ msgstr ""
 msgid "Business Registration"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:482
+#: lib/klass_hero_web/live/provider/team_live.ex:521
 #, elixir-autogen, elixir-format
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr ""
@@ -1733,7 +1733,7 @@ msgstr ""
 msgid "Team & Profiles"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:479
+#: lib/klass_hero_web/live/provider/team_live.ex:518
 #, elixir-autogen, elixir-format
 msgid "Team & Provider Profiles"
 msgstr ""
@@ -2228,7 +2228,7 @@ msgstr ""
 msgid "Add Member"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:529
+#: lib/klass_hero_web/live/provider/team_live.ex:568
 #, elixir-autogen, elixir-format
 msgid "Add your first staff member to get started!"
 msgstr ""
@@ -2408,12 +2408,12 @@ msgstr ""
 msgid "Contact Provider"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:333
+#: lib/klass_hero_web/live/provider/programs_live.ex:346
 #, elixir-autogen, elixir-format
 msgid "Could not read the uploaded file."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:301
+#: lib/klass_hero_web/live/provider/programs_live.ex:314
 #, elixir-autogen, elixir-format
 msgid "Could not remove invite."
 msgstr ""
@@ -2549,7 +2549,7 @@ msgstr ""
 msgid "Failed to reject document."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:283
+#: lib/klass_hero_web/live/provider/programs_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "Failed to resend invite."
 msgstr ""
@@ -2641,17 +2641,17 @@ msgstr ""
 msgid "Insurance Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:298
+#: lib/klass_hero_web/live/provider/programs_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "Invite not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:295
+#: lib/klass_hero_web/live/provider/programs_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "Invite removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:272
+#: lib/klass_hero_web/live/provider/programs_live.ex:285
 #, elixir-autogen, elixir-format
 msgid "Invite resent successfully."
 msgstr ""
@@ -2768,7 +2768,7 @@ msgstr ""
 msgid "No enrollments yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:329
+#: lib/klass_hero_web/live/provider/programs_live.ex:342
 #, elixir-autogen, elixir-format
 msgid "No file selected."
 msgstr ""
@@ -2808,7 +2808,7 @@ msgstr ""
 msgid "No rejected documents."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:528
+#: lib/klass_hero_web/live/provider/team_live.ex:567
 #, elixir-autogen, elixir-format
 msgid "No team members yet"
 msgstr ""
@@ -2866,11 +2866,11 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:103
-#: lib/klass_hero_web/live/provider/programs_live.ex:569
-#: lib/klass_hero_web/live/provider/programs_live.ex:627
-#: lib/klass_hero_web/live/provider/team_live.ex:227
-#: lib/klass_hero_web/live/provider/team_live.ex:278
-#: lib/klass_hero_web/live/provider/team_live.ex:383
+#: lib/klass_hero_web/live/provider/programs_live.ex:582
+#: lib/klass_hero_web/live/provider/programs_live.ex:641
+#: lib/klass_hero_web/live/provider/team_live.ex:252
+#: lib/klass_hero_web/live/provider/team_live.ex:303
+#: lib/klass_hero_web/live/provider/team_live.ex:422
 #, elixir-autogen, elixir-format
 msgid "Please fix the errors below."
 msgstr ""
@@ -2900,26 +2900,27 @@ msgstr ""
 msgid "Program Start"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:861
+#: lib/klass_hero_web/live/provider/programs_live.ex:875
 #, elixir-autogen, elixir-format
 msgid "Program created successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:868
+#: lib/klass_hero_web/live/provider/programs_live.ex:882
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:53
-#: lib/klass_hero_web/live/provider/programs_live.ex:139
-#: lib/klass_hero_web/live/provider/programs_live.ex:175
-#: lib/klass_hero_web/live/provider/programs_live.ex:178
-#: lib/klass_hero_web/live/provider/programs_live.ex:602
+#: lib/klass_hero_web/live/provider/programs_live.ex:149
+#: lib/klass_hero_web/live/provider/programs_live.ex:152
+#: lib/klass_hero_web/live/provider/programs_live.ex:188
+#: lib/klass_hero_web/live/provider/programs_live.ex:191
+#: lib/klass_hero_web/live/provider/programs_live.ex:616
 #, elixir-autogen, elixir-format
 msgid "Program not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:591
+#: lib/klass_hero_web/live/provider/programs_live.ex:605
 #, elixir-autogen, elixir-format
 msgid "Program updated successfully."
 msgstr ""
@@ -3079,8 +3080,8 @@ msgstr ""
 msgid "Selected child does not meet the program requirements."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:559
-#: lib/klass_hero_web/live/provider/programs_live.ex:617
+#: lib/klass_hero_web/live/provider/programs_live.ex:572
+#: lib/klass_hero_web/live/provider/programs_live.ex:631
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
@@ -3106,14 +3107,16 @@ msgstr ""
 msgid "Specialties"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:389
+#: lib/klass_hero_web/live/provider/team_live.ex:402
+#: lib/klass_hero_web/live/provider/team_live.ex:428
 #, elixir-autogen, elixir-format
 msgid "Staff member no longer exists."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:92
-#: lib/klass_hero_web/live/provider/team_live.ex:152
-#: lib/klass_hero_web/live/provider/team_live.ex:168
+#: lib/klass_hero_web/live/provider/team_live.ex:101
+#: lib/klass_hero_web/live/provider/team_live.ex:104
+#: lib/klass_hero_web/live/provider/team_live.ex:177
+#: lib/klass_hero_web/live/provider/team_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "Staff member not found."
 msgstr ""
@@ -3144,27 +3147,27 @@ msgstr ""
 msgid "Tax Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:331
+#: lib/klass_hero_web/live/provider/team_live.ex:356
 #, elixir-autogen, elixir-format
 msgid "Team member added, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:332
+#: lib/klass_hero_web/live/provider/team_live.ex:357
 #, elixir-autogen, elixir-format
 msgid "Team member added."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:149
+#: lib/klass_hero_web/live/provider/team_live.ex:167
 #, elixir-autogen, elixir-format
 msgid "Team member removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:355
+#: lib/klass_hero_web/live/provider/team_live.ex:382
 #, elixir-autogen, elixir-format
 msgid "Team member updated, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:356
+#: lib/klass_hero_web/live/provider/team_live.ex:383
 #, elixir-autogen, elixir-format
 msgid "Team member updated."
 msgstr ""
@@ -3179,12 +3182,12 @@ msgstr ""
 msgid "The Klass Hero Story"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:275
+#: lib/klass_hero_web/live/provider/programs_live.ex:288
 #, elixir-autogen, elixir-format
 msgid "This invite cannot be resent."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:609
+#: lib/klass_hero_web/live/provider/programs_live.ex:623
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
@@ -3412,7 +3415,7 @@ msgstr ""
 msgid "Program fee:"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:709
+#: lib/klass_hero_web/live/provider/programs_live.ex:723
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr ""
@@ -3628,7 +3631,7 @@ msgstr ""
 msgid "Cannot check out without a check-in"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:247
+#: lib/klass_hero_web/live/provider/programs_live.ex:260
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:146
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
@@ -3693,7 +3696,7 @@ msgid "Correct"
 msgstr ""
 
 #: lib/klass_hero_web/live/dashboard_live.ex:258
-#: lib/klass_hero_web/live/provider/programs_live.ex:244
+#: lib/klass_hero_web/live/provider/programs_live.ex:257
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "Could not start conversation. Please try again."
@@ -4266,7 +4269,7 @@ msgstr ""
 msgid "Failed to mark email as unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:184
+#: lib/klass_hero_web/live/provider/team_live.ex:209
 #, elixir-autogen, elixir-format
 msgid "Failed to resend invitation. Please try again."
 msgstr ""
@@ -4334,7 +4337,7 @@ msgstr ""
 msgid "Invitation Sent"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:165
+#: lib/klass_hero_web/live/provider/team_live.ex:190
 #, elixir-autogen, elixir-format
 msgid "Invitation resent successfully."
 msgstr ""
@@ -4460,7 +4463,7 @@ msgstr ""
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:24
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
-#: lib/klass_hero_web/live/provider/programs_live.ex:210
+#: lib/klass_hero_web/live/provider/programs_live.ex:223
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Program"
@@ -4581,7 +4584,7 @@ msgstr ""
 msgid "Staff Dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:234
+#: lib/klass_hero_web/live/provider/team_live.ex:259
 #, elixir-autogen, elixir-format
 msgid "Staff member created, but the invitation could not be sent. Try resending from the team list."
 msgstr ""
@@ -4612,7 +4615,7 @@ msgstr ""
 msgid "The business associated with your account could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:175
+#: lib/klass_hero_web/live/provider/team_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "This invitation cannot be resent in its current state."
 msgstr ""
@@ -4674,7 +4677,7 @@ msgid "Update your observation..."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:138
-#: lib/klass_hero_web/live/provider/programs_live.ex:326
+#: lib/klass_hero_web/live/provider/programs_live.ex:339
 #, elixir-autogen, elixir-format
 msgid "Upload connection lost. Please try again."
 msgstr ""
@@ -4978,7 +4981,7 @@ msgstr ""
 msgid "View sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:417
+#: lib/klass_hero_web/live/provider/programs_live.ex:430
 #, elixir-autogen, elixir-format
 msgid "Create a program before inviting participants."
 msgstr ""
@@ -5020,7 +5023,7 @@ msgstr ""
 msgid "Invite one person"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:413
+#: lib/klass_hero_web/live/provider/programs_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "Invite sent."
 msgstr ""
@@ -5123,7 +5126,7 @@ msgstr ""
 msgid "Upload a list"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:424
+#: lib/klass_hero_web/live/provider/programs_live.ex:437
 #, elixir-autogen, elixir-format
 msgid "An invite for this child and program already exists."
 msgstr ""
@@ -5300,7 +5303,7 @@ msgstr ""
 msgid "Go to dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:369
+#: lib/klass_hero_web/live/provider/programs_live.ex:382
 #, elixir-autogen, elixir-format
 msgid "%{count} row could not be processed."
 msgid_plural "%{count} rows could not be processed."
@@ -5603,7 +5606,7 @@ msgstr ""
 msgid "Contact Us →"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:286
+#: lib/klass_hero_web/live/provider/team_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "Could not add you to the team. Please try again."
 msgstr ""
@@ -5880,13 +5883,13 @@ msgstr ""
 msgid "How we vet providers"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:496
+#: lib/klass_hero_web/live/provider/team_live.ex:535
 #, elixir-autogen, elixir-format
 msgid "I'll be teaching"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:344
-#: lib/klass_hero_web/live/provider/programs_live.ex:366
+#: lib/klass_hero_web/live/provider/programs_live.ex:357
+#: lib/klass_hero_web/live/provider/programs_live.ex:379
 #, elixir-autogen, elixir-format
 msgid "Imported %{count} family."
 msgid_plural "Imported %{count} families."
@@ -6174,7 +6177,7 @@ msgstr ""
 msgid "No registered children for this session."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:353
+#: lib/klass_hero_web/live/provider/programs_live.ex:366
 #, elixir-autogen, elixir-format
 msgid "No rows imported. %{count} row could not be processed."
 msgid_plural "No rows imported. %{count} rows could not be processed."
@@ -6849,7 +6852,7 @@ msgstr ""
 msgid "You'll get your own provider profile to fill in, and your account will open on your business dashboard from now on. You stay on %{business}'s team."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:266
+#: lib/klass_hero_web/live/provider/team_live.ex:291
 #, elixir-autogen, elixir-format
 msgid "You're already on your team."
 msgstr ""
@@ -6869,12 +6872,12 @@ msgstr ""
 msgid "You're now part of the team."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:314
+#: lib/klass_hero_web/live/provider/team_live.ex:339
 #, elixir-autogen, elixir-format
 msgid "You're on the team — you can now be assigned to programs."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:313
+#: lib/klass_hero_web/live/provider/team_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "You're on the team, but the headshot upload failed."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -1599,7 +1599,7 @@ msgid "Active"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:577
-#: lib/klass_hero_web/live/provider/team_live.ex:505
+#: lib/klass_hero_web/live/provider/team_live.ex:544
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
 msgstr ""
@@ -1631,7 +1631,7 @@ msgstr ""
 msgid "Business Registration"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:482
+#: lib/klass_hero_web/live/provider/team_live.ex:521
 #, elixir-autogen, elixir-format
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr ""
@@ -1733,7 +1733,7 @@ msgstr ""
 msgid "Team & Profiles"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:479
+#: lib/klass_hero_web/live/provider/team_live.ex:518
 #, elixir-autogen, elixir-format
 msgid "Team & Provider Profiles"
 msgstr ""
@@ -2228,7 +2228,7 @@ msgstr ""
 msgid "Add Member"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:529
+#: lib/klass_hero_web/live/provider/team_live.ex:568
 #, elixir-autogen, elixir-format
 msgid "Add your first staff member to get started!"
 msgstr ""
@@ -2408,12 +2408,12 @@ msgstr ""
 msgid "Contact Provider"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:333
+#: lib/klass_hero_web/live/provider/programs_live.ex:346
 #, elixir-autogen, elixir-format
 msgid "Could not read the uploaded file."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:301
+#: lib/klass_hero_web/live/provider/programs_live.ex:314
 #, elixir-autogen, elixir-format
 msgid "Could not remove invite."
 msgstr ""
@@ -2549,7 +2549,7 @@ msgstr ""
 msgid "Failed to reject document."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:283
+#: lib/klass_hero_web/live/provider/programs_live.ex:296
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to resend invite."
 msgstr ""
@@ -2641,17 +2641,17 @@ msgstr ""
 msgid "Insurance Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:298
+#: lib/klass_hero_web/live/provider/programs_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "Invite not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:295
+#: lib/klass_hero_web/live/provider/programs_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "Invite removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:272
+#: lib/klass_hero_web/live/provider/programs_live.ex:285
 #, elixir-autogen, elixir-format
 msgid "Invite resent successfully."
 msgstr ""
@@ -2768,7 +2768,7 @@ msgstr ""
 msgid "No enrollments yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:329
+#: lib/klass_hero_web/live/provider/programs_live.ex:342
 #, elixir-autogen, elixir-format
 msgid "No file selected."
 msgstr ""
@@ -2808,7 +2808,7 @@ msgstr ""
 msgid "No rejected documents."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:528
+#: lib/klass_hero_web/live/provider/team_live.ex:567
 #, elixir-autogen, elixir-format
 msgid "No team members yet"
 msgstr ""
@@ -2866,11 +2866,11 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:103
-#: lib/klass_hero_web/live/provider/programs_live.ex:569
-#: lib/klass_hero_web/live/provider/programs_live.ex:627
-#: lib/klass_hero_web/live/provider/team_live.ex:227
-#: lib/klass_hero_web/live/provider/team_live.ex:278
-#: lib/klass_hero_web/live/provider/team_live.ex:383
+#: lib/klass_hero_web/live/provider/programs_live.ex:582
+#: lib/klass_hero_web/live/provider/programs_live.ex:641
+#: lib/klass_hero_web/live/provider/team_live.ex:252
+#: lib/klass_hero_web/live/provider/team_live.ex:303
+#: lib/klass_hero_web/live/provider/team_live.ex:422
 #, elixir-autogen, elixir-format
 msgid "Please fix the errors below."
 msgstr ""
@@ -2900,26 +2900,27 @@ msgstr ""
 msgid "Program Start"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:861
+#: lib/klass_hero_web/live/provider/programs_live.ex:875
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program created successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:868
+#: lib/klass_hero_web/live/provider/programs_live.ex:882
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:53
-#: lib/klass_hero_web/live/provider/programs_live.ex:139
-#: lib/klass_hero_web/live/provider/programs_live.ex:175
-#: lib/klass_hero_web/live/provider/programs_live.ex:178
-#: lib/klass_hero_web/live/provider/programs_live.ex:602
+#: lib/klass_hero_web/live/provider/programs_live.ex:149
+#: lib/klass_hero_web/live/provider/programs_live.ex:152
+#: lib/klass_hero_web/live/provider/programs_live.ex:188
+#: lib/klass_hero_web/live/provider/programs_live.ex:191
+#: lib/klass_hero_web/live/provider/programs_live.ex:616
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:591
+#: lib/klass_hero_web/live/provider/programs_live.ex:605
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program updated successfully."
 msgstr ""
@@ -3079,8 +3080,8 @@ msgstr ""
 msgid "Selected child does not meet the program requirements."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:559
-#: lib/klass_hero_web/live/provider/programs_live.ex:617
+#: lib/klass_hero_web/live/provider/programs_live.ex:572
+#: lib/klass_hero_web/live/provider/programs_live.ex:631
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
@@ -3106,14 +3107,16 @@ msgstr ""
 msgid "Specialties"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:389
+#: lib/klass_hero_web/live/provider/team_live.ex:402
+#: lib/klass_hero_web/live/provider/team_live.ex:428
 #, elixir-autogen, elixir-format
 msgid "Staff member no longer exists."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:92
-#: lib/klass_hero_web/live/provider/team_live.ex:152
-#: lib/klass_hero_web/live/provider/team_live.ex:168
+#: lib/klass_hero_web/live/provider/team_live.ex:101
+#: lib/klass_hero_web/live/provider/team_live.ex:104
+#: lib/klass_hero_web/live/provider/team_live.ex:177
+#: lib/klass_hero_web/live/provider/team_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "Staff member not found."
 msgstr ""
@@ -3144,27 +3147,27 @@ msgstr ""
 msgid "Tax Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:331
+#: lib/klass_hero_web/live/provider/team_live.ex:356
 #, elixir-autogen, elixir-format
 msgid "Team member added, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:332
+#: lib/klass_hero_web/live/provider/team_live.ex:357
 #, elixir-autogen, elixir-format
 msgid "Team member added."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:149
+#: lib/klass_hero_web/live/provider/team_live.ex:167
 #, elixir-autogen, elixir-format
 msgid "Team member removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:355
+#: lib/klass_hero_web/live/provider/team_live.ex:382
 #, elixir-autogen, elixir-format
 msgid "Team member updated, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:356
+#: lib/klass_hero_web/live/provider/team_live.ex:383
 #, elixir-autogen, elixir-format
 msgid "Team member updated."
 msgstr ""
@@ -3179,12 +3182,12 @@ msgstr ""
 msgid "The Klass Hero Story"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:275
+#: lib/klass_hero_web/live/provider/programs_live.ex:288
 #, elixir-autogen, elixir-format
 msgid "This invite cannot be resent."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:609
+#: lib/klass_hero_web/live/provider/programs_live.ex:623
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
@@ -3412,7 +3415,7 @@ msgstr ""
 msgid "Program fee:"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:709
+#: lib/klass_hero_web/live/provider/programs_live.ex:723
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr ""
@@ -3628,7 +3631,7 @@ msgstr ""
 msgid "Cannot check out without a check-in"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:247
+#: lib/klass_hero_web/live/provider/programs_live.ex:260
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:146
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
@@ -3693,7 +3696,7 @@ msgid "Correct"
 msgstr ""
 
 #: lib/klass_hero_web/live/dashboard_live.ex:258
-#: lib/klass_hero_web/live/provider/programs_live.ex:244
+#: lib/klass_hero_web/live/provider/programs_live.ex:257
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "Could not start conversation. Please try again."
@@ -4266,7 +4269,7 @@ msgstr ""
 msgid "Failed to mark email as unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:184
+#: lib/klass_hero_web/live/provider/team_live.ex:209
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to resend invitation. Please try again."
 msgstr ""
@@ -4334,7 +4337,7 @@ msgstr ""
 msgid "Invitation Sent"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:165
+#: lib/klass_hero_web/live/provider/team_live.ex:190
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invitation resent successfully."
 msgstr ""
@@ -4460,7 +4463,7 @@ msgstr ""
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:24
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
-#: lib/klass_hero_web/live/provider/programs_live.ex:210
+#: lib/klass_hero_web/live/provider/programs_live.ex:223
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program"
@@ -4581,7 +4584,7 @@ msgstr ""
 msgid "Staff Dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:234
+#: lib/klass_hero_web/live/provider/team_live.ex:259
 #, elixir-autogen, elixir-format
 msgid "Staff member created, but the invitation could not be sent. Try resending from the team list."
 msgstr ""
@@ -4612,7 +4615,7 @@ msgstr ""
 msgid "The business associated with your account could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:175
+#: lib/klass_hero_web/live/provider/team_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "This invitation cannot be resent in its current state."
 msgstr ""
@@ -4674,7 +4677,7 @@ msgid "Update your observation..."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:138
-#: lib/klass_hero_web/live/provider/programs_live.ex:326
+#: lib/klass_hero_web/live/provider/programs_live.ex:339
 #, elixir-autogen, elixir-format
 msgid "Upload connection lost. Please try again."
 msgstr ""
@@ -4978,7 +4981,7 @@ msgstr ""
 msgid "View sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:417
+#: lib/klass_hero_web/live/provider/programs_live.ex:430
 #, elixir-autogen, elixir-format
 msgid "Create a program before inviting participants."
 msgstr ""
@@ -5020,7 +5023,7 @@ msgstr ""
 msgid "Invite one person"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:413
+#: lib/klass_hero_web/live/provider/programs_live.ex:426
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invite sent."
 msgstr ""
@@ -5123,7 +5126,7 @@ msgstr ""
 msgid "Upload a list"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:424
+#: lib/klass_hero_web/live/provider/programs_live.ex:437
 #, elixir-autogen, elixir-format
 msgid "An invite for this child and program already exists."
 msgstr ""
@@ -5300,7 +5303,7 @@ msgstr ""
 msgid "Go to dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:369
+#: lib/klass_hero_web/live/provider/programs_live.ex:382
 #, elixir-autogen, elixir-format
 msgid "%{count} row could not be processed."
 msgid_plural "%{count} rows could not be processed."
@@ -5603,7 +5606,7 @@ msgstr ""
 msgid "Contact Us →"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:286
+#: lib/klass_hero_web/live/provider/team_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "Could not add you to the team. Please try again."
 msgstr ""
@@ -5880,13 +5883,13 @@ msgstr ""
 msgid "How we vet providers"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:496
+#: lib/klass_hero_web/live/provider/team_live.ex:535
 #, elixir-autogen, elixir-format
 msgid "I'll be teaching"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:344
-#: lib/klass_hero_web/live/provider/programs_live.ex:366
+#: lib/klass_hero_web/live/provider/programs_live.ex:357
+#: lib/klass_hero_web/live/provider/programs_live.ex:379
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Imported %{count} family."
 msgid_plural "Imported %{count} families."
@@ -6174,7 +6177,7 @@ msgstr ""
 msgid "No registered children for this session."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:353
+#: lib/klass_hero_web/live/provider/programs_live.ex:366
 #, elixir-autogen, elixir-format
 msgid "No rows imported. %{count} row could not be processed."
 msgid_plural "No rows imported. %{count} rows could not be processed."
@@ -6849,7 +6852,7 @@ msgstr ""
 msgid "You'll get your own provider profile to fill in, and your account will open on your business dashboard from now on. You stay on %{business}'s team."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:266
+#: lib/klass_hero_web/live/provider/team_live.ex:291
 #, elixir-autogen, elixir-format
 msgid "You're already on your team."
 msgstr ""
@@ -6869,12 +6872,12 @@ msgstr ""
 msgid "You're now part of the team."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:314
+#: lib/klass_hero_web/live/provider/team_live.ex:339
 #, elixir-autogen, elixir-format
 msgid "You're on the team — you can now be assigned to programs."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:313
+#: lib/klass_hero_web/live/provider/team_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "You're on the team, but the headshot upload failed."
 msgstr ""

--- a/test/klass_hero/accounts/remove_staff_member_test.exs
+++ b/test/klass_hero/accounts/remove_staff_member_test.exs
@@ -34,7 +34,7 @@ defmodule KlassHero.Accounts.RemoveStaffMemberTest do
       user = user_fixture(intended_roles: [:staff])
       staff = linked_staff_row(user, "Only Employer")
 
-      assert {:ok, _deleted} = Accounts.remove_staff_member(staff.id)
+      assert {:ok, _deleted} = Accounts.remove_staff_member(staff.provider_id, staff.id)
 
       assert {:error, :not_found} = Provider.get_staff_member(staff.id)
       assert reload_roles(user.id) == []
@@ -44,7 +44,7 @@ defmodule KlassHero.Accounts.RemoveStaffMemberTest do
       user = user_fixture(intended_roles: [:provider, :staff])
       staff = linked_staff_row(user, "Their Business")
 
-      assert {:ok, _deleted} = Accounts.remove_staff_member(staff.id)
+      assert {:ok, _deleted} = Accounts.remove_staff_member(staff.provider_id, staff.id)
 
       assert reload_roles(user.id) == [:provider]
     end
@@ -56,7 +56,7 @@ defmodule KlassHero.Accounts.RemoveStaffMemberTest do
       staff_a = linked_staff_row(user, "Alpha Sports")
       _staff_b = linked_staff_row(user, "Beta Camps")
 
-      assert {:ok, _deleted} = Accounts.remove_staff_member(staff_a.id)
+      assert {:ok, _deleted} = Accounts.remove_staff_member(staff_a.provider_id, staff_a.id)
 
       assert {:error, :not_found} = Provider.get_staff_member(staff_a.id)
       assert reload_roles(user.id) == [:staff]
@@ -73,19 +73,35 @@ defmodule KlassHero.Accounts.RemoveStaffMemberTest do
       owner = user_fixture(intended_roles: [:provider, :staff])
       owner_roles_before = reload_roles(owner.id)
 
-      assert {:ok, _deleted} = Accounts.remove_staff_member(staff.id)
+      assert {:ok, _deleted} = Accounts.remove_staff_member(staff.provider_id, staff.id)
 
       assert {:error, :not_found} = Provider.get_staff_member(staff.id)
       assert reload_roles(owner.id) == owner_roles_before
     end
   end
 
-  describe "remove_staff_member/1 — not found" do
+  describe "remove_staff_member/2 — not found" do
     test "returns :not_found and changes no roles" do
       user = user_fixture(intended_roles: [:staff])
 
-      assert {:error, :not_found} = Accounts.remove_staff_member(Ecto.UUID.generate())
+      assert {:error, :not_found} =
+               Accounts.remove_staff_member(Ecto.UUID.generate(), Ecto.UUID.generate())
 
+      assert reload_roles(user.id) == [:staff]
+    end
+  end
+
+  describe "remove_staff_member/2 — foreign provider (IDOR guard)" do
+    test "returns :not_found, deletes nothing, and revokes no role" do
+      user = user_fixture(intended_roles: [:staff])
+      staff = linked_staff_row(user, "Victim Employer")
+      other = provider_profile_fixture(%{business_name: "Attacker"})
+
+      # A foreign provider_id must not delete the row — indistinguishable from a
+      # genuine miss (no existence leak), and the role stays intact.
+      assert {:error, :not_found} = Accounts.remove_staff_member(other.id, staff.id)
+
+      assert {:ok, _still_there} = Provider.get_staff_member(staff.id)
       assert reload_roles(user.id) == [:staff]
     end
   end

--- a/test/klass_hero/program_catalog/update_program_integration_test.exs
+++ b/test/klass_hero/program_catalog/update_program_integration_test.exs
@@ -7,7 +7,7 @@ defmodule KlassHero.ProgramCatalog.UpdateProgramIntegrationTest do
   alias KlassHero.Repo
   alias KlassHero.Shared.DomainEventBus
 
-  describe "update_program/2" do
+  describe "update_program/3" do
     setup do
       provider = ProviderFixtures.provider_profile_fixture()
 
@@ -23,17 +23,17 @@ defmodule KlassHero.ProgramCatalog.UpdateProgramIntegrationTest do
       %{program: program, provider: provider}
     end
 
-    test "updates title successfully", %{program: program} do
+    test "updates title successfully", %{program: program, provider: provider} do
       assert {:ok, updated} =
-               ProgramCatalog.update_program(program.id, %{title: "New Title"})
+               ProgramCatalog.update_program(provider.id, program.id, %{title: "New Title"})
 
       assert updated.title == "New Title"
       assert updated.description == "Original description"
     end
 
-    test "updates multiple fields", %{program: program} do
+    test "updates multiple fields", %{program: program, provider: provider} do
       assert {:ok, updated} =
-               ProgramCatalog.update_program(program.id, %{
+               ProgramCatalog.update_program(provider.id, program.id, %{
                  title: "Updated",
                  price: Decimal.new("200.00")
                })
@@ -42,17 +42,31 @@ defmodule KlassHero.ProgramCatalog.UpdateProgramIntegrationTest do
       assert updated.price == Decimal.new("200.00")
     end
 
-    test "rejects invalid changes (empty title)", %{program: program} do
-      assert {:error, _} = ProgramCatalog.update_program(program.id, %{title: ""})
+    test "rejects invalid changes (empty title)", %{program: program, provider: provider} do
+      assert {:error, _} = ProgramCatalog.update_program(provider.id, program.id, %{title: ""})
 
       # Verify original unchanged
       assert {:ok, unchanged} = ProgramCatalog.get_program_by_id(program.id)
       assert unchanged.title == "Original Title"
     end
 
-    test "returns not_found for invalid ID" do
+    test "returns not_found for invalid ID", %{provider: provider} do
       assert {:error, :not_found} =
-               ProgramCatalog.update_program(Ecto.UUID.generate(), %{title: "New"})
+               ProgramCatalog.update_program(provider.id, Ecto.UUID.generate(), %{title: "New"})
+    end
+
+    test "returns not_found and leaves the row unchanged when another provider owns it", %{
+      program: program
+    } do
+      other = ProviderFixtures.provider_profile_fixture()
+
+      # IDOR guard: a foreign provider_id must not update — and must be
+      # indistinguishable from a genuine miss (no existence leak).
+      assert {:error, :not_found} =
+               ProgramCatalog.update_program(other.id, program.id, %{title: "Hijacked"})
+
+      assert {:ok, unchanged} = ProgramCatalog.get_program_by_id(program.id)
+      assert unchanged.title == "Original Title"
     end
 
     test "dispatches schedule event when scheduling fields change", %{
@@ -72,7 +86,7 @@ defmodule KlassHero.ProgramCatalog.UpdateProgramIntegrationTest do
       )
 
       assert {:ok, _updated} =
-               ProgramCatalog.update_program(program.id, %{
+               ProgramCatalog.update_program(provider.id, program.id, %{
                  meeting_days: ["Monday", "Wednesday"]
                })
 
@@ -87,7 +101,10 @@ defmodule KlassHero.ProgramCatalog.UpdateProgramIntegrationTest do
       assert Map.has_key?(event.payload, :end_date)
     end
 
-    test "does not dispatch schedule event for non-schedule changes", %{program: program} do
+    test "does not dispatch schedule event for non-schedule changes", %{
+      program: program,
+      provider: provider
+    } do
       test_pid = self()
 
       DomainEventBus.subscribe(
@@ -100,12 +117,15 @@ defmodule KlassHero.ProgramCatalog.UpdateProgramIntegrationTest do
       )
 
       assert {:ok, _updated} =
-               ProgramCatalog.update_program(program.id, %{title: "New Title"})
+               ProgramCatalog.update_program(provider.id, program.id, %{title: "New Title"})
 
       refute_receive {:schedule_event, _}, 100
     end
 
-    test "dispatches single event for multiple schedule field changes", %{program: program} do
+    test "dispatches single event for multiple schedule field changes", %{
+      program: program,
+      provider: provider
+    } do
       test_pid = self()
 
       DomainEventBus.subscribe(
@@ -118,7 +138,7 @@ defmodule KlassHero.ProgramCatalog.UpdateProgramIntegrationTest do
       )
 
       assert {:ok, _updated} =
-               ProgramCatalog.update_program(program.id, %{
+               ProgramCatalog.update_program(provider.id, program.id, %{
                  meeting_days: ["Tuesday", "Thursday"],
                  meeting_start_time: ~T[14:00:00],
                  meeting_end_time: ~T[15:30:00]

--- a/test/klass_hero/provider/staff/update_staff_member_test.exs
+++ b/test/klass_hero/provider/staff/update_staff_member_test.exs
@@ -18,9 +18,9 @@ defmodule KlassHero.Provider.Staff.UpdateStaffMemberTest do
     %{staff: staff}
   end
 
-  describe "execute/2" do
+  describe "update_staff_member/3" do
     test "updates first_name", %{staff: staff} do
-      assert {:ok, updated} = Provider.update_staff_member(staff.id, %{first_name: "Alicia"})
+      assert {:ok, updated} = Provider.update_staff_member(staff.provider_id, staff.id, %{first_name: "Alicia"})
       assert updated.first_name == "Alicia"
       assert updated.last_name == "Smith"
       assert updated.id == staff.id
@@ -28,33 +28,33 @@ defmodule KlassHero.Provider.Staff.UpdateStaffMemberTest do
 
     test "updates role, email, and bio", %{staff: staff} do
       attrs = %{role: "Head Coach", email: "alice@example.com", bio: "10 years experience"}
-      assert {:ok, updated} = Provider.update_staff_member(staff.id, attrs)
+      assert {:ok, updated} = Provider.update_staff_member(staff.provider_id, staff.id, attrs)
       assert updated.role == "Head Coach"
       assert updated.email == "alice@example.com"
       assert updated.bio == "10 years experience"
     end
 
     test "updates tags with valid category", %{staff: staff} do
-      assert {:ok, updated} = Provider.update_staff_member(staff.id, %{tags: ["sports", "arts"]})
+      assert {:ok, updated} = Provider.update_staff_member(staff.provider_id, staff.id, %{tags: ["sports", "arts"]})
       assert updated.tags == ["sports", "arts"]
     end
 
     test "updates qualifications", %{staff: staff} do
       assert {:ok, updated} =
-               Provider.update_staff_member(staff.id, %{qualifications: ["First Aid"]})
+               Provider.update_staff_member(staff.provider_id, staff.id, %{qualifications: ["First Aid"]})
 
       assert updated.qualifications == ["First Aid"]
     end
 
     test "deactivates a staff member", %{staff: staff} do
-      assert {:ok, updated} = Provider.update_staff_member(staff.id, %{active: false})
+      assert {:ok, updated} = Provider.update_staff_member(staff.provider_id, staff.id, %{active: false})
       assert updated.active == false
     end
 
     test "preserves unmodified fields", %{staff: staff} do
       original_provider_id = staff.provider_id
 
-      assert {:ok, updated} = Provider.update_staff_member(staff.id, %{role: "Assistant"})
+      assert {:ok, updated} = Provider.update_staff_member(staff.provider_id, staff.id, %{role: "Assistant"})
       assert updated.provider_id == original_provider_id
       assert updated.first_name == staff.first_name
       assert updated.last_name == staff.last_name
@@ -62,25 +62,41 @@ defmodule KlassHero.Provider.Staff.UpdateStaffMemberTest do
 
     test "returns :not_found for non-existent staff member" do
       fake_id = Ecto.UUID.generate()
-      assert {:error, :not_found} = Provider.update_staff_member(fake_id, %{first_name: "Bob"})
+
+      assert {:error, :not_found} =
+               Provider.update_staff_member(Ecto.UUID.generate(), fake_id, %{first_name: "Bob"})
+    end
+
+    test "returns :not_found and leaves the row unchanged when another provider owns it", %{
+      staff: staff
+    } do
+      other = ProviderFixtures.provider_profile_fixture()
+
+      # IDOR guard: a foreign provider_id must not update, and is indistinguishable
+      # from a genuine miss (no existence leak).
+      assert {:error, :not_found} =
+               Provider.update_staff_member(other.id, staff.id, %{first_name: "Hijacked"})
+
+      assert {:ok, unchanged} = Provider.get_staff_member(staff.id)
+      assert unchanged.first_name == "Alice"
     end
 
     test "returns validation error when first_name is set to empty string", %{staff: staff} do
       assert {:error, {:validation_error, errors}} =
-               Provider.update_staff_member(staff.id, %{first_name: ""})
+               Provider.update_staff_member(staff.provider_id, staff.id, %{first_name: ""})
 
       assert Enum.any?(errors, &String.contains?(&1, "First name"))
     end
 
     test "returns validation error for invalid tag", %{staff: staff} do
       assert {:error, {:validation_error, errors}} =
-               Provider.update_staff_member(staff.id, %{tags: ["not-a-real-category"]})
+               Provider.update_staff_member(staff.provider_id, staff.id, %{tags: ["not-a-real-category"]})
 
       assert Enum.any?(errors, &String.contains?(&1, "Invalid tags"))
     end
 
     test "persists changes to the database", %{staff: staff} do
-      assert {:ok, _updated} = Provider.update_staff_member(staff.id, %{role: "Director"})
+      assert {:ok, _updated} = Provider.update_staff_member(staff.provider_id, staff.id, %{role: "Director"})
 
       assert {:ok, fetched} = Provider.get_staff_member(staff.id)
       assert fetched.role == "Director"
@@ -88,7 +104,7 @@ defmodule KlassHero.Provider.Staff.UpdateStaffMemberTest do
 
     test "ignores fields not in the allowed list", %{staff: staff} do
       attrs = %{first_name: "Bob", provider_id: Ecto.UUID.generate()}
-      assert {:ok, updated} = Provider.update_staff_member(staff.id, attrs)
+      assert {:ok, updated} = Provider.update_staff_member(staff.provider_id, staff.id, attrs)
       assert updated.first_name == "Bob"
       assert updated.provider_id == staff.provider_id
     end
@@ -96,7 +112,7 @@ defmodule KlassHero.Provider.Staff.UpdateStaffMemberTest do
     test "sets an hourly pay_rate", %{staff: staff} do
       {:ok, pay_rate} = PayRate.hourly(Decimal.new("30.00"))
 
-      assert {:ok, updated} = Provider.update_staff_member(staff.id, %{pay_rate: pay_rate})
+      assert {:ok, updated} = Provider.update_staff_member(staff.provider_id, staff.id, %{pay_rate: pay_rate})
       assert updated.pay_rate.type == :hourly
       assert Decimal.equal?(updated.pay_rate.money.amount, Decimal.new("30.00"))
     end
@@ -104,16 +120,16 @@ defmodule KlassHero.Provider.Staff.UpdateStaffMemberTest do
     test "sets a per_session pay_rate", %{staff: staff} do
       {:ok, pay_rate} = PayRate.per_session(Decimal.new("80.00"))
 
-      assert {:ok, updated} = Provider.update_staff_member(staff.id, %{pay_rate: pay_rate})
+      assert {:ok, updated} = Provider.update_staff_member(staff.provider_id, staff.id, %{pay_rate: pay_rate})
       assert updated.pay_rate.type == :per_session
     end
 
     test "clears pay_rate when set to nil", %{staff: staff} do
       {:ok, pay_rate} = PayRate.hourly(Decimal.new("25.00"))
-      {:ok, staff_with_rate} = Provider.update_staff_member(staff.id, %{pay_rate: pay_rate})
+      {:ok, staff_with_rate} = Provider.update_staff_member(staff.provider_id, staff.id, %{pay_rate: pay_rate})
       assert staff_with_rate.pay_rate
 
-      assert {:ok, cleared} = Provider.update_staff_member(staff.id, %{pay_rate: nil})
+      assert {:ok, cleared} = Provider.update_staff_member(staff.provider_id, staff.id, %{pay_rate: nil})
       assert is_nil(cleared.pay_rate)
     end
   end

--- a/test/klass_hero/provider/staff_member_integration_test.exs
+++ b/test/klass_hero/provider/staff_member_integration_test.exs
@@ -72,7 +72,7 @@ defmodule KlassHero.Provider.StaffMemberIntegrationTest do
         )
 
       # Deactivate the second staff member
-      {:ok, _} = Provider.update_staff_member(inactive.id, %{active: false})
+      {:ok, _} = Provider.update_staff_member(inactive.provider_id, inactive.id, %{active: false})
 
       assert {:ok, members} = Provider.list_active_staff_members(provider.id)
       assert length(members) == 1
@@ -88,17 +88,17 @@ defmodule KlassHero.Provider.StaffMemberIntegrationTest do
           first_name: "Inactive"
         )
 
-      {:ok, _} = Provider.update_staff_member(staff.id, %{active: false})
+      {:ok, _} = Provider.update_staff_member(staff.provider_id, staff.id, %{active: false})
 
       assert {:ok, []} = Provider.list_active_staff_members(provider.id)
     end
   end
 
-  describe "update_staff_member/2" do
+  describe "update_staff_member/3" do
     test "updates allowed fields" do
       staff = ProviderFixtures.staff_member_fixture(first_name: "Old", role: "Assistant")
 
-      assert {:ok, updated} = Provider.update_staff_member(staff.id, %{role: "Head Coach"})
+      assert {:ok, updated} = Provider.update_staff_member(staff.provider_id, staff.id, %{role: "Head Coach"})
       assert updated.role == "Head Coach"
       assert updated.first_name == "Old"
     end
@@ -107,14 +107,16 @@ defmodule KlassHero.Provider.StaffMemberIntegrationTest do
       staff = ProviderFixtures.staff_member_fixture(first_name: "Valid")
 
       assert {:error, {:validation_error, errors}} =
-               Provider.update_staff_member(staff.id, %{first_name: ""})
+               Provider.update_staff_member(staff.provider_id, staff.id, %{first_name: ""})
 
       assert "First name cannot be empty" in errors
     end
 
     test "returns not_found for non-existent staff member" do
       assert {:error, :not_found} =
-               Provider.update_staff_member(Ecto.UUID.generate(), %{role: "Coach"})
+               Provider.update_staff_member(Ecto.UUID.generate(), Ecto.UUID.generate(), %{
+                 role: "Coach"
+               })
     end
 
     test "cannot change provider_id through update" do
@@ -125,7 +127,7 @@ defmodule KlassHero.Provider.StaffMemberIntegrationTest do
       # Why: edit_changeset excludes provider_id from cast, so it should be ignored
       # Outcome: provider_id remains unchanged after update
       assert {:ok, updated} =
-               Provider.update_staff_member(staff.id, %{
+               Provider.update_staff_member(staff.provider_id, staff.id, %{
                  provider_id: other_provider.id,
                  role: "New Role"
                })
@@ -138,7 +140,7 @@ defmodule KlassHero.Provider.StaffMemberIntegrationTest do
       staff = ProviderFixtures.staff_member_fixture(first_name: "Photo")
 
       assert {:ok, updated} =
-               Provider.update_staff_member(staff.id, %{
+               Provider.update_staff_member(staff.provider_id, staff.id, %{
                  headshot_url: "headshots/providers/abc/new_photo.jpg"
                })
 
@@ -150,7 +152,7 @@ defmodule KlassHero.Provider.StaffMemberIntegrationTest do
       staff =
         ProviderFixtures.staff_member_fixture(headshot_url: "headshots/providers/abc/old_photo.jpg")
 
-      assert {:ok, updated} = Provider.update_staff_member(staff.id, %{headshot_url: nil})
+      assert {:ok, updated} = Provider.update_staff_member(staff.provider_id, staff.id, %{headshot_url: nil})
       assert updated.headshot_url == nil
     end
   end

--- a/test/klass_hero_web/live/provider/dashboard_program_creation_test.exs
+++ b/test/klass_hero_web/live/provider/dashboard_program_creation_test.exs
@@ -479,4 +479,26 @@ defmodule KlassHeroWeb.Provider.DashboardProgramCreationTest do
       refute html =~ "program limit"
     end
   end
+
+  describe "IDOR ownership guard" do
+    test "edit_program on a foreign program id is rejected and opens no form", %{conn: conn} do
+      victim = ProviderFixtures.provider_profile_fixture()
+
+      {:ok, victim_program} =
+        KlassHero.ProgramCatalog.create_program(%{
+          provider_id: victim.id,
+          title: "Victim Program",
+          description: "Owned by another provider",
+          category: "sports",
+          price: Decimal.new("100.00")
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+
+      render_click(view, "edit_program", %{"id" => victim_program.id})
+
+      refute has_element?(view, "#program-form")
+      assert render(view) =~ "Program not found."
+    end
+  end
 end

--- a/test/klass_hero_web/live/provider/dashboard_team_test.exs
+++ b/test/klass_hero_web/live/provider/dashboard_team_test.exs
@@ -206,6 +206,46 @@ defmodule KlassHeroWeb.Provider.DashboardTeamTest do
     end
   end
 
+  describe "IDOR ownership guards" do
+    setup %{provider: _provider} do
+      # A second provider whose staff the logged-in provider must not touch.
+      victim = ProviderFixtures.provider_profile_fixture()
+
+      victim_staff =
+        ProviderFixtures.staff_member_fixture(
+          provider_id: victim.id,
+          first_name: "Victim",
+          last_name: "Member"
+        )
+
+      %{victim_staff: victim_staff}
+    end
+
+    test "edit_member on a foreign staff id is rejected and opens no form", %{
+      conn: conn,
+      victim_staff: victim_staff
+    } do
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/team")
+
+      render_click(view, "edit_member", %{"id" => victim_staff.id})
+
+      refute has_element?(view, "#staff-member-form")
+      assert render(view) =~ "Staff member not found."
+    end
+
+    test "delete_member on a foreign staff id is rejected and leaves the row intact", %{
+      conn: conn,
+      victim_staff: victim_staff
+    } do
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/team")
+
+      render_click(view, "delete_member", %{"id" => victim_staff.id})
+
+      assert render(view) =~ "Staff member not found."
+      assert {:ok, _still_there} = Provider.get_staff_member(victim_staff.id)
+    end
+  end
+
   describe "form validation" do
     test "validates on change and keeps form visible", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/provider/dashboard/team")

--- a/test/klass_hero_web/live/staff/staff_dashboard_live_test.exs
+++ b/test/klass_hero_web/live/staff/staff_dashboard_live_test.exs
@@ -48,7 +48,9 @@ defmodule KlassHeroWeb.Staff.StaffDashboardLiveTest do
 
     test "shows the staff member's own hourly pay rate when set", %{conn: conn, staff: staff} do
       {:ok, pay_rate} = PayRate.hourly(Decimal.new("25.00"))
-      {:ok, _updated} = KlassHero.Provider.update_staff_member(staff.id, %{pay_rate: pay_rate})
+
+      {:ok, _updated} =
+        KlassHero.Provider.update_staff_member(staff.provider_id, staff.id, %{pay_rate: pay_rate})
 
       {:ok, _view, html} = live(conn, ~p"/staff/dashboard")
 


### PR DESCRIPTION
## Summary

Five provider-dashboard handlers acted on a client-supplied `id` without verifying the record belongs to the calling provider — a provider could edit or **delete** another provider's program or staff by enumerating ids. `view_roster` already guarded; these did not (carried verbatim from the deleted `DashboardLive` god-module, #904).

Chosen fix (option B): push ownership enforcement **into the context** — a single enforcement point that cannot be forgotten — rather than a per-handler opt-in.

## Changes

**Context (scoped write/destructive funcs, `provider_id` first-arg, `{:error, :not_found}` on mismatch — no existence leak):**
- `ProgramCatalog.update_program/2 → /3`
- `Provider.update_staff_member/2 → /3` (delegate updated)
- `Accounts.remove_staff_member/1 → /2` (check inside the txn, before delete + role teardown)

**Web:**
- `edit_program`, `edit_member` — inline ownership guards mirroring `view_roster` (the shared getters have 7 / several callers and can't be scoped), with a `Logger.warning` on rejection.
- `validate_staff`, `handle_staff_validation_error` — defence-in-depth guards on staff form rehydration.
- `save_existing_staff` — explicit `{:error, :not_found}` clause so the new contract can't crash `to_form/2`.

## Review Focus

- `Accounts.remove_staff_member/2` orchestrates across contexts — confirmed it calls only the `Provider` facade (`get_staff_member`, `delete_staff_member`), no Repo reach-in.
- Owner mismatch returns `:not_found` (not `:unauthorized`) so an attacker can't distinguish a foreign id from a nonexistent one.

## Test Plan

- 6 new IDOR tests (context + LiveView): foreign provider → `:not_found`, target record untouched.
- All existing callers migrated to the new arities.
- `mix precommit` green: 3898 passed, 5 skipped.
- Architecture review (21 checks across 3 agents): 0 errors.

Closes #1048

🤖 Generated with [Claude Code](https://claude.com/claude-code)