### PR TITLE
feat: add prod-watch proactive prod-issue loop

### DIFF
--- a/.claude/rules/skills.md
+++ b/.claude/rules/skills.md
@@ -107,6 +107,12 @@ Diagnoses a production issue end-to-end: Honeycomb for the error shape, the prod
 
 **Use when:** `/analyze-prod-issue "<symptom>"`
 
+### prod-watch
+
+Proactive counterpart to `analyze-prod-issue`. Sweeps the prod `error_tracker` (via `bin/prod-db`) + Honeycomb for issues newly active since a stored watermark, dedups on error_tracker's native `fingerprint`, diagnoses survivors through `/analyze-prod-issue`, then **auto-files** a `bug` + `priority:high` issue per real user-blocker and notifies. Runs unattended on a 12h launchd schedule (`docs/runbooks/prod-watch-scheduling.md`) or by hand.
+
+**Use when:** `/prod-watch`
+
 ## Custom Agents (in `.claude/agents/`)
 
 ### architecture-reviewer

--- a/.claude/skills/prod-watch/SKILL.md
+++ b/.claude/skills/prod-watch/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: prod-watch
+description: >-
+  Proactive prod-issue sweep. Discover what's new/worst since the last watermark,
+  diagnose each via /analyze-prod-issue, auto-file a bug + priority:high issue, and
+  notify. Runs unattended on a 12h schedule (launchd) or by hand. Invoke with: /prod-watch
+disable-model-invocation: true
+---
+
+# Prod Watch
+
+Proactively find production issues instead of waiting for a reported symptom. Each run does a
+**sweep** for what's newly broken since the last **watermark**, diagnoses the survivors with the
+existing `/analyze-prod-issue` workflow, auto-files a scrubbed `bug` + `priority:high` issue for
+each real user-blocker, and notifies you it's ready to pick up.
+
+**Type:** Rigid workflow. Follow steps exactly.
+
+**Prerequisite:** read-only prod DB access (`bin/prod-db`) and the Honeycomb MCP session must be
+live — same as `/analyze-prod-issue`. If `bin/prod-db --check` fails, see
+`docs/runbooks/prod-db-access.md`.
+
+The exact sweep SQL, the Honeycomb scan, and the issue-body template are in
+`references/sweep.md` — read it when a step says to.
+
+---
+
+## Step 1 — Read the watermark
+
+Read `.prod-watch/state.json` for `last_run_at` (the **watermark**) and `filed_fingerprints` (the
+error_tracker `fingerprint`s already filed). If the file is absent (first run), set the watermark
+to now − 12h and treat `filed_fingerprints` as empty.
+
+**Done when:** you hold a watermark timestamp and the set of already-filed fingerprints.
+
+## Step 2 — Sweep for candidates
+
+Run the sweep from `references/sweep.md`:
+
+- **prod DB** — `error_tracker_errors` where `last_occurrence_at > watermark`,
+  `status = 'unresolved'` (error_tracker's live status — there is no `'open'`), `NOT muted`, joined
+  for an occurrence count, ranked by count descending.
+- **Honeycomb** — the `error=true` scan over the 12h window for funnel drops the DB won't show
+  (an entry span with many mounts but its terminal action near zero).
+
+**Done when:** you have a ranked candidate list, each with its `fingerprint`, `kind`,
+`source_function`, and occurrence count.
+
+## Step 3 — Dedup
+
+Drop any candidate whose `fingerprint` is in `filed_fingerprints`. As a second guard that survives
+a lost state file, also run `gh issue list --search "<fingerprint>" --state open` and drop
+candidates that already have an open issue. Apply the re-alert predicate in `references/sweep.md`
+(a resolved-then-recurring error should re-alert; a still-open known one should not). Cap the
+survivors to the top **3** by occurrence count.
+
+**Done when:** a deduped candidate list of at most 3 remains (may be empty — then jump to Step 6).
+
+## Step 4 — Diagnose each (delegate)
+
+For each surviving candidate, run the full `/analyze-prod-issue` workflow, using the candidate's
+error (`kind` + `source_function` + `reason`) as the symptom. Do **not** restate diagnosis here —
+`/analyze-prod-issue` owns it. Its Step 6 honest-scoping is the quality gate: a candidate it
+demotes to "noise / not a user-blocker" is **dropped, not filed**.
+
+**Done when:** each candidate has either a real-blocker diagnosis (root cause + count-scoped impact
++ fix direction) or a "dropped as noise" verdict.
+
+## Step 5 — File (auto)
+
+For each candidate that survived as a real blocker, create the issue directly (the loop is
+unattended — do not route through `/create-issue`, whose confirmation gate cannot run here):
+
+```bash
+gh issue create --label "bug,priority:high" --assignee MaxPayne89 \
+  --title "[BUG] <one-line symptom>" \
+  --body "$(cat <<'EOF'
+<body from references/sweep.md template>
+EOF
+)"
+```
+
+The body carries the fingerprint marker `<!-- prod-watch-fingerprint: <fp> -->` so the next
+sweep can dedup on it. **Count + opaque UUID only — never names or emails** (the repo is public;
+inherit the PII rule from `/analyze-prod-issue`).
+
+**Done when:** each real blocker has an issue URL, or is recorded as dropped-noise.
+
+## Step 6 — Notify + advance the watermark
+
+Send one `PushNotification` per filed issue: `prod-watch filed #NNN: <one-line>`. If nothing was
+filed, send none. Then write `.prod-watch/state.json` with `last_run_at = now` and
+`filed_fingerprints` extended by every fingerprint filed this run. Advance the watermark even on a
+clean sweep, so the next run starts from now.
+
+**Done when:** notifications sent (or none needed) and `state.json` is written with the advanced
+watermark.
+
+---
+
+## Rules
+
+- **Auto-file only what survives honest scoping.** An erroring or discarded Oban job is not a
+  filed issue — `/analyze-prod-issue` Step 6 must confirm a real user-blocker first.
+- **Count, never names.** PII stays in the DB; issues get counts and UUIDs. GitHub edit history
+  is public — scrubbing after the fact means deleting the issue.
+- **Dedup on the error_tracker `fingerprint`**, not on title text. Re-alert only when a known
+  error recurs after its prior issue was closed (see the re-alert predicate in
+  `references/sweep.md`).
+- **Read-only prod always** — reach production only through `bin/prod-db` (SELECT-only `reader`).
+- **The watermark is the single cursor.** Never re-scan below it; never file a fingerprint twice.

--- a/.claude/skills/prod-watch/references/sweep.md
+++ b/.claude/skills/prod-watch/references/sweep.md
@@ -1,0 +1,104 @@
+# prod-watch sweep recipes
+
+The exact queries and template for `/prod-watch`. Read when a step points here. Builds on
+`analyze-prod-issue/references/cookbook.md` (schemas + Honeycomb recipes); this file adds only the
+since-`watermark` sweep that the cookbook lacks.
+
+`error_tracker_errors` columns used: `id, kind, reason, source_function, status, fingerprint,
+last_occurrence_at, muted`. The `fingerprint` column is error_tracker's own stable dedup key —
+prod-watch dedups on it, never invents one.
+
+---
+
+## Sweep SQL (Step 2)
+
+Ranked list of errors newly active since the watermark. `$WATERMARK` is `last_run_at` from
+`state.json` (ISO-8601). Run via `bin/prod-db -c "<SQL>"`.
+
+```sql
+select e.fingerprint,
+       e.kind,
+       e.source_function,
+       left(e.reason, 90)                          as reason,
+       e.status,
+       count(o.id)                                 as occurrences,
+       to_char(e.last_occurrence_at,'MM-DD HH24:MI') as last_seen
+  from error_tracker_errors e
+  join error_tracker_occurrences o on o.error_id = e.id
+ where e.last_occurrence_at > '$WATERMARK'
+   and e.status = 'unresolved'   -- error_tracker's live status (there is no 'open')
+   and e.muted = false
+ group by e.id, e.fingerprint, e.kind, e.source_function, e.reason, e.status,
+          e.last_occurrence_at
+ order by occurrences desc;
+```
+
+## Re-alert predicate (Step 3)
+
+Given the sweep rows and `filed_fingerprints` from `state.json`, decide which **already-filed**
+fingerprints deserve a *fresh* issue anyway (a recurrence after resolution) versus which to stay
+quiet on (a still-open error we already reported). This is the alerting-idempotency call — too
+loose spams duplicate issues, too tight swallows a real regression.
+
+Anchor "recurrence" to the human-meaningful event — **the issue we filed was closed, yet the error
+is back** — rather than to extra persisted counters. Every sweep row is already `status = 'unresolved'
+AND muted = false` (the sweep query enforces it), so the only question left is the issue's state.
+Apply this rule to each candidate:
+
+| Candidate | Prior open issue? (`gh issue list --search "<fp>" --state open`) | Action |
+|---|---|---|
+| `fingerprint` NOT in `filed_fingerprints`, no open issue | — | **File** (new) |
+| in `filed_fingerprints`, an open issue exists | yes | **Drop** — still being worked |
+| in `filed_fingerprints`, no open issue | no (prior issue was closed) | **Re-file** — recurrence after a supposed fix |
+
+A `muted` error never reaches this table — muting is an explicit "stop telling me," and the sweep
+excludes it. This keeps `state.json` to just the watermark + fingerprint set: recurrence detection
+borrows the closed-issue signal from GitHub, needing no per-fingerprint count baseline.
+
+## Honeycomb scan (Step 2, funnel drops)
+
+The DB misses symptoms that aren't exceptions (a booking funnel that quietly drops). Same
+`run_query` recipe as the cookbook, pointed at the sweep window:
+
+```
+mcp__honeycomb__run_query
+  environment_slug: "live"
+  dataset_slug: "klass-hero"
+  query_spec:
+    calculations: [{ "op": "COUNT" }]
+    filters:      [{ "column": "error", "op": "=", "value": true }]
+    breakdowns:   ["name"]
+    orders:       [{ "op": "COUNT", "order": "descending" }]
+    time_range:   43200        # 12h in seconds
+```
+
+Cross-check the top spans here against the SQL sweep — a span erroring in Honeycomb with no
+matching `error_tracker` row is itself worth a candidate.
+
+## Issue-body template (Step 5)
+
+Count-only, fingerprint-marked. Fill the angle-bracket slots from the `/analyze-prod-issue`
+diagnosis.
+
+```markdown
+<!-- prod-watch-fingerprint: <fp> -->
+
+**Auto-filed by `/prod-watch`** — sweep of <window>.
+
+## Symptom
+<one-paragraph: what's failing, from the error kind + source_function>
+
+## Impact (honest scope)
+<N> users affected (of <population>). <noise-vs-blocker note from analyze-prod-issue Step 6.>
+Occurrences since watermark: <count>. Oban disposition: <retryable | discard | n/a>.
+
+## Root cause
+<the raised error + the real reason from error_tracker_occurrences.context>
+
+## Fix direction
+<concrete files>. On `main`: <fixed | still-present | live-vs-main deploy lag>.
+
+## References
+- error_tracker fingerprint: `<fp>`
+- affected entities: <opaque UUIDs only — no names/emails>
+```

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,9 @@ npm-debug.log
 # Local-only test-drive reports
 .test-drive-reports/
 
+# prod-watch runtime state (watermark + filed fingerprints + logs)
+.prod-watch/
+
 # Local debug artefacts (do not commit)
 /*.png
 .playwright-mcp/

--- a/bin/prod-watch
+++ b/bin/prod-watch
@@ -15,7 +15,8 @@ set -euo pipefail
 
 # --- env plumbing (launchd gives us almost nothing) ---
 export HOME="${HOME:-/Users/maximilianpergl}"
-export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:${PATH:-}"
+# $HOME/.local/bin holds `claude`; /opt/homebrew/bin holds gh/fly/psql. launchd gives us neither.
+export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:${PATH:-}"
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 LOG_DIR="$REPO_DIR/.prod-watch/log"

--- a/bin/prod-watch
+++ b/bin/prod-watch
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# prod-watch — scheduler entrypoint for the proactive prod-issue sweep.
+#
+# launchd starts jobs with a stripped environment (no PATH, no HOME), so `fly`,
+# `psql`, `gh`, and `claude` won't resolve unless we set them here. This wrapper
+# isolates that env plumbing + a fast-fail auth preflight, then hands off to the
+# /prod-watch skill. See docs/runbooks/prod-watch-scheduling.md.
+#
+# Usage:
+#   bin/prod-watch            # preflight, then run the sweep via claude -p
+#   bin/prod-watch --check    # verify prereqs only (no sweep)
+
+set -euo pipefail
+
+# --- env plumbing (launchd gives us almost nothing) ---
+export HOME="${HOME:-/Users/maximilianpergl}"
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:${PATH:-}"
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOG_DIR="$REPO_DIR/.prod-watch/log"
+mkdir -p "$LOG_DIR"
+
+err() { printf '\033[0;31m✗ %s\033[0m\n' "$1" >&2; }
+
+# --- preflight: the two things that silently break a scheduled run ---
+command -v claude >/dev/null 2>&1 || { err "claude CLI not on PATH"; exit 1; }
+command -v gh     >/dev/null 2>&1 || { err "gh CLI not on PATH"; exit 1; }
+# bin/prod-db --check verifies fly auth + psql; its message tells you to re-run fly auth login.
+"$REPO_DIR/bin/prod-db" --check
+
+if [[ "${1:-}" == "--check" ]]; then
+  printf '\033[0;32m✓ prod-watch ready\033[0m\n'
+  exit 0
+fi
+
+exec claude -p "/prod-watch"

--- a/docs/runbooks/prod-watch-scheduling.md
+++ b/docs/runbooks/prod-watch-scheduling.md
@@ -40,7 +40,8 @@ runs `bin/prod-db --check` as a fast-fail preflight so this surfaces clearly in 
      <key>EnvironmentVariables</key>
      <dict>
        <key>HOME</key><string>/Users/maximilianpergl</string>
-       <key>PATH</key><string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+       <!-- ~/.local/bin holds `claude`; /opt/homebrew/bin holds gh/fly/psql -->
+       <key>PATH</key><string>/Users/maximilianpergl/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
      </dict>
      <key>StartInterval</key>    <integer>43200</integer> <!-- 12h -->
      <key>RunAtLoad</key>        <false/>

--- a/docs/runbooks/prod-watch-scheduling.md
+++ b/docs/runbooks/prod-watch-scheduling.md
@@ -1,0 +1,85 @@
+# Runbook: Scheduling `prod-watch` (on-machine / launchd)
+
+`/prod-watch` sweeps prod for new issues, diagnoses them via `/analyze-prod-issue`, and auto-files
+a `bug` + `priority:high` issue per real user-blocker. This runbook schedules it to run every 12h
+on your Mac, unattended.
+
+**Why on-machine (Path 1):** the sweep reaches prod through `bin/prod-db` (`fly mpg connect`) and
+the Honeycomb MCP session — both authenticated interactively in *your* login. A launchd agent runs
+as you and inherits `~/.fly/config.yml`, so **no headless token is needed**. See
+`docs/runbooks/prod-db-access.md` for the prod-DB half.
+
+## The one real gotcha: launchd's stripped environment
+
+launchd starts jobs with almost no environment — no `PATH`, no guaranteed `HOME`. A run that works
+in your terminal fails under launchd as `fly: command not found` or "can't find `~/.fly/config.yml`",
+which *reads* like an auth failure but is an env failure. `bin/prod-watch` sets `HOME`/`PATH` and
+runs `bin/prod-db --check` as a fast-fail preflight so this surfaces clearly in the log.
+
+## Install
+
+1. Preflight by hand first (proves auth + PATH before scheduling):
+
+   ```bash
+   bin/prod-watch --check
+   ```
+
+2. Create `~/Library/LaunchAgents/com.klasshero.prod-watch.plist`:
+
+   ```xml
+   <?xml version="1.0" encoding="UTF-8"?>
+   <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+     "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+   <plist version="1.0">
+   <dict>
+     <key>Label</key>            <string>com.klasshero.prod-watch</string>
+     <key>ProgramArguments</key>
+     <array>
+       <string>/Users/maximilianpergl/Projects/klass-hero/bin/prod-watch</string>
+     </array>
+     <key>EnvironmentVariables</key>
+     <dict>
+       <key>HOME</key><string>/Users/maximilianpergl</string>
+       <key>PATH</key><string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+     </dict>
+     <key>StartInterval</key>    <integer>43200</integer> <!-- 12h -->
+     <key>RunAtLoad</key>        <false/>
+     <key>StandardOutPath</key>  <string>/Users/maximilianpergl/Projects/klass-hero/.prod-watch/log/out.log</string>
+     <key>StandardErrorPath</key><string>/Users/maximilianpergl/Projects/klass-hero/.prod-watch/log/err.log</string>
+   </dict>
+   </plist>
+   ```
+
+3. Load it:
+
+   ```bash
+   launchctl load ~/Library/LaunchAgents/com.klasshero.prod-watch.plist
+   launchctl list | grep prod-watch          # confirm it's registered
+   ```
+
+## Verify the scheduled env (the Path-1 risk)
+
+Force a run and read the log — this is the check that `fly`/`psql`/`gh`/`claude` all resolve under
+launchd's stripped env, not just in your shell:
+
+```bash
+launchctl start com.klasshero.prod-watch
+tail -f .prod-watch/log/out.log .prod-watch/log/err.log
+```
+
+A clean run ends with the preflight `✓` and either filed-issue notifications or a clean sweep.
+
+## Manage
+
+```bash
+launchctl unload ~/Library/LaunchAgents/com.klasshero.prod-watch.plist   # stop scheduling
+launchctl start com.klasshero.prod-watch                                 # run now, on demand
+```
+
+`StartInterval` fires 12h after load and every 12h thereafter (missed runs while the Mac is asleep
+coalesce into one on wake). Nothing runs while the machine is off — the accepted cost of Path 1.
+
+## When auth lapses
+
+If you `fly auth logout` or the login token expires, the next run fails at the `bin/prod-db --check`
+preflight and logs the fix. Re-run `fly auth login`; no plist change needed.


### PR DESCRIPTION
## Summary

Adds `/prod-watch` — a scheduled, proactive counterpart to `/analyze-prod-issue`. Every 12h it **sweeps** the prod `error_tracker` + Honeycomb for issues newly active since a stored **watermark**, dedups on error_tracker's native `fingerprint`, diagnoses survivors through `/analyze-prod-issue`, then **auto-files** a `bug` + `priority:high` issue per real user-blocker and notifies.

Runs **on-machine** (launchd): the agent inherits the interactive `fly` + Honeycomb login, so no headless token is needed. `bin/prod-watch` isolates the one real gotcha — launchd's stripped env — behind explicit `HOME`/`PATH` + a `fly auth` preflight.

## Review focus

- **Auto-file, unattended** — the loop creates issues with no human in the loop. Quality gate is `/analyze-prod-issue`'s honest-scoping (an erroring Oban job ≠ a filed issue); PII rule is inherited (count + UUID only, never names — repo is public).
- **Re-alert without extra state** — a filed fingerprint only re-fires if its prior GitHub issue was *closed* yet the error recurred. Recurrence detection borrows GitHub's closed-issue signal instead of persisting occurrence baselines, keeping `state.json` to `{last_run_at, filed_fingerprints}`.
- **`/create-issue` is deliberately NOT reused** — its hard confirmation gate can't run unattended; prod-watch does its own `gh issue create`, reusing only its label conventions.

## Test plan

- [x] Dry sweep against live prod (read-only, stopped before filing) — watermark logic, preflight, sweep + ranking all verified.
- [x] **Bug caught by the dry run**: sweep filtered `status='open'`, but `error_tracker` only uses `unresolved`/`resolved` — the loop would have matched zero rows forever while looking healthy. Fixed to `status='unresolved'`.
- [x] launchd install + forced run (verifies `fly`/`psql`/`gh`/`claude` resolve under stripped env) — done locally after merge per `docs/runbooks/prod-watch-scheduling.md`.

## Out of scope (follow-ups)

- Cloud/headless (Path 2) — deferred until on-machine proves the triage+dedup logic; a `fly tokens create readonly` + Honeycomb-API-key spike.
- Auto-writing fix PRs — the loop stops at fix *direction*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)