### PR TITLE
feat: capture all traces + free-tier observability uplift

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -360,7 +360,11 @@ config :opentelemetry, :resource,
 config :opentelemetry,
   span_processor: :batch,
   traces_exporter: :otlp,
-  sampler: {:parent_based, %{root: {:trace_id_ratio_based, 0.5}}}
+  # Keep every root trace (1.0). At current volume, 50% sampling discarded half the
+  # data for no benefit — the Honeycomb free tier allows 20M events/month and we are
+  # orders of magnitude under it. Reintroduce a ratio (e.g. 0.25) only once trace
+  # volume approaches that budget.
+  sampler: {:parent_based, %{root: {:trace_id_ratio_based, 1.0}}}
 
 # GDPR: Filter sensitive parameters from logs
 config :phoenix, :filter_parameters, [

--- a/docs/runbooks/fly-metrics.md
+++ b/docs/runbooks/fly-metrics.md
@@ -1,0 +1,69 @@
+# Runbook: Host & Infrastructure Metrics (Fly.io)
+
+**Purpose:** See CPU, memory, disk, and network health for the running app.
+**Cost:** Free. Fly.io includes managed Prometheus + Grafana at no extra charge.
+**Owner:** Technical founder. No app code required for host metrics.
+
+## Division of labour (which tool for what)
+
+| Question | Tool | Retention |
+|---|---|---|
+| Is a business flow failing? Who/why? (traces, errors, funnels) | **Honeycomb** (`live` env) — see the *Business Health* board | 60 days |
+| Is the host healthy? CPU/mem/disk/network | **Fly Grafana** (this runbook) | ~15 days |
+| BEAM internals (process count, run-queue, memory-by-type) | Not collected yet — see *Phase 2* below | — |
+
+Honeycomb is for **application behaviour**; Fly Grafana is for **infrastructure**. Don't
+pipe host metrics into Honeycomb — Fly already provides them free and it keeps the two
+concerns cleanly separated.
+
+## Accessing the dashboards
+
+1. Go to **https://fly-metrics.net** (managed Grafana, log in with your Fly account), **or**
+   run `fly dashboard metrics -a klass-hero-dev`.
+2. Open the built-in **"Fly Instance"** / **"Fly App"** dashboards. The Prometheus
+   datasource is pre-wired — no setup.
+3. Scope to app `klass-hero-dev`, region `fra`.
+
+## What you get out of the box (zero instrumentation)
+
+- **CPU:** `fly_instance_cpu` (+ baseline / balance / throttle — the last two matter on
+  our `shared` CPU VM; sustained throttle = we're being CPU-limited).
+- **Memory:** `fly_instance_memory_*` (total, available, cached, swap). Our VM is **1 GB**
+  (`fly.toml [[vm]]`) — watch `memory_available` trending toward zero and swap climbing.
+- **Disk:** `fly_instance_disk_*` (I/O ops).
+- **Network:** `fly_instance_net_*` (bytes/packets in/out, errors).
+- **Edge:** `fly_edge_http_responses_count`, `fly_app_concurrency`.
+
+## Important caveat — gaps are not outages
+
+`fly.toml` sets `auto_stop_machines = "suspend"` and `min_machines_running = 0`, so the
+machine **suspends when idle**. A suspended machine emits no metrics, so you'll see **gaps**
+in the CPU/mem graphs at low-traffic times. That is expected — not downtime. A real outage
+shows as failing `/health` checks (also in Fly), not merely a metric gap.
+
+## Verification (after enabling)
+
+- [ ] `fly-metrics.net` loads and shows the `klass-hero-dev` app.
+- [ ] CPU and memory panels render data for the last hour (trigger some traffic if the
+      machine was suspended).
+- [ ] Memory panel shows the 1 GB ceiling and current usage.
+
+## Phase 2 (optional, requires code) — BEAM/Elixir VM internals
+
+Fly does **not** infer BEAM internals (Erlang process count, run-queue length,
+memory-by-type, Oban queue depth). To get those into Fly Grafana for free:
+
+1. Add **PromEx** (`{:prom_ex, "~> 1.11"}`) — it ships plugins for `Beam`, `Phoenix`,
+   `Ecto`, `LiveView`, `Oban`. It exposes a Prometheus-format `/metrics` endpoint.
+2. Declare the scrape target in `fly.toml`:
+   ```toml
+   [metrics]
+     port = 4000
+     path = "/metrics"
+   ```
+   Fly auto-scrapes every 15s into the same managed Prometheus.
+
+Note the existing `KlassHeroWeb.Telemetry.periodic_measurements/0` returns `[]` — the VM
+metrics are *declared* in `metrics/0` but nothing polls/exports them. PromEx replaces that
+gap. **Deferred** until a BEAM-level problem actually surfaces; host metrics above cover
+the common "is it about to fall over" questions.


### PR DESCRIPTION
## Summary

Free-tier observability uplift. This PR carries the **code** changes; the Honeycomb board + alerts were created live via API (links below) and need no code.

**Code in this PR:**
- **Trace sampling 0.5 → 1.0** (`config/config.exs`). At current volume, head sampling discarded half the trace data for no cost benefit — free tier allows 20M events/mo and we're orders of magnitude under it. Revert to a ratio only when volume approaches the budget (noted inline).
- **`docs/runbooks/fly-metrics.md`** — how to use Fly.io's free managed Prometheus/Grafana for host CPU/mem/disk/network; the machine-suspend metric-gap caveat; optional PromEx path for BEAM VM internals (deferred).

**Created live in Honeycomb (`live` env), not in this repo:**
- 📊 Board **"Business Health — At a Glance"** — non-technical view of activity / enrollments / failures for the co-founder. `board/DP-9c115qvgE`
- 🔔 Trigger **"Error spike — investigate"** (>5 errors / 15 min, whole app).
- 🔔 Trigger **"Failed enrollment — revenue path"** (any error in Enrollment context).
- Both wired to the existing email recipient. Free tier caps at 2 triggers — both slots used.

## Why

Gaps before: no business-process dashboard for the non-technical partner; no recurring-problem alerting; host/BEAM health declared in `telemetry.ex` but never collected. SLOs would need Honeycomb Pro ($150+/mo) — substituted with the 2 free triggers.

## Review focus

- Sampling value is the only runtime-behaviour change. Verify it's acceptable to keep 100% of traces (doubles ingest; still far under free tier).
- Runbook is docs-only.

## Test plan

- `MIX_TEST_PARTITION=obs mix precommit` → **4049 passed, 0 failures**.
- Board: open `board/DP-9c115qvgE` in Honeycomb `live`, confirm panels return data over 30d.
- Triggers: both show "Not Triggered" (no current breach); thresholds validated against 30d data.
- Fly: follow `docs/runbooks/fly-metrics.md` to confirm `fly-metrics.net` shows CPU/mem for `klass-hero-dev`.

## Follow-ups (deferred)
- BEAM VM internals via PromEx (`telemetry.ex` `periodic_measurements` is currently `[]`).
- Real SLOs / burn alerts require Honeycomb Pro.