### PR TITLE
docs: define the payments domain and record the money-path decisions

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -16,6 +16,10 @@ _Avoid_: Type, Kind, Tag
 The window during which parents may enrol in a Program. When unbounded, registration is "always open".
 _Avoid_: Enrolment window, Signup period, Booking window
 
+**Price**:
+What a **Program** costs a parent, always **gross** — the final amount payable, VAT included whatever the rate turns out to be. A Provider entering "100" means the parent pays €100. Net and VAT are *derived* from it, never the other way round.
+_Avoid_: Net price, Fee (reserved for the platform's success-based fee), Cost
+
 ## Scheduling
 
 **Session**:
@@ -39,6 +43,44 @@ _Avoid_: Attendance record, Booking
 **Attendance**:
 The act and result of checking a child in and out of a **Session** (the state changes recorded on a **Participation Record**).
 _Avoid_: Presence, Sign-in
+
+## Payments & Invoicing
+
+**Invoice**:
+An immutable, numbered record of money owed or paid for one **Enrollment**, issued by Klass Hero. Append-only: it is never edited after issue, and a correction is a new Invoice, not a change to the old one. Comes in three kinds — a **Rechnung** to the **Parent**, a **Gutschrift** to the **Provider**, and a **Storno** reversing either. One concept rather than three, because German law treats a Gutschrift as an invoice issued by the recipient of the supply (§14 Abs. 2 S. 2 UStG).
+_Avoid_: Document (that's a **Verification Document**), Receipt, Bill, Booking invoice ("Booking" is not a domain noun)
+
+**Rechnung**:
+The **Invoice** kind issued by Klass Hero to a **Parent** for an **Enrollment**. Klass Hero's own VAT treatment governs it. The German term is kept because the document is German and consumer-facing.
+_Avoid_: Parent invoice, Receipt
+
+**Gutschrift**:
+The **Invoice** kind issued by Klass Hero to a **Provider**, self-billing for the provider's supply. The **Provider**'s own VAT status governs it, and issuing it requires the provider's prior agreement.
+_Avoid_: Credit note (means something else in English), Payout statement, Self-bill
+
+**Storno**:
+The **Invoice** kind that reverses a **Rechnung** or a **Gutschrift** after a cancellation or refund. Never mutates the invoice it reverses.
+_Avoid_: Cancellation (that's the **Enrollment** state change that may cause a Storno), Credit note, Refund (the money movement, not the document)
+
+**Payment**:
+The **Parent**'s money movement into Klass Hero for one **Enrollment**. Two-phase: the money is *held* when the parent books and only *taken* once the **Provider** accepts. Taking it is what confirms the **Enrollment** — neither the parent submitting the form nor the provider accepting does so alone. A held Payment that is never taken lapses and no money moves. Only programs with a **Price** above zero have one.
+_Avoid_: Charge (the processor's term), Transaction, Booking payment ("Booking" is not a domain noun)
+
+**Transfer**:
+The movement of a **Provider**'s share from Klass Hero to that provider's connected account. Held back until the **Program** begins, so that Klass Hero — not the provider — holds the money while a booking can still be cancelled. Separate from the **Payment**, later than it, and able to fail on its own.
+_Avoid_: Payout (that is the next leg), Settlement, Disbursement
+
+**Payout**:
+The movement of money from a **Provider**'s connected account to their bank account. Scheduled and executed by the payment processor — Klass Hero sets the schedule and may hold it, but does not move the money itself.
+_Avoid_: Transfer (that is the previous leg), Withdrawal
+
+**Processing Fee**:
+The payment processor's actual cost on one **Enrollment**'s **Payment**, passed through so that Klass Hero nets zero on it. It is a recovered cost, **not revenue**, and deliberately not the **Success Fee**. Deducted from what the **Provider** receives, so a provider's payout is less than the **Price** by this amount.
+_Avoid_: Commission (deleted with provider tiers, ADR-0004), Platform fee, Application fee (that's the processor's API term), Service charge
+
+**Success Fee**:
+The planned share of a **Provider**'s platform income that Klass Hero will earn ("we earn when you earn"). Not built and not modelled — see [ADR-0004](adr/0004-provider-tiers-removed-success-fee-planned.md). Distinct from the **Processing Fee**: one is Klass Hero's margin, the other is a cost recovered at zero margin. Do not let code, copy, or invoices blur them.
+_Avoid_: Commission, Tier rate, Take rate
 
 ## Providers & Staff
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -74,6 +74,10 @@ _Avoid_: Payout (that is the next leg), Settlement, Disbursement
 The movement of money from a **Provider**'s connected account to their bank account. Scheduled and executed by the payment processor — Klass Hero sets the schedule and may hold it, but does not move the money itself.
 _Avoid_: Transfer (that is the previous leg), Withdrawal
 
+**Refund**:
+The return of a **Payment** to the **Parent** after an **Enrollment** is cancelled. Always the full amount while the **Program** has not yet begun, which is the only window Klass Hero supports — because Klass Hero still holds the money then, a Refund is never reclaimed from the **Provider**. Recorded by a **Storno**.
+_Avoid_: Reversal, Chargeback (that is the parent's bank acting against us, not us refunding), Cancellation (the **Enrollment** state change that causes it)
+
 **Processing Fee**:
 The payment processor's actual cost on one **Enrollment**'s **Payment**, passed through so that Klass Hero nets zero on it. It is a recovered cost, **not revenue**, and deliberately not the **Success Fee**. Deducted from what the **Provider** receives, so a provider's payout is less than the **Price** by this amount.
 _Avoid_: Commission (deleted with provider tiers, ADR-0004), Platform fee, Application fee (that's the processor's API term), Service charge

--- a/docs/adr/0004-provider-tiers-removed-success-fee-planned.md
+++ b/docs/adr/0004-provider-tiers-removed-success-fee-planned.md
@@ -16,7 +16,11 @@ Tiers could be removed this bluntly because they were never monetised: the €19
 - Provider registration no longer asks for a plan; `/for-providers` marketing sells "free to join, all features included, success-based fee coming" instead of three pricing cards.
 - The column drop ships in the same PR as the code removal (single deploy, low traffic); a brief window where an old release selects a dropped column is accepted.
 
+## Update: fee machinery now exists, and it is not this fee
+
+[ADR-0012](0012-merchant-of-record-via-separate-charges-and-transfers.md) introduces a **Processing Fee** — the payment processor's actual cost, deducted from a Provider's payout and passed through at zero margin. A reader who finds fee-deduction code after reading the paragraph above would reasonably conclude this ADR had been ignored. It has not: a recovered cost is not a take rate. The **Success Fee** described here remains undesigned and unbuilt, and `CONTEXT.md` defines the two against each other precisely so they cannot be conflated.
+
 ## When to revisit
 
-- When the success-based fee is built: it defines its own fee schedule, storage, and statements from scratch — it must not resurrect tier vocabulary or the Entitlements provider map.
+- When the success-based fee is built: it defines its own fee schedule, storage, and statements from scratch — it must not resurrect tier vocabulary or the Entitlements provider map. It sits beside the Processing Fee, not inside it.
 - If provider-side capability gating is ever needed again (e.g. fee-delinquent Providers losing features), model it on the fee system's own state, not on a reintroduced tier.

--- a/docs/adr/0012-merchant-of-record-via-separate-charges-and-transfers.md
+++ b/docs/adr/0012-merchant-of-record-via-separate-charges-and-transfers.md
@@ -1,0 +1,83 @@
+# Klass Hero is merchant of record, and money moves by separate charges and transfers
+
+The Transaction Ready milestone is the GA blocker: nothing on the platform moves money today. A
+booking writes an **Enrollment** with `status: :pending` and zero in every money column, and the
+parent either pays the provider in cash or nothing happens at all.
+
+Building the money path forced a decision that is expensive to unwind, because it determines who
+is legally selling the service — and therefore what every **Invoice** says. It also sits upstream
+of an unanswered VAT question, so it was chosen to keep the charged amount independent of that
+answer.
+
+## Decision
+
+- **Klass Hero is merchant of record.** The charge settles on the platform account, so the parent's
+  bank statement shows Klass Hero and Klass Hero is the seller of record. The **Rechnung** to the
+  parent and the **Gutschrift** to the provider are both Klass Hero documents, which is only
+  coherent under this model.
+
+- **Money moves by separate charges and transfers, not destination charges.** Both keep the platform
+  as settlement merchant, so both preserve merchant-of-record. The difference is timing: a
+  destination charge sets `application_fee_amount` when the PaymentIntent is *created*, whereas the
+  real processing fee only exists once the charge has *settled* and appears on the balance
+  transaction. Decoupling the transfer is the only way to move an exact remainder.
+
+- **The Processing Fee is the processor's actual cost, passed through at zero margin.** Read from
+  the balance transaction, deducted from the **Transfer**. It is a recovered cost, not revenue, and
+  it is deliberately **not** the **Success Fee** that ADR-0004 left undesigned. Code, copy and
+  invoices must not blur them.
+
+- **Price is gross.** What a provider types is what a parent pays. Net and VAT are derived. This is
+  what makes the charged amount invariant to the outstanding VAT question, and it is what German
+  consumer price display expects.
+
+- **A new `Billing` bounded context owns the money.** **Payment**, **Transfer**, **Invoice**,
+  **Processing Fee** and **Refund** live there. **Enrollment** stays what the glossary says it is —
+  a child's commitment to a Program — and **Provider** gains only the connected-account identity.
+
+- **`Invoice` is one immutable entity with three kinds** (`:rechnung`, `:gutschrift`, `:storno`),
+  each with its own sequential number series. One concept rather than three because German law
+  treats a Gutschrift as an invoice issued by the recipient of the supply (§14 Abs. 2 S. 2 UStG).
+  Never edited after issue; a correction is a new Invoice.
+
+- **Stripe webhooks land in a Billing-owned inbox keyed on the Stripe event id**, storing the raw
+  payload, acking 200 immediately and processing via Oban. Not the existing `processed_events`
+  table, whose `event_id` is an `Ecto.UUID` and which retains no payload to replay or audit.
+
+- **Reconciliation treats Stripe as authoritative but never auto-corrects.** A daily job compares
+  our records against Stripe and raises through `error_tracker`; a human decides. Silently
+  rewriting financial records would destroy the audit trail the immutable Invoice exists to provide.
+
+## Considered and rejected
+
+- **Direct charges.** The only charge type where the connected account can be made to bear the
+  processing fee, which would have solved the fee question outright. Rejected because it makes the
+  *provider* the settlement merchant: the provider becomes seller of record, the parent's statement
+  shows them, and Klass Hero can no longer issue either document. It trades the whole invoicing
+  model for a fee mechanism.
+
+- **Destination charges with an estimated fee.** Simplest to build, and the payout is atomic with
+  the charge. Rejected because the estimate is wrong in both directions — a non-EEA card costs
+  materially more than an EEA one — and the over-collections are unintended revenue, which drags
+  VAT and accounting consequences onto a fee designed to be neutral.
+
+- **Absorbing the processing fee.** Keeps the single-call model and the marketing promise untouched.
+  Rejected as a deliberate per-transaction loss that worsens proportionally on cheap bookings.
+
+- **Putting the tax snapshot on `enrollments`.** What the milestone's issues originally specified.
+  Rejected because an Enrollment carries mutable lifecycle state, a cancellation would sit next to
+  frozen printed figures with only discipline keeping them apart, and a second document for the same
+  enrollment (a Storno) has nowhere to live.
+
+## When to revisit
+
+- **When the Success Fee is built.** It is Klass Hero's margin and belongs beside the Processing Fee
+  without merging into it. ADR-0004's warning stands: it must not resurrect tier vocabulary.
+
+- **If tax advice treats the Processing Fee as a supply to the provider.** Then it is taxable, Klass
+  Hero owes VAT on a fee collected at cost, and zero margin becomes unachievable — at which point
+  either the fee stops being a pure pass-through or it is abandoned in favour of absorbing the cost.
+
+- **If the VAT answer makes the platform materially pricier than booking direct.** If provider-level
+  exemptions turn out not to travel down the supply chain, merchant-of-record itself becomes the
+  thing to reconsider, and this ADR is what would be superseded.

--- a/docs/adr/0013-booking-authorizes-acceptance-captures-program-start-releases.md
+++ b/docs/adr/0013-booking-authorizes-acceptance-captures-program-start-releases.md
@@ -1,0 +1,90 @@
+# A booking authorizes, the provider's acceptance captures, and the program's start releases the money
+
+ADR-0012 settles who sells and how money moves. This one settles *when* — and that turns out to
+decide how much machinery the platform needs, because holding money for longer removes whole
+categories of failure rather than merely deferring them.
+
+Two facts constrain it. A **Provider** can already accept or decline a pending **Enrollment**
+(`Enrollment.confirm/1`, wired from the provider dashboard), so payment success and provider
+acceptance both want the same `:pending → :confirmed` transition. And programs can be booked far
+ahead — a camp listed in April may not run until August — so the gap between paying and receiving
+the service is often months.
+
+## Decision
+
+- **Booking authorizes; it does not charge.** The parent's card is held when they book. No money
+  moves yet.
+
+- **Provider acceptance captures, and capture is what confirms the Enrollment.** Neither the parent
+  submitting the form nor the provider clicking accept confirms it alone. A decline voids the hold,
+  so **no money ever moved and there is nothing to refund** — this is why refund machinery is not
+  needed to ship.
+
+- **Silence accepts.** Providers are notified on booking and reminded at days 2 and 5; if they have
+  still not acted, the hold is captured on day 6. Card authorizations expire after 7 days for
+  online customer-initiated payments, so day 6 is the last safe moment. The parent, who did
+  everything right, keeps their place; the provider listed the program publicly with a capacity, and
+  capacity and eligibility are already enforced automatically.
+
+- **The Transfer is held until the Program's `start_date`.** Klass Hero holds the money through the
+  entire window in which a booking can be cancelled. The provider is paid once delivery begins.
+
+- **`start_date` is required to publish a paid program.** It is currently nullable and, by the
+  glossary's own flagged ambiguity, advertised rather than authoritative. Making it required at the
+  publish gate stops a Transfer trigger from silently never firing — a money bug that would manifest
+  as absence, not error.
+
+- **Cancellation before `start_date` is a full refund**, recorded by a **Storno**. Because Klass Hero
+  still holds the funds, the refund is a write against our own balance and is never reclaimed from
+  the provider. Cancellation after a program has begun is out of scope and needs a policy.
+
+- **Cash and bank transfer are removed for paid programs.** Free programs (price zero) book with no
+  payment at all. This is not merely a second code path: under merchant-of-record, a cash booking
+  would create a Klass Hero VAT liability with no Klass Hero cash to pay it from, and the only
+  coherent alternative — the provider selling directly — means running two tax models on one
+  platform.
+
+- **Payout readiness is a separate publish gate, not a Verification Step.** Publishing requires
+  `vetted? AND payout_ready?` as independent predicates. ADR-0008 makes the vetting Track a trust
+  engine over three evidence kinds; a connected bank account is commercial readiness, not evidence
+  of trust, and would reset and cascade in ways that make no sense for it.
+
+- **Both feature flags are provider-scoped.** `:stripe_payouts` and `:stripe_checkout` — the latter
+  on the provider of the program being booked — so a single pilot provider can be switched on end to
+  end while every other provider behaves exactly as before. Parents are never subject to a flag.
+
+## Considered and rejected
+
+- **Charge immediately and refund on rejection.** Cleanest UX and providers keep full control.
+  Rejected because it makes refunds, reversals and Storno documents GA-blocking, in the one area
+  with no existing code at all.
+
+- **Removing the provider's veto.** Capacity and eligibility are already automatic, so the manual
+  accept is arguably redundant, and dropping it would remove the expiry problem entirely. Rejected
+  because declining a specific child — on age suitability or support needs — is a control worth
+  keeping for children's activities.
+
+- **Approve first, then ask the parent to pay.** No holds, no refunds, nobody over-committed.
+  Rejected as a materially different product: "book" becomes "request", the parent must return in a
+  second session, and drop-off is real.
+
+- **Transferring as soon as the payment settles.** Best provider cash flow and the simplest state
+  machine. Rejected because Klass Hero would hold nothing against a cancellation, and every refund
+  becomes a clawback against a provider who may already have been paid out to their bank — the loss
+  Stripe explicitly holds platforms responsible for.
+
+- **Tiered or provider-set refund policies.** More market-realistic and fairer to providers on late
+  cancellations. Rejected for GA because partial refunds require partial Storno documents and a
+  provider share on cancelled bookings, which means transfers must fire for cancellations too.
+
+## When to revisit
+
+- **Cancellation after a program has begun**, which this ADR leaves unspecified and which real usage
+  will force.
+- **Refund policy generally**, once providers start losing income to late cancellations that a full
+  refund makes entirely their problem.
+- **Auto-capture on silence**, if providers turn out to resent enrollments they never reviewed, or
+  if card network authorization windows change.
+- **The transfer trigger**, if Sessions ever become generated from the Program schedule rather than
+  hand-created — the glossary flags that as a known gap, and the real start of delivery is the first
+  Session, not an advertised date.


### PR DESCRIPTION
Milestone 15 (Transaction Ready) is the GA blocker, and nothing on the platform moves money today. Before writing any of it, the vocabulary and the two expensive-to-unwind decisions needed to exist in writing. This PR is documentation only — no code, no behaviour change.

## `CONTEXT.md` — 12 terms

A new **Payments & Invoicing** section (Invoice, Rechnung, Gutschrift, Storno, Payment, Transfer, Payout, Refund, Processing Fee, Success Fee), plus **Price** under The Offering.

Two definitions carry most of the weight:

- **Price is gross.** A provider typing "100" means the parent pays €100; net and VAT are derived from it, never the reverse. This is what makes the charged amount independent of the unresolved VAT question, and therefore what makes checkout buildable before the tax advice comes back.
- **Processing Fee ≠ Success Fee.** The first is the processor's actual cost, recovered at zero margin. The second is Klass Hero's margin, which ADR-0004 deliberately left undesigned. They are defined against each other so code and copy cannot conflate them.

## ADR-0012 — merchant of record, separate charges and transfers

Klass Hero settles the charge, so Klass Hero is seller of record and both invoice documents are coherently ours. Separate charges and transfers rather than destination charges: both preserve merchant-of-record, but a destination charge fixes the application fee when the PaymentIntent is *created*, while the real processing fee only exists once the charge has *settled*. Decoupling the transfer is the only way to move an exact remainder.

Also: a new `Billing` bounded context, one immutable `Invoice` entity with three kinds, a Billing-owned Stripe webhook inbox, and reconciliation that treats Stripe as authoritative but never auto-corrects.

## ADR-0013 — authorize, capture, then hold until the program starts

Booking authorizes. Provider acceptance captures. The transfer waits for `program.start_date`.

Holding funds across the whole cancellation window is what removes work rather than deferring it: a provider decline voids the hold so there is nothing to refund, and a cancellation is a write against our own balance rather than a clawback from a provider already paid out. Refund machinery stops being GA-blocking.

Two gaps the design surfaced that no ticket knew about: `start_date` is nullable, so the transfer trigger would silently never fire (→ #1170), and GDPR child deletion cancels enrollments on a path that would keep the money once capture exists (→ #1172).

## ADR-0004 — cross-reference

ADR-0004 says the fee system is "deliberately not designed or stubbed here". A reader who later finds fee-deduction code would reasonably conclude it had been ignored. The added section says plainly that a recovered cost is not a take rate.

---

Eleven tickets (#1165–#1175) were filed and five rewritten against these decisions; the milestone now stands at 22 open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)