### PR TITLE
ci: probe why CI recompiles the dev build on a cache hit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,23 @@ jobs:
           restore-keys: |
             v2-${{ runner.os }}-mix-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-
 
+      # TEMPORARY PROBE — remove before merge. Answers: does the restored cache
+      # actually contain a dev-env app build, or only a test-env one?
+      - name: PROBE cache contents after restore
+        run: |
+          echo "== _build envs present =="; ls -1 _build 2>/dev/null || echo "NO _build"
+          echo "== dep count per env =="
+          echo "dev:  $(ls -1 _build/dev/lib  2>/dev/null | wc -l)"
+          echo "test: $(ls -1 _build/test/lib 2>/dev/null | wc -l)"
+          echo "== klass_hero app build, dev =="
+          ls -la _build/dev/lib/klass_hero/.mix/ 2>/dev/null || echo "ABSENT"
+          echo "== klass_hero app build, test =="
+          ls -la _build/test/lib/klass_hero/.mix/ 2>/dev/null || echo "ABSENT"
+          echo "== mtimes (source vs manifest) =="
+          stat -c '%y %n' mix.exs mix.lock config/config.exs config/dev.exs 2>/dev/null
+          stat -c '%y %n' _build/dev/lib/klass_hero/.mix/compile.elixir 2>/dev/null || true
+          stat -c '%y %n' _build/test/lib/klass_hero/.mix/compile.elixir 2>/dev/null || true
+
       - name: Install dependencies
         run: mix deps.get
 
@@ -113,9 +130,32 @@ jobs:
       - name: Install dependencies
         run: mix deps.get
 
+      # TEMPORARY PROBE — remove before merge. Three compiles in sequence isolate
+      # WHY this job rebuilds all 397 lib files despite a primary-key cache hit.
+      #
+      #   A (plain, same flags as the deps job) | B (plain, repeat) | C (+WAE)
+      #   ---------------------------------------------------------------------
+      #   0    | 0    | 397  -> the --warnings-as-errors flag is the sole trigger
+      #   397  | 0    | 0    -> restore-time staleness; first compile settles it
+      #   397  | 0    | 397  -> both effects present, independently
+      #   397  | 397  | 397  -> not incremental at all; manifest never trusted
+      - name: PROBE cache contents after restore
+        run: |
+          echo "== klass_hero app build, dev =="
+          ls -la _build/dev/lib/klass_hero/.mix/ 2>/dev/null || echo "ABSENT"
+          echo "== mtimes (source vs manifest) =="
+          stat -c '%y %n' mix.exs mix.lock config/config.exs config/dev.exs 2>/dev/null
+          stat -c '%y %n' _build/dev/lib/klass_hero/.mix/compile.elixir 2>/dev/null || true
+
+      - name: 'PROBE A: plain compile (same flags as the deps job)'
+        run: mix compile
+
+      - name: 'PROBE B: plain compile again (expect: 0 files)'
+        run: mix compile
+
       # Dev env compile: catches warnings + runs boundary checker.
       # Near-instant when cache hits from deps job.
-      - name: Compile with warnings as errors
+      - name: 'PROBE C: Compile with warnings as errors'
         run: mix compile --warnings-as-errors
 
       - name: Check code formatting


### PR DESCRIPTION
**Diagnostic only — do not merge.** Temporary probe steps to answer one question, then this branch gets deleted and the real fix opens as its own PR.

## The question

The full 397-file dev-env compile runs 3x per CI run (~46s), and the second one happens in `Code Quality` *after a primary-key cache hit*:

```
Dependencies  | Compile (dev)                   | Compiling 397 files (.ex)  15s
Code Quality  | Compile with warnings-as-errors | Compiling 397 files (.ex)  15s   <- cache HIT
Code Quality  | Gettext catalog check           | Compiling 397 files (.ex)  16s
```

Meanwhile the test env stays properly incremental at 25 files. Reproduced on runs `30514079914` and `30389008273`.

The third compile is inherent — `gettext.extract` hard-forces it (`deps/gettext/lib/mix/tasks/gettext.extract.ex:129` calls `Mix.Task.run("compile", ["--force-elixir"])`). The second is the open question.

## Leading hypothesis

Compiler-option mismatch: `deps` compiles dev with plain `mix compile`, `quality` uses `mix compile --warnings-as-errors`. Mix records compiler options in the manifest. This would also explain the dev-vs-test asymmetry — the test env uses a bare compile on both sides.

It does **not** explain why the `deps` job rebuilds its own cache hit, hence the probe.

## Decision table

Three compiles in sequence in `quality`:

| A (plain) | B (plain, repeat) | C (+WAE) | Conclusion |
|---|---|---|---|
| 0 | 0 | 397 | `--warnings-as-errors` is the sole trigger |
| 397 | 0 | 0 | restore-time staleness; first compile settles it |
| 397 | 0 | 397 | both effects, independently |
| 397 | 397 | 397 | never incremental; manifest never trusted |

Plus a `deps`-job probe dumping what the restored cache actually contains per env, and source-vs-manifest mtimes.

## Ruled out already

No custom `Mix.Task.Compiler` in `lib/`; `lint_translations` and `lint_typography` are plain `Mix.Task`s that don't touch compiler options; `elixirc_options` and the `compilers:` list are env-independent; no optional `import_config` that could vary between jobs.