### PR TITLE
perf: run all CI jobs in parallel instead of behind the deps job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,16 @@ env:
   MIX_OS_DEPS_COMPILE_PARTITION_COUNT: '4'
 
 jobs:
+  # The ONLY job that writes the cache. Every other job restores it read-only, so the
+  # stored tree is deterministically the both-env one this job produces, rather than
+  # whichever job happened to win a race to save first.
+  #
+  # Nothing `needs:` this job. On a warm run it hits the primary key and therefore saves
+  # nothing — meaning downstream jobs restore byte-identical content whether or not it
+  # ran, and gating them on it was ~55s of pure serialisation. It earns its place only on
+  # a cold cache (a mix.lock change), where it is the single writer that seeds the next
+  # run. The cost of that: on a cold run the other jobs each compile deps independently,
+  # in parallel, and none of them seeds the cache.
   deps:
     name: Dependencies
     runs-on: ubuntu-latest
@@ -70,9 +80,12 @@ jobs:
         env:
           MIX_ENV: test
 
-      # Compile both envs so downstream jobs get cache hits.
-      # Dev: needed by quality job (includes boundary checker).
-      # Test: needed by test job (avoids recompilation).
+      # Compile both envs so the cache this job seeds is useful to both. Only matters on
+      # a cold run — on a warm one the primary key already exists and nothing is saved.
+      #
+      # (The old comment here claimed dev was "needed by quality job (includes boundary
+      # checker)". The boundary library was removed in #986-#1002, and a probe showed
+      # quality rebuilds the dev tree regardless — see the commit message.)
       - name: Compile (dev)
         run: mix compile
 
@@ -84,7 +97,6 @@ jobs:
   quality:
     name: Code Quality
     runs-on: ubuntu-latest
-    needs: deps
 
     steps:
       # actions/checkout@v7.0.1
@@ -99,9 +111,10 @@ jobs:
           otp-version: ${{ env.OTP_VERSION }}
           version-type: strict
 
-      # actions/cache@v6.1.0
+      # Restore-only — the `deps` job is the sole writer. See its comment.
+      # actions/cache/restore@v6.1.0 (same commit as actions/cache, sub-action path)
       - name: Restore dependencies cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: |
             deps
@@ -113,8 +126,15 @@ jobs:
       - name: Install dependencies
         run: mix deps.get
 
-      # Dev env compile: catches warnings + runs boundary checker.
-      # Near-instant when cache hits from deps job.
+      # ~16s, not "near-instant": the first `mix compile` after a cache restore always
+      # rebuilds the whole tree, because a fresh checkout gives every source a newer mtime
+      # than the restored manifest. Subsequent compiles in the same job are free.
+      #
+      # This step must stay the FIRST compile in the job. `mix lint_translations` below
+      # ends up recompiling everything too (gettext.extract calls
+      # `Mix.Task.run("compile", ["--force-elixir"])`), so running it first would leave
+      # nothing for --warnings-as-errors to process — silently turning the warning gate
+      # into a no-op. The duplicate compile is the price of keeping the gate real.
       - name: Compile with warnings as errors
         run: mix compile --warnings-as-errors
 
@@ -146,7 +166,6 @@ jobs:
   test:
     name: Tests
     runs-on: ubuntu-latest
-    needs: deps
     if: >-
       github.head_ref != 'release-please--branches--main' &&
       !startsWith(github.event.head_commit.message, 'chore: release main')
@@ -182,9 +201,10 @@ jobs:
           otp-version: ${{ env.OTP_VERSION }}
           version-type: strict
 
-      # actions/cache@v6.1.0
+      # Restore-only — the `deps` job is the sole writer. See its comment.
+      # actions/cache/restore@v6.1.0 (same commit as actions/cache, sub-action path)
       - name: Restore dependencies cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: |
             deps
@@ -207,7 +227,6 @@ jobs:
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
-    needs: deps
     if: >-
       github.head_ref != 'release-please--branches--main' &&
       !startsWith(github.event.head_commit.message, 'chore: release main')
@@ -243,9 +262,10 @@ jobs:
           otp-version: ${{ env.OTP_VERSION }}
           version-type: strict
 
-      # actions/cache@v6.1.0
+      # Restore-only — the `deps` job is the sole writer. See its comment.
+      # actions/cache/restore@v6.1.0 (same commit as actions/cache, sub-action path)
       - name: Restore dependencies cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: |
             deps


### PR DESCRIPTION
## Summary

Drops `needs: deps` from `Code Quality`, `Tests` and `E2E Tests`. All five CI jobs now start at t=0.

**Expected wall clock: ~152s → ~100s**, bounded by E2E rather than by `deps` + E2E.

## What the probe found

I did not assume the cause. PR #1200 (draft, now closed) ran three plain compiles in sequence in `Code Quality`, against a primary-key cache hit:

| Step | Command | Files | Time |
|---|---|---|---|
| A | `mix compile` | **396** | 16s |
| B | `mix compile` | 0 | 1s |
| C | `mix compile --warnings-as-errors` | **0** | **0s** |

**The first compile after a cache restore always rebuilds the whole tree; every compile after it in the same job is free.** A fresh `actions/checkout` gives every source a newer mtime than the restored manifest — sources at `Jul 30 05:48` against a manifest at `Jul 28 18:52`.

The compiler-flag mismatch between the deps job's plain `mix compile` and quality's `--warnings-as-errors` was my leading hypothesis and **it was wrong** — C recompiled nothing.

## Why that makes `needs: deps` dead weight

On a warm run the `deps` job hits the primary key and therefore **saves nothing**. Downstream jobs restore byte-identical content whether or not it ran. Its ~55s were pure serialisation, buying a warm build the probe shows does not survive the restore.

## Review focus

**1. Why keep the `deps` job at all?** A cold cache still needs a deterministic single writer that seeds *both* envs. Without one, whichever job finishes first writes the key — and a job that stores a test-only or dev-only tree leaves the next run recompiling the missing half.

**2. That's why the other three moved to `actions/cache/restore`.** Restore-only makes `deps` the sole writer by construction rather than by luck. Same pattern as `security.yml` in #1197.

**3. Cold-cache cost, stated plainly.** On a `mix.lock` change, each job now compiles deps independently, in parallel. That's the deliberate trade for making every warm run ~50s faster.

**4. What I deliberately did NOT do.** `Code Quality` still compiles the tree twice. `mix lint_translations` runs `gettext.extract`, which calls `Mix.Task.run("compile", ["--force-elixir"])` (`deps/gettext/lib/mix/tasks/gettext.extract.ex:129`). Reordering it ahead of the `--warnings-as-errors` step would save ~16s — but would leave that step with nothing to compile, **silently turning the warning gate into a no-op**. Not worth 16s.

**5. Two comments were falsified by the probe** and are corrected here: quality's compile is ~16s, not "near-instant", and the deps job's dev compile is not "needed by quality job (includes boundary checker)" — `boundary` was removed in #986–#1002.

## Test plan

Workflow YAML only — no Elixir changed, so no `mix precommit`.

- [x] `actionlint` clean (exit 0)
- [x] Job graph verified: no job has `needs`
- [ ] This run is green, and the job list shows all five starting together
- [ ] Wall clock measured against the baseline below

Baseline (run `30514079914`, warm):

| Job | Before |
|---|---|
| Dependencies | 54s |
| Code Quality | 63s (after waiting 54s) |
| Tests | 89s (after waiting 54s) |
| E2E Tests | 98s (after waiting 54s) |
| **Wall clock** | **~152s** |

Measure with:

```bash
gh run view <id> --json jobs \
  -q '.jobs[] | "\(.name)\t\(((.completedAt|fromdate)-(.startedAt|fromdate)))s"'
```

Verify the single-writer property held — exactly one "Cache saved" across the run, and only from `Dependencies`:

```bash
gh run view <id> --log | grep -E "Cache saved|Cache hit"
```