### PR TITLE
chore: bind test HTTP socket only for the e2e suite

### DIFF
--- a/.claude/rules/worktrees.md
+++ b/.claude/rules/worktrees.md
@@ -62,9 +62,21 @@ MIX_TEST_PARTITION=1060 mix precommit
 itself is shared and started once (`mix test.setup`); only the DB *name* is
 per-partition, so no extra container management is required.
 
-Test HTTP port is fixed at 4002 (`config/test.exs`) and only one test run binds it
-at a time — run worktree suites sequentially, not concurrently, or they collide on
-the port even with different partitions.
+`mix test` binds **no** HTTP port, so worktree suites can run concurrently — only the
+`MIX_TEST_PARTITION` DB isolation above is required. `config/test.exs` sets
+`server: System.get_env("WALLABY_E2E") == "true"`, and only `mix test.e2e` sets that
+var, because Wallaby is the sole consumer of a real socket.
+
+The e2e suite *does* bind (port 4002 by default), so only one `mix test.e2e` runs at a
+time. Override with `TEST_PORT` when 4002 is taken — by another worktree's e2e run, or
+by an unrelated project on the same machine:
+
+```bash
+TEST_PORT=4242 MIX_TEST_PARTITION=1060 mix test.e2e
+```
+
+`TEST_PORT` feeds both the endpoint and Wallaby's `base_url` from one binding, so the
+two can't drift apart.
 
 ## Tidewave / dev server per worktree (separate axis from the test partition)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,8 +240,10 @@ jobs:
       - name: Install ChromeDriver
         uses: nanasess/setup-chromedriver@c75c3d53d445b96d41dbf2355797b470953c6c30
 
+      # Use the alias rather than duplicating its body: it sets WALLABY_E2E, without which
+      # config/test.exs binds no HTTP socket and every browser test fails to connect.
       - name: Run E2E tests
-        run: mix test test/e2e --include e2e
+        run: mix test.e2e
 
       # actions/upload-artifact@v4.6.2
       - name: Upload E2E screenshots

--- a/config/test.exs
+++ b/config/test.exs
@@ -8,6 +8,11 @@ alias KlassHero.Shared.Adapters.Driven.FeatureFlags.StubFeatureFlagsAdapter
 alias KlassHero.Shared.Adapters.Driven.Storage.StubStorageAdapter
 alias Swoosh.Adapters.Test
 
+# The one source of truth for the test HTTP port, shared by the endpoint and Wallaby's
+# base_url below. Override with TEST_PORT when 4002 is taken (another worktree, or an
+# unrelated project on the same machine).
+test_port = String.to_integer(System.get_env("TEST_PORT") || "4002")
+
 # Only in tests, remove the complexity from the password hashing algorithm
 config :bcrypt_elixir, :log_rounds, 1
 
@@ -24,11 +29,14 @@ config :klass_hero, KlassHero.Repo,
   pool: Ecto.Adapters.SQL.Sandbox,
   pool_size: System.schedulers_online() * 2
 
-# We run a server during test for Wallaby E2E browser tests
+# Bind a real socket ONLY for the Wallaby e2e suite (`mix test.e2e`, which sets
+# WALLABY_E2E). Everything else drives the endpoint through Plug/LiveView test helpers and
+# needs no listener — binding unconditionally made one global port a prerequisite for the
+# entire suite, so any other worktree or project holding it blocked every test run.
 config :klass_hero, KlassHeroWeb.Endpoint,
-  http: [ip: {127, 0, 0, 1}, port: 4002],
+  http: [ip: {127, 0, 0, 1}, port: test_port],
   secret_key_base: "gY/oKuAYeC5ExhHrtu1JBwrpQdoGwtPOo3X9GdS7CFOnLe0eqRQ9w4cyV1MqvoYc",
-  server: true
+  server: System.get_env("WALLABY_E2E") == "true"
 
 # Oban runs inline in tests so critical event handlers execute synchronously
 config :klass_hero, Oban, testing: :inline
@@ -64,19 +72,18 @@ config :klass_hero, :stripe_webhook_secret, "whsec_test_secret"
 config :klass_hero, :verify_webhook_signature, false
 config :klass_hero, env: :test
 
-# Outcome: disabling projections prevents sandbox leaks across async tests
+# Enable Ecto sandbox plug for Wallaby browser sessions
 config :klass_hero, sql_sandbox: true
+
+# Trigger: VerifiedProviders GenServer bootstraps a DB query at app startup
+# Why: that query runs outside the Ecto test sandbox, poisoning the connection pool
+# Outcome: disabling projections prevents sandbox leaks across async tests
 config :klass_hero, start_projections: false
 
 # Print only warnings and errors during test
 config :logger, level: :warning
 
-# Enable Ecto sandbox plug for Wallaby browser sessions
-# Why: that query runs outside the Ecto test sandbox, poisoning the connection pool
-
 # OpenTelemetry: disable exporting in tests; tracing tests opt in via TracingHelpers.
-# Trigger: VerifiedProviders GenServer bootstraps a DB query at app startup
-
 # Sampler must be always_on so tracing tests receive every span deterministically.
 config :opentelemetry,
   traces_exporter: :none,
@@ -96,7 +103,7 @@ config :swoosh, :api_client, false
 
 # Wallaby E2E test configuration
 config :wallaby,
-  base_url: "http://localhost:4002",
+  base_url: "http://localhost:#{test_port}",
   driver: Wallaby.Chrome,
   screenshot_on_failure: true,
   screenshot_dir: "tmp/e2e_screenshots",

--- a/mix.exs
+++ b/mix.exs
@@ -144,7 +144,8 @@ defmodule KlassHero.MixProject do
       ],
       "test.clean": ["test.teardown --remove-volumes", "test.setup --force-recreate"],
       "test.watch": ["test.setup", "test.watch.continuous"],
-      "test.e2e": ["test test/e2e --include e2e"],
+      # WALLABY_E2E makes config/test.exs bind a real HTTP socket; no other test needs one.
+      "test.e2e": ["cmd env WALLABY_E2E=true mix test test/e2e --include e2e"],
       precommit: [
         "compile --warnings-as-errors",
         "deps.unlock --unused",

--- a/test/config/test_env_config_test.exs
+++ b/test/config/test_env_config_test.exs
@@ -1,0 +1,33 @@
+defmodule KlassHero.TestEnvConfigTest do
+  @moduledoc """
+  Guards the test-env HTTP endpoint configuration itself.
+
+  Two facts about `config/test.exs` are easy to break silently and expensive to debug,
+  because both fail as an `:eaddrinuse` or a connection refusal that names neither the
+  config line nor the cause.
+  """
+
+  use ExUnit.Case, async: true
+
+  describe "test endpoint binding" do
+    # Only the Wallaby e2e suite drives a real browser against a real socket; every other
+    # test reaches the endpoint through Plug/LiveView test helpers. Binding unconditionally
+    # made a single global port (4002) a prerequisite for the whole suite, so one unrelated
+    # process — another worktree, or another project entirely — blocked every test run.
+    test "binds an HTTP socket only when running the e2e suite" do
+      e2e? = System.get_env("WALLABY_E2E") == "true"
+
+      assert Application.get_env(:klass_hero, KlassHeroWeb.Endpoint)[:server] == e2e?
+    end
+
+    # The endpoint port and Wallaby's base_url are two separate config entries that must
+    # agree. Changing one alone breaks e2e with a connection error pointing at neither.
+    test "wallaby drives the same port the endpoint binds" do
+      endpoint_port = Application.get_env(:klass_hero, KlassHeroWeb.Endpoint)[:http][:port]
+      %URI{port: base_url_port} = URI.parse(Application.get_env(:wallaby, :base_url))
+
+      assert base_url_port == endpoint_port,
+             "wallaby base_url port #{base_url_port} != endpoint port #{endpoint_port}"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`config/test.exs` set `server: true` unconditionally, so **every** `mix test` run bound port 4002. Only the Wallaby e2e suite drives a real browser against a real socket — and it runs from a separate alias (`mix test.e2e`), excluded from the default run by `test_helper.exs`. So ~4200 tests took a global port as a hard prerequisite and never used it.

The practical cost: any process holding 4002 blocked the whole suite — another worktree, or an unrelated project on the same machine. Concurrent worktree runs were impossible even with distinct `MIX_TEST_PARTITION` values. Hit while working #1142, where an unrelated project's server held 4002 for hours.

## Changes

- **`server:` gated on `WALLABY_E2E`**, which only `mix test.e2e` sets. Default runs bind nothing → unlimited concurrency.
- **Port single-sourced** into `test_port`, feeding both the endpoint and Wallaby's `base_url`. These previously duplicated the `4002` literal; changing one alone broke e2e with an error naming neither line.
- **`TEST_PORT` override** for when 4002 is taken during an e2e run.
- **CI e2e job** called `mix test test/e2e --include e2e` directly, duplicating the alias body — it now calls `mix test.e2e` so it picks up the env var.
- **`worktrees.md`** updated: the "run worktree suites sequentially" rule is now false for `mix test`.
- **Comment repair** (see below).

## Review Focus

**The CI change is load-bearing, not cosmetic.** CI duplicated the alias body rather than calling it. Left alone, its e2e job would bind no socket and every browser test would fail to connect. This is the one way the change could break CI, and it's the line that prevents it.

**Comment repair in `config/test.exs`.** `.formatter.exs` runs Quokka, which sorts `config` calls alphabetically; detached comments get stranded when blocks move. A `Trigger:/Why:/Outcome:` triple describing `start_projections: false` was already split across three unrelated locations **on `main`** (verify: `git show HEAD:config/test.exs | sed -n '66,80p'`). Reassembled it, and attached the Stripe/OpenTelemetry comments directly to their config so future sorts carry them. Confirmed format-stable across a round-trip.

**New `test/config/test_env_config_test.exs`** pins both invariants — binds *iff* e2e, and wallaby port == endpoint port — so neither can silently regress.

## Test Plan

- [x] **Red→green**: the binding test failed (`left: true, right: false`) before the gate, passes after.
- [x] **The real proof** — with 4002 held by an unrelated process and **no** `TEST_PORT`: full suite green, 4209 passed.
- [x] **Discriminating pair**, same held port: `mix test` runs clean; `mix test.e2e` fails `:eaddrinuse` — confirming e2e *does* still bind.
- [x] Config resolves correctly in all three modes (default → `server: false`; `WALLABY_E2E=true` → `server: true`, base_url `:4002`; `+TEST_PORT=4242` → base_url `:4242`).
- [x] `mix precommit` exit 0.

⚠️ **Not verified locally: an actual browser e2e run.** No chromedriver on this machine — `mix test.e2e` gets past endpoint startup and dies on the missing driver. CI's e2e job is the real check on this PR; please confirm it's green before merging.
ℹ️ **Suite flakiness is pre-existing, and broader than one test.** I originally flagged a `family_programs_test.exs:79` `assign_async` timeout without a baseline, because while 4002 was held `main` couldn't run the suite at all. With the port freed I measured it: **20 full-suite runs on clean `origin/main` produced 3 failures (~15%), each in a different test** — `projection_test.exs:293` (`GenServer.stop` exit), `verifications_live_test.exs:246` (expected truthy, got false), and one uncaptured. So `main` has a flaky *suite*, not a flaky test, and the timeout I saw belongs to that baseline rather than to this change. Worth its own issue; out of scope here.
