### PR TITLE
fix: compensate jobs that die without running their compensation gate

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -37,6 +37,7 @@ alias KlassHero.Shared.Adapters.Driven.Events.ObanOutbox
 alias KlassHero.Shared.Adapters.Driven.FeatureFlags.FunWithFlagsAdapter
 alias KlassHero.Shared.Adapters.Driven.Persistence.Repositories.ProcessedEventRepository
 alias KlassHero.Shared.Adapters.Driven.Storage.S3StorageAdapter
+alias KlassHero.Shared.Adapters.Driven.Workers.CompensationSweepWorker
 alias KlassHero.Shared.ErrorContextFilter
 alias Swoosh.Adapters.Local
 
@@ -119,7 +120,11 @@ config :klass_hero, Oban,
     {Oban.Plugins.Cron,
      crontab: [
        {"0 3 * * *", MessageCleanupWorker},
-       {"0 4 * * *", RetentionPolicyWorker}
+       {"0 4 * * *", RetentionPolicyWorker},
+       # Every 5 minutes, not daily: this is what makes a permanently-failed invite or
+       # email visible to the provider when the job died without running its own gate.
+       # A day's delay would leave the row looking pending for a day.
+       {"*/5 * * * *", CompensationSweepWorker}
      ]}
   ],
   # email: 1 — serialized to stay under Resend's 2 req/sec rate limit (per-node;

--- a/config/config.exs
+++ b/config/config.exs
@@ -12,14 +12,18 @@ alias FunWithFlags.Notifications.PhoenixPubSub
 alias KlassHero.Accounts.Adapters.Driving.Events.StaffInvitationHandler
 alias KlassHero.Accounts.Scope
 alias KlassHero.Enrollment.Adapters.Driving.Events.InviteFamilyReadyHandler
+alias KlassHero.Enrollment.Adapters.Driving.Workers.SendInviteEmailWorker
 alias KlassHero.Family.Adapters.Driving.Events.FamilyEventHandler
 alias KlassHero.Family.Adapters.Driving.Events.InviteClaimedHandler
+alias KlassHero.Family.Adapters.Driving.Workers.ProcessInviteClaimWorker
 alias KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries
 alias KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildren
 alias KlassHero.Messaging.Adapters.Driving.Events.MessagingEventHandler
 alias KlassHero.Messaging.Adapters.Driving.Events.StaffAssignmentHandler
+alias KlassHero.Messaging.Adapters.Driving.Workers.FetchEmailContentWorker
 alias KlassHero.Messaging.Adapters.Driving.Workers.MessageCleanupWorker
 alias KlassHero.Messaging.Adapters.Driving.Workers.RetentionPolicyWorker
+alias KlassHero.Messaging.Adapters.Driving.Workers.SendEmailReplyWorker
 alias KlassHero.Participation.Adapters.Driving.Events.EventHandlers.SeedSessionRosterHandler
 alias KlassHero.Participation.Adapters.Driving.Events.ParticipationEventHandler
 alias KlassHero.ProgramCatalog.Adapters.Driven.Projections.ProgramListings
@@ -125,6 +129,18 @@ config :klass_hero, Oban,
 # Base URL for constructing links in emails and event handlers
 # (avoids boundary violations from referencing KlassHeroWeb.Endpoint in domain code)
 config :klass_hero, :app_base_url, "http://localhost:4000"
+
+# Workers whose permanently-dead jobs the compensation sweep reconciles. A worker
+# implementing `compensate/2` but missing here is never swept — the gate inside its
+# attempt still runs, but the three routes that bypass it (Lifeline discarding an orphan,
+# a raise, an early `{:discard, _}`) go uncompensated. The sweep also filters on this list
+# in SQL, so an unlisted worker's discarded jobs are not re-examined every tick.
+config :klass_hero, :compensating_workers, [
+  ProcessInviteClaimWorker,
+  SendInviteEmailWorker,
+  FetchEmailContentWorker,
+  SendEmailReplyWorker
+]
 
 # Contact information — centralized, configurable per environment
 config :klass_hero, :contact,

--- a/lib/klass_hero/enrollment/adapters/driving/workers/send_invite_email_worker.ex
+++ b/lib/klass_hero/enrollment/adapters/driving/workers/send_invite_email_worker.ex
@@ -84,16 +84,30 @@ defmodule KlassHero.Enrollment.Adapters.Driving.Workers.SendInviteEmailWorker do
         # `:failed` can only go back to `:pending` — and the non-pending guard above
         # then turns every retry into a silent :ok, so failing early both destroys the
         # send the next attempt makes and hides that it did (#1233).
-        if TracedWorker.final_attempt?(job) do
-          Enrollment.transition_invite(invite, %{
-            status: :failed,
-            error_details: "Email delivery failed: #{inspect(reason)}"
-          })
-        end
+        TracedWorker.compensate_if_final(__MODULE__, job, reason)
 
         {:error, reason}
     end
   end
+
+  # A rejected transition means the invite is already terminal — sent by a duplicate
+  # attempt, or failed by an earlier pass — which is a fact rather than something a later
+  # sweep could fix, so it reports `:ignore`.
+  @impl true
+  def compensate(%Oban.Job{args: %{"invite_id" => invite_id}}, reason) do
+    case Enrollment.transition_invite(%{id: invite_id}, %{
+           status: :failed,
+           error_details: describe(reason)
+         }) do
+      {:ok, _invite} -> :ok
+      {:error, _reason} -> :ignore
+    end
+  end
+
+  # The sweep cannot recover the failing attempt's reason — a Lifeline discard records
+  # none — so the provider gets the fact without a cause rather than "nil".
+  defp describe(nil), do: "Email delivery failed and no retries remain"
+  defp describe(reason), do: "Email delivery failed: #{inspect(reason)}"
 
   # Reads URL config at runtime — referencing KlassHeroWeb.Endpoint directly would violate boundary rules.
   defp base_url do

--- a/lib/klass_hero/family/adapters/driving/workers/process_invite_claim_worker.ex
+++ b/lib/klass_hero/family/adapters/driving/workers/process_invite_claim_worker.ex
@@ -33,14 +33,20 @@ defmodule KlassHero.Family.Adapters.Driving.Workers.ProcessInviteClaimWorker do
         # Only once Oban is done retrying. `registered -> :failed` is a one-way door —
         # `:failed` can only go back to `:pending` — so failing the invite on an earlier
         # attempt would destroy a claim that the next attempt heals.
-        if TracedWorker.final_attempt?(job), do: fail_invite(args["invite_id"], reason)
+        TracedWorker.compensate_if_final(__MODULE__, job, reason)
         error
     end
   end
 
   # The invite belongs to Enrollment, so this goes through its facade rather than touching
   # the schema. A rejected transition means the invite is already terminal — enrolled by a
-  # retry Lifeline re-ran, or failed by an earlier pass — which is a fact, not a fault.
+  # retry Lifeline re-ran, or failed by an earlier pass — which is a fact, not a fault, so
+  # it reports `:ignore` rather than an error the sweep would keep retrying.
+  @impl true
+  def compensate(%Oban.Job{args: args}, reason) do
+    fail_invite(args["invite_id"], reason)
+  end
+
   defp fail_invite(invite_id, reason) when is_binary(invite_id) do
     case Enrollment.transition_invite(%{id: invite_id}, %{status: :failed, error_details: describe(reason)}) do
       {:ok, _invite} ->
@@ -52,11 +58,11 @@ defmodule KlassHero.Family.Adapters.Driving.Workers.ProcessInviteClaimWorker do
           reason: inspect(transition_error)
         )
 
-        :ok
+        :ignore
     end
   end
 
-  defp fail_invite(_invite_id, _reason), do: :ok
+  defp fail_invite(_invite_id, _reason), do: :ignore
 
   # A provider reads this in the invites table, so it has to name what is wrong with the
   # row they uploaded. `inspect/1` of a changeset names it only to a developer.
@@ -68,6 +74,10 @@ defmodule KlassHero.Family.Adapters.Driving.Workers.ProcessInviteClaimWorker do
       fields -> Enum.map_join(fields, "; ", fn {field, message} -> "#{humanize_field(field)} #{message}" end)
     end
   end
+
+  # The sweep cannot recover the failing attempt's reason — a Lifeline discard records
+  # none — so the provider gets the fact without a cause rather than the string "nil".
+  defp describe(nil), do: "Processing failed and no retries remain"
 
   defp describe(reason), do: inspect(reason)
 

--- a/lib/klass_hero/messaging/adapters/driving/workers/fetch_email_content_worker.ex
+++ b/lib/klass_hero/messaging/adapters/driving/workers/fetch_email_content_worker.ex
@@ -42,20 +42,24 @@ defmodule KlassHero.Messaging.Adapters.Driving.Workers.FetchEmailContentWorker d
       {:error, reason} ->
         Logger.warning("Content fetch failed for #{email_id} (attempt #{job.attempt}): #{inspect(reason)}")
 
-        maybe_mark_permanently_failed(email_id, job)
+        TracedWorker.compensate_if_final(__MODULE__, job, reason)
         {:error, reason}
     end
   end
 
-  defp maybe_mark_permanently_failed(email_id, job) do
-    if TracedWorker.final_attempt?(job) do
-      case Messaging.update_inbound_email_content(email_id, %{content_status: "failed"}) do
-        {:ok, _} ->
-          Logger.error("Marked email #{email_id} content as permanently failed")
+  # An error here means the email is gone, or its content was fetched after all by a
+  # duplicate attempt — the `:fetched`-is-absorbing guard rejects that overwrite. Neither
+  # is something a later sweep could fix, so both report `:ignore`.
+  @impl true
+  def compensate(%Oban.Job{args: %{"email_id" => email_id}}, _reason) do
+    case Messaging.update_inbound_email_content(email_id, %{content_status: "failed"}) do
+      {:ok, _email} ->
+        Logger.error("Marked email #{email_id} content as permanently failed")
+        :ok
 
-        {:error, mark_reason} ->
-          Logger.error("Failed to mark email #{email_id} as failed: #{inspect(mark_reason)}")
-      end
+      {:error, mark_reason} ->
+        Logger.error("Failed to mark email #{email_id} as failed: #{inspect(mark_reason)}")
+        :ignore
     end
   end
 end

--- a/lib/klass_hero/messaging/adapters/driving/workers/fetch_email_content_worker.ex
+++ b/lib/klass_hero/messaging/adapters/driving/workers/fetch_email_content_worker.ex
@@ -6,21 +6,15 @@ defmodule KlassHero.Messaging.Adapters.Driving.Workers.FetchEmailContentWorker d
   body_html, body_text, headers, and sets content_status to fetched/failed.
   """
 
-  use Oban.Worker, queue: :email, max_attempts: 3
+  use KlassHero.Shared.RateLimitedEmailWorker, queue: :email, max_attempts: 3
 
   alias KlassHero.Messaging
   alias KlassHero.Messaging.Adapters.Driven.ResendEmailContentAdapter
-  alias KlassHero.Shared.RateLimitedEmailWorker
-  alias KlassHero.Shared.Tracing.TracedWorker
 
   require Logger
 
-  # Custom backoff: 429 responses need longer delay than Oban's default.
-  @impl Oban.Worker
-  def backoff(%Oban.Job{} = job), do: RateLimitedEmailWorker.backoff(job)
-
-  @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"email_id" => email_id, "resend_id" => resend_id}} = job) do
+  @impl true
+  def execute(%Oban.Job{args: %{"email_id" => email_id, "resend_id" => resend_id}} = job) do
     case ResendEmailContentAdapter.fetch_content(resend_id) do
       {:ok, content} ->
         attrs = %{

--- a/lib/klass_hero/messaging/adapters/driving/workers/send_email_reply_worker.ex
+++ b/lib/klass_hero/messaging/adapters/driving/workers/send_email_reply_worker.ex
@@ -34,13 +34,16 @@ defmodule KlassHero.Messaging.Adapters.Driving.Workers.SendEmailReplyWorker do
 
         {:error, reason} ->
           Logger.error("Reply delivery failed for #{reply_id}: #{inspect(reason)}")
-          mark_reply_failed_if_final(reply_id, job)
+          TracedWorker.compensate_if_final(__MODULE__, job, reason)
           {:error, reason}
       end
     else
+      # Ungated on purpose. This branch discards immediately rather than retrying, so
+      # gating on `final_attempt?/1` meant a first-attempt discard left the reply
+      # unmarked forever — a reply whose inbound email is missing never showed as failed.
       {:error, :not_found} ->
         Logger.error("Reply or email not found for reply #{reply_id}")
-        mark_reply_failed_if_final(reply_id, job)
+        compensate(job, :not_found)
         {:discard, :not_found}
     end
   end
@@ -68,15 +71,19 @@ defmodule KlassHero.Messaging.Adapters.Driving.Workers.SendEmailReplyWorker do
     end
   end
 
-  defp mark_reply_failed_if_final(reply_id, job) do
-    if TracedWorker.final_attempt?(job) do
-      case Messaging.update_email_reply_status(reply_id, "failed", %{}) do
-        {:ok, _} ->
-          Logger.error("Marked reply #{reply_id} as permanently failed")
+  # An error here means the reply is gone, or it was delivered after all by a duplicate
+  # attempt — the `:sent`-is-absorbing guard rejects that overwrite. Neither is something
+  # a later sweep could fix, so both report `:ignore`.
+  @impl true
+  def compensate(%Oban.Job{args: %{"reply_id" => reply_id}}, _reason) do
+    case Messaging.update_email_reply_status(reply_id, "failed", %{}) do
+      {:ok, _reply} ->
+        Logger.error("Marked reply #{reply_id} as permanently failed")
+        :ok
 
-        {:error, reason} ->
-          Logger.error("Failed to mark reply #{reply_id} as failed: #{inspect(reason)}")
-      end
+      {:error, reason} ->
+        Logger.error("Failed to mark reply #{reply_id} as failed: #{inspect(reason)}")
+        :ignore
     end
   end
 

--- a/lib/klass_hero/messaging/adapters/driving/workers/send_email_reply_worker.ex
+++ b/lib/klass_hero/messaging/adapters/driving/workers/send_email_reply_worker.ex
@@ -6,23 +6,17 @@ defmodule KlassHero.Messaging.Adapters.Driving.Workers.SendEmailReplyWorker do
   with proper threading headers, delivers, and updates reply status.
   """
 
-  use Oban.Worker, queue: :email, max_attempts: 3
+  use KlassHero.Shared.RateLimitedEmailWorker, queue: :email, max_attempts: 3
   use KlassHero.Shared.Interaction
 
   alias KlassHero.Messaging
-  alias KlassHero.Shared.RateLimitedEmailWorker
-  alias KlassHero.Shared.Tracing.TracedWorker
 
   require Logger
 
   @from Application.compile_env!(:klass_hero, [:mailer_defaults, :from])
 
-  # Custom backoff: 429 responses need longer delay than Oban's default.
-  @impl Oban.Worker
-  def backoff(%Oban.Job{} = job), do: RateLimitedEmailWorker.backoff(job)
-
-  @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"reply_id" => reply_id}} = job) do
+  @impl true
+  def execute(%Oban.Job{args: %{"reply_id" => reply_id}} = job) do
     with {:ok, reply} <- Messaging.get_email_reply_by_id(reply_id),
          {:ok, email} <- Messaging.get_inbound_email_by_id(reply.inbound_email_id) do
       now = DateTime.utc_now()

--- a/lib/klass_hero/messaging/email_reply.ex
+++ b/lib/klass_hero/messaging/email_reply.ex
@@ -64,5 +64,25 @@ defmodule KlassHero.Messaging.EmailReply do
     schema
     |> cast(attrs, [:status, :resend_message_id, :sent_at])
     |> validate_required([:status])
+    |> validate_status_transition()
+  end
+
+  # `:sent` is absorbing. Marking a reply failed is replayable — by the sweep over
+  # discarded Oban jobs, and by a Lifeline duplicate racing the original delivery — and a
+  # replay must not record a delivered reply as failed. `:failed -> :sent` stays open on
+  # purpose: a late delivery is ground truth and should heal a row the sweep failed
+  # pessimistically.
+  defp validate_status_transition(changeset) do
+    case {changeset.data.status, get_change(changeset, :status)} do
+      {:sent, target} when target not in [nil, :sent] ->
+        add_error(changeset, :status, "cannot transition from sent to #{target}",
+          validation: :status_transition,
+          from: :sent,
+          to: target
+        )
+
+      _unchanged_or_permitted ->
+        changeset
+    end
   end
 end

--- a/lib/klass_hero/messaging/inbound_email.ex
+++ b/lib/klass_hero/messaging/inbound_email.ex
@@ -93,5 +93,26 @@ defmodule KlassHero.Messaging.InboundEmail do
     schema
     |> cast(attrs, @content_fields)
     |> validate_required([:content_status])
+    |> validate_content_status_transition()
+  end
+
+  # `:fetched` is absorbing. Marking a fetch permanently failed is replayable — by the
+  # sweep over discarded jobs, and by a Lifeline duplicate racing the original — and a
+  # replay must not bury content that was in fact fetched under `content_status:
+  # :failed`, which would leave body_html populated next to a status saying it is not.
+  # Only that one edge is closed; `:failed -> :fetched` stays open so a later successful
+  # fetch still heals the row.
+  defp validate_content_status_transition(changeset) do
+    case {changeset.data.content_status, get_change(changeset, :content_status)} do
+      {:fetched, target} when target not in [nil, :fetched] ->
+        add_error(changeset, :content_status, "cannot transition from fetched to #{target}",
+          validation: :content_status_transition,
+          from: :fetched,
+          to: target
+        )
+
+      _unchanged_or_permitted ->
+        changeset
+    end
   end
 end

--- a/lib/klass_hero/shared/adapters/driven/persistence/repositories/job_compensation_repository.ex
+++ b/lib/klass_hero/shared/adapters/driven/persistence/repositories/job_compensation_repository.ex
@@ -1,0 +1,89 @@
+defmodule KlassHero.Shared.Adapters.Driven.Persistence.Repositories.JobCompensationRepository do
+  @moduledoc """
+  Exactly-once execution of a dead Oban job's compensating action.
+
+  Same shape as `ProcessedEventRepository.execute_atomically/3`, for the same
+  reason: the marker row and the work it describes commit together, so exactly-once
+  is a unique constraint rather than careful code. A compensation that fails leaves
+  no marker, and the next sweep retries it.
+
+  ## Why `:ignore` is not `{:error, _}`
+
+  A compensation whose entity is already terminal — an invite already `:enrolled`,
+  a reply already `:sent` — has nothing left to do. That is a success, and it must
+  commit its marker. Returning `{:error, _}` there would roll the marker back and
+  make the sweep re-attempt the same job on every tick until the Pruner deletes the
+  `oban_jobs` row a week later. `{:error, _}` is reserved for a transient failure
+  that a later sweep could genuinely fix.
+  """
+
+  use KlassHero.Shared.Interaction
+
+  alias KlassHero.Repo
+  alias KlassHero.Shared.Adapters.Driven.Persistence.Schemas.JobCompensation
+
+  require Logger
+
+  @doc """
+  Runs `compensation_fn` at most once for `job_id`, recording that it ran.
+
+  Returns `:ok` when the compensation ran (or was already recorded, or reported
+  `:ignore`), and `{:error, reason}` when it failed — in which case no marker is
+  left behind.
+  """
+  @spec compensate_once(integer(), String.t(), (-> :ok | :ignore | {:error, term()})) ::
+          :ok | {:error, term()}
+  def compensate_once(job_id, worker, compensation_fn)
+      when is_integer(job_id) and is_binary(worker) and is_function(compensation_fn, 0) do
+    db_interaction operation: :compensate_once, entity: "job_compensation" do
+      Repo.transaction(fn ->
+        case insert_marker(job_id, worker) do
+          # Another sweep — or an earlier tick — already compensated this job.
+          :already_compensated ->
+            :ok
+
+          # Runs inside the transaction so a rollback removes the marker with it.
+          :inserted ->
+            run_compensation(compensation_fn)
+        end
+      end)
+      |> unwrap_transaction_result()
+    end
+  end
+
+  # `insert_all` with `on_conflict: :nothing` rather than `Repo.insert`: the latter
+  # raises `Ecto.ConstraintError` on a duplicate, which aborts the enclosing
+  # transaction unless run at a savepoint (#1065). This never raises — a losing race
+  # simply reports zero rows affected.
+  defp insert_marker(job_id, worker) do
+    row = %{job_id: job_id, worker: worker, compensated_at: DateTime.utc_now()}
+
+    case Repo.insert_all(JobCompensation, [row], on_conflict: :nothing) do
+      {1, _returning} -> :inserted
+      {0, _returning} -> :already_compensated
+    end
+  end
+
+  defp run_compensation(compensation_fn) do
+    case compensation_fn.() do
+      :ok -> :ok
+      :ignore -> :ok
+      {:error, reason} -> Repo.rollback({:compensation_failed, reason})
+    end
+  rescue
+    error ->
+      # Log before Repo.rollback, which loses the original stacktrace.
+      Logger.error("Job compensation crashed: #{Exception.message(error)}",
+        stacktrace: Exception.format_stacktrace(__STACKTRACE__)
+      )
+
+      Repo.rollback({:compensation_crashed, error})
+  end
+
+  defp unwrap_transaction_result({:ok, :ok}), do: :ok
+  defp unwrap_transaction_result({:error, {:compensation_failed, reason}}), do: {:error, reason}
+
+  defp unwrap_transaction_result({:error, {:compensation_crashed, error}}), do: {:error, {:compensation_crashed, error}}
+
+  defp unwrap_transaction_result({:error, reason}), do: {:error, reason}
+end

--- a/lib/klass_hero/shared/adapters/driven/persistence/schemas/job_compensation.ex
+++ b/lib/klass_hero/shared/adapters/driven/persistence/schemas/job_compensation.ex
@@ -1,0 +1,20 @@
+defmodule KlassHero.Shared.Adapters.Driven.Persistence.Schemas.JobCompensation do
+  @moduledoc """
+  Ecto schema for the `job_compensations` ledger.
+
+  Internal to `JobCompensationRepository` — not a domain model. Each row records
+  that a permanently-dead Oban job has had its compensating fact established, so
+  the sweep stops reconsidering it. Identity is `job_id`; there is no synthetic
+  primary key and no association to `oban_jobs`, whose rows the Pruner deletes on
+  a schedule of its own.
+  """
+
+  use Ecto.Schema
+
+  @primary_key false
+  schema "job_compensations" do
+    field :job_id, :integer
+    field :worker, :string
+    field :compensated_at, :utc_datetime_usec
+  end
+end

--- a/lib/klass_hero/shared/adapters/driven/workers/compensation_sweep_worker.ex
+++ b/lib/klass_hero/shared/adapters/driven/workers/compensation_sweep_worker.ex
@@ -1,0 +1,120 @@
+defmodule KlassHero.Shared.Adapters.Driven.Workers.CompensationSweepWorker do
+  @moduledoc """
+  Establishes the compensating fact for jobs that died without running their gate.
+
+  Workers compensate inline when Oban tells them the attempt is the last one. Three
+  routes reach a terminal job without that branch ever evaluating:
+
+    * `Oban.Plugins.Lifeline` discards an orphan left `executing` by a machine that
+      went away. Its rescue is a bare `update_all`, so `perform/1` is never invoked.
+    * A raised exception bypasses the `{:error, _}` branch the gate lives in, and
+      lands the job in `discarded` once attempts are spent.
+    * An explicit `{:discard, _}` return gives up before the final attempt.
+
+  All three converge on `oban_jobs.state == "discarded"`, which is what this sweeps.
+  The job row is the only durable trace — Lifeline's telemetry carries ids and
+  nothing else — so reconciliation reads the table rather than listening for events.
+
+  Scope is the `CompensatingWorkerRegistry` list, filtered in SQL. Without that, a
+  discarded job from a worker that never compensates would be re-examined on every
+  tick for as long as the Pruner keeps its row.
+  """
+
+  # `unique` because the schedule can outpace the run: Cron inserts on the leader only,
+  # so nodes do not double-fire, but a sweep still executing when the next tick arrives
+  # would otherwise be joined by a second one racing it over the same rows. `:incomplete`
+  # rather than a hand-written state list, which silently omits `:suspended`/`:retryable`
+  # and lets a duplicate through exactly when the previous run is in trouble.
+  use KlassHero.Shared.Tracing.TracedWorker,
+    queue: :cleanup,
+    max_attempts: 3,
+    unique: [period: 300, states: Oban.Job.unique_states(:incomplete)]
+
+  import Ecto.Query
+
+  alias KlassHero.Repo
+  alias KlassHero.Shared.Adapters.Driven.Persistence.Repositories.JobCompensationRepository
+  alias KlassHero.Shared.Adapters.Driven.Persistence.Schemas.JobCompensation
+  alias KlassHero.Shared.CompensatingWorkerRegistry
+
+  require Logger
+
+  # Bounds one tick's work. Reaching it is reported rather than swallowed: a saturated
+  # batch means the backlog is growing faster than the schedule drains it.
+  @batch_limit 500
+
+  @impl true
+  def execute(%Oban.Job{}) do
+    pending = uncompensated_jobs()
+
+    if length(pending) == @batch_limit do
+      Logger.warning("Compensation sweep filled its batch; #{@batch_limit} jobs handled, more may remain")
+    end
+
+    Enum.each(pending, &compensate_job/1)
+    :ok
+  end
+
+  defp uncompensated_jobs do
+    names = CompensatingWorkerRegistry.worker_names()
+
+    Repo.all(
+      from(job in Oban.Job,
+        left_join: compensation in JobCompensation,
+        on: compensation.job_id == job.id,
+        where: job.state == "discarded",
+        where: job.worker in ^names,
+        where: is_nil(compensation.job_id),
+        order_by: [asc: job.discarded_at],
+        limit: @batch_limit,
+        select: job
+      )
+    )
+  end
+
+  defp compensate_job(%Oban.Job{} = job) do
+    case Oban.Worker.from_string(job.worker) do
+      {:ok, worker} ->
+        run(worker, job)
+
+      # Registered under a name nothing answers to any more — a worker renamed or deleted
+      # while its dead jobs were still on the table. Nothing to compensate with, and no
+      # marker written, so it resurfaces if the module comes back.
+      {:error, error} ->
+        Logger.error("Compensation sweep cannot resolve worker #{job.worker}: #{Exception.message(error)}")
+    end
+  end
+
+  defp run(worker, %Oban.Job{} = job) do
+    case JobCompensationRepository.compensate_once(job.id, job.worker, fn ->
+           worker.compensate(job, reason_from(job))
+         end) do
+      :ok ->
+        :ok
+
+      # Left uncompensated on purpose: no marker was written, so the next tick retries.
+      {:error, reason} ->
+        Logger.error("Compensation failed for #{job.worker} job #{job.id}: #{inspect(reason)}")
+    end
+  end
+
+  @doc """
+  Best-effort cause of death, or `nil` when none was recorded.
+
+  `oban_jobs.errors` holds maps of `%{"attempt" => _, "at" => _, "error" => _}`, and
+  that `"error"` is already-formatted text — `Exception.format/3` for a raise, or
+  `Oban.PerformError`'s `"... failed with \#{inspect(reason)}"` for a returned tuple.
+  The original term is gone by the time it lands here, so this is for rendering only.
+
+  A Lifeline discard appends nothing at all, so an orphan yields `nil`.
+  """
+  @spec reason_from(Oban.Job.t()) :: String.t() | nil
+  def reason_from(%Oban.Job{errors: errors}) when is_list(errors) do
+    case List.last(errors) do
+      %{"error" => error} when is_binary(error) -> error
+      _none -> nil
+    end
+  end
+
+  def reason_from(%Oban.Job{}), do: nil
+end

--- a/lib/klass_hero/shared/compensating_worker_registry.ex
+++ b/lib/klass_hero/shared/compensating_worker_registry.ex
@@ -1,0 +1,34 @@
+defmodule KlassHero.Shared.CompensatingWorkerRegistry do
+  @moduledoc """
+  The one list of workers whose dead jobs get swept for compensation.
+
+  Being in this list is the only condition, so a worker either gets its
+  compensation reconciled after the job dies or is visibly absent from
+  `config/config.exs` — the same bargain `EventConsumerRegistry` makes for event
+  delivery.
+
+  It is a list rather than a `function_exported?/3` scan for two reasons. The
+  sweep needs a bounded `worker in ^names` filter, because a discarded job from a
+  worker that never compensates would otherwise be re-examined on every tick for
+  as long as the Pruner keeps its row. And discovering implementers means loading
+  every module in the application, which starves the code server (#1232).
+  """
+
+  @doc "Workers registered for compensation sweeping."
+  @spec workers() :: [module()]
+  def workers do
+    Application.get_env(:klass_hero, :compensating_workers, [])
+  end
+
+  @doc """
+  Registered workers as `oban_jobs.worker` stores them.
+
+  `Oban.Worker.to_string/1` rather than `Kernel.to_string/1`: the column holds
+  `"KlassHero.Family..."`, not the `"Elixir."`-prefixed atom text, so a raw
+  conversion would match nothing.
+  """
+  @spec worker_names() :: [String.t()]
+  def worker_names do
+    Enum.map(workers(), &Oban.Worker.to_string/1)
+  end
+end

--- a/lib/klass_hero/shared/tracing/traced_worker.ex
+++ b/lib/klass_hero/shared/tracing/traced_worker.ex
@@ -30,6 +30,32 @@ defmodule KlassHero.Shared.Tracing.TracedWorker do
   @callback execute(Oban.Job.t()) :: :ok | {:ok, term()} | {:error, term()}
 
   @doc """
+  Establishes the business fact that this job gave up permanently.
+
+  Implement it when giving up has a consequence someone must see — an invite that
+  has to show as `:failed`, an email that has to stop looking pending. The
+  in-attempt `final_attempt?/1` gate calls it, and so does the sweep over
+  discarded jobs, because a job can die without ever running the gate: Lifeline
+  discards an orphan at the attempt ceiling without invoking `perform/1`, a raise
+  bypasses the error branch the gate lives in, and an explicit `{:discard, _}` can
+  return before the final attempt.
+
+  Return `:ignore` — never `{:error, _}` — when there is nothing left to do,
+  including when the entity is already terminal or no longer exists. `:ignore`
+  records the compensation as done; `{:error, _}` rolls that record back and asks
+  the next sweep to try again, so using it for a permanent condition re-runs the
+  compensation every tick until the job row is pruned.
+
+  `reason` is whatever the failing attempt returned, and `nil` when it cannot be
+  known. Lifeline's discard writes no error at all, and for the other routes Oban
+  stores `Exception.format/3` or `Oban.PerformError`'s message — formatted strings
+  embedding `inspect/1` output, not the original term. Render it; never match on it.
+  """
+  @callback compensate(Oban.Job.t(), reason :: term() | nil) :: :ok | :ignore | {:error, term()}
+
+  @optional_callbacks compensate: 2
+
+  @doc """
   True once Oban has no retries left for this job.
 
   Workers gate compensating actions on this: a compensation applied while
@@ -41,6 +67,18 @@ defmodule KlassHero.Shared.Tracing.TracedWorker do
   @spec final_attempt?(Oban.Job.t()) :: boolean()
   def final_attempt?(%Oban.Job{attempt: attempt, max_attempts: max_attempts}) do
     attempt >= max_attempts
+  end
+
+  @doc """
+  Compensates now if this is the last attempt, otherwise leaves it to a later one.
+
+  The in-attempt fast path. A job that dies without reaching it — orphaned, raised,
+  or discarded early — is caught later by the sweep over discarded jobs, which calls
+  the same `compensate/2`.
+  """
+  @spec compensate_if_final(module(), Oban.Job.t(), term()) :: :ok | :ignore | {:error, term()}
+  def compensate_if_final(worker, %Oban.Job{} = job, reason) when is_atom(worker) do
+    if final_attempt?(job), do: worker.compensate(job, reason), else: :ok
   end
 
   @doc false

--- a/priv/repo/migrations/20260802090000_create_job_compensations.exs
+++ b/priv/repo/migrations/20260802090000_create_job_compensations.exs
@@ -1,0 +1,26 @@
+defmodule KlassHero.Repo.Migrations.CreateJobCompensations do
+  @moduledoc """
+  Ledger recording that a permanently-dead Oban job has had its compensating
+  business fact established.
+
+  Deliberately carries no foreign key to `oban_jobs`: `Oban.Plugins.Pruner`
+  deletes those rows on its own schedule (7 days here), and a compensation
+  outliving the job row it describes is correct, not orphaned.
+
+  `job_id` is unique because that uniqueness *is* the exactly-once guarantee —
+  the sweep inserts the marker and runs the compensation in one transaction, so
+  a duplicate is refused by the database rather than by careful code.
+  """
+
+  use Ecto.Migration
+
+  def change do
+    create table(:job_compensations, primary_key: false) do
+      add :job_id, :bigint, null: false
+      add :worker, :string, null: false
+      add :compensated_at, :utc_datetime_usec, null: false
+    end
+
+    create unique_index(:job_compensations, [:job_id])
+  end
+end

--- a/test/config/oban_config_test.exs
+++ b/test/config/oban_config_test.exs
@@ -9,6 +9,8 @@ defmodule KlassHero.ObanConfigTest do
 
   use ExUnit.Case, async: true
 
+  alias KlassHero.Shared.Adapters.Driven.Workers.CompensationSweepWorker
+
   describe "oban plugins" do
     # A machine going away mid-job leaves that job `executing` with nothing to move it back.
     # fly.toml sets auto_stop_machines = "suspend" and min_machines_running = 0, so machines
@@ -29,10 +31,37 @@ defmodule KlassHero.ObanConfigTest do
       assert Keyword.get(opts, :max_age, 60) >= 86_400,
              "Pruner max_age is under a day — discarded jobs vanish before triage"
     end
+
+    # The sweep is the only thing that compensates a job which died without running its
+    # own gate. Dropped from the crontab it fails silently: nothing errors, invites and
+    # emails simply keep looking pending after the job that owned them is gone.
+    test "sweeps discarded jobs for uncompensated work" do
+      assert {_expression, CompensationSweepWorker} = crontab_entry(CompensationSweepWorker),
+             "CompensationSweepWorker is missing from the crontab — jobs that die without " <>
+               "running their compensation gate are never reconciled (#1234)"
+    end
+
+    # The sweep only ever sees a discarded job while its row survives, so the Pruner
+    # window is the sweep's window. Guarded together because tightening one silently
+    # shortens the other.
+    test "prunes no faster than the sweep can reach a discarded job" do
+      {expression, _worker} = crontab_entry(CompensationSweepWorker)
+      max_age = Oban.Plugins.Pruner |> plugin_opts() |> Keyword.get(:max_age, 60)
+
+      assert max_age > 3600,
+             "Pruner max_age (#{max_age}s) leaves too little room for the sweep at #{expression}"
+    end
   end
 
   # config/test.exs adds only `testing: :inline` and Config.Reader deep-merges, so the plugin list
   # read here is the one dev and prod actually run.
+  defp crontab_entry(worker) do
+    Oban.Plugins.Cron
+    |> plugin_opts()
+    |> Keyword.get(:crontab, [])
+    |> Enum.find(fn {_expression, scheduled} -> scheduled == worker end)
+  end
+
   defp plugin_opts(module) do
     :klass_hero
     |> Application.fetch_env!(Oban)

--- a/test/klass_hero/messaging/adapters/driving/workers/send_email_reply_worker_test.exs
+++ b/test/klass_hero/messaging/adapters/driving/workers/send_email_reply_worker_test.exs
@@ -58,5 +58,58 @@ defmodule KlassHero.Messaging.Adapters.Driving.Workers.SendEmailReplyWorkerTest 
       {:ok, updated} = Messaging.get_email_reply_by_id(reply.id)
       assert updated.status == :failed
     end
+
+    # This branch discards instead of retrying, so gating its compensation on
+    # final_attempt?/1 meant a first-attempt discard could never compensate. Reaching it
+    # with a reply still present requires the inbound email to vanish from under a live
+    # reply, which `on_delete: :delete_all` prevents — so the compensation has nothing to
+    # mark and must report that quietly rather than raise.
+    test "discards without raising when the reply is gone" do
+      assert {:discard, :not_found} =
+               SendEmailReplyWorker.perform(%Oban.Job{
+                 args: %{"reply_id" => Ecto.UUID.generate()},
+                 attempt: 1,
+                 max_attempts: 3
+               })
+    end
+  end
+
+  describe "compensate/2" do
+    test "marks the reply failed regardless of which attempt discovered the failure" do
+      email = MessagingFixtures.inbound_email_fixture()
+      reply = MessagingFixtures.email_reply_fixture(%{inbound_email_id: email.id})
+
+      assert :ok =
+               SendEmailReplyWorker.compensate(
+                 %Oban.Job{args: %{"reply_id" => reply.id}, attempt: 1, max_attempts: 3},
+                 :whatever
+               )
+
+      {:ok, updated} = Messaging.get_email_reply_by_id(reply.id)
+      assert updated.status == :failed
+    end
+
+    # The sweep replays compensation for any discarded job it has not yet recorded. If a
+    # duplicate attempt delivered the reply in the meantime, that replay must not record
+    # the delivered reply as failed — and must not report an error the sweep would retry.
+    test "reports :ignore rather than overwriting a delivered reply" do
+      email = MessagingFixtures.inbound_email_fixture()
+      reply = MessagingFixtures.email_reply_fixture(%{inbound_email_id: email.id})
+      {:ok, _sent} = Messaging.update_email_reply_status(reply.id, "sent", %{})
+
+      assert :ignore =
+               SendEmailReplyWorker.compensate(%Oban.Job{args: %{"reply_id" => reply.id}}, :whatever)
+
+      {:ok, unchanged} = Messaging.get_email_reply_by_id(reply.id)
+      assert unchanged.status == :sent
+    end
+
+    test "reports :ignore when the reply no longer exists" do
+      assert :ignore =
+               SendEmailReplyWorker.compensate(
+                 %Oban.Job{args: %{"reply_id" => Ecto.UUID.generate()}},
+                 :whatever
+               )
+    end
   end
 end

--- a/test/klass_hero/messaging/email_reply_test.exs
+++ b/test/klass_hero/messaging/email_reply_test.exs
@@ -38,6 +38,53 @@ defmodule KlassHero.Messaging.EmailReplyTest do
     end
   end
 
+  describe "status_changeset/2 transition guard" do
+    # `:sent` is absorbing. Compensation marking a reply failed can be replayed — by the
+    # sweep over discarded jobs, or by a Lifeline duplicate racing the original — and
+    # without this guard the replay records a delivered reply as failed.
+    @transitions [
+      {:sending, :sent, true},
+      {:sending, :failed, true},
+      {:failed, :sent, true},
+      {:failed, :failed, true},
+      {:sent, :sent, true},
+      {:sent, :failed, false}
+    ]
+
+    for {from, to, valid?} <- @transitions do
+      test "#{from} -> #{to} is #{if valid?, do: "allowed", else: "rejected"}" do
+        changeset =
+          EmailReply.status_changeset(%EmailReply{status: unquote(from)}, %{status: unquote(to)})
+
+        assert changeset.valid? == unquote(valid?),
+               "expected #{unquote(from)} -> #{unquote(to)} to be " <>
+                 "#{if unquote(valid?), do: "allowed", else: "rejected"}"
+      end
+    end
+
+    test "names the rejected transition in the error" do
+      changeset = EmailReply.status_changeset(%EmailReply{status: :sent}, %{status: :failed})
+
+      assert %{status: ["cannot transition from sent to failed"]} = errors_on(changeset)
+    end
+
+    # The delivery path writes resend_message_id/sent_at alongside the status, so the
+    # guard must not reject a changeset merely for carrying more than :status.
+    test "allows delivery metadata through on a permitted transition" do
+      now = DateTime.utc_now()
+
+      changeset =
+        EmailReply.status_changeset(%EmailReply{status: :sending}, %{
+          status: :sent,
+          resend_message_id: "resend_abc",
+          sent_at: now
+        })
+
+      assert changeset.valid?
+      assert Ecto.Changeset.get_field(changeset, :resend_message_id) == "resend_abc"
+    end
+  end
+
   describe "create_email_reply/1 and status transitions" do
     setup do
       email = MessagingFixtures.inbound_email_fixture()

--- a/test/klass_hero/messaging/inbound_email_test.exs
+++ b/test/klass_hero/messaging/inbound_email_test.exs
@@ -108,6 +108,58 @@ defmodule KlassHero.Messaging.InboundEmailTest do
     end
   end
 
+  describe "content_changeset/2 transition guard" do
+    # `:fetched` is absorbing. Compensation for a permanently-failed fetch job can be
+    # replayed — by the sweep over discarded jobs, or by a Lifeline duplicate execution
+    # racing the original — and without this guard the replay overwrites content that
+    # was in fact fetched, leaving body_html populated next to content_status: :failed.
+    @transitions [
+      {:pending, :fetched, true},
+      {:pending, :failed, true},
+      {:failed, :fetched, true},
+      {:failed, :failed, true},
+      {:fetched, :fetched, true},
+      {:fetched, :failed, false}
+    ]
+
+    for {from, to, valid?} <- @transitions do
+      test "#{from} -> #{to} is #{if valid?, do: "allowed", else: "rejected"}" do
+        changeset =
+          InboundEmail.content_changeset(
+            %InboundEmail{content_status: unquote(from)},
+            %{content_status: unquote(to)}
+          )
+
+        assert changeset.valid? == unquote(valid?),
+               "expected #{unquote(from)} -> #{unquote(to)} to be " <>
+                 "#{if unquote(valid?), do: "allowed", else: "rejected"}"
+      end
+    end
+
+    test "names the rejected transition in the error" do
+      changeset =
+        InboundEmail.content_changeset(
+          %InboundEmail{content_status: :fetched},
+          %{content_status: :failed}
+        )
+
+      assert %{content_status: ["cannot transition from fetched to failed"]} = errors_on(changeset)
+    end
+
+    # The happy path writes body fields alongside the status, so the guard must not
+    # reject a changeset merely because it carries more than content_status.
+    test "allows content fields through on a permitted transition" do
+      changeset =
+        InboundEmail.content_changeset(
+          %InboundEmail{content_status: :pending},
+          %{content_status: :fetched, body_html: "<p>Hi</p>", body_text: "Hi"}
+        )
+
+      assert changeset.valid?
+      assert Ecto.Changeset.get_field(changeset, :body_html) == "<p>Hi</p>"
+    end
+  end
+
   describe "mark_inbound_email_read/2" do
     test "marks an unread email as read, then is idempotent" do
       user = AccountsFixtures.user_fixture()

--- a/test/klass_hero/shared/adapters/driven/persistence/repositories/job_compensation_repository_test.exs
+++ b/test/klass_hero/shared/adapters/driven/persistence/repositories/job_compensation_repository_test.exs
@@ -1,0 +1,98 @@
+defmodule KlassHero.Shared.Adapters.Driven.Persistence.Repositories.JobCompensationRepositoryTest do
+  @moduledoc """
+  The exactly-once gate for compensating a permanently-dead Oban job.
+
+  The distinction that matters here is `:ignore` vs `{:error, _}`. A compensation
+  whose entity is already terminal (invite already `:enrolled`, reply already
+  `:sent`) has nothing left to do and must commit its marker — returning an error
+  there would roll the marker back and make the sweep re-attempt that job on every
+  tick until the Pruner deletes the row a week later.
+  """
+
+  use KlassHero.DataCase, async: true
+
+  import ExUnit.CaptureLog
+
+  alias KlassHero.Repo
+  alias KlassHero.Shared.Adapters.Driven.Persistence.Repositories.JobCompensationRepository
+  alias KlassHero.Shared.Adapters.Driven.Persistence.Schemas.JobCompensation
+
+  @worker "KlassHero.Family.Adapters.Driving.Workers.ProcessInviteClaimWorker"
+
+  describe "compensate_once/3" do
+    test "runs the compensation and records it" do
+      job_id = job_id()
+      test_pid = self()
+
+      result =
+        JobCompensationRepository.compensate_once(job_id, @worker, fn ->
+          send(test_pid, :compensated)
+          :ok
+        end)
+
+      assert result == :ok
+      assert_received :compensated
+      assert %JobCompensation{worker: @worker} = Repo.get_by(JobCompensation, job_id: job_id)
+    end
+
+    test "does not run the compensation a second time" do
+      job_id = job_id()
+      test_pid = self()
+
+      :ok = JobCompensationRepository.compensate_once(job_id, @worker, fn -> send(test_pid, :first) && :ok end)
+      assert_received :first
+
+      assert :ok =
+               JobCompensationRepository.compensate_once(job_id, @worker, fn -> send(test_pid, :second) && :ok end)
+
+      refute_received :second
+    end
+
+    # "Already terminal, nothing to do" is a success. The marker must persist so the
+    # sweep stops reconsidering this job.
+    test "records the marker when the compensation returns :ignore" do
+      job_id = job_id()
+
+      assert :ok = JobCompensationRepository.compensate_once(job_id, @worker, fn -> :ignore end)
+      assert Repo.get_by(JobCompensation, job_id: job_id)
+    end
+
+    # A transient failure must leave no marker, so the next sweep tries again.
+    test "rolls the marker back when the compensation fails" do
+      job_id = job_id()
+
+      assert {:error, :database_unavailable} =
+               JobCompensationRepository.compensate_once(job_id, @worker, fn ->
+                 {:error, :database_unavailable}
+               end)
+
+      refute Repo.get_by(JobCompensation, job_id: job_id)
+    end
+
+    test "rolls the marker back and logs when the compensation crashes" do
+      job_id = job_id()
+
+      log =
+        capture_log([level: :error], fn ->
+          JobCompensationRepository.compensate_once(job_id, @worker, fn -> raise "kaboom" end)
+        end)
+
+      assert log =~ "Job compensation crashed"
+      assert log =~ "kaboom"
+      refute Repo.get_by(JobCompensation, job_id: job_id)
+    end
+
+    test "a rolled-back compensation can be retried later" do
+      job_id = job_id()
+
+      assert {:error, :transient} =
+               JobCompensationRepository.compensate_once(job_id, @worker, fn -> {:error, :transient} end)
+
+      assert :ok = JobCompensationRepository.compensate_once(job_id, @worker, fn -> :ok end)
+      assert Repo.get_by(JobCompensation, job_id: job_id)
+    end
+  end
+
+  # oban_jobs ids are bigserial; these rows are never joined so any distinct integer works.
+  defp job_id, do: System.unique_integer([:positive])
+end

--- a/test/klass_hero/shared/adapters/driven/workers/compensation_sweep_worker_test.exs
+++ b/test/klass_hero/shared/adapters/driven/workers/compensation_sweep_worker_test.exs
@@ -1,0 +1,138 @@
+defmodule KlassHero.Shared.Adapters.Driven.Workers.CompensationSweepWorkerTest do
+  @moduledoc """
+  The three routes to a terminal job that never runs its own compensation gate all
+  end in the same place — an `oban_jobs` row in `discarded` — so they are exercised
+  here by writing that row directly rather than by staging a node failure.
+
+  `Oban.insert/1` cannot produce them: the suite runs `testing: :inline`, which
+  executes a job at insert and never lets one sit `executing` for Lifeline to find.
+  """
+
+  use KlassHero.DataCase, async: true
+
+  alias KlassHero.Messaging
+  alias KlassHero.MessagingFixtures
+  alias KlassHero.Repo
+  alias KlassHero.Shared.Adapters.Driven.Persistence.Schemas.JobCompensation
+  alias KlassHero.Shared.Adapters.Driven.Workers.CompensationSweepWorker
+
+  @registered "KlassHero.Messaging.Adapters.Driving.Workers.SendEmailReplyWorker"
+  @unregistered "KlassHero.Messaging.Adapters.Driving.Workers.MessageCleanupWorker"
+
+  describe "execute/1" do
+    test "compensates a discarded job and records that it did" do
+      reply = pending_reply()
+      job = discarded_job(@registered, %{"reply_id" => reply.id})
+
+      assert :ok = CompensationSweepWorker.perform(%Oban.Job{})
+
+      assert reply_status(reply) == :failed
+      assert Repo.get_by(JobCompensation, job_id: job.id)
+    end
+
+    # A Lifeline discard records no error at all, so the compensation runs with no cause
+    # to render. It must still establish the fact.
+    test "compensates an orphan discarded with no recorded error" do
+      reply = pending_reply()
+      discarded_job(@registered, %{"reply_id" => reply.id}, errors: [])
+
+      assert :ok = CompensationSweepWorker.perform(%Oban.Job{})
+      assert reply_status(reply) == :failed
+    end
+
+    test "does not compensate the same job twice" do
+      reply = pending_reply()
+      discarded_job(@registered, %{"reply_id" => reply.id})
+
+      assert :ok = CompensationSweepWorker.perform(%Oban.Job{})
+      assert reply_status(reply) == :failed
+
+      # A second reply delivered in the meantime proves the sweep re-ran at all; the
+      # first must not be touched again.
+      {:ok, _} = Messaging.update_email_reply_status(reply.id, "sending", %{})
+
+      assert :ok = CompensationSweepWorker.perform(%Oban.Job{})
+      assert reply_status(reply) == :sending
+    end
+
+    test "leaves jobs from unregistered workers alone" do
+      reply = pending_reply()
+      job = discarded_job(@unregistered, %{"reply_id" => reply.id})
+
+      assert :ok = CompensationSweepWorker.perform(%Oban.Job{})
+
+      assert reply_status(reply) == :sending
+      refute Repo.get_by(JobCompensation, job_id: job.id)
+    end
+
+    # Only `discarded` means "dead". A cancelled job was given up on deliberately by code
+    # that already handled it, and a retryable one still has attempts left.
+    for state <- ~w(completed cancelled retryable available) do
+      test "leaves #{state} jobs alone" do
+        reply = pending_reply()
+        job = discarded_job(@registered, %{"reply_id" => reply.id}, state: unquote(state))
+
+        assert :ok = CompensationSweepWorker.perform(%Oban.Job{})
+
+        assert reply_status(reply) == :sending, "expected a #{unquote(state)} job to be left alone"
+        refute Repo.get_by(JobCompensation, job_id: job.id)
+      end
+    end
+
+    test "compensates the remaining jobs when one of them is unresolvable" do
+      reply = pending_reply()
+      discarded_job("KlassHero.Workers.DeletedLongAgo", %{"reply_id" => reply.id})
+      discarded_job(@registered, %{"reply_id" => reply.id})
+
+      assert :ok = CompensationSweepWorker.perform(%Oban.Job{})
+      assert reply_status(reply) == :failed
+    end
+  end
+
+  describe "reason_from/1" do
+    test "returns the last recorded error string" do
+      job = %Oban.Job{
+        errors: [
+          %{"attempt" => 1, "error" => "** (RuntimeError) first"},
+          %{"attempt" => 2, "error" => "** (RuntimeError) last"}
+        ]
+      }
+
+      assert CompensationSweepWorker.reason_from(job) == "** (RuntimeError) last"
+    end
+
+    test "returns nil when nothing was recorded" do
+      assert CompensationSweepWorker.reason_from(%Oban.Job{errors: []}) == nil
+    end
+  end
+
+  defp pending_reply do
+    email = MessagingFixtures.inbound_email_fixture()
+    MessagingFixtures.email_reply_fixture(%{inbound_email_id: email.id})
+  end
+
+  defp reply_status(reply) do
+    {:ok, reloaded} = Messaging.get_email_reply_by_id(reply.id)
+    reloaded.status
+  end
+
+  # Written straight to the table: Oban's own insert path cannot leave a row in a
+  # terminal state under `testing: :inline`.
+  defp discarded_job(worker, args, opts \\ []) do
+    now = DateTime.utc_now()
+
+    Repo.insert!(%Oban.Job{
+      worker: worker,
+      args: args,
+      queue: "email",
+      state: Keyword.get(opts, :state, "discarded"),
+      attempt: 3,
+      max_attempts: 3,
+      discarded_at: now,
+      attempted_at: now,
+      inserted_at: now,
+      scheduled_at: now,
+      errors: Keyword.get(opts, :errors, [%{"attempt" => 3, "at" => DateTime.to_iso8601(now), "error" => "boom"}])
+    })
+  end
+end

--- a/test/klass_hero/shared/compensating_worker_registry_test.exs
+++ b/test/klass_hero/shared/compensating_worker_registry_test.exs
@@ -1,0 +1,56 @@
+defmodule KlassHero.Shared.CompensatingWorkerRegistryTest do
+  @moduledoc """
+  Guards the registry against the two ways it goes silently wrong: a worker listed
+  without the callback it promises, and a name that does not match what
+  `oban_jobs.worker` actually stores — either of which makes the sweep skip a job
+  while looking like it swept it.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias KlassHero.Shared.CompensatingWorkerRegistry
+
+  describe "workers/0" do
+    test "every registered worker implements the callback it is registered for" do
+      # Iterates the registry, never the whole module list: loading every module to find
+      # implementers starves the code server and surfaces as an unrelated DB pool timeout
+      # (#1232).
+      for worker <- CompensatingWorkerRegistry.workers() do
+        Code.ensure_loaded!(worker)
+
+        assert function_exported?(worker, :compensate, 2),
+               "#{inspect(worker)} is registered for compensation sweeping but does not implement compensate/2"
+      end
+    end
+
+    test "is not empty" do
+      # A registry emptied by a bad merge would make every assertion above vacuous.
+      refute CompensatingWorkerRegistry.workers() == []
+    end
+  end
+
+  describe "worker_names/0" do
+    # oban_jobs.worker holds "KlassHero.Foo", not "Elixir.KlassHero.Foo". A raw
+    # Kernel.to_string/1 would produce the latter and the sweep's `worker in ^names`
+    # filter would match nothing at all — a sweep that runs, reports success, and
+    # compensates nothing.
+    test "renders names the way Oban persists them" do
+      for name <- CompensatingWorkerRegistry.worker_names() do
+        assert is_binary(name)
+
+        refute String.starts_with?(name, "Elixir."),
+               "#{name} carries the Elixir. prefix that oban_jobs.worker does not store"
+      end
+    end
+
+    test "round-trips back to the registered modules" do
+      resolved =
+        for name <- CompensatingWorkerRegistry.worker_names() do
+          {:ok, module} = Oban.Worker.from_string(name)
+          module
+        end
+
+      assert resolved == CompensatingWorkerRegistry.workers()
+    end
+  end
+end


### PR DESCRIPTION
Closes #1234. Closes #1241.

## Summary

Four Oban workers establish a business fact when they give up permanently — an invite goes `:failed`, an inbound email goes `content_status: "failed"`, a reply goes `"failed"`. Each did it inside `if TracedWorker.final_attempt?(job)` in its own error branch.

That branch is *control flow*, but the fact it establishes is a *reconciliation*, so it inherits every way a process can fail to reach a line. Three exist, and all three land the job in `oban_jobs.state == "discarded"`:

1. **Lifeline discards an orphan** (#1234). `Engine.rescue_jobs/3` is a bare `update_all` — at `attempt >= max_attempts` the job goes straight to `discarded` without `perform/1` ever running. Its telemetry selects `[:id, :queue, :state]`, so no listener could recover the affected entity either. The job row is the only durable trace.
2. **A raise** (#1241). No worker has a `rescue`, so it bypasses the `{:error, _}` branch the gate lives in.
3. **An early `{:discard, _}`** on a non-final attempt.

One sweep over `discarded` closes all three.

## Review focus

**The `:ignore` return is load-bearing.** `compensate/2` returns `:ok | :ignore | {:error, _}`. An entity already terminal — or already gone — must report `:ignore`, which commits the ledger marker. Returning `{:error, _}` there would roll the marker back and re-attempt that job every 5 minutes until the Pruner deletes it a week later.

**Transition guards were a prerequisite, not scope creep.** `EmailReply.status_changeset` and `InboundEmail.content_changeset` were `cast |> validate_required` with no guard, unlike `BulkEnrollmentInvite`. Since the sweep replays compensation deliberately — and Lifeline's own docs warn it "may transition jobs that are genuinely executing" — an unguarded replay would record a *delivered* reply as failed. `:sent` and `:fetched` are now absorbing; the reverse direction stays open so a late success still heals.

**The registry is a config list, not reflection.** The sweep needs a bounded SQL filter (an unlisted worker's discarded jobs never earn a ledger row, so they'd be rescanned every tick for 7 days), and discovering implementers means loading every module, which starves the code server (#1232).

**`insert_all(on_conflict: :nothing)`, not `Repo.insert`.** The latter raises on duplicate and poisons the enclosing transaction unless run at a savepoint (#1065).

## Corrections to the issue

- The issue comment counts **five** `final_attempt?` gates; only **four** compensate. `EventDeliveryWorker:97` picks log severity — no state change, nothing to compensate — so it is out of scope.
- I claimed while triaging that the `SendEmailReplyWorker` early-discard was a **live** bug. It is latent: `email_replies.inbound_email_id` cascades `on_delete: :delete_all`, so a reply cannot outlive its inbound email and the branch is only reachable when the reply itself is gone. Ungated anyway, since the gate was wrong there regardless.

## Test plan

- `mix precommit` green: 4084 passed. Suite run 4× more to separate a pre-existing flake (`incident_live_test:302`, admin photo signing — unrelated) from this diff; 4 consecutive clean runs.
- All three bypass routes covered by writing `oban_jobs` rows directly — `testing: :inline` executes at insert and never lets a job sit `executing`, so Lifeline's path is unreachable through `Oban.insert/1`.
- Orphan-with-no-recorded-error covered specifically: Lifeline appends nothing to `errors`, so compensation must run with no cause to render.
- Idempotence proven by re-running the sweep and asserting the first reply is untouched.
- The two migrated workers' existing tests are unchanged and still pass — `TracedWorker`'s macro regenerates `perform/1` around the new `execute/1`.

## Not done

`job_compensations` has no pruning. One small row per compensated discard, ever. Worth a follow-up decision rather than a silent assumption.