### PR TITLE
fix: idempotent profile creation inside critical event transaction (#1065)

### DIFF
--- a/lib/klass_hero/family.ex
+++ b/lib/klass_hero/family.ex
@@ -47,9 +47,13 @@ defmodule KlassHero.Family do
   """
   def create_parent_profile(attrs) when is_map(attrs) do
     context_span entity: "parent" do
+      # `mode: :savepoint` so a unique-constraint hit rolls back only to a savepoint
+      # instead of poisoning an outer transaction — this runs inside
+      # `ProcessedEventRepository.execute_atomically`'s txn on the
+      # `:user_registered`/`:user_confirmed` compensation path (issue #1065).
       %ParentProfile{}
       |> ParentProfile.changeset(attrs)
-      |> Repo.insert()
+      |> Repo.insert(mode: :savepoint)
       |> case do
         {:ok, parent} ->
           {:ok, parent}

--- a/lib/klass_hero/provider/profiles.ex
+++ b/lib/klass_hero/provider/profiles.ex
@@ -205,9 +205,13 @@ defmodule KlassHero.Provider.Profiles do
   # unique-identity violation back to the frozen :duplicate_resource contract
   # (ProviderEventHandler/Accounts depend on that literal atom).
   defp insert_provider_profile(attrs) do
+    # `mode: :savepoint` so a unique-identity violation rolls back only to a
+    # savepoint instead of poisoning an outer transaction — this runs inside
+    # `ProcessedEventRepository.execute_atomically`'s txn on the
+    # `:user_registered`/`:user_confirmed` compensation path (issue #1065).
     %ProviderProfile{}
     |> ProviderProfile.changeset(attrs)
-    |> Repo.insert()
+    |> Repo.insert(mode: :savepoint)
     |> case do
       {:ok, profile} ->
         {:ok, profile}

--- a/test/klass_hero/family/adapters/driving/events/family_event_handler_test.exs
+++ b/test/klass_hero/family/adapters/driving/events/family_event_handler_test.exs
@@ -13,6 +13,8 @@ defmodule KlassHero.Family.Adapters.Driving.Events.FamilyEventHandlerTest do
   alias KlassHero.Family.Adapters.Driving.Events.FamilyEventHandler
   alias KlassHero.Family.Child
   alias KlassHero.Family.Consent
+  alias KlassHero.Shared.Adapters.Driven.Persistence.Repositories.ProcessedEventRepository
+  alias KlassHero.Shared.Adapters.Driven.Persistence.Schemas.ProcessedEvent
 
   describe "handle_event/1 for :user_anonymized" do
     setup do
@@ -132,6 +134,37 @@ defmodule KlassHero.Family.Adapters.Driving.Events.FamilyEventHandlerTest do
 
       event = build_user_confirmed_event(user, intended_roles: ["provider"])
       assert :ignore = FamilyEventHandler.handle_event(event)
+    end
+
+    # Regression for #1065. Unlike the "idempotent" test above (which calls the
+    # handler directly, exercising the safe out-of-transaction path), this drives
+    # the handler through the exactly-once wrapper the way production does
+    # (EventSubscriber / CriticalEventWorker → ProcessedEventRepository.execute_atomically),
+    # i.e. INSIDE a Repo.transaction. Before the `mode: :savepoint` fix, the
+    # duplicate-identity insert poisoned that transaction and execute_atomically
+    # returned {:error, :rollback}, so the dedup marker never committed and the
+    # Oban job was retried to discard.
+    test "is idempotent through execute_atomically when profile already exists (issue #1065)" do
+      user = AccountsFixtures.unconfirmed_user_fixture(intended_roles: [:parent])
+
+      # :user_registered has already created the profile.
+      assert :ok = FamilyEventHandler.handle_event(build_user_registered_event(user))
+
+      # :user_confirmed compensation now runs inside the atomic transaction.
+      event_id = Ecto.UUID.generate()
+
+      handler_fn = fn ->
+        FamilyEventHandler.handle_event(build_user_confirmed_event(user))
+      end
+
+      result =
+        ProcessedEventRepository.execute_atomically(event_id, "FamilyEventHandler", handler_fn)
+
+      # 1. The duplicate is tolerated as idempotent success — not {:error, :rollback}.
+      assert result == :ok
+
+      # 2. The dedup marker committed, so Oban won't redeliver forever.
+      assert Repo.get_by(ProcessedEvent, event_id: event_id, handler_ref: "FamilyEventHandler")
     end
   end
 

--- a/test/klass_hero/provider/adapters/driving/events/provider_event_handler_test.exs
+++ b/test/klass_hero/provider/adapters/driving/events/provider_event_handler_test.exs
@@ -4,6 +4,8 @@ defmodule KlassHero.Provider.Adapters.Driving.Events.ProviderEventHandlerTest do
   alias KlassHero.AccountsFixtures
   alias KlassHero.Provider
   alias KlassHero.Provider.Adapters.Driving.Events.ProviderEventHandler
+  alias KlassHero.Shared.Adapters.Driven.Persistence.Repositories.ProcessedEventRepository
+  alias KlassHero.Shared.Adapters.Driven.Persistence.Schemas.ProcessedEvent
 
   describe "handle_event/1 for :user_registered" do
     test "creates provider profile when 'provider' in intended_roles" do
@@ -98,6 +100,34 @@ defmodule KlassHero.Provider.Adapters.Driving.Events.ProviderEventHandlerTest do
 
       assert {:ok, profile} = Provider.get_provider_by_identity(user.id)
       assert profile.business_owner_email == "confirmed@example.com"
+    end
+
+    # Regression for #1065. The idempotent test above calls the handler directly
+    # (safe out-of-transaction path); this drives it through the exactly-once
+    # wrapper production uses (execute_atomically → Repo.transaction). Before the
+    # `mode: :savepoint` fix, the duplicate-identity insert poisoned the txn and
+    # execute_atomically returned {:error, :rollback}, discarding the Oban job.
+    test "is idempotent through execute_atomically when profile already exists (issue #1065)" do
+      user = AccountsFixtures.unconfirmed_user_fixture(intended_roles: [:provider])
+
+      # :user_registered has already created the profile.
+      assert :ok = ProviderEventHandler.handle_event(build_user_registered_event(user))
+
+      # :user_confirmed compensation now runs inside the atomic transaction.
+      event_id = Ecto.UUID.generate()
+
+      handler_fn = fn ->
+        ProviderEventHandler.handle_event(build_user_confirmed_event(user))
+      end
+
+      result =
+        ProcessedEventRepository.execute_atomically(event_id, "ProviderEventHandler", handler_fn)
+
+      # 1. The duplicate is tolerated as idempotent success — not {:error, :rollback}.
+      assert result == :ok
+
+      # 2. The dedup marker committed, so Oban won't redeliver forever.
+      assert Repo.get_by(ProcessedEvent, event_id: event_id, handler_ref: "ProviderEventHandler")
     end
   end
 


### PR DESCRIPTION
## Summary

Fixes #1065. Critical **integration** event handlers run inside `ProcessedEventRepository.execute_atomically`'s `Repo.transaction`. When `:user_registered` already created a parent/provider profile, the `:user_confirmed` compensation path re-attempts the same insert and hits the `identity_id` unique constraint. Without `mode: :savepoint`, that violation **aborts the whole Postgres transaction** — Ecto still returns `{:error, changeset}` (mapped to `:duplicate_resource` → `:ok`), but the surrounding `COMMIT` becomes a `ROLLBACK`, so `execute_atomically` returns `{:error, :rollback}`, the dedup marker never commits, and the Oban job retries to **discard**.

The issue's original "cause #1" (RetryHelpers passes the error through) was a misdiagnosis — RetryHelpers already maps `:duplicate_resource`→`:ok`. The handler simply never receives `:duplicate_resource` in-transaction; it receives `:rollback`.

## Fix

Add `mode: :savepoint` to the bare `Repo.insert` in two functions — the only two of all critical-handler-reachable writes that combine a *routine* constraint hit + bare insert + swallow-to-`:ok`:

- `Family.create_parent_profile/1`
- `Provider` → `insert_provider_profile/1`

A savepoint rolls back only the failed insert; the outer transaction survives. It is a no-op outside a transaction, so the non-transactional `:user_registered` first-attempt path is unaffected. Everything else reachable from a handler is already safe (Multi/nested transaction auto-savepoints, `on_conflict:` upserts, or error mapped straight to `Repo.rollback`).

## Review focus

- The two one-line `mode: :savepoint` changes.
- Regression tests drive each handler through `execute_atomically` (the in-transaction path). The **pre-existing** direct-call idempotency tests stayed green through the live bug because they never entered a transaction — that blind spot is why #1065 shipped. Confirmed red→green (revert → `{:error, :rollback}`; restore → `:ok` + committed marker).

## Impact (verified against live prod, read-only)

Not a booking blocker. All **14** affected parents (42 discarded jobs, 2026-05-07 → 07-08) **already have a profile — 0 blocked**. The bug was discarded jobs + wasted retries + masked observability. A disjoint set of **4** profile-less accounts are 2026-03-05 internal/seed accounts with zero occurrences of this error — a different, pre-history cause, not this issue. **No data cleanup required.**

## Test plan

- `mix precommit` — 3911 passed, 5 skipped, 19 excluded.
- New tests: `family_event_handler_test.exs`, `provider_event_handler_test.exs` (each: `execute_atomically` returns `:ok` + `ProcessedEvent` marker committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)