### PR TITLE
feat: default login method to password instead of magic link

### DIFF
--- a/lib/klass_hero_web/live/user_live/login.ex
+++ b/lib/klass_hero_web/live/user_live/login.ex
@@ -144,7 +144,7 @@ defmodule KlassHeroWeb.UserLive.Login do
      assign(socket,
        form: form,
        trigger_submit: false,
-       show_password_form: false,
+       show_password_form: true,
        active_nav: :auth
      )}
   end

--- a/test/e2e/support/messaging_helpers.ex
+++ b/test/e2e/support/messaging_helpers.ex
@@ -96,13 +96,12 @@ defmodule KlassHeroWeb.E2E.MessagingHelpers do
   @doc """
   Logs in through the UI as the given user.
 
-  Navigates to the login page, toggles to the password form,
+  Navigates to the login page (password is the default form),
   fills in credentials, and submits. The user must have had
   `AccountsFixtures.set_password/1` called on them.
   """
   def log_in(session, %{email: email}) do
     session = visit(session, "/users/log-in")
-    session = click(session, Query.button("Or use password"))
 
     assert_has(session, Query.css("#login_form_password"))
 

--- a/test/klass_hero_web/features/login_feature_test.exs
+++ b/test/klass_hero_web/features/login_feature_test.exs
@@ -17,6 +17,7 @@ defmodule KlassHeroWeb.Features.LoginFeatureTest do
       conn
       |> visit("/users/log-in")
       |> assert_has("h1", text: "Welcome")
+      |> click_button("Or use magic link")
       |> within("#login_form_magic", fn session ->
         session
         |> fill_in("Email", with: user.email)
@@ -33,13 +34,13 @@ defmodule KlassHeroWeb.Features.LoginFeatureTest do
 
     # Password login tests are in login_test.exs using LiveViewTest
     # phoenix_test cannot handle duplicate forms (mobile + desktop) with phx-trigger-action
-    test "user can toggle to password form", %{conn: conn} do
+    test "user can toggle to magic link form", %{conn: conn} do
       conn
       |> visit("/users/log-in")
-      |> assert_has("button", text: "Send magic link")
-      |> click_button("Or use password")
       |> assert_has("button", text: "Log in and stay logged in")
       |> assert_has("input[type='password']")
+      |> click_button("Or use magic link")
+      |> assert_has("button", text: "Send magic link")
     end
 
     test "user can navigate to registration from login", %{conn: _conn} do

--- a/test/klass_hero_web/live/flash_visibility_test.exs
+++ b/test/klass_hero_web/live/flash_visibility_test.exs
@@ -33,6 +33,9 @@ defmodule KlassHeroWeb.FlashVisibilityTest do
       user = user_fixture()
       {:ok, lv, _html} = live(conn, ~p"/users/log-in")
 
+      # Magic link is now the secondary method — toggle to it first
+      lv |> element("button", "Or use magic link") |> render_click()
+
       {:ok, view, _html} =
         form(lv, "#login_form_magic", user: %{email: user.email})
         |> render_submit()

--- a/test/klass_hero_web/live/user_live/login_test.exs
+++ b/test/klass_hero_web/live/user_live/login_test.exs
@@ -12,7 +12,8 @@ defmodule KlassHeroWeb.UserLive.LoginTest do
 
       assert html =~ "Welcome"
       assert html =~ "Register"
-      assert html =~ "Send magic link"
+      # Password is the default sign-in method; magic link is one toggle away
+      assert html =~ ~s(id="login_form_password")
     end
   end
 
@@ -21,6 +22,9 @@ defmodule KlassHeroWeb.UserLive.LoginTest do
       user = user_fixture()
 
       {:ok, lv, _html} = live(conn, ~p"/users/log-in")
+
+      # Magic link is now the secondary method — toggle to it first
+      lv |> element("button", "Or use magic link") |> render_click()
 
       {:ok, _lv, html} =
         form(lv, "#login_form_magic", user: %{email: user.email})
@@ -35,6 +39,9 @@ defmodule KlassHeroWeb.UserLive.LoginTest do
 
     test "does not disclose if user is registered", %{conn: conn} do
       {:ok, lv, _html} = live(conn, ~p"/users/log-in")
+
+      # Magic link is now the secondary method — toggle to it first
+      lv |> element("button", "Or use magic link") |> render_click()
 
       {:ok, _lv, html} =
         form(lv, "#login_form_magic", user: %{email: "idonotexist@example.com"})
@@ -51,9 +58,7 @@ defmodule KlassHeroWeb.UserLive.LoginTest do
 
       {:ok, lv, _html} = live(conn, ~p"/users/log-in")
 
-      # Toggle to password form
-      lv |> element("button", "Or use password") |> render_click()
-
+      # Password is the default form now — no toggle needed
       form =
         form(lv, "#login_form_password", user: %{email: user.email, password: valid_user_password(), remember_me: true})
 
@@ -67,9 +72,7 @@ defmodule KlassHeroWeb.UserLive.LoginTest do
     } do
       {:ok, lv, _html} = live(conn, ~p"/users/log-in")
 
-      # Toggle to password form
-      lv |> element("button", "Or use password") |> render_click()
-
+      # Password is the default form now — no toggle needed
       form =
         form(lv, "#login_form_password", user: %{email: "test@email.com", password: "123456"})
 
@@ -106,7 +109,7 @@ defmodule KlassHeroWeb.UserLive.LoginTest do
 
       assert html =~ "You need to reauthenticate"
       refute html =~ "Register"
-      assert html =~ "Send magic link"
+      assert html =~ "Log in and stay logged in"
 
       assert html =~ user.email
     end


### PR DESCRIPTION
## Summary

The login page (`KlassHeroWeb.UserLive.Login`) presented **magic link** as the default sign-in method — `mount/3` set `show_password_form: false`, so the magic-link form rendered first and password login sat behind an "Or use password" toggle. This flips the default: **password is now primary**, magic link one toggle away, on both the normal login page and the reauth/sudo-mode prompt.

The behavioral change is a single line (`show_password_form: true`); the rest is inverting tests that hard-coded the old default.

## Review Focus

- `lib/klass_hero_web/live/user_live/login.ex` — the one logic change. Render conditional (`if !@show_password_form`) and toggle-button labels left as-is; they switch correctly per branch.
- Reauth (sudo-mode) prompt now also defaults to password — consistent, one code path, no `@current_scope` conditional.
- **No new gettext strings** — both toggle labels ("Or use magic link" / "Or use password") already exist and are translated in `de`, so `mix lint_translations` stays clean.
- Test inversions touch a third file beyond the two login suites: `flash_visibility_test.exs` (used the magic-link success flash to set an info flash) and the Wallaby `messaging_helpers.ex` login helper both referenced `#login_form_magic` / the password toggle.

## Test Plan

- `mix precommit` — **4163 passed**, 5 skipped, 19 excluded; format, credo, lint_typography, lint_translations all clean.
- Manual: `/users/log-in` shows the password form (email + password + "Log in and stay logged in") first; "Or use magic link" reveals the magic form and toggles back. Reauth path (logged-in user revisiting) shows password default with email pre-filled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)