### PR TITLE
feat: prefill contact form name and email for logged-in users

### DIFF
--- a/lib/klass_hero_web/live/contact_live.ex
+++ b/lib/klass_hero_web/live/contact_live.ex
@@ -9,7 +9,7 @@ defmodule KlassHeroWeb.ContactLive do
 
   @impl true
   def mount(_params, _session, socket) do
-    changeset = ContactForm.changeset(%ContactForm{}, %{})
+    changeset = ContactForm.changeset(%ContactForm{}, prefill_attrs(socket.assigns.current_scope))
 
     socket =
       socket
@@ -52,6 +52,12 @@ defmodule KlassHeroWeb.ContactLive do
         {:noreply, assign(socket, form: to_form(changeset, as: :contact))}
     end
   end
+
+  # Seeds the contact form's initial name/email from the signed-in user, so
+  # logged-in visitors don't retype what we already know. On the public /contact
+  # route `current_scope.user` is nil for anonymous visitors — seed nothing then.
+  defp prefill_attrs(%{user: %{} = user}), do: %{"name" => user.name, "email" => user.email}
+  defp prefill_attrs(_scope), do: %{}
 
   defp contact_methods do
     email = KlassHero.Contact.email()

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -415,7 +415,7 @@ msgstr "Über uns"
 msgid "Account Termination"
 msgstr "Kontobeendigung"
 
-#: lib/klass_hero_web/live/contact_live.ex:79
+#: lib/klass_hero_web/live/contact_live.ex:85
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "Address"
@@ -436,7 +436,7 @@ msgstr "Bereits registriert?"
 msgid "An email was sent to %{email}, please access it to confirm your account."
 msgstr "Eine E-Mail wurde an %{email} gesendet. Bitte bestätigen Sie Ihr Konto über den Link."
 
-#: lib/klass_hero_web/live/contact_live.ex:91
+#: lib/klass_hero_web/live/contact_live.ex:97
 #, elixir-autogen, elixir-format
 msgid "Booking Support"
 msgstr "Buchungshilfe"
@@ -515,7 +515,7 @@ msgstr "Kontaktdaten"
 
 #: lib/klass_hero_web/components/composite_components.ex:651
 #: lib/klass_hero_web/live/contact_live.ex:16
-#: lib/klass_hero_web/live/contact_live.ex:101
+#: lib/klass_hero_web/live/contact_live.ex:107
 #: lib/klass_hero_web/live/privacy_policy_live.ex:221
 #, elixir-autogen, elixir-format
 msgid "Contact Us"
@@ -585,8 +585,8 @@ msgstr "Streitbeilegung"
 #: lib/klass_hero_web/components/provider_components.ex:647
 #: lib/klass_hero_web/components/provider_components.ex:2073
 #: lib/klass_hero_web/components/provider_components.ex:2091
-#: lib/klass_hero_web/live/contact_live.ex:65
-#: lib/klass_hero_web/live/contact_live.ex:154
+#: lib/klass_hero_web/live/contact_live.ex:71
+#: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
 #: lib/klass_hero_web/live/user_live/login.ex:89
 #: lib/klass_hero_web/live/user_live/registration.ex:48
@@ -653,7 +653,7 @@ msgstr "Sitzung konnte nicht gestartet werden: %{reason}"
 msgid "Find and book activities, camps, and classes for your children"
 msgstr "Aktivitäten, Camps und Kurse für Ihre Kinder finden und buchen"
 
-#: lib/klass_hero_web/live/contact_live.ex:89
+#: lib/klass_hero_web/live/contact_live.ex:95
 #, elixir-autogen, elixir-format
 msgid "General Inquiry"
 msgstr "Allgemeine Anfrage"
@@ -678,7 +678,7 @@ msgstr "Wenn Ihre E-Mail in unserem System ist, erhalten Sie in Kürze Anweisung
 msgid "Information We Collect"
 msgstr "Daten, die wir erheben"
 
-#: lib/klass_hero_web/live/contact_live.ex:92
+#: lib/klass_hero_web/live/contact_live.ex:98
 #, elixir-autogen, elixir-format
 msgid "Instructor Application"
 msgstr "Kursleiter-Bewerbung"
@@ -754,14 +754,14 @@ msgstr "Anmeldung läuft..."
 msgid "Magic link is invalid or it has expired."
 msgstr "Der Magic-Link ist ungültig oder abgelaufen."
 
-#: lib/klass_hero_web/live/contact_live.ex:170
+#: lib/klass_hero_web/live/contact_live.ex:176
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:177
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr "Nachricht"
 
-#: lib/klass_hero_web/live/contact_live.ex:129
+#: lib/klass_hero_web/live/contact_live.ex:135
 #, elixir-autogen, elixir-format
 msgid "Message sent successfully!"
 msgstr "Nachricht erfolgreich gesendet!"
@@ -774,7 +774,7 @@ msgstr "Nachricht erfolgreich gesendet!"
 msgid "My Sessions"
 msgstr "Meine Sitzungen"
 
-#: lib/klass_hero_web/live/contact_live.ex:147
+#: lib/klass_hero_web/live/contact_live.ex:153
 #: lib/klass_hero_web/live/user_live/registration.ex:41
 #: lib/klass_hero_web/live/user_live/staff_invitation.ex:62
 #, elixir-autogen, elixir-format
@@ -801,7 +801,7 @@ msgstr "Oder Magic-Link verwenden"
 msgid "Or use password"
 msgstr "Oder Passwort verwenden"
 
-#: lib/klass_hero_web/live/contact_live.ex:94
+#: lib/klass_hero_web/live/contact_live.ex:100
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:241
 #: lib/klass_hero_web/live/provider/verification_live.ex:626
 #: lib/klass_hero_web/presenters/provider_presenter.ex:97
@@ -821,7 +821,7 @@ msgstr "Passwort"
 msgid "Payment Terms"
 msgstr "Zahlungsbedingungen"
 
-#: lib/klass_hero_web/live/contact_live.ex:72
+#: lib/klass_hero_web/live/contact_live.ex:78
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "Phone"
@@ -839,7 +839,7 @@ msgstr "Datenschutzerklärung"
 msgid "Program Enrollment & Bookings"
 msgstr "Programm-Anmeldung & Buchungen"
 
-#: lib/klass_hero_web/live/contact_live.ex:90
+#: lib/klass_hero_web/live/contact_live.ex:96
 #, elixir-autogen, elixir-format
 msgid "Program Question"
 msgstr "Programmfrage"
@@ -918,7 +918,7 @@ msgstr "Sitzung nicht gefunden"
 msgid "Session started successfully"
 msgstr "Sitzung erfolgreich gestartet"
 
-#: lib/klass_hero_web/live/contact_live.ex:162
+#: lib/klass_hero_web/live/contact_live.ex:168
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:163
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:179
 #, elixir-autogen, elixir-format
@@ -930,7 +930,7 @@ msgstr "Betreff"
 msgid "Table of Contents"
 msgstr "Inhaltsverzeichnis"
 
-#: lib/klass_hero_web/live/contact_live.ex:93
+#: lib/klass_hero_web/live/contact_live.ex:99
 #, elixir-autogen, elixir-format
 msgid "Technical Issue"
 msgstr "Technisches Problem"
@@ -5514,7 +5514,7 @@ msgstr "Kann ich Programme an mehreren Standorten anbieten?"
 msgid "Cancel anytime"
 msgstr "Jederzeit kündbar"
 
-#: lib/klass_hero_web/live/contact_live.ex:209
+#: lib/klass_hero_web/live/contact_live.ex:215
 #, elixir-autogen, elixir-format
 msgid "Check our FAQ — most questions are answered there."
 msgstr "Schauen Sie in unsere FAQ — die meisten Fragen werden dort beantwortet."
@@ -5789,7 +5789,7 @@ msgstr "Buchungen erhalten"
 msgid "Get Started Today →"
 msgstr "Jetzt loslegen →"
 
-#: lib/klass_hero_web/live/contact_live.ex:189
+#: lib/klass_hero_web/live/contact_live.ex:195
 #, elixir-autogen, elixir-format
 msgid "Get in touch"
 msgstr "Kontaktieren Sie uns"
@@ -6046,7 +6046,7 @@ msgstr "Abmelden"
 msgid "Looking for programs for your child?"
 msgstr "Suchen Sie Programme für Ihr Kind?"
 
-#: lib/klass_hero_web/live/contact_live.ex:206
+#: lib/klass_hero_web/live/contact_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Looking for quick answers?"
 msgstr "Suchen Sie schnelle Antworten?"
@@ -6347,7 +6347,7 @@ msgstr "Fragen von Anbietern, beantwortet"
 msgid "Quality & accountability — always on."
 msgstr "Qualität & Verantwortung — jederzeit aktiv."
 
-#: lib/klass_hero_web/live/contact_live.ex:107
+#: lib/klass_hero_web/live/contact_live.ex:113
 #, elixir-autogen, elixir-format
 msgid "Questions about programs, bookings, or becoming a Hero — we read every message."
 msgstr "Fragen zu Programmen, Buchungen oder wie Sie ein Hero werden — wir lesen jede Nachricht."
@@ -6474,12 +6474,12 @@ msgstr "Preise ansehen"
 msgid "See provider plans"
 msgstr "Anbieter-Tarife ansehen"
 
-#: lib/klass_hero_web/live/contact_live.ex:163
+#: lib/klass_hero_web/live/contact_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Select a topic…"
 msgstr "Thema auswählen…"
 
-#: lib/klass_hero_web/live/contact_live.ex:181
+#: lib/klass_hero_web/live/contact_live.ex:187
 #, elixir-autogen, elixir-format
 msgid "Send Message →"
 msgstr "Nachricht senden →"
@@ -6489,7 +6489,7 @@ msgstr "Nachricht senden →"
 msgid "Send magic link"
 msgstr "Magic-Link senden"
 
-#: lib/klass_hero_web/live/contact_live.ex:116
+#: lib/klass_hero_web/live/contact_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "Send us a message"
 msgstr "Schreiben Sie uns eine Nachricht"
@@ -6612,7 +6612,7 @@ msgstr "Unterrichtserfahrung"
 msgid "Teaching kids is your thing? Join as a Hero."
 msgstr "Unterrichten von Kindern ist Ihr Ding? Werden Sie ein Hero."
 
-#: lib/klass_hero_web/live/contact_live.ex:119
+#: lib/klass_hero_web/live/contact_live.ex:125
 #, elixir-autogen, elixir-format
 msgid "Tell us a bit about what you need — we'll route you to the right person."
 msgstr "Erzählen Sie uns kurz, was Sie brauchen — wir leiten Sie an die richtige Person weiter."
@@ -6724,7 +6724,7 @@ msgstr "Alle anzeigen"
 msgid "View →"
 msgstr "Ansehen →"
 
-#: lib/klass_hero_web/live/contact_live.ex:221
+#: lib/klass_hero_web/live/contact_live.ex:227
 #, elixir-autogen, elixir-format
 msgid "Visit FAQ →"
 msgstr "FAQ besuchen →"
@@ -6739,7 +6739,7 @@ msgstr "Wir glauben, dass Kinder in einem sicheren, respektvollen und profession
 msgid "We earn when you earn"
 msgstr "Wir verdienen, wenn Sie verdienen"
 
-#: lib/klass_hero_web/live/contact_live.ex:178
+#: lib/klass_hero_web/live/contact_live.ex:184
 #, elixir-autogen, elixir-format
 msgid "We never share your details."
 msgstr "Wir geben Ihre Daten niemals weiter."
@@ -6749,7 +6749,7 @@ msgstr "Wir geben Ihre Daten niemals weiter."
 msgid "We use SEPA bank transfers, paid out every Monday for the previous week's completed sessions. You'll receive an automatic invoice for each payout, and VAT is handled per-booking."
 msgstr "Wir nutzen SEPA-Überweisungen, die jeden Montag für die abgeschlossenen Sitzungen der Vorwoche ausgezahlt werden. Sie erhalten für jede Auszahlung automatisch eine Rechnung, und die Mehrwertsteuer wird pro Buchung abgewickelt."
 
-#: lib/klass_hero_web/live/contact_live.ex:103
+#: lib/klass_hero_web/live/contact_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "We're here to"
 msgstr "Wir sind hier, um zu"
@@ -6759,7 +6759,7 @@ msgstr "Wir sind hier, um zu"
 msgid "We're parents, brothers, and partners of educators — building the infrastructure that helps every child learn and thrive."
 msgstr "Wir sind Eltern, Brüder und Partner von Pädagogen — wir bauen die Infrastruktur auf, die jedem Kind hilft, zu lernen und sich zu entfalten."
 
-#: lib/klass_hero_web/live/contact_live.ex:132
+#: lib/klass_hero_web/live/contact_live.ex:138
 #, elixir-autogen, elixir-format
 msgid "We've got it — we'll be in touch."
 msgstr "Alles klar — wir melden uns bei Ihnen."
@@ -6790,7 +6790,7 @@ msgstr "Willkommen"
 msgid "Welcome aboard! Let's set up your business profile."
 msgstr "Willkommen an Bord! Lassen Sie uns Ihr Geschäftsprofil einrichten."
 
-#: lib/klass_hero_web/live/contact_live.ex:171
+#: lib/klass_hero_web/live/contact_live.ex:177
 #, elixir-autogen, elixir-format
 msgid "What's on your mind?"
 msgstr "Was beschäftigt Sie?"
@@ -6916,7 +6916,7 @@ msgstr "Familien"
 msgid "for Our Youth"
 msgstr "für unsere Jugend"
 
-#: lib/klass_hero_web/live/contact_live.ex:104
+#: lib/klass_hero_web/live/contact_live.ex:110
 #, elixir-autogen, elixir-format
 msgid "help"
 msgstr "Hilfe"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -415,7 +415,7 @@ msgstr ""
 msgid "Account Termination"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:79
+#: lib/klass_hero_web/live/contact_live.ex:85
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "Address"
@@ -436,7 +436,7 @@ msgstr ""
 msgid "An email was sent to %{email}, please access it to confirm your account."
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:91
+#: lib/klass_hero_web/live/contact_live.ex:97
 #, elixir-autogen, elixir-format
 msgid "Booking Support"
 msgstr ""
@@ -515,7 +515,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/composite_components.ex:651
 #: lib/klass_hero_web/live/contact_live.ex:16
-#: lib/klass_hero_web/live/contact_live.ex:101
+#: lib/klass_hero_web/live/contact_live.ex:107
 #: lib/klass_hero_web/live/privacy_policy_live.ex:221
 #, elixir-autogen, elixir-format
 msgid "Contact Us"
@@ -585,8 +585,8 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:647
 #: lib/klass_hero_web/components/provider_components.ex:2073
 #: lib/klass_hero_web/components/provider_components.ex:2091
-#: lib/klass_hero_web/live/contact_live.ex:65
-#: lib/klass_hero_web/live/contact_live.ex:154
+#: lib/klass_hero_web/live/contact_live.ex:71
+#: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
 #: lib/klass_hero_web/live/user_live/login.ex:89
 #: lib/klass_hero_web/live/user_live/registration.ex:48
@@ -653,7 +653,7 @@ msgstr ""
 msgid "Find and book activities, camps, and classes for your children"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:89
+#: lib/klass_hero_web/live/contact_live.ex:95
 #, elixir-autogen, elixir-format
 msgid "General Inquiry"
 msgstr ""
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Information We Collect"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:92
+#: lib/klass_hero_web/live/contact_live.ex:98
 #, elixir-autogen, elixir-format
 msgid "Instructor Application"
 msgstr ""
@@ -754,14 +754,14 @@ msgstr ""
 msgid "Magic link is invalid or it has expired."
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:170
+#: lib/klass_hero_web/live/contact_live.ex:176
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:177
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:129
+#: lib/klass_hero_web/live/contact_live.ex:135
 #, elixir-autogen, elixir-format
 msgid "Message sent successfully!"
 msgstr ""
@@ -774,7 +774,7 @@ msgstr ""
 msgid "My Sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:147
+#: lib/klass_hero_web/live/contact_live.ex:153
 #: lib/klass_hero_web/live/user_live/registration.ex:41
 #: lib/klass_hero_web/live/user_live/staff_invitation.ex:62
 #, elixir-autogen, elixir-format
@@ -801,7 +801,7 @@ msgstr ""
 msgid "Or use password"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:94
+#: lib/klass_hero_web/live/contact_live.ex:100
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:241
 #: lib/klass_hero_web/live/provider/verification_live.ex:626
 #: lib/klass_hero_web/presenters/provider_presenter.ex:97
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Payment Terms"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:72
+#: lib/klass_hero_web/live/contact_live.ex:78
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "Phone"
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Program Enrollment & Bookings"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:90
+#: lib/klass_hero_web/live/contact_live.ex:96
 #, elixir-autogen, elixir-format
 msgid "Program Question"
 msgstr ""
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Session started successfully"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:162
+#: lib/klass_hero_web/live/contact_live.ex:168
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:163
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:179
 #, elixir-autogen, elixir-format
@@ -930,7 +930,7 @@ msgstr ""
 msgid "Table of Contents"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:93
+#: lib/klass_hero_web/live/contact_live.ex:99
 #, elixir-autogen, elixir-format
 msgid "Technical Issue"
 msgstr ""
@@ -5514,7 +5514,7 @@ msgstr ""
 msgid "Cancel anytime"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:209
+#: lib/klass_hero_web/live/contact_live.ex:215
 #, elixir-autogen, elixir-format
 msgid "Check our FAQ — most questions are answered there."
 msgstr ""
@@ -5789,7 +5789,7 @@ msgstr ""
 msgid "Get Started Today →"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:189
+#: lib/klass_hero_web/live/contact_live.ex:195
 #, elixir-autogen, elixir-format
 msgid "Get in touch"
 msgstr ""
@@ -6046,7 +6046,7 @@ msgstr ""
 msgid "Looking for programs for your child?"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:206
+#: lib/klass_hero_web/live/contact_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Looking for quick answers?"
 msgstr ""
@@ -6347,7 +6347,7 @@ msgstr ""
 msgid "Quality & accountability — always on."
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:107
+#: lib/klass_hero_web/live/contact_live.ex:113
 #, elixir-autogen, elixir-format
 msgid "Questions about programs, bookings, or becoming a Hero — we read every message."
 msgstr ""
@@ -6474,12 +6474,12 @@ msgstr ""
 msgid "See provider plans"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:163
+#: lib/klass_hero_web/live/contact_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Select a topic…"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:181
+#: lib/klass_hero_web/live/contact_live.ex:187
 #, elixir-autogen, elixir-format
 msgid "Send Message →"
 msgstr ""
@@ -6489,7 +6489,7 @@ msgstr ""
 msgid "Send magic link"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:116
+#: lib/klass_hero_web/live/contact_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "Send us a message"
 msgstr ""
@@ -6612,7 +6612,7 @@ msgstr ""
 msgid "Teaching kids is your thing? Join as a Hero."
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:119
+#: lib/klass_hero_web/live/contact_live.ex:125
 #, elixir-autogen, elixir-format
 msgid "Tell us a bit about what you need — we'll route you to the right person."
 msgstr ""
@@ -6724,7 +6724,7 @@ msgstr ""
 msgid "View →"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:221
+#: lib/klass_hero_web/live/contact_live.ex:227
 #, elixir-autogen, elixir-format
 msgid "Visit FAQ →"
 msgstr ""
@@ -6739,7 +6739,7 @@ msgstr ""
 msgid "We earn when you earn"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:178
+#: lib/klass_hero_web/live/contact_live.ex:184
 #, elixir-autogen, elixir-format
 msgid "We never share your details."
 msgstr ""
@@ -6749,7 +6749,7 @@ msgstr ""
 msgid "We use SEPA bank transfers, paid out every Monday for the previous week's completed sessions. You'll receive an automatic invoice for each payout, and VAT is handled per-booking."
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:103
+#: lib/klass_hero_web/live/contact_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "We're here to"
 msgstr ""
@@ -6759,7 +6759,7 @@ msgstr ""
 msgid "We're parents, brothers, and partners of educators — building the infrastructure that helps every child learn and thrive."
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:132
+#: lib/klass_hero_web/live/contact_live.ex:138
 #, elixir-autogen, elixir-format
 msgid "We've got it — we'll be in touch."
 msgstr ""
@@ -6790,7 +6790,7 @@ msgstr ""
 msgid "Welcome aboard! Let's set up your business profile."
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:171
+#: lib/klass_hero_web/live/contact_live.ex:177
 #, elixir-autogen, elixir-format
 msgid "What's on your mind?"
 msgstr ""
@@ -6916,7 +6916,7 @@ msgstr ""
 msgid "for Our Youth"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:104
+#: lib/klass_hero_web/live/contact_live.ex:110
 #, elixir-autogen, elixir-format
 msgid "help"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -415,7 +415,7 @@ msgstr ""
 msgid "Account Termination"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:79
+#: lib/klass_hero_web/live/contact_live.ex:85
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "Address"
@@ -436,7 +436,7 @@ msgstr ""
 msgid "An email was sent to %{email}, please access it to confirm your account."
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:91
+#: lib/klass_hero_web/live/contact_live.ex:97
 #, elixir-autogen, elixir-format
 msgid "Booking Support"
 msgstr ""
@@ -515,7 +515,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/composite_components.ex:651
 #: lib/klass_hero_web/live/contact_live.ex:16
-#: lib/klass_hero_web/live/contact_live.ex:101
+#: lib/klass_hero_web/live/contact_live.ex:107
 #: lib/klass_hero_web/live/privacy_policy_live.ex:221
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Contact Us"
@@ -585,8 +585,8 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:647
 #: lib/klass_hero_web/components/provider_components.ex:2073
 #: lib/klass_hero_web/components/provider_components.ex:2091
-#: lib/klass_hero_web/live/contact_live.ex:65
-#: lib/klass_hero_web/live/contact_live.ex:154
+#: lib/klass_hero_web/live/contact_live.ex:71
+#: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
 #: lib/klass_hero_web/live/user_live/login.ex:89
 #: lib/klass_hero_web/live/user_live/registration.ex:48
@@ -653,7 +653,7 @@ msgstr ""
 msgid "Find and book activities, camps, and classes for your children"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:89
+#: lib/klass_hero_web/live/contact_live.ex:95
 #, elixir-autogen, elixir-format
 msgid "General Inquiry"
 msgstr ""
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Information We Collect"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:92
+#: lib/klass_hero_web/live/contact_live.ex:98
 #, elixir-autogen, elixir-format
 msgid "Instructor Application"
 msgstr ""
@@ -754,14 +754,14 @@ msgstr ""
 msgid "Magic link is invalid or it has expired."
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:170
+#: lib/klass_hero_web/live/contact_live.ex:176
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:177
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:129
+#: lib/klass_hero_web/live/contact_live.ex:135
 #, elixir-autogen, elixir-format
 msgid "Message sent successfully!"
 msgstr ""
@@ -774,7 +774,7 @@ msgstr ""
 msgid "My Sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:147
+#: lib/klass_hero_web/live/contact_live.ex:153
 #: lib/klass_hero_web/live/user_live/registration.ex:41
 #: lib/klass_hero_web/live/user_live/staff_invitation.ex:62
 #, elixir-autogen, elixir-format
@@ -801,7 +801,7 @@ msgstr ""
 msgid "Or use password"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:94
+#: lib/klass_hero_web/live/contact_live.ex:100
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:241
 #: lib/klass_hero_web/live/provider/verification_live.ex:626
 #: lib/klass_hero_web/presenters/provider_presenter.ex:97
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Payment Terms"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:72
+#: lib/klass_hero_web/live/contact_live.ex:78
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "Phone"
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Program Enrollment & Bookings"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:90
+#: lib/klass_hero_web/live/contact_live.ex:96
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program Question"
 msgstr ""
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Session started successfully"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:162
+#: lib/klass_hero_web/live/contact_live.ex:168
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:163
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:179
 #, elixir-autogen, elixir-format
@@ -930,7 +930,7 @@ msgstr ""
 msgid "Table of Contents"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:93
+#: lib/klass_hero_web/live/contact_live.ex:99
 #, elixir-autogen, elixir-format
 msgid "Technical Issue"
 msgstr ""
@@ -5514,7 +5514,7 @@ msgstr ""
 msgid "Cancel anytime"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:209
+#: lib/klass_hero_web/live/contact_live.ex:215
 #, elixir-autogen, elixir-format
 msgid "Check our FAQ — most questions are answered there."
 msgstr ""
@@ -5789,7 +5789,7 @@ msgstr ""
 msgid "Get Started Today →"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:189
+#: lib/klass_hero_web/live/contact_live.ex:195
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Get in touch"
 msgstr ""
@@ -6046,7 +6046,7 @@ msgstr ""
 msgid "Looking for programs for your child?"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:206
+#: lib/klass_hero_web/live/contact_live.ex:212
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Looking for quick answers?"
 msgstr ""
@@ -6347,7 +6347,7 @@ msgstr ""
 msgid "Quality & accountability — always on."
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:107
+#: lib/klass_hero_web/live/contact_live.ex:113
 #, elixir-autogen, elixir-format
 msgid "Questions about programs, bookings, or becoming a Hero — we read every message."
 msgstr ""
@@ -6474,12 +6474,12 @@ msgstr ""
 msgid "See provider plans"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:163
+#: lib/klass_hero_web/live/contact_live.ex:169
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select a topic…"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:181
+#: lib/klass_hero_web/live/contact_live.ex:187
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Send Message →"
 msgstr ""
@@ -6489,7 +6489,7 @@ msgstr ""
 msgid "Send magic link"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:116
+#: lib/klass_hero_web/live/contact_live.ex:122
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Send us a message"
 msgstr ""
@@ -6612,7 +6612,7 @@ msgstr ""
 msgid "Teaching kids is your thing? Join as a Hero."
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:119
+#: lib/klass_hero_web/live/contact_live.ex:125
 #, elixir-autogen, elixir-format
 msgid "Tell us a bit about what you need — we'll route you to the right person."
 msgstr ""
@@ -6724,7 +6724,7 @@ msgstr ""
 msgid "View →"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:221
+#: lib/klass_hero_web/live/contact_live.ex:227
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Visit FAQ →"
 msgstr ""
@@ -6739,7 +6739,7 @@ msgstr ""
 msgid "We earn when you earn"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:178
+#: lib/klass_hero_web/live/contact_live.ex:184
 #, elixir-autogen, elixir-format
 msgid "We never share your details."
 msgstr ""
@@ -6749,7 +6749,7 @@ msgstr ""
 msgid "We use SEPA bank transfers, paid out every Monday for the previous week's completed sessions. You'll receive an automatic invoice for each payout, and VAT is handled per-booking."
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:103
+#: lib/klass_hero_web/live/contact_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "We're here to"
 msgstr ""
@@ -6759,7 +6759,7 @@ msgstr ""
 msgid "We're parents, brothers, and partners of educators — building the infrastructure that helps every child learn and thrive."
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:132
+#: lib/klass_hero_web/live/contact_live.ex:138
 #, elixir-autogen, elixir-format
 msgid "We've got it — we'll be in touch."
 msgstr ""
@@ -6790,7 +6790,7 @@ msgstr ""
 msgid "Welcome aboard! Let's set up your business profile."
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:171
+#: lib/klass_hero_web/live/contact_live.ex:177
 #, elixir-autogen, elixir-format
 msgid "What's on your mind?"
 msgstr ""
@@ -6916,7 +6916,7 @@ msgstr ""
 msgid "for Our Youth"
 msgstr ""
 
-#: lib/klass_hero_web/live/contact_live.ex:104
+#: lib/klass_hero_web/live/contact_live.ex:110
 #, elixir-autogen, elixir-format
 msgid "help"
 msgstr ""

--- a/test/klass_hero_web/live/contact_live_test.exs
+++ b/test/klass_hero_web/live/contact_live_test.exs
@@ -215,6 +215,14 @@ defmodule KlassHeroWeb.ContactLiveTest do
       end
     end
 
+    test "anonymous visitor sees blank name and email fields", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/contact")
+
+      # No logged-in user → nothing to prefill; value attr is omitted entirely
+      refute has_element?(view, "input#contact_name[value]")
+      refute has_element?(view, "input#contact_email[value]")
+    end
+
     test "real-time validation updates as user types", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/contact")
 
@@ -241,6 +249,17 @@ defmodule KlassHeroWeb.ContactLiveTest do
 
       html = render(view)
       refute html =~ "must be a valid email address"
+    end
+  end
+
+  describe "ContactLive prefill for logged-in users" do
+    setup :register_and_log_in_user
+
+    test "prefills name and email from the current user", %{conn: conn, user: user} do
+      {:ok, view, _html} = live(conn, ~p"/contact")
+
+      assert has_element?(view, "input#contact_name[value='#{user.name}']")
+      assert has_element?(view, "input#contact_email[value='#{user.email}']")
     end
   end
 end


### PR DESCRIPTION
## Summary

Logged-in visitors landing on `/contact` now have their **name** and **email** pre-filled from `current_scope.user` — no retyping what we already know. Fields stay editable; anonymous visitors see an unchanged blank form.

## Review Focus

- `lib/klass_hero_web/live/contact_live.ex` — `mount/3` seeds the changeset via a new pure `prefill_attrs/1`. Two function heads: a user-bearing scope → `%{"name" => ..., "email" => ...}`, anything else (anonymous on the public `:marketing` route, where `current_scope.user` is `nil`) → `%{}`.
- `validate`/`submit` untouched — they already rebuild the changeset from user input, so overrides work for free.
- `%{user: %{} = user}` matches "a scope carrying a user map" without aliasing `Accounts.Scope` into the web layer.
- gettext `.pot`/`.po` changes are **line-reference refreshes only** — the added lines shifted existing `gettext` calls. No new strings, no translations owed.

## Test Plan

New in `contact_live_test.exs`:
- **logged-in** (`register_and_log_in_user` setup) → `input#contact_name` / `input#contact_email` carry the user's values.
- **anonymous** → no `value` attr on either input (HEEx drops nil attrs).

`contact_live_test.exs` 15/15 green. `mix precommit` clean (format/credo/typography/gettext); full suite passes bar one pre-existing flake in `admin/sessions_live_test.exs` (16/16 in isolation, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)