### PR TITLE
refactor: give the supported-locale set a single declaration

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -42,6 +42,18 @@ alias KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorker
 alias KlassHero.Shared.ErrorContextFilter
 alias Swoosh.Adapters.Local
 
+# The supported-locale set, declared once. Config owns it because config.exs is
+# evaluated before the app compiles and so can never read a module — a domain
+# module holding the literal could not feed the Gettext key below. Two `config`
+# calls consume these bindings (Quokka sorts them elsewhere in this file); they
+# cannot drift because there is only one binding.
+#
+# Adding a locale means this line, `priv/gettext/<locale>/`, and a `label/1` +
+# `flag/1` clause in `KlassHeroWeb.Locale`. All four are asserted together by
+# "every supported locale is fully wired" in `locale_test.exs`.
+supported_locales = ~w(en de)
+default_locale = "en"
+
 config :backpex,
   translator_function: {KlassHeroWeb.CoreComponents, :translate_backpex},
   error_translator_function: {KlassHeroWeb.CoreComponents, :translate_error}
@@ -99,12 +111,14 @@ config :klass_hero, KlassHeroWeb.Endpoint,
     layout: false
   ],
   pubsub_server: KlassHero.PubSub,
-  # Configure Gettext for internationalization
   live_view: [signing_salt: "JU2osypv"]
 
+# `:locales` is not a Gettext option — the backend derives its own set from the
+# .po files on disk. It lives under this key because `mix lint_translations`
+# reads it here to decide which locales require translations.
 config :klass_hero, KlassHeroWeb.Gettext,
-  default_locale: "en",
-  locales: ~w(en de)
+  default_locale: default_locale,
+  locales: supported_locales
 
 # Configure Oban for background jobs
 config :klass_hero, Oban,
@@ -316,6 +330,12 @@ config :klass_hero, :event_consumers, %{
 
 # Configure Feature Flags bounded context
 config :klass_hero, :feature_flags, adapter: FunWithFlagsAdapter
+
+# Read by `KlassHero.Shared.Locales`, which is what application code calls.
+config :klass_hero, :locales,
+  supported: supported_locales,
+  default: default_locale
+
 config :klass_hero, :mailer_defaults, from: {"KlassHero", "noreply@mail.klasshero.com"}
 
 config :klass_hero, :messaging,

--- a/lib/klass_hero/accounts/user.ex
+++ b/lib/klass_hero/accounts/user.ex
@@ -17,6 +17,7 @@ defmodule KlassHero.Accounts.User do
   alias KlassHero.Accounts.User
   alias KlassHero.Family.ParentProfile
   alias KlassHero.Provider.ProviderProfile
+  alias KlassHero.Shared.Locales
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
@@ -238,16 +239,19 @@ defmodule KlassHero.Accounts.User do
     }
   end
 
-  @supported_locales ~w(en de)
-
   @doc """
-  A user changeset for changing locale preference. Validates against #{inspect(@supported_locales)}.
+  A user changeset for changing locale preference.
+
+  Validates against `KlassHero.Shared.Locales.supported/0` — the same set the web
+  layer reads, so a locale the UI offers can always be stored (#1227). Rejects
+  rather than coerces: an unsupported locale should render as the default, but
+  never be written to a profile.
   """
   def locale_changeset(user, attrs) do
     user
     |> cast(attrs, [:locale])
     |> validate_required([:locale])
-    |> validate_inclusion(:locale, @supported_locales)
+    |> validate_inclusion(:locale, Locales.supported())
   end
 
   @doc """

--- a/lib/klass_hero/shared/locales.ex
+++ b/lib/klass_hero/shared/locales.ex
@@ -1,0 +1,52 @@
+defmodule KlassHero.Shared.Locales do
+  @moduledoc """
+  The supported-locale set, for every layer.
+
+  Lives in the Shared kernel for the same reason `KlassHero.Shared.Categories`
+  does: both a domain changeset (`KlassHero.Accounts.User.locale_changeset/2`)
+  and the web layer (`KlassHeroWeb.Locale`) need the same list, and the domain
+  cannot depend on a web module to get it.
+
+  The list is sourced from config rather than declared here. `config/config.exs`
+  also feeds it to the `KlassHeroWeb.Gettext` key that `mix lint_translations`
+  reads, and config is evaluated before this module exists — so config, not this
+  module, has to be the one declaration (#1227).
+
+  This module answers *which* locales exist. How an unsupported one is handled
+  differs by caller and is not decided here: the changeset rejects it, while
+  `KlassHeroWeb.Locale.validate/1` coerces it to `default/0`, because every web
+  caller receives a locale from untrusted input.
+  """
+
+  @supported Application.compile_env!(:klass_hero, [:locales, :supported])
+  @default Application.compile_env!(:klass_hero, [:locales, :default])
+
+  @doc "Every locale the app supports."
+  @spec supported() :: [String.t()]
+  def supported, do: @supported
+
+  @doc "The locale used when nothing better is known."
+  @spec default() :: String.t()
+  def default, do: @default
+
+  @doc """
+  Whether the given term is a supported locale.
+
+  Accepts any term, not just a string — callers pass values straight from a query
+  param, a session written by an older release, or a `users.locale` column
+  holding a since-retired value.
+
+  ## Examples
+
+      iex> KlassHero.Shared.Locales.supported?("de")
+      true
+
+      iex> KlassHero.Shared.Locales.supported?("de-DE")
+      false
+
+      iex> KlassHero.Shared.Locales.supported?(nil)
+      false
+  """
+  @spec supported?(term()) :: boolean()
+  def supported?(locale), do: locale in @supported
+end

--- a/lib/klass_hero_web/components/layouts/root.html.heex
+++ b/lib/klass_hero_web/components/layouts/root.html.heex
@@ -15,8 +15,13 @@
           whichever language the session or Accept-Language implies, so it is the
           x-default target rather than a canonical of its own. --%>
     <link rel="canonical" href={Locale.url_for(seo_path(assigns), assigns[:locale])} />
-    <link rel="alternate" hreflang="en" href={Locale.url_for(seo_path(assigns), "en")} />
-    <link rel="alternate" hreflang="de" href={Locale.url_for(seo_path(assigns), "de")} />
+    <link
+      :for={locale <- Locale.supported()}
+      rel="alternate"
+      hreflang={locale}
+      href={Locale.url_for(seo_path(assigns), locale)}
+    />
+    <%!-- x-default is not a locale, so it stays outside the loop. --%>
     <link rel="alternate" hreflang="x-default" href={Locale.url_for(seo_path(assigns), nil)} />
     <.live_title default="Klass Hero" suffix=" · Afterschool Activities & Camps">
       {assigns[:page_title]}

--- a/lib/klass_hero_web/live/user_live/settings.ex
+++ b/lib/klass_hero_web/live/user_live/settings.ex
@@ -5,6 +5,7 @@ defmodule KlassHeroWeb.UserLive.Settings do
 
   alias KlassHero.Accounts
   alias KlassHeroWeb.Helpers.FamilyHelpers
+  alias KlassHeroWeb.Locale
   alias KlassHeroWeb.Presenters.ChildPresenter
 
   on_mount {KlassHeroWeb.UserAuth, :require_sudo_mode}
@@ -172,41 +173,29 @@ defmodule KlassHeroWeb.UserLive.Settings do
                 {gettext("Choose your preferred language for the interface")}
               </p>
               <.form for={@locale_form} id="locale_form" phx-change="update_locale">
+                <%!-- Labels are endonyms, so they are not translated — see
+                      KlassHeroWeb.Locale. --%>
                 <div class="flex flex-wrap gap-3">
-                  <label class={[
-                    "flex items-center gap-2 px-4 py-3 rounded-xl border-2 cursor-pointer transition-colors",
-                    if(@current_scope.user.locale == "en",
-                      do: "border-[var(--brand-primary)] bg-hero-pink-50",
-                      else: "border-[var(--border-light)] hover:border-[var(--border-medium)]"
-                    )
-                  ]}>
+                  <label
+                    :for={locale <- Locale.supported()}
+                    id={"locale-option-#{locale}"}
+                    class={[
+                      "flex items-center gap-2 px-4 py-3 rounded-xl border-2 cursor-pointer transition-colors",
+                      if(@current_scope.user.locale == locale,
+                        do: "border-[var(--brand-primary)] bg-hero-pink-50",
+                        else: "border-[var(--border-light)] hover:border-[var(--border-medium)]"
+                      )
+                    ]}
+                  >
                     <input
                       type="radio"
                       name="user[locale]"
-                      value="en"
-                      checked={@current_scope.user.locale == "en"}
+                      value={locale}
+                      checked={@current_scope.user.locale == locale}
                       class="hidden"
                     />
-                    <span class="text-2xl">🇬🇧</span>
-                    <span class="font-semibold text-hero-black">{gettext("English")}</span>
-                  </label>
-
-                  <label class={[
-                    "flex items-center gap-2 px-4 py-3 rounded-xl border-2 cursor-pointer transition-colors",
-                    if(@current_scope.user.locale == "de",
-                      do: "border-[var(--brand-primary)] bg-hero-pink-50",
-                      else: "border-[var(--border-light)] hover:border-[var(--border-medium)]"
-                    )
-                  ]}>
-                    <input
-                      type="radio"
-                      name="user[locale]"
-                      value="de"
-                      checked={@current_scope.user.locale == "de"}
-                      class="hidden"
-                    />
-                    <span class="text-2xl">🇩🇪</span>
-                    <span class="font-semibold text-hero-black">{gettext("Deutsch")}</span>
+                    <span class="text-2xl">{Locale.flag(locale)}</span>
+                    <span class="font-semibold text-hero-black">{Locale.label(locale)}</span>
                   </label>
                 </div>
               </.form>

--- a/lib/klass_hero_web/locale.ex
+++ b/lib/klass_hero_web/locale.ex
@@ -1,37 +1,59 @@
 defmodule KlassHeroWeb.Locale do
   @moduledoc """
-  The supported-locale whitelist, in one place.
+  Everything the web layer needs to know about locales.
 
-  This unifies the web layer's copies — the `SetLocale` plug, the `RestoreLocale`
-  hook, and (implicitly) the hardcoded `lang="en"` in the root layout, which had
-  drifted far enough to claim English on every German page (#1161).
+  The *set* is not declared here — `KlassHero.Shared.Locales` owns it, sourced
+  from one binding in `config/config.exs` that also feeds the Gettext key
+  `mix lint_translations` reads (#1227). Before that, this module and
+  `KlassHero.Accounts.User.locale_changeset/2` each kept their own copy, and they
+  disagreed in a way nothing surfaced: adding a locale here alone left the
+  changeset rejecting what this module accepted, so choosing it failed with
+  "Failed to update language preference." and no explanation anywhere.
 
-  `KlassHero.Accounts.User.locale_changeset/2` deliberately keeps its own list:
-  the domain cannot depend on a web module. The two agree today, so adding a
-  locale here without adding it there would leave the changeset rejecting what
-  this module accepts.
+  What lives here is the web's own answers about locales:
 
-  `validate/1` coerces rather than fails. Every caller receives a locale from
-  untrusted input — a `?locale=` param, a session cookie written by an older
-  release, a `users.locale` column holding a value since retired — and the right
-  response to all of them is to render the default, not to raise.
+  - `validate/1` coerces rather than fails. Every caller receives a locale from
+    untrusted input — a `?locale=` param, a session cookie written by an older
+    release, a `users.locale` column holding a value since retired — and the
+    right response to all of them is to render the default, not to raise. The
+    changeset is the strict half of that pair and rejects instead.
+  - `label/1` and `flag/1` are display metadata, which has no business in the
+    domain. Labels are endonyms — a language's own name for itself — so they are
+    deliberately not run through Gettext: an English speaker sees "Deutsch" too.
+  - `url_for/2` builds the canonical and hreflang URLs.
   """
 
-  @supported ~w(en de)
-  @default "en"
+  alias KlassHero.Shared.Locales
 
   @doc "Every locale the app can render."
-  def supported, do: @supported
+  defdelegate supported(), to: Locales
 
   @doc "The locale used when nothing better is known."
-  def default, do: @default
-
-  @doc "Coerces any term to a supported locale, falling back to `default/0`."
-  def validate(locale) when locale in @supported, do: locale
-  def validate(_locale), do: @default
+  defdelegate default(), to: Locales
 
   @doc "Whether the given term is a locale the app can render."
-  def supported?(locale), do: locale in @supported
+  defdelegate supported?(locale), to: Locales
+
+  @doc "Coerces any term to a supported locale, falling back to `default/0`."
+  def validate(locale) do
+    if Locales.supported?(locale), do: locale, else: Locales.default()
+  end
+
+  @doc """
+  The locale's own name for itself, or `nil` if it has none.
+
+  Returning `nil` rather than raising keeps a half-configured locale off the
+  settings page instead of crashing it. The "every supported locale is fully
+  wired" test in `locale_test.exs` is what makes the omission loud.
+  """
+  def label("en"), do: "English"
+  def label("de"), do: "Deutsch"
+  def label(_locale), do: nil
+
+  @doc "The locale's flag, or `nil` if it has none. See `label/1`."
+  def flag("en"), do: "🇬🇧"
+  def flag("de"), do: "🇩🇪"
+  def flag(_locale), do: nil
 
   @doc """
   The absolute URL serving `path` in `locale`, for `rel=canonical` and

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -26,7 +26,7 @@ msgstr "Über uns"
 msgid "Attempting to reconnect"
 msgstr "Verbindung wird wiederhergestellt"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:172
+#: lib/klass_hero_web/live/user_live/settings.ex:173
 #, elixir-autogen, elixir-format
 msgid "Choose your preferred language for the interface"
 msgstr "Wählen Sie Ihre bevorzugte Sprache für die Benutzeroberfläche"
@@ -51,12 +51,12 @@ msgstr "Kontakt"
 msgid "Dashboard"
 msgstr "Dashboard"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:263
+#: lib/klass_hero_web/live/user_live/settings.ex:252
 #, elixir-autogen, elixir-format
 msgid "Download My Data"
 msgstr "Meine Daten herunterladen"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:259
+#: lib/klass_hero_web/live/user_live/settings.ex:248
 #, elixir-autogen, elixir-format
 msgid "Download a copy of all your personal data"
 msgstr "Laden Sie eine Kopie aller Ihrer persönlichen Daten herunter"
@@ -73,7 +73,7 @@ msgstr "Spracheinstellung konnte nicht aktualisiert werden."
 msgid "Home"
 msgstr "Startseite"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:169
+#: lib/klass_hero_web/live/user_live/settings.ex:170
 #, elixir-autogen, elixir-format
 msgid "Language Preference"
 msgstr "Spracheinstellung"
@@ -131,7 +131,7 @@ msgstr "Etwas ist schief gelaufen!"
 msgid "We can't find the internet"
 msgstr "Keine Internetverbindung gefunden"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:257
+#: lib/klass_hero_web/live/user_live/settings.ex:246
 #, elixir-autogen, elixir-format
 msgid "Your Data"
 msgstr "Ihre Daten"
@@ -399,7 +399,7 @@ msgstr "Alle Programme ansehen →"
 msgid "✓ No hidden fees"
 msgstr "✓ Keine versteckten Gebühren"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:419
+#: lib/klass_hero_web/live/user_live/settings.ex:408
 #, elixir-autogen, elixir-format
 msgid "A link to confirm your email change has been sent to the new address."
 msgstr "Ein Bestätigungslink wurde an Ihre neue E-Mail-Adresse gesendet."
@@ -446,7 +446,7 @@ msgstr "Buchungshilfe"
 msgid "Cancellation & Refund Policy"
 msgstr "Stornierung & Rückerstattung"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:111
+#: lib/klass_hero_web/live/user_live/settings.ex:112
 #, elixir-autogen, elixir-format
 msgid "Change Email"
 msgstr "E-Mail ändern"
@@ -461,7 +461,7 @@ msgstr "Änderungen der Bedingungen"
 msgid "Changes to This Policy"
 msgstr "Änderungen dieser Richtlinie"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:109
+#: lib/klass_hero_web/live/user_live/settings.ex:110
 #, elixir-autogen, elixir-format
 msgid "Changing..."
 msgstr "Wird geändert..."
@@ -496,7 +496,7 @@ msgstr "Bestätigen und nur diesmal anmelden"
 msgid "Confirm and stay logged in"
 msgstr "Bestätigen und angemeldet bleiben"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:147
+#: lib/klass_hero_web/live/user_live/settings.ex:148
 #, elixir-autogen, elixir-format
 msgid "Confirm new password"
 msgstr "Neues Passwort bestätigen"
@@ -557,25 +557,20 @@ msgstr "Datensicherheit"
 msgid "Data Sharing"
 msgstr "Datenweitergabe"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:278
+#: lib/klass_hero_web/live/user_live/settings.ex:267
 #, elixir-autogen, elixir-format
 msgid "Delete Account"
 msgstr "Konto löschen"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:310
+#: lib/klass_hero_web/live/user_live/settings.ex:299
 #, elixir-autogen, elixir-format
 msgid "Delete My Account"
 msgstr "Mein Konto löschen"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:300
+#: lib/klass_hero_web/live/user_live/settings.ex:289
 #, elixir-autogen, elixir-format
 msgid "Deleting..."
 msgstr "Wird gelöscht..."
-
-#: lib/klass_hero_web/live/user_live/settings.ex:209
-#, elixir-autogen, elixir-format
-msgid "Deutsch"
-msgstr "Deutsch"
 
 #: lib/klass_hero_web/live/terms_of_service_live.ex:222
 #, elixir-autogen, elixir-format
@@ -590,33 +585,28 @@ msgstr "Streitbeilegung"
 #: lib/klass_hero_web/live/user_live/login.ex:60
 #: lib/klass_hero_web/live/user_live/login.ex:89
 #: lib/klass_hero_web/live/user_live/registration.ex:48
-#: lib/klass_hero_web/live/user_live/settings.ex:102
+#: lib/klass_hero_web/live/user_live/settings.ex:103
 #: lib/klass_hero_web/live/user_live/staff_invitation.ex:66
 #, elixir-autogen, elixir-format
 msgid "Email"
 msgstr "E-Mail"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:348
+#: lib/klass_hero_web/live/user_live/settings.ex:337
 #, elixir-autogen, elixir-format
 msgid "Email change link is invalid or it has expired."
 msgstr "Der Link zur E-Mail-Änderung ist ungültig oder abgelaufen."
 
-#: lib/klass_hero_web/live/user_live/settings.ex:345
+#: lib/klass_hero_web/live/user_live/settings.ex:334
 #, elixir-autogen, elixir-format
 msgid "Email changed successfully."
 msgstr "E-Mail erfolgreich geändert."
-
-#: lib/klass_hero_web/live/user_live/settings.ex:191
-#, elixir-autogen, elixir-format
-msgid "English"
-msgstr "Englisch"
 
 #: lib/klass_hero_web/live/user_live/registration.ex:71
 #, elixir-autogen, elixir-format
 msgid "Enroll children in programs"
 msgstr "Kinder für Programme anmelden"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:294
+#: lib/klass_hero_web/live/user_live/settings.ex:283
 #, elixir-autogen, elixir-format
 msgid "Enter your password to confirm"
 msgstr "Geben Sie Ihr Passwort zur Bestätigung ein"
@@ -637,7 +627,7 @@ msgstr "Auschecken fehlgeschlagen: %{reason}"
 msgid "Failed to complete session: %{reason}"
 msgstr "Sitzung konnte nicht abgeschlossen werden: %{reason}"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:497
+#: lib/klass_hero_web/live/user_live/settings.ex:486
 #, elixir-autogen, elixir-format
 msgid "Failed to delete account. Please try again."
 msgstr "Konto konnte nicht gelöscht werden. Bitte versuchen Sie es erneut."
@@ -700,7 +690,7 @@ msgstr "Einleitung"
 msgid "Invalid date format"
 msgstr "Ungültiges Datumsformat"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:491
+#: lib/klass_hero_web/live/user_live/settings.ex:480
 #, elixir-autogen, elixir-format
 msgid "Invalid password."
 msgstr "Ungültiges Passwort."
@@ -781,7 +771,7 @@ msgstr "Meine Sitzungen"
 msgid "Name"
 msgstr "Name"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:140
+#: lib/klass_hero_web/live/user_live/settings.ex:141
 #, elixir-autogen, elixir-format
 msgid "New password"
 msgstr "Neues Passwort"
@@ -810,7 +800,7 @@ msgid "Other"
 msgstr "Sonstiges"
 
 #: lib/klass_hero_web/live/user_live/login.ex:96
-#: lib/klass_hero_web/live/user_live/settings.ex:119
+#: lib/klass_hero_web/live/user_live/settings.ex:120
 #: lib/klass_hero_web/live/user_live/staff_invitation.ex:73
 #, elixir-autogen, elixir-format
 msgid "Password"
@@ -871,14 +861,14 @@ msgstr "Eintrag nicht gefunden"
 msgid "Register"
 msgstr "Registrieren"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:151
+#: lib/klass_hero_web/live/user_live/settings.ex:152
 #, elixir-autogen, elixir-format
 msgid "Save Password"
 msgstr "Passwort speichern"
 
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:381
 #: lib/klass_hero_web/live/settings/children_live.ex:743
-#: lib/klass_hero_web/live/user_live/settings.ex:150
+#: lib/klass_hero_web/live/user_live/settings.ex:151
 #, elixir-autogen, elixir-format
 msgid "Saving..."
 msgstr "Speichern..."
@@ -942,7 +932,7 @@ msgstr "Technisches Problem"
 msgid "Terms of Service"
 msgstr "Nutzungsbedingungen"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:281
+#: lib/klass_hero_web/live/user_live/settings.ex:270
 #, elixir-autogen, elixir-format
 msgid "This action cannot be undone. Your account data will be anonymized and you will be logged out."
 msgstr "Diese Aktion kann nicht rückgängig gemacht werden. Ihre Kontodaten werden anonymisiert und Sie werden abgemeldet."
@@ -1023,7 +1013,7 @@ msgstr "Sie müssen sich erneut authentifizieren, um sensible Aktionen auf Ihrem
 msgid "Your Privacy Rights"
 msgstr "Ihre Datenschutzrechte"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:479
+#: lib/klass_hero_web/live/user_live/settings.ex:468
 #, elixir-autogen, elixir-format
 msgid "Your account has been deleted."
 msgstr "Ihr Konto wurde gelöscht."
@@ -1126,7 +1116,7 @@ msgstr "Karten, Bankkonten, Rechnungsinformationen"
 #: lib/klass_hero_web/live/settings/children_live.ex:23
 #: lib/klass_hero_web/live/settings/children_live.ex:348
 #: lib/klass_hero_web/live/settings_live.ex:79
-#: lib/klass_hero_web/live/user_live/settings.ex:235
+#: lib/klass_hero_web/live/user_live/settings.ex:224
 #, elixir-autogen, elixir-format
 msgid "Children Profiles"
 msgstr "Kinderprofile"
@@ -1247,7 +1237,7 @@ msgid "Medical Information"
 msgstr "Medizinische Informationen"
 
 #: lib/klass_hero_web/live/settings_live.ex:73
-#: lib/klass_hero_web/live/user_live/settings.ex:221
+#: lib/klass_hero_web/live/user_live/settings.ex:210
 #, elixir-autogen, elixir-format
 msgid "My Family"
 msgstr "Meine Familie"
@@ -1531,58 +1521,58 @@ msgstr "Wöchentliches Aktivitätsziel"
 msgid "activities completed"
 msgstr "Aktivitäten abgeschlossen"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:81
+#: lib/klass_hero_web/live/user_live/settings.ex:82
 #, elixir-autogen, elixir-format
 msgid "Account Security"
 msgstr "Kontosicherheit"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:164
+#: lib/klass_hero_web/live/user_live/settings.ex:165
 #, elixir-autogen, elixir-format
 msgid "Customize your experience"
 msgstr "Passen Sie Ihre Erfahrung an"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:271
+#: lib/klass_hero_web/live/user_live/settings.ex:260
 #, elixir-autogen, elixir-format
 msgid "Danger Zone"
 msgstr "Gefahrenzone"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:249
+#: lib/klass_hero_web/live/user_live/settings.ex:238
 #, elixir-autogen, elixir-format
 msgid "Data & Privacy"
 msgstr "Daten & Datenschutz"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:251
+#: lib/klass_hero_web/live/user_live/settings.ex:240
 #, elixir-autogen, elixir-format
 msgid "Download your data or delete your account"
 msgstr "Daten herunterladen oder Konto löschen"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:90
+#: lib/klass_hero_web/live/user_live/settings.ex:91
 #, elixir-autogen, elixir-format
 msgid "Email Address"
 msgstr "E-Mail-Adresse"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:83
+#: lib/klass_hero_web/live/user_live/settings.ex:84
 #, elixir-autogen, elixir-format
 msgid "Manage your email and password"
 msgstr "E-Mail und Passwort verwalten"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:70
+#: lib/klass_hero_web/live/user_live/settings.ex:71
 #, elixir-autogen, elixir-format
 msgid "Member since"
 msgstr "Mitglied seit"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:47
-#: lib/klass_hero_web/live/user_live/settings.ex:163
+#: lib/klass_hero_web/live/user_live/settings.ex:48
+#: lib/klass_hero_web/live/user_live/settings.ex:164
 #, elixir-autogen, elixir-format
 msgid "Preferences"
 msgstr "Einstellungen"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:34
+#: lib/klass_hero_web/live/user_live/settings.ex:35
 #, elixir-autogen, elixir-format
 msgid "Profile"
 msgstr "Profil"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:30
+#: lib/klass_hero_web/live/user_live/settings.ex:31
 #, elixir-autogen, elixir-format
 msgid "Quick Navigation"
 msgstr "Schnellnavigation"
@@ -1967,7 +1957,7 @@ msgstr "Bekannte Allergien auflisten..."
 msgid "Manage your children's information and consents"
 msgstr "Informationen und Einwilligungen Ihrer Kinder verwalten"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:223
+#: lib/klass_hero_web/live/user_live/settings.ex:212
 #, elixir-autogen, elixir-format
 msgid "Manage your children's profiles"
 msgstr "Verwalten Sie die Profile Ihrer Kinder"
@@ -2052,17 +2042,17 @@ msgstr "Bitte überprüfen Sie das Formular auf Fehler."
 msgid "Please complete your profile before making a booking."
 msgstr "Bitte vervollständigen Sie Ihr Profil, bevor Sie eine Buchung vornehmen."
 
-#: lib/klass_hero_web/live/user_live/settings.ex:428
+#: lib/klass_hero_web/live/user_live/settings.ex:417
 #, elixir-autogen, elixir-format
 msgid "Please re-authenticate to change your email."
 msgstr "Bitte authentifizieren Sie sich erneut, um Ihre E-Mail-Adresse zu ändern."
 
-#: lib/klass_hero_web/live/user_live/settings.ex:460
+#: lib/klass_hero_web/live/user_live/settings.ex:449
 #, elixir-autogen, elixir-format
 msgid "Please re-authenticate to change your password."
 msgstr "Bitte authentifizieren Sie sich erneut, um Ihr Passwort zu ändern."
 
-#: lib/klass_hero_web/live/user_live/settings.ex:485
+#: lib/klass_hero_web/live/user_live/settings.ex:474
 #, elixir-autogen, elixir-format
 msgid "Please re-authenticate to delete your account."
 msgstr "Bitte authentifizieren Sie sich erneut, um Ihr Konto zu löschen."
@@ -5323,8 +5313,8 @@ msgstr "Über zehn Jahre Erfahrung im Coaching und der Leitung von Jugendförder
 msgid "Accept"
 msgstr "Akzeptieren"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:15
-#: lib/klass_hero_web/live/user_live/settings.ex:17
+#: lib/klass_hero_web/live/user_live/settings.ex:16
+#: lib/klass_hero_web/live/user_live/settings.ex:18
 #, elixir-autogen, elixir-format
 msgid "Account"
 msgstr "Konto"
@@ -5510,7 +5500,7 @@ msgstr "Jederzeit kündbar"
 msgid "Check our FAQ — most questions are answered there."
 msgstr "Schauen Sie in unsere FAQ — die meisten Fragen werden dort beantwortet."
 
-#: lib/klass_hero_web/live/user_live/settings.ex:37
+#: lib/klass_hero_web/live/user_live/settings.ex:38
 #, elixir-autogen, elixir-format
 msgid "Children"
 msgstr "Kinder"
@@ -5604,7 +5594,7 @@ msgstr "Ihr Anbieterprofil konnte nicht eingerichtet werden. Bitte versuchen Sie
 msgid "Create your"
 msgstr "Erstellen Sie Ihr"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:52
+#: lib/klass_hero_web/live/user_live/settings.ex:53
 #, elixir-autogen, elixir-format
 msgid "Data & privacy"
 msgstr "Daten & Datenschutz"
@@ -6052,7 +6042,7 @@ msgstr "Verwalten"
 msgid "Manage less."
 msgstr "Weniger verwalten."
 
-#: lib/klass_hero_web/live/user_live/settings.ex:20
+#: lib/klass_hero_web/live/user_live/settings.ex:21
 #, elixir-autogen, elixir-format
 msgid "Manage your account, preferences, and privacy in one place."
 msgstr "Verwalten Sie Ihr Konto, Ihre Einstellungen und Ihren Datenschutz an einem Ort."
@@ -6450,7 +6440,7 @@ msgstr "Sichere Zahlungen, Rechnungsstellung und Umsatzsteuer-Abwicklung"
 msgid "Secure weekly payouts. Insights into your business and opportunities to expand your impact."
 msgstr "Sichere wöchentliche Auszahlungen. Einblicke in Ihr Geschäft und Möglichkeiten, Ihre Wirkung auszubauen."
 
-#: lib/klass_hero_web/live/user_live/settings.ex:42
+#: lib/klass_hero_web/live/user_live/settings.ex:43
 #, elixir-autogen, elixir-format
 msgid "Security"
 msgstr "Sicherheit"
@@ -6935,7 +6925,7 @@ msgid_plural "programs"
 msgstr[0] "Programm"
 msgstr[1] "Programme"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:18
+#: lib/klass_hero_web/live/user_live/settings.ex:19
 #, elixir-autogen, elixir-format
 msgid "settings"
 msgstr "Einstellungen"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -26,7 +26,7 @@ msgstr ""
 msgid "Attempting to reconnect"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:172
+#: lib/klass_hero_web/live/user_live/settings.ex:173
 #, elixir-autogen, elixir-format
 msgid "Choose your preferred language for the interface"
 msgstr ""
@@ -51,12 +51,12 @@ msgstr ""
 msgid "Dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:263
+#: lib/klass_hero_web/live/user_live/settings.ex:252
 #, elixir-autogen, elixir-format
 msgid "Download My Data"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:259
+#: lib/klass_hero_web/live/user_live/settings.ex:248
 #, elixir-autogen, elixir-format
 msgid "Download a copy of all your personal data"
 msgstr ""
@@ -73,7 +73,7 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:169
+#: lib/klass_hero_web/live/user_live/settings.ex:170
 #, elixir-autogen, elixir-format
 msgid "Language Preference"
 msgstr ""
@@ -131,7 +131,7 @@ msgstr ""
 msgid "We can't find the internet"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:257
+#: lib/klass_hero_web/live/user_live/settings.ex:246
 #, elixir-autogen, elixir-format
 msgid "Your Data"
 msgstr ""
@@ -399,7 +399,7 @@ msgstr ""
 msgid "✓ No hidden fees"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:419
+#: lib/klass_hero_web/live/user_live/settings.ex:408
 #, elixir-autogen, elixir-format
 msgid "A link to confirm your email change has been sent to the new address."
 msgstr ""
@@ -446,7 +446,7 @@ msgstr ""
 msgid "Cancellation & Refund Policy"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:111
+#: lib/klass_hero_web/live/user_live/settings.ex:112
 #, elixir-autogen, elixir-format
 msgid "Change Email"
 msgstr ""
@@ -461,7 +461,7 @@ msgstr ""
 msgid "Changes to This Policy"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:109
+#: lib/klass_hero_web/live/user_live/settings.ex:110
 #, elixir-autogen, elixir-format
 msgid "Changing..."
 msgstr ""
@@ -496,7 +496,7 @@ msgstr ""
 msgid "Confirm and stay logged in"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:147
+#: lib/klass_hero_web/live/user_live/settings.ex:148
 #, elixir-autogen, elixir-format
 msgid "Confirm new password"
 msgstr ""
@@ -557,24 +557,19 @@ msgstr ""
 msgid "Data Sharing"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:278
+#: lib/klass_hero_web/live/user_live/settings.ex:267
 #, elixir-autogen, elixir-format
 msgid "Delete Account"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:310
+#: lib/klass_hero_web/live/user_live/settings.ex:299
 #, elixir-autogen, elixir-format
 msgid "Delete My Account"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:300
+#: lib/klass_hero_web/live/user_live/settings.ex:289
 #, elixir-autogen, elixir-format
 msgid "Deleting..."
-msgstr ""
-
-#: lib/klass_hero_web/live/user_live/settings.ex:209
-#, elixir-autogen, elixir-format
-msgid "Deutsch"
 msgstr ""
 
 #: lib/klass_hero_web/live/terms_of_service_live.ex:222
@@ -590,25 +585,20 @@ msgstr ""
 #: lib/klass_hero_web/live/user_live/login.ex:60
 #: lib/klass_hero_web/live/user_live/login.ex:89
 #: lib/klass_hero_web/live/user_live/registration.ex:48
-#: lib/klass_hero_web/live/user_live/settings.ex:102
+#: lib/klass_hero_web/live/user_live/settings.ex:103
 #: lib/klass_hero_web/live/user_live/staff_invitation.ex:66
 #, elixir-autogen, elixir-format
 msgid "Email"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:348
+#: lib/klass_hero_web/live/user_live/settings.ex:337
 #, elixir-autogen, elixir-format
 msgid "Email change link is invalid or it has expired."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:345
+#: lib/klass_hero_web/live/user_live/settings.ex:334
 #, elixir-autogen, elixir-format
 msgid "Email changed successfully."
-msgstr ""
-
-#: lib/klass_hero_web/live/user_live/settings.ex:191
-#, elixir-autogen, elixir-format
-msgid "English"
 msgstr ""
 
 #: lib/klass_hero_web/live/user_live/registration.ex:71
@@ -616,7 +606,7 @@ msgstr ""
 msgid "Enroll children in programs"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:294
+#: lib/klass_hero_web/live/user_live/settings.ex:283
 #, elixir-autogen, elixir-format
 msgid "Enter your password to confirm"
 msgstr ""
@@ -637,7 +627,7 @@ msgstr ""
 msgid "Failed to complete session: %{reason}"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:497
+#: lib/klass_hero_web/live/user_live/settings.ex:486
 #, elixir-autogen, elixir-format
 msgid "Failed to delete account. Please try again."
 msgstr ""
@@ -700,7 +690,7 @@ msgstr ""
 msgid "Invalid date format"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:491
+#: lib/klass_hero_web/live/user_live/settings.ex:480
 #, elixir-autogen, elixir-format
 msgid "Invalid password."
 msgstr ""
@@ -781,7 +771,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:140
+#: lib/klass_hero_web/live/user_live/settings.ex:141
 #, elixir-autogen, elixir-format
 msgid "New password"
 msgstr ""
@@ -810,7 +800,7 @@ msgid "Other"
 msgstr ""
 
 #: lib/klass_hero_web/live/user_live/login.ex:96
-#: lib/klass_hero_web/live/user_live/settings.ex:119
+#: lib/klass_hero_web/live/user_live/settings.ex:120
 #: lib/klass_hero_web/live/user_live/staff_invitation.ex:73
 #, elixir-autogen, elixir-format
 msgid "Password"
@@ -871,14 +861,14 @@ msgstr ""
 msgid "Register"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:151
+#: lib/klass_hero_web/live/user_live/settings.ex:152
 #, elixir-autogen, elixir-format
 msgid "Save Password"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:381
 #: lib/klass_hero_web/live/settings/children_live.ex:743
-#: lib/klass_hero_web/live/user_live/settings.ex:150
+#: lib/klass_hero_web/live/user_live/settings.ex:151
 #, elixir-autogen, elixir-format
 msgid "Saving..."
 msgstr ""
@@ -942,7 +932,7 @@ msgstr ""
 msgid "Terms of Service"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:281
+#: lib/klass_hero_web/live/user_live/settings.ex:270
 #, elixir-autogen, elixir-format
 msgid "This action cannot be undone. Your account data will be anonymized and you will be logged out."
 msgstr ""
@@ -1023,7 +1013,7 @@ msgstr ""
 msgid "Your Privacy Rights"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:479
+#: lib/klass_hero_web/live/user_live/settings.ex:468
 #, elixir-autogen, elixir-format
 msgid "Your account has been deleted."
 msgstr ""
@@ -1126,7 +1116,7 @@ msgstr ""
 #: lib/klass_hero_web/live/settings/children_live.ex:23
 #: lib/klass_hero_web/live/settings/children_live.ex:348
 #: lib/klass_hero_web/live/settings_live.ex:79
-#: lib/klass_hero_web/live/user_live/settings.ex:235
+#: lib/klass_hero_web/live/user_live/settings.ex:224
 #, elixir-autogen, elixir-format
 msgid "Children Profiles"
 msgstr ""
@@ -1247,7 +1237,7 @@ msgid "Medical Information"
 msgstr ""
 
 #: lib/klass_hero_web/live/settings_live.ex:73
-#: lib/klass_hero_web/live/user_live/settings.ex:221
+#: lib/klass_hero_web/live/user_live/settings.ex:210
 #, elixir-autogen, elixir-format
 msgid "My Family"
 msgstr ""
@@ -1531,58 +1521,58 @@ msgstr ""
 msgid "activities completed"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:81
+#: lib/klass_hero_web/live/user_live/settings.ex:82
 #, elixir-autogen, elixir-format
 msgid "Account Security"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:164
+#: lib/klass_hero_web/live/user_live/settings.ex:165
 #, elixir-autogen, elixir-format
 msgid "Customize your experience"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:271
+#: lib/klass_hero_web/live/user_live/settings.ex:260
 #, elixir-autogen, elixir-format
 msgid "Danger Zone"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:249
+#: lib/klass_hero_web/live/user_live/settings.ex:238
 #, elixir-autogen, elixir-format
 msgid "Data & Privacy"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:251
+#: lib/klass_hero_web/live/user_live/settings.ex:240
 #, elixir-autogen, elixir-format
 msgid "Download your data or delete your account"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:90
+#: lib/klass_hero_web/live/user_live/settings.ex:91
 #, elixir-autogen, elixir-format
 msgid "Email Address"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:83
+#: lib/klass_hero_web/live/user_live/settings.ex:84
 #, elixir-autogen, elixir-format
 msgid "Manage your email and password"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:70
+#: lib/klass_hero_web/live/user_live/settings.ex:71
 #, elixir-autogen, elixir-format
 msgid "Member since"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:47
-#: lib/klass_hero_web/live/user_live/settings.ex:163
+#: lib/klass_hero_web/live/user_live/settings.ex:48
+#: lib/klass_hero_web/live/user_live/settings.ex:164
 #, elixir-autogen, elixir-format
 msgid "Preferences"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:34
+#: lib/klass_hero_web/live/user_live/settings.ex:35
 #, elixir-autogen, elixir-format
 msgid "Profile"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:30
+#: lib/klass_hero_web/live/user_live/settings.ex:31
 #, elixir-autogen, elixir-format
 msgid "Quick Navigation"
 msgstr ""
@@ -1967,7 +1957,7 @@ msgstr ""
 msgid "Manage your children's information and consents"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:223
+#: lib/klass_hero_web/live/user_live/settings.ex:212
 #, elixir-autogen, elixir-format
 msgid "Manage your children's profiles"
 msgstr ""
@@ -2052,17 +2042,17 @@ msgstr ""
 msgid "Please complete your profile before making a booking."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:428
+#: lib/klass_hero_web/live/user_live/settings.ex:417
 #, elixir-autogen, elixir-format
 msgid "Please re-authenticate to change your email."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:460
+#: lib/klass_hero_web/live/user_live/settings.ex:449
 #, elixir-autogen, elixir-format
 msgid "Please re-authenticate to change your password."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:485
+#: lib/klass_hero_web/live/user_live/settings.ex:474
 #, elixir-autogen, elixir-format
 msgid "Please re-authenticate to delete your account."
 msgstr ""
@@ -5323,8 +5313,8 @@ msgstr ""
 msgid "Accept"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:15
-#: lib/klass_hero_web/live/user_live/settings.ex:17
+#: lib/klass_hero_web/live/user_live/settings.ex:16
+#: lib/klass_hero_web/live/user_live/settings.ex:18
 #, elixir-autogen, elixir-format
 msgid "Account"
 msgstr ""
@@ -5510,7 +5500,7 @@ msgstr ""
 msgid "Check our FAQ — most questions are answered there."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:37
+#: lib/klass_hero_web/live/user_live/settings.ex:38
 #, elixir-autogen, elixir-format
 msgid "Children"
 msgstr ""
@@ -5604,7 +5594,7 @@ msgstr ""
 msgid "Create your"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:52
+#: lib/klass_hero_web/live/user_live/settings.ex:53
 #, elixir-autogen, elixir-format
 msgid "Data & privacy"
 msgstr ""
@@ -6052,7 +6042,7 @@ msgstr ""
 msgid "Manage less."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:20
+#: lib/klass_hero_web/live/user_live/settings.ex:21
 #, elixir-autogen, elixir-format
 msgid "Manage your account, preferences, and privacy in one place."
 msgstr ""
@@ -6450,7 +6440,7 @@ msgstr ""
 msgid "Secure weekly payouts. Insights into your business and opportunities to expand your impact."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:42
+#: lib/klass_hero_web/live/user_live/settings.ex:43
 #, elixir-autogen, elixir-format
 msgid "Security"
 msgstr ""
@@ -6935,7 +6925,7 @@ msgid_plural "programs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:18
+#: lib/klass_hero_web/live/user_live/settings.ex:19
 #, elixir-autogen, elixir-format
 msgid "settings"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -26,7 +26,7 @@ msgstr ""
 msgid "Attempting to reconnect"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:172
+#: lib/klass_hero_web/live/user_live/settings.ex:173
 #, elixir-autogen, elixir-format
 msgid "Choose your preferred language for the interface"
 msgstr ""
@@ -51,12 +51,12 @@ msgstr ""
 msgid "Dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:263
+#: lib/klass_hero_web/live/user_live/settings.ex:252
 #, elixir-autogen, elixir-format
 msgid "Download My Data"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:259
+#: lib/klass_hero_web/live/user_live/settings.ex:248
 #, elixir-autogen, elixir-format
 msgid "Download a copy of all your personal data"
 msgstr ""
@@ -73,7 +73,7 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:169
+#: lib/klass_hero_web/live/user_live/settings.ex:170
 #, elixir-autogen, elixir-format
 msgid "Language Preference"
 msgstr ""
@@ -131,7 +131,7 @@ msgstr ""
 msgid "We can't find the internet"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:257
+#: lib/klass_hero_web/live/user_live/settings.ex:246
 #, elixir-autogen, elixir-format
 msgid "Your Data"
 msgstr ""
@@ -399,7 +399,7 @@ msgstr ""
 msgid "✓ No hidden fees"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:419
+#: lib/klass_hero_web/live/user_live/settings.ex:408
 #, elixir-autogen, elixir-format
 msgid "A link to confirm your email change has been sent to the new address."
 msgstr ""
@@ -446,7 +446,7 @@ msgstr ""
 msgid "Cancellation & Refund Policy"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:111
+#: lib/klass_hero_web/live/user_live/settings.ex:112
 #, elixir-autogen, elixir-format
 msgid "Change Email"
 msgstr ""
@@ -461,7 +461,7 @@ msgstr ""
 msgid "Changes to This Policy"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:109
+#: lib/klass_hero_web/live/user_live/settings.ex:110
 #, elixir-autogen, elixir-format
 msgid "Changing..."
 msgstr ""
@@ -496,7 +496,7 @@ msgstr ""
 msgid "Confirm and stay logged in"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:147
+#: lib/klass_hero_web/live/user_live/settings.ex:148
 #, elixir-autogen, elixir-format
 msgid "Confirm new password"
 msgstr ""
@@ -557,24 +557,19 @@ msgstr ""
 msgid "Data Sharing"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:278
+#: lib/klass_hero_web/live/user_live/settings.ex:267
 #, elixir-autogen, elixir-format
 msgid "Delete Account"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:310
+#: lib/klass_hero_web/live/user_live/settings.ex:299
 #, elixir-autogen, elixir-format
 msgid "Delete My Account"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:300
+#: lib/klass_hero_web/live/user_live/settings.ex:289
 #, elixir-autogen, elixir-format
 msgid "Deleting..."
-msgstr ""
-
-#: lib/klass_hero_web/live/user_live/settings.ex:209
-#, elixir-autogen, elixir-format
-msgid "Deutsch"
 msgstr ""
 
 #: lib/klass_hero_web/live/terms_of_service_live.ex:222
@@ -590,25 +585,20 @@ msgstr ""
 #: lib/klass_hero_web/live/user_live/login.ex:60
 #: lib/klass_hero_web/live/user_live/login.ex:89
 #: lib/klass_hero_web/live/user_live/registration.ex:48
-#: lib/klass_hero_web/live/user_live/settings.ex:102
+#: lib/klass_hero_web/live/user_live/settings.ex:103
 #: lib/klass_hero_web/live/user_live/staff_invitation.ex:66
 #, elixir-autogen, elixir-format
 msgid "Email"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:348
+#: lib/klass_hero_web/live/user_live/settings.ex:337
 #, elixir-autogen, elixir-format
 msgid "Email change link is invalid or it has expired."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:345
+#: lib/klass_hero_web/live/user_live/settings.ex:334
 #, elixir-autogen, elixir-format
 msgid "Email changed successfully."
-msgstr ""
-
-#: lib/klass_hero_web/live/user_live/settings.ex:191
-#, elixir-autogen, elixir-format
-msgid "English"
 msgstr ""
 
 #: lib/klass_hero_web/live/user_live/registration.ex:71
@@ -616,7 +606,7 @@ msgstr ""
 msgid "Enroll children in programs"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:294
+#: lib/klass_hero_web/live/user_live/settings.ex:283
 #, elixir-autogen, elixir-format
 msgid "Enter your password to confirm"
 msgstr ""
@@ -637,7 +627,7 @@ msgstr ""
 msgid "Failed to complete session: %{reason}"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:497
+#: lib/klass_hero_web/live/user_live/settings.ex:486
 #, elixir-autogen, elixir-format
 msgid "Failed to delete account. Please try again."
 msgstr ""
@@ -700,7 +690,7 @@ msgstr ""
 msgid "Invalid date format"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:491
+#: lib/klass_hero_web/live/user_live/settings.ex:480
 #, elixir-autogen, elixir-format
 msgid "Invalid password."
 msgstr ""
@@ -781,7 +771,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:140
+#: lib/klass_hero_web/live/user_live/settings.ex:141
 #, elixir-autogen, elixir-format
 msgid "New password"
 msgstr ""
@@ -810,7 +800,7 @@ msgid "Other"
 msgstr ""
 
 #: lib/klass_hero_web/live/user_live/login.ex:96
-#: lib/klass_hero_web/live/user_live/settings.ex:119
+#: lib/klass_hero_web/live/user_live/settings.ex:120
 #: lib/klass_hero_web/live/user_live/staff_invitation.ex:73
 #, elixir-autogen, elixir-format
 msgid "Password"
@@ -871,14 +861,14 @@ msgstr ""
 msgid "Register"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:151
+#: lib/klass_hero_web/live/user_live/settings.ex:152
 #, elixir-autogen, elixir-format
 msgid "Save Password"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:381
 #: lib/klass_hero_web/live/settings/children_live.ex:743
-#: lib/klass_hero_web/live/user_live/settings.ex:150
+#: lib/klass_hero_web/live/user_live/settings.ex:151
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Saving..."
 msgstr ""
@@ -942,7 +932,7 @@ msgstr ""
 msgid "Terms of Service"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:281
+#: lib/klass_hero_web/live/user_live/settings.ex:270
 #, elixir-autogen, elixir-format
 msgid "This action cannot be undone. Your account data will be anonymized and you will be logged out."
 msgstr ""
@@ -1023,7 +1013,7 @@ msgstr ""
 msgid "Your Privacy Rights"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:479
+#: lib/klass_hero_web/live/user_live/settings.ex:468
 #, elixir-autogen, elixir-format
 msgid "Your account has been deleted."
 msgstr ""
@@ -1126,7 +1116,7 @@ msgstr ""
 #: lib/klass_hero_web/live/settings/children_live.ex:23
 #: lib/klass_hero_web/live/settings/children_live.ex:348
 #: lib/klass_hero_web/live/settings_live.ex:79
-#: lib/klass_hero_web/live/user_live/settings.ex:235
+#: lib/klass_hero_web/live/user_live/settings.ex:224
 #, elixir-autogen, elixir-format
 msgid "Children Profiles"
 msgstr ""
@@ -1247,7 +1237,7 @@ msgid "Medical Information"
 msgstr ""
 
 #: lib/klass_hero_web/live/settings_live.ex:73
-#: lib/klass_hero_web/live/user_live/settings.ex:221
+#: lib/klass_hero_web/live/user_live/settings.ex:210
 #, elixir-autogen, elixir-format
 msgid "My Family"
 msgstr ""
@@ -1531,58 +1521,58 @@ msgstr ""
 msgid "activities completed"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:81
+#: lib/klass_hero_web/live/user_live/settings.ex:82
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Account Security"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:164
+#: lib/klass_hero_web/live/user_live/settings.ex:165
 #, elixir-autogen, elixir-format
 msgid "Customize your experience"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:271
+#: lib/klass_hero_web/live/user_live/settings.ex:260
 #, elixir-autogen, elixir-format
 msgid "Danger Zone"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:249
+#: lib/klass_hero_web/live/user_live/settings.ex:238
 #, elixir-autogen, elixir-format
 msgid "Data & Privacy"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:251
+#: lib/klass_hero_web/live/user_live/settings.ex:240
 #, elixir-autogen, elixir-format
 msgid "Download your data or delete your account"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:90
+#: lib/klass_hero_web/live/user_live/settings.ex:91
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Email Address"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:83
+#: lib/klass_hero_web/live/user_live/settings.ex:84
 #, elixir-autogen, elixir-format
 msgid "Manage your email and password"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:70
+#: lib/klass_hero_web/live/user_live/settings.ex:71
 #, elixir-autogen, elixir-format
 msgid "Member since"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:47
-#: lib/klass_hero_web/live/user_live/settings.ex:163
+#: lib/klass_hero_web/live/user_live/settings.ex:48
+#: lib/klass_hero_web/live/user_live/settings.ex:164
 #, elixir-autogen, elixir-format
 msgid "Preferences"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:34
+#: lib/klass_hero_web/live/user_live/settings.ex:35
 #, elixir-autogen, elixir-format
 msgid "Profile"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:30
+#: lib/klass_hero_web/live/user_live/settings.ex:31
 #, elixir-autogen, elixir-format
 msgid "Quick Navigation"
 msgstr ""
@@ -1967,7 +1957,7 @@ msgstr ""
 msgid "Manage your children's information and consents"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:223
+#: lib/klass_hero_web/live/user_live/settings.ex:212
 #, elixir-autogen, elixir-format
 msgid "Manage your children's profiles"
 msgstr ""
@@ -2052,17 +2042,17 @@ msgstr ""
 msgid "Please complete your profile before making a booking."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:428
+#: lib/klass_hero_web/live/user_live/settings.ex:417
 #, elixir-autogen, elixir-format
 msgid "Please re-authenticate to change your email."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:460
+#: lib/klass_hero_web/live/user_live/settings.ex:449
 #, elixir-autogen, elixir-format
 msgid "Please re-authenticate to change your password."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:485
+#: lib/klass_hero_web/live/user_live/settings.ex:474
 #, elixir-autogen, elixir-format
 msgid "Please re-authenticate to delete your account."
 msgstr ""
@@ -5323,8 +5313,8 @@ msgstr ""
 msgid "Accept"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:15
-#: lib/klass_hero_web/live/user_live/settings.ex:17
+#: lib/klass_hero_web/live/user_live/settings.ex:16
+#: lib/klass_hero_web/live/user_live/settings.ex:18
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Account"
 msgstr ""
@@ -5510,7 +5500,7 @@ msgstr ""
 msgid "Check our FAQ — most questions are answered there."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:37
+#: lib/klass_hero_web/live/user_live/settings.ex:38
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Children"
 msgstr ""
@@ -5604,7 +5594,7 @@ msgstr ""
 msgid "Create your"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:52
+#: lib/klass_hero_web/live/user_live/settings.ex:53
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Data & privacy"
 msgstr ""
@@ -6052,7 +6042,7 @@ msgstr ""
 msgid "Manage less."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:20
+#: lib/klass_hero_web/live/user_live/settings.ex:21
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Manage your account, preferences, and privacy in one place."
 msgstr ""
@@ -6450,7 +6440,7 @@ msgstr ""
 msgid "Secure weekly payouts. Insights into your business and opportunities to expand your impact."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:42
+#: lib/klass_hero_web/live/user_live/settings.ex:43
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Security"
 msgstr ""
@@ -6935,7 +6925,7 @@ msgid_plural "programs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:18
+#: lib/klass_hero_web/live/user_live/settings.ex:19
 #, elixir-autogen, elixir-format, fuzzy
 msgid "settings"
 msgstr ""

--- a/test/klass_hero/accounts/user_locale_test.exs
+++ b/test/klass_hero/accounts/user_locale_test.exs
@@ -1,0 +1,77 @@
+defmodule KlassHero.Accounts.UserLocaleTest do
+  @moduledoc """
+  The changeset that decides whether a language choice can be stored.
+
+  It is the strict half of an asymmetric pair: `KlassHeroWeb.Locale.validate/1`
+  coerces an unsupported locale to the default, while this rejects it. That is
+  correct — untrusted input should render the default rather than raise, but it
+  should never be written to a user's profile. It only holds while both halves
+  read the same set, which is why these assertions derive from
+  `Shared.Locales.supported/0` rather than naming "en" and "de" again (#1227).
+  """
+  use ExUnit.Case, async: true
+
+  alias Ecto.Changeset
+  alias KlassHero.Accounts.User
+  alias KlassHero.Shared.Locales
+
+  describe "locale_changeset/2" do
+    test "accepts every locale the app claims to support" do
+      for locale <- Locales.supported() do
+        changeset = User.locale_changeset(%User{}, %{locale: locale})
+
+        assert changeset.valid?,
+               "#{locale} is in Locales.supported/0 but the changeset rejects it: " <>
+                 inspect(changeset.errors)
+
+        # get_field, not get_change: casting the locale a user already has is a
+        # no-op change, so get_change would be nil for whichever locale is the
+        # schema default.
+        assert Changeset.get_field(changeset, :locale) == locale
+      end
+    end
+
+    # Deliberately not a plausible language code like "fr": adding French would
+    # make this fixture wrong. Case and region variants of locales the app does
+    # support can never themselves be supported — every configured code is a
+    # bare lowercase two-letter string.
+    @never_locales ["EN", "de-DE", "en-US", "not-a-locale"]
+
+    test "rejects anything outside that set" do
+      assert Enum.all?(@never_locales, &(&1 not in Locales.supported())),
+             "fixture overlaps Locales.supported/0 — this test would be vacuous"
+
+      for locale <- @never_locales do
+        changeset = User.locale_changeset(%User{locale: "en"}, %{locale: locale})
+
+        refute changeset.valid?, "#{inspect(locale)} was accepted as a locale"
+        assert Keyword.has_key?(changeset.errors, :locale)
+      end
+    end
+
+    test "requires a locale rather than silently keeping the old one" do
+      changeset = User.locale_changeset(%User{locale: "en"}, %{locale: nil})
+
+      refute changeset.valid?
+      assert {"can't be blank", _meta} = changeset.errors[:locale]
+    end
+
+    # Not the same as nil, and not a no-op either: Ecto's :empty_values replaces
+    # an empty param with the *field default*, so this resets a German user to
+    # English rather than erroring. Harmless in practice — the only write path
+    # runs it through `KlassHeroWeb.Locale.validate/1` first, which maps "" to
+    # the default anyway — but pinned so the behaviour is deliberate.
+    test "an empty string resets to the default locale rather than erroring" do
+      changeset = User.locale_changeset(%User{locale: "de"}, %{locale: ""})
+
+      assert changeset.valid?
+      assert Changeset.get_field(changeset, :locale) == Locales.default()
+    end
+
+    # The schema and migration defaults are literals — neither can read config —
+    # so they are pinned here instead.
+    test "the schema default is the configured default locale" do
+      assert %User{}.locale == Locales.default()
+    end
+  end
+end

--- a/test/klass_hero/shared/locales_test.exs
+++ b/test/klass_hero/shared/locales_test.exs
@@ -39,13 +39,14 @@ defmodule KlassHero.Shared.LocalesTest do
   end
 
   describe "supported?/1" do
-    # The false cases are non-strings and case/region variants of supported
-    # locales — none can ever become supported, so adding a language cannot
-    # invalidate them. `unsupported_locale/0` derives the one plain code.
+    # Every false case is a non-string or a case/region variant of a supported
+    # locale — none can ever itself become supported, so adding a language
+    # cannot silently invert what these assert. Naming a plain code like "fr"
+    # would. (The plain-code path is covered in KlassHeroWeb.LocaleTest, which
+    # is where the helper deriving one lives.)
     @cases [
       {"en", true},
       {"de", true},
-      {KlassHeroWeb.I18nHelpers.unsupported_locale(), false},
       {"", false},
       {"EN", false},
       {"de-DE", false},

--- a/test/klass_hero/shared/locales_test.exs
+++ b/test/klass_hero/shared/locales_test.exs
@@ -1,0 +1,64 @@
+defmodule KlassHero.Shared.LocalesTest do
+  @moduledoc """
+  The supported-locale set, declared once.
+
+  Before #1227 the same list was written out six times — here, in
+  `User.locale_changeset/2`, in the Gettext config, in the root layout's
+  hreflang tags, in the settings radios, and in a test helper. The two that
+  disagreed silently were the changeset (which rejects) and the web layer (which
+  coerces): adding a locale to one alone left users unable to select it, with
+  nothing in the web layer explaining the failure.
+  """
+  use ExUnit.Case, async: true
+
+  alias KlassHero.Shared.Locales
+
+  doctest Locales
+
+  describe "supported/0 and default/0" do
+    test "the default is itself a supported locale" do
+      assert Locales.default() in Locales.supported()
+    end
+
+    test "supports exactly English and German" do
+      assert Enum.sort(Locales.supported()) == ["de", "en"]
+    end
+
+    # The whole point of #1227: one binding in config/config.exs feeds both this
+    # module and the Gettext key that `mix lint_translations` reads. If these
+    # ever disagree, the binding was bypassed and a locale can be added that has
+    # no enforced translations.
+    test "agrees with the Gettext config the translation linter reads" do
+      gettext_config = Application.fetch_env!(:klass_hero, KlassHeroWeb.Gettext)
+
+      assert Enum.sort(Keyword.fetch!(gettext_config, :locales)) ==
+               Enum.sort(Locales.supported())
+
+      assert Keyword.fetch!(gettext_config, :default_locale) == Locales.default()
+    end
+  end
+
+  describe "supported?/1" do
+    # The false cases are non-strings and case/region variants of supported
+    # locales — none can ever become supported, so adding a language cannot
+    # invalidate them. `unsupported_locale/0` derives the one plain code.
+    @cases [
+      {"en", true},
+      {"de", true},
+      {KlassHeroWeb.I18nHelpers.unsupported_locale(), false},
+      {"", false},
+      {"EN", false},
+      {"de-DE", false},
+      {nil, false},
+      {:de, false},
+      {123, false}
+    ]
+
+    test "separates a supported locale from anything else, whatever its type" do
+      for {input, expected} <- @cases do
+        assert Locales.supported?(input) == expected,
+               "expected supported?(#{inspect(input)}) to be #{expected}"
+      end
+    end
+  end
+end

--- a/test/klass_hero_web/controllers/locale_controller_test.exs
+++ b/test/klass_hero_web/controllers/locale_controller_test.exs
@@ -19,7 +19,7 @@ defmodule KlassHeroWeb.LocaleControllerTest do
   alias KlassHero.Repo
 
   describe "update/2 session handling" do
-    for locale <- ~w(en de) do
+    for locale <- KlassHeroWeb.Locale.supported() do
       test "stores #{locale} in the session", %{conn: conn} do
         conn = get(conn, ~p"/locale/#{unquote(locale)}")
 
@@ -28,7 +28,7 @@ defmodule KlassHeroWeb.LocaleControllerTest do
     end
 
     test "coerces an unsupported locale to the default rather than storing it", %{conn: conn} do
-      conn = get(conn, ~p"/locale/fr")
+      conn = get(conn, ~p"/locale/#{KlassHeroWeb.I18nHelpers.unsupported_locale()}")
 
       assert get_session(conn, :locale) == KlassHeroWeb.Locale.default()
     end
@@ -56,7 +56,7 @@ defmodule KlassHeroWeb.LocaleControllerTest do
     # The path segment lands in conn.params before the :browser pipeline runs, so
     # SetLocale has already switched the process locale by the time the flash is
     # built — the confirmation arrives in the language just chosen, not the old one.
-    for locale <- ~w(en de) do
+    for locale <- KlassHeroWeb.Locale.supported() do
       test "confirms the change in the newly chosen language (#{locale})", %{conn: conn, user: user} do
         conn = conn |> log_in_user(user) |> get(~p"/locale/#{unquote(locale)}")
 

--- a/test/klass_hero_web/live/user_live/settings_test.exs
+++ b/test/klass_hero_web/live/user_live/settings_test.exs
@@ -290,6 +290,24 @@ defmodule KlassHeroWeb.UserLive.SettingsTest do
       %{conn: log_in_user(conn, user), user: user}
     end
 
+    # The radios are generated from Locale.supported/0, so a locale added to the
+    # config without display metadata renders a blank, unlabelled option rather
+    # than not rendering at all — assert the label and flag are actually there.
+    test "offers exactly one labelled option per supported locale", %{conn: conn} do
+      {:ok, lv, _html} = live(conn, ~p"/users/settings")
+
+      for locale <- KlassHeroWeb.Locale.supported() do
+        assert has_element?(lv, "#locale-option-#{locale}"),
+               "no radio rendered for supported locale #{locale}"
+
+        assert has_element?(lv, "#locale-option-#{locale} input[value='#{locale}']")
+
+        assert lv
+               |> element("#locale-option-#{locale}")
+               |> render() =~ KlassHeroWeb.Locale.label(locale)
+      end
+    end
+
     test "hands the change to the controller that can write the session", %{conn: conn} do
       {:ok, lv, _html} = live(conn, ~p"/users/settings")
 

--- a/test/klass_hero_web/locale_test.exs
+++ b/test/klass_hero_web/locale_test.exs
@@ -1,6 +1,10 @@
 defmodule KlassHeroWeb.LocaleTest do
   @moduledoc """
-  The locale whitelist, in one place.
+  The web layer's answers about locales.
+
+  The *set* is asserted in `KlassHero.Shared.LocalesTest`, which is where it now
+  lives; this file only checks that the web layer reads it rather than keeping a
+  copy (#1227), plus the concerns that are genuinely the web's own.
 
   `validate/1` never fails — an unknown locale renders the default rather than
   raising, because every caller receives it from untrusted input (`?locale=`, a
@@ -9,43 +13,69 @@ defmodule KlassHeroWeb.LocaleTest do
   """
   use ExUnit.Case, async: true
 
+  alias KlassHero.Accounts.User
+  alias KlassHero.Shared.Locales
+  alias KlassHeroWeb.I18nHelpers
   alias KlassHeroWeb.Locale
 
   describe "supported/0 and default/0" do
-    test "the default is itself a supported locale" do
-      assert Locale.default() in Locale.supported()
+    test "read the domain's set rather than keeping a copy" do
+      assert Locale.supported() == Locales.supported()
+      assert Locale.default() == Locales.default()
+    end
+  end
+
+  describe "the supported set is fully wired" do
+    # The one assertion that makes adding a locale safe. Each half fails in a
+    # different, silent way on its own: no PO directory means untranslated
+    # passthrough, no label or flag means a blank radio on the settings page.
+    test "every supported locale has translations, a label and a flag" do
+      for locale <- Locale.supported() do
+        assert File.dir?("priv/gettext/#{locale}/LC_MESSAGES"),
+               "#{locale} is supported but has no priv/gettext/#{locale}/LC_MESSAGES"
+
+        assert Locale.label(locale), "#{locale} is supported but has no label/1 clause"
+        assert Locale.flag(locale), "#{locale} is supported but has no flag/1 clause"
+      end
     end
 
-    test "supports exactly English and German" do
-      assert Enum.sort(Locale.supported()) == ["de", "en"]
+    # The schema and migration column defaults are literals — neither can read
+    # config — so the agreement is pinned rather than derived.
+    test "the user schema default is the configured default locale" do
+      assert %User{}.locale == Locale.default()
+    end
+
+    test "an unconfigured locale has no display metadata" do
+      refute Locale.label(I18nHelpers.unsupported_locale())
+      refute Locale.flag(I18nHelpers.unsupported_locale())
     end
   end
 
   describe "validate/1" do
-    @cases [
-      {"en", "en"},
-      {"de", "de"},
-      {"fr", "en"},
-      {"", "en"},
-      {"EN", "en"},
-      {"de-DE", "en"},
-      {nil, "en"},
-      {:de, "en"},
-      {123, "en"}
-    ]
+    test "passes a supported locale through unchanged" do
+      for locale <- Locale.supported() do
+        assert Locale.validate(locale) == locale
+      end
+    end
 
-    for {input, expected} <- @cases do
-      test "#{inspect(input)} validates to #{inspect(expected)}" do
-        assert Locale.validate(unquote(input)) == unquote(expected),
-               "expected #{inspect(unquote(input))} to validate to #{inspect(unquote(expected))}"
+    # Every entry is either a non-string or a case/region variant of a supported
+    # locale, so none can ever become supported — naming a real language like
+    # "fr" would make this wrong the day it is added.
+    test "coerces anything else to the default, whatever its type" do
+      coerced = [I18nHelpers.unsupported_locale(), "", "EN", "de-DE", nil, :de, 123]
+
+      for input <- coerced do
+        assert Locale.validate(input) == Locale.default(),
+               "expected #{inspect(input)} to coerce to #{inspect(Locale.default())}"
       end
     end
   end
 
   describe "supported?/1" do
     test "distinguishes a known locale from an unknown one" do
-      assert Locale.supported?("de")
-      refute Locale.supported?("fr")
+      for locale <- Locale.supported(), do: assert(Locale.supported?(locale))
+
+      refute Locale.supported?(I18nHelpers.unsupported_locale())
       refute Locale.supported?(nil)
     end
   end

--- a/test/klass_hero_web/plugs/set_locale_test.exs
+++ b/test/klass_hero_web/plugs/set_locale_test.exs
@@ -16,18 +16,23 @@ defmodule KlassHeroWeb.Plugs.SetLocaleTest do
   alias KlassHeroWeb.Plugs.SetLocale
 
   describe "precedence" do
+    # Derived, not the literal "fr" this used to name: the day French is added,
+    # a hardcoded example of an "unsupported" locale silently becomes a
+    # supported one and the test asserts the opposite of what it reads (#1227).
+    @unsupported KlassHeroWeb.I18nHelpers.unsupported_locale()
+
     # {description, param, session, stored preference, accept-language, expected}
     @precedence [
       {"the query param outranks everything", "de", "en", "en", "en-GB", "de"},
       {"the session outranks the stored preference", nil, "de", "en", "en-GB", "de"},
       {"the stored preference outranks the browser", nil, nil, "de", "en-GB", "de"},
       {"the browser is consulted last", nil, nil, nil, "de-DE,de;q=0.9,en;q=0.8", "de"},
-      {"an unsupported browser language falls back", nil, nil, nil, "fr-FR,fr;q=0.9", "en"},
+      {"an unsupported browser language falls back", nil, nil, nil, "#{@unsupported}-XX,#{@unsupported};q=0.9", "en"},
       {"nothing at all falls back", nil, nil, nil, nil, "en"},
       # An explicit but unsupported request resets to the default rather than
       # falling through to the session — asking for a language we don't have is
       # a clearer signal than the session it replaces.
-      {"an unsupported query param outranks a valid session", "fr", "de", nil, nil, "en"}
+      {"an unsupported query param outranks a valid session", @unsupported, "de", nil, nil, "en"}
     ]
 
     for {description, param, session, preference, accept_language, expected} <- @precedence do

--- a/test/klass_hero_web/root_layout_i18n_test.exs
+++ b/test/klass_hero_web/root_layout_i18n_test.exs
@@ -13,14 +13,16 @@ defmodule KlassHeroWeb.RootLayoutI18nTest do
   use KlassHeroWeb.ConnCase, async: true
 
   describe "html lang attribute" do
-    for locale <- ~w(en de) do
+    for locale <- KlassHeroWeb.Locale.supported() do
       test "declares lang=#{locale} when the request resolves to #{locale}", %{conn: conn} do
         assert lang_of(conn, "/?locale=#{unquote(locale)}") == unquote(locale)
       end
     end
 
     test "falls back to the default locale for an unsupported one", %{conn: conn} do
-      assert lang_of(conn, "/?locale=fr") == KlassHeroWeb.Locale.default()
+      unsupported = KlassHeroWeb.I18nHelpers.unsupported_locale()
+
+      assert lang_of(conn, "/?locale=#{unsupported}") == KlassHeroWeb.Locale.default()
     end
 
     test "declares a lang on an authenticated route too, not just marketing pages", %{conn: conn} do
@@ -44,13 +46,12 @@ defmodule KlassHeroWeb.RootLayoutI18nTest do
       assert hrefs(doc, ~s(link[rel="canonical"])) == [absolute("/programs?locale=de")]
     end
 
-    # A bare path serves whatever the visitor's session or Accept-Language says,
-    # which is exactly what x-default is for; the two locale URLs are stable.
-    @alternates [
-      {"en", "/programs?locale=en"},
-      {"de", "/programs?locale=de"},
-      {"x-default", "/programs"}
-    ]
+    # Derived from the supported set, so adding a locale extends this coverage
+    # instead of leaving the new one silently unasserted. A bare path serves
+    # whatever the visitor's session or Accept-Language says, which is exactly
+    # what x-default is for, so it is the one entry that is not a locale.
+    @alternates Enum.map(KlassHeroWeb.Locale.supported(), &{&1, "/programs?locale=#{&1}"}) ++
+                  [{"x-default", "/programs"}]
 
     for {hreflang, path} <- @alternates do
       test "declares the #{hreflang} alternate", %{doc: doc} do
@@ -62,7 +63,8 @@ defmodule KlassHeroWeb.RootLayoutI18nTest do
     test "every declared URL is absolute — a relative hreflang is ignored", %{doc: doc} do
       urls = hrefs(doc, ~s(link[rel="canonical"])) ++ hrefs(doc, ~s(link[rel="alternate"]))
 
-      assert length(urls) == 4
+      # one canonical + one alternate per locale + x-default
+      assert length(urls) == length(KlassHeroWeb.Locale.supported()) + 2
       assert Enum.all?(urls, &String.starts_with?(&1, "http")), "found a relative URL in #{inspect(urls)}"
     end
 

--- a/test/support/i18n_helpers.ex
+++ b/test/support/i18n_helpers.ex
@@ -16,6 +16,7 @@ defmodule KlassHeroWeb.I18nHelpers do
   alias KlassHero.Accounts.User
   alias KlassHero.AccountsFixtures
   alias KlassHero.Repo
+  alias KlassHero.Shared.Locales
   alias Phoenix.LiveViewTest.View
 
   @doc """
@@ -268,22 +269,25 @@ defmodule KlassHeroWeb.I18nHelpers do
   @doc """
   Returns a list of supported locales for the application.
 
-  ## Examples
-
-      supported_locales() # => ["en", "de"]
+  Delegates to `KlassHero.Shared.Locales`, which owns the set (#1227) — these
+  used to read the Gettext config with a hardcoded `["en", "de"]` fallback that
+  would silently mask a config problem.
   """
-  def supported_locales do
-    Application.get_env(:klass_hero, KlassHeroWeb.Gettext)[:locales] || ["en", "de"]
-  end
+  defdelegate supported_locales(), to: Locales, as: :supported
+
+  @doc "Returns the default locale for the application. See `supported_locales/0`."
+  defdelegate default_locale(), to: Locales, as: :default
 
   @doc """
-  Returns the default locale for the application.
+  A locale code the app is guaranteed not to support.
 
-  ## Examples
-
-      default_locale() # => "en"
+  For exercising the coercion and rejection paths. Derived rather than
+  hardcoded: tests used to name "fr", which quietly becomes wrong the day French
+  is added — the same class of drift #1227 removed from the production code.
+  Raises rather than returning a supported locale, so callers cannot go vacuous.
   """
-  def default_locale do
-    Application.get_env(:klass_hero, KlassHeroWeb.Gettext)[:default_locale] || "en"
+  def unsupported_locale do
+    Enum.find(~w(zz qq xx), &(&1 not in Locales.supported())) ||
+      raise "every candidate unsupported locale is now configured as supported"
   end
 end


### PR DESCRIPTION
Closes #1227.

## Summary

The issue reported the supported-locale whitelist declared **twice**. Tracing it found **six**:

| Site | Semantics |
|---|---|
| `KlassHeroWeb.Locale` | coerces unknown → default |
| `User.locale_changeset/2` | **rejects** unknown |
| `config :klass_hero, KlassHeroWeb.Gettext, locales:` | drives `mix lint_translations` |
| `root.html.heex` hreflang tags | SEO alternates |
| `settings.ex` radio blocks | the only way a user picks one |
| `i18n_helpers.ex` fallback | dead code |

The first two disagree asymmetrically, which is the reported bug: add a locale to the web layer alone and a user can pick a language that can never be stored — every attempt hits "Failed to update language preference." with nothing explaining why.

`config.exs` now binds the set once and feeds both the `:locales` key and the Gettext key. `KlassHero.Shared.Locales` exposes it via `compile_env!`; everything else reads that. The hreflang tags and settings radios are generated from it.

**Config has to be the owner, not a domain module.** `config.exs` is evaluated before the app compiles, so it can never read `Shared.Locales` — which means the fix sketched in the issue (a `Shared.Categories`-style module holding the literal) could not have unified the Gettext copy. It would have collapsed 2 of 6 and closed the ticket with four left.

## Review focus

- **`config/config.exs`** — Quokka sorts config calls and hoists bare bindings, so the binding and its two consumers land far apart by design. The explanation sits at the binding.
- **Endonyms left Gettext.** `label/1` returns "English"/"Deutsch" untranslated, because a language's own name reads the same in every UI language. **German users previously saw "Englisch" and will now see "English"** — a visible change, not just internal. Drops 2 msgids; the rest of the `.po` churn is `#:` reference comments.
- **`User.locale_changeset/2` had zero direct tests.** Added.
- **Tests naming `"fr"` as permanently-unsupported** carried the same latent bug in miniature — French is a language someone may add. They now derive a code via `I18nHelpers.unsupported_locale/0`, which raises rather than returning a supported one so they cannot go vacuous.

## Test plan

`mix precommit` green: 4105 tests, credo clean, `lint_translations` passes.

**The red was real** — with a third locale temporarily in config, the pre-fix changeset produced exactly the reported bug:

```
fr is in Locales.supported/0 but the changeset rejects it:
  [locale: {"is invalid", [validation: :inclusion, enum: ["en", "de"]]}]
```

**Third-locale drill** (add `fr` to the one binding, change nothing else) produces exactly three failures, all intended tripwires — while the hreflang and controller tests auto-extend to cover it:

```
1) supports exactly English and German     → ["de","en","fr"] ≠ ["de","en"]
2) every supported locale is fully wired   → fr has no priv/gettext/fr/LC_MESSAGES
3) offers one labelled option per locale   → fr has no label
```

`mix lint_translations` also exits 1 — though via a raw `File.Error` rather than a friendly message. Left alone; the invariant test reports it readably first. Worth a follow-up if you want it tidier.

**Browser pass** (mobile viewport, this branch's server): language switch works, survives reload, `?locale=fr` coerces to English without minting a canonical for it, hreflang alternates and radios both generated from the set.

**Architecture review**: 8/8 checks, 0 violations. One informational note — a domain test reaching into a `_web` test helper — fixed in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)