### PR TITLE
test: remove check-then-act teardown race in ProjectionTest

### DIFF
--- a/test/klass_hero/shared/projection_test.exs
+++ b/test/klass_hero/shared/projection_test.exs
@@ -42,11 +42,19 @@ defmodule KlassHero.Shared.ProjectionTest do
     end
   end
 
-  setup do
-    {:ok, agent_pid} =
-      Agent.start_link(fn -> %{bootstraps: 0, events: []} end, name: @agent_name)
+  # ExUnit's supervisor owns these Agents, so they are shut down in order before any
+  # on_exit callback runs and an already-stopped one is not an error.
+  #
+  # They used to be `Agent.start_link` plus `on_exit(fn -> if Process.alive?(pid), do:
+  # Agent.stop(pid) end)`. That is check-then-act: on_exit runs after the test process has
+  # exited, and a linked Agent is already dying by then, so the guard only sometimes won.
+  # When it lost, `GenServer.stop/3` exited `:noproc` and failed an otherwise-passing test.
+  defp start_agent!(name, initial_fun) do
+    start_supervised!(%{id: name, start: {Agent, :start_link, [initial_fun, [name: name]]}})
+  end
 
-    on_exit(fn -> if Process.alive?(agent_pid), do: Agent.stop(agent_pid) end)
+  setup do
+    start_agent!(@agent_name, fn -> %{bootstraps: 0, events: []} end)
     :ok
   end
 
@@ -226,10 +234,7 @@ defmodule KlassHero.Shared.ProjectionTest do
 
   describe "WithBootstrapRetry mixin" do
     setup do
-      {:ok, flaky_pid} =
-        Agent.start_link(fn -> 0 end, name: FlakyAgent)
-
-      on_exit(fn -> if Process.alive?(flaky_pid), do: Agent.stop(flaky_pid) end)
+      start_agent!(FlakyAgent, fn -> 0 end)
       :ok
     end
 
@@ -251,8 +256,7 @@ defmodule KlassHero.Shared.ProjectionTest do
     end
 
     test "succeeds on first attempt without retry without crashing" do
-      {:ok, instant_pid} = Agent.start_link(fn -> 0 end, name: InstantSuccessAgent)
-      on_exit(fn -> if Process.alive?(instant_pid), do: Agent.stop(instant_pid) end)
+      start_agent!(InstantSuccessAgent, fn -> 0 end)
       {:ok, pid} = InstantSuccessProjection.start_link(name: unique_name())
 
       # Drain handle_continue. With the bug present, the GenServer crashes here
@@ -267,12 +271,7 @@ defmodule KlassHero.Shared.ProjectionTest do
     test "reraises after max_attempts consecutive failures" do
       import ExUnit.CaptureLog
 
-      {:ok, always_fail_pid} =
-        Agent.start_link(fn -> 0 end, name: AlwaysFailAgent)
-
-      on_exit(fn ->
-        if Process.alive?(always_fail_pid), do: Agent.stop(always_fail_pid)
-      end)
+      start_agent!(AlwaysFailAgent, fn -> 0 end)
 
       Process.flag(:trap_exit, true)
 


### PR DESCRIPTION
## Summary

`Shared.ProjectionTest` fails intermittently in full-suite runs. Four setups clean up a named Agent with:

```elixir
on_exit(fn -> if Process.alive?(pid), do: Agent.stop(pid) end)
```

That is check-then-act. `on_exit` callbacks run **after** the test process has exited, and these Agents are `start_link`ed to it — so they are already dying by the time the guard runs. The guard just usually wins. When it loses:

```
** (exit) exited in: GenServer.stop(#PID<0.20294.0>, :normal, :infinity)
    ** (EXIT) no process: the process is not alive or there's no process
    currently associated with the given name
```

…and an otherwise-passing test fails.

## Fix

Hand the lifecycle to ExUnit with `start_supervised!/1`, which shuts children down in order *before* any `on_exit` runs and treats an already-stopped child as fine — removing the race rather than narrowing the window. The `on_exit` blocks are then dead weight and go away.

The Agents keep their fixed names (`FlakyAgent`, `InstantSuccessAgent`, `AlwaysFailAgent`) because the projection modules under test look them up by name, so the name is passed through the child spec's `start` tuple. Collapsed into one `start_agent!/2` helper since all four sites are identical.

## How it was found

Observed live during a full-suite run while working on an unrelated branch (#1217). Worth noting the shape is the same as the production bug that PR fixes — a check-then-act window on a resource that another party can change in between.

## Test plan

- `mix test test/klass_hero/shared/projection_test.exs` **8 consecutive runs, 10 passed each**. The old code passes in isolation too, so repetition is the only meaningful check here.
- `mix precommit` green: 3922 passed, 2 skipped, 18 excluded.
- Diff is one test file, 15 insertions / 16 deletions. No production code.

Note: an unrelated admin LiveView test failed on the first full run and passed on re-run and on three isolated runs — part of the same intermittent baseline this PR chips at, and outside this diff's reach.