### PR TITLE
fix: guard read-and-assess-issue against pull requests

### DIFF
--- a/.claude/skills/read-and-assess-issue/SKILL.md
+++ b/.claude/skills/read-and-assess-issue/SKILL.md
@@ -30,10 +30,16 @@ before doing anything else.
 ## 2. Fetch it
 
 ```bash
-gh issue view <number> --json title,body,labels,state,comments,assignees
+gh issue view <number> --json title,body,labels,state,comments,assignees,url
 ```
 
 If the issue does not exist or the command fails, report the error and stop.
+
+GitHub numbers issues and pull requests from one shared counter, and `gh issue view`
+returns a PR under that number without complaint. Confirm `url` ends `/issues/<n>`
+before trusting the result — a `/pull/` path, or a `state` of `MERGED` that no issue
+can hold, means you have a pull request. Say so and stop.
+
 Read the comments too — prior discussion often already names the deeper problem.
 
 ## 3. Do the legwork


### PR DESCRIPTION
## Summary

GitHub numbers issues and pull requests from one shared counter, and `gh issue view <n>` resolves a PR under that number without complaint. Running the skill on `35` returned the **merged 2024 pull request** `feat: Implement Program Catalog with DDD architecture` and it was assessed as though it were an open issue — including its long-since-flattened DDD architecture.

## Review focus

Two lines of behaviour: request `url` in the `--json` field list, and confirm it ends `/issues/<n>` before trusting the result. A `/pull/` path — or a `state` of `MERGED`, which no issue can hold — means the number is a pull request.

Stated as a positive check ("confirm X before trusting the result") rather than a prohibition, per the skill-writing doctrine already followed in this file.

## Test plan

`gh issue view 35 --json state,url` in this repo returns `MERGED` and a `/pull/35` URL, so the guard fires. A live open issue (e.g. 1195) returns `OPEN` and `/issues/1195` and passes through unchanged. Skill instructions only — no code paths touched.