### PR TITLE
fix: close 5 multi-tenant IDORs in provider web layer

### DIFF
--- a/lib/klass_hero/enrollment.ex
+++ b/lib/klass_hero/enrollment.ex
@@ -49,6 +49,7 @@ defmodule KlassHero.Enrollment do
 
   defp do_create_enrollment(%{identity_id: identity_id} = params) when is_binary(identity_id) do
     with {:ok, parent} <- fetch_parent(identity_id),
+         :ok <- ensure_child_belongs_to_parent(params[:child_id], parent.id),
          {:ok, :eligible} <- ensure_eligible(params[:program_id], params[:child_id]) do
       params
       |> build_enrollment_attrs(parent.id)
@@ -68,6 +69,20 @@ defmodule KlassHero.Enrollment do
       {:error, :not_found} -> {:error, :no_parent_profile}
     end
   end
+
+  # Ownership guard (IDOR): a parent may only enroll their own children. The
+  # child_id arrives from client params, so it must be checked against the
+  # authenticated parent before it reaches the DB (a foreign_key_constraint
+  # only proves the child exists, not that it belongs to this parent).
+  defp ensure_child_belongs_to_parent(child_id, parent_id) when is_binary(child_id) do
+    if ChildInfoACL.child_belongs_to_parent?(child_id, parent_id) do
+      :ok
+    else
+      {:error, :not_your_child}
+    end
+  end
+
+  defp ensure_child_belongs_to_parent(_child_id, _parent_id), do: {:error, :not_your_child}
 
   # 3-tuple {:error, :ineligible, reasons} bubbles verbatim; 2-tuple lookup failures map to
   # :processing_failed (fail-closed when eligibility cannot be verified).

--- a/lib/klass_hero/enrollment.ex
+++ b/lib/klass_hero/enrollment.ex
@@ -70,10 +70,8 @@ defmodule KlassHero.Enrollment do
     end
   end
 
-  # Ownership guard (IDOR): a parent may only enroll their own children. The
-  # child_id arrives from client params, so it must be checked against the
-  # authenticated parent before it reaches the DB (a foreign_key_constraint
-  # only proves the child exists, not that it belongs to this parent).
+  # Ownership guard (IDOR): child_id is client-supplied; the FK constraint proves
+  # the child exists, not that it belongs to this parent.
   defp ensure_child_belongs_to_parent(child_id, parent_id) when is_binary(child_id) do
     if ChildInfoACL.child_belongs_to_parent?(child_id, parent_id) do
       :ok

--- a/lib/klass_hero/enrollment/adapters/driven/acl/child_info_acl.ex
+++ b/lib/klass_hero/enrollment/adapters/driven/acl/child_info_acl.ex
@@ -27,4 +27,16 @@ defmodule KlassHero.Enrollment.Adapters.Driven.ACL.ChildInfoACL do
       end)
     end
   end
+
+  @doc """
+  Returns `true` when `child_id` is a child of `parent_id` (guardian link exists).
+
+  Used by the enrollment create flow to enforce that a parent can only enroll
+  their own children — closes a cross-family IDOR on `child_id`.
+  """
+  def child_belongs_to_parent?(child_id, parent_id) when is_binary(child_id) and is_binary(parent_id) do
+    acl_span source: "enrollment", target: "family" do
+      Family.child_belongs_to_parent?(child_id, parent_id)
+    end
+  end
 end

--- a/lib/klass_hero/provider.ex
+++ b/lib/klass_hero/provider.ex
@@ -201,8 +201,8 @@ defmodule KlassHero.Provider do
   @doc "Deletes a staff member by ID."
   defdelegate delete_staff_member(staff_id), to: Staff
 
-  @doc "Resends a staff invitation for a staff member in :failed or :expired status."
-  defdelegate resend_staff_invitation(staff_member_id), to: Staff
+  @doc "Resends a staff invitation for a `:failed`/`:expired` member owned by `provider_id`."
+  defdelegate resend_staff_invitation(provider_id, staff_member_id), to: Staff
 
   @doc "Transitions a staff member's invitation status to :expired."
   defdelegate expire_staff_invitation(staff_member_or_id), to: Staff
@@ -266,8 +266,8 @@ defmodule KlassHero.Provider do
   @doc "Lists all active program assignments for a staff member."
   defdelegate list_active_assignments_for_staff_member(staff_member_id), to: Assignments
 
-  @doc "Promotes a staff member to the program's lead instructor (single source of truth)."
-  defdelegate set_lead_instructor(program_id, staff_member_id), to: Assignments
+  @doc "Promotes a `provider_id`-owned staff member to the program's lead instructor (single source of truth)."
+  defdelegate set_lead_instructor(program_id, staff_member_id, provider_id), to: Assignments
 
   @doc "Clears the program's lead instructor, leaving the assignment active."
   defdelegate clear_lead_instructor(program_id), to: Assignments

--- a/lib/klass_hero/provider/assignments.ex
+++ b/lib/klass_hero/provider/assignments.ex
@@ -148,25 +148,36 @@ defmodule KlassHero.Provider.Assignments do
   mid-flight. Creates an active assignment when the staff member has none yet.
 
   Returns `{:ok, ProgramStaffAssignment.t()}` or `{:error, :not_found}` when the
-  staff member does not exist.
+  staff member does not exist **or is owned by another provider** (IDOR guard —
+  the two are indistinguishable, so no cross-tenant assignment is ever written).
   """
-  @spec set_lead_instructor(String.t(), String.t()) ::
+  @spec set_lead_instructor(String.t(), String.t(), String.t()) ::
           {:ok, ProgramStaffAssignment.t()} | {:error, :not_found | term()}
-  def set_lead_instructor(program_id, staff_member_id) when is_binary(program_id) and is_binary(staff_member_id) do
+  def set_lead_instructor(program_id, staff_member_id, provider_id)
+      when is_binary(program_id) and is_binary(staff_member_id) and is_binary(provider_id) do
     context_span entity: "program_staff_assignment" do
-      # Existence check up front so a missing staff member short-circuits before
-      # the transaction; provider_id is immutable so reusing it inside is safe.
-      with {:ok, staff_member} <- Provider.get_staff_member(staff_member_id) do
-        Multi.new()
-        |> Multi.update_all(:clear_other_leads, other_active_leads_query(program_id, staff_member_id),
-          set: [is_lead_instructor: false]
-        )
-        |> Multi.run(:lead, fn repo, _ -> upsert_lead(repo, program_id, staff_member) end)
-        |> Repo.transaction()
-        |> case do
-          {:ok, %{lead: lead}} -> {:ok, lead}
-          {:error, _step, reason, _changes} -> {:error, reason}
-        end
+      # Ownership guard (IDOR): the staff member must belong to the caller's
+      # provider — a foreign one is indistinguishable from missing (:not_found),
+      # so a competitor's staff can never be attached to this (publicly-rendered)
+      # program. The existence check also short-circuits before the transaction.
+      case Provider.get_staff_member(staff_member_id) do
+        {:ok, %StaffMember{provider_id: ^provider_id} = staff_member} ->
+          Multi.new()
+          |> Multi.update_all(:clear_other_leads, other_active_leads_query(program_id, staff_member_id),
+            set: [is_lead_instructor: false]
+          )
+          |> Multi.run(:lead, fn repo, _ -> upsert_lead(repo, program_id, staff_member) end)
+          |> Repo.transaction()
+          |> case do
+            {:ok, %{lead: lead}} -> {:ok, lead}
+            {:error, _step, reason, _changes} -> {:error, reason}
+          end
+
+        {:ok, %StaffMember{}} ->
+          {:error, :not_found}
+
+        error ->
+          error
       end
     end
   end

--- a/lib/klass_hero/provider/assignments.ex
+++ b/lib/klass_hero/provider/assignments.ex
@@ -156,10 +156,8 @@ defmodule KlassHero.Provider.Assignments do
   def set_lead_instructor(program_id, staff_member_id, provider_id)
       when is_binary(program_id) and is_binary(staff_member_id) and is_binary(provider_id) do
     context_span entity: "program_staff_assignment" do
-      # Ownership guard (IDOR): the staff member must belong to the caller's
-      # provider — a foreign one is indistinguishable from missing (:not_found),
-      # so a competitor's staff can never be attached to this (publicly-rendered)
-      # program. The existence check also short-circuits before the transaction.
+      # Foreign staff → :not_found (see @doc): a competitor's staff must never attach
+      # to this publicly-rendered program.
       case Provider.get_staff_member(staff_member_id) do
         {:ok, %StaffMember{provider_id: ^provider_id} = staff_member} ->
           Multi.new()

--- a/lib/klass_hero/provider/staff.ex
+++ b/lib/klass_hero/provider/staff.ex
@@ -129,22 +129,27 @@ defmodule KlassHero.Provider.Staff do
   end
 
   @doc """
-  Resends a staff invitation for a staff member in :failed or :expired status.
+  Resends a staff invitation for a `:failed`/`:expired` member owned by `provider_id`.
 
   Generates a fresh token, transitions status back to :pending, and re-emits
   :staff_member_invited to restart the invitation saga.
 
   Returns:
   - `{:ok, StaffMember.t(), raw_token}` on success
-  - `{:error, :not_found}` if the staff member does not exist
+  - `{:error, :not_found}` if the staff member does not exist **or is owned by
+    another provider** (IDOR guard — the two are indistinguishable)
   - `{:error, :invalid_invitation_transition}` if the current status does not allow resend
   """
-  @spec resend_staff_invitation(String.t()) ::
+  @spec resend_staff_invitation(String.t(), String.t()) ::
           {:ok, StaffMember.t(), String.t()}
           | {:error, :not_found | :invalid_invitation_transition}
-  def resend_staff_invitation(staff_member_id) when is_binary(staff_member_id) do
+  def resend_staff_invitation(provider_id, staff_member_id)
+      when is_binary(provider_id) and is_binary(staff_member_id) do
     context_span entity: "staff_member" do
-      with {:ok, staff} <- get_staff_member(staff_member_id),
+      # Ownership guard (IDOR): a staff member owned by another provider is
+      # indistinguishable from a missing one — both return :not_found, so no
+      # existence/status oracle leaks across tenants. Mirrors update_staff_member/3.
+      with {:ok, %StaffMember{provider_id: ^provider_id} = staff} <- get_staff_member(staff_member_id),
            {:ok, _transitioned} <- StaffMember.transition_invitation(staff, :pending),
            {raw_token, token_hash} = StaffMember.generate_invitation_token(),
            {:ok, persisted} <-
@@ -153,6 +158,9 @@ defmodule KlassHero.Provider.Staff do
                invitation_token_hash: token_hash
              }) do
         emit_or_compensate_staff_invitation(persisted, raw_token)
+      else
+        {:ok, %StaffMember{}} -> {:error, :not_found}
+        other -> other
       end
     end
   end

--- a/lib/klass_hero/provider/staff.ex
+++ b/lib/klass_hero/provider/staff.ex
@@ -146,9 +146,7 @@ defmodule KlassHero.Provider.Staff do
   def resend_staff_invitation(provider_id, staff_member_id)
       when is_binary(provider_id) and is_binary(staff_member_id) do
     context_span entity: "staff_member" do
-      # Ownership guard (IDOR): a staff member owned by another provider is
-      # indistinguishable from a missing one — both return :not_found, so no
-      # existence/status oracle leaks across tenants. Mirrors update_staff_member/3.
+      # Ownership guard (IDOR, see @doc) — mirrors update_staff_member/3 above.
       with {:ok, %StaffMember{provider_id: ^provider_id} = staff} <- get_staff_member(staff_member_id),
            {:ok, _transitioned} <- StaffMember.transition_invitation(staff, :pending),
            {raw_token, token_hash} = StaffMember.generate_invitation_token(),

--- a/lib/klass_hero_web/live/provider/broadcast_live.ex
+++ b/lib/klass_hero_web/live/provider/broadcast_live.ex
@@ -32,9 +32,8 @@ defmodule KlassHeroWeb.Provider.BroadcastLive do
   defp mount_broadcast_form(socket, program_id) do
     provider_id = socket.assigns.current_scope.provider.id
 
-    # Ownership guard (IDOR): a program owned by another provider is treated the
-    # same as a missing one — both redirect with "Program not found" so an
-    # attacker can't broadcast to, or probe the existence of, a foreign program.
+    # Verify ownership before rendering — a foreign program is treated as not_found
+    # so its existence can't be probed (IDOR guard).
     case ProgramCatalog.get_program_by_id(program_id) do
       {:ok, %{provider_id: ^provider_id} = program} ->
         form = to_form(%{"subject" => "", "content" => ""})

--- a/lib/klass_hero_web/live/provider/broadcast_live.ex
+++ b/lib/klass_hero_web/live/provider/broadcast_live.ex
@@ -30,8 +30,13 @@ defmodule KlassHeroWeb.Provider.BroadcastLive do
   end
 
   defp mount_broadcast_form(socket, program_id) do
+    provider_id = socket.assigns.current_scope.provider.id
+
+    # Ownership guard (IDOR): a program owned by another provider is treated the
+    # same as a missing one — both redirect with "Program not found" so an
+    # attacker can't broadcast to, or probe the existence of, a foreign program.
     case ProgramCatalog.get_program_by_id(program_id) do
-      {:ok, program} ->
+      {:ok, %{provider_id: ^provider_id} = program} ->
         form = to_form(%{"subject" => "", "content" => ""})
 
         socket =
@@ -49,7 +54,7 @@ defmodule KlassHeroWeb.Provider.BroadcastLive do
 
         {:ok, socket}
 
-      {:error, :not_found} ->
+      _not_found_or_foreign ->
         {:ok,
          socket
          |> put_flash(:error, gettext("Program not found"))

--- a/lib/klass_hero_web/live/provider/participation_live.ex
+++ b/lib/klass_hero_web/live/provider/participation_live.ex
@@ -259,9 +259,8 @@ defmodule KlassHeroWeb.Provider.ParticipationLive do
 
     case Participation.get_session_with_roster_enriched(session_id) do
       {:ok, session} ->
-        # Ownership guard (IDOR): the session's program must belong to this
-        # provider. Without it, any provider could read and mutate another
-        # business's roster by guessing a session id.
+        # Ownership guard (IDOR): the session's program must belong to this provider,
+        # else any provider could read/mutate another business's roster via a guessed id.
         if MapSet.member?(socket.assigns.assigned_program_ids, session.program_id) do
           socket
           |> assign(:session, session)

--- a/lib/klass_hero_web/live/provider/participation_live.ex
+++ b/lib/klass_hero_web/live/provider/participation_live.ex
@@ -10,6 +10,7 @@ defmodule KlassHeroWeb.Provider.ParticipationLive do
     ]
 
   alias KlassHero.Participation
+  alias KlassHero.ProgramCatalog
   alias KlassHero.Shared.Domain.Events.DomainEvent
   alias KlassHeroWeb.Helpers.ParticipationEditHelpers
   alias KlassHeroWeb.Helpers.ParticipationLiveHandlers
@@ -20,6 +21,7 @@ defmodule KlassHeroWeb.Provider.ParticipationLive do
   @impl true
   def mount(%{"session_id" => session_id}, _session, socket) do
     provider_id = socket.assigns.current_scope.provider.id
+    assigned_program_ids = MapSet.new(ProgramCatalog.list_program_ids_for_provider(provider_id))
 
     socket =
       socket
@@ -27,6 +29,7 @@ defmodule KlassHeroWeb.Provider.ParticipationLive do
       |> assign(:active_nav, :roster)
       |> assign(:session_id, session_id)
       |> assign(:provider_id, provider_id)
+      |> assign(:assigned_program_ids, assigned_program_ids)
       |> assign(:session, nil)
       # Regular assign (not stream): small bounded collection, needs Enum.find/filter, always fully replaced.
       |> assign(:participation_records, [])
@@ -256,11 +259,26 @@ defmodule KlassHeroWeb.Provider.ParticipationLive do
 
     case Participation.get_session_with_roster_enriched(session_id) do
       {:ok, session} ->
-        socket
-        |> assign(:session, session)
-        |> assign(:participation_records, session.participation_records || [])
-        |> assign(:session_error, nil)
-        |> load_provider_notes()
+        # Ownership guard (IDOR): the session's program must belong to this
+        # provider. Without it, any provider could read and mutate another
+        # business's roster by guessing a session id.
+        if MapSet.member?(socket.assigns.assigned_program_ids, session.program_id) do
+          socket
+          |> assign(:session, session)
+          |> assign(:participation_records, session.participation_records || [])
+          |> assign(:session_error, nil)
+          |> load_provider_notes()
+        else
+          Logger.warning(
+            "[ParticipationLive] Unauthorized access to session",
+            session_id: session_id,
+            provider_id: socket.assigns.provider_id
+          )
+
+          socket
+          |> put_flash(:error, gettext("You are not assigned to this program"))
+          |> push_navigate(to: ~p"/provider/sessions")
+        end
 
       {:error, :not_found} ->
         Logger.warning(

--- a/lib/klass_hero_web/live/provider/programs_live.ex
+++ b/lib/klass_hero_web/live/provider/programs_live.ex
@@ -754,10 +754,8 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
 
   defp maybe_flash_cover_warning(socket, _cover_result), do: socket
 
-  # Validates the picked lead instructor exists AND belongs to this provider before
-  # the program is written (IDOR guard), so a foreign/bad id short-circuits with a
-  # flash rather than orphaning or cross-tenant-attaching a lead assignment. This is
-  # the pre-write gate that keeps apply_lead_instructor's {:ok, _} = match safe.
+  # Validates the instructor exists AND belongs to this provider (IDOR guard) —
+  # the pre-write gate that keeps apply_lead_instructor's bang-match safe.
   defp resolve_instructor(id, _socket) when id in [nil, ""], do: {:ok, nil}
 
   defp resolve_instructor(instructor_id, socket) do
@@ -778,9 +776,8 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
   end
 
   # Persists the lead choice on program_staff_assignments (single source of truth).
-  # A blank pick clears the lead; the id is already validated (existence + ownership)
-  # by resolve_instructor/2, so the {:ok, _} match below is safe. provider_id is
-  # threaded so the context re-checks ownership (defence in depth).
+  # Blank pick clears the lead; id already ownership-validated by resolve_instructor/2.
+  # provider_id re-threaded so the context re-checks too (defence in depth).
   defp apply_lead_instructor(program_id, nil, _provider_id), do: Provider.clear_lead_instructor(program_id)
 
   defp apply_lead_instructor(program_id, instructor_id, provider_id) do

--- a/lib/klass_hero_web/live/provider/programs_live.ex
+++ b/lib/klass_hero_web/live/provider/programs_live.ex
@@ -541,7 +541,7 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
 
     with {:ok, instructor_id} <- resolve_instructor(program_params["instructor_id"], socket),
          {:ok, program} <- ProgramCatalog.create_program(attrs) do
-      :ok = apply_lead_instructor(program.id, instructor_id)
+      :ok = apply_lead_instructor(program.id, instructor_id, socket.assigns.current_scope.provider.id)
       policy_result = maybe_set_enrollment_policy(program.id, enrollment_params)
       set_participant_policy_on_create(program.id, participant_policy_params)
       capacity = resolve_capacity(policy_result, enrollment_params)
@@ -597,7 +597,7 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
 
     with {:ok, instructor_id} <- resolve_instructor(program_params["instructor_id"], socket),
          {:ok, updated} <- ProgramCatalog.update_program(provider_id, program_id, attrs) do
-      :ok = apply_lead_instructor(program_id, instructor_id)
+      :ok = apply_lead_instructor(program_id, instructor_id, provider_id)
       policy_result = maybe_set_enrollment_policy(program_id, enrollment_params)
       set_participant_policy_on_update(program_id, participant_policy_params)
 
@@ -754,19 +754,23 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
 
   defp maybe_flash_cover_warning(socket, _cover_result), do: socket
 
-  # Validates the picked lead instructor exists before the program is written, so a
-  # bad id short-circuits with a flash rather than orphaning a lead assignment.
+  # Validates the picked lead instructor exists AND belongs to this provider before
+  # the program is written (IDOR guard), so a foreign/bad id short-circuits with a
+  # flash rather than orphaning or cross-tenant-attaching a lead assignment. This is
+  # the pre-write gate that keeps apply_lead_instructor's {:ok, _} = match safe.
   defp resolve_instructor(id, _socket) when id in [nil, ""], do: {:ok, nil}
 
   defp resolve_instructor(instructor_id, socket) do
+    provider_id = socket.assigns.current_scope.provider.id
+
     case Provider.get_staff_member(instructor_id) do
-      {:ok, _staff} ->
+      {:ok, %{provider_id: ^provider_id}} ->
         {:ok, instructor_id}
 
-      {:error, _reason} ->
-        Logger.warning("Instructor not found during program creation",
+      _not_found_or_foreign ->
+        Logger.warning("Instructor not found or not owned by provider during program save",
           instructor_id: instructor_id,
-          provider_id: socket.assigns.current_scope.provider.id
+          provider_id: provider_id
         )
 
         {:error, :instructor_not_found}
@@ -774,11 +778,13 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
   end
 
   # Persists the lead choice on program_staff_assignments (single source of truth).
-  # A blank pick clears the lead; the id is already validated by resolve_instructor/2.
-  defp apply_lead_instructor(program_id, nil), do: Provider.clear_lead_instructor(program_id)
+  # A blank pick clears the lead; the id is already validated (existence + ownership)
+  # by resolve_instructor/2, so the {:ok, _} match below is safe. provider_id is
+  # threaded so the context re-checks ownership (defence in depth).
+  defp apply_lead_instructor(program_id, nil, _provider_id), do: Provider.clear_lead_instructor(program_id)
 
-  defp apply_lead_instructor(program_id, instructor_id) do
-    {:ok, _assignment} = Provider.set_lead_instructor(program_id, instructor_id)
+  defp apply_lead_instructor(program_id, instructor_id, provider_id) do
+    {:ok, _assignment} = Provider.set_lead_instructor(program_id, instructor_id, provider_id)
     :ok
   end
 

--- a/lib/klass_hero_web/live/provider/team_live.ex
+++ b/lib/klass_hero_web/live/provider/team_live.ex
@@ -179,7 +179,9 @@ defmodule KlassHeroWeb.Provider.TeamLive do
 
   @impl true
   def handle_event("resend_invitation", %{"id" => staff_member_id}, socket) do
-    case Provider.resend_staff_invitation(staff_member_id) do
+    provider_id = socket.assigns.current_scope.provider.id
+
+    case Provider.resend_staff_invitation(provider_id, staff_member_id) do
       {:ok, updated, _raw_token} ->
         staff_view = StaffMemberPresenter.to_admin_view(updated)
 
@@ -189,6 +191,13 @@ defmodule KlassHeroWeb.Provider.TeamLive do
          |> put_flash(:info, gettext("Invitation resent successfully."))}
 
       {:error, :not_found} ->
+        # A foreign staff_member_id is indistinguishable from a genuine miss (IDOR
+        # guard lives in the context) — log the attempt so enumeration is visible.
+        Logger.warning("[TeamLive] Resend invitation returned not_found",
+          staff_member_id: staff_member_id,
+          provider_id: provider_id
+        )
+
         {:noreply, put_flash(socket, :error, gettext("Staff member not found."))}
 
       {:error, :invalid_invitation_transition} ->

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -1600,7 +1600,7 @@ msgid "Active"
 msgstr "Aktiv"
 
 #: lib/klass_hero_web/components/provider_components.ex:600
-#: lib/klass_hero_web/live/provider/team_live.ex:532
+#: lib/klass_hero_web/live/provider/team_live.ex:541
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
 msgstr "Teammitglied hinzufügen"
@@ -1632,7 +1632,7 @@ msgstr "Geschäftsprofil"
 msgid "Business Registration"
 msgstr "Gewerbeanmeldung"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:509
+#: lib/klass_hero_web/live/provider/team_live.ex:518
 #, elixir-autogen, elixir-format
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr "Erstellen Sie Profile für Ihr Personal. Diese werden für Eltern sichtbar sein, wenn sie Programmen zugewiesen werden."
@@ -1735,7 +1735,7 @@ msgstr "Status"
 msgid "Team & Profiles"
 msgstr "Team & Profile"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:506
+#: lib/klass_hero_web/live/provider/team_live.ex:515
 #, elixir-autogen, elixir-format
 msgid "Team & Provider Profiles"
 msgstr "Team- & Anbieterprofile"
@@ -2225,7 +2225,7 @@ msgstr "Aktion erforderlich"
 msgid "Add Member"
 msgstr "Mitglied hinzufügen"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:556
+#: lib/klass_hero_web/live/provider/team_live.ex:565
 #, elixir-autogen, elixir-format
 msgid "Add your first staff member to get started!"
 msgstr "Fügen Sie Ihren ersten Mitarbeiter hinzu, um loszulegen!"
@@ -2809,7 +2809,7 @@ msgstr "Noch keine Programme gebucht"
 msgid "No rejected documents."
 msgstr "Keine abgelehnten Dokumente."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:555
+#: lib/klass_hero_web/live/provider/team_live.ex:564
 #, elixir-autogen, elixir-format
 msgid "No team members yet"
 msgstr "Noch keine Teammitglieder"
@@ -2871,9 +2871,9 @@ msgstr "Ausstehende Überprüfung"
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:106
 #: lib/klass_hero_web/live/provider/programs_live.ex:588
 #: lib/klass_hero_web/live/provider/programs_live.ex:654
-#: lib/klass_hero_web/live/provider/team_live.ex:251
-#: lib/klass_hero_web/live/provider/team_live.ex:302
-#: lib/klass_hero_web/live/provider/team_live.ex:421
+#: lib/klass_hero_web/live/provider/team_live.ex:260
+#: lib/klass_hero_web/live/provider/team_live.ex:311
+#: lib/klass_hero_web/live/provider/team_live.ex:430
 #, elixir-autogen, elixir-format
 msgid "Please fix the errors below."
 msgstr "Bitte korrigieren Sie die Fehler unten."
@@ -2903,12 +2903,12 @@ msgstr "Profil erfolgreich aktualisiert."
 msgid "Program Start"
 msgstr "Programmbeginn"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:908
+#: lib/klass_hero_web/live/provider/programs_live.ex:914
 #, elixir-autogen, elixir-format
 msgid "Program created successfully."
 msgstr "Programm erfolgreich erstellt."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:915
+#: lib/klass_hero_web/live/provider/programs_live.ex:921
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr "Programm erstellt, aber die Anmeldekapazität konnte nicht gespeichert werden. Bearbeiten Sie das Programm, um es erneut zu versuchen."
@@ -3111,8 +3111,8 @@ msgstr "Legen Sie die minimale und maximale Anmeldekapazität für dieses Progra
 msgid "Specialties"
 msgstr "Spezialisierungen"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:401
-#: lib/klass_hero_web/live/provider/team_live.ex:427
+#: lib/klass_hero_web/live/provider/team_live.ex:410
+#: lib/klass_hero_web/live/provider/team_live.ex:436
 #, elixir-autogen, elixir-format
 msgid "Staff member no longer exists."
 msgstr "Der Mitarbeiter existiert nicht mehr."
@@ -3120,7 +3120,7 @@ msgstr "Der Mitarbeiter existiert nicht mehr."
 #: lib/klass_hero_web/live/provider/team_live.ex:100
 #: lib/klass_hero_web/live/provider/team_live.ex:103
 #: lib/klass_hero_web/live/provider/team_live.ex:176
-#: lib/klass_hero_web/live/provider/team_live.ex:192
+#: lib/klass_hero_web/live/provider/team_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Staff member not found."
 msgstr "Mitarbeiter nicht gefunden."
@@ -3151,12 +3151,12 @@ msgstr "Noch offen"
 msgid "Tax Certificate"
 msgstr "Steuerbescheinigung"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:355
+#: lib/klass_hero_web/live/provider/team_live.ex:364
 #, elixir-autogen, elixir-format
 msgid "Team member added, but headshot upload failed."
 msgstr "Teammitglied hinzugefügt, aber der Upload des Profilfotos ist fehlgeschlagen."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:356
+#: lib/klass_hero_web/live/provider/team_live.ex:365
 #, elixir-autogen, elixir-format
 msgid "Team member added."
 msgstr "Teammitglied hinzugefügt."
@@ -3166,12 +3166,12 @@ msgstr "Teammitglied hinzugefügt."
 msgid "Team member removed."
 msgstr "Teammitglied entfernt."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:381
+#: lib/klass_hero_web/live/provider/team_live.ex:390
 #, elixir-autogen, elixir-format
 msgid "Team member updated, but headshot upload failed."
 msgstr "Teammitglied aktualisiert, aber der Upload des Profilfotos ist fehlgeschlagen."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:382
+#: lib/klass_hero_web/live/provider/team_live.ex:391
 #, elixir-autogen, elixir-format
 msgid "Team member updated."
 msgstr "Teammitglied aktualisiert."
@@ -4253,7 +4253,7 @@ msgstr "E-Mail-Inhalt konnte nicht abgerufen werden."
 msgid "Failed to mark email as unread"
 msgstr "E-Mail konnte nicht als ungelesen markiert werden"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:208
+#: lib/klass_hero_web/live/provider/team_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "Failed to resend invitation. Please try again."
 msgstr "Einladung konnte nicht erneut gesendet werden. Bitte versuchen Sie es erneut."
@@ -4321,7 +4321,7 @@ msgstr "Einladung ausstehend"
 msgid "Invitation Sent"
 msgstr "Einladung gesendet"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:189
+#: lib/klass_hero_web/live/provider/team_live.ex:191
 #, elixir-autogen, elixir-format
 msgid "Invitation resent successfully."
 msgstr "Einladung erfolgreich erneut gesendet."
@@ -4568,7 +4568,7 @@ msgstr "Sitzung erfolgreich erstellt"
 msgid "Staff Dashboard"
 msgstr "Mitarbeiter-Dashboard"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:258
+#: lib/klass_hero_web/live/provider/team_live.ex:267
 #, elixir-autogen, elixir-format
 msgid "Staff member created, but the invitation could not be sent. Try resending from the team list."
 msgstr "Mitarbeiter wurde erstellt, aber die Einladung konnte nicht gesendet werden. Versuchen Sie es erneut über die Team-Liste."
@@ -4599,7 +4599,7 @@ msgstr "Unterstützung: %{details}"
 msgid "The business associated with your account could not be found."
 msgstr "Das mit Ihrem Konto verknüpfte Unternehmen konnte nicht gefunden werden."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:199
+#: lib/klass_hero_web/live/provider/team_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "This invitation cannot be resent in its current state."
 msgstr "Diese Einladung kann in ihrem aktuellen Status nicht erneut gesendet werden."
@@ -5593,7 +5593,7 @@ msgstr "Familien verbinden mit"
 msgid "Contact Us →"
 msgstr "Kontakt →"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:310
+#: lib/klass_hero_web/live/provider/team_live.ex:319
 #, elixir-autogen, elixir-format
 msgid "Could not add you to the team. Please try again."
 msgstr "Sie konnten nicht zum Team hinzugefügt werden. Bitte versuchen Sie es erneut."
@@ -5872,7 +5872,7 @@ msgstr "So bringen Sie Ihr Jugendprogramm zum Wachsen"
 msgid "How we vet providers"
 msgstr "Wie wir Anbieter überprüfen"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:523
+#: lib/klass_hero_web/live/provider/team_live.ex:532
 #, elixir-autogen, elixir-format
 msgid "I'll be teaching"
 msgstr "Ich werde unterrichten"
@@ -6841,7 +6841,7 @@ msgstr "Sie haben bereits ein Konto für %{email}."
 msgid "You'll get your own provider profile to fill in, and your account will open on your business dashboard from now on. You stay on %{business}'s team."
 msgstr "Sie erhalten Ihr eigenes Anbieterprofil zum Ausfüllen, und Ihr Konto öffnet sich ab sofort auf Ihrem Geschäfts-Dashboard. Sie bleiben im Team von %{business}."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:290
+#: lib/klass_hero_web/live/provider/team_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "You're already on your team."
 msgstr "Sie sind bereits in Ihrem Team."
@@ -6861,12 +6861,12 @@ msgstr "Sie sind nicht mehr in diesem Team."
 msgid "You're now part of the team."
 msgstr "Sie sind jetzt Teil des Teams."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:338
+#: lib/klass_hero_web/live/provider/team_live.ex:347
 #, elixir-autogen, elixir-format
 msgid "You're on the team — you can now be assigned to programs."
 msgstr "Sie sind im Team — Sie können nun Programmen zugewiesen werden."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:337
+#: lib/klass_hero_web/live/provider/team_live.ex:346
 #, elixir-autogen, elixir-format
 msgid "You're on the team, but the headshot upload failed."
 msgstr "Sie sind im Team, aber der Upload des Profilfotos ist fehlgeschlagen."

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -332,7 +332,7 @@ msgid "Klass Hero - Connecting Families with Trusted Youth Educators"
 msgstr "Klass Hero - Wir verbinden Familien mit vertrauenswürdigen Jugendpädagogen"
 
 #: lib/klass_hero_web/live/booking_live.ex:54
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:55
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:59
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:67
 #, elixir-autogen, elixir-format
 msgid "Program not found"
@@ -755,7 +755,7 @@ msgid "Magic link is invalid or it has expired."
 msgstr "Der Magic-Link ist ungültig oder abgelaufen."
 
 #: lib/klass_hero_web/live/contact_live.ex:176
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:177
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:181
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "Message"
@@ -858,8 +858,8 @@ msgstr "Fragen zu diesen Bedingungen?"
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:61
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:94
 #: lib/klass_hero_web/live/admin/sessions_live.ex:251
-#: lib/klass_hero_web/live/provider/participation_live.ex:171
-#: lib/klass_hero_web/live/provider/participation_live.ex:217
+#: lib/klass_hero_web/live/provider/participation_live.ex:174
+#: lib/klass_hero_web/live/provider/participation_live.ex:220
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:115
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:161
 #, elixir-autogen, elixir-format
@@ -906,7 +906,7 @@ msgstr "Sitzung erfolgreich abgeschlossen"
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:67
 #: lib/klass_hero_web/live/admin/sessions_live.ex:73
-#: lib/klass_hero_web/live/provider/participation_live.ex:272
+#: lib/klass_hero_web/live/provider/participation_live.ex:289
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:226
 #, elixir-autogen, elixir-format
 msgid "Session not found"
@@ -919,7 +919,7 @@ msgid "Session started successfully"
 msgstr "Sitzung erfolgreich gestartet"
 
 #: lib/klass_hero_web/live/contact_live.ex:168
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:163
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:167
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "Subject"
@@ -1392,7 +1392,7 @@ msgstr "WhatsApp-Community"
 msgid "Failed to load participation history"
 msgstr "Teilnahmeverlauf konnte nicht geladen werden"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:26
+#: lib/klass_hero_web/live/provider/participation_live.ex:28
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:60
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:29
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:260
@@ -1816,7 +1816,7 @@ msgstr "Zurück zu Einstellungen"
 msgid "Broadcast"
 msgstr "Rundnachricht"
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:97
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:101
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "Broadcast sent to %{count} parents"
@@ -1831,7 +1831,7 @@ msgstr "Rundnachricht an %{count} Eltern gesendet"
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:478
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:218
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:222
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:356
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:186
 #: lib/klass_hero_web/live/settings/children_live.ex:579
@@ -1925,12 +1925,12 @@ msgstr "Notiz konnte nicht genehmigt werden"
 msgid "Failed to reject note"
 msgstr "Notiz konnte nicht abgelehnt werden"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:163
+#: lib/klass_hero_web/live/provider/participation_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Failed to resubmit note"
 msgstr "Notiz konnte nicht erneut eingereicht werden"
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:120
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:124
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:146
 #, elixir-autogen, elixir-format
 msgid "Failed to send broadcast"
@@ -1972,7 +1972,7 @@ msgstr "Informationen und Einwilligungen Ihrer Kinder verwalten"
 msgid "Manage your children's profiles"
 msgstr "Verwalten Sie die Profile Ihrer Kinder"
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:78
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:82
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:94
 #, elixir-autogen, elixir-format
 msgid "Message content is required"
@@ -2005,7 +2005,7 @@ msgstr "Noch keine Unterhaltungen"
 msgid "No messages yet"
 msgstr "Noch keine Nachrichten"
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:105
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:109
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "No parents are enrolled in this program"
@@ -2017,7 +2017,7 @@ msgid "Note approved"
 msgstr "Notiz genehmigt"
 
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:113
-#: lib/klass_hero_web/live/provider/participation_live.ex:155
+#: lib/klass_hero_web/live/provider/participation_live.ex:158
 #, elixir-autogen, elixir-format
 msgid "Note content cannot be blank"
 msgstr "Notizinhalt darf nicht leer sein"
@@ -2027,7 +2027,7 @@ msgstr "Notizinhalt darf nicht leer sein"
 msgid "Note rejected"
 msgstr "Notiz abgelehnt"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:149
+#: lib/klass_hero_web/live/provider/participation_live.ex:152
 #, elixir-autogen, elixir-format
 msgid "Note resubmitted for review"
 msgstr "Notiz erneut zur Überprüfung eingereicht"
@@ -2092,9 +2092,9 @@ msgstr "Änderungen speichern"
 
 #: lib/klass_hero_web/components/provider_components.ex:1554
 #: lib/klass_hero_web/components/provider_components.ex:1555
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:39
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:147
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:248
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:43
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:151
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:252
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:44
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:163
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:238
@@ -2110,7 +2110,7 @@ msgid "Send a message to start the conversation"
 msgstr "Senden Sie eine Nachricht, um die Unterhaltung zu beginnen"
 
 #: lib/klass_hero_web/components/provider_components.ex:2148
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:247
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:237
 #, elixir-autogen, elixir-format
 msgid "Sending..."
@@ -2122,7 +2122,7 @@ msgstr "Wird gesendet..."
 msgid "Support needs"
 msgstr "Unterstützungsbedarf"
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:206
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:210
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "This message will be sent to all parents with active enrollments in this program."
@@ -2133,13 +2133,13 @@ msgstr "Diese Nachricht wird an alle Eltern mit aktiven Anmeldungen in diesem Pr
 msgid "Type a message..."
 msgstr "Nachricht eingeben..."
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:292
+#: lib/klass_hero_web/live/provider/participation_live.ex:309
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "Unable to refresh roster. Please reload."
 msgstr "Teilnehmerliste konnte nicht aktualisiert werden. Bitte laden Sie die Seite neu."
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:184
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:188
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "Write your message to all enrolled parents..."
@@ -2175,13 +2175,13 @@ msgstr "Ihre Unterhaltungen mit Eltern werden hier angezeigt"
 msgid "Your conversations with providers will appear here"
 msgstr "Ihre Unterhaltungen mit Anbietern werden hier angezeigt"
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:171
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:175
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:187
 #, elixir-autogen, elixir-format
 msgid "e.g., Important Update"
 msgstr "z. B. Wichtiges Update"
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:163
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:167
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "optional"
@@ -2903,12 +2903,12 @@ msgstr "Profil erfolgreich aktualisiert."
 msgid "Program Start"
 msgstr "Programmbeginn"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:914
+#: lib/klass_hero_web/live/provider/programs_live.ex:911
 #, elixir-autogen, elixir-format
 msgid "Program created successfully."
 msgstr "Programm erfolgreich erstellt."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:921
+#: lib/klass_hero_web/live/provider/programs_live.ex:918
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr "Programm erstellt, aber die Anmeldekapazität konnte nicht gespeichert werden. Bearbeiten Sie das Programm, um es erneut zu versuchen."
@@ -4736,6 +4736,7 @@ msgstr "Unbegrenzte Team-Plätze"
 msgid "View and manage your assigned sessions"
 msgstr "Ihre zugewiesenen Sitzungen anzeigen und verwalten"
 
+#: lib/klass_hero_web/live/provider/participation_live.ex:278
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:60
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:215
 #, elixir-autogen, elixir-format
@@ -4983,13 +4984,13 @@ msgstr "Abgereist"
 msgid "Departure notes"
 msgstr "Notizen zur Abreise"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:220
+#: lib/klass_hero_web/live/provider/participation_live.ex:223
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:164
 #, elixir-autogen, elixir-format
 msgid "Departure time is not a valid date and time"
 msgstr "Abreisezeit ist kein gültiges Datum oder keine gültige Uhrzeit"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:231
+#: lib/klass_hero_web/live/provider/participation_live.ex:234
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:175
 #, elixir-autogen, elixir-format
 msgid "Failed to update record"
@@ -5030,7 +5031,7 @@ msgstr "Gesundheit & Einwilligungen (optional)"
 msgid "Medical conditions"
 msgstr "Gesundheitliche Besonderheiten"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:223
+#: lib/klass_hero_web/live/provider/participation_live.ex:226
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:167
 #, elixir-autogen, elixir-format
 msgid "Nothing to update"
@@ -5072,7 +5073,7 @@ msgstr "Abreise erfassen"
 msgid "Record departure time (optional)"
 msgstr "Abreisezeit erfassen (optional)"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:211
+#: lib/klass_hero_web/live/provider/participation_live.ex:214
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:155
 #, elixir-autogen, elixir-format
 msgid "Record updated"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -1600,7 +1600,7 @@ msgid "Active"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:600
-#: lib/klass_hero_web/live/provider/team_live.ex:532
+#: lib/klass_hero_web/live/provider/team_live.ex:541
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
 msgstr ""
@@ -1632,7 +1632,7 @@ msgstr ""
 msgid "Business Registration"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:509
+#: lib/klass_hero_web/live/provider/team_live.ex:518
 #, elixir-autogen, elixir-format
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr ""
@@ -1735,7 +1735,7 @@ msgstr ""
 msgid "Team & Profiles"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:506
+#: lib/klass_hero_web/live/provider/team_live.ex:515
 #, elixir-autogen, elixir-format
 msgid "Team & Provider Profiles"
 msgstr ""
@@ -2225,7 +2225,7 @@ msgstr ""
 msgid "Add Member"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:556
+#: lib/klass_hero_web/live/provider/team_live.ex:565
 #, elixir-autogen, elixir-format
 msgid "Add your first staff member to get started!"
 msgstr ""
@@ -2809,7 +2809,7 @@ msgstr ""
 msgid "No rejected documents."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:555
+#: lib/klass_hero_web/live/provider/team_live.ex:564
 #, elixir-autogen, elixir-format
 msgid "No team members yet"
 msgstr ""
@@ -2871,9 +2871,9 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:106
 #: lib/klass_hero_web/live/provider/programs_live.ex:588
 #: lib/klass_hero_web/live/provider/programs_live.ex:654
-#: lib/klass_hero_web/live/provider/team_live.ex:251
-#: lib/klass_hero_web/live/provider/team_live.ex:302
-#: lib/klass_hero_web/live/provider/team_live.ex:421
+#: lib/klass_hero_web/live/provider/team_live.ex:260
+#: lib/klass_hero_web/live/provider/team_live.ex:311
+#: lib/klass_hero_web/live/provider/team_live.ex:430
 #, elixir-autogen, elixir-format
 msgid "Please fix the errors below."
 msgstr ""
@@ -2903,12 +2903,12 @@ msgstr ""
 msgid "Program Start"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:908
+#: lib/klass_hero_web/live/provider/programs_live.ex:914
 #, elixir-autogen, elixir-format
 msgid "Program created successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:915
+#: lib/klass_hero_web/live/provider/programs_live.ex:921
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr ""
@@ -3111,8 +3111,8 @@ msgstr ""
 msgid "Specialties"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:401
-#: lib/klass_hero_web/live/provider/team_live.ex:427
+#: lib/klass_hero_web/live/provider/team_live.ex:410
+#: lib/klass_hero_web/live/provider/team_live.ex:436
 #, elixir-autogen, elixir-format
 msgid "Staff member no longer exists."
 msgstr ""
@@ -3120,7 +3120,7 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/team_live.ex:100
 #: lib/klass_hero_web/live/provider/team_live.ex:103
 #: lib/klass_hero_web/live/provider/team_live.ex:176
-#: lib/klass_hero_web/live/provider/team_live.ex:192
+#: lib/klass_hero_web/live/provider/team_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Staff member not found."
 msgstr ""
@@ -3151,12 +3151,12 @@ msgstr ""
 msgid "Tax Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:355
+#: lib/klass_hero_web/live/provider/team_live.ex:364
 #, elixir-autogen, elixir-format
 msgid "Team member added, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:356
+#: lib/klass_hero_web/live/provider/team_live.ex:365
 #, elixir-autogen, elixir-format
 msgid "Team member added."
 msgstr ""
@@ -3166,12 +3166,12 @@ msgstr ""
 msgid "Team member removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:381
+#: lib/klass_hero_web/live/provider/team_live.ex:390
 #, elixir-autogen, elixir-format
 msgid "Team member updated, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:382
+#: lib/klass_hero_web/live/provider/team_live.ex:391
 #, elixir-autogen, elixir-format
 msgid "Team member updated."
 msgstr ""
@@ -4253,7 +4253,7 @@ msgstr ""
 msgid "Failed to mark email as unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:208
+#: lib/klass_hero_web/live/provider/team_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "Failed to resend invitation. Please try again."
 msgstr ""
@@ -4321,7 +4321,7 @@ msgstr ""
 msgid "Invitation Sent"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:189
+#: lib/klass_hero_web/live/provider/team_live.ex:191
 #, elixir-autogen, elixir-format
 msgid "Invitation resent successfully."
 msgstr ""
@@ -4568,7 +4568,7 @@ msgstr ""
 msgid "Staff Dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:258
+#: lib/klass_hero_web/live/provider/team_live.ex:267
 #, elixir-autogen, elixir-format
 msgid "Staff member created, but the invitation could not be sent. Try resending from the team list."
 msgstr ""
@@ -4599,7 +4599,7 @@ msgstr ""
 msgid "The business associated with your account could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:199
+#: lib/klass_hero_web/live/provider/team_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "This invitation cannot be resent in its current state."
 msgstr ""
@@ -5593,7 +5593,7 @@ msgstr ""
 msgid "Contact Us →"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:310
+#: lib/klass_hero_web/live/provider/team_live.ex:319
 #, elixir-autogen, elixir-format
 msgid "Could not add you to the team. Please try again."
 msgstr ""
@@ -5872,7 +5872,7 @@ msgstr ""
 msgid "How we vet providers"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:523
+#: lib/klass_hero_web/live/provider/team_live.ex:532
 #, elixir-autogen, elixir-format
 msgid "I'll be teaching"
 msgstr ""
@@ -6841,7 +6841,7 @@ msgstr ""
 msgid "You'll get your own provider profile to fill in, and your account will open on your business dashboard from now on. You stay on %{business}'s team."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:290
+#: lib/klass_hero_web/live/provider/team_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "You're already on your team."
 msgstr ""
@@ -6861,12 +6861,12 @@ msgstr ""
 msgid "You're now part of the team."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:338
+#: lib/klass_hero_web/live/provider/team_live.ex:347
 #, elixir-autogen, elixir-format
 msgid "You're on the team — you can now be assigned to programs."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:337
+#: lib/klass_hero_web/live/provider/team_live.ex:346
 #, elixir-autogen, elixir-format
 msgid "You're on the team, but the headshot upload failed."
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -332,7 +332,7 @@ msgid "Klass Hero - Connecting Families with Trusted Youth Educators"
 msgstr ""
 
 #: lib/klass_hero_web/live/booking_live.ex:54
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:55
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:59
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:67
 #, elixir-autogen, elixir-format
 msgid "Program not found"
@@ -755,7 +755,7 @@ msgid "Magic link is invalid or it has expired."
 msgstr ""
 
 #: lib/klass_hero_web/live/contact_live.ex:176
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:177
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:181
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "Message"
@@ -858,8 +858,8 @@ msgstr ""
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:61
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:94
 #: lib/klass_hero_web/live/admin/sessions_live.ex:251
-#: lib/klass_hero_web/live/provider/participation_live.ex:171
-#: lib/klass_hero_web/live/provider/participation_live.ex:217
+#: lib/klass_hero_web/live/provider/participation_live.ex:174
+#: lib/klass_hero_web/live/provider/participation_live.ex:220
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:115
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:161
 #, elixir-autogen, elixir-format
@@ -906,7 +906,7 @@ msgstr ""
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:67
 #: lib/klass_hero_web/live/admin/sessions_live.ex:73
-#: lib/klass_hero_web/live/provider/participation_live.ex:272
+#: lib/klass_hero_web/live/provider/participation_live.ex:289
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:226
 #, elixir-autogen, elixir-format
 msgid "Session not found"
@@ -919,7 +919,7 @@ msgid "Session started successfully"
 msgstr ""
 
 #: lib/klass_hero_web/live/contact_live.ex:168
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:163
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:167
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "Subject"
@@ -1392,7 +1392,7 @@ msgstr ""
 msgid "Failed to load participation history"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:26
+#: lib/klass_hero_web/live/provider/participation_live.ex:28
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:60
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:29
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:260
@@ -1816,7 +1816,7 @@ msgstr ""
 msgid "Broadcast"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:97
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:101
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "Broadcast sent to %{count} parents"
@@ -1831,7 +1831,7 @@ msgstr ""
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:478
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:218
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:222
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:356
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:186
 #: lib/klass_hero_web/live/settings/children_live.ex:579
@@ -1925,12 +1925,12 @@ msgstr ""
 msgid "Failed to reject note"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:163
+#: lib/klass_hero_web/live/provider/participation_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Failed to resubmit note"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:120
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:124
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:146
 #, elixir-autogen, elixir-format
 msgid "Failed to send broadcast"
@@ -1972,7 +1972,7 @@ msgstr ""
 msgid "Manage your children's profiles"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:78
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:82
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:94
 #, elixir-autogen, elixir-format
 msgid "Message content is required"
@@ -2005,7 +2005,7 @@ msgstr ""
 msgid "No messages yet"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:105
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:109
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "No parents are enrolled in this program"
@@ -2017,7 +2017,7 @@ msgid "Note approved"
 msgstr ""
 
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:113
-#: lib/klass_hero_web/live/provider/participation_live.ex:155
+#: lib/klass_hero_web/live/provider/participation_live.ex:158
 #, elixir-autogen, elixir-format
 msgid "Note content cannot be blank"
 msgstr ""
@@ -2027,7 +2027,7 @@ msgstr ""
 msgid "Note rejected"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:149
+#: lib/klass_hero_web/live/provider/participation_live.ex:152
 #, elixir-autogen, elixir-format
 msgid "Note resubmitted for review"
 msgstr ""
@@ -2092,9 +2092,9 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1554
 #: lib/klass_hero_web/components/provider_components.ex:1555
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:39
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:147
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:248
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:43
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:151
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:252
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:44
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:163
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:238
@@ -2110,7 +2110,7 @@ msgid "Send a message to start the conversation"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:2148
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:247
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:237
 #, elixir-autogen, elixir-format
 msgid "Sending..."
@@ -2122,7 +2122,7 @@ msgstr ""
 msgid "Support needs"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:206
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:210
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "This message will be sent to all parents with active enrollments in this program."
@@ -2133,13 +2133,13 @@ msgstr ""
 msgid "Type a message..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:292
+#: lib/klass_hero_web/live/provider/participation_live.ex:309
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "Unable to refresh roster. Please reload."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:184
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:188
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "Write your message to all enrolled parents..."
@@ -2175,13 +2175,13 @@ msgstr ""
 msgid "Your conversations with providers will appear here"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:171
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:175
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:187
 #, elixir-autogen, elixir-format
 msgid "e.g., Important Update"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:163
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:167
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "optional"
@@ -2903,12 +2903,12 @@ msgstr ""
 msgid "Program Start"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:914
+#: lib/klass_hero_web/live/provider/programs_live.ex:911
 #, elixir-autogen, elixir-format
 msgid "Program created successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:921
+#: lib/klass_hero_web/live/provider/programs_live.ex:918
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr ""
@@ -4736,6 +4736,7 @@ msgstr ""
 msgid "View and manage your assigned sessions"
 msgstr ""
 
+#: lib/klass_hero_web/live/provider/participation_live.ex:278
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:60
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:215
 #, elixir-autogen, elixir-format
@@ -4983,13 +4984,13 @@ msgstr ""
 msgid "Departure notes"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:220
+#: lib/klass_hero_web/live/provider/participation_live.ex:223
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:164
 #, elixir-autogen, elixir-format
 msgid "Departure time is not a valid date and time"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:231
+#: lib/klass_hero_web/live/provider/participation_live.ex:234
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:175
 #, elixir-autogen, elixir-format
 msgid "Failed to update record"
@@ -5030,7 +5031,7 @@ msgstr ""
 msgid "Medical conditions"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:223
+#: lib/klass_hero_web/live/provider/participation_live.ex:226
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:167
 #, elixir-autogen, elixir-format
 msgid "Nothing to update"
@@ -5072,7 +5073,7 @@ msgstr ""
 msgid "Record departure time (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:211
+#: lib/klass_hero_web/live/provider/participation_live.ex:214
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:155
 #, elixir-autogen, elixir-format
 msgid "Record updated"

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -1600,7 +1600,7 @@ msgid "Active"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:600
-#: lib/klass_hero_web/live/provider/team_live.ex:532
+#: lib/klass_hero_web/live/provider/team_live.ex:541
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
 msgstr ""
@@ -1632,7 +1632,7 @@ msgstr ""
 msgid "Business Registration"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:509
+#: lib/klass_hero_web/live/provider/team_live.ex:518
 #, elixir-autogen, elixir-format
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr ""
@@ -1735,7 +1735,7 @@ msgstr ""
 msgid "Team & Profiles"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:506
+#: lib/klass_hero_web/live/provider/team_live.ex:515
 #, elixir-autogen, elixir-format
 msgid "Team & Provider Profiles"
 msgstr ""
@@ -2225,7 +2225,7 @@ msgstr ""
 msgid "Add Member"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:556
+#: lib/klass_hero_web/live/provider/team_live.ex:565
 #, elixir-autogen, elixir-format
 msgid "Add your first staff member to get started!"
 msgstr ""
@@ -2809,7 +2809,7 @@ msgstr ""
 msgid "No rejected documents."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:555
+#: lib/klass_hero_web/live/provider/team_live.ex:564
 #, elixir-autogen, elixir-format
 msgid "No team members yet"
 msgstr ""
@@ -2871,9 +2871,9 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:106
 #: lib/klass_hero_web/live/provider/programs_live.ex:588
 #: lib/klass_hero_web/live/provider/programs_live.ex:654
-#: lib/klass_hero_web/live/provider/team_live.ex:251
-#: lib/klass_hero_web/live/provider/team_live.ex:302
-#: lib/klass_hero_web/live/provider/team_live.ex:421
+#: lib/klass_hero_web/live/provider/team_live.ex:260
+#: lib/klass_hero_web/live/provider/team_live.ex:311
+#: lib/klass_hero_web/live/provider/team_live.ex:430
 #, elixir-autogen, elixir-format
 msgid "Please fix the errors below."
 msgstr ""
@@ -2903,12 +2903,12 @@ msgstr ""
 msgid "Program Start"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:908
+#: lib/klass_hero_web/live/provider/programs_live.ex:914
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program created successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:915
+#: lib/klass_hero_web/live/provider/programs_live.ex:921
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr ""
@@ -3111,8 +3111,8 @@ msgstr ""
 msgid "Specialties"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:401
-#: lib/klass_hero_web/live/provider/team_live.ex:427
+#: lib/klass_hero_web/live/provider/team_live.ex:410
+#: lib/klass_hero_web/live/provider/team_live.ex:436
 #, elixir-autogen, elixir-format
 msgid "Staff member no longer exists."
 msgstr ""
@@ -3120,7 +3120,7 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/team_live.ex:100
 #: lib/klass_hero_web/live/provider/team_live.ex:103
 #: lib/klass_hero_web/live/provider/team_live.ex:176
-#: lib/klass_hero_web/live/provider/team_live.ex:192
+#: lib/klass_hero_web/live/provider/team_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Staff member not found."
 msgstr ""
@@ -3151,12 +3151,12 @@ msgstr ""
 msgid "Tax Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:355
+#: lib/klass_hero_web/live/provider/team_live.ex:364
 #, elixir-autogen, elixir-format
 msgid "Team member added, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:356
+#: lib/klass_hero_web/live/provider/team_live.ex:365
 #, elixir-autogen, elixir-format
 msgid "Team member added."
 msgstr ""
@@ -3166,12 +3166,12 @@ msgstr ""
 msgid "Team member removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:381
+#: lib/klass_hero_web/live/provider/team_live.ex:390
 #, elixir-autogen, elixir-format
 msgid "Team member updated, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:382
+#: lib/klass_hero_web/live/provider/team_live.ex:391
 #, elixir-autogen, elixir-format
 msgid "Team member updated."
 msgstr ""
@@ -4253,7 +4253,7 @@ msgstr ""
 msgid "Failed to mark email as unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:208
+#: lib/klass_hero_web/live/provider/team_live.ex:217
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to resend invitation. Please try again."
 msgstr ""
@@ -4321,7 +4321,7 @@ msgstr ""
 msgid "Invitation Sent"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:189
+#: lib/klass_hero_web/live/provider/team_live.ex:191
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invitation resent successfully."
 msgstr ""
@@ -4568,7 +4568,7 @@ msgstr ""
 msgid "Staff Dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:258
+#: lib/klass_hero_web/live/provider/team_live.ex:267
 #, elixir-autogen, elixir-format
 msgid "Staff member created, but the invitation could not be sent. Try resending from the team list."
 msgstr ""
@@ -4599,7 +4599,7 @@ msgstr ""
 msgid "The business associated with your account could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:199
+#: lib/klass_hero_web/live/provider/team_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "This invitation cannot be resent in its current state."
 msgstr ""
@@ -5593,7 +5593,7 @@ msgstr ""
 msgid "Contact Us →"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:310
+#: lib/klass_hero_web/live/provider/team_live.ex:319
 #, elixir-autogen, elixir-format
 msgid "Could not add you to the team. Please try again."
 msgstr ""
@@ -5872,7 +5872,7 @@ msgstr ""
 msgid "How we vet providers"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:523
+#: lib/klass_hero_web/live/provider/team_live.ex:532
 #, elixir-autogen, elixir-format
 msgid "I'll be teaching"
 msgstr ""
@@ -6841,7 +6841,7 @@ msgstr ""
 msgid "You'll get your own provider profile to fill in, and your account will open on your business dashboard from now on. You stay on %{business}'s team."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:290
+#: lib/klass_hero_web/live/provider/team_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "You're already on your team."
 msgstr ""
@@ -6861,12 +6861,12 @@ msgstr ""
 msgid "You're now part of the team."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:338
+#: lib/klass_hero_web/live/provider/team_live.ex:347
 #, elixir-autogen, elixir-format
 msgid "You're on the team — you can now be assigned to programs."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:337
+#: lib/klass_hero_web/live/provider/team_live.ex:346
 #, elixir-autogen, elixir-format
 msgid "You're on the team, but the headshot upload failed."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -332,7 +332,7 @@ msgid "Klass Hero - Connecting Families with Trusted Youth Educators"
 msgstr ""
 
 #: lib/klass_hero_web/live/booking_live.ex:54
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:55
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:59
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:67
 #, elixir-autogen, elixir-format
 msgid "Program not found"
@@ -755,7 +755,7 @@ msgid "Magic link is invalid or it has expired."
 msgstr ""
 
 #: lib/klass_hero_web/live/contact_live.ex:176
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:177
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:181
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "Message"
@@ -858,8 +858,8 @@ msgstr ""
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:61
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:94
 #: lib/klass_hero_web/live/admin/sessions_live.ex:251
-#: lib/klass_hero_web/live/provider/participation_live.ex:171
-#: lib/klass_hero_web/live/provider/participation_live.ex:217
+#: lib/klass_hero_web/live/provider/participation_live.ex:174
+#: lib/klass_hero_web/live/provider/participation_live.ex:220
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:115
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:161
 #, elixir-autogen, elixir-format
@@ -906,7 +906,7 @@ msgstr ""
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:67
 #: lib/klass_hero_web/live/admin/sessions_live.ex:73
-#: lib/klass_hero_web/live/provider/participation_live.ex:272
+#: lib/klass_hero_web/live/provider/participation_live.ex:289
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:226
 #, elixir-autogen, elixir-format
 msgid "Session not found"
@@ -919,7 +919,7 @@ msgid "Session started successfully"
 msgstr ""
 
 #: lib/klass_hero_web/live/contact_live.ex:168
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:163
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:167
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "Subject"
@@ -1392,7 +1392,7 @@ msgstr ""
 msgid "Failed to load participation history"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:26
+#: lib/klass_hero_web/live/provider/participation_live.ex:28
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:60
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:29
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:260
@@ -1816,7 +1816,7 @@ msgstr ""
 msgid "Broadcast"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:97
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:101
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "Broadcast sent to %{count} parents"
@@ -1831,7 +1831,7 @@ msgstr ""
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:478
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:218
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:222
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:356
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:186
 #: lib/klass_hero_web/live/settings/children_live.ex:579
@@ -1925,12 +1925,12 @@ msgstr ""
 msgid "Failed to reject note"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:163
+#: lib/klass_hero_web/live/provider/participation_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Failed to resubmit note"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:120
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:124
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:146
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to send broadcast"
@@ -1972,7 +1972,7 @@ msgstr ""
 msgid "Manage your children's profiles"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:78
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:82
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:94
 #, elixir-autogen, elixir-format
 msgid "Message content is required"
@@ -2005,7 +2005,7 @@ msgstr ""
 msgid "No messages yet"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:105
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:109
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "No parents are enrolled in this program"
@@ -2017,7 +2017,7 @@ msgid "Note approved"
 msgstr ""
 
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:113
-#: lib/klass_hero_web/live/provider/participation_live.ex:155
+#: lib/klass_hero_web/live/provider/participation_live.ex:158
 #, elixir-autogen, elixir-format
 msgid "Note content cannot be blank"
 msgstr ""
@@ -2027,7 +2027,7 @@ msgstr ""
 msgid "Note rejected"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:149
+#: lib/klass_hero_web/live/provider/participation_live.ex:152
 #, elixir-autogen, elixir-format
 msgid "Note resubmitted for review"
 msgstr ""
@@ -2092,9 +2092,9 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1554
 #: lib/klass_hero_web/components/provider_components.ex:1555
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:39
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:147
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:248
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:43
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:151
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:252
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:44
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:163
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:238
@@ -2110,7 +2110,7 @@ msgid "Send a message to start the conversation"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:2148
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:247
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:237
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sending..."
@@ -2122,7 +2122,7 @@ msgstr ""
 msgid "Support needs"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:206
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:210
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "This message will be sent to all parents with active enrollments in this program."
@@ -2133,13 +2133,13 @@ msgstr ""
 msgid "Type a message..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:292
+#: lib/klass_hero_web/live/provider/participation_live.ex:309
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "Unable to refresh roster. Please reload."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:184
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:188
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "Write your message to all enrolled parents..."
@@ -2175,13 +2175,13 @@ msgstr ""
 msgid "Your conversations with providers will appear here"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:171
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:175
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:187
 #, elixir-autogen, elixir-format
 msgid "e.g., Important Update"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/broadcast_live.ex:163
+#: lib/klass_hero_web/live/provider/broadcast_live.ex:167
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "optional"
@@ -2903,12 +2903,12 @@ msgstr ""
 msgid "Program Start"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:914
+#: lib/klass_hero_web/live/provider/programs_live.ex:911
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program created successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:921
+#: lib/klass_hero_web/live/provider/programs_live.ex:918
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr ""
@@ -4736,6 +4736,7 @@ msgstr ""
 msgid "View and manage your assigned sessions"
 msgstr ""
 
+#: lib/klass_hero_web/live/provider/participation_live.ex:278
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:60
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:215
 #, elixir-autogen, elixir-format
@@ -4983,13 +4984,13 @@ msgstr ""
 msgid "Departure notes"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:220
+#: lib/klass_hero_web/live/provider/participation_live.ex:223
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:164
 #, elixir-autogen, elixir-format
 msgid "Departure time is not a valid date and time"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:231
+#: lib/klass_hero_web/live/provider/participation_live.ex:234
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:175
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to update record"
@@ -5030,7 +5031,7 @@ msgstr ""
 msgid "Medical conditions"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:223
+#: lib/klass_hero_web/live/provider/participation_live.ex:226
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:167
 #, elixir-autogen, elixir-format
 msgid "Nothing to update"
@@ -5072,7 +5073,7 @@ msgstr ""
 msgid "Record departure time (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:211
+#: lib/klass_hero_web/live/provider/participation_live.ex:214
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:155
 #, elixir-autogen, elixir-format
 msgid "Record updated"

--- a/test/klass_hero/enrollment/create_enrollment_test.exs
+++ b/test/klass_hero/enrollment/create_enrollment_test.exs
@@ -266,9 +266,8 @@ defmodule KlassHero.Enrollment.CreateEnrollmentTest do
           eligibility_at: "registration"
         })
 
-      # A child_id that exists nowhere is, by definition, not this parent's child.
-      # The ownership guard rejects it uniformly with :not_your_child — this also
-      # avoids an existence oracle (nonexistent vs. foreign-but-real look identical).
+      # A nonexistent child is, by definition, not this parent's — same :not_your_child
+      # as a foreign child, avoiding an existence oracle.
       result =
         KlassHero.Enrollment.create_enrollment(%{
           identity_id: parent.identity_id,

--- a/test/klass_hero/enrollment/create_enrollment_test.exs
+++ b/test/klass_hero/enrollment/create_enrollment_test.exs
@@ -255,7 +255,7 @@ defmodule KlassHero.Enrollment.CreateEnrollmentTest do
                })
     end
 
-    test "returns processing_failed when child does not exist" do
+    test "rejects a nonexistent child (ownership guard fires before eligibility)" do
       program = insert(:program_schema)
       parent = insert(:parent_profile_schema)
 
@@ -266,6 +266,9 @@ defmodule KlassHero.Enrollment.CreateEnrollmentTest do
           eligibility_at: "registration"
         })
 
+      # A child_id that exists nowhere is, by definition, not this parent's child.
+      # The ownership guard rejects it uniformly with :not_your_child — this also
+      # avoids an existence oracle (nonexistent vs. foreign-but-real look identical).
       result =
         KlassHero.Enrollment.create_enrollment(%{
           identity_id: parent.identity_id,
@@ -274,7 +277,27 @@ defmodule KlassHero.Enrollment.CreateEnrollmentTest do
           payment_method: "card"
         })
 
-      assert {:error, :processing_failed} = result
+      assert {:error, :not_your_child} = result
+    end
+
+    test "rejects enrolling a child that belongs to another parent (IDOR guard)" do
+      program = insert(:program_schema)
+      parent = insert(:parent_profile_schema)
+
+      other_parent = insert(:parent_profile_schema)
+      {other_child, _other_parent} = insert_child_with_guardian(parent: other_parent)
+
+      result =
+        KlassHero.Enrollment.create_enrollment(%{
+          identity_id: parent.identity_id,
+          program_id: program.id,
+          child_id: other_child.id,
+          payment_method: "card"
+        })
+
+      assert {:error, :not_your_child} = result
+
+      refute KlassHero.Repo.exists?(from(e in Enrollment, where: e.child_id == ^other_child.id))
     end
   end
 

--- a/test/klass_hero/integration/staff_invitation_saga_test.exs
+++ b/test/klass_hero/integration/staff_invitation_saga_test.exs
@@ -249,7 +249,8 @@ defmodule KlassHero.Integration.StaffInvitationSagaTest do
       assert staff_failed.invitation_status == :failed
 
       # Step 3: Provider resends the invitation → status back to :pending, new token
-      assert {:ok, staff_resent, new_raw_token} = Provider.resend_staff_invitation(staff.id)
+      assert {:ok, staff_resent, new_raw_token} =
+               Provider.resend_staff_invitation(provider.id, staff.id)
 
       assert staff_resent.invitation_status == :pending
       assert is_binary(new_raw_token)

--- a/test/klass_hero/provider/assignments/lead_instructor_test.exs
+++ b/test/klass_hero/provider/assignments/lead_instructor_test.exs
@@ -84,9 +84,7 @@ defmodule KlassHero.Provider.Assignments.LeadInstructorTest do
       foreign_provider = insert(:provider_profile_schema)
       foreign_staff = insert(:staff_member_schema, provider_id: foreign_provider.id)
 
-      # A competitor's staff must never be attachable to my program — the assignment
-      # would render publicly on /programs/:id. Foreign staff = indistinguishable
-      # from missing (:not_found), and NO cross-provider assignment row is written.
+      # Public-render risk: assert no row was written, not just :not_found.
       assert {:error, :not_found} =
                Provider.set_lead_instructor(program.id, foreign_staff.id, provider.id)
 

--- a/test/klass_hero/provider/assignments/lead_instructor_test.exs
+++ b/test/klass_hero/provider/assignments/lead_instructor_test.exs
@@ -14,7 +14,7 @@ defmodule KlassHero.Provider.Assignments.LeadInstructorTest do
     {provider, program, staff}
   end
 
-  describe "set_lead_instructor/2" do
+  describe "set_lead_instructor/3" do
     test "flags an existing active assignment as lead" do
       {provider, program, staff} = setup_provider_program_staff()
 
@@ -26,7 +26,7 @@ defmodule KlassHero.Provider.Assignments.LeadInstructorTest do
         })
 
       assert {:ok, %ProgramStaffAssignment{} = lead} =
-               Provider.set_lead_instructor(program.id, staff.id)
+               Provider.set_lead_instructor(program.id, staff.id, program.provider_id)
 
       assert lead.is_lead_instructor == true
       assert lead.staff_member_id == staff.id
@@ -36,7 +36,7 @@ defmodule KlassHero.Provider.Assignments.LeadInstructorTest do
       {_provider, program, staff} = setup_provider_program_staff()
 
       assert {:ok, %ProgramStaffAssignment{} = lead} =
-               Provider.set_lead_instructor(program.id, staff.id)
+               Provider.set_lead_instructor(program.id, staff.id, program.provider_id)
 
       assert lead.is_lead_instructor == true
       assert lead.program_id == program.id
@@ -49,8 +49,8 @@ defmodule KlassHero.Provider.Assignments.LeadInstructorTest do
       staff_a = insert(:staff_member_schema, provider_id: provider.id)
       staff_b = insert(:staff_member_schema, provider_id: provider.id)
 
-      {:ok, _} = Provider.set_lead_instructor(program.id, staff_a.id)
-      {:ok, _} = Provider.set_lead_instructor(program.id, staff_b.id)
+      {:ok, _} = Provider.set_lead_instructor(program.id, staff_a.id, program.provider_id)
+      {:ok, _} = Provider.set_lead_instructor(program.id, staff_b.id, program.provider_id)
 
       leads =
         ProgramStaffAssignment
@@ -64,8 +64,8 @@ defmodule KlassHero.Provider.Assignments.LeadInstructorTest do
     test "is idempotent when the staff member is already lead" do
       {_provider, program, staff} = setup_provider_program_staff()
 
-      {:ok, first} = Provider.set_lead_instructor(program.id, staff.id)
-      {:ok, second} = Provider.set_lead_instructor(program.id, staff.id)
+      {:ok, first} = Provider.set_lead_instructor(program.id, staff.id, program.provider_id)
+      {:ok, second} = Provider.set_lead_instructor(program.id, staff.id, program.provider_id)
 
       assert first.id == second.id
       assert second.is_lead_instructor == true
@@ -75,14 +75,29 @@ defmodule KlassHero.Provider.Assignments.LeadInstructorTest do
       {_provider, program, _staff} = setup_provider_program_staff()
 
       assert {:error, :not_found} =
-               Provider.set_lead_instructor(program.id, Ecto.UUID.generate())
+               Provider.set_lead_instructor(program.id, Ecto.UUID.generate(), program.provider_id)
+    end
+
+    test "rejects a staff member owned by another provider (IDOR guard)" do
+      {provider, program, _staff} = setup_provider_program_staff()
+
+      foreign_provider = insert(:provider_profile_schema)
+      foreign_staff = insert(:staff_member_schema, provider_id: foreign_provider.id)
+
+      # A competitor's staff must never be attachable to my program — the assignment
+      # would render publicly on /programs/:id. Foreign staff = indistinguishable
+      # from missing (:not_found), and NO cross-provider assignment row is written.
+      assert {:error, :not_found} =
+               Provider.set_lead_instructor(program.id, foreign_staff.id, provider.id)
+
+      refute Repo.exists?(from(a in ProgramStaffAssignment, where: a.program_id == ^program.id))
     end
   end
 
   describe "clear_lead_instructor/1" do
     test "unsets the lead flag but keeps the assignment active" do
       {_provider, program, staff} = setup_provider_program_staff()
-      {:ok, _} = Provider.set_lead_instructor(program.id, staff.id)
+      {:ok, _} = Provider.set_lead_instructor(program.id, staff.id, program.provider_id)
 
       assert :ok = Provider.clear_lead_instructor(program.id)
 
@@ -104,7 +119,7 @@ defmodule KlassHero.Provider.Assignments.LeadInstructorTest do
   describe "get_lead_instructor/1" do
     test "returns the lead as a display map" do
       {_provider, program, staff} = setup_provider_program_staff()
-      {:ok, _} = Provider.set_lead_instructor(program.id, staff.id)
+      {:ok, _} = Provider.set_lead_instructor(program.id, staff.id, program.provider_id)
 
       assert %{id: id, name: name, headshot_url: headshot} =
                Provider.get_lead_instructor(program.id)
@@ -127,8 +142,8 @@ defmodule KlassHero.Provider.Assignments.LeadInstructorTest do
       staff_b = insert(:staff_member_schema, provider_id: provider.id)
       program_c = insert(:program_schema, provider_id: provider.id)
 
-      {:ok, _} = Provider.set_lead_instructor(program_a.id, staff_a.id)
-      {:ok, _} = Provider.set_lead_instructor(program_b.id, staff_b.id)
+      {:ok, _} = Provider.set_lead_instructor(program_a.id, staff_a.id, program_a.provider_id)
+      {:ok, _} = Provider.set_lead_instructor(program_b.id, staff_b.id, program_b.provider_id)
 
       result =
         Provider.list_lead_instructors_for_programs([program_a.id, program_b.id, program_c.id])

--- a/test/klass_hero/provider/staff/resend_staff_invitation_test.exs
+++ b/test/klass_hero/provider/staff/resend_staff_invitation_test.exs
@@ -99,12 +99,10 @@ defmodule KlassHero.Provider.Staff.ResendStaffInvitationTest do
       # Drop fixture-setup event noise so the assertion below isolates the resend.
       clear_integration_events()
 
-      # A foreign staff member is indistinguishable from a missing one — both
-      # return :not_found, so no existence/status oracle leaks across tenants.
+      # Foreign staff → :not_found, same as missing (no existence oracle).
       assert {:error, :not_found} =
                Provider.resend_staff_invitation(attacker.id, foreign_staff.id)
 
-      # No resend fired: token + status untouched, no invitation event published.
       schema = Repo.get!(StaffMember, foreign_staff.id)
       assert schema.invitation_status == :failed
       assert schema.invitation_token_hash == old_token

--- a/test/klass_hero/provider/staff/resend_staff_invitation_test.exs
+++ b/test/klass_hero/provider/staff/resend_staff_invitation_test.exs
@@ -26,7 +26,7 @@ defmodule KlassHero.Provider.Staff.ResendStaffInvitationTest do
           invitation_token_hash: old_token
         })
 
-      assert {:ok, updated, raw_token} = Provider.resend_staff_invitation(staff.id)
+      assert {:ok, updated, raw_token} = Provider.resend_staff_invitation(provider.id, staff.id)
 
       assert updated.invitation_status == :pending
       assert updated.invitation_token_hash != old_token
@@ -44,7 +44,7 @@ defmodule KlassHero.Provider.Staff.ResendStaffInvitationTest do
           invitation_token_hash: :crypto.hash(:sha256, "old")
         })
 
-      assert {:ok, updated, _raw_token} = Provider.resend_staff_invitation(staff.id)
+      assert {:ok, updated, _raw_token} = Provider.resend_staff_invitation(provider.id, staff.id)
       assert updated.invitation_status == :pending
     end
 
@@ -59,7 +59,7 @@ defmodule KlassHero.Provider.Staff.ResendStaffInvitationTest do
           invitation_token_hash: :crypto.hash(:sha256, "tok")
         })
 
-      assert {:error, :invalid_invitation_transition} = Provider.resend_staff_invitation(staff.id)
+      assert {:error, :invalid_invitation_transition} = Provider.resend_staff_invitation(provider.id, staff.id)
     end
 
     test "fails for :accepted staff member" do
@@ -72,11 +72,43 @@ defmodule KlassHero.Provider.Staff.ResendStaffInvitationTest do
           invitation_status: :accepted
         })
 
-      assert {:error, :invalid_invitation_transition} = Provider.resend_staff_invitation(staff.id)
+      assert {:error, :invalid_invitation_transition} = Provider.resend_staff_invitation(provider.id, staff.id)
     end
 
     test "returns error for non-existent staff member" do
-      assert {:error, :not_found} = Provider.resend_staff_invitation(Ecto.UUID.generate())
+      provider = provider_profile_fixture()
+
+      assert {:error, :not_found} =
+               Provider.resend_staff_invitation(provider.id, Ecto.UUID.generate())
+    end
+
+    test "rejects resend for a staff member owned by another provider (IDOR guard)" do
+      attacker = provider_profile_fixture()
+      victim = provider_profile_fixture()
+
+      old_token = :crypto.hash(:sha256, "victim-token")
+
+      foreign_staff =
+        staff_member_fixture(%{
+          provider_id: victim.id,
+          email: "victim-staff@example.com",
+          invitation_status: :failed,
+          invitation_token_hash: old_token
+        })
+
+      # Drop fixture-setup event noise so the assertion below isolates the resend.
+      clear_integration_events()
+
+      # A foreign staff member is indistinguishable from a missing one — both
+      # return :not_found, so no existence/status oracle leaks across tenants.
+      assert {:error, :not_found} =
+               Provider.resend_staff_invitation(attacker.id, foreign_staff.id)
+
+      # No resend fired: token + status untouched, no invitation event published.
+      schema = Repo.get!(StaffMember, foreign_staff.id)
+      assert schema.invitation_status == :failed
+      assert schema.invitation_token_hash == old_token
+      assert_no_integration_events_published()
     end
 
     test "emits :staff_member_invited integration event on success" do
@@ -90,7 +122,7 @@ defmodule KlassHero.Provider.Staff.ResendStaffInvitationTest do
           invitation_token_hash: :crypto.hash(:sha256, "old-token")
         })
 
-      {:ok, _updated, _raw_token} = Provider.resend_staff_invitation(staff.id)
+      {:ok, _updated, _raw_token} = Provider.resend_staff_invitation(provider.id, staff.id)
 
       event = assert_integration_event_published(:staff_member_invited)
       assert event.entity_id == staff.id
@@ -112,7 +144,7 @@ defmodule KlassHero.Provider.Staff.ResendStaffInvitationTest do
           invitation_token_hash: :crypto.hash(:sha256, "old-token")
         })
 
-      {:ok, updated, raw_token} = Provider.resend_staff_invitation(staff.id)
+      {:ok, updated, raw_token} = Provider.resend_staff_invitation(provider.id, staff.id)
 
       assert :crypto.hash(:sha256, Base.url_decode64!(raw_token, padding: false)) ==
                updated.invitation_token_hash
@@ -133,7 +165,7 @@ defmodule KlassHero.Provider.Staff.ResendStaffInvitationTest do
       clear_integration_events()
       TestIntegrationEventPublisher.configure_publish_error(:pubsub_down)
 
-      assert {:error, :invitation_emission_failed} = Provider.resend_staff_invitation(staff.id)
+      assert {:error, :invitation_emission_failed} = Provider.resend_staff_invitation(provider.id, staff.id)
 
       # Verify compensation: staff member in :failed, not orphaned as :pending
       schema = Repo.get!(StaffMember, staff.id)

--- a/test/klass_hero_web/live/booking_live_test.exs
+++ b/test/klass_hero_web/live/booking_live_test.exs
@@ -180,6 +180,14 @@ defmodule KlassHeroWeb.BookingLiveTest do
       assert Decimal.equal?(enrollment.card_fee_amount, Decimal.new("0.00"))
     end
 
+    # NOTE: the cross-family IDOR guard is enforced (and tested) at the context
+    # boundary — see create_enrollment_test.exs "rejects enrolling a child that
+    # belongs to another parent". A LiveView-level test can't exercise it: the
+    # <select name="child_id"> only renders the user's own children as options,
+    # so render_submit rejects a foreign id before it reaches the server. The
+    # real attack path (a raw socket event) bypasses that select and hits the
+    # facade, which is exactly what the context test covers.
+
     test "back_to_program button navigates to program detail", %{conn: conn} do
       program = insert(:program_schema)
       {:ok, view, _html} = live(conn, ~p"/programs/#{program.id}/booking")

--- a/test/klass_hero_web/live/booking_live_test.exs
+++ b/test/klass_hero_web/live/booking_live_test.exs
@@ -180,13 +180,9 @@ defmodule KlassHeroWeb.BookingLiveTest do
       assert Decimal.equal?(enrollment.card_fee_amount, Decimal.new("0.00"))
     end
 
-    # NOTE: the cross-family IDOR guard is enforced (and tested) at the context
-    # boundary — see create_enrollment_test.exs "rejects enrolling a child that
-    # belongs to another parent". A LiveView-level test can't exercise it: the
-    # <select name="child_id"> only renders the user's own children as options,
-    # so render_submit rejects a foreign id before it reaches the server. The
-    # real attack path (a raw socket event) bypasses that select and hits the
-    # facade, which is exactly what the context test covers.
+    # NOTE: the cross-family IDOR guard is tested at the context boundary (see
+    # create_enrollment_test.exs). The child_id <select> only lists the user's own
+    # children, so a LiveView-level test can't submit a foreign id.
 
     test "back_to_program button navigates to program detail", %{conn: conn} do
       program = insert(:program_schema)

--- a/test/klass_hero_web/live/provider/broadcast_live_test.exs
+++ b/test/klass_hero_web/live/provider/broadcast_live_test.exs
@@ -34,13 +34,23 @@ defmodule KlassHeroWeb.Provider.BroadcastLiveTest do
 
       assert flash["error"] == "Program not found"
     end
+
+    test "redirects when program belongs to another provider (IDOR guard)", %{conn: conn} do
+      foreign_provider = insert(:provider_profile_schema)
+      foreign_program = insert(:program_schema, provider_id: foreign_provider.id)
+
+      assert {:error, {:live_redirect, %{to: "/provider/dashboard/programs", flash: flash}}} =
+               live(conn, ~p"/provider/programs/#{foreign_program.id}/broadcast")
+
+      assert flash["error"] == "Program not found"
+    end
   end
 
   describe "broadcast form" do
     setup :register_and_log_in_provider
 
-    test "renders broadcast form for valid program", %{conn: conn} do
-      program = insert(:program_schema)
+    test "renders broadcast form for valid program", %{conn: conn, provider: provider} do
+      program = insert(:program_schema, provider_id: provider.id)
 
       {:ok, view, _html} = live(conn, ~p"/provider/programs/#{program.id}/broadcast")
 
@@ -50,16 +60,16 @@ defmodule KlassHeroWeb.Provider.BroadcastLiveTest do
       assert has_element?(view, "textarea[name=\"content\"]")
     end
 
-    test "shows program title", %{conn: conn} do
-      program = insert(:program_schema, title: "Junior Soccer Academy")
+    test "shows program title", %{conn: conn, provider: provider} do
+      program = insert(:program_schema, provider_id: provider.id, title: "Junior Soccer Academy")
 
       {:ok, view, _html} = live(conn, ~p"/provider/programs/#{program.id}/broadcast")
 
       assert has_element?(view, "p", "Junior Soccer Academy")
     end
 
-    test "shows warning about broadcast reach", %{conn: conn} do
-      program = insert(:program_schema)
+    test "shows warning about broadcast reach", %{conn: conn, provider: provider} do
+      program = insert(:program_schema, provider_id: provider.id)
 
       {:ok, view, _html} = live(conn, ~p"/provider/programs/#{program.id}/broadcast")
 
@@ -70,8 +80,8 @@ defmodule KlassHeroWeb.Provider.BroadcastLiveTest do
   describe "sending broadcast" do
     setup :register_and_log_in_provider
 
-    test "shows error when content is empty", %{conn: conn} do
-      program = insert(:program_schema)
+    test "shows error when content is empty", %{conn: conn, provider: provider} do
+      program = insert(:program_schema, provider_id: provider.id)
 
       {:ok, view, _html} = live(conn, ~p"/provider/programs/#{program.id}/broadcast")
 
@@ -82,8 +92,8 @@ defmodule KlassHeroWeb.Provider.BroadcastLiveTest do
       assert_flash(view, :error, "Message content is required")
     end
 
-    test "shows error when content is only whitespace", %{conn: conn} do
-      program = insert(:program_schema)
+    test "shows error when content is only whitespace", %{conn: conn, provider: provider} do
+      program = insert(:program_schema, provider_id: provider.id)
 
       {:ok, view, _html} = live(conn, ~p"/provider/programs/#{program.id}/broadcast")
 
@@ -94,8 +104,8 @@ defmodule KlassHeroWeb.Provider.BroadcastLiveTest do
       assert_flash(view, :error, "Message content is required")
     end
 
-    test "shows no_enrollments error when no parents enrolled", %{conn: conn} do
-      program = insert(:program_schema)
+    test "shows no_enrollments error when no parents enrolled", %{conn: conn, provider: provider} do
+      program = insert(:program_schema, provider_id: provider.id)
 
       {:ok, view, _html} = live(conn, ~p"/provider/programs/#{program.id}/broadcast")
 
@@ -110,11 +120,10 @@ defmodule KlassHeroWeb.Provider.BroadcastLiveTest do
       # Provider tiers removed (ADR-0004): every provider can broadcast
       user = AccountsFixtures.user_fixture(%{intended_roles: [:provider]})
 
-      _provider =
-        insert(:provider_profile_schema, identity_id: user.id)
+      provider = insert(:provider_profile_schema, identity_id: user.id)
 
       conn = log_in_user(conn, user)
-      program = insert(:program_schema)
+      program = insert(:program_schema, provider_id: provider.id)
       parent = insert(:parent_profile_schema)
 
       insert(:enrollment_schema,
@@ -128,8 +137,8 @@ defmodule KlassHeroWeb.Provider.BroadcastLiveTest do
       assert has_element?(view, "#broadcast-form")
     end
 
-    test "successfully sends broadcast to enrolled parents", %{conn: conn} do
-      program = insert(:program_schema)
+    test "successfully sends broadcast to enrolled parents", %{conn: conn, provider: provider} do
+      program = insert(:program_schema, provider_id: provider.id)
       parent_user = AccountsFixtures.user_fixture()
       parent = insert(:parent_profile_schema, identity_id: parent_user.id)
 
@@ -155,8 +164,8 @@ defmodule KlassHeroWeb.Provider.BroadcastLiveTest do
       assert flash["info"] =~ "Broadcast sent"
     end
 
-    test "sends broadcast without subject", %{conn: conn} do
-      program = insert(:program_schema)
+    test "sends broadcast without subject", %{conn: conn, provider: provider} do
+      program = insert(:program_schema, provider_id: provider.id)
       parent_user = AccountsFixtures.user_fixture()
       parent = insert(:parent_profile_schema, identity_id: parent_user.id)
 
@@ -187,8 +196,8 @@ defmodule KlassHeroWeb.Provider.BroadcastLiveTest do
 
     @png_bytes <<137, 80, 78, 71, 13, 10, 26, 10>>
 
-    test "renders the attachment uploader trigger", %{conn: conn} do
-      program = insert(:program_schema)
+    test "renders the attachment uploader trigger", %{conn: conn, provider: provider} do
+      program = insert(:program_schema, provider_id: provider.id)
 
       {:ok, view, _html} = live(conn, ~p"/provider/programs/#{program.id}/broadcast")
 
@@ -196,8 +205,11 @@ defmodule KlassHeroWeb.Provider.BroadcastLiveTest do
       assert has_element?(view, "input[type='file']")
     end
 
-    test "sends broadcast with photo attachment and navigates to conversation", %{conn: conn} do
-      program = insert(:program_schema)
+    test "sends broadcast with photo attachment and navigates to conversation", %{
+      conn: conn,
+      provider: provider
+    } do
+      program = insert(:program_schema, provider_id: provider.id)
       parent_user = AccountsFixtures.user_fixture()
       parent = insert(:parent_profile_schema, identity_id: parent_user.id)
 
@@ -232,8 +244,8 @@ defmodule KlassHeroWeb.Provider.BroadcastLiveTest do
   describe "cancel navigation" do
     setup :register_and_log_in_provider
 
-    test "cancel link navigates back to programs", %{conn: conn} do
-      program = insert(:program_schema)
+    test "cancel link navigates back to programs", %{conn: conn, provider: provider} do
+      program = insert(:program_schema, provider_id: provider.id)
 
       {:ok, view, _html} = live(conn, ~p"/provider/programs/#{program.id}/broadcast")
 
@@ -246,8 +258,8 @@ defmodule KlassHeroWeb.Provider.BroadcastLiveTest do
   describe "sidebar navigation" do
     setup :register_and_log_in_provider
 
-    test "highlights Comms in the sidebar", %{conn: conn} do
-      program = insert(:program_schema)
+    test "highlights Comms in the sidebar", %{conn: conn, provider: provider} do
+      program = insert(:program_schema, provider_id: provider.id)
 
       {:ok, view, _html} = live(conn, ~p"/provider/programs/#{program.id}/broadcast")
 

--- a/test/klass_hero_web/live/provider/participation_live_test.exs
+++ b/test/klass_hero_web/live/provider/participation_live_test.exs
@@ -11,8 +11,9 @@ defmodule KlassHeroWeb.Provider.ParticipationLiveTest do
 
   setup :register_and_log_in_provider
 
-  defp create_session_with_child(%{provider: _provider}) do
-    session = insert(:program_session_schema, status: "in_progress")
+  defp create_session_with_child(%{provider: provider}) do
+    program = insert(:program_schema, provider_id: provider.id)
+    session = insert(:program_session_schema, program_id: program.id, status: "in_progress")
     parent = insert(:parent_profile_schema)
 
     {child, _parent} =
@@ -34,6 +35,21 @@ defmodule KlassHeroWeb.Provider.ParticipationLiveTest do
       )
 
     %{session: session, parent: parent, child: child, record: record}
+  end
+
+  describe "cross-provider authorization" do
+    test "redirects when the session belongs to another provider (IDOR guard)", %{conn: conn} do
+      foreign_provider = insert(:provider_profile_schema)
+      foreign_program = insert(:program_schema, provider_id: foreign_provider.id)
+
+      foreign_session =
+        insert(:program_session_schema, program_id: foreign_program.id, status: "in_progress")
+
+      assert {:error, {:live_redirect, %{to: "/provider/sessions", flash: flash}}} =
+               live(conn, ~p"/provider/participation/#{foreign_session.id}")
+
+      assert flash["error"] =~ "not"
+    end
   end
 
   describe "roster displays child name" do


### PR DESCRIPTION
## Summary

A whole-layer security review of `lib/klass_hero_web/` (shipped `main`, not a diff) found **5 multi-tenant IDORs** — 3 HIGH, 2 MEDIUM. This PR closes all five.

**Root cause (all 5):** the context fn resolves the *actor* correctly from `@current_scope` but trusts a client-supplied *target id* (`program_id`, `child_id`, `session_id`, `staff_member_id`, `instructor_id`) with only a `foreign_key_constraint` — proving the row *exists*, not that the actor *owns* it. In every case a sibling path already implemented the correct guard; each fix reuses that pattern, adding no new infrastructure.

## Fixes

| # | Sev | Vuln | Guard added |
|---|-----|------|-------------|
| 1 | HIGH | Broadcast to another provider's enrolled parents | `broadcast_live` mount requires `program.provider_id == provider.id` (mirrors `StaffBroadcastLive`) |
| 2 | HIGH | Enroll another family's child (`child_id` from client) | `Enrollment.create_enrollment` rejects non-owned child via new `ChildInfoACL.child_belongs_to_parent?/2` |
| 3 | HIGH | Cross-tenant participation roster read **and** mutation | `participation_live` gates roster on the provider's own `program_ids` (mirrors `StaffParticipationLive`) |
| 4 | MED | Cross-tenant staff-invitation resend | `resend_staff_invitation/1 → /2(provider_id, …)`, `^provider_id` match (mirrors `update_staff_member/3`) |
| 5 | MED | Cross-tenant lead-instructor assignment (publicly visible on `/programs/:id`) | `set_lead_instructor/2 → /3(…, provider_id)` + `resolve_instructor` pre-write gate |

## Architecture

- Ownership guards live in the **context/entity layer** (the exploitable facade), invoked from the LiveView shell — not shell-only checks a future caller could bypass.
- Cross-context reads stay behind the **root facade / ACL** (Fix 2 reaches Family only through `ChildInfoACL`, wrapped in `acl_span`); Fixes 4 & 5 use same-context `get_staff_member` — **zero cross-context reach**.
- Every guard reuses the pinned-match convention (`%Struct{provider_id: ^provider_id}` / `{:ok, %Struct{}} -> {:error, :not_found}`), so **foreign ≡ missing** — no existence/status oracle.

## Testing

- TDD red→green at each site (genuine behavioral RED: the guard-less version let the cross-tenant action *succeed*).
- `mix precommit` fully green — **4178 passed**, credo / format / lint_typography / lint_translations clean.
- No new gettext strings (reused existing translated flash copy); `.pot`/`.po` refresh is reference-only.

## Follow-ups (not in this PR)

- Broadcast (Fix 1) facade+ACL defense-in-depth: a `messaging/adapters/driven/program_catalog/` ACL so `BroadcastToProgram.execute/4` self-guards. The facade is only reachable from the two broadcast LiveViews today, both now guarded — deferred to keep this PR's boundary footprint minimal.