### PR TITLE
fix: compensate an invite only once Oban retries are exhausted

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -5,7 +5,7 @@ alias KlassHero.Provider.StripeIdentity
 alias KlassHero.Shared.Adapters.Driven.Events.TestOutbox
 alias KlassHero.Shared.Adapters.Driven.FeatureFlags.StubFeatureFlagsAdapter
 alias KlassHero.Shared.Adapters.Driven.Storage.StubStorageAdapter
-alias Swoosh.Adapters.Test
+alias KlassHero.Test.StubMailerAdapter
 
 # The one source of truth for the test HTTP port, shared by the endpoint and Wallaby's
 # base_url below. Override with TEST_PORT when 4002 is taken (another worktree, or an
@@ -23,7 +23,9 @@ config :error_tracker, enabled: false
 # Disable fun_with_flags PubSub notifications in tests
 config :fun_with_flags, :cache_bust_notifications, enabled: false
 
-config :klass_hero, KlassHero.Mailer, adapter: Test
+# Delegates to Swoosh.Adapters.Test unless a test arms a failure — Swoosh has no
+# built-in way to make delivery fail, which left every send-failure path untestable.
+config :klass_hero, KlassHero.Mailer, adapter: StubMailerAdapter
 
 config :klass_hero, KlassHero.Repo,
   username: "postgres",

--- a/lib/klass_hero/enrollment/adapters/driving/workers/send_invite_email_worker.ex
+++ b/lib/klass_hero/enrollment/adapters/driving/workers/send_invite_email_worker.ex
@@ -15,7 +15,7 @@ defmodule KlassHero.Enrollment.Adapters.Driving.Workers.SendInviteEmailWorker do
   require Logger
 
   @impl true
-  def execute(%Oban.Job{args: %{"invite_id" => invite_id, "program_name" => program_name}}) do
+  def execute(%Oban.Job{args: %{"invite_id" => invite_id, "program_name" => program_name}} = job) do
     case Enrollment.get_invite(invite_id) do
       {:error, :not_found} ->
         Logger.warning("[SendInviteEmailWorker] Invite not found", invite_id: invite_id)
@@ -30,16 +30,26 @@ defmodule KlassHero.Enrollment.Adapters.Driving.Workers.SendInviteEmailWorker do
 
         :ok
 
-      {:ok, %BulkEnrollmentInvite{invite_token: nil}} ->
+      # Every retry re-reads the same nil token, so the remaining attempts are
+      # guaranteed waste — cancel rather than spend them. Failing the invite here is
+      # what makes it visible: left :pending it would sit forever with no email sent
+      # and nothing to show the provider. A resend mints a fresh token.
+      {:ok, %BulkEnrollmentInvite{invite_token: nil} = invite} ->
         Logger.warning("[SendInviteEmailWorker] Invite has no token", invite_id: invite_id)
-        {:error, "invite has no token"}
+
+        Enrollment.transition_invite(invite, %{
+          status: :failed,
+          error_details: "Invite link could not be generated (no token). Please resend."
+        })
+
+        {:cancel, "invite has no token"}
 
       {:ok, %BulkEnrollmentInvite{} = invite} ->
-        send_and_transition(invite, program_name)
+        send_and_transition(invite, program_name, job)
     end
   end
 
-  defp send_and_transition(invite, program_name) do
+  defp send_and_transition(invite, program_name, job) do
     invite_url = "#{base_url()}/invites/#{invite.invite_token}"
 
     case InviteEmailNotifier.send_invite(invite, program_name, invite_url) do
@@ -70,10 +80,16 @@ defmodule KlassHero.Enrollment.Adapters.Driving.Workers.SendInviteEmailWorker do
           reason: inspect(reason)
         )
 
-        Enrollment.transition_invite(invite, %{
-          status: :failed,
-          error_details: "Email delivery failed: #{inspect(reason)}"
-        })
+        # Only once Oban is done retrying. `pending -> :failed` is a one-way door —
+        # `:failed` can only go back to `:pending` — and the non-pending guard above
+        # then turns every retry into a silent :ok, so failing early both destroys the
+        # send the next attempt makes and hides that it did (#1233).
+        if TracedWorker.final_attempt?(job) do
+          Enrollment.transition_invite(invite, %{
+            status: :failed,
+            error_details: "Email delivery failed: #{inspect(reason)}"
+          })
+        end
 
         {:error, reason}
     end

--- a/lib/klass_hero/family/adapters/driving/workers/process_invite_claim_worker.ex
+++ b/lib/klass_hero/family/adapters/driving/workers/process_invite_claim_worker.ex
@@ -30,15 +30,13 @@ defmodule KlassHero.Family.Adapters.Driving.Workers.ProcessInviteClaimWorker do
       :ok
     else
       {:error, reason} = error ->
-        if final_attempt?(job), do: fail_invite(args["invite_id"], reason)
+        # Only once Oban is done retrying. `registered -> :failed` is a one-way door —
+        # `:failed` can only go back to `:pending` — so failing the invite on an earlier
+        # attempt would destroy a claim that the next attempt heals.
+        if TracedWorker.final_attempt?(job), do: fail_invite(args["invite_id"], reason)
         error
     end
   end
-
-  # Only once Oban is done retrying. `registered -> :failed` is a one-way door — `:failed`
-  # can only go back to `:pending` — so failing the invite on an earlier attempt would
-  # destroy a claim that the next attempt heals.
-  defp final_attempt?(%Oban.Job{attempt: attempt, max_attempts: max_attempts}), do: attempt >= max_attempts
 
   # The invite belongs to Enrollment, so this goes through its facade rather than touching
   # the schema. A rejected transition means the invite is already terminal — enrolled by a

--- a/lib/klass_hero/messaging/adapters/driving/workers/fetch_email_content_worker.ex
+++ b/lib/klass_hero/messaging/adapters/driving/workers/fetch_email_content_worker.ex
@@ -11,6 +11,7 @@ defmodule KlassHero.Messaging.Adapters.Driving.Workers.FetchEmailContentWorker d
   alias KlassHero.Messaging
   alias KlassHero.Messaging.Adapters.Driven.ResendEmailContentAdapter
   alias KlassHero.Shared.RateLimitedEmailWorker
+  alias KlassHero.Shared.Tracing.TracedWorker
 
   require Logger
 
@@ -53,7 +54,7 @@ defmodule KlassHero.Messaging.Adapters.Driving.Workers.FetchEmailContentWorker d
   end
 
   defp maybe_mark_permanently_failed(email_id, job) do
-    if job.attempt >= job.max_attempts do
+    if TracedWorker.final_attempt?(job) do
       case Messaging.update_inbound_email_content(email_id, %{content_status: "failed"}) do
         {:ok, _} ->
           Logger.error("Marked email #{email_id} content as permanently failed")

--- a/lib/klass_hero/messaging/adapters/driving/workers/send_email_reply_worker.ex
+++ b/lib/klass_hero/messaging/adapters/driving/workers/send_email_reply_worker.ex
@@ -11,6 +11,7 @@ defmodule KlassHero.Messaging.Adapters.Driving.Workers.SendEmailReplyWorker do
 
   alias KlassHero.Messaging
   alias KlassHero.Shared.RateLimitedEmailWorker
+  alias KlassHero.Shared.Tracing.TracedWorker
 
   require Logger
 
@@ -74,7 +75,7 @@ defmodule KlassHero.Messaging.Adapters.Driving.Workers.SendEmailReplyWorker do
   end
 
   defp mark_reply_failed_if_final(reply_id, job) do
-    if job.attempt >= job.max_attempts do
+    if TracedWorker.final_attempt?(job) do
       case Messaging.update_email_reply_status(reply_id, "failed", %{}) do
         {:ok, _} ->
           Logger.error("Marked reply #{reply_id} as permanently failed")

--- a/lib/klass_hero/shared/adapters/driven/workers/event_delivery_worker.ex
+++ b/lib/klass_hero/shared/adapters/driven/workers/event_delivery_worker.ex
@@ -78,7 +78,13 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorker do
   end
 
   # error once retries are exhausted (ErrorTracker alerts on it), warning while any remain.
-  defp log_consumer_failure(event, topic, handler_ref, reason, %Oban.Job{attempt: attempt, max_attempts: max_attempts}) do
+  defp log_consumer_failure(
+         event,
+         topic,
+         handler_ref,
+         reason,
+         %Oban.Job{attempt: attempt, max_attempts: max_attempts} = job
+       ) do
     metadata = [
       event_id: event.event_id,
       topic: topic,
@@ -88,7 +94,7 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorker do
       max_attempts: max_attempts
     ]
 
-    if attempt >= max_attempts do
+    if TracedWorker.final_attempt?(job) do
       Logger.error(
         "Event delivery permanently failed after #{max_attempts} attempts: #{topic} -> #{handler_ref}",
         metadata

--- a/lib/klass_hero/shared/tracing/traced_worker.ex
+++ b/lib/klass_hero/shared/tracing/traced_worker.ex
@@ -29,11 +29,24 @@ defmodule KlassHero.Shared.Tracing.TracedWorker do
 
   @callback execute(Oban.Job.t()) :: :ok | {:ok, term()} | {:error, term()}
 
+  @doc """
+  True once Oban has no retries left for this job.
+
+  Workers gate compensating actions on this: a compensation applied while
+  retries remain destroys the state the next attempt would have healed.
+
+  `>=` rather than `==` because Lifeline re-runs a job orphaned by a node
+  crash, so an attempt can arrive already past the ceiling.
+  """
+  @spec final_attempt?(Oban.Job.t()) :: boolean()
+  def final_attempt?(%Oban.Job{attempt: attempt, max_attempts: max_attempts}) do
+    attempt >= max_attempts
+  end
+
   @doc false
   @spec record_result(term(), Oban.Job.t()) :: :ok
   def record_result({:error, _reason}, %Oban.Job{} = job) do
-    will_retry = job.attempt < job.max_attempts
-    Tracing.set_attribute("oban.will_retry", will_retry)
+    Tracing.set_attribute("oban.will_retry", not final_attempt?(job))
     OpenTelemetry.Tracer.set_status(:error, "job failed")
     :ok
   end

--- a/lib/klass_hero/shared/tracing/traced_worker.ex
+++ b/lib/klass_hero/shared/tracing/traced_worker.ex
@@ -51,6 +51,15 @@ defmodule KlassHero.Shared.Tracing.TracedWorker do
     :ok
   end
 
+  # A cancel is a failure the worker knows no retry can fix, so it belongs in the same
+  # error-status queries as a plain failure. Falling through to the no-op clause would
+  # make a job that gave up look, in the trace, exactly like one that succeeded.
+  def record_result({:cancel, _reason}, %Oban.Job{}) do
+    Tracing.set_attribute("oban.will_retry", false)
+    OpenTelemetry.Tracer.set_status(:error, "job cancelled")
+    :ok
+  end
+
   def record_result(_result, %Oban.Job{} = _job), do: :ok
 
   defmacro __using__(opts) do

--- a/test/klass_hero/enrollment/adapters/driven/notifications/invite_email_notifier_test.exs
+++ b/test/klass_hero/enrollment/adapters/driven/notifications/invite_email_notifier_test.exs
@@ -2,8 +2,9 @@ defmodule KlassHero.Enrollment.Adapters.Driven.Notifications.InviteEmailNotifier
   @moduledoc """
   Tests for the InviteEmailNotifier adapter.
 
-  Uses Swoosh.Adapters.Test (configured in test env) which returns
-  {:ok, %{}} from Mailer.deliver/1, so send_invite/3 returns {:ok, email}.
+  Delivery goes through StubMailerAdapter (configured in test env), which passes
+  to Swoosh.Adapters.Test unless a test arms a failure — so Mailer.deliver/1
+  returns {:ok, %{}} here and send_invite/3 returns {:ok, email}.
   """
 
   # async: false — the interaction telemetry handler is global, so suite-wide

--- a/test/klass_hero/enrollment/adapters/driving/workers/send_invite_email_worker_test.exs
+++ b/test/klass_hero/enrollment/adapters/driving/workers/send_invite_email_worker_test.exs
@@ -2,10 +2,12 @@ defmodule KlassHero.Enrollment.Adapters.Driving.Workers.SendInviteEmailWorkerTes
   use KlassHero.DataCase, async: true
 
   import KlassHero.Factory
+  import Swoosh.TestAssertions
 
   alias KlassHero.Enrollment.Adapters.Driving.Workers.SendInviteEmailWorker
   alias KlassHero.Enrollment.BulkEnrollmentInvite
   alias KlassHero.Repo
+  alias KlassHero.Test.StubMailerAdapter
 
   defp create_pending_invite(_context) do
     provider = insert(:provider_profile_schema)
@@ -63,13 +65,88 @@ defmodule KlassHero.Enrollment.Adapters.Driving.Workers.SendInviteEmailWorkerTes
                })
     end
 
-    test "returns error when invite has no token", %{invite: invite, program: program} do
+    # A retry re-reads the same nil token, so every remaining attempt is guaranteed
+    # waste — cancel instead of burning the retry budget, and fail the invite now so
+    # it surfaces as Failed rather than sitting :pending with no email forever.
+    test "cancels and fails an invite that has no token", %{invite: invite, program: program} do
       invite |> Ecto.Changeset.change(%{invite_token: nil}) |> Repo.update!()
 
-      assert {:error, "invite has no token"} =
+      assert {:cancel, "invite has no token"} =
                SendInviteEmailWorker.perform(%Oban.Job{
                  args: %{"invite_id" => invite.id, "program_name" => program.title}
                })
+
+      failed = Repo.get!(BulkEnrollmentInvite, invite.id)
+      assert failed.status == :failed
+      assert failed.error_details =~ "no token"
+    end
+  end
+
+  # #1233: this worker failed the invite on the *first* delivery error, then returned
+  # {:error, _} so Oban retried — and the retry hit the non-pending guard above and
+  # reported :ok. One transient blip permanently failed an invite and called it a
+  # success. These build %Oban.Job{} structs by hand because the behaviour under test
+  # is a decision about attempt vs max_attempts, which a drained queue cannot express.
+  describe "execute/1 compensation" do
+    setup :create_pending_invite
+
+    @max_attempts 3
+
+    defp job(invite, program, attempt) do
+      %Oban.Job{
+        args: %{"invite_id" => invite.id, "program_name" => program.title},
+        attempt: attempt,
+        max_attempts: @max_attempts
+      }
+    end
+
+    defp reload(invite), do: Repo.get!(BulkEnrollmentInvite, invite.id)
+
+    # pending -> :failed is a one-way door (:failed can only return to :pending), so
+    # failing while Oban would still retry destroys the send the next attempt makes.
+    test "leaves the invite pending while retries remain", %{invite: invite, program: program} do
+      StubMailerAdapter.fail_with({:network, :timeout})
+
+      for attempt <- 1..(@max_attempts - 1) do
+        assert {:error, _reason} = SendInviteEmailWorker.execute(job(invite, program, attempt))
+
+        assert reload(invite).status == :pending,
+               "attempt #{attempt} of #{@max_attempts} failed the invite before retries were exhausted"
+      end
+    end
+
+    # The whole point of retrying: the guardian gets the invite a blip nearly cost them.
+    test "delivers on the retry after a transient failure", %{invite: invite, program: program} do
+      StubMailerAdapter.fail_with({:network, :timeout})
+      assert {:error, _reason} = SendInviteEmailWorker.execute(job(invite, program, 1))
+
+      StubMailerAdapter.deliver_normally()
+      assert :ok = SendInviteEmailWorker.execute(job(invite, program, 2))
+
+      delivered = reload(invite)
+      assert delivered.status == :invite_sent
+      assert delivered.invite_sent_at != nil
+      assert_email_sent(fn email -> email.to == [{"Hans", "parent@example.com"}] end)
+    end
+
+    test "fails the invite once retries are exhausted", %{invite: invite, program: program} do
+      StubMailerAdapter.fail_with({:network, :timeout})
+
+      assert {:error, _reason} =
+               SendInviteEmailWorker.execute(job(invite, program, @max_attempts))
+
+      failed = reload(invite)
+      assert failed.status == :failed
+      assert failed.error_details =~ "Email delivery failed"
+    end
+
+    # Oban reads retry/discard off the return value; compensating must not look to it
+    # like the job succeeded, or the failure is invisible in the jobs table too.
+    test "still returns the error after compensating", %{invite: invite, program: program} do
+      StubMailerAdapter.fail_with({:network, :timeout})
+
+      assert {:error, _reason} =
+               SendInviteEmailWorker.execute(job(invite, program, @max_attempts))
     end
   end
 end

--- a/test/klass_hero/messaging/adapters/driving/workers/send_email_reply_worker_test.exs
+++ b/test/klass_hero/messaging/adapters/driving/workers/send_email_reply_worker_test.exs
@@ -4,6 +4,7 @@ defmodule KlassHero.Messaging.Adapters.Driving.Workers.SendEmailReplyWorkerTest 
   alias KlassHero.Messaging
   alias KlassHero.Messaging.Adapters.Driving.Workers.SendEmailReplyWorker
   alias KlassHero.MessagingFixtures
+  alias KlassHero.Test.StubMailerAdapter
 
   describe "perform/1" do
     test "delivers reply and updates status to sent" do
@@ -24,16 +25,38 @@ defmodule KlassHero.Messaging.Adapters.Driving.Workers.SendEmailReplyWorkerTest 
       assert updated.sent_at != nil
     end
 
+    # Until StubMailerAdapter existed there was no way to fail a delivery, so this test
+    # asserted the happy path under a failure name and could never have gone red.
+    test "leaves the reply sending while retries remain" do
+      email = MessagingFixtures.inbound_email_fixture()
+      reply = MessagingFixtures.email_reply_fixture(%{inbound_email_id: email.id})
+      StubMailerAdapter.fail_with({:network, :timeout})
+
+      assert {:error, _reason} =
+               SendEmailReplyWorker.perform(%Oban.Job{
+                 args: %{"reply_id" => reply.id},
+                 attempt: 1,
+                 max_attempts: 3
+               })
+
+      {:ok, updated} = Messaging.get_email_reply_by_id(reply.id)
+      assert updated.status == :sending
+    end
+
     test "marks reply as failed when delivery fails on final attempt" do
       email = MessagingFixtures.inbound_email_fixture()
       reply = MessagingFixtures.email_reply_fixture(%{inbound_email_id: email.id})
+      StubMailerAdapter.fail_with({:network, :timeout})
 
-      # In test env, Swoosh uses Local adapter which always succeeds.
-      # Test happy path here. Failure path tested via unit test on worker logic.
-      assert :ok =
+      assert {:error, _reason} =
                SendEmailReplyWorker.perform(%Oban.Job{
-                 args: %{"reply_id" => reply.id}
+                 args: %{"reply_id" => reply.id},
+                 attempt: 3,
+                 max_attempts: 3
                })
+
+      {:ok, updated} = Messaging.get_email_reply_by_id(reply.id)
+      assert updated.status == :failed
     end
   end
 end

--- a/test/klass_hero/provider/adapters/driven/notifications/incident_reported_email_notifier_test.exs
+++ b/test/klass_hero/provider/adapters/driven/notifications/incident_reported_email_notifier_test.exs
@@ -2,9 +2,9 @@ defmodule KlassHero.Provider.Adapters.Driven.Notifications.IncidentReportedEmail
   @moduledoc """
   Tests for the IncidentReportedEmailNotifier adapter.
 
-  Uses Swoosh.Adapters.Test (configured in test env) which returns
-  `{:ok, %{}}` from `Mailer.deliver/1`, so `send_incident_report/3`
-  returns `{:ok, email}`.
+  Delivery goes through `StubMailerAdapter` (configured in test env), which passes
+  to `Swoosh.Adapters.Test` unless a test arms a failure — so `Mailer.deliver/1`
+  returns `{:ok, %{}}` here and `send_incident_report/3` returns `{:ok, email}`.
   """
 
   # async: false — the interaction telemetry handler is global, so suite-wide

--- a/test/klass_hero/shared/tracing/traced_worker_test.exs
+++ b/test/klass_hero/shared/tracing/traced_worker_test.exs
@@ -191,4 +191,20 @@ defmodule KlassHero.Shared.Tracing.TracedWorkerTest do
       assert raw_status == :undefined or span_status_code(worker_span) != :error
     end
   end
+
+  describe "final_attempt?/1" do
+    # `>=`, not `==`: Lifeline re-runs a job orphaned by a node crash, so an
+    # attempt can arrive already past the ceiling. Equality would read that as
+    # "retries remain" and skip the compensation the caller is gating on.
+    test "is true only once no attempts remain" do
+      cases = [{1, 3, false}, {2, 3, false}, {3, 3, true}, {4, 3, true}]
+
+      for {attempt, max_attempts, expected} <- cases do
+        job = build_job(%{attempt: attempt, max_attempts: max_attempts})
+
+        assert TracedWorker.final_attempt?(job) == expected,
+               "attempt #{attempt} of #{max_attempts}: expected #{expected}"
+      end
+    end
+  end
 end

--- a/test/klass_hero/shared/tracing/traced_worker_test.exs
+++ b/test/klass_hero/shared/tracing/traced_worker_test.exs
@@ -58,6 +58,13 @@ defmodule KlassHero.Shared.Tracing.TracedWorkerTest do
     def execute(_job), do: {:ok, :some_result}
   end
 
+  defmodule CancelWorker do
+    use TracedWorker, queue: :test, max_attempts: 3
+
+    @impl TracedWorker
+    def execute(_job), do: {:cancel, "nothing a retry can fix"}
+  end
+
   # ---- Tests ----
 
   describe "span creation and attributes on success" do
@@ -168,6 +175,26 @@ defmodule KlassHero.Shared.Tracing.TracedWorkerTest do
       FailWorker.perform(job)
 
       assert_span("Shared.Tracing.TracedWorkerTest.FailWorker.execute/1",
+        "oban.will_retry": false
+      )
+    end
+
+    # A cancel is still a failure, just one no retry can fix. Before invite delivery
+    # started cancelling, that path returned {:error, _} and marked its span — leaving
+    # cancels unmarked would silently drop them out of every error-status query.
+    test "sets span status to error on cancel" do
+      job = build_job(%{attempt: 1, max_attempts: 3})
+      CancelWorker.perform(job)
+
+      worker_span = assert_span("Shared.Tracing.TracedWorkerTest.CancelWorker.execute/1")
+      assert span_status_code(worker_span) == :error
+    end
+
+    test "reports a cancelled job as not retrying" do
+      job = build_job(%{attempt: 1, max_attempts: 3})
+      CancelWorker.perform(job)
+
+      assert_span("Shared.Tracing.TracedWorkerTest.CancelWorker.execute/1",
         "oban.will_retry": false
       )
     end

--- a/test/support/stub_mailer_adapter.ex
+++ b/test/support/stub_mailer_adapter.ex
@@ -1,0 +1,68 @@
+defmodule KlassHero.Test.StubMailerAdapter do
+  @moduledoc """
+  Mailer adapter for tests: delivers through `Swoosh.Adapters.Test` unless the
+  calling process has armed a failure.
+
+  Swoosh ships no way to make delivery fail — `Swoosh.Adapters.Test` and
+  `Swoosh.Adapters.Sandbox` both always return `{:ok, _}` — so every worker
+  error path that begins with a failed send was untestable. One test
+  ("marks reply as failed when delivery fails on final attempt") asserted the
+  happy path under a failure name for exactly this reason.
+
+      test "fails the invite once retries are exhausted" do
+        StubMailerAdapter.fail_with({:network, :timeout})
+        ...
+      end
+
+  Arming is per-process, so tests stay `async: true`. It is read from the
+  delivering process *and* its `$callers` chain — the same lookup
+  `Swoosh.Adapters.Test` uses to find the test process behind a `Task`, so
+  arming still bites when delivery happens off the test process.
+  """
+
+  use Swoosh.Adapter
+
+  alias Swoosh.Adapters.Test
+
+  @key __MODULE__
+
+  @doc "Arms the calling process so its next deliveries fail with `reason`."
+  @spec fail_with(term()) :: :ok
+  def fail_with(reason) do
+    Process.put(@key, {:error, reason})
+    :ok
+  end
+
+  @doc "Disarms the calling process, restoring normal delivery."
+  @spec deliver_normally() :: :ok
+  def deliver_normally do
+    Process.delete(@key)
+    :ok
+  end
+
+  @impl Swoosh.Adapter
+  def deliver(email, config) do
+    armed_failure() || Test.deliver(email, config)
+  end
+
+  @impl Swoosh.Adapter
+  def deliver_many(emails, config) do
+    armed_failure() || Test.deliver_many(emails, config)
+  end
+
+  defp armed_failure do
+    [self() | List.wrap(Process.get(:"$callers"))]
+    |> Enum.find_value(&armed_failure_for/1)
+  end
+
+  # Reads another process's dictionary rather than an ETS table or Agent: arming
+  # dies with the test process, so no test can leak a failure into the next one.
+  defp armed_failure_for(pid) do
+    with {:dictionary, dictionary} <- Process.info(pid, :dictionary),
+         {@key, failure} <- List.keyfind(dictionary, @key, 0) do
+      failure
+    else
+      _not_armed -> nil
+    end
+  end
+end


### PR DESCRIPTION
Closes #1233.

## Summary

`SendInviteEmailWorker` failed the invite on its **first** delivery error, then returned `{:error, _}` so Oban retried. The retry re-fetched the invite, found it no longer `:pending`, hit the dedupe guard, and returned **`:ok`**. One transient blip permanently failed an invite *and* reported success — `max_attempts: 3` was decorative on that path.

Compensating early was destructive, not merely premature: `pending -> :failed` is a one-way door (`:failed` can only return to `:pending`), so the write closed the door the retry needed.

The fix gates the transition on the final attempt, matching `FetchEmailContentWorker`, `SendEmailReplyWorker` and `ProcessInviteClaimWorker`. Those three each hand-rolled the comparison, so it moves to `TracedWorker.final_attempt?/1` — the module that already computed it as `will_retry` — and all four now route through it.

Two adjacent gaps in the same worker, folded in deliberately:

- **No-token invites.** The branch burned all three attempts on a failure no retry could heal, then left the invite `:pending` forever — no email, and nothing to show the provider. It now fails the invite and returns `{:cancel, _}`. Defensive rather than user-facing: tokens and jobs commit in one transaction, so no traced path reaches it.
- **No way to fail a delivery in tests.** `Swoosh.Adapters.Test` and `Sandbox` both always return `{:ok, _}`, so every send-failure path was untestable — `send_email_reply_worker_test.exs` asserted the happy path under the name *"marks reply as failed when delivery fails on final attempt"*. `StubMailerAdapter` delegates to `Swoosh.Adapters.Test` unless the calling process arms a failure, so these tests stay `async: true`. That vacuous test is now real.

## Review Focus

- **`traced_worker.ex`** — `final_attempt?/1` uses `>=`, not `==`: Lifeline re-runs an orphaned job past its ceiling, and `==` would read that as "retries remain" and skip compensation. `record_result/2`'s `will_retry` is restated as its negation (`not (a >= m)` ≡ `a < m`).
- **Second commit** — returning `{:cancel, _}` dropped that path out of `record_result/2`'s `{:error, _}` clause, so a job that gave up looked like a successful one in the trace. Caught in review; cancels now get their own clause.
- **`StubMailerAdapter` lives in `test/support/`**, not beside the three config-swapped stubs in `lib/shared/adapters/driven/`. It is pure test machinery with no prod caller, and `elixirc_paths(:test)` exists so it needn't ship in the production build.

## Test Plan

- `mix precommit` green — 4041 passed.
- Every slice red-proven before green. The decisive test is *"delivers on the retry after a transient failure"*: against the old code, attempt 2 returned `:ok` while the invite sat `:failed` — the silent-success half of the bug, reproduced.
- The repaired Messaging test asserts a value equal to the row's initial state, so it was proven non-vacuous by temporarily breaking the gate and watching it fail (`left: :failed, right: :sending`).
- Four gate refactors verified byte-equivalent; `boundary-checker` 5/5 clean, `architecture-reviewer` 8 checks / 0 violations, `regression-analyzer` 8 checks / 1 warning (fixed in the second commit).

## Known gap, not addressed here

`TracedWorker` reraises rescued exceptions before `record_result/2` runs, so **every** compensation gate — the three that existed and the two added here — sits in a branch a raised exception skips. A crashing worker never compensates. Same failure class as this issue; worth its own ticket.