### PR TITLE
fix: render program cover thumbnails with object-cover

### DIFF
--- a/lib/klass_hero_web/components/parent_components.ex
+++ b/lib/klass_hero_web/components/parent_components.ex
@@ -494,17 +494,28 @@ defmodule KlassHeroWeb.ParentComponents do
   Enrolled-program tile with kid-avatar stack and category/title.
 
   `program` keys: `:id, :title, :category, :next, :provider, :status, :kids,
-  :cover` (CSS background string).
+  :cover_image_url` (a plain image URL, or nil for the gradient fallback).
   """
   attr :program, :map, required: true
 
   def pa_family_program_card(assigns) do
     ~H"""
     <.kh_card class="overflow-hidden hover:shadow-lg transition-all">
-      <div
-        class="h-24 relative"
-        style={"background: #{@program[:cover] || "linear-gradient(90deg,#33CFFF,#FFFF36)"}"}
-      >
+      <div class="h-24 relative overflow-hidden">
+        <img
+          :if={@program[:cover_image_url]}
+          id={"pa-program-cover-#{@program[:id]}"}
+          src={@program[:cover_image_url]}
+          alt={@program.title}
+          loading="lazy"
+          class="absolute inset-0 w-full h-full object-cover"
+        />
+        <div
+          :if={!@program[:cover_image_url]}
+          class="absolute inset-0"
+          style="background: linear-gradient(90deg,#33CFFF,#FFFF36)"
+        >
+        </div>
         <div :if={@program[:status]} class="absolute top-2 right-2">
           <.kh_pill tone={status_tone(@program[:status])}>
             {to_string(@program[:status])}

--- a/lib/klass_hero_web/components/provider_layout_components.ex
+++ b/lib/klass_hero_web/components/provider_layout_components.ex
@@ -455,6 +455,9 @@ defmodule KlassHeroWeb.ProviderLayoutComponents do
 
   @doc """
   Compact program-row primitive used by dashboard + sessions screens.
+
+  `program` keys: `:id, :title, :status, :cover_image_url` (a plain image URL,
+  or nil for the gradient fallback).
   """
   attr :program, :map, required: true
   attr :on_edit, :string, default: "edit_program"
@@ -463,10 +466,21 @@ defmodule KlassHeroWeb.ProviderLayoutComponents do
     ~H"""
     <.kh_list_row hover>
       <:media>
-        <div
-          class="w-14 h-14 rounded-xl"
-          style={"background: #{@program[:cover] || "linear-gradient(135deg,#33CFFF,#FFFF36)"}"}
-        >
+        <div class="w-14 h-14 rounded-xl overflow-hidden">
+          <img
+            :if={@program[:cover_image_url]}
+            id={"pv-program-cover-#{@program[:id]}"}
+            src={@program[:cover_image_url]}
+            alt={@program.title}
+            loading="lazy"
+            class="w-full h-full object-cover"
+          />
+          <div
+            :if={!@program[:cover_image_url]}
+            class="w-full h-full"
+            style="background: linear-gradient(135deg,#33CFFF,#FFFF36)"
+          >
+          </div>
         </div>
       </:media>
       <:title>{@program.title}</:title>

--- a/lib/klass_hero_web/live/provider/overview_live.ex
+++ b/lib/klass_hero_web/live/provider/overview_live.ex
@@ -183,7 +183,7 @@ defmodule KlassHeroWeb.Provider.OverviewLive do
       title: p.title,
       booked: Map.get(enrollment_counts, p.id, 0),
       status: derive_program_status(p, today),
-      cover: p.cover_image_url && "url(#{p.cover_image_url})"
+      cover_image_url: p.cover_image_url
     }
   end
 

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -2250,7 +2250,7 @@ msgstr "Zulässige Geschlechter"
 msgid "An unexpected error occurred during import."
 msgstr "Beim Import ist ein unerwarteter Fehler aufgetreten."
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:640
+#: lib/klass_hero_web/components/provider_layout_components.ex:654
 #: lib/klass_hero_web/live/admin/verifications_live.ex:438
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:53
 #, elixir-autogen, elixir-format
@@ -2512,7 +2512,7 @@ msgstr "Endzeit"
 
 #: lib/klass_hero_web/components/provider_components.ex:1751
 #: lib/klass_hero_web/components/provider_components.ex:2197
-#: lib/klass_hero_web/components/provider_layout_components.ex:630
+#: lib/klass_hero_web/components/provider_layout_components.ex:644
 #, elixir-autogen, elixir-format
 msgid "Enrolled"
 msgstr "Angemeldet"
@@ -5318,7 +5318,7 @@ msgstr "18+, amtlicher Ausweis vor Veröffentlichung verifiziert."
 msgid "A decade-plus coaching and running youth activity programs in Berlin. Built Prime Youth before founding Klass Hero."
 msgstr "Über zehn Jahre Erfahrung im Coaching und der Leitung von Jugendförderprogrammen in Berlin. Gründete Prime Youth, bevor er Klass Hero ins Leben rief."
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:605
+#: lib/klass_hero_web/components/provider_layout_components.ex:619
 #, elixir-autogen, elixir-format
 msgid "Accept"
 msgstr "Akzeptieren"
@@ -5609,7 +5609,7 @@ msgstr "Erstellen Sie Ihr"
 msgid "Data & privacy"
 msgstr "Daten & Datenschutz"
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:597
+#: lib/klass_hero_web/components/provider_layout_components.ex:611
 #, elixir-autogen, elixir-format
 msgid "Decline"
 msgstr "Ablehnen"
@@ -5644,7 +5644,7 @@ msgstr "Die Einnahmenverfolgung kommt bald."
 msgid "Earnings trend"
 msgstr "Einnahmenentwicklung"
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:481
+#: lib/klass_hero_web/components/provider_layout_components.ex:495
 #, elixir-autogen, elixir-format
 msgid "Edit program"
 msgstr "Programm bearbeiten"
@@ -6062,17 +6062,17 @@ msgstr "Verwalten Sie Ihr Konto, Ihre Einstellungen und Ihren Datenschutz an ein
 msgid "Mandatory child-protection course before going live."
 msgstr "Verpflichtender Kinderschutzkurs vor der Freischaltung."
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:548
+#: lib/klass_hero_web/components/provider_layout_components.ex:562
 #, elixir-autogen, elixir-format
 msgid "Mark absent"
 msgstr "Als abwesend markieren"
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:521
+#: lib/klass_hero_web/components/provider_layout_components.ex:535
 #, elixir-autogen, elixir-format
 msgid "Mark all present"
 msgstr "Alle als anwesend markieren"
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:548
+#: lib/klass_hero_web/components/provider_layout_components.ex:562
 #, elixir-autogen, elixir-format
 msgid "Mark present"
 msgstr "Als anwesend markieren"
@@ -6112,7 +6112,7 @@ msgstr "Neues Programm"
 msgid "Newest"
 msgstr "Neueste"
 
-#: lib/klass_hero_web/components/parent_components.ex:532
+#: lib/klass_hero_web/components/parent_components.ex:543
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr "Weiter"
@@ -6152,7 +6152,7 @@ msgstr "Derzeit keine ausstehenden Anfragen."
 msgid "No programs yet — add your first one from the Programs tab."
 msgstr "Noch keine Programme — fügen Sie Ihr erstes über den Tab „Programme“ hinzu."
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:525
+#: lib/klass_hero_web/components/provider_layout_components.ex:539
 #, elixir-autogen, elixir-format
 msgid "No registered children for this session."
 msgstr "Keine Kinder in dieser Sitzung angemeldet."
@@ -6194,7 +6194,7 @@ msgstr "Sobald Ihr Eintrag live ist und Sie die Hero-Verifizierung abgeschlossen
 msgid "Ongoing Quality"
 msgstr "Laufende Qualität"
 
-#: lib/klass_hero_web/components/parent_components.ex:538
+#: lib/klass_hero_web/components/parent_components.ex:549
 #, elixir-autogen, elixir-format
 msgid "Open"
 msgstr "Offen"
@@ -6239,7 +6239,7 @@ msgstr "Eltern-Navigation (unten)"
 msgid "Parent navigation"
 msgstr "Elternnavigation"
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:532
+#: lib/klass_hero_web/components/provider_layout_components.ex:546
 #, elixir-autogen, elixir-format
 msgid "Parent: %{name}"
 msgstr "Elternteil: %{name}"
@@ -6645,7 +6645,7 @@ msgstr "Diese Woche"
 msgid "To modernize how Berlin"
 msgstr "Um zu modernisieren, wie Berlin"
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:511
+#: lib/klass_hero_web/components/provider_layout_components.ex:525
 #, elixir-autogen, elixir-format
 msgid "Today's check-ins"
 msgstr "Heutige Check-ins"
@@ -6670,7 +6670,7 @@ msgstr "Vertrauenswürdige Heroes"
 msgid "Try adjusting your search or filter criteria — there's plenty more in Berlin."
 msgstr "Versuchen Sie, Ihre Such- oder Filterkriterien anzupassen — in Berlin gibt es noch viel mehr."
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:588
+#: lib/klass_hero_web/components/provider_layout_components.ex:602
 #, elixir-autogen, elixir-format
 msgid "Unknown parent"
 msgstr "Unbekannter Elternteil"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -2250,7 +2250,7 @@ msgstr ""
 msgid "An unexpected error occurred during import."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:640
+#: lib/klass_hero_web/components/provider_layout_components.ex:654
 #: lib/klass_hero_web/live/admin/verifications_live.ex:438
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:53
 #, elixir-autogen, elixir-format
@@ -2512,7 +2512,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1751
 #: lib/klass_hero_web/components/provider_components.ex:2197
-#: lib/klass_hero_web/components/provider_layout_components.ex:630
+#: lib/klass_hero_web/components/provider_layout_components.ex:644
 #, elixir-autogen, elixir-format
 msgid "Enrolled"
 msgstr ""
@@ -5318,7 +5318,7 @@ msgstr ""
 msgid "A decade-plus coaching and running youth activity programs in Berlin. Built Prime Youth before founding Klass Hero."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:605
+#: lib/klass_hero_web/components/provider_layout_components.ex:619
 #, elixir-autogen, elixir-format
 msgid "Accept"
 msgstr ""
@@ -5609,7 +5609,7 @@ msgstr ""
 msgid "Data & privacy"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:597
+#: lib/klass_hero_web/components/provider_layout_components.ex:611
 #, elixir-autogen, elixir-format
 msgid "Decline"
 msgstr ""
@@ -5644,7 +5644,7 @@ msgstr ""
 msgid "Earnings trend"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:481
+#: lib/klass_hero_web/components/provider_layout_components.ex:495
 #, elixir-autogen, elixir-format
 msgid "Edit program"
 msgstr ""
@@ -6062,17 +6062,17 @@ msgstr ""
 msgid "Mandatory child-protection course before going live."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:548
+#: lib/klass_hero_web/components/provider_layout_components.ex:562
 #, elixir-autogen, elixir-format
 msgid "Mark absent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:521
+#: lib/klass_hero_web/components/provider_layout_components.ex:535
 #, elixir-autogen, elixir-format
 msgid "Mark all present"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:548
+#: lib/klass_hero_web/components/provider_layout_components.ex:562
 #, elixir-autogen, elixir-format
 msgid "Mark present"
 msgstr ""
@@ -6112,7 +6112,7 @@ msgstr ""
 msgid "Newest"
 msgstr ""
 
-#: lib/klass_hero_web/components/parent_components.ex:532
+#: lib/klass_hero_web/components/parent_components.ex:543
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr ""
@@ -6152,7 +6152,7 @@ msgstr ""
 msgid "No programs yet — add your first one from the Programs tab."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:525
+#: lib/klass_hero_web/components/provider_layout_components.ex:539
 #, elixir-autogen, elixir-format
 msgid "No registered children for this session."
 msgstr ""
@@ -6194,7 +6194,7 @@ msgstr ""
 msgid "Ongoing Quality"
 msgstr ""
 
-#: lib/klass_hero_web/components/parent_components.ex:538
+#: lib/klass_hero_web/components/parent_components.ex:549
 #, elixir-autogen, elixir-format
 msgid "Open"
 msgstr ""
@@ -6239,7 +6239,7 @@ msgstr ""
 msgid "Parent navigation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:532
+#: lib/klass_hero_web/components/provider_layout_components.ex:546
 #, elixir-autogen, elixir-format
 msgid "Parent: %{name}"
 msgstr ""
@@ -6645,7 +6645,7 @@ msgstr ""
 msgid "To modernize how Berlin"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:511
+#: lib/klass_hero_web/components/provider_layout_components.ex:525
 #, elixir-autogen, elixir-format
 msgid "Today's check-ins"
 msgstr ""
@@ -6670,7 +6670,7 @@ msgstr ""
 msgid "Try adjusting your search or filter criteria — there's plenty more in Berlin."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:588
+#: lib/klass_hero_web/components/provider_layout_components.ex:602
 #, elixir-autogen, elixir-format
 msgid "Unknown parent"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -2250,7 +2250,7 @@ msgstr ""
 msgid "An unexpected error occurred during import."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:640
+#: lib/klass_hero_web/components/provider_layout_components.ex:654
 #: lib/klass_hero_web/live/admin/verifications_live.ex:438
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:53
 #, elixir-autogen, elixir-format
@@ -2512,7 +2512,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1751
 #: lib/klass_hero_web/components/provider_components.ex:2197
-#: lib/klass_hero_web/components/provider_layout_components.ex:630
+#: lib/klass_hero_web/components/provider_layout_components.ex:644
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrolled"
 msgstr ""
@@ -5318,7 +5318,7 @@ msgstr ""
 msgid "A decade-plus coaching and running youth activity programs in Berlin. Built Prime Youth before founding Klass Hero."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:605
+#: lib/klass_hero_web/components/provider_layout_components.ex:619
 #, elixir-autogen, elixir-format
 msgid "Accept"
 msgstr ""
@@ -5609,7 +5609,7 @@ msgstr ""
 msgid "Data & privacy"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:597
+#: lib/klass_hero_web/components/provider_layout_components.ex:611
 #, elixir-autogen, elixir-format
 msgid "Decline"
 msgstr ""
@@ -5644,7 +5644,7 @@ msgstr ""
 msgid "Earnings trend"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:481
+#: lib/klass_hero_web/components/provider_layout_components.ex:495
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit program"
 msgstr ""
@@ -6062,17 +6062,17 @@ msgstr ""
 msgid "Mandatory child-protection course before going live."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:548
+#: lib/klass_hero_web/components/provider_layout_components.ex:562
 #, elixir-autogen, elixir-format
 msgid "Mark absent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:521
+#: lib/klass_hero_web/components/provider_layout_components.ex:535
 #, elixir-autogen, elixir-format
 msgid "Mark all present"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:548
+#: lib/klass_hero_web/components/provider_layout_components.ex:562
 #, elixir-autogen, elixir-format
 msgid "Mark present"
 msgstr ""
@@ -6112,7 +6112,7 @@ msgstr ""
 msgid "Newest"
 msgstr ""
 
-#: lib/klass_hero_web/components/parent_components.ex:532
+#: lib/klass_hero_web/components/parent_components.ex:543
 #, elixir-autogen, elixir-format
 msgid "Next"
 msgstr ""
@@ -6152,7 +6152,7 @@ msgstr ""
 msgid "No programs yet — add your first one from the Programs tab."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:525
+#: lib/klass_hero_web/components/provider_layout_components.ex:539
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No registered children for this session."
 msgstr ""
@@ -6194,7 +6194,7 @@ msgstr ""
 msgid "Ongoing Quality"
 msgstr ""
 
-#: lib/klass_hero_web/components/parent_components.ex:538
+#: lib/klass_hero_web/components/parent_components.ex:549
 #, elixir-autogen, elixir-format
 msgid "Open"
 msgstr ""
@@ -6239,7 +6239,7 @@ msgstr ""
 msgid "Parent navigation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:532
+#: lib/klass_hero_web/components/provider_layout_components.ex:546
 #, elixir-autogen, elixir-format
 msgid "Parent: %{name}"
 msgstr ""
@@ -6645,7 +6645,7 @@ msgstr ""
 msgid "To modernize how Berlin"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:511
+#: lib/klass_hero_web/components/provider_layout_components.ex:525
 #, elixir-autogen, elixir-format
 msgid "Today's check-ins"
 msgstr ""
@@ -6670,7 +6670,7 @@ msgstr ""
 msgid "Try adjusting your search or filter criteria — there's plenty more in Berlin."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:588
+#: lib/klass_hero_web/components/provider_layout_components.ex:602
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Unknown parent"
 msgstr ""

--- a/test/klass_hero_web/components/parent_components_test.exs
+++ b/test/klass_hero_web/components/parent_components_test.exs
@@ -207,9 +207,49 @@ defmodule KlassHeroWeb.ParentComponentsTest do
       assert html =~ "Mon 14:00"
       assert html =~ "CodeKids Berlin"
     end
+
+    test "renders the cover as an object-cover img when cover_image_url is set", %{} do
+      html = render_family_program_card(cover_image_url: "https://example.com/cover.jpg")
+      doc = LazyHTML.from_fragment(html)
+
+      img = LazyHTML.query(doc, "img#pa-program-cover-1")
+
+      assert Enum.count(img) == 1
+      assert LazyHTML.attribute(img, "src") == ["https://example.com/cover.jpg"]
+      assert LazyHTML.attribute(img, "loading") == ["lazy"]
+      assert LazyHTML.attribute(img, "alt") == ["Code Camp"]
+      assert hd(LazyHTML.attribute(img, "class")) =~ "object-cover"
+
+      # The banner stacks the img beneath absolutely-positioned overlays; the
+      # kid-avatar stack must survive the switch from a background div to an img.
+      assert LazyHTML.text(LazyHTML.query(doc, ".absolute.bottom-2")) =~ "M"
+    end
+
+    test "renders the gradient fallback and no img when cover_image_url is nil", %{} do
+      html = render_family_program_card(cover_image_url: nil)
+      doc = LazyHTML.from_fragment(html)
+
+      assert Enum.empty?(LazyHTML.query(doc, "img#pa-program-cover-1"))
+      assert html =~ "linear-gradient"
+    end
   end
 
   ## ------------------------------------------------------------------ helpers
+
+  defp render_family_program_card(overrides) do
+    program =
+      Enum.into(overrides, %{
+        id: "1",
+        title: "Code Camp",
+        category: "Tech",
+        next: "Mon 14:00",
+        provider: "CodeKids Berlin",
+        status: :active,
+        kids: [%{name: "Mila", color: "#FFEAC9"}]
+      })
+
+    render_component(&ParentComponents.pa_family_program_card/1, %{program: program})
+  end
 
   defp render_pa_sidebar(opts) do
     assigns = %{

--- a/test/klass_hero_web/components/provider_layout_components_test.exs
+++ b/test/klass_hero_web/components/provider_layout_components_test.exs
@@ -178,6 +178,30 @@ defmodule KlassHeroWeb.ProviderLayoutComponentsTest do
       assert html =~ ~s|aria-label="Edit program"|
       assert html =~ ~s|phx-value-program-id="abc"|
     end
+
+    test "renders the cover as an object-cover img when cover_image_url is set", %{} do
+      html = render_program_row(cover_image_url: "https://example.com/cover.jpg")
+      doc = LazyHTML.from_fragment(html)
+
+      img = LazyHTML.query(doc, "img#pv-program-cover-abc")
+
+      assert Enum.count(img) == 1
+      assert LazyHTML.attribute(img, "src") == ["https://example.com/cover.jpg"]
+      assert LazyHTML.attribute(img, "loading") == ["lazy"]
+      assert LazyHTML.attribute(img, "alt") == ["Football Stars"]
+
+      # object-cover is what keeps the thumbnail from rendering a top-left crop
+      # at natural size — the bug in #1072.
+      assert hd(LazyHTML.attribute(img, "class")) =~ "object-cover"
+    end
+
+    test "renders the gradient fallback and no img when cover_image_url is nil", %{} do
+      html = render_program_row(cover_image_url: nil)
+      doc = LazyHTML.from_fragment(html)
+
+      assert Enum.empty?(LazyHTML.query(doc, "img#pv-program-cover-abc"))
+      assert html =~ "linear-gradient"
+    end
   end
 
   describe "pv_roster/1" do
@@ -236,6 +260,12 @@ defmodule KlassHeroWeb.ProviderLayoutComponentsTest do
   end
 
   ## ------------------------------------------------------------------ helpers
+
+  defp render_program_row(overrides) do
+    program = Enum.into(overrides, %{id: "abc", title: "Football Stars", status: :live})
+
+    render_component(&ProviderLayoutComponents.pv_program_row/1, %{program: program})
+  end
 
   defp render_pv_sidebar(opts) do
     assigns = %{active: Keyword.fetch!(opts, :active)}


### PR DESCRIPTION
Closes #1072

## Summary

The provider dashboard's "Your top programs" card showed only a small top-left fragment of each program's cover photo.

**Root cause — CSS shorthand reset.** `OverviewLive.build_program_row/3` passed the cover as a CSS *string* (`"url(#{cover_image_url})"`), which `pv_program_row/1` dropped into a `background:` **shorthand**. The shorthand resets every unmentioned sub-property to its initial value:

| sub-property | initial value |
|---|---|
| `background-size` | `auto` (natural pixel size) |
| `background-position` | `0% 0%` (top-left) |
| `background-repeat` | `repeat` |

So a 1200×800 photo rendered its top-left 56×56 pixels at 1:1 inside the thumbnail — a meaningless fragment of sky.

The deeper issue is the leaky contract: `:cover` was documented as "CSS background string", putting the rendering mechanism into the data contract. No caller passing a URL could see that sizing was never set — which is why this shipped.

## Approach

Replace `:cover` with a plain `:cover_image_url` and render the cover the way the rest of the app already does (`program_components.ex`, `marketing_components.ex`, `program_detail_live.ex`): an `<img>` with `object-cover` inside an `overflow-hidden` wrapper, gradient div as the fallback.

Side benefits: alt text, `loading="lazy"`, and the interpolated URL leaves the `style` attribute (HEEx escapes quotes but not `)`/`;`, so the old form permitted injecting sibling CSS declarations — low severity since URLs are storage-generated).

Also applied to `pa_family_program_card/1`, which carried the identical contract. It has no production call sites today, so this is a latent-bug removal rather than a live fix.

## Review focus

- `provider_layout_components.ex` — the 56px square thumbnail
- `parent_components.ex` — the `h-24` banner; the `<img>` is `absolute inset-0` so the existing status pill and kid-avatar overlays still stack above it
- `overview_live.ex` — one-line producer change
- gettext `.pot`/`.po` churn is **line references only** (no msgid/msgstr changes) — the edits shifted line numbers in files containing `gettext(...)` calls

## Test plan

- `MIX_TEST_PARTITION=1072 mix precommit` → **4045 passed**, 0 failures
- New component tests cover both branches per component: cover present (`<img>` with correct `src`/`alt`/`loading`/`object-cover`) and cover absent (gradient, no `<img>`). The cover-present test was verified red before the fix.
- Verified in a browser at desktop and 375×667 mobile against a seeded cover image: the full photo renders centred at 56×56 with `object-fit: cover` (`naturalWidth` 1200 → `renderedWidth` 56), and cover-less programs still show the gradient.
- Reconstructed the pre-fix markup client-side on the same page for an A/B: computed style confirmed `background-size: auto`, `background-position: 0% 0%`, `background-repeat: repeat`, rendering the same blue smear users reported.

## Notes

The issue described this as a "modal" — it is a card on `/provider/dashboard`. The issue is also labelled `backend`; this is a frontend/`design` change.