### PR TITLE
fix: pin prod-watch scheduler to a self-updating worktree

### DIFF
--- a/bin/prod-watch
+++ b/bin/prod-watch
@@ -24,6 +24,16 @@ mkdir -p "$LOG_DIR"
 
 err() { printf '\033[0;31m✗ %s\033[0m\n' "$1" >&2; }
 
+# --- self-update (pinned worktree only) ---
+# The scheduler runs from a dedicated worktree that must always execute canonical main.
+# Guarded by PROD_WATCH_SELF_UPDATE (set only in the launchd plist) so a manual run from the
+# primary tree — likely on a feature branch — never `reset --hard`s away uncommitted work.
+# .prod-watch/ (watermark + logs) is gitignored/untracked, so it survives the reset.
+if [[ "${PROD_WATCH_SELF_UPDATE:-}" == 1 ]]; then
+  git -C "$REPO_DIR" fetch origin main -q
+  git -C "$REPO_DIR" reset --hard FETCH_HEAD -q
+fi
+
 # --- preflight: the two things that silently break a scheduled run ---
 command -v claude >/dev/null 2>&1 || { err "claude CLI not on PATH"; exit 1; }
 command -v gh     >/dev/null 2>&1 || { err "gh CLI not on PATH"; exit 1; }
@@ -35,4 +45,7 @@ if [[ "${1:-}" == "--check" ]]; then
   exit 0
 fi
 
+# cd into the repo so `claude -p` discovers the project's .claude/skills/ — launchd starts jobs
+# with cwd=/, where the prod-watch skill is invisible.
+cd "$REPO_DIR"
 exec claude -p "/prod-watch"

--- a/docs/runbooks/prod-watch-scheduling.md
+++ b/docs/runbooks/prod-watch-scheduling.md
@@ -9,19 +9,42 @@ the Honeycomb MCP session — both authenticated interactively in *your* login. 
 as you and inherits `~/.fly/config.yml`, so **no headless token is needed**. See
 `docs/runbooks/prod-db-access.md` for the prod-DB half.
 
-## The one real gotcha: launchd's stripped environment
+## Two gotchas the setup is built around
 
-launchd starts jobs with almost no environment — no `PATH`, no guaranteed `HOME`. A run that works
-in your terminal fails under launchd as `fly: command not found` or "can't find `~/.fly/config.yml`",
-which *reads* like an auth failure but is an env failure. `bin/prod-watch` sets `HOME`/`PATH` and
-runs `bin/prod-db --check` as a fast-fail preflight so this surfaces clearly in the log.
+1. **launchd's stripped environment** — jobs start with almost no environment (no `PATH`, no
+   guaranteed `HOME`, cwd `/`). A run that works in your terminal fails under launchd as
+   `fly: command not found`, "can't find `~/.fly/config.yml`", or a skill-not-found — all of which
+   *read* like other failures but are env failures. `bin/prod-watch` sets `HOME`/`PATH`, `cd`s into
+   its repo (so `claude` discovers `.claude/skills/`), and runs `bin/prod-db --check` as a fast-fail
+   preflight so this surfaces clearly in the log.
+2. **Branch coupling** — launchd runs whatever is *checked out* at the wrapper's path when the
+   timer fires. Pointed at your primary working tree (which branch-switches), a scheduled sweep
+   could run stale or unrelated code. Fix: a **dedicated worktree pinned to `main`** that
+   self-updates each run.
+
+## Pinned worktree (the stable checkout the scheduler runs from)
+
+The scheduler runs from its own source-only worktree, never your primary tree:
+
+```bash
+git worktree add --detach ~/Projects/klass-hero-prod-watch origin/main
+```
+
+- `--detach` because `main` is already checked out in your primary tree (git forbids the same
+  branch in two worktrees). The wrapper's self-update (`fetch` + `reset --hard FETCH_HEAD`, gated on
+  `PROD_WATCH_SELF_UPDATE=1` set only in the plist) advances this detached HEAD to canonical `main`
+  every run — so scheduled sweeps are independent of whatever your primary tree is doing.
+- **Source-only — no `mix deps.get`/compile/test DB.** `/prod-watch` runs SQL via `bin/prod-db`
+  (a `fly` proxy, no mix) + Honeycomb + `gh`; none need the app compiled.
+- **Machine-owned — never edit this tree by hand.** The self-update `reset --hard`s it every run;
+  local edits would be wiped. `.prod-watch/` (watermark + logs) is gitignored, so it survives.
 
 ## Install
 
-1. Preflight by hand first (proves auth + PATH before scheduling):
+1. Preflight by hand first (proves auth + PATH + cwd before scheduling):
 
    ```bash
-   bin/prod-watch --check
+   ~/Projects/klass-hero-prod-watch/bin/prod-watch --check
    ```
 
 2. Create `~/Library/LaunchAgents/com.klasshero.prod-watch.plist`:
@@ -35,18 +58,20 @@ runs `bin/prod-db --check` as a fast-fail preflight so this surfaces clearly in 
      <key>Label</key>            <string>com.klasshero.prod-watch</string>
      <key>ProgramArguments</key>
      <array>
-       <string>/Users/maximilianpergl/Projects/klass-hero/bin/prod-watch</string>
+       <string>/Users/maximilianpergl/Projects/klass-hero-prod-watch/bin/prod-watch</string>
      </array>
      <key>EnvironmentVariables</key>
      <dict>
        <key>HOME</key><string>/Users/maximilianpergl</string>
        <!-- ~/.local/bin holds `claude`; /opt/homebrew/bin holds gh/fly/psql -->
        <key>PATH</key><string>/Users/maximilianpergl/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+       <!-- authorizes the wrapper's self-update; set ONLY here, never in the primary tree -->
+       <key>PROD_WATCH_SELF_UPDATE</key><string>1</string>
      </dict>
      <key>StartInterval</key>    <integer>43200</integer> <!-- 12h -->
      <key>RunAtLoad</key>        <false/>
-     <key>StandardOutPath</key>  <string>/Users/maximilianpergl/Projects/klass-hero/.prod-watch/log/out.log</string>
-     <key>StandardErrorPath</key><string>/Users/maximilianpergl/Projects/klass-hero/.prod-watch/log/err.log</string>
+     <key>StandardOutPath</key>  <string>/Users/maximilianpergl/Projects/klass-hero-prod-watch/.prod-watch/log/out.log</string>
+     <key>StandardErrorPath</key><string>/Users/maximilianpergl/Projects/klass-hero-prod-watch/.prod-watch/log/err.log</string>
    </dict>
    </plist>
    ```
@@ -65,10 +90,13 @@ launchd's stripped env, not just in your shell:
 
 ```bash
 launchctl start com.klasshero.prod-watch
-tail -f .prod-watch/log/out.log .prod-watch/log/err.log
+tail -f ~/Projects/klass-hero-prod-watch/.prod-watch/log/out.log \
+        ~/Projects/klass-hero-prod-watch/.prod-watch/log/err.log
 ```
 
-A clean run ends with the preflight `✓` and either filed-issue notifications or a clean sweep.
+A clean run ends with the preflight `✓` and either filed-issue notifications or a clean sweep. To
+prove branch-independence, check out any old branch in your *primary* tree first — the run still
+executes `main`'s skill from the pinned worktree.
 
 ## Manage
 


### PR DESCRIPTION
## Summary

Follow-up to #1092. The launchd agent runs `bin/prod-watch` from a **fixed path** — and executes whatever is checked out there when the 12h timer fires. Pointed at the primary tree (which branch-switches), a scheduled sweep could run stale or unrelated code. This makes a **dedicated worktree pinned to `main`** safe and correct via two wrapper fixes.

## Review focus

- **Latent cwd bug (would have hit on first fire)** — the wrapper ran `exec claude -p` with no `cd`. Under launchd (cwd `/`), Claude can't discover `.claude/skills/`, so the skill isn't found. Interactive tests passed only because they ran from the repo dir. Fixed with `cd "$REPO_DIR"`.
- **Guarded self-update** — `fetch` + `reset --hard FETCH_HEAD`, gated on `PROD_WATCH_SELF_UPDATE` (set only in the plist). The pinned worktree advances to canonical `main` each run; a manual run from the primary tree (likely a feature branch) never resets. **The guard is safety-critical** — unguarded, a hand-run from the primary tree would obliterate uncommitted work. `.prod-watch/` is gitignored/untracked and survives the reset.

## Test plan

- [x] `bash -n` parses.
- [x] Guard OFF (no env var) under stripped env (`env -i`): `--check` runs preflight, branch stays put — no self-reset.
- [ ] Post-merge (Phase B, local): create `~/Projects/klass-hero-prod-watch` worktree, repoint plist, verify skill discovery from cwd + self-update fast-forwards to `main` + branch-independence (old branch in primary tree, scheduled run still executes `main`).

## Notes

- The worktree is **source-only** — no `mix deps.get`/compile/test DB, since `/prod-watch` runs SQL via `bin/prod-db` (a `fly` proxy) + Honeycomb + `gh`, none of which need the app compiled.
- Runbook updated with the pinned-worktree model + machine-owned caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)