### PR TITLE
fix: resolve marketing CTA closer band and adjacent a11y issues

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -174,6 +174,11 @@
   --fg-primary:    var(--color-hero-black);
   --fg-body:       var(--color-hero-black-100);
   --fg-muted:      var(--color-hero-grey-600);
+  /* Muted text on warm-tinted light surfaces (hero-pink-50 / base_fade gradients):
+     grey-600 only reaches ~3.1:1 over the pink zone (fails WCAG AA). grey-800 clears
+     4.5:1 across the whole gradient. Use on pink/gradient surfaces; plain --fg-muted
+     stays for muted text on white. */
+  --fg-muted-on-light: var(--color-hero-grey-800);
   --fg-subtle:     var(--color-hero-grey-500);
   --fg-inverse:    #ffffff;
   --fg-link:       var(--color-hero-blue-600);

--- a/lib/klass_hero_web/components/marketing_components.ex
+++ b/lib/klass_hero_web/components/marketing_components.ex
@@ -26,6 +26,7 @@ defmodule KlassHeroWeb.MarketingComponents do
   import KlassHeroWeb.UIComponents,
     only: [kh_logo: 1, kh_button: 1, kh_card: 1, kh_pill: 1, kh_icon_chip: 1, icon: 1]
 
+  alias KlassHeroWeb.Theme
   alias Phoenix.HTML.FormField
   alias Phoenix.LiveView.JS
 
@@ -236,7 +237,7 @@ defmodule KlassHeroWeb.MarketingComponents do
           {gettext("for Our Youth")}
         </h1>
 
-        <p class="mt-6 text-lg md:text-xl text-[var(--fg-muted)] max-w-2xl mx-auto leading-relaxed">
+        <p class="mt-6 text-lg md:text-xl text-[var(--fg-muted-on-light)] max-w-2xl mx-auto leading-relaxed">
           {gettext(
             "Berlin's leading network for tutors, coaches, and camp providers — every one verified by our team."
           )}
@@ -941,7 +942,7 @@ defmodule KlassHeroWeb.MarketingComponents do
     ~H"""
     <section
       id="mk-programs-hero"
-      class="relative overflow-hidden bg-gradient-to-b from-hero-pink-50 to-white pt-14 pb-12 lg:pt-20 lg:pb-16"
+      class={[Theme.gradient(:base_fade), "relative overflow-hidden pt-14 pb-12 lg:pt-20 lg:pb-16"]}
     >
       <div class="absolute top-10 right-1/4 w-72 h-72 rounded-full bg-hero-yellow-500 opacity-20 blur-3xl pointer-events-none">
       </div>
@@ -958,7 +959,7 @@ defmodule KlassHeroWeb.MarketingComponents do
           {gettext(", camps & classes for your child")}
         </h1>
 
-        <p class="mt-5 text-lg text-[var(--fg-muted)] max-w-2xl mx-auto">
+        <p class="mt-5 text-lg text-[var(--fg-muted-on-light)] max-w-2xl mx-auto">
           {gettext(
             "Hand-picked, vetted programs across Berlin — filter by category, age, or schedule."
           )}
@@ -1276,7 +1277,7 @@ defmodule KlassHeroWeb.MarketingComponents do
     ~H"""
     <section
       id={@id}
-      class="relative overflow-hidden bg-gradient-to-b from-hero-pink-50 to-white pt-16 pb-20 lg:pt-24 lg:pb-28"
+      class={[Theme.gradient(:base_fade), "relative overflow-hidden pt-16 pb-20 lg:pt-24 lg:pb-28"]}
     >
       <div class="absolute top-10 right-1/4 w-72 h-72 rounded-full bg-hero-yellow-500 opacity-20 blur-3xl pointer-events-none">
       </div>
@@ -1295,7 +1296,7 @@ defmodule KlassHeroWeb.MarketingComponents do
         </h1>
         <p
           :if={@lede != []}
-          class="mt-6 text-lg md:text-xl text-[var(--fg-muted)] max-w-3xl mx-auto leading-relaxed"
+          class="mt-6 text-lg md:text-xl text-[var(--fg-muted-on-light)] max-w-3xl mx-auto leading-relaxed"
         >
           {render_slot(@lede)}
         </p>
@@ -1307,7 +1308,7 @@ defmodule KlassHeroWeb.MarketingComponents do
   @doc """
   Generic peach CTA closer used by Trust & Safety (and reusable by About /
   Contact follow-ups). H2 + lede + primary CTA via slot, with an optional
-  tracking-widest tagline + sub-tagline rendered below a horizontal rule.
+  tagline + sub-tagline rendered below a horizontal rule.
   """
   attr :id, :string, default: "mk-cta"
   attr :title, :string, required: true
@@ -1318,20 +1319,20 @@ defmodule KlassHeroWeb.MarketingComponents do
 
   def mk_cta_section(assigns) do
     ~H"""
-    <section id={@id} class="py-16 lg:py-20 bg-hero-pink-50 text-center">
+    <section id={@id} class={[Theme.gradient(:base_fade), "py-16 lg:py-20 text-center"]}>
       <div class="max-w-3xl mx-auto px-6">
         <%!-- typography-lint-ignore: marketing CTA closer title intentionally larger than Theme.typography(:page_title) --%>
         <h2 class="font-display font-bold tracking-tight text-4xl lg:text-5xl text-hero-black">
           {@title}
         </h2>
-        <p :if={@lede} class="text-lg text-[var(--fg-muted)] mt-4">{@lede}</p>
+        <p :if={@lede} class="text-lg text-[var(--fg-muted-on-light)] mt-4">{@lede}</p>
         <div class="mt-8">
           {render_slot(@cta)}
         </div>
 
         <div :if={@tagline} class="mt-14 pt-10 border-t border-[var(--border-light)]">
-          <%!-- typography-lint-ignore: tracking-widest tagline rendered in display font is intentional --%>
-          <p class="font-display font-bold text-2xl tracking-widest text-hero-black">
+          <%!-- typography-lint-ignore: display-font tagline is an intentional non-heading brand callout --%>
+          <p class="font-display font-bold text-2xl tracking-tight text-hero-black">
             {@tagline}
           </p>
           <p :if={@sub_tagline} class="text-xl text-[var(--brand-primary-dark)] font-bold mt-2">

--- a/lib/klass_hero_web/components/theme.ex
+++ b/lib/klass_hero_web/components/theme.ex
@@ -21,7 +21,8 @@ defmodule KlassHeroWeb.Theme do
     safety: "bg-gradient-to-r from-green-500 to-emerald-600",
     cool: "bg-gradient-to-r from-hero-blue-400 to-hero-blue-600",
     art: "bg-gradient-to-r from-hero-yellow-400 to-hero-pink-400",
-    cream: "bg-hero-cream-100"
+    cream: "bg-hero-cream-100",
+    base_fade: "bg-gradient-to-b from-hero-pink-50 to-white"
   }
 
   @doc """
@@ -32,6 +33,8 @@ defmodule KlassHeroWeb.Theme do
   - `:primary` - Hero blue horizontal gradient (hero-blue-500 to hero-blue-600)
   - `:hero` - Hero blue/yellow diagonal gradient
   - `:safety` - Green horizontal gradient (green-500 to emerald-600)
+  - `:base_fade` - Vertical fade from the base pink surface (hero-pink-50) to white,
+    for marketing sections that must meet a white/black seam on a clean edge
 
   ## Examples
 

--- a/lib/klass_hero_web/components/ui_components.ex
+++ b/lib/klass_hero_web/components/ui_components.ex
@@ -1745,8 +1745,12 @@ defmodule KlassHeroWeb.UIComponents do
       type={@type}
       class={
         [
+          # No `border-0` here: Tailwind preflight already zeroes borders on every element, and an
+          # explicit `border-0` in this base stack out-cascades the `:ghost` variant's opt-in `border`
+          # (equal-specificity single-class rules resolve by emit order, not markup order), leaving the
+          # ghost button invisible at rest. Borderless variants stay borderless via preflight.
           # typography-lint-ignore: KhButton owns its own display-font CTA styling (size scales separately)
-          "inline-flex items-center justify-center gap-2 font-display font-bold tracking-tight transition-all cursor-pointer border-0",
+          "inline-flex items-center justify-center gap-2 font-display font-bold tracking-tight transition-all cursor-pointer",
           "active:scale-[0.98]",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--brand-primary)]",
           "disabled:cursor-not-allowed disabled:bg-hero-grey-200 disabled:text-hero-grey-400 disabled:shadow-none disabled:translate-y-0",

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -13,9 +13,9 @@ msgstr ""
 
 #: lib/klass_hero_web/components/layouts/app.html.heex:44
 #: lib/klass_hero_web/components/layouts/app.html.heex:197
-#: lib/klass_hero_web/components/marketing_components.ex:193
-#: lib/klass_hero_web/components/marketing_components.ex:821
-#: lib/klass_hero_web/components/marketing_components.ex:910
+#: lib/klass_hero_web/components/marketing_components.ex:194
+#: lib/klass_hero_web/components/marketing_components.ex:822
+#: lib/klass_hero_web/components/marketing_components.ex:911
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr "Über uns"
@@ -34,9 +34,9 @@ msgstr "Wählen Sie Ihre bevorzugte Sprache für die Benutzeroberfläche"
 #: lib/klass_hero_web/components/composite_components.ex:468
 #: lib/klass_hero_web/components/layouts/app.html.heex:52
 #: lib/klass_hero_web/components/layouts/app.html.heex:198
-#: lib/klass_hero_web/components/marketing_components.ex:194
-#: lib/klass_hero_web/components/marketing_components.ex:822
-#: lib/klass_hero_web/components/marketing_components.ex:911
+#: lib/klass_hero_web/components/marketing_components.ex:195
+#: lib/klass_hero_web/components/marketing_components.ex:823
+#: lib/klass_hero_web/components/marketing_components.ex:912
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr "Kontakt"
@@ -68,7 +68,7 @@ msgstr "Spracheinstellung konnte nicht aktualisiert werden."
 
 #: lib/klass_hero_web/components/layouts/app.html.heex:28
 #: lib/klass_hero_web/components/layouts/app.html.heex:195
-#: lib/klass_hero_web/components/marketing_components.ex:189
+#: lib/klass_hero_web/components/marketing_components.ex:190
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr "Startseite"
@@ -93,7 +93,7 @@ msgstr "Anmelden"
 #: lib/klass_hero_web/components/composite_components.ex:484
 #: lib/klass_hero_web/components/layouts/app.html.heex:36
 #: lib/klass_hero_web/components/layouts/app.html.heex:196
-#: lib/klass_hero_web/components/marketing_components.ex:190
+#: lib/klass_hero_web/components/marketing_components.ex:191
 #, elixir-autogen, elixir-format
 msgid "Programs"
 msgstr "Programme"
@@ -182,7 +182,7 @@ msgstr "Nach Abschluss der Anmeldung erhalten Sie eine Rechnung per E-Mail"
 msgid "Any allergies, medical conditions, or special instructions..."
 msgstr "Allergien, medizinische Bedingungen oder besondere Hinweise..."
 
-#: lib/klass_hero_web/components/marketing_components.ex:491
+#: lib/klass_hero_web/components/marketing_components.ex:492
 #, elixir-autogen, elixir-format
 msgid "Book camps, tutors, and workshops instantly. Our integrated planner helps you manage your child's busy life."
 msgstr "Buchen Sie Camps, Nachhilfe und Workshops sofort. Unser integrierter Planer hilft Ihnen, den vollen Terminkalender Ihres Kindes zu verwalten."
@@ -197,7 +197,7 @@ msgstr "Bar / Überweisung"
 msgid "Cash/transfer payments will show as \"Pending\" until received"
 msgstr "Bar-/Überweisungszahlungen werden als \"Ausstehend\" angezeigt, bis sie eingegangen sind"
 
-#: lib/klass_hero_web/components/marketing_components.ex:499
+#: lib/klass_hero_web/components/marketing_components.ex:500
 #, elixir-autogen, elixir-format
 msgid "Community Focused"
 msgstr "Gemeinschaftsorientiert"
@@ -222,7 +222,7 @@ msgstr "Kreditkartenzahlungen werden sofort verarbeitet"
 msgid "Duration:"
 msgstr "Dauer:"
 
-#: lib/klass_hero_web/components/marketing_components.ex:489
+#: lib/klass_hero_web/components/marketing_components.ex:490
 #, elixir-autogen, elixir-format
 msgid "Easy Scheduling"
 msgstr "Einfache Terminplanung"
@@ -253,18 +253,18 @@ msgstr "Anmeldung fehlgeschlagen. Bitte versuchen Sie es erneut oder kontaktiere
 msgid "Enrollment successful! You'll receive a confirmation email shortly."
 msgstr "Anmeldung erfolgreich! Sie erhalten in Kürze eine Bestätigungs-E-Mail."
 
-#: lib/klass_hero_web/components/marketing_components.ex:481
+#: lib/klass_hero_web/components/marketing_components.ex:482
 #, elixir-autogen, elixir-format
 msgid "Every provider is rigorously vetted. We prioritize child safety above all else, giving parents peace of mind."
 msgstr "Jeder Anbieter wird sorgfältig geprüft. Wir stellen die Sicherheit der Kinder an erste Stelle und geben Eltern die nötige Sicherheit."
 
-#: lib/klass_hero_web/components/marketing_components.ex:952
+#: lib/klass_hero_web/components/marketing_components.ex:953
 #: lib/klass_hero_web/live/programs_live.ex:34
 #, elixir-autogen, elixir-format
 msgid "Explore Programs"
 msgstr "Programme entdecken"
 
-#: lib/klass_hero_web/components/marketing_components.ex:318
+#: lib/klass_hero_web/components/marketing_components.ex:319
 #, elixir-autogen, elixir-format
 msgid "Featured Programs"
 msgstr "Empfohlene Programme"
@@ -343,7 +343,7 @@ msgstr "Programm nicht gefunden"
 msgid "Program not found. It may have been removed or is no longer available."
 msgstr "Programm nicht gefunden. Es wurde möglicherweise entfernt oder ist nicht mehr verfügbar."
 
-#: lib/klass_hero_web/components/marketing_components.ex:479
+#: lib/klass_hero_web/components/marketing_components.ex:480
 #: lib/klass_hero_web/live/about_live.ex:19
 #, elixir-autogen, elixir-format
 msgid "Safety First"
@@ -389,7 +389,7 @@ msgstr "Gesamtpreis:"
 msgid "Total due today:"
 msgstr "Heute fällig:"
 
-#: lib/klass_hero_web/components/marketing_components.ex:337
+#: lib/klass_hero_web/components/marketing_components.ex:338
 #, elixir-autogen, elixir-format
 msgid "View All Programs →"
 msgstr "Alle Programme ansehen →"
@@ -1436,9 +1436,9 @@ msgid "Education"
 msgstr "Bildung"
 
 #: lib/klass_hero_web/components/composite_components.ex:472
-#: lib/klass_hero_web/components/marketing_components.ex:191
-#: lib/klass_hero_web/components/marketing_components.ex:537
-#: lib/klass_hero_web/components/marketing_components.ex:908
+#: lib/klass_hero_web/components/marketing_components.ex:192
+#: lib/klass_hero_web/components/marketing_components.ex:538
+#: lib/klass_hero_web/components/marketing_components.ex:909
 #: lib/klass_hero_web/live/for_providers_live.ex:10
 #: lib/klass_hero_web/live/for_providers_live.ex:39
 #, elixir-autogen, elixir-format
@@ -1450,7 +1450,7 @@ msgstr "Für Anbieter"
 msgid "From sports to arts, technology to languages, we make it easy to discover enriching activities that fit your family's schedule and budget."
 msgstr "Von Sport über Kunst, Technologie bis Sprachen – wir machen es einfach, bereichernde Aktivitäten zu entdecken, die zu Zeitplan und Budget Ihrer Familie passen."
 
-#: lib/klass_hero_web/components/marketing_components.ex:589
+#: lib/klass_hero_web/components/marketing_components.ex:590
 #, elixir-autogen, elixir-format
 msgid "Get Paid & Grow"
 msgstr "Verdienen & Wachsen"
@@ -1477,12 +1477,12 @@ msgstr "Qualifikationen"
 msgid "Ready to join the movement?"
 msgstr "Bereit, Teil der Bewegung zu werden?"
 
-#: lib/klass_hero_web/components/marketing_components.ex:986
+#: lib/klass_hero_web/components/marketing_components.ex:987
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr "Suche"
 
-#: lib/klass_hero_web/components/marketing_components.ex:573
+#: lib/klass_hero_web/components/marketing_components.ex:574
 #, elixir-autogen, elixir-format
 msgid "Set up your teaching profile and list your programs in minutes. Share your expertise with families who need it."
 msgstr "Richten Sie Ihr Kursleiterprofil ein und veröffentlichen Sie Ihre Programme in wenigen Minuten. Teilen Sie Ihr Fachwissen mit Familien, die es brauchen."
@@ -1498,7 +1498,7 @@ msgstr "Sport"
 msgid "Sustainability"
 msgstr "Nachhaltigkeit"
 
-#: lib/klass_hero_web/components/marketing_components.ex:269
+#: lib/klass_hero_web/components/marketing_components.ex:270
 #, elixir-autogen, elixir-format
 msgid "Trending in Berlin:"
 msgstr "Beliebt in Berlin:"
@@ -2276,7 +2276,7 @@ msgstr "Möchten Sie dieses Dokument wirklich genehmigen?"
 msgid "Are you sure you want to remove this team member?"
 msgstr "Möchten Sie dieses Teammitglied wirklich entfernen?"
 
-#: lib/klass_hero_web/components/marketing_components.ex:641
+#: lib/klass_hero_web/components/marketing_components.ex:642
 #, elixir-autogen, elixir-format
 msgid "As fathers and partners of teachers in Berlin, we saw and heard firsthand how hard it is to find, book, and manage quality youth activities outside the classroom. Klass Hero is the complete platform connecting Berlin families and schools with trusted, vetted activity providers — offering safe, supervised, and enriching experiences across sports, arts, tutoring, and more. We verify every provider, structure every booking, and support every step — so parents know their child is in good hands, and providers can focus on what they do best: inspiring kids."
 msgstr "Als Väter und Partner von Lehrkräften in Berlin haben wir aus erster Hand erlebt, wie schwer es ist, hochwertige außerschulische Aktivitäten für Kinder zu finden, zu buchen und zu organisieren. Klass Hero ist die umfassende Plattform, die Berliner Familien und Schulen mit vertrauenswürdigen, geprüften Anbietern verbindet — und bietet sichere, betreute und bereichernde Erlebnisse in den Bereichen Sport, Kunst, Nachhilfe und mehr. Wir überprüfen jeden Anbieter, strukturieren jede Buchung und unterstützen bei jedem Schritt — damit Eltern wissen, dass ihr Kind in guten Händen ist, und Anbieter sich auf das konzentrieren können, was sie am besten können: Kinder zu begeistern."
@@ -2313,7 +2313,7 @@ msgstr "Programm buchen"
 msgid "Brief description of experience and specialties..."
 msgstr "Kurze Beschreibung der Erfahrung und Spezialgebiete..."
 
-#: lib/klass_hero_web/components/marketing_components.ex:638
+#: lib/klass_hero_web/components/marketing_components.ex:639
 #, elixir-autogen, elixir-format
 msgid "Built by Parents to Empower Educators."
 msgstr "Von Eltern entwickelt, um Pädagogen zu stärken."
@@ -2837,7 +2837,7 @@ msgstr "Nicht verifiziert"
 msgid "Not specified"
 msgstr "Nicht angegeben"
 
-#: lib/klass_hero_web/components/marketing_components.ex:635
+#: lib/klass_hero_web/components/marketing_components.ex:636
 #, elixir-autogen, elixir-format
 msgid "Our Story"
 msgstr "Unsere Geschichte"
@@ -2935,7 +2935,7 @@ msgstr "Programm erfolgreich aktualisiert."
 msgid "Provider profile not found."
 msgstr "Anbieterprofil nicht gefunden."
 
-#: lib/klass_hero_web/components/marketing_components.ex:648
+#: lib/klass_hero_web/components/marketing_components.ex:649
 #, elixir-autogen, elixir-format
 msgid "Read our founding story →"
 msgstr "Lesen Sie unsere Gründungsgeschichte →"
@@ -3314,12 +3314,12 @@ msgstr "z. B. Art Adventures"
 msgid "e.g., Community Center, Main St"
 msgstr "z. B. Gemeindezentrum, Hauptstraße"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1462
+#: lib/klass_hero_web/components/marketing_components.ex:1463
 #, elixir-autogen, elixir-format
 msgid "All Heroes must hold or complete a recognized child safeguarding course, ensuring up-to-date knowledge."
 msgstr "Alle Heroes müssen einen anerkannten Kinderschutzkurs absolviert haben oder absolvieren, um stets aktuelles Wissen sicherzustellen."
 
-#: lib/klass_hero_web/components/marketing_components.ex:1430
+#: lib/klass_hero_web/components/marketing_components.ex:1431
 #, elixir-autogen, elixir-format
 msgid "All providers must be 18 years or older, ensuring legal accountability and professional responsibility."
 msgstr "Alle Anbieter müssen mindestens 18 Jahre alt sein, um rechtliche Verantwortlichkeit und professionelle Verlässlichkeit zu gewährleisten."
@@ -3329,12 +3329,12 @@ msgstr "Alle Anbieter müssen mindestens 18 Jahre alt sein, um rechtliche Verant
 msgid "And at Klass Hero, both come standard."
 msgstr "Und bei Klass Hero sind beide selbstverständlich."
 
-#: lib/klass_hero_web/components/marketing_components.ex:1460
+#: lib/klass_hero_web/components/marketing_components.ex:1461
 #, elixir-autogen, elixir-format
 msgid "Child Safeguarding Training"
 msgstr "Kinderschutzschulung"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1468
+#: lib/klass_hero_web/components/marketing_components.ex:1469
 #: lib/klass_hero_web/components/provider_components.ex:2607
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
@@ -3345,7 +3345,7 @@ msgstr "Vereinbarung zu Community-Standards"
 msgid "Create long-term trust across our community"
 msgstr "Langfristiges Vertrauen in unserer Community aufbauen"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1446
+#: lib/klass_hero_web/components/marketing_components.ex:1447
 #, elixir-autogen, elixir-format
 msgid "Each provider submits an extended police background check, confirming their eligibility to work safely with minors."
 msgstr "Jeder Anbieter reicht ein erweitertes polizeiliches Führungszeugnis ein, das seine Eignung bestätigt, sicher mit Minderjährigen zu arbeiten."
@@ -3355,17 +3355,17 @@ msgstr "Jeder Anbieter reicht ein erweitertes polizeiliches Führungszeugnis ein
 msgid "Enforcing platform standards and guidelines"
 msgstr "Durchsetzung von Plattformstandards und -richtlinien"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1470
+#: lib/klass_hero_web/components/marketing_components.ex:1471
 #, elixir-autogen, elixir-format
 msgid "Every provider agrees to follow our Community Guidelines, defining expectations around professionalism."
 msgstr "Jeder Anbieter verpflichtet sich, unsere Community-Richtlinien einzuhalten, die die Erwartungen an Professionalität festlegen."
 
-#: lib/klass_hero_web/components/marketing_components.ex:1436
+#: lib/klass_hero_web/components/marketing_components.ex:1437
 #, elixir-autogen, elixir-format
 msgid "Experience Validation"
 msgstr "Erfahrungsprüfung"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1444
+#: lib/klass_hero_web/components/marketing_components.ex:1445
 #, elixir-autogen, elixir-format
 msgid "Extended Background Checks"
 msgstr "Erweiterte Führungszeugnisprüfungen"
@@ -3375,12 +3375,12 @@ msgstr "Erweiterte Führungszeugnisprüfungen"
 msgid "From academic tutoring to sports, arts, and enrichment programs, every provider on Klass Hero is carefully reviewed to ensure they meet our high standards for child safety, professionalism, and educational quality."
 msgstr "Von akademischer Nachhilfe über Sport und Kunst bis hin zu Förderprogrammen wird jeder Anbieter auf Klass Hero sorgfältig geprüft, um sicherzustellen, dass er unseren hohen Standards für Kindersicherheit, Professionalität und pädagogische Qualität entspricht."
 
-#: lib/klass_hero_web/components/marketing_components.ex:1490
+#: lib/klass_hero_web/components/marketing_components.ex:1491
 #, elixir-autogen, elixir-format
 msgid "How We Verify Providers"
 msgstr "Wie wir Anbieter verifizieren"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1428
+#: lib/klass_hero_web/components/marketing_components.ex:1429
 #, elixir-autogen, elixir-format
 msgid "Identity & Age Verification"
 msgstr "Identitäts- und Altersverifizierung"
@@ -3415,7 +3415,7 @@ msgstr "Programm gespeichert, aber der Upload des Titelbilds ist fehlgeschlagen.
 msgid "Protect children and families"
 msgstr "Kinder und Familien schützen"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1438
+#: lib/klass_hero_web/components/marketing_components.ex:1439
 #, elixir-autogen, elixir-format
 msgid "Providers must demonstrate at least one year of experience working with children in their area of expertise."
 msgstr "Anbieter müssen mindestens ein Jahr Erfahrung in der Arbeit mit Kindern in ihrem Fachgebiet nachweisen."
@@ -3454,9 +3454,9 @@ msgstr "Dieses Kind ist bereits für dieses Programm angemeldet."
 #: lib/klass_hero_web/components/composite_components.ex:546
 #: lib/klass_hero_web/components/layouts/app.html.heex:60
 #: lib/klass_hero_web/components/layouts/app.html.heex:199
-#: lib/klass_hero_web/components/marketing_components.ex:192
-#: lib/klass_hero_web/components/marketing_components.ex:805
-#: lib/klass_hero_web/components/marketing_components.ex:909
+#: lib/klass_hero_web/components/marketing_components.ex:193
+#: lib/klass_hero_web/components/marketing_components.ex:806
+#: lib/klass_hero_web/components/marketing_components.ex:910
 #: lib/klass_hero_web/live/for_providers_live.ex:136
 #: lib/klass_hero_web/live/trust_safety_live.ex:10
 #, elixir-autogen, elixir-format
@@ -3478,12 +3478,12 @@ msgstr "Vertrauen muss man sich verdienen. Sicherheit ist nicht verhandelbar."
 msgid "Uphold professional and ethical teaching practices"
 msgstr "Professionelle und ethische Lehrpraktiken einhalten"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1387
+#: lib/klass_hero_web/components/marketing_components.ex:1388
 #, elixir-autogen, elixir-format
 msgid "Vetted with Care"
 msgstr "Mit Sorgfalt geprüft"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1452
+#: lib/klass_hero_web/components/marketing_components.ex:1453
 #: lib/klass_hero_web/components/provider_components.ex:2392
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
@@ -3854,7 +3854,7 @@ msgid "Private lessons and tutoring"
 msgstr "Privatunterricht und Nachhilfe"
 
 #: lib/klass_hero_web/components/layouts/admin.html.heex:31
-#: lib/klass_hero_web/components/marketing_components.ex:810
+#: lib/klass_hero_web/components/marketing_components.ex:811
 #, elixir-autogen, elixir-format
 msgid "Providers"
 msgstr "Anbieter"
@@ -4752,7 +4752,7 @@ msgstr "+1234567890"
 msgid "About the Provider"
 msgstr "Über den Anbieter"
 
-#: lib/klass_hero_web/components/marketing_components.ex:501
+#: lib/klass_hero_web/components/marketing_components.ex:502
 #, elixir-autogen, elixir-format
 msgid "Built for the Berlin international community. Integrated secure encrypted messaging to connect with local families and trusted educators nearby."
 msgstr "Entwickelt für die internationale Berliner Gemeinschaft. Integriertes sicheres verschlüsseltes Messaging, um sich mit lokalen Familien und vertrauenswürdigen Pädagogen in Ihrer Nähe zu verbinden."
@@ -5284,8 +5284,8 @@ msgstr "Guten Abend"
 msgid "Your week with the kids"
 msgstr "Ihre Woche mit den Kindern"
 
-#: lib/klass_hero_web/components/marketing_components.ex:91
-#: lib/klass_hero_web/components/marketing_components.ex:159
+#: lib/klass_hero_web/components/marketing_components.ex:92
+#: lib/klass_hero_web/components/marketing_components.ex:160
 #, elixir-autogen, elixir-format
 msgid "Go to dashboard"
 msgstr "Zum Dashboard"
@@ -5312,7 +5312,7 @@ msgstr ", Max' Bruder, kam als CFO dazu und brachte die finanzielle Sorgfalt und
 msgid ", a full-stack developer who shared a unique perspective. Both Shane and Max are partners of teachers who wanted to extend their expertise beyond the classroom — but without the time to manage the operational side on their own."
 msgstr ", ein Full-Stack-Entwickler, der eine besondere Perspektive einbrachte. Sowohl Shane als auch Max sind Partner von Lehrkräften, die ihre Expertise über den Unterricht hinaus erweitern wollten — jedoch ohne die Zeit, die operative Seite selbst zu verwalten."
 
-#: lib/klass_hero_web/components/marketing_components.ex:958
+#: lib/klass_hero_web/components/marketing_components.ex:959
 #, elixir-autogen, elixir-format
 msgid ", camps & classes for your child"
 msgstr ", Camps & Kurse für Ihr Kind"
@@ -5369,7 +5369,7 @@ msgstr "Fügen Sie 3+ Fotos hinzu, um Buchungen um ~40% zu steigern."
 msgid "Add a child"
 msgstr "Ein Kind hinzufügen"
 
-#: lib/klass_hero_web/components/marketing_components.ex:321
+#: lib/klass_hero_web/components/marketing_components.ex:322
 #, elixir-autogen, elixir-format
 msgid "Afterschool Adventures Await"
 msgstr "Nachmittagsabenteuer erwarten Sie"
@@ -5384,7 +5384,7 @@ msgstr "Alter & Identität"
 msgid "All instructors are background-checked and verified."
 msgstr "Alle Lehrkräfte sind hintergrundgeprüft und verifiziert."
 
-#: lib/klass_hero_web/components/marketing_components.ex:548
+#: lib/klass_hero_web/components/marketing_components.ex:549
 #, elixir-autogen, elixir-format
 msgid "Are you an educator, coach, or artist?"
 msgstr "Sind Sie Pädagog:in, Coach oder Künstler:in?"
@@ -5404,13 +5404,13 @@ msgstr "Foto anhängen"
 msgid "Back to Programs"
 msgstr "Zurück zu den Programmen"
 
-#: lib/klass_hero_web/components/marketing_components.ex:890
-#: lib/klass_hero_web/components/marketing_components.ex:900
+#: lib/klass_hero_web/components/marketing_components.ex:891
+#: lib/klass_hero_web/components/marketing_components.ex:901
 #, elixir-autogen, elixir-format
 msgid "Become a Hero"
 msgstr "Werden Sie ein Hero"
 
-#: lib/klass_hero_web/components/marketing_components.ex:858
+#: lib/klass_hero_web/components/marketing_components.ex:859
 #, elixir-autogen, elixir-format
 msgid "Become a Hero →"
 msgstr "Werden Sie ein Hero →"
@@ -5425,17 +5425,17 @@ msgstr "Anbieter werden"
 msgid "Berlin parents come to Klass Hero looking for trusted programs. You focus on teaching — we handle the funnel."
 msgstr "Berliner Eltern kommen zu Klass Hero auf der Suche nach vertrauenswürdigen Programmen. Sie konzentrieren sich aufs Unterrichten — wir übernehmen die Akquise."
 
-#: lib/klass_hero_web/components/marketing_components.ex:226
+#: lib/klass_hero_web/components/marketing_components.ex:227
 #, elixir-autogen, elixir-format
 msgid "Berlin's #1 network for youth educators"
 msgstr "Berlins Nr. 1-Netzwerk für Jugendpädagogen"
 
-#: lib/klass_hero_web/components/marketing_components.ex:240
+#: lib/klass_hero_web/components/marketing_components.ex:241
 #, elixir-autogen, elixir-format
 msgid "Berlin's leading network for tutors, coaches, and camp providers — every one verified by our team."
 msgstr "Berlins führendes Netzwerk für Nachhilfelehrer, Trainer und Camp-Anbieter — jeder Einzelne von unserem Team verifiziert."
 
-#: lib/klass_hero_web/components/marketing_components.ex:794
+#: lib/klass_hero_web/components/marketing_components.ex:795
 #, elixir-autogen, elixir-format
 msgid "Berlin's network for trusted youth educators. Built by parents, for parents."
 msgstr "Berlins Netzwerk für vertrauenswürdige Jugendpädagogen. Von Eltern für Eltern entwickelt."
@@ -5455,16 +5455,16 @@ msgstr "Buchungen, Teilnehmerlisten, Zeitpläne, Anwesenheit, Elternkommunikatio
 msgid "Brings the financial rigour and strategic planning needed for the German market and long-term provider stability."
 msgstr "Bringt die finanzielle Sorgfalt und strategische Planung mit, die für den deutschen Markt und langfristige Stabilität der Anbieter nötig sind."
 
-#: lib/klass_hero_web/components/marketing_components.ex:803
-#: lib/klass_hero_web/components/marketing_components.ex:907
+#: lib/klass_hero_web/components/marketing_components.ex:804
+#: lib/klass_hero_web/components/marketing_components.ex:908
 #, elixir-autogen, elixir-format
 msgid "Browse Programs"
 msgstr "Programme durchsuchen"
 
-#: lib/klass_hero_web/components/marketing_components.ex:868
-#: lib/klass_hero_web/components/marketing_components.ex:878
-#: lib/klass_hero_web/components/marketing_components.ex:888
-#: lib/klass_hero_web/components/marketing_components.ex:898
+#: lib/klass_hero_web/components/marketing_components.ex:869
+#: lib/klass_hero_web/components/marketing_components.ex:879
+#: lib/klass_hero_web/components/marketing_components.ex:889
+#: lib/klass_hero_web/components/marketing_components.ex:899
 #, elixir-autogen, elixir-format
 msgid "Browse Programs →"
 msgstr "Programme durchsuchen →"
@@ -5524,7 +5524,7 @@ msgstr "Schauen Sie in unsere FAQ — die meisten Fragen werden dort beantwortet
 msgid "Children"
 msgstr "Kinder"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1245
+#: lib/klass_hero_web/components/marketing_components.ex:1246
 #, elixir-autogen, elixir-format
 msgid "Clear filters"
 msgstr "Filter zurücksetzen"
@@ -5563,7 +5563,7 @@ msgstr "Kommunikation"
 msgid "Community Standards"
 msgstr "Gemeinschaftsstandards"
 
-#: lib/klass_hero_web/components/marketing_components.ex:819
+#: lib/klass_hero_web/components/marketing_components.ex:820
 #, elixir-autogen, elixir-format
 msgid "Company"
 msgstr "Unternehmen"
@@ -5583,7 +5583,7 @@ msgstr "Bestätigen"
 msgid "Confirm your account to finish signing up."
 msgstr "Bestätigen Sie Ihr Konto, um die Registrierung abzuschließen."
 
-#: lib/klass_hero_web/components/marketing_components.ex:232
+#: lib/klass_hero_web/components/marketing_components.ex:233
 #, elixir-autogen, elixir-format
 msgid "Connecting Families with"
 msgstr "Familien verbinden mit"
@@ -5638,7 +5638,7 @@ msgstr "Direktnachrichten und Rundnachrichten"
 msgid "Direct messaging, broadcast announcements, incident reports. Keep parents informed, automatically."
 msgstr "Direktnachrichten, Rundschreiben, Vorfallberichte. Halten Sie Eltern automatisch auf dem Laufenden."
 
-#: lib/klass_hero_web/components/marketing_components.ex:956
+#: lib/klass_hero_web/components/marketing_components.ex:957
 #, elixir-autogen, elixir-format
 msgid "Discover"
 msgstr "Entdecken"
@@ -5713,7 +5713,7 @@ msgstr "Jede Lehrkraft und jede pädagogische Fachkraft durchläuft vor der Gene
 msgid "Every feature included. No subscription, no setup fees."
 msgstr "Alle Funktionen inklusive. Kein Abo, keine Einrichtungsgebühren."
 
-#: lib/klass_hero_web/components/marketing_components.ex:472
+#: lib/klass_hero_web/components/marketing_components.ex:473
 #, elixir-autogen, elixir-format
 msgid "Everything parents need, nothing they don't"
 msgstr "Alles, was Eltern brauchen – nichts, was sie nicht brauchen"
@@ -5728,7 +5728,7 @@ msgstr "Alles, was Sie über Klass Hero wissen müssen."
 msgid "Extended Police Check"
 msgstr "Erweitertes Führungszeugnis"
 
-#: lib/klass_hero_web/components/marketing_components.ex:676
+#: lib/klass_hero_web/components/marketing_components.ex:677
 #: lib/klass_hero_web/live/for_providers_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "FAQ"
@@ -5739,17 +5739,17 @@ msgstr "FAQ"
 msgid "Failed to approve"
 msgstr "Genehmigung fehlgeschlagen"
 
-#: lib/klass_hero_web/components/marketing_components.ex:801
+#: lib/klass_hero_web/components/marketing_components.ex:802
 #, elixir-autogen, elixir-format
 msgid "Families"
 msgstr "Familien"
 
-#: lib/klass_hero_web/components/marketing_components.ex:260
+#: lib/klass_hero_web/components/marketing_components.ex:261
 #, elixir-autogen, elixir-format
 msgid "Find Programs"
 msgstr "Programme finden"
 
-#: lib/klass_hero_web/components/marketing_components.ex:764
+#: lib/klass_hero_web/components/marketing_components.ex:765
 #, elixir-autogen, elixir-format
 msgid "Footer mobile"
 msgstr "Fußzeile (mobil)"
@@ -5779,7 +5779,7 @@ msgstr "Vom Eintrag bis zur ersten Auszahlung in weniger als einer Woche"
 msgid "Full-stack developer. Partner of a teacher who saw the gap between great educators and good infrastructure."
 msgstr "Full-Stack-Entwickler. Partner einer Lehrerin, die die Lücke zwischen großartigen Pädagogen und guter Infrastruktur erkannte."
 
-#: lib/klass_hero_web/components/marketing_components.ex:580
+#: lib/klass_hero_web/components/marketing_components.ex:581
 #, elixir-autogen, elixir-format
 msgid "Get Bookings"
 msgstr "Buchungen erhalten"
@@ -5806,17 +5806,17 @@ msgstr "Wöchentlich bezahlt werden"
 msgid "Get verified"
 msgstr "Lassen Sie sich verifizieren"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1099
+#: lib/klass_hero_web/components/marketing_components.ex:1100
 #, elixir-autogen, elixir-format
 msgid "Grid"
 msgstr "Raster"
 
-#: lib/klass_hero_web/components/marketing_components.ex:324
+#: lib/klass_hero_web/components/marketing_components.ex:325
 #, elixir-autogen, elixir-format
 msgid "Hand-picked programs this week across Berlin."
 msgstr "Handverlesene Programme diese Woche in ganz Berlin."
 
-#: lib/klass_hero_web/components/marketing_components.ex:962
+#: lib/klass_hero_web/components/marketing_components.ex:963
 #, elixir-autogen, elixir-format
 msgid "Hand-picked, vetted programs across Berlin — filter by category, age, or schedule."
 msgstr "Handverlesene, geprüfte Programme in ganz Berlin — filtern Sie nach Kategorie, Alter oder Zeitplan."
@@ -5831,8 +5831,8 @@ msgstr "Haben Sie Fragen?"
 msgid "Head of Trust & Quality (joining)"
 msgstr "Leitung Vertrauen & Qualität (kommt bald dazu)"
 
-#: lib/klass_hero_web/components/marketing_components.ex:814
-#: lib/klass_hero_web/components/marketing_components.ex:912
+#: lib/klass_hero_web/components/marketing_components.ex:815
+#: lib/klass_hero_web/components/marketing_components.ex:913
 #, elixir-autogen, elixir-format
 msgid "Help Center"
 msgstr "Hilfezentrum"
@@ -5842,7 +5842,7 @@ msgstr "Hilfezentrum"
 msgid "How and when do I get paid?"
 msgstr "Wie und wann werde ich bezahlt?"
 
-#: lib/klass_hero_web/components/marketing_components.ex:804
+#: lib/klass_hero_web/components/marketing_components.ex:805
 #, elixir-autogen, elixir-format
 msgid "How it Works"
 msgstr "So funktioniert's"
@@ -5862,12 +5862,12 @@ msgstr "Wie viel kostet Klass Hero?"
 msgid "How quickly can I start accepting bookings?"
 msgstr "Wie schnell kann ich Buchungen annehmen?"
 
-#: lib/klass_hero_web/components/marketing_components.ex:540
+#: lib/klass_hero_web/components/marketing_components.ex:541
 #, elixir-autogen, elixir-format
 msgid "How to Grow Your Youth Program"
 msgstr "So bringen Sie Ihr Jugendprogramm zum Wachsen"
 
-#: lib/klass_hero_web/components/marketing_components.ex:870
+#: lib/klass_hero_web/components/marketing_components.ex:871
 #, elixir-autogen, elixir-format
 msgid "How we vet providers"
 msgstr "Wie wir Anbieter überprüfen"
@@ -5918,7 +5918,7 @@ msgstr "Das ist der Hero-Standard: Identitäts- und Altersprüfung, Erfahrungsna
 msgid "Join Berlin's growing network of trusted educators. Free to list. No setup fees."
 msgstr "Werden Sie Teil von Berlins wachsendem Netzwerk vertrauenswürdiger Pädagogen. Kostenlos eintragen. Keine Einrichtungsgebühren."
 
-#: lib/klass_hero_web/components/marketing_components.ex:543
+#: lib/klass_hero_web/components/marketing_components.ex:544
 #, elixir-autogen, elixir-format
 msgid "Join Berlin's trusted network of educators. We handle payments, scheduling, and discovery — you focus on teaching."
 msgstr "Werden Sie Teil von Berlins vertrauenswürdigem Netzwerk von Pädagogen. Wir kümmern uns um Zahlungen, Terminplanung und Sichtbarkeit — Sie konzentrieren sich aufs Unterrichten."
@@ -5965,12 +5965,12 @@ msgstr "Letzte 8 Wochen"
 msgid "Lead Instructor"
 msgstr "Leitender Kursleiter"
 
-#: lib/klass_hero_web/components/marketing_components.ex:553
+#: lib/klass_hero_web/components/marketing_components.ex:554
 #, elixir-autogen, elixir-format
 msgid "Learn How to Become a Hero →"
 msgstr "Werde zum Hero →"
 
-#: lib/klass_hero_web/components/marketing_components.ex:860
+#: lib/klass_hero_web/components/marketing_components.ex:861
 #, elixir-autogen, elixir-format
 msgid "Learn how vetting works"
 msgstr "Erfahren Sie, wie die Überprüfung funktioniert"
@@ -6000,12 +6000,12 @@ msgstr "Verknüpfen Sie diese Einladung mit Ihrem Konto %{email}."
 msgid "Linking..."
 msgstr "Wird verknüpft..."
 
-#: lib/klass_hero_web/components/marketing_components.ex:1115
+#: lib/klass_hero_web/components/marketing_components.ex:1116
 #, elixir-autogen, elixir-format
 msgid "List"
 msgstr "Liste"
 
-#: lib/klass_hero_web/components/marketing_components.ex:571
+#: lib/klass_hero_web/components/marketing_components.ex:572
 #, elixir-autogen, elixir-format
 msgid "List Your Program"
 msgstr "Ihr Programm eintragen"
@@ -6041,7 +6041,7 @@ msgstr "Melden Sie sich an und öffnen Sie diese Einladung erneut, um dem Team b
 msgid "Log out"
 msgstr "Abmelden"
 
-#: lib/klass_hero_web/components/marketing_components.ex:867
+#: lib/klass_hero_web/components/marketing_components.ex:868
 #, elixir-autogen, elixir-format
 msgid "Looking for programs for your child?"
 msgstr "Suchen Sie Programme für Ihr Kind?"
@@ -6091,7 +6091,7 @@ msgstr "Als anwesend markieren"
 msgid "Minimum one year working with children, validated."
 msgstr "Mindestens ein Jahr Erfahrung in der Arbeit mit Kindern, nachgewiesen."
 
-#: lib/klass_hero_web/components/marketing_components.ex:135
+#: lib/klass_hero_web/components/marketing_components.ex:136
 #, elixir-autogen, elixir-format
 msgid "Mobile primary"
 msgstr "Primäre mobile Navigation"
@@ -6116,7 +6116,7 @@ msgstr "Neue Unterhaltung"
 msgid "New program"
 msgstr "Neues Programm"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1126
+#: lib/klass_hero_web/components/marketing_components.ex:1127
 #, elixir-autogen, elixir-format
 msgid "Newest"
 msgstr "Neueste"
@@ -6131,7 +6131,7 @@ msgstr "Weiter"
 msgid "No credit card required"
 msgstr "Keine Kreditkarte erforderlich"
 
-#: lib/klass_hero_web/components/marketing_components.ex:352
+#: lib/klass_hero_web/components/marketing_components.ex:353
 #, elixir-autogen, elixir-format
 msgid "No featured programs available right now. Check back soon."
 msgstr "Derzeit keine empfohlenen Programme verfügbar. Schauen Sie bald wieder vorbei."
@@ -6198,7 +6198,7 @@ msgstr "Bieten Sie Ihre eigenen Programme auf Klass Hero an — zusätzlich zu I
 msgid "Once your listing is live and you've completed Hero verification (typically 3–5 business days), parents can book immediately. Most providers receive their first inquiry within the first week."
 msgstr "Sobald Ihr Eintrag live ist und Sie die Hero-Verifizierung abgeschlossen haben (in der Regel 3–5 Werktage), können Eltern sofort buchen. Die meisten Anbieter erhalten ihre erste Anfrage innerhalb der ersten Woche."
 
-#: lib/klass_hero_web/components/marketing_components.ex:1538
+#: lib/klass_hero_web/components/marketing_components.ex:1539
 #, elixir-autogen, elixir-format
 msgid "Ongoing Quality"
 msgstr "Laufende Qualität"
@@ -6218,12 +6218,12 @@ msgstr "Kontomenü öffnen"
 msgid "Open inbox"
 msgstr "Posteingang öffnen"
 
-#: lib/klass_hero_web/components/marketing_components.ex:110
+#: lib/klass_hero_web/components/marketing_components.ex:111
 #, elixir-autogen, elixir-format
 msgid "Open menu"
 msgstr "Menü öffnen"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1366
+#: lib/klass_hero_web/components/marketing_components.ex:1367
 #, elixir-autogen, elixir-format
 msgid "Our Commitment"
 msgstr "Unser Engagement"
@@ -6258,7 +6258,7 @@ msgstr "Elternteil: %{name}"
 msgid "Parents discover you on Klass Hero. Approve manually or auto-accept — your call."
 msgstr "Eltern entdecken Sie auf Klass Hero. Genehmigen Sie manuell oder automatisch — Sie entscheiden."
 
-#: lib/klass_hero_web/components/marketing_components.ex:582
+#: lib/klass_hero_web/components/marketing_components.ex:583
 #, elixir-autogen, elixir-format
 msgid "Parents find you through Klass Hero. Approve or auto-accept bookings with secure messaging built in."
 msgstr "Eltern finden Sie über Klass Hero. Genehmigen Sie Buchungen manuell oder automatisch — inklusive sicherer Nachrichtenfunktion."
@@ -6289,29 +6289,29 @@ msgstr "Ausstehende Anmeldungen"
 msgid "Predictable income"
 msgstr "Planbares Einkommen"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1128
+#: lib/klass_hero_web/components/marketing_components.ex:1129
 #, elixir-autogen, elixir-format
 msgid "Price: high to low"
 msgstr "Preis: hoch zu niedrig"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1127
+#: lib/klass_hero_web/components/marketing_components.ex:1128
 #, elixir-autogen, elixir-format
 msgid "Price: low to high"
 msgstr "Preis: niedrig zu hoch"
 
-#: lib/klass_hero_web/components/marketing_components.ex:813
+#: lib/klass_hero_web/components/marketing_components.ex:814
 #: lib/klass_hero_web/live/for_providers_live.ex:167
 #, elixir-autogen, elixir-format
 msgid "Pricing"
 msgstr "Preise"
 
-#: lib/klass_hero_web/components/marketing_components.ex:65
+#: lib/klass_hero_web/components/marketing_components.ex:66
 #, elixir-autogen, elixir-format
 msgid "Primary"
 msgstr "Primär"
 
-#: lib/klass_hero_web/components/marketing_components.ex:776
-#: lib/klass_hero_web/components/marketing_components.ex:823
+#: lib/klass_hero_web/components/marketing_components.ex:777
+#: lib/klass_hero_web/components/marketing_components.ex:824
 #: lib/klass_hero_web/live/privacy_policy_live.ex:238
 #, elixir-autogen, elixir-format
 msgid "Privacy"
@@ -6352,7 +6352,7 @@ msgstr "Qualität & Verantwortung — jederzeit aktiv."
 msgid "Questions about programs, bookings, or becoming a Hero — we read every message."
 msgstr "Fragen zu Programmen, Buchungen oder wie Sie ein Hero werden — wir lesen jede Nachricht."
 
-#: lib/klass_hero_web/components/marketing_components.ex:679
+#: lib/klass_hero_web/components/marketing_components.ex:680
 #, elixir-autogen, elixir-format
 msgid "Questions, answered."
 msgstr "Fragen, beantwortet."
@@ -6367,8 +6367,8 @@ msgstr "Bewertung"
 msgid "Ready to be a Hero?"
 msgstr "Bereit, ein Hero zu werden?"
 
-#: lib/klass_hero_web/components/marketing_components.ex:877
-#: lib/klass_hero_web/components/marketing_components.ex:897
+#: lib/klass_hero_web/components/marketing_components.ex:878
+#: lib/klass_hero_web/components/marketing_components.ex:898
 #, elixir-autogen, elixir-format
 msgid "Ready to find your child's next adventure?"
 msgstr "Bereit, das nächste Abenteuer für Ihr Kind zu finden?"
@@ -6383,8 +6383,8 @@ msgstr "Buchungen erhalten"
 msgid "Recent messages"
 msgstr "Neueste Nachrichten"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1125
-#: lib/klass_hero_web/components/marketing_components.ex:1137
+#: lib/klass_hero_web/components/marketing_components.ex:1126
+#: lib/klass_hero_web/components/marketing_components.ex:1138
 #, elixir-autogen, elixir-format
 msgid "Recommended"
 msgstr "Empfohlen"
@@ -6434,12 +6434,12 @@ msgstr "Kinderschutzschulung"
 msgid "Safety"
 msgstr "Sicherheit"
 
-#: lib/klass_hero_web/components/marketing_components.ex:982
+#: lib/klass_hero_web/components/marketing_components.ex:983
 #, elixir-autogen, elixir-format
 msgid "Search programs, providers, neighborhoods..."
 msgstr "Programme, Anbieter, Stadtteile durchsuchen..."
 
-#: lib/klass_hero_web/components/marketing_components.ex:255
+#: lib/klass_hero_web/components/marketing_components.ex:256
 #, elixir-autogen, elixir-format
 msgid "Search: coding, football, art..."
 msgstr "Suche: Programmieren, Fußball, Kunst..."
@@ -6454,7 +6454,7 @@ msgstr "Sichere SEPA-Auszahlungen jeden Montag. Rechnungen und Mehrwertsteuer we
 msgid "Secure payments, invoicing, and VAT handling"
 msgstr "Sichere Zahlungen, Rechnungsstellung und Umsatzsteuer-Abwicklung"
 
-#: lib/klass_hero_web/components/marketing_components.ex:591
+#: lib/klass_hero_web/components/marketing_components.ex:592
 #, elixir-autogen, elixir-format
 msgid "Secure weekly payouts. Insights into your business and opportunities to expand your impact."
 msgstr "Sichere wöchentliche Auszahlungen. Einblicke in Ihr Geschäft und Möglichkeiten, Ihre Wirkung auszubauen."
@@ -6469,7 +6469,7 @@ msgstr "Sicherheit"
 msgid "See pricing"
 msgstr "Preise ansehen"
 
-#: lib/klass_hero_web/components/marketing_components.ex:562
+#: lib/klass_hero_web/components/marketing_components.ex:563
 #, elixir-autogen, elixir-format
 msgid "See provider plans"
 msgstr "Anbieter-Tarife ansehen"
@@ -6499,8 +6499,8 @@ msgstr "Schreiben Sie uns eine Nachricht"
 msgid "Setting up..."
 msgstr "Wird eingerichtet..."
 
-#: lib/klass_hero_web/components/marketing_components.ex:95
-#: lib/klass_hero_web/components/marketing_components.ex:167
+#: lib/klass_hero_web/components/marketing_components.ex:96
+#: lib/klass_hero_web/components/marketing_components.ex:168
 #: lib/klass_hero_web/live/user_live/login.ex:12
 #, elixir-autogen, elixir-format
 msgid "Sign in"
@@ -6511,8 +6511,8 @@ msgstr "Anmelden"
 msgid "Sign in to continue. Don't have an account?"
 msgstr "Melden Sie sich an, um fortzufahren. Sie haben noch kein Konto?"
 
-#: lib/klass_hero_web/components/marketing_components.ex:98
-#: lib/klass_hero_web/components/marketing_components.ex:172
+#: lib/klass_hero_web/components/marketing_components.ex:99
+#: lib/klass_hero_web/components/marketing_components.ex:173
 #: lib/klass_hero_web/live/user_live/registration.ex:12
 #, elixir-autogen, elixir-format
 msgid "Sign up"
@@ -6523,7 +6523,7 @@ msgstr "Registrieren"
 msgid "Signed agreement on conduct and quality bar."
 msgstr "Unterzeichnete Vereinbarung zu Verhalten und Qualitätsstandards."
 
-#: lib/klass_hero_web/components/marketing_components.ex:154
+#: lib/klass_hero_web/components/marketing_components.ex:155
 #: lib/klass_hero_web/components/ui_components.ex:193
 #, elixir-autogen, elixir-format
 msgid "Signed in as"
@@ -6534,12 +6534,12 @@ msgstr "Angemeldet als"
 msgid "Six checks. No shortcuts."
 msgstr "Sechs Prüfungen. Keine Abkürzungen."
 
-#: lib/klass_hero_web/components/marketing_components.ex:1052
+#: lib/klass_hero_web/components/marketing_components.ex:1053
 #, elixir-autogen, elixir-format
 msgid "Sort:"
 msgstr "Sortieren:"
 
-#: lib/klass_hero_web/components/marketing_components.ex:812
+#: lib/klass_hero_web/components/marketing_components.ex:813
 #, elixir-autogen, elixir-format
 msgid "Start Teaching"
 msgstr "Unterrichten beginnen"
@@ -6590,7 +6590,7 @@ msgstr "Unternehmen wechseln"
 msgid "Talk to our team →"
 msgstr "Sprechen Sie mit unserem Team →"
 
-#: lib/klass_hero_web/components/marketing_components.ex:880
+#: lib/klass_hero_web/components/marketing_components.ex:881
 #: lib/klass_hero_web/live/about_live.ex:164
 #: lib/klass_hero_web/live/for_providers_live.ex:269
 #, elixir-autogen, elixir-format
@@ -6607,7 +6607,7 @@ msgstr "Mehr unterrichten."
 msgid "Teaching Experience"
 msgstr "Unterrichtserfahrung"
 
-#: lib/klass_hero_web/components/marketing_components.ex:857
+#: lib/klass_hero_web/components/marketing_components.ex:858
 #, elixir-autogen, elixir-format
 msgid "Teaching kids is your thing? Join as a Hero."
 msgstr "Unterrichten von Kindern ist Ihr Ding? Werden Sie ein Hero."
@@ -6617,8 +6617,8 @@ msgstr "Unterrichten von Kindern ist Ihr Ding? Werden Sie ein Hero."
 msgid "Tell us a bit about what you need — we'll route you to the right person."
 msgstr "Erzählen Sie uns kurz, was Sie brauchen — wir leiten Sie an die richtige Person weiter."
 
-#: lib/klass_hero_web/components/marketing_components.ex:777
-#: lib/klass_hero_web/components/marketing_components.ex:824
+#: lib/klass_hero_web/components/marketing_components.ex:778
+#: lib/klass_hero_web/components/marketing_components.ex:825
 #: lib/klass_hero_web/live/terms_of_service_live.ex:259
 #, elixir-autogen, elixir-format
 msgid "Terms"
@@ -6669,7 +6669,7 @@ msgstr "Verfolgen Sie Anmeldungen, Bindung, Nichterscheinen und Umsatz. Erkennen
 msgid "Trust &"
 msgstr "Vertrauen &"
 
-#: lib/klass_hero_web/components/marketing_components.ex:234
+#: lib/klass_hero_web/components/marketing_components.ex:235
 #, elixir-autogen, elixir-format
 msgid "Trusted Heroes"
 msgstr "Vertrauenswürdige Heroes"
@@ -6709,7 +6709,7 @@ msgstr "Diese Woche anstehend"
 msgid "Vetted"
 msgstr "Geprüft"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1212
+#: lib/klass_hero_web/components/marketing_components.ex:1213
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr "Ansehen"
@@ -6719,7 +6719,7 @@ msgstr "Ansehen"
 msgid "View all"
 msgstr "Alle anzeigen"
 
-#: lib/klass_hero_web/components/marketing_components.ex:431
+#: lib/klass_hero_web/components/marketing_components.ex:432
 #, elixir-autogen, elixir-format
 msgid "View →"
 msgstr "Ansehen →"
@@ -6800,12 +6800,12 @@ msgstr "Was beschäftigt Sie?"
 msgid "What's the verification process like?"
 msgstr "Wie läuft der Verifizierungsprozess ab?"
 
-#: lib/klass_hero_web/components/marketing_components.ex:887
+#: lib/klass_hero_web/components/marketing_components.ex:888
 #, elixir-autogen, elixir-format
 msgid "While you're here — explore programs."
 msgstr "Wo Sie schon mal hier sind — entdecken Sie Programme."
 
-#: lib/klass_hero_web/components/marketing_components.ex:469
+#: lib/klass_hero_web/components/marketing_components.ex:470
 #: lib/klass_hero_web/live/for_providers_live.ex:72
 #, elixir-autogen, elixir-format
 msgid "Why Klass Hero"
@@ -6886,7 +6886,7 @@ msgstr "Konto"
 msgid "active"
 msgstr "Aktiv"
 
-#: lib/klass_hero_web/components/marketing_components.ex:957
+#: lib/klass_hero_web/components/marketing_components.ex:958
 #, elixir-autogen, elixir-format
 msgid "activities"
 msgstr "Aktivitäten"
@@ -6911,7 +6911,7 @@ msgstr "Kinderprogramme entdecken und nutzen"
 msgid "families"
 msgstr "Familien"
 
-#: lib/klass_hero_web/components/marketing_components.ex:236
+#: lib/klass_hero_web/components/marketing_components.ex:237
 #, elixir-autogen, elixir-format
 msgid "for Our Youth"
 msgstr "für unsere Jugend"
@@ -6921,12 +6921,12 @@ msgstr "für unsere Jugend"
 msgid "help"
 msgstr "Hilfe"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1040
+#: lib/klass_hero_web/components/marketing_components.ex:1041
 #, elixir-autogen, elixir-format
 msgid "in"
 msgstr "in"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1044
+#: lib/klass_hero_web/components/marketing_components.ex:1045
 #, elixir-autogen, elixir-format
 msgid "matching"
 msgstr "Passend"
@@ -6937,7 +6937,7 @@ msgstr "Passend"
 msgid "pending"
 msgstr "Ausstehend"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1038
+#: lib/klass_hero_web/components/marketing_components.ex:1039
 #, elixir-autogen, elixir-format
 msgid "program"
 msgid_plural "programs"
@@ -7258,7 +7258,7 @@ msgstr "Der letzte Schritt: Lies die Klass Hero Community-Richtlinien und stimme
 msgid "You have agreed to the Community Guidelines."
 msgstr "Du hast den Community-Richtlinien zugestimmt."
 
-#: lib/klass_hero_web/components/marketing_components.ex:1454
+#: lib/klass_hero_web/components/marketing_components.ex:1455
 #, elixir-autogen, elixir-format
 msgid "Applicants submit a short recorded video (max 2 minutes) so we can assess communication skills and alignment with our values before approving their profile."
 msgstr "Bewerber reichen ein kurzes aufgezeichnetes Video (max. 2 Minuten) ein, damit wir vor der Freigabe ihres Profils Kommunikationsfähigkeiten und die Übereinstimmung mit unseren Werten beurteilen können."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -13,9 +13,9 @@ msgstr ""
 
 #: lib/klass_hero_web/components/layouts/app.html.heex:44
 #: lib/klass_hero_web/components/layouts/app.html.heex:197
-#: lib/klass_hero_web/components/marketing_components.ex:193
-#: lib/klass_hero_web/components/marketing_components.ex:821
-#: lib/klass_hero_web/components/marketing_components.ex:910
+#: lib/klass_hero_web/components/marketing_components.ex:194
+#: lib/klass_hero_web/components/marketing_components.ex:822
+#: lib/klass_hero_web/components/marketing_components.ex:911
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr ""
@@ -34,9 +34,9 @@ msgstr ""
 #: lib/klass_hero_web/components/composite_components.ex:468
 #: lib/klass_hero_web/components/layouts/app.html.heex:52
 #: lib/klass_hero_web/components/layouts/app.html.heex:198
-#: lib/klass_hero_web/components/marketing_components.ex:194
-#: lib/klass_hero_web/components/marketing_components.ex:822
-#: lib/klass_hero_web/components/marketing_components.ex:911
+#: lib/klass_hero_web/components/marketing_components.ex:195
+#: lib/klass_hero_web/components/marketing_components.ex:823
+#: lib/klass_hero_web/components/marketing_components.ex:912
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr ""
@@ -68,7 +68,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/layouts/app.html.heex:28
 #: lib/klass_hero_web/components/layouts/app.html.heex:195
-#: lib/klass_hero_web/components/marketing_components.ex:189
+#: lib/klass_hero_web/components/marketing_components.ex:190
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr ""
@@ -93,7 +93,7 @@ msgstr ""
 #: lib/klass_hero_web/components/composite_components.ex:484
 #: lib/klass_hero_web/components/layouts/app.html.heex:36
 #: lib/klass_hero_web/components/layouts/app.html.heex:196
-#: lib/klass_hero_web/components/marketing_components.ex:190
+#: lib/klass_hero_web/components/marketing_components.ex:191
 #, elixir-autogen, elixir-format
 msgid "Programs"
 msgstr ""
@@ -182,7 +182,7 @@ msgstr ""
 msgid "Any allergies, medical conditions, or special instructions..."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:491
+#: lib/klass_hero_web/components/marketing_components.ex:492
 #, elixir-autogen, elixir-format
 msgid "Book camps, tutors, and workshops instantly. Our integrated planner helps you manage your child's busy life."
 msgstr ""
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Cash/transfer payments will show as \"Pending\" until received"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:499
+#: lib/klass_hero_web/components/marketing_components.ex:500
 #, elixir-autogen, elixir-format
 msgid "Community Focused"
 msgstr ""
@@ -222,7 +222,7 @@ msgstr ""
 msgid "Duration:"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:489
+#: lib/klass_hero_web/components/marketing_components.ex:490
 #, elixir-autogen, elixir-format
 msgid "Easy Scheduling"
 msgstr ""
@@ -253,18 +253,18 @@ msgstr ""
 msgid "Enrollment successful! You'll receive a confirmation email shortly."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:481
+#: lib/klass_hero_web/components/marketing_components.ex:482
 #, elixir-autogen, elixir-format
 msgid "Every provider is rigorously vetted. We prioritize child safety above all else, giving parents peace of mind."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:952
+#: lib/klass_hero_web/components/marketing_components.ex:953
 #: lib/klass_hero_web/live/programs_live.ex:34
 #, elixir-autogen, elixir-format
 msgid "Explore Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:318
+#: lib/klass_hero_web/components/marketing_components.ex:319
 #, elixir-autogen, elixir-format
 msgid "Featured Programs"
 msgstr ""
@@ -343,7 +343,7 @@ msgstr ""
 msgid "Program not found. It may have been removed or is no longer available."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:479
+#: lib/klass_hero_web/components/marketing_components.ex:480
 #: lib/klass_hero_web/live/about_live.ex:19
 #, elixir-autogen, elixir-format
 msgid "Safety First"
@@ -389,7 +389,7 @@ msgstr ""
 msgid "Total due today:"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:337
+#: lib/klass_hero_web/components/marketing_components.ex:338
 #, elixir-autogen, elixir-format
 msgid "View All Programs →"
 msgstr ""
@@ -1436,9 +1436,9 @@ msgid "Education"
 msgstr ""
 
 #: lib/klass_hero_web/components/composite_components.ex:472
-#: lib/klass_hero_web/components/marketing_components.ex:191
-#: lib/klass_hero_web/components/marketing_components.ex:537
-#: lib/klass_hero_web/components/marketing_components.ex:908
+#: lib/klass_hero_web/components/marketing_components.ex:192
+#: lib/klass_hero_web/components/marketing_components.ex:538
+#: lib/klass_hero_web/components/marketing_components.ex:909
 #: lib/klass_hero_web/live/for_providers_live.ex:10
 #: lib/klass_hero_web/live/for_providers_live.ex:39
 #, elixir-autogen, elixir-format
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "From sports to arts, technology to languages, we make it easy to discover enriching activities that fit your family's schedule and budget."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:589
+#: lib/klass_hero_web/components/marketing_components.ex:590
 #, elixir-autogen, elixir-format
 msgid "Get Paid & Grow"
 msgstr ""
@@ -1477,12 +1477,12 @@ msgstr ""
 msgid "Ready to join the movement?"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:986
+#: lib/klass_hero_web/components/marketing_components.ex:987
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:573
+#: lib/klass_hero_web/components/marketing_components.ex:574
 #, elixir-autogen, elixir-format
 msgid "Set up your teaching profile and list your programs in minutes. Share your expertise with families who need it."
 msgstr ""
@@ -1498,7 +1498,7 @@ msgstr ""
 msgid "Sustainability"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:269
+#: lib/klass_hero_web/components/marketing_components.ex:270
 #, elixir-autogen, elixir-format
 msgid "Trending in Berlin:"
 msgstr ""
@@ -2276,7 +2276,7 @@ msgstr ""
 msgid "Are you sure you want to remove this team member?"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:641
+#: lib/klass_hero_web/components/marketing_components.ex:642
 #, elixir-autogen, elixir-format
 msgid "As fathers and partners of teachers in Berlin, we saw and heard firsthand how hard it is to find, book, and manage quality youth activities outside the classroom. Klass Hero is the complete platform connecting Berlin families and schools with trusted, vetted activity providers — offering safe, supervised, and enriching experiences across sports, arts, tutoring, and more. We verify every provider, structure every booking, and support every step — so parents know their child is in good hands, and providers can focus on what they do best: inspiring kids."
 msgstr ""
@@ -2313,7 +2313,7 @@ msgstr ""
 msgid "Brief description of experience and specialties..."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:638
+#: lib/klass_hero_web/components/marketing_components.ex:639
 #, elixir-autogen, elixir-format
 msgid "Built by Parents to Empower Educators."
 msgstr ""
@@ -2837,7 +2837,7 @@ msgstr ""
 msgid "Not specified"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:635
+#: lib/klass_hero_web/components/marketing_components.ex:636
 #, elixir-autogen, elixir-format
 msgid "Our Story"
 msgstr ""
@@ -2935,7 +2935,7 @@ msgstr ""
 msgid "Provider profile not found."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:648
+#: lib/klass_hero_web/components/marketing_components.ex:649
 #, elixir-autogen, elixir-format
 msgid "Read our founding story →"
 msgstr ""
@@ -3314,12 +3314,12 @@ msgstr ""
 msgid "e.g., Community Center, Main St"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1462
+#: lib/klass_hero_web/components/marketing_components.ex:1463
 #, elixir-autogen, elixir-format
 msgid "All Heroes must hold or complete a recognized child safeguarding course, ensuring up-to-date knowledge."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1430
+#: lib/klass_hero_web/components/marketing_components.ex:1431
 #, elixir-autogen, elixir-format
 msgid "All providers must be 18 years or older, ensuring legal accountability and professional responsibility."
 msgstr ""
@@ -3329,12 +3329,12 @@ msgstr ""
 msgid "And at Klass Hero, both come standard."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1460
+#: lib/klass_hero_web/components/marketing_components.ex:1461
 #, elixir-autogen, elixir-format
 msgid "Child Safeguarding Training"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1468
+#: lib/klass_hero_web/components/marketing_components.ex:1469
 #: lib/klass_hero_web/components/provider_components.ex:2607
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
@@ -3345,7 +3345,7 @@ msgstr ""
 msgid "Create long-term trust across our community"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1446
+#: lib/klass_hero_web/components/marketing_components.ex:1447
 #, elixir-autogen, elixir-format
 msgid "Each provider submits an extended police background check, confirming their eligibility to work safely with minors."
 msgstr ""
@@ -3355,17 +3355,17 @@ msgstr ""
 msgid "Enforcing platform standards and guidelines"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1470
+#: lib/klass_hero_web/components/marketing_components.ex:1471
 #, elixir-autogen, elixir-format
 msgid "Every provider agrees to follow our Community Guidelines, defining expectations around professionalism."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1436
+#: lib/klass_hero_web/components/marketing_components.ex:1437
 #, elixir-autogen, elixir-format
 msgid "Experience Validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1444
+#: lib/klass_hero_web/components/marketing_components.ex:1445
 #, elixir-autogen, elixir-format
 msgid "Extended Background Checks"
 msgstr ""
@@ -3375,12 +3375,12 @@ msgstr ""
 msgid "From academic tutoring to sports, arts, and enrichment programs, every provider on Klass Hero is carefully reviewed to ensure they meet our high standards for child safety, professionalism, and educational quality."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1490
+#: lib/klass_hero_web/components/marketing_components.ex:1491
 #, elixir-autogen, elixir-format
 msgid "How We Verify Providers"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1428
+#: lib/klass_hero_web/components/marketing_components.ex:1429
 #, elixir-autogen, elixir-format
 msgid "Identity & Age Verification"
 msgstr ""
@@ -3415,7 +3415,7 @@ msgstr ""
 msgid "Protect children and families"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1438
+#: lib/klass_hero_web/components/marketing_components.ex:1439
 #, elixir-autogen, elixir-format
 msgid "Providers must demonstrate at least one year of experience working with children in their area of expertise."
 msgstr ""
@@ -3454,9 +3454,9 @@ msgstr ""
 #: lib/klass_hero_web/components/composite_components.ex:546
 #: lib/klass_hero_web/components/layouts/app.html.heex:60
 #: lib/klass_hero_web/components/layouts/app.html.heex:199
-#: lib/klass_hero_web/components/marketing_components.ex:192
-#: lib/klass_hero_web/components/marketing_components.ex:805
-#: lib/klass_hero_web/components/marketing_components.ex:909
+#: lib/klass_hero_web/components/marketing_components.ex:193
+#: lib/klass_hero_web/components/marketing_components.ex:806
+#: lib/klass_hero_web/components/marketing_components.ex:910
 #: lib/klass_hero_web/live/for_providers_live.ex:136
 #: lib/klass_hero_web/live/trust_safety_live.ex:10
 #, elixir-autogen, elixir-format
@@ -3478,12 +3478,12 @@ msgstr ""
 msgid "Uphold professional and ethical teaching practices"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1387
+#: lib/klass_hero_web/components/marketing_components.ex:1388
 #, elixir-autogen, elixir-format
 msgid "Vetted with Care"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1452
+#: lib/klass_hero_web/components/marketing_components.ex:1453
 #: lib/klass_hero_web/components/provider_components.ex:2392
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
@@ -3854,7 +3854,7 @@ msgid "Private lessons and tutoring"
 msgstr ""
 
 #: lib/klass_hero_web/components/layouts/admin.html.heex:31
-#: lib/klass_hero_web/components/marketing_components.ex:810
+#: lib/klass_hero_web/components/marketing_components.ex:811
 #, elixir-autogen, elixir-format
 msgid "Providers"
 msgstr ""
@@ -4752,7 +4752,7 @@ msgstr ""
 msgid "About the Provider"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:501
+#: lib/klass_hero_web/components/marketing_components.ex:502
 #, elixir-autogen, elixir-format
 msgid "Built for the Berlin international community. Integrated secure encrypted messaging to connect with local families and trusted educators nearby."
 msgstr ""
@@ -5284,8 +5284,8 @@ msgstr ""
 msgid "Your week with the kids"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:91
-#: lib/klass_hero_web/components/marketing_components.ex:159
+#: lib/klass_hero_web/components/marketing_components.ex:92
+#: lib/klass_hero_web/components/marketing_components.ex:160
 #, elixir-autogen, elixir-format
 msgid "Go to dashboard"
 msgstr ""
@@ -5312,7 +5312,7 @@ msgstr ""
 msgid ", a full-stack developer who shared a unique perspective. Both Shane and Max are partners of teachers who wanted to extend their expertise beyond the classroom — but without the time to manage the operational side on their own."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:958
+#: lib/klass_hero_web/components/marketing_components.ex:959
 #, elixir-autogen, elixir-format
 msgid ", camps & classes for your child"
 msgstr ""
@@ -5369,7 +5369,7 @@ msgstr ""
 msgid "Add a child"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:321
+#: lib/klass_hero_web/components/marketing_components.ex:322
 #, elixir-autogen, elixir-format
 msgid "Afterschool Adventures Await"
 msgstr ""
@@ -5384,7 +5384,7 @@ msgstr ""
 msgid "All instructors are background-checked and verified."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:548
+#: lib/klass_hero_web/components/marketing_components.ex:549
 #, elixir-autogen, elixir-format
 msgid "Are you an educator, coach, or artist?"
 msgstr ""
@@ -5404,13 +5404,13 @@ msgstr ""
 msgid "Back to Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:890
-#: lib/klass_hero_web/components/marketing_components.ex:900
+#: lib/klass_hero_web/components/marketing_components.ex:891
+#: lib/klass_hero_web/components/marketing_components.ex:901
 #, elixir-autogen, elixir-format
 msgid "Become a Hero"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:858
+#: lib/klass_hero_web/components/marketing_components.ex:859
 #, elixir-autogen, elixir-format
 msgid "Become a Hero →"
 msgstr ""
@@ -5425,17 +5425,17 @@ msgstr ""
 msgid "Berlin parents come to Klass Hero looking for trusted programs. You focus on teaching — we handle the funnel."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:226
+#: lib/klass_hero_web/components/marketing_components.ex:227
 #, elixir-autogen, elixir-format
 msgid "Berlin's #1 network for youth educators"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:240
+#: lib/klass_hero_web/components/marketing_components.ex:241
 #, elixir-autogen, elixir-format
 msgid "Berlin's leading network for tutors, coaches, and camp providers — every one verified by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:794
+#: lib/klass_hero_web/components/marketing_components.ex:795
 #, elixir-autogen, elixir-format
 msgid "Berlin's network for trusted youth educators. Built by parents, for parents."
 msgstr ""
@@ -5455,16 +5455,16 @@ msgstr ""
 msgid "Brings the financial rigour and strategic planning needed for the German market and long-term provider stability."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:803
-#: lib/klass_hero_web/components/marketing_components.ex:907
+#: lib/klass_hero_web/components/marketing_components.ex:804
+#: lib/klass_hero_web/components/marketing_components.ex:908
 #, elixir-autogen, elixir-format
 msgid "Browse Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:868
-#: lib/klass_hero_web/components/marketing_components.ex:878
-#: lib/klass_hero_web/components/marketing_components.ex:888
-#: lib/klass_hero_web/components/marketing_components.ex:898
+#: lib/klass_hero_web/components/marketing_components.ex:869
+#: lib/klass_hero_web/components/marketing_components.ex:879
+#: lib/klass_hero_web/components/marketing_components.ex:889
+#: lib/klass_hero_web/components/marketing_components.ex:899
 #, elixir-autogen, elixir-format
 msgid "Browse Programs →"
 msgstr ""
@@ -5524,7 +5524,7 @@ msgstr ""
 msgid "Children"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1245
+#: lib/klass_hero_web/components/marketing_components.ex:1246
 #, elixir-autogen, elixir-format
 msgid "Clear filters"
 msgstr ""
@@ -5563,7 +5563,7 @@ msgstr ""
 msgid "Community Standards"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:819
+#: lib/klass_hero_web/components/marketing_components.ex:820
 #, elixir-autogen, elixir-format
 msgid "Company"
 msgstr ""
@@ -5583,7 +5583,7 @@ msgstr ""
 msgid "Confirm your account to finish signing up."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:232
+#: lib/klass_hero_web/components/marketing_components.ex:233
 #, elixir-autogen, elixir-format
 msgid "Connecting Families with"
 msgstr ""
@@ -5638,7 +5638,7 @@ msgstr ""
 msgid "Direct messaging, broadcast announcements, incident reports. Keep parents informed, automatically."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:956
+#: lib/klass_hero_web/components/marketing_components.ex:957
 #, elixir-autogen, elixir-format
 msgid "Discover"
 msgstr ""
@@ -5713,7 +5713,7 @@ msgstr ""
 msgid "Every feature included. No subscription, no setup fees."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:472
+#: lib/klass_hero_web/components/marketing_components.ex:473
 #, elixir-autogen, elixir-format
 msgid "Everything parents need, nothing they don't"
 msgstr ""
@@ -5728,7 +5728,7 @@ msgstr ""
 msgid "Extended Police Check"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:676
+#: lib/klass_hero_web/components/marketing_components.ex:677
 #: lib/klass_hero_web/live/for_providers_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "FAQ"
@@ -5739,17 +5739,17 @@ msgstr ""
 msgid "Failed to approve"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:801
+#: lib/klass_hero_web/components/marketing_components.ex:802
 #, elixir-autogen, elixir-format
 msgid "Families"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:260
+#: lib/klass_hero_web/components/marketing_components.ex:261
 #, elixir-autogen, elixir-format
 msgid "Find Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:764
+#: lib/klass_hero_web/components/marketing_components.ex:765
 #, elixir-autogen, elixir-format
 msgid "Footer mobile"
 msgstr ""
@@ -5779,7 +5779,7 @@ msgstr ""
 msgid "Full-stack developer. Partner of a teacher who saw the gap between great educators and good infrastructure."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:580
+#: lib/klass_hero_web/components/marketing_components.ex:581
 #, elixir-autogen, elixir-format
 msgid "Get Bookings"
 msgstr ""
@@ -5806,17 +5806,17 @@ msgstr ""
 msgid "Get verified"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1099
+#: lib/klass_hero_web/components/marketing_components.ex:1100
 #, elixir-autogen, elixir-format
 msgid "Grid"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:324
+#: lib/klass_hero_web/components/marketing_components.ex:325
 #, elixir-autogen, elixir-format
 msgid "Hand-picked programs this week across Berlin."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:962
+#: lib/klass_hero_web/components/marketing_components.ex:963
 #, elixir-autogen, elixir-format
 msgid "Hand-picked, vetted programs across Berlin — filter by category, age, or schedule."
 msgstr ""
@@ -5831,8 +5831,8 @@ msgstr ""
 msgid "Head of Trust & Quality (joining)"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:814
-#: lib/klass_hero_web/components/marketing_components.ex:912
+#: lib/klass_hero_web/components/marketing_components.ex:815
+#: lib/klass_hero_web/components/marketing_components.ex:913
 #, elixir-autogen, elixir-format
 msgid "Help Center"
 msgstr ""
@@ -5842,7 +5842,7 @@ msgstr ""
 msgid "How and when do I get paid?"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:804
+#: lib/klass_hero_web/components/marketing_components.ex:805
 #, elixir-autogen, elixir-format
 msgid "How it Works"
 msgstr ""
@@ -5862,12 +5862,12 @@ msgstr ""
 msgid "How quickly can I start accepting bookings?"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:540
+#: lib/klass_hero_web/components/marketing_components.ex:541
 #, elixir-autogen, elixir-format
 msgid "How to Grow Your Youth Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:870
+#: lib/klass_hero_web/components/marketing_components.ex:871
 #, elixir-autogen, elixir-format
 msgid "How we vet providers"
 msgstr ""
@@ -5918,7 +5918,7 @@ msgstr ""
 msgid "Join Berlin's growing network of trusted educators. Free to list. No setup fees."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:543
+#: lib/klass_hero_web/components/marketing_components.ex:544
 #, elixir-autogen, elixir-format
 msgid "Join Berlin's trusted network of educators. We handle payments, scheduling, and discovery — you focus on teaching."
 msgstr ""
@@ -5965,12 +5965,12 @@ msgstr ""
 msgid "Lead Instructor"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:553
+#: lib/klass_hero_web/components/marketing_components.ex:554
 #, elixir-autogen, elixir-format
 msgid "Learn How to Become a Hero →"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:860
+#: lib/klass_hero_web/components/marketing_components.ex:861
 #, elixir-autogen, elixir-format
 msgid "Learn how vetting works"
 msgstr ""
@@ -6000,12 +6000,12 @@ msgstr ""
 msgid "Linking..."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1115
+#: lib/klass_hero_web/components/marketing_components.ex:1116
 #, elixir-autogen, elixir-format
 msgid "List"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:571
+#: lib/klass_hero_web/components/marketing_components.ex:572
 #, elixir-autogen, elixir-format
 msgid "List Your Program"
 msgstr ""
@@ -6041,7 +6041,7 @@ msgstr ""
 msgid "Log out"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:867
+#: lib/klass_hero_web/components/marketing_components.ex:868
 #, elixir-autogen, elixir-format
 msgid "Looking for programs for your child?"
 msgstr ""
@@ -6091,7 +6091,7 @@ msgstr ""
 msgid "Minimum one year working with children, validated."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:135
+#: lib/klass_hero_web/components/marketing_components.ex:136
 #, elixir-autogen, elixir-format
 msgid "Mobile primary"
 msgstr ""
@@ -6116,7 +6116,7 @@ msgstr ""
 msgid "New program"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1126
+#: lib/klass_hero_web/components/marketing_components.ex:1127
 #, elixir-autogen, elixir-format
 msgid "Newest"
 msgstr ""
@@ -6131,7 +6131,7 @@ msgstr ""
 msgid "No credit card required"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:352
+#: lib/klass_hero_web/components/marketing_components.ex:353
 #, elixir-autogen, elixir-format
 msgid "No featured programs available right now. Check back soon."
 msgstr ""
@@ -6198,7 +6198,7 @@ msgstr ""
 msgid "Once your listing is live and you've completed Hero verification (typically 3–5 business days), parents can book immediately. Most providers receive their first inquiry within the first week."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1538
+#: lib/klass_hero_web/components/marketing_components.ex:1539
 #, elixir-autogen, elixir-format
 msgid "Ongoing Quality"
 msgstr ""
@@ -6218,12 +6218,12 @@ msgstr ""
 msgid "Open inbox"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:110
+#: lib/klass_hero_web/components/marketing_components.ex:111
 #, elixir-autogen, elixir-format
 msgid "Open menu"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1366
+#: lib/klass_hero_web/components/marketing_components.ex:1367
 #, elixir-autogen, elixir-format
 msgid "Our Commitment"
 msgstr ""
@@ -6258,7 +6258,7 @@ msgstr ""
 msgid "Parents discover you on Klass Hero. Approve manually or auto-accept — your call."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:582
+#: lib/klass_hero_web/components/marketing_components.ex:583
 #, elixir-autogen, elixir-format
 msgid "Parents find you through Klass Hero. Approve or auto-accept bookings with secure messaging built in."
 msgstr ""
@@ -6289,29 +6289,29 @@ msgstr ""
 msgid "Predictable income"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1128
+#: lib/klass_hero_web/components/marketing_components.ex:1129
 #, elixir-autogen, elixir-format
 msgid "Price: high to low"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1127
+#: lib/klass_hero_web/components/marketing_components.ex:1128
 #, elixir-autogen, elixir-format
 msgid "Price: low to high"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:813
+#: lib/klass_hero_web/components/marketing_components.ex:814
 #: lib/klass_hero_web/live/for_providers_live.ex:167
 #, elixir-autogen, elixir-format
 msgid "Pricing"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:65
+#: lib/klass_hero_web/components/marketing_components.ex:66
 #, elixir-autogen, elixir-format
 msgid "Primary"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:776
-#: lib/klass_hero_web/components/marketing_components.ex:823
+#: lib/klass_hero_web/components/marketing_components.ex:777
+#: lib/klass_hero_web/components/marketing_components.ex:824
 #: lib/klass_hero_web/live/privacy_policy_live.ex:238
 #, elixir-autogen, elixir-format
 msgid "Privacy"
@@ -6352,7 +6352,7 @@ msgstr ""
 msgid "Questions about programs, bookings, or becoming a Hero — we read every message."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:679
+#: lib/klass_hero_web/components/marketing_components.ex:680
 #, elixir-autogen, elixir-format
 msgid "Questions, answered."
 msgstr ""
@@ -6367,8 +6367,8 @@ msgstr ""
 msgid "Ready to be a Hero?"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:877
-#: lib/klass_hero_web/components/marketing_components.ex:897
+#: lib/klass_hero_web/components/marketing_components.ex:878
+#: lib/klass_hero_web/components/marketing_components.ex:898
 #, elixir-autogen, elixir-format
 msgid "Ready to find your child's next adventure?"
 msgstr ""
@@ -6383,8 +6383,8 @@ msgstr ""
 msgid "Recent messages"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1125
-#: lib/klass_hero_web/components/marketing_components.ex:1137
+#: lib/klass_hero_web/components/marketing_components.ex:1126
+#: lib/klass_hero_web/components/marketing_components.ex:1138
 #, elixir-autogen, elixir-format
 msgid "Recommended"
 msgstr ""
@@ -6434,12 +6434,12 @@ msgstr ""
 msgid "Safety"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:982
+#: lib/klass_hero_web/components/marketing_components.ex:983
 #, elixir-autogen, elixir-format
 msgid "Search programs, providers, neighborhoods..."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:255
+#: lib/klass_hero_web/components/marketing_components.ex:256
 #, elixir-autogen, elixir-format
 msgid "Search: coding, football, art..."
 msgstr ""
@@ -6454,7 +6454,7 @@ msgstr ""
 msgid "Secure payments, invoicing, and VAT handling"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:591
+#: lib/klass_hero_web/components/marketing_components.ex:592
 #, elixir-autogen, elixir-format
 msgid "Secure weekly payouts. Insights into your business and opportunities to expand your impact."
 msgstr ""
@@ -6469,7 +6469,7 @@ msgstr ""
 msgid "See pricing"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:562
+#: lib/klass_hero_web/components/marketing_components.ex:563
 #, elixir-autogen, elixir-format
 msgid "See provider plans"
 msgstr ""
@@ -6499,8 +6499,8 @@ msgstr ""
 msgid "Setting up..."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:95
-#: lib/klass_hero_web/components/marketing_components.ex:167
+#: lib/klass_hero_web/components/marketing_components.ex:96
+#: lib/klass_hero_web/components/marketing_components.ex:168
 #: lib/klass_hero_web/live/user_live/login.ex:12
 #, elixir-autogen, elixir-format
 msgid "Sign in"
@@ -6511,8 +6511,8 @@ msgstr ""
 msgid "Sign in to continue. Don't have an account?"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:98
-#: lib/klass_hero_web/components/marketing_components.ex:172
+#: lib/klass_hero_web/components/marketing_components.ex:99
+#: lib/klass_hero_web/components/marketing_components.ex:173
 #: lib/klass_hero_web/live/user_live/registration.ex:12
 #, elixir-autogen, elixir-format
 msgid "Sign up"
@@ -6523,7 +6523,7 @@ msgstr ""
 msgid "Signed agreement on conduct and quality bar."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:154
+#: lib/klass_hero_web/components/marketing_components.ex:155
 #: lib/klass_hero_web/components/ui_components.ex:193
 #, elixir-autogen, elixir-format
 msgid "Signed in as"
@@ -6534,12 +6534,12 @@ msgstr ""
 msgid "Six checks. No shortcuts."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1052
+#: lib/klass_hero_web/components/marketing_components.ex:1053
 #, elixir-autogen, elixir-format
 msgid "Sort:"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:812
+#: lib/klass_hero_web/components/marketing_components.ex:813
 #, elixir-autogen, elixir-format
 msgid "Start Teaching"
 msgstr ""
@@ -6590,7 +6590,7 @@ msgstr ""
 msgid "Talk to our team →"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:880
+#: lib/klass_hero_web/components/marketing_components.ex:881
 #: lib/klass_hero_web/live/about_live.ex:164
 #: lib/klass_hero_web/live/for_providers_live.ex:269
 #, elixir-autogen, elixir-format
@@ -6607,7 +6607,7 @@ msgstr ""
 msgid "Teaching Experience"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:857
+#: lib/klass_hero_web/components/marketing_components.ex:858
 #, elixir-autogen, elixir-format
 msgid "Teaching kids is your thing? Join as a Hero."
 msgstr ""
@@ -6617,8 +6617,8 @@ msgstr ""
 msgid "Tell us a bit about what you need — we'll route you to the right person."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:777
-#: lib/klass_hero_web/components/marketing_components.ex:824
+#: lib/klass_hero_web/components/marketing_components.ex:778
+#: lib/klass_hero_web/components/marketing_components.ex:825
 #: lib/klass_hero_web/live/terms_of_service_live.ex:259
 #, elixir-autogen, elixir-format
 msgid "Terms"
@@ -6669,7 +6669,7 @@ msgstr ""
 msgid "Trust &"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:234
+#: lib/klass_hero_web/components/marketing_components.ex:235
 #, elixir-autogen, elixir-format
 msgid "Trusted Heroes"
 msgstr ""
@@ -6709,7 +6709,7 @@ msgstr ""
 msgid "Vetted"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1212
+#: lib/klass_hero_web/components/marketing_components.ex:1213
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr ""
@@ -6719,7 +6719,7 @@ msgstr ""
 msgid "View all"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:431
+#: lib/klass_hero_web/components/marketing_components.ex:432
 #, elixir-autogen, elixir-format
 msgid "View →"
 msgstr ""
@@ -6800,12 +6800,12 @@ msgstr ""
 msgid "What's the verification process like?"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:887
+#: lib/klass_hero_web/components/marketing_components.ex:888
 #, elixir-autogen, elixir-format
 msgid "While you're here — explore programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:469
+#: lib/klass_hero_web/components/marketing_components.ex:470
 #: lib/klass_hero_web/live/for_providers_live.ex:72
 #, elixir-autogen, elixir-format
 msgid "Why Klass Hero"
@@ -6886,7 +6886,7 @@ msgstr ""
 msgid "active"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:957
+#: lib/klass_hero_web/components/marketing_components.ex:958
 #, elixir-autogen, elixir-format
 msgid "activities"
 msgstr ""
@@ -6911,7 +6911,7 @@ msgstr ""
 msgid "families"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:236
+#: lib/klass_hero_web/components/marketing_components.ex:237
 #, elixir-autogen, elixir-format
 msgid "for Our Youth"
 msgstr ""
@@ -6921,12 +6921,12 @@ msgstr ""
 msgid "help"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1040
+#: lib/klass_hero_web/components/marketing_components.ex:1041
 #, elixir-autogen, elixir-format
 msgid "in"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1044
+#: lib/klass_hero_web/components/marketing_components.ex:1045
 #, elixir-autogen, elixir-format
 msgid "matching"
 msgstr ""
@@ -6937,7 +6937,7 @@ msgstr ""
 msgid "pending"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1038
+#: lib/klass_hero_web/components/marketing_components.ex:1039
 #, elixir-autogen, elixir-format
 msgid "program"
 msgid_plural "programs"
@@ -7258,7 +7258,7 @@ msgstr ""
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1454
+#: lib/klass_hero_web/components/marketing_components.ex:1455
 #, elixir-autogen, elixir-format
 msgid "Applicants submit a short recorded video (max 2 minutes) so we can assess communication skills and alignment with our values before approving their profile."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -13,9 +13,9 @@ msgstr ""
 
 #: lib/klass_hero_web/components/layouts/app.html.heex:44
 #: lib/klass_hero_web/components/layouts/app.html.heex:197
-#: lib/klass_hero_web/components/marketing_components.ex:193
-#: lib/klass_hero_web/components/marketing_components.ex:821
-#: lib/klass_hero_web/components/marketing_components.ex:910
+#: lib/klass_hero_web/components/marketing_components.ex:194
+#: lib/klass_hero_web/components/marketing_components.ex:822
+#: lib/klass_hero_web/components/marketing_components.ex:911
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr ""
@@ -34,9 +34,9 @@ msgstr ""
 #: lib/klass_hero_web/components/composite_components.ex:468
 #: lib/klass_hero_web/components/layouts/app.html.heex:52
 #: lib/klass_hero_web/components/layouts/app.html.heex:198
-#: lib/klass_hero_web/components/marketing_components.ex:194
-#: lib/klass_hero_web/components/marketing_components.ex:822
-#: lib/klass_hero_web/components/marketing_components.ex:911
+#: lib/klass_hero_web/components/marketing_components.ex:195
+#: lib/klass_hero_web/components/marketing_components.ex:823
+#: lib/klass_hero_web/components/marketing_components.ex:912
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr ""
@@ -68,7 +68,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/layouts/app.html.heex:28
 #: lib/klass_hero_web/components/layouts/app.html.heex:195
-#: lib/klass_hero_web/components/marketing_components.ex:189
+#: lib/klass_hero_web/components/marketing_components.ex:190
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr ""
@@ -93,7 +93,7 @@ msgstr ""
 #: lib/klass_hero_web/components/composite_components.ex:484
 #: lib/klass_hero_web/components/layouts/app.html.heex:36
 #: lib/klass_hero_web/components/layouts/app.html.heex:196
-#: lib/klass_hero_web/components/marketing_components.ex:190
+#: lib/klass_hero_web/components/marketing_components.ex:191
 #, elixir-autogen, elixir-format
 msgid "Programs"
 msgstr ""
@@ -182,7 +182,7 @@ msgstr ""
 msgid "Any allergies, medical conditions, or special instructions..."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:491
+#: lib/klass_hero_web/components/marketing_components.ex:492
 #, elixir-autogen, elixir-format
 msgid "Book camps, tutors, and workshops instantly. Our integrated planner helps you manage your child's busy life."
 msgstr ""
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Cash/transfer payments will show as \"Pending\" until received"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:499
+#: lib/klass_hero_web/components/marketing_components.ex:500
 #, elixir-autogen, elixir-format
 msgid "Community Focused"
 msgstr ""
@@ -222,7 +222,7 @@ msgstr ""
 msgid "Duration:"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:489
+#: lib/klass_hero_web/components/marketing_components.ex:490
 #, elixir-autogen, elixir-format
 msgid "Easy Scheduling"
 msgstr ""
@@ -253,18 +253,18 @@ msgstr ""
 msgid "Enrollment successful! You'll receive a confirmation email shortly."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:481
+#: lib/klass_hero_web/components/marketing_components.ex:482
 #, elixir-autogen, elixir-format
 msgid "Every provider is rigorously vetted. We prioritize child safety above all else, giving parents peace of mind."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:952
+#: lib/klass_hero_web/components/marketing_components.ex:953
 #: lib/klass_hero_web/live/programs_live.ex:34
 #, elixir-autogen, elixir-format
 msgid "Explore Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:318
+#: lib/klass_hero_web/components/marketing_components.ex:319
 #, elixir-autogen, elixir-format
 msgid "Featured Programs"
 msgstr ""
@@ -343,7 +343,7 @@ msgstr ""
 msgid "Program not found. It may have been removed or is no longer available."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:479
+#: lib/klass_hero_web/components/marketing_components.ex:480
 #: lib/klass_hero_web/live/about_live.ex:19
 #, elixir-autogen, elixir-format
 msgid "Safety First"
@@ -389,7 +389,7 @@ msgstr ""
 msgid "Total due today:"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:337
+#: lib/klass_hero_web/components/marketing_components.ex:338
 #, elixir-autogen, elixir-format
 msgid "View All Programs →"
 msgstr ""
@@ -1436,9 +1436,9 @@ msgid "Education"
 msgstr ""
 
 #: lib/klass_hero_web/components/composite_components.ex:472
-#: lib/klass_hero_web/components/marketing_components.ex:191
-#: lib/klass_hero_web/components/marketing_components.ex:537
-#: lib/klass_hero_web/components/marketing_components.ex:908
+#: lib/klass_hero_web/components/marketing_components.ex:192
+#: lib/klass_hero_web/components/marketing_components.ex:538
+#: lib/klass_hero_web/components/marketing_components.ex:909
 #: lib/klass_hero_web/live/for_providers_live.ex:10
 #: lib/klass_hero_web/live/for_providers_live.ex:39
 #, elixir-autogen, elixir-format
@@ -1450,7 +1450,7 @@ msgstr ""
 msgid "From sports to arts, technology to languages, we make it easy to discover enriching activities that fit your family's schedule and budget."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:589
+#: lib/klass_hero_web/components/marketing_components.ex:590
 #, elixir-autogen, elixir-format
 msgid "Get Paid & Grow"
 msgstr ""
@@ -1477,12 +1477,12 @@ msgstr ""
 msgid "Ready to join the movement?"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:986
+#: lib/klass_hero_web/components/marketing_components.ex:987
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:573
+#: lib/klass_hero_web/components/marketing_components.ex:574
 #, elixir-autogen, elixir-format
 msgid "Set up your teaching profile and list your programs in minutes. Share your expertise with families who need it."
 msgstr ""
@@ -1498,7 +1498,7 @@ msgstr ""
 msgid "Sustainability"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:269
+#: lib/klass_hero_web/components/marketing_components.ex:270
 #, elixir-autogen, elixir-format
 msgid "Trending in Berlin:"
 msgstr ""
@@ -2276,7 +2276,7 @@ msgstr ""
 msgid "Are you sure you want to remove this team member?"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:641
+#: lib/klass_hero_web/components/marketing_components.ex:642
 #, elixir-autogen, elixir-format
 msgid "As fathers and partners of teachers in Berlin, we saw and heard firsthand how hard it is to find, book, and manage quality youth activities outside the classroom. Klass Hero is the complete platform connecting Berlin families and schools with trusted, vetted activity providers — offering safe, supervised, and enriching experiences across sports, arts, tutoring, and more. We verify every provider, structure every booking, and support every step — so parents know their child is in good hands, and providers can focus on what they do best: inspiring kids."
 msgstr ""
@@ -2313,7 +2313,7 @@ msgstr ""
 msgid "Brief description of experience and specialties..."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:638
+#: lib/klass_hero_web/components/marketing_components.ex:639
 #, elixir-autogen, elixir-format
 msgid "Built by Parents to Empower Educators."
 msgstr ""
@@ -2837,7 +2837,7 @@ msgstr ""
 msgid "Not specified"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:635
+#: lib/klass_hero_web/components/marketing_components.ex:636
 #, elixir-autogen, elixir-format
 msgid "Our Story"
 msgstr ""
@@ -2935,7 +2935,7 @@ msgstr ""
 msgid "Provider profile not found."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:648
+#: lib/klass_hero_web/components/marketing_components.ex:649
 #, elixir-autogen, elixir-format
 msgid "Read our founding story →"
 msgstr ""
@@ -3314,12 +3314,12 @@ msgstr ""
 msgid "e.g., Community Center, Main St"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1462
+#: lib/klass_hero_web/components/marketing_components.ex:1463
 #, elixir-autogen, elixir-format
 msgid "All Heroes must hold or complete a recognized child safeguarding course, ensuring up-to-date knowledge."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1430
+#: lib/klass_hero_web/components/marketing_components.ex:1431
 #, elixir-autogen, elixir-format
 msgid "All providers must be 18 years or older, ensuring legal accountability and professional responsibility."
 msgstr ""
@@ -3329,12 +3329,12 @@ msgstr ""
 msgid "And at Klass Hero, both come standard."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1460
+#: lib/klass_hero_web/components/marketing_components.ex:1461
 #, elixir-autogen, elixir-format
 msgid "Child Safeguarding Training"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1468
+#: lib/klass_hero_web/components/marketing_components.ex:1469
 #: lib/klass_hero_web/components/provider_components.ex:2607
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
@@ -3345,7 +3345,7 @@ msgstr ""
 msgid "Create long-term trust across our community"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1446
+#: lib/klass_hero_web/components/marketing_components.ex:1447
 #, elixir-autogen, elixir-format
 msgid "Each provider submits an extended police background check, confirming their eligibility to work safely with minors."
 msgstr ""
@@ -3355,17 +3355,17 @@ msgstr ""
 msgid "Enforcing platform standards and guidelines"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1470
+#: lib/klass_hero_web/components/marketing_components.ex:1471
 #, elixir-autogen, elixir-format
 msgid "Every provider agrees to follow our Community Guidelines, defining expectations around professionalism."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1436
+#: lib/klass_hero_web/components/marketing_components.ex:1437
 #, elixir-autogen, elixir-format
 msgid "Experience Validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1444
+#: lib/klass_hero_web/components/marketing_components.ex:1445
 #, elixir-autogen, elixir-format
 msgid "Extended Background Checks"
 msgstr ""
@@ -3375,12 +3375,12 @@ msgstr ""
 msgid "From academic tutoring to sports, arts, and enrichment programs, every provider on Klass Hero is carefully reviewed to ensure they meet our high standards for child safety, professionalism, and educational quality."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1490
+#: lib/klass_hero_web/components/marketing_components.ex:1491
 #, elixir-autogen, elixir-format
 msgid "How We Verify Providers"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1428
+#: lib/klass_hero_web/components/marketing_components.ex:1429
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Identity & Age Verification"
 msgstr ""
@@ -3415,7 +3415,7 @@ msgstr ""
 msgid "Protect children and families"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1438
+#: lib/klass_hero_web/components/marketing_components.ex:1439
 #, elixir-autogen, elixir-format
 msgid "Providers must demonstrate at least one year of experience working with children in their area of expertise."
 msgstr ""
@@ -3454,9 +3454,9 @@ msgstr ""
 #: lib/klass_hero_web/components/composite_components.ex:546
 #: lib/klass_hero_web/components/layouts/app.html.heex:60
 #: lib/klass_hero_web/components/layouts/app.html.heex:199
-#: lib/klass_hero_web/components/marketing_components.ex:192
-#: lib/klass_hero_web/components/marketing_components.ex:805
-#: lib/klass_hero_web/components/marketing_components.ex:909
+#: lib/klass_hero_web/components/marketing_components.ex:193
+#: lib/klass_hero_web/components/marketing_components.ex:806
+#: lib/klass_hero_web/components/marketing_components.ex:910
 #: lib/klass_hero_web/live/for_providers_live.ex:136
 #: lib/klass_hero_web/live/trust_safety_live.ex:10
 #, elixir-autogen, elixir-format
@@ -3478,12 +3478,12 @@ msgstr ""
 msgid "Uphold professional and ethical teaching practices"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1387
+#: lib/klass_hero_web/components/marketing_components.ex:1388
 #, elixir-autogen, elixir-format
 msgid "Vetted with Care"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1452
+#: lib/klass_hero_web/components/marketing_components.ex:1453
 #: lib/klass_hero_web/components/provider_components.ex:2392
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
@@ -3854,7 +3854,7 @@ msgid "Private lessons and tutoring"
 msgstr ""
 
 #: lib/klass_hero_web/components/layouts/admin.html.heex:31
-#: lib/klass_hero_web/components/marketing_components.ex:810
+#: lib/klass_hero_web/components/marketing_components.ex:811
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Providers"
 msgstr ""
@@ -4752,7 +4752,7 @@ msgstr ""
 msgid "About the Provider"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:501
+#: lib/klass_hero_web/components/marketing_components.ex:502
 #, elixir-autogen, elixir-format
 msgid "Built for the Berlin international community. Integrated secure encrypted messaging to connect with local families and trusted educators nearby."
 msgstr ""
@@ -5284,8 +5284,8 @@ msgstr ""
 msgid "Your week with the kids"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:91
-#: lib/klass_hero_web/components/marketing_components.ex:159
+#: lib/klass_hero_web/components/marketing_components.ex:92
+#: lib/klass_hero_web/components/marketing_components.ex:160
 #, elixir-autogen, elixir-format
 msgid "Go to dashboard"
 msgstr ""
@@ -5312,7 +5312,7 @@ msgstr ""
 msgid ", a full-stack developer who shared a unique perspective. Both Shane and Max are partners of teachers who wanted to extend their expertise beyond the classroom — but without the time to manage the operational side on their own."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:958
+#: lib/klass_hero_web/components/marketing_components.ex:959
 #, elixir-autogen, elixir-format
 msgid ", camps & classes for your child"
 msgstr ""
@@ -5369,7 +5369,7 @@ msgstr ""
 msgid "Add a child"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:321
+#: lib/klass_hero_web/components/marketing_components.ex:322
 #, elixir-autogen, elixir-format
 msgid "Afterschool Adventures Await"
 msgstr ""
@@ -5384,7 +5384,7 @@ msgstr ""
 msgid "All instructors are background-checked and verified."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:548
+#: lib/klass_hero_web/components/marketing_components.ex:549
 #, elixir-autogen, elixir-format
 msgid "Are you an educator, coach, or artist?"
 msgstr ""
@@ -5404,13 +5404,13 @@ msgstr ""
 msgid "Back to Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:890
-#: lib/klass_hero_web/components/marketing_components.ex:900
+#: lib/klass_hero_web/components/marketing_components.ex:891
+#: lib/klass_hero_web/components/marketing_components.ex:901
 #, elixir-autogen, elixir-format
 msgid "Become a Hero"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:858
+#: lib/klass_hero_web/components/marketing_components.ex:859
 #, elixir-autogen, elixir-format
 msgid "Become a Hero →"
 msgstr ""
@@ -5425,17 +5425,17 @@ msgstr ""
 msgid "Berlin parents come to Klass Hero looking for trusted programs. You focus on teaching — we handle the funnel."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:226
+#: lib/klass_hero_web/components/marketing_components.ex:227
 #, elixir-autogen, elixir-format
 msgid "Berlin's #1 network for youth educators"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:240
+#: lib/klass_hero_web/components/marketing_components.ex:241
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Berlin's leading network for tutors, coaches, and camp providers — every one verified by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:794
+#: lib/klass_hero_web/components/marketing_components.ex:795
 #, elixir-autogen, elixir-format
 msgid "Berlin's network for trusted youth educators. Built by parents, for parents."
 msgstr ""
@@ -5455,16 +5455,16 @@ msgstr ""
 msgid "Brings the financial rigour and strategic planning needed for the German market and long-term provider stability."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:803
-#: lib/klass_hero_web/components/marketing_components.ex:907
+#: lib/klass_hero_web/components/marketing_components.ex:804
+#: lib/klass_hero_web/components/marketing_components.ex:908
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Browse Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:868
-#: lib/klass_hero_web/components/marketing_components.ex:878
-#: lib/klass_hero_web/components/marketing_components.ex:888
-#: lib/klass_hero_web/components/marketing_components.ex:898
+#: lib/klass_hero_web/components/marketing_components.ex:869
+#: lib/klass_hero_web/components/marketing_components.ex:879
+#: lib/klass_hero_web/components/marketing_components.ex:889
+#: lib/klass_hero_web/components/marketing_components.ex:899
 #, elixir-autogen, elixir-format
 msgid "Browse Programs →"
 msgstr ""
@@ -5524,7 +5524,7 @@ msgstr ""
 msgid "Children"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1245
+#: lib/klass_hero_web/components/marketing_components.ex:1246
 #, elixir-autogen, elixir-format
 msgid "Clear filters"
 msgstr ""
@@ -5563,7 +5563,7 @@ msgstr ""
 msgid "Community Standards"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:819
+#: lib/klass_hero_web/components/marketing_components.ex:820
 #, elixir-autogen, elixir-format
 msgid "Company"
 msgstr ""
@@ -5583,7 +5583,7 @@ msgstr ""
 msgid "Confirm your account to finish signing up."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:232
+#: lib/klass_hero_web/components/marketing_components.ex:233
 #, elixir-autogen, elixir-format
 msgid "Connecting Families with"
 msgstr ""
@@ -5638,7 +5638,7 @@ msgstr ""
 msgid "Direct messaging, broadcast announcements, incident reports. Keep parents informed, automatically."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:956
+#: lib/klass_hero_web/components/marketing_components.ex:957
 #, elixir-autogen, elixir-format
 msgid "Discover"
 msgstr ""
@@ -5713,7 +5713,7 @@ msgstr ""
 msgid "Every feature included. No subscription, no setup fees."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:472
+#: lib/klass_hero_web/components/marketing_components.ex:473
 #, elixir-autogen, elixir-format
 msgid "Everything parents need, nothing they don't"
 msgstr ""
@@ -5728,7 +5728,7 @@ msgstr ""
 msgid "Extended Police Check"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:676
+#: lib/klass_hero_web/components/marketing_components.ex:677
 #: lib/klass_hero_web/live/for_providers_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "FAQ"
@@ -5739,17 +5739,17 @@ msgstr ""
 msgid "Failed to approve"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:801
+#: lib/klass_hero_web/components/marketing_components.ex:802
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Families"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:260
+#: lib/klass_hero_web/components/marketing_components.ex:261
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Find Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:764
+#: lib/klass_hero_web/components/marketing_components.ex:765
 #, elixir-autogen, elixir-format
 msgid "Footer mobile"
 msgstr ""
@@ -5779,7 +5779,7 @@ msgstr ""
 msgid "Full-stack developer. Partner of a teacher who saw the gap between great educators and good infrastructure."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:580
+#: lib/klass_hero_web/components/marketing_components.ex:581
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Get Bookings"
 msgstr ""
@@ -5806,17 +5806,17 @@ msgstr ""
 msgid "Get verified"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1099
+#: lib/klass_hero_web/components/marketing_components.ex:1100
 #, elixir-autogen, elixir-format
 msgid "Grid"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:324
+#: lib/klass_hero_web/components/marketing_components.ex:325
 #, elixir-autogen, elixir-format
 msgid "Hand-picked programs this week across Berlin."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:962
+#: lib/klass_hero_web/components/marketing_components.ex:963
 #, elixir-autogen, elixir-format
 msgid "Hand-picked, vetted programs across Berlin — filter by category, age, or schedule."
 msgstr ""
@@ -5831,8 +5831,8 @@ msgstr ""
 msgid "Head of Trust & Quality (joining)"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:814
-#: lib/klass_hero_web/components/marketing_components.ex:912
+#: lib/klass_hero_web/components/marketing_components.ex:815
+#: lib/klass_hero_web/components/marketing_components.ex:913
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Help Center"
 msgstr ""
@@ -5842,7 +5842,7 @@ msgstr ""
 msgid "How and when do I get paid?"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:804
+#: lib/klass_hero_web/components/marketing_components.ex:805
 #, elixir-autogen, elixir-format
 msgid "How it Works"
 msgstr ""
@@ -5862,12 +5862,12 @@ msgstr ""
 msgid "How quickly can I start accepting bookings?"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:540
+#: lib/klass_hero_web/components/marketing_components.ex:541
 #, elixir-autogen, elixir-format, fuzzy
 msgid "How to Grow Your Youth Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:870
+#: lib/klass_hero_web/components/marketing_components.ex:871
 #, elixir-autogen, elixir-format
 msgid "How we vet providers"
 msgstr ""
@@ -5918,7 +5918,7 @@ msgstr ""
 msgid "Join Berlin's growing network of trusted educators. Free to list. No setup fees."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:543
+#: lib/klass_hero_web/components/marketing_components.ex:544
 #, elixir-autogen, elixir-format
 msgid "Join Berlin's trusted network of educators. We handle payments, scheduling, and discovery — you focus on teaching."
 msgstr ""
@@ -5965,12 +5965,12 @@ msgstr ""
 msgid "Lead Instructor"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:553
+#: lib/klass_hero_web/components/marketing_components.ex:554
 #, elixir-autogen, elixir-format
 msgid "Learn How to Become a Hero →"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:860
+#: lib/klass_hero_web/components/marketing_components.ex:861
 #, elixir-autogen, elixir-format
 msgid "Learn how vetting works"
 msgstr ""
@@ -6000,12 +6000,12 @@ msgstr ""
 msgid "Linking..."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1115
+#: lib/klass_hero_web/components/marketing_components.ex:1116
 #, elixir-autogen, elixir-format
 msgid "List"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:571
+#: lib/klass_hero_web/components/marketing_components.ex:572
 #, elixir-autogen, elixir-format
 msgid "List Your Program"
 msgstr ""
@@ -6041,7 +6041,7 @@ msgstr ""
 msgid "Log out"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:867
+#: lib/klass_hero_web/components/marketing_components.ex:868
 #, elixir-autogen, elixir-format
 msgid "Looking for programs for your child?"
 msgstr ""
@@ -6091,7 +6091,7 @@ msgstr ""
 msgid "Minimum one year working with children, validated."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:135
+#: lib/klass_hero_web/components/marketing_components.ex:136
 #, elixir-autogen, elixir-format
 msgid "Mobile primary"
 msgstr ""
@@ -6116,7 +6116,7 @@ msgstr ""
 msgid "New program"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1126
+#: lib/klass_hero_web/components/marketing_components.ex:1127
 #, elixir-autogen, elixir-format
 msgid "Newest"
 msgstr ""
@@ -6131,7 +6131,7 @@ msgstr ""
 msgid "No credit card required"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:352
+#: lib/klass_hero_web/components/marketing_components.ex:353
 #, elixir-autogen, elixir-format
 msgid "No featured programs available right now. Check back soon."
 msgstr ""
@@ -6198,7 +6198,7 @@ msgstr ""
 msgid "Once your listing is live and you've completed Hero verification (typically 3–5 business days), parents can book immediately. Most providers receive their first inquiry within the first week."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1538
+#: lib/klass_hero_web/components/marketing_components.ex:1539
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Ongoing Quality"
 msgstr ""
@@ -6218,12 +6218,12 @@ msgstr ""
 msgid "Open inbox"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:110
+#: lib/klass_hero_web/components/marketing_components.ex:111
 #, elixir-autogen, elixir-format
 msgid "Open menu"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1366
+#: lib/klass_hero_web/components/marketing_components.ex:1367
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Our Commitment"
 msgstr ""
@@ -6258,7 +6258,7 @@ msgstr ""
 msgid "Parents discover you on Klass Hero. Approve manually or auto-accept — your call."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:582
+#: lib/klass_hero_web/components/marketing_components.ex:583
 #, elixir-autogen, elixir-format
 msgid "Parents find you through Klass Hero. Approve or auto-accept bookings with secure messaging built in."
 msgstr ""
@@ -6289,29 +6289,29 @@ msgstr ""
 msgid "Predictable income"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1128
+#: lib/klass_hero_web/components/marketing_components.ex:1129
 #, elixir-autogen, elixir-format
 msgid "Price: high to low"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1127
+#: lib/klass_hero_web/components/marketing_components.ex:1128
 #, elixir-autogen, elixir-format
 msgid "Price: low to high"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:813
+#: lib/klass_hero_web/components/marketing_components.ex:814
 #: lib/klass_hero_web/live/for_providers_live.ex:167
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Pricing"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:65
+#: lib/klass_hero_web/components/marketing_components.ex:66
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Primary"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:776
-#: lib/klass_hero_web/components/marketing_components.ex:823
+#: lib/klass_hero_web/components/marketing_components.ex:777
+#: lib/klass_hero_web/components/marketing_components.ex:824
 #: lib/klass_hero_web/live/privacy_policy_live.ex:238
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Privacy"
@@ -6352,7 +6352,7 @@ msgstr ""
 msgid "Questions about programs, bookings, or becoming a Hero — we read every message."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:679
+#: lib/klass_hero_web/components/marketing_components.ex:680
 #, elixir-autogen, elixir-format
 msgid "Questions, answered."
 msgstr ""
@@ -6367,8 +6367,8 @@ msgstr ""
 msgid "Ready to be a Hero?"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:877
-#: lib/klass_hero_web/components/marketing_components.ex:897
+#: lib/klass_hero_web/components/marketing_components.ex:878
+#: lib/klass_hero_web/components/marketing_components.ex:898
 #, elixir-autogen, elixir-format
 msgid "Ready to find your child's next adventure?"
 msgstr ""
@@ -6383,8 +6383,8 @@ msgstr ""
 msgid "Recent messages"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1125
-#: lib/klass_hero_web/components/marketing_components.ex:1137
+#: lib/klass_hero_web/components/marketing_components.ex:1126
+#: lib/klass_hero_web/components/marketing_components.ex:1138
 #, elixir-autogen, elixir-format
 msgid "Recommended"
 msgstr ""
@@ -6434,12 +6434,12 @@ msgstr ""
 msgid "Safety"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:982
+#: lib/klass_hero_web/components/marketing_components.ex:983
 #, elixir-autogen, elixir-format
 msgid "Search programs, providers, neighborhoods..."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:255
+#: lib/klass_hero_web/components/marketing_components.ex:256
 #, elixir-autogen, elixir-format
 msgid "Search: coding, football, art..."
 msgstr ""
@@ -6454,7 +6454,7 @@ msgstr ""
 msgid "Secure payments, invoicing, and VAT handling"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:591
+#: lib/klass_hero_web/components/marketing_components.ex:592
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Secure weekly payouts. Insights into your business and opportunities to expand your impact."
 msgstr ""
@@ -6469,7 +6469,7 @@ msgstr ""
 msgid "See pricing"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:562
+#: lib/klass_hero_web/components/marketing_components.ex:563
 #, elixir-autogen, elixir-format
 msgid "See provider plans"
 msgstr ""
@@ -6499,8 +6499,8 @@ msgstr ""
 msgid "Setting up..."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:95
-#: lib/klass_hero_web/components/marketing_components.ex:167
+#: lib/klass_hero_web/components/marketing_components.ex:96
+#: lib/klass_hero_web/components/marketing_components.ex:168
 #: lib/klass_hero_web/live/user_live/login.ex:12
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sign in"
@@ -6511,8 +6511,8 @@ msgstr ""
 msgid "Sign in to continue. Don't have an account?"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:98
-#: lib/klass_hero_web/components/marketing_components.ex:172
+#: lib/klass_hero_web/components/marketing_components.ex:99
+#: lib/klass_hero_web/components/marketing_components.ex:173
 #: lib/klass_hero_web/live/user_live/registration.ex:12
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sign up"
@@ -6523,7 +6523,7 @@ msgstr ""
 msgid "Signed agreement on conduct and quality bar."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:154
+#: lib/klass_hero_web/components/marketing_components.ex:155
 #: lib/klass_hero_web/components/ui_components.ex:193
 #, elixir-autogen, elixir-format
 msgid "Signed in as"
@@ -6534,12 +6534,12 @@ msgstr ""
 msgid "Six checks. No shortcuts."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1052
+#: lib/klass_hero_web/components/marketing_components.ex:1053
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sort:"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:812
+#: lib/klass_hero_web/components/marketing_components.ex:813
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Start Teaching"
 msgstr ""
@@ -6590,7 +6590,7 @@ msgstr ""
 msgid "Talk to our team →"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:880
+#: lib/klass_hero_web/components/marketing_components.ex:881
 #: lib/klass_hero_web/live/about_live.ex:164
 #: lib/klass_hero_web/live/for_providers_live.ex:269
 #, elixir-autogen, elixir-format
@@ -6607,7 +6607,7 @@ msgstr ""
 msgid "Teaching Experience"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:857
+#: lib/klass_hero_web/components/marketing_components.ex:858
 #, elixir-autogen, elixir-format
 msgid "Teaching kids is your thing? Join as a Hero."
 msgstr ""
@@ -6617,8 +6617,8 @@ msgstr ""
 msgid "Tell us a bit about what you need — we'll route you to the right person."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:777
-#: lib/klass_hero_web/components/marketing_components.ex:824
+#: lib/klass_hero_web/components/marketing_components.ex:778
+#: lib/klass_hero_web/components/marketing_components.ex:825
 #: lib/klass_hero_web/live/terms_of_service_live.ex:259
 #, elixir-autogen, elixir-format
 msgid "Terms"
@@ -6669,7 +6669,7 @@ msgstr ""
 msgid "Trust &"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:234
+#: lib/klass_hero_web/components/marketing_components.ex:235
 #, elixir-autogen, elixir-format
 msgid "Trusted Heroes"
 msgstr ""
@@ -6709,7 +6709,7 @@ msgstr ""
 msgid "Vetted"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1212
+#: lib/klass_hero_web/components/marketing_components.ex:1213
 #, elixir-autogen, elixir-format, fuzzy
 msgid "View"
 msgstr ""
@@ -6719,7 +6719,7 @@ msgstr ""
 msgid "View all"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:431
+#: lib/klass_hero_web/components/marketing_components.ex:432
 #, elixir-autogen, elixir-format, fuzzy
 msgid "View →"
 msgstr ""
@@ -6800,12 +6800,12 @@ msgstr ""
 msgid "What's the verification process like?"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:887
+#: lib/klass_hero_web/components/marketing_components.ex:888
 #, elixir-autogen, elixir-format
 msgid "While you're here — explore programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:469
+#: lib/klass_hero_web/components/marketing_components.ex:470
 #: lib/klass_hero_web/live/for_providers_live.ex:72
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Why Klass Hero"
@@ -6886,7 +6886,7 @@ msgstr ""
 msgid "active"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:957
+#: lib/klass_hero_web/components/marketing_components.ex:958
 #, elixir-autogen, elixir-format, fuzzy
 msgid "activities"
 msgstr ""
@@ -6911,7 +6911,7 @@ msgstr ""
 msgid "families"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:236
+#: lib/klass_hero_web/components/marketing_components.ex:237
 #, elixir-autogen, elixir-format
 msgid "for Our Youth"
 msgstr ""
@@ -6921,12 +6921,12 @@ msgstr ""
 msgid "help"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1040
+#: lib/klass_hero_web/components/marketing_components.ex:1041
 #, elixir-autogen, elixir-format
 msgid "in"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1044
+#: lib/klass_hero_web/components/marketing_components.ex:1045
 #, elixir-autogen, elixir-format
 msgid "matching"
 msgstr ""
@@ -6937,7 +6937,7 @@ msgstr ""
 msgid "pending"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1038
+#: lib/klass_hero_web/components/marketing_components.ex:1039
 #, elixir-autogen, elixir-format, fuzzy
 msgid "program"
 msgid_plural "programs"
@@ -7258,7 +7258,7 @@ msgstr ""
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1454
+#: lib/klass_hero_web/components/marketing_components.ex:1455
 #, elixir-autogen, elixir-format
 msgid "Applicants submit a short recorded video (max 2 minutes) so we can assess communication skills and alignment with our values before approving their profile."
 msgstr ""


### PR DESCRIPTION
## Summary
The closing CTA band at the bottom of **Trust & Safety** and **About** rendered as a flat pale-cream slab (`bg-hero-pink-50`) clashing with the black footer, and its tagline used out-of-place `tracking-widest`. Both pages share `mk_cta_section`, so one component fix corrects both. Per the design handoff, the band now fades to white and meets the footer on a clean seam, with tight tracking.

A rendered design review of the band surfaced two **pre-existing** a11y issues on the same surface (neither a regression from this change); fixed here too.

## Changes
- **CTA closer band** → `bg-gradient-to-b from-hero-pink-50 to-white`; tagline `tracking-widest` → `tracking-tight`; reworded the now-stale moduledoc + `typography-lint-ignore` reason.
- **DRY** → extracted the thrice-repeated `from-hero-pink-50 to-white` literal into `Theme.gradient(:base_fade)`; repointed the two marketing heroes + the closer.
- **Ghost `kh_button` borderless app-wide** → removed the redundant `border-0` from the base class stack. Tailwind preflight already zeroes borders, and the explicit `border-0` out-cascaded the `:ghost` variant's opt-in `border` (equal-specificity rules resolve by CSS emit order, not markup order), leaving every ghost button invisible at rest.
- **Muted lede contrast** → text over the warm-pink zone measured 3.1:1 (fails WCAG AA). Added a `--fg-muted-on-light` token (grey-800) and applied it to the four muted ledes on pink/gradient marketing surfaces.

## Review focus
- `Theme.gradient(:base_fade)` naming + that all three former literal sites now consume it.
- The `border-0` removal is app-wide — worth confirming filled variants stay borderless (they do; preflight).
- The gettext `.pot`/`.po` churn is **100% `#:` reference-line renumbering** (0 msgid changes) — a side effect of the added `alias` line shifting line numbers in a heavily-translated file.

## Test plan
- `mix precommit` green — **4173 passed**, 2 skipped.
- In-browser verification (Chrome DevTools):
  - Ghost button now computes `border-top-width: 1px` at rest; filled buttons stay `0px`.
  - Closer lede now `rgb(77,77,77)` → **7.31:1** at the lede, **6.83:1** worst-case (top of gradient). Was 3.13:1.
  - Gradient fades pink→white and meets the black footer on an exact seam at 375/768/1280 on both routes; tagline reads tight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)