### PR TITLE
feat: give each worktree its own dev server and Tidewave endpoint

### DIFF
--- a/.claude/rules/worktrees.md
+++ b/.claude/rules/worktrees.md
@@ -39,7 +39,11 @@ mix deps.get
 MIX_TEST_PARTITION=<n> mix compile
 MIX_TEST_PARTITION=<n> MIX_ENV=test mix ecto.create
 MIX_TEST_PARTITION=<n> MIX_ENV=test mix ecto.migrate
+bin/setup-mcp      # allocate this worktree's dev port + Tidewave endpoint
 ```
+
+`bin/setup-mcp` writes `.mcp.json`, which Claude Code reads **at session start** —
+so restart the session in the worktree afterwards. See the Tidewave section below.
 
 ## Test DB isolation — always set MIX_TEST_PARTITION in a worktree
 
@@ -81,19 +85,56 @@ two can't drift apart.
 ## Tidewave / dev server per worktree (separate axis from the test partition)
 
 `MIX_TEST_PARTITION` does **not** affect the dev server or Tidewave — it is
-test-DB-only. Tidewave is a plug on the **dev** endpoint
-(`lib/klass_hero_web/endpoint.ex`), which binds `PORT || 4000` (`config/dev.exs`).
-The MCP client points at a **hardcoded** `http://localhost:4000/tidewave/mcp`
-(in `~/.claude.json`). Consequences:
+test-DB-only. Every worktree gets its own dev server on its own port, and its own
+Tidewave endpoint on that port, so several can run at once.
 
-- Tidewave introspects **whichever `iex -S mix phx.server` owns port 4000** — not
-  "the main branch" specifically. Only one process can bind 4000.
-- **To point Tidewave at a worktree:** stop the server on 4000, then run
-  `iex -S mix phx.server` from the worktree (it grabs 4000). Same MCP URL, now
-  serving the worktree's code. One server at a time.
-- Running main **and** a worktree server together requires the worktree on an alt
-  port (`PORT=4001 iex -S mix phx.server`) **and** a second MCP-server entry
-  pointing at 4001, since the Tidewave URL is fixed to 4000. Usually not worth it.
+### Setup
+
+```bash
+bin/setup-mcp   # once per checkout — writes .mcp.json, then restart Claude Code here
+bin/dev         # starts the server on that checkout's port
+```
+
+`bin/setup-mcp` runs in **every** checkout, main included. Main takes 4000; a worktree
+takes the lowest free port in **4010–4039**. It writes `.mcp.json` declaring an MCP
+server named `tidewave` at `http://localhost:<port>/tidewave/mcp`, and `bin/dev` reads
+the port back out of that same file — so the client and the server it talks to cannot
+drift. `.mcp.json` is gitignored, which is why each checkout needs its own run.
+
+Ports derive from `PORT` in `config/dev.exs`: the endpoint binds it, `url:` and
+`:app_base_url` follow it (so generated links point at the right server), and
+live_debugger takes `PORT + 100`.
+
+### Why it works this way
+
+MCP servers resolve by **scope precedence — `local > project (.mcp.json) > user`** —
+matched *by name*, replacing the whole entry. Every checkout declares `tidewave` at
+project scope, so each one resolves to its own port with no global entry involved.
+The name stays `tidewave` everywhere on purpose: tool permissions are keyed on the
+server name (`mcp__tidewave__project_eval` and friends), so a per-checkout name would
+need its own grants.
+
+`~/.claude/settings.json` carries `"enabledMcpjsonServers": ["tidewave"]` to
+pre-approve it — project-scope servers otherwise prompt on first use in each new
+worktree. It must live at **user** level; a committed `.claude/settings.json` is
+ignored until a workspace is trusted, which a fresh worktree isn't yet.
+
+### Traps
+
+- **Never register `tidewave` at user or local scope** (`claude mcp add -s user|local`).
+  Local scope outranks `.mcp.json` and wins silently, and a worktree does **not** get
+  its own `~/.claude.json` project key — it resolves to the *main repo path*, so a
+  local-scope entry added for main applies inside every worktree and pins them all to
+  one port. User scope is nearly as bad in the other direction: it leaks a
+  `localhost:4000` Tidewave into every unrelated project on the machine. Project scope
+  only.
+- **A worktree resolving to 4000** means its `.mcp.json` is missing or being overridden.
+  Check with `claude mcp get tidewave` from that directory — the `Scope:` line must read
+  `Project config`. (A parent `.mcp.json` overriding a nested worktree's was reported in
+  anthropics/claude-code#42465; verified not to reproduce on 2.1.220, but this is the
+  symptom if it regresses.)
+- **live_debugger** binds its own endpoint and defaults to 4007. Before ports were
+  derived, a second concurrent `mix phx.server` died on `:eaddrinuse` here.
 - **Shared dev DB caveat:** `klass_hero_dev` is shared across all checkouts and is
   **not** partitioned like the test DB. A worktree server reads/writes the same
   dev DB as main — fine for reads, but running migrations from a worktree mutates

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Start the dev server on this checkout's port.
+#
+# The port is read from .mcp.json — the same file that points Claude Code at this
+# checkout's Tidewave endpoint — so the MCP client and the server it talks to can
+# never drift apart. Falls back to 4000 if the file is missing.
+#
+# Run bin/setup-mcp once per checkout to create it.
+#
+# Usage:
+#   bin/dev            start the server
+#   bin/dev --port     print the port and exit
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+port=4000
+
+if [[ -f .mcp.json ]]; then
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "bin/dev: .mcp.json exists but jq is not installed — cannot read the port." >&2
+    exit 1
+  fi
+
+  url=$(jq -r '.mcpServers.tidewave.url // empty' .mcp.json)
+
+  if [[ -n "$url" ]]; then
+    port="${url##*:}"  # http://localhost:4010/tidewave/mcp -> 4010/tidewave/mcp
+    port="${port%%/*}" # 4010/tidewave/mcp                  -> 4010
+  fi
+
+  if ! [[ "$port" =~ ^[0-9]+$ ]]; then
+    echo "bin/dev: could not parse a port out of .mcp.json (url: ${url:-none})" >&2
+    exit 1
+  fi
+fi
+
+if [[ "${1:-}" == "--port" ]]; then
+  echo "$port"
+  exit 0
+fi
+
+echo "Starting dev server on http://localhost:${port} (live_debugger on $((port + 100)))"
+exec env PORT="$port" iex -S mix phx.server

--- a/bin/setup-mcp
+++ b/bin/setup-mcp
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# Give this checkout its own dev-server port and Tidewave MCP endpoint by writing
+# .mcp.json. Run once per checkout — the main one included.
+#
+# The main checkout takes 4000; each worktree takes the lowest free port in
+# PORT_MIN..PORT_MAX, so several dev servers can run at once and each Claude Code
+# session talks to the server for the code it is actually looking at.
+#
+# .mcp.json is *project* scope, which outranks user scope and replaces the entry
+# wholesale (scopes match by name; fields are never merged). Keeping the name
+# `tidewave` is deliberate: MCP tool permissions are keyed on the server name, so a
+# per-worktree name would need its own mcp__<name>__* grants in settings.
+#
+# .mcp.json is gitignored, so every checkout needs this run once.
+#
+# Usage: bin/setup-mcp
+
+set -euo pipefail
+
+MAIN_PORT=4000
+PORT_MIN=4010
+PORT_MAX=4039
+
+cd "$(git rev-parse --show-toplevel)"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "setup-mcp: jq is required" >&2
+  exit 1
+fi
+
+# Extract the port from a .mcp.json, or nothing if it has no tidewave entry.
+port_from() {
+  jq -r '.mcpServers.tidewave.url // empty' "$1" 2>/dev/null |
+    sed -n 's#.*localhost:\([0-9][0-9]*\)/.*#\1#p'
+}
+
+if [[ -f .mcp.json ]]; then
+  echo "Already configured: port $(port_from .mcp.json). Nothing to do."
+  exit 0
+fi
+
+# Ports already written into some checkout's .mcp.json. Stale entries self-clean:
+# a deleted worktree stops appearing in `git worktree list`.
+claimed_ports() {
+  local worktree
+  while read -r worktree; do
+    if [[ -f "$worktree/.mcp.json" ]]; then
+      port_from "$worktree/.mcp.json"
+    fi
+  done < <(git worktree list --porcelain | awk '/^worktree /{print $2}')
+}
+
+# Ports currently bound by any listening process on this machine.
+bound_ports() {
+  lsof -nP -iTCP -sTCP:LISTEN 2>/dev/null |
+    sed -n 's/.*:\([0-9][0-9]*\) (LISTEN).*/\1/p'
+}
+
+# Lowest free port in the range. Claimed ports keep two worktrees off the same
+# number even while their servers are down; bound ports additionally dodge an
+# unrelated process squatting in the range.
+allocate_port() {
+  local taken port
+  taken=$(
+    {
+      claimed_ports
+      bound_ports
+    } | sort -u
+  )
+
+  for ((port = PORT_MIN; port <= PORT_MAX; port++)); do
+    if ! grep -qx "$port" <<<"$taken"; then
+      echo "$port"
+      return 0
+    fi
+  done
+
+  echo "setup-mcp: no free port in ${PORT_MIN}-${PORT_MAX}." >&2
+  echo "Prune a stale worktree, or widen the range at the top of this script." >&2
+  return 1
+}
+
+# A linked worktree has .git as a file ("gitdir: ..."); the main checkout has a directory.
+if [[ -d .git ]]; then
+  port=$MAIN_PORT
+  where="main checkout"
+else
+  port=$(allocate_port)
+  where=$(git branch --show-current)
+fi
+
+cat >.mcp.json <<EOF
+{
+  "mcpServers": {
+    "tidewave": {
+      "type": "http",
+      "url": "http://localhost:${port}/tidewave/mcp"
+    }
+  }
+}
+EOF
+
+cat <<EOF
+Configured port ${port} for ${where}.
+
+  wrote .mcp.json  -> tidewave at http://localhost:${port}/tidewave/mcp
+  bin/dev          -> starts the server on ${port} (live_debugger on $((port + 100)))
+
+Restart Claude Code here — .mcp.json is read at session start.
+EOF

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -2,6 +2,10 @@ import Config
 
 alias KlassHero.Shared.Adapters.Driven.Storage.S3StorageAdapter
 
+# Every dev port derives from PORT so a worktree can run its own server alongside
+# main's. See .claude/rules/worktrees.md.
+dev_port = String.to_integer(System.get_env("PORT") || "4000")
+
 config :klass_hero, KlassHero.Repo,
   username: "postgres",
   password: "postgres",
@@ -18,7 +22,8 @@ config :klass_hero, KlassHero.Repo,
   pool_size: 10
 
 config :klass_hero, KlassHeroWeb.Endpoint,
-  http: [ip: {127, 0, 0, 1}, port: String.to_integer(System.get_env("PORT") || "4000")],
+  http: [ip: {127, 0, 0, 1}, port: dev_port],
+  url: [host: "localhost", port: dev_port],
   check_origin: false,
   # The watchers configuration can be used to run external
   code_reloader: true,
@@ -41,6 +46,8 @@ config :klass_hero, KlassHeroWeb.Endpoint,
     ]
   ]
 
+config :klass_hero, :app_base_url, "http://localhost:#{dev_port}"
+
 # Storage: MinIO S3-compatible storage for development (via docker-compose)
 config :klass_hero, :storage,
   adapter: S3StorageAdapter,
@@ -52,6 +59,12 @@ config :klass_hero, :storage,
 
 # Enable dev routes for dashboard and mailbox
 config :klass_hero, dev_routes: true
+
+# live_debugger runs its own endpoint and defaults to 4007, so a second concurrent
+# dev server would hit :eaddrinuse. Offsetting by 100 keeps it collision-free without
+# per-worktree config. Deliberately not `auto_port: true` — its upward scan could
+# wander onto a neighbouring worktree's port.
+config :live_debugger, port: dev_port + 100
 
 # Do not include metadata nor timestamps in development logs
 # debugging and code reloading.


### PR DESCRIPTION
## Summary

Worktrees are the default for every task, but the Tidewave MCP URL was a single hardcoded `localhost:4000`. Tidewave therefore introspected whichever dev server happened to own that port — not the code being edited — which forced a choice between the worktree-per-task default and having Tidewave at all. `.claude/rules/worktrees.md` acknowledged this and recommended running one server at a time.

Each checkout now declares its own **project-scope** MCP server. Scope precedence is `local > project (.mcp.json) > user`, matched by name with whole-entry replacement, so each directory resolves `tidewave` to its own port with no global entry involved.

- `bin/setup-mcp` — run once per checkout. Main takes 4000; worktrees take the lowest free port in 4010–4039. Writes the gitignored `.mcp.json`.
- `bin/dev` — reads the port back out of that same file, so the MCP client and the server it talks to cannot drift.
- `config/dev.exs` — `url:`, `:app_base_url` and live_debugger's port all derive from `PORT`.

## Review focus

**The server is named `tidewave` in every checkout on purpose.** MCP tool permissions key on the server name (`mcp__tidewave__project_eval` and friends), so a per-worktree name like `tidewave-1142` would need its own `mcp__<name>__*` grants. Identical-name shadowing is what makes this free.

**live_debugger was an undocumented `:eaddrinuse` source.** It runs its own endpoint, defaults to 4007, and had no config in the repo — so any second concurrent `mix phx.server` died on it. Now `PORT + 100`. Deliberately not `auto_port: true`, whose upward scan could wander onto a neighbouring worktree's port.

**Allocation policy** (`allocate_port`): lowest free port in range, treating both *claimed* ports (written into some worktree's `.mcp.json`) and *bound* ports (currently listening) as taken. Claimed keeps two worktrees off the same number while their servers are down; bound dodges an unrelated squatter. Stale entries self-clean because a deleted worktree stops appearing in `git worktree list`.

## Test plan

Verified live, not just reasoned about:

- [x] Worktree resolves `Project config` → 4010; main resolves `Project config` → 4000
- [x] Both endpoint (4010) and live_debugger (4110) bound by the same pid, zero `eaddrinuse`
- [x] Tidewave MCP `initialize` handshake returns the tool list on 4010; app and live_debugger both serve HTTP 200
- [x] A request carrying an `Origin` header gets 403, per Tidewave's router
- [x] `bin/setup-mcp` idempotent on re-run; allocated 12 distinct ports (4011–4022) across the existing worktrees
- [x] `.mcp.json` stays untracked (already in `.gitignore`)
- [x] `mix precommit` — 4224 passed, 2 skipped, 18 excluded

## Follow-up needed on each machine

`.mcp.json` is gitignored, so **every checkout needs `bin/setup-mcp` run once**. Existing worktrees on this machine have already been done. Pre-approval lives in `~/.claude/settings.json` as `"enabledMcpjsonServers": ["tidewave"]` — it must be at user level, since a committed `.claude/settings.json` is ignored until a workspace is trusted, which a fresh worktree isn't yet.