### PR TITLE
test: condense IDOR guards and capacity-shape tests (#1116)

### DIFF
--- a/test/klass_hero_web/live/provider/dashboard_program_creation_test.exs
+++ b/test/klass_hero_web/live/provider/dashboard_program_creation_test.exs
@@ -329,77 +329,36 @@ defmodule KlassHeroWeb.Provider.DashboardProgramCreationTest do
       refute has_element?(view, "#program-form")
     end
 
-    test "creates program successfully with valid capacity", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+    # Each accepted capacity shape creates the program and shows no capacity
+    # warning; they differ only in the enrollment_policy map, so table-fold them.
+    for {label, policy} <- [
+          {"valid capacity", %{"min_enrollment" => "5", "max_enrollment" => "20"}},
+          {"only max_enrollment set", %{"max_enrollment" => "20"}},
+          {"only min_enrollment set", %{"min_enrollment" => "5"}}
+        ] do
+      @capacity_policy policy
 
-      view |> element("#new-program-btn") |> render_click()
+      test "creates program successfully with #{label}", %{conn: conn} do
+        {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
 
-      view
-      |> form("#program-form", %{
-        "program_schema" => %{
-          "title" => "Valid Capacity Program",
-          "description" => "Testing valid capacity handling",
-          "category" => "sports",
-          "price" => "30.00"
-        },
-        "enrollment_policy" => %{
-          "min_enrollment" => "5",
-          "max_enrollment" => "20"
-        }
-      })
-      |> render_submit()
+        view |> element("#new-program-btn") |> render_click()
 
-      html = render(view)
-      assert html =~ "Program created successfully."
-      refute html =~ "enrollment capacity could not be saved"
-    end
+        view
+        |> form("#program-form", %{
+          "program_schema" => %{
+            "title" => "Capacity Program",
+            "description" => "Testing an accepted enrollment capacity shape",
+            "category" => "sports",
+            "price" => "30.00"
+          },
+          "enrollment_policy" => @capacity_policy
+        })
+        |> render_submit()
 
-    test "creates policy with only max_enrollment set", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
-
-      view |> element("#new-program-btn") |> render_click()
-
-      view
-      |> form("#program-form", %{
-        "program_schema" => %{
-          "title" => "Max Only Program",
-          "description" => "Testing max-only capacity",
-          "category" => "sports",
-          "price" => "30.00"
-        },
-        "enrollment_policy" => %{
-          "max_enrollment" => "20"
-        }
-      })
-      |> render_submit()
-
-      html = render(view)
-      assert html =~ "Program created successfully."
-      refute html =~ "enrollment capacity could not be saved"
-    end
-
-    test "creates policy with only min_enrollment set", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
-
-      view |> element("#new-program-btn") |> render_click()
-
-      view
-      |> form("#program-form", %{
-        "program_schema" => %{
-          "title" => "Min Only Program",
-          "description" => "Testing min-only capacity",
-          "category" => "sports",
-          "price" => "30.00"
-        },
-        "enrollment_policy" => %{
-          "min_enrollment" => "5"
-        }
-      })
-      |> render_submit()
-
-      html = render(view)
-      assert html =~ "Program created successfully."
-      refute html =~ "enrollment capacity could not be saved"
+        html = render(view)
+        assert html =~ "Program created successfully."
+        refute html =~ "enrollment capacity could not be saved"
+      end
     end
 
     test "creates program without capacity fields (no policy created)", %{conn: conn} do
@@ -501,10 +460,9 @@ defmodule KlassHeroWeb.Provider.DashboardProgramCreationTest do
 
       {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
 
-      render_click(view, "edit_program", %{"id" => victim_program.id})
+      view = assert_idor_guarded(view, "edit_program", victim_program.id, "Program not found.")
 
       refute has_element?(view, "#program-form")
-      assert render(view) =~ "Program not found."
     end
   end
 end

--- a/test/klass_hero_web/live/provider/dashboard_team_test.exs
+++ b/test/klass_hero_web/live/provider/dashboard_team_test.exs
@@ -227,10 +227,9 @@ defmodule KlassHeroWeb.Provider.DashboardTeamTest do
     } do
       {:ok, view, _html} = live(conn, ~p"/provider/dashboard/team")
 
-      render_click(view, "edit_member", %{"id" => victim_staff.id})
+      view = assert_idor_guarded(view, "edit_member", victim_staff.id, "Staff member not found.")
 
       refute has_element?(view, "#staff-member-form")
-      assert render(view) =~ "Staff member not found."
     end
 
     test "delete_member on a foreign staff id is rejected and leaves the row intact", %{
@@ -239,9 +238,8 @@ defmodule KlassHeroWeb.Provider.DashboardTeamTest do
     } do
       {:ok, view, _html} = live(conn, ~p"/provider/dashboard/team")
 
-      render_click(view, "delete_member", %{"id" => victim_staff.id})
+      assert_idor_guarded(view, "delete_member", victim_staff.id, "Staff member not found.")
 
-      assert render(view) =~ "Staff member not found."
       assert {:ok, _still_there} = Provider.get_staff_member(victim_staff.id)
     end
   end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -83,6 +83,25 @@ defmodule KlassHeroWeb.ConnCase do
   end
 
   @doc """
+  Asserts a cross-tenant (IDOR) ownership guard.
+
+  Triggers `event` on the LiveView with a foreign resource `id` and asserts the
+  guard rejects it with the `error` flash. Covers only the shared spine — the
+  caller keeps its own tail assertion (no form opened, row still present).
+  Returns the view for chaining.
+
+  ## Examples
+
+      view = assert_idor_guarded(view, "edit_program", foreign_id, "Program not found.")
+      refute has_element?(view, "#program-form")
+  """
+  def assert_idor_guarded(view, event, id, error) do
+    Phoenix.LiveViewTest.render_click(view, event, %{"id" => id})
+    assert Phoenix.LiveViewTest.render(view) =~ error
+    view
+  end
+
+  @doc """
   Setup helper that registers and logs in users.
 
       setup :register_and_log_in_user


### PR DESCRIPTION
## Summary
Safe subset of the MODERATE-tier test condensation deferred from #1114. Only the folds that provably preserve assertion coverage; the risky ones are left discrete. Test-only, no production code, no migration.

- **`assert_idor_guarded/4`** added to `ConnCase` (beside `assert_flash/3`). Collapses the three near-duplicate cross-tenant guard sites onto a shared spine (`render_click` → assert error flash), each caller keeping its own tail (no form opened / row still present).
- **Enrollment-capacity fold**: the three accepted capacity shapes (valid / max-only / min-only) become one parametrised `for` test. Coverage unchanged — still three assertions.

## Left discrete (deliberately not folded)
- `program form validation errors` describe — three genuinely different shapes (blank→flash, negative→form-still-present, clear-on-success two-step).
- Capacity `min > max` and `no fields` cases — different submit/assert shapes.
- The five `(business track)` verification describes — different widgets, form IDs, params, assertions; no honest single helper. Per-doc-type correctness kept explicit.

Closes #1116.

## Review Focus
- `assert_idor_guarded/4` is spine-only by design: it asserts the shared guard and returns `view`, so the distinct tails stay visible at each call site rather than hidden in the helper.
- The `@capacity_policy` module attribute in the fold is the ExUnit tabular idiom — the loop var is captured per iteration for use inside the test body.

## Test Plan
- `MIX_TEST_PARTITION=1116 mix test <both files>` → 47 passed.
- `MIX_TEST_PARTITION=1116 mix precommit` → 4165 passed, 2 skipped (full suite, format, warnings-as-errors).