### PR TITLE
fix: rescue orphaned Oban jobs and widen the critical-event retry window

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -89,7 +89,14 @@ config :klass_hero, KlassHeroWeb.Gettext,
 config :klass_hero, Oban,
   repo: KlassHero.Repo,
   plugins: [
-    Oban.Plugins.Pruner,
+    # max_age is in seconds and defaults to 60, which deletes a permanently-failed job before anyone
+    # can open /oban to see what happened.
+    {Oban.Plugins.Pruner, max_age: 604_800},
+    # Rescues jobs left `executing` by a machine that went away — routine under
+    # auto_stop_machines = "suspend". Rescuing is time-based with no liveness check, so the 60-minute
+    # default is really a duplicate-execution budget: no job here runs anywhere near that long. Do not
+    # lower it without bounding worker runtime via `timeout/1`.
+    Oban.Plugins.Lifeline,
     {Oban.Plugins.Cron,
      crontab: [
        {"0 3 * * *", MessageCleanupWorker},

--- a/lib/klass_hero/shared/adapters/driven/workers/critical_event_worker.ex
+++ b/lib/klass_hero/shared/adapters/driven/workers/critical_event_worker.ex
@@ -12,9 +12,12 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.CriticalEventWorker do
     delivery (belt-and-suspenders, idempotency gate prevents double execution)
   """
 
+  # Lifeline rescues an orphan only while `attempt < max_attempts` and discards it at the ceiling, so
+  # this bound doubles as the window in which an orphaned event stays recoverable. 10 spans roughly
+  # 4.5 hours under Oban's default backoff.
   use KlassHero.Shared.Tracing.TracedWorker,
     queue: :critical_events,
-    max_attempts: 3
+    max_attempts: 10
 
   alias KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializer
   alias KlassHero.Shared.CriticalEventDispatcher

--- a/test/config/oban_config_test.exs
+++ b/test/config/oban_config_test.exs
@@ -1,0 +1,46 @@
+defmodule KlassHero.ObanConfigTest do
+  @moduledoc """
+  Guards two Oban plugin facts that regress silently.
+
+  Neither raises, logs, nor fails a test when it breaks. A missing `Lifeline` presents as jobs
+  sitting in `executing` in a table nobody watches; an over-eager `Pruner` presents as an empty
+  `/oban` dashboard. Both are only discoverable by reading the config block itself.
+  """
+
+  use ExUnit.Case, async: true
+
+  describe "oban plugins" do
+    # A machine going away mid-job leaves that job `executing` with nothing to move it back.
+    # fly.toml sets auto_stop_machines = "suspend" and min_machines_running = 0, so machines
+    # disappearing is routine rather than exceptional.
+    test "rescues jobs orphaned when a machine goes away" do
+      assert plugin_opts(Oban.Plugins.Lifeline),
+             "Oban.Plugins.Lifeline is missing — orphaned jobs stay `executing` forever (#1191)"
+    end
+
+    # Pruner defaults to max_age: 60 *seconds*, which deletes a permanently-failed critical event's
+    # row before anyone can open the dashboard. CriticalEventWorker retries for roughly 4.5 hours, so
+    # the row has to outlive that span by enough to be triaged the next morning.
+    test "keeps finished job rows long enough to triage" do
+      opts = plugin_opts(Oban.Plugins.Pruner)
+
+      assert opts, "Oban.Plugins.Pruner is missing"
+
+      assert Keyword.get(opts, :max_age, 60) >= 86_400,
+             "Pruner max_age is under a day — discarded jobs vanish before triage"
+    end
+  end
+
+  # config/test.exs adds only `testing: :inline` and Config.Reader deep-merges, so the plugin list
+  # read here is the one dev and prod actually run.
+  defp plugin_opts(module) do
+    :klass_hero
+    |> Application.fetch_env!(Oban)
+    |> Keyword.fetch!(:plugins)
+    |> Enum.find_value(fn
+      ^module -> []
+      {^module, opts} -> opts
+      _other -> nil
+    end)
+  end
+end

--- a/test/klass_hero/shared/adapters/driven/workers/critical_event_worker_test.exs
+++ b/test/klass_hero/shared/adapters/driven/workers/critical_event_worker_test.exs
@@ -69,6 +69,15 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.CriticalEventWorkerTest do
     end
   end
 
+  describe "retry envelope" do
+    # Lifeline only rescues an orphan while `attempt < max_attempts`; at or past the ceiling it
+    # discards instead. So this number is not just "how many retries" — it is how long a job orphaned
+    # by a vanishing machine remains rescuable at all.
+    test "retries long enough for Lifeline to rescue a late orphan" do
+      assert %{max_attempts: 10} = CriticalEventWorker.new(%{}).changes
+    end
+  end
+
   describe "perform/1 retry logging" do
     test "logs warning on non-final failure" do
       event = DomainEvent.new(:test_warn, "agg-1", :test_aggregate, %{})


### PR DESCRIPTION
Closes #1191. PR 1 of 6 in [ADR-0014](https://github.com/MaxPayne89/klass-hero/blob/main/docs/adr/0014-events-are-delivered-by-a-transactional-outbox-not-by-pubsub.md) — the one live defect fix that stands on its own regardless of what happens to the rest of that sequence.

## The defect

Oban ran without `Oban.Plugins.Lifeline`, so a job orphaned by a machine going away stayed `executing` indefinitely with nothing to move it back. `fly.toml` sets `auto_stop_machines = "suspend"` and `min_machines_running = 0`, so orphaning is routine rather than exceptional.

## Why the plugin alone wasn't enough

`Oban.Engine.Basic.rescue_jobs/3` splits orphans on one predicate:

```elixir
rescue_query = where(base, [j], j.attempt < j.max_attempts)   # -> "available"
discard_query = where(base, [j], j.attempt >= j.max_attempts) # -> "discarded"
```

`CriticalEventWorker` allowed 3 attempts — about five minutes under Oban's default backoff (`attempt^4 + 15 + rand(30)*attempt` seconds). A job orphaned on its final attempt would have been buried by the very plugin added to save it. Raising the ceiling to 10 spans roughly 4.5 hours and keeps the rescue window open across it.

## Three deliberate choices

| Knob | Value | Reasoning |
|---|---|---|
| `rescue_after` | 60 min (plugin default) | Rescuing is time-based with **no liveness check**, so this is a duplicate-execution budget, not a latency knob. `CriticalEventWorker` is idempotent via `processed_events`; the `email` queue workers are not, and no worker bounds runtime with `timeout/1`. Nothing here runs near an hour. Lowering it should come with worker timeouts. |
| `max_attempts` | `3` → `10` | ~4.5h before permanent failure. Rides out a deploy, downstream restart, or DB blip unattended. `20` was rejected — an alert arriving five days later is archaeology. |
| `Pruner.max_age` | `60` → `604_800` | The default is 60 **seconds**, deleting a permanently-failed job's row before anyone can open `/oban`. A longer retry span makes that gap worse. |

## Tests

`test/config/oban_config_test.exs` is new, a sibling to the existing `test/config/test_env_config_test.exs` and following its rationale: guard config facts that regress **silently**. A missing Lifeline presents as jobs sitting in `executing` in a table nobody watches; an over-eager Pruner presents as an empty dashboard. Neither raises, logs, or fails anything.

The `max_attempts` assertion goes through `CriticalEventWorker.new(%{}).changes`, i.e. the real `Oban.Worker` changeset path, so it pins the value that actually lands in the `oban_jobs` row and that Lifeline's predicate compares against. There was previously no test on it — the existing tests hand-build `%Oban.Job{max_attempts: 3}` fixtures and assert their own literal. Those are left alone; they exercise branch selection in `execute/1`, which is independent of the configured ceiling.

## Verification

- `mix precommit` — 4267 passed, 2 skipped
- Booted the dev app and inspected the *running* config, not just the file: `Oban.config().plugins` returns `{Oban.Plugins.Lifeline, []}` and `{Oban.Plugins.Pruner, [max_age: 604800]}`
- Not exercised end to end: an actual orphan being rescued in a live cluster. The rescue/discard behaviour is Oban's own, read from `deps/oban/lib/oban/engines/basic.ex:181-201`.

Inert in test env — `config/test.exs` sets `testing: :inline`, so plugins never start there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)