### PR TITLE
ci: update GitHub Actions to Node 24 releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,21 +24,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # actions/checkout@v6.0.2
+      # actions/checkout@v7.0.1
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
-      # erlef/setup-beam@v1.23.0
+      # erlef/setup-beam@v1.24.1
       - name: Set up Elixir
-        uses: erlef/setup-beam@ee09b1e59bb240681c382eb1f0abc6a04af72764
+        uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124
         with:
           elixir-version: ${{ env.ELIXIR_VERSION }}
           otp-version: ${{ env.OTP_VERSION }}
           version-type: strict
 
-      # actions/cache@v5.0.4
+      # actions/cache@v6.1.0
       - name: Restore dependencies cache
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: |
             deps
@@ -87,21 +87,21 @@ jobs:
     needs: deps
 
     steps:
-      # actions/checkout@v6.0.2
+      # actions/checkout@v7.0.1
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
-      # erlef/setup-beam@v1.23.0
+      # erlef/setup-beam@v1.24.1
       - name: Set up Elixir
-        uses: erlef/setup-beam@ee09b1e59bb240681c382eb1f0abc6a04af72764
+        uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124
         with:
           elixir-version: ${{ env.ELIXIR_VERSION }}
           otp-version: ${{ env.OTP_VERSION }}
           version-type: strict
 
-      # actions/cache@v5.0.4
+      # actions/cache@v6.1.0
       - name: Restore dependencies cache
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: |
             deps
@@ -170,21 +170,21 @@ jobs:
       MIX_ENV: test
 
     steps:
-      # actions/checkout@v6.0.2
+      # actions/checkout@v7.0.1
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
-      # erlef/setup-beam@v1.23.0
+      # erlef/setup-beam@v1.24.1
       - name: Set up Elixir
-        uses: erlef/setup-beam@ee09b1e59bb240681c382eb1f0abc6a04af72764
+        uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124
         with:
           elixir-version: ${{ env.ELIXIR_VERSION }}
           otp-version: ${{ env.OTP_VERSION }}
           version-type: strict
 
-      # actions/cache@v5.0.4
+      # actions/cache@v6.1.0
       - name: Restore dependencies cache
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: |
             deps
@@ -231,21 +231,21 @@ jobs:
       MIX_ENV: test
 
     steps:
-      # actions/checkout@v6.0.2
+      # actions/checkout@v7.0.1
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
-      # erlef/setup-beam@v1.23.0
+      # erlef/setup-beam@v1.24.1
       - name: Set up Elixir
-        uses: erlef/setup-beam@ee09b1e59bb240681c382eb1f0abc6a04af72764
+        uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124
         with:
           elixir-version: ${{ env.ELIXIR_VERSION }}
           otp-version: ${{ env.OTP_VERSION }}
           version-type: strict
 
-      # actions/cache@v5.0.4
+      # actions/cache@v6.1.0
       - name: Restore dependencies cache
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: |
             deps
@@ -263,19 +263,19 @@ jobs:
       - name: Build assets
         run: mix assets.setup && mix assets.build
 
-      # nanasess/setup-chromedriver@v2.4.0
+      # nanasess/setup-chromedriver@v3.0.0
       - name: Install ChromeDriver
-        uses: nanasess/setup-chromedriver@c75c3d53d445b96d41dbf2355797b470953c6c30
+        uses: nanasess/setup-chromedriver@e913548694400f275b4070efcd90f47dbbc8914c
 
       # Use the alias rather than duplicating its body: it sets WALLABY_E2E, without which
       # config/test.exs binds no HTTP socket and every browser test fails to connect.
       - name: Run E2E tests
         run: mix test.e2e
 
-      # actions/upload-artifact@v4.6.2
+      # actions/upload-artifact@v7.0.1
       - name: Upload E2E screenshots
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: e2e-screenshots
           path: tmp/e2e_screenshots/
@@ -297,9 +297,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # actions/checkout@v6.0.2
+      # actions/checkout@v7.0.1
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       # Node and Google Chrome both ship on the runner image, and the generator
       # has no npm dependencies — hence no setup-node and no install step.

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -19,9 +19,9 @@ jobs:
     name: Validate PR Title
     runs-on: ubuntu-latest
     steps:
-      # amannn/action-semantic-pull-request@v5.5.3
+      # amannn/action-semantic-pull-request@v6.1.1
       - name: Check PR title follows Conventional Commits
-        uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/deploy-dev-branch.yml
+++ b/.github/workflows/deploy-dev-branch.yml
@@ -17,9 +17,9 @@ jobs:
       name: dev
       url: https://klass-hero-dev.fly.dev
     steps:
-      # actions/checkout@v6.0.2
+      # actions/checkout@v7.0.1
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       # superfly/flyctl-actions/setup-flyctl@v1.5
       - name: Set up flyctl

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -18,9 +18,9 @@ jobs:
       name: live
       url: https://klass-hero-live.fly.dev
     steps:
-      # actions/checkout@v6.0.2
+      # actions/checkout@v7.0.1
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       # superfly/flyctl-actions/setup-flyctl@v1.5
       - name: Set up flyctl

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -19,9 +19,9 @@ jobs:
       name: dev
       url: https://klass-hero-dev.fly.dev
     steps:
-      # actions/checkout@v6.0.2
+      # actions/checkout@v7.0.1
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       # superfly/flyctl-actions/setup-flyctl@v1.5
       - name: Set up flyctl

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign PR and request review
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,10 +22,10 @@ jobs:
       tag_name: ${{ steps.release.outputs.tag_name }}
       version: ${{ steps.release.outputs.version }}
     steps:
-      # googleapis/release-please-action@v4.2.0
+      # googleapis/release-please-action@v5.0.0
       - name: Run release-please
         id: release
-        uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -35,7 +35,7 @@ jobs:
       # Outcome: deploy-production.yml runs against the release tag
       - name: Dispatch production deploy
         if: steps.release.outputs.release_created == 'true'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             await github.rest.actions.createWorkflowDispatch({

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -31,13 +31,13 @@ jobs:
     name: Sobelow & Dependency Audit
     runs-on: ubuntu-latest
     steps:
-      # actions/checkout@v6.0.2
+      # actions/checkout@v7.0.1
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
-      # erlef/setup-beam@v1.23.0
+      # erlef/setup-beam@v1.24.1
       - name: Set up Elixir
-        uses: erlef/setup-beam@ee09b1e59bb240681c382eb1f0abc6a04af72764
+        uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124
         with:
           elixir-version: ${{ env.ELIXIR_VERSION }}
           otp-version: ${{ env.OTP_VERSION }}
@@ -48,9 +48,9 @@ jobs:
       # win the race and store a deps-only tree (35MB, no _build app build) over CI's
       # (70MB) — forcing every downstream CI job to recompile from scratch next run.
       #
-      # actions/cache/restore@v5.0.4 (same commit as actions/cache, sub-action path)
+      # actions/cache/restore@v6.1.0 (same commit as actions/cache, sub-action path)
       - name: Restore dependencies cache
-        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: |
             deps
@@ -68,9 +68,9 @@ jobs:
       - name: Run Sobelow
         run: mix sobelow --config
 
-      # github/codeql-action@v4.34.1
+      # github/codeql-action@v4.37.3
       - name: Upload SARIF results
-        uses: github/codeql-action/upload-sarif@cb06a0a8527b2c6970741b3a0baa15231dc74a4c
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81
         if: always()
         with:
           sarif_file: results/sobelow.sarif
@@ -91,22 +91,22 @@ jobs:
     name: hex.pm Advisory Audit
     runs-on: ubuntu-latest
     steps:
-      # actions/checkout@v6.0.2
+      # actions/checkout@v7.0.1
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
-      # erlef/setup-beam@v1.23.0
+      # erlef/setup-beam@v1.24.1
       - name: Set up Elixir
-        uses: erlef/setup-beam@ee09b1e59bb240681c382eb1f0abc6a04af72764
+        uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124
         with:
           elixir-version: ${{ env.ELIXIR_VERSION }}
           otp-version: ${{ env.OTP_VERSION }}
           version-type: strict
 
       # Restore-only — see the note on the `audit` job above.
-      # actions/cache/restore@v5.0.4
+      # actions/cache/restore@v6.1.0
       - name: Restore dependencies cache
-        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: |
             deps


### PR DESCRIPTION
## Summary

GitHub is retiring the Node 20 runtime. Three pinned actions still target it and log a deprecation warning on **every run**:

```
##[warning]Node.js 20 is deprecated. The following actions target Node.js 20
but are being forced to run on Node.js 24: erlef/setup-beam@ee09b1e...
```

`setup-beam` fires in 7 jobs per PR. Bumped those three plus the remaining six, which had drifted by up to three majors.

| Action | From | To | Node20 warning today |
|---|---|---|---|
| `erlef/setup-beam` | v1.23.0 | v1.24.1 | ⚠️ yes (7 jobs/PR) |
| `actions/github-script` | v7.1.0 | v9.0.0 | ⚠️ yes |
| `googleapis/release-please-action` | v4.2.0 | v5.0.0 | ⚠️ yes |
| `actions/checkout` | v6.0.2 | v7.0.1 | no |
| `actions/cache` | v5.0.4 | v6.1.0 | no |
| `actions/upload-artifact` | v4.6.2 | v7.0.1 | no |
| `amannn/action-semantic-pull-request` | v5.5.3 | v6.1.1 | no |
| `nanasess/setup-chromedriver` | v2.4.0 | v3.0.0 | no |
| `github/codeql-action` | v4.34.1 | v4.37.3 | no |
| `superfly/flyctl-actions` | 1.5 | — | already current |

## Review focus

Four of these are majors, so compatibility was checked rather than assumed:

- **`github-script` v9 is ESM-only.** `require('@actions/github')` now fails at runtime, and a script-level `const getOctokit` is a `SyntaxError`. Neither call site does either — both use only `github.rest.*` and `context`. Verified by grep.
- **`action-semantic-pull-request` v6** is a Node24 + ESM rewrite. All four inputs in use here (`types`, `requireScope`, `subjectPattern`, `subjectPatternError`) are still declared in v6.1.1's `action.yml`.
- **`setup-chromedriver` v3** is a TypeScript rewrite; inputs and install location unchanged, and its Node 24 migration already shipped in v2.4.0. Exercised by the E2E job in this PR's own run.
- **`release-please-action` v5** is a Node 24 bump only; the `token` input is unchanged.

Every SHA was verified to exist upstream and to match its version comment.

## Test plan

Workflow YAML only — no Elixir changed, so no `mix precommit`.

- [x] `actionlint` clean across all 8 workflows (exit 0)
- [x] All 9 new SHAs resolve upstream
- [x] No stale SHA or mismatched version comment left behind
- [ ] This PR's run: `Conventional Commits` (semantic-PR v6), `E2E Tests` (chromedriver v3), `PR Automation` (github-script v9) all pass
- [ ] `gh run view <id> --log | grep -i "Node.js 20 is deprecated"` returns nothing

## Deferred verification

Two paths only exercise on a real push to `main` and cannot be proven by this PR:

- `release-please-action` v5 — first exercised on the next merge to `main`
- `deploy-production.yml` — first exercised on the next Release PR merge

**If the next Release PR fails to appear after merging this, revert this PR first.** Everything else here is proven by CI.