### PR TITLE
fix: rebuild every projection from the supervisor registry when seeding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,6 +247,82 @@ jobs:
           path: tmp/e2e_screenshots/
           retention-days: 7
 
+  # Nothing else in CI runs priv/repo/seeds.exs, so seeding drifted from the code it seeds
+  # until `mix setup` was broken for every new contributor and every fresh worktree (#1222).
+  # A unit test cannot cover this: seeds rebuild the CQRS read tables through
+  # `Projection.rebuild/1`, which is a GenServer.call on the named process, and
+  # config/test.exs sets `start_projections: false` so those processes never exist in
+  # MIX_ENV=test. Hence a dev-env job — do NOT "tidy" this to MIX_ENV=test, it would turn
+  # the gate into a no-op that passes on a database with empty read tables.
+  #
+  # Postgres only: seeds tolerate a dead MinIO (the Storage.upload call matches {:error, _}
+  # and warns), so no S3-compatible service is needed. That costs ~90s — a refused upload
+  # takes 7.7s of ExAws retry backoff, measured, times the 12 seeded verification documents.
+  # Paying it beats the alternatives: Actions service containers cannot express MinIO's
+  # `command: server /data` (see docker-compose.yml), and hand-rolling `docker run` would
+  # make a blocking gate depend on a service it does not even test.
+  #
+  # No assets step either — `mix run` does not set `server: true`, so the endpoint never
+  # binds and the esbuild/tailwind watchers never start.
+  #
+  # POSTGRES_DB is deliberately absent: `mix ecto.create` makes klass_hero_dev itself, which
+  # is the step a fresh contributor actually runs.
+  #
+  # Skip condition mirrors `test` above — see the rationale there.
+  seed:
+    name: Fresh Seed
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.head_ref != 'release-please--branches--main'
+
+    services:
+      postgres:
+        image: postgres:18-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      # actions/checkout@v7.0.1
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      # erlef/setup-beam@v1.24.1
+      - name: Set up Elixir
+        uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124
+        with:
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+          otp-version: ${{ env.OTP_VERSION }}
+          version-type: strict
+
+      # Restore-only — deps-cache.yml is the sole writer. See its header.
+      # actions/cache/restore@v6.1.0 (same commit as actions/cache, sub-action path)
+      - name: Restore dependencies cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: |
+            deps
+            _build
+          key: v2-${{ runner.os }}-mix-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            v2-${{ runner.os }}-mix-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-
+
+      - name: Install dependencies
+        run: mix deps.get
+
+      - name: Create and migrate a fresh database
+        run: mix ecto.create && mix ecto.migrate
+
+      - name: Seed it
+        run: mix ecto.seed
+
   # The site icons are committed release artifacts — nothing in mix assets.deploy
   # builds them — so this job is the only thing linking the bytes to their source,
   # priv/brand/kh-mark.svg. site_icons_test.exs covers a different axis: it proves

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,8 +256,11 @@ jobs:
   # the gate into a no-op that passes on a database with empty read tables.
   #
   # Postgres only: seeds tolerate a dead MinIO (the Storage.upload call matches {:error, _}
-  # and warns), so no S3-compatible service is needed. That costs ~90s — a refused upload
-  # takes 7.7s of ExAws retry backoff, measured, times the 12 seeded verification documents.
+  # and warns), so no S3-compatible service is needed. That costs ~60s, measured on the
+  # runner: 12 seeded verification documents at ~5s each of ExAws retry backoff against a
+  # refused connection. It dominates this job — the seeding itself is ~4s — so if the job
+  # ever needs to get cheaper, that is the thing to cut, not the steps.
+  #
   # Paying it beats the alternatives: Actions service containers cannot express MinIO's
   # `command: server /data` (see docker-compose.yml), and hand-rolling `docker run` would
   # make a blocking gate depend on a service it does not even test.

--- a/lib/klass_hero/projection_supervisor.ex
+++ b/lib/klass_hero/projection_supervisor.ex
@@ -38,6 +38,23 @@ defmodule KlassHero.ProjectionSupervisor do
     ]
   end
 
+  @doc """
+  Re-bootstraps every projection's read table from the authoritative write tables.
+
+  Needed whenever write tables change without the events that maintain the read
+  tables — seeding, a manual repair, a backfill migration. Order carries no
+  meaning here for the same reason it carries none in the supervisor: no
+  projection reads another's table.
+
+  Every projection must be running, so this is a dev/prod call — `config/test.exs`
+  sets `start_projections: false`.
+  """
+  @spec rebuild_all() :: :ok
+  def rebuild_all do
+    for projection <- projections(), do: projection.rebuild()
+    :ok
+  end
+
   @impl true
   def init(_init_arg) do
     Supervisor.init(projections(), strategy: :one_for_one, max_restarts: 10, max_seconds: 60)

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -12,16 +12,14 @@ alias KlassHero.Family.Child
 alias KlassHero.Family.ChildGuardian
 alias KlassHero.Family.Consent
 alias KlassHero.Family.ParentProfile
-alias KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries
 alias KlassHero.Messaging.Conversation
 alias KlassHero.Messaging.Message
 alias KlassHero.Messaging.Participant
 alias KlassHero.Participation.ParticipationRecord
 alias KlassHero.Participation.ProgramSession
 alias KlassHero.Participation.SessionNote
-alias KlassHero.ProgramCatalog.Adapters.Driven.Projections.ProgramListings
-alias KlassHero.ProgramCatalog.Adapters.Driven.Projections.VerifiedProviders
 alias KlassHero.ProgramCatalog.Program
+alias KlassHero.ProjectionSupervisor
 alias KlassHero.Provider.ProviderProfile
 alias KlassHero.Provider.StaffMember
 alias KlassHero.Provider.VerificationDocument
@@ -1499,13 +1497,14 @@ Logger.info("Created #{message_count} messages")
 # Why: projection GenServers only bootstrap on startup — seeding after startup leaves
 #      read tables empty (e.g. program_listings, conversation_summaries)
 # Outcome: all read tables rebuilt from authoritative write data
+#
+# Read off the supervisor's registry rather than listing modules here: a hand-kept
+# list drifted both ways (#1222) — one entry outlived its module, and four
+# projections were never rebuilt at all, leaving those read tables empty on every
+# seeded database.
 Logger.info("Rebuilding CQRS projections...")
 
-# Order matters: VerifiedProviders must be rebuilt first because ProgramListings
-# reads provider verification status from it during bootstrap
-VerifiedProviders.rebuild()
-ProgramListings.rebuild()
-ConversationSummaries.rebuild()
+ProjectionSupervisor.rebuild_all()
 
 Logger.info("Rebuilt CQRS projections")
 

--- a/test/klass_hero/projection_supervisor_test.exs
+++ b/test/klass_hero/projection_supervisor_test.exs
@@ -11,24 +11,37 @@ defmodule KlassHero.ProjectionSupervisorTest do
   yet.
   """
 
-  use ExUnit.Case, async: true
+  # async: false on purpose. Finding the projections means asking whether each of the
+  # ~410 application modules exports the pair, and `Code.ensure_loaded?/1` has to load
+  # any module the suite has not touched yet. Every one of those loads serialises
+  # through the single code server, so run concurrently this burst stalls whichever
+  # process next needs a module — and an Oban worker blocked there is a worker holding
+  # a checked-out DB connection. That is how the first version of this file reliably
+  # timed out `ImportEnrollmentCsvTest`'s 5k-row smoke test at the 15s pool checkout.
+  # In the sync phase nothing else is running, so the same sweep costs ~200ms and
+  # bothers no one.
+  use ExUnit.Case, async: false
 
   alias KlassHero.ProjectionSupervisor
 
-  # `use KlassHero.Shared.Projection` is what defines both of these, so exporting
-  # the pair identifies a projection without the macro having to register itself.
-  defp projection_modules do
+  setup_all do
+    # `use KlassHero.Shared.Projection` is what defines both of these, so exporting the
+    # pair identifies a projection without the macro having to register itself — and
+    # without this test encoding a naming convention the guard would then fail to police.
     {:ok, modules} = :application.get_key(:klass_hero, :modules)
 
-    for module <- modules,
-        Code.ensure_loaded?(module),
-        function_exported?(module, :rebuild, 1),
-        function_exported?(module, :topics, 0),
-        do: module
+    found =
+      for module <- modules,
+          Code.ensure_loaded?(module),
+          function_exported?(module, :rebuild, 1),
+          function_exported?(module, :topics, 0),
+          do: module
+
+    %{projection_modules: found}
   end
 
-  test "every projection module is registered in projections/0" do
-    unregistered = projection_modules() -- ProjectionSupervisor.projections()
+  test "every projection module is registered in projections/0", %{projection_modules: found} do
+    unregistered = found -- ProjectionSupervisor.projections()
 
     assert unregistered == [],
            """
@@ -40,8 +53,8 @@ defmodule KlassHero.ProjectionSupervisorTest do
            """
   end
 
-  test "projections/0 names no module that has stopped being a projection" do
-    stale = ProjectionSupervisor.projections() -- projection_modules()
+  test "projections/0 names no module that has stopped being a projection", %{projection_modules: found} do
+    stale = ProjectionSupervisor.projections() -- found
 
     assert stale == [],
            """

--- a/test/klass_hero/projection_supervisor_test.exs
+++ b/test/klass_hero/projection_supervisor_test.exs
@@ -1,0 +1,54 @@
+defmodule KlassHero.ProjectionSupervisorTest do
+  @moduledoc """
+  Guards `projections/0` against the projection modules that actually exist.
+
+  That list is not derived from anything — it is hand-written, and three separate
+  things trust it completely: the supervisor starts what it names, the consumer
+  wiring test only checks what it names, and `rebuild_all/0` only rebuilds what it
+  names. A projection missing from it therefore has no supervisor, no wiring
+  coverage and no rebuild, and every one of those failures is silent: the read
+  table is simply empty, which is indistinguishable from a feature with no data
+  yet.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias KlassHero.ProjectionSupervisor
+
+  # `use KlassHero.Shared.Projection` is what defines both of these, so exporting
+  # the pair identifies a projection without the macro having to register itself.
+  defp projection_modules do
+    {:ok, modules} = :application.get_key(:klass_hero, :modules)
+
+    for module <- modules,
+        Code.ensure_loaded?(module),
+        function_exported?(module, :rebuild, 1),
+        function_exported?(module, :topics, 0),
+        do: module
+  end
+
+  test "every projection module is registered in projections/0" do
+    unregistered = projection_modules() -- ProjectionSupervisor.projections()
+
+    assert unregistered == [],
+           """
+           Projection modules absent from ProjectionSupervisor.projections/0: \
+           #{inspect(unregistered)}
+           They are unsupervised, unrebuilt by the seeds, and invisible to the event
+           consumer wiring test. Add them to `projections/0` in
+           lib/klass_hero/projection_supervisor.ex.
+           """
+  end
+
+  test "projections/0 names no module that has stopped being a projection" do
+    stale = ProjectionSupervisor.projections() -- projection_modules()
+
+    assert stale == [],
+           """
+           ProjectionSupervisor.projections/0 names modules that are no longer \
+           projections: #{inspect(stale)}
+           Deleting a projection means deleting its entry here too — #1222 was a \
+           dangling entry like this reaching priv/repo/seeds.exs.
+           """
+  end
+end


### PR DESCRIPTION
Closes #1222

## Summary

`priv/repo/seeds.exs` called `VerifiedProviders.rebuild()` — a module deleted in #1196 — so `mix ecto.seed`, and therefore `mix setup`, died with `UndefinedFunctionError`. Seeds are not transactional, so the crash landed *after* every write-table insert committed: the database looked fully populated while every CQRS read table was empty.

The dangling module was the symptom. The cause is that seeds hand-maintained the list of projections to rebuild, with nothing in CI exercising the script. That list had drifted **both** ways:

- one entry outlived its module (`VerifiedProviders`);
- four projections were never rebuilt at all — `EnrolledChildren`, `ProviderPrograms`, `ProviderSessionDetails`, `ProviderSessionStats` — so those read tables have been silently empty on every seeded database.

Seeds now call `ProjectionSupervisor.rebuild_all/0`, reading the `projections/0` registry the supervisor already publishes for the consumer-wiring test.

## Review Focus

- **`ci.yml` runs the seed job in dev env, deliberately.** `Projection.rebuild/1` is a `GenServer.call` on the named process and `config/test.exs` sets `start_projections: false`, so a `MIX_ENV=test` run would pass against a database with empty read tables. The job comment says so; please keep it.
- **No MinIO service.** Seeds tolerate a dead MinIO (`{:error, _}` → warn). That costs ~60s, measured on the runner: 12 seeded documents at ~5s each of ExAws retry backoff. It dominates the job — the seeding itself is ~4s of the 64s step. The alternatives were worse: Actions service containers cannot express MinIO's `command: server /data`, and hand-rolled `docker run` would make a blocking gate depend on a service it does not test.
- **`Fresh Seed` is intended as a blocking check** — a broken `mix setup` blocks onboarding and every fresh worktree. It needs adding to the `main` ruleset's required checks *after* merge, since the job must exist on the default branch first.
- **The two guard tests** cover opposite drift directions and were each proven red by mutation, not just written green.

## Test Plan

- `mix ecto.seed` on the pre-fix commit → `UndefinedFunctionError` at `seeds.exs:1506`. ✅ reproduced
- `mix ecto.seed` after the fix → completes, all six projections log `rebuilt`. ✅
- Read-table row counts after seeding, including the four that were never rebuilt before:
  `program_listings` 133, `conversation_summaries` 70, `messaging_enrolled_children` 96, `provider_programs` 133, `provider_session_details` 429, `provider_session_stats` 59. ✅
- Guard tests proven red by mutation: removing `EnrolledChildren` from `projections/0` reds the first; adding back the deleted `VerifiedProviders` reds the second (i.e. this PR's own bug shape). ✅
- `mix precommit` — 4001 passed, 2 skipped. ✅
