### PR TITLE
fix: feed prod-watch prompt via stdin so --allowedTools doesn't eat it

### DIFF
--- a/bin/prod-watch
+++ b/bin/prod-watch
@@ -54,4 +54,7 @@ ALLOWED_TOOLS="Bash(bin/prod-db:*),Bash(./bin/prod-db:*),Bash(gh issue list:*),B
 # cd into the repo so `claude -p` discovers the project's .claude/skills/ — launchd starts jobs
 # with cwd=/, where the prod-watch skill is invisible.
 cd "$REPO_DIR"
-exec claude -p --allowedTools "$ALLOWED_TOOLS" "/prod-watch"
+# The prompt goes via stdin, not as a positional arg: --allowedTools is variadic (<tools...>) and
+# would otherwise swallow "/prod-watch" as another tool name, leaving no prompt ("Input must be
+# provided"). stdin is unambiguous.
+exec claude -p --allowedTools "$ALLOWED_TOOLS" <<< "/prod-watch"


### PR DESCRIPTION
## Summary

Follow-up to #1094. That PR added `--allowedTools "$LIST"` before the `/prod-watch` positional — but `--allowedTools` is **variadic** (`<tools...>`), so it swallowed `/prod-watch` as another tool name, leaving no prompt. The scheduled run died immediately with `Input must be provided either through stdin or as a prompt argument when using --print`.

Caught by the first real end-to-end fire after #1094 merged (`out.log` had only the preflight `✓`, `err.log` had the input error).

## Fix

Pass the prompt on **stdin** via here-string — `claude -p --allowedTools "$LIST" <<< "/prod-watch"` — so the variadic flag binds only the tool list.

## Test plan

- [x] Verified the stdin form round-trips a prompt with `--allowedTools` present (`printf ... | claude -p --allowedTools "Read,Grep"` → prompt received, not the input error).
- [x] `bash -n` parses.
- [ ] Full end-to-end fire re-run after merge + worktree sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)