### PR TITLE
test: record topic in TestIntegrationEventPublisher (#1122)

### DIFF
--- a/lib/klass_hero/shared/adapters/driven/events/test_integration_event_publisher.ex
+++ b/lib/klass_hero/shared/adapters/driven/events/test_integration_event_publisher.ex
@@ -78,12 +78,28 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.TestIntegrationEventPublisher 
   end
 
   @doc """
-  Returns all integration events published in the current test process.
+  Returns all integration events published in the current test process, without
+  their topics.
 
   Returns an empty list if setup() was not called.
   """
   @spec get_events() :: [IntegrationEvent.t()]
   def get_events do
+    for {event, _topic} <- get_published(), do: event
+  end
+
+  @doc """
+  Returns `{event, topic}` tuples for every integration event published in the
+  current test process, in publish order.
+
+  The topic is the exact `integration:<context>:<event>` string the event was
+  routed on — added for #1122 (mirroring #1108 on the domain-event axis) so tests
+  can assert the producer/consumer topic coupling of the `critical_event_handlers`
+  registry rather than pinning topic literals by hand. Events published via
+  `publish/1` carry their derived topic.
+  """
+  @spec get_published() :: [{IntegrationEvent.t(), String.t()}]
+  def get_published do
     Process.get(@key, [])
   end
 
@@ -91,7 +107,7 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.TestIntegrationEventPublisher 
   def publish(%IntegrationEvent{} = event) do
     case Process.get(@error_key) do
       nil ->
-        store_event(event)
+        store_event(event, derive_topic(event))
         :ok
 
       reason ->
@@ -100,19 +116,29 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.TestIntegrationEventPublisher 
   end
 
   @impl true
-  def publish(%IntegrationEvent{} = event, _topic) do
-    store_event(event)
-    :ok
+  def publish(%IntegrationEvent{} = event, topic) do
+    case Process.get(@error_key) do
+      nil ->
+        store_event(event, topic)
+        :ok
+
+      reason ->
+        {:error, reason}
+    end
   end
 
   @impl true
   def publish_all(events) when is_list(events) do
-    Enum.each(events, &store_event/1)
+    Enum.each(events, &store_event(&1, derive_topic(&1)))
     :ok
   end
 
-  defp store_event(%IntegrationEvent{} = event) do
-    events = Process.get(@key, [])
-    Process.put(@key, events ++ [event])
+  defp store_event(%IntegrationEvent{} = event, topic) do
+    published = Process.get(@key, [])
+    Process.put(@key, published ++ [{event, topic}])
+  end
+
+  defp derive_topic(%IntegrationEvent{source_context: source_context, event_type: event_type}) do
+    "integration:#{source_context}:#{event_type}"
   end
 end

--- a/test/klass_hero/shared/adapters/driven/events/test_integration_event_publisher_test.exs
+++ b/test/klass_hero/shared/adapters/driven/events/test_integration_event_publisher_test.exs
@@ -1,0 +1,69 @@
+defmodule KlassHero.Shared.Adapters.Driven.Events.TestIntegrationEventPublisherTest do
+  @moduledoc """
+  Covers the topic-recording added for #1122: the integration-event test double
+  now captures the `integration:<context>:<event>` topic each event is routed on,
+  so tests can assert the producer/consumer coupling of the
+  `critical_event_handlers` registry instead of pinning topic literals by hand.
+  Mirrors the domain-event double covered by #1108.
+  """
+  use ExUnit.Case, async: true
+
+  alias KlassHero.EventTestHelper
+  alias KlassHero.Shared.Adapters.Driven.Events.TestIntegrationEventPublisher
+  alias KlassHero.Shared.Domain.Events.IntegrationEvent
+
+  setup do
+    TestIntegrationEventPublisher.setup()
+    :ok
+  end
+
+  test "publish/2 records the event with the topic it was published to" do
+    event = IntegrationEvent.new(:invite_claimed, :enrollment, :invite, "invite-1", %{})
+
+    TestIntegrationEventPublisher.publish(event, "integration:enrollment:invite_claimed")
+
+    assert TestIntegrationEventPublisher.get_published() ==
+             [{event, "integration:enrollment:invite_claimed"}]
+  end
+
+  test "publish/1 records the event with its derived topic" do
+    event = IntegrationEvent.new(:invite_claimed, :enrollment, :invite, "invite-1", %{})
+
+    TestIntegrationEventPublisher.publish(event)
+
+    assert TestIntegrationEventPublisher.get_published() ==
+             [{event, "integration:enrollment:invite_claimed"}]
+  end
+
+  test "get_events/0 still returns bare events (backward compatible)" do
+    event = IntegrationEvent.new(:user_registered, :accounts, :user, "user-1", %{})
+
+    TestIntegrationEventPublisher.publish(event)
+
+    assert TestIntegrationEventPublisher.get_events() == [event]
+  end
+
+  describe "EventTestHelper.assert_integration_published_to/2" do
+    test "passes when the event was published to the topic" do
+      event = IntegrationEvent.new(:invite_claimed, :enrollment, :invite, "invite-1", %{})
+      TestIntegrationEventPublisher.publish(event)
+
+      assert EventTestHelper.assert_integration_published_to(
+               :invite_claimed,
+               "integration:enrollment:invite_claimed"
+             ) == event
+    end
+
+    test "fails when the event went to a different topic" do
+      event = IntegrationEvent.new(:invite_claimed, :enrollment, :invite, "invite-1", %{})
+      TestIntegrationEventPublisher.publish(event, "integration:enrolment:invite_claimed")
+
+      assert_raise ExUnit.AssertionError, fn ->
+        EventTestHelper.assert_integration_published_to(
+          :invite_claimed,
+          "integration:enrollment:invite_claimed"
+        )
+      end
+    end
+  end
+end

--- a/test/support/event_test_helper.ex
+++ b/test/support/event_test_helper.ex
@@ -356,6 +356,35 @@ defmodule KlassHero.EventTestHelper do
   end
 
   @doc """
+  Asserts that an integration event of the given type was published to `topic`.
+
+  Proves the real producer/consumer topic coupling (#1122): the topic recorded
+  here is the exact `integration:<context>:<event>` string the event was routed
+  on, so the `critical_event_handlers` registry entry keyed by `topic` would have
+  received it. Returns the matching event.
+
+  ## Examples
+
+      assert_integration_published_to(:invite_claimed, "integration:enrollment:invite_claimed")
+  """
+  @spec assert_integration_published_to(atom(), String.t()) :: IntegrationEvent.t()
+  def assert_integration_published_to(event_type, topic) when is_atom(event_type) and is_binary(topic) do
+    published = TestIntegrationEventPublisher.get_published()
+
+    match =
+      Enum.find(published, fn {%IntegrationEvent{event_type: type}, published_topic} ->
+        type == event_type and published_topic == topic
+      end)
+
+    assert match != nil,
+           "Expected integration event #{inspect(event_type)} to be published to #{inspect(topic)}.\n" <>
+             "Published: #{format_published(published)}"
+
+    {event, _topic} = match
+    event
+  end
+
+  @doc """
   Asserts that no integration events were published.
   """
   @spec assert_no_integration_events_published() :: :ok


### PR DESCRIPTION
## Summary

Closes #1122. Follow-up to #1108/#1120.

The integration-event test double `TestIntegrationEventPublisher.publish/2` bound `_topic` and threw it away, so `integration:<context>:<event>` topic-string drift in the `critical_event_handlers` registry was structurally unobservable in the suite — the same blind spot #1108 closed on the domain-event axis.

This mirrors the #1108 pattern one-for-one:
- store `{event, topic}` tuples internally
- `publish/1` derives the topic exactly as prod's `PubsubIntegrationEventPublisher.derive_topic/1` does (`integration:#{source_context}:#{event_type}`)
- `publish/2` records the passed topic **and** now honors the configured publish error (previously only `publish/1` gated on it — one-line symmetry fix)
- `get_events/0` keeps unwrapping to bare events (back-compat for existing consumers)
- add `get_published/0` + `EventTestHelper.assert_integration_published_to/2`

## Review Focus

- Back-compat: every existing caller of the bare-event getters still passes — the storage shape changed but `get_events/0`/`get_published_integration_events/0` contracts didn't.
- `publish/2` now returning `{:error, reason}` when an error is configured: safe, the error path is only driven via `configure_publish_error`.

## Test Plan

- New `test_integration_event_publisher_test.exs` (5 cases): publish/2 records topic, publish/1 records derived topic, get_events/0 bare-event back-compat, helper passes on match / raises on mismatch.
- Back-compat consumers green: `integration_event_publishing_test`, `staff_invitation_saga_test`, `anonymize_data_for_user_test`.
- Full suite: 4170 passed.

No migration. One bounded context (Shared test infra). No production behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)