### PR TITLE
test: assert vetting outcome in document_review_test

### DIFF
--- a/test/klass_hero/provider/verification/document_review_test.exs
+++ b/test/klass_hero/provider/verification/document_review_test.exs
@@ -1,30 +1,12 @@
 defmodule KlassHero.Provider.Verification.DocumentReviewTest do
   use KlassHero.DataCase, async: false
 
-  import KlassHero.EventTestHelper
-
   alias KlassHero.AccountsFixtures
   alias KlassHero.Provider.VerificationDocument
+  alias KlassHero.Provider.Vetting
   alias KlassHero.ProviderFixtures
-  alias KlassHero.Shared.Adapters.Driven.Events.TestEventPublisher
-  alias KlassHero.Shared.DomainEventBus
 
   setup do
-    setup_test_events()
-
-    # Trigger: EventDispatchHelper dispatches via DomainEventBus, not the publisher port
-    # Why: capture events into TestEventPublisher so assert_event_published works
-    # Outcome: domain bus events become visible to EventTestHelper assertions
-    DomainEventBus.subscribe(KlassHero.Provider, :verification_document_approved, fn event ->
-      TestEventPublisher.publish(event)
-      :ok
-    end)
-
-    DomainEventBus.subscribe(KlassHero.Provider, :verification_document_rejected, fn event ->
-      TestEventPublisher.publish(event)
-      :ok
-    end)
-
     provider = ProviderFixtures.provider_profile_fixture()
     admin = AccountsFixtures.user_fixture(%{is_admin: true})
     doc = ProviderFixtures.verification_document_fixture(provider_id: provider.id)
@@ -72,13 +54,20 @@ defmodule KlassHero.Provider.Verification.DocumentReviewTest do
                KlassHero.Provider.approve_verification_document(doc.id, admin.id)
     end
 
-    test "dispatches :verification_document_approved domain event", %{admin: admin, document: doc} do
-      assert {:ok, approved} = KlassHero.Provider.approve_verification_document(doc.id, admin.id)
+    # Asserts the OUTCOME, not the event: AdvanceVettingStepOnDocumentReview is registered at
+    # boot (application.ex), so approving a document must advance the step that consumes its
+    # document_type. Asserting the event alone passed even while the handler no-opped (#1142).
+    test "advances the vetting step that consumes the document type", %{
+      provider: provider,
+      admin: admin,
+      document: doc
+    } do
+      assert {:ok, _approved} = KlassHero.Provider.approve_verification_document(doc.id, admin.id)
 
-      event = assert_event_published(:verification_document_approved)
-      assert event.aggregate_id == doc.id
-      assert event.payload.provider_id == approved.provider_profile_id
-      assert event.payload.reviewer_id == admin.id
+      step = experience_step(provider.id)
+      assert step.status == :approved
+      assert step.evidence_ref == doc.id
+      assert step.reviewed_by_id == admin.id
     end
   end
 
@@ -153,18 +142,39 @@ defmodule KlassHero.Provider.Verification.DocumentReviewTest do
                KlassHero.Provider.reject_verification_document(doc.id, admin.id, "Too late")
     end
 
-    test "dispatches :verification_document_rejected domain event", %{admin: admin, document: doc} do
-      assert {:ok, rejected} =
-               KlassHero.Provider.reject_verification_document(
-                 doc.id,
-                 admin.id,
-                 "Expired document"
-               )
+    # The reset is the only handler-sensitive outcome of a rejection. Do NOT assert via
+    # Vetting.checklist_for_provider/1 — that read derives :rejected from the document
+    # evidence, not the step, so it would pass with the handler deleted.
+    #
+    # Two documents are needed: reject_verification_document/3 requires a :pending document,
+    # so the approved one cannot also be the rejected one.
+    test "resets the vetting step when a document of an approved type is rejected", %{
+      provider: provider,
+      admin: admin,
+      document: doc
+    } do
+      assert {:ok, _approved} = KlassHero.Provider.approve_verification_document(doc.id, admin.id)
 
-      event = assert_event_published(:verification_document_rejected)
-      assert event.aggregate_id == doc.id
-      assert event.payload.provider_id == rejected.provider_profile_id
-      assert event.payload.reviewer_id == admin.id
+      # Pin the intermediate state. Without it this test is vacuous: a dead handler leaves the
+      # step at its initial :not_started, which is also the post-reset value asserted below.
+      assert experience_step(provider.id).status == :approved
+
+      second = ProviderFixtures.verification_document_fixture(provider_id: provider.id)
+
+      assert {:ok, _rejected} =
+               KlassHero.Provider.reject_verification_document(second.id, admin.id, "Expired document")
+
+      step = experience_step(provider.id)
+      assert step.status == :not_started
+      assert step.evidence_ref == nil
+      assert step.reviewed_by_id == nil
     end
+  end
+
+  # The vetting step fed by this file's default document type ("experience_validation" on the
+  # individual track). Re-read from the case each time — the handler writes it out of band.
+  defp experience_step(provider_id) do
+    assert {:ok, case_} = Vetting.get_case_for_provider(provider_id)
+    Enum.find(case_.steps, &(&1.key == :experience))
   end
 end

--- a/test/support/fixtures/provider_fixtures.ex
+++ b/test/support/fixtures/provider_fixtures.ex
@@ -121,7 +121,11 @@ defmodule KlassHero.ProviderFixtures do
     {:ok, persisted} =
       %{
         provider_profile_id: attrs_map[:provider_id] || provider_profile_fixture().id,
-        document_type: attrs_map[:document_type] || "business_registration",
+        # Must stay an INDIVIDUAL-track type: provider_profile_fixture defaults to
+        # entity_type: :individual, and a business-only type here (e.g. the previous
+        # "business_registration") makes AdvanceVettingStepOnDocumentReview find no
+        # matching step and silently no-op — tests then pass vacuously (#1142).
+        document_type: attrs_map[:document_type] || "experience_validation",
         file_url: attrs_map[:file_url] || "verification-docs/#{Ecto.UUID.generate()}.pdf",
         original_filename: attrs_map[:original_filename] || "doc.pdf"
       }


### PR DESCRIPTION
## Summary

`document_review_test.exs` asserted that approving/rejecting a verification document emitted `:verification_document_approved` / `:verification_document_rejected`. A real consumer **is** registered at boot — `AdvanceVettingStepOnDocumentReview` (`lib/klass_hero/application.ex:89-90`) — but the file's fixtures made it no-op on every single run.

Two shared fixture defaults were mutually incoherent:

| fixture | default | track |
|---|---|---|
| `provider_profile_fixture/1` | `entity_type: :individual` | individual |
| `verification_document_fixture/1` | `"business_registration"` | **business only** |

So `VettingCase.step_key_for_document/2` returned `nil` and the handler took its `nil -> log_no_step(...); :ok` branch. Nothing in the file would have failed if the handler were broken or deleted — the coverage read as present but was not.

Extra tell that the fixture default was wrong (not just the test): `business_registration` is `dedicated: :command` in the business track, so it's excluded from `generic_document_types/1` — the generic upload path this fixture models can never produce it.

## Changes

- **`provider_fixtures.ex`** — default `document_type` → `"experience_validation"` (individual track), with the reason pinned in a comment so a future "simplify back to defaults" change can't silently re-arm the trap.
- **`document_review_test.exs`** — dropped the two `DomainEventBus.subscribe` blocks and the `EventTestHelper` scaffolding; both event tests replaced with vetting-step outcome assertions.

## Review Focus

**The rejection test needs the intermediate assertion.** Asserting only the post-reset `:not_started` is vacuous — a dead handler leaves the step at its *initial* `:not_started`, the same value. Pinning `:approved` between the approve and the reject is what makes it handler-sensitive.

**Do not "simplify" the rejection test to use `Vetting.checklist_for_provider/1`.** That read derives `ui_status: :rejected` from the *document* evidence, not the step (`vetting.ex:436-458`), so it would pass with the handler deleted.

Fixture default change is blast-radius zero: only three test files call it, and the other two pass an explicit `document_type`.

## Test Plan

- [x] **Red first** — new tests written against the old `"business_registration"` default; both fail, logging `No vetting step consumes document_type="business_registration"`.
- [x] **Green** — after the fixture change: 14/14 in the file.
- [x] **Siblings unaffected** — `vetting_checklist_test.exs` + `verification_live_test.exs`: 38 passed.
- [x] **Handler-live check** — temporarily unregistered the handler in `application.ex`; both new tests fail. Reverted.
- [x] `mix precommit` — 4207 passed, 2 skipped, 18 excluded.

Closes #1142