### PR TITLE
feat: add readiness endpoint reporting database health

### DIFF
--- a/lib/klass_hero_web/controllers/health_controller.ex
+++ b/lib/klass_hero_web/controllers/health_controller.ex
@@ -1,7 +1,38 @@
 defmodule KlassHeroWeb.HealthController do
+  @moduledoc """
+  Two probes with deliberately different contracts.
+
+  `index/2` (`/health`) is what `fly.production.toml` gates machine rotation on, so it
+  must never check dependencies: both machines run in `fra` against one database, so a
+  shared-dependency blip fails them together and Fly pulls the whole app. `runtime.exs`
+  documents that such blips already happen when a machine resumes from suspension.
+
+  `ready/2` (`/health/ready`) is monitored externally and gates nothing, so it is free to
+  report dependency state.
+  """
+
   use KlassHeroWeb, :controller
+
+  alias Ecto.Adapters.SQL
+  alias KlassHero.Repo
+
+  # Ecto's default is 15s; a DB that cannot answer SELECT 1 in 2s is not serving users.
+  @probe_timeout_ms 2_000
 
   def index(conn, _params) do
     json(conn, %{status: "ok"})
+  end
+
+  def ready(conn, _params) do
+    case SQL.query(Repo, "SELECT 1", [], timeout: @probe_timeout_ms) do
+      {:ok, _result} ->
+        json(conn, %{status: "ok"})
+
+      # Unauthenticated endpoint — report that the DB is unreachable, never why.
+      {:error, _exception} ->
+        conn
+        |> put_status(:service_unavailable)
+        |> json(%{status: "degraded", database: "down"})
+    end
   end
 end

--- a/lib/klass_hero_web/router.ex
+++ b/lib/klass_hero_web/router.ex
@@ -55,11 +55,13 @@ defmodule KlassHeroWeb.Router do
     plug Backpex.ThemeSelectorPlug
   end
 
-  # Health check endpoint for Fly.io
+  # /health is Fly.io's machine check; /health/ready is for external uptime monitoring.
+  # See KlassHeroWeb.HealthController for why they must stay separate.
   scope "/", KlassHeroWeb do
     pipe_through :api
 
     get "/health", HealthController, :index
+    get "/health/ready", HealthController, :ready
   end
 
   scope "/", KlassHeroWeb do

--- a/test/klass_hero_web/controllers/health_controller_test.exs
+++ b/test/klass_hero_web/controllers/health_controller_test.exs
@@ -1,0 +1,19 @@
+defmodule KlassHeroWeb.HealthControllerTest do
+  use KlassHeroWeb.ConnCase, async: true
+
+  describe "GET /health" do
+    test "reports ok", %{conn: conn} do
+      conn = get(conn, ~p"/health")
+
+      assert json_response(conn, 200) == %{"status" => "ok"}
+    end
+  end
+
+  describe "GET /health/ready" do
+    test "reports ok when the database is reachable", %{conn: conn} do
+      conn = get(conn, ~p"/health/ready")
+
+      assert json_response(conn, 200) == %{"status" => "ok"}
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Uptime monitoring showed ~220ms average on `/health`. Measurement showed that number is **network topology, not application latency** — ~117ms of it is TCP+TLS setup that uptime monitors pay on every check because they never reuse connections, plus three stacked proxy hops (Cloudflare → Fly edge LHR → Fly machine FRA). Bypassing Cloudflare halves it. No latency work was warranted.

The real finding was a monitoring gap: `HealthController.index/2` returned `%{status: "ok"}` unconditionally and never touched the Repo. If Postgres died, the check still passed and the first signal was users hitting 500s.

## Review Focus

**Why two endpoints instead of adding the check to `/health`.** `fly.production.toml` gates machine rotation on `/health`. Both machines run in `fra` against one database, so a shared-dependency failure fails them together and Fly pulls the whole app from rotation. `config/runtime.exs` already documents that this app sees transient connection loss when a machine resumes from suspension:

```elixir
# Trigger: Fly.io machine resumes from suspension with stale DB connections
disconnect_on_error_codes: [:protocol_violation, :idle_in_transaction_session_timeout]
```

Putting a DB check on the rotation gate would turn those self-healing blips into a restart loop. So `/health` stays dependency-free and `/health/ready` carries the dependency state.

**Latency.** Direct `SELECT 1`, no cache or background prober. ~1-3ms in-region against a 220ms total, and roughly 3 queries/min. A cached prober would have cost a supervised process plus staleness handling to save ~2ms.

**Error contract.** Verified empirically against a genuinely unreachable database (isolated repo on a dead port) that `Ecto.Adapters.SQL.query/4` returns `{:error, %DBConnection.ConnectionError{}}` rather than raising — so a real outage yields a clean 503, not a 500. The endpoint is unauthenticated, so the degraded body reports that the DB is down but never why.

**Test coverage gap, stated plainly.** The 503 branch is not covered in-suite. Faking an unreachable DB under the SQL sandbox requires injecting the query function — the port/DI ceremony PRs #986→#1002 removed. Checking the sandbox connection back in does not work either; the pool just hands out a fresh connection. Covered by parts instead: the input reaching the branch is empirically proven, and the branch body is three lines of stock Phoenix.

## Test Plan

- `mix precommit` — 4224 passed, 2 skipped, 18 excluded
- `mix sobelow` — no findings
- New `health_controller_test.exs` covers both routes on the happy path

## Follow-up (not in this PR)

- Repoint the uptime monitor at `/health/ready`
- Confirm the monitor uses `https://` — `http://klasshero.com/health` returns a 301, and a followed redirect means two full connection setups
- Alert on trend/p95 rather than the absolute 220ms, which is dominated by constants that cannot be removed without dropping Cloudflare or going multi-region