### PR TITLE
ci: add mix hex.audit gate alongside mix deps.audit

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -92,3 +92,47 @@ jobs:
 
       - name: Audit dependencies for vulnerabilities
         run: mix deps.audit --ignore-file .mix_audit.ignore
+
+  # Reads hex.pm's advisory feed; the mix-audit job above reads the community
+  # elixir-security-advisories repo. Disjoint sets — a HIGH against bandit was
+  # visible only to this one and passed CI silently (#1181).
+  #
+  # Report-only by intent: it gets its own job so a finding is visible as its own
+  # red entry, but it should stay out of any required-status-checks rule on `main`.
+  hex-audit:
+    name: hex.pm Advisory Audit
+    runs-on: ubuntu-latest
+    steps:
+      # actions/checkout@v6.0.2
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      # erlef/setup-beam@v1.23.0
+      - name: Set up Elixir
+        uses: erlef/setup-beam@ee09b1e59bb240681c382eb1f0abc6a04af72764
+        with:
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+          otp-version: ${{ env.OTP_VERSION }}
+          version-type: strict
+
+      # actions/cache@v5.0.4
+      - name: Restore dependencies cache
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
+        with:
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-mix-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-
+
+      # Populates the local Hex registry cache that hex.audit reads. `~/.hex` is
+      # absent from the cache above, so the advisory data is fetched fresh here.
+      - name: Install dependencies
+        run: mix deps.get
+
+      # Exits non-zero on advisories and on maintainer-retired versions. There is
+      # no --ignore-file equivalent to .mix_audit.ignore, so a finding that can't
+      # be fixed by a bump has to be handled here in the workflow.
+      - name: Audit dependencies against hex.pm advisories
+        run: mix hex.audit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,7 +179,8 @@ These checks run automatically on every PR — don't manually recheck what CI ca
 | `mix lint_typography` | Font/typography usage violations |
 | `mix test` | Functional regressions (full suite with PostgreSQL) |
 | Sobelow | Common Phoenix security vulnerabilities |
-| `mix deps.audit` | Known dependency vulnerabilities |
+| `mix deps.audit` | Known dependency vulnerabilities (community advisory DB) |
+| `mix hex.audit` | Known dependency vulnerabilities (hex.pm advisory DB) + retired packages — reports red, does not block merge |
 | Conventional commits | PR title format validation |
 
 ## Ecto Anti-Patterns


### PR DESCRIPTION
Closes #1181

## Summary

CI's dependency gate ran only `mix deps.audit`. That reads the community
`elixir-security-advisories` repo; `mix hex.audit` reads advisories baked into
the hex.pm registry. Neither is a superset of the other.

The gap was live, not theoretical. On `main@283be1f3`:

| Tool | Result |
|---|---|
| `mix deps.audit` | `No vulnerabilities found.` |
| `mix hex.audit` | `bandit 1.12.0` — **CVE-2026-65623 (HIGH)**, `mint 1.9.2` — CVE-2026-59249 (MEDIUM) |

The bandit advisory is a quadratic CPU blow-up reassembling fragmented WebSocket
messages — reachable by any unauthenticated client, since LiveView rides
WebSockets over Bandit. It was found by hand and closed in #1180. Nothing stopped
the next hex.pm-only advisory from passing CI the same way.

## Review focus

**Why a separate job rather than a step in `mix-audit`.** A finding needs to be
visible. A step folded into the existing job (especially a `continue-on-error`
one) leaves that job green and the signal easy to miss; a separate job earns its
own named row in the PR checks list.

**Why no `continue-on-error`.** `main`'s ruleset has no `required_status_checks`
rule, so no check gates merging in this repo today — `mix test`, sobelow and
`deps.audit` are all already advisory. The job therefore fails honestly in red
while `Squash and merge` stays enabled. It should stay out of any future
required-checks rule; the job comment says so.

**The `~/.hex` coupling.** `hex.audit` reads the *local* registry cache, not a
live API (`HEX_OFFLINE=1 mix hex.audit` succeeds). Advisory freshness therefore
depends on `~/.hex` being absent from the `actions/cache` paths — it is, so every
run fetches a fresh registry via `deps.get`. Adding `~/.hex` to that cache later
would silently stale the advisory data. Called out in a comment.

## Test plan

Verified locally — CI config can't be exercised any other way:

- **Green path:** `mix hex.audit` on this branch's lockfile →
  `No retired or security advisory packages found`, exit `0`.
- **Red path:** throwaway project pinning `bandit == 1.12.0` + `mint == 1.9.2` →
  both advisories listed, exit **`1`**. This answers the open question in #1181:
  the task exits non-zero on its own, so no explicit exit-code check is needed.
  `mix help hex.audit` confirms it for both advisories and retired packages.
- **Workflow YAML** parses; jobs resolve to `sobelow`, `mix-audit`, `hex-audit`.

On this PR, confirm `Security / hex.pm Advisory Audit` shows up as its own check
and is green.

## Notes / deliberately out of scope

- **Not added to `mix precommit`.** The alias starts with `compile`, and
  `hex.audit` de-registers itself after an app-loading task in the same mix
  invocation — `mix do compile + hex.audit` fails with
  `** (Mix) The task "hex.audit" could not be found`. It would need
  `cmd mix hex.audit` (a whole extra BEAM boot per precommit) for little gain.
- **No suppression mechanism.** `hex.audit` exposes no `--ignore-file` equivalent
  to `.mix_audit.ignore` (which currently carries 4 unfixable hackney advisories,
  tracked in #987), and has no machine-readable output format — a filtering
  wrapper would mean parsing prose. If an unfixable advisory ever lands, the
  escape hatch is a one-line workflow edit, and it blocks nothing meanwhile. Note
  that `hex.audit` also fails on maintainer-*retired* versions, which aren't
  always security issues.
- **No `schedule:` trigger.** Advisories published against an unchanged lockfile
  are only caught on the next PR. At this repo's cadence that lag is hours; worth
  its own issue if it ever matters.