### PR TITLE
refactor: unify Messaging event dispatch on EventDispatchHelper

### DIFF
--- a/lib/klass_hero/messaging/adapters/driving/events/event_handlers/promote_integration_events.ex
+++ b/lib/klass_hero/messaging/adapters/driving/events/event_handlers/promote_integration_events.ex
@@ -43,7 +43,6 @@ defmodule KlassHero.Messaging.Adapters.Driving.Events.EventHandlers.PromoteInteg
   end
 
   def handle(%DomainEvent{event_type: :message_sent} = event) do
-    # NOTE: SendMessage uses the lower-level bus (no Oban retry) until #849 lands.
     event.aggregate_id
     |> MessagingIntegrationEvents.message_sent(event.payload)
     |> IntegrationEventPublishing.publish_critical("message_sent",

--- a/lib/klass_hero/messaging/anonymize_user_data.ex
+++ b/lib/klass_hero/messaging/anonymize_user_data.ex
@@ -13,7 +13,7 @@ defmodule KlassHero.Messaging.AnonymizeUserData do
 
   alias KlassHero.Messaging.Domain.Events.MessagingEvents
   alias KlassHero.Repo
-  alias KlassHero.Shared.DomainEventBus
+  alias KlassHero.Shared.EventDispatchHelper
 
   require Logger
 
@@ -60,7 +60,7 @@ defmodule KlassHero.Messaging.AnonymizeUserData do
   defp tag_step(step, {:error, reason}), do: {:error, {step, reason}}
 
   defp handle_result({:ok, result}, user_id) do
-    DomainEventBus.dispatch(@context, MessagingEvents.user_data_anonymized(user_id))
+    EventDispatchHelper.dispatch(MessagingEvents.user_data_anonymized(user_id), @context)
 
     Logger.info("Anonymized messaging data for user",
       user_id: user_id,

--- a/lib/klass_hero/messaging/archive_ended_program_conversations.ex
+++ b/lib/klass_hero/messaging/archive_ended_program_conversations.ex
@@ -11,7 +11,7 @@ defmodule KlassHero.Messaging.ArchiveEndedProgramConversations do
   """
 
   alias KlassHero.Messaging.Domain.Events.MessagingEvents
-  alias KlassHero.Shared.DomainEventBus
+  alias KlassHero.Shared.EventDispatchHelper
 
   require Logger
 
@@ -73,7 +73,7 @@ defmodule KlassHero.Messaging.ArchiveEndedProgramConversations do
 
   defp publish_event(conversation_ids, count) do
     event = MessagingEvents.conversations_archived(conversation_ids, :program_ended, count)
-    DomainEventBus.dispatch(@context, event)
+    EventDispatchHelper.dispatch(event, @context)
     :ok
   end
 

--- a/lib/klass_hero/messaging/enforce_retention_policy.ex
+++ b/lib/klass_hero/messaging/enforce_retention_policy.ex
@@ -19,7 +19,7 @@ defmodule KlassHero.Messaging.EnforceRetentionPolicy do
 
   alias KlassHero.Messaging.Domain.Events.MessagingEvents
   alias KlassHero.Repo
-  alias KlassHero.Shared.DomainEventBus
+  alias KlassHero.Shared.EventDispatchHelper
   alias KlassHero.Shared.Storage
 
   require Logger
@@ -127,7 +127,7 @@ defmodule KlassHero.Messaging.EnforceRetentionPolicy do
 
   defp publish_event(messages_deleted, conversations_deleted) do
     event = MessagingEvents.retention_enforced(messages_deleted, conversations_deleted)
-    DomainEventBus.dispatch(@context, event)
+    EventDispatchHelper.dispatch(event, @context)
     :ok
   end
 end

--- a/lib/klass_hero/messaging/mark_as_read.ex
+++ b/lib/klass_hero/messaging/mark_as_read.ex
@@ -10,7 +10,7 @@ defmodule KlassHero.Messaging.MarkAsRead do
 
   alias KlassHero.Messaging.Domain.Events.MessagingEvents
   alias KlassHero.Messaging.Participant
-  alias KlassHero.Shared.DomainEventBus
+  alias KlassHero.Shared.EventDispatchHelper
 
   require Logger
 
@@ -53,7 +53,7 @@ defmodule KlassHero.Messaging.MarkAsRead do
 
   defp publish_event(conversation_id, user_id, read_at) do
     event = MessagingEvents.messages_read(conversation_id, user_id, read_at)
-    DomainEventBus.dispatch(@context, event)
+    EventDispatchHelper.dispatch(event, @context)
     :ok
   end
 end

--- a/lib/klass_hero/messaging/send_message.ex
+++ b/lib/klass_hero/messaging/send_message.ex
@@ -15,7 +15,7 @@ defmodule KlassHero.Messaging.SendMessage do
   alias KlassHero.Messaging.Message
   alias KlassHero.Messaging.Shared
   alias KlassHero.Repo
-  alias KlassHero.Shared.DomainEventBus
+  alias KlassHero.Shared.EventDispatchHelper
   alias KlassHero.Shared.Storage
 
   require Logger
@@ -306,7 +306,7 @@ defmodule KlassHero.Messaging.SendMessage do
         message.attachments
       )
 
-    DomainEventBus.dispatch(@context, event)
+    EventDispatchHelper.dispatch(event, @context)
     :ok
   end
 end


### PR DESCRIPTION
## Summary

Migrates the five remaining Messaging command-level domain-event dispatches from the low-level `DomainEventBus.dispatch/2` to the higher-level `EventDispatchHelper.dispatch/2`, matching the convention PR #848 established for conversation creation.

Files (all under `lib/klass_hero/messaging/`):
- `send_message.ex`
- `mark_as_read.ex`
- `archive_ended_program_conversations.ex`
- `enforce_retention_policy.ex`
- `anonymize_user_data.ex`

Each swaps `DomainEventBus.dispatch(@context, event)` → `EventDispatchHelper.dispatch(event, @context)` (event-first) and the now-unused `alias DomainEventBus` → `alias EventDispatchHelper`.

## Corrected rationale (⚠️ differs from the issue)

The issue framed this as gaining **Oban at-least-once retry** for `:message_sent` et al. That does **not** hold at this seam. `EventDispatchHelper.dispatch/2` branches on `DomainEvent.critical?(event)`, and Oban retry (`dispatch_critical`) only fires for **critical** events. All five Messaging *domain* events are `:normal` (no `criticality: :critical` in any `messaging_events.ex` constructor), so they route through `dispatch_normal/2` — the same bus call as before, **plus** it logs the `{:error, failures}` the commands previously swallowed silently.

The Oban durability that already exists lives one tier down, in `PromoteIntegrationEvents.handle/1 → IntegrationEventPublishing.publish_critical/*` (the *integration* tier), independent of which bus fires the domain event.

So the real wins here are **dispatcher consistency** with #848 and **failure-logging observability** — not new delivery guarantees. Actually delivering domain-event durability for `:message_sent` would require marking that domain event `:critical` (a behavioural change the issue excludes) and reshaping its payload to JSON-scalars to pass `validate_critical_payload!` — tracked as a potential follow-up.

## Review Focus

- Argument-order flip: `EventDispatchHelper.dispatch/2` is **event-first**.
- All five dispatches are **post-commit** (`handle_result({:ok, ...})` / after the `Repo.transaction` branch), so the fire-and-forget path is transaction-safe.
- Removed the obsolete `# NOTE: ... until #849 lands.` comment in `promote_integration_events.ex`.

## Test Plan

- `mix precommit` clean — **3898 passed, 5 skipped** (compile --warnings-as-errors, format, lint, full suite).
- Existing command tests in `test/klass_hero/messaging/` pass **unchanged** — they assert command outcomes, not dispatch internals; the swap is a happy-path no-op.

Closes #849