### PR TITLE
feat: child-scoped parent attendance routing

### DIFF
--- a/lib/klass_hero/participation.ex
+++ b/lib/klass_hero/participation.ex
@@ -357,6 +357,15 @@ defmodule KlassHero.Participation do
   defdelegate provider_topic(provider_id), to: NotifyLiveViews
 
   @doc """
+  Returns the child-scoped participation topic — the single topic carrying one
+  child's attendance and session-note events. Parent LiveViews subscribe to it
+  per child; `NotifyLiveViews` publishes to it. One builder, so the two sides
+  can't drift (#1121).
+  """
+  @spec child_topic(String.t()) :: String.t()
+  defdelegate child_topic(child_id), to: NotifyLiveViews
+
+  @doc """
   Seeds a session roster with the program's enrolled children. Best-effort: always returns `:ok`.
 
   Invoked by the `session_created` integration-event handler.

--- a/lib/klass_hero/participation/adapters/driving/events/event_handlers/notify_live_views.ex
+++ b/lib/klass_hero/participation/adapters/driving/events/event_handlers/notify_live_views.ex
@@ -2,9 +2,10 @@ defmodule KlassHero.Participation.Adapters.Driving.Events.EventHandlers.NotifyLi
   @moduledoc """
   Routes Participation domain events to PubSub topics for LiveView real-time updates.
 
-  Publishes each event to two topics:
+  Publishes each event to up to three topics:
   1. Generic topic (`participation:event_type`) — for context-wide subscribers
   2. Provider-specific topic (`participation:provider:provider_id`) — for provider-scoped LiveViews
+  3. Child-specific topic (`participation:child:child_id`) — for parent-scoped LiveViews (#1121)
 
   Provider ID is resolved via the ForResolvingProgramProvider ACL port.
   If resolution fails, the provider-specific publish is skipped (best-effort).
@@ -13,6 +14,11 @@ defmodule KlassHero.Participation.Adapters.Driving.Events.EventHandlers.NotifyLi
   `program_id` in their payload). Session note events use a different aggregate type
   and carry `provider_id` directly — they skip provider-specific routing and are delivered
   only via the generic topic.
+
+  Child-specific routing applies to any event carrying `child_id` in its payload
+  (attendance + session-note events). Unlike the provider topic, no resolution is
+  needed — `child_id` is already in the payload — so this fan-out is resolve-free.
+  Events without `child_id` (session events) skip it.
   """
 
   alias KlassHero.Participation.Adapters.Driven.ACL.ProgramProviderResolver
@@ -31,6 +37,7 @@ defmodule KlassHero.Participation.Adapters.Driving.Events.EventHandlers.NotifyLi
     SharedNotifyLiveViews.safe_publish(event, generic_topic)
 
     publish_to_provider_topic(event)
+    publish_to_child_topic(event)
 
     :ok
   end
@@ -47,6 +54,10 @@ defmodule KlassHero.Participation.Adapters.Driving.Events.EventHandlers.NotifyLi
   @spec provider_topic(String.t()) :: String.t()
   def provider_topic(provider_id), do: "participation:provider:#{provider_id}"
 
+  @doc "Builds the child-scoped participation topic. The single source both the publisher (here) and parent subscribers (via the `Participation` facade) use (#1121)."
+  @spec child_topic(String.t()) :: String.t()
+  def child_topic(child_id), do: "participation:child:#{child_id}"
+
   defp publish_to_provider_topic(%DomainEvent{payload: payload} = event) do
     case Map.fetch(payload, :program_id) do
       {:ok, program_id} ->
@@ -55,6 +66,19 @@ defmodule KlassHero.Participation.Adapters.Driving.Events.EventHandlers.NotifyLi
       :error ->
         Logger.debug(
           "[Participation.NotifyLiveViews] Skipping provider topic — no program_id in payload",
+          event_type: event.event_type
+        )
+    end
+  end
+
+  defp publish_to_child_topic(%DomainEvent{payload: payload} = event) do
+    case Map.fetch(payload, :child_id) do
+      {:ok, child_id} ->
+        SharedNotifyLiveViews.safe_publish(event, child_topic(child_id))
+
+      :error ->
+        Logger.debug(
+          "[Participation.NotifyLiveViews] Skipping child topic — no child_id in payload",
           event_type: event.event_type
         )
     end

--- a/lib/klass_hero_web/live/parent/participation_history_live.ex
+++ b/lib/klass_hero_web/live/parent/participation_history_live.ex
@@ -18,19 +18,18 @@ defmodule KlassHeroWeb.Parent.ParticipationHistoryLive do
       |> assign(:active_nav, :participation)
       |> assign(:parent_id, parent_id)
       |> assign(:child_names_map, %{})
-      |> assign(:children_ids, MapSet.new())
       |> stream(:participation_records, [])
       |> assign(:pending_notes, [])
       |> assign(:reject_form_expanded, nil)
       |> assign(:reject_forms, %{})
 
     if connected?(socket) do
-      # A parent's children can attend any provider's sessions, so subscribe to the
-      # generic attendance topics (filtered to this parent's children in handle_info)
-      # plus session-note submissions. Topics derive from the event registry (#1108).
-      topics = [Participation.event_topic(:session_note_submitted) | Participation.participation_topics(:attendance)]
-
-      for topic <- topics, do: Phoenix.PubSub.subscribe(KlassHero.PubSub, topic)
+      # Subscribe per child to child-scoped topics (#1121) so this LiveView only
+      # receives its own children's attendance + session-note events — no generic
+      # firehose, no handle_info membership filter. The subscription set is fixed at
+      # mount: a child added mid-session isn't streamed until the next remount.
+      for child_id <- Family.get_child_ids_for_parent(parent_id),
+          do: Phoenix.PubSub.subscribe(KlassHero.PubSub, Participation.child_topic(child_id))
     end
 
     {:ok, load_participation_history(socket)}
@@ -110,41 +109,28 @@ defmodule KlassHeroWeb.Parent.ParticipationHistoryLive do
     end
   end
 
+  # Ownership is guaranteed by the child-scoped subscription (#1121) — we only
+  # receive events for this parent's children, so no membership check is needed.
   @impl true
-  def handle_info(
-        {:domain_event, %DomainEvent{event_type: event_type, aggregate_id: record_id, payload: %{child_id: child_id}}},
-        socket
-      )
+  def handle_info({:domain_event, %DomainEvent{event_type: event_type, aggregate_id: record_id}}, socket)
       when event_type in [:child_checked_in, :child_checked_out, :child_marked_absent] do
-    socket =
-      if child_belongs_to_parent?(child_id, socket) do
-        opts = if event_type == :child_checked_in, do: [at: 0], else: []
-        load_and_stream_record(socket, record_id, opts)
-      else
-        socket
-      end
-
-    {:noreply, socket}
+    opts = if event_type == :child_checked_in, do: [at: 0], else: []
+    {:noreply, load_and_stream_record(socket, record_id, opts)}
   end
 
+  # Any session-note lifecycle event refreshes the pending list — submitted adds one,
+  # approved/rejected removes one (e.g. reviewed from another device/tab).
   @impl true
-  def handle_info(
-        {:domain_event, %DomainEvent{event_type: :session_note_submitted, payload: %{child_id: child_id}}},
-        socket
-      ) do
-    socket =
-      if child_belongs_to_parent?(child_id, socket) do
-        load_pending_notes(socket)
-      else
-        socket
-      end
-
-    {:noreply, socket}
+  def handle_info({:domain_event, %DomainEvent{event_type: event_type}}, socket)
+      when event_type in [:session_note_submitted, :session_note_approved, :session_note_rejected] do
+    {:noreply, load_pending_notes(socket)}
   end
 
-  defp child_belongs_to_parent?(child_id, socket) do
-    MapSet.member?(socket.assigns.children_ids, child_id)
-  end
+  # publish_to_child_topic/1 fans out ANY child_id-bearing event to this LiveView's
+  # subscribed child topics. Ignore the ones with no display effect here rather than
+  # crashing on an unmatched message (a new child_id event must not break the page).
+  @impl true
+  def handle_info({:domain_event, %DomainEvent{}}, socket), do: {:noreply, socket}
 
   defp load_participation_history(socket) do
     parent_id = socket.assigns.parent_id
@@ -170,14 +156,11 @@ defmodule KlassHeroWeb.Parent.ParticipationHistoryLive do
         {child.id, %{first_name: child.first_name, last_name: child.last_name}}
       end)
 
-    children_ids = MapSet.new(children, & &1.id)
-
     enriched_records =
       Enum.map(participation_records, &enrich_history_record(&1, child_names_map))
 
     socket
     |> assign(:child_names_map, child_names_map)
-    |> assign(:children_ids, children_ids)
     |> stream(:participation_records, enriched_records, reset: true)
     |> assign(:participation_error, nil)
     |> load_pending_notes()

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -1387,7 +1387,7 @@ msgstr "Willkommen zurück"
 msgid "WhatsApp Community"
 msgstr "WhatsApp-Community"
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:163
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:149
 #, elixir-autogen, elixir-format
 msgid "Failed to load participation history"
 msgstr "Teilnahmeverlauf konnte nicht geladen werden"
@@ -1915,12 +1915,12 @@ msgstr "Kind bearbeiten"
 msgid "Emergency contact"
 msgstr "Notfallkontakt"
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:58
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:57
 #, elixir-autogen, elixir-format
 msgid "Failed to approve note"
 msgstr "Notiz konnte nicht genehmigt werden"
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:109
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:108
 #, elixir-autogen, elixir-format
 msgid "Failed to reject note"
 msgstr "Notiz konnte nicht abgelehnt werden"
@@ -2011,7 +2011,7 @@ msgstr "Noch keine Nachrichten"
 msgid "No parents are enrolled in this program"
 msgstr "Für dieses Programm sind keine Eltern angemeldet"
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:49
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:48
 #, elixir-autogen, elixir-format
 msgid "Note approved"
 msgstr "Notiz genehmigt"
@@ -2022,7 +2022,7 @@ msgstr "Notiz genehmigt"
 msgid "Note content cannot be blank"
 msgstr "Notizinhalt darf nicht leer sein"
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:98
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:97
 #, elixir-autogen, elixir-format
 msgid "Note rejected"
 msgstr "Notiz abgelehnt"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -1387,7 +1387,7 @@ msgstr ""
 msgid "WhatsApp Community"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:163
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:149
 #, elixir-autogen, elixir-format
 msgid "Failed to load participation history"
 msgstr ""
@@ -1915,12 +1915,12 @@ msgstr ""
 msgid "Emergency contact"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:58
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:57
 #, elixir-autogen, elixir-format
 msgid "Failed to approve note"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:109
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:108
 #, elixir-autogen, elixir-format
 msgid "Failed to reject note"
 msgstr ""
@@ -2011,7 +2011,7 @@ msgstr ""
 msgid "No parents are enrolled in this program"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:49
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:48
 #, elixir-autogen, elixir-format
 msgid "Note approved"
 msgstr ""
@@ -2022,7 +2022,7 @@ msgstr ""
 msgid "Note content cannot be blank"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:98
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:97
 #, elixir-autogen, elixir-format
 msgid "Note rejected"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -1387,7 +1387,7 @@ msgstr ""
 msgid "WhatsApp Community"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:163
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:149
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to load participation history"
 msgstr ""
@@ -1915,12 +1915,12 @@ msgstr ""
 msgid "Emergency contact"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:58
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:57
 #, elixir-autogen, elixir-format
 msgid "Failed to approve note"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:109
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:108
 #, elixir-autogen, elixir-format
 msgid "Failed to reject note"
 msgstr ""
@@ -2011,7 +2011,7 @@ msgstr ""
 msgid "No parents are enrolled in this program"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:49
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:48
 #, elixir-autogen, elixir-format
 msgid "Note approved"
 msgstr ""
@@ -2022,7 +2022,7 @@ msgstr ""
 msgid "Note content cannot be blank"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:98
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:97
 #, elixir-autogen, elixir-format
 msgid "Note rejected"
 msgstr ""

--- a/test/klass_hero/participation/adapters/driving/events/event_handlers/notify_live_views_test.exs
+++ b/test/klass_hero/participation/adapters/driving/events/event_handlers/notify_live_views_test.exs
@@ -4,7 +4,20 @@ defmodule KlassHero.Participation.Adapters.Driving.Events.EventHandlers.NotifyLi
   import KlassHero.EventTestHelper
 
   alias KlassHero.Participation.Adapters.Driving.Events.EventHandlers.NotifyLiveViews
+  alias KlassHero.Participation.Domain.Events.ParticipationEvents
+  alias KlassHero.Shared.Adapters.Driven.Events.TestEventPublisher
   alias KlassHero.Shared.Domain.Events.DomainEvent
+
+  # Events that carry child_id in their payload → routed to the child-scoped topic (#1121).
+  # Includes every session-note lifecycle event, all of which carry child_id.
+  @child_scoped_events [
+    :child_checked_in,
+    :child_checked_out,
+    :child_marked_absent,
+    :session_note_submitted,
+    :session_note_approved,
+    :session_note_rejected
+  ]
 
   setup do
     setup_test_events()
@@ -41,6 +54,35 @@ defmodule KlassHero.Participation.Adapters.Driving.Events.EventHandlers.NotifyLi
 
       assert :ok = NotifyLiveViews.handle(event)
       assert_event_published(:child_checked_in)
+    end
+  end
+
+  describe "handle/1 — child-scoped fan-out (#1121)" do
+    test "publishes every child-bearing event to its participation:child:<child_id> topic" do
+      for event_type <- @child_scoped_events do
+        child_id = Ecto.UUID.generate()
+        aggregate = ParticipationEvents.aggregate_type_for(event_type)
+        event = DomainEvent.new(event_type, Ecto.UUID.generate(), aggregate, %{child_id: child_id})
+
+        assert :ok = NotifyLiveViews.handle(event)
+        assert_published_to(event_type, "participation:child:#{child_id}")
+      end
+    end
+
+    test "does not publish a child topic for events without child_id" do
+      event =
+        DomainEvent.new(:session_created, Ecto.UUID.generate(), :participation, %{
+          session_id: Ecto.UUID.generate()
+        })
+
+      assert :ok = NotifyLiveViews.handle(event)
+
+      child_topics =
+        for {_event, topic} <- TestEventPublisher.get_published(),
+            String.starts_with?(topic, "participation:child:"),
+            do: topic
+
+      assert child_topics == [], "no child-scoped topic expected, got #{inspect(child_topics)}"
     end
   end
 

--- a/test/klass_hero_web/live/parent/participation_history_live_test.exs
+++ b/test/klass_hero_web/live/parent/participation_history_live_test.exs
@@ -5,14 +5,20 @@ defmodule KlassHeroWeb.Parent.ParticipationHistoryLiveTest do
 
   use KlassHeroWeb.ConnCase, async: true
 
-  import KlassHero.EventTestHelper
   import KlassHero.Factory
   import Phoenix.LiveViewTest
 
+  alias KlassHero.Participation
   alias KlassHero.Participation.Domain.Events.ParticipationEvents
   alias KlassHero.Shared.Domain.Events.DomainEvent
 
   setup :register_and_log_in_parent
+
+  # Mirrors the prod publish path: broadcast the {:domain_event, _} envelope on the
+  # child-scoped topic. Only a view subscribed to that child's topic receives it.
+  defp broadcast_on_child_topic(%DomainEvent{payload: %{child_id: child_id}} = event) do
+    Phoenix.PubSub.broadcast(KlassHero.PubSub, Participation.child_topic(child_id), {:domain_event, event})
+  end
 
   defp create_child_with_note(%{parent: parent, user: user}) do
     {child, _parent} =
@@ -119,7 +125,7 @@ defmodule KlassHeroWeb.Parent.ParticipationHistoryLiveTest do
     end
   end
 
-  describe "real-time attendance updates (#1108)" do
+  describe "real-time attendance updates (child-scoped topics, #1121)" do
     setup %{parent: parent} do
       {child, _parent} =
         insert_child_with_guardian(parent: parent, first_name: "Emma", last_name: "Mueller")
@@ -129,25 +135,51 @@ defmodule KlassHeroWeb.Parent.ParticipationHistoryLiveTest do
       %{child: child}
     end
 
-    test "streams the parent's own child when a check-in event arrives", %{conn: conn, child: child} do
+    test "streams the parent's own child when a check-in is broadcast on its child topic", %{
+      conn: conn,
+      child: child
+    } do
       {:ok, view, _html} = live(conn, ~p"/parent/participation")
       record = insert(:participation_record_schema, child_id: child.id, status: :checked_in)
 
-      emit_domain_event(view, ParticipationEvents.child_checked_in(record, []))
+      broadcast_on_child_topic(ParticipationEvents.child_checked_in(record, []))
 
+      assert render(view) =~ record.id
       assert has_element?(view, "#participation_records-#{record.id}")
     end
 
-    test "handles child_marked_absent (guard atom fix)", %{conn: conn, child: child} do
+    test "streams on child_marked_absent (guard atom fix)", %{conn: conn, child: child} do
       {:ok, view, _html} = live(conn, ~p"/parent/participation")
       record = insert(:participation_record_schema, child_id: child.id, status: :absent)
 
-      emit_domain_event(view, ParticipationEvents.child_marked_absent(record, []))
+      broadcast_on_child_topic(ParticipationEvents.child_marked_absent(record, []))
 
+      assert render(view) =~ record.id
       assert has_element?(view, "#participation_records-#{record.id}")
     end
 
-    test "ignores an attendance event for another family's child (privacy)", %{conn: conn} do
+    test "survives session-note review events fanned out on its child topic (#1121)", %{
+      conn: conn,
+      child: child
+    } do
+      {:ok, view, _html} = live(conn, ~p"/parent/participation")
+
+      # publish_to_child_topic fans out ANY child_id-bearing event, including
+      # session_note_approved/rejected. The LiveView must handle them, not crash —
+      # review_session_note/1 dispatches these in the parent's own process.
+      for event_type <- [:session_note_approved, :session_note_rejected] do
+        event =
+          DomainEvent.new(event_type, Ecto.UUID.generate(), :session_note, %{
+            child_id: child.id,
+            note_id: Ecto.UUID.generate()
+          })
+
+        broadcast_on_child_topic(event)
+        assert render(view), "LiveView crashed on #{event_type}"
+      end
+    end
+
+    test "never receives another family's child event — not subscribed to its topic (privacy)", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/parent/participation")
       foreign_record_id = Ecto.UUID.generate()
 
@@ -157,7 +189,7 @@ defmodule KlassHeroWeb.Parent.ParticipationHistoryLiveTest do
           child_id: Ecto.UUID.generate()
         })
 
-      emit_domain_event(view, foreign_event)
+      broadcast_on_child_topic(foreign_event)
 
       refute has_element?(view, "#participation_records-#{foreign_record_id}")
     end


### PR DESCRIPTION
## Summary

Closes #1121. The parent participation LiveView subscribed to the **generic** attendance firehose (`participation:child_checked_in` etc. — every child across every provider) and filtered to its own children in `handle_info`. Every parent process received every child's attendance event and discarded most.

This adds a **child-scoped topic fan-out** mirroring the existing provider-scoped `participation:provider:<id>` pattern in the same `NotifyLiveViews` module:

- `NotifyLiveViews` publishes any `child_id`-bearing event to `participation:child:<child_id>` — resolve-free, since `child_id` is already in the payload (cheaper than the provider path, which needs an ACL resolve).
- `Participation.child_topic/1` is the single-source builder (defdelegate), so publisher and subscriber can't drift.
- The parent LiveView subscribes per child via `Family.get_child_ids_for_parent/1` and **drops the `child_belongs_to_parent?/2` filter + `:children_ids` assign** — ownership is now guaranteed by which topics it subscribed to. Session-note events route the same way.

Design chosen via a design gate (child-scoped over parent-scoped: parent-scoped would add a child→guardian resolve on the hot attendance publish path). Accepted trade-off: the subscription set is fixed at mount — a child added mid-session isn't streamed until remount (documented inline).

## Review focus

`handle_info` covers all **six** `child_id`-bearing event types (attendance + `session_note` submitted/approved/rejected) plus a defensive catch-all. This is the sharp edge: the fan-out delivers *any* `child_id` event, but the first cut only handled 4 of 6. Because `review_session_note/1` dispatches in the LiveView's own process and PubSub delivery includes the sender, a parent approving their own note would `FunctionClauseError`-crash their page in **dev/prod** — invisible to `mix test` because the test-env publisher never touches real PubSub. Caught by the regression-review pass, fixed, and pinned by a real-PubSub-broadcast test.

## Test plan

- `notify_live_views_test.exs` — publisher fan-out over all 6 child-bearing events (tabular); events without `child_id` skip the child topic.
- `participation_history_live_test.exs` — subscription-boundary privacy (owned child streams, foreign child never delivered) + survival of review events fanned out on the child topic, all via real `Phoenix.PubSub.broadcast`.
- Full suite: 4168 passed, `mix precommit` green.
- Architecture/boundary/regression review: 21/21 checks clean post-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)