### PR TITLE
ci: run the pipeline on pull requests only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,98 +1,37 @@
 name: CI
 
+# Pull requests only. Re-verifying a squash commit on `main` that a PR run verified minutes
+# earlier cost ~8 billable minutes per merge (#1198). The three roles the main-push run used
+# to fill are covered elsewhere now: the dev deploy triggers on push (fly-deploy.yml), the
+# default-branch dep cache is written by deps-cache.yml, and PR CI is enforced by the
+# `required_status_checks` rule on the `main` ruleset rather than after the merge.
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ '**' ]
 
-# Supersede an in-flight run when a PR is pushed again. NOT on `main`: fly-deploy.yml
-# waits on this workflow via `workflow_run`, so cancelling a main run silently drops a
-# dev deploy.
+# Supersede an in-flight run when a PR is pushed again.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: true
 
+# Bumping either version here means bumping it in deps-cache.yml and security.yml too. A
+# called workflow does not inherit the caller's `env`, and both versions are baked into the
+# cache key AND its restore-keys prefix — so a one-sided bump means the writer stores under a
+# key no reader ever asks for, and every job compiles from cold, indefinitely and silently.
 env:
   ELIXIR_VERSION: '1.20.2'
   OTP_VERSION: '29.0.2'
   MIX_OS_DEPS_COMPILE_PARTITION_COUNT: '4'
 
 jobs:
-  # The ONLY job that writes the cache. Every other job restores it read-only, so the
-  # stored tree is deterministically the both-env one this job produces, rather than
-  # whichever job happened to win a race to save first.
-  #
-  # Nothing `needs:` this job. On a warm run it hits the primary key and therefore saves
-  # nothing — meaning downstream jobs restore byte-identical content whether or not it
-  # ran, and gating them on it was ~55s of pure serialisation. It earns its place only on
-  # a cold cache (a mix.lock change), where it is the single writer that seeds the next
-  # run. The cost of that: on a cold run the other jobs each compile deps independently,
-  # in parallel, and none of them seeds the cache.
+  # The cache writer, defined once in deps-cache.yml because it also has to run on push to
+  # main — see that file's header. Nothing `needs:` it: on a warm run it hits the primary key
+  # and saves nothing, so downstream jobs restore byte-identical content whether or not it
+  # ran, and gating them on it was ~55s of pure serialisation (#1201). On a PR it earns its
+  # place only on a cold cache, where it seeds the PR-scoped cache that later pushes to the
+  # same PR restore.
   deps:
-    name: Dependencies
-    runs-on: ubuntu-latest
-
-    steps:
-      # actions/checkout@v7.0.1
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-
-      # erlef/setup-beam@v1.24.1
-      - name: Set up Elixir
-        uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124
-        with:
-          elixir-version: ${{ env.ELIXIR_VERSION }}
-          otp-version: ${{ env.OTP_VERSION }}
-          version-type: strict
-
-      # actions/cache@v6.1.0
-      - name: Restore dependencies cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
-        with:
-          path: |
-            deps
-            _build
-          key: v2-${{ runner.os }}-mix-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-${{ hashFiles('**/mix.lock') }}
-          restore-keys: |
-            v2-${{ runner.os }}-mix-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-
-
-      - name: Install dependencies
-        run: mix deps.get
-
-      # Compile all deps once before the NIF force-rebuild. `mix deps.compile
-      # lazy_html --force` only rebuilds lazy_html itself — it does NOT
-      # trigger compilation of transitive deps (fine, elixir_make,
-      # cc_precompiler). On a warm cache they're already in _build/; on a
-      # cold cache (e.g. after a runtime bump invalidates the cache key)
-      # the --force step fails with "could not find an app file at
-      # _build/test/lib/fine/ebin/fine.app".
-      - name: Compile dependencies
-        run: mix deps.compile
-        env:
-          MIX_ENV: test
-
-      # Force-recompile NIF deps to prevent stale cache issues.
-      # The restore-keys fallback can provide a NIF binary from a
-      # previous version that doesn't match the current mix.lock.
-      - name: Recompile NIF dependencies
-        run: mix deps.compile lazy_html --force
-        env:
-          MIX_ENV: test
-
-      # Compile both envs so the cache this job seeds is useful to both. Only matters on
-      # a cold run — on a warm one the primary key already exists and nothing is saved.
-      #
-      # (The old comment here claimed dev was "needed by quality job (includes boundary
-      # checker)". The boundary library was removed in #986-#1002, and a probe showed
-      # quality rebuilds the dev tree regardless — see the commit message.)
-      - name: Compile (dev)
-        run: mix compile
-
-      - name: Compile (test)
-        run: mix compile
-        env:
-          MIX_ENV: test
+    uses: ./.github/workflows/deps-cache.yml
 
   quality:
     name: Code Quality
@@ -111,7 +50,7 @@ jobs:
           otp-version: ${{ env.OTP_VERSION }}
           version-type: strict
 
-      # Restore-only — the `deps` job is the sole writer. See its comment.
+      # Restore-only — deps-cache.yml is the sole writer. See its header.
       # actions/cache/restore@v6.1.0 (same commit as actions/cache, sub-action path)
       - name: Restore dependencies cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
@@ -152,23 +91,24 @@ jobs:
 
   # Release-please's Release PR only ever touches .release-please-manifest.json,
   # CHANGELOG.md and mix.exs's `version:` — content already tested on main. Running the
-  # full suite plus a browser E2E pass for a version bump costs ~9 billable minutes twice
-  # (once on the PR, once on the squash commit). `quality` deliberately still runs: format
-  # and credo over a bumped mix.exs are cheap and catch a malformed version.
+  # full suite plus a browser E2E pass for a version bump costs ~9 billable minutes.
+  # `quality` deliberately still runs: format and credo over a bumped mix.exs are cheap and
+  # catch a malformed version.
   #
   # paths-ignore can't express this — mix.exs is in the changed set, and ignoring mix.exs
   # would blind CI to real dependency changes.
   #
   # Duplicated on `e2e` below because Actions does not support YAML anchors. Keep in sync.
   #
-  # NOTE: if required status checks are ever added to the `main` ruleset, verify GitHub's
-  # skipped-vs-required semantics before relying on both together.
+  # `Tests` and `E2E Tests` are required status checks on the `main` ruleset, which is safe
+  # alongside this skip: an `if:`-skipped job still emits a check run (conclusion `skipped`),
+  # and a skipped check satisfies a required one. The trap that leaves a required check
+  # Pending forever needs a WORKFLOW that never runs at all — path/branch filters — which is
+  # why the skip lives on the jobs and not on the trigger.
   test:
     name: Tests
     runs-on: ubuntu-latest
-    if: >-
-      github.head_ref != 'release-please--branches--main' &&
-      !startsWith(github.event.head_commit.message, 'chore: release main')
+    if: github.head_ref != 'release-please--branches--main'
 
     services:
       postgres:
@@ -201,7 +141,7 @@ jobs:
           otp-version: ${{ env.OTP_VERSION }}
           version-type: strict
 
-      # Restore-only — the `deps` job is the sole writer. See its comment.
+      # Restore-only — deps-cache.yml is the sole writer. See its header.
       # actions/cache/restore@v6.1.0 (same commit as actions/cache, sub-action path)
       - name: Restore dependencies cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
@@ -227,9 +167,7 @@ jobs:
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
-    if: >-
-      github.head_ref != 'release-please--branches--main' &&
-      !startsWith(github.event.head_commit.message, 'chore: release main')
+    if: github.head_ref != 'release-please--branches--main'
 
     services:
       postgres:
@@ -262,7 +200,7 @@ jobs:
           otp-version: ${{ env.OTP_VERSION }}
           version-type: strict
 
-      # Restore-only — the `deps` job is the sole writer. See its comment.
+      # Restore-only — deps-cache.yml is the sole writer. See its header.
       # actions/cache/restore@v6.1.0 (same commit as actions/cache, sub-action path)
       - name: Restore dependencies cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,15 @@ jobs:
   deps:
     uses: ./.github/workflows/deps-cache.yml
 
+  # Every job below caps `timeout-minutes`. The default is 360, so one hung process — a
+  # headless Chrome that never exits, a browser test waiting on a socket — can burn six
+  # billable hours in a job that normally takes one minute, which dwarfs anything this
+  # workflow's tuning saves. Caps are ~10x the observed runtime: generous enough that a
+  # slow runner never trips them, tight enough that a hang is cheap.
   quality:
     name: Code Quality
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       # actions/checkout@v7.0.1
@@ -108,6 +114,7 @@ jobs:
   test:
     name: Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     if: github.head_ref != 'release-please--branches--main'
 
     services:
@@ -167,6 +174,7 @@ jobs:
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     if: github.head_ref != 'release-please--branches--main'
 
     services:
@@ -250,9 +258,13 @@ jobs:
   # unrelated PR; the fix is a one-line regen commit, which must not gate a merge.
   #
   # No `needs:` and no Elixir — this runs off the deps job's critical path.
+  # 5 minutes against an observed ~30s: the generator drives headless Chrome, which is the
+  # one step here that can hang instead of fail — it did on the first run of PR #1202,
+  # sitting `in_progress` for half an hour on a job that had never taken a minute.
   site-icons:
     name: Site Icon Provenance
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       # actions/checkout@v7.0.1

--- a/.github/workflows/deps-cache.yml
+++ b/.github/workflows/deps-cache.yml
@@ -1,0 +1,105 @@
+name: Dependency Cache
+
+# The ONLY writer of the `v2-<os>-mix-<otp>-<elixir>-<mix.lock hash>` cache key. Every job
+# in every other workflow restores it read-only, so the stored tree is deterministically
+# the both-env one this job produces, rather than whichever job won a race to save first.
+#
+# It exists as its own file, called by ci.yml via `workflow_call`, because it has to run on
+# two triggers that no single workflow covers:
+#
+#   - `workflow_call` from ci.yml, on pull_request. Seeds a `refs/pull/N/merge`-scoped cache
+#     that later pushes to the same PR restore.
+#   - `push` to main, so the DEFAULT-BRANCH-scoped cache stays fresh. This is the one that
+#     matters: a run restores caches from its own ref or the default branch only, so a
+#     PR-scoped write is invisible to every other PR and never promotes. Without a main-side
+#     write, main's cache would freeze at whatever mix.lock was current when CI stopped
+#     running there, and every later dep change would make all three PR jobs recompile the
+#     delta forever (#1198).
+#
+# One definition rather than a copy per trigger: two copies drift, and a main-side copy
+# missing e.g. the NIF force-rebuild below would poison the cache every PR restores.
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  # The paths filter mirrors the cache key exactly: the key hashes mix.lock, and pins
+  # OTP_VERSION/ELIXIR_VERSION which live in the workflow files. So this fires only when the
+  # key actually changes — ~1 billable minute on a dep bump, zero on every other merge.
+  push:
+    branches: [main]
+    paths:
+      - 'mix.lock'
+      - '.github/workflows/*.yml'
+
+# Keep in sync with ci.yml and security.yml — see the note above their own env blocks.
+env:
+  ELIXIR_VERSION: '1.20.2'
+  OTP_VERSION: '29.0.2'
+  MIX_OS_DEPS_COMPILE_PARTITION_COUNT: '4'
+
+jobs:
+  deps:
+    name: Dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+      # actions/checkout@v7.0.1
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      # erlef/setup-beam@v1.24.1
+      - name: Set up Elixir
+        uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124
+        with:
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+          otp-version: ${{ env.OTP_VERSION }}
+          version-type: strict
+
+      # actions/cache@v6.1.0 — the read-write form, unlike every other workflow's
+      # cache/restore. See the note at the top of this file.
+      - name: Restore dependencies cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: |
+            deps
+            _build
+          key: v2-${{ runner.os }}-mix-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            v2-${{ runner.os }}-mix-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-
+
+      - name: Install dependencies
+        run: mix deps.get
+
+      # Compile all deps once before the NIF force-rebuild. `mix deps.compile
+      # lazy_html --force` only rebuilds lazy_html itself — it does NOT
+      # trigger compilation of transitive deps (fine, elixir_make,
+      # cc_precompiler). On a warm cache they're already in _build/; on a
+      # cold cache (e.g. after a runtime bump invalidates the cache key)
+      # the --force step fails with "could not find an app file at
+      # _build/test/lib/fine/ebin/fine.app".
+      - name: Compile dependencies
+        run: mix deps.compile
+        env:
+          MIX_ENV: test
+
+      # Force-recompile NIF deps to prevent stale cache issues.
+      # The restore-keys fallback can provide a NIF binary from a
+      # previous version that doesn't match the current mix.lock.
+      - name: Recompile NIF dependencies
+        run: mix deps.compile lazy_html --force
+        env:
+          MIX_ENV: test
+
+      # Compile both envs so the cache this job seeds is useful to both. Only matters on
+      # a cold run — on a warm one the primary key already exists and nothing is saved.
+      #
+      # (The old comment here claimed dev was "needed by quality job (includes boundary
+      # checker)". The boundary library was removed in #986-#1002, and a probe showed
+      # quality rebuilds the dev tree regardless — see #1201.)
+      - name: Compile (dev)
+        run: mix compile
+
+      - name: Compile (test)
+        run: mix compile
+        env:
+          MIX_ENV: test

--- a/.github/workflows/deps-cache.yml
+++ b/.github/workflows/deps-cache.yml
@@ -41,6 +41,8 @@ jobs:
   deps:
     name: Dependencies
     runs-on: ubuntu-latest
+    # See the note above ci.yml's jobs: the 360-minute default makes a hang expensive.
+    timeout-minutes: 15
 
     steps:
       # actions/checkout@v7.0.1

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -1,19 +1,23 @@
-# Deploy to Fly.io after CI passes
+# Deploy every push to `main` to the dev environment.
 # See https://fly.io/docs/launch/continuous-deployment-with-github-actions/
+#
+# Triggers on push rather than on a successful CI run: CI no longer runs on main at all
+# (#1198), and a `workflow_run` gate on a workflow that never fires means no deploy, with no
+# failing check to notice. Ungated by intent — dev is a QA environment, deploy-dev-branch.yml
+# is already deliberately ungated for the same reason, and the gate that matters now is the
+# `required_status_checks` rule on the `main` ruleset, which blocks the merge rather than the
+# deploy.
 
 name: Fly Deploy
 
 on:
-  workflow_run:
-    workflows: ["CI"]
+  push:
     branches: [main]
-    types: [completed]
 
 jobs:
   deploy:
     name: Deploy to dev
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     concurrency: deploy-klass-hero-dev
     environment:
       name: dev

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -39,9 +39,13 @@ jobs:
   # (setup-beam + deps.get, ~15s) and paying for it twice bought nothing. They stay
   # independent of each other: the audit step is `if: always()` so a Sobelow finding
   # can't mask a dependency advisory. Which one failed is visible per-step.
+  # Both jobs cap `timeout-minutes` against the 360-minute default — see the note above
+  # ci.yml's jobs. Both run in well under a minute; these fetch remote advisory feeds, so
+  # the plausible hang is a request that never returns.
   audit:
     name: Sobelow & Dependency Audit
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       # actions/checkout@v7.0.1
       - name: Checkout code
@@ -102,6 +106,7 @@ jobs:
   hex-audit:
     name: hex.pm Advisory Audit
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       # actions/checkout@v7.0.1
       - name: Checkout code

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,17 +1,29 @@
 name: Security
 
+# The weekly run replaces the old `push: branches: [main]` trigger (#1198), and is strictly
+# better on both axes:
+#
+#   - It keeps the DEFAULT-BRANCH Sobelow analysis fresh, which is what the Security tab's
+#     alert state is built from. PR-scoped SARIF uploads only annotate the PR; without a
+#     run on main, alerts fixed on main never close and new ones never open.
+#   - It catches advisories that appear with no commit. mix_audit and hex.audit read remote
+#     advisory feeds, so a quiet week used to mean no dependency audit at all.
+#
+# 06:17 UTC Monday — deliberately off the top of the hour, where scheduled runs queue.
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: ['**']
+  schedule:
+    - cron: '17 6 * * 1'
+  workflow_dispatch:
 
-# Supersede an in-flight run when a PR is pushed again. NOT on `main` — see the same
-# block in ci.yml for why.
+# Supersede an in-flight run when a PR is pushed again.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+# Keep the versions in sync with ci.yml and deps-cache.yml — they are part of the cache key
+# this workflow restores. See the note above ci.yml's env block.
 env:
   MIX_ENV: dev
   ELIXIR_VERSION: '1.20.2'
@@ -44,7 +56,7 @@ jobs:
           version-type: strict
 
       # Restore-only, on CI's key. This workflow must never WRITE that key: its jobs
-      # finish in ~35s while CI's `deps` job takes ~55s, so a writing Security job would
+      # finish in ~35s while deps-cache.yml's job takes ~55s, so a writing Security job would
       # win the race and store a deps-only tree (35MB, no _build app build) over CI's
       # (70MB) — forcing every downstream CI job to recompile from scratch next run.
       #


### PR DESCRIPTION
Closes #1198.

## Summary

Main-push CI/Security cost ~12 billable minutes per merge re-verifying a squash commit that a PR run had already verified. Deleting the trigger alone breaks four things — #1198 documents two, and querying the Actions cache and code-scanning APIs turned up two more:

| Role of the main-push run | Replacement |
|---|---|
| Dev deploy trigger (`workflow_run` on CI/main) | `fly-deploy.yml` triggers on `push` |
| Only enforced CI signal (no required checks) | `required_status_checks` on ruleset `11964877` — **already applied** |
| Sole writer of the default-branch dep cache | new `deps-cache.yml`, on `push` when `mix.lock`/workflow files change |
| Default-branch Sobelow analysis | `security.yml` on a weekly cron |

Net ~11 billable min/merge on top of #1197 and #1201.

## Review focus

- **Why the cache mattered.** Caches are ref-scoped: a run restores from its own ref or the default branch only, so `refs/pull/N/merge` writes never promote. Verified against the cache API — main held the 70MB entry every PR restores. Without a main-side writer that entry freezes and each later dep change makes all three PR jobs recompile the delta forever.
- **`workflow_call` instead of a second copy** of the writer. Two copies drift, and a main-side copy missing the NIF force-rebuild would poison the cache every PR restores. Note the PR check name becomes `deps / Dependencies`; it is not a required check.
- **The versions are pinned in three files** and are baked into the cache key *and* its restore-keys prefix, so a one-sided bump silently makes every job compile cold. Called workflows don't inherit `env`, so a comment is the only available guard — flagged in all three.
- **`strict_required_status_checks_policy: false`.** `true` would fix the main-drift caveat in #1198 by forcing rebase-before-merge, but with several worktree PRs open at once each merge would stale the rest and re-run full CI — costing more than this saves. Drift stays an accepted risk.
- **Dev deploys are now ungated.** Intentional: dev is a QA env, `deploy-dev-branch.yml` is already ungated for the same reason, and the gate that matters moved to the merge.
- **Skipped-vs-required** (#1198 caveat 1): `if:`-skipped jobs *do* emit check runs — verified `Tests`/`E2E Tests` as conclusion `skipped` on `f1b8dab9` — and a skipped check satisfies a required one. The eternal-Pending trap needs a workflow that never runs at all, which is why the release-please skip stays on the jobs, not the trigger.

## Test plan

CI is the test; no suite changes.

- [ ] This PR: `Code Quality`, `Tests`, `E2E Tests` show as required and green; `deps / Dependencies` runs via `workflow_call`
- [ ] At merge: `gh run list --branch main` shows `Fly Deploy` triggered by `push`, and no CI/Security run; https://klass-hero-dev.fly.dev is up
- [ ] Next `mix.lock` bump: `deps-cache` runs and a fresh `refs/heads/main` entry appears in `gh api repos/MaxPayne89/klass-hero/actions/caches`
- [ ] Next release-please PR: `Tests`/`E2E Tests` land as `skipped` and the PR stays mergeable
- [ ] `workflow_dispatch` Security once: a new `refs/heads/main` Sobelow analysis appears in `gh api repos/MaxPayne89/klass-hero/code-scanning/analyses`