### PR TITLE
refactor: in-memory dedup of confirmed enrollment in provider dashboard

### DIFF
--- a/lib/klass_hero_web/live/provider/overview_live.ex
+++ b/lib/klass_hero_web/live/provider/overview_live.ex
@@ -124,7 +124,21 @@ defmodule KlassHeroWeb.Provider.OverviewLive do
     end
   end
 
+  # The confirmed enrollment's id is on the event payload and on each pending
+  # read-model entry, so the loopback can drop the row from assigns without a DB
+  # round-trip. Fall back to a refresh only on a cross-tab miss (another tab
+  # approved before this one loaded, so the id isn't in local assigns yet).
   @impl true
+  def handle_info(
+        {:domain_event, %DomainEvent{event_type: :enrollment_confirmed, payload: %{enrollment_id: id}}},
+        socket
+      ) do
+    case Enum.split_with(socket.assigns.pending_enrollments, &(&1.enrollment_id == id)) do
+      {[_hit], rest} -> {:noreply, assign(socket, :pending_enrollments, rest)}
+      {[], _} -> {:noreply, refresh_pending_enrollments(socket)}
+    end
+  end
+
   def handle_info({:domain_event, %DomainEvent{event_type: :enrollment_confirmed}}, socket) do
     {:noreply, refresh_pending_enrollments(socket)}
   end

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -5359,7 +5359,7 @@ msgstr "Konto"
 msgid "Account settings"
 msgstr "Kontoeinstellungen"
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:255
+#: lib/klass_hero_web/live/provider/overview_live.ex:269
 #, elixir-autogen, elixir-format
 msgid "Across all programs"
 msgstr "Über alle Programme hinweg"
@@ -5370,7 +5370,7 @@ msgid "Active policy required to teach."
 msgstr "Aktive Versicherungspolice erforderlich, um zu unterrichten."
 
 #: lib/klass_hero_web/live/dashboard_live.ex:278
-#: lib/klass_hero_web/live/provider/overview_live.ex:245
+#: lib/klass_hero_web/live/provider/overview_live.ex:259
 #, elixir-autogen, elixir-format
 msgid "Active programs"
 msgstr "Aktive Programme"
@@ -5558,8 +5558,8 @@ msgstr "Mitgründer & CTO"
 #: lib/klass_hero_web/components/parent_components.ex:143
 #: lib/klass_hero_web/components/parent_components.ex:322
 #: lib/klass_hero_web/components/provider_layout_components.ex:147
-#: lib/klass_hero_web/live/provider/overview_live.ex:263
-#: lib/klass_hero_web/live/provider/overview_live.ex:271
+#: lib/klass_hero_web/live/provider/overview_live.ex:277
+#: lib/klass_hero_web/live/provider/overview_live.ex:285
 #, elixir-autogen, elixir-format
 msgid "Coming soon"
 msgstr "Demnächst verfügbar"
@@ -5679,7 +5679,7 @@ msgstr "Programm bearbeiten"
 msgid "Email the provider and us (support@mail.klasshero.com) as soon as you can — we'll help you and the provider work it out."
 msgstr "Schreiben Sie dem Anbieter und uns (support@mail.klasshero.com) so schnell wie möglich eine E-Mail — wir helfen Ihnen und dem Anbieter, eine Lösung zu finden."
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:251
+#: lib/klass_hero_web/live/provider/overview_live.ex:265
 #, elixir-autogen, elixir-format
 msgid "Enrolled kids"
 msgstr "Angemeldete Kinder"
@@ -6067,7 +6067,7 @@ msgstr "Suchen Sie Programme für Ihr Kind?"
 msgid "Looking for quick answers?"
 msgstr "Suchen Sie schnelle Antworten?"
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:287
+#: lib/klass_hero_web/live/provider/overview_live.ex:301
 #, elixir-autogen, elixir-format
 msgid "Manage"
 msgstr "Verwalten"
@@ -6162,17 +6162,17 @@ msgstr "Noch keine Vorfallberichte"
 msgid "No messages yet."
 msgstr "Noch keine Nachrichten."
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:321
+#: lib/klass_hero_web/live/provider/overview_live.ex:335
 #, elixir-autogen, elixir-format
 msgid "No pending enrollments right now."
 msgstr "Derzeit keine ausstehenden Anmeldungen."
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:306
+#: lib/klass_hero_web/live/provider/overview_live.ex:320
 #, elixir-autogen, elixir-format
 msgid "No pending requests right now."
 msgstr "Derzeit keine ausstehenden Anfragen."
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:291
+#: lib/klass_hero_web/live/provider/overview_live.ex:305
 #, elixir-autogen, elixir-format
 msgid "No programs yet — add your first one from the Programs tab."
 msgstr "Noch keine Programme — fügen Sie Ihr erstes über den Tab „Programme“ hinzu."
@@ -6290,12 +6290,12 @@ msgstr "Teilnahme"
 msgid "Pedagogical Interview"
 msgstr "Pädagogisches Interview"
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:300
+#: lib/klass_hero_web/live/provider/overview_live.ex:314
 #, elixir-autogen, elixir-format
 msgid "Pending booking requests"
 msgstr "Ausstehende Buchungsanfragen"
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:315
+#: lib/klass_hero_web/live/provider/overview_live.ex:329
 #, elixir-autogen, elixir-format
 msgid "Pending enrollments"
 msgstr "Ausstehende Anmeldungen"
@@ -6373,7 +6373,7 @@ msgstr "Fragen zu Programmen, Buchungen oder wie Sie ein Hero werden — wir les
 msgid "Questions, answered."
 msgstr "Fragen, beantwortet."
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:266
+#: lib/klass_hero_web/live/provider/overview_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Rating"
 msgstr "Bewertung"
@@ -6415,7 +6415,7 @@ msgstr "Berichte"
 msgid "Reports filed for this program will appear here."
 msgstr "Für dieses Programm eingereichte Berichte werden hier angezeigt."
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:258
+#: lib/klass_hero_web/live/provider/overview_live.ex:272
 #, elixir-autogen, elixir-format
 msgid "Revenue (this week)"
 msgstr "Umsatz (diese Woche)"
@@ -6887,7 +6887,7 @@ msgstr "Sie sind im Team — Sie können nun Programmen zugewiesen werden."
 msgid "You're on the team, but the headshot upload failed."
 msgstr "Sie sind im Team, aber der Upload des Profilfotos ist fehlgeschlagen."
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:282
+#: lib/klass_hero_web/live/provider/overview_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "Your top programs"
 msgstr "Ihre Top-Programme"
@@ -6947,8 +6947,8 @@ msgstr "in"
 msgid "matching"
 msgstr "Passend"
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:302
-#: lib/klass_hero_web/live/provider/overview_live.ex:317
+#: lib/klass_hero_web/live/provider/overview_live.ex:316
+#: lib/klass_hero_web/live/provider/overview_live.ex:331
 #, elixir-autogen, elixir-format
 msgid "pending"
 msgstr "Ausstehend"
@@ -7016,7 +7016,7 @@ msgstr "Gemeinschaftsstandards"
 msgid "Complete all steps to publish programs. %{approved} of %{total} approved."
 msgstr "Schließe alle Schritte ab, um Programme zu veröffentlichen. %{approved} von %{total} genehmigt."
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:234
+#: lib/klass_hero_web/live/provider/overview_live.ex:248
 #, elixir-autogen, elixir-format
 msgid "Complete your verification checklist so parents can find and book you."
 msgstr "Vervollständige deine Verifizierungs-Checkliste, damit Eltern dich finden und buchen können."
@@ -7151,7 +7151,7 @@ msgstr "Lade dein Kinderschutz-Zertifikat hoch."
 msgid "Verify identity"
 msgstr "Identität verifizieren"
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:231
+#: lib/klass_hero_web/live/provider/overview_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "Verify your identity to get approved"
 msgstr "Verifiziere deine Identität, um freigegeben zu werden"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -5359,7 +5359,7 @@ msgstr ""
 msgid "Account settings"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:255
+#: lib/klass_hero_web/live/provider/overview_live.ex:269
 #, elixir-autogen, elixir-format
 msgid "Across all programs"
 msgstr ""
@@ -5370,7 +5370,7 @@ msgid "Active policy required to teach."
 msgstr ""
 
 #: lib/klass_hero_web/live/dashboard_live.ex:278
-#: lib/klass_hero_web/live/provider/overview_live.ex:245
+#: lib/klass_hero_web/live/provider/overview_live.ex:259
 #, elixir-autogen, elixir-format
 msgid "Active programs"
 msgstr ""
@@ -5558,8 +5558,8 @@ msgstr ""
 #: lib/klass_hero_web/components/parent_components.ex:143
 #: lib/klass_hero_web/components/parent_components.ex:322
 #: lib/klass_hero_web/components/provider_layout_components.ex:147
-#: lib/klass_hero_web/live/provider/overview_live.ex:263
-#: lib/klass_hero_web/live/provider/overview_live.ex:271
+#: lib/klass_hero_web/live/provider/overview_live.ex:277
+#: lib/klass_hero_web/live/provider/overview_live.ex:285
 #, elixir-autogen, elixir-format
 msgid "Coming soon"
 msgstr ""
@@ -5679,7 +5679,7 @@ msgstr ""
 msgid "Email the provider and us (support@mail.klasshero.com) as soon as you can — we'll help you and the provider work it out."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:251
+#: lib/klass_hero_web/live/provider/overview_live.ex:265
 #, elixir-autogen, elixir-format
 msgid "Enrolled kids"
 msgstr ""
@@ -6067,7 +6067,7 @@ msgstr ""
 msgid "Looking for quick answers?"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:287
+#: lib/klass_hero_web/live/provider/overview_live.ex:301
 #, elixir-autogen, elixir-format
 msgid "Manage"
 msgstr ""
@@ -6162,17 +6162,17 @@ msgstr ""
 msgid "No messages yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:321
+#: lib/klass_hero_web/live/provider/overview_live.ex:335
 #, elixir-autogen, elixir-format
 msgid "No pending enrollments right now."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:306
+#: lib/klass_hero_web/live/provider/overview_live.ex:320
 #, elixir-autogen, elixir-format
 msgid "No pending requests right now."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:291
+#: lib/klass_hero_web/live/provider/overview_live.ex:305
 #, elixir-autogen, elixir-format
 msgid "No programs yet — add your first one from the Programs tab."
 msgstr ""
@@ -6290,12 +6290,12 @@ msgstr ""
 msgid "Pedagogical Interview"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:300
+#: lib/klass_hero_web/live/provider/overview_live.ex:314
 #, elixir-autogen, elixir-format
 msgid "Pending booking requests"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:315
+#: lib/klass_hero_web/live/provider/overview_live.ex:329
 #, elixir-autogen, elixir-format
 msgid "Pending enrollments"
 msgstr ""
@@ -6373,7 +6373,7 @@ msgstr ""
 msgid "Questions, answered."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:266
+#: lib/klass_hero_web/live/provider/overview_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Rating"
 msgstr ""
@@ -6415,7 +6415,7 @@ msgstr ""
 msgid "Reports filed for this program will appear here."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:258
+#: lib/klass_hero_web/live/provider/overview_live.ex:272
 #, elixir-autogen, elixir-format
 msgid "Revenue (this week)"
 msgstr ""
@@ -6887,7 +6887,7 @@ msgstr ""
 msgid "You're on the team, but the headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:282
+#: lib/klass_hero_web/live/provider/overview_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "Your top programs"
 msgstr ""
@@ -6947,8 +6947,8 @@ msgstr ""
 msgid "matching"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:302
-#: lib/klass_hero_web/live/provider/overview_live.ex:317
+#: lib/klass_hero_web/live/provider/overview_live.ex:316
+#: lib/klass_hero_web/live/provider/overview_live.ex:331
 #, elixir-autogen, elixir-format
 msgid "pending"
 msgstr ""
@@ -7016,7 +7016,7 @@ msgstr ""
 msgid "Complete all steps to publish programs. %{approved} of %{total} approved."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:234
+#: lib/klass_hero_web/live/provider/overview_live.ex:248
 #, elixir-autogen, elixir-format
 msgid "Complete your verification checklist so parents can find and book you."
 msgstr ""
@@ -7151,7 +7151,7 @@ msgstr ""
 msgid "Verify identity"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:231
+#: lib/klass_hero_web/live/provider/overview_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "Verify your identity to get approved"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -5359,7 +5359,7 @@ msgstr ""
 msgid "Account settings"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:255
+#: lib/klass_hero_web/live/provider/overview_live.ex:269
 #, elixir-autogen, elixir-format
 msgid "Across all programs"
 msgstr ""
@@ -5370,7 +5370,7 @@ msgid "Active policy required to teach."
 msgstr ""
 
 #: lib/klass_hero_web/live/dashboard_live.ex:278
-#: lib/klass_hero_web/live/provider/overview_live.ex:245
+#: lib/klass_hero_web/live/provider/overview_live.ex:259
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Active programs"
 msgstr ""
@@ -5558,8 +5558,8 @@ msgstr ""
 #: lib/klass_hero_web/components/parent_components.ex:143
 #: lib/klass_hero_web/components/parent_components.ex:322
 #: lib/klass_hero_web/components/provider_layout_components.ex:147
-#: lib/klass_hero_web/live/provider/overview_live.ex:263
-#: lib/klass_hero_web/live/provider/overview_live.ex:271
+#: lib/klass_hero_web/live/provider/overview_live.ex:277
+#: lib/klass_hero_web/live/provider/overview_live.ex:285
 #, elixir-autogen, elixir-format
 msgid "Coming soon"
 msgstr ""
@@ -5679,7 +5679,7 @@ msgstr ""
 msgid "Email the provider and us (support@mail.klasshero.com) as soon as you can — we'll help you and the provider work it out."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:251
+#: lib/klass_hero_web/live/provider/overview_live.ex:265
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrolled kids"
 msgstr ""
@@ -6067,7 +6067,7 @@ msgstr ""
 msgid "Looking for quick answers?"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:287
+#: lib/klass_hero_web/live/provider/overview_live.ex:301
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Manage"
 msgstr ""
@@ -6162,17 +6162,17 @@ msgstr ""
 msgid "No messages yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:321
+#: lib/klass_hero_web/live/provider/overview_live.ex:335
 #, elixir-autogen, elixir-format
 msgid "No pending enrollments right now."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:306
+#: lib/klass_hero_web/live/provider/overview_live.ex:320
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No pending requests right now."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:291
+#: lib/klass_hero_web/live/provider/overview_live.ex:305
 #, elixir-autogen, elixir-format
 msgid "No programs yet — add your first one from the Programs tab."
 msgstr ""
@@ -6290,12 +6290,12 @@ msgstr ""
 msgid "Pedagogical Interview"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:300
+#: lib/klass_hero_web/live/provider/overview_live.ex:314
 #, elixir-autogen, elixir-format
 msgid "Pending booking requests"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:315
+#: lib/klass_hero_web/live/provider/overview_live.ex:329
 #, elixir-autogen, elixir-format
 msgid "Pending enrollments"
 msgstr ""
@@ -6373,7 +6373,7 @@ msgstr ""
 msgid "Questions, answered."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:266
+#: lib/klass_hero_web/live/provider/overview_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Rating"
 msgstr ""
@@ -6415,7 +6415,7 @@ msgstr ""
 msgid "Reports filed for this program will appear here."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:258
+#: lib/klass_hero_web/live/provider/overview_live.ex:272
 #, elixir-autogen, elixir-format
 msgid "Revenue (this week)"
 msgstr ""
@@ -6887,7 +6887,7 @@ msgstr ""
 msgid "You're on the team, but the headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:282
+#: lib/klass_hero_web/live/provider/overview_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "Your top programs"
 msgstr ""
@@ -6947,8 +6947,8 @@ msgstr ""
 msgid "matching"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:302
-#: lib/klass_hero_web/live/provider/overview_live.ex:317
+#: lib/klass_hero_web/live/provider/overview_live.ex:316
+#: lib/klass_hero_web/live/provider/overview_live.ex:331
 #, elixir-autogen, elixir-format, fuzzy
 msgid "pending"
 msgstr ""
@@ -7016,7 +7016,7 @@ msgstr ""
 msgid "Complete all steps to publish programs. %{approved} of %{total} approved."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:234
+#: lib/klass_hero_web/live/provider/overview_live.ex:248
 #, elixir-autogen, elixir-format
 msgid "Complete your verification checklist so parents can find and book you."
 msgstr ""
@@ -7151,7 +7151,7 @@ msgstr ""
 msgid "Verify identity"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:231
+#: lib/klass_hero_web/live/provider/overview_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "Verify your identity to get approved"
 msgstr ""

--- a/test/klass_hero_web/live/provider/provider_dashboard_test.exs
+++ b/test/klass_hero_web/live/provider/provider_dashboard_test.exs
@@ -1570,6 +1570,77 @@ defmodule KlassHeroWeb.Provider.ProviderDashboardTest do
       refute has_element?(view, "#pending-enrollment-#{enrollment.id}")
     end
 
+    test "in-memory dedup drops the confirmed card without re-querying the DB",
+         %{conn: conn, provider: provider} do
+      program = insert_program_with_listing(provider_id: provider.id)
+      {child, parent} = KlassHero.Factory.insert_child_with_guardian()
+
+      enrollment =
+        KlassHero.Factory.insert(:enrollment_schema,
+          program_id: program.id,
+          parent_id: parent.id,
+          child_id: child.id,
+          status: :pending
+        )
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard")
+      assert has_element?(view, "#pending-enrollment-#{enrollment.id}")
+
+      # DB row deliberately left :pending. Only in-memory removal can drop the
+      # card — a refresh would re-query and the still-pending row would reappear.
+      event =
+        DomainEvent.new(
+          :enrollment_confirmed,
+          enrollment.id,
+          :enrollment,
+          %{provider_id: provider.id, enrollment_id: enrollment.id}
+        )
+
+      send(view.pid, {:domain_event, event})
+      _ = render(view)
+
+      refute has_element?(view, "#pending-enrollment-#{enrollment.id}")
+
+      {:ok, reloaded} = KlassHero.Enrollment.get_enrollment(enrollment.id)
+      assert reloaded.status == :pending
+    end
+
+    test "falls back to a refresh when the confirmed id is not in local assigns",
+         %{conn: conn, provider: provider} do
+      program = insert_program_with_listing(provider_id: provider.id)
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard")
+      assert render(view) =~ "No pending enrollments right now."
+
+      # A pending enrollment created after mount is absent from this tab's assigns
+      # (simulates another tab acting before this one loaded).
+      {child, parent} = KlassHero.Factory.insert_child_with_guardian()
+
+      unseen =
+        KlassHero.Factory.insert(:enrollment_schema,
+          program_id: program.id,
+          parent_id: parent.id,
+          child_id: child.id,
+          status: :pending
+        )
+
+      refute has_element?(view, "#pending-enrollment-#{unseen.id}")
+
+      # Event carries an id NOT in assigns → miss → fallback refresh re-queries.
+      event =
+        DomainEvent.new(
+          :enrollment_confirmed,
+          Ecto.UUID.generate(),
+          :enrollment,
+          %{provider_id: provider.id, enrollment_id: Ecto.UUID.generate()}
+        )
+
+      send(view.pid, {:domain_event, event})
+      _ = render(view)
+
+      assert has_element?(view, "#pending-enrollment-#{unseen.id}")
+    end
+
     test "approving an enrollment for another provider's program flashes an error",
          %{conn: conn} do
       other_provider = KlassHero.Factory.insert(:provider_profile_schema)


### PR DESCRIPTION
## Summary

The `:enrollment_confirmed` loopback handler in `OverviewLive` re-queried the DB (`list_programs_for_provider` + `list_pending_enrollments_for_provider`, 2 round-trips) just to drop one confirmed row from the pending-enrollments card. The event payload and each read-model entry both carry `enrollment_id`, so the handler now filters the confirmed row out of `socket.assigns.pending_enrollments` **in memory** — zero DB queries on the originator/same-provider tabs. A cross-tab miss (another tab approved before this one loaded, so the id isn't in local assigns) falls back to the existing refresh.

Stacks on #867 (double-fire, already fixed): the `approve_enrollment` handler no longer refreshes; only this loopback does.

> **Note for reviewers:** the issue's file anchor (`dashboard_live.ex:278`) is **stale** — the #904 split (PR #1047) moved this handler to `lib/klass_hero_web/live/provider/overview_live.ex`.

## Review Focus

- **Design — two `handle_info` clauses (head dispatch):** clause 1 matches a payload carrying `enrollment_id` → `Enum.split_with` (hit → `assign` filtered list; miss → refresh); clause 2 matches any id-less `:enrollment_confirmed` event → refresh. The two-clause shape (vs one in-body `case`) keeps pattern-matching in the function head per `elixir-style.md`, and clause 2 absorbs id-less events so the pre-existing test needed no change.
- **`Enum.split_with/2` (not a comprehension):** hit-vs-miss detection for the fallback in one pass — the good-reason carve-out to the comprehensions-by-default idiom.

## Test Plan

- **In-memory-hit test:** DB row left `:pending`; assert card gone. Only in-memory removal can drop the card — a refresh would re-query and the still-pending row would reappear, so the assertion can't pass by accident.
- **Fallback-miss test:** a pending row created after mount (absent from assigns); send an event with an `enrollment_id` not in assigns; assert the unseen row surfaces → proves the fallback refresh ran.
- Existing id-less-event test now exercises clause 2 (fallback), unchanged and green.
- `MIX_TEST_PARTITION=871 mix precommit`: 4045 passed, format/credo/gettext/deps all green.

Closes #871

🤖 Generated with [Claude Code](https://claude.com/claude-code)