### PR TITLE
fix: serve the active locale in <html lang> and make language changes stick

### DIFF
--- a/lib/klass_hero_web/components/layouts.ex
+++ b/lib/klass_hero_web/components/layouts.ex
@@ -4,6 +4,15 @@ defmodule KlassHeroWeb.Layouts do
   """
   use KlassHeroWeb, :html
 
+  # Must precede embed_templates: aliases are lexically scoped and the templates
+  # compile at that call site, so root.html.heex would not resolve `Locale`.
+  alias KlassHeroWeb.Locale
+
+  # The root layout renders on dead render only — which is exactly what crawlers
+  # see — so the request path SetLocale assigned is enough here; no per-navigation
+  # LiveView hook is needed.
+  defp seo_path(assigns), do: assigns[:current_path] || "/"
+
   embed_templates "layouts/*"
 
   @doc """

--- a/lib/klass_hero_web/components/layouts/root.html.heex
+++ b/lib/klass_hero_web/components/layouts/root.html.heex
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang={assigns[:locale] || Locale.default()}>
   <head>
     {Application.get_env(:live_debugger, :live_debugger_tags)}
 
@@ -11,6 +11,13 @@
     <link rel="icon" href={~p"/favicon.ico"} sizes="32x32" />
     <link rel="icon" type="image/svg+xml" href={~p"/images/icon.svg"} sizes="any" />
     <link rel="apple-touch-icon" sizes="180x180" href={~p"/images/apple-touch-icon.png"} />
+    <%!-- Canonical always names an explicit ?locale= URL. The bare path serves
+          whichever language the session or Accept-Language implies, so it is the
+          x-default target rather than a canonical of its own. --%>
+    <link rel="canonical" href={Locale.url_for(seo_path(assigns), assigns[:locale])} />
+    <link rel="alternate" hreflang="en" href={Locale.url_for(seo_path(assigns), "en")} />
+    <link rel="alternate" hreflang="de" href={Locale.url_for(seo_path(assigns), "de")} />
+    <link rel="alternate" hreflang="x-default" href={Locale.url_for(seo_path(assigns), nil)} />
     <.live_title default="Klass Hero" suffix=" · Afterschool Activities & Camps">
       {assigns[:page_title]}
     </.live_title>

--- a/lib/klass_hero_web/controllers/locale_controller.ex
+++ b/lib/klass_hero_web/controllers/locale_controller.ex
@@ -1,0 +1,62 @@
+defmodule KlassHeroWeb.LocaleController do
+  @moduledoc """
+  The one place a language choice is written.
+
+  A LiveView cannot set cookies, so it can never make a locale change stick:
+  `SetLocale` reads the session ahead of the user's stored preference, and only
+  a plug-pipeline response can write that session. Routing the change through a
+  controller writes both at once and answers with a redirect — a dead render,
+  which is also the only thing that can refresh `<html lang>` in the root
+  layout.
+
+  The session is the choice for this browsing session; the stored preference is
+  the durable default that seeds it after `clear_session/1` at login.
+  """
+  use KlassHeroWeb, :controller
+
+  alias KlassHero.Accounts
+  alias KlassHeroWeb.Locale
+
+  def update(conn, %{"locale" => requested} = params) do
+    conn
+    |> apply_locale(Locale.validate(requested))
+    |> redirect(to: return_to(params))
+  end
+
+  defp apply_locale(%{assigns: %{current_scope: %{user: %{} = user}}} = conn, locale) do
+    case Accounts.update_user_locale(user, %{locale: locale}) do
+      {:ok, _user} ->
+        conn
+        |> put_session(:locale, locale)
+        |> put_flash(:info, gettext("Language preference updated successfully."))
+
+      # SetLocale has already written the requested locale to the session by the
+      # time we get here — it reads :locale straight off the path param. So a
+      # failed persist has to put the stored preference back, or the rendered
+      # language would switch while the flash says it failed and the settings
+      # radio, which reads that preference, kept showing the old value.
+      {:error, _changeset} ->
+        conn
+        |> put_session(:locale, Locale.validate(user.locale))
+        |> put_flash(:error, gettext("Failed to update language preference."))
+    end
+  end
+
+  # Anonymous visitors have nowhere durable to store a preference; the session
+  # is the whole of their choice, so there is nothing to confirm.
+  defp apply_locale(conn, locale), do: put_session(conn, :locale, locale)
+
+  defp return_to(%{"return_to" => path}) when is_binary(path) do
+    if local_path?(path), do: path, else: ~p"/"
+  end
+
+  defp return_to(_params), do: ~p"/"
+
+  # Only a single-slash-prefixed path is ours. "//evil.com" is a protocol-relative
+  # URL and "/\evil.com" is treated as one by browsers, so both would send the
+  # visitor off-site from a link that looks like a language switch.
+  defp local_path?("//" <> _rest), do: false
+  defp local_path?("/\\" <> _rest), do: false
+  defp local_path?("/" <> _rest), do: true
+  defp local_path?(_path), do: false
+end

--- a/lib/klass_hero_web/hooks/restore_locale.ex
+++ b/lib/klass_hero_web/hooks/restore_locale.ex
@@ -20,7 +20,7 @@ defmodule KlassHeroWeb.Hooks.RestoreLocale do
 
   import Phoenix.Component
 
-  @default_locale "en"
+  alias KlassHeroWeb.Locale
 
   def on_mount(:restore_locale, _params, session, socket) do
     locale = determine_locale(session, socket)
@@ -31,6 +31,12 @@ defmodule KlassHeroWeb.Hooks.RestoreLocale do
   end
 
   defp determine_locale(session, socket) do
+    session
+    |> preferred_locale(socket)
+    |> Locale.validate()
+  end
+
+  defp preferred_locale(session, socket) do
     cond do
       # 1. Session locale (set by plug - includes query param for explicit user choice)
       session_locale = Map.get(session, "locale") ->
@@ -42,7 +48,7 @@ defmodule KlassHeroWeb.Hooks.RestoreLocale do
 
       # 3. Default
       true ->
-        @default_locale
+        Locale.default()
     end
   end
 

--- a/lib/klass_hero_web/live/user_live/settings.ex
+++ b/lib/klass_hero_web/live/user_live/settings.ex
@@ -462,22 +462,11 @@ defmodule KlassHeroWeb.UserLive.Settings do
     end
   end
 
+  # Handing this to the controller rather than writing it here is the whole fix
+  # for #1161: only the plug pipeline can write the session that SetLocale reads
+  # first, and only its redirect re-renders the root layout's <html lang>.
   def handle_event("update_locale", %{"user" => %{"locale" => locale}}, socket) do
-    user = socket.assigns.current_scope.user
-
-    case Accounts.update_user_locale(user, %{locale: locale}) do
-      {:ok, updated_user} ->
-        Gettext.put_locale(KlassHeroWeb.Gettext, locale)
-
-        {:noreply,
-         socket
-         |> assign(:current_scope, %{socket.assigns.current_scope | user: updated_user})
-         |> assign(:locale, locale)
-         |> put_flash(:info, gettext("Language preference updated successfully."))}
-
-      {:error, _changeset} ->
-        {:noreply, put_flash(socket, :error, gettext("Failed to update language preference."))}
-    end
+    {:noreply, redirect(socket, to: ~p"/locale/#{locale}?return_to=/users/settings")}
   end
 
   def handle_event("delete_account", %{"delete" => %{"password" => password}}, socket) do

--- a/lib/klass_hero_web/locale.ex
+++ b/lib/klass_hero_web/locale.ex
@@ -1,0 +1,50 @@
+defmodule KlassHeroWeb.Locale do
+  @moduledoc """
+  The supported-locale whitelist, in one place.
+
+  This unifies the web layer's copies — the `SetLocale` plug, the `RestoreLocale`
+  hook, and (implicitly) the hardcoded `lang="en"` in the root layout, which had
+  drifted far enough to claim English on every German page (#1161).
+
+  `KlassHero.Accounts.User.locale_changeset/2` deliberately keeps its own list:
+  the domain cannot depend on a web module. The two agree today, so adding a
+  locale here without adding it there would leave the changeset rejecting what
+  this module accepts.
+
+  `validate/1` coerces rather than fails. Every caller receives a locale from
+  untrusted input — a `?locale=` param, a session cookie written by an older
+  release, a `users.locale` column holding a value since retired — and the right
+  response to all of them is to render the default, not to raise.
+  """
+
+  @supported ~w(en de)
+  @default "en"
+
+  @doc "Every locale the app can render."
+  def supported, do: @supported
+
+  @doc "The locale used when nothing better is known."
+  def default, do: @default
+
+  @doc "Coerces any term to a supported locale, falling back to `default/0`."
+  def validate(locale) when locale in @supported, do: locale
+  def validate(_locale), do: @default
+
+  @doc "Whether the given term is a locale the app can render."
+  def supported?(locale), do: locale in @supported
+
+  @doc """
+  The absolute URL serving `path` in `locale`, for `rel=canonical` and
+  `rel=alternate hreflang`.
+
+  Passing `nil` yields the bare path — the `x-default` target, which serves
+  whatever the visitor's session or `Accept-Language` header implies. Every
+  other locale gets an explicit `?locale=`, so canonical never names the bare
+  path: that would leave it and `?locale=en` as two self-canonical URLs with
+  identical content.
+  """
+  def url_for(path, nil), do: base_url() <> path
+  def url_for(path, locale), do: base_url() <> path <> "?locale=" <> validate(locale)
+
+  defp base_url, do: Application.get_env(:klass_hero, :app_base_url, "http://localhost:4000")
+end

--- a/lib/klass_hero_web/plugs/set_locale.ex
+++ b/lib/klass_hero_web/plugs/set_locale.ex
@@ -10,14 +10,18 @@ defmodule KlassHeroWeb.Plugs.SetLocale do
   5. Default: "en"
 
   The locale is stored in session and assigned to conn for use by LiveView hooks.
+
+  Because the session outranks the stored preference and only the plug pipeline
+  can write a session, a durable language change must go through
+  `KlassHeroWeb.LocaleController` — a LiveView writing the preference alone
+  leaves the session stale and the change is lost on the next request (#1161).
   """
 
   @behaviour Plug
 
   import Plug.Conn
 
-  @supported_locales ~w(en de)
-  @default_locale "en"
+  alias KlassHeroWeb.Locale
 
   @impl Plug
   def init(opts), do: opts
@@ -30,6 +34,10 @@ defmodule KlassHeroWeb.Plugs.SetLocale do
 
     conn
     |> assign(:locale, locale)
+    # Path only, no query string: the root layout builds canonical and hreflang
+    # URLs from it, and folding filter params in would mint a separate canonical
+    # for every permutation of /programs?category=…
+    |> assign(:current_path, conn.request_path)
     |> put_session(:locale, locale)
   end
 
@@ -39,10 +47,10 @@ defmodule KlassHeroWeb.Plugs.SetLocale do
       &session_locale/1,
       &user_locale/1,
       &accept_language_locale/1,
-      fn _ -> @default_locale end
+      fn _ -> Locale.default() end
     ]
     |> Enum.find_value(fn detector -> detector.(conn) end)
-    |> validate_locale()
+    |> Locale.validate()
   end
 
   defp query_param_locale(%{params: %{"locale" => locale}}), do: locale
@@ -71,7 +79,7 @@ defmodule KlassHeroWeb.Plugs.SetLocale do
     |> String.split(",")
     |> Enum.map(&String.trim/1)
     |> Enum.map(&extract_language_code/1)
-    |> Enum.find(&(&1 in @supported_locales))
+    |> Enum.find(&Locale.supported?/1)
   end
 
   defp extract_language_code(lang_entry) do
@@ -82,7 +90,4 @@ defmodule KlassHeroWeb.Plugs.SetLocale do
     |> List.first()
     |> String.downcase()
   end
-
-  defp validate_locale(locale) when locale in @supported_locales, do: locale
-  defp validate_locale(_), do: @default_locale
 end

--- a/lib/klass_hero_web/router.ex
+++ b/lib/klass_hero_web/router.ex
@@ -67,6 +67,10 @@ defmodule KlassHeroWeb.Router do
   scope "/", KlassHeroWeb do
     pipe_through :browser
 
+    # Language changes go through the plug pipeline because only it can write the
+    # session, and only its redirect re-renders the root layout's <html lang>.
+    get "/locale/:locale", LocaleController, :update
+
     live_session :marketing,
       layout: {KlassHeroWeb.Layouts, :marketing},
       on_mount: [

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -20,8 +20,8 @@ msgstr ""
 msgid "About"
 msgstr "Über uns"
 
-#: lib/klass_hero_web/components/layouts.ex:34
-#: lib/klass_hero_web/components/layouts.ex:46
+#: lib/klass_hero_web/components/layouts.ex:43
+#: lib/klass_hero_web/components/layouts.ex:55
 #, elixir-autogen, elixir-format
 msgid "Attempting to reconnect"
 msgstr "Verbindung wird wiederhergestellt"
@@ -61,7 +61,7 @@ msgstr "Meine Daten herunterladen"
 msgid "Download a copy of all your personal data"
 msgstr "Laden Sie eine Kopie aller Ihrer persönlichen Daten herunter"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:479
+#: lib/klass_hero_web/controllers/locale_controller.ex:41
 #, elixir-autogen, elixir-format
 msgid "Failed to update language preference."
 msgstr "Spracheinstellung konnte nicht aktualisiert werden."
@@ -78,7 +78,7 @@ msgstr "Startseite"
 msgid "Language Preference"
 msgstr "Spracheinstellung"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:476
+#: lib/klass_hero_web/controllers/locale_controller.ex:31
 #, elixir-autogen, elixir-format
 msgid "Language preference updated successfully."
 msgstr "Spracheinstellung erfolgreich aktualisiert."
@@ -121,12 +121,12 @@ msgstr "Abmelden"
 msgid "Sign Up"
 msgstr "Registrieren"
 
-#: lib/klass_hero_web/components/layouts.ex:41
+#: lib/klass_hero_web/components/layouts.ex:50
 #, elixir-autogen, elixir-format
 msgid "Something went wrong!"
 msgstr "Etwas ist schief gelaufen!"
 
-#: lib/klass_hero_web/components/layouts.ex:29
+#: lib/klass_hero_web/components/layouts.ex:38
 #, elixir-autogen, elixir-format
 msgid "We can't find the internet"
 msgstr "Keine Internetverbindung gefunden"
@@ -637,7 +637,7 @@ msgstr "Auschecken fehlgeschlagen: %{reason}"
 msgid "Failed to complete session: %{reason}"
 msgstr "Sitzung konnte nicht abgeschlossen werden: %{reason}"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:508
+#: lib/klass_hero_web/live/user_live/settings.ex:497
 #, elixir-autogen, elixir-format
 msgid "Failed to delete account. Please try again."
 msgstr "Konto konnte nicht gelöscht werden. Bitte versuchen Sie es erneut."
@@ -700,7 +700,7 @@ msgstr "Einleitung"
 msgid "Invalid date format"
 msgstr "Ungültiges Datumsformat"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:502
+#: lib/klass_hero_web/live/user_live/settings.ex:491
 #, elixir-autogen, elixir-format
 msgid "Invalid password."
 msgstr "Ungültiges Passwort."
@@ -1023,7 +1023,7 @@ msgstr "Sie müssen sich erneut authentifizieren, um sensible Aktionen auf Ihrem
 msgid "Your Privacy Rights"
 msgstr "Ihre Datenschutzrechte"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:490
+#: lib/klass_hero_web/live/user_live/settings.ex:479
 #, elixir-autogen, elixir-format
 msgid "Your account has been deleted."
 msgstr "Ihr Konto wurde gelöscht."
@@ -2062,7 +2062,7 @@ msgstr "Bitte authentifizieren Sie sich erneut, um Ihre E-Mail-Adresse zu änder
 msgid "Please re-authenticate to change your password."
 msgstr "Bitte authentifizieren Sie sich erneut, um Ihr Passwort zu ändern."
 
-#: lib/klass_hero_web/live/user_live/settings.ex:496
+#: lib/klass_hero_web/live/user_live/settings.ex:485
 #, elixir-autogen, elixir-format
 msgid "Please re-authenticate to delete your account."
 msgstr "Bitte authentifizieren Sie sich erneut, um Ihr Konto zu löschen."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -20,8 +20,8 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts.ex:34
-#: lib/klass_hero_web/components/layouts.ex:46
+#: lib/klass_hero_web/components/layouts.ex:43
+#: lib/klass_hero_web/components/layouts.ex:55
 #, elixir-autogen, elixir-format
 msgid "Attempting to reconnect"
 msgstr ""
@@ -61,7 +61,7 @@ msgstr ""
 msgid "Download a copy of all your personal data"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:479
+#: lib/klass_hero_web/controllers/locale_controller.ex:41
 #, elixir-autogen, elixir-format
 msgid "Failed to update language preference."
 msgstr ""
@@ -78,7 +78,7 @@ msgstr ""
 msgid "Language Preference"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:476
+#: lib/klass_hero_web/controllers/locale_controller.ex:31
 #, elixir-autogen, elixir-format
 msgid "Language preference updated successfully."
 msgstr ""
@@ -121,12 +121,12 @@ msgstr ""
 msgid "Sign Up"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts.ex:41
+#: lib/klass_hero_web/components/layouts.ex:50
 #, elixir-autogen, elixir-format
 msgid "Something went wrong!"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts.ex:29
+#: lib/klass_hero_web/components/layouts.ex:38
 #, elixir-autogen, elixir-format
 msgid "We can't find the internet"
 msgstr ""
@@ -637,7 +637,7 @@ msgstr ""
 msgid "Failed to complete session: %{reason}"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:508
+#: lib/klass_hero_web/live/user_live/settings.ex:497
 #, elixir-autogen, elixir-format
 msgid "Failed to delete account. Please try again."
 msgstr ""
@@ -700,7 +700,7 @@ msgstr ""
 msgid "Invalid date format"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:502
+#: lib/klass_hero_web/live/user_live/settings.ex:491
 #, elixir-autogen, elixir-format
 msgid "Invalid password."
 msgstr ""
@@ -1023,7 +1023,7 @@ msgstr ""
 msgid "Your Privacy Rights"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:490
+#: lib/klass_hero_web/live/user_live/settings.ex:479
 #, elixir-autogen, elixir-format
 msgid "Your account has been deleted."
 msgstr ""
@@ -2062,7 +2062,7 @@ msgstr ""
 msgid "Please re-authenticate to change your password."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:496
+#: lib/klass_hero_web/live/user_live/settings.ex:485
 #, elixir-autogen, elixir-format
 msgid "Please re-authenticate to delete your account."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -20,8 +20,8 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts.ex:34
-#: lib/klass_hero_web/components/layouts.ex:46
+#: lib/klass_hero_web/components/layouts.ex:43
+#: lib/klass_hero_web/components/layouts.ex:55
 #, elixir-autogen, elixir-format
 msgid "Attempting to reconnect"
 msgstr ""
@@ -61,7 +61,7 @@ msgstr ""
 msgid "Download a copy of all your personal data"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:479
+#: lib/klass_hero_web/controllers/locale_controller.ex:41
 #, elixir-autogen, elixir-format
 msgid "Failed to update language preference."
 msgstr ""
@@ -78,7 +78,7 @@ msgstr ""
 msgid "Language Preference"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:476
+#: lib/klass_hero_web/controllers/locale_controller.ex:31
 #, elixir-autogen, elixir-format
 msgid "Language preference updated successfully."
 msgstr ""
@@ -121,12 +121,12 @@ msgstr ""
 msgid "Sign Up"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts.ex:41
+#: lib/klass_hero_web/components/layouts.ex:50
 #, elixir-autogen, elixir-format
 msgid "Something went wrong!"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts.ex:29
+#: lib/klass_hero_web/components/layouts.ex:38
 #, elixir-autogen, elixir-format
 msgid "We can't find the internet"
 msgstr ""
@@ -637,7 +637,7 @@ msgstr ""
 msgid "Failed to complete session: %{reason}"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:508
+#: lib/klass_hero_web/live/user_live/settings.ex:497
 #, elixir-autogen, elixir-format
 msgid "Failed to delete account. Please try again."
 msgstr ""
@@ -700,7 +700,7 @@ msgstr ""
 msgid "Invalid date format"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:502
+#: lib/klass_hero_web/live/user_live/settings.ex:491
 #, elixir-autogen, elixir-format
 msgid "Invalid password."
 msgstr ""
@@ -1023,7 +1023,7 @@ msgstr ""
 msgid "Your Privacy Rights"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:490
+#: lib/klass_hero_web/live/user_live/settings.ex:479
 #, elixir-autogen, elixir-format
 msgid "Your account has been deleted."
 msgstr ""
@@ -2062,7 +2062,7 @@ msgstr ""
 msgid "Please re-authenticate to change your password."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:496
+#: lib/klass_hero_web/live/user_live/settings.ex:485
 #, elixir-autogen, elixir-format
 msgid "Please re-authenticate to delete your account."
 msgstr ""

--- a/test/klass_hero_web/controllers/locale_controller_test.exs
+++ b/test/klass_hero_web/controllers/locale_controller_test.exs
@@ -1,0 +1,118 @@
+defmodule KlassHeroWeb.LocaleControllerTest do
+  @moduledoc """
+  The single write path for "change my language".
+
+  A LiveView cannot set cookies, so before this controller existed the settings
+  toggle wrote the database and its own socket but never the session — and
+  `SetLocale` reads the session ahead of the database preference. The chosen
+  language therefore vanished on the next page load (#1161).
+
+  Going through a controller also means the response is a redirect, i.e. a dead
+  render, which is the only thing that can refresh `<html lang>`.
+  """
+  use KlassHeroWeb.ConnCase, async: true
+  use Mimic
+
+  import KlassHero.AccountsFixtures
+  import KlassHeroWeb.I18nHelpers, only: [get_translation: 2]
+
+  alias KlassHero.Repo
+
+  describe "update/2 session handling" do
+    for locale <- ~w(en de) do
+      test "stores #{locale} in the session", %{conn: conn} do
+        conn = get(conn, ~p"/locale/#{unquote(locale)}")
+
+        assert get_session(conn, :locale) == unquote(locale)
+      end
+    end
+
+    test "coerces an unsupported locale to the default rather than storing it", %{conn: conn} do
+      conn = get(conn, ~p"/locale/fr")
+
+      assert get_session(conn, :locale) == KlassHeroWeb.Locale.default()
+    end
+
+    test "an anonymous visitor can switch language without an account", %{conn: conn} do
+      conn = get(conn, ~p"/locale/de")
+
+      assert get_session(conn, :locale) == "de"
+      assert redirected_to(conn) == "/"
+    end
+  end
+
+  describe "update/2 preference persistence" do
+    setup do
+      %{user: user_fixture()}
+    end
+
+    test "persists the choice to the signed-in user's profile", %{conn: conn, user: user} do
+      conn = conn |> log_in_user(user) |> get(~p"/locale/de")
+
+      assert Repo.reload!(user).locale == "de"
+      assert get_session(conn, :locale) == "de"
+    end
+
+    # The path segment lands in conn.params before the :browser pipeline runs, so
+    # SetLocale has already switched the process locale by the time the flash is
+    # built — the confirmation arrives in the language just chosen, not the old one.
+    for locale <- ~w(en de) do
+      test "confirms the change in the newly chosen language (#{locale})", %{conn: conn, user: user} do
+        conn = conn |> log_in_user(user) |> get(~p"/locale/#{unquote(locale)}")
+
+        assert Phoenix.Flash.get(conn.assigns.flash, :info) ==
+                 get_translation("Language preference updated successfully.", unquote(locale))
+      end
+    end
+
+    test "does not flash for an anonymous visitor, whose choice is session-only", %{conn: conn} do
+      conn = get(conn, ~p"/locale/de")
+
+      refute Phoenix.Flash.get(conn.assigns.flash, :info)
+    end
+
+    # Session and stored preference have to agree. SetLocale writes the requested
+    # locale to the session from the path param before the controller runs, so a
+    # failed persist must put the stored preference back — otherwise the rendered
+    # language switches while the flash says it failed and the settings radio,
+    # which reads that preference, still shows the old one.
+    test "restores the stored preference when the change cannot be persisted", %{conn: conn, user: user} do
+      changeset = KlassHero.Accounts.change_user_locale(user, %{locale: "de"})
+
+      expect(KlassHero.Accounts, :update_user_locale, fn _user, _attrs -> {:error, changeset} end)
+
+      conn = conn |> log_in_user(user) |> get(~p"/locale/de")
+
+      assert get_session(conn, :locale) == user.locale
+      assert Phoenix.Flash.get(conn.assigns.flash, :error)
+      assert Repo.reload!(user).locale == user.locale
+    end
+  end
+
+  describe "update/2 return_to handling" do
+    test "returns the visitor to the page they switched from", %{conn: conn} do
+      conn = get(conn, ~p"/locale/de?return_to=/programs")
+
+      assert redirected_to(conn) == "/programs"
+    end
+
+    # An unguarded return_to turns the switcher into an open redirect: a crafted
+    # link would bounce the visitor off-site while looking like a klass-hero URL.
+    @unsafe [
+      {"//evil.com", "protocol-relative URL"},
+      {"https://evil.com", "absolute URL"},
+      {"/\\evil.com", "backslash-smuggled host"},
+      {"evil.com", "schemeless host"},
+      {"", "empty path"}
+    ]
+
+    for {path, description} <- @unsafe do
+      test "rejects a #{description} and falls back to the home page", %{conn: conn} do
+        conn = get(conn, ~p"/locale/de?return_to=#{unquote(path)}")
+
+        assert redirected_to(conn) == "/",
+               "#{unquote(path)} was accepted as a redirect target — open redirect"
+      end
+    end
+  end
+end

--- a/test/klass_hero_web/live/user_live/settings_test.exs
+++ b/test/klass_hero_web/live/user_live/settings_test.exs
@@ -282,4 +282,45 @@ defmodule KlassHeroWeb.UserLive.SettingsTest do
       assert message == "You must log in to access this page."
     end
   end
+
+  describe "language preference" do
+    setup %{conn: conn} do
+      user = user_fixture()
+
+      %{conn: log_in_user(conn, user), user: user}
+    end
+
+    test "hands the change to the controller that can write the session", %{conn: conn} do
+      {:ok, lv, _html} = live(conn, ~p"/users/settings")
+
+      assert {:error, {:redirect, %{to: to}}} =
+               lv |> form("#locale_form", user: %{locale: "de"}) |> render_change()
+
+      assert to == "/locale/de?return_to=/users/settings"
+    end
+
+    # The bug in #1161: the LiveView wrote the database and its own socket, but
+    # SetLocale reads the session first and a LiveView cannot write one. The
+    # choice therefore evaporated on the very next page load.
+    test "the chosen language survives a page reload", %{conn: conn, user: user} do
+      {:ok, lv, _html} = live(conn, ~p"/users/settings")
+
+      {:error, {:redirect, %{to: to}}} =
+        lv |> form("#locale_form", user: %{locale: "de"}) |> render_change()
+
+      conn = get(conn, to)
+      assert redirected_to(conn) == "/users/settings"
+
+      reloaded =
+        conn
+        |> get(~p"/users/settings")
+        |> html_response(200)
+        |> LazyHTML.from_document()
+        |> LazyHTML.query("html")
+        |> LazyHTML.attribute("lang")
+
+      assert reloaded == ["de"], "the language reverted on reload — the session was never written"
+      assert KlassHero.Repo.reload!(user).locale == "de"
+    end
+  end
 end

--- a/test/klass_hero_web/locale_test.exs
+++ b/test/klass_hero_web/locale_test.exs
@@ -1,0 +1,52 @@
+defmodule KlassHeroWeb.LocaleTest do
+  @moduledoc """
+  The locale whitelist, in one place.
+
+  `validate/1` never fails — an unknown locale renders the default rather than
+  raising, because every caller receives it from untrusted input (`?locale=`, a
+  session written by an older release, a `:locale` column predating a value
+  being retired).
+  """
+  use ExUnit.Case, async: true
+
+  alias KlassHeroWeb.Locale
+
+  describe "supported/0 and default/0" do
+    test "the default is itself a supported locale" do
+      assert Locale.default() in Locale.supported()
+    end
+
+    test "supports exactly English and German" do
+      assert Enum.sort(Locale.supported()) == ["de", "en"]
+    end
+  end
+
+  describe "validate/1" do
+    @cases [
+      {"en", "en"},
+      {"de", "de"},
+      {"fr", "en"},
+      {"", "en"},
+      {"EN", "en"},
+      {"de-DE", "en"},
+      {nil, "en"},
+      {:de, "en"},
+      {123, "en"}
+    ]
+
+    for {input, expected} <- @cases do
+      test "#{inspect(input)} validates to #{inspect(expected)}" do
+        assert Locale.validate(unquote(input)) == unquote(expected),
+               "expected #{inspect(unquote(input))} to validate to #{inspect(unquote(expected))}"
+      end
+    end
+  end
+
+  describe "supported?/1" do
+    test "distinguishes a known locale from an unknown one" do
+      assert Locale.supported?("de")
+      refute Locale.supported?("fr")
+      refute Locale.supported?(nil)
+    end
+  end
+end

--- a/test/klass_hero_web/plugs/set_locale_test.exs
+++ b/test/klass_hero_web/plugs/set_locale_test.exs
@@ -1,0 +1,89 @@
+defmodule KlassHeroWeb.Plugs.SetLocaleTest do
+  @moduledoc """
+  The precedence chain that decides a request's language.
+
+  The order is load-bearing rather than arbitrary: the **session** is this
+  browsing session's choice (the `?locale=` pill), and the **stored preference**
+  is the durable default that seeds it after `clear_session/1` at login. Because
+  the session outranks the preference and only the plug pipeline can write a
+  session, a locale change has to go through `LocaleController` — writing it from
+  a LiveView leaves the session stale and the change evaporates (#1161).
+
+  This plug had no tests at all before that bug.
+  """
+  use KlassHeroWeb.ConnCase, async: true
+
+  alias KlassHeroWeb.Plugs.SetLocale
+
+  describe "precedence" do
+    # {description, param, session, stored preference, accept-language, expected}
+    @precedence [
+      {"the query param outranks everything", "de", "en", "en", "en-GB", "de"},
+      {"the session outranks the stored preference", nil, "de", "en", "en-GB", "de"},
+      {"the stored preference outranks the browser", nil, nil, "de", "en-GB", "de"},
+      {"the browser is consulted last", nil, nil, nil, "de-DE,de;q=0.9,en;q=0.8", "de"},
+      {"an unsupported browser language falls back", nil, nil, nil, "fr-FR,fr;q=0.9", "en"},
+      {"nothing at all falls back", nil, nil, nil, nil, "en"},
+      # An explicit but unsupported request resets to the default rather than
+      # falling through to the session — asking for a language we don't have is
+      # a clearer signal than the session it replaces.
+      {"an unsupported query param outranks a valid session", "fr", "de", nil, nil, "en"}
+    ]
+
+    for {description, param, session, preference, accept_language, expected} <- @precedence do
+      test description do
+        conn =
+          call(
+            param: unquote(param),
+            session: unquote(session),
+            preference: unquote(preference),
+            accept_language: unquote(accept_language)
+          )
+
+        assert conn.assigns.locale == unquote(expected)
+      end
+    end
+  end
+
+  describe "what the plug leaves behind" do
+    test "persists the resolved locale so the next request agrees with this one" do
+      conn = call(param: "de")
+
+      assert get_session(conn, :locale) == "de"
+    end
+
+    test "assigns the request path for the root layout's canonical and hreflang tags" do
+      conn = call(path: "/programs", param: "de")
+
+      assert conn.assigns.current_path == "/programs"
+    end
+
+    test "the assigned path excludes the query string" do
+      conn = call(path: "/programs", param: "de")
+
+      refute conn.assigns.current_path =~ "locale"
+    end
+  end
+
+  defp call(opts) do
+    path = Keyword.get(opts, :path, "/")
+    query = if opts[:param], do: "?locale=#{opts[:param]}", else: ""
+
+    :get
+    |> build_conn(path <> query)
+    |> Plug.Conn.fetch_query_params()
+    |> Plug.Test.init_test_session(session_for(opts[:session]))
+    |> put_accept_language(opts[:accept_language])
+    |> put_preference(opts[:preference])
+    |> SetLocale.call([])
+  end
+
+  defp session_for(nil), do: %{}
+  defp session_for(locale), do: %{locale: locale}
+
+  defp put_accept_language(conn, nil), do: conn
+  defp put_accept_language(conn, header), do: put_req_header(conn, "accept-language", header)
+
+  defp put_preference(conn, nil), do: conn
+  defp put_preference(conn, locale), do: assign(conn, :current_scope, %{user: %{locale: locale}})
+end

--- a/test/klass_hero_web/root_layout_i18n_test.exs
+++ b/test/klass_hero_web/root_layout_i18n_test.exs
@@ -1,0 +1,98 @@
+defmodule KlassHeroWeb.RootLayoutI18nTest do
+  @moduledoc """
+  What the root layout tells the browser about language.
+
+  `<html lang>` drives screen-reader pronunciation, browser translation offers
+  and hreflang indexing, so serving German content under `lang="en"` (#1161) is
+  wrong on all three at once.
+
+  These assertions can only go red through a DEAD render. `live/2` returns the
+  connected re-render with `root.html.heex` stripped, so the same assertion
+  there would pass no matter what the layout says — see `site_icons_test.exs`.
+  """
+  use KlassHeroWeb.ConnCase, async: true
+
+  describe "html lang attribute" do
+    for locale <- ~w(en de) do
+      test "declares lang=#{locale} when the request resolves to #{locale}", %{conn: conn} do
+        assert lang_of(conn, "/?locale=#{unquote(locale)}") == unquote(locale)
+      end
+    end
+
+    test "falls back to the default locale for an unsupported one", %{conn: conn} do
+      assert lang_of(conn, "/?locale=fr") == KlassHeroWeb.Locale.default()
+    end
+
+    test "declares a lang on an authenticated route too, not just marketing pages", %{conn: conn} do
+      user = KlassHero.AccountsFixtures.user_fixture()
+
+      lang =
+        conn
+        |> log_in_user(user)
+        |> lang_of("/users/settings?locale=de")
+
+      assert lang == "de"
+    end
+  end
+
+  describe "hreflang and canonical" do
+    setup %{conn: conn} do
+      %{doc: doc_for(conn, "/programs?locale=de")}
+    end
+
+    test "canonical names the explicit-locale URL, not the bare path", %{doc: doc} do
+      assert hrefs(doc, ~s(link[rel="canonical"])) == [absolute("/programs?locale=de")]
+    end
+
+    # A bare path serves whatever the visitor's session or Accept-Language says,
+    # which is exactly what x-default is for; the two locale URLs are stable.
+    @alternates [
+      {"en", "/programs?locale=en"},
+      {"de", "/programs?locale=de"},
+      {"x-default", "/programs"}
+    ]
+
+    for {hreflang, path} <- @alternates do
+      test "declares the #{hreflang} alternate", %{doc: doc} do
+        assert hrefs(doc, ~s(link[rel="alternate"][hreflang="#{unquote(hreflang)}"])) ==
+                 [absolute(unquote(path))]
+      end
+    end
+
+    test "every declared URL is absolute — a relative hreflang is ignored", %{doc: doc} do
+      urls = hrefs(doc, ~s(link[rel="canonical"])) ++ hrefs(doc, ~s(link[rel="alternate"]))
+
+      assert length(urls) == 4
+      assert Enum.all?(urls, &String.starts_with?(&1, "http")), "found a relative URL in #{inspect(urls)}"
+    end
+
+    test "the canonical follows the locale actually served", %{conn: conn} do
+      doc = doc_for(conn, "/programs?locale=en")
+
+      assert hrefs(doc, ~s(link[rel="canonical"])) == [absolute("/programs?locale=en")]
+    end
+  end
+
+  defp absolute(path), do: Application.get_env(:klass_hero, :app_base_url) <> path
+
+  defp hrefs(doc, selector), do: doc |> LazyHTML.query(selector) |> LazyHTML.attribute("href")
+
+  defp doc_for(conn, path) do
+    conn
+    |> get(path)
+    |> html_response(200)
+    |> LazyHTML.from_document()
+  end
+
+  defp lang_of(conn, path) do
+    [lang] =
+      conn
+      |> get(path)
+      |> html_response(200)
+      |> LazyHTML.from_document()
+      |> LazyHTML.query("html")
+      |> LazyHTML.attribute("lang")
+
+    lang
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -4,3 +4,4 @@ Ecto.Adapters.SQL.Sandbox.mode(KlassHero.Repo, :manual)
 # Mockable seams (Mimic). Copied modules pass through to the real implementation
 # unless a test sets an explicit stub/expect.
 Mimic.copy(KlassHero.Shared.Tracing.ObanEnqueue)
+Mimic.copy(KlassHero.Accounts)


### PR DESCRIPTION
Closes #1161.

## Summary

The root layout hardcoded `lang="en"` on every page while `SetLocale` served German — screen readers used English pronunciation rules, browser translation misfired, and every German page was mislabelled for indexing.

Tracing that one-line fix surfaced a worse defect behind it: **the settings language toggle never took effect past a page reload.** `SetLocale` reads the session ahead of the user's stored preference, and a LiveView cannot write a session — so the toggle updated the database and its own socket while the session kept serving the old language. It only took effect after a logout, because `clear_session/1` at login wipes the session locale.

Locale changes now go through a new `LocaleController`. It writes the session and the stored preference together and answers with a redirect — a dead render, which is the only thing that can refresh `<html lang>` and the page chrome.

The resulting model, which is what makes `SetLocale`'s precedence correct rather than accidental:

- **session** — this browsing session's choice, written by the `?locale=` pill
- **stored preference** — the durable default, seeding the session after `clear_session/1` at login

The pill switcher is unchanged: its *relative* `?locale=` href already resolves against the current address-bar URL, so it survives live navigation. Routing it through the controller would have needed an absolute path and therefore a `current_path` hook on every `live_session`.

Also adds `rel=canonical` plus `en`/`de`/`x-default` hreflang alternates — the first SEO head tags in the app. Canonical always names an explicit `?locale=` URL, so the bare path and `?locale=en` cannot both be self-canonical duplicates of each other.

## Review focus

- **`locale_controller.ex` failure branch.** `SetLocale` runs earlier in the `:browser` pipeline and writes the session from the `/locale/:locale` **path param**, so the request that asks for a change also applies it. The controller cannot decline that write — on a failed persist it restores the stored preference, or the rendered language would switch while the flash says it failed.
- **`?locale=fr` outranks a valid session** (`set_locale_test.exs`). Pre-existing behaviour, now pinned by a test rather than changed: an explicit request for a language we don't have resets to the default instead of falling through.
- **`RestoreLocale` now validates.** It previously passed the session value through unvalidated while the plug validated — so a stale cookie could render a LiveView under a locale the plug would have rejected. Deliberate hardening, not a pure extraction.
- **`alias` placement in `layouts.ex`** must precede `embed_templates` (lexical scope). Verified by moving it and watching the compile fail.
- **A fourth copy of the locale whitelist** remains in `Accounts.User.locale_changeset/2` and is intentionally not collapsed — the domain cannot depend on a web module. Documented in the `Locale` moduledoc; follow-up issue filed.

## Test plan

- `mix precommit` green on the rebased tree: 3997 passed, zero warnings.
- New coverage: `KlassHeroWeb.Locale` (whitelist + URL builders), `SetLocale` (**had no tests at all** — the full precedence chain, as a table), `LocaleController` (session, preference, flash language, open-redirect guard against `//evil.com`, `https://evil.com`, `/\evil.com`), root layout (`lang` + canonical + hreflang via dead render), and the settings regression: change language → reload → it persists. That last one fails on `main`.
- Root-layout assertions use `get/2`, not `live/2` — the connected re-render strips `root.html.heex`, so they could never go red there.
- Gettext re-extracted: two msgids moved file, no new strings, no fuzzy entries.
- Verified in Chrome against a dev server: German `Accept-Language` → `lang="de"` with correct canonical/alternates; `?locale=en` then a bare reload stayed English; signed in, picked Deutsch, **reloaded**, still German with the radio still on Deutsch.

## Deferred

- `og:*` and meta description — the rest of the SEO head pass.
- Path-based locales (`/de/programs`), which would remove the session ambiguity entirely. Touches every route and `~p` sigil; its own epic.