### PR TITLE
feat: dead-letter permanently undelivered integration events

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -38,6 +38,7 @@ alias KlassHero.Shared.Adapters.Driven.FeatureFlags.FunWithFlagsAdapter
 alias KlassHero.Shared.Adapters.Driven.Persistence.Repositories.ProcessedEventRepository
 alias KlassHero.Shared.Adapters.Driven.Storage.S3StorageAdapter
 alias KlassHero.Shared.Adapters.Driven.Workers.CompensationSweepWorker
+alias KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorker
 alias KlassHero.Shared.ErrorContextFilter
 alias Swoosh.Adapters.Local
 
@@ -144,7 +145,12 @@ config :klass_hero, :compensating_workers, [
   ProcessInviteClaimWorker,
   SendInviteEmailWorker,
   FetchEmailContentWorker,
-  SendEmailReplyWorker
+  SendEmailReplyWorker,
+  # The odd one out: its compensating fact is a negative one — a dead-letter record
+  # saying these consumers never reacted and now never will. It compensates only
+  # here, never inside its own attempt, because the routes an in-attempt gate cannot
+  # see are exactly the ones that lose an event silently.
+  EventDeliveryWorker
 ]
 
 # Contact information — centralized, configurable per environment

--- a/lib/klass_hero/shared/adapters/driven/persistence/repositories/processed_event_repository.ex
+++ b/lib/klass_hero/shared/adapters/driven/persistence/repositories/processed_event_repository.ex
@@ -10,10 +10,25 @@ defmodule KlassHero.Shared.Adapters.Driven.Persistence.Repositories.ProcessedEve
 
   use KlassHero.Shared.Interaction
 
+  import Ecto.Query
+
   alias KlassHero.Repo
   alias KlassHero.Shared.Adapters.Driven.Persistence.Schemas.ProcessedEvent
 
   require Logger
+
+  @doc """
+  Handler refs that have already processed `event_id`.
+
+  Not part of `ForTrackingProcessedEvents`: that behaviour is about executing a
+  handler atomically, and this is a plain read of what the table now knows. Its
+  one caller is `EventDeliveryWorker.compensate/2`, working out which consumers a
+  dead job never reached.
+  """
+  @spec processed_handler_refs(String.t()) :: [String.t()]
+  def processed_handler_refs(event_id) when is_binary(event_id) do
+    Repo.all(from(p in ProcessedEvent, where: p.event_id == ^event_id, select: p.handler_ref))
+  end
 
   @impl true
   def execute_atomically(event_id, handler_ref, handler_fn)

--- a/lib/klass_hero/shared/adapters/driven/persistence/repositories/undelivered_event_repository.ex
+++ b/lib/klass_hero/shared/adapters/driven/persistence/repositories/undelivered_event_repository.ex
@@ -1,0 +1,50 @@
+defmodule KlassHero.Shared.Adapters.Driven.Persistence.Repositories.UndeliveredEventRepository do
+  @moduledoc """
+  The dead-letter store for events delivery gave up on permanently.
+
+  Written only from `EventDeliveryWorker.compensate/2`, which the sweep over
+  discarded jobs calls. Read by whoever is asking what was lost, and by the prune
+  that forgets it 90 days later.
+  """
+
+  use KlassHero.Shared.Interaction
+
+  import Ecto.Query
+
+  alias KlassHero.Repo
+  alias KlassHero.Shared.Adapters.Driven.Persistence.Schemas.UndeliveredEvent
+
+  @doc """
+  Records the given rows, ignoring any event already recorded.
+
+  `insert_all` with `on_conflict: :nothing` rather than `Repo.insert`: this runs
+  inside `JobCompensationRepository.compensate_once`'s transaction, and the
+  `Ecto.ConstraintError` a duplicate would raise there aborts *that* transaction
+  unless run at a savepoint (#1065) — taking the compensation marker with it.
+  """
+  @spec record_all([map()]) :: :ok
+  def record_all([]), do: :ok
+
+  def record_all(rows) when is_list(rows) do
+    db_interaction operation: :record_all, entity: "undelivered_event" do
+      Repo.insert_all(UndeliveredEvent, rows, on_conflict: :nothing)
+      :ok
+    end
+  end
+
+  @doc """
+  Deletes records staged before `cutoff`, returning how many went.
+
+  The envelope carries whatever personal data its event carried, so its retention
+  is a rule someone chose rather than however long nobody deleted it.
+  """
+  @spec prune(DateTime.t()) :: non_neg_integer()
+  def prune(%DateTime{} = cutoff) do
+    db_interaction operation: :prune, entity: "undelivered_event" do
+      {deleted, _returning} =
+        Repo.delete_all(from(u in UndeliveredEvent, where: u.inserted_at < ^cutoff))
+
+      deleted
+    end
+  end
+end

--- a/lib/klass_hero/shared/adapters/driven/persistence/schemas/undelivered_event.ex
+++ b/lib/klass_hero/shared/adapters/driven/persistence/schemas/undelivered_event.ex
@@ -1,0 +1,25 @@
+defmodule KlassHero.Shared.Adapters.Driven.Persistence.Schemas.UndeliveredEvent do
+  @moduledoc """
+  Ecto schema for the `undelivered_events` dead-letter table.
+
+  Internal to `UndeliveredEventRepository` — not a domain model. Each row records
+  one integration event that delivery gave up on permanently, together with the
+  consumers that never received it and the serialized envelope needed to replay it.
+
+  Identity is `event_id`; there is no synthetic primary key and no association to
+  `oban_jobs`, whose rows the Pruner deletes on a schedule of its own.
+  """
+
+  use Ecto.Schema
+
+  @primary_key false
+  schema "undelivered_events" do
+    field :event_id, Ecto.UUID
+    field :topic, :string
+    field :payload, :map
+    field :missed_consumers, {:array, :string}
+    field :job_id, :integer
+    field :discarded_at, :utc_datetime_usec
+    field :inserted_at, :utc_datetime_usec
+  end
+end

--- a/lib/klass_hero/shared/adapters/driven/workers/compensation_sweep_worker.ex
+++ b/lib/klass_hero/shared/adapters/driven/workers/compensation_sweep_worker.ex
@@ -34,6 +34,7 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.CompensationSweepWorker do
 
   alias KlassHero.Repo
   alias KlassHero.Shared.Adapters.Driven.Persistence.Repositories.JobCompensationRepository
+  alias KlassHero.Shared.Adapters.Driven.Persistence.Repositories.UndeliveredEventRepository
   alias KlassHero.Shared.Adapters.Driven.Persistence.Schemas.JobCompensation
   alias KlassHero.Shared.CompensatingWorkerRegistry
 
@@ -42,6 +43,11 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.CompensationSweepWorker do
   # Bounds one tick's work. Reaching it is reported rather than swallowed: a saturated
   # batch means the backlog is growing faster than the schedule drains it.
   @batch_limit 500
+
+  # Dead-lettered events keep whatever personal data their payload carried, so they
+  # expire on a rule rather than on nobody getting round to it. Long enough that any
+  # realistic "what did we lose?" investigation still finds the payload.
+  @undelivered_retention_days 90
 
   @impl true
   def execute(%Oban.Job{}) do
@@ -52,7 +58,20 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.CompensationSweepWorker do
     end
 
     Enum.each(pending, &compensate_job/1)
+    prune_undelivered_events()
     :ok
+  end
+
+  # Rides the 5-minute tick rather than a cron of its own: an indexed delete over a
+  # table that is empty in the healthy case costs nothing, and the alternative is a
+  # second schedule to keep in agreement with this one.
+  defp prune_undelivered_events do
+    cutoff = DateTime.add(DateTime.utc_now(), -@undelivered_retention_days, :day)
+
+    case UndeliveredEventRepository.prune(cutoff) do
+      0 -> :ok
+      pruned -> Logger.info("Pruned #{pruned} undelivered event(s) past #{@undelivered_retention_days} days")
+    end
   end
 
   defp uncompensated_jobs do

--- a/lib/klass_hero/shared/adapters/driven/workers/event_delivery_worker.ex
+++ b/lib/klass_hero/shared/adapters/driven/workers/event_delivery_worker.ex
@@ -37,6 +37,8 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorker do
 
   alias KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializer
   alias KlassHero.Shared.Adapters.Driven.Events.EventConsumerRegistry
+  alias KlassHero.Shared.Adapters.Driven.Persistence.Repositories.ProcessedEventRepository
+  alias KlassHero.Shared.Adapters.Driven.Persistence.Repositories.UndeliveredEventRepository
   alias KlassHero.Shared.CriticalEventDispatcher
   alias KlassHero.Shared.Domain.Events.Event
   alias KlassHero.Shared.Tracing.Context
@@ -105,4 +107,69 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorker do
   end
 
   defp first_error(results), do: Enum.find(results, :ok, &match?({:error, _reason}, &1))
+
+  @doc """
+  Dead-letters whatever this job never managed to deliver.
+
+  The fact established here is a negative one: these consumers did not react, and
+  now never will. It is written by the sweep over discarded jobs rather than by
+  the in-attempt gate, because the three routes that skip that gate — a Lifeline
+  orphan, a raise, an early `{:discard, _}` — are exactly the ones a log line
+  cannot see, and nothing user-facing is waiting on this row within the five
+  minutes the sweep takes.
+
+  The loss is partial. `processed_events` keeps the consumers that did run, so an
+  event whose consumers all succeeded is recorded as nothing at all, and one that
+  half-landed records only the half that did not.
+
+  `missed_consumers` is resolved against the registry as it stands *now*, not as
+  it stood when the event was staged: a consumer deleted from `:event_consumers`
+  in between is not something anyone can still replay to.
+  """
+  @impl true
+  def compensate(%Oban.Job{args: %{"events" => raw_events}} = job, _reason) do
+    raw_events
+    |> Enum.map(&CriticalEventSerializer.deserialize/1)
+    |> Enum.flat_map(&undelivered_row(&1, job))
+    |> record()
+  end
+
+  # `:ignore`, never `{:error, _}`: nothing was lost, and an error would roll back
+  # the compensation marker and re-run this every sweep until the job row is pruned.
+  defp record([]), do: :ignore
+  defp record(rows), do: UndeliveredEventRepository.record_all(rows)
+
+  defp undelivered_row(%Event{} = event, %Oban.Job{} = job) do
+    topic = Event.topic(event)
+    processed = ProcessedEventRepository.processed_handler_refs(event.event_id)
+
+    case missed_consumers(topic, processed) do
+      [] ->
+        []
+
+      missed ->
+        [
+          %{
+            event_id: event.event_id,
+            topic: topic,
+            payload: CriticalEventSerializer.serialize(event),
+            missed_consumers: missed,
+            job_id: job.id,
+            discarded_at: job.discarded_at,
+            inserted_at: DateTime.utc_now()
+          }
+        ]
+    end
+  end
+
+  # Registry order is delivery order, and it is kept: reading the row should tell you
+  # which consumer was reached and which one the failure stopped at.
+  defp missed_consumers(topic, processed) do
+    delivered = MapSet.new(processed)
+
+    for consumer <- EventConsumerRegistry.consumers_for(topic),
+        ref = CriticalEventDispatcher.handler_ref(consumer),
+        not MapSet.member?(delivered, ref),
+        do: ref
+  end
 end

--- a/priv/repo/migrations/20260802184500_create_undelivered_events.exs
+++ b/priv/repo/migrations/20260802184500_create_undelivered_events.exs
@@ -1,0 +1,42 @@
+defmodule KlassHero.Repo.Migrations.CreateUndeliveredEvents do
+  @moduledoc """
+  Dead-letter record for an integration event whose delivery gave up permanently.
+
+  `payload` holds the whole serialized `Event` envelope rather than just its
+  `payload` field, because replaying one means handing those exact args back to
+  `EventDeliveryWorker` — `%{"events" => [payload]}`. Consumers that already
+  succeeded are skipped on replay by `processed_events`, which is never pruned.
+
+  No foreign key to `oban_jobs`, for the same reason `job_compensations` has none:
+  `Oban.Plugins.Pruner` deletes those rows after 7 days, and this record outliving
+  the job it describes is the entire point.
+
+  `event_id` is unique because that uniqueness *is* the idempotency guarantee —
+  the sweep may reach the same dead job more than once, and the database refuses
+  the duplicate rather than careful code.
+
+  Rows are pruned after 90 days by `CompensationSweepWorker`: the envelope carries
+  personal data (the last real production loss carried a parent's email), so its
+  retention is an explicit rule rather than an accident of what nobody deleted.
+  """
+
+  use Ecto.Migration
+
+  def change do
+    create table(:undelivered_events, primary_key: false) do
+      add :event_id, :uuid, null: false
+      add :topic, :string, null: false
+      add :payload, :map, null: false
+      add :missed_consumers, {:array, :string}, null: false
+      add :job_id, :bigint, null: false
+      add :discarded_at, :utc_datetime_usec
+      add :inserted_at, :utc_datetime_usec, null: false
+    end
+
+    create unique_index(:undelivered_events, [:event_id])
+
+    # The prune's access path. Every other read of this table is a human looking
+    # at a handful of rows, so this is the only index worth its write cost.
+    create index(:undelivered_events, [:inserted_at])
+  end
+end

--- a/test/klass_hero/shared/adapters/driven/workers/compensation_sweep_worker_test.exs
+++ b/test/klass_hero/shared/adapters/driven/workers/compensation_sweep_worker_test.exs
@@ -13,11 +13,15 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.CompensationSweepWorkerTest d
   alias KlassHero.Messaging
   alias KlassHero.MessagingFixtures
   alias KlassHero.Repo
+  alias KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializer
   alias KlassHero.Shared.Adapters.Driven.Persistence.Schemas.JobCompensation
+  alias KlassHero.Shared.Adapters.Driven.Persistence.Schemas.UndeliveredEvent
   alias KlassHero.Shared.Adapters.Driven.Workers.CompensationSweepWorker
+  alias KlassHero.Shared.Domain.Events.Event
 
   @registered "KlassHero.Messaging.Adapters.Driving.Workers.SendEmailReplyWorker"
   @unregistered "KlassHero.Messaging.Adapters.Driving.Workers.MessageCleanupWorker"
+  @delivery "KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorker"
 
   describe "execute/1" do
     test "compensates a discarded job and records that it did" do
@@ -89,6 +93,34 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.CompensationSweepWorkerTest d
     end
   end
 
+  # The registration in `:compensating_workers` is the whole mechanism here: without
+  # it the sweep's SQL filter never returns the job, whatever `compensate/2` does.
+  describe "undelivered events" do
+    test "dead-letters an event delivery that gave up permanently" do
+      event = Event.new(:user_registered, :accounts, :user, Ecto.UUID.generate(), %{})
+      job = discarded_job(@delivery, %{"events" => [CriticalEventSerializer.serialize(event)]})
+
+      assert :ok = CompensationSweepWorker.perform(%Oban.Job{})
+
+      row = Repo.get_by(UndeliveredEvent, event_id: event.event_id)
+      assert row.topic == "integration:accounts:user_registered"
+      assert row.job_id == job.id
+      assert row.missed_consumers != []
+      assert Repo.get_by(JobCompensation, job_id: job.id)
+    end
+
+    for {age_days, kept?} <- [{89, true}, {91, false}] do
+      test "a record staged #{age_days} days ago is #{if kept?, do: "kept", else: "pruned"}" do
+        event_id = stale_record(unquote(age_days))
+
+        assert :ok = CompensationSweepWorker.perform(%Oban.Job{})
+
+        assert Repo.get_by(UndeliveredEvent, event_id: event_id) != nil == unquote(kept?),
+               "expected a #{unquote(age_days)}-day-old record to be #{unquote(if kept?, do: "kept", else: "pruned")}"
+      end
+    end
+  end
+
   describe "reason_from/1" do
     test "returns the last recorded error string" do
       job = %Oban.Job{
@@ -114,6 +146,28 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.CompensationSweepWorkerTest d
   defp reply_status(reply) do
     {:ok, reloaded} = Messaging.get_email_reply_by_id(reply.id)
     reloaded.status
+  end
+
+  # Written straight to the table rather than produced by a compensation: the prune
+  # only cares how old a record is, and staging one by its real route would mean
+  # back-dating the `oban_jobs` row it came from as well.
+  defp stale_record(age_days) do
+    event_id = Ecto.UUID.generate()
+    staged_at = DateTime.add(DateTime.utc_now(), -age_days, :day)
+
+    Repo.insert_all(UndeliveredEvent, [
+      %{
+        event_id: event_id,
+        topic: "integration:accounts:user_registered",
+        payload: %{},
+        missed_consumers: ["Elixir.Whoever:handle_event"],
+        job_id: 1,
+        discarded_at: staged_at,
+        inserted_at: staged_at
+      }
+    ])
+
+    event_id
   end
 
   # Written straight to the table: Oban's own insert path cannot leave a row in a

--- a/test/klass_hero/shared/adapters/driven/workers/event_delivery_worker_test.exs
+++ b/test/klass_hero/shared/adapters/driven/workers/event_delivery_worker_test.exs
@@ -5,6 +5,7 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorkerTest do
 
   alias KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializer
   alias KlassHero.Shared.Adapters.Driven.Persistence.Schemas.ProcessedEvent
+  alias KlassHero.Shared.Adapters.Driven.Persistence.Schemas.UndeliveredEvent
   alias KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorker
   alias KlassHero.Shared.CriticalEventDispatcher
   alias KlassHero.Shared.Domain.Events.Event
@@ -45,10 +46,26 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorkerTest do
 
   defp job(events, attempt \\ 1) do
     %Oban.Job{
+      id: 4242,
       args: %{"events" => Enum.map(events, &CriticalEventSerializer.serialize/1)},
       attempt: attempt,
-      max_attempts: 10
+      max_attempts: 10,
+      discarded_at: DateTime.utc_now()
     }
+  end
+
+  defp handler_ref(consumer), do: CriticalEventDispatcher.handler_ref(consumer)
+
+  defp mark_processed(event, consumer) do
+    Repo.insert!(%ProcessedEvent{
+      event_id: event.event_id,
+      handler_ref: handler_ref(consumer),
+      processed_at: DateTime.utc_now()
+    })
+  end
+
+  defp undelivered(event) do
+    Repo.get_by(UndeliveredEvent, event_id: event.event_id)
   end
 
   test "delivers each event to every consumer of its topic", ctx do
@@ -130,5 +147,86 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorkerTest do
 
     assert :ok = EventDeliveryWorker.perform(job([event("thing-1")]))
     assert [] = Recorder.calls()
+  end
+
+  describe "compensate/2" do
+    test "records the event and the consumers that never received it", ctx do
+      route([{Recorder, :first}, {Recorder, :second}], ctx)
+      event = event("thing-1")
+
+      assert :ok = EventDeliveryWorker.compensate(job([event]), "boom")
+
+      row = undelivered(event)
+      assert row.topic == @topic
+      assert row.job_id == 4242
+      assert row.discarded_at
+      assert row.missed_consumers == [handler_ref({Recorder, :first}), handler_ref({Recorder, :second})]
+    end
+
+    # Replay hands these args straight back to the worker, so the whole envelope has
+    # to survive — not just the event's own payload.
+    test "keeps the serialized envelope so the event can be replayed", ctx do
+      route([{Recorder, :first}], ctx)
+      event = event("thing-1")
+
+      assert :ok = EventDeliveryWorker.compensate(job([event]), nil)
+
+      assert undelivered(event).payload == CriticalEventSerializer.serialize(event)
+    end
+
+    # The loss is partial: `processed_events` keeps the consumers that did run, and a
+    # retry only ever re-runs the rest. Recording the ones that succeeded would
+    # overstate what was lost.
+    test "records only the consumers still outstanding", ctx do
+      route([{Recorder, :first}, {Recorder, :second}], ctx)
+      event = event("thing-1")
+      mark_processed(event, {Recorder, :first})
+
+      assert :ok = EventDeliveryWorker.compensate(job([event]), "boom")
+
+      assert undelivered(event).missed_consumers == [handler_ref({Recorder, :second})]
+    end
+
+    test "records nothing for an event every consumer received", ctx do
+      route([{Recorder, :first}], ctx)
+      event = event("thing-1")
+      mark_processed(event, {Recorder, :first})
+
+      assert :ignore = EventDeliveryWorker.compensate(job([event]), "boom")
+
+      refute undelivered(event)
+    end
+
+    test "records only the undelivered events of a job that lost some of them", ctx do
+      route([{Recorder, :first}], ctx)
+      delivered = event("a")
+      lost = event("b")
+      mark_processed(delivered, {Recorder, :first})
+
+      assert :ok = EventDeliveryWorker.compensate(job([delivered, lost]), "boom")
+
+      refute undelivered(delivered)
+      assert undelivered(lost)
+    end
+
+    # A topic whose consumers were all removed from config since the event was staged.
+    test "records nothing for an event that is no longer routed anywhere", ctx do
+      route([], ctx)
+
+      assert :ignore = EventDeliveryWorker.compensate(job([event("thing-1")]), "boom")
+    end
+
+    # The sweep can reach the same dead job twice; the unique index refuses the
+    # duplicate rather than the compensation having to remember.
+    test "does not duplicate a row when the same job is compensated twice", ctx do
+      route([{Recorder, :first}], ctx)
+      event = event("thing-1")
+      job = job([event])
+
+      assert :ok = EventDeliveryWorker.compensate(job, "boom")
+      assert :ok = EventDeliveryWorker.compensate(job, "boom")
+
+      assert [_one] = Repo.all(from(u in UndeliveredEvent, where: u.event_id == ^event.event_id))
+    end
   end
 end


### PR DESCRIPTION
Closes #1247.

## Summary

When `EventDeliveryWorker` exhausts its 10 attempts, one or more consumers never ran and the event is gone. What remained was a `Logger.error`, an ErrorTracker row whose `job.args` are **redacted** (`ErrorContextFilter` allowlists no `events` key), and an `oban_jobs` row the Pruner deletes after 7 days. Nothing recorded that a cross-context reaction did not happen, and after a week the payload needed to replay it was gone too.

Not hypothetical: the predecessor `CriticalEventWorker` exhausted **14 times in production** between 2026-05-07 and 2026-07-08 (`error_tracker_errors` id 71, still `unresolved`), the last one a `user_confirmed` event for a real parent. That loss was only ever found by going looking for it.

`EventDeliveryWorker` now implements `compensate/2` and is registered in `:compensating_workers`, so the sweep shipped in #1244 records what was lost into a new `undelivered_events` table: topic, serialized envelope, and the consumers that never received it.

## Review focus

- **Sweep-only, no in-attempt gate.** The existing `final_attempt?/1` log branch is untouched. A final attempt returns `{:error, _}` → Oban discards → the sweep picks it up within 5 minutes. The three routes that bypass an in-attempt gate (Lifeline orphan, raise, early `{:discard, _}`) are exactly the ones that lose an event silently, and nothing user-facing waits on this row. This makes it the first entry in `:compensating_workers` whose compensating fact is a *negative* one.
- **The loss is partial.** `processed_events` is never pruned, so it already knew which consumers succeeded. An event everything received records nothing (`:ignore`); one that half-landed records only the half that did not. Replay is re-inserting the delivery job — the dispatcher skips consumers that already ran.
- **`insert_all` + `on_conflict: :nothing`, not `Repo.insert`.** `compensate/2` runs inside `JobCompensationRepository.compensate_once`'s transaction; the `Ecto.ConstraintError` a duplicate would raise there aborts that transaction unless run at a savepoint (#1065), taking the compensation marker with it.
- **90-day retention.** Envelopes carry whatever personal data their event carried — the last real production loss carried a parent's email — which is why `ErrorContextFilter` redacts them in the first place. The prune rides the existing 5-minute sweep rather than a second schedule to keep in agreement; it is an indexed delete over a table that is empty in the healthy case. It is *not* hung off Messaging's `RetentionPolicyWorker`, which is another bounded context.
- **`ProcessedEventRepository.processed_handler_refs/1`** is deliberately a plain public function, not part of the `ForTrackingProcessedEvents` behaviour — that contract is about executing a handler atomically, this is a read of what the table now knows.

## Test plan

- `mix precommit` — 4098 passed, 2 skipped.
- 15 tests on `compensate/2`: records the outstanding consumers in delivery order; keeps the full envelope for replay; records only the still-outstanding consumers; records nothing when every consumer received it; records only the lost events of a partially-delivered job; nothing for an unrouted topic; no duplicate row when the same job is compensated twice.
- Sweep test proves the `:compensating_workers` registration end-to-end against the **real** config — no app-env override — since without that line the sweep's SQL filter never returns the job.
- Prune boundary as a table: 89 days kept, 91 days pruned. The 91-day case is the one that proved red; the 89-day case alone would pass with no prune at all.

Not covered: the Oban cron trigger itself, which would need a dev-server run against the shared `klass_hero_dev` database.

## Follow-up

Visibility — a row nobody reads repeats the problem one table over. The cheap surfacing is a Backpex admin resource next to `/oban` and `/errors`; worth its own issue.