### PR TITLE
fix: make a failed invite claim visible and actionable

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -33,6 +33,7 @@ alias KlassHero.Shared.Adapters.Driven.Events.ObanOutbox
 alias KlassHero.Shared.Adapters.Driven.FeatureFlags.FunWithFlagsAdapter
 alias KlassHero.Shared.Adapters.Driven.Persistence.Repositories.ProcessedEventRepository
 alias KlassHero.Shared.Adapters.Driven.Storage.S3StorageAdapter
+alias KlassHero.Shared.ErrorContextFilter
 alias Swoosh.Adapters.Local
 
 config :backpex,
@@ -43,7 +44,13 @@ config :backpex,
 # Europe/Berlin and other named zones with DST.
 config :elixir, :time_zone_database, Tz.TimeZoneDatabase
 
-config :error_tracker, repo: KlassHero.Repo, otp_app: :klass_hero, enabled: true
+# `filter` narrows what gets persisted: Oban job args reach here in full, and some
+# carry child health data. See KlassHero.Shared.ErrorContextFilter.
+config :error_tracker,
+  repo: KlassHero.Repo,
+  otp_app: :klass_hero,
+  enabled: true,
+  filter: ErrorContextFilter
 
 # Configure esbuild (the version is required)
 config :esbuild,

--- a/config/test.exs
+++ b/config/test.exs
@@ -15,6 +15,11 @@ test_port = String.to_integer(System.get_env("TEST_PORT") || "4002")
 # Only in tests, remove the complexity from the password hashing algorithm
 config :bcrypt_elixir, :log_rounds, 1
 
+# The suite deliberately fails Oban jobs; reporting each one would write error rows
+# for expected failures. `enabled?/0` gates before the insert, so the Oban telemetry
+# handler still attaches and simply no-ops. ErrorContextFilter is unit-tested directly.
+config :error_tracker, enabled: false
+
 # Disable fun_with_flags PubSub notifications in tests
 config :fun_with_flags, :cache_bust_notifications, enabled: false
 
@@ -35,9 +40,9 @@ config :klass_hero, KlassHero.Repo,
 config :klass_hero, KlassHeroWeb.Endpoint,
   http: [ip: {127, 0, 0, 1}, port: test_port],
   secret_key_base: "gY/oKuAYeC5ExhHrtu1JBwrpQdoGwtPOo3X9GdS7CFOnLe0eqRQ9w4cyV1MqvoYc",
+  # Oban runs inline in tests so critical event handlers execute synchronously
   server: System.get_env("WALLABY_E2E") == "true"
 
-# Oban runs inline in tests so critical event handlers execute synchronously
 config :klass_hero, Oban, testing: :inline
 config :klass_hero, :feature_flags, adapter: StubFeatureFlagsAdapter
 

--- a/lib/klass_hero/enrollment/import_enrollment_csv.ex
+++ b/lib/klass_hero/enrollment/import_enrollment_csv.ex
@@ -26,11 +26,11 @@ defmodule KlassHero.Enrollment.ImportEnrollmentCsv do
 
   alias KlassHero.Enrollment
   alias KlassHero.Enrollment.BulkEnrollmentInvite
-  alias KlassHero.Enrollment.ChangesetErrors
   alias KlassHero.Enrollment.Domain.Services.CsvParser
   alias KlassHero.Enrollment.Domain.Services.ImportRowValidator
   alias KlassHero.Enrollment.EnqueueInviteEmails
   alias KlassHero.Enrollment.ProviderProgramContext
+  alias KlassHero.Shared.ChangesetErrors
 
   require Logger
 

--- a/lib/klass_hero/enrollment/invite_single_participant.ex
+++ b/lib/klass_hero/enrollment/invite_single_participant.ex
@@ -9,10 +9,10 @@ defmodule KlassHero.Enrollment.InviteSingleParticipant do
   """
 
   alias KlassHero.Enrollment
-  alias KlassHero.Enrollment.ChangesetErrors
   alias KlassHero.Enrollment.EnqueueInviteEmails
   alias KlassHero.Enrollment.ProviderProgramContext
   alias KlassHero.Enrollment.SingleInviteForm
+  alias KlassHero.Shared.ChangesetErrors
 
   require Logger
 

--- a/lib/klass_hero/family/adapters/driving/workers/process_invite_claim_worker.ex
+++ b/lib/klass_hero/family/adapters/driving/workers/process_invite_claim_worker.ex
@@ -14,6 +14,7 @@ defmodule KlassHero.Family.Adapters.Driving.Workers.ProcessInviteClaimWorker do
 
   alias KlassHero.Enrollment
   alias KlassHero.Family.ProcessInviteClaim
+  alias KlassHero.Shared.ChangesetErrors
 
   require Logger
 
@@ -38,7 +39,7 @@ defmodule KlassHero.Family.Adapters.Driving.Workers.ProcessInviteClaimWorker do
   # the schema. A rejected transition means the invite is already terminal — enrolled by a
   # retry Lifeline re-ran, or failed by an earlier pass — which is a fact, not a fault.
   defp fail_invite(invite_id, reason) when is_binary(invite_id) do
-    case Enrollment.transition_invite(%{id: invite_id}, %{status: :failed, error_details: inspect(reason)}) do
+    case Enrollment.transition_invite(%{id: invite_id}, %{status: :failed, error_details: describe(reason)}) do
       {:ok, _invite} ->
         :ok
 
@@ -53,6 +54,22 @@ defmodule KlassHero.Family.Adapters.Driving.Workers.ProcessInviteClaimWorker do
   end
 
   defp fail_invite(_invite_id, _reason), do: :ok
+
+  # A provider reads this in the invites table, so it has to name what is wrong with the
+  # row they uploaded. `inspect/1` of a changeset names it only to a developer.
+  defp describe(%Ecto.Changeset{} = changeset) do
+    changeset
+    |> ChangesetErrors.field_list()
+    |> Enum.map_join("; ", fn {field, message} -> "#{humanize_field(field)} #{message}" end)
+  end
+
+  defp describe(reason), do: inspect(reason)
+
+  defp humanize_field(field) do
+    field
+    |> Atom.to_string()
+    |> String.replace("_", " ")
+  end
 
   # Oban JSON args use string keys and ISO date strings; convert to atom keys and Date.
   defp deserialize_args(args) do

--- a/lib/klass_hero/family/adapters/driving/workers/process_invite_claim_worker.ex
+++ b/lib/klass_hero/family/adapters/driving/workers/process_invite_claim_worker.ex
@@ -12,15 +12,47 @@ defmodule KlassHero.Family.Adapters.Driving.Workers.ProcessInviteClaimWorker do
     queue: :family,
     max_attempts: 3
 
+  alias KlassHero.Enrollment
   alias KlassHero.Family.ProcessInviteClaim
 
+  require Logger
+
   @impl true
-  def execute(%Oban.Job{args: args}) do
+  def execute(%Oban.Job{args: args} = job) do
     with {:ok, attrs} <- deserialize_args(args),
          {:ok, _result} <- ProcessInviteClaim.execute(attrs) do
       :ok
+    else
+      {:error, reason} = error ->
+        if final_attempt?(job), do: fail_invite(args["invite_id"], reason)
+        error
     end
   end
+
+  # Only once Oban is done retrying. `registered -> :failed` is a one-way door — `:failed`
+  # can only go back to `:pending` — so failing the invite on an earlier attempt would
+  # destroy a claim that the next attempt heals.
+  defp final_attempt?(%Oban.Job{attempt: attempt, max_attempts: max_attempts}), do: attempt >= max_attempts
+
+  # The invite belongs to Enrollment, so this goes through its facade rather than touching
+  # the schema. A rejected transition means the invite is already terminal — enrolled by a
+  # retry Lifeline re-ran, or failed by an earlier pass — which is a fact, not a fault.
+  defp fail_invite(invite_id, reason) when is_binary(invite_id) do
+    case Enrollment.transition_invite(%{id: invite_id}, %{status: :failed, error_details: inspect(reason)}) do
+      {:ok, _invite} ->
+        :ok
+
+      {:error, transition_error} ->
+        Logger.warning("[ProcessInviteClaimWorker] Invite already past :registered, not failing it",
+          invite_id: invite_id,
+          reason: inspect(transition_error)
+        )
+
+        :ok
+    end
+  end
+
+  defp fail_invite(_invite_id, _reason), do: :ok
 
   # Oban JSON args use string keys and ISO date strings; convert to atom keys and Date.
   defp deserialize_args(args) do

--- a/lib/klass_hero/family/adapters/driving/workers/process_invite_claim_worker.ex
+++ b/lib/klass_hero/family/adapters/driving/workers/process_invite_claim_worker.ex
@@ -6,6 +6,11 @@ defmodule KlassHero.Family.Adapters.Driving.Workers.ProcessInviteClaimWorker do
   `ProcessInviteClaim` use case. The `family` queue runs with
   concurrency 1, serializing all invite processing globally
   to prevent duplicate child records from concurrent events.
+
+  When the last attempt fails, it also fails the invite. The guardian has already
+  been told their account exists by the time this runs, so giving up quietly left
+  them with an account, no child and no enrollment, and the invite frozen in
+  `:registered` (#1221).
   """
 
   use KlassHero.Shared.Tracing.TracedWorker,
@@ -58,9 +63,12 @@ defmodule KlassHero.Family.Adapters.Driving.Workers.ProcessInviteClaimWorker do
   # A provider reads this in the invites table, so it has to name what is wrong with the
   # row they uploaded. `inspect/1` of a changeset names it only to a developer.
   defp describe(%Ecto.Changeset{} = changeset) do
-    changeset
-    |> ChangesetErrors.field_list()
-    |> Enum.map_join("; ", fn {field, message} -> "#{humanize_field(field)} #{message}" end)
+    case ChangesetErrors.field_list(changeset) do
+      # A changeset can be invalid with its errors on an association rather than a field,
+      # and an empty string here would render as a blank reason line rather than none.
+      [] -> inspect(changeset)
+      fields -> Enum.map_join(fields, "; ", fn {field, message} -> "#{humanize_field(field)} #{message}" end)
+    end
   end
 
   defp describe(reason), do: inspect(reason)

--- a/lib/klass_hero/shared/changeset_errors.ex
+++ b/lib/klass_hero/shared/changeset_errors.ex
@@ -1,10 +1,13 @@
-defmodule KlassHero.Enrollment.ChangesetErrors do
+defmodule KlassHero.Shared.ChangesetErrors do
   @moduledoc """
-  Converts an `Ecto.Changeset`'s errors into the flat
-  `[{field :: atom, message :: String.t()}]` list that enrollment commands
-  surface to the LiveView layer. Expands `%{count}`-style placeholders so
-  messages like `"should be at most %{count} character(s)"` don't leak to
-  end users.
+  Converts an `Ecto.Changeset`'s errors into a flat
+  `[{field :: atom, message :: String.t()}]` list for anything that has to show a
+  validation failure to a person. Expands `%{count}`-style placeholders so messages
+  like `"should be at most %{count} character(s)"` don't leak to end users.
+
+  Lives in Shared rather than a context because it knows only about Ecto: Enrollment's
+  commands surface it to the LiveView layer, and Family writes it into the reason a
+  provider reads on a failed invite.
 
   Formatting must never raise — this helper is called on the error path
   where throwing would swallow the real validation errors. Unknown

--- a/lib/klass_hero/shared/error_context_filter.ex
+++ b/lib/klass_hero/shared/error_context_filter.ex
@@ -1,0 +1,50 @@
+defmodule KlassHero.Shared.ErrorContextFilter do
+  @moduledoc """
+  Narrows the context ErrorTracker persists, before it is written.
+
+  `ErrorTracker.Integrations.Oban` sets the whole of `job.args` as context on every
+  job start, and ErrorTracker stores context alongside each error occurrence in the
+  production database. `ProcessInviteClaimWorker`'s args carry a child's name, date of
+  birth and medical conditions, so the unfiltered default would put children's health
+  data in an error log.
+
+  Job args are therefore allowlisted rather than denylisted: a new worker, or a new
+  field on an existing one, is excluded until someone adds it here. Everything else in
+  the context passes through — `KlassHeroWeb.Router.set_error_tracker_context/2`'s
+  user_id/email predate this filter and are deliberate.
+
+  Wired via `config :error_tracker, filter: KlassHero.Shared.ErrorContextFilter`.
+  """
+
+  @behaviour ErrorTracker.Filter
+
+  @args_key "job.args"
+  @redacted_key "job.args.redacted"
+
+  # Correlation ids only — enough to find the row this job was about, never its contents.
+  # "trace_context" carries OTel propagation (`Shared.Tracing.Context.inject_into_args/1`);
+  # dropping it would silently unlink every error report from its Honeycomb trace.
+  @allowed_args ~w(
+    invite_id user_id program_id parent_id child_id provider_id
+    enrollment_id staff_member_id conversation_id message_id email_id
+    trace_context
+  )
+
+  @impl true
+  def sanitize(context) when is_map(context) do
+    case context do
+      %{@args_key => args} when is_map(args) -> put_filtered_args(context, args)
+      _ -> context
+    end
+  end
+
+  defp put_filtered_args(context, args) do
+    kept = Map.take(args, @allowed_args)
+    context = Map.put(context, @args_key, kept)
+
+    case Map.keys(args) -- Map.keys(kept) do
+      [] -> context
+      dropped -> Map.put(context, @redacted_key, Enum.sort(dropped))
+    end
+  end
+end

--- a/lib/klass_hero_web/components/provider_components.ex
+++ b/lib/klass_hero_web/components/provider_components.ex
@@ -1993,6 +1993,15 @@ defmodule KlassHeroWeb.ProviderComponents do
                 <.status_pill color={invite_status_color(invite.status)}>
                   {invite_status_label(invite.status)}
                 </.status_pill>
+                <%!-- Written by three places and shown by none until #1221: a red pill with no
+                      reason tells a provider that something is wrong but not what to do about it. --%>
+                <p
+                  :if={invite.status == :failed && invite.error_details}
+                  id={"invite-error-#{invite.id}"}
+                  class="mt-1 text-xs text-hero-grey-500 break-words"
+                >
+                  {invite.error_details}
+                </p>
               </td>
               <td class="px-3 py-3 text-right">
                 <div class="flex items-center justify-end gap-1">

--- a/lib/klass_hero_web/telemetry.ex
+++ b/lib/klass_hero_web/telemetry.ex
@@ -3,6 +3,8 @@ defmodule KlassHeroWeb.Telemetry do
 
   import Telemetry.Metrics
 
+  # Aliased away from `Oban` so it cannot shadow the real Oban module.
+  alias ErrorTracker.Integrations.Oban, as: ObanErrorReporting
   alias KlassHero.Shared.Interaction.TelemetryLogger
   alias KlassHero.Shared.Tracing.EctoSpanBridge
 
@@ -14,6 +16,11 @@ defmodule KlassHeroWeb.Telemetry do
   def init(_arg) do
     TelemetryLogger.attach()
     EctoSpanBridge.attach()
+    # Without this, no Oban failure from any worker has ever reached the error_tracker
+    # tables — a discarded job was discoverable only by querying the database by hand.
+    # This supervisor starts before {Oban, ...}, so the handler is attached before the
+    # first job can run. Context is narrowed by Shared.ErrorContextFilter (#1221).
+    ObanErrorReporting.attach()
 
     children = [
       {:telemetry_poller, measurements: periodic_measurements(), period: 10_000}

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -583,8 +583,8 @@ msgid "Dispute Resolution"
 msgstr "Streitbeilegung"
 
 #: lib/klass_hero_web/components/provider_components.ex:647
-#: lib/klass_hero_web/components/provider_components.ex:2073
-#: lib/klass_hero_web/components/provider_components.ex:2091
+#: lib/klass_hero_web/components/provider_components.ex:2082
+#: lib/klass_hero_web/components/provider_components.ex:2100
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
@@ -1680,8 +1680,8 @@ msgstr "Übersicht"
 #: lib/klass_hero_web/components/provider_components.ex:46
 #: lib/klass_hero_web/components/provider_components.ex:72
 #: lib/klass_hero_web/components/provider_components.ex:1470
-#: lib/klass_hero_web/components/provider_components.ex:2167
-#: lib/klass_hero_web/components/provider_components.ex:2185
+#: lib/klass_hero_web/components/provider_components.ex:2176
+#: lib/klass_hero_web/components/provider_components.ex:2194
 #: lib/klass_hero_web/live/admin/sessions_live.ex:297
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
@@ -1893,7 +1893,7 @@ msgstr "Kind konnte nicht entfernt werden. Bitte versuchen Sie es erneut."
 msgid "Data sharing consent"
 msgstr "Einwilligung zur Datenweitergabe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2054
+#: lib/klass_hero_web/components/provider_components.ex:2063
 #: lib/klass_hero_web/live/settings/children_live.ex:657
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1941,17 +1941,17 @@ msgstr "Rundnachricht konnte nicht gesendet werden"
 msgid "Failed to submit note"
 msgstr "Notiz konnte nicht eingereicht werden"
 
-#: lib/klass_hero_web/components/provider_components.ex:2048
-#: lib/klass_hero_web/components/provider_components.ex:2077
-#: lib/klass_hero_web/components/provider_components.ex:2093
+#: lib/klass_hero_web/components/provider_components.ex:2057
+#: lib/klass_hero_web/components/provider_components.ex:2086
+#: lib/klass_hero_web/components/provider_components.ex:2102
 #: lib/klass_hero_web/live/settings/children_live.ex:643
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr "Vorname"
 
-#: lib/klass_hero_web/components/provider_components.ex:2049
-#: lib/klass_hero_web/components/provider_components.ex:2078
-#: lib/klass_hero_web/components/provider_components.ex:2094
+#: lib/klass_hero_web/components/provider_components.ex:2058
+#: lib/klass_hero_web/components/provider_components.ex:2087
+#: lib/klass_hero_web/components/provider_components.ex:2103
 #: lib/klass_hero_web/live/settings/children_live.ex:649
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -2109,7 +2109,7 @@ msgstr "Rundnachricht senden"
 msgid "Send a message to start the conversation"
 msgstr "Senden Sie eine Nachricht, um die Unterhaltung zu beginnen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2148
+#: lib/klass_hero_web/components/provider_components.ex:2157
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:245
 #, elixir-autogen, elixir-format
@@ -2245,7 +2245,7 @@ msgstr "Alter %{min}+"
 msgid "Allowed Genders"
 msgstr "Zulässige Geschlechter"
 
-#: lib/klass_hero_web/components/provider_components.ex:2207
+#: lib/klass_hero_web/components/provider_components.ex:2216
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred during import."
 msgstr "Beim Import ist ein unerwarteter Fehler aufgetreten."
@@ -2396,7 +2396,7 @@ msgstr "Schließen Sie die Geschäftsverifizierung ab, um Programme zu erstellen
 msgid "Confirm rejection"
 msgstr "Ablehnung bestätigen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2168
+#: lib/klass_hero_web/components/provider_components.ex:2177
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr "Bestätigt"
@@ -2445,7 +2445,7 @@ msgstr "Beschreibung"
 msgid "Diverse"
 msgstr "Divers"
 
-#: lib/klass_hero_web/components/provider_components.ex:2305
+#: lib/klass_hero_web/components/provider_components.ex:2314
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr "Dokumenttyp"
@@ -2511,7 +2511,7 @@ msgid "End Time"
 msgstr "Endzeit"
 
 #: lib/klass_hero_web/components/provider_components.ex:1751
-#: lib/klass_hero_web/components/provider_components.ex:2188
+#: lib/klass_hero_web/components/provider_components.ex:2197
 #: lib/klass_hero_web/components/provider_layout_components.ex:630
 #, elixir-autogen, elixir-format
 msgid "Enrolled"
@@ -2533,7 +2533,7 @@ msgid "Explain why this document is being rejected..."
 msgstr "Erklären Sie, warum dieses Dokument abgelehnt wird..."
 
 #: lib/klass_hero_web/components/provider_components.ex:70
-#: lib/klass_hero_web/components/provider_components.ex:2189
+#: lib/klass_hero_web/components/provider_components.ex:2198
 #: lib/klass_hero_web/live/admin/emails_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2577,12 +2577,12 @@ msgstr "Weiblich"
 msgid "File"
 msgstr "Datei"
 
-#: lib/klass_hero_web/components/provider_components.ex:2239
+#: lib/klass_hero_web/components/provider_components.ex:2248
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr "Die Datei ist zu groß."
 
-#: lib/klass_hero_web/components/provider_components.ex:2241
+#: lib/klass_hero_web/components/provider_components.ex:2250
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr "Dateityp wird nicht akzeptiert."
@@ -2758,7 +2758,7 @@ msgstr "Niedrigste Klassenstufe"
 msgid "No approved documents."
 msgstr "Keine genehmigten Dokumente."
 
-#: lib/klass_hero_web/components/provider_components.ex:2267
+#: lib/klass_hero_web/components/provider_components.ex:2276
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr "Noch keine Dokumente hochgeladen."
@@ -2842,7 +2842,7 @@ msgstr "Nicht angegeben"
 msgid "Our Story"
 msgstr "Unsere Geschichte"
 
-#: lib/klass_hero_web/components/provider_components.ex:2342
+#: lib/klass_hero_web/components/provider_components.ex:2351
 #: lib/klass_hero_web/live/provider/verification_live.ex:698
 #: lib/klass_hero_web/live/provider/verification_live.ex:770
 #, elixir-autogen, elixir-format
@@ -2939,7 +2939,7 @@ msgid "Read our founding story →"
 msgstr "Lesen Sie unsere Gründungsgeschichte →"
 
 #: lib/klass_hero_web/components/participation_components.ex:805
-#: lib/klass_hero_web/components/provider_components.ex:2187
+#: lib/klass_hero_web/components/provider_components.ex:2196
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Registered"
@@ -3021,16 +3021,16 @@ msgstr "Ablehnungsgrund"
 
 #: lib/klass_hero_web/components/provider_components.ex:767
 #: lib/klass_hero_web/components/provider_components.ex:1166
-#: lib/klass_hero_web/components/provider_components.ex:2009
-#: lib/klass_hero_web/components/provider_components.ex:2361
-#: lib/klass_hero_web/components/provider_components.ex:2440
+#: lib/klass_hero_web/components/provider_components.ex:2018
+#: lib/klass_hero_web/components/provider_components.ex:2370
+#: lib/klass_hero_web/components/provider_components.ex:2449
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:253
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr "Entfernen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2002
+#: lib/klass_hero_web/components/provider_components.ex:2011
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr "Einladung erneut senden"
@@ -3071,7 +3071,7 @@ msgstr "Zeitplan noch offen"
 msgid "School Grade (optional)"
 msgstr "Klassenstufe (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2339
+#: lib/klass_hero_web/components/provider_components.ex:2348
 #, elixir-autogen, elixir-format
 msgid "Select File"
 msgstr "Datei auswählen"
@@ -3088,7 +3088,7 @@ msgstr "Das ausgewählte Kind erfüllt die Programmanforderungen nicht."
 msgid "Selected instructor could not be found. Please try again."
 msgstr "Der ausgewählte Kursleiter konnte nicht gefunden werden. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2186
+#: lib/klass_hero_web/components/provider_components.ex:2195
 #: lib/klass_hero_web/live/admin/emails_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Sent"
@@ -3198,7 +3198,7 @@ msgstr "Dieses Programm wurde von jemand anderem geändert. Bitte schließen Sie
 msgid "Title"
 msgstr "Titel"
 
-#: lib/klass_hero_web/components/provider_components.ex:2240
+#: lib/klass_hero_web/components/provider_components.ex:2249
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr "Zu viele Dateien."
@@ -3223,27 +3223,27 @@ msgstr "Bis Klassenstufe %{max}"
 msgid "Upload CSV"
 msgstr "CSV hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2385
+#: lib/klass_hero_web/components/provider_components.ex:2394
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr "Dokument hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2294
+#: lib/klass_hero_web/components/provider_components.ex:2303
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr "Neues Dokument hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2262
+#: lib/klass_hero_web/components/provider_components.ex:2271
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr "Laden Sie Dokumente hoch, um Ihr Unternehmen zu verifizieren. Die Dokumente werden von unserem Team überprüft."
 
-#: lib/klass_hero_web/components/provider_components.ex:2242
+#: lib/klass_hero_web/components/provider_components.ex:2251
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr "Upload-Fehler."
 
-#: lib/klass_hero_web/components/provider_components.ex:2259
+#: lib/klass_hero_web/components/provider_components.ex:2268
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr "Verifizierungsdokumente"
@@ -3333,7 +3333,7 @@ msgid "Child Safeguarding Training"
 msgstr "Kinderschutzschulung"
 
 #: lib/klass_hero_web/components/marketing_components.ex:1469
-#: lib/klass_hero_web/components/provider_components.ex:2607
+#: lib/klass_hero_web/components/provider_components.ex:2616
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr "Vereinbarung zu Community-Standards"
@@ -3483,7 +3483,7 @@ msgid "Vetted with Care"
 msgstr "Mit Sorgfalt geprüft"
 
 #: lib/klass_hero_web/components/marketing_components.ex:1453
-#: lib/klass_hero_web/components/provider_components.ex:2392
+#: lib/klass_hero_web/components/provider_components.ex:2401
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr "Video-Überprüfung"
@@ -3657,7 +3657,7 @@ msgstr "Eingecheckt"
 msgid "Checked Out"
 msgstr "Ausgecheckt"
 
-#: lib/klass_hero_web/components/provider_components.ex:2045
+#: lib/klass_hero_web/components/provider_components.ex:2054
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Child"
@@ -4986,7 +4986,7 @@ msgstr "Abreisezeit ist kein gültiges Datum oder keine gültige Uhrzeit"
 msgid "Failed to update record"
 msgstr "Aktualisieren des Datensatzes fehlgeschlagen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2109
+#: lib/klass_hero_web/components/provider_components.ex:2118
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr "Klassenstufe"
@@ -5011,12 +5011,12 @@ msgstr "Einladung verschickt."
 msgid "Leave blank to keep this child marked as present."
 msgstr "Leer lassen, um dieses Kind als anwesend markiert zu lassen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2122
+#: lib/klass_hero_web/components/provider_components.ex:2131
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr "Gesundheit & Einwilligungen (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2128
+#: lib/klass_hero_web/components/provider_components.ex:2137
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr "Gesundheitliche Besonderheiten"
@@ -5027,17 +5027,17 @@ msgstr "Gesundheitliche Besonderheiten"
 msgid "Nothing to update"
 msgstr "Nichts zu aktualisieren"
 
-#: lib/klass_hero_web/components/provider_components.ex:2130
+#: lib/klass_hero_web/components/provider_components.ex:2139
 #, elixir-autogen, elixir-format
 msgid "Nut allergy"
 msgstr "Nussallergie"
 
-#: lib/klass_hero_web/components/provider_components.ex:2134
+#: lib/klass_hero_web/components/provider_components.ex:2143
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr "Fotos dürfen in Marketingmaterialien verwendet werden"
 
-#: lib/klass_hero_web/components/provider_components.ex:2139
+#: lib/klass_hero_web/components/provider_components.ex:2148
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr "Fotos dürfen in sozialen Medien erscheinen"
@@ -5047,7 +5047,7 @@ msgstr "Fotos dürfen in sozialen Medien erscheinen"
 msgid "Present"
 msgstr "Anwesend"
 
-#: lib/klass_hero_web/components/provider_components.ex:2066
+#: lib/klass_hero_web/components/provider_components.ex:2075
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr "Hauptansprechpartner"
@@ -5074,22 +5074,22 @@ msgstr "Datensatz aktualisiert"
 msgid "Save changes"
 msgstr "Änderungen speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:2103
+#: lib/klass_hero_web/components/provider_components.ex:2112
 #, elixir-autogen, elixir-format
 msgid "School (optional)"
 msgstr "Schule (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2113
+#: lib/klass_hero_web/components/provider_components.ex:2122
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr "Schulname"
 
-#: lib/klass_hero_web/components/provider_components.ex:2087
+#: lib/klass_hero_web/components/provider_components.ex:2096
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr "Zweiter Ansprechpartner (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2156
+#: lib/klass_hero_web/components/provider_components.ex:2165
 #, elixir-autogen, elixir-format
 msgid "Send invite"
 msgstr "Einladung senden"
@@ -6400,12 +6400,12 @@ msgstr "Umsatz (diese Woche)"
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr "Strenge Überprüfung, damit Familien immer wissen, wer die Gruppe leitet."
 
-#: lib/klass_hero_web/components/provider_components.ex:2195
+#: lib/klass_hero_web/components/provider_components.ex:2204
 #, elixir-autogen, elixir-format
 msgid "Row %{row}"
 msgstr "Zeile %{row}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2195
+#: lib/klass_hero_web/components/provider_components.ex:2204
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr "Zeile —"
@@ -7169,12 +7169,12 @@ msgstr "Deine Identität ist verifiziert."
 msgid "Experience validation"
 msgstr "Erfahrungsnachweis"
 
-#: lib/klass_hero_web/components/provider_components.ex:2421
+#: lib/klass_hero_web/components/provider_components.ex:2430
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr "MP4, MOV oder WEBM. Max. 100 MB."
 
-#: lib/klass_hero_web/components/provider_components.ex:2395
+#: lib/klass_hero_web/components/provider_components.ex:2404
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr "Nimm ein kurzes Video auf, in dem du dich vorstellst. Unser Team prüft es, um Kommunikationsfähigkeit und Übereinstimmung mit unseren Werten einzuschätzen."
@@ -7184,12 +7184,12 @@ msgstr "Nimm ein kurzes Video auf, in dem du dich vorstellst. Unser Team prüft 
 msgid "Safeguarding certificate"
 msgstr "Kinderschutz-Zertifikat"
 
-#: lib/klass_hero_web/components/provider_components.ex:2418
+#: lib/klass_hero_web/components/provider_components.ex:2427
 #, elixir-autogen, elixir-format
 msgid "Select Video"
 msgstr "Video auswählen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2464
+#: lib/klass_hero_web/components/provider_components.ex:2473
 #, elixir-autogen, elixir-format
 msgid "Upload Video"
 msgstr "Video hochladen"
@@ -7199,7 +7199,7 @@ msgstr "Video hochladen"
 msgid "Your browser does not support video playback."
 msgstr "Dein Browser unterstützt keine Videowiedergabe."
 
-#: lib/klass_hero_web/components/provider_components.ex:2611
+#: lib/klass_hero_web/components/provider_components.ex:2620
 #, elixir-autogen, elixir-format
 msgid "Confirm agreement"
 msgstr "Zustimmung bestätigen"
@@ -7209,12 +7209,12 @@ msgstr "Zustimmung bestätigen"
 msgid "Couldn't record your agreement. Please try again."
 msgstr "Deine Zustimmung konnte nicht gespeichert werden. Bitte versuche es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2634
+#: lib/klass_hero_web/components/provider_components.ex:2643
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr "Vereinbarung herunterladen (PDF)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2610
+#: lib/klass_hero_web/components/provider_components.ex:2619
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr "Ich habe die Klass Hero Community-Richtlinien gelesen und stimme ihnen zu."
@@ -7224,7 +7224,7 @@ msgstr "Ich habe die Klass Hero Community-Richtlinien gelesen und stimme ihnen z
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr "Bitte bestätige, dass du die Community-Richtlinien gelesen hast und ihnen zustimmst."
 
-#: lib/klass_hero_web/components/provider_components.ex:2519
+#: lib/klass_hero_web/components/provider_components.ex:2528
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr "Unterzeichnet von %{name} am %{date} (v%{version})."
@@ -7234,17 +7234,17 @@ msgstr "Unterzeichnet von %{name} am %{date} (v%{version})."
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr "Danke – deine Zustimmung zu den Community-Richtlinien wurde gespeichert."
 
-#: lib/klass_hero_web/components/provider_components.ex:2619
+#: lib/klass_hero_web/components/provider_components.ex:2628
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr "Die Community-Richtlinien wurden seit deiner letzten Zustimmung aktualisiert (v%{old}). Bitte lies sie erneut und stimme erneut zu."
 
-#: lib/klass_hero_web/components/provider_components.ex:2608
+#: lib/klass_hero_web/components/provider_components.ex:2617
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr "Der letzte Schritt: Lies die Klass Hero Community-Richtlinien und stimme ihnen zu."
 
-#: lib/klass_hero_web/components/provider_components.ex:2609
+#: lib/klass_hero_web/components/provider_components.ex:2618
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr "Du hast den Community-Richtlinien zugestimmt."
@@ -7513,12 +7513,12 @@ msgstr "Ihre Versicherungsbescheinigung wird geprüft."
 msgid "Your insurance is verified."
 msgstr "Ihre Versicherung ist verifiziert."
 
-#: lib/klass_hero_web/components/provider_components.ex:2563
+#: lib/klass_hero_web/components/provider_components.ex:2572
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr "Unterzeichnung durch %{name} im Namen des Unternehmens."
 
-#: lib/klass_hero_web/components/provider_components.ex:2666
+#: lib/klass_hero_web/components/provider_components.ex:2675
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr "Bestätige im Namen deines Unternehmens, dass alle Mitarbeitenden gemäß dem deutschen Kinderschutzrecht überprüft sind."
@@ -7528,7 +7528,7 @@ msgstr "Bestätige im Namen deines Unternehmens, dass alle Mitarbeitenden gemä�
 msgid "Couldn't record your declaration. Please try again."
 msgstr "Deine Erklärung konnte nicht gespeichert werden. Bitte versuche es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2672
+#: lib/klass_hero_web/components/provider_components.ex:2681
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr "Ich bestätige im Namen des Unternehmens, dass die obige Erklärung zutrifft und ich zu ihrer Unterzeichnung berechtigt bin."
@@ -7538,17 +7538,17 @@ msgstr "Ich bestätige im Namen des Unternehmens, dass die obige Erklärung zutr
 msgid "Please confirm the declaration before signing."
 msgstr "Bitte bestätige die Erklärung vor der Unterzeichnung."
 
-#: lib/klass_hero_web/components/provider_components.ex:2697
+#: lib/klass_hero_web/components/provider_components.ex:2706
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr "Vorläufiger Text — vor der Freischaltung noch von einer in Deutschland zugelassenen Anwältin bzw. einem Anwalt zu prüfen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2676
+#: lib/klass_hero_web/components/provider_components.ex:2685
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr "Erklärung unterzeichnen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2664
+#: lib/klass_hero_web/components/provider_components.ex:2673
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr "Erklärung zur Mitarbeiter-Compliance"
@@ -7558,12 +7558,12 @@ msgstr "Erklärung zur Mitarbeiter-Compliance"
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr "Danke — deine Erklärung zur Mitarbeiter-Compliance wurde erfasst."
 
-#: lib/klass_hero_web/components/provider_components.ex:2684
+#: lib/klass_hero_web/components/provider_components.ex:2693
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr "Die Erklärung zur Mitarbeiter-Compliance wurde seit deiner letzten Unterzeichnung aktualisiert (v%{old}). Bitte prüfe sie und unterzeichne erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2670
+#: lib/klass_hero_web/components/provider_components.ex:2679
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr "Du hast die Erklärung zur Mitarbeiter-Compliance unterzeichnet."

--- a/priv/gettext/de/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/de/LC_MESSAGES/enrollment.po
@@ -11,62 +11,62 @@ msgstr ""
 "Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:2216
+#: lib/klass_hero_web/components/provider_components.ex:2225
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr "Vorname des Kindes"
 
-#: lib/klass_hero_web/components/provider_components.ex:2217
+#: lib/klass_hero_web/components/provider_components.ex:2226
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr "Nachname des Kindes"
 
-#: lib/klass_hero_web/components/provider_components.ex:2218
+#: lib/klass_hero_web/components/provider_components.ex:2227
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr "Geburtsdatum"
 
-#: lib/klass_hero_web/components/provider_components.ex:2229
+#: lib/klass_hero_web/components/provider_components.ex:2238
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr "Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2219
+#: lib/klass_hero_web/components/provider_components.ex:2228
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr "E-Mail des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2220
+#: lib/klass_hero_web/components/provider_components.ex:2229
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr "Vorname des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2221
+#: lib/klass_hero_web/components/provider_components.ex:2230
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr "Nachname des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2228
+#: lib/klass_hero_web/components/provider_components.ex:2237
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr "Programm"
 
-#: lib/klass_hero_web/components/provider_components.ex:2230
+#: lib/klass_hero_web/components/provider_components.ex:2239
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr "Schule"
 
-#: lib/klass_hero_web/components/provider_components.ex:2222
+#: lib/klass_hero_web/components/provider_components.ex:2231
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr "E-Mail des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2224
+#: lib/klass_hero_web/components/provider_components.ex:2233
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr "Vorname des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2226
+#: lib/klass_hero_web/components/provider_components.ex:2235
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr "Nachname des zweiten Erziehungsberechtigten"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -583,8 +583,8 @@ msgid "Dispute Resolution"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:647
-#: lib/klass_hero_web/components/provider_components.ex:2073
-#: lib/klass_hero_web/components/provider_components.ex:2091
+#: lib/klass_hero_web/components/provider_components.ex:2082
+#: lib/klass_hero_web/components/provider_components.ex:2100
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
@@ -1680,8 +1680,8 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:46
 #: lib/klass_hero_web/components/provider_components.ex:72
 #: lib/klass_hero_web/components/provider_components.ex:1470
-#: lib/klass_hero_web/components/provider_components.ex:2167
-#: lib/klass_hero_web/components/provider_components.ex:2185
+#: lib/klass_hero_web/components/provider_components.ex:2176
+#: lib/klass_hero_web/components/provider_components.ex:2194
 #: lib/klass_hero_web/live/admin/sessions_live.ex:297
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
@@ -1893,7 +1893,7 @@ msgstr ""
 msgid "Data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2054
+#: lib/klass_hero_web/components/provider_components.ex:2063
 #: lib/klass_hero_web/live/settings/children_live.ex:657
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1941,17 +1941,17 @@ msgstr ""
 msgid "Failed to submit note"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2048
-#: lib/klass_hero_web/components/provider_components.ex:2077
-#: lib/klass_hero_web/components/provider_components.ex:2093
+#: lib/klass_hero_web/components/provider_components.ex:2057
+#: lib/klass_hero_web/components/provider_components.ex:2086
+#: lib/klass_hero_web/components/provider_components.ex:2102
 #: lib/klass_hero_web/live/settings/children_live.ex:643
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2049
-#: lib/klass_hero_web/components/provider_components.ex:2078
-#: lib/klass_hero_web/components/provider_components.ex:2094
+#: lib/klass_hero_web/components/provider_components.ex:2058
+#: lib/klass_hero_web/components/provider_components.ex:2087
+#: lib/klass_hero_web/components/provider_components.ex:2103
 #: lib/klass_hero_web/live/settings/children_live.ex:649
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -2109,7 +2109,7 @@ msgstr ""
 msgid "Send a message to start the conversation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2148
+#: lib/klass_hero_web/components/provider_components.ex:2157
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:245
 #, elixir-autogen, elixir-format
@@ -2245,7 +2245,7 @@ msgstr ""
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2207
+#: lib/klass_hero_web/components/provider_components.ex:2216
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred during import."
 msgstr ""
@@ -2396,7 +2396,7 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2168
+#: lib/klass_hero_web/components/provider_components.ex:2177
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
@@ -2445,7 +2445,7 @@ msgstr ""
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2305
+#: lib/klass_hero_web/components/provider_components.ex:2314
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2511,7 +2511,7 @@ msgid "End Time"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1751
-#: lib/klass_hero_web/components/provider_components.ex:2188
+#: lib/klass_hero_web/components/provider_components.ex:2197
 #: lib/klass_hero_web/components/provider_layout_components.ex:630
 #, elixir-autogen, elixir-format
 msgid "Enrolled"
@@ -2533,7 +2533,7 @@ msgid "Explain why this document is being rejected..."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:70
-#: lib/klass_hero_web/components/provider_components.ex:2189
+#: lib/klass_hero_web/components/provider_components.ex:2198
 #: lib/klass_hero_web/live/admin/emails_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2577,12 +2577,12 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2239
+#: lib/klass_hero_web/components/provider_components.ex:2248
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2241
+#: lib/klass_hero_web/components/provider_components.ex:2250
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
@@ -2758,7 +2758,7 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2267
+#: lib/klass_hero_web/components/provider_components.ex:2276
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
@@ -2842,7 +2842,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2342
+#: lib/klass_hero_web/components/provider_components.ex:2351
 #: lib/klass_hero_web/live/provider/verification_live.ex:698
 #: lib/klass_hero_web/live/provider/verification_live.ex:770
 #, elixir-autogen, elixir-format
@@ -2939,7 +2939,7 @@ msgid "Read our founding story →"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:805
-#: lib/klass_hero_web/components/provider_components.ex:2187
+#: lib/klass_hero_web/components/provider_components.ex:2196
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Registered"
@@ -3021,16 +3021,16 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:767
 #: lib/klass_hero_web/components/provider_components.ex:1166
-#: lib/klass_hero_web/components/provider_components.ex:2009
-#: lib/klass_hero_web/components/provider_components.ex:2361
-#: lib/klass_hero_web/components/provider_components.ex:2440
+#: lib/klass_hero_web/components/provider_components.ex:2018
+#: lib/klass_hero_web/components/provider_components.ex:2370
+#: lib/klass_hero_web/components/provider_components.ex:2449
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:253
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2002
+#: lib/klass_hero_web/components/provider_components.ex:2011
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2339
+#: lib/klass_hero_web/components/provider_components.ex:2348
 #, elixir-autogen, elixir-format
 msgid "Select File"
 msgstr ""
@@ -3088,7 +3088,7 @@ msgstr ""
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2186
+#: lib/klass_hero_web/components/provider_components.ex:2195
 #: lib/klass_hero_web/live/admin/emails_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Sent"
@@ -3198,7 +3198,7 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2240
+#: lib/klass_hero_web/components/provider_components.ex:2249
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -3223,27 +3223,27 @@ msgstr ""
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2385
+#: lib/klass_hero_web/components/provider_components.ex:2394
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2294
+#: lib/klass_hero_web/components/provider_components.ex:2303
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2262
+#: lib/klass_hero_web/components/provider_components.ex:2271
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2242
+#: lib/klass_hero_web/components/provider_components.ex:2251
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2259
+#: lib/klass_hero_web/components/provider_components.ex:2268
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -3333,7 +3333,7 @@ msgid "Child Safeguarding Training"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1469
-#: lib/klass_hero_web/components/provider_components.ex:2607
+#: lib/klass_hero_web/components/provider_components.ex:2616
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr ""
@@ -3483,7 +3483,7 @@ msgid "Vetted with Care"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1453
-#: lib/klass_hero_web/components/provider_components.ex:2392
+#: lib/klass_hero_web/components/provider_components.ex:2401
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr ""
@@ -3657,7 +3657,7 @@ msgstr ""
 msgid "Checked Out"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2045
+#: lib/klass_hero_web/components/provider_components.ex:2054
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Child"
@@ -4986,7 +4986,7 @@ msgstr ""
 msgid "Failed to update record"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2109
+#: lib/klass_hero_web/components/provider_components.ex:2118
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
@@ -5011,12 +5011,12 @@ msgstr ""
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2122
+#: lib/klass_hero_web/components/provider_components.ex:2131
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2128
+#: lib/klass_hero_web/components/provider_components.ex:2137
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr ""
@@ -5027,17 +5027,17 @@ msgstr ""
 msgid "Nothing to update"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2130
+#: lib/klass_hero_web/components/provider_components.ex:2139
 #, elixir-autogen, elixir-format
 msgid "Nut allergy"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2134
+#: lib/klass_hero_web/components/provider_components.ex:2143
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2139
+#: lib/klass_hero_web/components/provider_components.ex:2148
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr ""
@@ -5047,7 +5047,7 @@ msgstr ""
 msgid "Present"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2066
+#: lib/klass_hero_web/components/provider_components.ex:2075
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr ""
@@ -5074,22 +5074,22 @@ msgstr ""
 msgid "Save changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2103
+#: lib/klass_hero_web/components/provider_components.ex:2112
 #, elixir-autogen, elixir-format
 msgid "School (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2113
+#: lib/klass_hero_web/components/provider_components.ex:2122
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2087
+#: lib/klass_hero_web/components/provider_components.ex:2096
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2156
+#: lib/klass_hero_web/components/provider_components.ex:2165
 #, elixir-autogen, elixir-format
 msgid "Send invite"
 msgstr ""
@@ -6400,12 +6400,12 @@ msgstr ""
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2195
+#: lib/klass_hero_web/components/provider_components.ex:2204
 #, elixir-autogen, elixir-format
 msgid "Row %{row}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2195
+#: lib/klass_hero_web/components/provider_components.ex:2204
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr ""
@@ -7169,12 +7169,12 @@ msgstr ""
 msgid "Experience validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2421
+#: lib/klass_hero_web/components/provider_components.ex:2430
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2395
+#: lib/klass_hero_web/components/provider_components.ex:2404
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
@@ -7184,12 +7184,12 @@ msgstr ""
 msgid "Safeguarding certificate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2418
+#: lib/klass_hero_web/components/provider_components.ex:2427
 #, elixir-autogen, elixir-format
 msgid "Select Video"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2464
+#: lib/klass_hero_web/components/provider_components.ex:2473
 #, elixir-autogen, elixir-format
 msgid "Upload Video"
 msgstr ""
@@ -7199,7 +7199,7 @@ msgstr ""
 msgid "Your browser does not support video playback."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2611
+#: lib/klass_hero_web/components/provider_components.ex:2620
 #, elixir-autogen, elixir-format
 msgid "Confirm agreement"
 msgstr ""
@@ -7209,12 +7209,12 @@ msgstr ""
 msgid "Couldn't record your agreement. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2634
+#: lib/klass_hero_web/components/provider_components.ex:2643
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2610
+#: lib/klass_hero_web/components/provider_components.ex:2619
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr ""
@@ -7224,7 +7224,7 @@ msgstr ""
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2519
+#: lib/klass_hero_web/components/provider_components.ex:2528
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr ""
@@ -7234,17 +7234,17 @@ msgstr ""
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2619
+#: lib/klass_hero_web/components/provider_components.ex:2628
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2608
+#: lib/klass_hero_web/components/provider_components.ex:2617
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2609
+#: lib/klass_hero_web/components/provider_components.ex:2618
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
@@ -7513,12 +7513,12 @@ msgstr ""
 msgid "Your insurance is verified."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2563
+#: lib/klass_hero_web/components/provider_components.ex:2572
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2666
+#: lib/klass_hero_web/components/provider_components.ex:2675
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr ""
@@ -7528,7 +7528,7 @@ msgstr ""
 msgid "Couldn't record your declaration. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2672
+#: lib/klass_hero_web/components/provider_components.ex:2681
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr ""
@@ -7538,17 +7538,17 @@ msgstr ""
 msgid "Please confirm the declaration before signing."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2697
+#: lib/klass_hero_web/components/provider_components.ex:2706
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2676
+#: lib/klass_hero_web/components/provider_components.ex:2685
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2664
+#: lib/klass_hero_web/components/provider_components.ex:2673
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr ""
@@ -7558,12 +7558,12 @@ msgstr ""
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2684
+#: lib/klass_hero_web/components/provider_components.ex:2693
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2670
+#: lib/klass_hero_web/components/provider_components.ex:2679
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -583,8 +583,8 @@ msgid "Dispute Resolution"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:647
-#: lib/klass_hero_web/components/provider_components.ex:2073
-#: lib/klass_hero_web/components/provider_components.ex:2091
+#: lib/klass_hero_web/components/provider_components.ex:2082
+#: lib/klass_hero_web/components/provider_components.ex:2100
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
@@ -1680,8 +1680,8 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:46
 #: lib/klass_hero_web/components/provider_components.ex:72
 #: lib/klass_hero_web/components/provider_components.ex:1470
-#: lib/klass_hero_web/components/provider_components.ex:2167
-#: lib/klass_hero_web/components/provider_components.ex:2185
+#: lib/klass_hero_web/components/provider_components.ex:2176
+#: lib/klass_hero_web/components/provider_components.ex:2194
 #: lib/klass_hero_web/live/admin/sessions_live.ex:297
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
@@ -1893,7 +1893,7 @@ msgstr ""
 msgid "Data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2054
+#: lib/klass_hero_web/components/provider_components.ex:2063
 #: lib/klass_hero_web/live/settings/children_live.ex:657
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1941,17 +1941,17 @@ msgstr ""
 msgid "Failed to submit note"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2048
-#: lib/klass_hero_web/components/provider_components.ex:2077
-#: lib/klass_hero_web/components/provider_components.ex:2093
+#: lib/klass_hero_web/components/provider_components.ex:2057
+#: lib/klass_hero_web/components/provider_components.ex:2086
+#: lib/klass_hero_web/components/provider_components.ex:2102
 #: lib/klass_hero_web/live/settings/children_live.ex:643
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2049
-#: lib/klass_hero_web/components/provider_components.ex:2078
-#: lib/klass_hero_web/components/provider_components.ex:2094
+#: lib/klass_hero_web/components/provider_components.ex:2058
+#: lib/klass_hero_web/components/provider_components.ex:2087
+#: lib/klass_hero_web/components/provider_components.ex:2103
 #: lib/klass_hero_web/live/settings/children_live.ex:649
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -2109,7 +2109,7 @@ msgstr ""
 msgid "Send a message to start the conversation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2148
+#: lib/klass_hero_web/components/provider_components.ex:2157
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:245
 #, elixir-autogen, elixir-format, fuzzy
@@ -2245,7 +2245,7 @@ msgstr ""
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2207
+#: lib/klass_hero_web/components/provider_components.ex:2216
 #, elixir-autogen, elixir-format, fuzzy
 msgid "An unexpected error occurred during import."
 msgstr ""
@@ -2396,7 +2396,7 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2168
+#: lib/klass_hero_web/components/provider_components.ex:2177
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
@@ -2445,7 +2445,7 @@ msgstr ""
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2305
+#: lib/klass_hero_web/components/provider_components.ex:2314
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2511,7 +2511,7 @@ msgid "End Time"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1751
-#: lib/klass_hero_web/components/provider_components.ex:2188
+#: lib/klass_hero_web/components/provider_components.ex:2197
 #: lib/klass_hero_web/components/provider_layout_components.ex:630
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrolled"
@@ -2533,7 +2533,7 @@ msgid "Explain why this document is being rejected..."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:70
-#: lib/klass_hero_web/components/provider_components.ex:2189
+#: lib/klass_hero_web/components/provider_components.ex:2198
 #: lib/klass_hero_web/live/admin/emails_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2577,12 +2577,12 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2239
+#: lib/klass_hero_web/components/provider_components.ex:2248
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2241
+#: lib/klass_hero_web/components/provider_components.ex:2250
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
@@ -2758,7 +2758,7 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2267
+#: lib/klass_hero_web/components/provider_components.ex:2276
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
@@ -2842,7 +2842,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2342
+#: lib/klass_hero_web/components/provider_components.ex:2351
 #: lib/klass_hero_web/live/provider/verification_live.ex:698
 #: lib/klass_hero_web/live/provider/verification_live.ex:770
 #, elixir-autogen, elixir-format
@@ -2939,7 +2939,7 @@ msgid "Read our founding story →"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:805
-#: lib/klass_hero_web/components/provider_components.ex:2187
+#: lib/klass_hero_web/components/provider_components.ex:2196
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registered"
@@ -3021,16 +3021,16 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:767
 #: lib/klass_hero_web/components/provider_components.ex:1166
-#: lib/klass_hero_web/components/provider_components.ex:2009
-#: lib/klass_hero_web/components/provider_components.ex:2361
-#: lib/klass_hero_web/components/provider_components.ex:2440
+#: lib/klass_hero_web/components/provider_components.ex:2018
+#: lib/klass_hero_web/components/provider_components.ex:2370
+#: lib/klass_hero_web/components/provider_components.ex:2449
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:253
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2002
+#: lib/klass_hero_web/components/provider_components.ex:2011
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2339
+#: lib/klass_hero_web/components/provider_components.ex:2348
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select File"
 msgstr ""
@@ -3088,7 +3088,7 @@ msgstr ""
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2186
+#: lib/klass_hero_web/components/provider_components.ex:2195
 #: lib/klass_hero_web/live/admin/emails_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Sent"
@@ -3198,7 +3198,7 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2240
+#: lib/klass_hero_web/components/provider_components.ex:2249
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -3223,27 +3223,27 @@ msgstr ""
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2385
+#: lib/klass_hero_web/components/provider_components.ex:2394
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2294
+#: lib/klass_hero_web/components/provider_components.ex:2303
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2262
+#: lib/klass_hero_web/components/provider_components.ex:2271
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2242
+#: lib/klass_hero_web/components/provider_components.ex:2251
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2259
+#: lib/klass_hero_web/components/provider_components.ex:2268
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -3333,7 +3333,7 @@ msgid "Child Safeguarding Training"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1469
-#: lib/klass_hero_web/components/provider_components.ex:2607
+#: lib/klass_hero_web/components/provider_components.ex:2616
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr ""
@@ -3483,7 +3483,7 @@ msgid "Vetted with Care"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1453
-#: lib/klass_hero_web/components/provider_components.ex:2392
+#: lib/klass_hero_web/components/provider_components.ex:2401
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr ""
@@ -3657,7 +3657,7 @@ msgstr ""
 msgid "Checked Out"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2045
+#: lib/klass_hero_web/components/provider_components.ex:2054
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Child"
@@ -4986,7 +4986,7 @@ msgstr ""
 msgid "Failed to update record"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2109
+#: lib/klass_hero_web/components/provider_components.ex:2118
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
@@ -5011,12 +5011,12 @@ msgstr ""
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2122
+#: lib/klass_hero_web/components/provider_components.ex:2131
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2128
+#: lib/klass_hero_web/components/provider_components.ex:2137
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr ""
@@ -5027,17 +5027,17 @@ msgstr ""
 msgid "Nothing to update"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2130
+#: lib/klass_hero_web/components/provider_components.ex:2139
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nut allergy"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2134
+#: lib/klass_hero_web/components/provider_components.ex:2143
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2139
+#: lib/klass_hero_web/components/provider_components.ex:2148
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr ""
@@ -5047,7 +5047,7 @@ msgstr ""
 msgid "Present"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2066
+#: lib/klass_hero_web/components/provider_components.ex:2075
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr ""
@@ -5074,22 +5074,22 @@ msgstr ""
 msgid "Save changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2103
+#: lib/klass_hero_web/components/provider_components.ex:2112
 #, elixir-autogen, elixir-format, fuzzy
 msgid "School (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2113
+#: lib/klass_hero_web/components/provider_components.ex:2122
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2087
+#: lib/klass_hero_web/components/provider_components.ex:2096
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2156
+#: lib/klass_hero_web/components/provider_components.ex:2165
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Send invite"
 msgstr ""
@@ -6400,12 +6400,12 @@ msgstr ""
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2195
+#: lib/klass_hero_web/components/provider_components.ex:2204
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Row %{row}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2195
+#: lib/klass_hero_web/components/provider_components.ex:2204
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr ""
@@ -7169,12 +7169,12 @@ msgstr ""
 msgid "Experience validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2421
+#: lib/klass_hero_web/components/provider_components.ex:2430
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2395
+#: lib/klass_hero_web/components/provider_components.ex:2404
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
@@ -7184,12 +7184,12 @@ msgstr ""
 msgid "Safeguarding certificate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2418
+#: lib/klass_hero_web/components/provider_components.ex:2427
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select Video"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2464
+#: lib/klass_hero_web/components/provider_components.ex:2473
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload Video"
 msgstr ""
@@ -7199,7 +7199,7 @@ msgstr ""
 msgid "Your browser does not support video playback."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2611
+#: lib/klass_hero_web/components/provider_components.ex:2620
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Confirm agreement"
 msgstr ""
@@ -7209,12 +7209,12 @@ msgstr ""
 msgid "Couldn't record your agreement. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2634
+#: lib/klass_hero_web/components/provider_components.ex:2643
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2610
+#: lib/klass_hero_web/components/provider_components.ex:2619
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr ""
@@ -7224,7 +7224,7 @@ msgstr ""
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2519
+#: lib/klass_hero_web/components/provider_components.ex:2528
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr ""
@@ -7234,17 +7234,17 @@ msgstr ""
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2619
+#: lib/klass_hero_web/components/provider_components.ex:2628
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2608
+#: lib/klass_hero_web/components/provider_components.ex:2617
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2609
+#: lib/klass_hero_web/components/provider_components.ex:2618
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
@@ -7513,12 +7513,12 @@ msgstr ""
 msgid "Your insurance is verified."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2563
+#: lib/klass_hero_web/components/provider_components.ex:2572
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2666
+#: lib/klass_hero_web/components/provider_components.ex:2675
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr ""
@@ -7528,7 +7528,7 @@ msgstr ""
 msgid "Couldn't record your declaration. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2672
+#: lib/klass_hero_web/components/provider_components.ex:2681
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr ""
@@ -7538,17 +7538,17 @@ msgstr ""
 msgid "Please confirm the declaration before signing."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2697
+#: lib/klass_hero_web/components/provider_components.ex:2706
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2676
+#: lib/klass_hero_web/components/provider_components.ex:2685
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2664
+#: lib/klass_hero_web/components/provider_components.ex:2673
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr ""
@@ -7558,12 +7558,12 @@ msgstr ""
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2684
+#: lib/klass_hero_web/components/provider_components.ex:2693
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2670
+#: lib/klass_hero_web/components/provider_components.ex:2679
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/en/LC_MESSAGES/enrollment.po
@@ -11,62 +11,62 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:2216
+#: lib/klass_hero_web/components/provider_components.ex:2225
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2217
+#: lib/klass_hero_web/components/provider_components.ex:2226
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2218
+#: lib/klass_hero_web/components/provider_components.ex:2227
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2229
+#: lib/klass_hero_web/components/provider_components.ex:2238
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2219
+#: lib/klass_hero_web/components/provider_components.ex:2228
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2220
+#: lib/klass_hero_web/components/provider_components.ex:2229
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2221
+#: lib/klass_hero_web/components/provider_components.ex:2230
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2228
+#: lib/klass_hero_web/components/provider_components.ex:2237
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2230
+#: lib/klass_hero_web/components/provider_components.ex:2239
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2222
+#: lib/klass_hero_web/components/provider_components.ex:2231
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2224
+#: lib/klass_hero_web/components/provider_components.ex:2233
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2226
+#: lib/klass_hero_web/components/provider_components.ex:2235
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""

--- a/priv/gettext/enrollment.pot
+++ b/priv/gettext/enrollment.pot
@@ -11,62 +11,62 @@
 msgid ""
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2216
+#: lib/klass_hero_web/components/provider_components.ex:2225
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2217
+#: lib/klass_hero_web/components/provider_components.ex:2226
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2218
+#: lib/klass_hero_web/components/provider_components.ex:2227
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2229
+#: lib/klass_hero_web/components/provider_components.ex:2238
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2219
+#: lib/klass_hero_web/components/provider_components.ex:2228
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2220
+#: lib/klass_hero_web/components/provider_components.ex:2229
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2221
+#: lib/klass_hero_web/components/provider_components.ex:2230
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2228
+#: lib/klass_hero_web/components/provider_components.ex:2237
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2230
+#: lib/klass_hero_web/components/provider_components.ex:2239
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2222
+#: lib/klass_hero_web/components/provider_components.ex:2231
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2224
+#: lib/klass_hero_web/components/provider_components.ex:2233
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2226
+#: lib/klass_hero_web/components/provider_components.ex:2235
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""

--- a/test/klass_hero/enrollment/invite_claim_saga_test.exs
+++ b/test/klass_hero/enrollment/invite_claim_saga_test.exs
@@ -1,66 +1,35 @@
 defmodule KlassHero.Enrollment.InviteClaimSagaTest do
   @moduledoc """
-  Integration test for the full invite claim saga.
+  Integration test for the full invite claim saga: token claim -> user creation ->
+  `invite_claimed` -> family creation -> `invite_family_ready` -> enrollment.
 
-  Verifies the end-to-end flow: token claim -> user creation ->
-  invite_claimed event -> registered status transition ->
-  integration event -> family creation -> enrollment creation.
-
-  Since integration events propagate asynchronously via PubSub
-  (through EventSubscriber GenServers started in the application tree),
-  this test:
-
-  1. Swaps the integration event publisher to the real PubSub publisher
-     so that the events a claim stages are visible to assertions
-  2. Grants Ecto Sandbox access to the EventSubscriber processes so they
-     can access the database within the test's transaction
-  3. Polls for the expected terminal state ("enrolled")
+  Every hop travels through the outbox (ADR-0014). Manual testing mode plus explicit
+  drains is what makes this resemble production: under the suite's `testing: :inline`,
+  staging executes the delivery job at insert — inside the producer's transaction — so
+  the whole chain collapses into one synchronous cascade in which no job is ever
+  retried, a sequencing production never has.
   """
+
   use KlassHero.DataCase, async: false
 
   import KlassHero.Factory
 
-  alias Ecto.Adapters.SQL.Sandbox
+  alias KlassHero.Accounts
   alias KlassHero.Enrollment
-  alias KlassHero.Enrollment.Adapters.Driving.Events.InviteFamilyReadyHandler
   alias KlassHero.Enrollment.BulkEnrollmentInvite
   alias KlassHero.Enrollment.ClaimResult
   alias KlassHero.Family
-  # EventSubscriber process names that participate in the saga.
-  # These GenServers receive PubSub integration events and access the DB.
-  alias KlassHero.Family.Adapters.Driving.Events.FamilyEventHandler
-  alias KlassHero.Family.Adapters.Driving.Events.InviteClaimedHandler
-  alias KlassHero.Provider.Adapters.Driving.Events.ProviderEventHandler
-  alias KlassHero.Repo
   alias KlassHero.Shared.Adapters.Driven.Events.ObanOutbox
-  alias KlassHero.Shared.Adapters.Driven.Events.PubSubEventPublisher
-
-  @saga_subscribers [
-    # Handles integration:enrollment:invite_claimed -> creates parent + child
-    InviteClaimedHandler,
-    # Handles integration:family:invite_family_ready -> creates enrollment
-    InviteFamilyReadyHandler,
-    # Handles integration:accounts:user_registered -> creates parent profile (may race)
-    FamilyEventHandler,
-    # Handles integration:accounts:user_registered -> creates provider profile stub
-    ProviderEventHandler
-  ]
 
   defp create_claimable_invite(_context) do
-    import Ecto.Query
-
     provider = insert(:provider_profile_schema)
-
-    program =
-      insert(:program_schema,
-        provider_id: provider.id
-      )
+    program = insert(:program_schema, provider_id: provider.id)
 
     token = "saga-test-#{System.unique_integer([:positive])}"
     email = "saga-test-#{System.unique_integer([:positive])}@example.com"
 
     {:ok, _} =
-      KlassHero.Enrollment.create_invite(%{
+      Enrollment.create_invite(%{
         program_id: program.id,
         provider_id: provider.id,
         child_first_name: "Emma",
@@ -73,115 +42,85 @@ defmodule KlassHero.Enrollment.InviteClaimSagaTest do
 
     invite =
       BulkEnrollmentInvite
-      |> where([i], i.guardian_email == ^email and i.program_id == ^program.id)
-      |> Repo.one!()
+      |> Repo.get_by!(guardian_email: email)
+      |> Ecto.Changeset.change(%{invite_token: token, status: :invite_sent})
+      |> Repo.update!()
 
-    # Transition invite to "invite_sent" with a token so it can be claimed
-    invite
-    |> Ecto.Changeset.change(%{invite_token: token, status: :invite_sent})
-    |> Repo.update!()
+    %{invite: invite, token: token, program: program, provider: provider, email: email}
+  end
 
-    updated_invite =
-      BulkEnrollmentInvite
-      |> where([i], i.id == ^invite.id)
-      |> Repo.one!()
+  setup context do
+    invite_data = create_claimable_invite(context)
 
-    %{
-      invite: updated_invite,
-      token: token,
-      program: program,
-      provider: provider,
-      email: email
-    }
+    # The suite records staged events instead of enqueueing them; this test needs the real
+    # delivery job, because the hops it asserts on are the ones that job invokes.
+    original_outbox = Application.get_env(:klass_hero, :outbox)
+    Application.put_env(:klass_hero, :outbox, module: ObanOutbox)
+    on_exit(fn -> Application.put_env(:klass_hero, :outbox, original_outbox) end)
+
+    invite_data
+  end
+
+  # Deliver the staged events, run the family hop they enqueue, then deliver whatever that
+  # hop staged in turn. `with_scheduled` drives a failing job through its retries instead
+  # of stopping at the first backoff.
+  defp run_saga do
+    Oban.drain_queue(queue: :critical_events, with_recursion: true)
+    Oban.drain_queue(queue: :family, with_recursion: true, with_scheduled: true)
+    Oban.drain_queue(queue: :critical_events, with_recursion: true)
   end
 
   describe "full invite claim saga" do
-    setup context do
-      # Trigger: provider_profile_schema factory calls unconfirmed_user_fixture(:provider)
-      # Why: with real PubSub, ProviderEventHandler receives user_registered and creates a
-      #      provider profile — then factory's Repo.insert! duplicates the identity_id → crash
-      # Outcome: create test data FIRST with test publisher, then swap to real PubSub
-      invite_data = create_claimable_invite(context)
+    test "claim_invite drives user -> registered -> family -> enrolled", ctx do
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        assert {:ok, %ClaimResult{user_type: :new_user, user: user}} = Enrollment.claim_invite(ctx.token)
 
-      # Trigger: test config uses TestOutbox (process dictionary storage)
-      # Why: the claim must actually stage its events so the
-      #      EventSubscriber GenServers receive the events and drive the saga forward
-      # Outcome: swap to real PubSub publisher for this test, restore in on_exit
-      original_config = Application.get_env(:klass_hero, :integration_event_publisher)
+        # Marking the invite registered and staging the claim are one transaction, so this
+        # holds before anything has been delivered.
+        registered = Repo.get!(BulkEnrollmentInvite, ctx.invite.id)
+        assert registered.status == :registered
+        assert registered.registered_at != nil
 
-      Application.put_env(:klass_hero, :integration_event_publisher,
-        module: PubSubEventPublisher,
-        pubsub: KlassHero.PubSub
-      )
+        run_saga()
 
-      # The saga now crosses both transports: Enrollment stages `invite_claimed` in the
-      # outbox, Family still publishes `invite_family_ready`. Both have to be real for
-      # the chain to run end to end; the second swap goes when the last producer moves.
-      original_outbox = Application.get_env(:klass_hero, :outbox)
-      Application.put_env(:klass_hero, :outbox, module: ObanOutbox)
+        final = Repo.get!(BulkEnrollmentInvite, ctx.invite.id)
+        assert final.status == :enrolled
+        assert final.enrolled_at != nil
+        assert final.enrollment_id != nil
 
-      on_exit(fn ->
-        Application.put_env(:klass_hero, :integration_event_publisher, original_config)
-        Application.put_env(:klass_hero, :outbox, original_outbox)
+        assert {:ok, parent} = Family.get_parent_by_identity(user.id)
+        assert Enum.any?(Family.get_children(parent.id), &(&1.first_name == "Emma"))
       end)
-
-      # Trigger: EventSubscriber GenServers run in separate processes outside the test
-      # Why: they need DB access to handle integration events (create parent, child, enrollment)
-      # Outcome: allow each subscriber to share the test process's sandboxed connection
-      Enum.each(@saga_subscribers, fn subscriber_name ->
-        case Process.whereis(subscriber_name) do
-          nil -> :ok
-          pid -> Sandbox.allow(KlassHero.Repo, self(), pid)
-        end
-      end)
-
-      invite_data
     end
 
-    test "claim_invite triggers the full saga: user -> registered -> family -> enrolled", %{
-      token: token,
-      invite: invite
-    } do
-      # Step 1: Claim the invite. Marking it registered and staging the cross-context
-      # event happen in one transaction.
-      #
-      # Manual mode, then an explicit drain, is what makes this test model production:
-      # under the suite's `testing: :inline`, staging would execute the delivery job
-      # inside the producer's transaction, which is a sequencing production never has.
-      assert {:ok, %ClaimResult{user_type: :new_user, user: user}} =
-               Oban.Testing.with_testing_mode(:manual, fn -> Enrollment.claim_invite(token) end)
+    # #1221, end to end. The guardian has already been told their account exists by the
+    # time this hop runs, so a failure here left them with an account, no child and no
+    # enrollment, and the invite stuck in :registered where no :failed filter could find it.
+    test "a claim the family hop cannot process ends failed, not stuck", ctx do
+      # Written past the invite changeset, which requires a first name. Both layers reject
+      # this, so reaching the state takes a deliberate write — `child_date_of_birth` is
+      # NOT NULL in the database and cannot be emptied at all. What is being exercised is
+      # the failure path, not a claim that this row is easy to produce. It fails the same
+      # way on every attempt, which is the part that matters.
+      ctx.invite
+      |> Ecto.Changeset.change(%{child_first_name: ""})
+      |> Repo.update!()
 
-      # Step 2: Verify the synchronous effect of the bus handler.
-      updated = Repo.get!(BulkEnrollmentInvite, invite.id)
-      assert updated.status == :registered
-      assert updated.registered_at != nil
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        assert {:ok, %ClaimResult{user: user}} = Enrollment.claim_invite(ctx.token)
 
-      # Step 3: Deliver the staged event, as a queue worker would after the commit.
-      # with_recursion so events staged by the handlers this drains are drained too.
-      Oban.drain_queue(queue: :critical_events, with_recursion: true)
+        run_saga()
 
-      # Step 4: The remainder still travels by PubSub — Family publishes
-      # :invite_family_ready, and Enrollment's subscriber creates the enrollment.
-      assert_eventually(
-        fn ->
-          final = Repo.get!(BulkEnrollmentInvite, invite.id)
-          final.status == :enrolled
-        end,
-        timeout_ms: 5000,
-        interval_ms: 100
-      )
+        final = Repo.get!(BulkEnrollmentInvite, ctx.invite.id)
+        assert final.status == :failed
+        assert final.error_details =~ "first name"
 
-      # Verify terminal invite state
-      final = Repo.get!(BulkEnrollmentInvite, invite.id)
-      assert final.status == :enrolled
-      assert final.enrolled_at != nil
-      assert final.enrollment_id != nil
+        # The account is real and stays; only the enrollment never happened.
+        assert Accounts.get_user_by_email(ctx.email).id == user.id
 
-      # Verify family was created
-      assert {:ok, parent} = Family.get_parent_by_identity(user.id)
-      children = Family.get_children(parent.id)
-      assert [_ | _] = children
-      assert Enum.any?(children, &(&1.first_name == "Emma"))
+        {:ok, parent} = Family.get_parent_by_identity(user.id)
+        assert Family.get_children(parent.id) == []
+      end)
     end
   end
 end

--- a/test/klass_hero/family/adapters/driving/workers/process_invite_claim_worker_test.exs
+++ b/test/klass_hero/family/adapters/driving/workers/process_invite_claim_worker_test.exs
@@ -138,14 +138,30 @@ defmodule KlassHero.Family.Adapters.Driving.Workers.ProcessInviteClaimWorkerTest
       end
     end
 
-    test "fails the invite on the final attempt, recording the reason", ctx do
+    # error_details is read by a provider in the invites table, not by a developer in a
+    # log, so a raw inspect/1 of the changeset would be no more actionable than the
+    # silence it replaced.
+    test "fails the invite on the final attempt, recording a readable reason", ctx do
       args = failing_args(ctx.invite, ctx.program, ctx.user)
 
       assert {:error, _reason} = ProcessInviteClaimWorker.execute(job(args, @max_attempts))
 
       failed = reload(ctx.invite)
       assert failed.status == :failed
-      assert is_binary(failed.error_details)
+      assert failed.error_details =~ "date of birth"
+      assert failed.error_details =~ "can't be blank"
+      refute failed.error_details =~ "Ecto.Changeset"
+    end
+
+    test "records a reason for a failure that carries no changeset", ctx do
+      args =
+        ctx.invite
+        |> failing_args(ctx.program, ctx.user)
+        |> Map.put("child_date_of_birth", "not-a-date")
+
+      assert {:error, _reason} = ProcessInviteClaimWorker.execute(job(args, @max_attempts))
+
+      assert reload(ctx.invite).error_details =~ "not-a-date"
     end
 
     # Oban reads retry/discard off the return value; compensating must not look to it

--- a/test/klass_hero/family/adapters/driving/workers/process_invite_claim_worker_test.exs
+++ b/test/klass_hero/family/adapters/driving/workers/process_invite_claim_worker_test.exs
@@ -2,9 +2,14 @@ defmodule KlassHero.Family.Adapters.Driving.Workers.ProcessInviteClaimWorkerTest
   use KlassHero.DataCase, async: true
 
   import KlassHero.AccountsFixtures
+  import KlassHero.Factory
 
+  alias KlassHero.Enrollment
+  alias KlassHero.Enrollment.BulkEnrollmentInvite
   alias KlassHero.Family
   alias KlassHero.Family.Adapters.Driving.Workers.ProcessInviteClaimWorker
+
+  @max_attempts 3
 
   describe "perform/1" do
     test "processes invite claim and creates parent + child" do
@@ -68,6 +73,111 @@ defmodule KlassHero.Family.Adapters.Driving.Workers.ProcessInviteClaimWorkerTest
       # Will fail at domain validation (date_of_birth required), but worker should not crash
       result = ProcessInviteClaimWorker.perform(job)
       assert {:error, _reason} = result
+    end
+  end
+
+  # #1221: until this existed, a claim that failed here left the guardian with an account,
+  # no child and no enrollment, and froze the invite in :registered forever — a state no
+  # list filtering on :failed could show. These build %Oban.Job{} structs by hand because
+  # the behaviour under test is a decision about attempt vs max_attempts, and a drained
+  # queue cannot express "this is the second of three tries".
+  describe "execute/1 compensation" do
+    setup do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+      user = user_fixture()
+
+      {:ok, _} =
+        Enrollment.create_invite(%{
+          program_id: program.id,
+          provider_id: provider.id,
+          child_first_name: "Emma",
+          child_last_name: "Schmidt",
+          child_date_of_birth: ~D[2016-03-15],
+          guardian_email: "parent-#{System.unique_integer([:positive])}@example.com"
+        })
+
+      # The claim already happened: ClaimInvite marked the invite registered and told the
+      # guardian their account exists. Everything this worker does happens after that.
+      invite =
+        BulkEnrollmentInvite
+        |> Repo.one!()
+        |> Ecto.Changeset.change(%{invite_token: "tok-1", status: :registered})
+        |> Repo.update!()
+
+      %{invite: invite, program: program, user: user}
+    end
+
+    # A nil date of birth fails Family.Child's validate_required the same way on every
+    # attempt — the deterministic failure the issue describes.
+    defp failing_args(invite, program, user) do
+      %{
+        "invite_id" => invite.id,
+        "user_id" => user.id,
+        "program_id" => program.id,
+        "child_first_name" => "Emma",
+        "child_last_name" => "Schmidt",
+        "child_date_of_birth" => nil
+      }
+    end
+
+    defp job(args, attempt), do: %Oban.Job{args: args, attempt: attempt, max_attempts: @max_attempts}
+
+    defp reload(invite), do: Repo.get!(BulkEnrollmentInvite, invite.id)
+
+    # failed -> enrolled is not a legal transition, so failing the invite while Oban would
+    # still retry destroys a claim the next attempt would have healed.
+    test "leaves the invite registered while retries remain", ctx do
+      args = failing_args(ctx.invite, ctx.program, ctx.user)
+
+      for attempt <- 1..(@max_attempts - 1) do
+        assert {:error, _reason} = ProcessInviteClaimWorker.execute(job(args, attempt))
+
+        assert reload(ctx.invite).status == :registered,
+               "attempt #{attempt} of #{@max_attempts} failed the invite before retries were exhausted"
+      end
+    end
+
+    test "fails the invite on the final attempt, recording the reason", ctx do
+      args = failing_args(ctx.invite, ctx.program, ctx.user)
+
+      assert {:error, _reason} = ProcessInviteClaimWorker.execute(job(args, @max_attempts))
+
+      failed = reload(ctx.invite)
+      assert failed.status == :failed
+      assert is_binary(failed.error_details)
+    end
+
+    # Oban reads retry/discard off the return value; compensating must not look to it
+    # like the job succeeded.
+    test "still returns the error after compensating", ctx do
+      args = failing_args(ctx.invite, ctx.program, ctx.user)
+
+      assert {:error, _reason} = ProcessInviteClaimWorker.execute(job(args, @max_attempts))
+    end
+
+    # Lifeline can re-run a job whose earlier attempt already committed, so the final
+    # attempt can arrive at an invite that has moved on. transition_invite/2 rejects
+    # enrolled -> failed, and that rejection is the correct outcome, not a crash.
+    test "does not disturb an invite that already reached a terminal state", ctx do
+      {:ok, enrolled} = Enrollment.transition_invite(ctx.invite, %{status: :enrolled})
+      args = failing_args(ctx.invite, ctx.program, ctx.user)
+
+      assert {:error, _reason} = ProcessInviteClaimWorker.execute(job(args, @max_attempts))
+
+      assert reload(enrolled).status == :enrolled
+    end
+
+    test "leaves the invite alone when the claim succeeds", ctx do
+      args =
+        ctx.invite
+        |> failing_args(ctx.program, ctx.user)
+        |> Map.put("child_date_of_birth", "2016-03-15")
+
+      assert :ok = ProcessInviteClaimWorker.execute(job(args, 1))
+
+      # Reaching :enrolled is InviteFamilyReadyHandler's job, one hop downstream.
+      assert reload(ctx.invite).status == :registered
     end
   end
 end

--- a/test/klass_hero/shared/changeset_errors_test.exs
+++ b/test/klass_hero/shared/changeset_errors_test.exs
@@ -1,9 +1,9 @@
-defmodule KlassHero.Enrollment.ChangesetErrorsTest do
+defmodule KlassHero.Shared.ChangesetErrorsTest do
   use ExUnit.Case, async: true
 
   import Ecto.Changeset
 
-  alias KlassHero.Enrollment.ChangesetErrors
+  alias KlassHero.Shared.ChangesetErrors
 
   # A small inline changeset module so these tests don't depend on a
   # persistence schema — the helper works on any Ecto.Changeset regardless

--- a/test/klass_hero/shared/error_context_filter_test.exs
+++ b/test/klass_hero/shared/error_context_filter_test.exs
@@ -1,0 +1,79 @@
+defmodule KlassHero.Shared.ErrorContextFilterTest do
+  use ExUnit.Case, async: true
+
+  alias KlassHero.Shared.ErrorContextFilter
+
+  describe "sanitize/1 on Oban job args" do
+    test "keeps correlation ids and the trace context" do
+      context = %{
+        "job.args" => %{
+          "invite_id" => "inv-1",
+          "user_id" => "usr-1",
+          "program_id" => "prg-1",
+          "trace_context" => %{"traceparent" => "00-abc-def-01"}
+        }
+      }
+
+      assert %{"job.args" => args} = ErrorContextFilter.sanitize(context)
+
+      assert args == %{
+               "invite_id" => "inv-1",
+               "user_id" => "usr-1",
+               "program_id" => "prg-1",
+               "trace_context" => %{"traceparent" => "00-abc-def-01"}
+             }
+    end
+
+    # The reason this filter exists: ProcessInviteClaimWorker's args carry a child's
+    # name, date of birth and medical conditions, and ErrorTracker persists context to
+    # the production database on every failure.
+    test "drops child identity and health fields" do
+      context = %{
+        "job.args" => %{
+          "invite_id" => "inv-1",
+          "child_first_name" => "Emma",
+          "child_last_name" => "Schmidt",
+          "child_date_of_birth" => "2016-03-15",
+          "medical_conditions" => "Asthma",
+          "nut_allergy" => true,
+          "school_name" => "Berlin Elementary"
+        }
+      }
+
+      assert %{"job.args" => args} = ErrorContextFilter.sanitize(context)
+
+      assert Map.keys(args) == ["invite_id"]
+    end
+
+    # Key names are not PII, and an operator who cannot see that anything was removed
+    # will read the surviving args as the whole story.
+    test "records which keys were redacted, by name only" do
+      context = %{"job.args" => %{"invite_id" => "inv-1", "medical_conditions" => "Asthma"}}
+
+      assert %{"job.args.redacted" => redacted} = ErrorContextFilter.sanitize(context)
+      assert redacted == ["medical_conditions"]
+    end
+
+    test "adds no redaction key when nothing was dropped" do
+      context = %{"job.args" => %{"invite_id" => "inv-1"}}
+
+      refute Map.has_key?(ErrorContextFilter.sanitize(context), "job.args.redacted")
+    end
+  end
+
+  describe "sanitize/1 on everything else" do
+    # The router sets user_id/email via ErrorTracker.set_context/1. Those are deliberate
+    # and pre-date this filter; narrowing to job args must leave them alone.
+    test "passes non-job context through untouched" do
+      context = %{"job.queue" => "family", user_id: "usr-1", email: "parent@example.com"}
+
+      assert ErrorContextFilter.sanitize(context) == context
+    end
+
+    test "leaves a non-map job.args alone" do
+      context = %{"job.args" => "not-a-map"}
+
+      assert ErrorContextFilter.sanitize(context) == context
+    end
+  end
+end

--- a/test/klass_hero_web/live/provider/provider_dashboard_test.exs
+++ b/test/klass_hero_web/live/provider/provider_dashboard_test.exs
@@ -13,6 +13,7 @@ defmodule KlassHeroWeb.Provider.ProviderDashboardTest do
   import Phoenix.LiveViewTest
 
   alias Ecto.Adapters.SQL.Sandbox
+  alias KlassHero.Enrollment.BulkEnrollmentInvite
   alias KlassHero.ProgramCatalog.ProgramListing
   alias KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails
   alias KlassHero.ProviderFixtures
@@ -505,6 +506,34 @@ defmodule KlassHeroWeb.Provider.ProviderDashboardTest do
       view |> element("#roster-tab-invites") |> render_click()
 
       assert has_element?(view, "[phx-click=delete_invite]")
+    end
+
+    # #1221: a failed invite showed a red pill and nothing else, so the provider could see
+    # that something broke but not what, nor whether resending could possibly help.
+    test "shows why a failed invite failed", %{conn: conn, program: program} do
+      invite = Repo.one!(BulkEnrollmentInvite)
+
+      invite
+      |> Ecto.Changeset.change(%{status: :failed, error_details: "date of birth can't be blank"})
+      |> Repo.update!()
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+
+      view |> element("#view-roster-#{program.id}") |> render_click()
+      view |> element("#roster-tab-invites") |> render_click()
+
+      assert has_element?(view, "#invite-error-#{invite.id}", "date of birth can't be blank")
+    end
+
+    test "shows no reason line for an invite that has not failed", %{conn: conn, program: program} do
+      invite = Repo.one!(BulkEnrollmentInvite)
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+
+      view |> element("#view-roster-#{program.id}") |> render_click()
+      view |> element("#roster-tab-invites") |> render_click()
+
+      refute has_element?(view, "#invite-error-#{invite.id}")
     end
   end
 


### PR DESCRIPTION
Closes #1221

## Summary

A guardian clicks their invite link, `ClaimInvite` creates their account and returns — everything after that is asynchronous. If the next hop (`Family.ProcessInviteClaim`) failed, it logged, returned `{:error, reason}`, and stopped. Oban retried three times and discarded the job. The guardian was left with an account, no child and no enrollment, and the invite frozen in `:registered` — a state no list filtering on `:failed` could show.

Four changes, each independently reviewable:

**1. Oban failures reach production error tracking.** `ErrorTracker.Integrations.Oban.attach/0` was never called anywhere in `lib/` or `config/`, so *no* Oban failure from *any* worker has ever reached the `error_tracker` tables. Attached alongside the existing boot-time handlers in `KlassHeroWeb.Telemetry`, which starts before `{Oban, ...}`.

**2. The invite fails when the claim hop gives up.** Compensation gated on `attempt >= max_attempts` — the same idiom `FetchEmailContentWorker:56` and `SendEmailReplyWorker:77` already use.

**3. The provider can see why.** `error_details` was written by three call sites and rendered by zero, so a failed invite showed a red pill and nothing else.

**4. The saga test's failure path is covered**, and its dead scaffolding removed.

## Review focus

- **Why the final attempt, not the first.** `failed -> enrolled` is not a legal transition (`bulk_enrollment_invite.ex:77-83`). Compensating on a transient attempt-1 failure would permanently destroy a claim that attempt 2 heals. This is not hypothetical — `SendInviteEmailWorker` gets it wrong today (filed as #1233).
- **A rejected transition is treated as success.** It means the invite is already terminal — enrolled by a retry, or failed by an earlier pass — which is a fact, not a fault. The original error is still returned so Oban records the failure.
- **`ChangesetErrors` moved to `Shared`.** `inspect/1` of a rejected changeset names the problem to a developer, not to the person who uploaded the CSV row, so the reason is now formatted as e.g. `"date of birth can't be blank"`. That formatting is pure Ecto and knew nothing about Enrollment; Family cannot reach into another context's internals, and duplicating it was the worse option. Two call sites updated.
- **PII.** The Oban integration sets the whole of `job.args` as ErrorTracker context on every job start, and context is persisted with each occurrence. `ProcessInviteClaimWorker`'s args carry a child's name, date of birth and `medical_conditions`. `Shared.ErrorContextFilter` allowlists correlation ids instead, and records the *names* of dropped keys so an operator can tell something was removed. Disabled in test, where `enabled?/0` gates before the insert.

## Not in scope (filed)

- **#1234** — `Oban.Plugins.Lifeline` discards orphaned jobs at `attempt >= max_attempts` with a bare `UPDATE`, without running the worker, so a node dying mid-final-attempt still skips compensation. Pre-existing and shared by three workers; a bug fix is the wrong place to introduce shared job infrastructure for the first time.
- **#1233** — `SendInviteEmailWorker` fails an invite on the first delivery error, then reports `:ok` on the retry.

## Test plan

- `MIX_TEST_PARTITION=1221 mix precommit` — 4014 passed, credo clean, typography and translations pass.
- Both new guards were proven red before green: neutralising `ErrorContextFilter.sanitize/1` fails the two redaction tests; forcing `final_attempt?/1` to `true` fails the retries-remain test with `"attempt 1 of 3 failed the invite before retries were exhausted"`.
- The saga test drives all three attempts via `drain_queue(with_scheduled: true)`, so the end-to-end path exercises real exhaustion rather than a hand-built job struct.

### Notes for the reviewer

- Gettext churn is line references only — no `msgid` or `msgstr` changed.
- The removed saga scaffolding referenced `PubSubEventPublisher`, a module PR 6 deleted; this test file held the only remaining reference in the repo.
- `child_date_of_birth` is `NOT NULL` on `bulk_enrollment_invites`, so the issue's null-date scenario cannot reach the family hop through the real path at all. The failure is provoked with a blank first name instead. This narrows the reachability of #1221 further than the issue estimated — the fix is about the unhandled *path*, not a common trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)