### PR TITLE
ci: cut redundant pipeline work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [ '**' ]
 
+# Supersede an in-flight run when a PR is pushed again. NOT on `main`: fly-deploy.yml
+# waits on this workflow via `workflow_run`, so cancelling a main run silently drops a
+# dev deploy.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   ELIXIR_VERSION: '1.20.2'
   OTP_VERSION: '29.0.2'
@@ -123,10 +130,26 @@ jobs:
       - name: Gettext catalog check (structure + DE completeness)
         run: mix lint_translations
 
+  # Release-please's Release PR only ever touches .release-please-manifest.json,
+  # CHANGELOG.md and mix.exs's `version:` — content already tested on main. Running the
+  # full suite plus a browser E2E pass for a version bump costs ~9 billable minutes twice
+  # (once on the PR, once on the squash commit). `quality` deliberately still runs: format
+  # and credo over a bumped mix.exs are cheap and catch a malformed version.
+  #
+  # paths-ignore can't express this — mix.exs is in the changed set, and ignoring mix.exs
+  # would blind CI to real dependency changes.
+  #
+  # Duplicated on `e2e` below because Actions does not support YAML anchors. Keep in sync.
+  #
+  # NOTE: if required status checks are ever added to the `main` ruleset, verify GitHub's
+  # skipped-vs-required semantics before relying on both together.
   test:
     name: Tests
     runs-on: ubuntu-latest
     needs: deps
+    if: >-
+      github.head_ref != 'release-please--branches--main' &&
+      !startsWith(github.event.head_commit.message, 'chore: release main')
 
     services:
       postgres:
@@ -180,10 +203,14 @@ jobs:
       - name: Run tests
         run: mix test --include slow
 
+  # Skip condition mirrors `test` above — see the rationale there.
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
     needs: deps
+    if: >-
+      github.head_ref != 'release-please--branches--main' &&
+      !startsWith(github.event.head_commit.message, 'chore: release main')
 
     services:
       postgres:

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -4,6 +4,13 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+# Unconditional, unlike ci.yml/security.yml: this workflow only ever runs on
+# pull_request, so there is no `main` run to protect. Retitling a PR twice in quick
+# succession should supersede, not queue.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: read
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: ['**']
 
+# Supersede an in-flight run when a PR is pushed again. NOT on `main` — see the same
+# block in ci.yml for why.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   MIX_ENV: dev
   ELIXIR_VERSION: '1.20.2'
@@ -17,8 +23,12 @@ permissions:
   contents: read
 
 jobs:
-  sobelow:
-    name: Sobelow Security Scan
+  # Sobelow and mix_audit share a job because the setup they need is identical
+  # (setup-beam + deps.get, ~15s) and paying for it twice bought nothing. They stay
+  # independent of each other: the audit step is `if: always()` so a Sobelow finding
+  # can't mask a dependency advisory. Which one failed is visible per-step.
+  audit:
+    name: Sobelow & Dependency Audit
     runs-on: ubuntu-latest
     steps:
       # actions/checkout@v6.0.2
@@ -33,16 +43,21 @@ jobs:
           otp-version: ${{ env.OTP_VERSION }}
           version-type: strict
 
-      # actions/cache@v5.0.4
+      # Restore-only, on CI's key. This workflow must never WRITE that key: its jobs
+      # finish in ~35s while CI's `deps` job takes ~55s, so a writing Security job would
+      # win the race and store a deps-only tree (35MB, no _build app build) over CI's
+      # (70MB) — forcing every downstream CI job to recompile from scratch next run.
+      #
+      # actions/cache/restore@v5.0.4 (same commit as actions/cache, sub-action path)
       - name: Restore dependencies cache
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7
         with:
           path: |
             deps
             _build
-          key: ${{ runner.os }}-mix-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-${{ hashFiles('**/mix.lock') }}
+          key: v2-${{ runner.os }}-mix-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
-            ${{ runner.os }}-mix-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-
+            v2-${{ runner.os }}-mix-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-
 
       - name: Install dependencies
         run: mix deps.get
@@ -60,40 +75,13 @@ jobs:
         with:
           sarif_file: results/sobelow.sarif
 
-  mix-audit:
-    name: Dependency Audit
-    runs-on: ubuntu-latest
-    steps:
-      # actions/checkout@v6.0.2
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-
-      # erlef/setup-beam@v1.23.0
-      - name: Set up Elixir
-        uses: erlef/setup-beam@ee09b1e59bb240681c382eb1f0abc6a04af72764
-        with:
-          elixir-version: ${{ env.ELIXIR_VERSION }}
-          otp-version: ${{ env.OTP_VERSION }}
-          version-type: strict
-
-      # actions/cache@v5.0.4
-      - name: Restore dependencies cache
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
-        with:
-          path: |
-            deps
-            _build
-          key: ${{ runner.os }}-mix-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-${{ hashFiles('**/mix.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-mix-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-
-
-      - name: Install dependencies
-        run: mix deps.get
-
+      # `always()` keeps this independent of Sobelow's exit status — the two read
+      # different threat surfaces and neither should hide the other.
       - name: Audit dependencies for vulnerabilities
+        if: always()
         run: mix deps.audit --ignore-file .mix_audit.ignore
 
-  # Reads hex.pm's advisory feed; the mix-audit job above reads the community
+  # Reads hex.pm's advisory feed; the mix_audit step above reads the community
   # elixir-security-advisories repo. Disjoint sets — a HIGH against bandit was
   # visible only to this one and passed CI silently (#1181).
   #
@@ -115,16 +103,17 @@ jobs:
           otp-version: ${{ env.OTP_VERSION }}
           version-type: strict
 
-      # actions/cache@v5.0.4
+      # Restore-only — see the note on the `audit` job above.
+      # actions/cache/restore@v5.0.4
       - name: Restore dependencies cache
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7
         with:
           path: |
             deps
             _build
-          key: ${{ runner.os }}-mix-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-${{ hashFiles('**/mix.lock') }}
+          key: v2-${{ runner.os }}-mix-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
-            ${{ runner.os }}-mix-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-
+            v2-${{ runner.os }}-mix-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-
 
       # Populates the local Hex registry cache that hex.audit reads. `~/.hex` is
       # absent from the cache above, so the advisory data is fetched fresh here.


### PR DESCRIPTION
## Summary

Three independent sources of Actions waste, found while auditing the last ~200 runs. Measured against runs `30514079914` (warm cache, push to main) and `30389008273` (cold cache, deps bump).

| Change | Why |
|---|---|
| Concurrency groups on CI / Security / Conventional Commits | No workflow had one — superseded PR pushes ran to completion |
| Security cache → `actions/cache/restore` on CI's `v2-` key | Security kept a second 35MB cache entry and never reused CI's warm 70MB build |
| Merge `sobelow` + `mix-audit` into one job | Each paid for its own `setup-beam` + `deps.get` (~15s, 1 billable min) |
| Skip `Tests` + `E2E` for release-please | The Release PR ran the full suite twice for a CHANGELOG/version bump |

## Review focus

**1. `cancel-in-progress` is deliberately gated on `pull_request`.** `fly-deploy.yml` triggers on `workflow_run` of CI/main/success. An unconditional `cancel-in-progress: true` would let a second main push cancel the run a dev deploy is waiting on. This is the subtlest line in the PR.

**2. Security's cache is restore-only, not key-aligned.** Simply pointing Security at CI's key would be a regression: Security's jobs finish in ~35s while CI's `deps` job takes ~55s, so Security would win the race to write the shared key and store a deps-only tree (35MB, no `_build` app build) over CI's (70MB) — forcing every downstream CI job to recompile from scratch on the next run. Verified both entries exist today via `gh api repos/MaxPayne89/klass-hero/actions/caches`.

**3. The merged audit job keeps its two signals independent.** `mix deps.audit` is `if: always()`, so a Sobelow finding can't mask a dependency advisory. `hex-audit` stays a separate job — that separation is deliberate (see its comment, and #1181).

**4. The release-please skip matches on two signals.** Branch `release-please--branches--main` for the PR event, commit-subject prefix `chore: release main` for the push event. `github.event.head_commit` is null on PR events, and `startsWith(null, ...)` coerces to false — so each signal only fires for its own event type. `Code Quality` still runs on release PRs, so a malformed `mix.exs` version bump is still caught.

`paths-ignore` was considered and rejected: release-please modifies `mix.exs`, and path-ignoring `mix.exs` would blind CI to real dependency changes.

## Test plan

Workflow YAML only — no Elixir changed, so no `mix precommit`.

- [x] `actionlint` clean across all 8 workflows (exit 0)
- [ ] This PR's own run confirms CI, Security and Conventional Commits still pass with the new job names
- [ ] Push twice in quick succession → first run shows as **cancelled**
- [ ] Next push to `main` → run is **not** cancelled, and Fly Deploy still fires
- [ ] Next release-please PR → `Tests` and `E2E Tests` show **skipped**, `Code Quality` still runs
- [ ] `gh api repos/MaxPayne89/klass-hero/actions/caches` stops growing a second key family

## Out of scope

Dropping CI on `main` entirely is the bigger win (~12 billable min/merge) but is blocked on a chain: there are currently **no required status checks** on `main` (ruleset `11964877`), and `fly-deploy` depends on the main CI run. Tracked separately.