### PR TITLE
fix: give recoverable ids to the two hand-rolled phx-change forms

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -86,6 +86,13 @@ config :opentelemetry,
 # Initialize plugs at runtime for faster test compilation
 config :phoenix, :plug_init_mode, :runtime
 
+# A form without an id cannot be recovered on reconnect, so treat it as a failure rather than
+# the LiveView default of a warning — it is the only test_warnings check that defaults to :warn,
+# which is how 142 of them accumulated unnoticed (#1228). `mix test --warnings-as-errors` does
+# not cover this: the check is a runtime IO.warn, not a compile warning.
+# :duplicate_id and :duplicate_live_component already default to :raise and need no entry here.
+config :phoenix_live_view, :test_warnings, missing_form_id: :raise
+
 # Enable helpful, but potentially expensive runtime checks
 config :phoenix_live_view,
   enable_expensive_runtime_checks: true

--- a/lib/klass_hero_web/components/ui_components.ex
+++ b/lib/klass_hero_web/components/ui_components.ex
@@ -1295,6 +1295,10 @@ defmodule KlassHeroWeb.UIComponents do
   Commonly used for date-based filtering in lists and streams. Automatically
   handles date formatting for the HTML date input.
 
+  The wrapping form is given `"<id>-form"`. That id is what the client uses to recover the
+  form after a reconnect, so it is load-bearing, not decorative — without it the selected
+  date silently reverts to the mount default when the socket drops.
+
   ## Examples
 
       <.date_selector
@@ -1311,7 +1315,7 @@ defmodule KlassHeroWeb.UIComponents do
         value={@filter_date}
       />
   """
-  attr :id, :string, required: true, doc: "Input element ID"
+  attr :id, :string, required: true, doc: "Input element ID; the wrapping form gets `<id>-form`"
   attr :name, :string, required: true, doc: "Form field name"
   attr :value, :any, default: nil, doc: "Current date value (Date or ISO8601 string)"
   attr :label, :string, default: nil, doc: "Optional label text"
@@ -1322,6 +1326,7 @@ defmodule KlassHeroWeb.UIComponents do
   def date_selector(assigns) do
     ~H"""
     <form
+      id={"#{@id}-form"}
       phx-change={@phx_change}
       class={["flex flex-col sm:flex-row gap-4 items-start sm:items-center", @class]}
     >

--- a/lib/klass_hero_web/live/admin/components/searchable_select.ex
+++ b/lib/klass_hero_web/live/admin/components/searchable_select.ex
@@ -85,7 +85,13 @@ defmodule KlassHeroWeb.Admin.Components.SearchableSelect do
       </div>
 
       <%!-- Wrap in <form> because phx-change requires a form ancestor --%>
-      <form :if={!@selected} phx-change="search" phx-submit="noop" phx-target={@myself}>
+      <form
+        :if={!@selected}
+        id={"#{@id}-search-form"}
+        phx-change="search"
+        phx-submit="noop"
+        phx-target={@myself}
+      >
         <input
           type="text"
           placeholder={@placeholder}

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -4376,7 +4376,7 @@ msgstr "Noch keine Teilnahmeeinträge"
 msgid "No programs assigned yet."
 msgstr "Noch keine Programme zugewiesen."
 
-#: lib/klass_hero_web/live/admin/components/searchable_select.ex:107
+#: lib/klass_hero_web/live/admin/components/searchable_select.ex:113
 #, elixir-autogen, elixir-format
 msgid "No results"
 msgstr "Keine Ergebnisse"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -4376,7 +4376,7 @@ msgstr ""
 msgid "No programs assigned yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/components/searchable_select.ex:107
+#: lib/klass_hero_web/live/admin/components/searchable_select.ex:113
 #, elixir-autogen, elixir-format
 msgid "No results"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -4376,7 +4376,7 @@ msgstr ""
 msgid "No programs assigned yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/components/searchable_select.ex:107
+#: lib/klass_hero_web/live/admin/components/searchable_select.ex:113
 #, elixir-autogen, elixir-format
 msgid "No results"
 msgstr ""

--- a/test/klass_hero_web/live/admin/components/searchable_select_test.exs
+++ b/test/klass_hero_web/live/admin/components/searchable_select_test.exs
@@ -88,6 +88,15 @@ defmodule KlassHeroWeb.Admin.Components.SearchableSelectTest do
 
       assert has_element?(view, "input[type=hidden][name=provider_id]")
     end
+
+    test "derives the search form id from the component id, so it can be recovered", %{conn: conn} do
+      {:ok, view, _html} = mount_harness(conn)
+
+      # Must not reuse @id itself — that belongs to the outer <div>, and a duplicate DOM id
+      # trips LiveViewTest's :duplicate_id check, which raises by default.
+      assert has_element?(view, "form#test-select-search-form[phx-change=search]")
+      assert has_element?(view, "div#test-select")
+    end
   end
 
   describe "filtering" do

--- a/test/klass_hero_web/live/admin/sessions_live_test.exs
+++ b/test/klass_hero_web/live/admin/sessions_live_test.exs
@@ -77,6 +77,14 @@ defmodule KlassHeroWeb.Admin.SessionsLiveTest do
       assert has_element?(view, "#program-select")
     end
 
+    test "gives both searchable selects a recoverable search form", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/admin/sessions")
+
+      # Two instances on one page, so the derived ids must stay distinct.
+      assert has_element?(view, "form#provider-select-search-form")
+      assert has_element?(view, "form#program-select-search-form")
+    end
+
     test "renders date inputs defaulting to today", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/admin/sessions")
       today = Date.utc_today() |> Date.to_iso8601()

--- a/test/klass_hero_web/live/provider/sessions_live_test.exs
+++ b/test/klass_hero_web/live/provider/sessions_live_test.exs
@@ -31,6 +31,10 @@ defmodule KlassHeroWeb.Provider.SessionsLiveTest do
 
       assert has_element?(view, "h2", "My Sessions")
       assert has_element?(view, "#date-select")
+
+      # The form id is what the client recovers the date by on reconnect. Pinned here so it
+      # survives independently of config/test.exs's missing_form_id: :raise gate.
+      assert has_element?(view, "form#date-select-form[phx-change=change_date]")
     end
 
     test "shows empty state when no sessions scheduled for today", %{conn: conn} do

--- a/test/klass_hero_web/live/staff/staff_sessions_live_test.exs
+++ b/test/klass_hero_web/live/staff/staff_sessions_live_test.exs
@@ -29,6 +29,10 @@ defmodule KlassHeroWeb.Staff.StaffSessionsLiveTest do
 
       assert has_element?(view, "#staff-sessions")
       assert has_element?(view, "#date-select")
+
+      # The form id is what the client recovers the date by on reconnect. Pinned here so it
+      # survives independently of config/test.exs's missing_form_id: :raise gate.
+      assert has_element?(view, "form#date-select-form[phx-change=change_date]")
     end
 
     test "names each session's program and shows how many children are enrolled", %{


### PR DESCRIPTION
Closes #1228

## Summary

Two hand-written `<form phx-change=...>` tags rendered without an `id`, so the LiveView client could not locate them during **form recovery** — the reconnect path that replays a form's current DOM values after a socket drop (deploy, network blip, crash).

The user-visible effect:

- `/provider/sessions` and `/staff/sessions` — a chosen date reverted to `Date.utc_today()` on reconnect while the date input could still show the old value, so the roster silently displayed the wrong day.
- `/admin/sessions` — a typed searchable-select query was lost the same way.

`Phoenix.LiveViewTest` had been reporting this on every DOM merge all along: **142** warnings across the suite, 95 from `date_selector/1` and 46 from `SearchableSelect`. It is the only `test_warnings` check that defaults to `:warn` rather than `:raise` (`client_proxy.ex:621-622`), which is how it accumulated unnoticed. After this PR the count is **0**.

## Review Focus

**Why the ids are derived rather than `id={@id}`.** `@id` is already taken at both sites — by the `<input>` in `date_selector` (and `<label for={@id}>` binds to it), and by the outer `<div id={@id}>` in `SearchableSelect`. Reusing it produces a duplicate DOM id, and `duplicate_id` *does* default to `:raise`, so the naive fix would trade 142 warnings for a red suite. Hence `"#{@id}-form"` and `"#{@id}-search-form"`, checked for collisions against every id on `admin/sessions_live.html.heex` and the component test harness.

**`date_selector/1`'s interface is unchanged** — the form id is derived inside the component, so neither call site changed. The naming contract is now documented on `attr :id` and in the `@doc`, since the derived id is load-bearing rather than decorative.

**The config gate is required, not belt-and-braces.** `mix test --warnings-as-errors` does *not* catch this: the LiveView check is a runtime `IO.warn` during test execution, not a compile warning. Verified — `mix test test/klass_hero_web/live/admin/components/searchable_select_test.exs --warnings-as-errors` emits 10 of these warnings and still exits 0.

**Untouched on purpose:** `booking_live.ex:336` and `composite_components.ex:418` are `phx-submit`-only. Form recovery replays live input state, not submissions, so the check ignores them and they need no id.

**Not in scope:** the suite also emits 10 unused-alias/import/variable warnings in test files, which CI never gates (`elixirc_paths(:test)` excludes `test/**/*_test.exs`, and nothing passes `mix test --warnings-as-errors`). Different root cause, different fix — filed separately rather than mixed into this diff.

The `priv/gettext` churn is line-reference only: reformatting the `SearchableSelect` `<form>` onto multiple lines shifted an existing `gettext("No results")` down six lines. No new strings, so no new German translations.

## Test Plan

Red was established *before* the fix by adding the config gate alone — 28 of 30 tests in `provider/sessions_live_test.exs` went from passing-with-warnings to failing.

Coverage is two-layer, because neither half suffices:

- **`config/test.exs` gate** catches any *future* hand-rolled form, but could be set back to `:ignore` by someone chasing green.
- **Four `has_element?` assertions** pin *these* ids independently of the gate, but say nothing about a form added next month.

The assertions were proven non-vacuous: with the gate flipped to `:ignore` and both ids stripped, exactly 4 tests failed — the 4 added here.

```
MIX_TEST_PARTITION=1228 mix test 2>&1 | grep -c "missing id"    # 142 -> 0
MIX_TEST_PARTITION=1228 mix precommit                            # 3999 passed
```

Not yet done: the manual reconnect check (change the date, restart the server, confirm the selection survives). The suite proves the id exists; only a real reconnect proves recovery fires.
