### PR TITLE
test: stop the large-CSV smoke test executing 5000 Oban jobs inline

### DIFF
--- a/test/klass_hero/enrollment/import_enrollment_csv_test.exs
+++ b/test/klass_hero/enrollment/import_enrollment_csv_test.exs
@@ -585,7 +585,9 @@ defmodule KlassHero.Enrollment.ImportEnrollmentCsvTest do
       csv = build_csv(valid_rows ++ invalid_rows)
 
       {:ok, %{created: created, failed: failed}} =
-        ImportEnrollmentCsv.execute(provider.id, csv)
+        Oban.Testing.with_testing_mode(:manual, fn ->
+          ImportEnrollmentCsv.execute(provider.id, csv)
+        end)
 
       assert created == 5_000
       assert length(failed) == 500


### PR DESCRIPTION
## Summary

`ImportEnrollmentCsvTest`'s 5,000-row smoke test times out intermittently on CI:

```
Postgrex.Protocol disconnected: ** (DBConnection.ConnectionError) client
(KlassHero.Enrollment.Adapters.Driving.Workers.SendInviteEmailWorker) timed out
because it queued and checked out the connection for longer than 15000ms
```

Seen on two unrelated branches so far — `fix/1222-seeds-projection-rebuild` (2026-08-01) and `fix/1072-program-thumbnail-crop` (2026-08-02).

## Root cause

`config/test.exs:48` sets `Oban, testing: :inline`, which runs a job **at insert time**. `EnqueueInviteEmails.enqueue/3` wraps `Oban.insert_all/1` in a `Repo.transaction`, so importing 5,000 rows executes 5,000 `SendInviteEmailWorker` runs **synchronously, inside one transaction, on a single sandbox connection** — each one a `get_invite/1` SELECT plus an OpenTelemetry span.

That entire serial pile has to complete inside DBConnection's 15,000 ms checkout timeout. The test reads as if it measures CSV parsing; in fact most of its runtime is email workers it never asserts on.

## Measurements

| Condition | Runtime (isolated, idle machine) | Margin vs 15s |
|---|---|---|
| Current (`:inline`) | 8.3s | 1.8× |
| With `:manual` | **3.4s** | **4.4×** |

8.3s is the best case: one test, no contention. CI adds a slower shared runner plus 19 other async tests competing for the pool, and the 1.8× margin disappears.

## Fix

Run the import under `Oban.Testing.with_testing_mode(:manual, ...)` so `insert_all` inserts rows without executing workers — the same pattern already used in `resend_invite_test.exs`, `outbox_test.exs`, `invite_claim_saga_test.exs`, and `erasure_cascade_test.exs`.

**No coverage is lost.** The smoke test asserts only `created` / `failed` counts and the failure category — never jobs or emails. The enqueue path has five dedicated tests in `enqueue_invite_emails_test.exs`, including "assigns a unique token to every pending invite and enqueues its email".

## Test plan

- `MIX_TEST_PARTITION=1072 mix test test/klass_hero/enrollment/import_enrollment_csv_test.exs:582 --include slow` → passes, 8.3s → 3.4s
- Full suite runs in CI on this PR