### PR TITLE
refactor: extract emit_domain_event LiveView test helper

### DIFF
--- a/test/klass_hero_web/live/provider/provider_dashboard_test.exs
+++ b/test/klass_hero_web/live/provider/provider_dashboard_test.exs
@@ -9,6 +9,7 @@ defmodule KlassHeroWeb.Provider.ProviderDashboardTest do
   """
   use KlassHeroWeb.ConnCase, async: true
 
+  import KlassHero.EventTestHelper
   import Phoenix.LiveViewTest
 
   alias Ecto.Adapters.SQL.Sandbox
@@ -249,8 +250,6 @@ defmodule KlassHeroWeb.Provider.ProviderDashboardTest do
       conn: conn,
       provider: provider
     } do
-      import KlassHero.EventTestHelper
-
       setup_test_integration_events()
 
       _staff =
@@ -1564,7 +1563,7 @@ defmodule KlassHeroWeb.Provider.ProviderDashboardTest do
           %{provider_id: provider.id}
         )
 
-      send(view.pid, {:domain_event, event})
+      emit_domain_event(view, event)
       _ = render(view)
 
       refute has_element?(view, "#pending-enrollment-#{enrollment.id}")
@@ -1596,7 +1595,7 @@ defmodule KlassHeroWeb.Provider.ProviderDashboardTest do
           %{provider_id: provider.id, enrollment_id: enrollment.id}
         )
 
-      send(view.pid, {:domain_event, event})
+      emit_domain_event(view, event)
       _ = render(view)
 
       refute has_element?(view, "#pending-enrollment-#{enrollment.id}")
@@ -1635,7 +1634,7 @@ defmodule KlassHeroWeb.Provider.ProviderDashboardTest do
           %{provider_id: provider.id, enrollment_id: Ecto.UUID.generate()}
         )
 
-      send(view.pid, {:domain_event, event})
+      emit_domain_event(view, event)
       _ = render(view)
 
       assert has_element?(view, "#pending-enrollment-#{unseen.id}")

--- a/test/klass_hero_web/live/provider/sessions_live_test.exs
+++ b/test/klass_hero_web/live/provider/sessions_live_test.exs
@@ -1,6 +1,7 @@
 defmodule KlassHeroWeb.Provider.SessionsLiveTest do
   use KlassHeroWeb.ConnCase, async: true
 
+  import KlassHero.EventTestHelper
   import KlassHero.Factory
   import Phoenix.LiveViewTest
 
@@ -178,7 +179,7 @@ defmodule KlassHeroWeb.Provider.SessionsLiveTest do
       # Transition the session in DB so the re-fetch picks it up
       {:ok, _} = Participation.start_session(session.id)
 
-      send(view.pid, {:domain_event, event})
+      emit_domain_event(view, event)
 
       # After PubSub update, should show in_progress actions
       assert has_element?(view, "a", "Manage Participation")
@@ -210,7 +211,7 @@ defmodule KlassHeroWeb.Provider.SessionsLiveTest do
           1
         )
 
-      send(view.pid, {:domain_event, event})
+      emit_domain_event(view, event)
 
       # Session still present in stream after roster_seeded event (no crash)
       assert has_element?(view, "button", "Start Session")
@@ -476,7 +477,7 @@ defmodule KlassHeroWeb.Provider.SessionsLiveTest do
           })
         )
 
-      send(view.pid, {:domain_event, event})
+      emit_domain_event(view, event)
 
       # Session for today should appear in stream
       assert has_element?(view, "button", "Start Session")
@@ -517,7 +518,7 @@ defmodule KlassHeroWeb.Provider.SessionsLiveTest do
           })
         )
 
-      send(view.pid, {:domain_event, event})
+      emit_domain_event(view, event)
 
       # Session is for tomorrow but we're viewing today — should NOT appear
       refute has_element?(view, "button", "Start Session")

--- a/test/support/event_test_helper.ex
+++ b/test/support/event_test_helper.ex
@@ -58,6 +58,23 @@ defmodule KlassHero.EventTestHelper do
   alias KlassHero.TestableIntegrationEventHandler
 
   @doc """
+  Simulates PubSub fan-out by delivering `event` straight to a LiveView's
+  `handle_info/2`.
+
+  Bypasses the real publisher: use when a test needs to drive the LiveView's
+  event-handling branch directly rather than exercise publish → subscribe.
+  Owns the `{:domain_event, _}` envelope so tests don't repeat it.
+
+      event = ParticipationEvents.roster_seeded(session.id, program.id, 1)
+      emit_domain_event(view, event)
+  """
+  @spec emit_domain_event(%{pid: pid()}, DomainEvent.t()) :: :ok
+  def emit_domain_event(%{pid: pid}, %DomainEvent{} = event) when is_pid(pid) do
+    send(pid, {:domain_event, event})
+    :ok
+  end
+
+  @doc """
   Initializes event collection for the current test.
 
   Call this in your test setup block.


### PR DESCRIPTION
Closes #869.

## Summary

LiveView tests simulated PubSub fan-out by hand-sending the internal envelope the LiveView's `handle_info` expects — `send(view.pid, {:domain_event, event})` — duplicated across **7** sites. Extracted into the existing `KlassHero.EventTestHelper`, so the `{:domain_event, _}` envelope now lives in exactly one place.

## Deviations from the issue (it was stale on three points)

- **Not a new file.** `test/support/event_test_helper.ex` already exists (`KlassHero.EventTestHelper`, ~600 lines, already aliases `DomainEvent`). This adds a function to it.
- **7 sites, not 5.** The issue lists `dashboard_live_test.exs:1530` (1 site); the real file is `provider_dashboard_test.exs` with **3** (1567/1599/1638) — #867's PR grew after filing.
- **Send-only 2-arg, not the issue's 5-arg builder.** All 4 `sessions_live_test` sites build events via `ParticipationEvents.session_created/1` / `roster_seeded/3` and already hold a `%DomainEvent{}`; only the 3 dashboard sites call `DomainEvent.new/4`. A build-and-send helper would serve 3/7 and force the other 4 to destructure an event they already have. The duplicated thing is the `send`, so that's what got extracted.

## Review focus

- **Guards:** `%{pid: pid}` keeps the helper decoupled from `Phoenix.LiveViewTest.View`'s struct; `%DomainEvent{}` + `is_pid` turn a misuse into a `FunctionClauseError` rather than a silent `send` to a live pid — this module also handles `%IntegrationEvent{}`, so that confusion is plausible.
- **Import scope:** `provider_dashboard_test`'s `EventTestHelper` import was *test-local* (inside one `test` block) and not in scope at the refactored sites. Hoisted to module level; the redundant local one removed.

## Test plan

- `mix test` on both affected files: **100 passed**.
- Full suite: **4156 passed**, 5 skipped.
- **Falsification probe:** stubbed the helper body to a no-op to confirm the tests catch a dead helper. **4 of 7 failed** — see below.

## Follow-up worth filing (pre-existing, not introduced here)

The no-op probe showed 3 of the 7 tests pass even when the event is never delivered:

- `sessions_live_test.exs:214` (`roster_seeded`), `:480` and `:521` (`session_created`)

Their assertions are satisfied before any event arrives (e.g. *"Session still present in stream after roster_seeded event (no crash)"* asserts presence, already true). They'd pass with the `send` deleted outright. This weakness predates this PR — the refactor is behaviour-preserving — but those three tests aren't currently proving what their names claim.