### PR TITLE
fix: scope domain-event subscriptions to their owning process

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -61,3 +61,16 @@ This command:
 ## Projection Tests: `async: false`
 
 Test modules covering event-driven projections (modules under `**/adapters/driven/projections/`) use `use KlassHero.DataCase, async: false`. Projection GenServers run DB queries during `init/1`'s `{:continue, :bootstrap}` before the test process can call `Ecto.Adapters.SQL.Sandbox.allow/3` on the spawned pid, so the only reliable fix is shared-sandbox mode (which `async: false` flips on automatically via `DataCase.setup_sandbox/1`). Don't add `Sandbox.allow` calls in these files — they're redundant under shared mode. This rule does NOT apply to macro-level tests like `test/klass_hero/shared/projection_test.exs`, which exercise the macro against `Agent`-backed fakes with no DB at all and stay `async: true`.
+
+## Domain-Event Subscriptions Are Process-Scoped
+
+`DomainEventBus.subscribe/4` is a test-only affordance — production registers handlers at boot via `handlers:` child-spec entries in `application.ex`. Each context's bus is a **globally-named singleton**, so a subscription is scoped to the process that made it: the handler fires only for dispatches from that process or a `Task` descendant of it (`:"$callers"`), and is dropped when the process exits. Boot-time (`handlers:`) registrations are exempt and always fire.
+
+That scoping is what makes `subscribe/4` safe in an `async: true` module. Before it existed, a subscriber heard *every* concurrent test's dispatch, so an under-specified `assert_receive` pattern could match a foreign test's event — the cause of #1136, which presented as a timeout but was actually a wrong-value match.
+
+Consequences when writing tests:
+
+- **Subscribe inside `setup` or the test body, never `setup_all`.** `setup_all` runs in its own process, unrelated to each test's process, so its handlers can never fire. The same applies to `on_exit`.
+- **A handler that doesn't fire is silent.** If an `assert_receive` on a domain event times out, suspect process lineage before suspecting the production code. Run with `mix test --trace` at `:debug` log level — the bus logs how many handlers it skipped and why.
+- **Still pin test-unique data** (a generated `provider_id`, `user_id`, …) in the `assert_receive` pattern. Scoping makes a foreign event unreachable, but a discriminating pattern documents intent and survives future changes to the bus.
+- **Dispatches from another process need boot registration.** A handler that must observe events dispatched by an Oban job, an `EventSubscriber`, or a LiveView process cannot use `subscribe/4` — those processes are not in the subscriber's lineage.

--- a/lib/klass_hero/shared/domain_event_bus.ex
+++ b/lib/klass_hero/shared/domain_event_bus.ex
@@ -38,6 +38,17 @@ defmodule KlassHero.Shared.DomainEventBus do
       # With priority (lower number runs first, default 100)
       DomainEventBus.subscribe(KlassHero.Family, :child_updated, handler_fn, priority: 10)
 
+  ### Subscriptions are owned by the calling process
+
+  A bus is a globally-named singleton per context, so without scoping every
+  runtime subscription would hear every dispatch in the VM — including those of
+  concurrent `async: true` tests, which is what made #1136 flaky.
+
+  A `subscribe/4` handler therefore fires only for dispatches from its owning
+  process or a `Task` descendant of it, and is dropped when that process exits.
+  Handlers registered at boot via `handlers:` are exempt and always fire, so
+  production delivery is unaffected. See `subscribe/4` for the full contract.
+
   ## Dispatching
 
       DomainEventBus.dispatch(KlassHero.Family, %DomainEvent{event_type: :child_updated, ...})
@@ -80,11 +91,26 @@ defmodule KlassHero.Shared.DomainEventBus do
 
   - `:priority` - Integer priority (lower runs first, default #{@default_priority})
   - `:mode` - Reserved for future async support (default `:sync`)
+
+  ## Warning — subscriptions are owned by the calling process
+
+  A handler registered here fires **only** for events dispatched from the
+  subscribing process, or from a process descended from it via `Task.async` /
+  `Task.Supervisor.async(_nolink)` (which propagate `:"$callers"`). It is
+  dropped automatically when that process exits.
+
+  It will **not** fire for dispatches from a bare `spawn`, another GenServer's
+  callback, an Oban job, `setup_all` (a different process from each test body),
+  or `on_exit`. In those cases the handler is skipped silently — set the log
+  level to `:debug` to see a line naming how many were skipped and why.
+
+  For a durable, always-on handler, register via the `handlers:` option on
+  `start_link/1` instead; those are exempt from owner scoping and always fire.
   """
   @spec subscribe(module(), atom(), (DomainEvent.t() -> :ok | {:error, term()}), keyword()) ::
           :ok
   def subscribe(context, event_type, handler_fn, opts \\ []) when is_atom(event_type) and is_function(handler_fn, 1) do
-    GenServer.call(process_name(context), {:subscribe, event_type, handler_fn, opts})
+    GenServer.call(process_name(context), {:subscribe, event_type, handler_fn, opts, self()})
   end
 
   @doc """
@@ -97,7 +123,10 @@ defmodule KlassHero.Shared.DomainEventBus do
   @spec dispatch(module(), DomainEvent.t()) :: :ok | {:error, [term()]}
   def dispatch(context, %DomainEvent{event_type: event_type} = event) do
     handlers = GenServer.call(process_name(context), {:get_handlers, event_type})
-    execute_handlers(handlers, event)
+
+    handlers
+    |> visible_to(caller_chain(), event_type)
+    |> execute_handlers(event)
   end
 
   @doc """
@@ -115,7 +144,11 @@ defmodule KlassHero.Shared.DomainEventBus do
           {:ok, list({{module(), atom()} | :anonymous, :ok | {:error, term()}})}
   def dispatch_critical(context, %DomainEvent{event_type: event_type} = event) do
     handlers = GenServer.call(process_name(context), {:get_handlers, event_type})
-    {:ok, execute_handlers_with_identity(handlers, event)}
+
+    {:ok,
+     handlers
+     |> visible_to(caller_chain(), event_type)
+     |> execute_handlers_with_identity(event)}
   end
 
   @doc """
@@ -135,9 +168,13 @@ defmodule KlassHero.Shared.DomainEventBus do
   end
 
   @impl true
-  def handle_call({:subscribe, event_type, handler_fn, opts}, _from, state) do
+  def handle_call({:subscribe, event_type, handler_fn, opts, owner}, _from, state) do
+    # Monitoring the owner is what bounds the handler list: without it a subscription
+    # lives for the life of the bus, so a long test run accumulates dead closures.
+    Process.monitor(owner)
+
     # :anonymous identity signals to dispatch_critical/2 that this handler has no named origin for retry
-    entry = {handler_fn, opts, :anonymous}
+    entry = {handler_fn, opts, :anonymous, owner}
     handlers = Map.update(state.handlers, event_type, [entry], &(&1 ++ [entry]))
     {:reply, :ok, %{state | handlers: handlers}}
   end
@@ -148,13 +185,25 @@ defmodule KlassHero.Shared.DomainEventBus do
     {:reply, entries, state}
   end
 
+  @impl true
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
+    # Enum.reject preserves the relative order of survivors, so sort_by_priority/1's
+    # registration-order tie-break is unaffected.
+    handlers =
+      Map.new(state.handlers, fn {event_type, entries} ->
+        {event_type, Enum.reject(entries, fn {_fn, _opts, _identity, owner} -> owner == pid end)}
+      end)
+
+    {:noreply, %{state | handlers: handlers}}
+  end
+
   defp execute_handlers([], _event), do: :ok
 
   defp execute_handlers(entries, event) do
     failures =
       entries
       |> sort_by_priority()
-      |> Enum.map(fn {{handler_fn, _opts, _identity}, _index} -> safe_call(handler_fn, event) end)
+      |> Enum.map(fn {{handler_fn, _opts, _identity, _owner}, _index} -> safe_call(handler_fn, event) end)
       |> Enum.filter(&match?({:error, _}, &1))
 
     if failures == [], do: :ok, else: {:error, failures}
@@ -165,7 +214,7 @@ defmodule KlassHero.Shared.DomainEventBus do
   defp execute_handlers_with_identity(entries, event) do
     entries
     |> sort_by_priority()
-    |> Enum.map(fn {{handler_fn, _opts, identity}, _index} ->
+    |> Enum.map(fn {{handler_fn, _opts, identity, _owner}, _index} ->
       {identity, safe_call(handler_fn, event)}
     end)
   end
@@ -174,8 +223,38 @@ defmodule KlassHero.Shared.DomainEventBus do
   defp sort_by_priority(entries) do
     entries
     |> Enum.with_index()
-    |> Enum.sort_by(fn {{_fn, opts, _identity}, index} ->
+    |> Enum.sort_by(fn {{_fn, opts, _identity, _owner}, index} ->
       {Keyword.get(opts, :priority, @default_priority), index}
+    end)
+  end
+
+  # Anonymous (runtime-subscribed) handlers are owned by the process that registered
+  # them and fire only for dispatches from that process or a `Task` descendant of it
+  # (`:"$callers"`). Boot-time handlers carry `:boot` and always fire, so production
+  # behaviour is unchanged. Without this, a subscription on a globally-named bus hears
+  # every concurrent async test's dispatch — see #1136.
+  defp visible_to(entries, chain, event_type) do
+    visible =
+      Enum.filter(entries, fn
+        {_handler_fn, _opts, _identity, :boot} -> true
+        {_handler_fn, _opts, _identity, owner} -> owner in chain
+      end)
+
+    log_scoped_out(length(entries) - length(visible), event_type)
+
+    visible
+  end
+
+  defp caller_chain, do: [self() | Process.get(:"$callers", [])]
+
+  defp log_scoped_out(0, _event_type), do: :ok
+
+  # A handler that silently never fires is this design's one bad failure mode.
+  # Lazy, so it costs nothing unless someone turns debug on to investigate.
+  defp log_scoped_out(count, event_type) do
+    Logger.debug(fn ->
+      "[DomainEventBus] #{count} anonymous handler(s) for #{inspect(event_type)} skipped — " <>
+        "not owned by #{inspect(self())} nor any process in its :\"$callers\" chain"
     end)
   end
 
@@ -198,7 +277,7 @@ defmodule KlassHero.Shared.DomainEventBus do
   defp register_init_handlers(specs) do
     Enum.reduce(specs, %{}, fn spec, acc ->
       {event_type, handler_fn, opts, identity} = normalize_handler_spec(spec)
-      entry = {handler_fn, opts, identity}
+      entry = {handler_fn, opts, identity, :boot}
       Map.update(acc, event_type, [entry], &(&1 ++ [entry]))
     end)
   end

--- a/test/klass_hero/enrollment/import_enrollment_csv_test.exs
+++ b/test/klass_hero/enrollment/import_enrollment_csv_test.exs
@@ -509,10 +509,15 @@ defmodule KlassHero.Enrollment.ImportEnrollmentCsvTest do
       assert {:ok, %{created: 1, failed: [%{category: :validation}]}} =
                ImportEnrollmentCsv.execute(provider.id, csv)
 
+      provider_id = provider.id
+
+      # provider_id is pinned as defence in depth. Owner-scoped delivery already makes a
+      # foreign event unreachable here (#1136); an unpinned `count: 1` payload would
+      # otherwise match another provider's single-invite import.
       assert_receive {:bulk_invites_imported,
                       %DomainEvent{
                         event_type: :bulk_invites_imported,
-                        payload: %{program_ids: ids, count: 1}
+                        payload: %{provider_id: ^provider_id, program_ids: ids, count: 1}
                       }},
                      1_000
 

--- a/test/klass_hero/shared/domain_event_bus_test.exs
+++ b/test/klass_hero/shared/domain_event_bus_test.exs
@@ -8,6 +8,9 @@ defmodule KlassHero.Shared.DomainEventBusTest do
   - Priority ordering (lower number runs first, default 100)
   - Same-priority handlers preserve registration order
   - Init-time {Module, :function} handler registration via `handlers:` opt
+  - Owner-scoped delivery: a subscribe/4 handler fires only for dispatches from
+    its owning process or a Task descendant, is exempt for `handlers:` (boot)
+    registrations, and is dropped when its owner exits (#1136)
   """
 
   use ExUnit.Case, async: true
@@ -41,6 +44,14 @@ defmodule KlassHero.Shared.DomainEventBusTest do
 
   defp build_event(event_type, payload \\ %{}) do
     DomainEvent.new(event_type, "entity-1", :test, payload)
+  end
+
+  defp handler_count(context, event_type) do
+    state = :sys.get_state(DomainEventBus.process_name(context))
+
+    state.handlers
+    |> Map.get(event_type, [])
+    |> length()
   end
 
   # Handler result tests
@@ -133,6 +144,93 @@ defmodule KlassHero.Shared.DomainEventBusTest do
       # Why: proves execution happens in the caller, not inside the GenServer
       # Outcome: confirms caller-side execution model
       assert handler_pid == test_pid
+    end
+  end
+
+  # Owner-scoped delivery (#1136)
+
+  describe "owner-scoped delivery" do
+    test "handler does not fire for a dispatch from an unrelated process" do
+      test_pid = self()
+
+      DomainEventBus.subscribe(@test_context, :scoped_event, fn _event ->
+        send(test_pid, :handler_fired)
+        :ok
+      end)
+
+      # Trigger: a bare spawn does not inherit :"$callers", so this process is
+      #   genuinely unrelated — the shape of two concurrent async tests (#1136).
+      # Why: both sends originate in the spawned process, so message order is
+      #   guaranteed; :dispatch_done arriving means the handler would already
+      #   have delivered :handler_fired if it had run.
+      # Outcome: a subscriber never hears another process's dispatch.
+      spawn(fn ->
+        DomainEventBus.dispatch(@test_context, build_event(:scoped_event))
+        send(test_pid, :dispatch_done)
+      end)
+
+      assert_receive :dispatch_done
+      refute_received :handler_fired
+    end
+
+    test "handler fires for a dispatch from a Task descendant of its owner" do
+      test_pid = self()
+
+      DomainEventBus.subscribe(@test_context, :task_event, fn _event ->
+        send(test_pid, :handler_fired)
+        :ok
+      end)
+
+      # Trigger: Task propagates :"$callers", so the owner is in the chain.
+      # Why: work a test farms out to a Task is still that test's own work.
+      # Outcome: scoping follows process lineage, not strict pid equality.
+      Task.await(Task.async(fn -> DomainEventBus.dispatch(@test_context, build_event(:task_event)) end))
+
+      assert_received :handler_fired
+    end
+
+    test "boot-time handlers fire regardless of the dispatching process" do
+      context = __MODULE__.BootScopeContext
+      test_pid = self()
+
+      _bus =
+        start_supervised!(
+          {DomainEventBus, context: context, handlers: [{:boot_event, {TestHandler, :report_pid}}]},
+          id: :boot_scope_test
+        )
+
+      # Trigger: dispatch from an unrelated process, as production does from
+      #   Oban workers and EventSubscriber GenServers.
+      # Why: owner-scoping must never narrow production handler delivery.
+      # Outcome: `handlers:` registrations are exempt from the owner filter.
+      spawn(fn ->
+        DomainEventBus.dispatch(context, build_event(:boot_event, %{test_pid: test_pid}))
+      end)
+
+      assert_receive {:handler_ran_in, _pid}
+    end
+
+    test "handlers are dropped when their owner process exits" do
+      test_pid = self()
+
+      owner =
+        spawn(fn ->
+          DomainEventBus.subscribe(@test_context, :cleanup_event, fn _event -> :ok end)
+          send(test_pid, :subscribed)
+          receive do: (:stop -> :ok)
+        end)
+
+      assert_receive :subscribed
+      assert handler_count(@test_context, :cleanup_event) == 1
+
+      ref = Process.monitor(owner)
+      send(owner, :stop)
+      assert_receive {:DOWN, ^ref, :process, ^owner, _reason}
+
+      # Both :DOWN messages are enqueued when the owner dies; ours arrives first
+      # by the assert above, so the :sys.get_state call inside handler_count/2 is
+      # enqueued behind the bus's own :DOWN. FIFO makes this deterministic — no sleep.
+      assert handler_count(@test_context, :cleanup_event) == 0
     end
   end
 


### PR DESCRIPTION
Closes #1136.

## Summary

The issue diagnosed `ImportEnrollmentCsvTest`'s intermittent failure as an `assert_receive` timeout under full-suite load, and proposed raising the deadline `1_000 → 5_000`. **That diagnosis is wrong and the proposed fix cannot work** — `DomainEventBus.dispatch/2` runs handlers *synchronously in the caller's process*, so the test's own event is already in its mailbox before `assert_receive` runs. The deadline was never reachable.

What actually happened: each context's bus is a **globally-named singleton**, and `subscribe/4` had no scoping, so a test's handler lambda heard *every* dispatch in the VM. A concurrent `async: true` test (`InviteSingleParticipantTest`, which emits the same `:bulk_invites_imported` event with `count: 1` and one program_id) invoked that lambda and pushed a **foreign** event into the CSV test's mailbox. The assertion at `import_enrollment_csv_test.exs:512` didn't pin `provider_id`, so it matched the foreign event and the follow-up `assert ids == [program1.id]` failed on **value**, not deadline.

The issue's own reasoning contains the misstep: *"a pattern-matched `assert_receive` scans the mailbox... so unrelated events from concurrent tests cannot corrupt it."* Scanning only protects you if the pattern discriminates. This one didn't.

## Why not just add `unsubscribe/2`

That was the obvious reading of "no unsubscribe exists", but it doesn't close the class: cleanup stops handlers leaking **after** a test ends, while the flake happens **while** the subscriber is alive. The root cause is that *delivery* was unscoped, so that is what this changes.

## What changed

A handler entry gains an owner:

- `subscribe/4` records the calling pid. Its handler fires only when the dispatching process is that owner or a `:"$callers"` (`Task`) descendant of it.
- Boot-time `handlers:` registrations carry `:boot` and **always** fire.
- `Process.monitor` + a `:DOWN` clause drop a dead owner's handlers, which also ends the unbounded accumulation of dead closures over a long test run.

Public `@spec`s for `subscribe/4`, `dispatch/2` and `dispatch_critical/2` are unchanged — `owner` never leaks into a return value.

## Review focus

**Production delivery is provably unaffected.** `subscribe/4` has **zero production callers** — the only `lib/` hits are moduledoc examples. All 7 buses in `application.ex` register via `handlers:`, which takes the `:boot` path and is exempt from the filter. That includes the four sites that dispatch from a *different* process than the request initiator (two Oban workers, two `EventSubscriber` callbacks) — they only ever run boot handlers.

**No existing test needed changing.** All ~27 subscribe sites in the bus's own suite, and all 4 app-bus subscribers, already subscribe and dispatch in the same process. The one-line `provider_id` pin added to the CSV test is defence in depth, not the fix.

**The accepted trade-off** is that a handler outside its owner's lineage is now skipped *silently*. Mitigated three ways: `:boot` exemption, a lazy `Logger.debug` naming how many handlers were skipped and why, and an explicit `subscribe/4` warning calling out the `setup_all` trap (`setup_all` runs in a different process from each test body, so handlers registered there can never fire). The convention is recorded in `.claude/rules/testing.md`.

## Test plan

- New `describe "owner-scoped delivery"` block, 4 tests: cross-process non-delivery (the #1136 regression test, deterministic — no timing dependence), `Task`-descendant delivery, boot-handler exemption, and owner-death cleanup. The cleanup test forces `:DOWN` ordering via a `:sys.get_state` round-trip rather than sleeping.
- `mix precommit` green.
- Full suite run **4× sequentially**, 4190 passed each time (the issue reported 4189/4190). The flake surfaced ~1 in 7, so this is supporting evidence; the deterministic regression test is the actual proof.
- 21/21 architecture, boundary, and behaviour-preservation checks passed.

## Follow-ups (filed separately, not in this PR)

Surfaced while investigating; none block this change:

- `:incident_reported` and `:program_schedule_updated` are dispatched with **zero registered handlers anywhere** — missing wiring or dead code.
- `document_review_test.exs` exercises a consumer that no-ops on every run (its fixture defaults `entity_type: :individual` while the document type is `business_registration`, a business-track-only step), so it passes vacuously.
- 9 of 13 bus-sourced `assert_receive` patterns don't pin test-unique data. Harmless after this change, worth tightening.
- Issue #1136's body still states the incorrect root cause and will send the next reader to ship the useless timeout bump.