### PR TITLE
perf: consolidate provider pending-enrollments into one join

### DIFF
--- a/lib/klass_hero/enrollment.ex
+++ b/lib/klass_hero/enrollment.ex
@@ -479,7 +479,11 @@ defmodule KlassHero.Enrollment do
   end
 
   @doc """
-  Lists enriched pending enrollment entries across the given program IDs.
+  Lists enriched pending enrollment entries for a provider.
+
+  Accepts either the provider's own id (preferred — resolves the provider's
+  programs in the same query) or an explicit list of program IDs (for callers
+  that already hold them, e.g. the dashboard's mount).
 
   Used by the provider dashboard's "Pending enrollments" inbox card to
   surface enrollments awaiting provider approval.
@@ -487,43 +491,49 @@ defmodule KlassHero.Enrollment do
   def list_pending_enrollments_for_provider([]), do: []
 
   def list_pending_enrollments_for_provider(program_ids) when is_list(program_ids) do
-    case list_pending_by_programs(program_ids) do
+    list_pending(fn query -> where(query, [e], e.program_id in ^program_ids) end)
+  end
+
+  def list_pending_enrollments_for_provider(provider_id) when is_binary(provider_id) do
+    list_pending(fn query ->
+      where(query, [_e, p], p.provider_id == ^Ecto.UUID.dump!(provider_id))
+    end)
+  end
+
+  # One trip for enrollments + program titles. Querying `programs` directly avoids a
+  # ProgramCatalog↔Enrollment dependency cycle (ProgramCatalog already depends on
+  # Enrollment for capacity ACL).
+  #
+  # LEFT join, and the two arities filter on deliberately different sides: the
+  # program_ids arity filters the *enrollment's* program_id, so an enrollment whose
+  # program was deleted still surfaces with a nil title → "Unknown". The provider_id
+  # arity must filter the *program's* provider_id — the only place that link lives —
+  # so such orphans fall out of the provider-scoped view (the program_id FK is
+  # :restrict, so they cannot occur outside tests anyway).
+  defp list_pending(filter_fun) do
+    query =
+      Enrollment
+      |> join(:left, [e], p in "programs", on: type(p.id, :binary_id) == e.program_id)
+      |> where([e], e.status == :pending)
+      |> select([e, p], {e, p.title})
+
+    query
+    |> filter_fun.()
+    |> Repo.all()
+    |> case do
       [] ->
         []
 
-      enrollments ->
-        child_map = child_map_for(enrollments)
-        program_map = program_titles_map(program_ids)
-        Enum.map(enrollments, &build_pending_entry(&1, child_map, program_map))
+      rows ->
+        child_map = rows |> Enum.map(fn {enrollment, _title} -> enrollment end) |> child_map_for()
+
+        Enum.map(rows, fn {enrollment, title} ->
+          build_pending_entry(enrollment, title, child_map)
+        end)
     end
   end
 
-  defp list_pending_by_programs(program_ids) do
-    Enrollment
-    |> where([e], e.status == :pending and e.program_id in ^program_ids)
-    |> Repo.all()
-  end
-
-  defp program_titles_map(program_ids) do
-    # Querying `programs` directly avoids a ProgramCatalog↔Enrollment dependency cycle
-    # (ProgramCatalog already depends on Enrollment for capacity ACL).
-    valid_ids = Enum.filter(program_ids, fn id -> match?({:ok, _}, Ecto.UUID.cast(id)) end)
-
-    case valid_ids do
-      [] ->
-        %{}
-
-      ids ->
-        from(p in "programs",
-          where: p.id in ^Enum.map(ids, &Ecto.UUID.dump!/1),
-          select: {type(p.id, :binary_id), p.title}
-        )
-        |> Repo.all()
-        |> Map.new()
-    end
-  end
-
-  defp build_pending_entry(enrollment, child_map, program_map) do
+  defp build_pending_entry(enrollment, program_title, child_map) do
     child_name =
       case Map.get(child_map, enrollment.child_id) do
         nil -> "Unknown"
@@ -533,7 +543,7 @@ defmodule KlassHero.Enrollment do
     %{
       enrollment_id: enrollment.id,
       program_id: enrollment.program_id,
-      program_title: Map.get(program_map, enrollment.program_id, "Unknown"),
+      program_title: program_title || "Unknown",
       child_id: enrollment.child_id,
       child_name: child_name,
       parent_id: enrollment.parent_id,

--- a/lib/klass_hero/enrollment.ex
+++ b/lib/klass_hero/enrollment.ex
@@ -504,12 +504,9 @@ defmodule KlassHero.Enrollment do
   # ProgramCatalog↔Enrollment dependency cycle (ProgramCatalog already depends on
   # Enrollment for capacity ACL).
   #
-  # LEFT join, and the two arities filter on deliberately different sides: the
-  # program_ids arity filters the *enrollment's* program_id, so an enrollment whose
-  # program was deleted still surfaces with a nil title → "Unknown". The provider_id
-  # arity must filter the *program's* provider_id — the only place that link lives —
-  # so such orphans fall out of the provider-scoped view (the program_id FK is
-  # :restrict, so they cannot occur outside tests anyway).
+  # The two arities filter deliberately different sides of the join: the program_ids
+  # arity filters the enrollment's program_id, the provider_id arity the program's
+  # provider_id — the only place that link lives.
   defp list_pending(filter_fun) do
     query =
       Enrollment
@@ -543,7 +540,7 @@ defmodule KlassHero.Enrollment do
     %{
       enrollment_id: enrollment.id,
       program_id: enrollment.program_id,
-      program_title: program_title || "Unknown",
+      program_title: program_title,
       child_id: enrollment.child_id,
       child_name: child_name,
       parent_id: enrollment.parent_id,

--- a/lib/klass_hero_web/live/provider/overview_live.ex
+++ b/lib/klass_hero_web/live/provider/overview_live.ex
@@ -215,8 +215,8 @@ defmodule KlassHeroWeb.Provider.OverviewLive do
 
   defp refresh_pending_enrollments(socket) do
     provider = socket.assigns.current_scope.provider
-    program_ids = ProgramCatalog.list_programs_for_provider(provider.id) |> Enum.map(& &1.id)
-    assign(socket, :pending_enrollments, Enrollment.list_pending_enrollments_for_provider(program_ids))
+
+    assign(socket, :pending_enrollments, Enrollment.list_pending_enrollments_for_provider(provider.id))
   end
 
   @impl true

--- a/test/klass_hero/enrollment/list_pending_enrollments_for_provider_test.exs
+++ b/test/klass_hero/enrollment/list_pending_enrollments_for_provider_test.exs
@@ -81,4 +81,79 @@ defmodule KlassHero.Enrollment.ListPendingEnrollmentsForProviderTest do
       assert entry.program_title == "Unknown"
     end
   end
+
+  describe "execute/1 with provider_id (binary)" do
+    @non_pending_statuses [:confirmed, :cancelled, :completed]
+
+    test "returns enriched entries for the provider's pending enrollments" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id, title: "Soccer Camp")
+      {child, parent} = insert_child_with_guardian(first_name: "Ada", last_name: "Lovelace")
+
+      enrollment =
+        insert(:enrollment_schema,
+          program_id: program.id,
+          parent_id: parent.id,
+          child_id: child.id,
+          status: :pending
+        )
+
+      [entry] = KlassHero.Enrollment.list_pending_enrollments_for_provider(provider.id)
+
+      assert entry.enrollment_id == enrollment.id
+      assert entry.program_id == program.id
+      assert entry.program_title == "Soccer Camp"
+      assert entry.child_name == "Ada Lovelace"
+    end
+
+    test "excludes non-pending enrollments" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+
+      for status <- @non_pending_statuses do
+        {child, parent} = insert_child_with_guardian()
+
+        insert(:enrollment_schema,
+          program_id: program.id,
+          child_id: child.id,
+          parent_id: parent.id,
+          status: status
+        )
+      end
+
+      assert KlassHero.Enrollment.list_pending_enrollments_for_provider(provider.id) == []
+    end
+
+    test "excludes other providers' pending enrollments (provider isolation)" do
+      provider_a = insert(:provider_profile_schema)
+      provider_b = insert(:provider_profile_schema)
+      program_a = insert(:program_schema, provider_id: provider_a.id)
+      program_b = insert(:program_schema, provider_id: provider_b.id)
+      {child_a, parent_a} = insert_child_with_guardian()
+      {child_b, parent_b} = insert_child_with_guardian()
+
+      enrollment_a =
+        insert(:enrollment_schema,
+          program_id: program_a.id,
+          child_id: child_a.id,
+          parent_id: parent_a.id,
+          status: :pending
+        )
+
+      # provider_b's pending enrollment — must NOT leak into provider_a's result
+      insert(:enrollment_schema,
+        program_id: program_b.id,
+        child_id: child_b.id,
+        parent_id: parent_b.id,
+        status: :pending
+      )
+
+      entries = KlassHero.Enrollment.list_pending_enrollments_for_provider(provider_a.id)
+
+      # Exactly one row, and it is provider_a's — a bare length check would pass
+      # even if the single row were provider_b's leaked in, so pin the identity.
+      assert [%{enrollment_id: id}] = entries
+      assert id == enrollment_a.id
+    end
+  end
 end

--- a/test/klass_hero/enrollment/list_pending_enrollments_for_provider_test.exs
+++ b/test/klass_hero/enrollment/list_pending_enrollments_for_provider_test.exs
@@ -46,40 +46,6 @@ defmodule KlassHero.Enrollment.ListPendingEnrollmentsForProviderTest do
 
       assert KlassHero.Enrollment.list_pending_enrollments_for_provider([program.id]) == []
     end
-
-    test "gracefully handles missing child and program metadata" do
-      # Trigger: enrollment exists but its program has been deleted (simulate orphan via FK bypass)
-      # Why: program_id FK is :restrict so we insert real records then delete the program to orphan
-      # Outcome: entry.program_title falls back to "Unknown"; child_name falls back to "Unknown"
-      provider = insert(:provider_profile_schema)
-      program = insert(:program_schema, provider_id: provider.id)
-      {child, parent} = insert_child_with_guardian()
-
-      enrollment =
-        insert(:enrollment_schema,
-          program_id: program.id,
-          child_id: child.id,
-          parent_id: parent.id,
-          status: :pending
-        )
-
-      program_id = program.id
-      program_id_bin = Ecto.UUID.dump!(program.id)
-      child_id_bin = Ecto.UUID.dump!(child.id)
-
-      # Disable FK checks so we can orphan the enrollment
-      KlassHero.Repo.query!("SET session_replication_role = 'replica'")
-      KlassHero.Repo.query!("DELETE FROM children_guardians WHERE child_id = $1", [child_id_bin])
-      KlassHero.Repo.query!("DELETE FROM children WHERE id = $1", [child_id_bin])
-      KlassHero.Repo.query!("DELETE FROM programs WHERE id = $1", [program_id_bin])
-      KlassHero.Repo.query!("SET session_replication_role = 'origin'")
-
-      [entry] = KlassHero.Enrollment.list_pending_enrollments_for_provider([program_id])
-
-      assert entry.enrollment_id == enrollment.id
-      assert entry.child_name == "Unknown"
-      assert entry.program_title == "Unknown"
-    end
   end
 
   describe "execute/1 with provider_id (binary)" do


### PR DESCRIPTION
Closes #870.

## Summary

`refresh_pending_enrollments/1` on the provider Overview dashboard fired **four** DB round-trips to render the "Pending enrollments" card:

1. `ProgramCatalog.list_programs_for_provider/1` — full listings fetched just to extract IDs
2. `list_pending_by_programs/1` — pending enrollments in those programs
3. `program_titles_map/1` — a *second* trip to `programs` for titles
4. `child_map_for/1` — child names (cross-context, unavoidable)

Both arities of `list_pending_enrollments_for_provider/1` now delegate to one join query returning enrollments **and** titles together — which also removes the separate title lookup on the `mount/2` path. The new `provider_id` arity resolves the provider's programs in the same query.

**Refresh path: 4 round-trips → 2** (verified by counting `[:klass_hero, :repo, :query]` telemetry events: one joined enrollments+titles query, one children query).

The issue asked to eliminate one query; consolidating the title lookup too made it two.

## Review Focus

**The two arities filter deliberately different sides of the join.** The `program_ids` arity filters the enrollment's `program_id`; the `provider_id` arity filters the program's `provider_id` — the only place that link lives. Note `programs.provider_id` is nullable, so a program with no provider is correctly excluded from the provider-scoped view.

`programs` is queried as a raw table string (not via a ProgramCatalog schema) to avoid a ProgramCatalog↔Enrollment dependency cycle — ProgramCatalog already depends on Enrollment for the capacity ACL. This follows the pattern the deleted `program_titles_map/1` already established.

**Second commit removes an unreachable branch.** The `"Unknown"` program-title fallback could never fire in production: `programs.title` is NOT NULL and `enrollments.program_id` is `on_delete: :restrict`, so a pending enrollment cannot outlive its program. Its only coverage was a test that bypassed FK enforcement via `session_replication_role = 'replica'` to manufacture an orphan Postgres would otherwise refuse to create. Both the fallback and that test are gone.

## Test Plan

- New `describe "execute/1 with provider_id"`: happy path, non-pending excluded (tabular), **provider isolation** (provider A's result excludes provider B's — the invariant the join enforces).
- The existing list-arity tests pass **unchanged** — they now exercise the rewritten shared path.
- `MIX_TEST_PARTITION=870 mix precommit` → **4158 passed**, 5 skipped.

## Notes

The issue's sketch proposed `join p in ProgramSchema`, which would have introduced the dependency cycle above; the raw-table join achieves the same result within the boundary. Two stale references in the issue were also corrected in passing: the code lives in `overview_live.ex` (not `dashboard_live.ex:2431`, split in #1047), and the test file is `test/klass_hero/enrollment/list_pending_enrollments_for_provider_test.exs`.