### PR TITLE
feat: grant prod-watch a least-privilege headless allowlist

### DIFF
--- a/bin/prod-watch
+++ b/bin/prod-watch
@@ -45,7 +45,13 @@ if [[ "${1:-}" == "--check" ]]; then
   exit 0
 fi
 
+# Least-privilege allowlist: a headless `claude -p` has no human to approve tool prompts, so every
+# tool the loop uses must be pre-granted or it dead-ends. This is exactly the loop's surface — prod
+# reads (bin/prod-db), Honeycomb reads, code anchoring (Read/Grep/Glob), issue dedup+file (gh), the
+# watermark write (.prod-watch/), and the notify. Anything outside this list still fails closed.
+ALLOWED_TOOLS="Bash(bin/prod-db:*),Bash(./bin/prod-db:*),Bash(gh issue list:*),Bash(gh issue create:*),mcp__honeycomb__*,Read,Grep,Glob,Write(.prod-watch/**),PushNotification"
+
 # cd into the repo so `claude -p` discovers the project's .claude/skills/ — launchd starts jobs
 # with cwd=/, where the prod-watch skill is invisible.
 cd "$REPO_DIR"
-exec claude -p "/prod-watch"
+exec claude -p --allowedTools "$ALLOWED_TOOLS" "/prod-watch"

--- a/docs/runbooks/prod-watch-scheduling.md
+++ b/docs/runbooks/prod-watch-scheduling.md
@@ -21,6 +21,12 @@ as you and inherits `~/.fly/config.yml`, so **no headless token is needed**. See
    timer fires. Pointed at your primary working tree (which branch-switches), a scheduled sweep
    could run stale or unrelated code. Fix: a **dedicated worktree pinned to `main`** that
    self-updates each run.
+3. **No approver for tool prompts** — a headless `claude -p` can't ask a human to approve tools, so
+   every tool the loop touches must be pre-granted or it dead-ends mid-sweep. Inherited *credentials*
+   are not inherited *permissions*. The wrapper passes a **least-privilege `--allowedTools`** list —
+   exactly the loop's surface (`bin/prod-db` reads, `mcp__honeycomb__*`, `Read/Grep/Glob`,
+   `gh issue list`/`create`, `Write(.prod-watch/**)`, `PushNotification`). Anything else fails
+   closed by design; add to `ALLOWED_TOOLS` in `bin/prod-watch` only when the skill grows a new tool.
 
 ## Pinned worktree (the stable checkout the scheduler runs from)
 


### PR DESCRIPTION
## Summary

Third and final gap in the `/prod-watch` autonomy chain (after #1092 scaffold, #1093 pinned worktree). A scheduled `claude -p` has no human to approve tool prompts, so a forced run dead-ended at Step 2 — both `bin/prod-db` and `mcp__honeycomb__*` came back "requires permission". Inherited *credentials* are not inherited *permissions*.

The wrapper now passes an explicit least-privilege `--allowedTools` list. Everything outside it still fails closed.

## The grant (exactly the loop's surface)

`Bash(bin/prod-db:*)`, `Bash(./bin/prod-db:*)`, `Bash(gh issue list:*)`, `Bash(gh issue create:*)`, `mcp__honeycomb__*`, `Read`, `Grep`, `Glob`, `Write(.prod-watch/**)`, `PushNotification`

## Review focus

- **Least-privilege, not skip-permissions** — deliberately chosen over `--dangerously-skip-permissions` given prod credentials + auto-file to a public repo. A diagnosis step (or a prompt-injected error payload) that reaches for anything off-list dead-ends instead of executing.
- **`gh issue create` is the one write with real blast radius** — bounded by the skill's honest-scoping + count-only PII rule, and the grant is command-scoped (`gh issue create:*`), not blanket `Bash`.
- **Maintenance note** — if the skill grows a new tool, it must be added to `ALLOWED_TOOLS` in `bin/prod-watch` or it'll silently dead-end.

## What's proven vs pending

- [x] Forced run confirmed skill discovery (cwd fix), self-update, preflight, and that Honeycomb MCP is present headless.
- [ ] The allowlist itself is verified on the **first real run** (self-hosted trigger or the 12h timer). It is not verified by execution in this PR by design — the autonomous headless loop shouldn't be self-launched during review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)