### PR TITLE
ci: gate the site icons against their source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,3 +253,44 @@ jobs:
           name: e2e-screenshots
           path: tmp/e2e_screenshots/
           retention-days: 7
+
+  # The site icons are committed release artifacts — nothing in mix assets.deploy
+  # builds them — so this job is the only thing linking the bytes to their source,
+  # priv/brand/kh-mark.svg. site_icons_test.exs covers a different axis: it proves
+  # the committed ICO is well-formed, which a stale ICO also is.
+  #
+  # Report-only by intent, like the hex-audit job in security.yml: it gets its own
+  # red PR entry, but must stay OUT of the required-status-checks ruleset on
+  # `main`. A Chrome major bump can shift Skia's antialiasing and red this on an
+  # unrelated PR; the fix is a one-line regen commit, which must not gate a merge.
+  #
+  # No `needs:` and no Elixir — this runs off the deps job's critical path.
+  site-icons:
+    name: Site Icon Provenance
+    runs-on: ubuntu-latest
+
+    steps:
+      # actions/checkout@v6.0.2
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      # Node and Google Chrome both ship on the runner image, and the generator
+      # has no npm dependencies — hence no setup-node and no install step.
+      # CHROME_BIN is set explicitly rather than leaning on the generator's
+      # fallback list, so a runner image that moves the binary fails loudly.
+      - name: Regenerate the site icons from kh-mark.svg
+        run: node priv/brand/generate_icons.mjs
+        env:
+          CHROME_BIN: /usr/bin/google-chrome
+          CHROME_NO_SANDBOX: '1'
+
+      - name: Fail if the committed artifacts drifted from their source
+        run: |
+          git diff --exit-code --stat \
+            priv/static/favicon.ico \
+            priv/static/images/icon.svg \
+            priv/static/images/apple-touch-icon.png \
+          || {
+            echo "::error::Site icons are stale. Run 'node priv/brand/generate_icons.mjs' and commit the result."
+            exit 1
+          }

--- a/priv/brand/generate_icons.mjs
+++ b/priv/brand/generate_icons.mjs
@@ -133,6 +133,11 @@ function rasterize(chrome, svg, size, tmp) {
     chrome,
     [
       '--headless=new',
+      // Ubuntu 23.10+ sets apparmor_restrict_unprivileged_userns=1, so Chrome's
+      // namespace sandbox cannot start on the CI image. Opt-in rather than
+      // unconditional: local runs keep the sandbox. The only content rendered is
+      // a data: URI built two lines up, and the flag does not alter output bytes.
+      ...(process.env.CHROME_NO_SANDBOX ? ['--no-sandbox'] : []),
       '--disable-gpu',
       '--hide-scrollbars',
       '--force-device-scale-factor=1',

--- a/test/klass_hero_web/site_icons_test.exs
+++ b/test/klass_hero_web/site_icons_test.exs
@@ -7,6 +7,10 @@ defmodule KlassHeroWeb.SiteIconsTest do
   was broken (#1159) — only the structure tests cover the actual root cause: a
   paletted 8bpp entry whose 1-bit AND mask clipped every antialiased stroke, at
   the 32x32 size Chrome requests on a 2x display.
+
+  These assert the committed bytes are well-formed, never that they are current —
+  a stale ICO is still a valid ICO. Regeneration from `priv/brand/kh-mark.svg` is
+  gated by the `site-icons` job in `.github/workflows/ci.yml` (#1163).
   """
   use KlassHeroWeb.ConnCase, async: true
 


### PR DESCRIPTION
Closes #1163.

## Summary

`priv/static/favicon.ico`, `images/icon.svg` and `images/apple-touch-icon.png` are committed release artifacts generated from `priv/brand/kh-mark.svg` by `priv/brand/generate_icons.mjs`. Nothing runs the generator automatically.

`site_icons_test.exs` proves the committed ICO is **well-formed** — 3 entries, 32bpp, PNG payloads, IHDR agreement. That is real cover for #1159 recurring. It is not cover for the source drifting from the bytes: a stale ICO is still a valid ICO, so editing `kh-mark.svg` or the `VARIANT`/`TOKENS` constants and skipping the re-run passed all 12 assertions.

This adds a `site-icons` job that regenerates the icons and fails on any diff.

## Review Focus

**Why a separate job rather than `continue-on-error` in `quality`.** Both are non-blocking; they differ in what you see. `continue-on-error` reports the job green and buries the failure in a log annotation. A separate job gets its own red PR entry while staying out of the required-status-checks ruleset — the same shape as `hex-audit` in `security.yml:96-101` (#1182). New jobs are not auto-added to rulesets, so **no GitHub settings change is needed**; it is non-blocking on creation. Please leave it that way.

**Why non-blocking at all.** A Chrome major bump could shift Skia's antialiasing and red this on an unrelated PR. The failure is legible and the fix is a one-line regen commit, but it must not gate a merge.

**Determinism.** The approach only works if the generator is byte-reproducible. Verified:

| Environment | Chrome build | `favicon.ico` sha256 |
|---|---|---|
| macOS arm64, Google Chrome | 150.0.7871.**187** | `d5f0708…f196a1` |
| Debian bookworm arm64, Chromium (docker) | 150.0.7871.**181** | `d5f0708…f196a1` |
| Committed artifact | — | `d5f0708…f196a1` |

Identical across different OS, vendor and patch build. It holds because `--disable-gpu` pins Skia to CPU raster and `--force-device-scale-factor=1` pins the scale.

**Cross-architecture: resolved.** Both local runs were arm64 while the runner is x86_64, and Skia has arch-specific SIMD paths, so this was unverified at PR time (an amd64 emulation attempt aborted: `hardware lacks support for the sse3 instruction set`). This PR's own CI run settled it — the job passed in 14s having actually rasterized, writing `605 / 3546 / 7603 B`, byte-identical to both arm64 runs. Determinism now holds across arm64 macOS, arm64 Linux and x86_64 Linux.

The job still ships non-blocking, for the Chrome-major-bump reason above rather than this one.

**`CHROME_NO_SANDBOX`.** Ubuntu 23.10+ sets `apparmor_restrict_unprivileged_userns=1`, which stops Chrome's namespace sandbox from starting — the same thing that broke Puppeteer on runners after the 22.04→24.04 image bump, and what aborted the docker verification above until the flag was added. Env-gated rather than unconditional so local runs keep the sandbox. The only content rendered is a `data:` URI the script builds itself.

**Cost.** No `needs:`, no Elixir, no deps cache, no `mix deps.get`. Node 22.23.1 and Google Chrome 150.0.7871.128 both ship on the runner image and the generator has no npm dependencies. Runs in parallel; adds nothing to the critical path.

## Test Plan

- [x] `node priv/brand/generate_icons.mjs` on a clean tree → no diff
- [x] `CHROME_NO_SANDBOX=1 node priv/brand/generate_icons.mjs` → byte-identical, so the flag does not perturb output
- [x] **Gate proven red:** perturbed `heroBlue`, regenerated, ran the exact job command → `exit=1`, all 3 files changed, `::error::` annotation emitted. Restored after.
- [x] Workflow YAML parses; `site-icons` has no `needs:` and the expected steps/env
- [x] `mix precommit` → **4224 passed, 2 skipped, 18 excluded**

## Note for the reviewer

#1163 also flags that #1159's Verification section calls the test suite "the permanent gate", which overstates what shipped. Happy to post a correcting comment on #1159 once this lands.
