### PR TITLE
refactor: cut vetting save_case/1 to N+1 writes, 0 reads

### DIFF
--- a/lib/klass_hero/provider/vetting.ex
+++ b/lib/klass_hero/provider/vetting.ex
@@ -102,27 +102,29 @@ defmodule KlassHero.Provider.Vetting do
 
   @doc """
   Persists the aggregate's current steps and lifecycle back to an already-persisted
-  case, in one transaction. Each step is updated from its stored row so Ecto sees the
-  real field changes (a `put_assoc` of already-persisted structs diffs to nothing).
+  case, in one transaction. Each row is written unconditionally with `Repo.update_all`
+  keyed by id: the mutable attrs are already in hand, so no read-before-write is needed
+  and `updated_at` is bumped explicitly (update_all does not touch timestamps). Returns
+  the passed-in case unchanged — callers already hold the post-mutation aggregate with
+  its steps loaded, so a re-fetch would be pure waste.
   """
   @spec save_case(VettingCase.t()) :: {:ok, VettingCase.t()} | {:error, term()}
-  def save_case(%VettingCase{id: id, steps: steps, lifecycle: lifecycle}) do
-    Repo.transaction(fn ->
-      VettingCase
-      |> Repo.get!(id)
-      |> Ecto.Changeset.change(lifecycle: lifecycle)
-      |> Repo.update!()
+  def save_case(%VettingCase{id: id, steps: steps, lifecycle: lifecycle} = case_) do
+    now = DateTime.utc_now()
 
-      Enum.each(steps, &save_step!/1)
-      VettingCase |> Repo.get!(id) |> Repo.preload(steps: step_order())
+    Repo.transaction(fn ->
+      Repo.update_all(from(c in VettingCase, where: c.id == ^id),
+        set: [lifecycle: lifecycle, updated_at: now]
+      )
+
+      Enum.each(steps, &save_step!(&1, now))
+      case_
     end)
   end
 
-  defp save_step!(%VerificationStep{id: step_id} = step) do
-    VerificationStep
-    |> Repo.get!(step_id)
-    |> VerificationStep.changeset(step_mutable_attrs(step))
-    |> Repo.update!()
+  defp save_step!(%VerificationStep{id: step_id} = step, now) do
+    set = step |> step_mutable_attrs() |> Map.to_list() |> Keyword.put(:updated_at, now)
+    Repo.update_all(from(s in VerificationStep, where: s.id == ^step_id), set: set)
   end
 
   defp step_mutable_attrs(%VerificationStep{} = step) do

--- a/test/klass_hero/provider/vetting_persistence_test.exs
+++ b/test/klass_hero/provider/vetting_persistence_test.exs
@@ -11,6 +11,8 @@ defmodule KlassHero.Provider.VettingPersistenceTest do
   alias KlassHero.Provider.VettingCase
   alias KlassHero.ProviderFixtures
 
+  @tracked_sources ["verification_steps", "vetting_cases"]
+
   describe "get_case_for_provider/1" do
     test "lazily backfills a case on first read for an existing provider" do
       provider = ProviderFixtures.provider_profile_fixture()
@@ -55,6 +57,93 @@ defmodule KlassHero.Provider.VettingPersistenceTest do
       identity = Enum.find(reloaded.steps, &(&1.key == :identity))
       assert identity.status == :approved
       assert reloaded.lifecycle == :in_progress
+    end
+  end
+
+  describe "save_case/1 query budget" do
+    test "persists a transition with zero reads and N+1 writes" do
+      provider = ProviderFixtures.provider_profile_fixture()
+      admin = AccountsFixtures.user_fixture(%{is_admin: true})
+      {:ok, case_} = Vetting.get_case_for_provider(provider.id)
+      {:ok, approved} = VettingCase.approve_step(case_, :identity, admin.id, Ecto.UUID.generate())
+
+      {result, verbs} = count_tracked_queries(fn -> Vetting.save_case(approved) end)
+
+      assert {:ok, _} = result
+
+      # `verbs` buckets the SQL run against verification_steps + vetting_cases by
+      # leading keyword, e.g. %{"SELECT" => 0, "UPDATE" => 7}. Design A's budget is
+      # zero reads and one write per step plus one for the case row. Tie UPDATE to
+      # the step count (not a literal) so the test survives a track gaining a step.
+      assert Map.get(verbs, "SELECT", 0) == 0
+      assert Map.get(verbs, "UPDATE", 0) == length(approved.steps) + 1
+    end
+  end
+
+  describe "save_case/1 side effects" do
+    test "bumps updated_at on the persisted steps" do
+      provider = ProviderFixtures.provider_profile_fixture()
+      admin = AccountsFixtures.user_fixture(%{is_admin: true})
+      {:ok, case_} = Vetting.get_case_for_provider(provider.id)
+      before_save = DateTime.utc_now()
+
+      {:ok, approved} = VettingCase.approve_step(case_, :identity, admin.id, Ecto.UUID.generate())
+      assert {:ok, _} = Vetting.save_case(approved)
+
+      {:ok, reloaded} = Vetting.get_case_for_provider(provider.id)
+      identity = Enum.find(reloaded.steps, &(&1.key == :identity))
+      assert DateTime.after?(identity.updated_at, before_save)
+    end
+
+    test "returns the in-hand case with steps loaded so verified?/1 holds" do
+      provider = ProviderFixtures.provider_profile_fixture()
+      admin = AccountsFixtures.user_fixture(%{is_admin: true})
+      {:ok, case_} = Vetting.get_case_for_provider(provider.id)
+
+      approved =
+        Enum.reduce(case_.steps, case_, fn step, acc ->
+          {:ok, next} = VettingCase.approve_step(acc, step.key, admin.id, Ecto.UUID.generate())
+          next
+        end)
+
+      assert {:ok, saved} = Vetting.save_case(approved)
+      assert is_list(saved.steps)
+      assert VettingCase.verified?(saved)
+    end
+  end
+
+  # Buckets queries emitted against @tracked_sources during `fun` by leading SQL
+  # keyword, so a test can assert the read/write budget of a persistence path.
+  defp count_tracked_queries(fun) do
+    ref = make_ref()
+    test_pid = self()
+    handler_id = {:vetting_query_budget, ref}
+
+    :telemetry.attach(
+      handler_id,
+      [:klass_hero, :repo, :query],
+      fn _event, _measurements, metadata, _config ->
+        # Ecto emits query telemetry in the calling process (the test process under
+        # the sandbox); gating on self() isolates THIS test from concurrent async ones,
+        # since :telemetry handlers are process-global.
+        if self() == test_pid and metadata.source in @tracked_sources do
+          verb = metadata.query |> String.trim_leading() |> String.split(" ", parts: 2) |> hd() |> String.upcase()
+          send(test_pid, {ref, verb})
+        end
+      end,
+      nil
+    )
+
+    result = fun.()
+    :telemetry.detach(handler_id)
+    {result, drain_verbs(ref, %{})}
+  end
+
+  defp drain_verbs(ref, acc) do
+    receive do
+      {^ref, verb} -> drain_verbs(ref, Map.update(acc, verb, 1, &(&1 + 1)))
+    after
+      0 -> acc
     end
   end
 end


### PR DESCRIPTION
Closes #1068.

## Summary

`Provider.Vetting.save_case/1` persisted a step transition in **2N+4 queries** (16 on the 6-step individual track) where **N+1 writes / 0 reads** suffice. It fires on the hottest vetting write paths — every document approval/rejection and every Stripe Identity webhook outcome.

Two wastes removed:
- **Read-before-write per row** — `save_step!`'s `Repo.get!` existed only so the changeset diff saw changes; the mutable attrs are already in hand.
- **Trailing re-fetch** — `get!(id) |> preload(...)` re-fetched a case the caller already holds.

Design A (per-row `update_all`): write each row unconditionally keyed by id, bump `updated_at` explicitly (`update_all` does not touch timestamps), return the in-hand case.

| | Before | After |
|---|---|---|
| Queries (N=6) | 2N+4 = 16 | N+1 = 7 |
| Reads | 9 | 0 |
| Writes | 7 | 7 |

Contract (`{:ok, VettingCase.t()} \| {:error, term()}`) unchanged. No migration. Change confined to Provider context.

## Review focus

- **Return-value consumer:** the issue claimed all callers discard the return via `{:ok, _}`; `SubmitCommunityAgreement` actually feeds it to `verify_if_complete/3` → `verified?/1`. Safe because `verified?` is an order-agnostic `Enum.all?` over the in-memory steps, and the returned case keeps its steps loaded. Pinned by a test.
- **Timestamps:** `update_all` skips `updated_at`; set explicitly. Pinned by a test.
- **Enum dumping:** `:status` / `:lifecycle` are standard `Ecto.Enum`; `update_all set:` on a schema-scoped query dumps atom→string. Round-trip test covers.

## Test plan

- New telemetry-backed **query-budget** test: asserts `SELECT: 0`, `UPDATE: length(steps)+1` — the regression guard that stops a slide back to 2N+4. (Handler gated on `self() == test_pid` because `:telemetry` handlers are process-global and would otherwise count concurrent async tests' queries.)
- New side-effect tests: `updated_at` bump; steps-loaded return satisfies `verified?/1`.
- `MIX_TEST_PARTITION=1068 mix test` → 4048 passed, 0 failed. Format/credo/warnings-as-errors clean.
