### PR TITLE
fix: guard broadcasts against foreign programs and unauthorized provider_id

### DIFF
--- a/lib/klass_hero/messaging.ex
+++ b/lib/klass_hero/messaging.ex
@@ -201,6 +201,8 @@ defmodule KlassHero.Messaging do
 
   ## Returns
   - `{:ok, conversation, message, recipient_count}` - Broadcast sent
+  - `{:error, :not_found}` - Program missing, not owned by the acting provider,
+    or the scope isn't authorised to act as that provider
   - `{:error, :not_entitled}` - Provider cannot send broadcasts
   - `{:error, :no_enrollments}` - No enrolled parents
 
@@ -212,7 +214,7 @@ defmodule KlassHero.Messaging do
   """
   @spec broadcast_to_program(Scope.t(), String.t(), String.t(), keyword()) ::
           {:ok, Conversation.t(), Message.t(), non_neg_integer()}
-          | {:error, :not_entitled | :no_enrollments | term()}
+          | {:error, :not_found | :not_entitled | :no_enrollments | term()}
   defdelegate broadcast_to_program(scope, program_id, content, opts \\ []),
     to: BroadcastToProgram,
     as: :execute

--- a/lib/klass_hero/messaging/broadcast_to_program.ex
+++ b/lib/klass_hero/messaging/broadcast_to_program.ex
@@ -82,6 +82,10 @@ defmodule KlassHero.Messaging.BroadcastToProgram do
     # facade safe on its own.
     with {:ok, provider_id} <- Shared.resolve_acting_provider(scope, opts),
          {:ok, _program} <- ProgramCatalog.get_program_for_provider(provider_id, program_id),
+         # Vestigial today: ADR-0004 removed provider tiers, so this can only
+         # reject a staff-shaped scope that omits skip_entitlement_check — a
+         # shape no caller produces. Kept as the seam for the planned
+         # success-fee model, not as active defence.
          :ok <- Shared.maybe_check_entitlement(scope, opts, provider_id: provider_id),
          {:ok, parent_user_ids} <- get_enrolled_parent_user_ids(program_id),
          :ok <- verify_has_recipients(parent_user_ids),

--- a/lib/klass_hero/messaging/broadcast_to_program.ex
+++ b/lib/klass_hero/messaging/broadcast_to_program.ex
@@ -19,6 +19,7 @@ defmodule KlassHero.Messaging.BroadcastToProgram do
   alias KlassHero.Messaging.Message
   alias KlassHero.Messaging.SendMessage
   alias KlassHero.Messaging.Shared
+  alias KlassHero.ProgramCatalog
   alias KlassHero.Repo
   alias KlassHero.Shared.EventDispatchHelper
 
@@ -37,13 +38,17 @@ defmodule KlassHero.Messaging.BroadcastToProgram do
     - subject: Subject line for the broadcast
     - attachments: List of `%{binary, filename, content_type, size}` maps,
       forwarded verbatim to `SendMessage`
-    - provider_id: Explicit provider ID (defaults to scope.provider.id).
-      Required when scope.provider is nil (e.g. staff member scopes).
+    - provider_id: Acting provider ID (defaults to scope.provider.id). Required
+      when scope.provider is nil (e.g. staff member scopes). Authorised against
+      the scope — a provider the scope neither owns nor staffs is rejected.
     - skip_entitlement_check: When true, skips the entitlement check.
       Caller is responsible for verifying entitlements before calling.
 
   ## Returns
   - `{:ok, conversation, message, recipient_count}` - Broadcast sent
+  - `{:error, :not_found}` - The program doesn't exist, doesn't belong to the
+    acting provider, or the scope isn't authorised to act as that provider
+    (all three collapse to one atom so ids can't be probed)
   - `{:error, :not_entitled}` - Provider cannot send broadcasts
   - `{:error, :no_enrollments}` - No enrolled parents to broadcast to
   - `{:error, :missing_provider_id}` - Could not resolve a provider_id
@@ -52,7 +57,8 @@ defmodule KlassHero.Messaging.BroadcastToProgram do
   @spec execute(Scope.t(), String.t(), String.t(), keyword()) ::
           {:ok, Conversation.t(), Message.t(), non_neg_integer()}
           | {:error,
-             :not_entitled
+             :not_found
+             | :not_entitled
              | :no_enrollments
              | :missing_provider_id
              | :empty_message
@@ -64,28 +70,19 @@ defmodule KlassHero.Messaging.BroadcastToProgram do
              | :broadcast_reply_not_allowed
              | term()}
   def execute(%Scope{} = scope, program_id, content, opts \\ []) do
-    provider_id = Keyword.get(opts, :provider_id) || (scope.provider && scope.provider.id)
-
-    if is_nil(provider_id) do
-      Logger.error("BroadcastToProgram called without provider_id",
-        user_id: scope.user.id,
-        program_id: program_id
-      )
-
-      {:error, :missing_provider_id}
-    else
-      execute_broadcast(scope, program_id, content, provider_id, opts)
-    end
-  end
-
-  defp execute_broadcast(scope, program_id, content, provider_id, opts) do
     subject = Keyword.get(opts, :subject)
     attachments = Keyword.get(opts, :attachments, [])
     # normalize_content: attachment-only broadcasts submit "" which must become nil
     # to match direct-message behaviour (SendMessage.trim_content/1 preserves "").
     normalized_content = normalize_content(content, attachments)
 
-    with :ok <- Shared.maybe_check_entitlement(scope, opts, provider_id: provider_id),
+    # Authorise before touching anything: the acting provider must be bound to
+    # the scope, and the program must belong to that provider. Both guards are
+    # defence-in-depth — callers are expected to check too — but they keep the
+    # facade safe on its own.
+    with {:ok, provider_id} <- Shared.resolve_acting_provider(scope, opts),
+         {:ok, _program} <- ProgramCatalog.get_program_for_provider(provider_id, program_id),
+         :ok <- Shared.maybe_check_entitlement(scope, opts, provider_id: provider_id),
          {:ok, parent_user_ids} <- get_enrolled_parent_user_ids(program_id),
          :ok <- verify_has_recipients(parent_user_ids),
          {:ok, conversation} <- get_or_create_broadcast_conversation(provider_id, program_id, subject),

--- a/lib/klass_hero/messaging/shared.ex
+++ b/lib/klass_hero/messaging/shared.ex
@@ -8,8 +8,51 @@ defmodule KlassHero.Messaging.Shared do
   """
 
   alias KlassHero.Accounts.Scope
+  alias KlassHero.Messaging.Adapters.Driven.Provider.ProviderStaffResolver
 
   require Logger
+
+  @doc """
+  Resolves the provider the scope is acting as, and authorises it.
+
+  The `:provider_id` option is a *hint*, not an override: staff scopes carry no
+  `scope.provider`, so the acting provider has to come from the caller — but it
+  is only accepted once it is bound back to the scope, either as the provider's
+  own profile or as an active staff membership.
+
+  Returns `{:error, :not_found}` (not `:unauthorized`) for an unauthorised
+  provider so an attacker can't distinguish "not yours" from "doesn't exist".
+  """
+  @spec resolve_acting_provider(Scope.t(), keyword()) ::
+          {:ok, String.t()} | {:error, :missing_provider_id | :not_found}
+  def resolve_acting_provider(%Scope{} = scope, opts) do
+    case Keyword.get(opts, :provider_id) || (scope.provider && scope.provider.id) do
+      nil ->
+        Logger.error("Messaging command called without a resolvable provider_id",
+          user_id: scope.user.id
+        )
+
+        {:error, :missing_provider_id}
+
+      provider_id ->
+        authorize_acting_provider(scope, provider_id)
+    end
+  end
+
+  defp authorize_acting_provider(%Scope{provider: %{id: provider_id}}, provider_id), do: {:ok, provider_id}
+
+  defp authorize_acting_provider(%Scope{} = scope, provider_id) do
+    if ProviderStaffResolver.active_staff_for_provider?(provider_id, scope.user.id) do
+      {:ok, provider_id}
+    else
+      Logger.warning("Scope not authorised to act as provider",
+        user_id: scope.user.id,
+        provider_id: provider_id
+      )
+
+      {:error, :not_found}
+    end
+  end
 
   @doc """
   Verifies that a user is a participant in a conversation.

--- a/lib/klass_hero/messaging/shared.ex
+++ b/lib/klass_hero/messaging/shared.ex
@@ -26,22 +26,26 @@ defmodule KlassHero.Messaging.Shared do
   @spec resolve_acting_provider(Scope.t(), keyword()) ::
           {:ok, String.t()} | {:error, :missing_provider_id | :not_found}
   def resolve_acting_provider(%Scope{} = scope, opts) do
-    case Keyword.get(opts, :provider_id) || (scope.provider && scope.provider.id) do
-      nil ->
-        Logger.error("Messaging command called without a resolvable provider_id",
-          user_id: scope.user.id
-        )
+    provider_id = Keyword.get(opts, :provider_id) || (scope.provider && scope.provider.id)
 
-        {:error, :missing_provider_id}
-
-      provider_id ->
-        authorize_acting_provider(scope, provider_id)
-    end
+    authorize_acting_provider(provider_id, scope)
   end
 
-  defp authorize_acting_provider(%Scope{provider: %{id: provider_id}}, provider_id), do: {:ok, provider_id}
+  defp authorize_acting_provider(nil, %Scope{} = scope) do
+    Logger.error("Messaging command called without a resolvable provider_id",
+      user_id: scope.user.id
+    )
 
-  defp authorize_acting_provider(%Scope{} = scope, provider_id) do
+    {:error, :missing_provider_id}
+  end
+
+  defp authorize_acting_provider(provider_id, %Scope{provider: %{id: provider_id}}), do: {:ok, provider_id}
+
+  # Staff scopes are re-checked against the DB rather than `scope.staff_member`:
+  # that field is a mount-time snapshot loaded via get_active_staff_member_by_user/1,
+  # which is `limit: 1` and not provider-scoped, so it would authorize a
+  # multi-employer staffer against the wrong provider.
+  defp authorize_acting_provider(provider_id, %Scope{} = scope) do
     if ProviderStaffResolver.active_staff_for_provider?(provider_id, scope.user.id) do
       {:ok, provider_id}
     else

--- a/lib/klass_hero/program_catalog.ex
+++ b/lib/klass_hero/program_catalog.ex
@@ -90,20 +90,13 @@ defmodule KlassHero.ProgramCatalog do
           {:ok, Program.t()} | {:error, :not_found | :stale_data | Ecto.Changeset.t()}
   def update_program(provider_id, id, changes) when is_binary(provider_id) and is_binary(id) and is_map(changes) do
     context_span entity: "program" do
-      # Ownership guard (IDOR): a program owned by another provider is
-      # indistinguishable from a missing one — both return :not_found so an
-      # attacker can't probe for existence by enumerating ids.
-      case fetch_program(id) do
-        %Program{provider_id: ^provider_id} = current ->
-          do_update_program(current, changes, Program.load_value_objects(current))
-
-        _nil_or_foreign ->
-          {:error, :not_found}
+      with {:ok, current} <- get_program_for_provider(provider_id, id) do
+        do_update_program(current, changes)
       end
     end
   end
 
-  defp do_update_program(current, attrs, original) do
+  defp do_update_program(current, attrs) do
     current
     |> Program.update_changeset(attrs)
     |> Repo.update()
@@ -111,7 +104,7 @@ defmodule KlassHero.ProgramCatalog do
       {:ok, schema} ->
         updated = Program.load_value_objects(schema)
         dispatch_program_updated(updated)
-        maybe_dispatch_schedule_updated(original, updated)
+        maybe_dispatch_schedule_updated(current, updated)
         {:ok, updated}
 
       {:error, changeset} ->
@@ -142,9 +135,10 @@ defmodule KlassHero.ProgramCatalog do
   @doc """
   Gets a program by ID, scoped to its owning provider.
 
-  Same IDOR idiom as `update_program/3`: a program owned by another provider is
+  Ownership guard (IDOR): a program owned by another provider is
   indistinguishable from a missing one — both return `{:error, :not_found}`, so
-  callers can't probe for existence by enumerating ids.
+  callers can't probe for existence by enumerating ids. `update_program/3`
+  routes through this, so every scoped access shares one definition of "yours".
   """
   @spec get_program_for_provider(String.t(), String.t()) :: {:ok, Program.t()} | {:error, :not_found}
   def get_program_for_provider(provider_id, program_id) when is_binary(provider_id) do

--- a/lib/klass_hero/program_catalog.ex
+++ b/lib/klass_hero/program_catalog.ex
@@ -139,6 +139,21 @@ defmodule KlassHero.ProgramCatalog do
     end
   end
 
+  @doc """
+  Gets a program by ID, scoped to its owning provider.
+
+  Same IDOR idiom as `update_program/3`: a program owned by another provider is
+  indistinguishable from a missing one — both return `{:error, :not_found}`, so
+  callers can't probe for existence by enumerating ids.
+  """
+  @spec get_program_for_provider(String.t(), String.t()) :: {:ok, Program.t()} | {:error, :not_found}
+  def get_program_for_provider(provider_id, program_id) when is_binary(provider_id) do
+    case fetch_program(program_id) do
+      %Program{provider_id: ^provider_id} = program -> {:ok, Program.load_value_objects(program)}
+      _nil_or_foreign -> {:error, :not_found}
+    end
+  end
+
   @doc "Fetches multiple programs by ID in one query. Missing IDs are silently omitted."
   @spec get_programs_by_ids([String.t()]) :: [Program.t()]
   def get_programs_by_ids(ids) when is_list(ids) do

--- a/test/klass_hero/messaging/broadcast_to_program_test.exs
+++ b/test/klass_hero/messaging/broadcast_to_program_test.exs
@@ -362,11 +362,8 @@ defmodule KlassHero.Messaging.BroadcastToProgramTest do
   end
 
   describe "authorization" do
-    test "rejects every unclaimable target with :not_found and fans nothing out", %{scope: scope} do
-      foreign_provider = insert(:provider_profile_schema)
-      foreign_program = insert(:program_schema, provider_id: foreign_provider.id)
-      # Enrol a parent so a rejection here can't be mistaken for :no_enrollments.
-      enroll_parent(foreign_program)
+    test "rejects every unclaimable target with :not_found", %{scope: scope} do
+      %{provider: foreign_provider, program: foreign_program} = insert_foreign_program()
 
       cases = [
         {"another provider's program", foreign_program.id, []},
@@ -380,12 +377,21 @@ defmodule KlassHero.Messaging.BroadcastToProgramTest do
         assert {:error, :not_found} = BroadcastToProgram.execute(scope, program_id, "Leak?", opts),
                "expected :not_found for #{label}"
       end
+    end
+
+    # Separate from the table above on purpose: `assert` inside a `for` raises on
+    # the first failure, so trailing invariants would go unchecked whenever an
+    # earlier case regressed — exactly when they matter most.
+    test "rejected broadcasts leave no trace", %{scope: scope} do
+      %{provider: foreign_provider, program: foreign_program} = insert_foreign_program()
+
+      assert {:error, :not_found} = BroadcastToProgram.execute(scope, foreign_program.id, "Leak?")
 
       assert {:error, :not_found} =
                KlassHero.Messaging.find_active_broadcast_for_program(foreign_provider.id, foreign_program.id)
 
       assert Repo.aggregate(Message, :count) == 0,
-             "no message may be persisted for any rejected broadcast"
+             "no message may be persisted for a rejected broadcast"
     end
 
     test "allows active staff to broadcast for their provider", %{provider: provider, program: program} do
@@ -405,6 +411,16 @@ defmodule KlassHero.Messaging.BroadcastToProgramTest do
       assert {:error, :missing_provider_id} =
                BroadcastToProgram.execute(scope, Ecto.UUID.generate(), "Hi")
     end
+  end
+
+  # A program owned by somebody else, with a parent enrolled so that a rejection
+  # can't be mistaken for :no_enrollments.
+  defp insert_foreign_program do
+    provider = insert(:provider_profile_schema)
+    program = insert(:program_schema, provider_id: provider.id)
+    enroll_parent(program)
+
+    %{provider: provider, program: program}
   end
 
   # Enrolls a fresh parent (backed by a real user for the FK) into the program.

--- a/test/klass_hero/messaging/broadcast_to_program_test.exs
+++ b/test/klass_hero/messaging/broadcast_to_program_test.exs
@@ -361,6 +361,52 @@ defmodule KlassHero.Messaging.BroadcastToProgramTest do
     end
   end
 
+  describe "authorization" do
+    test "rejects every unclaimable target with :not_found and fans nothing out", %{scope: scope} do
+      foreign_provider = insert(:provider_profile_schema)
+      foreign_program = insert(:program_schema, provider_id: foreign_provider.id)
+      # Enrol a parent so a rejection here can't be mistaken for :no_enrollments.
+      enroll_parent(foreign_program)
+
+      cases = [
+        {"another provider's program", foreign_program.id, []},
+        {"an unknown program id", Ecto.UUID.generate(), []},
+        {"a malformed program id", "not-a-uuid", []},
+        {"a provider_id the scope neither owns nor staffs", foreign_program.id,
+         [provider_id: foreign_provider.id, skip_entitlement_check: true]}
+      ]
+
+      for {label, program_id, opts} <- cases do
+        assert {:error, :not_found} = BroadcastToProgram.execute(scope, program_id, "Leak?", opts),
+               "expected :not_found for #{label}"
+      end
+
+      assert {:error, :not_found} =
+               KlassHero.Messaging.find_active_broadcast_for_program(foreign_provider.id, foreign_program.id)
+
+      assert Repo.aggregate(Message, :count) == 0,
+             "no message may be persisted for any rejected broadcast"
+    end
+
+    test "allows active staff to broadcast for their provider", %{provider: provider, program: program} do
+      staff_scope = build_staff_scope(provider)
+      enroll_parent(program)
+
+      assert {:ok, _conversation, _message, 1} =
+               BroadcastToProgram.execute(staff_scope, program.id, "From staff",
+                 provider_id: provider.id,
+                 skip_entitlement_check: true
+               )
+    end
+
+    test "returns missing_provider_id when neither scope nor opts resolve a provider" do
+      scope = %Scope{user: AccountsFixtures.user_fixture(), roles: [], provider: nil, parent: nil}
+
+      assert {:error, :missing_provider_id} =
+               BroadcastToProgram.execute(scope, Ecto.UUID.generate(), "Hi")
+    end
+  end
+
   # Enrolls a fresh parent (backed by a real user for the FK) into the program.
   # Returns the created %{user, parent}.
   defp enroll_parent(program, opts \\ []) do
@@ -396,6 +442,21 @@ defmodule KlassHero.Messaging.BroadcastToProgramTest do
       roles: [:provider],
       provider: provider_profile,
       parent: nil
+    }
+  end
+
+  # A staff scope has no `provider` — the acting provider is carried in opts and
+  # must be authorised against an active staff row (as StaffBroadcastLive does).
+  defp build_staff_scope(provider_schema) do
+    user = AccountsFixtures.user_fixture()
+    staff = insert(:staff_member_schema, provider_id: provider_schema.id, user_id: user.id, active: true)
+
+    %Scope{
+      user: user,
+      roles: [:staff],
+      provider: nil,
+      parent: nil,
+      staff_member: staff
     }
   end
 end

--- a/test/klass_hero/messaging/messaging_integration_test.exs
+++ b/test/klass_hero/messaging/messaging_integration_test.exs
@@ -130,7 +130,7 @@ defmodule KlassHero.Messaging.MessagingIntegrationTest do
   describe "complete broadcast flow" do
     test "provider broadcasts to all enrolled parents" do
       provider = insert(:provider_profile_schema)
-      program = insert(:program_schema)
+      program = insert(:program_schema, provider_id: provider.id)
       provider_scope = build_scope_with_provider(provider)
 
       # Create parents with real users to satisfy FK constraint

--- a/test/klass_hero/program_catalog/adapters/driven/projections/verified_providers_test.exs
+++ b/test/klass_hero/program_catalog/adapters/driven/projections/verified_providers_test.exs
@@ -4,7 +4,6 @@ defmodule KlassHero.ProgramCatalog.Adapters.Driven.Projections.VerifiedProviders
   alias KlassHero.AccountsFixtures
   alias KlassHero.ProgramCatalog.Adapters.Driven.Projections.VerifiedProviders
   alias KlassHero.Provider
-  alias KlassHero.Provider.ProviderProfile
   alias KlassHero.Shared.Domain.Events.IntegrationEvent
 
   # Use a unique name for each test to avoid conflicts with the supervision tree

--- a/test/klass_hero/program_catalog/get_program_for_provider_test.exs
+++ b/test/klass_hero/program_catalog/get_program_for_provider_test.exs
@@ -1,0 +1,35 @@
+defmodule KlassHero.ProgramCatalog.GetProgramForProviderTest do
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+
+  alias KlassHero.ProgramCatalog
+
+  describe "get_program_for_provider/2" do
+    test "returns the program when the provider owns it" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+
+      assert {:ok, found} = ProgramCatalog.get_program_for_provider(provider.id, program.id)
+      assert found.id == program.id
+    end
+
+    # Foreign, unknown and malformed all collapse to the same atom — that
+    # indistinguishability is the point, so they belong in one table.
+    test "returns :not_found for any id the provider can't claim" do
+      provider = insert(:provider_profile_schema)
+      foreign_program = insert(:program_schema, provider_id: insert(:provider_profile_schema).id)
+
+      cases = [
+        {"another provider's program", foreign_program.id},
+        {"an unknown program id", Ecto.UUID.generate()},
+        {"a malformed program id", "not-a-uuid"}
+      ]
+
+      for {label, program_id} <- cases do
+        assert {:error, :not_found} = ProgramCatalog.get_program_for_provider(provider.id, program_id),
+               "expected :not_found for #{label}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #1132.

## Summary

`BroadcastToProgram.execute/4` trusted **two** caller-supplied inputs, not one:

1. `program_id` — never checked against the acting provider (what the issue names).
2. `opts[:provider_id]` — a caller-supplied **override** of `scope.provider.id`, never bound back to the scope. The entitlement check runs on `scope`, not on that id, and the staff path passes `skip_entitlement_check: true`.

Guarding only (1) would leave a caller that supplies both an attacker-controlled `provider_id` and its matching `program_id` able to broadcast cross-tenant — so the issue's stated goal ("the next caller can't reintroduce the hole") would not have been met. Both are closed here.

**No live vulnerability**: both current callers were guarded at mount by #1131 and pass `socket.assigns.program.id`. This is defense-in-depth at the facade.

## Changes

- **`ProgramCatalog.get_program_for_provider/2`** — scoped read reusing the private `fetch_program/1` (UUID-validating) and the ownership idiom from `update_program/3`. Foreign ≡ missing → both `{:error, :not_found}`, so ids can't be probed by enumeration.
- **`Messaging.Shared.resolve_acting_provider/2`** — treats `:provider_id` as a *hint*, not an override: accepted only when it is the scope's own provider, or an active staff membership (via the existing `ProviderStaffResolver` ACL). Staff scopes carry no `scope.provider`, so the option can't simply be deleted.
- **`BroadcastToProgram.execute/4`** — both guards lead the `with` chain; `execute_broadcast/5` folded in, and the `if is_nil(provider_id)` branch became an error clause in the new helper.
- Specs/docs updated on the use case and the `Messaging.broadcast_to_program/4` delegate.

Deliberately **no new ACL**: `boundary-checker` lists a root-facade call and an ACL as two valid options, and Messaging already calls `ProgramCatalog` directly in two places (`conversation_summaries.ex:668`, `conversation_queries.ex:175`). A third ACL beside two direct calls would add ceremony without gain.

## Review focus

- **Ordering**: authorization now runs *before* the entitlement check. Safe — ADR-0004 removed provider tiers, so nothing asserts `:not_entitled` on this path.
- **Side effect fixed for free**: running the guards ahead of the enrollment lookup stops a malformed `program_id` from reaching Enrollment's query, which previously raised `Ecto.Query.CastError` (500) instead of returning an error.
- **One existing test changed**: `messaging_integration_test.exs` built its program with `insert(:program_schema)` and no `provider_id`, so the happy-path assertion was silently exercising a cross-tenant broadcast. Fixture now binds the program to the broadcasting provider.
- No web-layer changes; both LiveViews already have a generic `{:error, _}` flash branch and keep their mount-time guards.

## Test plan

- TDD: red first — the foreign-program case returned `{:ok, conversation, message, 1}` (IDOR reproduced at the facade), the malformed id crashed with `Ecto.Query.CastError`, the foreign `provider_id` was caught only incidentally by `SendMessage` as `:broadcast_reply_not_allowed`.
- New `test/klass_hero/program_catalog/get_program_for_provider_test.exs` — owned → `{:ok, program}`; foreign / unknown / malformed folded into one tabular test asserting the shared `:not_found`.
- New `authorization` block in `broadcast_to_program_test.exs` — all four unclaimable targets folded into one table, plus assertions that **no conversation and no message** were persisted for any of them; active staff may still broadcast for their provider; `:missing_provider_id` pinned (previously untested).
- `mix precommit` green: 4185 passed, 29 properties, 2 skipped.