### PR TITLE
test: de-flake HeroCardsPresenter property generator

### DIFF
--- a/test/klass_hero_web/presenters/hero_cards_presenter_test.exs
+++ b/test/klass_hero_web/presenters/hero_cards_presenter_test.exs
@@ -25,8 +25,11 @@ defmodule KlassHeroWeb.Presenters.HeroCardsPresenterTest do
   # their ids OR nil OR an id absent from the list — the three shapes the presenter
   # must handle.
   defp staff_and_lead do
+    # `integer(1..1_000)` (not `positive_integer()`): a bounded domain is size-independent, so
+    # `uniq_list_of` can always find up to 6 distinct values. `positive_integer()` draws from
+    # `1..size`, which on small early sizes starves uniqueness and raises TooManyDuplicatesError.
     gen all(
-          raw_ids <- uniq_list_of(positive_integer(), min_length: 1, max_length: 6),
+          raw_ids <- uniq_list_of(integer(1..1_000), min_length: 1, max_length: 6),
           lead <- member_of([nil, "absent-id" | Enum.map(raw_ids, &"staff-#{&1}")])
         ) do
       staff_members =


### PR DESCRIPTION
## Problem

`KlassHeroWeb.Presenters.HeroCardsPresenterTest`'s three property tests flake — the full suite intermittently reports "3 properties failed" while every example test passes. Reproduces deterministically on ~16% of seeds (e.g. 10, 11, 15, 18):

```
mix test test/klass_hero_web/presenters/hero_cards_presenter_test.exs --seed 10
```

fails all three with `StreamData.TooManyDuplicatesError`.

## Root cause

The three properties share the `staff_and_lead/0` generator, which built distinct ids via:

```elixir
uniq_list_of(positive_integer(), min_length: 1, max_length: 6)
```

`StreamData.positive_integer/0` draws from `1..size`. On StreamData's small early generation sizes, that domain can hold fewer than 6 distinct values, so `uniq_list_of` hits 10 consecutive duplicate draws and raises before the property body ever runs. `HeroCardsPresenter.for_program/2` is never invoked — this is a starved generator, not a presenter bug.

## Fix

```elixir
uniq_list_of(integer(1..1_000), min_length: 1, max_length: 6)
```

`integer(low..high)` is bounded and size-independent, so six distinct draws are always available and the error is impossible by construction. Coverage is unchanged: ids stay random, non-sequential, and randomly ordered — so the "non-lead cards keep their input order" property still catches a presenter that erroneously sorts by id.

## Verification

- Pre-fix: seed 10 fails all 3 properties.
- Post-fix: 14 seeds incl. the 4 known-bad (10/11/15/18) all pass; `mix precommit` green (3909 tests).

Test-only, one-line change. Unrelated to any feature branch — clears intermittent CI red for all open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)