### PR TITLE
refactor: route staff broadcast lookup through provider-scoped getter

### DIFF
--- a/lib/klass_hero_web/live/staff/staff_broadcast_live.ex
+++ b/lib/klass_hero_web/live/staff/staff_broadcast_live.ex
@@ -34,39 +34,47 @@ defmodule KlassHeroWeb.Staff.StaffBroadcastLive do
   end
 
   defp mount_broadcast_form(socket, provider, staff_member, program_id) do
-    case ProgramCatalog.get_program_by_id(program_id) do
+    # program_id is untrusted URL input; the scoped getter makes a foreign program
+    # unreachable (IDOR guard) rather than fetched and then compared. A foreign and
+    # a missing program are deliberately indistinguishable here.
+    case ProgramCatalog.get_program_for_provider(provider.id, program_id) do
       {:ok, program} ->
-        if program.provider_id == provider.id and staff_assigned?(staff_member, program) do
-          form = to_form(%{"subject" => "", "content" => ""})
-
-          socket =
-            socket
-            |> assign(:page_title, gettext("Send Broadcast"))
-            |> assign(:active_nav, :messages)
-            |> assign(:program, program)
-            |> assign(:provider, provider)
-            |> assign(:form, form)
-            |> assign(:sending, false)
-            |> allow_upload(:attachments,
-              accept: ~w(.jpg .jpeg .png .gif .webp),
-              max_entries: Attachment.max_per_message(),
-              max_file_size: Attachment.max_file_size_bytes()
-            )
-
-          {:ok, socket}
+        if staff_assigned?(staff_member, program) do
+          mount_form(socket, provider, program)
         else
-          {:ok,
-           socket
-           |> put_flash(:error, gettext("You are not assigned to this program"))
-           |> push_navigate(to: ~p"/staff/dashboard")}
+          redirect_to_dashboard(socket, gettext("You are not assigned to this program"))
         end
 
       {:error, :not_found} ->
-        {:ok,
-         socket
-         |> put_flash(:error, gettext("Program not found"))
-         |> push_navigate(to: ~p"/staff/dashboard")}
+        redirect_to_dashboard(socket, gettext("Program not found"))
     end
+  end
+
+  defp mount_form(socket, provider, program) do
+    form = to_form(%{"subject" => "", "content" => ""})
+
+    socket =
+      socket
+      |> assign(:page_title, gettext("Send Broadcast"))
+      |> assign(:active_nav, :messages)
+      |> assign(:program, program)
+      |> assign(:provider, provider)
+      |> assign(:form, form)
+      |> assign(:sending, false)
+      |> allow_upload(:attachments,
+        accept: ~w(.jpg .jpeg .png .gif .webp),
+        max_entries: Attachment.max_per_message(),
+        max_file_size: Attachment.max_file_size_bytes()
+      )
+
+    {:ok, socket}
+  end
+
+  defp redirect_to_dashboard(socket, message) do
+    {:ok,
+     socket
+     |> put_flash(:error, message)
+     |> push_navigate(to: ~p"/staff/dashboard")}
   end
 
   defp staff_assigned?(staff_member, program) do

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -333,7 +333,7 @@ msgstr "Klass Hero - Wir verbinden Familien mit vertrauenswürdigen Jugendpädag
 
 #: lib/klass_hero_web/live/booking_live.ex:54
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:59
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:67
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:49
 #, elixir-autogen, elixir-format
 msgid "Program not found"
 msgstr "Programm nicht gefunden"
@@ -756,7 +756,7 @@ msgstr "Der Magic-Link ist ungültig oder abgelaufen."
 
 #: lib/klass_hero_web/live/contact_live.ex:176
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:181
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:193
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr "Nachricht"
@@ -920,7 +920,7 @@ msgstr "Sitzung erfolgreich gestartet"
 
 #: lib/klass_hero_web/live/contact_live.ex:168
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:167
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:179
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:187
 #, elixir-autogen, elixir-format
 msgid "Subject"
 msgstr "Betreff"
@@ -1817,7 +1817,7 @@ msgid "Broadcast"
 msgstr "Rundnachricht"
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:101
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:114
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "Broadcast sent to %{count} parents"
 msgstr "Rundnachricht an %{count} Eltern gesendet"
@@ -1836,7 +1836,7 @@ msgstr "Rundnachricht an %{count} Eltern gesendet"
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:186
 #: lib/klass_hero_web/live/settings/children_live.ex:579
 #: lib/klass_hero_web/live/settings/children_live.ex:738
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:225
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:233
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr "Abbrechen"
@@ -1931,7 +1931,7 @@ msgid "Failed to resubmit note"
 msgstr "Notiz konnte nicht erneut eingereicht werden"
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:124
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:146
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:154
 #, elixir-autogen, elixir-format
 msgid "Failed to send broadcast"
 msgstr "Rundnachricht konnte nicht gesendet werden"
@@ -1973,7 +1973,7 @@ msgid "Manage your children's profiles"
 msgstr "Verwalten Sie die Profile Ihrer Kinder"
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:82
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:94
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:102
 #, elixir-autogen, elixir-format
 msgid "Message content is required"
 msgstr "Nachrichteninhalt ist erforderlich"
@@ -2006,7 +2006,7 @@ msgid "No messages yet"
 msgstr "Noch keine Nachrichten"
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:109
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:122
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:130
 #, elixir-autogen, elixir-format
 msgid "No parents are enrolled in this program"
 msgstr "Für dieses Programm sind keine Eltern angemeldet"
@@ -2095,9 +2095,9 @@ msgstr "Änderungen speichern"
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:43
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:151
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:252
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:44
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:163
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:238
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:58
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:171
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:246
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:392
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:393
 #, elixir-autogen, elixir-format
@@ -2111,7 +2111,7 @@ msgstr "Senden Sie eine Nachricht, um die Unterhaltung zu beginnen"
 
 #: lib/klass_hero_web/components/provider_components.ex:2148
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:237
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "Sending..."
 msgstr "Wird gesendet..."
@@ -2123,7 +2123,7 @@ msgid "Support needs"
 msgstr "Unterstützungsbedarf"
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:210
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:213
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:221
 #, elixir-autogen, elixir-format
 msgid "This message will be sent to all parents with active enrollments in this program."
 msgstr "Diese Nachricht wird an alle Eltern mit aktiven Anmeldungen in diesem Programm gesendet."
@@ -2140,7 +2140,7 @@ msgid "Unable to refresh roster. Please reload."
 msgstr "Teilnehmerliste konnte nicht aktualisiert werden. Bitte laden Sie die Seite neu."
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:188
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:200
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "Write your message to all enrolled parents..."
 msgstr "Schreiben Sie Ihre Nachricht an alle angemeldeten Eltern..."
@@ -2176,13 +2176,13 @@ msgid "Your conversations with providers will appear here"
 msgstr "Ihre Unterhaltungen mit Anbietern werden hier angezeigt"
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:175
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:187
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:195
 #, elixir-autogen, elixir-format
 msgid "e.g., Important Update"
 msgstr "z. B. Wichtiges Update"
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:167
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:179
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:187
 #, elixir-autogen, elixir-format
 msgid "optional"
 msgstr "optional"
@@ -4734,7 +4734,7 @@ msgid "View and manage your assigned sessions"
 msgstr "Ihre zugewiesenen Sitzungen anzeigen und verwalten"
 
 #: lib/klass_hero_web/live/provider/participation_live.ex:278
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:60
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:45
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:215
 #, elixir-autogen, elixir-format
 msgid "You are not assigned to this program"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -333,7 +333,7 @@ msgstr ""
 
 #: lib/klass_hero_web/live/booking_live.ex:54
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:59
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:67
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:49
 #, elixir-autogen, elixir-format
 msgid "Program not found"
 msgstr ""
@@ -756,7 +756,7 @@ msgstr ""
 
 #: lib/klass_hero_web/live/contact_live.ex:176
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:181
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:193
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr ""
@@ -920,7 +920,7 @@ msgstr ""
 
 #: lib/klass_hero_web/live/contact_live.ex:168
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:167
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:179
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:187
 #, elixir-autogen, elixir-format
 msgid "Subject"
 msgstr ""
@@ -1817,7 +1817,7 @@ msgid "Broadcast"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:101
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:114
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "Broadcast sent to %{count} parents"
 msgstr ""
@@ -1836,7 +1836,7 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:186
 #: lib/klass_hero_web/live/settings/children_live.ex:579
 #: lib/klass_hero_web/live/settings/children_live.ex:738
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:225
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:233
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr ""
@@ -1931,7 +1931,7 @@ msgid "Failed to resubmit note"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:124
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:146
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:154
 #, elixir-autogen, elixir-format
 msgid "Failed to send broadcast"
 msgstr ""
@@ -1973,7 +1973,7 @@ msgid "Manage your children's profiles"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:82
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:94
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:102
 #, elixir-autogen, elixir-format
 msgid "Message content is required"
 msgstr ""
@@ -2006,7 +2006,7 @@ msgid "No messages yet"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:109
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:122
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:130
 #, elixir-autogen, elixir-format
 msgid "No parents are enrolled in this program"
 msgstr ""
@@ -2095,9 +2095,9 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:43
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:151
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:252
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:44
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:163
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:238
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:58
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:171
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:246
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:392
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:393
 #, elixir-autogen, elixir-format
@@ -2111,7 +2111,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:2148
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:237
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "Sending..."
 msgstr ""
@@ -2123,7 +2123,7 @@ msgid "Support needs"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:210
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:213
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:221
 #, elixir-autogen, elixir-format
 msgid "This message will be sent to all parents with active enrollments in this program."
 msgstr ""
@@ -2140,7 +2140,7 @@ msgid "Unable to refresh roster. Please reload."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:188
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:200
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "Write your message to all enrolled parents..."
 msgstr ""
@@ -2176,13 +2176,13 @@ msgid "Your conversations with providers will appear here"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:175
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:187
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:195
 #, elixir-autogen, elixir-format
 msgid "e.g., Important Update"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:167
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:179
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:187
 #, elixir-autogen, elixir-format
 msgid "optional"
 msgstr ""
@@ -4734,7 +4734,7 @@ msgid "View and manage your assigned sessions"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/participation_live.ex:278
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:60
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:45
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:215
 #, elixir-autogen, elixir-format
 msgid "You are not assigned to this program"

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -333,7 +333,7 @@ msgstr ""
 
 #: lib/klass_hero_web/live/booking_live.ex:54
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:59
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:67
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:49
 #, elixir-autogen, elixir-format
 msgid "Program not found"
 msgstr ""
@@ -756,7 +756,7 @@ msgstr ""
 
 #: lib/klass_hero_web/live/contact_live.ex:176
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:181
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:193
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr ""
@@ -920,7 +920,7 @@ msgstr ""
 
 #: lib/klass_hero_web/live/contact_live.ex:168
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:167
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:179
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:187
 #, elixir-autogen, elixir-format
 msgid "Subject"
 msgstr ""
@@ -1817,7 +1817,7 @@ msgid "Broadcast"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:101
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:114
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "Broadcast sent to %{count} parents"
 msgstr ""
@@ -1836,7 +1836,7 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:186
 #: lib/klass_hero_web/live/settings/children_live.ex:579
 #: lib/klass_hero_web/live/settings/children_live.ex:738
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:225
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:233
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr ""
@@ -1931,7 +1931,7 @@ msgid "Failed to resubmit note"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:124
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:146
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:154
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to send broadcast"
 msgstr ""
@@ -1973,7 +1973,7 @@ msgid "Manage your children's profiles"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:82
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:94
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:102
 #, elixir-autogen, elixir-format
 msgid "Message content is required"
 msgstr ""
@@ -2006,7 +2006,7 @@ msgid "No messages yet"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:109
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:122
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:130
 #, elixir-autogen, elixir-format
 msgid "No parents are enrolled in this program"
 msgstr ""
@@ -2095,9 +2095,9 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:43
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:151
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:252
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:44
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:163
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:238
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:58
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:171
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:246
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:392
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:393
 #, elixir-autogen, elixir-format
@@ -2111,7 +2111,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:2148
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:237
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:245
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sending..."
 msgstr ""
@@ -2123,7 +2123,7 @@ msgid "Support needs"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:210
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:213
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:221
 #, elixir-autogen, elixir-format
 msgid "This message will be sent to all parents with active enrollments in this program."
 msgstr ""
@@ -2140,7 +2140,7 @@ msgid "Unable to refresh roster. Please reload."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:188
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:200
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "Write your message to all enrolled parents..."
 msgstr ""
@@ -2176,13 +2176,13 @@ msgid "Your conversations with providers will appear here"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:175
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:187
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:195
 #, elixir-autogen, elixir-format
 msgid "e.g., Important Update"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:167
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:179
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:187
 #, elixir-autogen, elixir-format
 msgid "optional"
 msgstr ""
@@ -4734,7 +4734,7 @@ msgid "View and manage your assigned sessions"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/participation_live.ex:278
-#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:60
+#: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:45
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:215
 #, elixir-autogen, elixir-format
 msgid "You are not assigned to this program"

--- a/test/klass_hero_web/live/staff/staff_broadcast_live_test.exs
+++ b/test/klass_hero_web/live/staff/staff_broadcast_live_test.exs
@@ -122,6 +122,25 @@ defmodule KlassHeroWeb.Staff.StaffBroadcastLiveTest do
 
       assert flash["error"] =~ "not assigned"
     end
+
+    test "redirects to dashboard for any unreachable program (IDOR guard)", %{conn: conn} do
+      foreign_provider = insert(:provider_profile_schema, %{})
+      foreign_program = insert(:program_schema, provider_id: foreign_provider.id)
+
+      unreachable = [
+        {"foreign provider's program", foreign_program.id},
+        {"nonexistent program", Ecto.UUID.generate()},
+        {"malformed id", "not-a-uuid"}
+      ]
+
+      for {label, program_id} <- unreachable do
+        assert {:error, {:live_redirect, %{to: "/staff/dashboard", flash: flash}}} =
+                 live(conn, ~p"/staff/programs/#{program_id}/broadcast"),
+               "expected #{label} to be rejected"
+
+        assert flash["error"] == "Program not found", "wrong flash for #{label}"
+      end
+    end
   end
 
   describe "staff broadcast (former starter-tier provider)" do


### PR DESCRIPTION
Closes #1138.

## Summary

`StaffBroadcastLive` was the last place in the web layer fetching a program unscoped and then hand-comparing `provider_id`. It now routes through `ProgramCatalog.get_program_for_provider/2`, which composes `Program.owned_by/2` into the query — a foreign program is *unreachable* rather than fetched-then-rejected.

Ownership and staff assignment were fused into one boolean (`program.provider_id == provider.id and staff_assigned?(...)`). They're now separate concerns: ownership is enforced by the query, `staff_assigned?/2` keeps its own branch.

**Three of the four call sites the issue names were already done** — PR #1137 converted `programs_live.ex` (`edit_program`, `view_roster`) and `provider/broadcast_live.ex`, including the two stale comments #1138 flags. Only the staff one remained.

## Review focus

**One observable behaviour change.** A program belonging to *another* provider now flashes `"Program not found"` instead of `"You are not assigned to this program"`. The scoped getter deliberately cannot distinguish foreign from missing — that's the IDOR property — so the merged branch needs one message. `"Program not found"` was chosen because it stops a foreign staff member confirming the program exists, and it matches `provider/broadcast_live.ex:59`. An owned-but-wrong-category program still flashes `"You are not assigned to this program"`.

Two alternatives were considered and rejected: a single `"not assigned"` message for every failure (misreports a deleted program, and reinstates the three-way `with/else` the issue set out to remove), and folding assignment into a domain-level `may_broadcast?` (a cross-context join — `StaffMember.tags` in Provider, `Program.category` in ProgramCatalog — for one call site).

**Gettext diff is noise.** `0 new messages, 0 removed, 1427 unchanged`. Both strings already existed with German translations; moving the `gettext(...)` calls shifted the `file:line` references `.pot` records, which fails `lint_translations --check-up-to-date`.

## Test plan

New coverage for the mount guard, which previously had none — foreign-provider, nonexistent, and malformed program ids, folded into one tabular test with per-row failure messages. It fails on `main` at the foreign-provider row, which is what drove the change.

The existing `"rejects broadcast for non-assigned program"` test uses a same-provider/wrong-category program, so it exercises `staff_assigned?/2` only and passes unchanged.

- `mix precommit` — 4208 passed, 29 properties, 2 skipped
- Verified on the default test port with no local config overrides