### PR TITLE
feat: generate sessions from a program's recurring schedule

### DIFF
--- a/lib/klass_hero/application.ex
+++ b/lib/klass_hero/application.ex
@@ -181,6 +181,16 @@ defmodule KlassHero.Application do
             {KlassHero.Participation.Adapters.Driving.Events.EventHandlers.PromoteIntegrationEvents, :handle},
             priority: 10},
            {:session_created, {KlassHero.Participation.Adapters.Driving.Events.EventHandlers.NotifyLiveViews, :handle}},
+           {:sessions_generated,
+            {KlassHero.Participation.Adapters.Driving.Events.EventHandlers.PromoteIntegrationEvents, :handle},
+            priority: 10},
+           {:sessions_generated,
+            {KlassHero.Participation.Adapters.Driving.Events.EventHandlers.NotifyLiveViews, :handle}},
+           {:session_cancelled,
+            {KlassHero.Participation.Adapters.Driving.Events.EventHandlers.PromoteIntegrationEvents, :handle},
+            priority: 10},
+           {:session_cancelled,
+            {KlassHero.Participation.Adapters.Driving.Events.EventHandlers.NotifyLiveViews, :handle}},
            {:session_started,
             {KlassHero.Participation.Adapters.Driving.Events.EventHandlers.PromoteIntegrationEvents, :handle},
             priority: 10},
@@ -258,7 +268,12 @@ defmodule KlassHero.Application do
       Supervisor.child_spec(
         {EventSubscriber,
          handler: ParticipationEventHandler,
-         topics: ["integration:family:child_data_anonymized"],
+         topics: [
+           "integration:family:child_data_anonymized",
+           "integration:program_catalog:program_created",
+           "integration:program_catalog:program_updated",
+           "integration:enrollment:enrollment_created"
+         ],
          message_tag: :integration_event,
          event_label: "Integration event"},
         id: :participation_integration_event_subscriber

--- a/lib/klass_hero/application.ex
+++ b/lib/klass_hero/application.ex
@@ -231,7 +231,16 @@ defmodule KlassHero.Application do
     ]
   end
 
-  defp integration_event_subscribers do
+  @doc """
+  Integration-event subscriber child specs.
+
+  Public so a test can check each subscriber's `topics:` covers everything its
+  handler declares in `subscribed_events/0` — `EventSubscriber` subscribes off
+  the literal topic list and never consults the handler, so the two drift
+  silently, and a handler clause that never receives its event looks exactly
+  like a feature that quietly does nothing.
+  """
+  def integration_event_subscribers do
     [
       Supervisor.child_spec(
         {EventSubscriber,
@@ -304,11 +313,15 @@ defmodule KlassHero.Application do
          event_label: "Integration event"},
         id: :enrollment_family_invite_subscriber
       ),
-      # Participation seeds session roster when a session is created
+      # Participation seeds session rosters, whether a session was created by hand
+      # or derived from a program's schedule.
       Supervisor.child_spec(
         {EventSubscriber,
          handler: SeedSessionRosterHandler,
-         topics: ["integration:participation:session_created"],
+         topics: [
+           "integration:participation:session_created",
+           "integration:participation:sessions_generated"
+         ],
          message_tag: :integration_event,
          event_label: "Integration event"},
         id: :participation_seed_roster_subscriber

--- a/lib/klass_hero/participation.ex
+++ b/lib/klass_hero/participation.ex
@@ -211,6 +211,54 @@ defmodule KlassHero.Participation do
   # Statuses that count toward the attendance tally ("has attended", not "currently present").
   @admin_checked_in_statuses ~w(checked_in checked_out)
 
+  @doc """
+  Roster size and attendance tally for the given sessions, keyed by session id.
+
+  One grouped query for the whole list, so a day's sessions cost the same as one.
+  Sessions with an empty roster are absent from the map rather than mapping to
+  zeroes — callers decide what "no roster yet" should render as.
+  """
+  @spec session_attendance_counts([String.t()]) ::
+          %{optional(String.t()) => %{roster: non_neg_integer(), checked_in: non_neg_integer()}}
+  def session_attendance_counts([]), do: %{}
+
+  def session_attendance_counts(session_ids) when is_list(session_ids) do
+    from(r in ParticipationRecord,
+      where: r.session_id in ^session_ids,
+      group_by: r.session_id,
+      select: {
+        r.session_id,
+        count(r.id),
+        count(fragment("CASE WHEN ? = ANY(?) THEN 1 END", r.status, ^@admin_checked_in_statuses))
+      }
+    )
+    |> Repo.all()
+    |> Map.new(fn {id, roster, checked_in} -> {id, %{roster: roster, checked_in: checked_in}} end)
+  end
+
+  @doc """
+  Counts an already-loaded roster into the same shape as `session_attendance_counts/1`.
+
+  Live updates arrive with the roster already fetched, so recounting in memory
+  keeps a check-in from costing another query.
+  """
+  @spec attendance_from_roster([map()]) :: %{roster: non_neg_integer(), checked_in: non_neg_integer()}
+  def attendance_from_roster(roster) when is_list(roster),
+    do: roster |> Enum.map(& &1.record) |> attendance_from_records()
+
+  @doc """
+  Same tally as `attendance_from_roster/1`, for a bare list of participation records.
+
+  Detail pages hold enriched records rather than roster entries.
+  """
+  @spec attendance_from_records([map()]) :: %{roster: non_neg_integer(), checked_in: non_neg_integer()}
+  def attendance_from_records(records) when is_list(records) do
+    %{
+      roster: length(records),
+      checked_in: Enum.count(records, &("#{&1.status}" in @admin_checked_in_statuses))
+    }
+  end
+
   # Translate a cross-context :provider_id filter into a local :program_ids filter,
   # so the aggregation query stays free of ProgramCatalog/Provider vocabulary.
   defp resolve_provider_scope(%{provider_id: provider_id} = filters) do

--- a/lib/klass_hero/participation.ex
+++ b/lib/klass_hero/participation.ex
@@ -78,6 +78,45 @@ defmodule KlassHero.Participation do
   end
 
   @doc """
+  Brings a program's generated sessions into agreement with its recurring schedule.
+
+  Idempotent, and deliberately so: `program_updated` carries a full snapshot
+  rather than a diff, so a caller cannot tell a schedule edit from a title edit
+  and must be safe to run on every write.
+
+  Three steps, all scoped to `origin: :generated` sessions dated today or later:
+  slots that returned to the schedule are revived, missing ones are created, and
+  ones that fell out are cancelled. Manually created sessions are never touched,
+  and neither is any session already started, completed or cancelled.
+
+  Returns `{:error, :incomplete_schedule}` when the program has no full schedule
+  to derive from — distinct from a complete schedule that yields no dates.
+  """
+  @spec sync_sessions_for_program(String.t()) ::
+          {:ok, %{generated: non_neg_integer(), cancelled: non_neg_integer(), revived: non_neg_integer()}}
+          | {:error, :program_not_found | :incomplete_schedule | :schedule_range_too_large}
+  def sync_sessions_for_program(program_id) when is_binary(program_id) do
+    context_span entity: "session" do
+      with {:ok, program} <- fetch_program_for_sync(program_id),
+           {:ok, dates} <- ProgramCatalog.meeting_dates(program) do
+        today = Date.utc_today()
+        upcoming = Enum.reject(dates, &Date.before?(&1, today))
+
+        {:ok, tally} =
+          Repo.transaction(fn ->
+            revived = revive_generated_sessions(program, upcoming)
+            inserted = insert_generated_sessions(program, upcoming)
+            cancelled = cancel_orphaned_sessions(program, upcoming, today)
+
+            %{generated: length(inserted), cancelled: cancelled, revived: revived}
+          end)
+
+        {:ok, tally}
+      end
+    end
+  end
+
+  @doc """
   Starts a scheduled session.
 
   Returns `{:ok, session}`, `{:error, :not_found}`, or `{:error, :invalid_status_transition}`.
@@ -1105,6 +1144,89 @@ defmodule KlassHero.Participation do
 
     {:ok, count}
   end
+
+  defp fetch_program_for_sync(program_id) do
+    case ProgramCatalog.get_program_by_id(program_id) do
+      {:ok, program} -> {:ok, program}
+      {:error, :not_found} -> {:error, :program_not_found}
+    end
+  end
+
+  # A generated session is identified by its slot — date *and* start time — so
+  # moving a program's meeting time orphans the old slot rather than editing it.
+  defp generated_slot_query(program) do
+    from(s in ProgramSession,
+      where: s.program_id == ^program.id,
+      where: s.origin == :generated,
+      where: s.start_time == ^program.meeting_start_time
+    )
+  end
+
+  defp revive_generated_sessions(_program, []), do: 0
+
+  # Without this a narrow-then-revert edit would silently lose those sessions:
+  # the slot's row still exists, so the insert below skips it, and nothing else
+  # would ever move it back off :cancelled.
+  defp revive_generated_sessions(program, dates) do
+    {count, _} =
+      program
+      |> generated_slot_query()
+      |> where([s], s.status == :cancelled and s.session_date in ^dates)
+      |> Repo.update_all(set: [status: :scheduled, updated_at: now_utc()])
+
+    count
+  end
+
+  defp insert_generated_sessions(_program, []), do: []
+
+  defp insert_generated_sessions(program, dates) do
+    now = now_utc()
+
+    rows =
+      for date <- dates do
+        %{
+          id: Ecto.UUID.generate(),
+          program_id: program.id,
+          session_date: date,
+          start_time: program.meeting_start_time,
+          end_time: program.meeting_end_time,
+          status: :scheduled,
+          origin: :generated,
+          location: program.location,
+          lock_version: 1,
+          inserted_at: now,
+          updated_at: now
+        }
+      end
+
+    {_count, inserted} =
+      Repo.insert_all(ProgramSession, rows,
+        on_conflict: :nothing,
+        conflict_target: [:program_id, :session_date, :start_time],
+        returning: [:id, :session_date, :start_time, :end_time]
+      )
+
+    inserted
+  end
+
+  # Only :scheduled rows are swept, so a session already under way or finished
+  # keeps its outcome no matter what happens to the schedule.
+  defp cancel_orphaned_sessions(program, dates, today) do
+    orphans =
+      from(s in ProgramSession,
+        where: s.program_id == ^program.id,
+        where: s.origin == :generated,
+        where: s.status == :scheduled,
+        where: s.session_date >= ^today,
+        where: s.session_date not in ^dates or s.start_time != ^program.meeting_start_time
+      )
+
+    {count, _} = Repo.update_all(orphans, set: [status: :cancelled, updated_at: now_utc()])
+
+    count
+  end
+
+  defp now_utc, do: DateTime.utc_now() |> DateTime.truncate(:second)
 
   defp upcoming_scheduled_session_ids(program_id) do
     today = Date.utc_today()

--- a/lib/klass_hero/participation.ex
+++ b/lib/klass_hero/participation.ex
@@ -401,6 +401,45 @@ defmodule KlassHero.Participation do
       :ok
   end
 
+  @doc """
+  Places a newly-enrolled child on the roster of every upcoming scheduled session
+  of the program. Best-effort: always returns `:ok`.
+
+  Invoked by the `enrollment_created` integration-event handler. Sessions in the
+  past, in progress, completed or cancelled are left alone — enrolling today must
+  never rewrite attendance history.
+  """
+  @spec backfill_roster_for_enrollment(String.t(), String.t()) :: :ok
+  def backfill_roster_for_enrollment(child_id, program_id) when is_binary(child_id) and is_binary(program_id) do
+    context_span entity: "participation_record" do
+      session_ids = upcoming_scheduled_session_ids(program_id)
+      {:ok, seeded_ids} = seed_child_records(session_ids, child_id)
+
+      Logger.info(
+        "[Participation] Backfilled roster — upcoming=#{length(session_ids)} inserted=#{length(seeded_ids)}",
+        child_id: child_id,
+        program_id: program_id
+      )
+
+      # One event per session that actually gained a row, so each session's
+      # read-model count moves by exactly the number of rows it gained.
+      Enum.each(seeded_ids, &safe_publish_roster_seeded(&1, program_id, 1))
+
+      :ok
+    end
+  rescue
+    error ->
+      Logger.error(
+        "[Participation] Failed to backfill roster: #{Exception.message(error)}",
+        child_id: child_id,
+        program_id: program_id,
+        step: "session_query_or_bulk_insert",
+        stacktrace: Exception.format_stacktrace(__STACKTRACE__)
+      )
+
+      :ok
+  end
+
   # ============================================================================
   # Attendance
   # ============================================================================
@@ -1065,6 +1104,47 @@ defmodule KlassHero.Participation do
       |> Repo.update_all(inc: [lock_version: 1], set: [status: :absent, updated_at: now])
 
     {:ok, count}
+  end
+
+  defp upcoming_scheduled_session_ids(program_id) do
+    today = Date.utc_today()
+
+    from(s in ProgramSession,
+      where: s.program_id == ^program_id and s.status == :scheduled and s.session_date >= ^today,
+      select: s.id
+    )
+    |> Repo.all()
+  end
+
+  defp seed_child_records([], _child_id), do: {:ok, []}
+
+  # Returns the ids of sessions that actually gained a row: with `on_conflict:
+  # :nothing`, Postgres RETURNING reports only rows that landed, so a child
+  # already on a roster is skipped silently rather than double-counted.
+  defp seed_child_records(session_ids, child_id) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    rows =
+      Enum.map(session_ids, fn session_id ->
+        %{
+          id: Ecto.UUID.generate(),
+          session_id: session_id,
+          child_id: child_id,
+          status: :registered,
+          lock_version: 1,
+          inserted_at: now,
+          updated_at: now
+        }
+      end)
+
+    {_count, inserted} =
+      Repo.insert_all(ParticipationRecord, rows,
+        on_conflict: :nothing,
+        conflict_target: [:session_id, :child_id],
+        returning: [:session_id]
+      )
+
+    {:ok, Enum.map(inserted, & &1.session_id)}
   end
 
   defp seed_records(_session_id, []), do: {:ok, 0}

--- a/lib/klass_hero/participation.ex
+++ b/lib/klass_hero/participation.ex
@@ -102,16 +102,20 @@ defmodule KlassHero.Participation do
         today = Date.utc_today()
         upcoming = Enum.reject(dates, &Date.before?(&1, today))
 
-        {:ok, tally} =
+        {:ok, {inserted, cancelled, revived}} =
           Repo.transaction(fn ->
             revived = revive_generated_sessions(program, upcoming)
             inserted = insert_generated_sessions(program, upcoming)
             cancelled = cancel_orphaned_sessions(program, upcoming, today)
 
-            %{generated: length(inserted), cancelled: cancelled, revived: revived}
+            {inserted, cancelled, revived}
           end)
 
-        {:ok, tally}
+        # Dispatched after commit, fire-and-forget, as every other write path here.
+        publish_sessions_generated(program_id, inserted)
+        Enum.each(cancelled, &DomainEventBus.dispatch(@context, ParticipationEvents.session_cancelled(&1)))
+
+        {:ok, %{generated: length(inserted), cancelled: length(cancelled), revived: revived}}
       end
     end
   end
@@ -432,6 +436,45 @@ defmodule KlassHero.Participation do
       Logger.error(
         "[Participation] Failed to seed roster: #{Exception.message(error)}",
         session_id: session_id,
+        program_id: program_id,
+        step: "acl_query_or_bulk_insert",
+        stacktrace: Exception.format_stacktrace(__STACKTRACE__)
+      )
+
+      :ok
+  end
+
+  @doc """
+  Seeds the rosters of a batch of sessions that share one program. Best-effort:
+  always returns `:ok`.
+
+  Invoked by the `sessions_generated` integration-event handler. The program's
+  enrolled children are resolved once for the batch, rather than once per
+  session as `seed_session_roster/2` would.
+  """
+  @spec seed_rosters_for_sessions([String.t()], String.t()) :: :ok
+  def seed_rosters_for_sessions([], _program_id), do: :ok
+
+  def seed_rosters_for_sessions(session_ids, program_id) when is_list(session_ids) and is_binary(program_id) do
+    context_span entity: "participation_record" do
+      child_ids = EnrolledChildrenResolver.list_enrolled_child_ids(program_id)
+
+      for session_id <- session_ids do
+        {:ok, count} = seed_records(session_id, child_ids)
+        safe_publish_roster_seeded(session_id, program_id, count)
+      end
+
+      Logger.info(
+        "[Participation] Seeded generated rosters — sessions=#{length(session_ids)} enrolled=#{length(child_ids)}",
+        program_id: program_id
+      )
+
+      :ok
+    end
+  rescue
+    error ->
+      Logger.error(
+        "[Participation] Failed to seed generated rosters: #{Exception.message(error)}",
         program_id: program_id,
         step: "acl_query_or_bulk_insert",
         stacktrace: Exception.format_stacktrace(__STACKTRACE__)
@@ -1221,9 +1264,20 @@ defmodule KlassHero.Participation do
         where: s.session_date not in ^dates or s.start_time != ^program.meeting_start_time
       )
 
-    {count, _} = Repo.update_all(orphans, set: [status: :cancelled, updated_at: now_utc()])
+    # `select` rather than the :returning option — update_all returns the updated
+    # rows only when the query itself selects them.
+    {_count, cancelled} =
+      orphans
+      |> select([s], s)
+      |> Repo.update_all(set: [status: :cancelled, updated_at: now_utc()])
 
-    count
+    cancelled
+  end
+
+  defp publish_sessions_generated(_program_id, []), do: :ok
+
+  defp publish_sessions_generated(program_id, sessions) do
+    DomainEventBus.dispatch(@context, ParticipationEvents.sessions_generated(program_id, sessions))
   end
 
   defp now_utc, do: DateTime.utc_now() |> DateTime.truncate(:second)

--- a/lib/klass_hero/participation/adapters/driving/events/event_handlers/promote_integration_events.ex
+++ b/lib/klass_hero/participation/adapters/driving/events/event_handlers/promote_integration_events.ex
@@ -50,6 +50,13 @@ defmodule KlassHero.Participation.Adapters.Driving.Events.EventHandlers.PromoteI
     )
   end
 
+  def handle(%DomainEvent{event_type: :sessions_generated} = event) do
+    ParticipationIntegrationEvents.sessions_generated(event.aggregate_id, event.payload)
+    |> IntegrationEventPublishing.publish_best_effort("sessions_generated",
+      program_id: event.aggregate_id
+    )
+  end
+
   def handle(%DomainEvent{event_type: :roster_seeded} = event) do
     ParticipationIntegrationEvents.roster_seeded(event.aggregate_id, event.payload)
     |> IntegrationEventPublishing.publish_best_effort("roster_seeded",

--- a/lib/klass_hero/participation/adapters/driving/events/event_handlers/seed_session_roster_handler.ex
+++ b/lib/klass_hero/participation/adapters/driving/events/event_handlers/seed_session_roster_handler.ex
@@ -25,11 +25,20 @@ defmodule KlassHero.Participation.Adapters.Driving.Events.EventHandlers.SeedSess
   alias KlassHero.Shared.Domain.Events.IntegrationEvent
 
   @impl true
-  def subscribed_events, do: [:session_created]
+  def subscribed_events, do: [:session_created, :sessions_generated]
 
   @impl true
   def handle_event(%IntegrationEvent{event_type: :session_created, payload: payload}) do
     Participation.seed_session_roster(payload.session_id, payload.program_id)
+  end
+
+  # A schedule-derived batch shares one program, so the enrolled children are
+  # resolved once for the whole batch rather than once per session.
+  def handle_event(%IntegrationEvent{
+        event_type: :sessions_generated,
+        payload: %{program_id: program_id, sessions: sessions}
+      }) do
+    Participation.seed_rosters_for_sessions(Enum.map(sessions, & &1.session_id), program_id)
   end
 
   def handle_event(_event), do: :ignore

--- a/lib/klass_hero/participation/adapters/driving/events/participation_event_handler.ex
+++ b/lib/klass_hero/participation/adapters/driving/events/participation_event_handler.ex
@@ -26,11 +26,32 @@ defmodule KlassHero.Participation.Adapters.Driving.Events.ParticipationEventHand
   alias KlassHero.Shared.Domain.Events.IntegrationEvent
 
   @impl true
-  def subscribed_events, do: [:child_data_anonymized]
+  def subscribed_events, do: [:child_data_anonymized, :program_created, :program_updated, :enrollment_created]
 
   @impl true
   def handle_event(%IntegrationEvent{event_type: :child_data_anonymized, entity_id: child_id}) do
     anonymize_notes_with_retry(child_id)
+  end
+
+  # Only the program id is taken from the payload: the schedule is re-read from
+  # the owning context, so a lost broadcast can't leave sessions derived from a
+  # stale snapshot. `program_updated` carries no diff, so this runs on every
+  # program write and is a no-op when the schedule hasn't moved.
+  def handle_event(%IntegrationEvent{event_type: type, entity_id: program_id})
+      when type in [:program_created, :program_updated] do
+    case Participation.sync_sessions_for_program(program_id) do
+      {:ok, _tally} -> :ok
+      # A program without a full schedule simply has no sessions to derive.
+      {:error, :incomplete_schedule} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  def handle_event(%IntegrationEvent{
+        event_type: :enrollment_created,
+        payload: %{child_id: child_id, program_id: program_id}
+      }) do
+    Participation.backfill_roster_for_enrollment(child_id, program_id)
   end
 
   def handle_event(_event), do: :ignore

--- a/lib/klass_hero/participation/domain/events/participation_events.ex
+++ b/lib/klass_hero/participation/domain/events/participation_events.ex
@@ -37,8 +37,10 @@ defmodule KlassHero.Participation.Domain.Events.ParticipationEvents do
   # atom moves the publisher and every LiveView subscriber together.
   @event_aggregates %{
     session_created: :participation,
+    sessions_generated: :participation,
     session_started: :participation,
     session_completed: :participation,
+    session_cancelled: :participation,
     roster_seeded: :participation,
     child_checked_in: :participation,
     child_checked_out: :participation,
@@ -77,6 +79,45 @@ defmodule KlassHero.Participation.Domain.Events.ParticipationEvents do
     }
 
     new_event(:session_created, session.id, payload, opts)
+  end
+
+  @doc """
+  Creates a sessions_generated event for a batch derived from a program's schedule.
+
+  One event per sync rather than one per session: consumers resolve the program
+  once for the whole batch, and the roster is seeded in a single pass instead of
+  re-querying enrollments per session.
+  """
+  @spec sessions_generated(String.t(), [map()], keyword()) :: DomainEvent.t()
+  def sessions_generated(program_id, sessions, opts \\ []) when is_binary(program_id) and is_list(sessions) do
+    payload = %{
+      program_id: program_id,
+      sessions:
+        for session <- sessions do
+          %{
+            session_id: session.id,
+            program_id: program_id,
+            session_date: session.session_date,
+            start_time: session.start_time,
+            end_time: session.end_time
+          }
+        end
+    }
+
+    new_event(:sessions_generated, program_id, payload, opts)
+  end
+
+  @doc "Creates a session_cancelled event."
+  @spec session_cancelled(ProgramSession.t(), keyword()) :: DomainEvent.t()
+  def session_cancelled(%ProgramSession{} = session, opts \\ []) do
+    payload = %{
+      session_id: session.id,
+      program_id: session.program_id,
+      session_date: session.session_date,
+      start_time: session.start_time
+    }
+
+    new_event(:session_cancelled, session.id, payload, opts)
   end
 
   @doc "Creates a session_started event."

--- a/lib/klass_hero/participation/domain/events/participation_integration_events.ex
+++ b/lib/klass_hero/participation/domain/events/participation_integration_events.ex
@@ -174,6 +174,35 @@ defmodule KlassHero.Participation.Domain.Events.ParticipationIntegrationEvents d
           "session_completed/3 requires a non-empty session_id string, got: #{inspect(session_id)}"
   end
 
+  @doc """
+  Creates a `sessions_generated` integration event for a schedule-derived batch.
+
+  Keyed on the program rather than a session: the batch is the unit, so consumers
+  resolve the program once and write all its rows in a single pass.
+  """
+  def sessions_generated(program_id, payload \\ %{}, opts \\ [])
+
+  def sessions_generated(program_id, %{sessions: _} = payload, opts)
+      when is_binary(program_id) and byte_size(program_id) > 0 do
+    IntegrationEvent.new(
+      :sessions_generated,
+      @source_context,
+      :program,
+      program_id,
+      Map.put(payload, :program_id, program_id),
+      opts
+    )
+  end
+
+  def sessions_generated(program_id, _payload, _opts) when is_binary(program_id) and byte_size(program_id) > 0 do
+    raise ArgumentError, "sessions_generated missing required payload key: :sessions"
+  end
+
+  def sessions_generated(program_id, _payload, _opts) do
+    raise ArgumentError,
+          "sessions_generated/3 requires a non-empty program_id string, got: #{inspect(program_id)}"
+  end
+
   @doc "Creates a `roster_seeded` integration event."
   def roster_seeded(session_id, payload \\ %{}, opts \\ [])
 

--- a/lib/klass_hero/participation/program_session.ex
+++ b/lib/klass_hero/participation/program_session.ex
@@ -32,6 +32,10 @@ defmodule KlassHero.Participation.ProgramSession do
     field :max_capacity, :integer
     field :lock_version, :integer, default: 1
 
+    # Deliberately absent from both changesets: set server-side only, so the
+    # manual create path can never claim a session was schedule-derived.
+    field :origin, Ecto.Enum, values: [:generated, :manual], default: :manual
+
     has_many :participation_records, ParticipationRecord, foreign_key: :session_id
 
     timestamps(type: :utc_datetime)

--- a/lib/klass_hero/program_catalog.ex
+++ b/lib/klass_hero/program_catalog.ex
@@ -293,6 +293,16 @@ defmodule KlassHero.ProgramCatalog do
   @spec format_price(Decimal.t() | number() | nil) :: String.t()
   defdelegate format_price(price), to: ProgramPricing
 
+  @doc """
+  Expands a program's recurring schedule into the dates it meets on.
+
+  Exposed on the facade so other contexts derive session dates without importing
+  the schema or the weekday vocabulary.
+  """
+  @spec meeting_dates(Program.t()) ::
+          {:ok, [Date.t()]} | {:error, :incomplete_schedule | :schedule_range_too_large}
+  defdelegate meeting_dates(program), to: Program
+
   @doc "Checks if the program's registration is currently open."
   @spec registration_open?(Program.t()) :: boolean()
   defdelegate registration_open?(program), to: Program

--- a/lib/klass_hero/program_catalog/program.ex
+++ b/lib/klass_hero/program_catalog/program.ex
@@ -207,6 +207,64 @@ defmodule KlassHero.ProgramCatalog.Program do
 
   @valid_weekdays ~w(Monday Tuesday Wednesday Thursday Friday Saturday Sunday)
 
+  # Derived from @valid_weekdays so the weekday vocabulary has one definition:
+  # `Date.day_of_week/1` numbers Monday 1 through Sunday 7.
+  @weekday_numbers @valid_weekdays |> Enum.with_index(1) |> Map.new()
+
+  # A term of twice-weekly sessions is ~40; the cap only rejects schedules no
+  # provider plausibly means, rather than letting one expand to tens of thousands
+  # of rows in a single insert.
+  @max_meeting_dates 500
+
+  @doc """
+  Expands the advertised recurring schedule into the concrete dates it falls on,
+  in ascending order.
+
+  Pure. The weekday vocabulary stays here beside `validate_meeting_days/1`, so
+  consumers receive `Date` structs and never handle day-name strings themselves.
+
+  Requires the whole schedule — meeting days plus both times plus both dates.
+  A partial schedule is `{:error, :incomplete_schedule}` rather than an empty
+  list, so a caller can tell "this program has no schedule" apart from "this
+  schedule genuinely has no matching dates".
+  """
+  @spec meeting_dates(t()) :: {:ok, [Date.t()]} | {:error, :incomplete_schedule | :schedule_range_too_large}
+  def meeting_dates(%__MODULE__{} = program) do
+    with {:ok, weekdays} <- scheduled_weekdays(program) do
+      dates =
+        program.start_date
+        |> Date.range(program.end_date)
+        |> Stream.filter(&(Date.day_of_week(&1) in weekdays))
+        |> Enum.take(@max_meeting_dates + 1)
+
+      if length(dates) > @max_meeting_dates do
+        {:error, :schedule_range_too_large}
+      else
+        {:ok, dates}
+      end
+    end
+  end
+
+  defp scheduled_weekdays(%__MODULE__{
+         meeting_days: [_ | _] = days,
+         meeting_start_time: %Time{},
+         meeting_end_time: %Time{},
+         start_date: %Date{} = start_date,
+         end_date: %Date{} = end_date
+       }) do
+    # Unrecognised names are dropped rather than raising: the changeset already
+    # rejects them, so reaching here means data that predates that validation.
+    weekdays = for day <- days, number = Map.get(@weekday_numbers, day), into: MapSet.new(), do: number
+
+    if Enum.empty?(weekdays) or Date.after?(start_date, end_date) do
+      {:error, :incomplete_schedule}
+    else
+      {:ok, weekdays}
+    end
+  end
+
+  defp scheduled_weekdays(%__MODULE__{}), do: {:error, :incomplete_schedule}
+
   defp validate_meeting_days(changeset) do
     validate_change(changeset, :meeting_days, fn :meeting_days, days ->
       invalid = Enum.reject(days, &(&1 in @valid_weekdays))

--- a/lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex
+++ b/lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex
@@ -75,11 +75,14 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
     update_status(event.entity_id, :cancelled)
   end
 
+  # `seeded_count` is the delta a seeding inserted, not a running total — a roster
+  # is seeded once at session creation and again whenever a child enrols later, so
+  # this accumulates rather than overwrites.
   def handle_event(:roster_seeded, %IntegrationEvent{payload: %{seeded_count: seeded_count}} = event) do
     now = DateTime.utc_now() |> DateTime.truncate(:second)
 
     from(d in ProviderSessionDetailSchema, where: d.session_id == ^event.entity_id)
-    |> Repo.update_all(set: [total_count: seeded_count, updated_at: now])
+    |> Repo.update_all(inc: [total_count: seeded_count], set: [updated_at: now])
     |> warn_if_missing("roster_seeded", session_id: event.entity_id, seeded_count: seeded_count)
   end
 

--- a/lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex
+++ b/lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex
@@ -30,6 +30,7 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
   use KlassHero.Shared.Projection,
     topics: [
       "integration:participation:session_created",
+      "integration:participation:sessions_generated",
       "integration:participation:session_started",
       "integration:participation:session_completed",
       "integration:participation:session_cancelled",
@@ -61,6 +62,12 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
     )
 
     project_session_created(event.payload)
+  end
+
+  # The batch shares one program, so its title/provider/staff resolve once here
+  # rather than once per session as the per-session clause above does.
+  def handle_event(:sessions_generated, %IntegrationEvent{payload: %{program_id: program_id, sessions: sessions}}) do
+    Enum.each(sessions, &project_session_created(Map.put(&1, :program_id, program_id)))
   end
 
   def handle_event(:session_started, %IntegrationEvent{} = event) do

--- a/lib/klass_hero_web/components/participation_components.ex
+++ b/lib/klass_hero_web/components/participation_components.ex
@@ -47,6 +47,13 @@ defmodule KlassHeroWeb.ParticipationComponents do
     generic label.
     """
 
+  attr :attendance, :map,
+    default: nil,
+    doc: """
+    `%{roster: n, checked_in: n}` for this session. Nil hides the line — used by
+    callers with no roster data to hand rather than rendering a misleading zero.
+    """
+
   slot :actions, doc: "Action buttons for the session"
 
   def participation_card(assigns) do
@@ -77,14 +84,20 @@ defmodule KlassHeroWeb.ParticipationComponents do
           <span>{Map.get(@session, :location) || gettext("Location TBD")}</span>
         </div>
 
-        <%= if @role in [:provider, :staff] && Map.get(@session, :capacity) do %>
+        <%= if @role in [:provider, :staff] && @attendance do %>
           <div class="flex items-center gap-2 text-sm text-hero-black-100">
             <.icon name="hero-user-group" class="w-4 h-4 text-hero-grey-400" />
             <span>
-              {gettext("%{checked_in} / %{capacity} checked in",
-                checked_in: Map.get(@session, :checked_in_count, 0),
-                capacity: Map.get(@session, :capacity)
-              )}
+              <%= if @session.status == :scheduled do %>
+                {ngettext("%{count} child enrolled", "%{count} children enrolled", @attendance.roster,
+                  count: @attendance.roster
+                )}
+              <% else %>
+                {gettext("%{checked_in} of %{roster} checked in",
+                  checked_in: @attendance.checked_in,
+                  roster: @attendance.roster
+                )}
+              <% end %>
             </span>
           </div>
         <% end %>

--- a/lib/klass_hero_web/components/participation_components.ex
+++ b/lib/klass_hero_web/components/participation_components.ex
@@ -38,6 +38,15 @@ defmodule KlassHeroWeb.ParticipationComponents do
     doc: "User role viewing the card"
 
   attr :class, :string, default: "", doc: "Additional CSS classes"
+
+  attr :program_name, :string,
+    default: nil,
+    doc: """
+    Heading for the card. A bare `ProgramSession` carries only `program_id`, so
+    callers that can resolve the title pass it here; the rest fall back to a
+    generic label.
+    """
+
   slot :actions, doc: "Action buttons for the session"
 
   def participation_card(assigns) do
@@ -51,7 +60,7 @@ defmodule KlassHeroWeb.ParticipationComponents do
       <div class="flex items-start justify-between gap-4 mb-4">
         <div class="flex-1">
           <h3 class="text-lg font-semibold text-hero-black">
-            {Map.get(@session, :program_name, gettext("Session"))}
+            {@program_name || Map.get(@session, :program_name) || gettext("Session")}
           </h3>
           <p class="text-sm text-hero-black-100 mt-1">
             {format_session_datetime(@session)}
@@ -63,7 +72,9 @@ defmodule KlassHeroWeb.ParticipationComponents do
       <div class="space-y-2 mb-4">
         <div class="flex items-center gap-2 text-sm text-hero-black-100">
           <.icon name="hero-map-pin" class="w-4 h-4 text-hero-grey-400" />
-          <span>{Map.get(@session, :location, gettext("Location TBD"))}</span>
+          <%!-- `Map.get/3`'s default never fires here: the key exists holding nil,
+                which renders a lone pin icon with no text. --%>
+          <span>{Map.get(@session, :location) || gettext("Location TBD")}</span>
         </div>
 
         <%= if @role in [:provider, :staff] && Map.get(@session, :capacity) do %>

--- a/lib/klass_hero_web/live/provider/participation_live.html.heex
+++ b/lib/klass_hero_web/live/provider/participation_live.html.heex
@@ -18,7 +18,11 @@
     </.page_header>
 
     <div class="mb-6">
-      <.participation_card session={@session} role={:provider} />
+      <.participation_card
+        session={@session}
+        role={:provider}
+        attendance={Participation.attendance_from_records(@participation_records)}
+      />
     </div>
 
     <div class="mt-6">

--- a/lib/klass_hero_web/live/provider/sessions_live.ex
+++ b/lib/klass_hero_web/live/provider/sessions_live.ex
@@ -186,18 +186,9 @@ defmodule KlassHeroWeb.Provider.SessionsLive do
   end
 
   @impl true
-  def handle_info(
-        {:domain_event, %DomainEvent{event_type: event_type, aggregate_id: session_id, payload: payload}},
-        socket
-      )
+  def handle_info({:domain_event, %DomainEvent{event_type: event_type, aggregate_id: session_id}}, socket)
       when event_type in [:session_started, :session_completed, :session_created, :session_cancelled, :roster_seeded] do
-    # session_created may be for a different date; only insert if it matches the current view.
-    if event_type == :session_created and
-         Map.get(payload, :session_date) != socket.assigns.selected_date do
-      {:noreply, socket}
-    else
-      {:noreply, update_session_in_stream(socket, session_id)}
-    end
+    {:noreply, update_session_in_stream(socket, session_id)}
   end
 
   # A generated batch is keyed on the program, not one session, and may span any
@@ -214,6 +205,13 @@ defmodule KlassHeroWeb.Provider.SessionsLive do
       ) do
     {:noreply, update_session_in_stream(socket, session_id)}
   end
+
+  # The provider topic carries every participation event for this provider, not
+  # only the ones this view renders — child_checked_out and child_marked_absent
+  # already arrive here. Without this, an unmatched event is a FunctionClauseError
+  # that takes the LiveView down. Mirrors ParticipationLive and StaffParticipationLive.
+  @impl true
+  def handle_info({:domain_event, %DomainEvent{}}, socket), do: {:noreply, socket}
 
   defp build_initial_form_data(selected_date) do
     %{
@@ -379,7 +377,15 @@ defmodule KlassHeroWeb.Provider.SessionsLive do
   defp update_session_in_stream(socket, session_id) do
     case Participation.get_session_with_roster(session_id) do
       {:ok, %{session: session}} ->
-        stream_insert(socket, :sessions, session)
+        # Session events fan out across dates — a schedule edit cancels every
+        # orphaned date at once, an enrolment seeds every upcoming roster — so
+        # check the session's own date rather than trusting the event to concern
+        # the day on screen.
+        if session.session_date == socket.assigns.selected_date do
+          stream_insert(socket, :sessions, session)
+        else
+          socket
+        end
 
       {:error, reason} ->
         Logger.error(

--- a/lib/klass_hero_web/live/provider/sessions_live.ex
+++ b/lib/klass_hero_web/live/provider/sessions_live.ex
@@ -50,6 +50,7 @@ defmodule KlassHeroWeb.Provider.SessionsLive do
       |> assign(:selected_date, selected_date)
       |> assign(:provider_programs, provider_programs)
       |> assign(:provider_program_ids, provider_program_ids)
+      |> assign(:program_names, program_names(provider_programs))
       |> assign(:business, business)
       |> assign(:form, nil)
       |> stream(:sessions, [])
@@ -193,9 +194,20 @@ defmodule KlassHeroWeb.Provider.SessionsLive do
 
   # A generated batch is keyed on the program, not one session, and may span any
   # number of dates — so reload the day being viewed rather than patching rows.
+  # The batch may also belong to a program created after mount, so refresh the
+  # title map or its sessions would render under the generic fallback.
   @impl true
   def handle_info({:domain_event, %DomainEvent{event_type: :sessions_generated}}, socket) do
-    {:noreply, load_sessions(socket)}
+    programs = ProgramCatalog.list_programs_for_provider(socket.assigns.provider_id)
+
+    socket =
+      socket
+      |> assign(:provider_programs, programs)
+      |> assign(:provider_program_ids, MapSet.new(programs, & &1.id))
+      |> assign(:program_names, program_names(programs))
+      |> load_sessions()
+
+    {:noreply, socket}
   end
 
   @impl true
@@ -212,6 +224,8 @@ defmodule KlassHeroWeb.Provider.SessionsLive do
   # that takes the LiveView down. Mirrors ParticipationLive and StaffParticipationLive.
   @impl true
   def handle_info({:domain_event, %DomainEvent{}}, socket), do: {:noreply, socket}
+
+  defp program_names(programs), do: Map.new(programs, &{&1.id, &1.title})
 
   defp build_initial_form_data(selected_date) do
     %{

--- a/lib/klass_hero_web/live/provider/sessions_live.ex
+++ b/lib/klass_hero_web/live/provider/sessions_live.ex
@@ -190,7 +190,7 @@ defmodule KlassHeroWeb.Provider.SessionsLive do
         {:domain_event, %DomainEvent{event_type: event_type, aggregate_id: session_id, payload: payload}},
         socket
       )
-      when event_type in [:session_started, :session_completed, :session_created, :roster_seeded] do
+      when event_type in [:session_started, :session_completed, :session_created, :session_cancelled, :roster_seeded] do
     # session_created may be for a different date; only insert if it matches the current view.
     if event_type == :session_created and
          Map.get(payload, :session_date) != socket.assigns.selected_date do
@@ -198,6 +198,13 @@ defmodule KlassHeroWeb.Provider.SessionsLive do
     else
       {:noreply, update_session_in_stream(socket, session_id)}
     end
+  end
+
+  # A generated batch is keyed on the program, not one session, and may span any
+  # number of dates — so reload the day being viewed rather than patching rows.
+  @impl true
+  def handle_info({:domain_event, %DomainEvent{event_type: :sessions_generated}}, socket) do
+    {:noreply, load_sessions(socket)}
   end
 
   @impl true

--- a/lib/klass_hero_web/live/provider/sessions_live.ex
+++ b/lib/klass_hero_web/live/provider/sessions_live.ex
@@ -252,6 +252,7 @@ defmodule KlassHeroWeb.Provider.SessionsLive do
   defp apply_sessions_result(socket, {:ok, sessions}) do
     socket
     |> stream(:sessions, sessions, reset: true)
+    |> assign(:attendance, Participation.session_attendance_counts(Enum.map(sessions, & &1.id)))
     |> assign(:sessions_error, nil)
   end
 
@@ -390,13 +391,19 @@ defmodule KlassHeroWeb.Provider.SessionsLive do
 
   defp update_session_in_stream(socket, session_id) do
     case Participation.get_session_with_roster(session_id) do
-      {:ok, %{session: session}} ->
+      {:ok, %{session: session, roster: roster}} ->
         # Session events fan out across dates — a schedule edit cancels every
         # orphaned date at once, an enrolment seeds every upcoming roster — so
         # check the session's own date rather than trusting the event to concern
         # the day on screen.
         if session.session_date == socket.assigns.selected_date do
-          stream_insert(socket, :sessions, session)
+          # The roster came back with the session, so the recount is free.
+          socket
+          |> assign(
+            :attendance,
+            Map.put(socket.assigns.attendance, session.id, Participation.attendance_from_roster(roster))
+          )
+          |> stream_insert(:sessions, session)
         else
           socket
         end

--- a/lib/klass_hero_web/live/provider/sessions_live.html.heex
+++ b/lib/klass_hero_web/live/provider/sessions_live.html.heex
@@ -33,7 +33,11 @@
 
   <div id="sessions" phx-update="stream" class="space-y-4">
     <div :for={{id, session} <- @streams.sessions} id={id}>
-      <.participation_card session={session} role={:provider}>
+      <.participation_card
+        session={session}
+        role={:provider}
+        program_name={@program_names[session.program_id]}
+      >
         <:actions>
           <%= cond do %>
             <% session.status == :scheduled -> %>

--- a/lib/klass_hero_web/live/provider/sessions_live.html.heex
+++ b/lib/klass_hero_web/live/provider/sessions_live.html.heex
@@ -37,6 +37,7 @@
         session={session}
         role={:provider}
         program_name={@program_names[session.program_id]}
+        attendance={@attendance[session.id]}
       >
         <:actions>
           <%= cond do %>

--- a/lib/klass_hero_web/live/staff/staff_participation_live.html.heex
+++ b/lib/klass_hero_web/live/staff/staff_participation_live.html.heex
@@ -18,7 +18,11 @@
     </.page_header>
 
     <div class="mb-6">
-      <.participation_card session={@session} role={:staff} />
+      <.participation_card
+        session={@session}
+        role={:staff}
+        attendance={Participation.attendance_from_records(@participation_records)}
+      />
     </div>
 
     <div class="mt-6">

--- a/lib/klass_hero_web/live/staff/staff_sessions_live.ex
+++ b/lib/klass_hero_web/live/staff/staff_sessions_live.ex
@@ -14,11 +14,13 @@ defmodule KlassHeroWeb.Staff.StaffSessionsLive do
     provider_id = staff_member.provider_id
     selected_date = Date.utc_today()
 
-    {_programs, assigned_program_ids} = StaffLiveHelpers.load_assigned_programs(staff_member)
+    {programs, assigned_program_ids} = StaffLiveHelpers.load_assigned_programs(staff_member)
 
     socket =
       socket
       |> assign(:page_title, gettext("My Sessions"))
+      |> assign(:program_names, Map.new(programs, &{&1.id, &1.title}))
+      |> assign(:attendance, %{})
       |> assign(:active_nav, :roster)
       |> assign(:provider_id, provider_id)
       |> assign(:staff_member, staff_member)
@@ -124,17 +126,16 @@ defmodule KlassHeroWeb.Staff.StaffSessionsLive do
   end
 
   @impl true
-  def handle_info(
-        {:domain_event, %DomainEvent{event_type: event_type, aggregate_id: session_id, payload: payload}},
-        socket
-      )
-      when event_type in [:session_started, :session_completed, :session_created, :roster_seeded] do
-    if event_type == :session_created and
-         Map.get(payload, :session_date) != socket.assigns.selected_date do
-      {:noreply, socket}
-    else
-      {:noreply, update_session_in_stream(socket, session_id)}
-    end
+  def handle_info({:domain_event, %DomainEvent{event_type: event_type, aggregate_id: session_id}}, socket)
+      when event_type in [:session_started, :session_completed, :session_created, :session_cancelled, :roster_seeded] do
+    {:noreply, update_session_in_stream(socket, session_id)}
+  end
+
+  # A generated batch spans many dates and is keyed on the program, so reload the
+  # day being viewed rather than patching individual rows.
+  @impl true
+  def handle_info({:domain_event, %DomainEvent{event_type: :sessions_generated}}, socket) do
+    {:noreply, load_sessions(socket)}
   end
 
   @impl true
@@ -144,6 +145,11 @@ defmodule KlassHeroWeb.Staff.StaffSessionsLive do
       ) do
     {:noreply, update_session_in_stream(socket, session_id)}
   end
+
+  # The provider topic carries every participation event for this provider, not
+  # only the ones this view renders.
+  @impl true
+  def handle_info({:domain_event, %DomainEvent{}}, socket), do: {:noreply, socket}
 
   defp load_sessions(socket) do
     provider_id = socket.assigns.provider_id
@@ -160,6 +166,7 @@ defmodule KlassHeroWeb.Staff.StaffSessionsLive do
 
     socket
     |> stream(:sessions, filtered, reset: true)
+    |> assign(:attendance, Participation.session_attendance_counts(Enum.map(filtered, & &1.id)))
     |> assign(:sessions_error, nil)
   end
 
@@ -190,9 +197,18 @@ defmodule KlassHeroWeb.Staff.StaffSessionsLive do
 
   defp update_session_in_stream(socket, session_id) do
     case Participation.get_session_with_roster(session_id) do
-      {:ok, %{session: session}} ->
-        if MapSet.member?(socket.assigns.assigned_program_ids, session.program_id) do
-          stream_insert(socket, :sessions, session)
+      {:ok, %{session: session, roster: roster}} ->
+        # Session events fan out across dates — a schedule edit cancels every
+        # orphaned date, an enrolment seeds every upcoming roster — so check the
+        # session's own date rather than trusting the event to concern this day.
+        if MapSet.member?(socket.assigns.assigned_program_ids, session.program_id) and
+             session.session_date == socket.assigns.selected_date do
+          socket
+          |> assign(
+            :attendance,
+            Map.put(socket.assigns.attendance, session.id, Participation.attendance_from_roster(roster))
+          )
+          |> stream_insert(:sessions, session)
         else
           socket
         end
@@ -233,7 +249,12 @@ defmodule KlassHeroWeb.Staff.StaffSessionsLive do
 
       <div id="sessions" phx-update="stream" class="space-y-4">
         <div :for={{id, session} <- @streams.sessions} id={id}>
-          <.participation_card session={session} role={:staff}>
+          <.participation_card
+            session={session}
+            role={:staff}
+            program_name={@program_names[session.program_id]}
+            attendance={@attendance[session.id]}
+          >
             <:actions>
               <%= cond do %>
                 <% session.status == :scheduled -> %>

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -694,7 +694,7 @@ msgid "Introduction"
 msgstr "Einleitung"
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:113
-#: lib/klass_hero_web/live/provider/sessions_live.ex:348
+#: lib/klass_hero_web/live/provider/sessions_live.ex:355
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:64
 #, elixir-autogen, elixir-format
 msgid "Invalid date format"
@@ -3997,7 +3997,7 @@ msgstr "%{checked_in} / %{total} eingecheckt"
 msgid "%{count} unread"
 msgstr "%{count} ungelesen"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:366
+#: lib/klass_hero_web/live/provider/sessions_live.ex:373
 #, elixir-autogen, elixir-format
 msgid "A session already exists at this time"
 msgstr "Zu dieser Zeit existiert bereits eine Sitzung"
@@ -4176,8 +4176,8 @@ msgstr "Sitzung erstellen"
 msgid "Date"
 msgstr "Datum"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:342
-#: lib/klass_hero_web/live/provider/sessions_live.ex:343
+#: lib/klass_hero_web/live/provider/sessions_live.ex:349
+#: lib/klass_hero_web/live/provider/sessions_live.ex:350
 #, elixir-autogen, elixir-format
 msgid "Date is required"
 msgstr "Datum ist erforderlich"
@@ -4220,7 +4220,7 @@ msgstr "E-Mails"
 msgid "Emergency: %{details}"
 msgstr "Notfall: %{details}"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:365
+#: lib/klass_hero_web/live/provider/sessions_live.ex:372
 #, elixir-autogen, elixir-format
 msgid "End time must be after start time"
 msgstr "Die Endzeit muss nach der Startzeit liegen"
@@ -4235,7 +4235,7 @@ msgstr "Erwartet"
 msgid "Failed to archive email"
 msgstr "E-Mail konnte nicht archiviert werden"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:302
+#: lib/klass_hero_web/live/provider/sessions_live.ex:309
 #, elixir-autogen, elixir-format
 msgid "Failed to create session: %{reason}"
 msgstr "Sitzung konnte nicht erstellt werden: %{reason}"
@@ -4292,7 +4292,7 @@ msgid "Invalid Invitation"
 msgstr "Ungültige Einladung"
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:259
-#: lib/klass_hero_web/live/provider/sessions_live.ex:361
+#: lib/klass_hero_web/live/provider/sessions_live.ex:368
 #, elixir-autogen, elixir-format
 msgid "Invalid time format"
 msgstr "Ungültiges Zeitformat"
@@ -4431,7 +4431,7 @@ msgstr "Ausstehende Überprüfungen"
 msgid "Please explain why you're rejecting this note..."
 msgstr "Bitte erklären Sie, warum Sie diese Notiz ablehnen..."
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:368
+#: lib/klass_hero_web/live/provider/sessions_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "Please fill in all required fields"
 msgstr "Bitte füllen Sie alle erforderlichen Felder aus"
@@ -4555,7 +4555,7 @@ msgstr "Sitzungsnotizen (optional)"
 msgid "Session Roster"
 msgstr "Teilnehmerliste"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:284
+#: lib/klass_hero_web/live/provider/sessions_live.ex:291
 #, elixir-autogen, elixir-format
 msgid "Session created successfully"
 msgstr "Sitzung erfolgreich erstellt"
@@ -4621,8 +4621,8 @@ msgstr "Diese Einladung wurde bereits verwendet."
 msgid "This invite link is invalid or has expired."
 msgstr "Dieser Einladungslink ist ungültig oder abgelaufen."
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:352
-#: lib/klass_hero_web/live/provider/sessions_live.ex:353
+#: lib/klass_hero_web/live/provider/sessions_live.ex:359
+#: lib/klass_hero_web/live/provider/sessions_live.ex:360
 #, elixir-autogen, elixir-format
 msgid "Time is required"
 msgstr "Uhrzeit ist erforderlich"

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -631,7 +631,7 @@ msgstr "Einchecken fehlgeschlagen: %{reason}"
 msgid "Failed to check out: %{reason}"
 msgstr "Auschecken fehlgeschlagen: %{reason}"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:158
+#: lib/klass_hero_web/live/provider/sessions_live.ex:159
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:117
 #, elixir-autogen, elixir-format
 msgid "Failed to complete session: %{reason}"
@@ -642,7 +642,7 @@ msgstr "Sitzung konnte nicht abgeschlossen werden: %{reason}"
 msgid "Failed to delete account. Please try again."
 msgstr "Konto konnte nicht gelöscht werden. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:135
+#: lib/klass_hero_web/live/provider/sessions_live.ex:136
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:88
 #, elixir-autogen, elixir-format
 msgid "Failed to start session: %{reason}"
@@ -693,8 +693,8 @@ msgstr "Geistiges Eigentum"
 msgid "Introduction"
 msgstr "Einleitung"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:113
-#: lib/klass_hero_web/live/provider/sessions_live.ex:355
+#: lib/klass_hero_web/live/provider/sessions_live.ex:114
+#: lib/klass_hero_web/live/provider/sessions_live.ex:367
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:64
 #, elixir-autogen, elixir-format
 msgid "Invalid date format"
@@ -898,7 +898,7 @@ msgstr "Wählen Sie eine oder beide Optionen"
 msgid "Send Message"
 msgstr "Nachricht senden"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:144
+#: lib/klass_hero_web/live/provider/sessions_live.ex:145
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:103
 #, elixir-autogen, elixir-format
 msgid "Session completed successfully"
@@ -912,7 +912,7 @@ msgstr "Sitzung erfolgreich abgeschlossen"
 msgid "Session not found"
 msgstr "Sitzung nicht gefunden"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:121
+#: lib/klass_hero_web/live/provider/sessions_live.ex:122
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:74
 #, elixir-autogen, elixir-format
 msgid "Session started successfully"
@@ -1393,7 +1393,7 @@ msgid "Failed to load participation history"
 msgstr "Teilnahmeverlauf konnte nicht geladen werden"
 
 #: lib/klass_hero_web/live/provider/participation_live.ex:28
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:60
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:64
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:29
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:260
 #, elixir-autogen, elixir-format
@@ -1822,9 +1822,9 @@ msgstr "Rundnachricht"
 msgid "Broadcast sent to %{count} parents"
 msgstr "Rundnachricht an %{count} Eltern gesendet"
 
-#: lib/klass_hero_web/components/participation_components.ex:417
-#: lib/klass_hero_web/components/participation_components.ex:607
-#: lib/klass_hero_web/components/participation_components.ex:693
+#: lib/klass_hero_web/components/participation_components.ex:428
+#: lib/klass_hero_web/components/participation_components.ex:618
+#: lib/klass_hero_web/components/participation_components.ex:704
 #: lib/klass_hero_web/components/provider_components.ex:817
 #: lib/klass_hero_web/components/provider_components.ex:1214
 #: lib/klass_hero_web/components/provider_components.ex:1919
@@ -1833,7 +1833,7 @@ msgstr "Rundnachricht an %{count} Eltern gesendet"
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:222
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:356
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:186
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:190
 #: lib/klass_hero_web/live/settings/children_live.ex:579
 #: lib/klass_hero_web/live/settings/children_live.ex:738
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:233
@@ -2257,7 +2257,7 @@ msgstr "Beim Import ist ein unerwarteter Fehler aufgetreten."
 msgid "Approve"
 msgstr "Genehmigen"
 
-#: lib/klass_hero_web/components/participation_components.ex:802
+#: lib/klass_hero_web/components/participation_components.ex:813
 #: lib/klass_hero_web/components/provider_components.ex:47
 #: lib/klass_hero_web/live/admin/sessions_live.ex:294
 #: lib/klass_hero_web/live/admin/verifications_live.ex:202
@@ -2505,7 +2505,7 @@ msgid "End Date"
 msgstr "Enddatum"
 
 #: lib/klass_hero_web/components/provider_components.ex:952
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:161
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "End Time"
 msgstr "Endzeit"
@@ -2700,7 +2700,7 @@ msgid "Leave unchecked to allow all genders."
 msgstr "Nicht markiert lassen, um alle Geschlechter zuzulassen."
 
 #: lib/klass_hero_web/components/provider_components.ex:908
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:167
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "Location"
 msgstr "Ort"
@@ -2859,7 +2859,7 @@ msgstr "Teilnahmevoraussetzungen"
 msgid "Participant Restrictions (optional)"
 msgstr "Teilnahmebeschränkungen (optional)"
 
-#: lib/klass_hero_web/components/participation_components.ex:801
+#: lib/klass_hero_web/components/participation_components.ex:812
 #: lib/klass_hero_web/components/provider_components.ex:292
 #, elixir-autogen, elixir-format
 msgid "Pending Review"
@@ -2938,7 +2938,7 @@ msgstr "Anbieterprofil nicht gefunden."
 msgid "Read our founding story →"
 msgstr "Lesen Sie unsere Gründungsgeschichte →"
 
-#: lib/klass_hero_web/components/participation_components.ex:781
+#: lib/klass_hero_web/components/participation_components.ex:792
 #: lib/klass_hero_web/components/provider_components.ex:2187
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
@@ -3006,7 +3006,7 @@ msgstr "Anmeldung öffnet am %{date}"
 msgid "Reject"
 msgstr "Ablehnen"
 
-#: lib/klass_hero_web/components/participation_components.ex:803
+#: lib/klass_hero_web/components/participation_components.ex:814
 #: lib/klass_hero_web/components/provider_components.ex:48
 #: lib/klass_hero_web/live/admin/verifications_live.ex:207
 #, elixir-autogen, elixir-format
@@ -3128,7 +3128,7 @@ msgid "Start Date"
 msgstr "Startdatum"
 
 #: lib/klass_hero_web/components/provider_components.ex:947
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:160
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:164
 #, elixir-autogen, elixir-format
 msgid "Start Time"
 msgstr "Startzeit"
@@ -3536,7 +3536,7 @@ msgstr "Diese Löschanfrage ist abgelaufen. Bitte versuchen Sie es erneut."
 msgid "A reason is required for corrections"
 msgstr "Ein Grund für die Korrektur ist erforderlich"
 
-#: lib/klass_hero_web/components/participation_components.ex:787
+#: lib/klass_hero_web/components/participation_components.ex:798
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:201
 #, elixir-autogen, elixir-format
 msgid "Absent"
@@ -3666,7 +3666,7 @@ msgstr "Kind"
 msgid "Coming soon! Sign up for our newsletter to be notified when gift vouchers launch."
 msgstr "Demnächst verfügbar! Melden Sie sich für unseren Newsletter an, um benachrichtigt zu werden, sobald Geschenkgutscheine verfügbar sind."
 
-#: lib/klass_hero_web/components/participation_components.ex:784
+#: lib/klass_hero_web/components/participation_components.ex:795
 #, elixir-autogen, elixir-format
 msgid "Completed"
 msgstr "Abgeschlossen"
@@ -3739,7 +3739,7 @@ msgstr "So werden Sie bezahlt:"
 msgid "How does the booking system work?"
 msgstr "Wie funktioniert das Buchungssystem?"
 
-#: lib/klass_hero_web/components/participation_components.ex:783
+#: lib/klass_hero_web/components/participation_components.ex:794
 #: lib/klass_hero_web/live/admin/sessions_live.ex:275
 #, elixir-autogen, elixir-format
 msgid "In Progress"
@@ -3797,9 +3797,9 @@ msgstr "Keine angemeldeten Eltern"
 msgid "No risk of non-payment"
 msgstr "Kein Risiko von Zahlungsausfällen"
 
-#: lib/klass_hero_web/components/participation_components.ex:806
+#: lib/klass_hero_web/components/participation_components.ex:817
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:155
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:173
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:177
 #, elixir-autogen, elixir-format
 msgid "Notes"
 msgstr "Notizen"
@@ -3886,7 +3886,7 @@ msgstr "SEPA-Lastschrift"
 msgid "Save Correction"
 msgstr "Korrektur speichern"
 
-#: lib/klass_hero_web/components/participation_components.ex:782
+#: lib/klass_hero_web/components/participation_components.ex:793
 #, elixir-autogen, elixir-format
 msgid "Scheduled"
 msgstr "Geplant"
@@ -3982,12 +3982,12 @@ msgstr "Sie werden bezahlt, BEVOR Sie das Programm durchführen (kein Warten)"
 msgid "You receive instant email with booking details and parent contact info"
 msgstr "Sie erhalten sofort eine E-Mail mit den Buchungsdetails und den Kontaktdaten der Eltern"
 
-#: lib/klass_hero_web/components/participation_components.ex:73
+#: lib/klass_hero_web/components/participation_components.ex:84
 #, elixir-autogen, elixir-format
 msgid "%{checked_in} / %{capacity} checked in"
 msgstr "%{checked_in} / %{capacity} eingecheckt"
 
-#: lib/klass_hero_web/components/participation_components.ex:311
+#: lib/klass_hero_web/components/participation_components.ex:322
 #, elixir-autogen, elixir-format
 msgid "%{checked_in} / %{total} checked in"
 msgstr "%{checked_in} / %{total} eingecheckt"
@@ -3997,7 +3997,7 @@ msgstr "%{checked_in} / %{total} eingecheckt"
 msgid "%{count} unread"
 msgstr "%{count} ungelesen"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:373
+#: lib/klass_hero_web/live/provider/sessions_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "A session already exists at this time"
 msgstr "Zu dieser Zeit existiert bereits eine Sitzung"
@@ -4030,12 +4030,12 @@ msgstr "Alle Programme"
 msgid "All providers"
 msgstr "Alle Anbieter"
 
-#: lib/klass_hero_web/components/participation_components.ex:713
+#: lib/klass_hero_web/components/participation_components.ex:724
 #, elixir-autogen, elixir-format
 msgid "Allergies: %{details}"
 msgstr "Allergien: %{details}"
 
-#: lib/klass_hero_web/components/participation_components.ex:224
+#: lib/klass_hero_web/components/participation_components.ex:235
 #, elixir-autogen, elixir-format
 msgid "Any important notes about today's session..."
 msgstr "Wichtige Notizen zur heutigen Sitzung..."
@@ -4083,22 +4083,22 @@ msgstr "Einchecken"
 msgid "Check-in time must be before check-out time"
 msgstr "Die Eincheckzeit muss vor der Auscheckzeit liegen"
 
-#: lib/klass_hero_web/components/participation_components.ex:352
+#: lib/klass_hero_web/components/participation_components.ex:363
 #, elixir-autogen, elixir-format
 msgid "Check-in:"
 msgstr "Einchecken:"
 
-#: lib/klass_hero_web/components/participation_components.ex:389
+#: lib/klass_hero_web/components/participation_components.ex:400
 #, elixir-autogen, elixir-format
 msgid "Check-out notes (optional)"
 msgstr "Auschecken-Notizen (optional)"
 
-#: lib/klass_hero_web/components/participation_components.ex:358
+#: lib/klass_hero_web/components/participation_components.ex:369
 #, elixir-autogen, elixir-format
 msgid "Check-out:"
 msgstr "Auschecken:"
 
-#: lib/klass_hero_web/components/participation_components.ex:209
+#: lib/klass_hero_web/components/participation_components.ex:220
 #, elixir-autogen, elixir-format
 msgid "Checked in at %{time}"
 msgstr "Eingecheckt um %{time}"
@@ -4123,13 +4123,13 @@ msgstr "Auswahl aufheben"
 msgid "Complete Registration"
 msgstr "Registrierung abschließen"
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:71
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:75
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:271
 #, elixir-autogen, elixir-format
 msgid "Complete Session"
 msgstr "Sitzung abschließen"
 
-#: lib/klass_hero_web/components/participation_components.ex:404
+#: lib/klass_hero_web/components/participation_components.ex:415
 #, elixir-autogen, elixir-format
 msgid "Confirm Check Out"
 msgstr "Auschecken bestätigen"
@@ -4165,24 +4165,24 @@ msgid "Could not start private conversation"
 msgstr "Private Unterhaltung konnte nicht gestartet werden"
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:18
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:130
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:195
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:134
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "Create Session"
 msgstr "Sitzung erstellen"
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:157
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:161
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr "Datum"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:349
-#: lib/klass_hero_web/live/provider/sessions_live.ex:350
+#: lib/klass_hero_web/live/provider/sessions_live.ex:361
+#: lib/klass_hero_web/live/provider/sessions_live.ex:362
 #, elixir-autogen, elixir-format
 msgid "Date is required"
 msgstr "Datum ist erforderlich"
 
-#: lib/klass_hero_web/components/participation_components.ex:390
+#: lib/klass_hero_web/components/participation_components.ex:401
 #, elixir-autogen, elixir-format
 msgid "E.g., picked up by parent, gave medication reminder..."
 msgstr "Z.B. von Eltern abgeholt, Medikamentenerinnerung gegeben..."
@@ -4215,17 +4215,17 @@ msgstr "E-Mail nicht gefunden"
 msgid "Emails"
 msgstr "E-Mails"
 
-#: lib/klass_hero_web/components/participation_components.ex:725
+#: lib/klass_hero_web/components/participation_components.ex:736
 #, elixir-autogen, elixir-format
 msgid "Emergency: %{details}"
 msgstr "Notfall: %{details}"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:372
+#: lib/klass_hero_web/live/provider/sessions_live.ex:384
 #, elixir-autogen, elixir-format
 msgid "End time must be after start time"
 msgstr "Die Endzeit muss nach der Startzeit liegen"
 
-#: lib/klass_hero_web/components/participation_components.ex:788
+#: lib/klass_hero_web/components/participation_components.ex:799
 #, elixir-autogen, elixir-format
 msgid "Expected"
 msgstr "Erwartet"
@@ -4235,7 +4235,7 @@ msgstr "Erwartet"
 msgid "Failed to archive email"
 msgstr "E-Mail konnte nicht archiviert werden"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:309
+#: lib/klass_hero_web/live/provider/sessions_live.ex:321
 #, elixir-autogen, elixir-format
 msgid "Failed to create session: %{reason}"
 msgstr "Sitzung konnte nicht erstellt werden: %{reason}"
@@ -4281,7 +4281,7 @@ msgstr "Von:"
 msgid "Go to Home"
 msgstr "Zur Startseite"
 
-#: lib/klass_hero_web/components/participation_components.ex:337
+#: lib/klass_hero_web/components/participation_components.ex:348
 #, elixir-autogen, elixir-format
 msgid "In: %{time}"
 msgstr "Ein: %{time}"
@@ -4292,7 +4292,7 @@ msgid "Invalid Invitation"
 msgstr "Ungültige Einladung"
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:259
-#: lib/klass_hero_web/live/provider/sessions_live.ex:368
+#: lib/klass_hero_web/live/provider/sessions_live.ex:380
 #, elixir-autogen, elixir-format
 msgid "Invalid time format"
 msgstr "Ungültiges Zeitformat"
@@ -4333,7 +4333,7 @@ msgstr "Beigetreten"
 msgid "Load images"
 msgstr "Bilder laden"
 
-#: lib/klass_hero_web/components/participation_components.ex:66
+#: lib/klass_hero_web/components/participation_components.ex:77
 #, elixir-autogen, elixir-format
 msgid "Location TBD"
 msgstr "Ort noch offen"
@@ -4348,18 +4348,18 @@ msgstr "Verwalten Sie Ihre geplanten Sitzungen und die Anwesenheit"
 msgid "Mark Unread"
 msgstr "Als ungelesen markieren"
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:176
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:180
 #, elixir-autogen, elixir-format
 msgid "Max Capacity"
 msgstr "Maximale Kapazität"
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:85
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:89
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:285
 #, elixir-autogen, elixir-format
 msgid "No actions available"
 msgstr "Keine Aktionen verfügbar"
 
-#: lib/klass_hero_web/components/participation_components.ex:434
+#: lib/klass_hero_web/components/participation_components.ex:445
 #, elixir-autogen, elixir-format
 msgid "No children enrolled in this session"
 msgstr "Keine Kinder in dieser Sitzung angemeldet"
@@ -4389,28 +4389,28 @@ msgstr "Keine Ergebnisse"
 msgid "No sessions found for the selected filters."
 msgstr "Keine Sitzungen für die ausgewählten Filter gefunden."
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:100
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:104
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:300
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled"
 msgstr "Keine Sitzungen geplant"
 
-#: lib/klass_hero_web/components/participation_components.ex:634
+#: lib/klass_hero_web/components/participation_components.ex:645
 #, elixir-autogen, elixir-format
 msgid "Note:"
 msgstr "Notiz:"
 
-#: lib/klass_hero_web/components/participation_components.ex:496
+#: lib/klass_hero_web/components/participation_components.ex:507
 #, elixir-autogen, elixir-format
 msgid "Observation about the child's participation..."
 msgstr "Beobachtung zur Teilnahme des Kindes..."
 
-#: lib/klass_hero_web/components/participation_components.ex:343
+#: lib/klass_hero_web/components/participation_components.ex:354
 #, elixir-autogen, elixir-format
 msgid "Out: %{time}"
 msgstr "Aus: %{time}"
 
-#: lib/klass_hero_web/components/participation_components.ex:172
+#: lib/klass_hero_web/components/participation_components.ex:183
 #, elixir-autogen, elixir-format
 msgid "Participation Check-In"
 msgstr "Teilnahme-Einchecken"
@@ -4431,7 +4431,7 @@ msgstr "Ausstehende Überprüfungen"
 msgid "Please explain why you're rejecting this note..."
 msgstr "Bitte erklären Sie, warum Sie diese Notiz ablehnen..."
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:375
+#: lib/klass_hero_web/live/provider/sessions_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "Please fill in all required fields"
 msgstr "Bitte füllen Sie alle erforderlichen Felder aus"
@@ -4445,12 +4445,12 @@ msgstr "Absenden"
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
 #: lib/klass_hero_web/live/provider/programs_live.ex:217
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:151
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:155
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr "Programm"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:177
+#: lib/klass_hero_web/live/provider/sessions_live.ex:178
 #, elixir-autogen, elixir-format
 msgid "Program is required"
 msgstr "Programm ist erforderlich"
@@ -4507,7 +4507,7 @@ msgstr "Erneut senden"
 msgid "Reset to today"
 msgstr "Auf heute zurücksetzen"
 
-#: lib/klass_hero_web/components/participation_components.ex:527
+#: lib/klass_hero_web/components/participation_components.ex:538
 #, elixir-autogen, elixir-format
 msgid "Resubmit Note"
 msgstr "Notiz erneut einreichen"
@@ -4517,12 +4517,12 @@ msgstr "Notiz erneut einreichen"
 msgid "Retry"
 msgstr "Erneut versuchen"
 
-#: lib/klass_hero_web/components/participation_components.ex:525
+#: lib/klass_hero_web/components/participation_components.ex:536
 #, elixir-autogen, elixir-format
 msgid "Revised Note"
 msgstr "Überarbeitete Notiz"
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:152
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:156
 #, elixir-autogen, elixir-format
 msgid "Select a program..."
 msgstr "Programm auswählen..."
@@ -4537,25 +4537,25 @@ msgstr "Antwort senden"
 msgid "Sending"
 msgstr "Wird gesendet"
 
-#: lib/klass_hero_web/components/participation_components.ex:54
+#: lib/klass_hero_web/components/participation_components.ex:63
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:16
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:16
 #, elixir-autogen, elixir-format
 msgid "Session"
 msgstr "Sitzung"
 
-#: lib/klass_hero_web/components/participation_components.ex:223
+#: lib/klass_hero_web/components/participation_components.ex:234
 #, elixir-autogen, elixir-format
 msgid "Session Notes (optional)"
 msgstr "Sitzungsnotizen (optional)"
 
-#: lib/klass_hero_web/components/participation_components.ex:180
-#: lib/klass_hero_web/components/participation_components.ex:308
+#: lib/klass_hero_web/components/participation_components.ex:191
+#: lib/klass_hero_web/components/participation_components.ex:319
 #, elixir-autogen, elixir-format
 msgid "Session Roster"
 msgstr "Teilnehmerliste"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:291
+#: lib/klass_hero_web/live/provider/sessions_live.ex:303
 #, elixir-autogen, elixir-format
 msgid "Session created successfully"
 msgstr "Sitzung erfolgreich erstellt"
@@ -4570,23 +4570,23 @@ msgstr "Mitarbeiter-Dashboard"
 msgid "Staff member created, but the invitation could not be sent. Try resending from the team list."
 msgstr "Mitarbeiter wurde erstellt, aber die Einladung konnte nicht gesendet werden. Versuchen Sie es erneut über die Team-Liste."
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:49
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:53
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:249
 #, elixir-autogen, elixir-format
 msgid "Start Session"
 msgstr "Sitzung starten"
 
-#: lib/klass_hero_web/components/participation_components.ex:497
+#: lib/klass_hero_web/components/participation_components.ex:508
 #, elixir-autogen, elixir-format
 msgid "Submit Note"
 msgstr "Notiz absenden"
 
-#: lib/klass_hero_web/components/participation_components.ex:238
+#: lib/klass_hero_web/components/participation_components.ex:249
 #, elixir-autogen, elixir-format
 msgid "Submit Participation"
 msgstr "Teilnahme bestätigen"
 
-#: lib/klass_hero_web/components/participation_components.ex:719
+#: lib/klass_hero_web/components/participation_components.ex:730
 #, elixir-autogen, elixir-format
 msgid "Support: %{details}"
 msgstr "Unterstützung: %{details}"
@@ -4621,8 +4621,8 @@ msgstr "Diese Einladung wurde bereits verwendet."
 msgid "This invite link is invalid or has expired."
 msgstr "Dieser Einladungslink ist ungültig oder abgelaufen."
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:359
-#: lib/klass_hero_web/live/provider/sessions_live.ex:360
+#: lib/klass_hero_web/live/provider/sessions_live.ex:371
+#: lib/klass_hero_web/live/provider/sessions_live.ex:372
 #, elixir-autogen, elixir-format
 msgid "Time is required"
 msgstr "Uhrzeit ist erforderlich"
@@ -4637,7 +4637,7 @@ msgstr "An"
 msgid "Type your reply..."
 msgstr "Ihre Antwort eingeben..."
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:181
+#: lib/klass_hero_web/live/provider/sessions_live.ex:182
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:122
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:93
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:122
@@ -4652,7 +4652,7 @@ msgstr "Nicht autorisiert"
 msgid "Unread"
 msgstr "Ungelesen"
 
-#: lib/klass_hero_web/components/participation_components.ex:526
+#: lib/klass_hero_web/components/participation_components.ex:537
 #, elixir-autogen, elixir-format
 msgid "Update your observation..."
 msgstr "Aktualisieren Sie Ihre Beobachtung..."
@@ -4666,7 +4666,7 @@ msgstr "Aktualisieren Sie Ihre Beobachtung..."
 msgid "Upload connection lost. Please try again."
 msgstr "Upload-Verbindung unterbrochen. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:82
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:86
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "View Participation"
@@ -4692,7 +4692,7 @@ msgstr "Kommentar schreiben..."
 msgid "You already have an account. Log in to see your new enrollment."
 msgstr "Sie haben bereits ein Konto. Melden Sie sich an, um Ihre neue Anmeldung zu sehen."
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:103
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:107
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:303
 #, elixir-autogen, elixir-format
 msgid "You have no sessions scheduled for %{date}"
@@ -4760,7 +4760,7 @@ msgstr "Entwickelt für die internationale Berliner Gemeinschaft. Integriertes s
 msgid "Business Name"
 msgstr "Unternehmensname"
 
-#: lib/klass_hero_web/components/participation_components.ex:789
+#: lib/klass_hero_web/components/participation_components.ex:800
 #, elixir-autogen, elixir-format
 msgid "Cancelled"
 msgstr "Abgesagt"
@@ -4971,12 +4971,12 @@ msgstr "Sessions anzeigen"
 msgid "Create a program before inviting participants."
 msgstr "Erstellen Sie zuerst ein Programm, bevor Sie Teilnehmer einladen."
 
-#: lib/klass_hero_web/components/participation_components.ex:786
+#: lib/klass_hero_web/components/participation_components.ex:797
 #, elixir-autogen, elixir-format
 msgid "Departed"
 msgstr "Abgereist"
 
-#: lib/klass_hero_web/components/participation_components.ex:805
+#: lib/klass_hero_web/components/participation_components.ex:816
 #, elixir-autogen, elixir-format
 msgid "Departure notes"
 msgstr "Notizen zur Abreise"
@@ -5013,7 +5013,7 @@ msgstr "Einzelperson einladen"
 msgid "Invite sent."
 msgstr "Einladung verschickt."
 
-#: lib/klass_hero_web/components/participation_components.ex:580
+#: lib/klass_hero_web/components/participation_components.ex:591
 #, elixir-autogen, elixir-format
 msgid "Leave blank to keep this child marked as present."
 msgstr "Leer lassen, um dieses Kind als anwesend markiert zu lassen."
@@ -5049,7 +5049,7 @@ msgstr "Fotos dürfen in Marketingmaterialien verwendet werden"
 msgid "Photos may appear on social media"
 msgstr "Fotos dürfen in sozialen Medien erscheinen"
 
-#: lib/klass_hero_web/components/participation_components.ex:785
+#: lib/klass_hero_web/components/participation_components.ex:796
 #, elixir-autogen, elixir-format
 msgid "Present"
 msgstr "Anwesend"
@@ -5065,7 +5065,7 @@ msgstr "Hauptansprechpartner"
 msgid "Record departure"
 msgstr "Abreise erfassen"
 
-#: lib/klass_hero_web/components/participation_components.ex:577
+#: lib/klass_hero_web/components/participation_components.ex:588
 #, elixir-autogen, elixir-format
 msgid "Record departure time (optional)"
 msgstr "Abreisezeit erfassen (optional)"
@@ -5076,7 +5076,7 @@ msgstr "Abreisezeit erfassen (optional)"
 msgid "Record updated"
 msgstr "Datensatz aktualisiert"
 
-#: lib/klass_hero_web/components/participation_components.ex:594
+#: lib/klass_hero_web/components/participation_components.ex:605
 #, elixir-autogen, elixir-format
 msgid "Save changes"
 msgstr "Änderungen speichern"
@@ -5101,7 +5101,7 @@ msgstr "Zweiter Ansprechpartner (optional)"
 msgid "Send invite"
 msgstr "Einladung senden"
 
-#: lib/klass_hero_web/components/participation_components.ex:569
+#: lib/klass_hero_web/components/participation_components.ex:580
 #, elixir-autogen, elixir-format
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr "Aktualisieren Sie die Notiz für dieses Kind (z. B. um zu klären, was passiert ist)"
@@ -7575,7 +7575,7 @@ msgstr "Die Erklärung zur Mitarbeiter-Compliance wurde seit deiner letzten Unte
 msgid "You have signed the Staff Compliance Declaration."
 msgstr "Du hast die Erklärung zur Mitarbeiter-Compliance unterzeichnet."
 
-#: lib/klass_hero_web/components/participation_components.ex:495
+#: lib/klass_hero_web/components/participation_components.ex:506
 #, elixir-autogen, elixir-format
 msgid "Session Note"
 msgstr "Sitzungsnotiz"

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -632,7 +632,7 @@ msgid "Failed to check out: %{reason}"
 msgstr "Auschecken fehlgeschlagen: %{reason}"
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:159
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:117
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:119
 #, elixir-autogen, elixir-format
 msgid "Failed to complete session: %{reason}"
 msgstr "Sitzung konnte nicht abgeschlossen werden: %{reason}"
@@ -643,7 +643,7 @@ msgid "Failed to delete account. Please try again."
 msgstr "Konto konnte nicht gelöscht werden. Bitte versuchen Sie es erneut."
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:136
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:88
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "Failed to start session: %{reason}"
 msgstr "Sitzung konnte nicht gestartet werden: %{reason}"
@@ -694,8 +694,8 @@ msgid "Introduction"
 msgstr "Einleitung"
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:114
-#: lib/klass_hero_web/live/provider/sessions_live.ex:367
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:64
+#: lib/klass_hero_web/live/provider/sessions_live.ex:368
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:66
 #, elixir-autogen, elixir-format
 msgid "Invalid date format"
 msgstr "Ungültiges Datumsformat"
@@ -769,7 +769,7 @@ msgstr "Nachricht erfolgreich gesendet!"
 #: lib/klass_hero_web/live/provider/sessions_live.ex:47
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:4
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:21
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:217
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:233
 #, elixir-autogen, elixir-format
 msgid "My Sessions"
 msgstr "Meine Sitzungen"
@@ -899,7 +899,7 @@ msgid "Send Message"
 msgstr "Nachricht senden"
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:145
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:103
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:105
 #, elixir-autogen, elixir-format
 msgid "Session completed successfully"
 msgstr "Sitzung erfolgreich abgeschlossen"
@@ -913,7 +913,7 @@ msgid "Session not found"
 msgstr "Sitzung nicht gefunden"
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:122
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:74
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:76
 #, elixir-autogen, elixir-format
 msgid "Session started successfully"
 msgstr "Sitzung erfolgreich gestartet"
@@ -1393,9 +1393,9 @@ msgid "Failed to load participation history"
 msgstr "Teilnahmeverlauf konnte nicht geladen werden"
 
 #: lib/klass_hero_web/live/provider/participation_live.ex:28
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:64
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:65
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:29
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:260
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:281
 #, elixir-autogen, elixir-format
 msgid "Manage Participation"
 msgstr "Teilnahme verwalten"
@@ -1639,11 +1639,11 @@ msgstr "Erstellen Sie Profile für Ihr Personal. Diese werden für Eltern sichtb
 
 #: lib/klass_hero_web/components/provider_components.ex:538
 #: lib/klass_hero_web/components/provider_components.ex:1432
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:50
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:77
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:54
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:81
 #: lib/klass_hero_web/live/settings/children_live.ex:448
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:50
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:77
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:54
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr "Bearbeiten"
@@ -1822,9 +1822,9 @@ msgstr "Rundnachricht"
 msgid "Broadcast sent to %{count} parents"
 msgstr "Rundnachricht an %{count} Eltern gesendet"
 
-#: lib/klass_hero_web/components/participation_components.ex:428
-#: lib/klass_hero_web/components/participation_components.ex:618
-#: lib/klass_hero_web/components/participation_components.ex:704
+#: lib/klass_hero_web/components/participation_components.ex:441
+#: lib/klass_hero_web/components/participation_components.ex:631
+#: lib/klass_hero_web/components/participation_components.ex:717
 #: lib/klass_hero_web/components/provider_components.ex:817
 #: lib/klass_hero_web/components/provider_components.ex:1214
 #: lib/klass_hero_web/components/provider_components.ex:1919
@@ -1833,7 +1833,7 @@ msgstr "Rundnachricht an %{count} Eltern gesendet"
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:222
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:356
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:190
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:191
 #: lib/klass_hero_web/live/settings/children_live.ex:579
 #: lib/klass_hero_web/live/settings/children_live.ex:738
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:233
@@ -2257,7 +2257,7 @@ msgstr "Beim Import ist ein unerwarteter Fehler aufgetreten."
 msgid "Approve"
 msgstr "Genehmigen"
 
-#: lib/klass_hero_web/components/participation_components.ex:813
+#: lib/klass_hero_web/components/participation_components.ex:826
 #: lib/klass_hero_web/components/provider_components.ex:47
 #: lib/klass_hero_web/live/admin/sessions_live.ex:294
 #: lib/klass_hero_web/live/admin/verifications_live.ex:202
@@ -2505,7 +2505,7 @@ msgid "End Date"
 msgstr "Enddatum"
 
 #: lib/klass_hero_web/components/provider_components.ex:952
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:165
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:166
 #, elixir-autogen, elixir-format
 msgid "End Time"
 msgstr "Endzeit"
@@ -2700,7 +2700,7 @@ msgid "Leave unchecked to allow all genders."
 msgstr "Nicht markiert lassen, um alle Geschlechter zuzulassen."
 
 #: lib/klass_hero_web/components/provider_components.ex:908
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:171
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Location"
 msgstr "Ort"
@@ -2859,7 +2859,7 @@ msgstr "Teilnahmevoraussetzungen"
 msgid "Participant Restrictions (optional)"
 msgstr "Teilnahmebeschränkungen (optional)"
 
-#: lib/klass_hero_web/components/participation_components.ex:812
+#: lib/klass_hero_web/components/participation_components.ex:825
 #: lib/klass_hero_web/components/provider_components.ex:292
 #, elixir-autogen, elixir-format
 msgid "Pending Review"
@@ -2938,7 +2938,7 @@ msgstr "Anbieterprofil nicht gefunden."
 msgid "Read our founding story →"
 msgstr "Lesen Sie unsere Gründungsgeschichte →"
 
-#: lib/klass_hero_web/components/participation_components.ex:792
+#: lib/klass_hero_web/components/participation_components.ex:805
 #: lib/klass_hero_web/components/provider_components.ex:2187
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
@@ -3006,7 +3006,7 @@ msgstr "Anmeldung öffnet am %{date}"
 msgid "Reject"
 msgstr "Ablehnen"
 
-#: lib/klass_hero_web/components/participation_components.ex:814
+#: lib/klass_hero_web/components/participation_components.ex:827
 #: lib/klass_hero_web/components/provider_components.ex:48
 #: lib/klass_hero_web/live/admin/verifications_live.ex:207
 #, elixir-autogen, elixir-format
@@ -3128,7 +3128,7 @@ msgid "Start Date"
 msgstr "Startdatum"
 
 #: lib/klass_hero_web/components/provider_components.ex:947
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:164
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Start Time"
 msgstr "Startzeit"
@@ -3536,7 +3536,7 @@ msgstr "Diese Löschanfrage ist abgelaufen. Bitte versuchen Sie es erneut."
 msgid "A reason is required for corrections"
 msgstr "Ein Grund für die Korrektur ist erforderlich"
 
-#: lib/klass_hero_web/components/participation_components.ex:798
+#: lib/klass_hero_web/components/participation_components.ex:811
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:201
 #, elixir-autogen, elixir-format
 msgid "Absent"
@@ -3666,7 +3666,7 @@ msgstr "Kind"
 msgid "Coming soon! Sign up for our newsletter to be notified when gift vouchers launch."
 msgstr "Demnächst verfügbar! Melden Sie sich für unseren Newsletter an, um benachrichtigt zu werden, sobald Geschenkgutscheine verfügbar sind."
 
-#: lib/klass_hero_web/components/participation_components.ex:795
+#: lib/klass_hero_web/components/participation_components.ex:808
 #, elixir-autogen, elixir-format
 msgid "Completed"
 msgstr "Abgeschlossen"
@@ -3739,7 +3739,7 @@ msgstr "So werden Sie bezahlt:"
 msgid "How does the booking system work?"
 msgstr "Wie funktioniert das Buchungssystem?"
 
-#: lib/klass_hero_web/components/participation_components.ex:794
+#: lib/klass_hero_web/components/participation_components.ex:807
 #: lib/klass_hero_web/live/admin/sessions_live.ex:275
 #, elixir-autogen, elixir-format
 msgid "In Progress"
@@ -3797,9 +3797,9 @@ msgstr "Keine angemeldeten Eltern"
 msgid "No risk of non-payment"
 msgstr "Kein Risiko von Zahlungsausfällen"
 
-#: lib/klass_hero_web/components/participation_components.ex:817
+#: lib/klass_hero_web/components/participation_components.ex:830
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:155
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:177
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:178
 #, elixir-autogen, elixir-format
 msgid "Notes"
 msgstr "Notizen"
@@ -3886,7 +3886,7 @@ msgstr "SEPA-Lastschrift"
 msgid "Save Correction"
 msgstr "Korrektur speichern"
 
-#: lib/klass_hero_web/components/participation_components.ex:793
+#: lib/klass_hero_web/components/participation_components.ex:806
 #, elixir-autogen, elixir-format
 msgid "Scheduled"
 msgstr "Geplant"
@@ -3982,12 +3982,7 @@ msgstr "Sie werden bezahlt, BEVOR Sie das Programm durchführen (kein Warten)"
 msgid "You receive instant email with booking details and parent contact info"
 msgstr "Sie erhalten sofort eine E-Mail mit den Buchungsdetails und den Kontaktdaten der Eltern"
 
-#: lib/klass_hero_web/components/participation_components.ex:84
-#, elixir-autogen, elixir-format
-msgid "%{checked_in} / %{capacity} checked in"
-msgstr "%{checked_in} / %{capacity} eingecheckt"
-
-#: lib/klass_hero_web/components/participation_components.ex:322
+#: lib/klass_hero_web/components/participation_components.ex:335
 #, elixir-autogen, elixir-format
 msgid "%{checked_in} / %{total} checked in"
 msgstr "%{checked_in} / %{total} eingecheckt"
@@ -3997,7 +3992,7 @@ msgstr "%{checked_in} / %{total} eingecheckt"
 msgid "%{count} unread"
 msgstr "%{count} ungelesen"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:385
+#: lib/klass_hero_web/live/provider/sessions_live.ex:386
 #, elixir-autogen, elixir-format
 msgid "A session already exists at this time"
 msgstr "Zu dieser Zeit existiert bereits eine Sitzung"
@@ -4007,8 +4002,8 @@ msgstr "Zu dieser Zeit existiert bereits eine Sitzung"
 msgid "Account created! Check your email to confirm and log in."
 msgstr "Konto erstellt! Überprüfen Sie Ihre E-Mails, um zu bestätigen und sich anzumelden."
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:111
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:111
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:115
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:115
 #, elixir-autogen, elixir-format
 msgid "Add Note"
 msgstr "Notiz hinzufügen"
@@ -4030,12 +4025,12 @@ msgstr "Alle Programme"
 msgid "All providers"
 msgstr "Alle Anbieter"
 
-#: lib/klass_hero_web/components/participation_components.ex:724
+#: lib/klass_hero_web/components/participation_components.ex:737
 #, elixir-autogen, elixir-format
 msgid "Allergies: %{details}"
 msgstr "Allergien: %{details}"
 
-#: lib/klass_hero_web/components/participation_components.ex:235
+#: lib/klass_hero_web/components/participation_components.ex:248
 #, elixir-autogen, elixir-format
 msgid "Any important notes about today's session..."
 msgstr "Wichtige Notizen zur heutigen Sitzung..."
@@ -4072,8 +4067,8 @@ msgstr "Zurück zu E-Mails"
 msgid "Broadcast messages are one-way"
 msgstr "Broadcast-Nachrichten sind einseitig"
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:92
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:92
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:96
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:96
 #, elixir-autogen, elixir-format
 msgid "Check In"
 msgstr "Einchecken"
@@ -4083,22 +4078,22 @@ msgstr "Einchecken"
 msgid "Check-in time must be before check-out time"
 msgstr "Die Eincheckzeit muss vor der Auscheckzeit liegen"
 
-#: lib/klass_hero_web/components/participation_components.ex:363
+#: lib/klass_hero_web/components/participation_components.ex:376
 #, elixir-autogen, elixir-format
 msgid "Check-in:"
 msgstr "Einchecken:"
 
-#: lib/klass_hero_web/components/participation_components.ex:400
+#: lib/klass_hero_web/components/participation_components.ex:413
 #, elixir-autogen, elixir-format
 msgid "Check-out notes (optional)"
 msgstr "Auschecken-Notizen (optional)"
 
-#: lib/klass_hero_web/components/participation_components.ex:369
+#: lib/klass_hero_web/components/participation_components.ex:382
 #, elixir-autogen, elixir-format
 msgid "Check-out:"
 msgstr "Auschecken:"
 
-#: lib/klass_hero_web/components/participation_components.ex:220
+#: lib/klass_hero_web/components/participation_components.ex:233
 #, elixir-autogen, elixir-format
 msgid "Checked in at %{time}"
 msgstr "Eingecheckt um %{time}"
@@ -4123,13 +4118,13 @@ msgstr "Auswahl aufheben"
 msgid "Complete Registration"
 msgstr "Registrierung abschließen"
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:75
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:271
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:76
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:292
 #, elixir-autogen, elixir-format
 msgid "Complete Session"
 msgstr "Sitzung abschließen"
 
-#: lib/klass_hero_web/components/participation_components.ex:415
+#: lib/klass_hero_web/components/participation_components.ex:428
 #, elixir-autogen, elixir-format
 msgid "Confirm Check Out"
 msgstr "Auschecken bestätigen"
@@ -4165,29 +4160,29 @@ msgid "Could not start private conversation"
 msgstr "Private Unterhaltung konnte nicht gestartet werden"
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:18
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:134
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:199
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:135
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:200
 #, elixir-autogen, elixir-format
 msgid "Create Session"
 msgstr "Sitzung erstellen"
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:161
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:162
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr "Datum"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:361
 #: lib/klass_hero_web/live/provider/sessions_live.ex:362
+#: lib/klass_hero_web/live/provider/sessions_live.ex:363
 #, elixir-autogen, elixir-format
 msgid "Date is required"
 msgstr "Datum ist erforderlich"
 
-#: lib/klass_hero_web/components/participation_components.ex:401
+#: lib/klass_hero_web/components/participation_components.ex:414
 #, elixir-autogen, elixir-format
 msgid "E.g., picked up by parent, gave medication reminder..."
 msgstr "Z.B. von Eltern abgeholt, Medikamentenerinnerung gegeben..."
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:140
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "Edit & Resubmit"
 msgstr "Bearbeiten & erneut einreichen"
@@ -4215,17 +4210,17 @@ msgstr "E-Mail nicht gefunden"
 msgid "Emails"
 msgstr "E-Mails"
 
-#: lib/klass_hero_web/components/participation_components.ex:736
+#: lib/klass_hero_web/components/participation_components.ex:749
 #, elixir-autogen, elixir-format
 msgid "Emergency: %{details}"
 msgstr "Notfall: %{details}"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:384
+#: lib/klass_hero_web/live/provider/sessions_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "End time must be after start time"
 msgstr "Die Endzeit muss nach der Startzeit liegen"
 
-#: lib/klass_hero_web/components/participation_components.ex:799
+#: lib/klass_hero_web/components/participation_components.ex:812
 #, elixir-autogen, elixir-format
 msgid "Expected"
 msgstr "Erwartet"
@@ -4235,7 +4230,7 @@ msgstr "Erwartet"
 msgid "Failed to archive email"
 msgstr "E-Mail konnte nicht archiviert werden"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:321
+#: lib/klass_hero_web/live/provider/sessions_live.ex:322
 #, elixir-autogen, elixir-format
 msgid "Failed to create session: %{reason}"
 msgstr "Sitzung konnte nicht erstellt werden: %{reason}"
@@ -4281,7 +4276,7 @@ msgstr "Von:"
 msgid "Go to Home"
 msgstr "Zur Startseite"
 
-#: lib/klass_hero_web/components/participation_components.ex:348
+#: lib/klass_hero_web/components/participation_components.ex:361
 #, elixir-autogen, elixir-format
 msgid "In: %{time}"
 msgstr "Ein: %{time}"
@@ -4292,7 +4287,7 @@ msgid "Invalid Invitation"
 msgstr "Ungültige Einladung"
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:259
-#: lib/klass_hero_web/live/provider/sessions_live.ex:380
+#: lib/klass_hero_web/live/provider/sessions_live.ex:381
 #, elixir-autogen, elixir-format
 msgid "Invalid time format"
 msgstr "Ungültiges Zeitformat"
@@ -4333,7 +4328,7 @@ msgstr "Beigetreten"
 msgid "Load images"
 msgstr "Bilder laden"
 
-#: lib/klass_hero_web/components/participation_components.ex:77
+#: lib/klass_hero_web/components/participation_components.ex:84
 #, elixir-autogen, elixir-format
 msgid "Location TBD"
 msgstr "Ort noch offen"
@@ -4348,18 +4343,18 @@ msgstr "Verwalten Sie Ihre geplanten Sitzungen und die Anwesenheit"
 msgid "Mark Unread"
 msgstr "Als ungelesen markieren"
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:180
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:181
 #, elixir-autogen, elixir-format
 msgid "Max Capacity"
 msgstr "Maximale Kapazität"
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:89
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:285
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:90
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "No actions available"
 msgstr "Keine Aktionen verfügbar"
 
-#: lib/klass_hero_web/components/participation_components.ex:445
+#: lib/klass_hero_web/components/participation_components.ex:458
 #, elixir-autogen, elixir-format
 msgid "No children enrolled in this session"
 msgstr "Keine Kinder in dieser Sitzung angemeldet"
@@ -4389,34 +4384,34 @@ msgstr "Keine Ergebnisse"
 msgid "No sessions found for the selected filters."
 msgstr "Keine Sitzungen für die ausgewählten Filter gefunden."
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:104
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:300
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:105
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:321
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled"
 msgstr "Keine Sitzungen geplant"
 
-#: lib/klass_hero_web/components/participation_components.ex:645
+#: lib/klass_hero_web/components/participation_components.ex:658
 #, elixir-autogen, elixir-format
 msgid "Note:"
 msgstr "Notiz:"
 
-#: lib/klass_hero_web/components/participation_components.ex:507
+#: lib/klass_hero_web/components/participation_components.ex:520
 #, elixir-autogen, elixir-format
 msgid "Observation about the child's participation..."
 msgstr "Beobachtung zur Teilnahme des Kindes..."
 
-#: lib/klass_hero_web/components/participation_components.ex:354
+#: lib/klass_hero_web/components/participation_components.ex:367
 #, elixir-autogen, elixir-format
 msgid "Out: %{time}"
 msgstr "Aus: %{time}"
 
-#: lib/klass_hero_web/components/participation_components.ex:183
+#: lib/klass_hero_web/components/participation_components.ex:196
 #, elixir-autogen, elixir-format
 msgid "Participation Check-In"
 msgstr "Teilnahme-Einchecken"
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:26
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:26
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:30
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:30
 #, elixir-autogen, elixir-format
 msgid "Participation Management"
 msgstr "Teilnahmeverwaltung"
@@ -4431,7 +4426,7 @@ msgstr "Ausstehende Überprüfungen"
 msgid "Please explain why you're rejecting this note..."
 msgstr "Bitte erklären Sie, warum Sie diese Notiz ablehnen..."
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:387
+#: lib/klass_hero_web/live/provider/sessions_live.ex:388
 #, elixir-autogen, elixir-format
 msgid "Please fill in all required fields"
 msgstr "Bitte füllen Sie alle erforderlichen Felder aus"
@@ -4445,7 +4440,7 @@ msgstr "Absenden"
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
 #: lib/klass_hero_web/live/provider/programs_live.ex:217
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:155
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:156
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr "Programm"
@@ -4507,7 +4502,7 @@ msgstr "Erneut senden"
 msgid "Reset to today"
 msgstr "Auf heute zurücksetzen"
 
-#: lib/klass_hero_web/components/participation_components.ex:538
+#: lib/klass_hero_web/components/participation_components.ex:551
 #, elixir-autogen, elixir-format
 msgid "Resubmit Note"
 msgstr "Notiz erneut einreichen"
@@ -4517,12 +4512,12 @@ msgstr "Notiz erneut einreichen"
 msgid "Retry"
 msgstr "Erneut versuchen"
 
-#: lib/klass_hero_web/components/participation_components.ex:536
+#: lib/klass_hero_web/components/participation_components.ex:549
 #, elixir-autogen, elixir-format
 msgid "Revised Note"
 msgstr "Überarbeitete Notiz"
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:156
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "Select a program..."
 msgstr "Programm auswählen..."
@@ -4537,25 +4532,25 @@ msgstr "Antwort senden"
 msgid "Sending"
 msgstr "Wird gesendet"
 
-#: lib/klass_hero_web/components/participation_components.ex:63
+#: lib/klass_hero_web/components/participation_components.ex:70
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:16
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:16
 #, elixir-autogen, elixir-format
 msgid "Session"
 msgstr "Sitzung"
 
-#: lib/klass_hero_web/components/participation_components.ex:234
+#: lib/klass_hero_web/components/participation_components.ex:247
 #, elixir-autogen, elixir-format
 msgid "Session Notes (optional)"
 msgstr "Sitzungsnotizen (optional)"
 
-#: lib/klass_hero_web/components/participation_components.ex:191
-#: lib/klass_hero_web/components/participation_components.ex:319
+#: lib/klass_hero_web/components/participation_components.ex:204
+#: lib/klass_hero_web/components/participation_components.ex:332
 #, elixir-autogen, elixir-format
 msgid "Session Roster"
 msgstr "Teilnehmerliste"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:303
+#: lib/klass_hero_web/live/provider/sessions_live.ex:304
 #, elixir-autogen, elixir-format
 msgid "Session created successfully"
 msgstr "Sitzung erfolgreich erstellt"
@@ -4570,23 +4565,23 @@ msgstr "Mitarbeiter-Dashboard"
 msgid "Staff member created, but the invitation could not be sent. Try resending from the team list."
 msgstr "Mitarbeiter wurde erstellt, aber die Einladung konnte nicht gesendet werden. Versuchen Sie es erneut über die Team-Liste."
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:53
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:249
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:54
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:270
 #, elixir-autogen, elixir-format
 msgid "Start Session"
 msgstr "Sitzung starten"
 
-#: lib/klass_hero_web/components/participation_components.ex:508
+#: lib/klass_hero_web/components/participation_components.ex:521
 #, elixir-autogen, elixir-format
 msgid "Submit Note"
 msgstr "Notiz absenden"
 
-#: lib/klass_hero_web/components/participation_components.ex:249
+#: lib/klass_hero_web/components/participation_components.ex:262
 #, elixir-autogen, elixir-format
 msgid "Submit Participation"
 msgstr "Teilnahme bestätigen"
 
-#: lib/klass_hero_web/components/participation_components.ex:730
+#: lib/klass_hero_web/components/participation_components.ex:743
 #, elixir-autogen, elixir-format
 msgid "Support: %{details}"
 msgstr "Unterstützung: %{details}"
@@ -4621,8 +4616,8 @@ msgstr "Diese Einladung wurde bereits verwendet."
 msgid "This invite link is invalid or has expired."
 msgstr "Dieser Einladungslink ist ungültig oder abgelaufen."
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:371
 #: lib/klass_hero_web/live/provider/sessions_live.ex:372
+#: lib/klass_hero_web/live/provider/sessions_live.ex:373
 #, elixir-autogen, elixir-format
 msgid "Time is required"
 msgstr "Uhrzeit ist erforderlich"
@@ -4639,8 +4634,8 @@ msgstr "Ihre Antwort eingeben..."
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:182
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:122
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:93
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:122
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:95
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:124
 #, elixir-autogen, elixir-format
 msgid "Unauthorized"
 msgstr "Nicht autorisiert"
@@ -4652,7 +4647,7 @@ msgstr "Nicht autorisiert"
 msgid "Unread"
 msgstr "Ungelesen"
 
-#: lib/klass_hero_web/components/participation_components.ex:537
+#: lib/klass_hero_web/components/participation_components.ex:550
 #, elixir-autogen, elixir-format
 msgid "Update your observation..."
 msgstr "Aktualisieren Sie Ihre Beobachtung..."
@@ -4666,8 +4661,8 @@ msgstr "Aktualisieren Sie Ihre Beobachtung..."
 msgid "Upload connection lost. Please try again."
 msgstr "Upload-Verbindung unterbrochen. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:86
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:282
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:87
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:303
 #, elixir-autogen, elixir-format
 msgid "View Participation"
 msgstr "Teilnahme anzeigen"
@@ -4692,8 +4687,8 @@ msgstr "Kommentar schreiben..."
 msgid "You already have an account. Log in to see your new enrollment."
 msgstr "Sie haben bereits ein Konto. Melden Sie sich an, um Ihre neue Anmeldung zu sehen."
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:107
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:303
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:108
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:324
 #, elixir-autogen, elixir-format
 msgid "You have no sessions scheduled for %{date}"
 msgstr "Sie haben keine Sitzungen geplant für %{date}"
@@ -4728,7 +4723,7 @@ msgstr "Teilnehmerliste"
 msgid "Unlimited team seats"
 msgstr "Unbegrenzte Team-Plätze"
 
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:218
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:234
 #, elixir-autogen, elixir-format
 msgid "View and manage your assigned sessions"
 msgstr "Ihre zugewiesenen Sitzungen anzeigen und verwalten"
@@ -4760,7 +4755,7 @@ msgstr "Entwickelt für die internationale Berliner Gemeinschaft. Integriertes s
 msgid "Business Name"
 msgstr "Unternehmensname"
 
-#: lib/klass_hero_web/components/participation_components.ex:800
+#: lib/klass_hero_web/components/participation_components.ex:813
 #, elixir-autogen, elixir-format
 msgid "Cancelled"
 msgstr "Abgesagt"
@@ -4971,12 +4966,12 @@ msgstr "Sessions anzeigen"
 msgid "Create a program before inviting participants."
 msgstr "Erstellen Sie zuerst ein Programm, bevor Sie Teilnehmer einladen."
 
-#: lib/klass_hero_web/components/participation_components.ex:797
+#: lib/klass_hero_web/components/participation_components.ex:810
 #, elixir-autogen, elixir-format
 msgid "Departed"
 msgstr "Abgereist"
 
-#: lib/klass_hero_web/components/participation_components.ex:816
+#: lib/klass_hero_web/components/participation_components.ex:829
 #, elixir-autogen, elixir-format
 msgid "Departure notes"
 msgstr "Notizen zur Abreise"
@@ -5013,7 +5008,7 @@ msgstr "Einzelperson einladen"
 msgid "Invite sent."
 msgstr "Einladung verschickt."
 
-#: lib/klass_hero_web/components/participation_components.ex:591
+#: lib/klass_hero_web/components/participation_components.ex:604
 #, elixir-autogen, elixir-format
 msgid "Leave blank to keep this child marked as present."
 msgstr "Leer lassen, um dieses Kind als anwesend markiert zu lassen."
@@ -5049,7 +5044,7 @@ msgstr "Fotos dürfen in Marketingmaterialien verwendet werden"
 msgid "Photos may appear on social media"
 msgstr "Fotos dürfen in sozialen Medien erscheinen"
 
-#: lib/klass_hero_web/components/participation_components.ex:796
+#: lib/klass_hero_web/components/participation_components.ex:809
 #, elixir-autogen, elixir-format
 msgid "Present"
 msgstr "Anwesend"
@@ -5059,13 +5054,13 @@ msgstr "Anwesend"
 msgid "Primary guardian"
 msgstr "Hauptansprechpartner"
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:62
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:62
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:66
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:66
 #, elixir-autogen, elixir-format
 msgid "Record departure"
 msgstr "Abreise erfassen"
 
-#: lib/klass_hero_web/components/participation_components.ex:588
+#: lib/klass_hero_web/components/participation_components.ex:601
 #, elixir-autogen, elixir-format
 msgid "Record departure time (optional)"
 msgstr "Abreisezeit erfassen (optional)"
@@ -5076,7 +5071,7 @@ msgstr "Abreisezeit erfassen (optional)"
 msgid "Record updated"
 msgstr "Datensatz aktualisiert"
 
-#: lib/klass_hero_web/components/participation_components.ex:605
+#: lib/klass_hero_web/components/participation_components.ex:618
 #, elixir-autogen, elixir-format
 msgid "Save changes"
 msgstr "Änderungen speichern"
@@ -5101,7 +5096,7 @@ msgstr "Zweiter Ansprechpartner (optional)"
 msgid "Send invite"
 msgstr "Einladung senden"
 
-#: lib/klass_hero_web/components/participation_components.ex:580
+#: lib/klass_hero_web/components/participation_components.ex:593
 #, elixir-autogen, elixir-format
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr "Aktualisieren Sie die Notiz für dieses Kind (z. B. um zu klären, was passiert ist)"
@@ -7575,7 +7570,7 @@ msgstr "Die Erklärung zur Mitarbeiter-Compliance wurde seit deiner letzten Unte
 msgid "You have signed the Staff Compliance Declaration."
 msgstr "Du hast die Erklärung zur Mitarbeiter-Compliance unterzeichnet."
 
-#: lib/klass_hero_web/components/participation_components.ex:506
+#: lib/klass_hero_web/components/participation_components.ex:519
 #, elixir-autogen, elixir-format
 msgid "Session Note"
 msgstr "Sitzungsnotiz"
@@ -7599,3 +7594,15 @@ msgstr "Wird geladen…"
 #, elixir-autogen, elixir-format
 msgid "Incidents"
 msgstr "Vorfälle"
+
+#: lib/klass_hero_web/components/participation_components.ex:96
+#, elixir-autogen, elixir-format
+msgid "%{checked_in} of %{roster} checked in"
+msgstr "%{checked_in} von %{roster} eingecheckt"
+
+#: lib/klass_hero_web/components/participation_components.ex:92
+#, elixir-autogen, elixir-format
+msgid "%{count} child enrolled"
+msgid_plural "%{count} children enrolled"
+msgstr[0] "%{count} Kind angemeldet"
+msgstr[1] "%{count} Kinder angemeldet"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -694,7 +694,7 @@ msgid "Introduction"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:113
-#: lib/klass_hero_web/live/provider/sessions_live.ex:348
+#: lib/klass_hero_web/live/provider/sessions_live.ex:355
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:64
 #, elixir-autogen, elixir-format
 msgid "Invalid date format"
@@ -3997,7 +3997,7 @@ msgstr ""
 msgid "%{count} unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:366
+#: lib/klass_hero_web/live/provider/sessions_live.ex:373
 #, elixir-autogen, elixir-format
 msgid "A session already exists at this time"
 msgstr ""
@@ -4176,8 +4176,8 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:342
-#: lib/klass_hero_web/live/provider/sessions_live.ex:343
+#: lib/klass_hero_web/live/provider/sessions_live.ex:349
+#: lib/klass_hero_web/live/provider/sessions_live.ex:350
 #, elixir-autogen, elixir-format
 msgid "Date is required"
 msgstr ""
@@ -4220,7 +4220,7 @@ msgstr ""
 msgid "Emergency: %{details}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:365
+#: lib/klass_hero_web/live/provider/sessions_live.ex:372
 #, elixir-autogen, elixir-format
 msgid "End time must be after start time"
 msgstr ""
@@ -4235,7 +4235,7 @@ msgstr ""
 msgid "Failed to archive email"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:302
+#: lib/klass_hero_web/live/provider/sessions_live.ex:309
 #, elixir-autogen, elixir-format
 msgid "Failed to create session: %{reason}"
 msgstr ""
@@ -4292,7 +4292,7 @@ msgid "Invalid Invitation"
 msgstr ""
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:259
-#: lib/klass_hero_web/live/provider/sessions_live.ex:361
+#: lib/klass_hero_web/live/provider/sessions_live.ex:368
 #, elixir-autogen, elixir-format
 msgid "Invalid time format"
 msgstr ""
@@ -4431,7 +4431,7 @@ msgstr ""
 msgid "Please explain why you're rejecting this note..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:368
+#: lib/klass_hero_web/live/provider/sessions_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "Please fill in all required fields"
 msgstr ""
@@ -4555,7 +4555,7 @@ msgstr ""
 msgid "Session Roster"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:284
+#: lib/klass_hero_web/live/provider/sessions_live.ex:291
 #, elixir-autogen, elixir-format
 msgid "Session created successfully"
 msgstr ""
@@ -4621,8 +4621,8 @@ msgstr ""
 msgid "This invite link is invalid or has expired."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:352
-#: lib/klass_hero_web/live/provider/sessions_live.ex:353
+#: lib/klass_hero_web/live/provider/sessions_live.ex:359
+#: lib/klass_hero_web/live/provider/sessions_live.ex:360
 #, elixir-autogen, elixir-format
 msgid "Time is required"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -632,7 +632,7 @@ msgid "Failed to check out: %{reason}"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:159
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:117
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:119
 #, elixir-autogen, elixir-format
 msgid "Failed to complete session: %{reason}"
 msgstr ""
@@ -643,7 +643,7 @@ msgid "Failed to delete account. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:136
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:88
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "Failed to start session: %{reason}"
 msgstr ""
@@ -694,8 +694,8 @@ msgid "Introduction"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:114
-#: lib/klass_hero_web/live/provider/sessions_live.ex:367
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:64
+#: lib/klass_hero_web/live/provider/sessions_live.ex:368
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:66
 #, elixir-autogen, elixir-format
 msgid "Invalid date format"
 msgstr ""
@@ -769,7 +769,7 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/sessions_live.ex:47
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:4
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:21
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:217
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:233
 #, elixir-autogen, elixir-format
 msgid "My Sessions"
 msgstr ""
@@ -899,7 +899,7 @@ msgid "Send Message"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:145
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:103
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:105
 #, elixir-autogen, elixir-format
 msgid "Session completed successfully"
 msgstr ""
@@ -913,7 +913,7 @@ msgid "Session not found"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:122
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:74
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:76
 #, elixir-autogen, elixir-format
 msgid "Session started successfully"
 msgstr ""
@@ -1393,9 +1393,9 @@ msgid "Failed to load participation history"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/participation_live.ex:28
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:64
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:65
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:29
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:260
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:281
 #, elixir-autogen, elixir-format
 msgid "Manage Participation"
 msgstr ""
@@ -1639,11 +1639,11 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:538
 #: lib/klass_hero_web/components/provider_components.ex:1432
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:50
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:77
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:54
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:81
 #: lib/klass_hero_web/live/settings/children_live.ex:448
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:50
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:77
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:54
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
@@ -1822,9 +1822,9 @@ msgstr ""
 msgid "Broadcast sent to %{count} parents"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:428
-#: lib/klass_hero_web/components/participation_components.ex:618
-#: lib/klass_hero_web/components/participation_components.ex:704
+#: lib/klass_hero_web/components/participation_components.ex:441
+#: lib/klass_hero_web/components/participation_components.ex:631
+#: lib/klass_hero_web/components/participation_components.ex:717
 #: lib/klass_hero_web/components/provider_components.ex:817
 #: lib/klass_hero_web/components/provider_components.ex:1214
 #: lib/klass_hero_web/components/provider_components.ex:1919
@@ -1833,7 +1833,7 @@ msgstr ""
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:222
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:356
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:190
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:191
 #: lib/klass_hero_web/live/settings/children_live.ex:579
 #: lib/klass_hero_web/live/settings/children_live.ex:738
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:233
@@ -2257,7 +2257,7 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:813
+#: lib/klass_hero_web/components/participation_components.ex:826
 #: lib/klass_hero_web/components/provider_components.ex:47
 #: lib/klass_hero_web/live/admin/sessions_live.ex:294
 #: lib/klass_hero_web/live/admin/verifications_live.ex:202
@@ -2505,7 +2505,7 @@ msgid "End Date"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:952
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:165
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:166
 #, elixir-autogen, elixir-format
 msgid "End Time"
 msgstr ""
@@ -2700,7 +2700,7 @@ msgid "Leave unchecked to allow all genders."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:908
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:171
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Location"
 msgstr ""
@@ -2859,7 +2859,7 @@ msgstr ""
 msgid "Participant Restrictions (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:812
+#: lib/klass_hero_web/components/participation_components.ex:825
 #: lib/klass_hero_web/components/provider_components.ex:292
 #, elixir-autogen, elixir-format
 msgid "Pending Review"
@@ -2938,7 +2938,7 @@ msgstr ""
 msgid "Read our founding story →"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:792
+#: lib/klass_hero_web/components/participation_components.ex:805
 #: lib/klass_hero_web/components/provider_components.ex:2187
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
@@ -3006,7 +3006,7 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:814
+#: lib/klass_hero_web/components/participation_components.ex:827
 #: lib/klass_hero_web/components/provider_components.ex:48
 #: lib/klass_hero_web/live/admin/verifications_live.ex:207
 #, elixir-autogen, elixir-format
@@ -3128,7 +3128,7 @@ msgid "Start Date"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:947
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:164
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Start Time"
 msgstr ""
@@ -3536,7 +3536,7 @@ msgstr ""
 msgid "A reason is required for corrections"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:798
+#: lib/klass_hero_web/components/participation_components.ex:811
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:201
 #, elixir-autogen, elixir-format
 msgid "Absent"
@@ -3666,7 +3666,7 @@ msgstr ""
 msgid "Coming soon! Sign up for our newsletter to be notified when gift vouchers launch."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:795
+#: lib/klass_hero_web/components/participation_components.ex:808
 #, elixir-autogen, elixir-format
 msgid "Completed"
 msgstr ""
@@ -3739,7 +3739,7 @@ msgstr ""
 msgid "How does the booking system work?"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:794
+#: lib/klass_hero_web/components/participation_components.ex:807
 #: lib/klass_hero_web/live/admin/sessions_live.ex:275
 #, elixir-autogen, elixir-format
 msgid "In Progress"
@@ -3797,9 +3797,9 @@ msgstr ""
 msgid "No risk of non-payment"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:817
+#: lib/klass_hero_web/components/participation_components.ex:830
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:155
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:177
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:178
 #, elixir-autogen, elixir-format
 msgid "Notes"
 msgstr ""
@@ -3886,7 +3886,7 @@ msgstr ""
 msgid "Save Correction"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:793
+#: lib/klass_hero_web/components/participation_components.ex:806
 #, elixir-autogen, elixir-format
 msgid "Scheduled"
 msgstr ""
@@ -3982,12 +3982,7 @@ msgstr ""
 msgid "You receive instant email with booking details and parent contact info"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:84
-#, elixir-autogen, elixir-format
-msgid "%{checked_in} / %{capacity} checked in"
-msgstr ""
-
-#: lib/klass_hero_web/components/participation_components.ex:322
+#: lib/klass_hero_web/components/participation_components.ex:335
 #, elixir-autogen, elixir-format
 msgid "%{checked_in} / %{total} checked in"
 msgstr ""
@@ -3997,7 +3992,7 @@ msgstr ""
 msgid "%{count} unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:385
+#: lib/klass_hero_web/live/provider/sessions_live.ex:386
 #, elixir-autogen, elixir-format
 msgid "A session already exists at this time"
 msgstr ""
@@ -4007,8 +4002,8 @@ msgstr ""
 msgid "Account created! Check your email to confirm and log in."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:111
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:111
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:115
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:115
 #, elixir-autogen, elixir-format
 msgid "Add Note"
 msgstr ""
@@ -4030,12 +4025,12 @@ msgstr ""
 msgid "All providers"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:724
+#: lib/klass_hero_web/components/participation_components.ex:737
 #, elixir-autogen, elixir-format
 msgid "Allergies: %{details}"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:235
+#: lib/klass_hero_web/components/participation_components.ex:248
 #, elixir-autogen, elixir-format
 msgid "Any important notes about today's session..."
 msgstr ""
@@ -4072,8 +4067,8 @@ msgstr ""
 msgid "Broadcast messages are one-way"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:92
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:92
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:96
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:96
 #, elixir-autogen, elixir-format
 msgid "Check In"
 msgstr ""
@@ -4083,22 +4078,22 @@ msgstr ""
 msgid "Check-in time must be before check-out time"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:363
+#: lib/klass_hero_web/components/participation_components.ex:376
 #, elixir-autogen, elixir-format
 msgid "Check-in:"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:400
+#: lib/klass_hero_web/components/participation_components.ex:413
 #, elixir-autogen, elixir-format
 msgid "Check-out notes (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:369
+#: lib/klass_hero_web/components/participation_components.ex:382
 #, elixir-autogen, elixir-format
 msgid "Check-out:"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:220
+#: lib/klass_hero_web/components/participation_components.ex:233
 #, elixir-autogen, elixir-format
 msgid "Checked in at %{time}"
 msgstr ""
@@ -4123,13 +4118,13 @@ msgstr ""
 msgid "Complete Registration"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:75
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:271
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:76
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:292
 #, elixir-autogen, elixir-format
 msgid "Complete Session"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:415
+#: lib/klass_hero_web/components/participation_components.ex:428
 #, elixir-autogen, elixir-format
 msgid "Confirm Check Out"
 msgstr ""
@@ -4165,29 +4160,29 @@ msgid "Could not start private conversation"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:18
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:134
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:199
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:135
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:200
 #, elixir-autogen, elixir-format
 msgid "Create Session"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:161
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:162
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:361
 #: lib/klass_hero_web/live/provider/sessions_live.ex:362
+#: lib/klass_hero_web/live/provider/sessions_live.ex:363
 #, elixir-autogen, elixir-format
 msgid "Date is required"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:401
+#: lib/klass_hero_web/components/participation_components.ex:414
 #, elixir-autogen, elixir-format
 msgid "E.g., picked up by parent, gave medication reminder..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:140
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "Edit & Resubmit"
 msgstr ""
@@ -4215,17 +4210,17 @@ msgstr ""
 msgid "Emails"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:736
+#: lib/klass_hero_web/components/participation_components.ex:749
 #, elixir-autogen, elixir-format
 msgid "Emergency: %{details}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:384
+#: lib/klass_hero_web/live/provider/sessions_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "End time must be after start time"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:799
+#: lib/klass_hero_web/components/participation_components.ex:812
 #, elixir-autogen, elixir-format
 msgid "Expected"
 msgstr ""
@@ -4235,7 +4230,7 @@ msgstr ""
 msgid "Failed to archive email"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:321
+#: lib/klass_hero_web/live/provider/sessions_live.ex:322
 #, elixir-autogen, elixir-format
 msgid "Failed to create session: %{reason}"
 msgstr ""
@@ -4281,7 +4276,7 @@ msgstr ""
 msgid "Go to Home"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:348
+#: lib/klass_hero_web/components/participation_components.ex:361
 #, elixir-autogen, elixir-format
 msgid "In: %{time}"
 msgstr ""
@@ -4292,7 +4287,7 @@ msgid "Invalid Invitation"
 msgstr ""
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:259
-#: lib/klass_hero_web/live/provider/sessions_live.ex:380
+#: lib/klass_hero_web/live/provider/sessions_live.ex:381
 #, elixir-autogen, elixir-format
 msgid "Invalid time format"
 msgstr ""
@@ -4333,7 +4328,7 @@ msgstr ""
 msgid "Load images"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:77
+#: lib/klass_hero_web/components/participation_components.ex:84
 #, elixir-autogen, elixir-format
 msgid "Location TBD"
 msgstr ""
@@ -4348,18 +4343,18 @@ msgstr ""
 msgid "Mark Unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:180
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:181
 #, elixir-autogen, elixir-format
 msgid "Max Capacity"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:89
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:285
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:90
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "No actions available"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:445
+#: lib/klass_hero_web/components/participation_components.ex:458
 #, elixir-autogen, elixir-format
 msgid "No children enrolled in this session"
 msgstr ""
@@ -4389,34 +4384,34 @@ msgstr ""
 msgid "No sessions found for the selected filters."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:104
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:300
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:105
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:321
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:645
+#: lib/klass_hero_web/components/participation_components.ex:658
 #, elixir-autogen, elixir-format
 msgid "Note:"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:507
+#: lib/klass_hero_web/components/participation_components.ex:520
 #, elixir-autogen, elixir-format
 msgid "Observation about the child's participation..."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:354
+#: lib/klass_hero_web/components/participation_components.ex:367
 #, elixir-autogen, elixir-format
 msgid "Out: %{time}"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:183
+#: lib/klass_hero_web/components/participation_components.ex:196
 #, elixir-autogen, elixir-format
 msgid "Participation Check-In"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:26
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:26
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:30
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:30
 #, elixir-autogen, elixir-format
 msgid "Participation Management"
 msgstr ""
@@ -4431,7 +4426,7 @@ msgstr ""
 msgid "Please explain why you're rejecting this note..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:387
+#: lib/klass_hero_web/live/provider/sessions_live.ex:388
 #, elixir-autogen, elixir-format
 msgid "Please fill in all required fields"
 msgstr ""
@@ -4445,7 +4440,7 @@ msgstr ""
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
 #: lib/klass_hero_web/live/provider/programs_live.ex:217
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:155
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:156
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
@@ -4507,7 +4502,7 @@ msgstr ""
 msgid "Reset to today"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:538
+#: lib/klass_hero_web/components/participation_components.ex:551
 #, elixir-autogen, elixir-format
 msgid "Resubmit Note"
 msgstr ""
@@ -4517,12 +4512,12 @@ msgstr ""
 msgid "Retry"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:536
+#: lib/klass_hero_web/components/participation_components.ex:549
 #, elixir-autogen, elixir-format
 msgid "Revised Note"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:156
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "Select a program..."
 msgstr ""
@@ -4537,25 +4532,25 @@ msgstr ""
 msgid "Sending"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:63
+#: lib/klass_hero_web/components/participation_components.ex:70
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:16
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:16
 #, elixir-autogen, elixir-format
 msgid "Session"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:234
+#: lib/klass_hero_web/components/participation_components.ex:247
 #, elixir-autogen, elixir-format
 msgid "Session Notes (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:191
-#: lib/klass_hero_web/components/participation_components.ex:319
+#: lib/klass_hero_web/components/participation_components.ex:204
+#: lib/klass_hero_web/components/participation_components.ex:332
 #, elixir-autogen, elixir-format
 msgid "Session Roster"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:303
+#: lib/klass_hero_web/live/provider/sessions_live.ex:304
 #, elixir-autogen, elixir-format
 msgid "Session created successfully"
 msgstr ""
@@ -4570,23 +4565,23 @@ msgstr ""
 msgid "Staff member created, but the invitation could not be sent. Try resending from the team list."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:53
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:249
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:54
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:270
 #, elixir-autogen, elixir-format
 msgid "Start Session"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:508
+#: lib/klass_hero_web/components/participation_components.ex:521
 #, elixir-autogen, elixir-format
 msgid "Submit Note"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:249
+#: lib/klass_hero_web/components/participation_components.ex:262
 #, elixir-autogen, elixir-format
 msgid "Submit Participation"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:730
+#: lib/klass_hero_web/components/participation_components.ex:743
 #, elixir-autogen, elixir-format
 msgid "Support: %{details}"
 msgstr ""
@@ -4621,8 +4616,8 @@ msgstr ""
 msgid "This invite link is invalid or has expired."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:371
 #: lib/klass_hero_web/live/provider/sessions_live.ex:372
+#: lib/klass_hero_web/live/provider/sessions_live.ex:373
 #, elixir-autogen, elixir-format
 msgid "Time is required"
 msgstr ""
@@ -4639,8 +4634,8 @@ msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:182
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:122
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:93
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:122
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:95
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:124
 #, elixir-autogen, elixir-format
 msgid "Unauthorized"
 msgstr ""
@@ -4652,7 +4647,7 @@ msgstr ""
 msgid "Unread"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:537
+#: lib/klass_hero_web/components/participation_components.ex:550
 #, elixir-autogen, elixir-format
 msgid "Update your observation..."
 msgstr ""
@@ -4666,8 +4661,8 @@ msgstr ""
 msgid "Upload connection lost. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:86
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:282
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:87
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:303
 #, elixir-autogen, elixir-format
 msgid "View Participation"
 msgstr ""
@@ -4692,8 +4687,8 @@ msgstr ""
 msgid "You already have an account. Log in to see your new enrollment."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:107
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:303
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:108
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:324
 #, elixir-autogen, elixir-format
 msgid "You have no sessions scheduled for %{date}"
 msgstr ""
@@ -4728,7 +4723,7 @@ msgstr ""
 msgid "Unlimited team seats"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:218
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:234
 #, elixir-autogen, elixir-format
 msgid "View and manage your assigned sessions"
 msgstr ""
@@ -4760,7 +4755,7 @@ msgstr ""
 msgid "Business Name"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:800
+#: lib/klass_hero_web/components/participation_components.ex:813
 #, elixir-autogen, elixir-format
 msgid "Cancelled"
 msgstr ""
@@ -4971,12 +4966,12 @@ msgstr ""
 msgid "Create a program before inviting participants."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:797
+#: lib/klass_hero_web/components/participation_components.ex:810
 #, elixir-autogen, elixir-format
 msgid "Departed"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:816
+#: lib/klass_hero_web/components/participation_components.ex:829
 #, elixir-autogen, elixir-format
 msgid "Departure notes"
 msgstr ""
@@ -5013,7 +5008,7 @@ msgstr ""
 msgid "Invite sent."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:591
+#: lib/klass_hero_web/components/participation_components.ex:604
 #, elixir-autogen, elixir-format
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
@@ -5049,7 +5044,7 @@ msgstr ""
 msgid "Photos may appear on social media"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:796
+#: lib/klass_hero_web/components/participation_components.ex:809
 #, elixir-autogen, elixir-format
 msgid "Present"
 msgstr ""
@@ -5059,13 +5054,13 @@ msgstr ""
 msgid "Primary guardian"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:62
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:62
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:66
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:66
 #, elixir-autogen, elixir-format
 msgid "Record departure"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:588
+#: lib/klass_hero_web/components/participation_components.ex:601
 #, elixir-autogen, elixir-format
 msgid "Record departure time (optional)"
 msgstr ""
@@ -5076,7 +5071,7 @@ msgstr ""
 msgid "Record updated"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:605
+#: lib/klass_hero_web/components/participation_components.ex:618
 #, elixir-autogen, elixir-format
 msgid "Save changes"
 msgstr ""
@@ -5101,7 +5096,7 @@ msgstr ""
 msgid "Send invite"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:580
+#: lib/klass_hero_web/components/participation_components.ex:593
 #, elixir-autogen, elixir-format
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr ""
@@ -7575,7 +7570,7 @@ msgstr ""
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:506
+#: lib/klass_hero_web/components/participation_components.ex:519
 #, elixir-autogen, elixir-format
 msgid "Session Note"
 msgstr ""
@@ -7599,3 +7594,15 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Incidents"
 msgstr ""
+
+#: lib/klass_hero_web/components/participation_components.ex:96
+#, elixir-autogen, elixir-format
+msgid "%{checked_in} of %{roster} checked in"
+msgstr ""
+
+#: lib/klass_hero_web/components/participation_components.ex:92
+#, elixir-autogen, elixir-format
+msgid "%{count} child enrolled"
+msgid_plural "%{count} children enrolled"
+msgstr[0] ""
+msgstr[1] ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -631,7 +631,7 @@ msgstr ""
 msgid "Failed to check out: %{reason}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:158
+#: lib/klass_hero_web/live/provider/sessions_live.ex:159
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:117
 #, elixir-autogen, elixir-format
 msgid "Failed to complete session: %{reason}"
@@ -642,7 +642,7 @@ msgstr ""
 msgid "Failed to delete account. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:135
+#: lib/klass_hero_web/live/provider/sessions_live.ex:136
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:88
 #, elixir-autogen, elixir-format
 msgid "Failed to start session: %{reason}"
@@ -693,8 +693,8 @@ msgstr ""
 msgid "Introduction"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:113
-#: lib/klass_hero_web/live/provider/sessions_live.ex:355
+#: lib/klass_hero_web/live/provider/sessions_live.ex:114
+#: lib/klass_hero_web/live/provider/sessions_live.ex:367
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:64
 #, elixir-autogen, elixir-format
 msgid "Invalid date format"
@@ -898,7 +898,7 @@ msgstr ""
 msgid "Send Message"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:144
+#: lib/klass_hero_web/live/provider/sessions_live.ex:145
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:103
 #, elixir-autogen, elixir-format
 msgid "Session completed successfully"
@@ -912,7 +912,7 @@ msgstr ""
 msgid "Session not found"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:121
+#: lib/klass_hero_web/live/provider/sessions_live.ex:122
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:74
 #, elixir-autogen, elixir-format
 msgid "Session started successfully"
@@ -1393,7 +1393,7 @@ msgid "Failed to load participation history"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/participation_live.ex:28
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:60
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:64
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:29
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:260
 #, elixir-autogen, elixir-format
@@ -1822,9 +1822,9 @@ msgstr ""
 msgid "Broadcast sent to %{count} parents"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:417
-#: lib/klass_hero_web/components/participation_components.ex:607
-#: lib/klass_hero_web/components/participation_components.ex:693
+#: lib/klass_hero_web/components/participation_components.ex:428
+#: lib/klass_hero_web/components/participation_components.ex:618
+#: lib/klass_hero_web/components/participation_components.ex:704
 #: lib/klass_hero_web/components/provider_components.ex:817
 #: lib/klass_hero_web/components/provider_components.ex:1214
 #: lib/klass_hero_web/components/provider_components.ex:1919
@@ -1833,7 +1833,7 @@ msgstr ""
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:222
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:356
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:186
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:190
 #: lib/klass_hero_web/live/settings/children_live.ex:579
 #: lib/klass_hero_web/live/settings/children_live.ex:738
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:233
@@ -2257,7 +2257,7 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:802
+#: lib/klass_hero_web/components/participation_components.ex:813
 #: lib/klass_hero_web/components/provider_components.ex:47
 #: lib/klass_hero_web/live/admin/sessions_live.ex:294
 #: lib/klass_hero_web/live/admin/verifications_live.ex:202
@@ -2505,7 +2505,7 @@ msgid "End Date"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:952
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:161
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "End Time"
 msgstr ""
@@ -2700,7 +2700,7 @@ msgid "Leave unchecked to allow all genders."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:908
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:167
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "Location"
 msgstr ""
@@ -2859,7 +2859,7 @@ msgstr ""
 msgid "Participant Restrictions (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:801
+#: lib/klass_hero_web/components/participation_components.ex:812
 #: lib/klass_hero_web/components/provider_components.ex:292
 #, elixir-autogen, elixir-format
 msgid "Pending Review"
@@ -2938,7 +2938,7 @@ msgstr ""
 msgid "Read our founding story →"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:781
+#: lib/klass_hero_web/components/participation_components.ex:792
 #: lib/klass_hero_web/components/provider_components.ex:2187
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
@@ -3006,7 +3006,7 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:803
+#: lib/klass_hero_web/components/participation_components.ex:814
 #: lib/klass_hero_web/components/provider_components.ex:48
 #: lib/klass_hero_web/live/admin/verifications_live.ex:207
 #, elixir-autogen, elixir-format
@@ -3128,7 +3128,7 @@ msgid "Start Date"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:947
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:160
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:164
 #, elixir-autogen, elixir-format
 msgid "Start Time"
 msgstr ""
@@ -3536,7 +3536,7 @@ msgstr ""
 msgid "A reason is required for corrections"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:787
+#: lib/klass_hero_web/components/participation_components.ex:798
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:201
 #, elixir-autogen, elixir-format
 msgid "Absent"
@@ -3666,7 +3666,7 @@ msgstr ""
 msgid "Coming soon! Sign up for our newsletter to be notified when gift vouchers launch."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:784
+#: lib/klass_hero_web/components/participation_components.ex:795
 #, elixir-autogen, elixir-format
 msgid "Completed"
 msgstr ""
@@ -3739,7 +3739,7 @@ msgstr ""
 msgid "How does the booking system work?"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:783
+#: lib/klass_hero_web/components/participation_components.ex:794
 #: lib/klass_hero_web/live/admin/sessions_live.ex:275
 #, elixir-autogen, elixir-format
 msgid "In Progress"
@@ -3797,9 +3797,9 @@ msgstr ""
 msgid "No risk of non-payment"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:806
+#: lib/klass_hero_web/components/participation_components.ex:817
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:155
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:173
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:177
 #, elixir-autogen, elixir-format
 msgid "Notes"
 msgstr ""
@@ -3886,7 +3886,7 @@ msgstr ""
 msgid "Save Correction"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:782
+#: lib/klass_hero_web/components/participation_components.ex:793
 #, elixir-autogen, elixir-format
 msgid "Scheduled"
 msgstr ""
@@ -3982,12 +3982,12 @@ msgstr ""
 msgid "You receive instant email with booking details and parent contact info"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:73
+#: lib/klass_hero_web/components/participation_components.ex:84
 #, elixir-autogen, elixir-format
 msgid "%{checked_in} / %{capacity} checked in"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:311
+#: lib/klass_hero_web/components/participation_components.ex:322
 #, elixir-autogen, elixir-format
 msgid "%{checked_in} / %{total} checked in"
 msgstr ""
@@ -3997,7 +3997,7 @@ msgstr ""
 msgid "%{count} unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:373
+#: lib/klass_hero_web/live/provider/sessions_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "A session already exists at this time"
 msgstr ""
@@ -4030,12 +4030,12 @@ msgstr ""
 msgid "All providers"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:713
+#: lib/klass_hero_web/components/participation_components.ex:724
 #, elixir-autogen, elixir-format
 msgid "Allergies: %{details}"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:224
+#: lib/klass_hero_web/components/participation_components.ex:235
 #, elixir-autogen, elixir-format
 msgid "Any important notes about today's session..."
 msgstr ""
@@ -4083,22 +4083,22 @@ msgstr ""
 msgid "Check-in time must be before check-out time"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:352
+#: lib/klass_hero_web/components/participation_components.ex:363
 #, elixir-autogen, elixir-format
 msgid "Check-in:"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:389
+#: lib/klass_hero_web/components/participation_components.ex:400
 #, elixir-autogen, elixir-format
 msgid "Check-out notes (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:358
+#: lib/klass_hero_web/components/participation_components.ex:369
 #, elixir-autogen, elixir-format
 msgid "Check-out:"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:209
+#: lib/klass_hero_web/components/participation_components.ex:220
 #, elixir-autogen, elixir-format
 msgid "Checked in at %{time}"
 msgstr ""
@@ -4123,13 +4123,13 @@ msgstr ""
 msgid "Complete Registration"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:71
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:75
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:271
 #, elixir-autogen, elixir-format
 msgid "Complete Session"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:404
+#: lib/klass_hero_web/components/participation_components.ex:415
 #, elixir-autogen, elixir-format
 msgid "Confirm Check Out"
 msgstr ""
@@ -4165,24 +4165,24 @@ msgid "Could not start private conversation"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:18
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:130
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:195
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:134
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "Create Session"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:157
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:161
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:349
-#: lib/klass_hero_web/live/provider/sessions_live.ex:350
+#: lib/klass_hero_web/live/provider/sessions_live.ex:361
+#: lib/klass_hero_web/live/provider/sessions_live.ex:362
 #, elixir-autogen, elixir-format
 msgid "Date is required"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:390
+#: lib/klass_hero_web/components/participation_components.ex:401
 #, elixir-autogen, elixir-format
 msgid "E.g., picked up by parent, gave medication reminder..."
 msgstr ""
@@ -4215,17 +4215,17 @@ msgstr ""
 msgid "Emails"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:725
+#: lib/klass_hero_web/components/participation_components.ex:736
 #, elixir-autogen, elixir-format
 msgid "Emergency: %{details}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:372
+#: lib/klass_hero_web/live/provider/sessions_live.ex:384
 #, elixir-autogen, elixir-format
 msgid "End time must be after start time"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:788
+#: lib/klass_hero_web/components/participation_components.ex:799
 #, elixir-autogen, elixir-format
 msgid "Expected"
 msgstr ""
@@ -4235,7 +4235,7 @@ msgstr ""
 msgid "Failed to archive email"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:309
+#: lib/klass_hero_web/live/provider/sessions_live.ex:321
 #, elixir-autogen, elixir-format
 msgid "Failed to create session: %{reason}"
 msgstr ""
@@ -4281,7 +4281,7 @@ msgstr ""
 msgid "Go to Home"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:337
+#: lib/klass_hero_web/components/participation_components.ex:348
 #, elixir-autogen, elixir-format
 msgid "In: %{time}"
 msgstr ""
@@ -4292,7 +4292,7 @@ msgid "Invalid Invitation"
 msgstr ""
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:259
-#: lib/klass_hero_web/live/provider/sessions_live.ex:368
+#: lib/klass_hero_web/live/provider/sessions_live.ex:380
 #, elixir-autogen, elixir-format
 msgid "Invalid time format"
 msgstr ""
@@ -4333,7 +4333,7 @@ msgstr ""
 msgid "Load images"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:66
+#: lib/klass_hero_web/components/participation_components.ex:77
 #, elixir-autogen, elixir-format
 msgid "Location TBD"
 msgstr ""
@@ -4348,18 +4348,18 @@ msgstr ""
 msgid "Mark Unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:176
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:180
 #, elixir-autogen, elixir-format
 msgid "Max Capacity"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:85
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:89
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:285
 #, elixir-autogen, elixir-format
 msgid "No actions available"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:434
+#: lib/klass_hero_web/components/participation_components.ex:445
 #, elixir-autogen, elixir-format
 msgid "No children enrolled in this session"
 msgstr ""
@@ -4389,28 +4389,28 @@ msgstr ""
 msgid "No sessions found for the selected filters."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:100
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:104
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:300
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:634
+#: lib/klass_hero_web/components/participation_components.ex:645
 #, elixir-autogen, elixir-format
 msgid "Note:"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:496
+#: lib/klass_hero_web/components/participation_components.ex:507
 #, elixir-autogen, elixir-format
 msgid "Observation about the child's participation..."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:343
+#: lib/klass_hero_web/components/participation_components.ex:354
 #, elixir-autogen, elixir-format
 msgid "Out: %{time}"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:172
+#: lib/klass_hero_web/components/participation_components.ex:183
 #, elixir-autogen, elixir-format
 msgid "Participation Check-In"
 msgstr ""
@@ -4431,7 +4431,7 @@ msgstr ""
 msgid "Please explain why you're rejecting this note..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:375
+#: lib/klass_hero_web/live/provider/sessions_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "Please fill in all required fields"
 msgstr ""
@@ -4445,12 +4445,12 @@ msgstr ""
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
 #: lib/klass_hero_web/live/provider/programs_live.ex:217
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:151
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:155
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:177
+#: lib/klass_hero_web/live/provider/sessions_live.ex:178
 #, elixir-autogen, elixir-format
 msgid "Program is required"
 msgstr ""
@@ -4507,7 +4507,7 @@ msgstr ""
 msgid "Reset to today"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:527
+#: lib/klass_hero_web/components/participation_components.ex:538
 #, elixir-autogen, elixir-format
 msgid "Resubmit Note"
 msgstr ""
@@ -4517,12 +4517,12 @@ msgstr ""
 msgid "Retry"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:525
+#: lib/klass_hero_web/components/participation_components.ex:536
 #, elixir-autogen, elixir-format
 msgid "Revised Note"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:152
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:156
 #, elixir-autogen, elixir-format
 msgid "Select a program..."
 msgstr ""
@@ -4537,25 +4537,25 @@ msgstr ""
 msgid "Sending"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:54
+#: lib/klass_hero_web/components/participation_components.ex:63
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:16
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:16
 #, elixir-autogen, elixir-format
 msgid "Session"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:223
+#: lib/klass_hero_web/components/participation_components.ex:234
 #, elixir-autogen, elixir-format
 msgid "Session Notes (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:180
-#: lib/klass_hero_web/components/participation_components.ex:308
+#: lib/klass_hero_web/components/participation_components.ex:191
+#: lib/klass_hero_web/components/participation_components.ex:319
 #, elixir-autogen, elixir-format
 msgid "Session Roster"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:291
+#: lib/klass_hero_web/live/provider/sessions_live.ex:303
 #, elixir-autogen, elixir-format
 msgid "Session created successfully"
 msgstr ""
@@ -4570,23 +4570,23 @@ msgstr ""
 msgid "Staff member created, but the invitation could not be sent. Try resending from the team list."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:49
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:53
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:249
 #, elixir-autogen, elixir-format
 msgid "Start Session"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:497
+#: lib/klass_hero_web/components/participation_components.ex:508
 #, elixir-autogen, elixir-format
 msgid "Submit Note"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:238
+#: lib/klass_hero_web/components/participation_components.ex:249
 #, elixir-autogen, elixir-format
 msgid "Submit Participation"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:719
+#: lib/klass_hero_web/components/participation_components.ex:730
 #, elixir-autogen, elixir-format
 msgid "Support: %{details}"
 msgstr ""
@@ -4621,8 +4621,8 @@ msgstr ""
 msgid "This invite link is invalid or has expired."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:359
-#: lib/klass_hero_web/live/provider/sessions_live.ex:360
+#: lib/klass_hero_web/live/provider/sessions_live.ex:371
+#: lib/klass_hero_web/live/provider/sessions_live.ex:372
 #, elixir-autogen, elixir-format
 msgid "Time is required"
 msgstr ""
@@ -4637,7 +4637,7 @@ msgstr ""
 msgid "Type your reply..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:181
+#: lib/klass_hero_web/live/provider/sessions_live.ex:182
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:122
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:93
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:122
@@ -4652,7 +4652,7 @@ msgstr ""
 msgid "Unread"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:526
+#: lib/klass_hero_web/components/participation_components.ex:537
 #, elixir-autogen, elixir-format
 msgid "Update your observation..."
 msgstr ""
@@ -4666,7 +4666,7 @@ msgstr ""
 msgid "Upload connection lost. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:82
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:86
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "View Participation"
@@ -4692,7 +4692,7 @@ msgstr ""
 msgid "You already have an account. Log in to see your new enrollment."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:103
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:107
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:303
 #, elixir-autogen, elixir-format
 msgid "You have no sessions scheduled for %{date}"
@@ -4760,7 +4760,7 @@ msgstr ""
 msgid "Business Name"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:789
+#: lib/klass_hero_web/components/participation_components.ex:800
 #, elixir-autogen, elixir-format
 msgid "Cancelled"
 msgstr ""
@@ -4971,12 +4971,12 @@ msgstr ""
 msgid "Create a program before inviting participants."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:786
+#: lib/klass_hero_web/components/participation_components.ex:797
 #, elixir-autogen, elixir-format
 msgid "Departed"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:805
+#: lib/klass_hero_web/components/participation_components.ex:816
 #, elixir-autogen, elixir-format
 msgid "Departure notes"
 msgstr ""
@@ -5013,7 +5013,7 @@ msgstr ""
 msgid "Invite sent."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:580
+#: lib/klass_hero_web/components/participation_components.ex:591
 #, elixir-autogen, elixir-format
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
@@ -5049,7 +5049,7 @@ msgstr ""
 msgid "Photos may appear on social media"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:785
+#: lib/klass_hero_web/components/participation_components.ex:796
 #, elixir-autogen, elixir-format
 msgid "Present"
 msgstr ""
@@ -5065,7 +5065,7 @@ msgstr ""
 msgid "Record departure"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:577
+#: lib/klass_hero_web/components/participation_components.ex:588
 #, elixir-autogen, elixir-format
 msgid "Record departure time (optional)"
 msgstr ""
@@ -5076,7 +5076,7 @@ msgstr ""
 msgid "Record updated"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:594
+#: lib/klass_hero_web/components/participation_components.ex:605
 #, elixir-autogen, elixir-format
 msgid "Save changes"
 msgstr ""
@@ -5101,7 +5101,7 @@ msgstr ""
 msgid "Send invite"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:569
+#: lib/klass_hero_web/components/participation_components.ex:580
 #, elixir-autogen, elixir-format
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr ""
@@ -7575,7 +7575,7 @@ msgstr ""
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:495
+#: lib/klass_hero_web/components/participation_components.ex:506
 #, elixir-autogen, elixir-format
 msgid "Session Note"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -632,7 +632,7 @@ msgid "Failed to check out: %{reason}"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:159
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:117
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:119
 #, elixir-autogen, elixir-format
 msgid "Failed to complete session: %{reason}"
 msgstr ""
@@ -643,7 +643,7 @@ msgid "Failed to delete account. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:136
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:88
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "Failed to start session: %{reason}"
 msgstr ""
@@ -694,8 +694,8 @@ msgid "Introduction"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:114
-#: lib/klass_hero_web/live/provider/sessions_live.ex:367
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:64
+#: lib/klass_hero_web/live/provider/sessions_live.ex:368
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:66
 #, elixir-autogen, elixir-format
 msgid "Invalid date format"
 msgstr ""
@@ -769,7 +769,7 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/sessions_live.ex:47
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:4
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:21
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:217
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:233
 #, elixir-autogen, elixir-format
 msgid "My Sessions"
 msgstr ""
@@ -899,7 +899,7 @@ msgid "Send Message"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:145
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:103
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:105
 #, elixir-autogen, elixir-format
 msgid "Session completed successfully"
 msgstr ""
@@ -913,7 +913,7 @@ msgid "Session not found"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:122
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:74
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:76
 #, elixir-autogen, elixir-format
 msgid "Session started successfully"
 msgstr ""
@@ -1393,9 +1393,9 @@ msgid "Failed to load participation history"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/participation_live.ex:28
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:64
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:65
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:29
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:260
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:281
 #, elixir-autogen, elixir-format
 msgid "Manage Participation"
 msgstr ""
@@ -1639,11 +1639,11 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:538
 #: lib/klass_hero_web/components/provider_components.ex:1432
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:50
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:77
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:54
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:81
 #: lib/klass_hero_web/live/settings/children_live.ex:448
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:50
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:77
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:54
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:81
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
@@ -1822,9 +1822,9 @@ msgstr ""
 msgid "Broadcast sent to %{count} parents"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:428
-#: lib/klass_hero_web/components/participation_components.ex:618
-#: lib/klass_hero_web/components/participation_components.ex:704
+#: lib/klass_hero_web/components/participation_components.ex:441
+#: lib/klass_hero_web/components/participation_components.ex:631
+#: lib/klass_hero_web/components/participation_components.ex:717
 #: lib/klass_hero_web/components/provider_components.ex:817
 #: lib/klass_hero_web/components/provider_components.ex:1214
 #: lib/klass_hero_web/components/provider_components.ex:1919
@@ -1833,7 +1833,7 @@ msgstr ""
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:222
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:356
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:190
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:191
 #: lib/klass_hero_web/live/settings/children_live.ex:579
 #: lib/klass_hero_web/live/settings/children_live.ex:738
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:233
@@ -2257,7 +2257,7 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:813
+#: lib/klass_hero_web/components/participation_components.ex:826
 #: lib/klass_hero_web/components/provider_components.ex:47
 #: lib/klass_hero_web/live/admin/sessions_live.ex:294
 #: lib/klass_hero_web/live/admin/verifications_live.ex:202
@@ -2505,7 +2505,7 @@ msgid "End Date"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:952
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:165
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:166
 #, elixir-autogen, elixir-format
 msgid "End Time"
 msgstr ""
@@ -2700,7 +2700,7 @@ msgid "Leave unchecked to allow all genders."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:908
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:171
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:172
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Location"
 msgstr ""
@@ -2859,7 +2859,7 @@ msgstr ""
 msgid "Participant Restrictions (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:812
+#: lib/klass_hero_web/components/participation_components.ex:825
 #: lib/klass_hero_web/components/provider_components.ex:292
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Pending Review"
@@ -2938,7 +2938,7 @@ msgstr ""
 msgid "Read our founding story →"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:792
+#: lib/klass_hero_web/components/participation_components.ex:805
 #: lib/klass_hero_web/components/provider_components.ex:2187
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format, fuzzy
@@ -3006,7 +3006,7 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:814
+#: lib/klass_hero_web/components/participation_components.ex:827
 #: lib/klass_hero_web/components/provider_components.ex:48
 #: lib/klass_hero_web/live/admin/verifications_live.ex:207
 #, elixir-autogen, elixir-format
@@ -3128,7 +3128,7 @@ msgid "Start Date"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:947
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:164
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:165
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Start Time"
 msgstr ""
@@ -3536,7 +3536,7 @@ msgstr ""
 msgid "A reason is required for corrections"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:798
+#: lib/klass_hero_web/components/participation_components.ex:811
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:201
 #, elixir-autogen, elixir-format
 msgid "Absent"
@@ -3666,7 +3666,7 @@ msgstr ""
 msgid "Coming soon! Sign up for our newsletter to be notified when gift vouchers launch."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:795
+#: lib/klass_hero_web/components/participation_components.ex:808
 #, elixir-autogen, elixir-format
 msgid "Completed"
 msgstr ""
@@ -3739,7 +3739,7 @@ msgstr ""
 msgid "How does the booking system work?"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:794
+#: lib/klass_hero_web/components/participation_components.ex:807
 #: lib/klass_hero_web/live/admin/sessions_live.ex:275
 #, elixir-autogen, elixir-format, fuzzy
 msgid "In Progress"
@@ -3797,9 +3797,9 @@ msgstr ""
 msgid "No risk of non-payment"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:817
+#: lib/klass_hero_web/components/participation_components.ex:830
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:155
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:177
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:178
 #, elixir-autogen, elixir-format
 msgid "Notes"
 msgstr ""
@@ -3886,7 +3886,7 @@ msgstr ""
 msgid "Save Correction"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:793
+#: lib/klass_hero_web/components/participation_components.ex:806
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Scheduled"
 msgstr ""
@@ -3982,12 +3982,7 @@ msgstr ""
 msgid "You receive instant email with booking details and parent contact info"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:84
-#, elixir-autogen, elixir-format
-msgid "%{checked_in} / %{capacity} checked in"
-msgstr ""
-
-#: lib/klass_hero_web/components/participation_components.ex:322
+#: lib/klass_hero_web/components/participation_components.ex:335
 #, elixir-autogen, elixir-format
 msgid "%{checked_in} / %{total} checked in"
 msgstr ""
@@ -3997,7 +3992,7 @@ msgstr ""
 msgid "%{count} unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:385
+#: lib/klass_hero_web/live/provider/sessions_live.ex:386
 #, elixir-autogen, elixir-format
 msgid "A session already exists at this time"
 msgstr ""
@@ -4007,8 +4002,8 @@ msgstr ""
 msgid "Account created! Check your email to confirm and log in."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:111
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:111
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:115
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:115
 #, elixir-autogen, elixir-format
 msgid "Add Note"
 msgstr ""
@@ -4030,12 +4025,12 @@ msgstr ""
 msgid "All providers"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:724
+#: lib/klass_hero_web/components/participation_components.ex:737
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Allergies: %{details}"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:235
+#: lib/klass_hero_web/components/participation_components.ex:248
 #, elixir-autogen, elixir-format
 msgid "Any important notes about today's session..."
 msgstr ""
@@ -4072,8 +4067,8 @@ msgstr ""
 msgid "Broadcast messages are one-way"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:92
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:92
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:96
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:96
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Check In"
 msgstr ""
@@ -4083,22 +4078,22 @@ msgstr ""
 msgid "Check-in time must be before check-out time"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:363
+#: lib/klass_hero_web/components/participation_components.ex:376
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Check-in:"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:400
+#: lib/klass_hero_web/components/participation_components.ex:413
 #, elixir-autogen, elixir-format
 msgid "Check-out notes (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:369
+#: lib/klass_hero_web/components/participation_components.ex:382
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Check-out:"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:220
+#: lib/klass_hero_web/components/participation_components.ex:233
 #, elixir-autogen, elixir-format
 msgid "Checked in at %{time}"
 msgstr ""
@@ -4123,13 +4118,13 @@ msgstr ""
 msgid "Complete Registration"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:75
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:271
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:76
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:292
 #, elixir-autogen, elixir-format
 msgid "Complete Session"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:415
+#: lib/klass_hero_web/components/participation_components.ex:428
 #, elixir-autogen, elixir-format
 msgid "Confirm Check Out"
 msgstr ""
@@ -4165,29 +4160,29 @@ msgid "Could not start private conversation"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:18
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:134
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:199
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:135
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:200
 #, elixir-autogen, elixir-format
 msgid "Create Session"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:161
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:162
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:361
 #: lib/klass_hero_web/live/provider/sessions_live.ex:362
+#: lib/klass_hero_web/live/provider/sessions_live.ex:363
 #, elixir-autogen, elixir-format
 msgid "Date is required"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:401
+#: lib/klass_hero_web/components/participation_components.ex:414
 #, elixir-autogen, elixir-format
 msgid "E.g., picked up by parent, gave medication reminder..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:140
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "Edit & Resubmit"
 msgstr ""
@@ -4215,17 +4210,17 @@ msgstr ""
 msgid "Emails"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:736
+#: lib/klass_hero_web/components/participation_components.ex:749
 #, elixir-autogen, elixir-format
 msgid "Emergency: %{details}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:384
+#: lib/klass_hero_web/live/provider/sessions_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "End time must be after start time"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:799
+#: lib/klass_hero_web/components/participation_components.ex:812
 #, elixir-autogen, elixir-format
 msgid "Expected"
 msgstr ""
@@ -4235,7 +4230,7 @@ msgstr ""
 msgid "Failed to archive email"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:321
+#: lib/klass_hero_web/live/provider/sessions_live.ex:322
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to create session: %{reason}"
 msgstr ""
@@ -4281,7 +4276,7 @@ msgstr ""
 msgid "Go to Home"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:348
+#: lib/klass_hero_web/components/participation_components.ex:361
 #, elixir-autogen, elixir-format
 msgid "In: %{time}"
 msgstr ""
@@ -4292,7 +4287,7 @@ msgid "Invalid Invitation"
 msgstr ""
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:259
-#: lib/klass_hero_web/live/provider/sessions_live.ex:380
+#: lib/klass_hero_web/live/provider/sessions_live.ex:381
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invalid time format"
 msgstr ""
@@ -4333,7 +4328,7 @@ msgstr ""
 msgid "Load images"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:77
+#: lib/klass_hero_web/components/participation_components.ex:84
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Location TBD"
 msgstr ""
@@ -4348,18 +4343,18 @@ msgstr ""
 msgid "Mark Unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:180
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:181
 #, elixir-autogen, elixir-format
 msgid "Max Capacity"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:89
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:285
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:90
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "No actions available"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:445
+#: lib/klass_hero_web/components/participation_components.ex:458
 #, elixir-autogen, elixir-format
 msgid "No children enrolled in this session"
 msgstr ""
@@ -4389,34 +4384,34 @@ msgstr ""
 msgid "No sessions found for the selected filters."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:104
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:300
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:105
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:321
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:645
+#: lib/klass_hero_web/components/participation_components.ex:658
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Note:"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:507
+#: lib/klass_hero_web/components/participation_components.ex:520
 #, elixir-autogen, elixir-format
 msgid "Observation about the child's participation..."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:354
+#: lib/klass_hero_web/components/participation_components.ex:367
 #, elixir-autogen, elixir-format
 msgid "Out: %{time}"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:183
+#: lib/klass_hero_web/components/participation_components.ex:196
 #, elixir-autogen, elixir-format
 msgid "Participation Check-In"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:26
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:26
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:30
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:30
 #, elixir-autogen, elixir-format
 msgid "Participation Management"
 msgstr ""
@@ -4431,7 +4426,7 @@ msgstr ""
 msgid "Please explain why you're rejecting this note..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:387
+#: lib/klass_hero_web/live/provider/sessions_live.ex:388
 #, elixir-autogen, elixir-format
 msgid "Please fill in all required fields"
 msgstr ""
@@ -4445,7 +4440,7 @@ msgstr ""
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
 #: lib/klass_hero_web/live/provider/programs_live.ex:217
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:155
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:156
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program"
 msgstr ""
@@ -4507,7 +4502,7 @@ msgstr ""
 msgid "Reset to today"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:538
+#: lib/klass_hero_web/components/participation_components.ex:551
 #, elixir-autogen, elixir-format
 msgid "Resubmit Note"
 msgstr ""
@@ -4517,12 +4512,12 @@ msgstr ""
 msgid "Retry"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:536
+#: lib/klass_hero_web/components/participation_components.ex:549
 #, elixir-autogen, elixir-format
 msgid "Revised Note"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:156
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:157
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select a program..."
 msgstr ""
@@ -4537,25 +4532,25 @@ msgstr ""
 msgid "Sending"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:63
+#: lib/klass_hero_web/components/participation_components.ex:70
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:16
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:16
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Session"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:234
+#: lib/klass_hero_web/components/participation_components.ex:247
 #, elixir-autogen, elixir-format
 msgid "Session Notes (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:191
-#: lib/klass_hero_web/components/participation_components.ex:319
+#: lib/klass_hero_web/components/participation_components.ex:204
+#: lib/klass_hero_web/components/participation_components.ex:332
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Session Roster"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:303
+#: lib/klass_hero_web/live/provider/sessions_live.ex:304
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Session created successfully"
 msgstr ""
@@ -4570,23 +4565,23 @@ msgstr ""
 msgid "Staff member created, but the invitation could not be sent. Try resending from the team list."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:53
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:249
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:54
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:270
 #, elixir-autogen, elixir-format
 msgid "Start Session"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:508
+#: lib/klass_hero_web/components/participation_components.ex:521
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Submit Note"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:249
+#: lib/klass_hero_web/components/participation_components.ex:262
 #, elixir-autogen, elixir-format
 msgid "Submit Participation"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:730
+#: lib/klass_hero_web/components/participation_components.ex:743
 #, elixir-autogen, elixir-format
 msgid "Support: %{details}"
 msgstr ""
@@ -4621,8 +4616,8 @@ msgstr ""
 msgid "This invite link is invalid or has expired."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:371
 #: lib/klass_hero_web/live/provider/sessions_live.ex:372
+#: lib/klass_hero_web/live/provider/sessions_live.ex:373
 #, elixir-autogen, elixir-format
 msgid "Time is required"
 msgstr ""
@@ -4639,8 +4634,8 @@ msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:182
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:122
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:93
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:122
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:95
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:124
 #, elixir-autogen, elixir-format
 msgid "Unauthorized"
 msgstr ""
@@ -4652,7 +4647,7 @@ msgstr ""
 msgid "Unread"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:537
+#: lib/klass_hero_web/components/participation_components.ex:550
 #, elixir-autogen, elixir-format
 msgid "Update your observation..."
 msgstr ""
@@ -4666,8 +4661,8 @@ msgstr ""
 msgid "Upload connection lost. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:86
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:282
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:87
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:303
 #, elixir-autogen, elixir-format
 msgid "View Participation"
 msgstr ""
@@ -4692,8 +4687,8 @@ msgstr ""
 msgid "You already have an account. Log in to see your new enrollment."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:107
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:303
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:108
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:324
 #, elixir-autogen, elixir-format
 msgid "You have no sessions scheduled for %{date}"
 msgstr ""
@@ -4728,7 +4723,7 @@ msgstr ""
 msgid "Unlimited team seats"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:218
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:234
 #, elixir-autogen, elixir-format
 msgid "View and manage your assigned sessions"
 msgstr ""
@@ -4760,7 +4755,7 @@ msgstr ""
 msgid "Business Name"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:800
+#: lib/klass_hero_web/components/participation_components.ex:813
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cancelled"
 msgstr ""
@@ -4971,12 +4966,12 @@ msgstr ""
 msgid "Create a program before inviting participants."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:797
+#: lib/klass_hero_web/components/participation_components.ex:810
 #, elixir-autogen, elixir-format
 msgid "Departed"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:816
+#: lib/klass_hero_web/components/participation_components.ex:829
 #, elixir-autogen, elixir-format
 msgid "Departure notes"
 msgstr ""
@@ -5013,7 +5008,7 @@ msgstr ""
 msgid "Invite sent."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:591
+#: lib/klass_hero_web/components/participation_components.ex:604
 #, elixir-autogen, elixir-format
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
@@ -5049,7 +5044,7 @@ msgstr ""
 msgid "Photos may appear on social media"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:796
+#: lib/klass_hero_web/components/participation_components.ex:809
 #, elixir-autogen, elixir-format
 msgid "Present"
 msgstr ""
@@ -5059,13 +5054,13 @@ msgstr ""
 msgid "Primary guardian"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:62
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:62
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:66
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:66
 #, elixir-autogen, elixir-format
 msgid "Record departure"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:588
+#: lib/klass_hero_web/components/participation_components.ex:601
 #, elixir-autogen, elixir-format
 msgid "Record departure time (optional)"
 msgstr ""
@@ -5076,7 +5071,7 @@ msgstr ""
 msgid "Record updated"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:605
+#: lib/klass_hero_web/components/participation_components.ex:618
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Save changes"
 msgstr ""
@@ -5101,7 +5096,7 @@ msgstr ""
 msgid "Send invite"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:580
+#: lib/klass_hero_web/components/participation_components.ex:593
 #, elixir-autogen, elixir-format
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr ""
@@ -7575,7 +7570,7 @@ msgstr ""
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:506
+#: lib/klass_hero_web/components/participation_components.ex:519
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Session Note"
 msgstr ""
@@ -7599,3 +7594,15 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Incidents"
 msgstr ""
+
+#: lib/klass_hero_web/components/participation_components.ex:96
+#, elixir-autogen, elixir-format, fuzzy
+msgid "%{checked_in} of %{roster} checked in"
+msgstr ""
+
+#: lib/klass_hero_web/components/participation_components.ex:92
+#, elixir-autogen, elixir-format
+msgid "%{count} child enrolled"
+msgid_plural "%{count} children enrolled"
+msgstr[0] ""
+msgstr[1] ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -694,7 +694,7 @@ msgid "Introduction"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:113
-#: lib/klass_hero_web/live/provider/sessions_live.ex:348
+#: lib/klass_hero_web/live/provider/sessions_live.ex:355
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:64
 #, elixir-autogen, elixir-format
 msgid "Invalid date format"
@@ -3997,7 +3997,7 @@ msgstr ""
 msgid "%{count} unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:366
+#: lib/klass_hero_web/live/provider/sessions_live.ex:373
 #, elixir-autogen, elixir-format
 msgid "A session already exists at this time"
 msgstr ""
@@ -4176,8 +4176,8 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:342
-#: lib/klass_hero_web/live/provider/sessions_live.ex:343
+#: lib/klass_hero_web/live/provider/sessions_live.ex:349
+#: lib/klass_hero_web/live/provider/sessions_live.ex:350
 #, elixir-autogen, elixir-format
 msgid "Date is required"
 msgstr ""
@@ -4220,7 +4220,7 @@ msgstr ""
 msgid "Emergency: %{details}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:365
+#: lib/klass_hero_web/live/provider/sessions_live.ex:372
 #, elixir-autogen, elixir-format
 msgid "End time must be after start time"
 msgstr ""
@@ -4235,7 +4235,7 @@ msgstr ""
 msgid "Failed to archive email"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:302
+#: lib/klass_hero_web/live/provider/sessions_live.ex:309
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to create session: %{reason}"
 msgstr ""
@@ -4292,7 +4292,7 @@ msgid "Invalid Invitation"
 msgstr ""
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:259
-#: lib/klass_hero_web/live/provider/sessions_live.ex:361
+#: lib/klass_hero_web/live/provider/sessions_live.ex:368
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invalid time format"
 msgstr ""
@@ -4431,7 +4431,7 @@ msgstr ""
 msgid "Please explain why you're rejecting this note..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:368
+#: lib/klass_hero_web/live/provider/sessions_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "Please fill in all required fields"
 msgstr ""
@@ -4555,7 +4555,7 @@ msgstr ""
 msgid "Session Roster"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:284
+#: lib/klass_hero_web/live/provider/sessions_live.ex:291
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Session created successfully"
 msgstr ""
@@ -4621,8 +4621,8 @@ msgstr ""
 msgid "This invite link is invalid or has expired."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:352
-#: lib/klass_hero_web/live/provider/sessions_live.ex:353
+#: lib/klass_hero_web/live/provider/sessions_live.ex:359
+#: lib/klass_hero_web/live/provider/sessions_live.ex:360
 #, elixir-autogen, elixir-format
 msgid "Time is required"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -631,7 +631,7 @@ msgstr ""
 msgid "Failed to check out: %{reason}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:158
+#: lib/klass_hero_web/live/provider/sessions_live.ex:159
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:117
 #, elixir-autogen, elixir-format
 msgid "Failed to complete session: %{reason}"
@@ -642,7 +642,7 @@ msgstr ""
 msgid "Failed to delete account. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:135
+#: lib/klass_hero_web/live/provider/sessions_live.ex:136
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:88
 #, elixir-autogen, elixir-format
 msgid "Failed to start session: %{reason}"
@@ -693,8 +693,8 @@ msgstr ""
 msgid "Introduction"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:113
-#: lib/klass_hero_web/live/provider/sessions_live.ex:355
+#: lib/klass_hero_web/live/provider/sessions_live.ex:114
+#: lib/klass_hero_web/live/provider/sessions_live.ex:367
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:64
 #, elixir-autogen, elixir-format
 msgid "Invalid date format"
@@ -898,7 +898,7 @@ msgstr ""
 msgid "Send Message"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:144
+#: lib/klass_hero_web/live/provider/sessions_live.ex:145
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:103
 #, elixir-autogen, elixir-format
 msgid "Session completed successfully"
@@ -912,7 +912,7 @@ msgstr ""
 msgid "Session not found"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:121
+#: lib/klass_hero_web/live/provider/sessions_live.ex:122
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:74
 #, elixir-autogen, elixir-format
 msgid "Session started successfully"
@@ -1393,7 +1393,7 @@ msgid "Failed to load participation history"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/participation_live.ex:28
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:60
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:64
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:29
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:260
 #, elixir-autogen, elixir-format
@@ -1822,9 +1822,9 @@ msgstr ""
 msgid "Broadcast sent to %{count} parents"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:417
-#: lib/klass_hero_web/components/participation_components.ex:607
-#: lib/klass_hero_web/components/participation_components.ex:693
+#: lib/klass_hero_web/components/participation_components.ex:428
+#: lib/klass_hero_web/components/participation_components.ex:618
+#: lib/klass_hero_web/components/participation_components.ex:704
 #: lib/klass_hero_web/components/provider_components.ex:817
 #: lib/klass_hero_web/components/provider_components.ex:1214
 #: lib/klass_hero_web/components/provider_components.ex:1919
@@ -1833,7 +1833,7 @@ msgstr ""
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:222
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:356
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:186
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:190
 #: lib/klass_hero_web/live/settings/children_live.ex:579
 #: lib/klass_hero_web/live/settings/children_live.ex:738
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:233
@@ -2257,7 +2257,7 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:802
+#: lib/klass_hero_web/components/participation_components.ex:813
 #: lib/klass_hero_web/components/provider_components.ex:47
 #: lib/klass_hero_web/live/admin/sessions_live.ex:294
 #: lib/klass_hero_web/live/admin/verifications_live.ex:202
@@ -2505,7 +2505,7 @@ msgid "End Date"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:952
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:161
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "End Time"
 msgstr ""
@@ -2700,7 +2700,7 @@ msgid "Leave unchecked to allow all genders."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:908
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:167
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:171
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Location"
 msgstr ""
@@ -2859,7 +2859,7 @@ msgstr ""
 msgid "Participant Restrictions (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:801
+#: lib/klass_hero_web/components/participation_components.ex:812
 #: lib/klass_hero_web/components/provider_components.ex:292
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Pending Review"
@@ -2938,7 +2938,7 @@ msgstr ""
 msgid "Read our founding story →"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:781
+#: lib/klass_hero_web/components/participation_components.ex:792
 #: lib/klass_hero_web/components/provider_components.ex:2187
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format, fuzzy
@@ -3006,7 +3006,7 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:803
+#: lib/klass_hero_web/components/participation_components.ex:814
 #: lib/klass_hero_web/components/provider_components.ex:48
 #: lib/klass_hero_web/live/admin/verifications_live.ex:207
 #, elixir-autogen, elixir-format
@@ -3128,7 +3128,7 @@ msgid "Start Date"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:947
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:160
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:164
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Start Time"
 msgstr ""
@@ -3536,7 +3536,7 @@ msgstr ""
 msgid "A reason is required for corrections"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:787
+#: lib/klass_hero_web/components/participation_components.ex:798
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:201
 #, elixir-autogen, elixir-format
 msgid "Absent"
@@ -3666,7 +3666,7 @@ msgstr ""
 msgid "Coming soon! Sign up for our newsletter to be notified when gift vouchers launch."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:784
+#: lib/klass_hero_web/components/participation_components.ex:795
 #, elixir-autogen, elixir-format
 msgid "Completed"
 msgstr ""
@@ -3739,7 +3739,7 @@ msgstr ""
 msgid "How does the booking system work?"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:783
+#: lib/klass_hero_web/components/participation_components.ex:794
 #: lib/klass_hero_web/live/admin/sessions_live.ex:275
 #, elixir-autogen, elixir-format, fuzzy
 msgid "In Progress"
@@ -3797,9 +3797,9 @@ msgstr ""
 msgid "No risk of non-payment"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:806
+#: lib/klass_hero_web/components/participation_components.ex:817
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:155
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:173
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:177
 #, elixir-autogen, elixir-format
 msgid "Notes"
 msgstr ""
@@ -3886,7 +3886,7 @@ msgstr ""
 msgid "Save Correction"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:782
+#: lib/klass_hero_web/components/participation_components.ex:793
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Scheduled"
 msgstr ""
@@ -3982,12 +3982,12 @@ msgstr ""
 msgid "You receive instant email with booking details and parent contact info"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:73
+#: lib/klass_hero_web/components/participation_components.ex:84
 #, elixir-autogen, elixir-format
 msgid "%{checked_in} / %{capacity} checked in"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:311
+#: lib/klass_hero_web/components/participation_components.ex:322
 #, elixir-autogen, elixir-format
 msgid "%{checked_in} / %{total} checked in"
 msgstr ""
@@ -3997,7 +3997,7 @@ msgstr ""
 msgid "%{count} unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:373
+#: lib/klass_hero_web/live/provider/sessions_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "A session already exists at this time"
 msgstr ""
@@ -4030,12 +4030,12 @@ msgstr ""
 msgid "All providers"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:713
+#: lib/klass_hero_web/components/participation_components.ex:724
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Allergies: %{details}"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:224
+#: lib/klass_hero_web/components/participation_components.ex:235
 #, elixir-autogen, elixir-format
 msgid "Any important notes about today's session..."
 msgstr ""
@@ -4083,22 +4083,22 @@ msgstr ""
 msgid "Check-in time must be before check-out time"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:352
+#: lib/klass_hero_web/components/participation_components.ex:363
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Check-in:"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:389
+#: lib/klass_hero_web/components/participation_components.ex:400
 #, elixir-autogen, elixir-format
 msgid "Check-out notes (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:358
+#: lib/klass_hero_web/components/participation_components.ex:369
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Check-out:"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:209
+#: lib/klass_hero_web/components/participation_components.ex:220
 #, elixir-autogen, elixir-format
 msgid "Checked in at %{time}"
 msgstr ""
@@ -4123,13 +4123,13 @@ msgstr ""
 msgid "Complete Registration"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:71
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:75
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:271
 #, elixir-autogen, elixir-format
 msgid "Complete Session"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:404
+#: lib/klass_hero_web/components/participation_components.ex:415
 #, elixir-autogen, elixir-format
 msgid "Confirm Check Out"
 msgstr ""
@@ -4165,24 +4165,24 @@ msgid "Could not start private conversation"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:18
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:130
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:195
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:134
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "Create Session"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:157
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:161
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:349
-#: lib/klass_hero_web/live/provider/sessions_live.ex:350
+#: lib/klass_hero_web/live/provider/sessions_live.ex:361
+#: lib/klass_hero_web/live/provider/sessions_live.ex:362
 #, elixir-autogen, elixir-format
 msgid "Date is required"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:390
+#: lib/klass_hero_web/components/participation_components.ex:401
 #, elixir-autogen, elixir-format
 msgid "E.g., picked up by parent, gave medication reminder..."
 msgstr ""
@@ -4215,17 +4215,17 @@ msgstr ""
 msgid "Emails"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:725
+#: lib/klass_hero_web/components/participation_components.ex:736
 #, elixir-autogen, elixir-format
 msgid "Emergency: %{details}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:372
+#: lib/klass_hero_web/live/provider/sessions_live.ex:384
 #, elixir-autogen, elixir-format
 msgid "End time must be after start time"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:788
+#: lib/klass_hero_web/components/participation_components.ex:799
 #, elixir-autogen, elixir-format
 msgid "Expected"
 msgstr ""
@@ -4235,7 +4235,7 @@ msgstr ""
 msgid "Failed to archive email"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:309
+#: lib/klass_hero_web/live/provider/sessions_live.ex:321
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to create session: %{reason}"
 msgstr ""
@@ -4281,7 +4281,7 @@ msgstr ""
 msgid "Go to Home"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:337
+#: lib/klass_hero_web/components/participation_components.ex:348
 #, elixir-autogen, elixir-format
 msgid "In: %{time}"
 msgstr ""
@@ -4292,7 +4292,7 @@ msgid "Invalid Invitation"
 msgstr ""
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:259
-#: lib/klass_hero_web/live/provider/sessions_live.ex:368
+#: lib/klass_hero_web/live/provider/sessions_live.ex:380
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invalid time format"
 msgstr ""
@@ -4333,7 +4333,7 @@ msgstr ""
 msgid "Load images"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:66
+#: lib/klass_hero_web/components/participation_components.ex:77
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Location TBD"
 msgstr ""
@@ -4348,18 +4348,18 @@ msgstr ""
 msgid "Mark Unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:176
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:180
 #, elixir-autogen, elixir-format
 msgid "Max Capacity"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:85
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:89
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:285
 #, elixir-autogen, elixir-format
 msgid "No actions available"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:434
+#: lib/klass_hero_web/components/participation_components.ex:445
 #, elixir-autogen, elixir-format
 msgid "No children enrolled in this session"
 msgstr ""
@@ -4389,28 +4389,28 @@ msgstr ""
 msgid "No sessions found for the selected filters."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:100
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:104
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:300
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:634
+#: lib/klass_hero_web/components/participation_components.ex:645
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Note:"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:496
+#: lib/klass_hero_web/components/participation_components.ex:507
 #, elixir-autogen, elixir-format
 msgid "Observation about the child's participation..."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:343
+#: lib/klass_hero_web/components/participation_components.ex:354
 #, elixir-autogen, elixir-format
 msgid "Out: %{time}"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:172
+#: lib/klass_hero_web/components/participation_components.ex:183
 #, elixir-autogen, elixir-format
 msgid "Participation Check-In"
 msgstr ""
@@ -4431,7 +4431,7 @@ msgstr ""
 msgid "Please explain why you're rejecting this note..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:375
+#: lib/klass_hero_web/live/provider/sessions_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "Please fill in all required fields"
 msgstr ""
@@ -4445,12 +4445,12 @@ msgstr ""
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
 #: lib/klass_hero_web/live/provider/programs_live.ex:217
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:151
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:155
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:177
+#: lib/klass_hero_web/live/provider/sessions_live.ex:178
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program is required"
 msgstr ""
@@ -4507,7 +4507,7 @@ msgstr ""
 msgid "Reset to today"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:527
+#: lib/klass_hero_web/components/participation_components.ex:538
 #, elixir-autogen, elixir-format
 msgid "Resubmit Note"
 msgstr ""
@@ -4517,12 +4517,12 @@ msgstr ""
 msgid "Retry"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:525
+#: lib/klass_hero_web/components/participation_components.ex:536
 #, elixir-autogen, elixir-format
 msgid "Revised Note"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:152
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:156
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select a program..."
 msgstr ""
@@ -4537,25 +4537,25 @@ msgstr ""
 msgid "Sending"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:54
+#: lib/klass_hero_web/components/participation_components.ex:63
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:16
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:16
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Session"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:223
+#: lib/klass_hero_web/components/participation_components.ex:234
 #, elixir-autogen, elixir-format
 msgid "Session Notes (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:180
-#: lib/klass_hero_web/components/participation_components.ex:308
+#: lib/klass_hero_web/components/participation_components.ex:191
+#: lib/klass_hero_web/components/participation_components.ex:319
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Session Roster"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:291
+#: lib/klass_hero_web/live/provider/sessions_live.ex:303
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Session created successfully"
 msgstr ""
@@ -4570,23 +4570,23 @@ msgstr ""
 msgid "Staff member created, but the invitation could not be sent. Try resending from the team list."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:49
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:53
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:249
 #, elixir-autogen, elixir-format
 msgid "Start Session"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:497
+#: lib/klass_hero_web/components/participation_components.ex:508
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Submit Note"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:238
+#: lib/klass_hero_web/components/participation_components.ex:249
 #, elixir-autogen, elixir-format
 msgid "Submit Participation"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:719
+#: lib/klass_hero_web/components/participation_components.ex:730
 #, elixir-autogen, elixir-format
 msgid "Support: %{details}"
 msgstr ""
@@ -4621,8 +4621,8 @@ msgstr ""
 msgid "This invite link is invalid or has expired."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:359
-#: lib/klass_hero_web/live/provider/sessions_live.ex:360
+#: lib/klass_hero_web/live/provider/sessions_live.ex:371
+#: lib/klass_hero_web/live/provider/sessions_live.ex:372
 #, elixir-autogen, elixir-format
 msgid "Time is required"
 msgstr ""
@@ -4637,7 +4637,7 @@ msgstr ""
 msgid "Type your reply..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:181
+#: lib/klass_hero_web/live/provider/sessions_live.ex:182
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:122
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:93
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:122
@@ -4652,7 +4652,7 @@ msgstr ""
 msgid "Unread"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:526
+#: lib/klass_hero_web/components/participation_components.ex:537
 #, elixir-autogen, elixir-format
 msgid "Update your observation..."
 msgstr ""
@@ -4666,7 +4666,7 @@ msgstr ""
 msgid "Upload connection lost. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:82
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:86
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "View Participation"
@@ -4692,7 +4692,7 @@ msgstr ""
 msgid "You already have an account. Log in to see your new enrollment."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:103
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:107
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:303
 #, elixir-autogen, elixir-format
 msgid "You have no sessions scheduled for %{date}"
@@ -4760,7 +4760,7 @@ msgstr ""
 msgid "Business Name"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:789
+#: lib/klass_hero_web/components/participation_components.ex:800
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cancelled"
 msgstr ""
@@ -4971,12 +4971,12 @@ msgstr ""
 msgid "Create a program before inviting participants."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:786
+#: lib/klass_hero_web/components/participation_components.ex:797
 #, elixir-autogen, elixir-format
 msgid "Departed"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:805
+#: lib/klass_hero_web/components/participation_components.ex:816
 #, elixir-autogen, elixir-format
 msgid "Departure notes"
 msgstr ""
@@ -5013,7 +5013,7 @@ msgstr ""
 msgid "Invite sent."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:580
+#: lib/klass_hero_web/components/participation_components.ex:591
 #, elixir-autogen, elixir-format
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
@@ -5049,7 +5049,7 @@ msgstr ""
 msgid "Photos may appear on social media"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:785
+#: lib/klass_hero_web/components/participation_components.ex:796
 #, elixir-autogen, elixir-format
 msgid "Present"
 msgstr ""
@@ -5065,7 +5065,7 @@ msgstr ""
 msgid "Record departure"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:577
+#: lib/klass_hero_web/components/participation_components.ex:588
 #, elixir-autogen, elixir-format
 msgid "Record departure time (optional)"
 msgstr ""
@@ -5076,7 +5076,7 @@ msgstr ""
 msgid "Record updated"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:594
+#: lib/klass_hero_web/components/participation_components.ex:605
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Save changes"
 msgstr ""
@@ -5101,7 +5101,7 @@ msgstr ""
 msgid "Send invite"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:569
+#: lib/klass_hero_web/components/participation_components.ex:580
 #, elixir-autogen, elixir-format
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr ""
@@ -7575,7 +7575,7 @@ msgstr ""
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:495
+#: lib/klass_hero_web/components/participation_components.ex:506
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Session Note"
 msgstr ""

--- a/priv/repo/migrations/20260729090000_add_origin_to_program_sessions.exs
+++ b/priv/repo/migrations/20260729090000_add_origin_to_program_sessions.exs
@@ -1,0 +1,28 @@
+defmodule KlassHero.Repo.Migrations.AddOriginToProgramSessions do
+  @moduledoc """
+  Distinguishes sessions derived from a program's recurring schedule from
+  one-offs a provider entered by hand.
+
+  Only `generated` sessions are swept when a schedule changes, so a deliberate
+  one-off survives an edit. Existing rows take the `manual` default, which means
+  no session that exists today can ever be cancelled by that sweep.
+
+  `max_capacity` is relaxed to nullable in the same change: it has been
+  `null: false` with no default since the table was created, and a program
+  carries no capacity to derive one from, so generated rows would have nothing
+  to put there. It also fixes an existing hole — the manual session form omits
+  the field entirely when a provider leaves it blank.
+  """
+
+  use Ecto.Migration
+
+  def change do
+    alter table(:program_sessions) do
+      # Constant default: metadata-only on PG 11+, so no table rewrite.
+      add :origin, :string, null: false, default: "manual"
+      modify :max_capacity, :integer, null: true, from: {:integer, null: false}
+    end
+
+    create index(:program_sessions, [:program_id, :origin, :status])
+  end
+end

--- a/test/klass_hero/event_subscriber_wiring_test.exs
+++ b/test/klass_hero/event_subscriber_wiring_test.exs
@@ -1,0 +1,56 @@
+defmodule KlassHero.EventSubscriberWiringTest do
+  @moduledoc """
+  Guards the gap between what a handler says it handles and what its subscriber
+  is actually subscribed to.
+
+  `EventSubscriber` subscribes off the literal `topics:` list it is given and
+  never consults `subscribed_events/0`. So adding a clause to a handler without
+  extending its topic list produces a handler that compiles, reads correctly and
+  silently never fires — indistinguishable from a feature that does nothing.
+  """
+
+  use ExUnit.Case, async: true
+
+  defp subscriber_wiring do
+    for spec <- KlassHero.Application.integration_event_subscribers(),
+        {_module, _fun, [opts]} = spec.start,
+        handler = Keyword.fetch!(opts, :handler),
+        topics = Keyword.fetch!(opts, :topics) do
+      {spec.id, handler, topics}
+    end
+  end
+
+  # "integration:<context>:<event>" — the event is the last segment.
+  defp event_from_topic(topic) do
+    topic |> String.split(":") |> List.last() |> String.to_existing_atom()
+  end
+
+  test "every subscriber is subscribed to a topic for each event its handler declares" do
+    for {id, handler, topics} <- subscriber_wiring() do
+      subscribed = MapSet.new(handler.subscribed_events())
+      reachable = MapSet.new(topics, &event_from_topic/1)
+      unreachable = MapSet.difference(subscribed, reachable)
+
+      assert Enum.empty?(unreachable),
+             """
+             #{inspect(id)} (#{inspect(handler)}) declares events it can never receive: \
+             #{inspect(MapSet.to_list(unreachable))}
+             Add the matching "integration:<context>:<event>" topic to its child spec \
+             in KlassHero.Application, or drop the handler clause.
+             """
+    end
+  end
+
+  test "every subscribed topic maps to an event the handler declares" do
+    for {id, handler, topics} <- subscriber_wiring() do
+      subscribed = MapSet.new(handler.subscribed_events())
+      unhandled = topics |> MapSet.new(&event_from_topic/1) |> MapSet.difference(subscribed)
+
+      assert Enum.empty?(unhandled),
+             """
+             #{inspect(id)} (#{inspect(handler)}) subscribes to topics its handler ignores: \
+             #{inspect(MapSet.to_list(unhandled))}
+             """
+    end
+  end
+end

--- a/test/klass_hero/participation/adapters/driving/events/participation_event_handler_schedule_test.exs
+++ b/test/klass_hero/participation/adapters/driving/events/participation_event_handler_schedule_test.exs
@@ -1,0 +1,100 @@
+defmodule KlassHero.Participation.Adapters.Driving.Events.ParticipationEventHandlerScheduleTest do
+  @moduledoc """
+  The seam that makes schedule-derived sessions actually happen: a program write
+  in another context reaching Participation's reconcile.
+  """
+
+  use KlassHero.DataCase, async: true
+
+  import Ecto.Query
+  import KlassHero.Factory
+
+  alias KlassHero.Participation.Adapters.Driving.Events.ParticipationEventHandler
+  alias KlassHero.Participation.ProgramSession
+  alias KlassHero.Repo
+  alias KlassHero.Shared.Domain.Events.IntegrationEvent
+
+  @weekdays ~w(Monday Tuesday Wednesday Thursday Friday Saturday Sunday)
+
+  defp scheduled_program(overrides \\ []) do
+    today = Date.utc_today()
+
+    insert(
+      :program_schema,
+      Keyword.merge(
+        [
+          meeting_days: [Enum.at(@weekdays, Date.day_of_week(today) - 1)],
+          meeting_start_time: ~T[15:00:00],
+          meeting_end_time: ~T[17:00:00],
+          start_date: today,
+          end_date: Date.add(today, 13)
+        ],
+        overrides
+      )
+    )
+  end
+
+  defp program_event(type, program_id) do
+    IntegrationEvent.new(type, :program_catalog, :program, program_id, %{program_id: program_id})
+  end
+
+  defp session_count(program_id) do
+    Repo.aggregate(from(s in ProgramSession, where: s.program_id == ^program_id), :count)
+  end
+
+  describe "program schedule events" do
+    for event_type <- [:program_created, :program_updated] do
+      test "#{event_type} generates the program's sessions" do
+        program = scheduled_program()
+
+        assert :ok = ParticipationEventHandler.handle_event(program_event(unquote(event_type), program.id))
+
+        assert session_count(program.id) == 2
+      end
+    end
+
+    test "a program without a full schedule is accepted, not an error" do
+      program = scheduled_program(meeting_days: [])
+
+      assert :ok = ParticipationEventHandler.handle_event(program_event(:program_updated, program.id))
+
+      assert session_count(program.id) == 0
+    end
+
+    test "re-running on an unchanged schedule adds nothing" do
+      program = scheduled_program()
+      event = program_event(:program_updated, program.id)
+
+      assert :ok = ParticipationEventHandler.handle_event(event)
+      assert :ok = ParticipationEventHandler.handle_event(event)
+
+      assert session_count(program.id) == 2
+    end
+  end
+
+  describe "enrollment_created" do
+    test "puts the enrolled child on the program's upcoming rosters" do
+      program = scheduled_program()
+      {child, _parent} = insert_child_with_guardian()
+
+      assert :ok = ParticipationEventHandler.handle_event(program_event(:program_updated, program.id))
+
+      insert(:enrollment_schema, program_id: program.id, child_id: child.id, status: :confirmed)
+
+      event =
+        IntegrationEvent.new(:enrollment_created, :enrollment, :enrollment, Ecto.UUID.generate(), %{
+          child_id: child.id,
+          program_id: program.id
+        })
+
+      assert :ok = ParticipationEventHandler.handle_event(event)
+
+      session_ids = Repo.all(from(s in ProgramSession, where: s.program_id == ^program.id, select: s.id))
+
+      for session_id <- session_ids do
+        assert {:ok, %{roster: [entry]}} = KlassHero.Participation.get_session_with_roster(session_id)
+        assert entry.record.child_id == child.id
+      end
+    end
+  end
+end

--- a/test/klass_hero/participation/backfill_roster_for_enrollment_test.exs
+++ b/test/klass_hero/participation/backfill_roster_for_enrollment_test.exs
@@ -1,0 +1,85 @@
+defmodule KlassHero.Participation.BackfillRosterForEnrollmentTest do
+  @moduledoc """
+  A child who enrolls *after* a Session already exists must still appear on that
+  Session's Roster.
+
+  `CONTEXT.md` states the invariant directly: an Enrollment "feeds the Roster of
+  every Session in that Program". Today the only seeding trigger is
+  `session_created`, so the Roster is a snapshot frozen at Session-creation time
+  and a later Enrollment reaches no Roster at all.
+  """
+
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+
+  alias KlassHero.Participation
+
+  describe "backfill_roster_for_enrollment/2" do
+    test "puts a late-enrolling child on an existing future Session's Roster" do
+      program = insert(:program_schema)
+      {child, _parent} = insert_child_with_guardian()
+
+      {:ok, session} =
+        Participation.create_session(%{
+          program_id: program.id,
+          session_date: Date.add(Date.utc_today(), 7),
+          start_time: ~T[15:00:00],
+          end_time: ~T[17:00:00],
+          max_capacity: 20
+        })
+
+      # The Session's Roster is seeded at creation, when nobody is enrolled yet.
+      assert {:ok, %{roster: []}} = Participation.get_session_with_roster(session.id)
+
+      insert(:enrollment_schema, program_id: program.id, child_id: child.id, status: :confirmed)
+
+      assert :ok = Participation.backfill_roster_for_enrollment(child.id, program.id)
+
+      assert {:ok, %{roster: [entry]}} = Participation.get_session_with_roster(session.id)
+      assert entry.record.child_id == child.id
+      assert entry.record.status == :registered
+    end
+
+    test "is idempotent — re-running does not duplicate the Roster entry" do
+      program = insert(:program_schema)
+      {child, _parent} = insert_child_with_guardian()
+
+      {:ok, session} =
+        Participation.create_session(%{
+          program_id: program.id,
+          session_date: Date.add(Date.utc_today(), 7),
+          start_time: ~T[15:00:00],
+          end_time: ~T[17:00:00],
+          max_capacity: 20
+        })
+
+      insert(:enrollment_schema, program_id: program.id, child_id: child.id, status: :confirmed)
+
+      assert :ok = Participation.backfill_roster_for_enrollment(child.id, program.id)
+      assert :ok = Participation.backfill_roster_for_enrollment(child.id, program.id)
+
+      assert {:ok, %{roster: [_only_one]}} = Participation.get_session_with_roster(session.id)
+    end
+
+    test "leaves past Sessions alone — attendance history is not rewritten" do
+      program = insert(:program_schema)
+      {child, _parent} = insert_child_with_guardian()
+
+      {:ok, past_session} =
+        Participation.create_session(%{
+          program_id: program.id,
+          session_date: Date.add(Date.utc_today(), -7),
+          start_time: ~T[15:00:00],
+          end_time: ~T[17:00:00],
+          max_capacity: 20
+        })
+
+      insert(:enrollment_schema, program_id: program.id, child_id: child.id, status: :confirmed)
+
+      assert :ok = Participation.backfill_roster_for_enrollment(child.id, program.id)
+
+      assert {:ok, %{roster: []}} = Participation.get_session_with_roster(past_session.id)
+    end
+  end
+end

--- a/test/klass_hero/participation/sync_sessions_for_program_test.exs
+++ b/test/klass_hero/participation/sync_sessions_for_program_test.exs
@@ -1,0 +1,157 @@
+defmodule KlassHero.Participation.SyncSessionsForProgramTest do
+  @moduledoc """
+  Reconciling a program's generated sessions against its recurring schedule.
+
+  The operation is idempotent by design: `program_updated` carries a full
+  snapshot rather than a diff, so the handler cannot tell a schedule edit from a
+  title edit and must be safe to run on every write.
+  """
+
+  use KlassHero.DataCase, async: true
+
+  import Ecto.Query
+  import KlassHero.Factory
+
+  alias KlassHero.Participation
+  alias KlassHero.Participation.ProgramSession
+  alias KlassHero.Repo
+
+  @weekdays ~w(Monday Tuesday Wednesday Thursday Friday Saturday Sunday)
+
+  defp weekday_name(date), do: Enum.at(@weekdays, Date.day_of_week(date) - 1)
+
+  # A fortnight starting today, meeting on today's weekday: two occurrences,
+  # today and a week from today.
+  defp fortnightly_program(overrides \\ []) do
+    today = Date.utc_today()
+
+    insert(
+      :program_schema,
+      Keyword.merge(
+        [
+          meeting_days: [weekday_name(today)],
+          meeting_start_time: ~T[15:00:00],
+          meeting_end_time: ~T[17:00:00],
+          start_date: today,
+          end_date: Date.add(today, 13)
+        ],
+        overrides
+      )
+    )
+  end
+
+  defp sessions_for(program_id) do
+    from(s in ProgramSession, where: s.program_id == ^program_id, order_by: [asc: s.session_date])
+    |> Repo.all()
+  end
+
+  describe "sync_sessions_for_program/1" do
+    test "generates one session per scheduled date" do
+      program = fortnightly_program()
+
+      assert {:ok, %{generated: 2, cancelled: 0}} = Participation.sync_sessions_for_program(program.id)
+
+      assert [first, second] = sessions_for(program.id)
+      assert first.session_date == Date.utc_today()
+      assert second.session_date == Date.add(Date.utc_today(), 7)
+      assert first.start_time == ~T[15:00:00]
+      assert first.end_time == ~T[17:00:00]
+      assert first.status == :scheduled
+      assert first.origin == :generated
+    end
+
+    test "is idempotent — a second run generates nothing" do
+      program = fortnightly_program()
+
+      assert {:ok, %{generated: 2}} = Participation.sync_sessions_for_program(program.id)
+      assert {:ok, %{generated: 0, cancelled: 0}} = Participation.sync_sessions_for_program(program.id)
+
+      assert length(sessions_for(program.id)) == 2
+    end
+
+    test "cancels generated sessions that fall out of the schedule" do
+      program = fortnightly_program()
+      assert {:ok, %{generated: 2}} = Participation.sync_sessions_for_program(program.id)
+
+      # Move the meeting day to the following weekday: both old dates orphan.
+      tomorrow = Date.add(Date.utc_today(), 1)
+      {:ok, program} = update_meeting_days(program, [weekday_name(tomorrow)])
+
+      assert {:ok, %{generated: 2, cancelled: 2}} = Participation.sync_sessions_for_program(program.id)
+
+      statuses = sessions_for(program.id) |> Enum.frequencies_by(& &1.status)
+      assert statuses == %{cancelled: 2, scheduled: 2}
+    end
+
+    test "revives a cancelled slot when the schedule swings back" do
+      program = fortnightly_program()
+      original_days = program.meeting_days
+
+      assert {:ok, %{generated: 2}} = Participation.sync_sessions_for_program(program.id)
+
+      tomorrow = Date.add(Date.utc_today(), 1)
+      {:ok, program} = update_meeting_days(program, [weekday_name(tomorrow)])
+      assert {:ok, %{cancelled: 2}} = Participation.sync_sessions_for_program(program.id)
+
+      {:ok, program} = update_meeting_days(program, original_days)
+      assert {:ok, %{generated: 0, cancelled: 2}} = Participation.sync_sessions_for_program(program.id)
+
+      revived =
+        sessions_for(program.id)
+        |> Enum.filter(&(&1.session_date in [Date.utc_today(), Date.add(Date.utc_today(), 7)]))
+
+      assert Enum.all?(revived, &(&1.status == :scheduled)),
+             "a slot that returns to the schedule must come back, not stay cancelled"
+    end
+
+    test "never touches a manually created session" do
+      program = fortnightly_program()
+
+      {:ok, manual} =
+        Participation.create_session(%{
+          program_id: program.id,
+          session_date: Date.add(Date.utc_today(), 3),
+          start_time: ~T[09:00:00],
+          end_time: ~T[10:00:00]
+        })
+
+      assert {:ok, %{generated: 2, cancelled: 0}} = Participation.sync_sessions_for_program(program.id)
+
+      reloaded = Repo.get!(ProgramSession, manual.id)
+      assert reloaded.status == :scheduled
+      assert reloaded.origin == :manual
+    end
+
+    test "leaves a completed session alone even when its slot leaves the schedule" do
+      program = fortnightly_program()
+      assert {:ok, %{generated: 2}} = Participation.sync_sessions_for_program(program.id)
+
+      [first | _] = sessions_for(program.id)
+      {:ok, _} = Participation.start_session(first.id)
+      {:ok, _} = Participation.complete_session(first.id)
+
+      tomorrow = Date.add(Date.utc_today(), 1)
+      {:ok, program} = update_meeting_days(program, [weekday_name(tomorrow)])
+
+      assert {:ok, %{cancelled: 1}} = Participation.sync_sessions_for_program(program.id)
+      assert Repo.get!(ProgramSession, first.id).status == :completed
+    end
+
+    test "refuses an incomplete schedule without writing anything" do
+      program = fortnightly_program(meeting_days: [])
+
+      assert {:error, :incomplete_schedule} = Participation.sync_sessions_for_program(program.id)
+      assert sessions_for(program.id) == []
+    end
+
+    test "reports a missing program" do
+      assert {:error, :program_not_found} = Participation.sync_sessions_for_program(Ecto.UUID.generate())
+    end
+  end
+
+  defp update_meeting_days(program, days) do
+    program
+    |> Ecto.Changeset.change(%{meeting_days: days})
+    |> Repo.update()
+  end
+end

--- a/test/klass_hero/program_catalog/program_meeting_dates_test.exs
+++ b/test/klass_hero/program_catalog/program_meeting_dates_test.exs
@@ -1,0 +1,129 @@
+defmodule KlassHero.ProgramCatalog.ProgramMeetingDatesTest do
+  @moduledoc """
+  Expansion of a program's advertised recurring schedule into the concrete dates
+  its sessions fall on. Pure — no database.
+  """
+
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias KlassHero.ProgramCatalog.Program
+
+  @weekdays ~w(Monday Tuesday Wednesday Thursday Friday Saturday Sunday)
+  @weekday_numbers @weekdays |> Enum.with_index(1) |> Map.new()
+
+  @full_schedule %Program{
+    meeting_days: ["Monday", "Wednesday"],
+    meeting_start_time: ~T[15:00:00],
+    meeting_end_time: ~T[17:00:00],
+    start_date: ~D[2026-03-02],
+    end_date: ~D[2026-03-15]
+  }
+
+  describe "meeting_dates/1" do
+    test "returns every matching weekday within the range, in order" do
+      assert {:ok, dates} = Program.meeting_dates(@full_schedule)
+
+      assert dates == [
+               ~D[2026-03-02],
+               ~D[2026-03-04],
+               ~D[2026-03-09],
+               ~D[2026-03-11]
+             ]
+    end
+
+    test "includes both range endpoints when they match" do
+      program = %{@full_schedule | start_date: ~D[2026-03-02], end_date: ~D[2026-03-04]}
+
+      assert {:ok, [~D[2026-03-02], ~D[2026-03-04]]} = Program.meeting_dates(program)
+    end
+
+    test "handles a single-day range" do
+      # 2026-03-02 is a Monday.
+      program = %{@full_schedule | start_date: ~D[2026-03-02], end_date: ~D[2026-03-02]}
+
+      assert {:ok, [~D[2026-03-02]]} = Program.meeting_dates(program)
+    end
+
+    test "returns an empty list when no day in the range matches" do
+      program = %{@full_schedule | meeting_days: ["Sunday"], start_date: ~D[2026-03-02], end_date: ~D[2026-03-04]}
+
+      assert {:ok, []} = Program.meeting_dates(program)
+    end
+
+    test "spans a leap-year February" do
+      program = %{
+        @full_schedule
+        | meeting_days: ["Saturday"],
+          start_date: ~D[2028-02-25],
+          end_date: ~D[2028-03-01]
+      }
+
+      assert {:ok, [~D[2028-02-26]]} = Program.meeting_dates(program)
+    end
+
+    for {label, overrides} <- [
+          {"no meeting days", %{meeting_days: []}},
+          {"nil meeting days", %{meeting_days: nil}},
+          {"only unrecognised day names", %{meeting_days: ["Caturday"]}},
+          {"no start time", %{meeting_start_time: nil}},
+          {"no end time", %{meeting_end_time: nil}},
+          {"no start date", %{start_date: nil}},
+          {"no end date", %{end_date: nil}}
+        ] do
+      test "returns :incomplete_schedule with #{label}" do
+        program = struct(@full_schedule, unquote(Macro.escape(overrides)))
+
+        assert {:error, :incomplete_schedule} = Program.meeting_dates(program),
+               "expected #{unquote(label)} to be treated as an incomplete schedule"
+      end
+    end
+
+    test "refuses a range that would generate more sessions than the cap" do
+      program = %{
+        @full_schedule
+        | meeting_days: ~w(Monday Tuesday Wednesday Thursday Friday Saturday Sunday),
+          start_date: ~D[2026-01-01],
+          end_date: ~D[2036-01-01]
+      }
+
+      assert {:error, :schedule_range_too_large} = Program.meeting_dates(program)
+    end
+
+    property "every returned date matches a requested weekday and sits inside the range" do
+      check all(
+              day_count <- integer(1..7),
+              span <- integer(0..120),
+              start_offset <- integer(-200..200)
+            ) do
+        days = Enum.take(@weekdays, day_count)
+        start_date = Date.add(~D[2026-01-01], start_offset)
+        end_date = Date.add(start_date, span)
+        wanted = MapSet.new(days, &Map.fetch!(@weekday_numbers, &1))
+
+        program = %{@full_schedule | meeting_days: days, start_date: start_date, end_date: end_date}
+
+        assert {:ok, dates} = Program.meeting_dates(program)
+
+        for date <- dates do
+          assert Date.day_of_week(date) in wanted
+          assert Date.compare(date, start_date) != :lt
+          assert Date.compare(date, end_date) != :gt
+        end
+
+        assert dates == Enum.sort_by(dates, & &1, Date)
+      end
+    end
+
+    property "a schedule naming all seven days returns every date in the range" do
+      check all(span <- integer(0..90)) do
+        start_date = ~D[2026-04-01]
+        end_date = Date.add(start_date, span)
+        program = %{@full_schedule | meeting_days: @weekdays, start_date: start_date, end_date: end_date}
+
+        assert {:ok, dates} = Program.meeting_dates(program)
+        assert length(dates) == span + 1
+      end
+    end
+  end
+end

--- a/test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs
+++ b/test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs
@@ -217,6 +217,24 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetailsT
       assert %{total_count: 7} = reload(session_id)
     end
 
+    test "accumulates across seedings instead of overwriting", %{session_id: session_id} do
+      # seeded_count is the *delta* an insert added, not a running total: a later
+      # back-fill of one child must not stomp an existing roster of five.
+      broadcast(:roster_seeded, session_id, %{
+        session_id: session_id,
+        program_id: "prog",
+        seeded_count: 5
+      })
+
+      broadcast(:roster_seeded, session_id, %{
+        session_id: session_id,
+        program_id: "prog",
+        seeded_count: 1
+      })
+
+      assert %{total_count: 6} = reload(session_id)
+    end
+
     test "logs a warning when the session row is missing" do
       unknown_id = Ecto.UUID.generate()
 

--- a/test/klass_hero_web/live/provider/sessions_live_test.exs
+++ b/test/klass_hero_web/live/provider/sessions_live_test.exs
@@ -55,6 +55,39 @@ defmodule KlassHeroWeb.Provider.SessionsLiveTest do
       assert has_element?(view, "button", "Start Session")
     end
 
+    test "names each session's program so a day's cards are distinguishable", %{
+      conn: conn,
+      provider: provider
+    } do
+      # Generating a term produces many same-shaped cards on one day; without the
+      # program name they all read alike and a provider cannot tell them apart.
+      for {title, start_time, end_time} <- [
+            {"Junior Choir", ~T[09:00:00], ~T[10:00:00]},
+            {"Piano for Beginners", ~T[15:00:00], ~T[16:00:00]}
+          ] do
+        program = insert(:program_schema, provider_id: provider.id, title: title)
+        # Titles reach the page through the ProviderPrograms read model, not `programs`.
+        insert(:program_listing_schema, id: program.id, provider_id: provider.id, title: title)
+
+        insert(:program_session_schema,
+          program_id: program.id,
+          session_date: Date.utc_today(),
+          start_time: start_time,
+          end_time: end_time,
+          status: :scheduled
+        )
+      end
+
+      {:ok, view, _html} = live(conn, ~p"/provider/sessions")
+
+      assert has_element?(view, "h3", "Junior Choir")
+      assert has_element?(view, "h3", "Piano for Beginners")
+
+      # Generated sessions carry no location, so the placeholder has to render
+      # rather than leaving a bare map-pin icon.
+      assert has_element?(view, "span", "Location TBD")
+    end
+
     test "does not show sessions for other providers", %{conn: conn} do
       other_provider = insert(:provider_profile_schema)
       program = insert(:program_schema, provider_id: other_provider.id)

--- a/test/klass_hero_web/live/provider/sessions_live_test.exs
+++ b/test/klass_hero_web/live/provider/sessions_live_test.exs
@@ -88,6 +88,27 @@ defmodule KlassHeroWeb.Provider.SessionsLiveTest do
       assert has_element?(view, "span", "Location TBD")
     end
 
+    test "shows how many children are on each session's roster", %{conn: conn, provider: provider} do
+      program = insert(:program_schema, provider_id: provider.id, title: "Junior Choir")
+      insert(:program_listing_schema, id: program.id, provider_id: provider.id, title: "Junior Choir")
+
+      session =
+        insert(:program_session_schema,
+          program_id: program.id,
+          session_date: Date.utc_today(),
+          status: :scheduled
+        )
+
+      for _ <- 1..2 do
+        {child, _parent} = insert_child_with_guardian()
+        insert(:participation_record_schema, session_id: session.id, child_id: child.id)
+      end
+
+      {:ok, view, _html} = live(conn, ~p"/provider/sessions")
+
+      assert has_element?(view, "span", "2 children enrolled")
+    end
+
     test "does not show sessions for other providers", %{conn: conn} do
       other_provider = insert(:provider_profile_schema)
       program = insert(:program_schema, provider_id: other_provider.id)

--- a/test/klass_hero_web/live/provider/sessions_live_test.exs
+++ b/test/klass_hero_web/live/provider/sessions_live_test.exs
@@ -7,6 +7,7 @@ defmodule KlassHeroWeb.Provider.SessionsLiveTest do
 
   alias KlassHero.Participation
   alias KlassHero.Participation.Domain.Events.ParticipationEvents
+  alias KlassHero.Participation.ParticipationRecord
   alias KlassHero.Participation.ProgramSession
 
   describe "authentication and authorization" do
@@ -522,6 +523,68 @@ defmodule KlassHeroWeb.Provider.SessionsLiveTest do
 
       # Session is for tomorrow but we're viewing today — should NOT appear
       refute has_element?(view, "button", "Start Session")
+    end
+
+    test "cancelling a session on another date does not add it to today's list", %{
+      conn: conn,
+      provider: provider
+    } do
+      listing = insert(:program_listing_schema, provider_id: provider.id)
+      program = insert(:program_schema, id: listing.id, provider_id: provider.id)
+      tomorrow = Date.add(Date.utc_today(), 1)
+
+      session =
+        insert(:program_session_schema, program_id: program.id, session_date: tomorrow, status: :scheduled)
+
+      {:ok, view, _html} = live(conn, ~p"/provider/sessions")
+      refute has_element?(view, "button", "Start Session")
+
+      # A schedule edit cancels every orphaned date at once, so this event routinely
+      # concerns a day other than the one on screen.
+      event =
+        ParticipationEvents.session_cancelled(
+          struct!(ProgramSession, %{
+            id: session.id,
+            program_id: program.id,
+            session_date: tomorrow,
+            start_time: ~T[09:00:00]
+          })
+        )
+
+      emit_domain_event(view, event)
+
+      refute has_element?(view, "button", "Start Session")
+    end
+
+    test "an unrelated participation event does not crash the view", %{conn: conn, provider: provider} do
+      listing = insert(:program_listing_schema, provider_id: provider.id)
+      program = insert(:program_schema, id: listing.id, provider_id: provider.id)
+
+      {:ok, view, _html} = live(conn, ~p"/provider/sessions")
+
+      # child_marked_absent already reaches the provider topic and this view
+      # renders no clause for it — without a catch-all that is a FunctionClauseError.
+      record =
+        struct!(ParticipationRecord, %{
+          id: Ecto.UUID.generate(),
+          session_id: Ecto.UUID.generate(),
+          child_id: Ecto.UUID.generate(),
+          status: :absent
+        })
+
+      session =
+        struct!(ProgramSession, %{
+          id: record.session_id,
+          program_id: program.id,
+          session_date: Date.utc_today(),
+          start_time: ~T[09:00:00]
+        })
+
+      event = ParticipationEvents.child_marked_absent(record, session)
+
+      emit_domain_event(view, event)
+
+      assert render(view) =~ "Select Date"
     end
   end
 

--- a/test/klass_hero_web/live/staff/staff_sessions_live_test.exs
+++ b/test/klass_hero_web/live/staff/staff_sessions_live_test.exs
@@ -1,10 +1,12 @@
 defmodule KlassHeroWeb.Staff.StaffSessionsLiveTest do
   use KlassHeroWeb.ConnCase, async: true
 
+  import KlassHero.EventTestHelper
   import KlassHero.Factory
   import Phoenix.LiveViewTest
 
   alias KlassHero.Participation
+  alias KlassHero.Participation.Domain.Events.ParticipationEvents
 
   describe "authentication and authorization" do
     test "redirects unauthenticated users to login", %{conn: conn} do
@@ -27,6 +29,65 @@ defmodule KlassHeroWeb.Staff.StaffSessionsLiveTest do
 
       assert has_element?(view, "#staff-sessions")
       assert has_element?(view, "#date-select")
+    end
+
+    test "names each session's program and shows how many children are enrolled", %{
+      conn: conn,
+      provider: provider
+    } do
+      program = insert(:program_schema, provider_id: provider.id, category: "sports")
+
+      insert(:program_listing_schema,
+        id: program.id,
+        provider_id: provider.id,
+        category: "sports",
+        title: "Soccer Training"
+      )
+
+      session =
+        insert(:program_session_schema,
+          program_id: program.id,
+          session_date: Date.utc_today(),
+          status: :scheduled
+        )
+
+      {child, _parent} = insert_child_with_guardian()
+      insert(:participation_record_schema, session_id: session.id, child_id: child.id)
+
+      {:ok, view, _html} = live(conn, ~p"/staff/sessions")
+
+      assert has_element?(view, "h3", "Soccer Training")
+      assert has_element?(view, "span", "1 child enrolled")
+    end
+
+    test "an event for another date does not inject that session into today's list", %{
+      conn: conn,
+      provider: provider
+    } do
+      # A schedule edit cancels every orphaned date at once and an enrolment seeds
+      # every upcoming roster, so session events routinely concern other days.
+      program = insert(:program_schema, provider_id: provider.id, category: "sports")
+
+      insert(:program_listing_schema,
+        id: program.id,
+        provider_id: provider.id,
+        category: "sports",
+        title: "Soccer Training"
+      )
+
+      future =
+        insert(:program_session_schema,
+          program_id: program.id,
+          session_date: Date.add(Date.utc_today(), 21),
+          status: :scheduled
+        )
+
+      {:ok, view, _html} = live(conn, ~p"/staff/sessions")
+      refute has_element?(view, "button[phx-value-session_id='#{future.id}']")
+
+      emit_domain_event(view, ParticipationEvents.roster_seeded(future.id, program.id, 1))
+
+      refute has_element?(view, "button[phx-value-session_id='#{future.id}']")
     end
 
     test "shows only assigned program sessions (matching staff tags)", %{


### PR DESCRIPTION
Closes #921.

A Program already stores its recurring schedule — `meeting_days`,
`meeting_start_time`/`meeting_end_time`, and a `start_date`/`end_date` range — but
Sessions were entered by hand, one at a time. The schedule was stored twice and the
Program's meeting fields enforced nothing.

Now the schedule is authoritative. Editing it brings the Program's future Sessions
into agreement: missing dates are created, orphaned generated ones are cancelled,
and hand-made one-offs are left alone.

## A second bug had to be fixed in the same PR

A Session's Roster was a snapshot taken exactly once, at Session-creation time.
`SeedSessionRosterHandler` fired on `session_created` and nothing else, so nothing
back-filled the Roster of an existing Session when a child enrolled later.

That was masked by the very shortcoming this issue removes: because Sessions were
hand-made close to their date, "enrolled now" happened to equal "enrolled then".
Generate a term's Sessions up front and every Roster is seeded from zero
enrollments — silently, since `seed_session_roster/2` is `rescue`-wrapped and
returns `:ok` unconditionally.

Shipping generation without the back-fill would let providers create permanently
empty Rosters in the interim, which no later PR can repair without a data
migration. `CONTEXT.md` already promises the correct behaviour ("an Enrollment
feeds the Roster of **every** Session in that Program"), so this makes the code
match the documented ubiquitous language rather than adding scope.

## Design

**One idempotent reconcile**, not separate generate/cancel commands.
`program_updated` carries a full post-update snapshot but **no diff**, so a handler
cannot tell a schedule edit from a title edit and must be safe to run on every
Program write.

- `ProgramCatalog.Program.meeting_dates/1` — pure expansion, in Program's functional
  core beside `validate_meeting_days/1`, so the English-weekday vocabulary never
  crosses the context boundary. Participation receives `Date` structs.
- `Participation.sync_sessions_for_program/1` — in one transaction: revive → insert
  → sweep orphans. Events dispatch after commit.
- `origin` column (`:generated | :manual`), deliberately **not** in any changeset
  `cast` list, so the manual UI path can never set it. The column default backfills
  every existing row to `:manual`, so no pre-existing Session can be cancelled by
  the orphan sweep.

### Decisions worth flagging

| Decision | Choice | Why |
|---|---|---|
| Orphans on a schedule edit | **Cancel, never delete** | `participation_records` and `incident_reports` FK to `program_sessions` with `on_delete: :restrict`, so deletion is blocked once a Roster exists. Cancelling also preserves attendance history. |
| Generation horizon | **Requires a complete schedule incl. `end_date`** | An open-ended schedule has no finite expansion. Keeps expansion pure and fully testable with no rolling-window job that would silently stop producing Sessions at the horizon. |
| Clearing the schedule | **Abort, don't mass-cancel** | An incomplete schedule is also the transient state of a half-finished edit. Consequence: clearing a schedule leaves previously generated Sessions in place. |
| Safety cap | 500 dates → `{:error, :schedule_range_too_large}` | A multi-year, seven-day-a-week Program would otherwise write tens of thousands of rows in one transaction. |

### Why the revive step exists

`ProgramSession` has no un-cancel transition and the unique index blocks
re-inserting an identical `(program_id, session_date, start_time)`. Without revival,
a provider who narrows the schedule and then restores it would **silently never get
those Sessions back** — `on_conflict: :nothing` skips the cancelled row. Revival is
scoped to `origin: :generated` **and** future dates, so it cannot resurrect a
manually cancelled Session or rewrite history.

## Two migration changes

`max_capacity` was `null: false` with no default and was never relaxed. A Program
has no capacity concept to derive one from, so `insert_all` would have violated the
constraint — the feature would have been dead on arrival. Relaxing it also fixes a
**latent existing bug**: `coerce_session_params/1` only sets `max_capacity` when
`Integer.parse/1` succeeds, so a provider leaving the field blank on the manual form
already hit a NOT NULL violation. Verified fixed in the browser.

`origin` is added with a constant `DEFAULT`, which is metadata-only on PG 11+ — no
table rewrite, no data migration.

## Fixes found by review and test-drive

- **`ProviderSessionDetails` used `set:` where it needed `inc:`.** `seeded_count` is
  the *delta* from `insert_all ... on_conflict: :nothing`, not a total. Harmless
  while a Session was seeded exactly once; the back-fill this PR adds seeds existing
  Sessions again, which would have stomped a Roster of 12 down to 1. Confirmed live:
  the count now tracks 1 → 2 → 3 across three enrolments.
- **Event registration drift.** `SeedSessionRosterHandler` declared
  `:sessions_generated` but its subscriber was not subscribed to that topic —
  generated Sessions would have had permanently empty Rosters. Fixed, plus
  `event_subscriber_wiring_test.exs` now guards every subscriber against
  handler/topic drift.
- **Off-date stream inserts, in both sessions LiveViews.** Only `session_created`
  was date-guarded, and from the event payload. This PR's producers fan out across
  dates — a schedule edit cancels every orphaned date, an enrolment seeds every
  upcoming Roster — so a provider viewing Monday would get Thursday's session
  dropped into the list. The guard now lives in `update_session_in_stream/2`, which
  already loads the session and can check its real date. `StaffSessionsLive`
  subscribes to the same provider topic and had the identical defect.

## UI

Generating a term turns the sessions list from one or two hand-made entries into
dozens of same-shaped cards, which exposed three dead reads in `participation_card`:

- The heading read `:program_name` off a `ProgramSession` that only carries
  `:program_id`, so every card rendered the literal "Session". A day with two
  programs showed two identical cards.
- The location line's `Map.get/3` default never fired, because the key exists
  holding `nil` — generated Sessions rendered a bare map-pin icon.
- The attendance line read `:capacity` against a `max_capacity` field, so it had
  never rendered for anyone. Fixing the key alone would not help, since generated
  Sessions have no capacity; it now shows the roster count instead
  (`N children enrolled`, then `X of Y checked in` once underway), reusing the admin
  tally's `checked_in|checked_out` definition rather than a second one.

Titles and counts cost no new context queries on the list pages: both LiveViews
already load the provider's programs, and attendance is one grouped query per
day-load that recounts for free on live updates from the roster
`get_session_with_roster/1` already returns.

## Verification

- **4264 passed** (31 properties), full precommit green.
- Expansion is property-tested and checked against a brute-force oracle; the 500-cap
  is pinned at both 500 and 501.
- Test-driven against the running app on real seed data: a schedule edit alone —
  no manual call — cut 27 scheduled Sessions to 13 and restored them to 18, with the
  last Session landing on Dec 4 (Dec 5 is a Saturday, correctly excluded).
- Enrolling a child after every Session already existed took the Rosters 0 → 19.
- Mobile checked at 375×667; German translations shipped.
