### PR TITLE
fix: make provider ownership a query scope, not a caller convention

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -43,10 +43,11 @@
       #
       requires: [],
       #
-      # If you want to enforce a style guide and need a more traditional linting
-      # experience, you can change `strict` to `true` below:
+      # Strict by default so a bare `mix credo` gives the same verdict as CI and
+      # `mix precommit`, which both run `--strict`. A weaker default here is how
+      # local runs silently drift from the gate.
       #
-      strict: false,
+      strict: true,
       #
       # To modify the timeout for parsing files, change this value:
       #
@@ -72,8 +73,9 @@
           {Credo.Check.Consistency.ExceptionNames, []},
           {Credo.Check.Consistency.LineEndings, []},
           {Credo.Check.Consistency.ParameterPatternMatching, []},
-          # TODO: Re-enable when Credo supports Elixir 1.20 sigil token format
-          # Crashes on ~D[] and ~w() sigils with FunctionClauseError in Token.position/1
+          # Disabled upstream-bug workaround: crashes on ~D[] and ~w() sigils with
+          # FunctionClauseError in Token.position/1. Re-enable once Credo supports
+          # the Elixir 1.20 sigil token format.
           {Credo.Check.Consistency.SpaceAroundOperators, false},
           {Credo.Check.Consistency.SpaceInParentheses, []},
           {Credo.Check.Consistency.TabsOrSpaces, []},

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
         run: mix format --check-formatted
 
       - name: Credo
-        run: mix credo --min-priority=high
+        run: mix credo --strict
 
       - name: Typography lint
         run: mix lint_typography

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,8 +24,8 @@ mix test --failed            # Re-run failed tests
 mix test.e2e                 # Run end-to-end tests (Wallaby)
 
 # Quality
-mix precommit                # Full pre-commit: compile --warnings-as-errors, deps.unlock --unused, format, lint_typography, test
-mix credo --strict           # Elixir linting (runs in CI)
+mix precommit                # Full pre-commit: compile --warnings-as-errors, deps.unlock --unused, format, lint_typography, lint_translations, credo --strict, test --include slow
+mix credo --strict           # Elixir linting (runs in CI; .credo.exs sets strict: true, so bare `mix credo` is equivalent)
 mix lint_typography          # Check font/typography usage in templates
 
 # Database
@@ -175,7 +175,7 @@ These checks run automatically on every PR — don't manually recheck what CI ca
 |---|---|
 | `mix compile --warnings-as-errors` | Unused vars/imports, deprecations |
 | `mix format --check-formatted` | Formatting issues |
-| `mix credo --min-priority=high` | Style violations, code smells |
+| `mix credo --strict` | Style violations, code smells, long lines, TODO tags |
 | `mix lint_typography` | Font/typography usage violations |
 | `mix test` | Functional regressions (full suite with PostgreSQL) |
 | Sobelow | Common Phoenix security vulnerabilities |

--- a/lib/klass_hero/accounts.ex
+++ b/lib/klass_hero/accounts.ex
@@ -157,11 +157,11 @@ defmodule KlassHero.Accounts do
   def remove_staff_member(provider_id, staff_id) when is_binary(provider_id) and is_binary(staff_id) do
     context_span entity: "user" do
       Repo.transaction(fn ->
-        # Ownership guard (IDOR): a staff row owned by another provider is
-        # indistinguishable from a missing one — both roll back :not_found so an
-        # attacker can't probe existence, and no foreign row/role is touched.
+        # The fetch supplies the struct the caller gets back and the role teardown
+        # needs; the delete is independently provider-scoped, so neither step can
+        # reach a foreign row.
         with {:ok, staff} <- Provider.get_staff_member(staff_id, provider_id),
-             :ok <- Provider.delete_staff_member(staff_id),
+             :ok <- Provider.delete_staff_member(staff_id, provider_id),
              :ok <- maybe_revoke_staff_role(staff) do
           staff
         else

--- a/lib/klass_hero/accounts.ex
+++ b/lib/klass_hero/accounts.ex
@@ -160,13 +160,11 @@ defmodule KlassHero.Accounts do
         # Ownership guard (IDOR): a staff row owned by another provider is
         # indistinguishable from a missing one — both roll back :not_found so an
         # attacker can't probe existence, and no foreign row/role is touched.
-        with {:ok, %StaffMember{provider_id: ^provider_id} = staff} <-
-               Provider.get_staff_member(staff_id),
+        with {:ok, staff} <- Provider.get_staff_member(staff_id, provider_id),
              :ok <- Provider.delete_staff_member(staff_id),
              :ok <- maybe_revoke_staff_role(staff) do
           staff
         else
-          {:ok, %StaffMember{}} -> Repo.rollback(:not_found)
           {:error, reason} -> Repo.rollback(reason)
         end
       end)

--- a/lib/klass_hero/program_catalog.ex
+++ b/lib/klass_hero/program_catalog.ex
@@ -123,7 +123,13 @@ defmodule KlassHero.ProgramCatalog do
 
   ## Write-model reads
 
-  @doc "Gets a program by ID. Returns `{:error, :not_found}` if absent or the ID is not a valid UUID."
+  @doc """
+  Gets a program by ID, **unscoped**. Returns `{:error, :not_found}` if absent or
+  the ID is not a valid UUID.
+
+  Only for paths with no provider in scope (public program pages, cross-context
+  reads). Any path that has a `provider_id` must use `get_program_for_provider/2`.
+  """
   @spec get_program_by_id(String.t()) :: {:ok, Program.t()} | {:error, :not_found}
   def get_program_by_id(id) do
     case fetch_program(id) do
@@ -135,16 +141,21 @@ defmodule KlassHero.ProgramCatalog do
   @doc """
   Gets a program by ID, scoped to its owning provider.
 
-  Ownership guard (IDOR): a program owned by another provider is
-  indistinguishable from a missing one — both return `{:error, :not_found}`, so
-  callers can't probe for existence by enumerating ids. `update_program/3`
-  routes through this, so every scoped access shares one definition of "yours".
+  A foreign program is *unreachable* rather than fetched-then-rejected:
+  `Program.owned_by/2` narrows the query, so foreign, missing and malformed ids
+  all arrive as `nil` and collapse to `{:error, :not_found}` — callers can't probe
+  for existence by enumerating ids, and there is no ownership check left to forget.
+
+  Every provider-initiated program read routes through this, so they share one
+  definition of "yours".
   """
   @spec get_program_for_provider(String.t(), String.t()) :: {:ok, Program.t()} | {:error, :not_found}
   def get_program_for_provider(provider_id, program_id) when is_binary(provider_id) do
-    case fetch_program(program_id) do
-      %Program{provider_id: ^provider_id} = program -> {:ok, Program.load_value_objects(program)}
-      _nil_or_foreign -> {:error, :not_found}
+    program_id
+    |> fetch_program(Program.owned_by(provider_id))
+    |> case do
+      nil -> {:error, :not_found}
+      program -> {:ok, Program.load_value_objects(program)}
     end
   end
 
@@ -307,15 +318,17 @@ defmodule KlassHero.ProgramCatalog do
 
   ## Internals
 
-  defp fetch_program(id) when is_binary(id) do
+  defp fetch_program(id), do: fetch_program(id, Program)
+
+  defp fetch_program(id, queryable) when is_binary(id) do
     # dump/1 validates UUID format; cast/1 wrongly accepts any 16-byte binary.
     case Ecto.UUID.dump(id) do
-      {:ok, _binary} -> Repo.get(Program, id)
+      {:ok, _binary} -> Repo.get(queryable, id)
       :error -> nil
     end
   end
 
-  defp fetch_program(_), do: nil
+  defp fetch_program(_, _queryable), do: nil
 
   defp listing_page(limit, cursor_data, category) do
     ProgramListing

--- a/lib/klass_hero/program_catalog/program.ex
+++ b/lib/klass_hero/program_catalog/program.ex
@@ -16,6 +16,7 @@ defmodule KlassHero.ProgramCatalog.Program do
   use Ecto.Schema
 
   import Ecto.Changeset
+  import Ecto.Query, only: [from: 2]
 
   alias KlassHero.ProgramCatalog.Domain.Services.ProgramCategories
   alias KlassHero.ProgramCatalog.RegistrationPeriod
@@ -158,6 +159,17 @@ defmodule KlassHero.ProgramCatalog.Program do
     |> validate_date_range()
     |> validate_registration_date_range()
     |> optimistic_lock(:lock_version)
+  end
+
+  @doc """
+  Narrows a query to programs owned by `provider_id`.
+
+  Composing this scope makes a foreign row *unreachable* rather than fetched and
+  then rejected, so a caller's `nil` branch already collapses foreign to missing.
+  """
+  @spec owned_by(Ecto.Queryable.t(), String.t()) :: Ecto.Query.t()
+  def owned_by(query \\ __MODULE__, provider_id) when is_binary(provider_id) do
+    from p in query, where: p.provider_id == ^provider_id
   end
 
   @doc """

--- a/lib/klass_hero/provider.ex
+++ b/lib/klass_hero/provider.ex
@@ -198,8 +198,8 @@ defmodule KlassHero.Provider do
   @doc "Updates an existing staff member."
   defdelegate update_staff_member(provider_id, staff_id, attrs), to: Staff
 
-  @doc "Deletes a staff member by ID."
-  defdelegate delete_staff_member(staff_id), to: Staff
+  @doc "Deletes a staff member owned by `provider_id`; foreign ≡ missing."
+  defdelegate delete_staff_member(staff_id, provider_id), to: Staff
 
   @doc "Resends a staff invitation for a `:failed`/`:expired` member owned by `provider_id`."
   defdelegate resend_staff_invitation(provider_id, staff_member_id), to: Staff
@@ -294,7 +294,15 @@ defmodule KlassHero.Provider do
   @doc "Lists per-session detail rows for a provider's program from the projection."
   defdelegate list_program_sessions(provider_id, program_id), to: Programs
 
-  @doc "Returns the provider-owned program by ID from the `provider_programs` projection."
+  @doc """
+  Returns a projected program owned by `provider_id`; foreign ≡ missing (IDOR guard).
+
+  The default getter for provider-initiated paths — prefer it over the unscoped
+  `get_provider_program/1`.
+  """
+  defdelegate get_provider_program(program_id, provider_id), to: Programs
+
+  @doc "Returns a program by ID from the `provider_programs` projection, unscoped."
   defdelegate get_provider_program(program_id), to: Programs
 
   @doc "Lists all programs owned by the given provider, ordered by name asc."

--- a/lib/klass_hero/provider.ex
+++ b/lib/klass_hero/provider.ex
@@ -210,7 +210,15 @@ defmodule KlassHero.Provider do
   @doc "Links a user to a staff member and accepts the invitation (synchronous, #967)."
   defdelegate accept_staff_invitation(staff_member, user_id), to: Staff
 
-  @doc "Retrieves a single staff member by ID."
+  @doc """
+  Retrieves a staff member owned by `provider_id`; foreign ≡ missing (IDOR guard).
+
+  The default getter for provider-initiated paths — prefer it over the unscoped
+  `get_staff_member/1`.
+  """
+  defdelegate get_staff_member(staff_id, provider_id), to: Staff
+
+  @doc "Retrieves a single staff member by ID, unscoped (no provider in scope)."
   defdelegate get_staff_member(staff_id), to: Staff
 
   @doc "Lists all staff members for a provider, ordered by insertion date."
@@ -248,8 +256,8 @@ defmodule KlassHero.Provider do
   @doc "Assigns a staff member to a program."
   defdelegate assign_staff_to_program(attrs), to: Assignments
 
-  @doc "Unassigns a staff member from a program."
-  defdelegate unassign_staff_from_program(program_id, staff_member_id), to: Assignments
+  @doc "Unassigns a staff member from a program owned by the provider."
+  defdelegate unassign_staff_from_program(program_id, staff_member_id, provider_id), to: Assignments
 
   @doc "Filters a list of programs to only those assigned to a staff member."
   defdelegate list_assigned_programs(staff_member, programs), to: Assignments
@@ -270,7 +278,7 @@ defmodule KlassHero.Provider do
   defdelegate set_lead_instructor(program_id, staff_member_id, provider_id), to: Assignments
 
   @doc "Clears the program's lead instructor, leaving the assignment active."
-  defdelegate clear_lead_instructor(program_id), to: Assignments
+  defdelegate clear_lead_instructor(program_id, provider_id), to: Assignments
 
   @doc "Returns the program's lead instructor as a `%{id, name, headshot_url}` map, or nil."
   defdelegate get_lead_instructor(program_id), to: Assignments

--- a/lib/klass_hero/provider/adapters/driven/persistence/repositories/provider_program_repository.ex
+++ b/lib/klass_hero/provider/adapters/driven/persistence/repositories/provider_program_repository.ex
@@ -12,7 +12,23 @@ defmodule KlassHero.Provider.Adapters.Driven.Persistence.Repositories.ProviderPr
   alias KlassHero.Repo
 
   def get_by_id(program_id) when is_binary(program_id) do
-    case Repo.get(ProviderProgramProjectionSchema, program_id) do
+    fetch(ProviderProgramProjectionSchema, program_id)
+  end
+
+  @doc """
+  Fetches a projected program owned by `provider_id`; foreign ≡ missing.
+
+  The `provider_id` predicate is composed into the query, so a foreign row is
+  never loaded rather than loaded-then-rejected.
+  """
+  def get_by_id(program_id, provider_id) when is_binary(program_id) and is_binary(provider_id) do
+    ProviderProgramProjectionSchema
+    |> where([p], p.provider_id == ^provider_id)
+    |> fetch(program_id)
+  end
+
+  defp fetch(queryable, program_id) do
+    case Repo.get(queryable, program_id) do
       nil -> {:error, :not_found}
       row -> {:ok, ProviderProgramMapper.to_read_model(row)}
     end

--- a/lib/klass_hero/provider/adapters/driven/projections/provider_programs.ex
+++ b/lib/klass_hero/provider/adapters/driven/projections/provider_programs.ex
@@ -3,7 +3,15 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderPrograms do
   Event-driven projection maintaining the `provider_programs` read table.
 
   Mirrors program ownership + display metadata from the Program Catalog context
-  so Provider use cases never reach across the context boundary at runtime.
+  so Provider's **list and display** reads need no cross-context call.
+
+  Not a substitute for an authorization check. Being event-driven, this table is
+  eventually consistent: a program created moments ago may not be projected yet.
+  Ownership *guards* on write paths therefore read
+  `ProgramCatalog.get_program_by_id/1` directly — see
+  `KlassHero.Provider.Assignments.ensure_program_owned/2` (#1134), where
+  projection lag would otherwise reject a lead set immediately after the program
+  is created.
 
   Built on `KlassHero.Shared.Projection` (base) + `Projection.WithBootstrapRetry`
   (linear-backoff retry on transient bootstrap failure).

--- a/lib/klass_hero/provider/assignments.ex
+++ b/lib/klass_hero/provider/assignments.ex
@@ -9,12 +9,18 @@ defmodule KlassHero.Provider.Assignments do
   ## Tenancy
 
   Every write takes a `provider_id` and enforces it uniformly (#1134): the staff
-  member is fetched through the provider-scoped `Provider.get_staff_member/2`,
-  the program is checked by `ensure_program_owned/2`, and each mutation query is
-  narrowed by `ProgramStaffAssignment.owned_by/2`. Ownership is a property of the
-  queries rather than a caller convention, so a foreign row cannot be reached even
-  if a pre-check were missed. Foreign and missing are deliberately
-  indistinguishable — both `{:error, :not_found}`, leaking no existence oracle.
+  member comes from the scoped `Provider.get_staff_member/2`, the program from the
+  scoped `ProgramCatalog.get_program_for_provider/2` (via `ensure_program_owned/2`), and
+  every UPDATE is narrowed by `ProgramStaffAssignment.owned_by/2`. Ownership is a
+  property of the queries, not a caller convention, so no UPDATE can reach a
+  foreign row even if a pre-check were missed.
+
+  INSERTs are the one shape a query scope can't cover, so they take their
+  `provider_id` from the ownership-proven `StaffMember` rather than from caller
+  attrs — see `build_assignment_attrs/2` and `upsert_lead/4`.
+
+  Foreign and missing are deliberately indistinguishable throughout — both
+  `{:error, :not_found}`, leaking no existence oracle.
 
   Reads are intentionally *not* provider-scoped: `get_lead_instructor/1` and its
   batch sibling feed publicly-rendered program pages.
@@ -46,17 +52,16 @@ defmodule KlassHero.Provider.Assignments do
   Returns:
   - `{:ok, ProgramStaffAssignment.t()}` on success
   - `{:error, :already_assigned}` if the staff member is already assigned
-  - `{:error, :not_found}` if the staff member or program does not exist **or is
-    owned by another provider** (IDOR guard — the two are indistinguishable)
+  - `{:error, :not_found}` if the staff member or program is missing or foreign
   """
   @spec assign_staff_to_program(map()) ::
           {:ok, ProgramStaffAssignment.t()}
           | {:error, :already_assigned | :not_found | term()}
-  def assign_staff_to_program(%{provider_id: provider_id} = attrs) when is_map(attrs) do
+  def assign_staff_to_program(%{provider_id: provider_id} = attrs) do
     context_span entity: "program_staff_assignment" do
       with {:ok, staff_member} <- Provider.get_staff_member(attrs.staff_member_id, provider_id),
            :ok <- ensure_program_owned(attrs.program_id, provider_id),
-           assignment_attrs = Map.put(attrs, :assigned_at, DateTime.utc_now()),
+           assignment_attrs = build_assignment_attrs(attrs, staff_member),
            {:ok, assignment} <- insert_program_staff_assignment(assignment_attrs) do
         assignment
         |> ProviderEvents.staff_assigned_to_program(staff_member)
@@ -77,10 +82,7 @@ defmodule KlassHero.Provider.Assignments do
 
   Returns:
   - `{:ok, ProgramStaffAssignment.t()}` on success
-  - `{:error, :not_found}` if no active assignment exists **or it belongs to
-    another provider** (IDOR guard — the two are indistinguishable). The lookup
-    query itself is provider-scoped, so a foreign row is never reached, let alone
-    updated.
+  - `{:error, :not_found}` if no active assignment exists or it is foreign
   """
   @spec unassign_staff_from_program(String.t(), String.t(), String.t()) ::
           {:ok, ProgramStaffAssignment.t()} | {:error, :not_found | term()}
@@ -172,18 +174,16 @@ defmodule KlassHero.Provider.Assignments do
   `program_staff_assignments_single_lead` partial unique index is never violated
   mid-flight. Creates an active assignment when the staff member has none yet.
 
-  Returns `{:ok, ProgramStaffAssignment.t()}` or `{:error, :not_found}` when the
-  staff member **or the program** does not exist or is owned by another provider
-  (IDOR guard — the cases are indistinguishable, so no cross-tenant assignment is
-  ever written).
+  Returns `{:ok, ProgramStaffAssignment.t()}`, or `{:error, :not_found}` when the
+  staff member **or the program** is missing or foreign — both sides are checked,
+  so a competitor's staff can never attach to this program, nor this provider's
+  staff to theirs.
   """
   @spec set_lead_instructor(String.t(), String.t(), String.t()) ::
           {:ok, ProgramStaffAssignment.t()} | {:error, :not_found | term()}
   def set_lead_instructor(program_id, staff_member_id, provider_id)
       when is_binary(program_id) and is_binary(staff_member_id) and is_binary(provider_id) do
     context_span entity: "program_staff_assignment" do
-      # Both sides are checked (see @doc): a competitor's staff must never attach to
-      # this publicly-rendered program, nor this provider's staff to their program.
       with {:ok, staff_member} <- Provider.get_staff_member(staff_member_id, provider_id),
            :ok <- ensure_program_owned(program_id, provider_id) do
         Multi.new()
@@ -192,7 +192,7 @@ defmodule KlassHero.Provider.Assignments do
           other_active_leads_query(program_id, staff_member_id, provider_id),
           set: [is_lead_instructor: false]
         )
-        |> Multi.run(:lead, fn repo, _ -> upsert_lead(repo, program_id, staff_member) end)
+        |> Multi.run(:lead, fn repo, _ -> upsert_lead(repo, program_id, staff_member, provider_id) end)
         |> Repo.transaction()
         |> case do
           {:ok, %{lead: lead}} -> {:ok, lead}
@@ -206,8 +206,7 @@ defmodule KlassHero.Provider.Assignments do
   Clears the lead instructor on a program owned by `provider_id`, leaving the
   assignment otherwise active.
 
-  No-op when the program has no lead **or belongs to another provider** — the
-  update query is provider-scoped, so a foreign lead is never reached.
+  No-op when the program has no lead or is foreign.
   """
   @spec clear_lead_instructor(String.t(), String.t()) :: :ok
   def clear_lead_instructor(program_id, provider_id) when is_binary(program_id) and is_binary(provider_id) do
@@ -268,14 +267,12 @@ defmodule KlassHero.Provider.Assignments do
       where: a.is_lead_instructor and is_nil(a.unassigned_at)
   end
 
-  defp upsert_lead(repo, program_id, staff_member) do
-    # staff_member is already proven owned by the caller's provider, so its
-    # provider_id is the tenancy key for both the lookup and the inserted row.
-    case repo.one(active_assignment_scope(program_id, staff_member.id, staff_member.provider_id)) do
+  defp upsert_lead(repo, program_id, staff_member, provider_id) do
+    case repo.one(active_assignment_scope(program_id, staff_member.id, provider_id)) do
       nil ->
         %ProgramStaffAssignment{}
         |> ProgramStaffAssignment.create_changeset(%{
-          provider_id: staff_member.provider_id,
+          provider_id: provider_id,
           program_id: program_id,
           staff_member_id: staff_member.id,
           assigned_at: DateTime.utc_now() |> DateTime.truncate(:microsecond),
@@ -307,12 +304,11 @@ defmodule KlassHero.Provider.Assignments do
   # Programs are owned by Program Catalog, so ownership is read through its public
   # facade — strongly consistent, unlike the `provider_programs` projection, whose
   # lag would reject a lead set immediately after the program is created.
-  # Foreign ≡ missing, matching the staff guard.
   defp ensure_program_owned(program_id, provider_id) do
     acl_span source: "provider", target: "program_catalog" do
-      case ProgramCatalog.get_program_by_id(program_id) do
-        {:ok, %{provider_id: ^provider_id}} -> :ok
-        _foreign_or_missing -> {:error, :not_found}
+      case ProgramCatalog.get_program_for_provider(provider_id, program_id) do
+        {:ok, _owned} -> :ok
+        {:error, :not_found} -> {:error, :not_found}
       end
     end
   end
@@ -324,6 +320,15 @@ defmodule KlassHero.Provider.Assignments do
   # prevents double execution). The bus is keyed on the Provider context module,
   # so dispatch explicitly through `Provider`, not this sub-module.
   defp dispatch_assignment_event(event), do: DomainEventBus.dispatch(Provider, event)
+
+  # An INSERT can't carry a query scope, so the row's tenancy key is taken from
+  # the ownership-proven staff member rather than the caller's attrs — the same
+  # rule `upsert_lead/4` follows.
+  defp build_assignment_attrs(attrs, %StaffMember{provider_id: provider_id}) do
+    attrs
+    |> Map.put(:assigned_at, DateTime.utc_now())
+    |> Map.put(:provider_id, provider_id)
+  end
 
   defp insert_program_staff_assignment(attrs) do
     %ProgramStaffAssignment{}
@@ -343,13 +348,8 @@ defmodule KlassHero.Provider.Assignments do
   end
 
   defp unassign_program_staff_assignment(program_id, staff_member_id, provider_id) do
-    ProgramStaffAssignment
-    |> ProgramStaffAssignment.owned_by(provider_id)
-    |> where(
-      [a],
-      a.program_id == ^program_id and a.staff_member_id == ^staff_member_id and
-        is_nil(a.unassigned_at)
-    )
+    program_id
+    |> active_assignment_scope(staff_member_id, provider_id)
     |> Repo.one()
     |> case do
       nil ->

--- a/lib/klass_hero/provider/assignments.ex
+++ b/lib/klass_hero/provider/assignments.ex
@@ -12,6 +12,7 @@ defmodule KlassHero.Provider.Assignments do
   import Ecto.Query, warn: false
 
   alias Ecto.Multi
+  alias KlassHero.ProgramCatalog
   alias KlassHero.Provider
   alias KlassHero.Provider.Domain.Events.ProviderEvents
   alias KlassHero.Provider.ProgramStaffAssignment
@@ -25,17 +26,23 @@ defmodule KlassHero.Provider.Assignments do
   @doc """
   Assigns a staff member to a program.
 
+  `attrs.provider_id` is the tenancy authority and must come from the
+  authenticated scope, never from client input. Both the staff member and the
+  program are verified to belong to it.
+
   Returns:
   - `{:ok, ProgramStaffAssignment.t()}` on success
   - `{:error, :already_assigned}` if the staff member is already assigned
-  - `{:error, :not_found}` if staff member does not exist
+  - `{:error, :not_found}` if the staff member or program does not exist **or is
+    owned by another provider** (IDOR guard — the two are indistinguishable)
   """
   @spec assign_staff_to_program(map()) ::
           {:ok, ProgramStaffAssignment.t()}
           | {:error, :already_assigned | :not_found | term()}
-  def assign_staff_to_program(attrs) when is_map(attrs) do
+  def assign_staff_to_program(%{provider_id: provider_id} = attrs) when is_map(attrs) do
     context_span entity: "program_staff_assignment" do
-      with {:ok, staff_member} <- Provider.get_staff_member(attrs.staff_member_id),
+      with {:ok, staff_member} <- Provider.get_staff_member(attrs.staff_member_id, provider_id),
+           :ok <- ensure_program_owned(attrs.program_id, provider_id),
            assignment_attrs = Map.put(attrs, :assigned_at, DateTime.utc_now()),
            {:ok, assignment} <- insert_program_staff_assignment(assignment_attrs) do
         assignment
@@ -53,19 +60,23 @@ defmodule KlassHero.Provider.Assignments do
   end
 
   @doc """
-  Unassigns a staff member from a program.
+  Unassigns a staff member from a program owned by `provider_id`.
 
   Returns:
   - `{:ok, ProgramStaffAssignment.t()}` on success
-  - `{:error, :not_found}` if no active assignment exists
+  - `{:error, :not_found}` if no active assignment exists **or it belongs to
+    another provider** (IDOR guard — the two are indistinguishable). The lookup
+    query itself is provider-scoped, so a foreign row is never reached, let alone
+    updated.
   """
-  @spec unassign_staff_from_program(String.t(), String.t()) ::
+  @spec unassign_staff_from_program(String.t(), String.t(), String.t()) ::
           {:ok, ProgramStaffAssignment.t()} | {:error, :not_found | term()}
-  def unassign_staff_from_program(program_id, staff_member_id)
-      when is_binary(program_id) and is_binary(staff_member_id) do
+  def unassign_staff_from_program(program_id, staff_member_id, provider_id)
+      when is_binary(program_id) and is_binary(staff_member_id) and is_binary(provider_id) do
     context_span entity: "program_staff_assignment" do
-      with {:ok, staff_member} <- Provider.get_staff_member(staff_member_id),
-           {:ok, assignment} <- unassign_program_staff_assignment(program_id, staff_member_id) do
+      with {:ok, staff_member} <- Provider.get_staff_member(staff_member_id, provider_id),
+           {:ok, assignment} <-
+             unassign_program_staff_assignment(program_id, staff_member_id, provider_id) do
         assignment
         |> ProviderEvents.staff_unassigned_from_program(staff_member)
         |> dispatch_assignment_event()
@@ -148,45 +159,45 @@ defmodule KlassHero.Provider.Assignments do
   mid-flight. Creates an active assignment when the staff member has none yet.
 
   Returns `{:ok, ProgramStaffAssignment.t()}` or `{:error, :not_found}` when the
-  staff member does not exist **or is owned by another provider** (IDOR guard —
-  the two are indistinguishable, so no cross-tenant assignment is ever written).
+  staff member **or the program** does not exist or is owned by another provider
+  (IDOR guard — the cases are indistinguishable, so no cross-tenant assignment is
+  ever written).
   """
   @spec set_lead_instructor(String.t(), String.t(), String.t()) ::
           {:ok, ProgramStaffAssignment.t()} | {:error, :not_found | term()}
   def set_lead_instructor(program_id, staff_member_id, provider_id)
       when is_binary(program_id) and is_binary(staff_member_id) and is_binary(provider_id) do
     context_span entity: "program_staff_assignment" do
-      # Foreign staff → :not_found (see @doc): a competitor's staff must never attach
-      # to this publicly-rendered program.
-      case Provider.get_staff_member(staff_member_id) do
-        {:ok, %StaffMember{provider_id: ^provider_id} = staff_member} ->
-          Multi.new()
-          |> Multi.update_all(:clear_other_leads, other_active_leads_query(program_id, staff_member_id),
-            set: [is_lead_instructor: false]
-          )
-          |> Multi.run(:lead, fn repo, _ -> upsert_lead(repo, program_id, staff_member) end)
-          |> Repo.transaction()
-          |> case do
-            {:ok, %{lead: lead}} -> {:ok, lead}
-            {:error, _step, reason, _changes} -> {:error, reason}
-          end
-
-        {:ok, %StaffMember{}} ->
-          {:error, :not_found}
-
-        error ->
-          error
+      # Both sides are checked (see @doc): a competitor's staff must never attach to
+      # this publicly-rendered program, nor this provider's staff to their program.
+      with {:ok, staff_member} <- Provider.get_staff_member(staff_member_id, provider_id),
+           :ok <- ensure_program_owned(program_id, provider_id) do
+        Multi.new()
+        |> Multi.update_all(
+          :clear_other_leads,
+          other_active_leads_query(program_id, staff_member_id, provider_id),
+          set: [is_lead_instructor: false]
+        )
+        |> Multi.run(:lead, fn repo, _ -> upsert_lead(repo, program_id, staff_member) end)
+        |> Repo.transaction()
+        |> case do
+          {:ok, %{lead: lead}} -> {:ok, lead}
+          {:error, _step, reason, _changes} -> {:error, reason}
+        end
       end
     end
   end
 
   @doc """
-  Clears the program's lead instructor, leaving the assignment otherwise active.
-  No-op when the program has no lead.
+  Clears the lead instructor on a program owned by `provider_id`, leaving the
+  assignment otherwise active.
+
+  No-op when the program has no lead **or belongs to another provider** — the
+  update query is provider-scoped, so a foreign lead is never reached.
   """
-  @spec clear_lead_instructor(String.t()) :: :ok
-  def clear_lead_instructor(program_id) when is_binary(program_id) do
-    active_leads_query(program_id)
+  @spec clear_lead_instructor(String.t(), String.t()) :: :ok
+  def clear_lead_instructor(program_id, provider_id) when is_binary(program_id) and is_binary(provider_id) do
+    active_leads_query(program_id, provider_id)
     |> Repo.update_all(set: [is_lead_instructor: false])
 
     :ok
@@ -220,16 +231,17 @@ defmodule KlassHero.Provider.Assignments do
     |> Map.new(fn {program_id, staff} -> {program_id, to_lead_map(staff)} end)
   end
 
-  # Active lead assignment(s) for a program (should be at most one via the index).
-  defp active_leads_query(program_id) do
-    from a in ProgramStaffAssignment,
+  # Active lead assignment(s) for a program (should be at most one via the index),
+  # scoped to the owning provider so no mutation can reach a foreign lead.
+  defp active_leads_query(program_id, provider_id) do
+    from a in ProgramStaffAssignment.owned_by(provider_id),
       where: a.program_id == ^program_id and a.is_lead_instructor and is_nil(a.unassigned_at)
   end
 
   # Active leads for the program EXCEPT the incoming staff member — cleared first
   # so promoting a new lead never collides with the partial unique index.
-  defp other_active_leads_query(program_id, staff_member_id) do
-    from a in active_leads_query(program_id),
+  defp other_active_leads_query(program_id, staff_member_id, provider_id) do
+    from a in active_leads_query(program_id, provider_id),
       where: a.staff_member_id != ^staff_member_id
   end
 
@@ -243,7 +255,9 @@ defmodule KlassHero.Provider.Assignments do
   end
 
   defp upsert_lead(repo, program_id, staff_member) do
-    case repo.one(active_assignment_scope(program_id, staff_member.id)) do
+    # staff_member is already proven owned by the caller's provider, so its
+    # provider_id is the tenancy key for both the lookup and the inserted row.
+    case repo.one(active_assignment_scope(program_id, staff_member.id, staff_member.provider_id)) do
       nil ->
         %ProgramStaffAssignment{}
         |> ProgramStaffAssignment.create_changeset(%{
@@ -262,9 +276,9 @@ defmodule KlassHero.Provider.Assignments do
     end
   end
 
-  # The single active (program, staff) assignment, if one exists.
-  defp active_assignment_scope(program_id, staff_member_id) do
-    from a in ProgramStaffAssignment,
+  # The single active (program, staff) assignment for the provider, if one exists.
+  defp active_assignment_scope(program_id, staff_member_id, provider_id) do
+    from a in ProgramStaffAssignment.owned_by(provider_id),
       where:
         a.program_id == ^program_id and a.staff_member_id == ^staff_member_id and
           is_nil(a.unassigned_at)
@@ -274,6 +288,19 @@ defmodule KlassHero.Provider.Assignments do
 
   defp to_lead_map(%StaffMember{} = staff) do
     %{id: staff.id, name: StaffMember.full_name(staff), headshot_url: staff.headshot_url}
+  end
+
+  # Programs are owned by Program Catalog, so ownership is read through its public
+  # facade — strongly consistent, unlike the `provider_programs` projection, whose
+  # lag would reject a lead set immediately after the program is created.
+  # Foreign ≡ missing, matching the staff guard.
+  defp ensure_program_owned(program_id, provider_id) do
+    acl_span source: "provider", target: "program_catalog" do
+      case ProgramCatalog.get_program_by_id(program_id) do
+        {:ok, %{provider_id: ^provider_id}} -> :ok
+        _foreign_or_missing -> {:error, :not_found}
+      end
+    end
   end
 
   # Dispatches the domain event on the Provider bus. PromoteIntegrationEvents
@@ -301,8 +328,9 @@ defmodule KlassHero.Provider.Assignments do
     end
   end
 
-  defp unassign_program_staff_assignment(program_id, staff_member_id) do
+  defp unassign_program_staff_assignment(program_id, staff_member_id, provider_id) do
     ProgramStaffAssignment
+    |> ProgramStaffAssignment.owned_by(provider_id)
     |> where(
       [a],
       a.program_id == ^program_id and a.staff_member_id == ^staff_member_id and

--- a/lib/klass_hero/provider/assignments.ex
+++ b/lib/klass_hero/provider/assignments.ex
@@ -5,6 +5,19 @@ defmodule KlassHero.Provider.Assignments do
   Assignment writes emit domain events on the Provider bus (promoted to durable
   integration events); reads expose active assignments and the staff behind them.
   Reached through `KlassHero.Provider`'s public API.
+
+  ## Tenancy
+
+  Every write takes a `provider_id` and enforces it uniformly (#1134): the staff
+  member is fetched through the provider-scoped `Provider.get_staff_member/2`,
+  the program is checked by `ensure_program_owned/2`, and each mutation query is
+  narrowed by `ProgramStaffAssignment.owned_by/2`. Ownership is a property of the
+  queries rather than a caller convention, so a foreign row cannot be reached even
+  if a pre-check were missed. Foreign and missing are deliberately
+  indistinguishable — both `{:error, :not_found}`, leaking no existence oracle.
+
+  Reads are intentionally *not* provider-scoped: `get_lead_instructor/1` and its
+  batch sibling feed publicly-rendered program pages.
   """
 
   use KlassHero.Shared.Tracing
@@ -97,9 +110,10 @@ defmodule KlassHero.Provider.Assignments do
   If the staff member has no tags, returns all programs unchanged.
   If tags are set, returns only programs whose category matches a tag.
 
-  The caller is responsible for fetching the programs list (typically
-  from `ProgramCatalog.list_programs_for_provider/1`), keeping the
-  Provider context free of cross-context dependencies.
+  The caller is responsible for fetching the programs list (typically from
+  `ProgramCatalog.list_programs_for_provider/1`), which keeps this function pure
+  and free of I/O. (The module does read the Program Catalog facade elsewhere —
+  see `ensure_program_owned/2` — but only for write-path ownership guards.)
   """
   @spec list_assigned_programs(StaffMember.t(), [map()]) :: [map()]
   def list_assigned_programs(%StaffMember{} = staff_member, programs) when is_list(programs) do

--- a/lib/klass_hero/provider/program_staff_assignment.ex
+++ b/lib/klass_hero/provider/program_staff_assignment.ex
@@ -12,6 +12,7 @@ defmodule KlassHero.Provider.ProgramStaffAssignment do
   use Ecto.Schema
 
   import Ecto.Changeset
+  import Ecto.Query, only: [from: 2]
 
   alias KlassHero.Provider.ProviderProfile
   alias KlassHero.Provider.StaffMember
@@ -81,6 +82,18 @@ defmodule KlassHero.Provider.ProgramStaffAssignment do
       name: :program_staff_assignments_single_lead,
       message: "program already has a lead instructor"
     )
+  end
+
+  @doc """
+  Narrows a query to assignments owned by `provider_id`.
+
+  Composed into every mutation query so a crafted `program_id`/`staff_member_id`
+  pair cannot reach another provider's row — the guard holds even where a
+  caller's pre-check is missing.
+  """
+  @spec owned_by(Ecto.Queryable.t(), String.t()) :: Ecto.Query.t()
+  def owned_by(query \\ __MODULE__, provider_id) when is_binary(provider_id) do
+    from a in query, where: a.provider_id == ^provider_id
   end
 
   @doc "Returns true when the assignment is still active (never unassigned)."

--- a/lib/klass_hero/provider/programs.ex
+++ b/lib/klass_hero/provider/programs.ex
@@ -29,7 +29,23 @@ defmodule KlassHero.Provider.Programs do
     SessionDetailsRepository.list_by_program(provider_id, program_id)
   end
 
-  @doc "Returns the provider-owned program by ID from the `provider_programs` projection."
+  @doc """
+  Returns a projected program owned by `provider_id` — the tenancy-safe getter.
+
+  Foreign and missing are indistinguishable: the `provider_id` predicate is part
+  of the query, so a foreign row is never reached.
+  """
+  @spec get_provider_program(String.t(), String.t()) :: {:ok, ProviderProgram.t()} | {:error, :not_found}
+  def get_provider_program(program_id, provider_id) when is_binary(program_id) and is_binary(provider_id) do
+    ProviderProgramRepository.get_by_id(program_id, provider_id)
+  end
+
+  @doc """
+  Returns a program by ID from the `provider_programs` projection, **unscoped**.
+
+  Only for paths with no provider in scope. Any path that has a `provider_id`
+  must use `get_provider_program/2`.
+  """
   @spec get_provider_program(String.t()) :: {:ok, ProviderProgram.t()} | {:error, :not_found}
   def get_provider_program(program_id) when is_binary(program_id) do
     ProviderProgramRepository.get_by_id(program_id)

--- a/lib/klass_hero/provider/staff.ex
+++ b/lib/klass_hero/provider/staff.ex
@@ -102,13 +102,12 @@ defmodule KlassHero.Provider.Staff do
     context_span entity: "staff_member" do
       attrs = Map.take(attrs, @staff_updatable_fields)
 
-      with {:ok, %StaffMember{provider_id: ^provider_id} = existing} <- get_staff_member(staff_id),
+      with {:ok, existing} <- get_staff_member(staff_id, provider_id),
            merged = Map.merge(Map.from_struct(existing), attrs),
            {:ok, _validated} <- StaffMember.new(merged),
            {:ok, persisted} <- persist_staff_update(existing, attrs) do
         {:ok, persisted}
       else
-        {:ok, %StaffMember{}} -> {:error, :not_found}
         result -> CommandResult.wrap_validation_errors(result)
       end
     end
@@ -147,7 +146,7 @@ defmodule KlassHero.Provider.Staff do
       when is_binary(provider_id) and is_binary(staff_member_id) do
     context_span entity: "staff_member" do
       # Ownership guard (IDOR, see @doc) — mirrors update_staff_member/3 above.
-      with {:ok, %StaffMember{provider_id: ^provider_id} = staff} <- get_staff_member(staff_member_id),
+      with {:ok, staff} <- get_staff_member(staff_member_id, provider_id),
            {:ok, _transitioned} <- StaffMember.transition_invitation(staff, :pending),
            {raw_token, token_hash} = StaffMember.generate_invitation_token(),
            {:ok, persisted} <-
@@ -156,9 +155,6 @@ defmodule KlassHero.Provider.Staff do
                invitation_token_hash: token_hash
              }) do
         emit_or_compensate_staff_invitation(persisted, raw_token)
-      else
-        {:ok, %StaffMember{}} -> {:error, :not_found}
-        other -> other
       end
     end
   end
@@ -198,7 +194,34 @@ defmodule KlassHero.Provider.Staff do
     end
   end
 
-  @doc "Retrieves a single staff member by ID."
+  @doc """
+  Retrieves a staff member owned by `provider_id` — the tenancy-safe getter.
+
+  A staff member owned by another provider is *unreachable*, not fetched-then-
+  rejected: `StaffMember.owned_by/2` narrows the query, so foreign and missing
+  both arrive as `nil` and collapse to `{:error, :not_found}`. No existence
+  oracle, and no ownership check for the caller to forget.
+
+  Prefer this over `get_staff_member/1` on every provider-initiated path.
+  """
+  @spec get_staff_member(String.t(), String.t()) :: {:ok, StaffMember.t()} | {:error, :not_found}
+  def get_staff_member(staff_id, provider_id) when is_binary(staff_id) and is_binary(provider_id) do
+    StaffMember
+    |> StaffMember.owned_by(provider_id)
+    |> Repo.get(staff_id)
+    |> case do
+      nil -> {:error, :not_found}
+      staff -> {:ok, StaffMember.load_pay_rate(staff)}
+    end
+  end
+
+  @doc """
+  Retrieves a single staff member by ID, **unscoped**.
+
+  Only for paths with no provider in scope — invitation-token and accept flows,
+  and event handlers reacting to a staff id they were handed. Any path that has
+  a `provider_id` must use `get_staff_member/2` instead.
+  """
   @spec get_staff_member(String.t()) :: {:ok, StaffMember.t()} | {:error, :not_found}
   def get_staff_member(staff_id) when is_binary(staff_id) do
     case Repo.get(StaffMember, staff_id) do

--- a/lib/klass_hero/provider/staff.ex
+++ b/lib/klass_hero/provider/staff.ex
@@ -18,6 +18,7 @@ defmodule KlassHero.Provider.Staff do
   alias KlassHero.Provider.ProviderProfile
   alias KlassHero.Provider.StaffMember
   alias KlassHero.Repo
+  alias KlassHero.Shared.Adapters.Driven.Persistence.RepositoryHelpers
   alias KlassHero.Shared.CommandResult
   alias KlassHero.Shared.IntegrationEventPublishing
 
@@ -113,16 +114,22 @@ defmodule KlassHero.Provider.Staff do
     end
   end
 
-  @doc "Deletes a staff member by ID."
-  def delete_staff_member(staff_id) when is_binary(staff_id) do
-    context_span entity: "staff_member" do
-      case Repo.get(StaffMember, staff_id) do
-        nil ->
-          {:error, :not_found}
+  @doc """
+  Deletes a staff member owned by `provider_id`.
 
-        staff ->
+  Scoped like `get_staff_member/2`, so a foreign row is unreachable rather than
+  fetched and then rejected — the guard cannot be skipped by a caller.
+  """
+  @spec delete_staff_member(String.t(), String.t()) :: :ok | {:error, :not_found}
+  def delete_staff_member(staff_id, provider_id) when is_binary(staff_id) and is_binary(provider_id) do
+    context_span entity: "staff_member" do
+      case get_staff_member(staff_id, provider_id) do
+        {:ok, staff} ->
           {:ok, _} = Repo.delete(staff)
           :ok
+
+        {:error, :not_found} ->
+          {:error, :not_found}
       end
     end
   end
@@ -195,23 +202,20 @@ defmodule KlassHero.Provider.Staff do
   end
 
   @doc """
-  Retrieves a staff member owned by `provider_id` — the tenancy-safe getter.
+  Retrieves a staff member owned by `provider_id`; foreign ≡ missing.
 
-  A staff member owned by another provider is *unreachable*, not fetched-then-
-  rejected: `StaffMember.owned_by/2` narrows the query, so foreign and missing
-  both arrive as `nil` and collapse to `{:error, :not_found}`. No existence
-  oracle, and no ownership check for the caller to forget.
-
-  Prefer this over `get_staff_member/1` on every provider-initiated path.
+  Scoped via `StaffMember.owned_by/2` (see its docs for why). Prefer this over
+  `get_staff_member/1` on every provider-initiated path. A malformed `staff_id`
+  is `{:error, :not_found}`, not a raise.
   """
   @spec get_staff_member(String.t(), String.t()) :: {:ok, StaffMember.t()} | {:error, :not_found}
   def get_staff_member(staff_id, provider_id) when is_binary(staff_id) and is_binary(provider_id) do
-    StaffMember
-    |> StaffMember.owned_by(provider_id)
-    |> Repo.get(staff_id)
+    provider_id
+    |> StaffMember.owned_by()
+    |> RepositoryHelpers.get_schema_by_uuid(staff_id)
     |> case do
-      nil -> {:error, :not_found}
-      staff -> {:ok, StaffMember.load_pay_rate(staff)}
+      {:ok, staff} -> {:ok, StaffMember.load_pay_rate(staff)}
+      {:error, :not_found} -> {:error, :not_found}
     end
   end
 

--- a/lib/klass_hero/provider/staff_member.ex
+++ b/lib/klass_hero/provider/staff_member.ex
@@ -29,6 +29,7 @@ defmodule KlassHero.Provider.StaffMember do
   use Ecto.Schema
 
   import Ecto.Changeset
+  import Ecto.Query, only: [from: 2]
 
   # Parked alias to the still-DDD ProviderProfile schema — repointed to the
   # flattened KlassHero.Provider.ProviderProfile in Slice 5.
@@ -284,6 +285,21 @@ defmodule KlassHero.Provider.StaffMember do
   end
 
   defp build_pay_rate(_), do: nil
+
+  # ── Query scopes ─────────────────────────────────────────────────────────
+
+  @doc """
+  Narrows a query to staff owned by `provider_id` — the tenancy guard for every
+  provider-initiated read or write.
+
+  Composing this scope makes a foreign row *unreachable* rather than fetched and
+  then rejected, so the caller's `nil` branch already collapses foreign to
+  missing: no existence oracle, and no ownership check left to forget.
+  """
+  @spec owned_by(Ecto.Queryable.t(), String.t()) :: Ecto.Query.t()
+  def owned_by(query \\ __MODULE__, provider_id) when is_binary(provider_id) do
+    from s in query, where: s.provider_id == ^provider_id
+  end
 
   # ── Functional core (ported domain validator + helpers) ──────────────────
 

--- a/lib/klass_hero/provider/submit_incident_report.ex
+++ b/lib/klass_hero/provider/submit_incident_report.ex
@@ -71,12 +71,17 @@ defmodule KlassHero.Provider.SubmitIncidentReport do
   end
 
   # Ownership enforced via Provider-local projections — no cross-context sync read.
-  defp validate_ownership(%{program_id: pid, provider_profile_id: prov_id}) when is_binary(pid) do
-    case Programs.get_provider_program(pid) do
-      {:ok, %{provider_id: ^prov_id}} -> :ok
-      _ -> {:error, [program_id: "does not belong to this provider"]}
+  defp validate_ownership(%{program_id: pid, provider_profile_id: prov_id})
+       when is_binary(pid) and is_binary(prov_id) do
+    case Programs.get_provider_program(pid, prov_id) do
+      {:ok, _owned} -> :ok
+      {:error, :not_found} -> {:error, [program_id: "does not belong to this provider"]}
     end
   end
+
+  # No provider to own it — same outcome as a foreign program.
+  defp validate_ownership(%{program_id: pid}) when is_binary(pid),
+    do: {:error, [program_id: "does not belong to this provider"]}
 
   defp validate_ownership(%{session_id: sid, provider_profile_id: prov_id}) when is_binary(sid) do
     case SessionDetailsRepository.get_by_id(sid) do

--- a/lib/klass_hero/shared/adapters/driven/persistence/repository_helpers.ex
+++ b/lib/klass_hero/shared/adapters/driven/persistence/repository_helpers.ex
@@ -23,8 +23,11 @@ defmodule KlassHero.Shared.Adapters.Driven.Persistence.RepositoryHelpers do
 
   Uses `Ecto.UUID.dump/1`, not `cast/1`: `cast/1` accepts raw 16-byte binaries
   that are not valid textual UUIDs.
+
+  Accepts any `Ecto.Queryable` — pass a scoped query (e.g. `Schema.owned_by(id)`)
+  to make a foreign row unreachable rather than fetched and then rejected.
   """
-  @spec get_schema_by_uuid(module(), term()) :: {:ok, struct()} | {:error, :not_found}
+  @spec get_schema_by_uuid(Ecto.Queryable.t(), term()) :: {:ok, struct()} | {:error, :not_found}
   def get_schema_by_uuid(schema, id) do
     case Ecto.UUID.dump(id) do
       {:ok, _binary} ->

--- a/lib/klass_hero/shared/adapters/driven/storage/stub_storage_adapter.ex
+++ b/lib/klass_hero/shared/adapters/driven/storage/stub_storage_adapter.ex
@@ -15,7 +15,8 @@ defmodule KlassHero.Shared.Adapters.Driven.Storage.StubStorageAdapter do
   end
 
   @impl true
-  # Agent may not be started in LiveView integration tests (can't pass custom storage_opts) — store if alive, return stub URL regardless.
+  # Agent may not be started in LiveView integration tests (can't pass custom
+  # storage_opts) — store if alive, return stub URL regardless.
   def upload(bucket_type, path, binary, opts) do
     agent = Keyword.get(opts, :agent, __MODULE__)
     key = make_key(bucket_type, path)

--- a/lib/klass_hero/shared/interaction.ex
+++ b/lib/klass_hero/shared/interaction.ex
@@ -40,6 +40,9 @@ defmodule KlassHero.Shared.Interaction do
     `attributes/2`.
   """
 
+  # Self-alias so the generated code below can say `Interaction.…`. Alias hygiene
+  # carries the expansion into the caller's module, where the macro expands.
+  alias KlassHero.Shared.Interaction
   alias KlassHero.Shared.Interaction.Kind
   alias KlassHero.Shared.Tracing
 
@@ -159,12 +162,10 @@ defmodule KlassHero.Shared.Interaction do
             result = unquote(block)
             duration_us = System.monotonic_time(:microsecond) - start_us
 
-            # unquote(__MODULE__) rather than an alias: this expands in the caller's
-            # module, where an alias declared here would not apply.
-            status = unquote(__MODULE__).classify(result, kind_mod, success_fun)
+            status = Interaction.classify(result, kind_mod, success_fun)
             attributes = kind_mod.attributes(result, kind_opts)
 
-            interaction = %unquote(__MODULE__){
+            interaction = %Interaction{
               kind: unquote(kind),
               operation: unquote(operation),
               adapter: unquote(adapter),
@@ -178,9 +179,9 @@ defmodule KlassHero.Shared.Interaction do
               metadata: attributes
             }
 
-            unquote(__MODULE__).set_span_attributes(attributes)
+            Interaction.set_span_attributes(attributes)
 
-            {result, %{duration_us: duration_us}, unquote(__MODULE__).to_telemetry_metadata(interaction)}
+            {result, %{duration_us: duration_us}, Interaction.to_telemetry_metadata(interaction)}
           end
         )
       end

--- a/lib/klass_hero/shared/interaction.ex
+++ b/lib/klass_hero/shared/interaction.ex
@@ -159,10 +159,12 @@ defmodule KlassHero.Shared.Interaction do
             result = unquote(block)
             duration_us = System.monotonic_time(:microsecond) - start_us
 
-            status = KlassHero.Shared.Interaction.classify(result, kind_mod, success_fun)
+            # unquote(__MODULE__) rather than an alias: this expands in the caller's
+            # module, where an alias declared here would not apply.
+            status = unquote(__MODULE__).classify(result, kind_mod, success_fun)
             attributes = kind_mod.attributes(result, kind_opts)
 
-            interaction = %KlassHero.Shared.Interaction{
+            interaction = %unquote(__MODULE__){
               kind: unquote(kind),
               operation: unquote(operation),
               adapter: unquote(adapter),
@@ -176,9 +178,9 @@ defmodule KlassHero.Shared.Interaction do
               metadata: attributes
             }
 
-            KlassHero.Shared.Interaction.set_span_attributes(attributes)
+            unquote(__MODULE__).set_span_attributes(attributes)
 
-            {result, %{duration_us: duration_us}, KlassHero.Shared.Interaction.to_telemetry_metadata(interaction)}
+            {result, %{duration_us: duration_us}, unquote(__MODULE__).to_telemetry_metadata(interaction)}
           end
         )
       end

--- a/lib/klass_hero_web/live/admin/provider_live.ex
+++ b/lib/klass_hero_web/live/admin/provider_live.ex
@@ -115,7 +115,8 @@ defmodule KlassHeroWeb.Admin.ProviderLive do
     ]
   end
 
-  # admin_changeset bypasses domain use cases; publish events so projections (VerifiedProviders, ProgramListings) stay in sync.
+  # admin_changeset bypasses domain use cases; publish events so projections
+  # (VerifiedProviders, ProgramListings) stay in sync.
   KlassHeroWeb.BackpexCompat.override :on_item_updated, 2 do
     @impl Backpex.LiveResource
     def on_item_updated(socket, item) do

--- a/lib/klass_hero_web/live/programs_live.ex
+++ b/lib/klass_hero_web/live/programs_live.ex
@@ -98,7 +98,8 @@ defmodule KlassHeroWeb.ProgramsLive do
       |> assign(active_filter: active_filter)
       |> assign(sort_by: sort_by)
       |> assign(next_cursor: page_result.next_cursor)
-      # Load-more disabled for non-recommended sorts: merging paginated batches would break the visual order (follow-up: pass sort to list_programs_paginated/3).
+      # Load-more disabled for non-recommended sorts: merging paginated batches would
+      # break the visual order (follow-up: pass sort to list_programs_paginated/3).
       |> assign(has_more: page_result.has_more and sort_by == "recommended")
       |> stream(:programs, programs, reset: true)
       |> assign(loaded_programs: programs)

--- a/lib/klass_hero_web/live/provider/broadcast_live.ex
+++ b/lib/klass_hero_web/live/provider/broadcast_live.ex
@@ -32,10 +32,10 @@ defmodule KlassHeroWeb.Provider.BroadcastLive do
   defp mount_broadcast_form(socket, program_id) do
     provider_id = socket.assigns.current_scope.provider.id
 
-    # Verify ownership before rendering — a foreign program is treated as not_found
-    # so its existence can't be probed (IDOR guard).
-    case ProgramCatalog.get_program_by_id(program_id) do
-      {:ok, %{provider_id: ^provider_id} = program} ->
+    # Scoped getter — a foreign program is unreachable, so its existence can't be
+    # probed (IDOR guard).
+    case ProgramCatalog.get_program_for_provider(provider_id, program_id) do
+      {:ok, program} ->
         form = to_form(%{"subject" => "", "content" => ""})
 
         socket =
@@ -53,7 +53,7 @@ defmodule KlassHeroWeb.Provider.BroadcastLive do
 
         {:ok, socket}
 
-      _not_found_or_foreign ->
+      {:error, :not_found} ->
         {:ok,
          socket
          |> put_flash(:error, gettext("Program not found"))

--- a/lib/klass_hero_web/live/provider/incident_report_live.ex
+++ b/lib/klass_hero_web/live/provider/incident_report_live.ex
@@ -66,9 +66,9 @@ defmodule KlassHeroWeb.Provider.IncidentReportLive do
   end
 
   defp resolve_preselection(%{"program_id" => program_id}, provider_id) when is_binary(program_id) do
-    case Provider.get_provider_program(program_id) do
-      {:ok, %{provider_id: ^provider_id} = program} -> {:ok, {:program, program}}
-      _ -> {:error, :preselection_invalid}
+    case Provider.get_provider_program(program_id, provider_id) do
+      {:ok, program} -> {:ok, {:program, program}}
+      {:error, :not_found} -> {:error, :preselection_invalid}
     end
   end
 

--- a/lib/klass_hero_web/live/provider/incident_reports_live.ex
+++ b/lib/klass_hero_web/live/provider/incident_reports_live.ex
@@ -29,10 +29,11 @@ defmodule KlassHeroWeb.Provider.IncidentReportsLive do
     end
   end
 
-  # A single projection read verifies ownership and fetches the record, avoiding a race between two queries.
+  # A single scoped projection read verifies ownership and fetches the record,
+  # avoiding a race between two queries.
   defp mount_for_provider(socket, provider, program_id) do
-    case Provider.get_provider_program(program_id) do
-      {:ok, %{provider_id: prov_id} = program} when prov_id == provider.id ->
+    case Provider.get_provider_program(program_id, provider.id) do
+      {:ok, program} ->
         summaries = Provider.list_incident_reports_for_program(provider.id, program_id)
         rows = Enum.map(summaries, &IncidentReportPresenter.to_list_view/1)
 
@@ -47,7 +48,7 @@ defmodule KlassHeroWeb.Provider.IncidentReportsLive do
          )
          |> stream(:incident_reports, rows)}
 
-      _ ->
+      {:error, :not_found} ->
         {:ok,
          socket
          |> put_flash(:error, gettext("Program not found."))

--- a/lib/klass_hero_web/live/provider/programs_live.ex
+++ b/lib/klass_hero_web/live/provider/programs_live.ex
@@ -122,33 +122,29 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
   def handle_event("edit_program", %{"id" => program_id}, socket) do
     provider_id = socket.assigns.current_scope.provider.id
 
-    # Verify ownership before loading into the form — program_id is untrusted
-    # client input (IDOR guard). The shared getter is unscoped (7 callers), so the
-    # guard lives here, mirroring view_roster.
-    with {:ok, program} <- ProgramCatalog.get_program_by_id(program_id),
-         true <- program.provider_id == provider_id do
-      changeset = ProgramCatalog.new_program_changeset(program_to_form_params(program))
+    # program_id is untrusted client input; the scoped getter makes a foreign
+    # program unreachable (IDOR guard) rather than fetched and then compared.
+    case ProgramCatalog.get_program_for_provider(provider_id, program_id) do
+      {:ok, program} ->
+        changeset = ProgramCatalog.new_program_changeset(program_to_form_params(program))
 
-      {:noreply,
-       socket
-       |> assign(
-         show_program_form: true,
-         editing_program_id: program_id,
-         program_form: to_form(changeset, as: :program_schema),
-         enrollment_form: load_enrollment_policy_form(program_id),
-         participant_policy_form: load_participant_policy_form(program_id),
-         instructor_options: build_instructor_options(provider_id)
-       )}
-    else
-      false ->
-        Logger.warning("[ProgramsLive] Unauthorized program edit attempt",
+        {:noreply,
+         socket
+         |> assign(
+           show_program_form: true,
+           editing_program_id: program_id,
+           program_form: to_form(changeset, as: :program_schema),
+           enrollment_form: load_enrollment_policy_form(program_id),
+           participant_policy_form: load_participant_policy_form(program_id),
+           instructor_options: build_instructor_options(provider_id)
+         )}
+
+      {:error, :not_found} ->
+        Logger.warning("[ProgramsLive] Program edit attempt for unknown or foreign program",
           program_id: program_id,
           provider_id: provider_id
         )
 
-        {:noreply, put_flash(socket, :error, gettext("Program not found."))}
-
-      {:error, :not_found} ->
         {:noreply, put_flash(socket, :error, gettext("Program not found."))}
     end
   end
@@ -157,37 +153,35 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
   def handle_event("view_roster", %{"id" => program_id}, socket) do
     provider_id = socket.assigns.current_scope.provider.id
 
-    # Verify ownership before loading — program_id is untrusted client input (IDOR guard).
-    with {:ok, program} <- ProgramCatalog.get_program_by_id(program_id),
-         true <- program.provider_id == provider_id do
-      roster = Enrollment.list_program_enrollments(program_id)
-      invite_count = Enrollment.count_program_invites(program_id)
+    # program_id is untrusted client input; the scoped getter makes a foreign
+    # program unreachable (IDOR guard).
+    case ProgramCatalog.get_program_for_provider(provider_id, program_id) do
+      {:ok, program} ->
+        roster = Enrollment.list_program_enrollments(program_id)
+        invite_count = Enrollment.count_program_invites(program_id)
 
-      {:noreply,
-       assign(socket,
-         show_roster: true,
-         roster_program_name: program.title,
-         roster_program_id: program_id,
-         roster_entries: roster,
-         roster_tab: "enrolled",
-         roster_invites: [],
-         roster_enrolled_count: length(roster),
-         roster_invite_count: invite_count,
-         import_errors: nil,
-         can_message?: Messaging.can_initiate_messaging?(socket.assigns.current_scope),
-         invite_mode: "single",
-         single_invite_form: blank_single_invite_form()
-       )}
-    else
-      false ->
-        Logger.warning("[ProgramsLive] Unauthorized roster access attempt",
+        {:noreply,
+         assign(socket,
+           show_roster: true,
+           roster_program_name: program.title,
+           roster_program_id: program_id,
+           roster_entries: roster,
+           roster_tab: "enrolled",
+           roster_invites: [],
+           roster_enrolled_count: length(roster),
+           roster_invite_count: invite_count,
+           import_errors: nil,
+           can_message?: Messaging.can_initiate_messaging?(socket.assigns.current_scope),
+           invite_mode: "single",
+           single_invite_form: blank_single_invite_form()
+         )}
+
+      {:error, :not_found} ->
+        Logger.warning("[ProgramsLive] Roster access attempt for unknown or foreign program",
           program_id: program_id,
           provider_id: provider_id
         )
 
-        {:noreply, put_flash(socket, :error, gettext("Program not found."))}
-
-      {:error, :not_found} ->
         {:noreply, put_flash(socket, :error, gettext("Program not found."))}
     end
   end

--- a/lib/klass_hero_web/live/provider/programs_live.ex
+++ b/lib/klass_hero_web/live/provider/programs_live.ex
@@ -761,8 +761,8 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
   defp resolve_instructor(instructor_id, socket) do
     provider_id = socket.assigns.current_scope.provider.id
 
-    case Provider.get_staff_member(instructor_id) do
-      {:ok, %{provider_id: ^provider_id}} ->
+    case Provider.get_staff_member(instructor_id, provider_id) do
+      {:ok, _staff} ->
         {:ok, instructor_id}
 
       _not_found_or_foreign ->
@@ -778,7 +778,7 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
   # Persists the lead choice on program_staff_assignments (single source of truth).
   # Blank pick clears the lead; id already ownership-validated by resolve_instructor/2.
   # provider_id re-threaded so the context re-checks too (defence in depth).
-  defp apply_lead_instructor(program_id, nil, _provider_id), do: Provider.clear_lead_instructor(program_id)
+  defp apply_lead_instructor(program_id, nil, provider_id), do: Provider.clear_lead_instructor(program_id, provider_id)
 
   defp apply_lead_instructor(program_id, instructor_id, provider_id) do
     {:ok, _assignment} = Provider.set_lead_instructor(program_id, instructor_id, provider_id)

--- a/lib/klass_hero_web/live/provider/team_live.ex
+++ b/lib/klass_hero_web/live/provider/team_live.ex
@@ -92,8 +92,7 @@ defmodule KlassHeroWeb.Provider.TeamLive do
          |> assign(staff_form: to_form(changeset, as: :staff_member_schema))}
 
       {:error, :not_found} ->
-        # Foreign and missing are one branch now — the scoped getter can't tell them
-        # apart, which is the point. Logged either way; the user sees one message.
+        # Logged either way so enumeration is visible; the user sees one message.
         Logger.warning("[TeamLive] Staff edit attempt for unknown or foreign member",
           staff_member_id: staff_id,
           provider_id: provider_id
@@ -165,8 +164,7 @@ defmodule KlassHeroWeb.Provider.TeamLive do
          |> put_flash(:info, gettext("Team member removed."))}
 
       {:error, :not_found} ->
-        # Foreign id is indistinguishable from a genuine miss here — log the
-        # attempt so an enumeration attack is visible (IDOR guard).
+        # Log the attempt so an enumeration attack is visible.
         Logger.warning("[TeamLive] Staff delete returned not_found",
           staff_member_id: staff_id,
           provider_id: provider_id
@@ -190,8 +188,7 @@ defmodule KlassHeroWeb.Provider.TeamLive do
          |> put_flash(:info, gettext("Invitation resent successfully."))}
 
       {:error, :not_found} ->
-        # A foreign staff_member_id is indistinguishable from a genuine miss (IDOR
-        # guard lives in the context) — log the attempt so enumeration is visible.
+        # Log the attempt so enumeration is visible.
         Logger.warning("[TeamLive] Resend invitation returned not_found",
           staff_member_id: staff_member_id,
           provider_id: provider_id

--- a/lib/klass_hero_web/live/provider/team_live.ex
+++ b/lib/klass_hero_web/live/provider/team_live.ex
@@ -80,26 +80,25 @@ defmodule KlassHeroWeb.Provider.TeamLive do
   def handle_event("edit_member", %{"id" => staff_id}, socket) do
     provider_id = socket.assigns.current_scope.provider.id
 
-    # Verify ownership before loading into the form — staff_id is untrusted client
-    # input (IDOR guard). The shared getter is unscoped, so the guard lives here.
-    with {:ok, staff} <- Provider.get_staff_member(staff_id),
-         true <- staff.provider_id == provider_id do
-      changeset = Provider.change_staff_member(staff)
+    # staff_id is untrusted client input; the scoped getter makes a foreign row
+    # unreachable (IDOR guard) rather than fetched and then compared.
+    case Provider.get_staff_member(staff_id, provider_id) do
+      {:ok, staff} ->
+        changeset = Provider.change_staff_member(staff)
 
-      {:noreply,
-       socket
-       |> assign(show_staff_form: true, editing_staff_id: staff_id, self_staffing?: false)
-       |> assign(staff_form: to_form(changeset, as: :staff_member_schema))}
-    else
-      false ->
-        Logger.warning("[TeamLive] Unauthorized staff edit attempt",
+        {:noreply,
+         socket
+         |> assign(show_staff_form: true, editing_staff_id: staff_id, self_staffing?: false)
+         |> assign(staff_form: to_form(changeset, as: :staff_member_schema))}
+
+      {:error, :not_found} ->
+        # Foreign and missing are one branch now — the scoped getter can't tell them
+        # apart, which is the point. Logged either way; the user sees one message.
+        Logger.warning("[TeamLive] Staff edit attempt for unknown or foreign member",
           staff_member_id: staff_id,
           provider_id: provider_id
         )
 
-        {:noreply, put_flash(socket, :error, gettext("Staff member not found."))}
-
-      {:error, :not_found} ->
         {:noreply, put_flash(socket, :error, gettext("Staff member not found."))}
     end
   end
@@ -123,8 +122,8 @@ defmodule KlassHeroWeb.Provider.TeamLive do
           # Member may have been deleted between form open and keystroke — fall back
           # to a new changeset. Ownership is re-checked here too (defence in depth):
           # a foreign row must never rehydrate into the form via a crafted event.
-          case Provider.get_staff_member(staff_id) do
-            {:ok, %{provider_id: ^provider_id} = staff} ->
+          case Provider.get_staff_member(staff_id, provider_id) do
+            {:ok, staff} ->
               Provider.change_staff_member(staff, params)
 
             _not_found_or_foreign ->
@@ -418,8 +417,8 @@ defmodule KlassHeroWeb.Provider.TeamLive do
     provider_id = socket.assigns.current_scope.provider.id
 
     # Ownership re-checked (defence in depth): a foreign row is treated as gone.
-    case Provider.get_staff_member(staff_id) do
-      {:ok, %{provider_id: ^provider_id} = staff} ->
+    case Provider.get_staff_member(staff_id, provider_id) do
+      {:ok, staff} ->
         changeset =
           Provider.change_staff_member(staff, normalize_staff_form_params(params))
           |> Map.put(:action, :validate)

--- a/mix.exs
+++ b/mix.exs
@@ -9,6 +9,12 @@ defmodule KlassHero.MixProject do
       erlang: "~> 29.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: [module_definition: :interpreted],
+      # Consolidate only where the dispatch win matters. In dev, recompiling a module
+      # that carries a `defimpl` (e.g. Accounts.User's GDPR Inspect) while consolidated
+      # protocols are already loaded emits an "already consolidated" warning — which
+      # `mix precommit`'s --warnings-as-errors then turns into a failure that can't
+      # clear itself, since the failed compile never marks the module done.
+      consolidate_protocols: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),
       deps: deps(),
@@ -140,12 +146,13 @@ defmodule KlassHero.MixProject do
       "test.watch": ["test.setup", "test.watch.continuous"],
       "test.e2e": ["test test/e2e --include e2e"],
       precommit: [
-        "compile --warning-as-errors",
+        "compile --warnings-as-errors",
         "deps.unlock --unused",
         "format",
         "lint_typography",
         "lint_translations",
-        "cmd env MIX_ENV=test mix test"
+        "credo --strict",
+        "cmd env MIX_ENV=test mix test --include slow"
       ]
     ]
   end

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -1600,7 +1600,7 @@ msgid "Active"
 msgstr "Aktiv"
 
 #: lib/klass_hero_web/components/provider_components.ex:600
-#: lib/klass_hero_web/live/provider/team_live.ex:540
+#: lib/klass_hero_web/live/provider/team_live.ex:537
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
 msgstr "Teammitglied hinzufügen"
@@ -1632,7 +1632,7 @@ msgstr "Geschäftsprofil"
 msgid "Business Registration"
 msgstr "Gewerbeanmeldung"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:517
+#: lib/klass_hero_web/live/provider/team_live.ex:514
 #, elixir-autogen, elixir-format
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr "Erstellen Sie Profile für Ihr Personal. Diese werden für Eltern sichtbar sein, wenn sie Programmen zugewiesen werden."
@@ -1735,7 +1735,7 @@ msgstr "Status"
 msgid "Team & Profiles"
 msgstr "Team & Profile"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:514
+#: lib/klass_hero_web/live/provider/team_live.ex:511
 #, elixir-autogen, elixir-format
 msgid "Team & Provider Profiles"
 msgstr "Team- & Anbieterprofile"
@@ -2225,7 +2225,7 @@ msgstr "Aktion erforderlich"
 msgid "Add Member"
 msgstr "Mitglied hinzufügen"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:564
+#: lib/klass_hero_web/live/provider/team_live.ex:561
 #, elixir-autogen, elixir-format
 msgid "Add your first staff member to get started!"
 msgstr "Fügen Sie Ihren ersten Mitarbeiter hinzu, um loszulegen!"
@@ -2406,12 +2406,12 @@ msgstr "Bestätigt"
 msgid "Contact Provider"
 msgstr "Anbieter kontaktieren"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:346
+#: lib/klass_hero_web/live/provider/programs_live.ex:340
 #, elixir-autogen, elixir-format
 msgid "Could not read the uploaded file."
 msgstr "Die hochgeladene Datei konnte nicht gelesen werden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:314
+#: lib/klass_hero_web/live/provider/programs_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "Could not remove invite."
 msgstr "Einladung konnte nicht entfernt werden."
@@ -2549,7 +2549,7 @@ msgstr "Dokument konnte nicht genehmigt werden."
 msgid "Failed to reject document."
 msgstr "Dokument konnte nicht abgelehnt werden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:296
+#: lib/klass_hero_web/live/provider/programs_live.ex:290
 #, elixir-autogen, elixir-format
 msgid "Failed to resend invite."
 msgstr "Einladung konnte nicht erneut gesendet werden."
@@ -2642,17 +2642,17 @@ msgstr "Importieren"
 msgid "Insurance Certificate"
 msgstr "Versicherungsnachweis"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:311
+#: lib/klass_hero_web/live/provider/programs_live.ex:305
 #, elixir-autogen, elixir-format
 msgid "Invite not found."
 msgstr "Einladung nicht gefunden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:308
+#: lib/klass_hero_web/live/provider/programs_live.ex:302
 #, elixir-autogen, elixir-format
 msgid "Invite removed."
 msgstr "Einladung entfernt."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:285
+#: lib/klass_hero_web/live/provider/programs_live.ex:279
 #, elixir-autogen, elixir-format
 msgid "Invite resent successfully."
 msgstr "Einladung erfolgreich erneut gesendet."
@@ -2769,7 +2769,7 @@ msgstr "Noch keine Dokumente hochgeladen."
 msgid "No enrollments yet."
 msgstr "Noch keine Anmeldungen."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:342
+#: lib/klass_hero_web/live/provider/programs_live.ex:336
 #, elixir-autogen, elixir-format
 msgid "No file selected."
 msgstr "Keine Datei ausgewählt."
@@ -2809,7 +2809,7 @@ msgstr "Noch keine Programme gebucht"
 msgid "No rejected documents."
 msgstr "Keine abgelehnten Dokumente."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:563
+#: lib/klass_hero_web/live/provider/team_live.ex:560
 #, elixir-autogen, elixir-format
 msgid "No team members yet"
 msgstr "Noch keine Teammitglieder"
@@ -2869,11 +2869,11 @@ msgstr "Ausstehende Überprüfung"
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:106
-#: lib/klass_hero_web/live/provider/programs_live.ex:588
-#: lib/klass_hero_web/live/provider/programs_live.ex:654
-#: lib/klass_hero_web/live/provider/team_live.ex:259
-#: lib/klass_hero_web/live/provider/team_live.ex:310
-#: lib/klass_hero_web/live/provider/team_live.ex:429
+#: lib/klass_hero_web/live/provider/programs_live.ex:582
+#: lib/klass_hero_web/live/provider/programs_live.ex:648
+#: lib/klass_hero_web/live/provider/team_live.ex:256
+#: lib/klass_hero_web/live/provider/team_live.ex:307
+#: lib/klass_hero_web/live/provider/team_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "Please fix the errors below."
 msgstr "Bitte korrigieren Sie die Fehler unten."
@@ -2903,27 +2903,25 @@ msgstr "Profil erfolgreich aktualisiert."
 msgid "Program Start"
 msgstr "Programmbeginn"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:911
+#: lib/klass_hero_web/live/provider/programs_live.ex:905
 #, elixir-autogen, elixir-format
 msgid "Program created successfully."
 msgstr "Programm erfolgreich erstellt."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:918
+#: lib/klass_hero_web/live/provider/programs_live.ex:912
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr "Programm erstellt, aber die Anmeldekapazität konnte nicht gespeichert werden. Bearbeiten Sie das Programm, um es erneut zu versuchen."
 
-#: lib/klass_hero_web/live/provider/incident_reports_live.ex:53
-#: lib/klass_hero_web/live/provider/programs_live.ex:149
-#: lib/klass_hero_web/live/provider/programs_live.ex:152
-#: lib/klass_hero_web/live/provider/programs_live.ex:188
-#: lib/klass_hero_web/live/provider/programs_live.ex:191
-#: lib/klass_hero_web/live/provider/programs_live.ex:629
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:54
+#: lib/klass_hero_web/live/provider/programs_live.ex:148
+#: lib/klass_hero_web/live/provider/programs_live.ex:185
+#: lib/klass_hero_web/live/provider/programs_live.ex:623
 #, elixir-autogen, elixir-format
 msgid "Program not found."
 msgstr "Programm nicht gefunden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:618
+#: lib/klass_hero_web/live/provider/programs_live.ex:612
 #, elixir-autogen, elixir-format
 msgid "Program updated successfully."
 msgstr "Programm erfolgreich aktualisiert."
@@ -3084,8 +3082,8 @@ msgstr "Datei auswählen"
 msgid "Selected child does not meet the program requirements."
 msgstr "Das ausgewählte Kind erfüllt die Programmanforderungen nicht."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:578
-#: lib/klass_hero_web/live/provider/programs_live.ex:644
+#: lib/klass_hero_web/live/provider/programs_live.ex:572
+#: lib/klass_hero_web/live/provider/programs_live.ex:638
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr "Der ausgewählte Kursleiter konnte nicht gefunden werden. Bitte versuchen Sie es erneut."
@@ -3111,15 +3109,15 @@ msgstr "Legen Sie die minimale und maximale Anmeldekapazität für dieses Progra
 msgid "Specialties"
 msgstr "Spezialisierungen"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:409
-#: lib/klass_hero_web/live/provider/team_live.ex:435
+#: lib/klass_hero_web/live/provider/team_live.ex:406
+#: lib/klass_hero_web/live/provider/team_live.ex:432
 #, elixir-autogen, elixir-format
 msgid "Staff member no longer exists."
 msgstr "Der Mitarbeiter existiert nicht mehr."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:102
-#: lib/klass_hero_web/live/provider/team_live.ex:175
-#: lib/klass_hero_web/live/provider/team_live.ex:200
+#: lib/klass_hero_web/live/provider/team_live.ex:101
+#: lib/klass_hero_web/live/provider/team_live.ex:173
+#: lib/klass_hero_web/live/provider/team_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Staff member not found."
 msgstr "Mitarbeiter nicht gefunden."
@@ -3150,27 +3148,27 @@ msgstr "Noch offen"
 msgid "Tax Certificate"
 msgstr "Steuerbescheinigung"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:363
+#: lib/klass_hero_web/live/provider/team_live.ex:360
 #, elixir-autogen, elixir-format
 msgid "Team member added, but headshot upload failed."
 msgstr "Teammitglied hinzugefügt, aber der Upload des Profilfotos ist fehlgeschlagen."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:364
+#: lib/klass_hero_web/live/provider/team_live.ex:361
 #, elixir-autogen, elixir-format
 msgid "Team member added."
 msgstr "Teammitglied hinzugefügt."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:165
+#: lib/klass_hero_web/live/provider/team_live.ex:164
 #, elixir-autogen, elixir-format
 msgid "Team member removed."
 msgstr "Teammitglied entfernt."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:389
+#: lib/klass_hero_web/live/provider/team_live.ex:386
 #, elixir-autogen, elixir-format
 msgid "Team member updated, but headshot upload failed."
 msgstr "Teammitglied aktualisiert, aber der Upload des Profilfotos ist fehlgeschlagen."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:390
+#: lib/klass_hero_web/live/provider/team_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "Team member updated."
 msgstr "Teammitglied aktualisiert."
@@ -3185,12 +3183,12 @@ msgstr "Erzählen Sie Eltern von Ihrer Organisation..."
 msgid "The Klass Hero Story"
 msgstr "Die Geschichte von Klass Hero"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:288
+#: lib/klass_hero_web/live/provider/programs_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "This invite cannot be resent."
 msgstr "Diese Einladung kann nicht erneut gesendet werden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:636
+#: lib/klass_hero_web/live/provider/programs_live.ex:630
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr "Dieses Programm wurde von jemand anderem geändert. Bitte schließen Sie es und versuchen Sie es erneut."
@@ -3404,7 +3402,7 @@ msgstr "Zahlung per Bargeld oder Banküberweisung"
 msgid "Program fee:"
 msgstr "Programmgebühr:"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:751
+#: lib/klass_hero_web/live/provider/programs_live.ex:745
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr "Programm gespeichert, aber der Upload des Titelbilds ist fehlgeschlagen. Sie können es erneut hochladen, indem Sie das Programm bearbeiten."
@@ -3619,7 +3617,7 @@ msgstr "Kann ich meine Programme auf Klass Hero listen und was kostet das?"
 msgid "Cannot check out without a check-in"
 msgstr "Auschecken ohne Einchecken nicht möglich"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:260
+#: lib/klass_hero_web/live/provider/programs_live.ex:254
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:146
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
@@ -3684,7 +3682,7 @@ msgid "Correct"
 msgstr "Korrigieren"
 
 #: lib/klass_hero_web/live/dashboard_live.ex:286
-#: lib/klass_hero_web/live/provider/programs_live.ex:257
+#: lib/klass_hero_web/live/provider/programs_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "Could not start conversation. Please try again."
@@ -4252,7 +4250,7 @@ msgstr "E-Mail-Inhalt konnte nicht abgerufen werden."
 msgid "Failed to mark email as unread"
 msgstr "E-Mail konnte nicht als ungelesen markiert werden"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:216
+#: lib/klass_hero_web/live/provider/team_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "Failed to resend invitation. Please try again."
 msgstr "Einladung konnte nicht erneut gesendet werden. Bitte versuchen Sie es erneut."
@@ -4320,7 +4318,7 @@ msgstr "Einladung ausstehend"
 msgid "Invitation Sent"
 msgstr "Einladung gesendet"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:190
+#: lib/klass_hero_web/live/provider/team_live.ex:188
 #, elixir-autogen, elixir-format
 msgid "Invitation resent successfully."
 msgstr "Einladung erfolgreich erneut gesendet."
@@ -4446,7 +4444,7 @@ msgstr "Absenden"
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:24
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
-#: lib/klass_hero_web/live/provider/programs_live.ex:223
+#: lib/klass_hero_web/live/provider/programs_live.ex:217
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Program"
@@ -4567,7 +4565,7 @@ msgstr "Sitzung erfolgreich erstellt"
 msgid "Staff Dashboard"
 msgstr "Mitarbeiter-Dashboard"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:266
+#: lib/klass_hero_web/live/provider/team_live.ex:263
 #, elixir-autogen, elixir-format
 msgid "Staff member created, but the invitation could not be sent. Try resending from the team list."
 msgstr "Mitarbeiter wurde erstellt, aber die Einladung konnte nicht gesendet werden. Versuchen Sie es erneut über die Team-Liste."
@@ -4598,7 +4596,7 @@ msgstr "Unterstützung: %{details}"
 msgid "The business associated with your account could not be found."
 msgstr "Das mit Ihrem Konto verknüpfte Unternehmen konnte nicht gefunden werden."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:207
+#: lib/klass_hero_web/live/provider/team_live.ex:204
 #, elixir-autogen, elixir-format
 msgid "This invitation cannot be resent in its current state."
 msgstr "Diese Einladung kann in ihrem aktuellen Status nicht erneut gesendet werden."
@@ -4660,7 +4658,7 @@ msgid "Update your observation..."
 msgstr "Aktualisieren Sie Ihre Beobachtung..."
 
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:138
-#: lib/klass_hero_web/live/provider/programs_live.ex:339
+#: lib/klass_hero_web/live/provider/programs_live.ex:333
 #: lib/klass_hero_web/live/provider/verification_live.ex:240
 #: lib/klass_hero_web/live/provider/verification_live.ex:556
 #: lib/klass_hero_web/live/provider/verification_live.ex:594
@@ -4968,7 +4966,7 @@ msgstr "Sessions — %{title}"
 msgid "View sessions"
 msgstr "Sessions anzeigen"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:430
+#: lib/klass_hero_web/live/provider/programs_live.ex:424
 #, elixir-autogen, elixir-format
 msgid "Create a program before inviting participants."
 msgstr "Erstellen Sie zuerst ein Programm, bevor Sie Teilnehmer einladen."
@@ -5010,7 +5008,7 @@ msgstr "Einladungsmodus"
 msgid "Invite one person"
 msgstr "Einzelperson einladen"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:426
+#: lib/klass_hero_web/live/provider/programs_live.ex:420
 #, elixir-autogen, elixir-format
 msgid "Invite sent."
 msgstr "Einladung verschickt."
@@ -5113,7 +5111,7 @@ msgstr "Aktualisieren Sie die Notiz für dieses Kind (z. B. um zu klären, was p
 msgid "Upload a list"
 msgstr "Liste hochladen"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:437
+#: lib/klass_hero_web/live/provider/programs_live.ex:431
 #, elixir-autogen, elixir-format
 msgid "An invite for this child and program already exists."
 msgstr "Für dieses Kind und Programm existiert bereits eine Einladung."
@@ -5290,7 +5288,7 @@ msgstr "Ihre Woche mit den Kindern"
 msgid "Go to dashboard"
 msgstr "Zum Dashboard"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:382
+#: lib/klass_hero_web/live/provider/programs_live.ex:376
 #, elixir-autogen, elixir-format
 msgid "%{count} row could not be processed."
 msgid_plural "%{count} rows could not be processed."
@@ -5399,7 +5397,7 @@ msgstr "Bei Klass Hero ist Vertrauen kein Feature — es ist das Fundament von a
 msgid "Attach photo"
 msgstr "Foto anhängen"
 
-#: lib/klass_hero_web/live/provider/incident_reports_live.ex:68
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:69
 #, elixir-autogen, elixir-format
 msgid "Back to Programs"
 msgstr "Zurück zu den Programmen"
@@ -5593,7 +5591,7 @@ msgstr "Familien verbinden mit"
 msgid "Contact Us →"
 msgstr "Kontakt →"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:318
+#: lib/klass_hero_web/live/provider/team_live.ex:315
 #, elixir-autogen, elixir-format
 msgid "Could not add you to the team. Please try again."
 msgstr "Sie konnten nicht zum Team hinzugefügt werden. Bitte versuchen Sie es erneut."
@@ -5872,13 +5870,13 @@ msgstr "So bringen Sie Ihr Jugendprogramm zum Wachsen"
 msgid "How we vet providers"
 msgstr "Wie wir Anbieter überprüfen"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:531
+#: lib/klass_hero_web/live/provider/team_live.ex:528
 #, elixir-autogen, elixir-format
 msgid "I'll be teaching"
 msgstr "Ich werde unterrichten"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:357
-#: lib/klass_hero_web/live/provider/programs_live.ex:379
+#: lib/klass_hero_web/live/provider/programs_live.ex:351
+#: lib/klass_hero_web/live/provider/programs_live.ex:373
 #, elixir-autogen, elixir-format
 msgid "Imported %{count} family."
 msgid_plural "Imported %{count} families."
@@ -5891,8 +5889,8 @@ msgid "In 2025, Shane connected with his friend"
 msgstr "2025 tat sich Shane mit seinem Freund zusammen"
 
 #: lib/klass_hero_web/components/provider_components.ex:1451
-#: lib/klass_hero_web/live/provider/incident_reports_live.ex:42
-#: lib/klass_hero_web/live/provider/incident_reports_live.ex:73
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:43
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:74
 #, elixir-autogen, elixir-format
 msgid "Incident Reports"
 msgstr "Vorfallberichte"
@@ -6136,7 +6134,7 @@ msgstr "Keine Kreditkarte erforderlich"
 msgid "No featured programs available right now. Check back soon."
 msgstr "Derzeit keine empfohlenen Programme verfügbar. Schauen Sie bald wieder vorbei."
 
-#: lib/klass_hero_web/live/provider/incident_reports_live.ex:115
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:116
 #, elixir-autogen, elixir-format
 msgid "No incident reports yet"
 msgstr "Noch keine Vorfallberichte"
@@ -6166,7 +6164,7 @@ msgstr "Noch keine Programme — fügen Sie Ihr erstes über den Tab „Programm
 msgid "No registered children for this session."
 msgstr "Keine Kinder in dieser Sitzung angemeldet."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:366
+#: lib/klass_hero_web/live/provider/programs_live.ex:360
 #, elixir-autogen, elixir-format
 msgid "No rows imported. %{count} row could not be processed."
 msgid_plural "No rows imported. %{count} rows could not be processed."
@@ -6394,7 +6392,7 @@ msgstr "Empfohlen"
 msgid "Reporting"
 msgstr "Berichte"
 
-#: lib/klass_hero_web/live/provider/incident_reports_live.ex:118
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:119
 #, elixir-autogen, elixir-format
 msgid "Reports filed for this program will appear here."
 msgstr "Für dieses Programm eingereichte Berichte werden hier angezeigt."
@@ -6570,7 +6568,7 @@ msgstr "Noch neugierig?"
 msgid "Stop chasing leads"
 msgstr "Hören Sie auf, Leads hinterherzujagen"
 
-#: lib/klass_hero_web/live/provider/incident_reports_live.ex:98
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:99
 #, elixir-autogen, elixir-format
 msgid "Submitted by"
 msgstr "Eingereicht von"
@@ -6841,7 +6839,7 @@ msgstr "Sie haben bereits ein Konto für %{email}."
 msgid "You'll get your own provider profile to fill in, and your account will open on your business dashboard from now on. You stay on %{business}'s team."
 msgstr "Sie erhalten Ihr eigenes Anbieterprofil zum Ausfüllen, und Ihr Konto öffnet sich ab sofort auf Ihrem Geschäfts-Dashboard. Sie bleiben im Team von %{business}."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:298
+#: lib/klass_hero_web/live/provider/team_live.ex:295
 #, elixir-autogen, elixir-format
 msgid "You're already on your team."
 msgstr "Sie sind bereits in Ihrem Team."
@@ -6861,12 +6859,12 @@ msgstr "Sie sind nicht mehr in diesem Team."
 msgid "You're now part of the team."
 msgstr "Sie sind jetzt Teil des Teams."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:346
+#: lib/klass_hero_web/live/provider/team_live.ex:343
 #, elixir-autogen, elixir-format
 msgid "You're on the team — you can now be assigned to programs."
 msgstr "Sie sind im Team — Sie können nun Programmen zugewiesen werden."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:345
+#: lib/klass_hero_web/live/provider/team_live.ex:342
 #, elixir-autogen, elixir-format
 msgid "You're on the team, but the headshot upload failed."
 msgstr "Sie sind im Team, aber der Upload des Profilfotos ist fehlgeschlagen."

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -269,7 +269,7 @@ msgstr "Programme entdecken"
 msgid "Featured Programs"
 msgstr "Empfohlene Programme"
 
-#: lib/klass_hero_web/live/programs_live.ex:220
+#: lib/klass_hero_web/live/programs_live.ex:221
 #, elixir-autogen, elixir-format
 msgid "Invalid pagination state. Please refresh the page."
 msgstr "Ungültiger Seitenstatus. Bitte laden Sie die Seite neu."
@@ -279,7 +279,7 @@ msgstr "Ungültiger Seitenstatus. Bitte laden Sie die Seite neu."
 msgid "Invoice & Payment Confirmation"
 msgstr "Rechnung & Zahlungsbestätigung"
 
-#: lib/klass_hero_web/live/programs_live.ex:360
+#: lib/klass_hero_web/live/programs_live.ex:361
 #, elixir-autogen, elixir-format
 msgid "Loading..."
 msgstr "Laden..."
@@ -291,7 +291,7 @@ msgid_plural "Meet the Heroes"
 msgstr[0] "Lernen Sie den Helden kennen"
 msgstr[1] "Lernen Sie die Helden kennen"
 
-#: lib/klass_hero_web/live/programs_live.ex:305
+#: lib/klass_hero_web/live/programs_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "No programs found"
 msgstr "Keine Programme gefunden"
@@ -6018,7 +6018,7 @@ msgstr "Ihr Programm eintragen"
 msgid "Live video screen with our safeguarding lead."
 msgstr "Live-Video-Screening mit unserer Kinderschutzbeauftragten."
 
-#: lib/klass_hero_web/live/programs_live.ex:362
+#: lib/klass_hero_web/live/programs_live.ex:363
 #, elixir-autogen, elixir-format
 msgid "Load more programs"
 msgstr "Weitere Programme laden"
@@ -6672,7 +6672,7 @@ msgstr "Vertrauen &"
 msgid "Trusted Heroes"
 msgstr "Vertrauenswürdige Heroes"
 
-#: lib/klass_hero_web/live/programs_live.ex:307
+#: lib/klass_hero_web/live/programs_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "Try adjusting your search or filter criteria — there's plenty more in Berlin."
 msgstr "Versuchen Sie, Ihre Such- oder Filterkriterien anzupassen — in Berlin gibt es noch viel mehr."

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -1600,7 +1600,7 @@ msgid "Active"
 msgstr "Aktiv"
 
 #: lib/klass_hero_web/components/provider_components.ex:600
-#: lib/klass_hero_web/live/provider/team_live.ex:541
+#: lib/klass_hero_web/live/provider/team_live.ex:540
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
 msgstr "Teammitglied hinzufügen"
@@ -1632,7 +1632,7 @@ msgstr "Geschäftsprofil"
 msgid "Business Registration"
 msgstr "Gewerbeanmeldung"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:518
+#: lib/klass_hero_web/live/provider/team_live.ex:517
 #, elixir-autogen, elixir-format
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr "Erstellen Sie Profile für Ihr Personal. Diese werden für Eltern sichtbar sein, wenn sie Programmen zugewiesen werden."
@@ -1735,7 +1735,7 @@ msgstr "Status"
 msgid "Team & Profiles"
 msgstr "Team & Profile"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:515
+#: lib/klass_hero_web/live/provider/team_live.ex:514
 #, elixir-autogen, elixir-format
 msgid "Team & Provider Profiles"
 msgstr "Team- & Anbieterprofile"
@@ -2225,7 +2225,7 @@ msgstr "Aktion erforderlich"
 msgid "Add Member"
 msgstr "Mitglied hinzufügen"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:565
+#: lib/klass_hero_web/live/provider/team_live.ex:564
 #, elixir-autogen, elixir-format
 msgid "Add your first staff member to get started!"
 msgstr "Fügen Sie Ihren ersten Mitarbeiter hinzu, um loszulegen!"
@@ -2809,7 +2809,7 @@ msgstr "Noch keine Programme gebucht"
 msgid "No rejected documents."
 msgstr "Keine abgelehnten Dokumente."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:564
+#: lib/klass_hero_web/live/provider/team_live.ex:563
 #, elixir-autogen, elixir-format
 msgid "No team members yet"
 msgstr "Noch keine Teammitglieder"
@@ -2871,9 +2871,9 @@ msgstr "Ausstehende Überprüfung"
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:106
 #: lib/klass_hero_web/live/provider/programs_live.ex:588
 #: lib/klass_hero_web/live/provider/programs_live.ex:654
-#: lib/klass_hero_web/live/provider/team_live.ex:260
-#: lib/klass_hero_web/live/provider/team_live.ex:311
-#: lib/klass_hero_web/live/provider/team_live.ex:430
+#: lib/klass_hero_web/live/provider/team_live.ex:259
+#: lib/klass_hero_web/live/provider/team_live.ex:310
+#: lib/klass_hero_web/live/provider/team_live.ex:429
 #, elixir-autogen, elixir-format
 msgid "Please fix the errors below."
 msgstr "Bitte korrigieren Sie die Fehler unten."
@@ -3111,16 +3111,15 @@ msgstr "Legen Sie die minimale und maximale Anmeldekapazität für dieses Progra
 msgid "Specialties"
 msgstr "Spezialisierungen"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:410
-#: lib/klass_hero_web/live/provider/team_live.ex:436
+#: lib/klass_hero_web/live/provider/team_live.ex:409
+#: lib/klass_hero_web/live/provider/team_live.ex:435
 #, elixir-autogen, elixir-format
 msgid "Staff member no longer exists."
 msgstr "Der Mitarbeiter existiert nicht mehr."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:100
-#: lib/klass_hero_web/live/provider/team_live.ex:103
-#: lib/klass_hero_web/live/provider/team_live.ex:176
-#: lib/klass_hero_web/live/provider/team_live.ex:201
+#: lib/klass_hero_web/live/provider/team_live.ex:102
+#: lib/klass_hero_web/live/provider/team_live.ex:175
+#: lib/klass_hero_web/live/provider/team_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "Staff member not found."
 msgstr "Mitarbeiter nicht gefunden."
@@ -3151,27 +3150,27 @@ msgstr "Noch offen"
 msgid "Tax Certificate"
 msgstr "Steuerbescheinigung"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:364
+#: lib/klass_hero_web/live/provider/team_live.ex:363
 #, elixir-autogen, elixir-format
 msgid "Team member added, but headshot upload failed."
 msgstr "Teammitglied hinzugefügt, aber der Upload des Profilfotos ist fehlgeschlagen."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:365
+#: lib/klass_hero_web/live/provider/team_live.ex:364
 #, elixir-autogen, elixir-format
 msgid "Team member added."
 msgstr "Teammitglied hinzugefügt."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:166
+#: lib/klass_hero_web/live/provider/team_live.ex:165
 #, elixir-autogen, elixir-format
 msgid "Team member removed."
 msgstr "Teammitglied entfernt."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:390
+#: lib/klass_hero_web/live/provider/team_live.ex:389
 #, elixir-autogen, elixir-format
 msgid "Team member updated, but headshot upload failed."
 msgstr "Teammitglied aktualisiert, aber der Upload des Profilfotos ist fehlgeschlagen."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:391
+#: lib/klass_hero_web/live/provider/team_live.ex:390
 #, elixir-autogen, elixir-format
 msgid "Team member updated."
 msgstr "Teammitglied aktualisiert."
@@ -4253,7 +4252,7 @@ msgstr "E-Mail-Inhalt konnte nicht abgerufen werden."
 msgid "Failed to mark email as unread"
 msgstr "E-Mail konnte nicht als ungelesen markiert werden"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:217
+#: lib/klass_hero_web/live/provider/team_live.ex:216
 #, elixir-autogen, elixir-format
 msgid "Failed to resend invitation. Please try again."
 msgstr "Einladung konnte nicht erneut gesendet werden. Bitte versuchen Sie es erneut."
@@ -4321,7 +4320,7 @@ msgstr "Einladung ausstehend"
 msgid "Invitation Sent"
 msgstr "Einladung gesendet"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:191
+#: lib/klass_hero_web/live/provider/team_live.ex:190
 #, elixir-autogen, elixir-format
 msgid "Invitation resent successfully."
 msgstr "Einladung erfolgreich erneut gesendet."
@@ -4568,7 +4567,7 @@ msgstr "Sitzung erfolgreich erstellt"
 msgid "Staff Dashboard"
 msgstr "Mitarbeiter-Dashboard"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:267
+#: lib/klass_hero_web/live/provider/team_live.ex:266
 #, elixir-autogen, elixir-format
 msgid "Staff member created, but the invitation could not be sent. Try resending from the team list."
 msgstr "Mitarbeiter wurde erstellt, aber die Einladung konnte nicht gesendet werden. Versuchen Sie es erneut über die Team-Liste."
@@ -4599,7 +4598,7 @@ msgstr "Unterstützung: %{details}"
 msgid "The business associated with your account could not be found."
 msgstr "Das mit Ihrem Konto verknüpfte Unternehmen konnte nicht gefunden werden."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:208
+#: lib/klass_hero_web/live/provider/team_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "This invitation cannot be resent in its current state."
 msgstr "Diese Einladung kann in ihrem aktuellen Status nicht erneut gesendet werden."
@@ -5594,7 +5593,7 @@ msgstr "Familien verbinden mit"
 msgid "Contact Us →"
 msgstr "Kontakt →"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:319
+#: lib/klass_hero_web/live/provider/team_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "Could not add you to the team. Please try again."
 msgstr "Sie konnten nicht zum Team hinzugefügt werden. Bitte versuchen Sie es erneut."
@@ -5873,7 +5872,7 @@ msgstr "So bringen Sie Ihr Jugendprogramm zum Wachsen"
 msgid "How we vet providers"
 msgstr "Wie wir Anbieter überprüfen"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:532
+#: lib/klass_hero_web/live/provider/team_live.ex:531
 #, elixir-autogen, elixir-format
 msgid "I'll be teaching"
 msgstr "Ich werde unterrichten"
@@ -6842,7 +6841,7 @@ msgstr "Sie haben bereits ein Konto für %{email}."
 msgid "You'll get your own provider profile to fill in, and your account will open on your business dashboard from now on. You stay on %{business}'s team."
 msgstr "Sie erhalten Ihr eigenes Anbieterprofil zum Ausfüllen, und Ihr Konto öffnet sich ab sofort auf Ihrem Geschäfts-Dashboard. Sie bleiben im Team von %{business}."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:299
+#: lib/klass_hero_web/live/provider/team_live.ex:298
 #, elixir-autogen, elixir-format
 msgid "You're already on your team."
 msgstr "Sie sind bereits in Ihrem Team."
@@ -6862,12 +6861,12 @@ msgstr "Sie sind nicht mehr in diesem Team."
 msgid "You're now part of the team."
 msgstr "Sie sind jetzt Teil des Teams."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:347
+#: lib/klass_hero_web/live/provider/team_live.ex:346
 #, elixir-autogen, elixir-format
 msgid "You're on the team — you can now be assigned to programs."
 msgstr "Sie sind im Team — Sie können nun Programmen zugewiesen werden."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:346
+#: lib/klass_hero_web/live/provider/team_live.ex:345
 #, elixir-autogen, elixir-format
 msgid "You're on the team, but the headshot upload failed."
 msgstr "Sie sind im Team, aber der Upload des Profilfotos ist fehlgeschlagen."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -269,7 +269,7 @@ msgstr ""
 msgid "Featured Programs"
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:220
+#: lib/klass_hero_web/live/programs_live.ex:221
 #, elixir-autogen, elixir-format
 msgid "Invalid pagination state. Please refresh the page."
 msgstr ""
@@ -279,7 +279,7 @@ msgstr ""
 msgid "Invoice & Payment Confirmation"
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:360
+#: lib/klass_hero_web/live/programs_live.ex:361
 #, elixir-autogen, elixir-format
 msgid "Loading..."
 msgstr ""
@@ -291,7 +291,7 @@ msgid_plural "Meet the Heroes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/live/programs_live.ex:305
+#: lib/klass_hero_web/live/programs_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "No programs found"
 msgstr ""
@@ -6018,7 +6018,7 @@ msgstr ""
 msgid "Live video screen with our safeguarding lead."
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:362
+#: lib/klass_hero_web/live/programs_live.ex:363
 #, elixir-autogen, elixir-format
 msgid "Load more programs"
 msgstr ""
@@ -6672,7 +6672,7 @@ msgstr ""
 msgid "Trusted Heroes"
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:307
+#: lib/klass_hero_web/live/programs_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "Try adjusting your search or filter criteria — there's plenty more in Berlin."
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -1600,7 +1600,7 @@ msgid "Active"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:600
-#: lib/klass_hero_web/live/provider/team_live.ex:541
+#: lib/klass_hero_web/live/provider/team_live.ex:540
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
 msgstr ""
@@ -1632,7 +1632,7 @@ msgstr ""
 msgid "Business Registration"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:518
+#: lib/klass_hero_web/live/provider/team_live.ex:517
 #, elixir-autogen, elixir-format
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr ""
@@ -1735,7 +1735,7 @@ msgstr ""
 msgid "Team & Profiles"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:515
+#: lib/klass_hero_web/live/provider/team_live.ex:514
 #, elixir-autogen, elixir-format
 msgid "Team & Provider Profiles"
 msgstr ""
@@ -2225,7 +2225,7 @@ msgstr ""
 msgid "Add Member"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:565
+#: lib/klass_hero_web/live/provider/team_live.ex:564
 #, elixir-autogen, elixir-format
 msgid "Add your first staff member to get started!"
 msgstr ""
@@ -2809,7 +2809,7 @@ msgstr ""
 msgid "No rejected documents."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:564
+#: lib/klass_hero_web/live/provider/team_live.ex:563
 #, elixir-autogen, elixir-format
 msgid "No team members yet"
 msgstr ""
@@ -2871,9 +2871,9 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:106
 #: lib/klass_hero_web/live/provider/programs_live.ex:588
 #: lib/klass_hero_web/live/provider/programs_live.ex:654
-#: lib/klass_hero_web/live/provider/team_live.ex:260
-#: lib/klass_hero_web/live/provider/team_live.ex:311
-#: lib/klass_hero_web/live/provider/team_live.ex:430
+#: lib/klass_hero_web/live/provider/team_live.ex:259
+#: lib/klass_hero_web/live/provider/team_live.ex:310
+#: lib/klass_hero_web/live/provider/team_live.ex:429
 #, elixir-autogen, elixir-format
 msgid "Please fix the errors below."
 msgstr ""
@@ -3111,16 +3111,15 @@ msgstr ""
 msgid "Specialties"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:410
-#: lib/klass_hero_web/live/provider/team_live.ex:436
+#: lib/klass_hero_web/live/provider/team_live.ex:409
+#: lib/klass_hero_web/live/provider/team_live.ex:435
 #, elixir-autogen, elixir-format
 msgid "Staff member no longer exists."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:100
-#: lib/klass_hero_web/live/provider/team_live.ex:103
-#: lib/klass_hero_web/live/provider/team_live.ex:176
-#: lib/klass_hero_web/live/provider/team_live.ex:201
+#: lib/klass_hero_web/live/provider/team_live.ex:102
+#: lib/klass_hero_web/live/provider/team_live.ex:175
+#: lib/klass_hero_web/live/provider/team_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "Staff member not found."
 msgstr ""
@@ -3151,27 +3150,27 @@ msgstr ""
 msgid "Tax Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:364
+#: lib/klass_hero_web/live/provider/team_live.ex:363
 #, elixir-autogen, elixir-format
 msgid "Team member added, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:365
+#: lib/klass_hero_web/live/provider/team_live.ex:364
 #, elixir-autogen, elixir-format
 msgid "Team member added."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:166
+#: lib/klass_hero_web/live/provider/team_live.ex:165
 #, elixir-autogen, elixir-format
 msgid "Team member removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:390
+#: lib/klass_hero_web/live/provider/team_live.ex:389
 #, elixir-autogen, elixir-format
 msgid "Team member updated, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:391
+#: lib/klass_hero_web/live/provider/team_live.ex:390
 #, elixir-autogen, elixir-format
 msgid "Team member updated."
 msgstr ""
@@ -4253,7 +4252,7 @@ msgstr ""
 msgid "Failed to mark email as unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:217
+#: lib/klass_hero_web/live/provider/team_live.ex:216
 #, elixir-autogen, elixir-format
 msgid "Failed to resend invitation. Please try again."
 msgstr ""
@@ -4321,7 +4320,7 @@ msgstr ""
 msgid "Invitation Sent"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:191
+#: lib/klass_hero_web/live/provider/team_live.ex:190
 #, elixir-autogen, elixir-format
 msgid "Invitation resent successfully."
 msgstr ""
@@ -4568,7 +4567,7 @@ msgstr ""
 msgid "Staff Dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:267
+#: lib/klass_hero_web/live/provider/team_live.ex:266
 #, elixir-autogen, elixir-format
 msgid "Staff member created, but the invitation could not be sent. Try resending from the team list."
 msgstr ""
@@ -4599,7 +4598,7 @@ msgstr ""
 msgid "The business associated with your account could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:208
+#: lib/klass_hero_web/live/provider/team_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "This invitation cannot be resent in its current state."
 msgstr ""
@@ -5594,7 +5593,7 @@ msgstr ""
 msgid "Contact Us →"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:319
+#: lib/klass_hero_web/live/provider/team_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "Could not add you to the team. Please try again."
 msgstr ""
@@ -5873,7 +5872,7 @@ msgstr ""
 msgid "How we vet providers"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:532
+#: lib/klass_hero_web/live/provider/team_live.ex:531
 #, elixir-autogen, elixir-format
 msgid "I'll be teaching"
 msgstr ""
@@ -6842,7 +6841,7 @@ msgstr ""
 msgid "You'll get your own provider profile to fill in, and your account will open on your business dashboard from now on. You stay on %{business}'s team."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:299
+#: lib/klass_hero_web/live/provider/team_live.ex:298
 #, elixir-autogen, elixir-format
 msgid "You're already on your team."
 msgstr ""
@@ -6862,12 +6861,12 @@ msgstr ""
 msgid "You're now part of the team."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:347
+#: lib/klass_hero_web/live/provider/team_live.ex:346
 #, elixir-autogen, elixir-format
 msgid "You're on the team — you can now be assigned to programs."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:346
+#: lib/klass_hero_web/live/provider/team_live.ex:345
 #, elixir-autogen, elixir-format
 msgid "You're on the team, but the headshot upload failed."
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -1600,7 +1600,7 @@ msgid "Active"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:600
-#: lib/klass_hero_web/live/provider/team_live.ex:540
+#: lib/klass_hero_web/live/provider/team_live.ex:537
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
 msgstr ""
@@ -1632,7 +1632,7 @@ msgstr ""
 msgid "Business Registration"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:517
+#: lib/klass_hero_web/live/provider/team_live.ex:514
 #, elixir-autogen, elixir-format
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr ""
@@ -1735,7 +1735,7 @@ msgstr ""
 msgid "Team & Profiles"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:514
+#: lib/klass_hero_web/live/provider/team_live.ex:511
 #, elixir-autogen, elixir-format
 msgid "Team & Provider Profiles"
 msgstr ""
@@ -2225,7 +2225,7 @@ msgstr ""
 msgid "Add Member"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:564
+#: lib/klass_hero_web/live/provider/team_live.ex:561
 #, elixir-autogen, elixir-format
 msgid "Add your first staff member to get started!"
 msgstr ""
@@ -2406,12 +2406,12 @@ msgstr ""
 msgid "Contact Provider"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:346
+#: lib/klass_hero_web/live/provider/programs_live.ex:340
 #, elixir-autogen, elixir-format
 msgid "Could not read the uploaded file."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:314
+#: lib/klass_hero_web/live/provider/programs_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "Could not remove invite."
 msgstr ""
@@ -2549,7 +2549,7 @@ msgstr ""
 msgid "Failed to reject document."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:296
+#: lib/klass_hero_web/live/provider/programs_live.ex:290
 #, elixir-autogen, elixir-format
 msgid "Failed to resend invite."
 msgstr ""
@@ -2642,17 +2642,17 @@ msgstr ""
 msgid "Insurance Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:311
+#: lib/klass_hero_web/live/provider/programs_live.ex:305
 #, elixir-autogen, elixir-format
 msgid "Invite not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:308
+#: lib/klass_hero_web/live/provider/programs_live.ex:302
 #, elixir-autogen, elixir-format
 msgid "Invite removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:285
+#: lib/klass_hero_web/live/provider/programs_live.ex:279
 #, elixir-autogen, elixir-format
 msgid "Invite resent successfully."
 msgstr ""
@@ -2769,7 +2769,7 @@ msgstr ""
 msgid "No enrollments yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:342
+#: lib/klass_hero_web/live/provider/programs_live.ex:336
 #, elixir-autogen, elixir-format
 msgid "No file selected."
 msgstr ""
@@ -2809,7 +2809,7 @@ msgstr ""
 msgid "No rejected documents."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:563
+#: lib/klass_hero_web/live/provider/team_live.ex:560
 #, elixir-autogen, elixir-format
 msgid "No team members yet"
 msgstr ""
@@ -2869,11 +2869,11 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:106
-#: lib/klass_hero_web/live/provider/programs_live.ex:588
-#: lib/klass_hero_web/live/provider/programs_live.ex:654
-#: lib/klass_hero_web/live/provider/team_live.ex:259
-#: lib/klass_hero_web/live/provider/team_live.ex:310
-#: lib/klass_hero_web/live/provider/team_live.ex:429
+#: lib/klass_hero_web/live/provider/programs_live.ex:582
+#: lib/klass_hero_web/live/provider/programs_live.ex:648
+#: lib/klass_hero_web/live/provider/team_live.ex:256
+#: lib/klass_hero_web/live/provider/team_live.ex:307
+#: lib/klass_hero_web/live/provider/team_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "Please fix the errors below."
 msgstr ""
@@ -2903,27 +2903,25 @@ msgstr ""
 msgid "Program Start"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:911
+#: lib/klass_hero_web/live/provider/programs_live.ex:905
 #, elixir-autogen, elixir-format
 msgid "Program created successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:918
+#: lib/klass_hero_web/live/provider/programs_live.ex:912
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_reports_live.ex:53
-#: lib/klass_hero_web/live/provider/programs_live.ex:149
-#: lib/klass_hero_web/live/provider/programs_live.ex:152
-#: lib/klass_hero_web/live/provider/programs_live.ex:188
-#: lib/klass_hero_web/live/provider/programs_live.ex:191
-#: lib/klass_hero_web/live/provider/programs_live.ex:629
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:54
+#: lib/klass_hero_web/live/provider/programs_live.ex:148
+#: lib/klass_hero_web/live/provider/programs_live.ex:185
+#: lib/klass_hero_web/live/provider/programs_live.ex:623
 #, elixir-autogen, elixir-format
 msgid "Program not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:618
+#: lib/klass_hero_web/live/provider/programs_live.ex:612
 #, elixir-autogen, elixir-format
 msgid "Program updated successfully."
 msgstr ""
@@ -3084,8 +3082,8 @@ msgstr ""
 msgid "Selected child does not meet the program requirements."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:578
-#: lib/klass_hero_web/live/provider/programs_live.ex:644
+#: lib/klass_hero_web/live/provider/programs_live.ex:572
+#: lib/klass_hero_web/live/provider/programs_live.ex:638
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
@@ -3111,15 +3109,15 @@ msgstr ""
 msgid "Specialties"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:409
-#: lib/klass_hero_web/live/provider/team_live.ex:435
+#: lib/klass_hero_web/live/provider/team_live.ex:406
+#: lib/klass_hero_web/live/provider/team_live.ex:432
 #, elixir-autogen, elixir-format
 msgid "Staff member no longer exists."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:102
-#: lib/klass_hero_web/live/provider/team_live.ex:175
-#: lib/klass_hero_web/live/provider/team_live.ex:200
+#: lib/klass_hero_web/live/provider/team_live.ex:101
+#: lib/klass_hero_web/live/provider/team_live.ex:173
+#: lib/klass_hero_web/live/provider/team_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Staff member not found."
 msgstr ""
@@ -3150,27 +3148,27 @@ msgstr ""
 msgid "Tax Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:363
+#: lib/klass_hero_web/live/provider/team_live.ex:360
 #, elixir-autogen, elixir-format
 msgid "Team member added, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:364
+#: lib/klass_hero_web/live/provider/team_live.ex:361
 #, elixir-autogen, elixir-format
 msgid "Team member added."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:165
+#: lib/klass_hero_web/live/provider/team_live.ex:164
 #, elixir-autogen, elixir-format
 msgid "Team member removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:389
+#: lib/klass_hero_web/live/provider/team_live.ex:386
 #, elixir-autogen, elixir-format
 msgid "Team member updated, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:390
+#: lib/klass_hero_web/live/provider/team_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "Team member updated."
 msgstr ""
@@ -3185,12 +3183,12 @@ msgstr ""
 msgid "The Klass Hero Story"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:288
+#: lib/klass_hero_web/live/provider/programs_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "This invite cannot be resent."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:636
+#: lib/klass_hero_web/live/provider/programs_live.ex:630
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
@@ -3404,7 +3402,7 @@ msgstr ""
 msgid "Program fee:"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:751
+#: lib/klass_hero_web/live/provider/programs_live.ex:745
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr ""
@@ -3619,7 +3617,7 @@ msgstr ""
 msgid "Cannot check out without a check-in"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:260
+#: lib/klass_hero_web/live/provider/programs_live.ex:254
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:146
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
@@ -3684,7 +3682,7 @@ msgid "Correct"
 msgstr ""
 
 #: lib/klass_hero_web/live/dashboard_live.ex:286
-#: lib/klass_hero_web/live/provider/programs_live.ex:257
+#: lib/klass_hero_web/live/provider/programs_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "Could not start conversation. Please try again."
@@ -4252,7 +4250,7 @@ msgstr ""
 msgid "Failed to mark email as unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:216
+#: lib/klass_hero_web/live/provider/team_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "Failed to resend invitation. Please try again."
 msgstr ""
@@ -4320,7 +4318,7 @@ msgstr ""
 msgid "Invitation Sent"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:190
+#: lib/klass_hero_web/live/provider/team_live.ex:188
 #, elixir-autogen, elixir-format
 msgid "Invitation resent successfully."
 msgstr ""
@@ -4446,7 +4444,7 @@ msgstr ""
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:24
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
-#: lib/klass_hero_web/live/provider/programs_live.ex:223
+#: lib/klass_hero_web/live/provider/programs_live.ex:217
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Program"
@@ -4567,7 +4565,7 @@ msgstr ""
 msgid "Staff Dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:266
+#: lib/klass_hero_web/live/provider/team_live.ex:263
 #, elixir-autogen, elixir-format
 msgid "Staff member created, but the invitation could not be sent. Try resending from the team list."
 msgstr ""
@@ -4598,7 +4596,7 @@ msgstr ""
 msgid "The business associated with your account could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:207
+#: lib/klass_hero_web/live/provider/team_live.ex:204
 #, elixir-autogen, elixir-format
 msgid "This invitation cannot be resent in its current state."
 msgstr ""
@@ -4660,7 +4658,7 @@ msgid "Update your observation..."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:138
-#: lib/klass_hero_web/live/provider/programs_live.ex:339
+#: lib/klass_hero_web/live/provider/programs_live.ex:333
 #: lib/klass_hero_web/live/provider/verification_live.ex:240
 #: lib/klass_hero_web/live/provider/verification_live.ex:556
 #: lib/klass_hero_web/live/provider/verification_live.ex:594
@@ -4968,7 +4966,7 @@ msgstr ""
 msgid "View sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:430
+#: lib/klass_hero_web/live/provider/programs_live.ex:424
 #, elixir-autogen, elixir-format
 msgid "Create a program before inviting participants."
 msgstr ""
@@ -5010,7 +5008,7 @@ msgstr ""
 msgid "Invite one person"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:426
+#: lib/klass_hero_web/live/provider/programs_live.ex:420
 #, elixir-autogen, elixir-format
 msgid "Invite sent."
 msgstr ""
@@ -5113,7 +5111,7 @@ msgstr ""
 msgid "Upload a list"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:437
+#: lib/klass_hero_web/live/provider/programs_live.ex:431
 #, elixir-autogen, elixir-format
 msgid "An invite for this child and program already exists."
 msgstr ""
@@ -5290,7 +5288,7 @@ msgstr ""
 msgid "Go to dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:382
+#: lib/klass_hero_web/live/provider/programs_live.ex:376
 #, elixir-autogen, elixir-format
 msgid "%{count} row could not be processed."
 msgid_plural "%{count} rows could not be processed."
@@ -5399,7 +5397,7 @@ msgstr ""
 msgid "Attach photo"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_reports_live.ex:68
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:69
 #, elixir-autogen, elixir-format
 msgid "Back to Programs"
 msgstr ""
@@ -5593,7 +5591,7 @@ msgstr ""
 msgid "Contact Us →"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:318
+#: lib/klass_hero_web/live/provider/team_live.ex:315
 #, elixir-autogen, elixir-format
 msgid "Could not add you to the team. Please try again."
 msgstr ""
@@ -5872,13 +5870,13 @@ msgstr ""
 msgid "How we vet providers"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:531
+#: lib/klass_hero_web/live/provider/team_live.ex:528
 #, elixir-autogen, elixir-format
 msgid "I'll be teaching"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:357
-#: lib/klass_hero_web/live/provider/programs_live.ex:379
+#: lib/klass_hero_web/live/provider/programs_live.ex:351
+#: lib/klass_hero_web/live/provider/programs_live.ex:373
 #, elixir-autogen, elixir-format
 msgid "Imported %{count} family."
 msgid_plural "Imported %{count} families."
@@ -5891,8 +5889,8 @@ msgid "In 2025, Shane connected with his friend"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1451
-#: lib/klass_hero_web/live/provider/incident_reports_live.ex:42
-#: lib/klass_hero_web/live/provider/incident_reports_live.ex:73
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:43
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:74
 #, elixir-autogen, elixir-format
 msgid "Incident Reports"
 msgstr ""
@@ -6136,7 +6134,7 @@ msgstr ""
 msgid "No featured programs available right now. Check back soon."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_reports_live.ex:115
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:116
 #, elixir-autogen, elixir-format
 msgid "No incident reports yet"
 msgstr ""
@@ -6166,7 +6164,7 @@ msgstr ""
 msgid "No registered children for this session."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:366
+#: lib/klass_hero_web/live/provider/programs_live.ex:360
 #, elixir-autogen, elixir-format
 msgid "No rows imported. %{count} row could not be processed."
 msgid_plural "No rows imported. %{count} rows could not be processed."
@@ -6394,7 +6392,7 @@ msgstr ""
 msgid "Reporting"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_reports_live.ex:118
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:119
 #, elixir-autogen, elixir-format
 msgid "Reports filed for this program will appear here."
 msgstr ""
@@ -6570,7 +6568,7 @@ msgstr ""
 msgid "Stop chasing leads"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_reports_live.ex:98
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:99
 #, elixir-autogen, elixir-format
 msgid "Submitted by"
 msgstr ""
@@ -6841,7 +6839,7 @@ msgstr ""
 msgid "You'll get your own provider profile to fill in, and your account will open on your business dashboard from now on. You stay on %{business}'s team."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:298
+#: lib/klass_hero_web/live/provider/team_live.ex:295
 #, elixir-autogen, elixir-format
 msgid "You're already on your team."
 msgstr ""
@@ -6861,12 +6859,12 @@ msgstr ""
 msgid "You're now part of the team."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:346
+#: lib/klass_hero_web/live/provider/team_live.ex:343
 #, elixir-autogen, elixir-format
 msgid "You're on the team — you can now be assigned to programs."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:345
+#: lib/klass_hero_web/live/provider/team_live.ex:342
 #, elixir-autogen, elixir-format
 msgid "You're on the team, but the headshot upload failed."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -1600,7 +1600,7 @@ msgid "Active"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:600
-#: lib/klass_hero_web/live/provider/team_live.ex:541
+#: lib/klass_hero_web/live/provider/team_live.ex:540
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
 msgstr ""
@@ -1632,7 +1632,7 @@ msgstr ""
 msgid "Business Registration"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:518
+#: lib/klass_hero_web/live/provider/team_live.ex:517
 #, elixir-autogen, elixir-format
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr ""
@@ -1735,7 +1735,7 @@ msgstr ""
 msgid "Team & Profiles"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:515
+#: lib/klass_hero_web/live/provider/team_live.ex:514
 #, elixir-autogen, elixir-format
 msgid "Team & Provider Profiles"
 msgstr ""
@@ -2225,7 +2225,7 @@ msgstr ""
 msgid "Add Member"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:565
+#: lib/klass_hero_web/live/provider/team_live.ex:564
 #, elixir-autogen, elixir-format
 msgid "Add your first staff member to get started!"
 msgstr ""
@@ -2809,7 +2809,7 @@ msgstr ""
 msgid "No rejected documents."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:564
+#: lib/klass_hero_web/live/provider/team_live.ex:563
 #, elixir-autogen, elixir-format
 msgid "No team members yet"
 msgstr ""
@@ -2871,9 +2871,9 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:106
 #: lib/klass_hero_web/live/provider/programs_live.ex:588
 #: lib/klass_hero_web/live/provider/programs_live.ex:654
-#: lib/klass_hero_web/live/provider/team_live.ex:260
-#: lib/klass_hero_web/live/provider/team_live.ex:311
-#: lib/klass_hero_web/live/provider/team_live.ex:430
+#: lib/klass_hero_web/live/provider/team_live.ex:259
+#: lib/klass_hero_web/live/provider/team_live.ex:310
+#: lib/klass_hero_web/live/provider/team_live.ex:429
 #, elixir-autogen, elixir-format
 msgid "Please fix the errors below."
 msgstr ""
@@ -3111,16 +3111,15 @@ msgstr ""
 msgid "Specialties"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:410
-#: lib/klass_hero_web/live/provider/team_live.ex:436
+#: lib/klass_hero_web/live/provider/team_live.ex:409
+#: lib/klass_hero_web/live/provider/team_live.ex:435
 #, elixir-autogen, elixir-format
 msgid "Staff member no longer exists."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:100
-#: lib/klass_hero_web/live/provider/team_live.ex:103
-#: lib/klass_hero_web/live/provider/team_live.ex:176
-#: lib/klass_hero_web/live/provider/team_live.ex:201
+#: lib/klass_hero_web/live/provider/team_live.ex:102
+#: lib/klass_hero_web/live/provider/team_live.ex:175
+#: lib/klass_hero_web/live/provider/team_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "Staff member not found."
 msgstr ""
@@ -3151,27 +3150,27 @@ msgstr ""
 msgid "Tax Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:364
+#: lib/klass_hero_web/live/provider/team_live.ex:363
 #, elixir-autogen, elixir-format
 msgid "Team member added, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:365
+#: lib/klass_hero_web/live/provider/team_live.ex:364
 #, elixir-autogen, elixir-format
 msgid "Team member added."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:166
+#: lib/klass_hero_web/live/provider/team_live.ex:165
 #, elixir-autogen, elixir-format
 msgid "Team member removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:390
+#: lib/klass_hero_web/live/provider/team_live.ex:389
 #, elixir-autogen, elixir-format
 msgid "Team member updated, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:391
+#: lib/klass_hero_web/live/provider/team_live.ex:390
 #, elixir-autogen, elixir-format
 msgid "Team member updated."
 msgstr ""
@@ -4253,7 +4252,7 @@ msgstr ""
 msgid "Failed to mark email as unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:217
+#: lib/klass_hero_web/live/provider/team_live.ex:216
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to resend invitation. Please try again."
 msgstr ""
@@ -4321,7 +4320,7 @@ msgstr ""
 msgid "Invitation Sent"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:191
+#: lib/klass_hero_web/live/provider/team_live.ex:190
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invitation resent successfully."
 msgstr ""
@@ -4568,7 +4567,7 @@ msgstr ""
 msgid "Staff Dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:267
+#: lib/klass_hero_web/live/provider/team_live.ex:266
 #, elixir-autogen, elixir-format
 msgid "Staff member created, but the invitation could not be sent. Try resending from the team list."
 msgstr ""
@@ -4599,7 +4598,7 @@ msgstr ""
 msgid "The business associated with your account could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:208
+#: lib/klass_hero_web/live/provider/team_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "This invitation cannot be resent in its current state."
 msgstr ""
@@ -5594,7 +5593,7 @@ msgstr ""
 msgid "Contact Us →"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:319
+#: lib/klass_hero_web/live/provider/team_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "Could not add you to the team. Please try again."
 msgstr ""
@@ -5873,7 +5872,7 @@ msgstr ""
 msgid "How we vet providers"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:532
+#: lib/klass_hero_web/live/provider/team_live.ex:531
 #, elixir-autogen, elixir-format
 msgid "I'll be teaching"
 msgstr ""
@@ -6842,7 +6841,7 @@ msgstr ""
 msgid "You'll get your own provider profile to fill in, and your account will open on your business dashboard from now on. You stay on %{business}'s team."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:299
+#: lib/klass_hero_web/live/provider/team_live.ex:298
 #, elixir-autogen, elixir-format
 msgid "You're already on your team."
 msgstr ""
@@ -6862,12 +6861,12 @@ msgstr ""
 msgid "You're now part of the team."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:347
+#: lib/klass_hero_web/live/provider/team_live.ex:346
 #, elixir-autogen, elixir-format
 msgid "You're on the team — you can now be assigned to programs."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:346
+#: lib/klass_hero_web/live/provider/team_live.ex:345
 #, elixir-autogen, elixir-format
 msgid "You're on the team, but the headshot upload failed."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -269,7 +269,7 @@ msgstr ""
 msgid "Featured Programs"
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:220
+#: lib/klass_hero_web/live/programs_live.ex:221
 #, elixir-autogen, elixir-format
 msgid "Invalid pagination state. Please refresh the page."
 msgstr ""
@@ -279,7 +279,7 @@ msgstr ""
 msgid "Invoice & Payment Confirmation"
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:360
+#: lib/klass_hero_web/live/programs_live.ex:361
 #, elixir-autogen, elixir-format
 msgid "Loading..."
 msgstr ""
@@ -291,7 +291,7 @@ msgid_plural "Meet the Heroes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/live/programs_live.ex:305
+#: lib/klass_hero_web/live/programs_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "No programs found"
 msgstr ""
@@ -6018,7 +6018,7 @@ msgstr ""
 msgid "Live video screen with our safeguarding lead."
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:362
+#: lib/klass_hero_web/live/programs_live.ex:363
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Load more programs"
 msgstr ""
@@ -6672,7 +6672,7 @@ msgstr ""
 msgid "Trusted Heroes"
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:307
+#: lib/klass_hero_web/live/programs_live.ex:308
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Try adjusting your search or filter criteria — there's plenty more in Berlin."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -1600,7 +1600,7 @@ msgid "Active"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:600
-#: lib/klass_hero_web/live/provider/team_live.ex:540
+#: lib/klass_hero_web/live/provider/team_live.ex:537
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
 msgstr ""
@@ -1632,7 +1632,7 @@ msgstr ""
 msgid "Business Registration"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:517
+#: lib/klass_hero_web/live/provider/team_live.ex:514
 #, elixir-autogen, elixir-format
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr ""
@@ -1735,7 +1735,7 @@ msgstr ""
 msgid "Team & Profiles"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:514
+#: lib/klass_hero_web/live/provider/team_live.ex:511
 #, elixir-autogen, elixir-format
 msgid "Team & Provider Profiles"
 msgstr ""
@@ -2225,7 +2225,7 @@ msgstr ""
 msgid "Add Member"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:564
+#: lib/klass_hero_web/live/provider/team_live.ex:561
 #, elixir-autogen, elixir-format
 msgid "Add your first staff member to get started!"
 msgstr ""
@@ -2406,12 +2406,12 @@ msgstr ""
 msgid "Contact Provider"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:346
+#: lib/klass_hero_web/live/provider/programs_live.ex:340
 #, elixir-autogen, elixir-format
 msgid "Could not read the uploaded file."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:314
+#: lib/klass_hero_web/live/provider/programs_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "Could not remove invite."
 msgstr ""
@@ -2549,7 +2549,7 @@ msgstr ""
 msgid "Failed to reject document."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:296
+#: lib/klass_hero_web/live/provider/programs_live.ex:290
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to resend invite."
 msgstr ""
@@ -2642,17 +2642,17 @@ msgstr ""
 msgid "Insurance Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:311
+#: lib/klass_hero_web/live/provider/programs_live.ex:305
 #, elixir-autogen, elixir-format
 msgid "Invite not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:308
+#: lib/klass_hero_web/live/provider/programs_live.ex:302
 #, elixir-autogen, elixir-format
 msgid "Invite removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:285
+#: lib/klass_hero_web/live/provider/programs_live.ex:279
 #, elixir-autogen, elixir-format
 msgid "Invite resent successfully."
 msgstr ""
@@ -2769,7 +2769,7 @@ msgstr ""
 msgid "No enrollments yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:342
+#: lib/klass_hero_web/live/provider/programs_live.ex:336
 #, elixir-autogen, elixir-format
 msgid "No file selected."
 msgstr ""
@@ -2809,7 +2809,7 @@ msgstr ""
 msgid "No rejected documents."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:563
+#: lib/klass_hero_web/live/provider/team_live.ex:560
 #, elixir-autogen, elixir-format
 msgid "No team members yet"
 msgstr ""
@@ -2869,11 +2869,11 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:106
-#: lib/klass_hero_web/live/provider/programs_live.ex:588
-#: lib/klass_hero_web/live/provider/programs_live.ex:654
-#: lib/klass_hero_web/live/provider/team_live.ex:259
-#: lib/klass_hero_web/live/provider/team_live.ex:310
-#: lib/klass_hero_web/live/provider/team_live.ex:429
+#: lib/klass_hero_web/live/provider/programs_live.ex:582
+#: lib/klass_hero_web/live/provider/programs_live.ex:648
+#: lib/klass_hero_web/live/provider/team_live.ex:256
+#: lib/klass_hero_web/live/provider/team_live.ex:307
+#: lib/klass_hero_web/live/provider/team_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "Please fix the errors below."
 msgstr ""
@@ -2903,27 +2903,25 @@ msgstr ""
 msgid "Program Start"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:911
+#: lib/klass_hero_web/live/provider/programs_live.ex:905
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program created successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:918
+#: lib/klass_hero_web/live/provider/programs_live.ex:912
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_reports_live.ex:53
-#: lib/klass_hero_web/live/provider/programs_live.ex:149
-#: lib/klass_hero_web/live/provider/programs_live.ex:152
-#: lib/klass_hero_web/live/provider/programs_live.ex:188
-#: lib/klass_hero_web/live/provider/programs_live.ex:191
-#: lib/klass_hero_web/live/provider/programs_live.ex:629
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:54
+#: lib/klass_hero_web/live/provider/programs_live.ex:148
+#: lib/klass_hero_web/live/provider/programs_live.ex:185
+#: lib/klass_hero_web/live/provider/programs_live.ex:623
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:618
+#: lib/klass_hero_web/live/provider/programs_live.ex:612
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program updated successfully."
 msgstr ""
@@ -3084,8 +3082,8 @@ msgstr ""
 msgid "Selected child does not meet the program requirements."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:578
-#: lib/klass_hero_web/live/provider/programs_live.ex:644
+#: lib/klass_hero_web/live/provider/programs_live.ex:572
+#: lib/klass_hero_web/live/provider/programs_live.ex:638
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
@@ -3111,15 +3109,15 @@ msgstr ""
 msgid "Specialties"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:409
-#: lib/klass_hero_web/live/provider/team_live.ex:435
+#: lib/klass_hero_web/live/provider/team_live.ex:406
+#: lib/klass_hero_web/live/provider/team_live.ex:432
 #, elixir-autogen, elixir-format
 msgid "Staff member no longer exists."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:102
-#: lib/klass_hero_web/live/provider/team_live.ex:175
-#: lib/klass_hero_web/live/provider/team_live.ex:200
+#: lib/klass_hero_web/live/provider/team_live.ex:101
+#: lib/klass_hero_web/live/provider/team_live.ex:173
+#: lib/klass_hero_web/live/provider/team_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Staff member not found."
 msgstr ""
@@ -3150,27 +3148,27 @@ msgstr ""
 msgid "Tax Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:363
+#: lib/klass_hero_web/live/provider/team_live.ex:360
 #, elixir-autogen, elixir-format
 msgid "Team member added, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:364
+#: lib/klass_hero_web/live/provider/team_live.ex:361
 #, elixir-autogen, elixir-format
 msgid "Team member added."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:165
+#: lib/klass_hero_web/live/provider/team_live.ex:164
 #, elixir-autogen, elixir-format
 msgid "Team member removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:389
+#: lib/klass_hero_web/live/provider/team_live.ex:386
 #, elixir-autogen, elixir-format
 msgid "Team member updated, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:390
+#: lib/klass_hero_web/live/provider/team_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "Team member updated."
 msgstr ""
@@ -3185,12 +3183,12 @@ msgstr ""
 msgid "The Klass Hero Story"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:288
+#: lib/klass_hero_web/live/provider/programs_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "This invite cannot be resent."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:636
+#: lib/klass_hero_web/live/provider/programs_live.ex:630
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
@@ -3404,7 +3402,7 @@ msgstr ""
 msgid "Program fee:"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:751
+#: lib/klass_hero_web/live/provider/programs_live.ex:745
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr ""
@@ -3619,7 +3617,7 @@ msgstr ""
 msgid "Cannot check out without a check-in"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:260
+#: lib/klass_hero_web/live/provider/programs_live.ex:254
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:146
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
@@ -3684,7 +3682,7 @@ msgid "Correct"
 msgstr ""
 
 #: lib/klass_hero_web/live/dashboard_live.ex:286
-#: lib/klass_hero_web/live/provider/programs_live.ex:257
+#: lib/klass_hero_web/live/provider/programs_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "Could not start conversation. Please try again."
@@ -4252,7 +4250,7 @@ msgstr ""
 msgid "Failed to mark email as unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:216
+#: lib/klass_hero_web/live/provider/team_live.ex:213
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to resend invitation. Please try again."
 msgstr ""
@@ -4320,7 +4318,7 @@ msgstr ""
 msgid "Invitation Sent"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:190
+#: lib/klass_hero_web/live/provider/team_live.ex:188
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invitation resent successfully."
 msgstr ""
@@ -4446,7 +4444,7 @@ msgstr ""
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:24
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
-#: lib/klass_hero_web/live/provider/programs_live.ex:223
+#: lib/klass_hero_web/live/provider/programs_live.ex:217
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program"
@@ -4567,7 +4565,7 @@ msgstr ""
 msgid "Staff Dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:266
+#: lib/klass_hero_web/live/provider/team_live.ex:263
 #, elixir-autogen, elixir-format
 msgid "Staff member created, but the invitation could not be sent. Try resending from the team list."
 msgstr ""
@@ -4598,7 +4596,7 @@ msgstr ""
 msgid "The business associated with your account could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:207
+#: lib/klass_hero_web/live/provider/team_live.ex:204
 #, elixir-autogen, elixir-format
 msgid "This invitation cannot be resent in its current state."
 msgstr ""
@@ -4660,7 +4658,7 @@ msgid "Update your observation..."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:138
-#: lib/klass_hero_web/live/provider/programs_live.ex:339
+#: lib/klass_hero_web/live/provider/programs_live.ex:333
 #: lib/klass_hero_web/live/provider/verification_live.ex:240
 #: lib/klass_hero_web/live/provider/verification_live.ex:556
 #: lib/klass_hero_web/live/provider/verification_live.ex:594
@@ -4968,7 +4966,7 @@ msgstr ""
 msgid "View sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:430
+#: lib/klass_hero_web/live/provider/programs_live.ex:424
 #, elixir-autogen, elixir-format
 msgid "Create a program before inviting participants."
 msgstr ""
@@ -5010,7 +5008,7 @@ msgstr ""
 msgid "Invite one person"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:426
+#: lib/klass_hero_web/live/provider/programs_live.ex:420
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invite sent."
 msgstr ""
@@ -5113,7 +5111,7 @@ msgstr ""
 msgid "Upload a list"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:437
+#: lib/klass_hero_web/live/provider/programs_live.ex:431
 #, elixir-autogen, elixir-format
 msgid "An invite for this child and program already exists."
 msgstr ""
@@ -5290,7 +5288,7 @@ msgstr ""
 msgid "Go to dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:382
+#: lib/klass_hero_web/live/provider/programs_live.ex:376
 #, elixir-autogen, elixir-format
 msgid "%{count} row could not be processed."
 msgid_plural "%{count} rows could not be processed."
@@ -5399,7 +5397,7 @@ msgstr ""
 msgid "Attach photo"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_reports_live.ex:68
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:69
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Back to Programs"
 msgstr ""
@@ -5593,7 +5591,7 @@ msgstr ""
 msgid "Contact Us →"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:318
+#: lib/klass_hero_web/live/provider/team_live.ex:315
 #, elixir-autogen, elixir-format
 msgid "Could not add you to the team. Please try again."
 msgstr ""
@@ -5872,13 +5870,13 @@ msgstr ""
 msgid "How we vet providers"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:531
+#: lib/klass_hero_web/live/provider/team_live.ex:528
 #, elixir-autogen, elixir-format
 msgid "I'll be teaching"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:357
-#: lib/klass_hero_web/live/provider/programs_live.ex:379
+#: lib/klass_hero_web/live/provider/programs_live.ex:351
+#: lib/klass_hero_web/live/provider/programs_live.ex:373
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Imported %{count} family."
 msgid_plural "Imported %{count} families."
@@ -5891,8 +5889,8 @@ msgid "In 2025, Shane connected with his friend"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1451
-#: lib/klass_hero_web/live/provider/incident_reports_live.ex:42
-#: lib/klass_hero_web/live/provider/incident_reports_live.ex:73
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:43
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:74
 #, elixir-autogen, elixir-format
 msgid "Incident Reports"
 msgstr ""
@@ -6136,7 +6134,7 @@ msgstr ""
 msgid "No featured programs available right now. Check back soon."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_reports_live.ex:115
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:116
 #, elixir-autogen, elixir-format
 msgid "No incident reports yet"
 msgstr ""
@@ -6166,7 +6164,7 @@ msgstr ""
 msgid "No registered children for this session."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:366
+#: lib/klass_hero_web/live/provider/programs_live.ex:360
 #, elixir-autogen, elixir-format
 msgid "No rows imported. %{count} row could not be processed."
 msgid_plural "No rows imported. %{count} rows could not be processed."
@@ -6394,7 +6392,7 @@ msgstr ""
 msgid "Reporting"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_reports_live.ex:118
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:119
 #, elixir-autogen, elixir-format
 msgid "Reports filed for this program will appear here."
 msgstr ""
@@ -6570,7 +6568,7 @@ msgstr ""
 msgid "Stop chasing leads"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/incident_reports_live.ex:98
+#: lib/klass_hero_web/live/provider/incident_reports_live.ex:99
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Submitted by"
 msgstr ""
@@ -6841,7 +6839,7 @@ msgstr ""
 msgid "You'll get your own provider profile to fill in, and your account will open on your business dashboard from now on. You stay on %{business}'s team."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:298
+#: lib/klass_hero_web/live/provider/team_live.ex:295
 #, elixir-autogen, elixir-format
 msgid "You're already on your team."
 msgstr ""
@@ -6861,12 +6859,12 @@ msgstr ""
 msgid "You're now part of the team."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:346
+#: lib/klass_hero_web/live/provider/team_live.ex:343
 #, elixir-autogen, elixir-format
 msgid "You're on the team — you can now be assigned to programs."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:345
+#: lib/klass_hero_web/live/provider/team_live.ex:342
 #, elixir-autogen, elixir-format
 msgid "You're on the team, but the headshot upload failed."
 msgstr ""

--- a/test/klass_hero/messaging/staff_messaging_integration_test.exs
+++ b/test/klass_hero/messaging/staff_messaging_integration_test.exs
@@ -86,7 +86,7 @@ defmodule KlassHero.Messaging.StaffMessagingIntegrationTest do
 
       # 5. Unassign staff (and drive the handler directly as above)
       assert {:ok, unassigned} =
-               Provider.unassign_staff_from_program(ctx.program.id, ctx.staff.id)
+               Provider.unassign_staff_from_program(ctx.program.id, ctx.staff.id, ctx.provider.id)
 
       assert :ok =
                StaffAssignmentHandler.handle_event(

--- a/test/klass_hero/provider/adapters/driving/events/event_handlers/staff_invitation_status_handler_test.exs
+++ b/test/klass_hero/provider/adapters/driving/events/event_handlers/staff_invitation_status_handler_test.exs
@@ -205,43 +205,6 @@ defmodule KlassHero.Provider.Adapters.Driving.Events.EventHandlers.StaffInvitati
       # ...but being hired created NO provider profile.
       assert {:error, :not_found} = KlassHero.Provider.get_provider_by_identity(user.id)
     end
-
-    test "ignores a legacy create_provider_profile flag — still no profile" do
-      # create_provider_profile is not in the staff_user_registered contract (ADR-0005,
-      # #965). Originally added to defend that deploy's drain window; kept permanently
-      # because the invariant outlives it — a staff registration must never create a
-      # provider profile, whatever extra fields an event payload happens to carry.
-      user = KlassHero.AccountsFixtures.user_fixture(intended_roles: [:staff])
-      provider = KlassHero.ProviderFixtures.provider_profile_fixture()
-
-      staff =
-        KlassHero.ProviderFixtures.staff_member_fixture(
-          provider_id: provider.id,
-          email: "staff2@test.com",
-          first_name: "Test",
-          last_name: "Staff",
-          invitation_status: :sent,
-          invitation_token_hash: :crypto.hash(:sha256, "test-token-2"),
-          invitation_sent_at: DateTime.utc_now()
-        )
-
-      event =
-        AccountsIntegrationEvents.staff_user_registered(
-          user.id,
-          %{
-            staff_member_id: staff.id,
-            provider_id: provider.id,
-            create_provider_profile: true,
-            user_name: user.name
-          }
-        )
-
-      assert :ok = StaffInvitationStatusHandler.handle_event(event)
-
-      assert {:ok, linked} = KlassHero.Provider.get_staff_member(staff.id)
-      assert linked.invitation_status == :accepted
-      assert {:error, :not_found} = KlassHero.Provider.get_provider_by_identity(user.id)
-    end
   end
 
   describe "handle_event/1 for unknown events" do

--- a/test/klass_hero/provider/adapters/driving/events/event_handlers/staff_invitation_status_handler_test.exs
+++ b/test/klass_hero/provider/adapters/driving/events/event_handlers/staff_invitation_status_handler_test.exs
@@ -207,10 +207,10 @@ defmodule KlassHero.Provider.Adapters.Driving.Events.EventHandlers.StaffInvitati
     end
 
     test "ignores a legacy create_provider_profile flag — still no profile" do
-      # Defends the #965 deploy window: in-flight staff_user_registered events enqueued
-      # by old code may still carry create_provider_profile: true. The handler must ignore it.
-      # TODO(#965): remove once those old jobs have drained post-deploy — the field is no
-      # longer in the event contract and no live code path can produce it.
+      # create_provider_profile is not in the staff_user_registered contract (ADR-0005,
+      # #965). Originally added to defend that deploy's drain window; kept permanently
+      # because the invariant outlives it — a staff registration must never create a
+      # provider profile, whatever extra fields an event payload happens to carry.
       user = KlassHero.AccountsFixtures.user_fixture(intended_roles: [:staff])
       provider = KlassHero.ProviderFixtures.provider_profile_fixture()
 

--- a/test/klass_hero/provider/assignments/assign_staff_to_program_test.exs
+++ b/test/klass_hero/provider/assignments/assign_staff_to_program_test.exs
@@ -53,4 +53,19 @@ defmodule KlassHero.Provider.Assignments.AssignStaffToProgramTest do
                })
     end
   end
+
+  # Cross-tenant rejection is asserted module-wide in ownership_guard_test.exs.
+  describe "assign_staff_to_program/1 ownership guard" do
+    test "rejects a missing program" do
+      provider = insert(:provider_profile_schema)
+      staff = insert(:staff_member_schema, provider_id: provider.id)
+
+      assert {:error, :not_found} =
+               Provider.assign_staff_to_program(%{
+                 provider_id: provider.id,
+                 program_id: Ecto.UUID.generate(),
+                 staff_member_id: staff.id
+               })
+    end
+  end
 end

--- a/test/klass_hero/provider/assignments/assign_staff_to_program_test.exs
+++ b/test/klass_hero/provider/assignments/assign_staff_to_program_test.exs
@@ -52,11 +52,9 @@ defmodule KlassHero.Provider.Assignments.AssignStaffToProgramTest do
                  staff_member_id: Ecto.UUID.generate()
                })
     end
-  end
 
-  # Cross-tenant rejection is asserted module-wide in ownership_guard_test.exs.
-  describe "assign_staff_to_program/1 ownership guard" do
-    test "rejects a missing program" do
+    # Cross-tenant rejection is asserted module-wide in ownership_guard_test.exs.
+    test "returns not_found when the program does not exist" do
       provider = insert(:provider_profile_schema)
       staff = insert(:staff_member_schema, provider_id: provider.id)
 

--- a/test/klass_hero/provider/assignments/lead_instructor_test.exs
+++ b/test/klass_hero/provider/assignments/lead_instructor_test.exs
@@ -78,26 +78,21 @@ defmodule KlassHero.Provider.Assignments.LeadInstructorTest do
                Provider.set_lead_instructor(program.id, Ecto.UUID.generate(), program.provider_id)
     end
 
-    test "rejects a staff member owned by another provider (IDOR guard)" do
-      {provider, program, _staff} = setup_provider_program_staff()
+    test "returns :not_found when the program does not exist" do
+      {provider, _program, staff} = setup_provider_program_staff()
 
-      foreign_provider = insert(:provider_profile_schema)
-      foreign_staff = insert(:staff_member_schema, provider_id: foreign_provider.id)
-
-      # Public-render risk: assert no row was written, not just :not_found.
       assert {:error, :not_found} =
-               Provider.set_lead_instructor(program.id, foreign_staff.id, provider.id)
-
-      refute Repo.exists?(from(a in ProgramStaffAssignment, where: a.program_id == ^program.id))
+               Provider.set_lead_instructor(Ecto.UUID.generate(), staff.id, provider.id)
     end
   end
 
-  describe "clear_lead_instructor/1" do
+  # Cross-tenant rejection is asserted module-wide in ownership_guard_test.exs.
+  describe "clear_lead_instructor/2" do
     test "unsets the lead flag but keeps the assignment active" do
       {_provider, program, staff} = setup_provider_program_staff()
       {:ok, _} = Provider.set_lead_instructor(program.id, staff.id, program.provider_id)
 
-      assert :ok = Provider.clear_lead_instructor(program.id)
+      assert :ok = Provider.clear_lead_instructor(program.id, program.provider_id)
 
       [assignment] =
         ProgramStaffAssignment
@@ -110,7 +105,7 @@ defmodule KlassHero.Provider.Assignments.LeadInstructorTest do
 
     test "is a no-op when there is no lead" do
       {_provider, program, _staff} = setup_provider_program_staff()
-      assert :ok = Provider.clear_lead_instructor(program.id)
+      assert :ok = Provider.clear_lead_instructor(program.id, program.provider_id)
     end
   end
 

--- a/test/klass_hero/provider/assignments/ownership_guard_test.exs
+++ b/test/klass_hero/provider/assignments/ownership_guard_test.exs
@@ -1,0 +1,115 @@
+defmodule KlassHero.Provider.Assignments.OwnershipGuardTest do
+  @moduledoc """
+  The module-wide tenancy policy for `Provider.Assignments`.
+
+  Every write proves the same rule from a single place: a foreign staff member or
+  a foreign program is indistinguishable from a missing one, and no cross-tenant
+  row is ever written. Per-function edge cases (already-assigned, idempotent
+  re-promotion, ...) stay in the per-function test files.
+  """
+  use KlassHero.DataCase, async: true
+
+  import Ecto.Query
+  import KlassHero.Factory
+
+  alias KlassHero.Provider
+  alias KlassHero.Provider.ProgramStaffAssignment
+
+  setup do
+    provider = insert(:provider_profile_schema)
+    other = insert(:provider_profile_schema)
+
+    %{
+      provider: provider,
+      program: insert(:program_schema, provider_id: provider.id),
+      staff: insert(:staff_member_schema, provider_id: provider.id),
+      foreign_program: insert(:program_schema, provider_id: other.id),
+      foreign_staff: insert(:staff_member_schema, provider_id: other.id)
+    }
+  end
+
+  describe "cross-tenant writes" do
+    test "every row-creating write rejects a foreign staff member or program", ctx do
+      # {label, call, program the row would have landed on}
+      writes = [
+        {"assign_staff_to_program/foreign staff",
+         fn ->
+           Provider.assign_staff_to_program(%{
+             provider_id: ctx.provider.id,
+             program_id: ctx.program.id,
+             staff_member_id: ctx.foreign_staff.id
+           })
+         end, ctx.program.id},
+        {"assign_staff_to_program/foreign program",
+         fn ->
+           Provider.assign_staff_to_program(%{
+             provider_id: ctx.provider.id,
+             program_id: ctx.foreign_program.id,
+             staff_member_id: ctx.staff.id
+           })
+         end, ctx.foreign_program.id},
+        {"set_lead_instructor/foreign staff",
+         fn ->
+           Provider.set_lead_instructor(ctx.program.id, ctx.foreign_staff.id, ctx.provider.id)
+         end, ctx.program.id},
+        {"set_lead_instructor/foreign program",
+         fn ->
+           Provider.set_lead_instructor(ctx.foreign_program.id, ctx.staff.id, ctx.provider.id)
+         end, ctx.foreign_program.id}
+      ]
+
+      for {label, call, program_id} <- writes do
+        assert call.() == {:error, :not_found}, "#{label}: expected {:error, :not_found}"
+
+        refute assignments_on?(program_id),
+               "#{label}: a cross-tenant assignment row was written"
+      end
+    end
+
+    test "a missing staff member or program is indistinguishable from a foreign one", ctx do
+      missing_id = Ecto.UUID.generate()
+
+      assert Provider.set_lead_instructor(ctx.program.id, missing_id, ctx.provider.id) ==
+               Provider.set_lead_instructor(ctx.program.id, ctx.foreign_staff.id, ctx.provider.id)
+
+      assert Provider.set_lead_instructor(missing_id, ctx.staff.id, ctx.provider.id) ==
+               Provider.set_lead_instructor(ctx.foreign_program.id, ctx.staff.id, ctx.provider.id)
+    end
+
+    # The remaining two writes mutate existing rows rather than creating them, so
+    # each asserts on the row it must NOT have touched — not foldable into the
+    # table above, and `clear_lead_instructor` returns :ok either way by design.
+    test "unassign leaves another provider's assignment active", ctx do
+      {:ok, _} =
+        Provider.assign_staff_to_program(%{
+          provider_id: ctx.provider.id,
+          program_id: ctx.program.id,
+          staff_member_id: ctx.staff.id
+        })
+
+      attacker = insert(:provider_profile_schema)
+
+      assert {:error, :not_found} =
+               Provider.unassign_staff_from_program(ctx.program.id, ctx.staff.id, attacker.id)
+
+      assert %ProgramStaffAssignment{unassigned_at: nil} =
+               Repo.get_by(ProgramStaffAssignment,
+                 program_id: ctx.program.id,
+                 staff_member_id: ctx.staff.id
+               )
+    end
+
+    test "clear_lead_instructor leaves another provider's lead in place", ctx do
+      {:ok, _} = Provider.set_lead_instructor(ctx.program.id, ctx.staff.id, ctx.provider.id)
+      attacker = insert(:provider_profile_schema)
+
+      assert :ok = Provider.clear_lead_instructor(ctx.program.id, attacker.id)
+      assert %{id: lead_id} = Provider.get_lead_instructor(ctx.program.id)
+      assert lead_id == ctx.staff.id
+    end
+  end
+
+  defp assignments_on?(program_id) do
+    Repo.exists?(from a in ProgramStaffAssignment, where: a.program_id == ^program_id)
+  end
+end

--- a/test/klass_hero/provider/assignments/unassign_staff_from_program_test.exs
+++ b/test/klass_hero/provider/assignments/unassign_staff_from_program_test.exs
@@ -6,48 +6,56 @@ defmodule KlassHero.Provider.Assignments.UnassignStaffFromProgramTest do
   alias KlassHero.Provider
   alias KlassHero.Provider.ProgramStaffAssignment
 
-  describe "unassign_staff_from_program/2" do
-    test "unassigns an active assignment and sets unassigned_at" do
-      provider = insert(:provider_profile_schema)
-      program = insert(:program_schema, provider_id: provider.id)
-      staff = insert(:staff_member_schema, provider_id: provider.id)
+  setup do
+    provider = insert(:provider_profile_schema)
+    program = insert(:program_schema, provider_id: provider.id)
+    staff = insert(:staff_member_schema, provider_id: provider.id)
 
-      {:ok, _} =
-        Provider.assign_staff_to_program(%{
-          provider_id: provider.id,
-          program_id: program.id,
-          staff_member_id: staff.id
-        })
+    %{provider: provider, program: program, staff: staff}
+  end
+
+  describe "unassign_staff_from_program/3" do
+    test "unassigns an active assignment and sets unassigned_at", ctx do
+      assign!(ctx)
 
       assert {:ok, %ProgramStaffAssignment{} = assignment} =
-               Provider.unassign_staff_from_program(program.id, staff.id)
+               Provider.unassign_staff_from_program(ctx.program.id, ctx.staff.id, ctx.provider.id)
 
-      assert assignment.staff_member_id == staff.id
-      assert assignment.program_id == program.id
+      assert assignment.staff_member_id == ctx.staff.id
+      assert assignment.program_id == ctx.program.id
       assert %DateTime{} = assignment.unassigned_at
     end
 
-    test "returns not_found when no active assignment exists" do
+    test "returns not_found when no active assignment exists", ctx do
       assert {:error, :not_found} =
-               Provider.unassign_staff_from_program(Ecto.UUID.generate(), Ecto.UUID.generate())
+               Provider.unassign_staff_from_program(
+                 Ecto.UUID.generate(),
+                 Ecto.UUID.generate(),
+                 ctx.provider.id
+               )
     end
 
-    test "returns not_found when assignment was already unassigned" do
-      provider = insert(:provider_profile_schema)
-      program = insert(:program_schema, provider_id: provider.id)
-      staff = insert(:staff_member_schema, provider_id: provider.id)
+    test "returns not_found when assignment was already unassigned", ctx do
+      assign!(ctx)
 
-      {:ok, _} =
-        Provider.assign_staff_to_program(%{
-          provider_id: provider.id,
-          program_id: program.id,
-          staff_member_id: staff.id
-        })
+      assert {:ok, _} =
+               Provider.unassign_staff_from_program(ctx.program.id, ctx.staff.id, ctx.provider.id)
 
-      assert {:ok, _} = Provider.unassign_staff_from_program(program.id, staff.id)
-
-      # Second unassign on same pair should return not_found (no active assignment)
-      assert {:error, :not_found} = Provider.unassign_staff_from_program(program.id, staff.id)
+      assert {:error, :not_found} =
+               Provider.unassign_staff_from_program(ctx.program.id, ctx.staff.id, ctx.provider.id)
     end
+  end
+
+  # Cross-tenant rejection is asserted module-wide in ownership_guard_test.exs.
+
+  defp assign!(ctx) do
+    {:ok, assignment} =
+      Provider.assign_staff_to_program(%{
+        provider_id: ctx.provider.id,
+        program_id: ctx.program.id,
+        staff_member_id: ctx.staff.id
+      })
+
+    assignment
   end
 end

--- a/test/klass_hero/provider/get_provider_program_scoped_test.exs
+++ b/test/klass_hero/provider/get_provider_program_scoped_test.exs
@@ -1,0 +1,44 @@
+defmodule KlassHero.Provider.GetProviderProgramScopedTest do
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+  import KlassHero.ProviderFixtures, only: [provider_program_projection_fixture: 1]
+
+  alias KlassHero.Provider
+
+  describe "get_provider_program/2 (provider-scoped)" do
+    setup do
+      provider = insert(:provider_profile_schema)
+      other_provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+
+      provider_program_projection_fixture(
+        provider_id: provider.id,
+        program_id: program.id,
+        name: "Art Club"
+      )
+
+      %{provider: provider, other_provider: other_provider, program_id: program.id}
+    end
+
+    test "returns the program when owned by the provider", ctx do
+      assert {:ok, program} = Provider.get_provider_program(ctx.program_id, ctx.provider.id)
+      assert program.program_id == ctx.program_id
+    end
+
+    test "returns not_found for a program owned by another provider", ctx do
+      assert {:error, :not_found} = Provider.get_provider_program(ctx.program_id, ctx.other_provider.id)
+    end
+
+    test "returns not_found for a program that does not exist", ctx do
+      assert {:error, :not_found} = Provider.get_provider_program(Ecto.UUID.generate(), ctx.provider.id)
+    end
+
+    test "foreign and missing are indistinguishable (no existence oracle)", ctx do
+      foreign = Provider.get_provider_program(ctx.program_id, ctx.other_provider.id)
+      missing = Provider.get_provider_program(Ecto.UUID.generate(), ctx.other_provider.id)
+
+      assert foreign == missing
+    end
+  end
+end

--- a/test/klass_hero/provider/staff/delete_staff_member_test.exs
+++ b/test/klass_hero/provider/staff/delete_staff_member_test.exs
@@ -2,32 +2,49 @@ defmodule KlassHero.Provider.Staff.DeleteStaffMemberTest do
   use KlassHero.DataCase, async: true
 
   alias KlassHero.Provider
+  alias KlassHero.Provider.StaffMember
   alias KlassHero.ProviderFixtures
 
   setup do
     provider = ProviderFixtures.provider_profile_fixture()
     staff = ProviderFixtures.staff_member_fixture(provider_id: provider.id)
-    %{staff: staff}
+    %{provider: provider, staff: staff}
   end
 
-  describe "execute/1" do
-    test "deletes an existing staff member", %{staff: staff} do
-      assert :ok = Provider.delete_staff_member(staff.id)
-      assert {:error, :not_found} = Provider.get_staff_member(staff.id)
+  describe "delete_staff_member/2" do
+    test "deletes a staff member owned by the provider", ctx do
+      assert :ok = Provider.delete_staff_member(ctx.staff.id, ctx.provider.id)
+      assert {:error, :not_found} = Provider.get_staff_member(ctx.staff.id)
     end
 
-    test "returns :not_found for non-existent staff member" do
-      fake_id = Ecto.UUID.generate()
-      assert {:error, :not_found} = Provider.delete_staff_member(fake_id)
+    test "returns not_found for a staff member that does not exist", ctx do
+      assert {:error, :not_found} =
+               Provider.delete_staff_member(Ecto.UUID.generate(), ctx.provider.id)
     end
 
-    test "does not affect other staff members", %{staff: staff} do
-      provider_id = staff.provider_id
-      other_staff = ProviderFixtures.staff_member_fixture(provider_id: provider_id)
+    test "does not affect other staff members", ctx do
+      other_staff = ProviderFixtures.staff_member_fixture(provider_id: ctx.provider.id)
 
-      assert :ok = Provider.delete_staff_member(staff.id)
+      assert :ok = Provider.delete_staff_member(ctx.staff.id, ctx.provider.id)
 
       assert {:ok, _} = Provider.get_staff_member(other_staff.id)
+    end
+
+    test "leaves another provider's staff member intact", ctx do
+      attacker = ProviderFixtures.provider_profile_fixture()
+
+      assert {:error, :not_found} = Provider.delete_staff_member(ctx.staff.id, attacker.id)
+
+      assert %StaffMember{} = Repo.get(StaffMember, ctx.staff.id)
+    end
+
+    test "foreign and missing are indistinguishable (no existence oracle)", ctx do
+      attacker = ProviderFixtures.provider_profile_fixture()
+
+      foreign = Provider.delete_staff_member(ctx.staff.id, attacker.id)
+      missing = Provider.delete_staff_member(Ecto.UUID.generate(), attacker.id)
+
+      assert foreign == missing
     end
   end
 end

--- a/test/klass_hero/provider/staff/get_staff_member_scoped_test.exs
+++ b/test/klass_hero/provider/staff/get_staff_member_scoped_test.exs
@@ -1,0 +1,45 @@
+defmodule KlassHero.Provider.Staff.GetStaffMemberScopedTest do
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+
+  alias KlassHero.Provider
+  alias KlassHero.Provider.StaffMember
+
+  describe "get_staff_member/2 (provider-scoped)" do
+    setup do
+      provider = insert(:provider_profile_schema)
+      other_provider = insert(:provider_profile_schema)
+      staff = insert(:staff_member_schema, provider_id: provider.id)
+
+      %{provider: provider, other_provider: other_provider, staff: staff}
+    end
+
+    test "returns the staff member when owned by the provider", ctx do
+      assert {:ok, %StaffMember{id: id}} = Provider.get_staff_member(ctx.staff.id, ctx.provider.id)
+      assert id == ctx.staff.id
+    end
+
+    test "loads the pay rate, matching the unscoped getter", ctx do
+      assert {:ok, scoped} = Provider.get_staff_member(ctx.staff.id, ctx.provider.id)
+      assert {:ok, unscoped} = Provider.get_staff_member(ctx.staff.id)
+
+      assert scoped.pay_rate == unscoped.pay_rate
+    end
+
+    test "returns not_found for a staff member owned by another provider", ctx do
+      assert {:error, :not_found} = Provider.get_staff_member(ctx.staff.id, ctx.other_provider.id)
+    end
+
+    test "returns not_found for a staff member that does not exist", ctx do
+      assert {:error, :not_found} = Provider.get_staff_member(Ecto.UUID.generate(), ctx.provider.id)
+    end
+
+    test "foreign and missing are indistinguishable (no existence oracle)", ctx do
+      foreign = Provider.get_staff_member(ctx.staff.id, ctx.other_provider.id)
+      missing = Provider.get_staff_member(Ecto.UUID.generate(), ctx.other_provider.id)
+
+      assert foreign == missing
+    end
+  end
+end

--- a/test/klass_hero/provider/staff/get_staff_member_scoped_test.exs
+++ b/test/klass_hero/provider/staff/get_staff_member_scoped_test.exs
@@ -35,6 +35,12 @@ defmodule KlassHero.Provider.Staff.GetStaffMemberScopedTest do
       assert {:error, :not_found} = Provider.get_staff_member(Ecto.UUID.generate(), ctx.provider.id)
     end
 
+    # staff_id reaches here straight from phx-value-id, so a malformed one must
+    # not crash the LiveView.
+    test "returns not_found for a malformed id instead of raising", ctx do
+      assert {:error, :not_found} = Provider.get_staff_member("not-a-uuid", ctx.provider.id)
+    end
+
     test "foreign and missing are indistinguishable (no existence oracle)", ctx do
       foreign = Provider.get_staff_member(ctx.staff.id, ctx.other_provider.id)
       missing = Provider.get_staff_member(Ecto.UUID.generate(), ctx.other_provider.id)

--- a/test/klass_hero/provider/staff_member_integration_test.exs
+++ b/test/klass_hero/provider/staff_member_integration_test.exs
@@ -157,15 +157,18 @@ defmodule KlassHero.Provider.StaffMemberIntegrationTest do
     end
   end
 
-  describe "delete_staff_member/1" do
+  describe "delete_staff_member/2" do
     test "deletes existing staff member" do
       staff = ProviderFixtures.staff_member_fixture()
-      assert :ok = Provider.delete_staff_member(staff.id)
+      assert :ok = Provider.delete_staff_member(staff.id, staff.provider_id)
       assert {:error, :not_found} = Provider.get_staff_member(staff.id)
     end
 
     test "returns not_found for missing id" do
-      assert {:error, :not_found} = Provider.delete_staff_member(Ecto.UUID.generate())
+      staff = ProviderFixtures.staff_member_fixture()
+
+      assert {:error, :not_found} =
+               Provider.delete_staff_member(Ecto.UUID.generate(), staff.provider_id)
     end
   end
 


### PR DESCRIPTION
Closes #1134.

## Summary

#1134 reported that three of the four `Provider.Assignments` writes lacked the ownership guard PR #1131 added to the fourth. The root cause was one level down: `get_staff_member/1` is a bare `Repo.get` whose ownership contract lived in prose, so 8 call sites re-derived a pin-match by hand and 2 forgot.

This makes ownership a property of the **queries** instead of a caller habit, on both entities that had the problem.

### Staff

- `StaffMember.owned_by/2` query scope + `Staff.get_staff_member/2`.
- All 4 `Assignments` writes guarded; `unassign_staff_from_program/2 → /3`, `clear_lead_instructor/1 → /2`.
- Every hand-rolled staff pin-match in the codebase is gone.
- `delete_staff_member/1 → /2` — it was a public, delegated, unscoped `Repo.get` + `Repo.delete`, safe only because its one caller happened to pre-check.

### Programs

Two ownership sources, neither scoped:

- **Write model** — converges on `ProgramCatalog.get_program_for_provider/2` from #1135 (which landed while this was in review) and upgrades its body from fetch-then-pin-match to a `Program.owned_by/2` query scope. Migrated: `ensure_program_owned/2`, `programs_live` edit + roster, `broadcast_live` mount.
- **`provider_programs` projection** — had no scoped getter at all. Adds `Provider.get_provider_program/2`; migrated `incident_report_live`, `incident_reports_live`, `submit_incident_report`.

`ensure_program_owned/2` reads the facade rather than the projection deliberately: the projection is eventually consistent, and `programs_live` creates a program then immediately sets its lead, bang-matching the result.

## Two live bugs the tests exposed

Beyond what the issue described:

- `assign_staff_to_program/1` inserted a real row for a **foreign staff member**.
- `set_lead_instructor/3` — the function #1131 "fixed" — returned `{:ok, _}` when attaching this provider's staff to **another provider's program**.

Both latent (no LiveView reaches them today), both now `{:error, :not_found}` with no row written.

## Also fixed

A malformed id reaching `get_staff_member/2` raised `Ecto.Query.CastError` rather than returning `:not_found` — reachable, since `team_live` feeds it `phx-value-id` straight from the client. Now routes through the existing `RepositoryHelpers.get_schema_by_uuid/2`. Same class as the `CastError` #1135 fixed for broadcasts.

## Review focus

1. **`ensure_program_owned/2` reads across a context boundary.** Deliberate — see the comment there and the follow-up note below.
2. **Reads stay unscoped.** `get_lead_instructor/1` renders on *public* program pages; scoping it would break intended behaviour, not close a leak.
3. **INSERTs can't carry a query scope,** so they take their tenancy key from the ownership-proven `StaffMember` rather than caller attrs.
4. **`get_staff_member/1` and `get_program_by_id/1` are kept** — token/invite paths and event handlers have no provider in scope.

## Test plan

- 4203 pass (+13). The 8 migrated call sites needed **no** test assertion changes — that's the behaviour-preservation proof.
- New: scoped-getter tests for staff, projection programs, and `delete_staff_member/2`, each asserting foreign ≡ missing and that the row survives a cross-tenant attempt.
- `ownership_guard_test.exs` states the module-wide policy once, folding the 4 uniform row-creating cases into a table.
- Production audit (read-only) before the guards landed: `mismatched_program_owner=0, mismatched_staff_owner=0` across 8 rows — no pre-existing cross-tenant residue that the new scopes would strand.

## Follow-up

`notify_incident_reported.ex` reads a program label through the projection unscoped. Not a leak today (label only), but worth revisiting if it ever returns more.

---

## Also in this PR: build-gate hygiene (`mix.exs`, `ci.yml`, `.credo.exs`)

Unrelated to the IDOR fix — found while verifying this PR's own precommit run, and left here rather than split off because the second commit is self-contained (`ci: make precommit enforce what CI enforces`).

`mix.exs` read `compile --warning-as-errors` — **singular**, not a real flag, so Mix ignored it. Since 2025-09-28, `mix precommit` has never failed on a warning; only CI's separate compile step caught them. Auditing the rest turned up the same class of gap:

| Gate | CI | `precommit` before | now |
|---|---|---|---|
| `compile --warnings-as-errors` | ✅ | inert (typo) | ✅ |
| `credo` | `--min-priority=high` | **absent** | `--strict` both |
| `test --include slow` | ✅ | absent | ✅ |

`CLAUDE.md` also documented `mix credo --strict` as the CI command — it wasn't, and `--strict` didn't pass. Rather than weaken the doc, the 7 issues are fixed and the bar is raised: `.credo.exs` now sets `strict: true`, so a bare `mix credo` gives the same verdict as CI.

Worth a look in review:

- **`shared/interaction.ex`** — took credo's `AliasUsage` advice. I first read these as false positives, reasoning that the generated code expands in the *caller's* module where a local alias wouldn't apply. That's wrong: Elixir records the expansion in the quoted AST's `:alias` metadata, so an aliased reference inside `quote` resolves correctly at the call site. Self-aliased and verified against the macro's real callers.
- **`consolidate_protocols: Mix.env() == :prod`** — with the compile flag actually live, recompiling a module carrying a `defimpl` (`Accounts.User`'s GDPR `Inspect`) while consolidated protocols were loaded failed the build, and couldn't recover: a failed compile never marks the module done, so every subsequent run repeated it.
- **One `TODO` removed, and the test it guarded dropped.** Its premise expired when #965 shipped (2026-06-12) and no live code path can produce the field. The sibling test in the same file still asserts the ADR-0005 invariant — a staff registration links the user and creates no provider profile — so that guarantee keeps its coverage.

`mix precommit` is green: **4203 pass, 18 excluded** (was 4203/19 — the slow test now runs locally, and one expired legacy test was dropped).
