### PR TITLE
fix: close every path that 500s an invite claim

### DIFF
--- a/lib/klass_hero/enrollment.ex
+++ b/lib/klass_hero/enrollment.ex
@@ -34,6 +34,8 @@ defmodule KlassHero.Enrollment do
   alias KlassHero.Shared.Adapters.Driven.Persistence.EctoErrorHelpers
   alias KlassHero.Shared.Outbox
 
+  require Logger
+
   @active_statuses ~w(pending confirmed)
 
   @doc """
@@ -963,14 +965,34 @@ defmodule KlassHero.Enrollment do
   matching what a sequential second claim gets.
   """
   @spec register_claimed_invite(String.t()) ::
-          {:ok, BulkEnrollmentInvite.t()} | {:error, :not_found | :already_claimed | term()}
+          {:ok, BulkEnrollmentInvite.t()}
+          | {:error, :not_found | :already_claimed | :invite_transition_failed}
   def register_claimed_invite(invite_id) when is_binary(invite_id) do
     with {:ok, invite} <- get_invite(invite_id),
          {:ok, invite} <- BulkEnrollmentInvite.ensure_claimable(invite) do
-      transition_invite(invite, %{
+      invite
+      |> transition_invite(%{
         status: :registered,
         registered_at: DateTime.utc_now() |> DateTime.truncate(:second)
       })
+      |> case do
+        {:ok, invite} ->
+          {:ok, invite}
+
+        {:error, :not_found} = error ->
+          error
+
+        # `transition_invite/2` ends in a bare `Repo.update()`. The claimability case is
+        # already an atom above, but the changeset's other constraints would arrive at
+        # `InviteClaimController` raw — the exact shape that 500s (#1215).
+        {:error, %Ecto.Changeset{} = changeset} ->
+          Logger.error("[Enrollment] Invite transition failed unexpectedly",
+            invite_id: invite_id,
+            errors: inspect(changeset.errors)
+          )
+
+          {:error, :invite_transition_failed}
+      end
     end
   end
 

--- a/lib/klass_hero/enrollment.ex
+++ b/lib/klass_hero/enrollment.ex
@@ -953,13 +953,21 @@ defmodule KlassHero.Enrollment do
   end
 
   @doc """
-  Marks a claimed invite registered, re-reading it first so the decision is made on
-  the row as it stands now.
+  Marks a claimed invite registered, re-reading it under a row lock so the decision is
+  made on the row as it stands now and stays true until this transaction commits.
 
   `ClaimInvite` checks claimability before it opens its transaction; this is the same
   check made again inside it. Two concurrent claims of one token both pass the first
-  check, and the loser must be told the invite is spoken for rather than be handed a
-  changeset error for an invalid `:registered -> :registered` transition.
+  check, and the loser must be told the invite is spoken for.
+
+  The lock is what makes that reliable. Without it there are two reads — this one and
+  `transition_invite/2`'s own refetch — and Postgres runs at READ COMMITTED, so each
+  statement takes a fresh snapshot even inside one transaction. The claimability guard
+  would then be checked against a row the changeset is not built from: a claim committing
+  between the two reads let the guard pass and the transition still be rejected as
+  `:registered -> :registered`. `FOR UPDATE` makes the loser block until the winner
+  commits, so it re-reads `:registered` and gets `:already_claimed` before any changeset
+  exists. Only meaningful inside a transaction, which is how `ClaimInvite` calls it.
 
   Returns `{:error, :already_claimed}` for an invite that has moved past `:invite_sent`,
   matching what a sequential second claim gets.
@@ -968,7 +976,7 @@ defmodule KlassHero.Enrollment do
           {:ok, BulkEnrollmentInvite.t()}
           | {:error, :not_found | :already_claimed | :invite_transition_failed}
   def register_claimed_invite(invite_id) when is_binary(invite_id) do
-    with {:ok, invite} <- get_invite(invite_id),
+    with {:ok, invite} <- get_invite_for_update(invite_id),
          {:ok, invite} <- BulkEnrollmentInvite.ensure_claimable(invite) do
       invite
       |> transition_invite(%{
@@ -982,17 +990,49 @@ defmodule KlassHero.Enrollment do
         {:error, :not_found} = error ->
           error
 
-        # `transition_invite/2` ends in a bare `Repo.update()`. The claimability case is
-        # already an atom above, but the changeset's other constraints would arrive at
-        # `InviteClaimController` raw — the exact shape that 500s (#1215).
         {:error, %Ecto.Changeset{} = changeset} ->
-          Logger.error("[Enrollment] Invite transition failed unexpectedly",
-            invite_id: invite_id,
-            errors: inspect(changeset.errors)
-          )
-
-          {:error, :invite_transition_failed}
+          classify_transition_failure(changeset, invite_id)
       end
+    end
+  end
+
+  defp get_invite_for_update(id) do
+    BulkEnrollmentInvite
+    |> where([i], i.id == ^id)
+    |> lock("FOR UPDATE")
+    |> Repo.one()
+    |> case do
+      nil -> {:error, :not_found}
+      invite -> {:ok, invite}
+    end
+  end
+
+  # `transition_invite/2` ends in a bare `Repo.update()`, so its changeset would otherwise
+  # arrive at `InviteClaimController` raw — the exact shape that 500s (#1215).
+  #
+  # A `:status` error means the row moved on after `ensure_claimable/1` saw it — someone
+  # else claimed the invite — so it earns the same answer a sequential second claim gets.
+  # `:already_claimed` tells the guardian "this invite has already been used" and sends
+  # them to log in, which is true and actionable; `:invite_transition_failed` only apologises.
+  #
+  # Keyed on the field, not the error tag, because the race produces the *untagged* variant:
+  # `validate_status_transition` matches `{_current, nil}` first, and `get_change/2` is nil
+  # when the cast value equals the stored one, so `:registered -> :registered` yields
+  # "status change is required for transitions" with no `validation:` opt at all.
+  defp classify_transition_failure(%Ecto.Changeset{errors: errors} = changeset, invite_id) do
+    if Enum.any?(errors, fn {field, _error} -> field == :status end) do
+      Logger.info("[Enrollment] Invite already claimed by a concurrent request",
+        invite_id: invite_id
+      )
+
+      {:error, :already_claimed}
+    else
+      Logger.error("[Enrollment] Invite transition failed unexpectedly",
+        invite_id: invite_id,
+        errors: inspect(changeset.errors)
+      )
+
+      {:error, :invite_transition_failed}
     end
   end
 

--- a/lib/klass_hero/enrollment/claim_invite.ex
+++ b/lib/klass_hero/enrollment/claim_invite.ex
@@ -12,9 +12,17 @@ defmodule KlassHero.Enrollment.ClaimInvite do
   alias KlassHero.Enrollment.BulkEnrollmentInvite
   alias KlassHero.Enrollment.ClaimResult
   alias KlassHero.Enrollment.Domain.Events.EnrollmentEvents
+  alias KlassHero.Shared.Adapters.Driven.Persistence.EctoErrorHelpers
   alias KlassHero.Shared.Outbox
 
   require Logger
+
+  @typedoc """
+  Every way a claim can fail. Closed on purpose: `InviteClaimController` renders this
+  set, and an `%Ecto.Changeset{}` reaching it raised `CaseClauseError` — a 500 on a link
+  from an invitation email (#1215). Widening this means widening the controller too.
+  """
+  @type error :: :not_found | :already_claimed | :registration_failed | :invite_transition_failed
 
   @doc """
   Claims an invite by its token.
@@ -24,10 +32,10 @@ defmodule KlassHero.Enrollment.ClaimInvite do
   - `{:ok, %ClaimResult{user_type: :existing_user, user: user, invite: invite}}` — existing account found
   - `{:error, :not_found}` — invalid or expired token
   - `{:error, :already_claimed}` — invite already processed
+  - `{:error, :registration_failed}` — the guardian's account could not be created
+  - `{:error, :invite_transition_failed}` — the invite could not be marked registered
   """
-  @spec execute(binary()) ::
-          {:ok, ClaimResult.t()}
-          | {:error, :not_found | :already_claimed | term()}
+  @spec execute(binary()) :: {:ok, ClaimResult.t()} | {:error, error()}
   def execute(token) when is_binary(token) do
     with {:ok, invite} <- Enrollment.get_invite_by_token(token),
          {:ok, invite} <- BulkEnrollmentInvite.ensure_claimable(invite),
@@ -62,8 +70,49 @@ defmodule KlassHero.Enrollment.ClaimInvite do
     }
 
     case Accounts.register_user(attrs) do
-      {:ok, user} -> {:ok, :new_user, to_user_result(user)}
-      {:error, reason} -> {:error, reason}
+      {:ok, user} ->
+        {:ok, :new_user, to_user_result(user)}
+
+      {:error, %Ecto.Changeset{errors: errors}} ->
+        if EctoErrorHelpers.unique_conflict?(errors, :email) do
+          resolve_after_conflict(invite)
+        else
+          Logger.warning("[ClaimInvite] Guardian account rejected",
+            invite_id: invite.id,
+            errors: inspect(errors)
+          )
+
+          {:error, :registration_failed}
+        end
+    end
+  end
+
+  @doc """
+  Resolves the guardian after `Accounts.register_user/1` lost a uniqueness race.
+
+  `resolve_user/1` checks for an account and then creates one, and the two are not atomic —
+  a guardian who double-clicks their invite link, or whose email client prefetches the URL,
+  can register twice concurrently. The loser gets a duplicate-email changeset for an account
+  that, by then, genuinely exists; the right answer is the existing-user path, not an error.
+
+  Public for the same reason `Enrollment.register_claimed_invite/1` is: two requests cannot
+  be interleaved deterministically from one sandboxed connection, so the test drives this
+  step directly with the world already in the post-race state.
+  """
+  @spec resolve_after_conflict(BulkEnrollmentInvite.t()) ::
+          {:ok, :existing_user, map()} | {:error, :registration_failed}
+  def resolve_after_conflict(%BulkEnrollmentInvite{} = invite) do
+    case Accounts.get_user_by_email(invite.guardian_email) do
+      %{} = user ->
+        {:ok, :existing_user, to_user_result(user)}
+
+      nil ->
+        # The email was reported taken but no account answers to it. Nothing to recover to.
+        Logger.error("[ClaimInvite] Email conflict with no resolvable account",
+          invite_id: invite.id
+        )
+
+        {:error, :registration_failed}
     end
   end
 
@@ -71,13 +120,20 @@ defmodule KlassHero.Enrollment.ClaimInvite do
   # ClaimResult never leaks an %Accounts.User{} type across the context boundary.
   defp to_user_result(user), do: %{id: user.id, email: user.email, name: user.name}
 
+  # `User.name` must be 2..100 chars, but invite fields are looser: names are `max: 100`
+  # each with no minimum, and `guardian_email` is `max: 160`. So imported data can overflow
+  # (two names reach 201; the old email fallback reached 160) or underflow (a lone initial).
+  # The clamp rescues both overflows; an initial can't be rescued and fails the claim.
+  # The nameless case gets a placeholder, not the email — truncating an address to fit
+  # would store a mid-word fragment as somebody's name.
   defp guardian_name(invite) do
     case {invite.guardian_first_name, invite.guardian_last_name} do
-      {nil, nil} -> invite.guardian_email
+      {nil, nil} -> "Guardian"
       {first, nil} -> first
       {nil, last} -> last
       {first, last} -> "#{first} #{last}"
     end
+    |> String.slice(0, 100)
   end
 
   @spec build_and_publish(BulkEnrollmentInvite.t(), ClaimResult.user_type(), map()) ::

--- a/lib/klass_hero/enrollment/domain/services/invite_field_validations.ex
+++ b/lib/klass_hero/enrollment/domain/services/invite_field_validations.ex
@@ -28,8 +28,13 @@ defmodule KlassHero.Enrollment.Domain.Services.InviteFieldValidations do
     |> validate_length(:child_last_name, max: 100)
     |> validate_length(:guardian_email, max: 160)
     |> validate_format(:guardian_email, @email_regex, message: "must be a valid email")
-    |> validate_length(:guardian_first_name, max: 100)
-    |> validate_length(:guardian_last_name, max: 100)
+    # `min: 2` mirrors `Accounts.User`'s `validate_length(:name, min: 2, max: 100)`, because
+    # claiming an invite builds that user's name from these two fields. Without it a CSV of
+    # initials imports cleanly and dead-ends the guardian weeks later, when the row is no
+    # longer in front of the person who could fix it. Guardian 2 is deliberately exempt —
+    # only guardian 1 becomes a user account.
+    |> validate_length(:guardian_first_name, min: 2, max: 100)
+    |> validate_length(:guardian_last_name, min: 2, max: 100)
     |> validate_length(:guardian2_email, max: 160)
     |> maybe_validate_guardian2_email()
     |> validate_length(:guardian2_first_name, max: 100)

--- a/lib/klass_hero/shared/adapters/driven/persistence/ecto_error_helpers.ex
+++ b/lib/klass_hero/shared/adapters/driven/persistence/ecto_error_helpers.ex
@@ -27,6 +27,28 @@ defmodule KlassHero.Shared.Adapters.Driven.Persistence.EctoErrorHelpers do
   end
 
   @doc """
+  Returns true if `field` carries a uniqueness conflict from *either* mechanism.
+
+  A schema that pairs `unsafe_validate_unique/3` with `unique_constraint/2` rejects a
+  duplicate two different ways depending on when the competing row lands: the pre-flight
+  SELECT tags the error `validation: :unsafe_unique`, the database constraint tags it
+  `constraint: :unique`. Both mean the same thing to a caller recovering from a lost race,
+  and the pre-flight one wins the wider window — so recovery code must accept both.
+
+  Use `unique_constraint_violation?/2` instead when you specifically mean "the database
+  rejected this write".
+  """
+  @spec unique_conflict?(errors :: [{atom(), {String.t(), Keyword.t()}}], field :: atom()) ::
+          boolean()
+  def unique_conflict?(errors, field) when is_list(errors) and is_atom(field) do
+    Enum.any?(errors, fn {error_field, {_message, opts}} ->
+      error_field == field and
+        (Keyword.get(opts, :constraint) == :unique or
+           Keyword.get(opts, :validation) == :unsafe_unique)
+    end)
+  end
+
+  @doc """
   Returns true if `field` has a foreign key constraint violation in the changeset error list.
   """
   @spec foreign_key_violation?(

--- a/lib/klass_hero_web/controllers/invite_claim_controller.ex
+++ b/lib/klass_hero_web/controllers/invite_claim_controller.ex
@@ -49,6 +49,23 @@ defmodule KlassHeroWeb.InviteClaimController do
         conn
         |> put_flash(:info, gettext("This invite has already been used."))
         |> redirect(to: ~p"/users/log-in")
+
+      {:error, reason} when reason in [:registration_failed, :invite_transition_failed] ->
+        Logger.error("[InviteClaimController] Invite claim failed", reason: reason)
+
+        conn
+        |> put_flash(:error, gettext("Something went wrong. Please try again or contact support."))
+        |> redirect(to: ~p"/")
+
+      # `ClaimInvite.error()` is closed, but `case` has no compile-time exhaustiveness
+      # check against a typespec — so this is the guarantee, not the type. Its absence
+      # is what turned a changeset into a 500 (#1215).
+      other ->
+        Logger.error("[InviteClaimController] Unexpected claim_invite result", result: inspect(other))
+
+        conn
+        |> put_flash(:error, gettext("Something went wrong. Please try again."))
+        |> redirect(to: ~p"/")
     end
   end
 end

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -3427,6 +3427,7 @@ msgstr "Anbieter, die unseren Erwartungen nicht gerecht werden, können gesperrt
 msgid "Reviewing concerns or reports promptly and seriously"
 msgstr "Bedenken oder Meldungen zügig und gewissenhaft prüfen"
 
+#: lib/klass_hero_web/controllers/invite_claim_controller.ex:57
 #: lib/klass_hero_web/live/booking_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Please try again or contact support."
@@ -4853,6 +4854,7 @@ msgstr "Anbieter nicht gefunden"
 msgid "Remove attachment"
 msgstr "Anhang entfernen"
 
+#: lib/klass_hero_web/controllers/invite_claim_controller.ex:67
 #: lib/klass_hero_web/live/messaging_live_helper.ex:439
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:132
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:110

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -3427,6 +3427,7 @@ msgstr ""
 msgid "Reviewing concerns or reports promptly and seriously"
 msgstr ""
 
+#: lib/klass_hero_web/controllers/invite_claim_controller.ex:57
 #: lib/klass_hero_web/live/booking_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Please try again or contact support."
@@ -4853,6 +4854,7 @@ msgstr ""
 msgid "Remove attachment"
 msgstr ""
 
+#: lib/klass_hero_web/controllers/invite_claim_controller.ex:67
 #: lib/klass_hero_web/live/messaging_live_helper.ex:439
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:132
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:110

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -3427,6 +3427,7 @@ msgstr ""
 msgid "Reviewing concerns or reports promptly and seriously"
 msgstr ""
 
+#: lib/klass_hero_web/controllers/invite_claim_controller.ex:57
 #: lib/klass_hero_web/live/booking_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Please try again or contact support."
@@ -4853,6 +4854,7 @@ msgstr ""
 msgid "Remove attachment"
 msgstr ""
 
+#: lib/klass_hero_web/controllers/invite_claim_controller.ex:67
 #: lib/klass_hero_web/live/messaging_live_helper.ex:439
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:132
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:110

--- a/test/klass_hero/enrollment/claim_invite_atomicity_test.exs
+++ b/test/klass_hero/enrollment/claim_invite_atomicity_test.exs
@@ -114,6 +114,27 @@ defmodule KlassHero.Enrollment.ClaimInviteAtomicityTest do
     assert user.email == invite.guardian_email
   end
 
+  # The row lock means a loser normally blocks, re-reads `:registered`, and is answered by
+  # `ensure_claimable/1` before a changeset exists. This pins the shape underneath it: a
+  # re-registration attempt is somebody else's claim, and the raw error it produces carries
+  # no `validation:` tag — `get_change/2` is nil when the value already matches, so
+  # `validate_status_transition` reports "status change is required", not an illegal
+  # transition. The classifier keys on the field for exactly that reason.
+  test "re-registering an already-registered invite errors on :status, untagged", %{invite: invite} do
+    {:ok, registered} = Enrollment.register_claimed_invite(invite.id)
+
+    assert {:error, %Ecto.Changeset{errors: errors}} =
+             Enrollment.transition_invite(registered, %{status: :registered})
+
+    assert Keyword.has_key?(errors, :status)
+  end
+
+  test "a second registration of one invite is reported as already claimed", %{invite: invite} do
+    assert {:ok, _} = Enrollment.register_claimed_invite(invite.id)
+
+    assert {:error, :already_claimed} = Enrollment.register_claimed_invite(invite.id)
+  end
+
   test "a reported conflict with no resolvable account gives up gracefully" do
     orphan = %BulkEnrollmentInvite{
       id: Ecto.UUID.generate(),

--- a/test/klass_hero/enrollment/claim_invite_atomicity_test.exs
+++ b/test/klass_hero/enrollment/claim_invite_atomicity_test.exs
@@ -100,4 +100,26 @@ defmodule KlassHero.Enrollment.ClaimInviteAtomicityTest do
   test "registering an invite that vanished reports not_found" do
     assert {:error, :not_found} = Enrollment.register_claimed_invite(Ecto.UUID.generate())
   end
+
+  # `resolve_user/1` checks for an account and then creates one, and the two are not atomic.
+  # A guardian who double-clicks their invite link — or whose email client prefetches the URL —
+  # registers twice concurrently, and the loser gets a duplicate-email changeset. Before #1215
+  # that changeset reached `InviteClaimController`, which has no clause for it.
+  #
+  # Driven through the post-race step directly, for the same reason as the concurrent-claim
+  # test above: the two requests cannot be interleaved from one sandboxed connection.
+  test "the loser of a registration race resolves to the winner's account", %{invite: invite} do
+    assert {:ok, :existing_user, user} = ClaimInvite.resolve_after_conflict(invite)
+
+    assert user.email == invite.guardian_email
+  end
+
+  test "a reported conflict with no resolvable account gives up gracefully" do
+    orphan = %BulkEnrollmentInvite{
+      id: Ecto.UUID.generate(),
+      guardian_email: "no-such-guardian-#{System.unique_integer([:positive])}@example.com"
+    }
+
+    assert {:error, :registration_failed} = ClaimInvite.resolve_after_conflict(orphan)
+  end
 end

--- a/test/klass_hero/enrollment/claim_invite_test.exs
+++ b/test/klass_hero/enrollment/claim_invite_test.exs
@@ -9,34 +9,37 @@ defmodule KlassHero.Enrollment.ClaimInviteTest do
   alias KlassHero.Enrollment.ClaimResult
   alias KlassHero.Repo
 
-  defp create_invite_with_token(_context) do
+  defp create_invite_with_token(_context), do: create_invite(%{})
+
+  defp create_invite(overrides) do
     provider = insert(:provider_profile_schema)
     program = insert(:program_schema, provider_id: provider.id)
     unique = System.unique_integer([:positive])
     token = "claim-test-#{unique}"
     email = "claim-test-#{unique}@example.com"
 
-    {:ok, _} =
-      KlassHero.Enrollment.create_invite(%{
-        program_id: program.id,
-        provider_id: provider.id,
-        child_first_name: "Emma",
-        child_last_name: "Schmidt",
-        child_date_of_birth: ~D[2016-03-15],
-        guardian_email: email,
-        guardian_first_name: "Anna",
-        guardian_last_name: "Schmidt"
-      })
+    attrs =
+      Map.merge(
+        %{
+          program_id: program.id,
+          provider_id: provider.id,
+          child_first_name: "Emma",
+          child_last_name: "Schmidt",
+          child_date_of_birth: ~D[2016-03-15],
+          guardian_email: email,
+          guardian_first_name: "Anna",
+          guardian_last_name: "Schmidt"
+        },
+        overrides
+      )
 
-    # Fetch the created invite and manually assign the token + status
+    {:ok, _} = KlassHero.Enrollment.create_invite(attrs)
+
     invite =
       BulkEnrollmentInvite
-      |> Repo.one!()
+      |> Repo.get_by!(guardian_email: attrs.guardian_email)
       |> Ecto.Changeset.change(%{invite_token: token, status: :invite_sent})
       |> Repo.update!()
-
-    # Re-fetch to get clean state
-    invite = Repo.get!(BulkEnrollmentInvite, invite.id)
 
     %{invite: invite, token: token, program: program, provider: provider}
   end
@@ -70,6 +73,47 @@ defmodule KlassHero.Enrollment.ClaimInviteTest do
                ClaimInvite.execute(token)
 
       assert user.id == existing_user.id
+    end
+  end
+
+  # Invite fields are validated far more loosely than `Accounts.User`: guardian names are
+  # `max: 100` with no minimum, and `guardian_email` is `max: 160` against `User.name`'s
+  # `max: 100`. So ordinary imported data can describe a guardian no valid user can be
+  # built from. Each of these raised `CaseClauseError` in the controller before #1215.
+  describe "execute/1 when the invite cannot produce a valid user name" do
+    test "a nameless guardian with an over-long email claims under a placeholder" do
+      %{token: token} =
+        create_invite(%{
+          guardian_first_name: nil,
+          guardian_last_name: nil,
+          guardian_email: String.duplicate("a", 140) <> "@example.com"
+        })
+
+      assert {:ok, %ClaimResult{user_type: :new_user, user: user}} = ClaimInvite.execute(token)
+
+      assert user.name == "Guardian"
+    end
+
+    test "two max-length guardian names are clamped rather than rejected" do
+      %{token: token} =
+        create_invite(%{
+          guardian_first_name: String.duplicate("a", 100),
+          guardian_last_name: String.duplicate("b", 100)
+        })
+
+      assert {:ok, %ClaimResult{user_type: :new_user, user: user}} = ClaimInvite.execute(token)
+
+      assert String.length(user.name) == 100
+    end
+
+    test "a single-initial guardian name reports registration_failed" do
+      %{token: token, invite: invite} =
+        create_invite(%{guardian_first_name: "A", guardian_last_name: nil})
+
+      assert {:error, :registration_failed} = ClaimInvite.execute(token)
+
+      # No half-created account left behind.
+      assert KlassHero.Accounts.get_user_by_email(invite.guardian_email) == nil
     end
   end
 end

--- a/test/klass_hero/enrollment/claim_invite_test.exs
+++ b/test/klass_hero/enrollment/claim_invite_test.exs
@@ -106,14 +106,61 @@ defmodule KlassHero.Enrollment.ClaimInviteTest do
       assert String.length(user.name) == 100
     end
 
-    test "a single-initial guardian name reports registration_failed" do
+    test "a single-initial guardian name is now rejected at import" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+
+      assert {:error, changeset} =
+               KlassHero.Enrollment.create_invite(%{
+                 program_id: program.id,
+                 provider_id: provider.id,
+                 child_first_name: "Emma",
+                 child_last_name: "Schmidt",
+                 child_date_of_birth: ~D[2016-03-15],
+                 guardian_email: "initials-#{System.unique_integer([:positive])}@example.com",
+                 guardian_first_name: "A"
+               })
+
+      assert changeset.errors[:guardian_first_name]
+    end
+
+    # Rows imported before that validation existed are still in the database, so the claim
+    # path must keep failing them gracefully. Inserted as a struct to bypass the changeset,
+    # the same way import_enrollment_csv_test.exs seeds pre-validation rows.
+    test "a legacy invite with a single-initial name reports registration_failed" do
       %{token: token, invite: invite} =
-        create_invite(%{guardian_first_name: "A", guardian_last_name: nil})
+        create_legacy_invite(%{guardian_first_name: "A", guardian_last_name: nil})
 
       assert {:error, :registration_failed} = ClaimInvite.execute(token)
 
       # No half-created account left behind.
       assert KlassHero.Accounts.get_user_by_email(invite.guardian_email) == nil
     end
+  end
+
+  defp create_legacy_invite(overrides) do
+    provider = insert(:provider_profile_schema)
+    program = insert(:program_schema, provider_id: provider.id)
+    unique = System.unique_integer([:positive])
+    token = "legacy-claim-#{unique}"
+
+    invite =
+      Repo.insert!(
+        struct(
+          %BulkEnrollmentInvite{
+            program_id: program.id,
+            provider_id: provider.id,
+            child_first_name: "Emma",
+            child_last_name: "Schmidt",
+            child_date_of_birth: ~D[2016-03-15],
+            guardian_email: "legacy-claim-#{unique}@example.com",
+            invite_token: token,
+            status: :invite_sent
+          },
+          overrides
+        )
+      )
+
+    %{invite: invite, token: token}
   end
 end

--- a/test/klass_hero/enrollment/domain/services/invite_field_validations_test.exs
+++ b/test/klass_hero/enrollment/domain/services/invite_field_validations_test.exs
@@ -96,6 +96,38 @@ defmodule KlassHero.Enrollment.Domain.Services.InviteFieldValidationsTest do
     end
   end
 
+  # Only guardian 1 becomes an `Accounts.User`, whose name is `min: 2`. Guardian 2 and the
+  # child have no such floor, so the minimum is deliberately asymmetric.
+  @length_min_cases [
+    {:guardian_first_name, 2},
+    {:guardian_last_name, 2}
+  ]
+
+  describe "guardian name minimum length" do
+    test "rejects a name one character under its min, accepts it at the min" do
+      for {field, min} <- @length_min_cases do
+        under_cs = TestSchema.changeset(Map.put(@valid_attrs, field, filler(field, min - 1)))
+        at_cs = TestSchema.changeset(Map.put(@valid_attrs, field, filler(field, min)))
+
+        assert errors_on(under_cs)[field],
+               "expected length error on #{field} at #{min - 1} chars, got: #{inspect(errors_on(under_cs))}"
+
+        refute errors_on(at_cs)[field],
+               "expected no length error on #{field} at #{min} chars, got: #{inspect(errors_on(at_cs))}"
+      end
+    end
+
+    # A guardian known only by email is legitimate — `ClaimInvite` names them "Guardian".
+    # The minimum must not turn that into an import rejection.
+    test "leaves absent guardian names alone" do
+      cs =
+        TestSchema.changeset(Map.merge(@valid_attrs, %{guardian_first_name: nil, guardian_last_name: nil}))
+
+      refute errors_on(cs)[:guardian_first_name]
+      refute errors_on(cs)[:guardian_last_name]
+    end
+  end
+
   describe "guardian_email format" do
     # Format validation is a distinct semantic from length
     test "rejects an invalid format" do

--- a/test/klass_hero/shared/adapters/driven/persistence/ecto_error_helpers_test.exs
+++ b/test/klass_hero/shared/adapters/driven/persistence/ecto_error_helpers_test.exs
@@ -187,4 +187,30 @@ defmodule KlassHero.Shared.Adapters.Driven.Persistence.EctoErrorHelpersTest do
       refute EctoErrorHelpers.constraint_violation?(errors, :email, :unique)
     end
   end
+
+  # `unsafe_validate_unique` and `unique_constraint` reject the same duplicate with
+  # differently-tagged errors depending on which race window the competing row lands in.
+  # Recovery code has to treat them alike, so both tags must be recognised — and nothing else.
+  @conflict_cases [
+    {"database constraint", [{:email, {"has already been taken", [constraint: :unique]}}], true},
+    {"pre-flight check", [{:email, {"has already been taken", [validation: :unsafe_unique]}}], true},
+    {"conflict alongside other errors",
+     [
+       {:name, {"should be at least %{count} character(s)", [count: 2, validation: :length]}},
+       {:email, {"has already been taken", [validation: :unsafe_unique]}}
+     ], true},
+    {"unrelated validation on the same field", [{:email, {"is invalid", [validation: :format]}}], false},
+    {"conflict on a different field", [{:identity_id, {"has already been taken", [constraint: :unique]}}], false},
+    {"foreign-key rather than unique", [{:email, {"does not exist", [constraint: :foreign]}}], false},
+    {"no errors at all", [], false}
+  ]
+
+  describe "unique_conflict?/2" do
+    test "recognises a uniqueness conflict from either mechanism, and nothing else" do
+      for {label, errors, expected} <- @conflict_cases do
+        assert EctoErrorHelpers.unique_conflict?(errors, :email) == expected,
+               "#{label}: expected unique_conflict?(#{inspect(errors)}, :email) to be #{expected}"
+      end
+    end
+  end
 end

--- a/test/klass_hero_web/controllers/invite_claim_controller_test.exs
+++ b/test/klass_hero_web/controllers/invite_claim_controller_test.exs
@@ -83,12 +83,28 @@ defmodule KlassHeroWeb.InviteClaimControllerTest do
   end
 
   describe "GET /invites/:token when the account cannot be created" do
-    # Invite names are validated `max: 100` with no minimum, but `User.name` is
-    # `min: 2` — so a CSV carrying initials produces a registration failure with
-    # no user to recover to. `claim_invite/1` must report it as an atom the
-    # controller handles, not raise CaseClauseError on a leaked changeset.
+    # A one-character guardian name clears the invite's own rules but falls under
+    # `User.name`'s `min: 2`, so no account can be built and there is none to recover to.
+    # Import now rejects such rows, but ones predating that validation still exist — hence
+    # the struct insert. `claim_invite/1` must report an atom the controller handles rather
+    # than leak a changeset and raise CaseClauseError.
     test "redirects with a generic error rather than 500ing", %{conn: conn} do
-      %{token: token} = create_invite(%{guardian_first_name: "A", guardian_last_name: nil})
+      unique = System.unique_integer([:positive])
+      token = "legacy-controller-#{unique}"
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+
+      Repo.insert!(%BulkEnrollmentInvite{
+        program_id: program.id,
+        provider_id: provider.id,
+        child_first_name: "Emma",
+        child_last_name: "Schmidt",
+        child_date_of_birth: ~D[2016-03-15],
+        guardian_email: "legacy-controller-#{unique}@example.com",
+        guardian_first_name: "A",
+        invite_token: token,
+        status: :invite_sent
+      })
 
       conn = get(conn, ~p"/invites/#{token}")
 

--- a/test/klass_hero_web/controllers/invite_claim_controller_test.exs
+++ b/test/klass_hero_web/controllers/invite_claim_controller_test.exs
@@ -7,31 +7,38 @@ defmodule KlassHeroWeb.InviteClaimControllerTest do
   alias KlassHero.Enrollment.BulkEnrollmentInvite
   alias KlassHero.Repo
 
-  defp create_invite_with_token(_context) do
+  defp create_invite_with_token(_context), do: create_invite(%{})
+
+  defp create_invite(overrides) do
     provider = insert(:provider_profile_schema)
     program = insert(:program_schema, provider_id: provider.id)
     token = "controller-test-#{System.unique_integer([:positive])}"
     email = "controller-test-#{System.unique_integer([:positive])}@example.com"
 
-    {:ok, _} =
-      KlassHero.Enrollment.create_invite(%{
-        program_id: program.id,
-        provider_id: provider.id,
-        child_first_name: "Emma",
-        child_last_name: "Schmidt",
-        child_date_of_birth: ~D[2016-03-15],
-        guardian_email: email,
-        guardian_first_name: "Anna",
-        guardian_last_name: "Schmidt"
-      })
+    attrs =
+      Map.merge(
+        %{
+          program_id: program.id,
+          provider_id: provider.id,
+          child_first_name: "Emma",
+          child_last_name: "Schmidt",
+          child_date_of_birth: ~D[2016-03-15],
+          guardian_email: email,
+          guardian_first_name: "Anna",
+          guardian_last_name: "Schmidt"
+        },
+        overrides
+      )
 
-    invite = Repo.one!(BulkEnrollmentInvite)
+    {:ok, _} = KlassHero.Enrollment.create_invite(attrs)
 
-    invite
-    |> Ecto.Changeset.change(%{invite_token: token, status: :invite_sent})
-    |> Repo.update!()
+    invite =
+      BulkEnrollmentInvite
+      |> Repo.get_by!(guardian_email: attrs.guardian_email)
+      |> Ecto.Changeset.change(%{invite_token: token, status: :invite_sent})
+      |> Repo.update!()
 
-    %{invite: Repo.one!(BulkEnrollmentInvite), token: token, email: email}
+    %{invite: invite, token: token, email: attrs.guardian_email}
   end
 
   describe "GET /invites/:token" do
@@ -72,6 +79,21 @@ defmodule KlassHeroWeb.InviteClaimControllerTest do
 
       assert redirected_to(conn) == "/users/log-in"
       assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "already been used"
+    end
+  end
+
+  describe "GET /invites/:token when the account cannot be created" do
+    # Invite names are validated `max: 100` with no minimum, but `User.name` is
+    # `min: 2` — so a CSV carrying initials produces a registration failure with
+    # no user to recover to. `claim_invite/1` must report it as an atom the
+    # controller handles, not raise CaseClauseError on a leaked changeset.
+    test "redirects with a generic error rather than 500ing", %{conn: conn} do
+      %{token: token} = create_invite(%{guardian_first_name: "A", guardian_last_name: nil})
+
+      conn = get(conn, ~p"/invites/#{token}")
+
+      assert redirected_to(conn) == "/"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "Something went wrong"
     end
   end
 end


### PR DESCRIPTION
Closes #1215.

## Summary

`InviteClaimController.show/2` matched `Enrollment.claim_invite/1` with four clauses and **no catch-all**, while the use case's own `@spec` already admitted `{:error, term()}`. Any fifth shape raised `CaseClauseError` — an HTTP 500 on a link clicked from an invitation email.

The first commit stops the 500. The second removes the causes.

| # | Gap | Fix |
|---|---|---|
| 1 | Missing catch-all | Closed error union + guarded clause + literal `other ->` |
| 2 | TOCTOU race on email uniqueness | Recover to the winner's account via `resolve_after_conflict/1` |
| 3 | Invite data that can't make a valid `User.name` | `guardian_name/1` clamps; import now rejects the unfixable case |
| 4 | `register_claimed_invite/1` changeset leak | Row lock removes the race; a `:status` error maps to `:already_claimed` |

## Correction to an earlier version of this description

An earlier revision said gap 4's changeset branch was **unreachable** through the fixed attrs. **That was wrong.** `register_claimed_invite/1` read the invite twice — its own `get_invite/1` and `transition_invite/2`'s refetch — and Postgres runs at READ COMMITTED, so each statement takes a fresh snapshot even inside one transaction. The claimability guard was checked against a row the changeset was not built from, so a claim committing between the two reads let the guard pass and the transition still be rejected. Reachable, and now fixed at the cause rather than translated.

## Review focus

**The two error tags for one duplicate.** `User.validate_email/2` pairs `unsafe_validate_unique` with `unique_constraint`, and they tag the same duplicate differently depending on which window the competing row lands in:

| Race window | Caught by | Error opts |
|---|---|---|
| Wide: our `get_user_by_email` → `register_user`'s SELECT | `unsafe_validate_unique` | `validation: :unsafe_unique` |
| Narrow: that SELECT → the INSERT | DB `unique_constraint` | `constraint: :unique` |

The existing `EctoErrorHelpers.unique_constraint_violation?/2` sees only the second, and the **first owns the wider window** — so recovery keyed on it alone would silently miss the common case. Hence the new additive `unique_conflict?/2`.

**Gap 3 had three routes, not one.** Guardian names are validated `max: 100` *each* with no minimum and `guardian_email` `max: 160`, against `User.name`'s 2..100:

- both names nil + a 101–160 char email → the old email fallback overflows
- two names, each up to 100 → `"first last"` reaches **201 chars**
- a single initial (`"A"`) → falls under `min: 2`

The middle needs nothing unusual — two 60-character names. The clamp rescues both overflows. The initial cannot be rescued, so `InviteFieldValidations` now carries `min: 2` and the importer gets a per-row rejection it can fix, instead of the guardian dead-ending weeks later. Guardian 2 is exempt — only guardian 1 becomes an account. Rows predating that validation still exist, so the claim path keeps failing them gracefully and the tests seed those by struct insert.

**First `FOR UPDATE` in this codebase.** Worth a look. Collapsing to a single read would also close the window and is worse: with no version column, `Repo.update` writes by id unconditionally, so the loser would silently overwrite the winner's `registered_at`. The second read is protective; it fails safe. The defect was only the shape it failed into.

**The classifier keys on the field, not the error tag** — deliberately. `validate_status_transition` matches `{_current, nil}` first, and `get_change/2` is nil when the cast value equals the stored one, so `:registered -> :registered` reports "status change is required for transitions" with **no** `validation:` opt. Keying on `validation: :status_transition` would have routed the actual race to the generic branch; a test caught that.

**`transition_invite/2` is deliberately left alone.** It serves five transitions, and its only lib callers (`invite_family_ready_handler.ex`, `send_invite_email_worker.ex`) just `inspect(reason)`. Collapsing its changeset would blunt SendInviteEmailWorker's `Logger.critical` "email sent but status transition failed" alarm.

**Considered and rejected:** a new `Accounts.get_or_register_user/1`. Grepping every caller of `get_user_by_email/1` + `register_user/1` showed `ClaimInvite` is the *only* check-then-register site. It would be a new public API for one caller, carrying a security footgun (never safe for self-service signup, where a colliding email would resolve an attacker onto a victim's account), and would keep `Ecto.Changeset` in the public error union — the shape that caused this bug.

## Audited and cleared

- **Email format and length** — the invite regex and `User.validate_email/2`'s are byte-identical (`~r/^[^@,;\s]+@[^@,;\s]+$/`), both `max: 160`. No mismatch.
- **Email case** — `users.email` is `citext`, so lookup and the unique index are case-insensitive in the DB; invites reach the same end via a `LOWER()` index.
- **The child path** — `Family.Child` is `min: 1` on names while the invite's `validate_required` plus CSV `clean_string/1` already guarantee ≥1 non-blank char; date and school-grade bounds are identical. The guardian-name gap was the only instance of that bug class.

## Test plan

- Red first: the controller test for a one-character guardian name failed with `CaseClauseError` before any fix landed.
- `unique_conflict?/2`: one tabular test over 7 cases, pure, no DB.
- Both race arms driven through `resolve_after_conflict/1` directly — the house technique, since two requests can't be interleaved from one sandboxed connection.
- All three gap-3 routes covered end-to-end; import rejection covered at the changeset level with a min/max boundary table.
- `mix precommit` green: **3934 passed**, 2 skipped, 18 excluded.
- `mix gettext.extract` reports **0 new messages** in every locale — both flash strings already existed.

## Follow-ups found while tracing (separate PRs)

- **Photo consent is silently discarded.** `ClaimInvite` stages `consent_photo_marketing`/`consent_photo_social_media` into the `:invite_claimed` payload, but `InviteClaimedHandler.build_worker_args/2` never copies them into the Oban args, and `grant_consent/1` is called only from the settings UI. No consent record is ever created from an invite claim.
- **A saga failure is invisible.** If child creation fails, the invite sticks in `:registered` forever — there is no `transition_to_failed` in the Family context — and the guardian already saw "account created", so they have an account and silently no enrollment.
- **A teardown flake** in `Shared.ProjectionTest` (`if Process.alive?(pid), do: Agent.stop(pid)` — check-then-act, the same shape as the bug above).