### PR TITLE
feat: add read-only admin view for incident reports

### DIFF
--- a/lib/klass_hero/provider/incident_report.ex
+++ b/lib/klass_hero/provider/incident_report.ex
@@ -15,6 +15,18 @@ defmodule KlassHero.Provider.IncidentReport do
   The struct field is `provider_profile_id` (semantic clarity) but the DB column
   is `provider_id`, which references the `providers` table. The `source:` option
   carries the mapping so consumers keep reading `report.provider_profile_id`.
+
+  ## Admin affordances
+
+  `provider_name` and `program_title` are **virtual** — nothing in the write path
+  populates them. They exist for `KlassHeroWeb.Admin.IncidentLive`, whose
+  `item_query/3` joins the owning provider and program and merges the names in.
+  Virtual fields rather than `belongs_to` associations deliberately: an
+  association added for a Backpex field becomes an invisible consumer, so a later
+  removal breaks the admin view silently.
+
+  `admin_changeset/3` is inert config, not a second validation path —
+  `create_changeset/1` remains the only gatekeeper.
   """
 
   use Ecto.Schema
@@ -50,6 +62,10 @@ defmodule KlassHero.Provider.IncidentReport do
     field :occurred_at, :utc_datetime
     field :photo_url, :string
     field :original_filename, :string
+
+    # Populated only by KlassHeroWeb.Admin.IncidentLive's item_query/3 join.
+    field :provider_name, :string, virtual: true
+    field :program_title, :string, virtual: true
 
     timestamps()
   end
@@ -120,6 +136,9 @@ defmodule KlassHero.Provider.IncidentReport do
     |> foreign_key_constraint(:program_id)
     |> foreign_key_constraint(:session_id)
   end
+
+  @doc "No-op changeset required by Backpex even when edit is disabled via `can?/3`."
+  def admin_changeset(schema, _attrs, _metadata), do: change(schema)
 
   defp validate_occurred_at_not_future(changeset) do
     validate_change(changeset, :occurred_at, fn :occurred_at, occurred_at ->

--- a/lib/klass_hero_web/components/layouts/admin.html.heex
+++ b/lib/klass_hero_web/components/layouts/admin.html.heex
@@ -45,6 +45,11 @@
         "Consents"
       )}
     </Backpex.HTML.Layout.sidebar_item>
+    <Backpex.HTML.Layout.sidebar_item current_url={@current_url} navigate={~p"/admin/incidents"}>
+      <Backpex.HTML.CoreComponents.icon name="hero-exclamation-triangle" class="h-5 w-5" /> {gettext(
+        "Incidents"
+      )}
+    </Backpex.HTML.Layout.sidebar_item>
     <Backpex.HTML.Layout.sidebar_item current_url={@current_url} navigate={~p"/admin/emails"}>
       <Backpex.HTML.CoreComponents.icon name="hero-envelope" class="h-5 w-5" /> {gettext("Emails")}
       <span

--- a/lib/klass_hero_web/live/admin/filters/incident_category_filter.ex
+++ b/lib/klass_hero_web/live/admin/filters/incident_category_filter.ex
@@ -1,0 +1,25 @@
+defmodule KlassHeroWeb.Admin.Filters.IncidentCategoryFilter do
+  @moduledoc false
+
+  use Backpex.Filters.Boolean
+
+  import Ecto.Query
+
+  alias Backpex.Filters.Boolean
+  alias KlassHero.Provider.IncidentReport
+
+  @impl Backpex.Filter
+  def label, do: "Category"
+
+  # Options are derived from the entity so the list cannot drift from the enum.
+  @impl Boolean
+  def options(_assigns) do
+    for category <- IncidentReport.valid_categories() do
+      %{
+        label: IncidentReport.category_label(category),
+        key: Atom.to_string(category),
+        predicate: dynamic([x], x.category == ^category)
+      }
+    end
+  end
+end

--- a/lib/klass_hero_web/live/admin/filters/incident_severity_filter.ex
+++ b/lib/klass_hero_web/live/admin/filters/incident_severity_filter.ex
@@ -1,0 +1,25 @@
+defmodule KlassHeroWeb.Admin.Filters.IncidentSeverityFilter do
+  @moduledoc false
+
+  use Backpex.Filters.Boolean
+
+  import Ecto.Query
+
+  alias Backpex.Filters.Boolean
+  alias KlassHero.Provider.IncidentReport
+
+  @impl Backpex.Filter
+  def label, do: "Severity"
+
+  # Options are derived from the entity so the list cannot drift from the enum.
+  @impl Boolean
+  def options(_assigns) do
+    for severity <- IncidentReport.valid_severities() do
+      %{
+        label: IncidentReport.severity_label(severity),
+        key: Atom.to_string(severity),
+        predicate: dynamic([x], x.severity == ^severity)
+      }
+    end
+  end
+end

--- a/lib/klass_hero_web/live/admin/incident_live.ex
+++ b/lib/klass_hero_web/live/admin/incident_live.ex
@@ -113,15 +113,21 @@ defmodule KlassHeroWeb.Admin.IncidentLive do
   @impl Backpex.LiveResource
   def fields do
     [
+      # `orderable: false` is load-bearing on both virtual fields. Backpex's
+      # orderable default is `true`, and it validates `order_by` against the
+      # orderable list — so leaving it out lets `?order_by=provider_name` through
+      # to `ORDER BY i0."provider_name"`, a column that does not exist (42703).
       provider_name: %{
         module: Text,
         label: "Provider",
-        only: [:index, :show]
+        only: [:index, :show],
+        orderable: false
       },
       program_title: %{
         module: Text,
         label: "Target",
         only: [:index, :show],
+        orderable: false,
         render: fn assigns ->
           ~H"""
           <span>

--- a/lib/klass_hero_web/live/admin/incident_live.ex
+++ b/lib/klass_hero_web/live/admin/incident_live.ex
@@ -1,0 +1,247 @@
+defmodule KlassHeroWeb.Admin.IncidentLive do
+  @moduledoc """
+  Backpex LiveResource for viewing incident reports across all providers.
+
+  Strictly read-only — no create, edit, or delete. Incident reports are filed by
+  providers and staff; the platform's interest is visibility (spotting safety
+  patterns, responding to serious incidents), not authorship. Actioning an
+  incident remains the provider's responsibility.
+
+  Note: Backpex operates directly on Ecto schemas and Repo, bypassing
+  the Ports & Adapters layering used elsewhere. This is a pragmatic
+  exception scoped to admin-only read operations.
+
+  ## Reads, not events
+
+  Reports are queried directly. The row and its provider-notification Oban job
+  already commit in one transaction (`SubmitIncidentReport`), so the data is
+  durable before this view ever runs — there is no delivery to make reliable and
+  therefore no integration event or projection here.
+
+  ## Access and audit
+
+  Every admin (`is_admin: true`) can read every report, including the free-text
+  description and any photo. There are no admin sub-roles to scope this to, and
+  no record is kept of which admin viewed which report. Photo links are signed
+  with a short TTL but are bearer URLs for their lifetime.
+  """
+
+  # Backpex requires FQ refs in `use` args — alias can't precede `use` per formatter rules
+  # credo:disable-for-lines:11 Credo.Check.Design.AliasUsage
+  use Backpex.LiveResource,
+    adapter_config: [
+      schema: KlassHero.Provider.IncidentReport,
+      repo: KlassHero.Repo,
+      update_changeset: &KlassHero.Provider.IncidentReport.admin_changeset/3,
+      create_changeset: &KlassHero.Provider.IncidentReport.admin_changeset/3,
+      item_query: &__MODULE__.item_query/3
+    ],
+    pubsub: [server: KlassHero.PubSub],
+    init_order: %{by: :occurred_at, direction: :desc}
+
+  import Ecto.Query
+
+  alias Backpex.Fields.Text
+  alias Backpex.Fields.Textarea
+  alias KlassHero.Provider.IncidentReport
+  alias KlassHero.Shared.Storage
+  alias KlassHeroWeb.Admin.Filters.IncidentCategoryFilter
+  alias KlassHeroWeb.Admin.Filters.IncidentSeverityFilter
+  alias KlassHeroWeb.Presenters.IncidentReportPresenter
+
+  require Logger
+
+  # Matches the admin verification-document viewer (`Provider.Verification`):
+  # long enough to open and inspect in a browser, short enough to expire fast.
+  @photo_url_ttl_seconds 900
+
+  @impl Backpex.LiveResource
+  def layout(_assigns), do: {KlassHeroWeb.Layouts, :admin}
+
+  # Reports are filed by providers/staff and are an audit record — admins read only.
+  @impl Backpex.LiveResource
+  def can?(_assigns, :new, _item), do: false
+  def can?(_assigns, :edit, _item), do: false
+  def can?(_assigns, :delete, _item), do: false
+  def can?(_assigns, :index, _item), do: true
+  def can?(_assigns, :show, _item), do: true
+  def can?(_assigns, _action, _item), do: false
+
+  @impl Backpex.LiveResource
+  def singular_name, do: "Incident Report"
+
+  @impl Backpex.LiveResource
+  def plural_name, do: "Incident Reports"
+
+  @impl Backpex.LiveResource
+  def filters do
+    [
+      severity: %{module: IncidentSeverityFilter},
+      category: %{module: IncidentCategoryFilter}
+    ]
+  end
+
+  @doc """
+  Resolves the owning provider's and program's names into virtual fields.
+
+  Joined on raw table names rather than through another context's schemas, so
+  this stays a column-level read and imports nothing from Program Catalog.
+  `programs` is a LEFT join because a report is polymorphic: exactly one of
+  `program_id` / `session_id` is set (DB CHECK `one_of_program_or_session`), so
+  session-scoped reports carry a NULL `program_id` and would vanish from an
+  inner join.
+  """
+  def item_query(query, _live_action, _assigns) do
+    from r in query,
+      join: p in "providers",
+      on: p.id == r.provider_id,
+      left_join: prog in "programs",
+      on: prog.id == r.program_id,
+      select_merge: %{provider_name: p.business_name, program_title: prog.title}
+  end
+
+  @impl Backpex.LiveResource
+  def render_resource_slot(assigns, :index, :before_main) do
+    ~H"""
+    <div class="mb-4 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
+      Read-only safety record. Reports contain child-safety details and are actioned
+      by the provider, who is notified by email when a report is filed.
+    </div>
+    """
+  end
+
+  @impl Backpex.LiveResource
+  def fields do
+    [
+      provider_name: %{
+        module: Text,
+        label: "Provider",
+        only: [:index, :show]
+      },
+      program_title: %{
+        module: Text,
+        label: "Target",
+        only: [:index, :show],
+        render: fn assigns ->
+          ~H"""
+          <span>
+            <%= if @value do %>
+              {@value}
+            <% else %>
+              <span class="text-gray-400 italic">Session report</span>
+            <% end %>
+          </span>
+          """
+        end
+      },
+      category: %{
+        module: Text,
+        label: "Category",
+        orderable: true,
+        render: fn assigns ->
+          ~H"""
+          <span>{IncidentReport.category_label(@value)}</span>
+          """
+        end
+      },
+      severity: %{
+        module: Text,
+        label: "Severity",
+        orderable: true,
+        render: fn assigns ->
+          ~H"""
+          <span class={[
+            "inline-flex items-center rounded-full px-2 py-1 text-xs font-medium",
+            severity_badge_class(@value)
+          ]}>
+            {IncidentReport.severity_label(@value)}
+          </span>
+          """
+        end
+      },
+      reporter_display_name: %{
+        module: Text,
+        label: "Reported By",
+        searchable: true,
+        orderable: true
+      },
+      occurred_at: %{
+        module: Backpex.Fields.DateTime,
+        label: "Occurred At",
+        orderable: true
+      },
+      description: %{
+        module: Textarea,
+        label: "Description",
+        only: [:show]
+      },
+      photo_url: %{
+        module: Text,
+        label: "Photo",
+        only: [:show],
+        # The wrapping <div> is required, not cosmetic: Backpex.Fields.Text is a
+        # stateful LiveComponent, so its root must be a single static HTML tag —
+        # a bare component call or a top-level `if` raises at render time.
+        render: fn assigns ->
+          ~H"""
+          <div>
+            <.photo_preview storage_key={@value} />
+          </div>
+          """
+        end
+      }
+    ]
+  end
+
+  # Signing happens at render time because Backpex owns mount/3, so there is no
+  # earlier hook to stash the URL in. S3 presigning is local URL math, not a
+  # round-trip, so re-signing per render is cheap.
+  #
+  # No `attr` declaration: `use Backpex.LiveResource` only *imports*
+  # Phoenix.Component, and `attr/3` requires `use`.
+  defp photo_preview(assigns) do
+    assigns = assign(assigns, :signed_url, signed_photo_url(assigns.storage_key))
+
+    ~H"""
+    <%= if @signed_url do %>
+      <a href={@signed_url} target="_blank" rel="noopener noreferrer">
+        <img
+          src={@signed_url}
+          alt="Incident photo"
+          class="max-h-64 rounded-lg border border-gray-200"
+        />
+      </a>
+    <% else %>
+      <span class="text-gray-400 italic">No photo</span>
+    <% end %>
+    """
+  end
+
+  defp signed_photo_url(nil), do: nil
+
+  # Degrade to no photo rather than crash the page — mirrors
+  # `NotifyIncidentReported.maybe_sign_photo/2`, which sends the email regardless.
+  defp signed_photo_url(key) when is_binary(key) do
+    case Storage.signed_url(:private, key, @photo_url_ttl_seconds) do
+      {:ok, url} ->
+        url
+
+      {:error, reason} ->
+        Logger.warning("[Admin.IncidentLive] photo signing failed, rendering without photo",
+          photo_url: key,
+          reason: inspect(reason)
+        )
+
+        nil
+    end
+  end
+
+  defp severity_badge_class(severity) do
+    case IncidentReportPresenter.severity_color(severity) do
+      "error" -> "bg-red-100 text-red-800"
+      "warning" -> "bg-amber-100 text-amber-800"
+      "info" -> "bg-blue-100 text-blue-800"
+      "success" -> "bg-green-100 text-green-800"
+    end
+  end
+end

--- a/lib/klass_hero_web/router.ex
+++ b/lib/klass_hero_web/router.ex
@@ -216,6 +216,7 @@ defmodule KlassHeroWeb.Router do
         live_resources("/staff", StaffLive, only: [:index, :show, :edit])
         live_resources("/bookings", BookingLive, only: [:index, :show])
         live_resources("/consents", ConsentLive, only: [:index, :show])
+        live_resources("/incidents", IncidentLive, only: [:index, :show])
       end
     end
 

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -1333,7 +1333,7 @@ msgid "Push, email, SMS settings"
 msgstr "Push-, E-Mail-, SMS-Einstellungen"
 
 #: lib/klass_hero_web/components/composite_components.ex:103
-#: lib/klass_hero_web/components/layouts/admin.html.heex:58
+#: lib/klass_hero_web/components/layouts/admin.html.heex:63
 #: lib/klass_hero_web/components/provider_components.ex:119
 #: lib/klass_hero_web/live/admin/sessions_live.ex:26
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:3
@@ -4207,7 +4207,7 @@ msgstr "E-Mail als ungelesen markiert"
 msgid "Email not found"
 msgstr "E-Mail nicht gefunden"
 
-#: lib/klass_hero_web/components/layouts/admin.html.heex:49
+#: lib/klass_hero_web/components/layouts/admin.html.heex:54
 #: lib/klass_hero_web/live/admin/emails_live.ex:21
 #: lib/klass_hero_web/live/admin/emails_live.ex:41
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:4
@@ -7594,3 +7594,8 @@ msgstr "Deine Programme werden geladen…"
 #, elixir-autogen, elixir-format
 msgid "Loading…"
 msgstr "Wird geladen…"
+
+#: lib/klass_hero_web/components/layouts/admin.html.heex:49
+#, elixir-autogen, elixir-format
+msgid "Incidents"
+msgstr "Vorfälle"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -1333,7 +1333,7 @@ msgid "Push, email, SMS settings"
 msgstr ""
 
 #: lib/klass_hero_web/components/composite_components.ex:103
-#: lib/klass_hero_web/components/layouts/admin.html.heex:58
+#: lib/klass_hero_web/components/layouts/admin.html.heex:63
 #: lib/klass_hero_web/components/provider_components.ex:119
 #: lib/klass_hero_web/live/admin/sessions_live.ex:26
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:3
@@ -4207,7 +4207,7 @@ msgstr ""
 msgid "Email not found"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/admin.html.heex:49
+#: lib/klass_hero_web/components/layouts/admin.html.heex:54
 #: lib/klass_hero_web/live/admin/emails_live.ex:21
 #: lib/klass_hero_web/live/admin/emails_live.ex:41
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:4
@@ -7593,4 +7593,9 @@ msgstr ""
 #: lib/klass_hero_web/live/dashboard_live.ex:340
 #, elixir-autogen, elixir-format
 msgid "Loading…"
+msgstr ""
+
+#: lib/klass_hero_web/components/layouts/admin.html.heex:49
+#, elixir-autogen, elixir-format
+msgid "Incidents"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -1333,7 +1333,7 @@ msgid "Push, email, SMS settings"
 msgstr ""
 
 #: lib/klass_hero_web/components/composite_components.ex:103
-#: lib/klass_hero_web/components/layouts/admin.html.heex:58
+#: lib/klass_hero_web/components/layouts/admin.html.heex:63
 #: lib/klass_hero_web/components/provider_components.ex:119
 #: lib/klass_hero_web/live/admin/sessions_live.ex:26
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:3
@@ -4207,7 +4207,7 @@ msgstr ""
 msgid "Email not found"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/admin.html.heex:49
+#: lib/klass_hero_web/components/layouts/admin.html.heex:54
 #: lib/klass_hero_web/live/admin/emails_live.ex:21
 #: lib/klass_hero_web/live/admin/emails_live.ex:41
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:4
@@ -7593,4 +7593,9 @@ msgstr ""
 #: lib/klass_hero_web/live/dashboard_live.ex:340
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Loading…"
+msgstr ""
+
+#: lib/klass_hero_web/components/layouts/admin.html.heex:49
+#, elixir-autogen, elixir-format
+msgid "Incidents"
 msgstr ""

--- a/test/klass_hero_web/live/admin/incident_live_test.exs
+++ b/test/klass_hero_web/live/admin/incident_live_test.exs
@@ -148,6 +148,29 @@ defmodule KlassHeroWeb.Admin.IncidentLiveTest do
       {:ok, view, _html} = live(conn, ~p"/admin/incidents")
       assert has_element?(view, "div.bg-amber-50", "Read-only safety record")
     end
+
+    # Backpex's orderable default is `true`, so a virtual field is sortable unless
+    # opted out — and sorting one emits `ORDER BY i0."provider_name"`, a column
+    # that does not exist. Both must be rejected and fall back to init_order.
+    @virtual_order_fields ["provider_name", "program_title"]
+
+    test "sorting by a virtual field does not reach the database", %{conn: conn} do
+      %{provider: provider, program: program} = provider_with_program("Acme Clubs", "Robotics")
+
+      incident_report_fixture(
+        provider_profile_id: provider.id,
+        reporter_user_id: provider.identity_id,
+        program_id: program.id
+      )
+
+      for field <- @virtual_order_fields do
+        {:ok, view, _html} =
+          live(conn, ~p"/admin/incidents?order_by=#{field}&order_direction=asc")
+
+        assert has_element?(view, "td", "Acme Clubs"),
+               "order_by=#{field} should render rather than raise"
+      end
+    end
   end
 
   describe "filters" do

--- a/test/klass_hero_web/live/admin/incident_live_test.exs
+++ b/test/klass_hero_web/live/admin/incident_live_test.exs
@@ -5,6 +5,8 @@ defmodule KlassHeroWeb.Admin.IncidentLiveTest do
   import KlassHero.ProviderFixtures
   import Phoenix.LiveViewTest
 
+  alias KlassHero.Provider.IncidentReport
+
   # A provider distinct from the logged-in admin, plus a program it owns.
   # `provider_profile_fixture/1` creates the backing user, which doubles as the
   # incident's reporter.
@@ -234,6 +236,37 @@ defmodule KlassHeroWeb.Admin.IncidentLiveTest do
       {:ok, _view, html} = live(conn, ~p"/admin/incidents/#{report.id}/show")
 
       assert html =~ "slipped near the play area"
+    end
+
+    # Backpex still renders a (disabled) bulk Delete button and row checkboxes on
+    # the index regardless of `can?/3`. That is cosmetic — `can?/3` is enforced
+    # server-side in `Backpex.LiveComponents.FormComponent`, which filters the
+    # selected items before the action module runs.
+    #
+    # The `item-action` event alone only opens the confirm modal, so submitting
+    # that modal's form is what actually reaches the delete. Asserting on the
+    # event alone would pass even with `can?(:delete)` returning true.
+    test "confirming a forged delete does not delete the report", %{conn: conn} do
+      %{provider: provider, program: program} = provider_with_program("Acme Clubs", "Robotics")
+
+      report =
+        incident_report_fixture(
+          provider_profile_id: provider.id,
+          reporter_user_id: provider.identity_id,
+          program_id: program.id
+        )
+
+      {:ok, view, _html} = live(conn, ~p"/admin/incidents")
+
+      render_hook(view, "item-action", %{"action-key" => "delete", "item-id" => report.id})
+
+      assert has_element?(view, "#action-confirm-modal"),
+             "the delete confirm modal should open, otherwise this test proves nothing"
+
+      view |> element("#resource-form") |> render_submit(%{"action-key" => "delete"})
+
+      assert KlassHero.Repo.get(IncidentReport, report.id),
+             "incident report must survive a confirmed delete"
     end
 
     test "edit and delete buttons are not shown", %{conn: conn} do

--- a/test/klass_hero_web/live/admin/incident_live_test.exs
+++ b/test/klass_hero_web/live/admin/incident_live_test.exs
@@ -1,0 +1,265 @@
+defmodule KlassHeroWeb.Admin.IncidentLiveTest do
+  use KlassHeroWeb.ConnCase, async: true
+
+  import KlassHero.Factory
+  import KlassHero.ProviderFixtures
+  import Phoenix.LiveViewTest
+
+  # A provider distinct from the logged-in admin, plus a program it owns.
+  # `provider_profile_fixture/1` creates the backing user, which doubles as the
+  # incident's reporter.
+  defp provider_with_program(business_name, program_title) do
+    provider = provider_profile_fixture(business_name: business_name)
+    program = insert(:program_schema, title: program_title, provider_id: provider.id)
+
+    %{provider: provider, program: program}
+  end
+
+  describe "admin access control" do
+    setup :register_and_log_in_admin
+
+    test "admin can access /admin/incidents", %{conn: conn} do
+      {:ok, _view, html} = live(conn, ~p"/admin/incidents")
+      assert html =~ "Incident"
+    end
+  end
+
+  describe "non-admin access control" do
+    setup :register_and_log_in_user
+
+    test "non-admin is redirected from /admin/incidents", %{conn: conn} do
+      assert {:error, {:redirect, %{to: "/", flash: flash}}} =
+               live(conn, ~p"/admin/incidents")
+
+      assert flash["error"] =~ "access"
+    end
+
+    test "non-admin is redirected from the incident show page", %{conn: conn} do
+      %{provider: provider, program: program} = provider_with_program("Acme Clubs", "Robotics")
+
+      report =
+        incident_report_fixture(
+          provider_profile_id: provider.id,
+          reporter_user_id: provider.identity_id,
+          program_id: program.id
+        )
+
+      assert {:error, {:redirect, %{to: "/", flash: flash}}} =
+               live(conn, ~p"/admin/incidents/#{report.id}/show")
+
+      assert flash["error"] =~ "access"
+    end
+  end
+
+  describe "unauthenticated access control" do
+    test "unauthenticated user is redirected from /admin/incidents", %{conn: conn} do
+      assert {:error, {:redirect, %{to: "/users/log-in"}}} =
+               live(conn, ~p"/admin/incidents")
+    end
+  end
+
+  describe "incident list" do
+    setup :register_and_log_in_admin
+
+    test "displays provider name, program title and severity", %{conn: conn} do
+      %{provider: provider, program: program} = provider_with_program("Acme Clubs", "Robotics")
+
+      incident_report_fixture(
+        provider_profile_id: provider.id,
+        reporter_user_id: provider.identity_id,
+        program_id: program.id,
+        reporter_display_name: "Maria Schmidt",
+        category: :injury,
+        severity: :critical
+      )
+
+      {:ok, view, _html} = live(conn, ~p"/admin/incidents")
+
+      assert has_element?(view, "td", "Acme Clubs")
+      assert has_element?(view, "td", "Robotics")
+      assert has_element?(view, "td", "Maria Schmidt")
+      assert has_element?(view, "span", "Critical")
+      assert has_element?(view, "td", "Injury")
+    end
+
+    test "lists reports from every provider, not just one", %{conn: conn} do
+      %{provider: first, program: first_program} = provider_with_program("Acme Clubs", "Robotics")
+      %{provider: second, program: second_program} = provider_with_program("Zeta Camps", "Chess")
+
+      incident_report_fixture(
+        provider_profile_id: first.id,
+        reporter_user_id: first.identity_id,
+        program_id: first_program.id
+      )
+
+      incident_report_fixture(
+        provider_profile_id: second.id,
+        reporter_user_id: second.identity_id,
+        program_id: second_program.id
+      )
+
+      {:ok, view, _html} = live(conn, ~p"/admin/incidents")
+
+      assert has_element?(view, "td", "Acme Clubs")
+      assert has_element?(view, "td", "Zeta Camps")
+    end
+
+    # The programs join must be a LEFT join: a session-scoped report has a NULL
+    # program_id (DB CHECK one_of_program_or_session), so an inner join drops it.
+    test "displays session-scoped reports, which have no program_id", %{conn: conn} do
+      provider = provider_profile_fixture(business_name: "Session Only Provider")
+      session = insert(:program_session_schema)
+
+      incident_report_fixture(
+        provider_profile_id: provider.id,
+        reporter_user_id: provider.identity_id,
+        session_id: session.id,
+        reporter_display_name: "Session Reporter"
+      )
+
+      {:ok, view, _html} = live(conn, ~p"/admin/incidents")
+
+      assert has_element?(view, "td", "Session Only Provider")
+      assert has_element?(view, "td", "Session Reporter")
+      assert has_element?(view, "span", "Session report")
+    end
+
+    test "description is not shown on the index", %{conn: conn} do
+      %{provider: provider, program: program} = provider_with_program("Acme Clubs", "Robotics")
+
+      incident_report_fixture(
+        provider_profile_id: provider.id,
+        reporter_user_id: provider.identity_id,
+        program_id: program.id,
+        description: "Sensitive free text that must stay off the index."
+      )
+
+      {:ok, _view, html} = live(conn, ~p"/admin/incidents")
+
+      refute html =~ "Sensitive free text"
+    end
+
+    test "new incident button is not shown on index", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/admin/incidents")
+      refute has_element?(view, "a", "New")
+    end
+
+    test "displays the read-only safety banner", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/admin/incidents")
+      assert has_element?(view, "div.bg-amber-50", "Read-only safety record")
+    end
+  end
+
+  describe "filters" do
+    setup :register_and_log_in_admin
+
+    setup do
+      %{provider: provider, program: program} = provider_with_program("Acme Clubs", "Robotics")
+
+      for {category, severity} <- [{:injury, :critical}, {:property_damage, :low}] do
+        incident_report_fixture(
+          provider_profile_id: provider.id,
+          reporter_user_id: provider.identity_id,
+          program_id: program.id,
+          category: category,
+          severity: severity
+        )
+      end
+
+      :ok
+    end
+
+    # {filter key, submitted value, label that must survive, label that must not}
+    @filter_cases [
+      {"severity", "critical", "Critical", "Low"},
+      {"category", "injury", "Injury", "Property damage"}
+    ]
+
+    test "each filter narrows the list to matching reports", %{conn: conn} do
+      for {key, value, kept, dropped} <- @filter_cases do
+        {:ok, view, _html} = live(conn, ~p"/admin/incidents")
+
+        # Boolean filters render checkboxes (`name[]`), so the param is a list —
+        # unlike the Select-based filters elsewhere in admin, which take a string.
+        view
+        |> element("form[phx-change='change-filter']")
+        |> render_change(%{"filters" => %{key => [value]}})
+
+        assert has_element?(view, "td", kept),
+               "#{key}=#{value} should keep the #{kept} report"
+
+        refute has_element?(view, "td", dropped),
+               "#{key}=#{value} should drop the #{dropped} report"
+      end
+    end
+  end
+
+  describe "incident show" do
+    setup :register_and_log_in_admin
+
+    test "displays the full description", %{conn: conn} do
+      %{provider: provider, program: program} = provider_with_program("Acme Clubs", "Robotics")
+
+      report =
+        incident_report_fixture(
+          provider_profile_id: provider.id,
+          reporter_user_id: provider.identity_id,
+          program_id: program.id,
+          description: "A child slipped near the play area but is unharmed."
+        )
+
+      {:ok, _view, html} = live(conn, ~p"/admin/incidents/#{report.id}/show")
+
+      assert html =~ "slipped near the play area"
+    end
+
+    test "edit and delete buttons are not shown", %{conn: conn} do
+      %{provider: provider, program: program} = provider_with_program("Acme Clubs", "Robotics")
+
+      report =
+        incident_report_fixture(
+          provider_profile_id: provider.id,
+          reporter_user_id: provider.identity_id,
+          program_id: program.id
+        )
+
+      {:ok, view, _html} = live(conn, ~p"/admin/incidents/#{report.id}/show")
+
+      refute has_element?(view, "a", "Edit")
+      refute has_element?(view, "a", "Delete")
+    end
+
+    test "renders a signed URL for an attached photo", %{conn: conn} do
+      %{provider: provider, program: program} = provider_with_program("Acme Clubs", "Robotics")
+
+      report =
+        incident_report_fixture(
+          provider_profile_id: provider.id,
+          reporter_user_id: provider.identity_id,
+          program_id: program.id,
+          photo_url: "incident-reports/providers/#{provider.id}/123_photo.jpg",
+          original_filename: "photo.jpg"
+        )
+
+      {:ok, view, _html} = live(conn, ~p"/admin/incidents/#{report.id}/show")
+
+      assert has_element?(view, ~s{img[src^="stub://signed/"]})
+    end
+
+    test "renders a no-photo marker when no photo is attached", %{conn: conn} do
+      %{provider: provider, program: program} = provider_with_program("Acme Clubs", "Robotics")
+
+      report =
+        incident_report_fixture(
+          provider_profile_id: provider.id,
+          reporter_user_id: provider.identity_id,
+          program_id: program.id
+        )
+
+      {:ok, view, _html} = live(conn, ~p"/admin/incidents/#{report.id}/show")
+
+      assert has_element?(view, "span", "No photo")
+      refute has_element?(view, "img[src^='stub://signed/']")
+    end
+  end
+end


### PR DESCRIPTION
Closes #1146

## Summary

Incident reports previously reached exactly one place: an email to the provider's `business_owner_email`. The platform had no visibility into safety events across providers. This adds a read-only Backpex resource at `/admin/incidents`.

#1146 asked for a decision, not just an implementation. The decisions taken:

| Question | Answer |
|---|---|
| Build platform-side visibility? | Yes — read-only |
| Surface | Backpex LiveResource (`consent_live.ex` shape) |
| Delivery | Direct query — **no** integration event, no projection |
| Read access | All admins (`is_admin: true`) |
| Photo | Signed URL, show page only, 900s TTL |
| Retention / GDPR | Deferred — filed separately (see below) |

**Why no durable event.** The report row and its notification Oban job already commit in one transaction (`submit_incident_report.ex`), so the data is ACID-durable before any admin view runs. Admin visibility is a query over already-committed rows, not a delivery problem — there is no message to lose. Re-adding the domain event → `PromoteIntegrationEvents` → registry → Oban handler chain would re-create exactly what #1141 deleted and would touch the shared event registry to denormalise data already in the same database.

## Review Focus

- **Virtual fields, not `belongs_to`.** Provider and program names resolve via a join in `item_query/3` merged into `virtual: true` fields. An association added to serve a Backpex field becomes an invisible consumer whose later removal breaks admin silently (the #1052 / PR #1057 trap). The join uses raw table names, so nothing from Program Catalog is imported.
- **`left_join` on `programs` is load-bearing.** A report is polymorphic — exactly one of `program_id` / `session_id` is set (DB CHECK `one_of_program_or_session`), so session-scoped reports have a NULL `program_id` and an inner join would silently omit them. Verified by mutation: swapping to an inner join fails exactly one test.
- **`orderable: false` on both virtual fields** (second commit). Backpex's `orderable` default is `true` and it validates `order_by` against that list, so a column-header click emitted `ORDER BY i0."provider_name"` → Postgrex 42703, a hard 500. Found by driving the page in a browser, not by the unit tests.
- **Entity touched for admin's benefit.** `IncidentReport` gains `admin_changeset/3` (inert; Backpex demands arity-3 changesets even with `can?` denying edit — same as `Family.Consent`) and two virtual fields. `create_changeset/1` remains the sole validation gatekeeper.
- **Accepted gap, documented in the moduledoc:** all admins can read every description and photo; there are no admin sub-roles to scope to, and nothing records who viewed what. Signed photo URLs are bearer links for their 900s lifetime.

## Test Plan

- `mix test test/klass_hero_web/live/admin/incident_live_test.exs` — 16 tests: auth (admin / non-admin / unauthenticated, index + show), cross-provider listing, provider and program name resolution, session-scoped reports, description absent from index, no New/Edit/Delete affordances, banner, tabular severity + category filter narrowing, show description, signed photo URL, no-photo fallback, and the virtual-field sort regression.
- Full suite: 4208 passed. `credo --strict`, `lint_typography`, `lint_translations` all green. New `gettext("Incidents")` ships with its German translation (`Vorfälle`).
- Test-driven in a browser against a worktree dev server: verified all three report shapes render with resolved provider names, both filters, the show page with a real presigned MinIO URL (`X-Amz-Expires=900`), the non-admin redirect, and a mobile viewport. Seeded dev rows removed afterwards.

## Follow-up filed separately

`reporter_user_id` is `references(:users, on_delete: :restrict)`, so any user who has filed an incident report cannot be deleted — a GDPR erasure blocker already in production, independent of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)