### PR TITLE
fix: single-source PubSub topics; fix dead attendance subscriptions (#1108)

### DIFF
--- a/lib/klass_hero/participation.ex
+++ b/lib/klass_hero/participation.ex
@@ -22,6 +22,7 @@ defmodule KlassHero.Participation do
   alias KlassHero.Participation.Adapters.Driven.ACL.ProgramProviderResolver
   alias KlassHero.Participation.Adapters.Driven.Persistence.Queries.ParticipationQueries
   alias KlassHero.Participation.Adapters.Driven.Persistence.Queries.SessionNoteQueries
+  alias KlassHero.Participation.Adapters.Driving.Events.EventHandlers.NotifyLiveViews
   alias KlassHero.Participation.Domain.Events.ParticipationEvents
   alias KlassHero.Participation.ParticipationRecord
   alias KlassHero.Participation.ProgramSession
@@ -327,6 +328,33 @@ defmodule KlassHero.Participation do
 
   @doc "Returns the list of valid session statuses."
   def session_statuses, do: ProgramSession.valid_statuses()
+
+  @doc """
+  Returns the PubSub topics a LiveView should subscribe to for a subscription
+  group (`:session_note` or `:attendance`).
+
+  Topics derive from `ParticipationEvents`' event registry (#1108), so renaming an
+  event atom moves the publisher and every subscriber together — no hand-typed
+  topic strings in LiveViews.
+  """
+  @spec participation_topics(atom()) :: [String.t()]
+  def participation_topics(group) do
+    for event_type <- ParticipationEvents.subscription_event_types(group), do: event_topic(event_type)
+  end
+
+  @doc "Returns the PubSub topic a single event type is published on."
+  @spec event_topic(atom()) :: String.t()
+  def event_topic(event_type) do
+    NotifyLiveViews.build_topic(ParticipationEvents.aggregate_type_for(event_type), event_type)
+  end
+
+  @doc """
+  Returns the provider-scoped participation topic — the single topic carrying all
+  of a provider's participation events. Provider/staff LiveViews subscribe to it;
+  `NotifyLiveViews` publishes to it. One builder, so the two sides can't drift.
+  """
+  @spec provider_topic(String.t()) :: String.t()
+  defdelegate provider_topic(provider_id), to: NotifyLiveViews
 
   @doc """
   Seeds a session roster with the program's enrolled children. Best-effort: always returns `:ok`.

--- a/lib/klass_hero/participation/adapters/driving/events/event_handlers/notify_live_views.ex
+++ b/lib/klass_hero/participation/adapters/driving/events/event_handlers/notify_live_views.ex
@@ -43,6 +43,10 @@ defmodule KlassHero.Participation.Adapters.Driving.Events.EventHandlers.NotifyLi
   @spec build_topic(atom(), atom()) :: String.t()
   defdelegate build_topic(aggregate_type, event_type), to: SharedNotifyLiveViews
 
+  @doc "Builds the provider-scoped participation topic. The single source both the publisher (here) and subscribers (via the `Participation` facade) use."
+  @spec provider_topic(String.t()) :: String.t()
+  def provider_topic(provider_id), do: "participation:provider:#{provider_id}"
+
   defp publish_to_provider_topic(%DomainEvent{payload: payload} = event) do
     case Map.fetch(payload, :program_id) do
       {:ok, program_id} ->
@@ -59,8 +63,7 @@ defmodule KlassHero.Participation.Adapters.Driving.Events.EventHandlers.NotifyLi
   defp resolve_and_publish(event, program_id) do
     case ProgramProviderResolver.resolve_provider_id(program_id) do
       {:ok, provider_id} ->
-        provider_topic = "participation:provider:#{provider_id}"
-        SharedNotifyLiveViews.safe_publish(event, provider_topic)
+        SharedNotifyLiveViews.safe_publish(event, provider_topic(provider_id))
 
       {:error, reason} ->
         # Best-effort: generic topic already published. Demoted from :warning — sustained

--- a/lib/klass_hero/participation/domain/events/participation_events.ex
+++ b/lib/klass_hero/participation/domain/events/participation_events.ex
@@ -31,7 +31,37 @@ defmodule KlassHero.Participation.Domain.Events.ParticipationEvents do
           parent_id: String.t() | nil
         }
 
-  @aggregate_type :participation
+  # Single source of truth for event routing (#1108). Each event's aggregate_type
+  # is looked up here rather than hand-written at each call site, and subscription
+  # topics on the `Participation` facade derive from the same map — so renaming an
+  # atom moves the publisher and every LiveView subscriber together.
+  @event_aggregates %{
+    session_created: :participation,
+    session_started: :participation,
+    session_completed: :participation,
+    roster_seeded: :participation,
+    child_checked_in: :participation,
+    child_checked_out: :participation,
+    child_marked_absent: :participation,
+    session_note_submitted: :session_note,
+    session_note_approved: :session_note,
+    session_note_rejected: :session_note
+  }
+
+  # The event_types each LiveView group subscribes to. Kept alongside the registry
+  # so the facade can build the exact topic strings subscribers need.
+  @subscription_groups %{
+    attendance: [:child_checked_in, :child_checked_out, :child_marked_absent],
+    session_note: [:session_note_submitted, :session_note_approved, :session_note_rejected]
+  }
+
+  @doc "Returns the aggregate_type registered for an event type. Raises if unknown."
+  @spec aggregate_type_for(atom()) :: atom()
+  def aggregate_type_for(event_type), do: Map.fetch!(@event_aggregates, event_type)
+
+  @doc "Returns the ordered event types a subscription group listens for."
+  @spec subscription_event_types(atom()) :: [atom()]
+  def subscription_event_types(group), do: Map.fetch!(@subscription_groups, group)
 
   @doc "Creates a session_created event."
   @spec session_created(ProgramSession.t(), keyword()) :: DomainEvent.t()
@@ -46,7 +76,7 @@ defmodule KlassHero.Participation.Domain.Events.ParticipationEvents do
       max_capacity: session.max_capacity
     }
 
-    DomainEvent.new(:session_created, session.id, @aggregate_type, payload, opts)
+    new_event(:session_created, session.id, payload, opts)
   end
 
   @doc "Creates a session_started event."
@@ -58,7 +88,7 @@ defmodule KlassHero.Participation.Domain.Events.ParticipationEvents do
       started_at: DateTime.utc_now()
     }
 
-    DomainEvent.new(:session_started, session.id, @aggregate_type, payload, opts)
+    new_event(:session_started, session.id, payload, opts)
   end
 
   @doc "Creates a session_completed event."
@@ -74,7 +104,7 @@ defmodule KlassHero.Participation.Domain.Events.ParticipationEvents do
 
     payload = Map.merge(extra, base_payload)
 
-    DomainEvent.new(:session_completed, session.id, @aggregate_type, payload, event_opts)
+    new_event(:session_completed, session.id, payload, event_opts)
   end
 
   @doc "Creates a roster_seeded event."
@@ -86,7 +116,7 @@ defmodule KlassHero.Participation.Domain.Events.ParticipationEvents do
       seeded_count: count
     }
 
-    DomainEvent.new(:roster_seeded, session_id, @aggregate_type, payload, opts)
+    new_event(:roster_seeded, session_id, payload, opts)
   end
 
   @doc deprecated: "Use child_checked_in/2 with ProgramSession to include program_id in payload"
@@ -106,7 +136,7 @@ defmodule KlassHero.Participation.Domain.Events.ParticipationEvents do
       notes: record.check_in_notes
     }
 
-    DomainEvent.new(:child_checked_in, record.id, @aggregate_type, payload, opts)
+    new_event(:child_checked_in, record.id, payload, opts)
   end
 
   def child_checked_in(%ParticipationRecord{} = record, nil), do: child_checked_in(record, [])
@@ -125,7 +155,7 @@ defmodule KlassHero.Participation.Domain.Events.ParticipationEvents do
       program_id: session.program_id
     }
 
-    DomainEvent.new(:child_checked_in, record.id, @aggregate_type, payload, [])
+    new_event(:child_checked_in, record.id, payload, [])
   end
 
   @doc deprecated: "Use child_checked_out/2 with ProgramSession to include program_id in payload"
@@ -145,7 +175,7 @@ defmodule KlassHero.Participation.Domain.Events.ParticipationEvents do
       notes: record.check_out_notes
     }
 
-    DomainEvent.new(:child_checked_out, record.id, @aggregate_type, payload, opts)
+    new_event(:child_checked_out, record.id, payload, opts)
   end
 
   def child_checked_out(%ParticipationRecord{} = record, nil), do: child_checked_out(record, [])
@@ -163,7 +193,7 @@ defmodule KlassHero.Participation.Domain.Events.ParticipationEvents do
       program_id: session.program_id
     }
 
-    DomainEvent.new(:child_checked_out, record.id, @aggregate_type, payload, [])
+    new_event(:child_checked_out, record.id, payload, [])
   end
 
   @doc deprecated: "Use child_marked_absent/2 with ProgramSession to include program_id in payload"
@@ -180,7 +210,7 @@ defmodule KlassHero.Participation.Domain.Events.ParticipationEvents do
       child_id: record.child_id
     }
 
-    DomainEvent.new(:child_marked_absent, record.id, @aggregate_type, payload, opts)
+    new_event(:child_marked_absent, record.id, payload, opts)
   end
 
   def child_marked_absent(%ParticipationRecord{} = record, nil), do: child_marked_absent(record, [])
@@ -195,7 +225,7 @@ defmodule KlassHero.Participation.Domain.Events.ParticipationEvents do
       program_id: session.program_id
     }
 
-    DomainEvent.new(:child_marked_absent, record.id, @aggregate_type, payload, [])
+    new_event(:child_marked_absent, record.id, payload, [])
   end
 
   @doc "Creates a session_note_submitted event."
@@ -203,7 +233,7 @@ defmodule KlassHero.Participation.Domain.Events.ParticipationEvents do
   def session_note_submitted(%SessionNote{} = note, opts \\ []) do
     payload = session_note_payload(note)
 
-    DomainEvent.new(:session_note_submitted, note.id, :session_note, payload, opts)
+    new_event(:session_note_submitted, note.id, payload, opts)
   end
 
   @doc "Creates a session_note_approved event."
@@ -211,7 +241,7 @@ defmodule KlassHero.Participation.Domain.Events.ParticipationEvents do
   def session_note_approved(%SessionNote{} = note, opts \\ []) do
     payload = session_note_payload(note)
 
-    DomainEvent.new(:session_note_approved, note.id, :session_note, payload, opts)
+    new_event(:session_note_approved, note.id, payload, opts)
   end
 
   @doc "Creates a session_note_rejected event."
@@ -219,7 +249,14 @@ defmodule KlassHero.Participation.Domain.Events.ParticipationEvents do
   def session_note_rejected(%SessionNote{} = note, opts \\ []) do
     payload = session_note_payload(note)
 
-    DomainEvent.new(:session_note_rejected, note.id, :session_note, payload, opts)
+    new_event(:session_note_rejected, note.id, payload, opts)
+  end
+
+  # Builds a DomainEvent, deriving aggregate_type from the registry so no call site
+  # hand-writes it (#1108).
+  @spec new_event(atom(), String.t(), map(), keyword()) :: DomainEvent.t()
+  defp new_event(event_type, aggregate_id, payload, opts) do
+    DomainEvent.new(event_type, aggregate_id, aggregate_type_for(event_type), payload, opts)
   end
 
   @spec session_note_payload(SessionNote.t()) :: session_note_payload()

--- a/lib/klass_hero/shared/adapters/driven/events/test_event_publisher.ex
+++ b/lib/klass_hero/shared/adapters/driven/events/test_event_publisher.ex
@@ -59,35 +59,52 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.TestEventPublisher do
   end
 
   @doc """
-  Returns all events published in the current test process.
+  Returns all events published in the current test process, without their topics.
 
   Returns an empty list if setup() was not called.
   """
   @spec get_events() :: [DomainEvent.t()]
   def get_events do
+    for {event, _topic} <- get_published(), do: event
+  end
+
+  @doc """
+  Returns `{event, topic}` tuples for everything published in the current test
+  process, in publish order.
+
+  The topic is the exact string the event was broadcast on — added for #1108 so
+  tests can assert the publish→subscribe coupling rather than pinning topic
+  literals by hand. Events published via `publish/1` carry their derived topic.
+  """
+  @spec get_published() :: [{DomainEvent.t(), String.t()}]
+  def get_published do
     Process.get(@key, [])
   end
 
   @impl true
   def publish(%DomainEvent{} = event) do
-    store_event(event)
+    store_event(event, derive_topic(event))
     :ok
   end
 
   @impl true
-  def publish(%DomainEvent{} = event, _topic) do
-    store_event(event)
+  def publish(%DomainEvent{} = event, topic) do
+    store_event(event, topic)
     :ok
   end
 
   @impl true
   def publish_all(events) when is_list(events) do
-    Enum.each(events, &store_event/1)
+    Enum.each(events, &store_event(&1, derive_topic(&1)))
     :ok
   end
 
-  defp store_event(%DomainEvent{} = event) do
-    events = Process.get(@key, [])
-    Process.put(@key, events ++ [event])
+  defp store_event(%DomainEvent{} = event, topic) do
+    published = Process.get(@key, [])
+    Process.put(@key, published ++ [{event, topic}])
+  end
+
+  defp derive_topic(%DomainEvent{aggregate_type: aggregate_type, event_type: event_type}) do
+    "#{aggregate_type}:#{event_type}"
   end
 end

--- a/lib/klass_hero_web/live/parent/participation_history_live.ex
+++ b/lib/klass_hero_web/live/parent/participation_history_live.ex
@@ -25,15 +25,12 @@ defmodule KlassHeroWeb.Parent.ParticipationHistoryLive do
       |> assign(:reject_forms, %{})
 
     if connected?(socket) do
-      Phoenix.PubSub.subscribe(KlassHero.PubSub, "participation_record:child_checked_in")
-      Phoenix.PubSub.subscribe(KlassHero.PubSub, "participation_record:child_checked_out")
+      # A parent's children can attend any provider's sessions, so subscribe to the
+      # generic attendance topics (filtered to this parent's children in handle_info)
+      # plus session-note submissions. Topics derive from the event registry (#1108).
+      topics = [Participation.event_topic(:session_note_submitted) | Participation.participation_topics(:attendance)]
 
-      Phoenix.PubSub.subscribe(
-        KlassHero.PubSub,
-        "participation_record:participation_marked_absent"
-      )
-
-      Phoenix.PubSub.subscribe(KlassHero.PubSub, "session_note:session_note_submitted")
+      for topic <- topics, do: Phoenix.PubSub.subscribe(KlassHero.PubSub, topic)
     end
 
     {:ok, load_participation_history(socket)}
@@ -118,7 +115,7 @@ defmodule KlassHeroWeb.Parent.ParticipationHistoryLive do
         {:domain_event, %DomainEvent{event_type: event_type, aggregate_id: record_id, payload: %{child_id: child_id}}},
         socket
       )
-      when event_type in [:child_checked_in, :child_checked_out, :participation_marked_absent] do
+      when event_type in [:child_checked_in, :child_checked_out, :child_marked_absent] do
     socket =
       if child_belongs_to_parent?(child_id, socket) do
         opts = if event_type == :child_checked_in, do: [at: 0], else: []

--- a/lib/klass_hero_web/live/provider/participation_live.ex
+++ b/lib/klass_hero_web/live/provider/participation_live.ex
@@ -42,17 +42,12 @@ defmodule KlassHeroWeb.Provider.ParticipationLive do
       |> assign(:record_note_map, %{})
 
     if connected?(socket) do
-      Phoenix.PubSub.subscribe(KlassHero.PubSub, "participation_record:child_checked_in")
-      Phoenix.PubSub.subscribe(KlassHero.PubSub, "participation_record:child_checked_out")
+      # Attendance updates arrive on the provider-scoped topic (the publisher routes
+      # per provider); session-note topics derive from the event registry (#1108).
+      provider_topic = Participation.provider_topic(provider_id)
 
-      Phoenix.PubSub.subscribe(
-        KlassHero.PubSub,
-        "participation_record:participation_marked_absent"
-      )
-
-      Phoenix.PubSub.subscribe(KlassHero.PubSub, "session_note:session_note_submitted")
-      Phoenix.PubSub.subscribe(KlassHero.PubSub, "session_note:session_note_approved")
-      Phoenix.PubSub.subscribe(KlassHero.PubSub, "session_note:session_note_rejected")
+      for topic <- [provider_topic | Participation.participation_topics(:session_note)],
+          do: Phoenix.PubSub.subscribe(KlassHero.PubSub, topic)
     end
 
     {:ok, load_session_data(socket)}
@@ -239,7 +234,7 @@ defmodule KlassHeroWeb.Provider.ParticipationLive do
 
   @impl true
   def handle_info({:domain_event, %DomainEvent{event_type: event_type, aggregate_id: record_id}}, socket)
-      when event_type in [:child_checked_in, :child_checked_out, :participation_marked_absent] do
+      when event_type in [:child_checked_in, :child_checked_out, :child_marked_absent] do
     {:noreply, update_participation_record(socket, record_id)}
   end
 
@@ -247,6 +242,13 @@ defmodule KlassHeroWeb.Provider.ParticipationLive do
   def handle_info({:domain_event, %DomainEvent{event_type: event_type}}, socket)
       when event_type in [:session_note_submitted, :session_note_approved, :session_note_rejected] do
     {:noreply, load_session_data(socket)}
+  end
+
+  @impl true
+  def handle_info({:domain_event, _event}, socket) do
+    # The provider-scoped topic also carries session-lifecycle events this view
+    # doesn't act on. Ignore them rather than crash on an unmatched message.
+    {:noreply, socket}
   end
 
   defp load_session_data(socket) do

--- a/lib/klass_hero_web/live/staff/staff_participation_live.ex
+++ b/lib/klass_hero_web/live/staff/staff_participation_live.ex
@@ -43,15 +43,12 @@ defmodule KlassHeroWeb.Staff.StaffParticipationLive do
       |> assign(:record_note_map, %{})
 
     if connected?(socket) do
-      Phoenix.PubSub.subscribe(
-        KlassHero.PubSub,
-        "participation:provider:#{staff_member.provider_id}"
-      )
+      # Attendance on the provider-scoped topic; session-note topics derive from the
+      # event registry (#1108). Both come from the Participation facade.
+      provider_topic = Participation.provider_topic(staff_member.provider_id)
 
-      # Session note events use global topics; no provider-scoped version exists.
-      Phoenix.PubSub.subscribe(KlassHero.PubSub, "session_note:session_note_submitted")
-      Phoenix.PubSub.subscribe(KlassHero.PubSub, "session_note:session_note_approved")
-      Phoenix.PubSub.subscribe(KlassHero.PubSub, "session_note:session_note_rejected")
+      for topic <- [provider_topic | Participation.participation_topics(:session_note)],
+          do: Phoenix.PubSub.subscribe(KlassHero.PubSub, topic)
     end
 
     {:ok, load_session_data(socket)}
@@ -181,7 +178,7 @@ defmodule KlassHeroWeb.Staff.StaffParticipationLive do
 
   @impl true
   def handle_info({:domain_event, %DomainEvent{event_type: event_type, aggregate_id: record_id}}, socket)
-      when event_type in [:child_checked_in, :child_checked_out, :participation_marked_absent] do
+      when event_type in [:child_checked_in, :child_checked_out, :child_marked_absent] do
     {:noreply, update_participation_record(socket, record_id)}
   end
 

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -858,10 +858,10 @@ msgstr "Fragen zu diesen Bedingungen?"
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:61
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:94
 #: lib/klass_hero_web/live/admin/sessions_live.ex:251
-#: lib/klass_hero_web/live/provider/participation_live.ex:176
-#: lib/klass_hero_web/live/provider/participation_live.ex:222
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:118
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:164
+#: lib/klass_hero_web/live/provider/participation_live.ex:171
+#: lib/klass_hero_web/live/provider/participation_live.ex:217
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:115
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:161
 #, elixir-autogen, elixir-format
 msgid "Record not found"
 msgstr "Eintrag nicht gefunden"
@@ -906,8 +906,8 @@ msgstr "Sitzung erfolgreich abgeschlossen"
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:67
 #: lib/klass_hero_web/live/admin/sessions_live.ex:73
-#: lib/klass_hero_web/live/provider/participation_live.ex:270
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:229
+#: lib/klass_hero_web/live/provider/participation_live.ex:272
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:226
 #, elixir-autogen, elixir-format
 msgid "Session not found"
 msgstr "Sitzung nicht gefunden"
@@ -1387,7 +1387,7 @@ msgstr "Willkommen zurück"
 msgid "WhatsApp Community"
 msgstr "WhatsApp-Community"
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:166
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:163
 #, elixir-autogen, elixir-format
 msgid "Failed to load participation history"
 msgstr "Teilnahmeverlauf konnte nicht geladen werden"
@@ -1915,17 +1915,17 @@ msgstr "Kind bearbeiten"
 msgid "Emergency contact"
 msgstr "Notfallkontakt"
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:61
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:58
 #, elixir-autogen, elixir-format
 msgid "Failed to approve note"
 msgstr "Notiz konnte nicht genehmigt werden"
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:112
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "Failed to reject note"
 msgstr "Notiz konnte nicht abgelehnt werden"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:168
+#: lib/klass_hero_web/live/provider/participation_live.ex:163
 #, elixir-autogen, elixir-format
 msgid "Failed to resubmit note"
 msgstr "Notiz konnte nicht erneut eingereicht werden"
@@ -2011,23 +2011,23 @@ msgstr "Noch keine Nachrichten"
 msgid "No parents are enrolled in this program"
 msgstr "Für dieses Programm sind keine Eltern angemeldet"
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:52
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:49
 #, elixir-autogen, elixir-format
 msgid "Note approved"
 msgstr "Notiz genehmigt"
 
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:113
-#: lib/klass_hero_web/live/provider/participation_live.ex:160
+#: lib/klass_hero_web/live/provider/participation_live.ex:155
 #, elixir-autogen, elixir-format
 msgid "Note content cannot be blank"
 msgstr "Notizinhalt darf nicht leer sein"
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:101
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:98
 #, elixir-autogen, elixir-format
 msgid "Note rejected"
 msgstr "Notiz abgelehnt"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:154
+#: lib/klass_hero_web/live/provider/participation_live.ex:149
 #, elixir-autogen, elixir-format
 msgid "Note resubmitted for review"
 msgstr "Notiz erneut zur Überprüfung eingereicht"
@@ -2133,8 +2133,8 @@ msgstr "Diese Nachricht wird an alle Eltern mit aktiven Anmeldungen in diesem Pr
 msgid "Type a message..."
 msgstr "Nachricht eingeben..."
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:290
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:249
+#: lib/klass_hero_web/live/provider/participation_live.ex:292
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "Unable to refresh roster. Please reload."
 msgstr "Teilnehmerliste konnte nicht aktualisiert werden. Bitte laden Sie die Seite neu."
@@ -4737,7 +4737,7 @@ msgid "View and manage your assigned sessions"
 msgstr "Ihre zugewiesenen Sitzungen anzeigen und verwalten"
 
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:60
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:218
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:215
 #, elixir-autogen, elixir-format
 msgid "You are not assigned to this program"
 msgstr "Sie sind diesem Programm nicht zugewiesen"
@@ -4983,14 +4983,14 @@ msgstr "Abgereist"
 msgid "Departure notes"
 msgstr "Notizen zur Abreise"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:225
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:167
+#: lib/klass_hero_web/live/provider/participation_live.ex:220
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:164
 #, elixir-autogen, elixir-format
 msgid "Departure time is not a valid date and time"
 msgstr "Abreisezeit ist kein gültiges Datum oder keine gültige Uhrzeit"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:236
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:178
+#: lib/klass_hero_web/live/provider/participation_live.ex:231
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:175
 #, elixir-autogen, elixir-format
 msgid "Failed to update record"
 msgstr "Aktualisieren des Datensatzes fehlgeschlagen"
@@ -5030,8 +5030,8 @@ msgstr "Gesundheit & Einwilligungen (optional)"
 msgid "Medical conditions"
 msgstr "Gesundheitliche Besonderheiten"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:228
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:170
+#: lib/klass_hero_web/live/provider/participation_live.ex:223
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:167
 #, elixir-autogen, elixir-format
 msgid "Nothing to update"
 msgstr "Nichts zu aktualisieren"
@@ -5072,8 +5072,8 @@ msgstr "Abreise erfassen"
 msgid "Record departure time (optional)"
 msgstr "Abreisezeit erfassen (optional)"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:216
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:158
+#: lib/klass_hero_web/live/provider/participation_live.ex:211
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:155
 #, elixir-autogen, elixir-format
 msgid "Record updated"
 msgstr "Datensatz aktualisiert"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -858,10 +858,10 @@ msgstr ""
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:61
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:94
 #: lib/klass_hero_web/live/admin/sessions_live.ex:251
-#: lib/klass_hero_web/live/provider/participation_live.ex:176
-#: lib/klass_hero_web/live/provider/participation_live.ex:222
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:118
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:164
+#: lib/klass_hero_web/live/provider/participation_live.ex:171
+#: lib/klass_hero_web/live/provider/participation_live.ex:217
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:115
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:161
 #, elixir-autogen, elixir-format
 msgid "Record not found"
 msgstr ""
@@ -906,8 +906,8 @@ msgstr ""
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:67
 #: lib/klass_hero_web/live/admin/sessions_live.ex:73
-#: lib/klass_hero_web/live/provider/participation_live.ex:270
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:229
+#: lib/klass_hero_web/live/provider/participation_live.ex:272
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:226
 #, elixir-autogen, elixir-format
 msgid "Session not found"
 msgstr ""
@@ -1387,7 +1387,7 @@ msgstr ""
 msgid "WhatsApp Community"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:166
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:163
 #, elixir-autogen, elixir-format
 msgid "Failed to load participation history"
 msgstr ""
@@ -1915,17 +1915,17 @@ msgstr ""
 msgid "Emergency contact"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:61
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:58
 #, elixir-autogen, elixir-format
 msgid "Failed to approve note"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:112
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "Failed to reject note"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:168
+#: lib/klass_hero_web/live/provider/participation_live.ex:163
 #, elixir-autogen, elixir-format
 msgid "Failed to resubmit note"
 msgstr ""
@@ -2011,23 +2011,23 @@ msgstr ""
 msgid "No parents are enrolled in this program"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:52
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:49
 #, elixir-autogen, elixir-format
 msgid "Note approved"
 msgstr ""
 
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:113
-#: lib/klass_hero_web/live/provider/participation_live.ex:160
+#: lib/klass_hero_web/live/provider/participation_live.ex:155
 #, elixir-autogen, elixir-format
 msgid "Note content cannot be blank"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:101
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:98
 #, elixir-autogen, elixir-format
 msgid "Note rejected"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:154
+#: lib/klass_hero_web/live/provider/participation_live.ex:149
 #, elixir-autogen, elixir-format
 msgid "Note resubmitted for review"
 msgstr ""
@@ -2133,8 +2133,8 @@ msgstr ""
 msgid "Type a message..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:290
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:249
+#: lib/klass_hero_web/live/provider/participation_live.ex:292
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "Unable to refresh roster. Please reload."
 msgstr ""
@@ -4737,7 +4737,7 @@ msgid "View and manage your assigned sessions"
 msgstr ""
 
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:60
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:218
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:215
 #, elixir-autogen, elixir-format
 msgid "You are not assigned to this program"
 msgstr ""
@@ -4983,14 +4983,14 @@ msgstr ""
 msgid "Departure notes"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:225
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:167
+#: lib/klass_hero_web/live/provider/participation_live.ex:220
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:164
 #, elixir-autogen, elixir-format
 msgid "Departure time is not a valid date and time"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:236
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:178
+#: lib/klass_hero_web/live/provider/participation_live.ex:231
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:175
 #, elixir-autogen, elixir-format
 msgid "Failed to update record"
 msgstr ""
@@ -5030,8 +5030,8 @@ msgstr ""
 msgid "Medical conditions"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:228
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:170
+#: lib/klass_hero_web/live/provider/participation_live.ex:223
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:167
 #, elixir-autogen, elixir-format
 msgid "Nothing to update"
 msgstr ""
@@ -5072,8 +5072,8 @@ msgstr ""
 msgid "Record departure time (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:216
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:158
+#: lib/klass_hero_web/live/provider/participation_live.ex:211
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:155
 #, elixir-autogen, elixir-format
 msgid "Record updated"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -858,10 +858,10 @@ msgstr ""
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:61
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:94
 #: lib/klass_hero_web/live/admin/sessions_live.ex:251
-#: lib/klass_hero_web/live/provider/participation_live.ex:176
-#: lib/klass_hero_web/live/provider/participation_live.ex:222
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:118
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:164
+#: lib/klass_hero_web/live/provider/participation_live.ex:171
+#: lib/klass_hero_web/live/provider/participation_live.ex:217
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:115
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:161
 #, elixir-autogen, elixir-format
 msgid "Record not found"
 msgstr ""
@@ -906,8 +906,8 @@ msgstr ""
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:67
 #: lib/klass_hero_web/live/admin/sessions_live.ex:73
-#: lib/klass_hero_web/live/provider/participation_live.ex:270
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:229
+#: lib/klass_hero_web/live/provider/participation_live.ex:272
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:226
 #, elixir-autogen, elixir-format
 msgid "Session not found"
 msgstr ""
@@ -1387,7 +1387,7 @@ msgstr ""
 msgid "WhatsApp Community"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:166
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:163
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to load participation history"
 msgstr ""
@@ -1915,17 +1915,17 @@ msgstr ""
 msgid "Emergency contact"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:61
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:58
 #, elixir-autogen, elixir-format
 msgid "Failed to approve note"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:112
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "Failed to reject note"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:168
+#: lib/klass_hero_web/live/provider/participation_live.ex:163
 #, elixir-autogen, elixir-format
 msgid "Failed to resubmit note"
 msgstr ""
@@ -2011,23 +2011,23 @@ msgstr ""
 msgid "No parents are enrolled in this program"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:52
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:49
 #, elixir-autogen, elixir-format
 msgid "Note approved"
 msgstr ""
 
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:113
-#: lib/klass_hero_web/live/provider/participation_live.ex:160
+#: lib/klass_hero_web/live/provider/participation_live.ex:155
 #, elixir-autogen, elixir-format
 msgid "Note content cannot be blank"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:101
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:98
 #, elixir-autogen, elixir-format
 msgid "Note rejected"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:154
+#: lib/klass_hero_web/live/provider/participation_live.ex:149
 #, elixir-autogen, elixir-format
 msgid "Note resubmitted for review"
 msgstr ""
@@ -2133,8 +2133,8 @@ msgstr ""
 msgid "Type a message..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:290
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:249
+#: lib/klass_hero_web/live/provider/participation_live.ex:292
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "Unable to refresh roster. Please reload."
 msgstr ""
@@ -4737,7 +4737,7 @@ msgid "View and manage your assigned sessions"
 msgstr ""
 
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:60
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:218
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:215
 #, elixir-autogen, elixir-format
 msgid "You are not assigned to this program"
 msgstr ""
@@ -4983,14 +4983,14 @@ msgstr ""
 msgid "Departure notes"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:225
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:167
+#: lib/klass_hero_web/live/provider/participation_live.ex:220
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:164
 #, elixir-autogen, elixir-format
 msgid "Departure time is not a valid date and time"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:236
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:178
+#: lib/klass_hero_web/live/provider/participation_live.ex:231
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:175
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to update record"
 msgstr ""
@@ -5030,8 +5030,8 @@ msgstr ""
 msgid "Medical conditions"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:228
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:170
+#: lib/klass_hero_web/live/provider/participation_live.ex:223
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:167
 #, elixir-autogen, elixir-format
 msgid "Nothing to update"
 msgstr ""
@@ -5072,8 +5072,8 @@ msgstr ""
 msgid "Record departure time (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:216
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:158
+#: lib/klass_hero_web/live/provider/participation_live.ex:211
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:155
 #, elixir-autogen, elixir-format
 msgid "Record updated"
 msgstr ""

--- a/test/klass_hero/participation/participation_events_test.exs
+++ b/test/klass_hero/participation/participation_events_test.exs
@@ -1,0 +1,83 @@
+defmodule KlassHero.Participation.Domain.Events.ParticipationEventsTest do
+  use ExUnit.Case, async: true
+
+  alias KlassHero.Participation.Domain.Events.ParticipationEvents
+  alias KlassHero.Participation.ParticipationRecord
+  alias KlassHero.Participation.SessionNote
+
+  # Single source of truth: event_type => aggregate_type. Renaming an atom here
+  # must propagate to constructors (this file) AND subscription topics
+  # (participation.ex facade). See #1108.
+  @aggregate_table [
+    {:session_created, :participation},
+    {:session_started, :participation},
+    {:session_completed, :participation},
+    {:roster_seeded, :participation},
+    {:child_checked_in, :participation},
+    {:child_checked_out, :participation},
+    {:child_marked_absent, :participation},
+    {:session_note_submitted, :session_note},
+    {:session_note_approved, :session_note},
+    {:session_note_rejected, :session_note}
+  ]
+
+  describe "aggregate_type_for/1" do
+    for {event_type, aggregate} <- @aggregate_table do
+      test "#{event_type} => #{aggregate}" do
+        assert ParticipationEvents.aggregate_type_for(unquote(event_type)) ==
+                 unquote(aggregate)
+      end
+    end
+
+    test "raises on an unregistered event type" do
+      assert_raise KeyError, fn -> ParticipationEvents.aggregate_type_for(:not_an_event) end
+    end
+  end
+
+  describe "subscription_event_types/1" do
+    test ":attendance group" do
+      assert ParticipationEvents.subscription_event_types(:attendance) ==
+               [:child_checked_in, :child_checked_out, :child_marked_absent]
+    end
+
+    test ":session_note group" do
+      assert ParticipationEvents.subscription_event_types(:session_note) ==
+               [:session_note_submitted, :session_note_approved, :session_note_rejected]
+    end
+
+    test "every subscription-group atom is a registered event type" do
+      registered = Map.new(@aggregate_table) |> Map.keys() |> MapSet.new()
+
+      for group <- [:attendance, :session_note],
+          event_type <- ParticipationEvents.subscription_event_types(group) do
+        assert MapSet.member?(registered, event_type),
+               "#{event_type} in group #{group} is not in @event_aggregates"
+      end
+    end
+  end
+
+  describe "constructors derive aggregate_type from the registry" do
+    test "attendance event carries :participation" do
+      record = %ParticipationRecord{id: "rec-1", session_id: "sess-1", child_id: "child-1"}
+      event = ParticipationEvents.child_checked_in(record, [])
+
+      assert event.event_type == :child_checked_in
+      assert event.aggregate_type == :participation
+    end
+
+    test "session-note event carries :session_note" do
+      note = %SessionNote{
+        id: "note-1",
+        participation_record_id: "rec-1",
+        child_id: "child-1",
+        provider_id: "prov-1",
+        parent_id: "parent-1"
+      }
+
+      event = ParticipationEvents.session_note_submitted(note)
+
+      assert event.event_type == :session_note_submitted
+      assert event.aggregate_type == :session_note
+    end
+  end
+end

--- a/test/klass_hero/participation/submit_session_note_test.exs
+++ b/test/klass_hero/participation/submit_session_note_test.exs
@@ -5,11 +5,13 @@ defmodule KlassHero.Participation.SubmitSessionNoteTest do
 
   use KlassHero.DataCase, async: true
 
+  import KlassHero.EventTestHelper
   import KlassHero.Factory
 
+  alias KlassHero.Participation
+  alias KlassHero.Participation.Adapters.Driving.Events.EventHandlers.NotifyLiveViews
   alias KlassHero.Participation.Domain.Events.ParticipationEvents
   alias KlassHero.Participation.SessionNote
-  alias KlassHero.Shared.Adapters.Driven.Events.EventHandlers.NotifyLiveViews
 
   describe "execute/1" do
     test "submits a session note for a checked-in record" do
@@ -187,34 +189,34 @@ defmodule KlassHero.Participation.SubmitSessionNoteTest do
     end
   end
 
-  describe "session_note PubSub topics" do
-    # The publisher derives its topic from the event's atoms, while
-    # provider/staff/parent LiveViews hand-type the resulting string to
-    # subscribe. Nothing links the two: rename the atoms without the literals
-    # and delivery stops silently.
-    #
-    # This cannot be covered end-to-end — TestEventPublisher.publish/2 discards
-    # the topic argument, so the test double makes the topic unobservable. These
-    # pin the derived topics to the literals the LiveViews subscribe to, so a
-    # future atom rename fails here instead of in production.
+  describe "session_note PubSub topics (#1108)" do
+    # Proves publisher and subscriber meet: publish each session-note event through
+    # the real handler, then assert the topic it was actually broadcast on is one the
+    # LiveViews subscribe to (`Participation.participation_topics(:session_note)`).
+    # Both sides derive from the event registry, so a rename that touches only one
+    # side fails here instead of silently in production. Supersedes #924's literal
+    # pins now that TestEventPublisher records the topic.
 
     setup do
+      setup_test_events()
       %{note: build(:session_note)}
     end
 
-    test "submitted topic matches the LiveView subscribe literal", %{note: note} do
-      event = ParticipationEvents.session_note_submitted(note)
-      assert NotifyLiveViews.derive_topic(event) == "session_note:session_note_submitted"
-    end
+    @topic_cases [
+      {:session_note_submitted, "session_note:session_note_submitted"},
+      {:session_note_approved, "session_note:session_note_approved"},
+      {:session_note_rejected, "session_note:session_note_rejected"}
+    ]
 
-    test "approved topic matches the LiveView subscribe literal", %{note: note} do
-      event = ParticipationEvents.session_note_approved(%{note | status: :approved})
-      assert NotifyLiveViews.derive_topic(event) == "session_note:session_note_approved"
-    end
+    for {event_type, expected_topic} <- @topic_cases do
+      test "#{event_type} is published to a topic the LiveViews subscribe to", %{note: note} do
+        event = apply(ParticipationEvents, unquote(event_type), [note])
 
-    test "rejected topic matches the LiveView subscribe literal", %{note: note} do
-      event = ParticipationEvents.session_note_rejected(%{note | status: :rejected})
-      assert NotifyLiveViews.derive_topic(event) == "session_note:session_note_rejected"
+        NotifyLiveViews.handle(event)
+
+        assert_published_to(unquote(event_type), unquote(expected_topic))
+        assert unquote(expected_topic) in Participation.participation_topics(:session_note)
+      end
     end
   end
 end

--- a/test/klass_hero/participation_topics_test.exs
+++ b/test/klass_hero/participation_topics_test.exs
@@ -1,0 +1,39 @@
+defmodule KlassHero.ParticipationTopicsTest do
+  @moduledoc """
+  Pins the PubSub topic strings LiveViews subscribe to against the single source
+  of truth (#1108). If the derived topics ever drift from these literals, every
+  subscriber has silently stopped receiving real-time updates.
+  """
+  use ExUnit.Case, async: true
+
+  alias KlassHero.Participation
+
+  describe "participation_topics/1" do
+    @groups [
+      {:session_note,
+       [
+         "session_note:session_note_submitted",
+         "session_note:session_note_approved",
+         "session_note:session_note_rejected"
+       ]},
+      {:attendance,
+       [
+         "participation:child_checked_in",
+         "participation:child_checked_out",
+         "participation:child_marked_absent"
+       ]}
+    ]
+
+    for {group, expected} <- @groups do
+      test "#{group} derives #{inspect(expected)}" do
+        assert Participation.participation_topics(unquote(group)) == unquote(expected)
+      end
+    end
+  end
+
+  describe "provider_topic/1" do
+    test "builds the provider-scoped topic" do
+      assert Participation.provider_topic("prov-123") == "participation:provider:prov-123"
+    end
+  end
+end

--- a/test/klass_hero/shared/adapters/driven/events/test_event_publisher_test.exs
+++ b/test/klass_hero/shared/adapters/driven/events/test_event_publisher_test.exs
@@ -1,0 +1,52 @@
+defmodule KlassHero.Shared.Adapters.Driven.Events.TestEventPublisherTest do
+  @moduledoc """
+  Covers the topic-recording added for #1108: the test double now captures the
+  topic passed to `publish/2`, so tests can assert the real publish→subscribe
+  coupling instead of pinning topic literals by hand.
+  """
+  use ExUnit.Case, async: true
+
+  alias KlassHero.EventTestHelper
+  alias KlassHero.Shared.Adapters.Driven.Events.TestEventPublisher
+  alias KlassHero.Shared.Domain.Events.DomainEvent
+
+  setup do
+    TestEventPublisher.setup()
+    :ok
+  end
+
+  test "publish/2 records the event with the topic it was published to" do
+    event = DomainEvent.new(:session_note_submitted, "note-1", :session_note, %{})
+
+    TestEventPublisher.publish(event, "session_note:session_note_submitted")
+
+    assert TestEventPublisher.get_published() == [{event, "session_note:session_note_submitted"}]
+  end
+
+  test "get_events/0 still returns bare events (backward compatible)" do
+    event = DomainEvent.new(:child_checked_in, "rec-1", :participation, %{})
+
+    TestEventPublisher.publish(event, "participation:child_checked_in")
+
+    assert TestEventPublisher.get_events() == [event]
+  end
+
+  describe "EventTestHelper.assert_published_to/2" do
+    test "passes when the event was published to the topic" do
+      event = DomainEvent.new(:child_checked_in, "rec-1", :participation, %{})
+      TestEventPublisher.publish(event, "participation:child_checked_in")
+
+      assert EventTestHelper.assert_published_to(:child_checked_in, "participation:child_checked_in") ==
+               event
+    end
+
+    test "fails when the event went to a different topic" do
+      event = DomainEvent.new(:child_checked_in, "rec-1", :participation, %{})
+      TestEventPublisher.publish(event, "participation_record:child_checked_in")
+
+      assert_raise ExUnit.AssertionError, fn ->
+        EventTestHelper.assert_published_to(:child_checked_in, "participation:child_checked_in")
+      end
+    end
+  end
+end

--- a/test/klass_hero_web/live/parent/participation_history_live_test.exs
+++ b/test/klass_hero_web/live/parent/participation_history_live_test.exs
@@ -5,8 +5,12 @@ defmodule KlassHeroWeb.Parent.ParticipationHistoryLiveTest do
 
   use KlassHeroWeb.ConnCase, async: true
 
+  import KlassHero.EventTestHelper
   import KlassHero.Factory
   import Phoenix.LiveViewTest
+
+  alias KlassHero.Participation.Domain.Events.ParticipationEvents
+  alias KlassHero.Shared.Domain.Events.DomainEvent
 
   setup :register_and_log_in_parent
 
@@ -112,6 +116,50 @@ defmodule KlassHeroWeb.Parent.ParticipationHistoryLiveTest do
       |> render_submit()
 
       refute has_element?(view, "#pending-note-#{note.id}")
+    end
+  end
+
+  describe "real-time attendance updates (#1108)" do
+    setup %{parent: parent} do
+      {child, _parent} =
+        insert_child_with_guardian(parent: parent, first_name: "Emma", last_name: "Mueller")
+
+      # No participation record at mount — the history stream starts empty, so an
+      # event that streams a row is an unambiguous, observable delta.
+      %{child: child}
+    end
+
+    test "streams the parent's own child when a check-in event arrives", %{conn: conn, child: child} do
+      {:ok, view, _html} = live(conn, ~p"/parent/participation")
+      record = insert(:participation_record_schema, child_id: child.id, status: :checked_in)
+
+      emit_domain_event(view, ParticipationEvents.child_checked_in(record, []))
+
+      assert has_element?(view, "#participation_records-#{record.id}")
+    end
+
+    test "handles child_marked_absent (guard atom fix)", %{conn: conn, child: child} do
+      {:ok, view, _html} = live(conn, ~p"/parent/participation")
+      record = insert(:participation_record_schema, child_id: child.id, status: :absent)
+
+      emit_domain_event(view, ParticipationEvents.child_marked_absent(record, []))
+
+      assert has_element?(view, "#participation_records-#{record.id}")
+    end
+
+    test "ignores an attendance event for another family's child (privacy)", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/parent/participation")
+      foreign_record_id = Ecto.UUID.generate()
+
+      foreign_event =
+        DomainEvent.new(:child_checked_in, foreign_record_id, :participation, %{
+          record_id: foreign_record_id,
+          child_id: Ecto.UUID.generate()
+        })
+
+      emit_domain_event(view, foreign_event)
+
+      refute has_element?(view, "#participation_records-#{foreign_record_id}")
     end
   end
 

--- a/test/klass_hero_web/live/provider/participation_live_test.exs
+++ b/test/klass_hero_web/live/provider/participation_live_test.exs
@@ -4,6 +4,8 @@ defmodule KlassHeroWeb.Provider.ParticipationLiveTest do
   import KlassHero.Factory
   import Phoenix.LiveViewTest
 
+  alias KlassHero.Participation
+  alias KlassHero.Participation.Domain.Events.ParticipationEvents
   alias KlassHero.Participation.ParticipationRecord
   alias KlassHero.Participation.SessionNote
 
@@ -786,6 +788,39 @@ defmodule KlassHeroWeb.Provider.ParticipationLiveTest do
       |> render_click()
 
       refute has_element?(view, "#edit-record-form-#{record.id}")
+    end
+  end
+
+  describe "real-time roster updates over PubSub (#1108)" do
+    setup [:create_session_with_child]
+
+    test "re-renders when a check-in event arrives on the provider-scoped topic", %{
+      conn: conn,
+      user: user,
+      provider: provider,
+      session: session,
+      record: record
+    } do
+      {:ok, view, _html} = live(conn, ~p"/provider/participation/#{session.id}")
+
+      # A registered record shows the check-in control, not the edit control.
+      refute has_element?(view, "#edit-btn-#{record.id}")
+
+      # Flip the record in the DB, then broadcast on the exact topic the view
+      # subscribes to. If the subscription targeted the wrong topic (the pre-#1108
+      # bug), this broadcast never arrives and the edit control never appears.
+      {:ok, _} =
+        record
+        |> Ecto.Changeset.change(status: :checked_in, check_in_by: user.id)
+        |> KlassHero.Repo.update()
+
+      Phoenix.PubSub.broadcast(
+        KlassHero.PubSub,
+        Participation.provider_topic(provider.id),
+        {:domain_event, ParticipationEvents.child_checked_in(record, [])}
+      )
+
+      assert render(view) =~ "edit-btn-#{record.id}"
     end
   end
 end

--- a/test/support/event_test_helper.ex
+++ b/test/support/event_test_helper.ex
@@ -171,6 +171,34 @@ defmodule KlassHero.EventTestHelper do
   end
 
   @doc """
+  Asserts that an event of the given type was published to `topic`.
+
+  Proves the real publish→subscribe coupling (#1108): the topic recorded here is
+  the exact string the event was broadcast on, so a subscriber listening on
+  `topic` would have received it. Returns the matching event.
+
+  ## Examples
+
+      assert_published_to(:child_checked_in, "participation:child_checked_in")
+  """
+  @spec assert_published_to(atom(), String.t()) :: DomainEvent.t()
+  def assert_published_to(event_type, topic) when is_atom(event_type) and is_binary(topic) do
+    published = TestEventPublisher.get_published()
+
+    match =
+      Enum.find(published, fn {%DomainEvent{event_type: type}, published_topic} ->
+        type == event_type and published_topic == topic
+      end)
+
+    assert match != nil,
+           "Expected #{inspect(event_type)} to be published to #{inspect(topic)}.\n" <>
+             "Published: #{format_published(published)}"
+
+    {event, _topic} = match
+    event
+  end
+
+  @doc """
   Asserts that no events were published.
 
   ## Examples
@@ -215,6 +243,14 @@ defmodule KlassHero.EventTestHelper do
 
   defp format_event_types([]), do: "(none)"
   defp format_event_types(events), do: Enum.map_join(events, ", ", &inspect(&1.event_type))
+
+  defp format_published([]), do: "(none)"
+
+  defp format_published(published) do
+    Enum.map_join(published, ", ", fn {event, topic} ->
+      "#{inspect(event.event_type)}→#{inspect(topic)}"
+    end)
+  end
 
   defp format_event_payloads(events) do
     events


### PR DESCRIPTION
Closes #1108.

## Summary

LiveView subscribers hand-typed the PubSub topic strings that the publisher derives from a domain event's atoms (`"#{aggregate_type}:#{event_type}"`). Nothing linked the two sides, so an atom rename silently stranded subscribers — no compile error, no test failure.

**The legwork found this had already shipped as a live bug:** `provider/participation_live` and `parent/participation_history_live` subscribed to `participation_record:*` topics **no publisher ever writes** (real aggregate_type is `:participation`), and all three `handle_info` guards keyed on `:participation_marked_absent` vs the real `:child_marked_absent`. Provider + parent check-in/out/absent real-time updates were dead — "works after refresh, never live." Only `staff_participation_live` used a correct (provider-scoped) topic.

## What changed

- **Single event registry** in `ParticipationEvents` (`@event_aggregates` + `@subscription_groups`). Every constructor now derives `aggregate_type` from it (removed the hardcoded `:session_note`); subscription topics derive from the same map.
- **Facade helpers** `Participation.{participation_topics/1, event_topic/1, provider_topic/1}` — LiveViews subscribe through the facade, no hand-typed strings. An atom rename now moves publisher + every subscriber together.
- **Dead-topic fix:** provider/staff → provider-scoped topic (provider gained a catch-all `handle_info` for the lifecycle events that topic also carries); parent → generic attendance topics, filtered to its own children by the existing `child_belongs_to_parent?` guard. All three guards corrected to `:child_marked_absent`.
- **Test observability (Option 3):** `TestEventPublisher` now records `{event, topic}` (`get_published/0`, `EventTestHelper.assert_published_to/2`); `get_events/0` still returns bare events. Replaces #924's hand-pinned topic literals with a real publish→topic assertion. Resolves the blind spot that hid this class of drift from the suite.

## Review focus

- `ParticipationEvents` registry reproduces every prior `aggregate_type` mapping exactly (pinned by a new tabular test + a registry-drift invariant test).
- Provider's new catch-all `handle_info` — needed because the provider-scoped topic carries session-lifecycle events the view ignores.
- `get_events/0` back-compat (unwraps the new tuples).

## Test plan

- New: `participation_events_test.exs`, `participation_topics_test.exs`, `test_event_publisher_test.exs`; rewritten topic block in `submit_session_note_test.exs`; real subscribe→PubSub→re-render test in `provider/participation_live_test.exs` + parent privacy/guard tests.
- Full suite green (4183 passed). Boundary review 5/5, regression review 8/8.

## Follow-ups

- Child-scoped parent attendance routing (vs. filtering the generic firehose).
- `TestIntegrationEventPublisher` has the same topic-discard on the integration-event axis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)