### PR TITLE
chore: read-only prod DB access + /analyze-prod-issue skill

### DIFF
--- a/.claude/rules/skills.md
+++ b/.claude/rules/skills.md
@@ -101,6 +101,12 @@ Runs a comprehensive 21-check review of conventional-Phoenix conventions by spaw
 
 **Use when:** `/review-architecture` or when reviewing a PR, checking architecture before merge, or after modifying bounded context code
 
+### analyze-prod-issue
+
+Diagnoses a production issue end-to-end: Honeycomb for the error shape, the prod DB `error_tracker` tables (via `bin/prod-db`) for the who + why, schema cross-referencing to scope impact honestly, then an optional PII-scrubbed issue. Read-only. Needs prod DB access set up (`docs/runbooks/prod-db-access.md`).
+
+**Use when:** `/analyze-prod-issue "<symptom>"`
+
 ## Custom Agents (in `.claude/agents/`)
 
 ### architecture-reviewer

--- a/.claude/skills/analyze-prod-issue/SKILL.md
+++ b/.claude/skills/analyze-prod-issue/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: analyze-prod-issue
+description: >-
+  Diagnose a production issue end-to-end across Honeycomb (error shape) and the
+  prod DB error_tracker tables (who + why), scope impact honestly, and optionally
+  file a PII-scrubbed issue. Invoke with: /analyze-prod-issue "<symptom>"
+disable-model-invocation: true
+---
+
+# Analyze Prod Issue
+
+Take a production symptom (e.g. "parents can't book") and diagnose it end-to-end by
+correlating **two** sources — Honeycomb for the error *shape*, the prod DB `error_tracker`
+tables for the *who + why* — then scope impact honestly and optionally file a scrubbed issue.
+
+**Type:** Rigid workflow. Follow steps exactly.
+
+**Prerequisite:** read-only prod DB access must be set up (`bin/prod-db`). If it errors, see
+`docs/runbooks/prod-db-access.md` first.
+
+The exact Honeycomb tool calls and prod SQL are in `references/cookbook.md` — read it when a
+step says to.
+
+---
+
+## Step 1 — Orient (Honeycomb)
+
+Call `mcp__honeycomb__get_workspace_context`. Note the environment slugs; production is the
+`live` environment (there is also `dev`). Use `live` in every subsequent Honeycomb call.
+
+**Done when:** you know the `live` env slug and its dataset.
+
+## Step 2 — Find the error surface
+
+- `mcp__honeycomb__list_spans` over `14d` — ranks span names by count with `root_count`.
+  Scan for the failing area *and* for **funnel drops** (an entry span with many mounts but
+  its terminal action span near zero often is the reported symptom).
+- `mcp__honeycomb__run_query` with `filter error=true`, `breakdown ["name"]`, `time_range
+  "14d"` — ranks the actually-failing spans by count.
+
+**Done when:** you have candidate failing span name(s) with counts. If there are zero
+`error=true` spans, the symptom is not an exception — pivot to the funnel-drop reading.
+
+## Step 3 — Trace the causal chain
+
+`mcp__honeycomb__get_trace` on a failing trace (`show_events: true`). Read the waterfall:
+find the span where the error is *raised* and the call chain above it (HTTP entry → worker →
+context function → repo query).
+
+**Honeycomb gap to expect:** a DB error inside a rolled-back transaction surfaces only as
+`query_error` / `status_message` with **no exception text** (spans carry no event). That
+absence is the signal to go to the prod DB — do not stop here.
+
+**Done when:** the failing chain and the raising span are mapped.
+
+## Step 4 — Pull the real reason (prod DB)
+
+Query `error_tracker` via `bin/prod-db -c "<SQL>"` (read-only reader role). See
+`references/cookbook.md` for the schema and the exact queries.
+
+- `error_tracker_errors` — `kind`, `reason`, `source_function`, `last_occurrence_at`,
+  `status`. Find the error matching the trace.
+- `error_tracker_occurrences` — `context` (Oban `job.args` + the full event payload:
+  `event_type`, `entity_id`, user email/name), `stacktrace`, `breadcrumbs`, and
+  `job.state` / `job.attempt`.
+
+This is where the swallowed DB error, the affected user, the triggering event, and the Oban
+disposition (`retryable` vs `discard`) actually live.
+
+**Done when:** you know the underlying error, the affected entity, the triggering event, and
+the occurrence count + date range.
+
+## Step 5 — Cross-reference schema & data
+
+Confirm the hypothesis against real rows before believing it:
+
+- Does the row the handler tried to create **already exist**? (duplicate vs genuinely missing)
+- What are the **actual** constraint/index names? (a changeset `unique_constraint` name
+  mismatch makes a violation *raise* instead of returning a changeset error)
+- **Affected-vs-total counts** — how many entities are in the bad state vs the population?
+
+**Done when:** the mechanism is proven from data, not assumed.
+
+## Step 6 — Scope impact honestly
+
+The point of Step 5 is to *correct the premise*, not confirm it. Produce a one-paragraph
+impact statement that:
+
+- Separates **noise vs a real user-blocker** — an erroring/discarded job is not automatically
+  a blocked user (the side effect may already have succeeded on another path).
+- Quantifies affected users by **count**.
+- **Splits disjoint phenomena** — two symptoms with the same surface can have different
+  causes and different populations; do not conflate them.
+
+**Done when:** an honest, numeric impact statement exists — even if it contradicts the
+original complaint.
+
+## Step 7 — Confirm root cause in code
+
+Grep the implicated modules to anchor the fix. State explicitly whether the bug exists on
+`main` or the behaviour is a **live-vs-main deploy lag** (live can raise what `main` already
+handles). Check the current commit on `live` if it matters.
+
+**Done when:** the fix direction names concrete files and says whether deploying `main` fixes it.
+
+## Step 8 — (Optional) File a scrubbed issue
+
+If the finding warrants tracking, hand off to `/create-issue`.
+
+**Public-repo PII rule (non-negotiable):** reference affected users by **count + opaque UUID
+only**. Never put names or emails in a public issue — GitHub edit history is public, so
+scrubbing after the fact requires deleting and recreating the issue. Keep the
+user_id ↔ identity mapping in the DB, not the issue.
+
+**Done when:** the issue exists with count-only references, or you and the user decide not to file.
+
+---
+
+## Rules
+
+- **Two sources, not one.** Honeycomb gives the *shape* (chain, span, timing); `error_tracker`
+  gives the *who + why* (reason, event payload, stacktrace, Oban state). Neither alone is enough.
+- **Read-only always.** Reach prod only through `bin/prod-db` (the SELECT-only `reader` role).
+  Never open a write path against production.
+- **Count, never names, in public artifacts.** PII stays in the DB; issues and PRs get counts
+  and UUIDs.
+- **Scope honestly.** "Erroring" ≠ "user-blocked." Prove impact from data before claiming it,
+  and correct the premise when the data disagrees.
+- **The rollback hides the error.** When Honeycomb shows only `:rollback` / `query_error` with
+  no text, the real reason is in `error_tracker_occurrences.context`, not the span.

--- a/.claude/skills/analyze-prod-issue/references/cookbook.md
+++ b/.claude/skills/analyze-prod-issue/references/cookbook.md
@@ -1,0 +1,123 @@
+# analyze-prod-issue — cookbook
+
+Loaded from SKILL.md steps 2–5. Concrete Honeycomb tool calls and prod SQL, copied from a
+real end-to-end investigation so they run as written. Adjust identifiers to the case at hand.
+
+---
+
+## Honeycomb recipes (env slug: `live`)
+
+**Orient (Step 1):**
+```
+mcp__honeycomb__get_workspace_context   # no args → team, environments, dataset counts
+```
+
+**Span landscape + funnel drops (Step 2):**
+```
+mcp__honeycomb__list_spans
+  environment_slug: "live"
+  time_range: "14d"
+  items_per_page: 200
+```
+Read `count` vs `root_count`: `root_count == count` = trace entry point (HTTP handler, root
+job). A high-count entry span whose terminal action span is near zero is a funnel drop.
+
+**Rank failing spans (Step 2):**
+```
+mcp__honeycomb__run_query
+  environment_slug: "live"
+  dataset_slug: "klass-hero"
+  query_spec:
+    calculations: [{ "op": "COUNT" }]
+    filters:      [{ "column": "error", "op": "=", "value": true }]
+    breakdowns:   ["name"]
+    orders:       [{ "op": "COUNT", "order": "descending" }]
+    time_range:   "14d"
+```
+Add `include_samples: true` and a `filter name = "<span>"` to see raw sample rows (columns
+like `db.statement`, `status_message`, `trace.trace_id`) for one failing span.
+
+**Trace the chain (Step 3):**
+```
+mcp__honeycomb__get_trace
+  environment_slug: "live"
+  trace_id: "<32-hex from the sample>"
+  time_range: "14d"
+  show_events: true
+```
+`ERROR` / `error=true` rows mark the failing spans; the parent chain above the raising span
+is the causal path. Expect DB errors to appear only as `query_error` with no exception text.
+
+---
+
+## error_tracker SQL cookbook (via `bin/prod-db -c "<SQL>"`)
+
+ErrorTracker persists to two tables. `bin/prod-db` runs SQL read-only as the `reader` role.
+
+**Schemas:**
+```
+error_tracker_errors:       id, kind, reason, source_line, source_function, status,
+                            fingerprint, last_occurrence_at, inserted_at, updated_at, muted
+error_tracker_occurrences:  id, context, reason, stacktrace, error_id, inserted_at, breadcrumbs
+```
+`context` is JSONB holding the Oban job (`job.state`, `job.attempt`, `job.args`) and, for
+event-driven workers, the full event payload under `job.args -> payload`.
+
+**1. Recent errors, newest first (Step 4):**
+```sql
+select id, kind, left(reason,90) as reason, source_function, status,
+       to_char(last_occurrence_at,'MM-DD HH24:MI') as last_seen
+  from error_tracker_errors
+ order by last_occurrence_at desc;
+```
+
+**2. Latest occurrence context for one error (Step 4):**
+```sql
+select id, inserted_at, context
+  from error_tracker_occurrences
+ where error_id = <ID>
+ order by inserted_at desc limit 1;
+```
+
+**3. All occurrences of one error, with who + when (Step 4):**
+```sql
+select to_char(inserted_at,'MM-DD HH24:MI') as seen,
+       context->>'job.state'                            as state,
+       context->'job.args'->>'event_type'              as event,
+       context->'job.args'->'payload'->>'email'        as email,
+       context->'job.args'->'payload'->>'user_id'      as user_id
+  from error_tracker_occurrences
+ where error_id = <ID>
+ order by inserted_at desc;
+```
+
+**4. Impact sizing — are the error victims actually in a bad state? (Steps 5–6):**
+Cross-reference the affected user_ids against the domain table. Example used to prove the
+error was noise (every victim still had a profile):
+```sql
+with victims as (
+  select distinct (context->'job.args'->'payload'->>'user_id')::uuid as user_id
+    from error_tracker_occurrences where error_id = <ID>
+)
+select count(*) as victims, count(p.id) as have_row, count(*) - count(p.id) as missing
+  from victims v
+  left join parents p on p.identity_id = v.user_id;
+```
+
+**5. Population-level bad-state count — the disjoint set (Step 6):**
+Find entities genuinely missing the side effect, independent of the error. Example: confirmed
+parents with no profile row (a *different* population than the error victims above):
+```sql
+select count(*) filter (where p.id is null) as confirmed_parents_no_profile
+  from users u
+  left join parents p on p.identity_id = u.id
+ where 'parent' = any(u.intended_roles) and u.confirmed_at is not null;
+```
+
+**Verify the mechanism, not just the symptom (Step 5):**
+```sql
+-- does the row the handler tried to create already exist?
+select id, inserted_at from parents where identity_id = '<uuid>';
+-- actual constraint/index names (a changeset name mismatch makes violations RAISE)
+select indexname, indexdef from pg_indexes where tablename = '<table>';
+```

--- a/bin/prod-db
+++ b/bin/prod-db
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# prod-db — read-only SQL access to the klass-hero-live Managed Postgres cluster.
+#
+# Transport: `fly mpg connect`, which opens its own proxy AND resolves the
+# password for the `debug-ro` (reader / SELECT-only) role. Fly never exposes the
+# raw password, so this wrapper — not a standalone psql DSN — is the reliable path.
+#
+# Usage:
+#   bin/prod-db -c "select count(*) from error_tracker_errors;"   # one-shot query
+#   echo "select 1;" | bin/prod-db                                # SQL from stdin
+#   bin/prod-db                                                    # interactive psql
+#   bin/prod-db --check                                           # verify prereqs only
+#
+# See docs/runbooks/prod-db-access.md.
+
+set -euo pipefail
+
+CLUSTER_ID="${MPG_CLUSTER_ID:-ey5qn0y5d47o8zmw}"   # klass-hero-live-db (org klass-hero, fra)
+DB_NAME="${MPG_DB_NAME:-fly-db}"
+DB_USER="${MPG_DB_USER:-debug-ro}"                 # reader role — SELECT only
+
+err() { printf '\033[0;31m✗ %s\033[0m\n' "$1" >&2; }
+
+command -v fly >/dev/null 2>&1 || { err "fly CLI not found (brew install flyctl)"; exit 1; }
+fly auth whoami >/dev/null 2>&1 || { err "not logged in — run: fly auth login"; exit 1; }
+
+if [[ "${1:-}" == "--check" ]]; then
+  command -v psql >/dev/null 2>&1 || { err "psql not found — brew install libpq && brew link --force libpq"; exit 1; }
+  printf '\033[0;32m✓ ready — cluster=%s db=%s user=%s\033[0m\n' "$CLUSTER_ID" "$DB_NAME" "$DB_USER"
+  exit 0
+fi
+
+# The "Proxying localhost:... to remote ..." status line is stripped so callers get clean output.
+if [[ "${1:-}" == "-c" ]]; then
+  [[ $# -ge 2 ]] || { err 'usage: bin/prod-db -c "SQL"'; exit 1; }
+  printf '%s\n\\q\n' "$2" | fly mpg connect "$CLUSTER_ID" -u "$DB_USER" -d "$DB_NAME" 2>&1 | grep -v '^Proxying '
+elif [[ ! -t 0 ]]; then
+  { cat; printf '\n\\q\n'; } | fly mpg connect "$CLUSTER_ID" -u "$DB_USER" -d "$DB_NAME" 2>&1 | grep -v '^Proxying '
+else
+  exec fly mpg connect "$CLUSTER_ID" -u "$DB_USER" -d "$DB_NAME"
+fi

--- a/docs/runbooks/prod-db-access.md
+++ b/docs/runbooks/prod-db-access.md
@@ -1,0 +1,80 @@
+# Runbook: Read-only prod DB access
+
+Reproducible, read-only access to the production Managed Postgres cluster for
+debugging — e.g. reading `error_tracker_errors` / `error_tracker_occurrences`,
+which hold the full exception, `context` (Oban job args, event payload), and
+`stacktrace` that the Honeycomb spans do not carry.
+
+## Facts
+
+| Thing | Value |
+|---|---|
+| Cluster name | `klass-hero-live-db` |
+| Cluster ID | `ey5qn0y5d47o8zmw` |
+| Org | `klass-hero` |
+| Region | `fra` |
+| Attached app | `klass-hero-live` |
+| Database | `fly-db` |
+| Flavor | Fly **Managed** Postgres (MPG) — use `fly mpg`, not `fly pg` |
+| Read-only user | `debug-ro` (role `reader`, SELECT only) |
+
+## How it works
+
+`fly mpg connect` opens its own proxy **and** resolves the user's password
+internally — Fly never exposes the raw password, so there is no standalone
+`psql` DSN and no `.env` file. `bin/prod-db` wraps `fly mpg connect` as the
+single reliable transport.
+
+## One-time setup
+
+```bash
+# 1. authenticate
+fly auth login
+
+# 2. read-only role (already created; re-run only if it was deleted)
+fly mpg users create ey5qn0y5d47o8zmw -u debug-ro -r reader
+#    NB: MPG usernames allow lowercase/dashes only — no underscores.
+
+# 3. psql client (used for the interactive mode)
+brew install libpq && brew link --force libpq
+```
+
+## Use
+
+```bash
+bin/prod-db -c "select count(*) from error_tracker_errors;"   # one-shot
+echo "select 1;" | bin/prod-db                                # SQL from stdin
+bin/prod-db                                                    # interactive psql
+bin/prod-db --check                                           # verify prereqs
+```
+
+### Useful queries
+
+```sql
+-- recent tracked errors, newest first
+select id, kind, left(reason,90) as reason, source_function, status,
+       to_char(last_occurrence_at,'MM-DD HH24:MI') as last_seen
+  from error_tracker_errors order by last_occurrence_at desc;
+
+-- full context (Oban job args + event payload) for one error's latest occurrence
+select context from error_tracker_occurrences
+ where error_id = <ID> order by inserted_at desc limit 1;
+```
+
+## Safety model
+
+- `debug-ro` is the MPG `reader` role — **SELECT-only, structurally**. Writes are
+  impossible, not merely discouraged. Never use the cluster's `schema_admin`
+  logins for debugging reads.
+- `fly mpg connect` proxies to the cluster **primary**; the read-only role — not
+  a replica target — is what makes that safe.
+- Revoke anytime: `fly mpg users delete ey5qn0y5d47o8zmw -u debug-ro`.
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `not logged in` | `fly auth login` |
+| `psql not found` (interactive mode) | `brew install libpq && brew link --force libpq` |
+| `user_name must contain only lowercase letters, numbers, and dashes` | MPG rejects underscores — use `debug-ro`, not `debug_ro` |
+| port 16380 in use | another `fly mpg connect` is still running |


### PR DESCRIPTION
## Summary

Reproducible, **read-only** production debugging, plus a skill that encodes the workflow.

**1. Prod DB access (`bin/prod-db` + runbook)**
Wraps `fly mpg connect` for SELECT-only access to the `klass-hero-live` Managed Postgres cluster via the `debug-ro` reader role. Used to read `error_tracker_errors` / `error_tracker_occurrences` — the full exception, Oban job context, and stacktrace that Honeycomb spans omit.

**2. `/analyze-prod-issue` skill**
User-invoked skill (`.claude/skills/analyze-prod-issue/`) that captures the end-to-end diagnosis flow so we stop re-discovering it: Honeycomb for the error *shape* → prod `error_tracker` (via `bin/prod-db`) for the *who + why* → schema/data cross-reference for honest impact scoping → optional PII-scrubbed `/create-issue`. Ships with a `references/cookbook.md` of the exact Honeycomb calls and prod SQL. Registered in `.claude/rules/skills.md`.

## Review focus

- **No secrets/credentials/PII committed.** Only infra identifiers (cluster ID, db name, `reader` username). Passwords are Fly-managed and never exposed; the app name is already public in `fly.production.toml`.
- `debug-ro` is the MPG `reader` role — **SELECT-only, structurally**. Writes are impossible.
- Skill is `disable-model-invocation: true` — it only runs when a human types `/analyze-prod-issue`, so the agent never hits prod autonomously.

## Test plan

- `bin/prod-db --check` → verifies fly auth + psql.
- `bin/prod-db -c "select count(*) from error_tracker_errors;"` → returns a count over the proxy.
- `/analyze-prod-issue` resolves as a user-invocable skill; frontmatter `name` matches the dir.

## Context

Built while diagnosing #1065 (parent-profile creation discards) end-to-end across Honeycomb + prod DB.