### PR TITLE
refactor: route TeamLive pay rate through Provider facade (#1060)

### DIFF
--- a/lib/klass_hero/provider/staff.ex
+++ b/lib/klass_hero/provider/staff.ex
@@ -38,7 +38,8 @@ defmodule KlassHero.Provider.Staff do
     "invitation_sent_at"
   ]
 
-  @staff_updatable_fields ~w(first_name last_name role email bio headshot_url tags qualifications active pay_rate)a
+  @staff_updatable_fields ~w(first_name last_name role email bio headshot_url tags qualifications active
+                             pay_rate rate_type rate_amount rate_currency)a
 
   @doc """
   Creates the provider's OWN staff row — pre-linked, `:accepted`, no

--- a/lib/klass_hero/provider/staff_member.ex
+++ b/lib/klass_hero/provider/staff_member.ex
@@ -328,7 +328,6 @@ defmodule KlassHero.Provider.StaffMember do
     |> validate_headshot_url(staff.headshot_url)
     |> validate_tags(staff.tags)
     |> validate_qualifications(staff.qualifications)
-    |> validate_pay_rate(staff.pay_rate)
   end
 
   defp validate_provider_id(errors, id) when is_binary(id) do
@@ -424,16 +423,6 @@ defmodule KlassHero.Provider.StaffMember do
   end
 
   defp validate_qualifications(errors, _), do: ["Qualifications must be a list" | errors]
-
-  defp validate_pay_rate(errors, nil), do: errors
-
-  defp validate_pay_rate(errors, %PayRate{} = pay_rate) do
-    if PayRate.valid?(pay_rate),
-      do: errors,
-      else: ["Pay rate is invalid" | errors]
-  end
-
-  defp validate_pay_rate(errors, _), do: ["Pay rate must be a %PayRate{} struct or nil" | errors]
 
   @doc """
   Generates a URL-safe invitation token and its SHA-256 hash.

--- a/lib/klass_hero_web/live/provider/team_live.ex
+++ b/lib/klass_hero_web/live/provider/team_live.ex
@@ -14,7 +14,6 @@ defmodule KlassHeroWeb.Provider.TeamLive do
   alias KlassHero.Accounts
   alias KlassHero.ProgramCatalog
   alias KlassHero.Provider
-  alias KlassHero.Provider.PayRate
   alias KlassHero.Shared.NameUtils
   alias KlassHeroWeb.Presenters.StaffMemberPresenter
   alias KlassHeroWeb.Provider.Dashboard.Chrome
@@ -443,43 +442,32 @@ defmodule KlassHeroWeb.Provider.TeamLive do
   end
 
   defp atomize_staff_params(params) do
-    %{
+    base = %{
       first_name: params["first_name"],
       last_name: params["last_name"],
       role: Params.presence(params["role"]),
       email: Params.presence(params["email"]),
       bio: Params.presence(params["bio"]),
       tags: (params["tags"] || []) |> Enum.reject(&(&1 == "")),
-      qualifications: parse_qualifications(params["qualifications"]),
-      pay_rate: build_pay_rate_from_params(params)
+      qualifications: parse_qualifications(params["qualifications"])
+    }
+
+    Map.merge(base, flat_rate_params(params))
+  end
+
+  # Pass raw rate_* params straight to the Provider facade — StaffMember's changeset is
+  # the pay-rate validation gatekeeper (#1060). The rate_currency field is a hidden EUR
+  # input that is always submitted, so the three columns are gated on an actual rate_type
+  # selection; otherwise a rate-less staff member would trip the all-or-none constraint.
+  defp flat_rate_params(%{"rate_type" => type} = params) when type in ["hourly", "per_session"] do
+    %{
+      rate_type: type,
+      rate_amount: Params.presence(params["rate_amount"]),
+      rate_currency: Params.presence(params["rate_currency"]) || "EUR"
     }
   end
 
-  defp build_pay_rate_from_params(%{"rate_type" => "hourly"} = params) do
-    build_pay_rate(&PayRate.hourly/2, params)
-  end
-
-  defp build_pay_rate_from_params(%{"rate_type" => "per_session"} = params) do
-    build_pay_rate(&PayRate.per_session/2, params)
-  end
-
-  defp build_pay_rate_from_params(_params), do: nil
-
-  # When rate_type is present but construction fails (bad amount, unknown currency, etc.),
-  # return the `:invalid` sentinel rather than `nil`. Domain validation via
-  # `StaffMember.validate_pay_rate/2` rejects non-PayRate non-nil values, which surfaces
-  # an `{:error, {:validation_error, _}}` tuple from the use case. The LiveView's
-  # existing error branch then re-renders the form via the schema's changeset, which
-  # flags bad `rate_amount` strings (Decimal cast failure) directly on the field.
-  defp build_pay_rate(constructor, params) do
-    amount = Params.presence(params["rate_amount"])
-    currency = Params.presence(params["rate_currency"]) || "EUR"
-
-    case amount && constructor.(amount, currency) do
-      {:ok, pay_rate} -> pay_rate
-      _ -> :invalid
-    end
-  end
+  defp flat_rate_params(_params), do: %{rate_type: nil, rate_amount: nil, rate_currency: nil}
 
   defp parse_qualifications(nil), do: []
   defp parse_qualifications(""), do: []

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -1599,7 +1599,7 @@ msgid "Active"
 msgstr "Aktiv"
 
 #: lib/klass_hero_web/components/provider_components.ex:600
-#: lib/klass_hero_web/live/provider/team_live.ex:544
+#: lib/klass_hero_web/live/provider/team_live.ex:532
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
 msgstr "Teammitglied hinzufügen"
@@ -1631,7 +1631,7 @@ msgstr "Geschäftsprofil"
 msgid "Business Registration"
 msgstr "Gewerbeanmeldung"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:521
+#: lib/klass_hero_web/live/provider/team_live.ex:509
 #, elixir-autogen, elixir-format
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr "Erstellen Sie Profile für Ihr Personal. Diese werden für Eltern sichtbar sein, wenn sie Programmen zugewiesen werden."
@@ -1729,12 +1729,12 @@ msgid "Status"
 msgstr "Status"
 
 #: lib/klass_hero_web/components/provider_components.ex:105
-#: lib/klass_hero_web/live/provider/team_live.ex:37
+#: lib/klass_hero_web/live/provider/team_live.ex:36
 #, elixir-autogen, elixir-format
 msgid "Team & Profiles"
 msgstr "Team & Profile"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:518
+#: lib/klass_hero_web/live/provider/team_live.ex:506
 #, elixir-autogen, elixir-format
 msgid "Team & Provider Profiles"
 msgstr "Team- & Anbieterprofile"
@@ -2229,7 +2229,7 @@ msgstr "Aktion erforderlich"
 msgid "Add Member"
 msgstr "Mitglied hinzufügen"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:568
+#: lib/klass_hero_web/live/provider/team_live.ex:556
 #, elixir-autogen, elixir-format
 msgid "Add your first staff member to get started!"
 msgstr "Fügen Sie Ihren ersten Mitarbeiter hinzu, um loszulegen!"
@@ -2813,7 +2813,7 @@ msgstr "Noch keine Programme gebucht"
 msgid "No rejected documents."
 msgstr "Keine abgelehnten Dokumente."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:567
+#: lib/klass_hero_web/live/provider/team_live.ex:555
 #, elixir-autogen, elixir-format
 msgid "No team members yet"
 msgstr "Noch keine Teammitglieder"
@@ -2873,9 +2873,9 @@ msgstr "Ausstehende Überprüfung"
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:103
 #: lib/klass_hero_web/live/provider/programs_live.ex:588
 #: lib/klass_hero_web/live/provider/programs_live.ex:654
-#: lib/klass_hero_web/live/provider/team_live.ex:252
-#: lib/klass_hero_web/live/provider/team_live.ex:303
-#: lib/klass_hero_web/live/provider/team_live.ex:422
+#: lib/klass_hero_web/live/provider/team_live.ex:251
+#: lib/klass_hero_web/live/provider/team_live.ex:302
+#: lib/klass_hero_web/live/provider/team_live.ex:421
 #, elixir-autogen, elixir-format
 msgid "Please fix the errors below."
 msgstr "Bitte korrigieren Sie die Fehler unten."
@@ -3113,16 +3113,16 @@ msgstr "Legen Sie die minimale und maximale Anmeldekapazität für dieses Progra
 msgid "Specialties"
 msgstr "Spezialisierungen"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:402
-#: lib/klass_hero_web/live/provider/team_live.ex:428
+#: lib/klass_hero_web/live/provider/team_live.ex:401
+#: lib/klass_hero_web/live/provider/team_live.ex:427
 #, elixir-autogen, elixir-format
 msgid "Staff member no longer exists."
 msgstr "Der Mitarbeiter existiert nicht mehr."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:101
-#: lib/klass_hero_web/live/provider/team_live.ex:104
-#: lib/klass_hero_web/live/provider/team_live.ex:177
-#: lib/klass_hero_web/live/provider/team_live.ex:193
+#: lib/klass_hero_web/live/provider/team_live.ex:100
+#: lib/klass_hero_web/live/provider/team_live.ex:103
+#: lib/klass_hero_web/live/provider/team_live.ex:176
+#: lib/klass_hero_web/live/provider/team_live.ex:192
 #, elixir-autogen, elixir-format
 msgid "Staff member not found."
 msgstr "Mitarbeiter nicht gefunden."
@@ -3153,27 +3153,27 @@ msgstr "Noch offen"
 msgid "Tax Certificate"
 msgstr "Steuerbescheinigung"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:356
+#: lib/klass_hero_web/live/provider/team_live.ex:355
 #, elixir-autogen, elixir-format
 msgid "Team member added, but headshot upload failed."
 msgstr "Teammitglied hinzugefügt, aber der Upload des Profilfotos ist fehlgeschlagen."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:357
+#: lib/klass_hero_web/live/provider/team_live.ex:356
 #, elixir-autogen, elixir-format
 msgid "Team member added."
 msgstr "Teammitglied hinzugefügt."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:167
+#: lib/klass_hero_web/live/provider/team_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Team member removed."
 msgstr "Teammitglied entfernt."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:382
+#: lib/klass_hero_web/live/provider/team_live.ex:381
 #, elixir-autogen, elixir-format
 msgid "Team member updated, but headshot upload failed."
 msgstr "Teammitglied aktualisiert, aber der Upload des Profilfotos ist fehlgeschlagen."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:383
+#: lib/klass_hero_web/live/provider/team_live.ex:382
 #, elixir-autogen, elixir-format
 msgid "Team member updated."
 msgstr "Teammitglied aktualisiert."
@@ -4271,7 +4271,7 @@ msgstr "E-Mail-Inhalt konnte nicht abgerufen werden."
 msgid "Failed to mark email as unread"
 msgstr "E-Mail konnte nicht als ungelesen markiert werden"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:209
+#: lib/klass_hero_web/live/provider/team_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "Failed to resend invitation. Please try again."
 msgstr "Einladung konnte nicht erneut gesendet werden. Bitte versuchen Sie es erneut."
@@ -4339,7 +4339,7 @@ msgstr "Einladung ausstehend"
 msgid "Invitation Sent"
 msgstr "Einladung gesendet"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:190
+#: lib/klass_hero_web/live/provider/team_live.ex:189
 #, elixir-autogen, elixir-format
 msgid "Invitation resent successfully."
 msgstr "Einladung erfolgreich erneut gesendet."
@@ -4586,7 +4586,7 @@ msgstr "Sitzung erfolgreich erstellt"
 msgid "Staff Dashboard"
 msgstr "Mitarbeiter-Dashboard"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:259
+#: lib/klass_hero_web/live/provider/team_live.ex:258
 #, elixir-autogen, elixir-format
 msgid "Staff member created, but the invitation could not be sent. Try resending from the team list."
 msgstr "Mitarbeiter wurde erstellt, aber die Einladung konnte nicht gesendet werden. Versuchen Sie es erneut über die Team-Liste."
@@ -4617,7 +4617,7 @@ msgstr "Unterstützung: %{details}"
 msgid "The business associated with your account could not be found."
 msgstr "Das mit Ihrem Konto verknüpfte Unternehmen konnte nicht gefunden werden."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:200
+#: lib/klass_hero_web/live/provider/team_live.ex:199
 #, elixir-autogen, elixir-format
 msgid "This invitation cannot be resent in its current state."
 msgstr "Diese Einladung kann in ihrem aktuellen Status nicht erneut gesendet werden."
@@ -5609,7 +5609,7 @@ msgstr "Familien verbinden mit"
 msgid "Contact Us →"
 msgstr "Kontakt →"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:311
+#: lib/klass_hero_web/live/provider/team_live.ex:310
 #, elixir-autogen, elixir-format
 msgid "Could not add you to the team. Please try again."
 msgstr "Sie konnten nicht zum Team hinzugefügt werden. Bitte versuchen Sie es erneut."
@@ -5888,7 +5888,7 @@ msgstr "So bringen Sie Ihr Jugendprogramm zum Wachsen"
 msgid "How we vet providers"
 msgstr "Wie wir Anbieter überprüfen"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:535
+#: lib/klass_hero_web/live/provider/team_live.ex:523
 #, elixir-autogen, elixir-format
 msgid "I'll be teaching"
 msgstr "Ich werde unterrichten"
@@ -6857,7 +6857,7 @@ msgstr "Sie haben bereits ein Konto für %{email}."
 msgid "You'll get your own provider profile to fill in, and your account will open on your business dashboard from now on. You stay on %{business}'s team."
 msgstr "Sie erhalten Ihr eigenes Anbieterprofil zum Ausfüllen, und Ihr Konto öffnet sich ab sofort auf Ihrem Geschäfts-Dashboard. Sie bleiben im Team von %{business}."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:291
+#: lib/klass_hero_web/live/provider/team_live.ex:290
 #, elixir-autogen, elixir-format
 msgid "You're already on your team."
 msgstr "Sie sind bereits in Ihrem Team."
@@ -6877,12 +6877,12 @@ msgstr "Sie sind nicht mehr in diesem Team."
 msgid "You're now part of the team."
 msgstr "Sie sind jetzt Teil des Teams."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:339
+#: lib/klass_hero_web/live/provider/team_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "You're on the team — you can now be assigned to programs."
 msgstr "Sie sind im Team — Sie können nun Programmen zugewiesen werden."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:338
+#: lib/klass_hero_web/live/provider/team_live.ex:337
 #, elixir-autogen, elixir-format
 msgid "You're on the team, but the headshot upload failed."
 msgstr "Sie sind im Team, aber der Upload des Profilfotos ist fehlgeschlagen."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -1599,7 +1599,7 @@ msgid "Active"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:600
-#: lib/klass_hero_web/live/provider/team_live.ex:544
+#: lib/klass_hero_web/live/provider/team_live.ex:532
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
 msgstr ""
@@ -1631,7 +1631,7 @@ msgstr ""
 msgid "Business Registration"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:521
+#: lib/klass_hero_web/live/provider/team_live.ex:509
 #, elixir-autogen, elixir-format
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr ""
@@ -1729,12 +1729,12 @@ msgid "Status"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:105
-#: lib/klass_hero_web/live/provider/team_live.ex:37
+#: lib/klass_hero_web/live/provider/team_live.ex:36
 #, elixir-autogen, elixir-format
 msgid "Team & Profiles"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:518
+#: lib/klass_hero_web/live/provider/team_live.ex:506
 #, elixir-autogen, elixir-format
 msgid "Team & Provider Profiles"
 msgstr ""
@@ -2229,7 +2229,7 @@ msgstr ""
 msgid "Add Member"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:568
+#: lib/klass_hero_web/live/provider/team_live.ex:556
 #, elixir-autogen, elixir-format
 msgid "Add your first staff member to get started!"
 msgstr ""
@@ -2813,7 +2813,7 @@ msgstr ""
 msgid "No rejected documents."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:567
+#: lib/klass_hero_web/live/provider/team_live.ex:555
 #, elixir-autogen, elixir-format
 msgid "No team members yet"
 msgstr ""
@@ -2873,9 +2873,9 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:103
 #: lib/klass_hero_web/live/provider/programs_live.ex:588
 #: lib/klass_hero_web/live/provider/programs_live.ex:654
-#: lib/klass_hero_web/live/provider/team_live.ex:252
-#: lib/klass_hero_web/live/provider/team_live.ex:303
-#: lib/klass_hero_web/live/provider/team_live.ex:422
+#: lib/klass_hero_web/live/provider/team_live.ex:251
+#: lib/klass_hero_web/live/provider/team_live.ex:302
+#: lib/klass_hero_web/live/provider/team_live.ex:421
 #, elixir-autogen, elixir-format
 msgid "Please fix the errors below."
 msgstr ""
@@ -3113,16 +3113,16 @@ msgstr ""
 msgid "Specialties"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:402
-#: lib/klass_hero_web/live/provider/team_live.ex:428
+#: lib/klass_hero_web/live/provider/team_live.ex:401
+#: lib/klass_hero_web/live/provider/team_live.ex:427
 #, elixir-autogen, elixir-format
 msgid "Staff member no longer exists."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:101
-#: lib/klass_hero_web/live/provider/team_live.ex:104
-#: lib/klass_hero_web/live/provider/team_live.ex:177
-#: lib/klass_hero_web/live/provider/team_live.ex:193
+#: lib/klass_hero_web/live/provider/team_live.ex:100
+#: lib/klass_hero_web/live/provider/team_live.ex:103
+#: lib/klass_hero_web/live/provider/team_live.ex:176
+#: lib/klass_hero_web/live/provider/team_live.ex:192
 #, elixir-autogen, elixir-format
 msgid "Staff member not found."
 msgstr ""
@@ -3153,27 +3153,27 @@ msgstr ""
 msgid "Tax Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:356
+#: lib/klass_hero_web/live/provider/team_live.ex:355
 #, elixir-autogen, elixir-format
 msgid "Team member added, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:357
+#: lib/klass_hero_web/live/provider/team_live.ex:356
 #, elixir-autogen, elixir-format
 msgid "Team member added."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:167
+#: lib/klass_hero_web/live/provider/team_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Team member removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:382
+#: lib/klass_hero_web/live/provider/team_live.ex:381
 #, elixir-autogen, elixir-format
 msgid "Team member updated, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:383
+#: lib/klass_hero_web/live/provider/team_live.ex:382
 #, elixir-autogen, elixir-format
 msgid "Team member updated."
 msgstr ""
@@ -4271,7 +4271,7 @@ msgstr ""
 msgid "Failed to mark email as unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:209
+#: lib/klass_hero_web/live/provider/team_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "Failed to resend invitation. Please try again."
 msgstr ""
@@ -4339,7 +4339,7 @@ msgstr ""
 msgid "Invitation Sent"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:190
+#: lib/klass_hero_web/live/provider/team_live.ex:189
 #, elixir-autogen, elixir-format
 msgid "Invitation resent successfully."
 msgstr ""
@@ -4586,7 +4586,7 @@ msgstr ""
 msgid "Staff Dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:259
+#: lib/klass_hero_web/live/provider/team_live.ex:258
 #, elixir-autogen, elixir-format
 msgid "Staff member created, but the invitation could not be sent. Try resending from the team list."
 msgstr ""
@@ -4617,7 +4617,7 @@ msgstr ""
 msgid "The business associated with your account could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:200
+#: lib/klass_hero_web/live/provider/team_live.ex:199
 #, elixir-autogen, elixir-format
 msgid "This invitation cannot be resent in its current state."
 msgstr ""
@@ -5609,7 +5609,7 @@ msgstr ""
 msgid "Contact Us →"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:311
+#: lib/klass_hero_web/live/provider/team_live.ex:310
 #, elixir-autogen, elixir-format
 msgid "Could not add you to the team. Please try again."
 msgstr ""
@@ -5888,7 +5888,7 @@ msgstr ""
 msgid "How we vet providers"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:535
+#: lib/klass_hero_web/live/provider/team_live.ex:523
 #, elixir-autogen, elixir-format
 msgid "I'll be teaching"
 msgstr ""
@@ -6857,7 +6857,7 @@ msgstr ""
 msgid "You'll get your own provider profile to fill in, and your account will open on your business dashboard from now on. You stay on %{business}'s team."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:291
+#: lib/klass_hero_web/live/provider/team_live.ex:290
 #, elixir-autogen, elixir-format
 msgid "You're already on your team."
 msgstr ""
@@ -6877,12 +6877,12 @@ msgstr ""
 msgid "You're now part of the team."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:339
+#: lib/klass_hero_web/live/provider/team_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "You're on the team — you can now be assigned to programs."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:338
+#: lib/klass_hero_web/live/provider/team_live.ex:337
 #, elixir-autogen, elixir-format
 msgid "You're on the team, but the headshot upload failed."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -1599,7 +1599,7 @@ msgid "Active"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:600
-#: lib/klass_hero_web/live/provider/team_live.ex:544
+#: lib/klass_hero_web/live/provider/team_live.ex:532
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
 msgstr ""
@@ -1631,7 +1631,7 @@ msgstr ""
 msgid "Business Registration"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:521
+#: lib/klass_hero_web/live/provider/team_live.ex:509
 #, elixir-autogen, elixir-format
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr ""
@@ -1729,12 +1729,12 @@ msgid "Status"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:105
-#: lib/klass_hero_web/live/provider/team_live.ex:37
+#: lib/klass_hero_web/live/provider/team_live.ex:36
 #, elixir-autogen, elixir-format
 msgid "Team & Profiles"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:518
+#: lib/klass_hero_web/live/provider/team_live.ex:506
 #, elixir-autogen, elixir-format
 msgid "Team & Provider Profiles"
 msgstr ""
@@ -2229,7 +2229,7 @@ msgstr ""
 msgid "Add Member"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:568
+#: lib/klass_hero_web/live/provider/team_live.ex:556
 #, elixir-autogen, elixir-format
 msgid "Add your first staff member to get started!"
 msgstr ""
@@ -2813,7 +2813,7 @@ msgstr ""
 msgid "No rejected documents."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:567
+#: lib/klass_hero_web/live/provider/team_live.ex:555
 #, elixir-autogen, elixir-format
 msgid "No team members yet"
 msgstr ""
@@ -2873,9 +2873,9 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:103
 #: lib/klass_hero_web/live/provider/programs_live.ex:588
 #: lib/klass_hero_web/live/provider/programs_live.ex:654
-#: lib/klass_hero_web/live/provider/team_live.ex:252
-#: lib/klass_hero_web/live/provider/team_live.ex:303
-#: lib/klass_hero_web/live/provider/team_live.ex:422
+#: lib/klass_hero_web/live/provider/team_live.ex:251
+#: lib/klass_hero_web/live/provider/team_live.ex:302
+#: lib/klass_hero_web/live/provider/team_live.ex:421
 #, elixir-autogen, elixir-format
 msgid "Please fix the errors below."
 msgstr ""
@@ -3113,16 +3113,16 @@ msgstr ""
 msgid "Specialties"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:402
-#: lib/klass_hero_web/live/provider/team_live.ex:428
+#: lib/klass_hero_web/live/provider/team_live.ex:401
+#: lib/klass_hero_web/live/provider/team_live.ex:427
 #, elixir-autogen, elixir-format
 msgid "Staff member no longer exists."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:101
-#: lib/klass_hero_web/live/provider/team_live.ex:104
-#: lib/klass_hero_web/live/provider/team_live.ex:177
-#: lib/klass_hero_web/live/provider/team_live.ex:193
+#: lib/klass_hero_web/live/provider/team_live.ex:100
+#: lib/klass_hero_web/live/provider/team_live.ex:103
+#: lib/klass_hero_web/live/provider/team_live.ex:176
+#: lib/klass_hero_web/live/provider/team_live.ex:192
 #, elixir-autogen, elixir-format
 msgid "Staff member not found."
 msgstr ""
@@ -3153,27 +3153,27 @@ msgstr ""
 msgid "Tax Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:356
+#: lib/klass_hero_web/live/provider/team_live.ex:355
 #, elixir-autogen, elixir-format
 msgid "Team member added, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:357
+#: lib/klass_hero_web/live/provider/team_live.ex:356
 #, elixir-autogen, elixir-format
 msgid "Team member added."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:167
+#: lib/klass_hero_web/live/provider/team_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Team member removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:382
+#: lib/klass_hero_web/live/provider/team_live.ex:381
 #, elixir-autogen, elixir-format
 msgid "Team member updated, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:383
+#: lib/klass_hero_web/live/provider/team_live.ex:382
 #, elixir-autogen, elixir-format
 msgid "Team member updated."
 msgstr ""
@@ -4271,7 +4271,7 @@ msgstr ""
 msgid "Failed to mark email as unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:209
+#: lib/klass_hero_web/live/provider/team_live.ex:208
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to resend invitation. Please try again."
 msgstr ""
@@ -4339,7 +4339,7 @@ msgstr ""
 msgid "Invitation Sent"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:190
+#: lib/klass_hero_web/live/provider/team_live.ex:189
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invitation resent successfully."
 msgstr ""
@@ -4586,7 +4586,7 @@ msgstr ""
 msgid "Staff Dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:259
+#: lib/klass_hero_web/live/provider/team_live.ex:258
 #, elixir-autogen, elixir-format
 msgid "Staff member created, but the invitation could not be sent. Try resending from the team list."
 msgstr ""
@@ -4617,7 +4617,7 @@ msgstr ""
 msgid "The business associated with your account could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:200
+#: lib/klass_hero_web/live/provider/team_live.ex:199
 #, elixir-autogen, elixir-format
 msgid "This invitation cannot be resent in its current state."
 msgstr ""
@@ -5609,7 +5609,7 @@ msgstr ""
 msgid "Contact Us →"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:311
+#: lib/klass_hero_web/live/provider/team_live.ex:310
 #, elixir-autogen, elixir-format
 msgid "Could not add you to the team. Please try again."
 msgstr ""
@@ -5888,7 +5888,7 @@ msgstr ""
 msgid "How we vet providers"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:535
+#: lib/klass_hero_web/live/provider/team_live.ex:523
 #, elixir-autogen, elixir-format
 msgid "I'll be teaching"
 msgstr ""
@@ -6857,7 +6857,7 @@ msgstr ""
 msgid "You'll get your own provider profile to fill in, and your account will open on your business dashboard from now on. You stay on %{business}'s team."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:291
+#: lib/klass_hero_web/live/provider/team_live.ex:290
 #, elixir-autogen, elixir-format
 msgid "You're already on your team."
 msgstr ""
@@ -6877,12 +6877,12 @@ msgstr ""
 msgid "You're now part of the team."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:339
+#: lib/klass_hero_web/live/provider/team_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "You're on the team — you can now be assigned to programs."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:338
+#: lib/klass_hero_web/live/provider/team_live.ex:337
 #, elixir-autogen, elixir-format
 msgid "You're on the team, but the headshot upload failed."
 msgstr ""

--- a/test/klass_hero/provider/staff/create_staff_member_test.exs
+++ b/test/klass_hero/provider/staff/create_staff_member_test.exs
@@ -136,5 +136,34 @@ defmodule KlassHero.Provider.Staff.CreateStaffMemberTest do
       assert {:ok, staff} = Provider.create_staff_member(attrs)
       assert is_nil(staff.pay_rate)
     end
+
+    test "creates a staff member from flat rate_* params", %{provider_id: provider_id} do
+      attrs = %{
+        provider_id: provider_id,
+        first_name: "Fern",
+        last_name: "Flat",
+        rate_type: "hourly",
+        rate_amount: "25.00",
+        rate_currency: "EUR"
+      }
+
+      assert {:ok, staff} = Provider.create_staff_member(attrs)
+      assert staff.pay_rate.type == :hourly
+      assert Decimal.equal?(staff.pay_rate.money.amount, Decimal.new("25.00"))
+      assert staff.pay_rate.money.currency == :EUR
+    end
+
+    test "returns an error for an invalid flat rate_amount", %{provider_id: provider_id} do
+      attrs = %{
+        provider_id: provider_id,
+        first_name: "Nora",
+        last_name: "Negative",
+        rate_type: "hourly",
+        rate_amount: "-5.00",
+        rate_currency: "EUR"
+      }
+
+      assert {:error, _} = Provider.create_staff_member(attrs)
+    end
   end
 end

--- a/test/klass_hero/provider/staff/update_staff_member_test.exs
+++ b/test/klass_hero/provider/staff/update_staff_member_test.exs
@@ -132,5 +132,24 @@ defmodule KlassHero.Provider.Staff.UpdateStaffMemberTest do
       assert {:ok, cleared} = Provider.update_staff_member(staff.provider_id, staff.id, %{pay_rate: nil})
       assert is_nil(cleared.pay_rate)
     end
+
+    test "sets an hourly pay_rate from flat rate_* params", %{staff: staff} do
+      attrs = %{rate_type: "hourly", rate_amount: "30.00", rate_currency: "EUR"}
+
+      assert {:ok, updated} = Provider.update_staff_member(staff.provider_id, staff.id, attrs)
+      assert updated.pay_rate.type == :hourly
+      assert Decimal.equal?(updated.pay_rate.money.amount, Decimal.new("30.00"))
+      assert updated.pay_rate.money.currency == :EUR
+    end
+
+    test "clears pay_rate from empty flat params", %{staff: staff} do
+      {:ok, pay_rate} = PayRate.hourly(Decimal.new("25.00"))
+      {:ok, seeded} = Provider.update_staff_member(staff.provider_id, staff.id, %{pay_rate: pay_rate})
+      assert seeded.pay_rate
+
+      attrs = %{rate_type: nil, rate_amount: nil, rate_currency: nil}
+      assert {:ok, cleared} = Provider.update_staff_member(staff.provider_id, staff.id, attrs)
+      assert is_nil(cleared.pay_rate)
+    end
   end
 end

--- a/test/klass_hero/provider/staff_member_test.exs
+++ b/test/klass_hero/provider/staff_member_test.exs
@@ -104,6 +104,20 @@ defmodule KlassHero.Provider.StaffMemberTest do
 
       assert Enum.any?(errors, &String.contains?(&1, "Invalid tags"))
     end
+
+    test "does not gatekeep pay rate — the changeset owns flat rate_* validation (#1060)" do
+      # new/1 is the pure core; pay-rate validity depends on Ecto casting rate_type/
+      # rate_amount, so it lives in the changeset. A garbage flat rate is therefore not
+      # rejected here — it is caught downstream by create_changeset/edit_changeset.
+      assert {:ok, %StaffMember{}} =
+               StaffMember.new(%{
+                 provider_id: "p",
+                 first_name: "Alice",
+                 last_name: "Smith",
+                 rate_type: "not-a-real-type",
+                 rate_amount: "-5.00"
+               })
+    end
   end
 
   describe "pay_rate round-trip (virtual field + flat columns)" do


### PR DESCRIPTION
## Summary

`KlassHeroWeb.Provider.TeamLive` constructed Provider's internal `PayRate` value object client-side (`PayRate.hourly/2`, `per_session/2`) inside `build_pay_rate_from_params/1` — running Provider's smart-constructor in the web layer and duplicating `StaffMember`'s changeset validation. This PR passes flat `rate_type`/`rate_amount`/`rate_currency` params through the `KlassHero.Provider` facade and makes `StaffMember`'s changeset the sole pay-rate gatekeeper (**Design A — changeset-only**).

## Root cause (deeper than the ticket)

`StaffMember` validated pay rate through **two representations that disagreed** — the functional core `new/1` on the virtual `%PayRate{}` struct, the changeset on the flat `rate_*` columns. The LiveView built a `%PayRate{}` only to satisfy `new/1`. This also created a latent **update-path hazard**: `update_staff_member` merges the hydrated `existing.pay_rate` struct, so `new/1` validated the *stale* rate while the changeset persisted the *new* flat values. Design A removes the dual validation rather than relocating it.

## Changes

- **`team_live.ex`** — drop the `PayRate` alias and `build_pay_rate*` constructors; `atomize_staff_params/1` emits flat `rate_*` keys, gated on an actual `rate_type` selection (the currency is a hidden always-submitted `EUR` input, so a rate-less staff member would otherwise trip the all-or-none constraint).
- **`staff_member.ex`** — remove `new/1`'s struct-based pay-rate validation (dead once the web layer stops building `%PayRate{}`). The changeset (`Ecto.Enum` on `rate_type`/`rate_currency`, `validate_number ≥ 0`, all-or-none `check_constraint`) is the gatekeeper.
- **`staff.ex`** — widen `@staff_updatable_fields` with the flat `rate_*` keys so `update_staff_member`'s `Map.take/2` (a mass-assignment allowlist) doesn't silently drop pay-rate updates. **This is the correctness-critical fix** the "delete 3 web-layer lines" framing missed.

Struct-input remains a valid facade contract — existing struct-based facade tests pass unchanged.

## Review focus

- `@staff_updatable_fields` widening — without it, pay-rate *updates* silently no-op while create keeps working (a test-evading regression). Covered by new update-path tests.
- The `flat_rate_params/1` gating on `rate_type` — preserves the old "no type → no rate" semantics against the always-submitted hidden currency field.

## Test plan

- New: 2 update-path flat-param tests (the genuine red — `Map.take` gap), 2 create-path flat guards, 1 `new/1` non-gatekeeping guard.
- Existing `dashboard_team_test.exs` "pay rate flow" (already flat) + struct-input facade tests stay green.
- `mix precommit` — **4043 passed, 5 skipped**; format, credo, lint_typography, gettext all pass.
- `boundary-checker` (changed-files): 5/5 clean, 0 violations, #1060 resolved.

## Out of scope

`staff_member_presenter.ex` reads `%PayRate{}` for a display label — a read of the facade's hydrated struct (sanctioned schema-as-struct contract), not a construction. Noted as a possible separate low-priority hygiene ticket; does not block.

Closes #1060

🤖 Generated with [Claude Code](https://claude.com/claude-code)