### PR TITLE
fix: record photo consent collected on an invite

### DIFF
--- a/lib/klass_hero/family.ex
+++ b/lib/klass_hero/family.ex
@@ -214,7 +214,10 @@ defmodule KlassHero.Family do
 
       %Consent{}
       |> Consent.changeset(attrs)
-      |> Repo.insert()
+      # `mode: :savepoint` because callers run this inside a transaction (ProcessInviteClaim
+      # grants invite consents inside its Outbox.transact). Without it the constraint hit
+      # below aborts the enclosing transaction instead of being caught here — issue #1065.
+      |> Repo.insert(mode: :savepoint)
       |> case do
         {:ok, consent} ->
           {:ok, consent}

--- a/lib/klass_hero/family/adapters/driving/events/invite_claimed_handler.ex
+++ b/lib/klass_hero/family/adapters/driving/events/invite_claimed_handler.ex
@@ -61,7 +61,9 @@ defmodule KlassHero.Family.Adapters.Driving.Events.InviteClaimedHandler do
       school_grade: Map.get(payload, :school_grade),
       school_name: Map.get(payload, :school_name),
       medical_conditions: Map.get(payload, :medical_conditions),
-      nut_allergy: Map.get(payload, :nut_allergy, false)
+      nut_allergy: Map.get(payload, :nut_allergy, false),
+      consent_photo_marketing: Map.get(payload, :consent_photo_marketing, false),
+      consent_photo_social_media: Map.get(payload, :consent_photo_social_media, false)
     }
   end
 

--- a/lib/klass_hero/family/adapters/driving/workers/process_invite_claim_worker.ex
+++ b/lib/klass_hero/family/adapters/driving/workers/process_invite_claim_worker.ex
@@ -36,7 +36,9 @@ defmodule KlassHero.Family.Adapters.Driving.Workers.ProcessInviteClaimWorker do
          school_grade: args["school_grade"],
          school_name: args["school_name"],
          medical_conditions: args["medical_conditions"],
-         nut_allergy: args["nut_allergy"]
+         nut_allergy: args["nut_allergy"],
+         consent_photo_marketing: args["consent_photo_marketing"],
+         consent_photo_social_media: args["consent_photo_social_media"]
        }}
     end
   end

--- a/lib/klass_hero/family/process_invite_claim.ex
+++ b/lib/klass_hero/family/process_invite_claim.ex
@@ -39,7 +39,8 @@ defmodule KlassHero.Family.ProcessInviteClaim do
     result =
       Outbox.transact(KlassHero.Family, fn ->
         with {:ok, parent} <- ensure_parent_profile(user_id, invite_id),
-             {:ok, child} <- find_or_create_child(parent.id, attrs) do
+             {:ok, child} <- find_or_create_child(parent.id, attrs),
+             :ok <- grant_invite_consents(parent.id, child.id, attrs) do
           event = family_ready_event(invite_id, user_id, child.id, parent.id, program_id)
           {:ok, %{parent: parent, child: child}, [event]}
         end
@@ -57,6 +58,43 @@ defmodule KlassHero.Family.ProcessInviteClaim do
         )
 
         {:error, reason}
+    end
+  end
+
+  @consent_fields %{
+    consent_photo_marketing: "photo_marketing",
+    consent_photo_social_media: "photo_social_media"
+  }
+
+  # The provider collects photo permission in the CSV and the parent's answer rides all the
+  # way here in the event payload, so it has to become a Consent record — previously it was
+  # read, staged, and then dropped, and no invite ever produced a consent.
+  #
+  # Only a `true` grants: a Consent row means "granted", and there is no representation for
+  # a decline, so absence is the safe reading of "did not agree".
+  #
+  # `:already_active` is success, not failure. This runs on an Oban worker that retries, and
+  # a second invite for the same child reuses that child — either way the consent may exist.
+  defp grant_invite_consents(parent_id, child_id, attrs) do
+    @consent_fields
+    |> Enum.filter(fn {field, _consent_type} -> Map.get(attrs, field) end)
+    |> Enum.reduce_while(:ok, fn {_field, consent_type}, :ok ->
+      case grant_one_consent(parent_id, child_id, consent_type) do
+        :ok -> {:cont, :ok}
+        error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp grant_one_consent(parent_id, child_id, consent_type) do
+    case Family.grant_consent(%{
+           parent_id: parent_id,
+           child_id: child_id,
+           consent_type: consent_type
+         }) do
+      {:ok, _consent} -> :ok
+      {:error, :already_active} -> :ok
+      {:error, reason} -> {:error, reason}
     end
   end
 

--- a/test/klass_hero/family/process_invite_claim_test.exs
+++ b/test/klass_hero/family/process_invite_claim_test.exs
@@ -24,6 +24,56 @@ defmodule KlassHero.Family.ProcessInviteClaimTest do
     )
   end
 
+  # The provider collects photo permission in the CSV and it rides the whole way here in the
+  # event payload. It used to stop at the handler, which never copied it into the worker's
+  # args — so no invite claim ever produced a consent record.
+  describe "photo consent from the invite" do
+    test "grants each consent the parent agreed to" do
+      user = user_fixture()
+
+      attrs =
+        valid_attrs(user.id, %{
+          consent_photo_marketing: true,
+          consent_photo_social_media: true
+        })
+
+      assert {:ok, %{child: child}} = ProcessInviteClaim.execute(attrs)
+
+      assert Family.child_has_active_consent?(child.id, "photo_marketing")
+      assert Family.child_has_active_consent?(child.id, "photo_social_media")
+    end
+
+    test "records nothing for a consent the parent declined" do
+      user = user_fixture()
+
+      attrs =
+        valid_attrs(user.id, %{
+          consent_photo_marketing: true,
+          consent_photo_social_media: false
+        })
+
+      assert {:ok, %{child: child}} = ProcessInviteClaim.execute(attrs)
+
+      assert Family.child_has_active_consent?(child.id, "photo_marketing")
+      refute Family.child_has_active_consent?(child.id, "photo_social_media")
+    end
+
+    # The worker retries, and a second program's invite reuses the same child, so the grant
+    # runs again against a consent that already exists. `grant_consent/1` catches that
+    # constraint inside the enclosing transaction, which is why it needs `mode: :savepoint` —
+    # without it the violation aborts the whole transaction rather than being caught (#1065).
+    test "a replay grants no duplicates and does not poison the transaction" do
+      user = user_fixture()
+      attrs = valid_attrs(user.id, %{consent_photo_marketing: true})
+
+      assert {:ok, %{child: child}} = ProcessInviteClaim.execute(attrs)
+      assert {:ok, %{child: same_child}} = ProcessInviteClaim.execute(attrs)
+
+      assert same_child.id == child.id
+      assert Family.child_has_active_consent?(child.id, "photo_marketing")
+    end
+  end
+
   describe "execute/1" do
     test "creates parent profile and child for new user" do
       user = user_fixture()


### PR DESCRIPTION
## Summary

**Photo consent collected from parents is silently discarded on every invite claim.**

The chain is intact right up to the last hop:

1. `csv_parser.ex:36-37` maps two photography-permission columns from the provider's CSV
2. `bulk_enrollment_invites` stores them (`consent_photo_marketing`, `consent_photo_social_media`)
3. `ClaimInvite.build_and_publish/3` stages both into the `:invite_claimed` payload
4. **`InviteClaimedHandler.build_worker_args/2` never copies them into the Oban args** — they stop here
5. `Family.grant_consent/1` is called only from the settings UI (`children_live.ex:268`)

So no invite claim has ever produced a consent record, for any invite. A parent's answer is collected, carried three hops, and dropped.

## Fix

Nothing new is modelled — `Consent`'s valid types already include `photo_marketing` and `photo_social_media` (`consent.ex:18`), one-for-one with the two booleans. The wiring threads through `build_worker_args/2` and `deserialize_args/1`, and the grants happen inside `ProcessInviteClaim`'s existing `Outbox.transact` where `parent` and `child` are already in scope — a same-context call inside the producer's transaction, per the documented pattern.

**Only `true` grants.** A `Consent` row means "granted" and there is no representation for a decline, so absence is the honest reading of "did not agree". Recording declines explicitly would need a schema change and is deliberately not in this PR.

## Review focus: `grant_consent/1` needs `mode: :savepoint`

This is the subtle half. `grant_consent/1` catches a unique-constraint violation with a bare `Repo.insert()` — fine from the settings UI, wrong from inside a transaction: the violation **aborts the enclosing transaction** rather than being caught, so `{:error, :already_active}` never comes back.

Same trap as issue #1065, and already handled the same way in `create_parent_profile/1` a few functions above.

It is not hypothetical here — the grant re-runs on every Oban retry, and whenever a second program's invite reuses an existing child.

**Verified rather than assumed.** With the option removed, the replay test fails:

```
** (RuntimeError) operation :rollback is rolling back unexpectedly.
```

…surfacing through `Outbox.transact`'s `Ecto.Multi`. With it, green. Exactly one test moves, which is also a check that the test targets the right thing.

## Test plan

- Three tests in `process_invite_claim_test.exs`: both consents granted; a declined one records nothing; a replay produces no duplicates and does not poison the transaction.
- The replay test is the savepoint regression test — confirmed red without the option, green with it.
- `mix precommit` green: **3925 passed**, 2 skipped, 18 excluded.

## Related

Found while tracing the invite claim path for #1215 (PR #1217). Independent of that fix — this branches off `main` and touches only Family.

A second bug from the same trace is **not** addressed here and deserves its own issue: if child creation fails, the invite sticks in `:registered` forever (there is no `transition_to_failed` in the Family context) and the guardian has already been shown "account created", so they get an account and silently no enrollment.