### PR TITLE
perf: cut fixed per-request cost on dashboard + admin; fix dead sessions tile

### DIFF
--- a/lib/klass_hero/participation.ex
+++ b/lib/klass_hero/participation.ex
@@ -117,6 +117,16 @@ defmodule KlassHero.Participation do
   def list_sessions(%{date: %Date{} = date}), do: list_sessions_today(date)
   def list_sessions(params) when is_map(params), do: list_sessions_today(Date.utc_today())
 
+  @doc "Lists sessions on or after `from_date` across many programs in one query, ordered soonest-first."
+  @spec list_upcoming_sessions_for_programs([String.t()], Date.t()) :: [ProgramSession.t()]
+  def list_upcoming_sessions_for_programs(program_ids, %Date{} = from_date) when is_list(program_ids) do
+    from(s in ProgramSession,
+      where: s.program_id in ^program_ids and s.session_date >= ^from_date,
+      order_by: [asc: s.session_date, asc: s.start_time]
+    )
+    |> Repo.all()
+  end
+
   @doc "Lists sessions with enriched data for the admin dashboard."
   def list_admin_sessions(filters \\ %{}) when is_map(filters) do
     # Default to today when no date filter is provided to avoid loading all sessions.

--- a/lib/klass_hero/program_catalog.ex
+++ b/lib/klass_hero/program_catalog.ex
@@ -201,8 +201,13 @@ defmodule KlassHero.ProgramCatalog do
   @doc "Lists featured programs for homepage display (first 2 active, ordered by title)."
   @spec list_featured_programs() :: [ProgramListing.t()]
   def list_featured_programs do
-    active_listings()
-    |> Enum.take(2)
+    today = Date.utc_today()
+
+    ProgramListing
+    |> where([l], is_nil(l.end_date) or l.end_date >= ^today)
+    |> order_by([l], asc: l.title)
+    |> limit(2)
+    |> Repo.all()
   end
 
   @doc "Lists all programs for a provider, ordered by title (includes expired — #610)."
@@ -302,15 +307,6 @@ defmodule KlassHero.ProgramCatalog do
   end
 
   defp fetch_program(_), do: nil
-
-  defp active_listings do
-    today = Date.utc_today()
-
-    ProgramListing
-    |> where([l], is_nil(l.end_date) or l.end_date >= ^today)
-    |> order_by([l], asc: l.title)
-    |> Repo.all()
-  end
 
   defp listing_page(limit, cursor_data, category) do
     ProgramListing

--- a/lib/klass_hero_web/live/dashboard_live.ex
+++ b/lib/klass_hero_web/live/dashboard_live.ex
@@ -10,7 +10,6 @@ defmodule KlassHeroWeb.DashboardLive do
   alias KlassHero.Messaging
   alias KlassHero.ProgramCatalog
   alias KlassHeroWeb.Helpers.Greeting
-  alias KlassHeroWeb.Helpers.TaskHelpers
   alias KlassHeroWeb.Presenters.ChildPresenter
   alias KlassHeroWeb.Presenters.ProgramPresenter
   alias KlassHeroWeb.Theme
@@ -21,37 +20,6 @@ defmodule KlassHeroWeb.DashboardLive do
   def mount(_params, _session, socket) do
     user = socket.assigns.current_scope.user
 
-    # user.id is the Accounts identity_id; enrollment.parent_id is the Family profile ID — resolve once, then fan out.
-    {_parent, children, active_programs, expired_programs} =
-      case Family.get_parent_by_identity(user.id) do
-        {:ok, parent} ->
-          children_task =
-            Task.Supervisor.async_nolink(KlassHero.TaskSupervisor, fn ->
-              Family.get_children(parent.id)
-            end)
-
-          programs_task =
-            Task.Supervisor.async_nolink(KlassHero.TaskSupervisor, fn ->
-              load_family_programs(parent.id)
-            end)
-
-          children = TaskHelpers.safe_await(children_task, [], label: "DashboardLive.children")
-
-          {active, expired} =
-            TaskHelpers.safe_await(programs_task, {[], []}, label: "DashboardLive.programs")
-
-          {parent, children, active, expired}
-
-        {:error, _} ->
-          {nil, [], [], []}
-      end
-
-    children_for_view = Enum.map(children, &ChildPresenter.to_profile_view/1)
-    kid_picker_items = build_kid_picker_items(children, active_programs)
-    upcoming_sessions = load_upcoming_sessions(active_programs, children)
-    recent_messages = load_recent_messages(user.id)
-    unread_count = socket.assigns[:total_unread_count] || 0
-
     socket =
       socket
       |> assign(
@@ -59,18 +27,77 @@ defmodule KlassHeroWeb.DashboardLive do
         page_subtitle: gettext("Your week with the kids"),
         active_nav: :home,
         user: user,
-        children_count: length(children_for_view),
-        kid_picker_items: kid_picker_items,
-        active_program_count: length(active_programs),
-        upcoming_count: length(upcoming_sessions),
-        upcoming_sessions: upcoming_sessions,
-        recent_messages: recent_messages,
-        unread_count: unread_count,
-        family_programs_empty?: active_programs == [] and expired_programs == []
+        loading?: true,
+        children_count: 0,
+        kid_picker_items: [],
+        active_program_count: 0,
+        upcoming_count: 0,
+        upcoming_sessions: [],
+        recent_messages: [],
+        unread_count: socket.assigns[:total_unread_count] || 0,
+        family_programs_empty?: true
       )
-      |> stream(:family_programs, build_family_program_items(active_programs, expired_programs))
+      |> stream(:family_programs, [])
+      |> maybe_start_load(user)
 
     {:ok, socket}
+  end
+
+  # Fetch on the connected mount only (runs once, not on the disconnected render).
+  # Parent comes from the auth chain's already-resolved scope, not a fresh query.
+  defp maybe_start_load(socket, user) do
+    if connected?(socket) do
+      parent = socket.assigns.current_scope.parent
+      start_async(socket, :load_dashboard, fn -> load_dashboard_data(parent, user.id) end)
+    else
+      socket
+    end
+  end
+
+  @impl true
+  def handle_async(:load_dashboard, {:ok, data}, socket) do
+    %{children: children, active_programs: active, expired_programs: expired} = data
+
+    socket =
+      socket
+      |> assign(
+        loading?: false,
+        children_count: length(children),
+        kid_picker_items: build_kid_picker_items(children, active),
+        active_program_count: length(active),
+        upcoming_count: length(data.upcoming_sessions),
+        upcoming_sessions: data.upcoming_sessions,
+        recent_messages: data.recent_messages,
+        family_programs_empty?: active == [] and expired == []
+      )
+      |> stream(:family_programs, build_family_program_items(active, expired), reset: true)
+
+    {:noreply, socket}
+  end
+
+  def handle_async(:load_dashboard, {:exit, reason}, socket) do
+    Logger.error("[DashboardLive] dashboard load failed", reason: inspect(reason))
+    {:noreply, assign(socket, :loading?, false)}
+  end
+
+  defp load_dashboard_data(parent, user_id) do
+    {children, active, expired} = load_family(parent)
+
+    %{
+      children: children,
+      active_programs: active,
+      expired_programs: expired,
+      upcoming_sessions: load_upcoming_sessions(active, children),
+      recent_messages: load_recent_messages(user_id)
+    }
+  end
+
+  defp load_family(nil), do: {[], [], []}
+
+  defp load_family(parent) do
+    children = Family.get_children(parent.id)
+    {active, expired} = load_family_programs(parent.id)
+    {children, active, expired}
   end
 
   # Stable color rotation per child index keeps the palette consistent across mount cycles.
@@ -308,7 +335,13 @@ defmodule KlassHeroWeb.DashboardLive do
             {gettext("View all")} →
           </.link>
         </div>
-        <div :if={@upcoming_sessions == []} class="text-sm text-hero-grey-600">
+        <div :if={@loading?} class="text-sm text-hero-grey-500">
+          {gettext("Loading…")}
+        </div>
+        <div
+          :if={@upcoming_sessions == [] and not @loading?}
+          class="text-sm text-hero-grey-600"
+        >
           {gettext("No upcoming sessions in the next few weeks.")}
         </div>
         <div class="space-y-1">
@@ -327,48 +360,56 @@ defmodule KlassHeroWeb.DashboardLive do
           </h2>
         </div>
 
-        <%= if @family_programs_empty? do %>
-          <div id="family-programs-empty" class="text-center py-12 bg-white rounded-2xl shadow-sm">
-            <.icon name="hero-book-open" class="w-12 h-12 text-hero-grey-300 mx-auto mb-4" />
-            <p class="text-hero-grey-500 mb-4">
-              {gettext("No programs booked yet")}
-            </p>
-            <.link
-              navigate={~p"/programs"}
-              class={[
-                "inline-flex items-center px-6 py-3 text-white font-medium",
-                "bg-hero-blue-600 hover:bg-hero-blue-700",
-                Theme.rounded(:lg),
-                Theme.transition(:normal)
-              ]}
+        <%= cond do %>
+          <% @loading? -> %>
+            <div
+              id="family-programs-loading"
+              class="text-center py-12 bg-white rounded-2xl shadow-sm text-hero-grey-500"
             >
-              {gettext("Book a Program")}
-            </.link>
-          </div>
-        <% else %>
-          <div
-            id="family-programs-list"
-            phx-update="stream"
-            class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
-          >
-            <.program_card
-              :for={{dom_id, item} <- @streams.family_programs}
-              id={dom_id}
-              program={ProgramPresenter.to_card_view(item.program)}
-              variant={:detailed}
-              expired={item.expired}
-              phx-click="program_click"
-              phx-value-program-id={item.program.id}
+              {gettext("Loading your programs…")}
+            </div>
+          <% @family_programs_empty? -> %>
+            <div id="family-programs-empty" class="text-center py-12 bg-white rounded-2xl shadow-sm">
+              <.icon name="hero-book-open" class="w-12 h-12 text-hero-grey-300 mx-auto mb-4" />
+              <p class="text-hero-grey-500 mb-4">
+                {gettext("No programs booked yet")}
+              </p>
+              <.link
+                navigate={~p"/programs"}
+                class={[
+                  "inline-flex items-center px-6 py-3 text-white font-medium",
+                  "bg-hero-blue-600 hover:bg-hero-blue-700",
+                  Theme.rounded(:lg),
+                  Theme.transition(:normal)
+                ]}
+              >
+                {gettext("Book a Program")}
+              </.link>
+            </div>
+          <% true -> %>
+            <div
+              id="family-programs-list"
+              phx-update="stream"
+              class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
             >
-              <:actions :if={!item.expired}>
-                <.contact_provider_button
-                  program_id={item.program.id}
-                  provider_id={item.program.provider_id}
-                  phx-click="contact_provider"
-                />
-              </:actions>
-            </.program_card>
-          </div>
+              <.program_card
+                :for={{dom_id, item} <- @streams.family_programs}
+                id={dom_id}
+                program={ProgramPresenter.to_card_view(item.program)}
+                variant={:detailed}
+                expired={item.expired}
+                phx-click="program_click"
+                phx-value-program-id={item.program.id}
+              >
+                <:actions :if={!item.expired}>
+                  <.contact_provider_button
+                    program_id={item.program.id}
+                    provider_id={item.program.provider_id}
+                    phx-click="contact_provider"
+                  />
+                </:actions>
+              </.program_card>
+            </div>
         <% end %>
       </section>
     </div>

--- a/lib/klass_hero_web/live/dashboard_live.ex
+++ b/lib/klass_hero_web/live/dashboard_live.ex
@@ -8,6 +8,7 @@ defmodule KlassHeroWeb.DashboardLive do
   alias KlassHero.Family
   alias KlassHero.Family.Child
   alias KlassHero.Messaging
+  alias KlassHero.Participation
   alias KlassHero.ProgramCatalog
   alias KlassHeroWeb.Helpers.Greeting
   alias KlassHeroWeb.Presenters.ChildPresenter
@@ -125,23 +126,23 @@ defmodule KlassHeroWeb.DashboardLive do
   end
 
   # Top 5 upcoming sessions across active programs, ascending by date.
+  # One batched query; each session fans out to every {enrollment, program}
+  # pair sharing its program (a program can hold more than one enrolled child).
   defp load_upcoming_sessions([], _children), do: []
 
   defp load_upcoming_sessions(active_programs, children) do
-    today = Date.utc_today()
     children_by_id = Map.new(children, &{&1.id, &1})
+    pairs_by_program = Enum.group_by(active_programs, fn {_enrollment, program} -> program.id end)
 
-    active_programs
-    |> Enum.flat_map(fn {enrollment, program} ->
-      case KlassHero.Participation.list_sessions(%{program_id: program.id}) do
-        {:ok, sessions} ->
-          sessions
-          |> Enum.filter(&(Date.compare(&1.session_date, today) != :lt))
-          |> Enum.map(&{enrollment, program, &1, Map.get(children_by_id, enrollment.child_id)})
-
-        _ ->
-          []
-      end
+    pairs_by_program
+    |> Map.keys()
+    |> Participation.list_upcoming_sessions_for_programs(Date.utc_today())
+    |> Enum.flat_map(fn session ->
+      pairs_by_program
+      |> Map.get(session.program_id, [])
+      |> Enum.map(fn {enrollment, program} ->
+        {enrollment, program, session, Map.get(children_by_id, enrollment.child_id)}
+      end)
     end)
     |> Enum.sort_by(fn {_, _, session, _} -> session.session_date end, {:asc, Date})
     |> Enum.take(5)

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -1872,7 +1872,7 @@ msgstr "Kind erfolgreich aktualisiert."
 msgid "Child updated, but consent update failed. Please try again."
 msgstr "Kind aktualisiert, aber Einwilligungsaktualisierung fehlgeschlagen. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/live/dashboard_live.ex:194
+#: lib/klass_hero_web/live/dashboard_live.ex:195
 #: lib/klass_hero_web/live/messaging_live_helper.ex:343
 #, elixir-autogen, elixir-format
 msgid "Conversation"
@@ -2303,7 +2303,7 @@ msgstr "Zurück zu den Verifizierungen"
 msgid "Bio"
 msgstr "Biografie"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:386
+#: lib/klass_hero_web/live/dashboard_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "Book a Program"
 msgstr "Programm buchen"
@@ -2560,7 +2560,7 @@ msgstr "Einladung konnte nicht erneut gesendet werden."
 msgid "Failed to upload document."
 msgstr "Dokument konnte nicht hochgeladen werden."
 
-#: lib/klass_hero_web/live/dashboard_live.ex:359
+#: lib/klass_hero_web/live/dashboard_live.ex:360
 #, elixir-autogen, elixir-format
 msgid "Family Programs"
 msgstr "Familienprogramme"
@@ -2799,7 +2799,7 @@ msgstr "Kein Minimum"
 msgid "No pending documents to review."
 msgstr "Keine ausstehenden Dokumente zur Überprüfung."
 
-#: lib/klass_hero_web/live/dashboard_live.ex:375
+#: lib/klass_hero_web/live/dashboard_live.ex:376
 #, elixir-autogen, elixir-format
 msgid "No programs booked yet"
 msgstr "Noch keine Programme gebucht"
@@ -3684,7 +3684,7 @@ msgstr "Kontaktieren Sie den Anbieter direkt (Details in der Bestätigungs-E-Mai
 msgid "Correct"
 msgstr "Korrigieren"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:285
+#: lib/klass_hero_web/live/dashboard_live.ex:286
 #: lib/klass_hero_web/live/provider/programs_live.ex:257
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:200
 #, elixir-autogen, elixir-format
@@ -3914,7 +3914,7 @@ msgstr "Mitarbeiter"
 msgid "Track Everything:"
 msgstr "Alles im Überblick:"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:272
+#: lib/klass_hero_web/live/dashboard_live.ex:273
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "Upgrade your plan to send messages."
@@ -5279,7 +5279,7 @@ msgstr "Guten Tag"
 msgid "Good evening"
 msgstr "Guten Abend"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:27
+#: lib/klass_hero_web/live/dashboard_live.ex:28
 #, elixir-autogen, elixir-format
 msgid "Your week with the kids"
 msgstr "Ihre Woche mit den Kindern"
@@ -5353,7 +5353,7 @@ msgstr "Über alle Programme hinweg"
 msgid "Active policy required to teach."
 msgstr "Aktive Versicherungspolice erforderlich, um zu unterrichten."
 
-#: lib/klass_hero_web/live/dashboard_live.ex:305
+#: lib/klass_hero_web/live/dashboard_live.ex:306
 #: lib/klass_hero_web/live/provider/overview_live.ex:259
 #, elixir-autogen, elixir-format
 msgid "Active programs"
@@ -6106,7 +6106,7 @@ msgstr "Monat"
 msgid "Mother and child-safety specialist with 10+ years in quality assurance. Architecting our Safety-First Verification engine."
 msgstr "Mutter und Kindersicherheitsspezialistin mit über 10 Jahren Erfahrung in der Qualitätssicherung. Verantwortlich für die Konzeption unserer Safety-First-Verifizierungs-Engine."
 
-#: lib/klass_hero_web/live/dashboard_live.ex:182
+#: lib/klass_hero_web/live/dashboard_live.ex:183
 #, elixir-autogen, elixir-format
 msgid "New conversation"
 msgstr "Neue Unterhaltung"
@@ -6173,7 +6173,7 @@ msgid_plural "No rows imported. %{count} rows could not be processed."
 msgstr[0] "Keine Zeilen importiert. %{count} Zeile konnte nicht verarbeitet werden."
 msgstr[1] "Keine Zeilen importiert. %{count} Zeilen konnten nicht verarbeitet werden."
 
-#: lib/klass_hero_web/live/dashboard_live.ex:345
+#: lib/klass_hero_web/live/dashboard_live.ex:346
 #, elixir-autogen, elixir-format
 msgid "No upcoming sessions in the next few weeks."
 msgstr "Keine bevorstehenden Sitzungen in den nächsten Wochen."
@@ -6689,17 +6689,17 @@ msgstr "Unbekannter Elternteil"
 msgid "Unlimited programs and locations"
 msgstr "Unbegrenzte Programme und Standorte"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:317
+#: lib/klass_hero_web/live/dashboard_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "Unread messages"
 msgstr "Ungelesene Nachrichten"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:330
+#: lib/klass_hero_web/live/dashboard_live.ex:331
 #, elixir-autogen, elixir-format
 msgid "Upcoming sessions"
 msgstr "Anstehende Sitzungen"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:311
+#: lib/klass_hero_web/live/dashboard_live.ex:312
 #, elixir-autogen, elixir-format
 msgid "Upcoming this week"
 msgstr "Diese Woche anstehend"
@@ -6714,7 +6714,7 @@ msgstr "Geprüft"
 msgid "View"
 msgstr "Ansehen"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:335
+#: lib/klass_hero_web/live/dashboard_live.ex:336
 #, elixir-autogen, elixir-format
 msgid "View all"
 msgstr "Alle anzeigen"
@@ -7587,12 +7587,12 @@ msgstr "Sitzungsnotiz"
 msgid "Session note submitted for review"
 msgstr "Sitzungsnotiz zur Überprüfung eingereicht"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:369
+#: lib/klass_hero_web/live/dashboard_live.ex:370
 #, elixir-autogen, elixir-format
 msgid "Loading your programs…"
 msgstr "Deine Programme werden geladen…"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:339
+#: lib/klass_hero_web/live/dashboard_live.ex:340
 #, elixir-autogen, elixir-format
 msgid "Loading…"
 msgstr "Wird geladen…"

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -1872,7 +1872,7 @@ msgstr "Kind erfolgreich aktualisiert."
 msgid "Child updated, but consent update failed. Please try again."
 msgstr "Kind aktualisiert, aber Einwilligungsaktualisierung fehlgeschlagen. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/live/dashboard_live.ex:167
+#: lib/klass_hero_web/live/dashboard_live.ex:194
 #: lib/klass_hero_web/live/messaging_live_helper.ex:343
 #, elixir-autogen, elixir-format
 msgid "Conversation"
@@ -2303,7 +2303,7 @@ msgstr "Zurück zu den Verifizierungen"
 msgid "Bio"
 msgstr "Biografie"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:345
+#: lib/klass_hero_web/live/dashboard_live.ex:386
 #, elixir-autogen, elixir-format
 msgid "Book a Program"
 msgstr "Programm buchen"
@@ -2560,7 +2560,7 @@ msgstr "Einladung konnte nicht erneut gesendet werden."
 msgid "Failed to upload document."
 msgstr "Dokument konnte nicht hochgeladen werden."
 
-#: lib/klass_hero_web/live/dashboard_live.ex:326
+#: lib/klass_hero_web/live/dashboard_live.ex:359
 #, elixir-autogen, elixir-format
 msgid "Family Programs"
 msgstr "Familienprogramme"
@@ -2799,7 +2799,7 @@ msgstr "Kein Minimum"
 msgid "No pending documents to review."
 msgstr "Keine ausstehenden Dokumente zur Überprüfung."
 
-#: lib/klass_hero_web/live/dashboard_live.ex:334
+#: lib/klass_hero_web/live/dashboard_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "No programs booked yet"
 msgstr "Noch keine Programme gebucht"
@@ -3684,7 +3684,7 @@ msgstr "Kontaktieren Sie den Anbieter direkt (Details in der Bestätigungs-E-Mai
 msgid "Correct"
 msgstr "Korrigieren"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:258
+#: lib/klass_hero_web/live/dashboard_live.ex:285
 #: lib/klass_hero_web/live/provider/programs_live.ex:257
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:200
 #, elixir-autogen, elixir-format
@@ -3914,7 +3914,7 @@ msgstr "Mitarbeiter"
 msgid "Track Everything:"
 msgstr "Alles im Überblick:"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:245
+#: lib/klass_hero_web/live/dashboard_live.ex:272
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "Upgrade your plan to send messages."
@@ -5279,7 +5279,7 @@ msgstr "Guten Tag"
 msgid "Good evening"
 msgstr "Guten Abend"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:59
+#: lib/klass_hero_web/live/dashboard_live.ex:27
 #, elixir-autogen, elixir-format
 msgid "Your week with the kids"
 msgstr "Ihre Woche mit den Kindern"
@@ -5353,7 +5353,7 @@ msgstr "Über alle Programme hinweg"
 msgid "Active policy required to teach."
 msgstr "Aktive Versicherungspolice erforderlich, um zu unterrichten."
 
-#: lib/klass_hero_web/live/dashboard_live.ex:278
+#: lib/klass_hero_web/live/dashboard_live.ex:305
 #: lib/klass_hero_web/live/provider/overview_live.ex:259
 #, elixir-autogen, elixir-format
 msgid "Active programs"
@@ -6106,7 +6106,7 @@ msgstr "Monat"
 msgid "Mother and child-safety specialist with 10+ years in quality assurance. Architecting our Safety-First Verification engine."
 msgstr "Mutter und Kindersicherheitsspezialistin mit über 10 Jahren Erfahrung in der Qualitätssicherung. Verantwortlich für die Konzeption unserer Safety-First-Verifizierungs-Engine."
 
-#: lib/klass_hero_web/live/dashboard_live.ex:155
+#: lib/klass_hero_web/live/dashboard_live.ex:182
 #, elixir-autogen, elixir-format
 msgid "New conversation"
 msgstr "Neue Unterhaltung"
@@ -6173,7 +6173,7 @@ msgid_plural "No rows imported. %{count} rows could not be processed."
 msgstr[0] "Keine Zeilen importiert. %{count} Zeile konnte nicht verarbeitet werden."
 msgstr[1] "Keine Zeilen importiert. %{count} Zeilen konnten nicht verarbeitet werden."
 
-#: lib/klass_hero_web/live/dashboard_live.ex:312
+#: lib/klass_hero_web/live/dashboard_live.ex:345
 #, elixir-autogen, elixir-format
 msgid "No upcoming sessions in the next few weeks."
 msgstr "Keine bevorstehenden Sitzungen in den nächsten Wochen."
@@ -6689,17 +6689,17 @@ msgstr "Unbekannter Elternteil"
 msgid "Unlimited programs and locations"
 msgstr "Unbegrenzte Programme und Standorte"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:290
+#: lib/klass_hero_web/live/dashboard_live.ex:317
 #, elixir-autogen, elixir-format
 msgid "Unread messages"
 msgstr "Ungelesene Nachrichten"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:303
+#: lib/klass_hero_web/live/dashboard_live.ex:330
 #, elixir-autogen, elixir-format
 msgid "Upcoming sessions"
 msgstr "Anstehende Sitzungen"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:284
+#: lib/klass_hero_web/live/dashboard_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "Upcoming this week"
 msgstr "Diese Woche anstehend"
@@ -6714,7 +6714,7 @@ msgstr "Geprüft"
 msgid "View"
 msgstr "Ansehen"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:308
+#: lib/klass_hero_web/live/dashboard_live.ex:335
 #, elixir-autogen, elixir-format
 msgid "View all"
 msgstr "Alle anzeigen"
@@ -7586,3 +7586,13 @@ msgstr "Sitzungsnotiz"
 #, elixir-autogen, elixir-format
 msgid "Session note submitted for review"
 msgstr "Sitzungsnotiz zur Überprüfung eingereicht"
+
+#: lib/klass_hero_web/live/dashboard_live.ex:369
+#, elixir-autogen, elixir-format
+msgid "Loading your programs…"
+msgstr "Deine Programme werden geladen…"
+
+#: lib/klass_hero_web/live/dashboard_live.ex:339
+#, elixir-autogen, elixir-format
+msgid "Loading…"
+msgstr "Wird geladen…"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -1872,7 +1872,7 @@ msgstr ""
 msgid "Child updated, but consent update failed. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:167
+#: lib/klass_hero_web/live/dashboard_live.ex:194
 #: lib/klass_hero_web/live/messaging_live_helper.ex:343
 #, elixir-autogen, elixir-format
 msgid "Conversation"
@@ -2303,7 +2303,7 @@ msgstr ""
 msgid "Bio"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:345
+#: lib/klass_hero_web/live/dashboard_live.ex:386
 #, elixir-autogen, elixir-format
 msgid "Book a Program"
 msgstr ""
@@ -2560,7 +2560,7 @@ msgstr ""
 msgid "Failed to upload document."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:326
+#: lib/klass_hero_web/live/dashboard_live.ex:359
 #, elixir-autogen, elixir-format
 msgid "Family Programs"
 msgstr ""
@@ -2799,7 +2799,7 @@ msgstr ""
 msgid "No pending documents to review."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:334
+#: lib/klass_hero_web/live/dashboard_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "No programs booked yet"
 msgstr ""
@@ -3684,7 +3684,7 @@ msgstr ""
 msgid "Correct"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:258
+#: lib/klass_hero_web/live/dashboard_live.ex:285
 #: lib/klass_hero_web/live/provider/programs_live.ex:257
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:200
 #, elixir-autogen, elixir-format
@@ -3914,7 +3914,7 @@ msgstr ""
 msgid "Track Everything:"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:245
+#: lib/klass_hero_web/live/dashboard_live.ex:272
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "Upgrade your plan to send messages."
@@ -5279,7 +5279,7 @@ msgstr ""
 msgid "Good evening"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:59
+#: lib/klass_hero_web/live/dashboard_live.ex:27
 #, elixir-autogen, elixir-format
 msgid "Your week with the kids"
 msgstr ""
@@ -5353,7 +5353,7 @@ msgstr ""
 msgid "Active policy required to teach."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:278
+#: lib/klass_hero_web/live/dashboard_live.ex:305
 #: lib/klass_hero_web/live/provider/overview_live.ex:259
 #, elixir-autogen, elixir-format
 msgid "Active programs"
@@ -6106,7 +6106,7 @@ msgstr ""
 msgid "Mother and child-safety specialist with 10+ years in quality assurance. Architecting our Safety-First Verification engine."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:155
+#: lib/klass_hero_web/live/dashboard_live.ex:182
 #, elixir-autogen, elixir-format
 msgid "New conversation"
 msgstr ""
@@ -6173,7 +6173,7 @@ msgid_plural "No rows imported. %{count} rows could not be processed."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:312
+#: lib/klass_hero_web/live/dashboard_live.ex:345
 #, elixir-autogen, elixir-format
 msgid "No upcoming sessions in the next few weeks."
 msgstr ""
@@ -6689,17 +6689,17 @@ msgstr ""
 msgid "Unlimited programs and locations"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:290
+#: lib/klass_hero_web/live/dashboard_live.ex:317
 #, elixir-autogen, elixir-format
 msgid "Unread messages"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:303
+#: lib/klass_hero_web/live/dashboard_live.ex:330
 #, elixir-autogen, elixir-format
 msgid "Upcoming sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:284
+#: lib/klass_hero_web/live/dashboard_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "Upcoming this week"
 msgstr ""
@@ -6714,7 +6714,7 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:308
+#: lib/klass_hero_web/live/dashboard_live.ex:335
 #, elixir-autogen, elixir-format
 msgid "View all"
 msgstr ""
@@ -7585,4 +7585,14 @@ msgstr ""
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:107
 #, elixir-autogen, elixir-format
 msgid "Session note submitted for review"
+msgstr ""
+
+#: lib/klass_hero_web/live/dashboard_live.ex:369
+#, elixir-autogen, elixir-format
+msgid "Loading your programs…"
+msgstr ""
+
+#: lib/klass_hero_web/live/dashboard_live.ex:339
+#, elixir-autogen, elixir-format
+msgid "Loading…"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -1872,7 +1872,7 @@ msgstr ""
 msgid "Child updated, but consent update failed. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:194
+#: lib/klass_hero_web/live/dashboard_live.ex:195
 #: lib/klass_hero_web/live/messaging_live_helper.ex:343
 #, elixir-autogen, elixir-format
 msgid "Conversation"
@@ -2303,7 +2303,7 @@ msgstr ""
 msgid "Bio"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:386
+#: lib/klass_hero_web/live/dashboard_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "Book a Program"
 msgstr ""
@@ -2560,7 +2560,7 @@ msgstr ""
 msgid "Failed to upload document."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:359
+#: lib/klass_hero_web/live/dashboard_live.ex:360
 #, elixir-autogen, elixir-format
 msgid "Family Programs"
 msgstr ""
@@ -2799,7 +2799,7 @@ msgstr ""
 msgid "No pending documents to review."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:375
+#: lib/klass_hero_web/live/dashboard_live.ex:376
 #, elixir-autogen, elixir-format
 msgid "No programs booked yet"
 msgstr ""
@@ -3684,7 +3684,7 @@ msgstr ""
 msgid "Correct"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:285
+#: lib/klass_hero_web/live/dashboard_live.ex:286
 #: lib/klass_hero_web/live/provider/programs_live.ex:257
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:200
 #, elixir-autogen, elixir-format
@@ -3914,7 +3914,7 @@ msgstr ""
 msgid "Track Everything:"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:272
+#: lib/klass_hero_web/live/dashboard_live.ex:273
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "Upgrade your plan to send messages."
@@ -5279,7 +5279,7 @@ msgstr ""
 msgid "Good evening"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:27
+#: lib/klass_hero_web/live/dashboard_live.ex:28
 #, elixir-autogen, elixir-format
 msgid "Your week with the kids"
 msgstr ""
@@ -5353,7 +5353,7 @@ msgstr ""
 msgid "Active policy required to teach."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:305
+#: lib/klass_hero_web/live/dashboard_live.ex:306
 #: lib/klass_hero_web/live/provider/overview_live.ex:259
 #, elixir-autogen, elixir-format
 msgid "Active programs"
@@ -6106,7 +6106,7 @@ msgstr ""
 msgid "Mother and child-safety specialist with 10+ years in quality assurance. Architecting our Safety-First Verification engine."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:182
+#: lib/klass_hero_web/live/dashboard_live.ex:183
 #, elixir-autogen, elixir-format
 msgid "New conversation"
 msgstr ""
@@ -6173,7 +6173,7 @@ msgid_plural "No rows imported. %{count} rows could not be processed."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:345
+#: lib/klass_hero_web/live/dashboard_live.ex:346
 #, elixir-autogen, elixir-format
 msgid "No upcoming sessions in the next few weeks."
 msgstr ""
@@ -6689,17 +6689,17 @@ msgstr ""
 msgid "Unlimited programs and locations"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:317
+#: lib/klass_hero_web/live/dashboard_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "Unread messages"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:330
+#: lib/klass_hero_web/live/dashboard_live.ex:331
 #, elixir-autogen, elixir-format
 msgid "Upcoming sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:311
+#: lib/klass_hero_web/live/dashboard_live.ex:312
 #, elixir-autogen, elixir-format
 msgid "Upcoming this week"
 msgstr ""
@@ -6714,7 +6714,7 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:335
+#: lib/klass_hero_web/live/dashboard_live.ex:336
 #, elixir-autogen, elixir-format
 msgid "View all"
 msgstr ""
@@ -7587,12 +7587,12 @@ msgstr ""
 msgid "Session note submitted for review"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:369
+#: lib/klass_hero_web/live/dashboard_live.ex:370
 #, elixir-autogen, elixir-format
 msgid "Loading your programs…"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:339
+#: lib/klass_hero_web/live/dashboard_live.ex:340
 #, elixir-autogen, elixir-format
 msgid "Loading…"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -1872,7 +1872,7 @@ msgstr ""
 msgid "Child updated, but consent update failed. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:194
+#: lib/klass_hero_web/live/dashboard_live.ex:195
 #: lib/klass_hero_web/live/messaging_live_helper.ex:343
 #, elixir-autogen, elixir-format
 msgid "Conversation"
@@ -2303,7 +2303,7 @@ msgstr ""
 msgid "Bio"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:386
+#: lib/klass_hero_web/live/dashboard_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "Book a Program"
 msgstr ""
@@ -2560,7 +2560,7 @@ msgstr ""
 msgid "Failed to upload document."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:359
+#: lib/klass_hero_web/live/dashboard_live.ex:360
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Family Programs"
 msgstr ""
@@ -2799,7 +2799,7 @@ msgstr ""
 msgid "No pending documents to review."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:375
+#: lib/klass_hero_web/live/dashboard_live.ex:376
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No programs booked yet"
 msgstr ""
@@ -3684,7 +3684,7 @@ msgstr ""
 msgid "Correct"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:285
+#: lib/klass_hero_web/live/dashboard_live.ex:286
 #: lib/klass_hero_web/live/provider/programs_live.ex:257
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:200
 #, elixir-autogen, elixir-format
@@ -3914,7 +3914,7 @@ msgstr ""
 msgid "Track Everything:"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:272
+#: lib/klass_hero_web/live/dashboard_live.ex:273
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "Upgrade your plan to send messages."
@@ -5279,7 +5279,7 @@ msgstr ""
 msgid "Good evening"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:27
+#: lib/klass_hero_web/live/dashboard_live.ex:28
 #, elixir-autogen, elixir-format
 msgid "Your week with the kids"
 msgstr ""
@@ -5353,7 +5353,7 @@ msgstr ""
 msgid "Active policy required to teach."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:305
+#: lib/klass_hero_web/live/dashboard_live.ex:306
 #: lib/klass_hero_web/live/provider/overview_live.ex:259
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Active programs"
@@ -6106,7 +6106,7 @@ msgstr ""
 msgid "Mother and child-safety specialist with 10+ years in quality assurance. Architecting our Safety-First Verification engine."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:182
+#: lib/klass_hero_web/live/dashboard_live.ex:183
 #, elixir-autogen, elixir-format, fuzzy
 msgid "New conversation"
 msgstr ""
@@ -6173,7 +6173,7 @@ msgid_plural "No rows imported. %{count} rows could not be processed."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:345
+#: lib/klass_hero_web/live/dashboard_live.ex:346
 #, elixir-autogen, elixir-format
 msgid "No upcoming sessions in the next few weeks."
 msgstr ""
@@ -6689,17 +6689,17 @@ msgstr ""
 msgid "Unlimited programs and locations"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:317
+#: lib/klass_hero_web/live/dashboard_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "Unread messages"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:330
+#: lib/klass_hero_web/live/dashboard_live.ex:331
 #, elixir-autogen, elixir-format
 msgid "Upcoming sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:311
+#: lib/klass_hero_web/live/dashboard_live.ex:312
 #, elixir-autogen, elixir-format
 msgid "Upcoming this week"
 msgstr ""
@@ -6714,7 +6714,7 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:335
+#: lib/klass_hero_web/live/dashboard_live.ex:336
 #, elixir-autogen, elixir-format, fuzzy
 msgid "View all"
 msgstr ""
@@ -7587,12 +7587,12 @@ msgstr ""
 msgid "Session note submitted for review"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:369
+#: lib/klass_hero_web/live/dashboard_live.ex:370
 #, elixir-autogen, elixir-format
 msgid "Loading your programs…"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:339
+#: lib/klass_hero_web/live/dashboard_live.ex:340
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Loading…"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -1872,7 +1872,7 @@ msgstr ""
 msgid "Child updated, but consent update failed. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:167
+#: lib/klass_hero_web/live/dashboard_live.ex:194
 #: lib/klass_hero_web/live/messaging_live_helper.ex:343
 #, elixir-autogen, elixir-format
 msgid "Conversation"
@@ -2303,7 +2303,7 @@ msgstr ""
 msgid "Bio"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:345
+#: lib/klass_hero_web/live/dashboard_live.ex:386
 #, elixir-autogen, elixir-format
 msgid "Book a Program"
 msgstr ""
@@ -2560,7 +2560,7 @@ msgstr ""
 msgid "Failed to upload document."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:326
+#: lib/klass_hero_web/live/dashboard_live.ex:359
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Family Programs"
 msgstr ""
@@ -2799,7 +2799,7 @@ msgstr ""
 msgid "No pending documents to review."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:334
+#: lib/klass_hero_web/live/dashboard_live.ex:375
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No programs booked yet"
 msgstr ""
@@ -3684,7 +3684,7 @@ msgstr ""
 msgid "Correct"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:258
+#: lib/klass_hero_web/live/dashboard_live.ex:285
 #: lib/klass_hero_web/live/provider/programs_live.ex:257
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:200
 #, elixir-autogen, elixir-format
@@ -3914,7 +3914,7 @@ msgstr ""
 msgid "Track Everything:"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:245
+#: lib/klass_hero_web/live/dashboard_live.ex:272
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "Upgrade your plan to send messages."
@@ -5279,7 +5279,7 @@ msgstr ""
 msgid "Good evening"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:59
+#: lib/klass_hero_web/live/dashboard_live.ex:27
 #, elixir-autogen, elixir-format
 msgid "Your week with the kids"
 msgstr ""
@@ -5353,7 +5353,7 @@ msgstr ""
 msgid "Active policy required to teach."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:278
+#: lib/klass_hero_web/live/dashboard_live.ex:305
 #: lib/klass_hero_web/live/provider/overview_live.ex:259
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Active programs"
@@ -6106,7 +6106,7 @@ msgstr ""
 msgid "Mother and child-safety specialist with 10+ years in quality assurance. Architecting our Safety-First Verification engine."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:155
+#: lib/klass_hero_web/live/dashboard_live.ex:182
 #, elixir-autogen, elixir-format, fuzzy
 msgid "New conversation"
 msgstr ""
@@ -6173,7 +6173,7 @@ msgid_plural "No rows imported. %{count} rows could not be processed."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:312
+#: lib/klass_hero_web/live/dashboard_live.ex:345
 #, elixir-autogen, elixir-format
 msgid "No upcoming sessions in the next few weeks."
 msgstr ""
@@ -6689,17 +6689,17 @@ msgstr ""
 msgid "Unlimited programs and locations"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:290
+#: lib/klass_hero_web/live/dashboard_live.ex:317
 #, elixir-autogen, elixir-format
 msgid "Unread messages"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:303
+#: lib/klass_hero_web/live/dashboard_live.ex:330
 #, elixir-autogen, elixir-format
 msgid "Upcoming sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:284
+#: lib/klass_hero_web/live/dashboard_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "Upcoming this week"
 msgstr ""
@@ -6714,7 +6714,7 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:308
+#: lib/klass_hero_web/live/dashboard_live.ex:335
 #, elixir-autogen, elixir-format, fuzzy
 msgid "View all"
 msgstr ""
@@ -7585,4 +7585,14 @@ msgstr ""
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:107
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Session note submitted for review"
+msgstr ""
+
+#: lib/klass_hero_web/live/dashboard_live.ex:369
+#, elixir-autogen, elixir-format
+msgid "Loading your programs…"
+msgstr ""
+
+#: lib/klass_hero_web/live/dashboard_live.ex:339
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Loading…"
 msgstr ""

--- a/priv/repo/migrations/20260718083437_add_session_date_status_index_to_program_sessions.exs
+++ b/priv/repo/migrations/20260718083437_add_session_date_status_index_to_program_sessions.exs
@@ -1,0 +1,16 @@
+defmodule KlassHero.Repo.Migrations.AddSessionDateStatusIndexToProgramSessions do
+  use Ecto.Migration
+
+  @moduledoc """
+  Admin sessions dashboard (`Participation.list_admin_sessions/1`) defaults to
+  `session_date == today` and optionally filters `status`. The only existing
+  index — `unique_index(:program_sessions, [:program_id, :session_date, :start_time])`
+  — leads with `program_id`, so a `session_date`-led lookup can't use it and
+  Postgres seq-scans the table on every dashboard load. Lead with `session_date`
+  (also serves `list_sessions_today/1`), trail with `status` to cover the filter.
+  """
+
+  def change do
+    create index(:program_sessions, [:session_date, :status])
+  end
+end

--- a/priv/repo/migrations/20260718165427_add_provider_id_index_to_session_notes.exs
+++ b/priv/repo/migrations/20260718165427_add_provider_id_index_to_session_notes.exs
@@ -1,0 +1,14 @@
+defmodule KlassHero.Repo.Migrations.AddProviderIdIndexToSessionNotes do
+  use Ecto.Migration
+
+  @moduledoc """
+  Provider-scoped note lookups (`SessionNoteQueries.by_provider/2`) filter
+  `provider_id`, but the only index touching it is the composite unique
+  `(participation_record_id, provider_id)`, which can't serve a provider-only
+  predicate. Index the FK directly.
+  """
+
+  def change do
+    create index(:session_notes, [:provider_id])
+  end
+end

--- a/priv/repo/migrations/20260718165428_add_status_enrolled_at_index_to_enrollments.exs
+++ b/priv/repo/migrations/20260718165428_add_status_enrolled_at_index_to_enrollments.exs
@@ -1,0 +1,14 @@
+defmodule KlassHero.Repo.Migrations.AddStatusEnrolledAtIndexToEnrollments do
+  use Ecto.Migration
+
+  @moduledoc """
+  The admin bookings screen filters enrollments by `status` and sorts by
+  `enrolled_at desc`. No existing index leads with `status`, so Postgres walks
+  the `enrolled_at` index discarding non-matching rows. Lead with `status`,
+  trail with `enrolled_at` to serve filter + sort together.
+  """
+
+  def change do
+    create index(:enrollments, [:status, :enrolled_at])
+  end
+end

--- a/priv/repo/migrations/20260718165429_add_program_id_status_index_to_provider_session_details.exs
+++ b/priv/repo/migrations/20260718165429_add_program_id_status_index_to_provider_session_details.exs
@@ -1,0 +1,13 @@
+defmodule KlassHero.Repo.Migrations.AddProgramIdStatusIndexToProviderSessionDetails do
+  use Ecto.Migration
+
+  @moduledoc """
+  Staff assign/unassign projection handlers update rows `where program_id == ^id
+  and status == :scheduled`. Both existing indexes lead with `provider_id`, which
+  isn't in that predicate, forcing a scan of the read table on every assignment.
+  """
+
+  def change do
+    create index(:provider_session_details, [:program_id, :status])
+  end
+end

--- a/test/klass_hero/participation/list_upcoming_sessions_for_programs_test.exs
+++ b/test/klass_hero/participation/list_upcoming_sessions_for_programs_test.exs
@@ -1,0 +1,75 @@
+defmodule KlassHero.Participation.ListUpcomingSessionsForProgramsTest do
+  # async: false — the query-count assertion uses a process-global telemetry handler.
+  use KlassHero.DataCase, async: false
+
+  import KlassHero.Factory
+
+  alias KlassHero.Participation
+  alias KlassHero.QueryCounter
+
+  describe "list_upcoming_sessions_for_programs/2" do
+    setup do
+      %{program_a: insert(:program_schema), program_b: insert(:program_schema), today: Date.utc_today()}
+    end
+
+    test "returns only sessions on or after from_date, across all given programs", %{
+      program_a: a,
+      program_b: b,
+      today: today
+    } do
+      past = insert(:program_session_schema, program_id: a.id, session_date: Date.add(today, -3))
+      today_session = insert(:program_session_schema, program_id: a.id, session_date: today)
+      future = insert(:program_session_schema, program_id: b.id, session_date: Date.add(today, 5))
+
+      ids =
+        [a.id, b.id]
+        |> Participation.list_upcoming_sessions_for_programs(today)
+        |> Enum.map(& &1.id)
+
+      assert today_session.id in ids
+      assert future.id in ids
+      refute past.id in ids
+    end
+
+    test "orders by session_date then start_time ascending", %{program_a: a, today: today} do
+      later =
+        insert(:program_session_schema, program_id: a.id, session_date: Date.add(today, 2), start_time: ~T[09:00:00])
+
+      sooner =
+        insert(:program_session_schema,
+          program_id: a.id,
+          session_date: Date.add(today, 1),
+          start_time: ~T[15:00:00],
+          end_time: ~T[16:00:00]
+        )
+
+      same_day_early =
+        insert(:program_session_schema, program_id: a.id, session_date: Date.add(today, 1), start_time: ~T[08:00:00])
+
+      ids =
+        [a.id]
+        |> Participation.list_upcoming_sessions_for_programs(today)
+        |> Enum.map(& &1.id)
+
+      assert ids == [same_day_early.id, sooner.id, later.id]
+    end
+
+    test "excludes sessions from programs not in the list", %{program_a: a, program_b: b, today: today} do
+      insert(:program_session_schema, program_id: b.id, session_date: Date.add(today, 1))
+
+      assert Participation.list_upcoming_sessions_for_programs([a.id], today) == []
+    end
+
+    test "issues a single query regardless of program count", %{today: today} do
+      ids = for _ <- 1..3, do: insert(:program_schema).id
+
+      queries = QueryCounter.count_only(fn -> Participation.list_upcoming_sessions_for_programs(ids, today) end)
+
+      assert queries == 1
+    end
+
+    test "returns an empty list for an empty program list", %{today: today} do
+      assert Participation.list_upcoming_sessions_for_programs([], today) == []
+    end
+  end
+end

--- a/test/klass_hero/program_catalog/list_featured_programs_test.exs
+++ b/test/klass_hero/program_catalog/list_featured_programs_test.exs
@@ -1,0 +1,47 @@
+defmodule KlassHero.ProgramCatalog.ListFeaturedProgramsTest do
+  # async: false — the row-count assertion uses a process-global telemetry
+  # handler; concurrent tests' queries would otherwise inflate the count.
+  use KlassHero.DataCase, async: false
+
+  import KlassHero.Factory
+
+  alias KlassHero.ProgramCatalog
+  alias KlassHero.QueryCounter
+
+  describe "list_featured_programs/0" do
+    test "returns at most 2 active listings" do
+      insert_list(4, :program_listing_schema)
+
+      assert length(ProgramCatalog.list_featured_programs()) == 2
+    end
+
+    test "fetches at most 2 rows from the database (bounded in SQL, not trimmed in Elixir)" do
+      insert_list(4, :program_listing_schema)
+
+      {result, rows_fetched} =
+        QueryCounter.count_rows(fn -> ProgramCatalog.list_featured_programs() end)
+
+      assert length(result) == 2
+      # The whole point of the fix: don't pull every active listing back just to keep 2.
+      assert rows_fetched <= 2
+    end
+
+    test "orders by title ascending" do
+      insert(:program_listing_schema, title: "Zebra")
+      insert(:program_listing_schema, title: "Apple")
+      insert(:program_listing_schema, title: "Mango")
+
+      assert [%{title: "Apple"}, %{title: "Mango"}] = ProgramCatalog.list_featured_programs()
+    end
+
+    test "excludes expired listings (end_date in the past)" do
+      insert(:program_listing_schema, title: "Active", end_date: nil)
+      insert(:program_listing_schema, title: "Expired", end_date: Date.add(Date.utc_today(), -1))
+
+      titles = ProgramCatalog.list_featured_programs() |> Enum.map(& &1.title)
+
+      assert "Active" in titles
+      refute "Expired" in titles
+    end
+  end
+end

--- a/test/klass_hero_web/live/dashboard_live/family_programs_test.exs
+++ b/test/klass_hero_web/live/dashboard_live/family_programs_test.exs
@@ -9,6 +9,7 @@ defmodule KlassHeroWeb.DashboardLive.FamilyProgramsTest do
 
     test "shows empty state when parent has no enrollments", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/dashboard")
+      render_async(view)
 
       assert has_element?(view, "#family-programs")
       assert has_element?(view, "#family-programs-empty")
@@ -31,6 +32,7 @@ defmodule KlassHeroWeb.DashboardLive.FamilyProgramsTest do
         )
 
       {:ok, view, _html} = live(conn, ~p"/dashboard")
+      render_async(view)
 
       refute has_element?(view, "#family-programs-empty")
       assert has_element?(view, "#family_programs-#{enrollment.id}")
@@ -47,6 +49,7 @@ defmodule KlassHeroWeb.DashboardLive.FamilyProgramsTest do
       )
 
       {:ok, view, _html} = live(conn, ~p"/dashboard")
+      render_async(view)
 
       assert has_element?(
                view,
@@ -67,6 +70,7 @@ defmodule KlassHeroWeb.DashboardLive.FamilyProgramsTest do
         )
 
       {:ok, view, _html} = live(conn, ~p"/dashboard")
+      render_async(view)
 
       refute has_element?(view, "#family-programs-empty")
       assert has_element?(view, "#family_programs-#{enrollment.id}")
@@ -88,6 +92,7 @@ defmodule KlassHeroWeb.DashboardLive.FamilyProgramsTest do
         )
 
       {:ok, view, _html} = live(conn, ~p"/dashboard")
+      render_async(view)
 
       refute has_element?(view, "#family-programs-empty")
       assert has_element?(view, "#family_programs-#{enrollment.id}")
@@ -118,7 +123,7 @@ defmodule KlassHeroWeb.DashboardLive.FamilyProgramsTest do
         )
 
       {:ok, view, _html} = live(conn, ~p"/dashboard")
-      html = render(view)
+      html = render_async(view)
 
       active_pos = :binary.match(html, "family_programs-#{active_enrollment.id}") |> elem(0)
       expired_pos = :binary.match(html, "family_programs-#{expired_enrollment.id}") |> elem(0)

--- a/test/klass_hero_web/live/dashboard_live_test.exs
+++ b/test/klass_hero_web/live/dashboard_live_test.exs
@@ -6,6 +6,7 @@ defmodule KlassHeroWeb.DashboardLiveTest do
   import Phoenix.LiveViewTest
 
   alias KlassHero.AccountsFixtures
+  alias KlassHero.Family.Child
 
   describe "DashboardLive (Phase 2.1 — Pa* component layout)" do
     setup :register_and_log_in_user
@@ -201,6 +202,40 @@ defmodule KlassHeroWeb.DashboardLiveTest do
 
       refute upcoming =~ "No upcoming sessions"
       assert upcoming =~ program.title
+    end
+  end
+
+  describe "upcoming sessions fan-out (perf pass #2)" do
+    test "a session in a program shared by two children renders one row per child", %{conn: conn} do
+      user = AccountsFixtures.user_fixture(intended_roles: [:parent])
+      parent = insert(:parent_profile_schema, identity_id: user.id)
+      owner = AccountsFixtures.user_fixture()
+      provider = insert(:provider_profile_schema, identity_id: owner.id)
+      program = insert(:program_schema, provider_id: provider.id)
+
+      {child_a, _} = insert_child_with_guardian(parent: parent, first_name: "Ada", last_name: "Alpha")
+      {child_b, _} = insert_child_with_guardian(parent: parent, first_name: "Ben", last_name: "Beta")
+
+      for child <- [child_a, child_b] do
+        insert(:enrollment_schema,
+          parent_id: parent.id,
+          program_id: program.id,
+          child_id: child.id,
+          status: "confirmed",
+          confirmed_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        )
+      end
+
+      insert(:program_session_schema, program_id: program.id, session_date: Date.add(Date.utc_today(), 2))
+
+      conn = log_in_user(conn, user)
+      {:ok, view, _html} = live(conn, ~p"/dashboard")
+      render_async(view)
+
+      upcoming = view |> element("#upcoming-sessions") |> render()
+
+      assert upcoming =~ Child.full_name(child_a)
+      assert upcoming =~ Child.full_name(child_b)
     end
   end
 

--- a/test/klass_hero_web/live/dashboard_live_test.exs
+++ b/test/klass_hero_web/live/dashboard_live_test.exs
@@ -12,6 +12,7 @@ defmodule KlassHeroWeb.DashboardLiveTest do
 
     test "renders dashboard page successfully", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/dashboard")
+      render_async(view)
 
       # New surface anchors: kid picker, KPI grid, upcoming sessions card.
       assert has_element?(view, "#dashboard-stats")
@@ -20,7 +21,8 @@ defmodule KlassHeroWeb.DashboardLiveTest do
     end
 
     test "sidebar links to user settings", %{conn: conn} do
-      {:ok, _view, html} = live(conn, ~p"/dashboard")
+      {:ok, view, _html} = live(conn, ~p"/dashboard")
+      html = render_async(view)
 
       # parent_app layout's sidebar puts the account row at the bottom.
       assert html =~ "/users/settings"
@@ -30,7 +32,8 @@ defmodule KlassHeroWeb.DashboardLiveTest do
       conn: conn,
       user: user
     } do
-      {:ok, _view, html} = live(conn, ~p"/dashboard")
+      {:ok, view, _html} = live(conn, ~p"/dashboard")
+      html = render_async(view)
 
       # New copy: subtitle is fixed; title contains a time-bucket greeting +
       # the user's first name (extracted from `user.name`).
@@ -48,7 +51,7 @@ defmodule KlassHeroWeb.DashboardLiveTest do
     } do
       {:ok, view, _html} = live(conn, ~p"/dashboard")
 
-      assert html = render(view)
+      assert html = render_async(view)
       assert html =~ "Active programs"
       assert html =~ "Upcoming this week"
       assert html =~ "Unread messages"
@@ -63,7 +66,8 @@ defmodule KlassHeroWeb.DashboardLiveTest do
     end
 
     test "renders weekly goal card with the bundle's title", %{conn: conn} do
-      {:ok, _view, html} = live(conn, ~p"/dashboard")
+      {:ok, view, _html} = live(conn, ~p"/dashboard")
+      html = render_async(view)
 
       assert html =~ "Weekly adventure goal"
     end
@@ -74,18 +78,20 @@ defmodule KlassHeroWeb.DashboardLiveTest do
       # is therefore not rendered — verify the section is absent rather
       # than asserting on its inner button.
       {:ok, view, _html} = live(conn, ~p"/dashboard")
+      render_async(view)
 
       refute has_element?(view, "#kid-picker")
     end
 
     test "upcoming sessions section renders an empty-state copy", %{conn: conn} do
-      {:ok, _view, html} = live(conn, ~p"/dashboard")
+      {:ok, view, _html} = live(conn, ~p"/dashboard")
 
-      assert html =~ "No upcoming sessions"
+      assert render_async(view) =~ "No upcoming sessions"
     end
 
     test "recent messages preview renders an empty-state copy", %{conn: conn} do
-      {:ok, _view, html} = live(conn, ~p"/dashboard")
+      {:ok, view, _html} = live(conn, ~p"/dashboard")
+      html = render_async(view)
 
       assert html =~ "No messages yet."
     end
@@ -102,9 +108,9 @@ defmodule KlassHeroWeb.DashboardLiveTest do
         latest_message_at: DateTime.utc_now() |> DateTime.truncate(:second)
       )
 
-      {:ok, _view, html} = live(conn, ~p"/dashboard")
+      {:ok, view, _html} = live(conn, ~p"/dashboard")
 
-      assert html =~ preview_text
+      assert render_async(view) =~ preview_text
     end
   end
 
@@ -127,6 +133,7 @@ defmodule KlassHeroWeb.DashboardLiveTest do
 
       conn = log_in_user(conn, user)
       {:ok, view, _html} = live(conn, ~p"/dashboard")
+      render_async(view)
 
       selector =
         ~s|button[phx-click="contact_provider"][phx-value-program-id="#{program.id}"]|
@@ -135,6 +142,49 @@ defmodule KlassHeroWeb.DashboardLiveTest do
                view |> element(selector) |> render_click()
 
       assert path =~ ~r"^/messages/[0-9a-f-]+$"
+    end
+  end
+
+  describe "async loading (perf pass #1)" do
+    setup %{conn: conn} do
+      user = AccountsFixtures.user_fixture(intended_roles: [:parent])
+      parent = insert(:parent_profile_schema, identity_id: user.id)
+      owner = AccountsFixtures.user_fixture()
+      provider = insert(:provider_profile_schema, identity_id: owner.id)
+      program = insert(:program_schema, provider_id: provider.id)
+      {child, _parent} = insert_child_with_guardian(parent: parent)
+
+      insert(:enrollment_schema,
+        parent_id: parent.id,
+        program_id: program.id,
+        child_id: child.id,
+        status: "confirmed",
+        confirmed_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      )
+
+      %{conn: log_in_user(conn, user), program: program}
+    end
+
+    test "disconnected render shows a loading skeleton, not the family data", %{conn: conn} do
+      html = conn |> get(~p"/dashboard") |> html_response(200)
+
+      assert html =~ ~s(id="family-programs-loading")
+      refute html =~ ~s(id="family-programs-list")
+    end
+
+    test "connected mount loads family data via async (sourced from current_scope.parent)", %{
+      conn: conn
+    } do
+      {:ok, view, _loading_html} = live(conn, ~p"/dashboard")
+
+      assert has_element?(view, "#family-programs-loading")
+      refute has_element?(view, "#family-programs-list")
+
+      render_async(view)
+
+      assert has_element?(view, "#family-programs-list")
+      assert has_element?(view, "#kid-picker")
+      refute has_element?(view, "#family-programs-loading")
     end
   end
 

--- a/test/klass_hero_web/live/dashboard_live_test.exs
+++ b/test/klass_hero_web/live/dashboard_live_test.exs
@@ -186,6 +186,22 @@ defmodule KlassHeroWeb.DashboardLiveTest do
       assert has_element?(view, "#kid-picker")
       refute has_element?(view, "#family-programs-loading")
     end
+
+    test "upcoming sessions tile renders a future session (was always empty before the batch fix)",
+         %{conn: conn, program: program} do
+      insert(:program_session_schema,
+        program_id: program.id,
+        session_date: Date.add(Date.utc_today(), 3)
+      )
+
+      {:ok, view, _html} = live(conn, ~p"/dashboard")
+      render_async(view)
+
+      upcoming = view |> element("#upcoming-sessions") |> render()
+
+      refute upcoming =~ "No upcoming sessions"
+      assert upcoming =~ program.title
+    end
   end
 
   describe "role-based redirect from /dashboard" do

--- a/test/support/query_counter.ex
+++ b/test/support/query_counter.ex
@@ -1,0 +1,87 @@
+defmodule KlassHero.QueryCounter do
+  @moduledoc """
+  Test helper that counts Ecto queries executed during a block.
+
+  Attaches a temporary `:telemetry` handler to the Repo's
+  `[:klass_hero, :repo, :query]` event and tallies emissions into an atomic
+  `:counters` reference. `:counters` is used (rather than message-passing to the
+  test pid) so queries emitted from OTHER processes — e.g. a LiveView
+  `start_async/3` task — are still counted, since the handler runs in whichever
+  process executes the query.
+
+  ## Usage
+
+      {result, query_count} = QueryCounter.count(fn -> Context.some_read() end)
+      assert query_count == 1
+
+  Note: only synchronous work done inside `fun` is guaranteed to be counted.
+  When measuring async work (e.g. `handle_async`), make sure the block waits for
+  that work to complete (render/await) before returning.
+  """
+
+  @event [:klass_hero, :repo, :query]
+
+  @doc """
+  Runs `fun`, returning `{result, query_count}` where `query_count` is the number
+  of Ecto queries executed during the call.
+  """
+  @spec count((-> result)) :: {result, non_neg_integer()} when result: term()
+  def count(fun) when is_function(fun, 0) do
+    counter = :counters.new(1, [:write_concurrency])
+    handler_id = {__MODULE__, System.unique_integer([:positive])}
+
+    :telemetry.attach(
+      handler_id,
+      @event,
+      fn _event, _measurements, _metadata, _config -> :counters.add(counter, 1, 1) end,
+      nil
+    )
+
+    try do
+      result = fun.()
+      {result, :counters.get(counter, 1)}
+    after
+      :telemetry.detach(handler_id)
+    end
+  end
+
+  @doc "Convenience wrapper returning only the query count, discarding the result."
+  @spec count_only((-> term())) :: non_neg_integer()
+  def count_only(fun) when is_function(fun, 0) do
+    {_result, count} = count(fun)
+    count
+  end
+
+  @doc """
+  Runs `fun`, returning `{result, total_rows}` where `total_rows` is the sum of
+  `num_rows` across every query executed during the call.
+
+  Useful for proving a query is bounded in SQL (e.g. `LIMIT`) rather than trimmed
+  in Elixir after fetching everything — the return value can be identical either
+  way, but the rows pulled from the database differ.
+  """
+  @spec count_rows((-> result)) :: {result, non_neg_integer()} when result: term()
+  def count_rows(fun) when is_function(fun, 0) do
+    counter = :counters.new(1, [:write_concurrency])
+    handler_id = {__MODULE__, :rows, System.unique_integer([:positive])}
+
+    :telemetry.attach(
+      handler_id,
+      @event,
+      fn _event, _measurements, metadata, _config ->
+        case metadata do
+          %{result: {:ok, %{num_rows: n}}} when is_integer(n) -> :counters.add(counter, 1, n)
+          _ -> :ok
+        end
+      end,
+      nil
+    )
+
+    try do
+      result = fun.()
+      {result, :counters.get(counter, 1)}
+    after
+      :telemetry.detach(handler_id)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Investigation traced "slow at near-zero traffic" to **fixed per-request cost**, not load — the read paths and facades are already well-batched; the cost sits in the shared mount path, one unbounded query, and missing indexes. This bundles the six highest-impact, lowest-effort fixes across two passes.

**Pass #1 — per-request path**
- **Dashboard async load** — `mount` deferred to the connected mount via `start_async`, so data fetches run once (not on the throwaway disconnected render) and never block first paint. Reads the parent profile from the already-resolved `current_scope.parent` instead of re-querying it.
- **Home unbounded query** — `list_featured_programs/0` now bounds in SQL (`LIMIT 2`) instead of loading every active listing and trimming to two in Elixir.
- **Admin sessions index** — `program_sessions(session_date, status)`; the admin dashboard defaults to `session_date = today`, which the existing `program_id`-led composite index could not serve.

**Pass #2**
- **Batched upcoming sessions + dead-tile fix** — `load_upcoming_sessions/2` called `Participation.list_sessions/1` once per program (N+1) **and** matched `{:ok, sessions}` against a bare-list return, so the "upcoming sessions" tile was **always empty on main**. New `Participation.list_upcoming_sessions_for_programs/2` (one date-filtered `IN` query) + a `program_id` fan-out that preserves the multi-child case. Repairs the tile and removes the N+1.
- **Three indexes** — `session_notes(provider_id)`, `enrollments(status, enrolled_at)`, `provider_session_details(program_id, status)`.

## Review focus

- `lib/klass_hero_web/live/dashboard_live.ex` — the `start_async`/`handle_async` restructure and the `load_upcoming_sessions/2` fan-out (a program shared by two enrolled children yields one row per child).
- `lib/klass_hero/participation.ex` — new `list_upcoming_sessions_for_programs/2` (bare-list return, matching `get_programs_by_ids/1`).
- Migrations use plain `create index` (no `concurrently`) per repo convention; tables are small on current volumes.

## Test plan

- New `QueryCounter` test helper (telemetry-based) proves the row/query wins: `list_featured_programs` fetches 2 rows not all; `list_upcoming_sessions_for_programs` issues 1 query for N programs.
- Dashboard tests await the async load (`render_async`) so it settles within each test rather than leaking a late span into the `async: false` tracing test.
- Coverage added for the dead-tile repair and the multi-child fan-out.
- `mix precommit` green (4176 tests); suite stable across repeated runs.

## Follow-ups

- #1111 — public-page (home/programs/program_detail) double-fetch needs an SEO-safe cache-backed deferral.
- Deferred perf items (per-deploy projection bootstrap N+1s) noted for a later pass.
- Reviewer flagged: index migrations take a build-time write lock (fine at current volumes; revisit with `concurrently` before scale), and `list_upcoming_sessions_for_programs/2` has no upper date bound (still a strict improvement over the prior all-history fetch; a "next few weeks" horizon is the natural follow-up).