### PR TITLE
docs: point the compensation gate at its tripwire issue

### DIFF
--- a/lib/klass_hero/shared/adapters/driven/persistence/repositories/job_compensation_repository.ex
+++ b/lib/klass_hero/shared/adapters/driven/persistence/repositories/job_compensation_repository.ex
@@ -7,6 +7,9 @@ defmodule KlassHero.Shared.Adapters.Driven.Persistence.Repositories.JobCompensat
   is a unique constraint rather than careful code. A compensation that fails leaves
   no marker, and the next sweep retries it.
 
+  That duplication is deliberate and was surveyed — see #1249 for why the two are not
+  extracted into one gate, and what would justify extracting them.
+
   ## Why `:ignore` is not `{:error, _}`
 
   A compensation whose entity is already terminal — an invite already `:enrolled`,


### PR DESCRIPTION
## Summary

Adds one sentence to `JobCompensationRepository`'s moduledoc pointing at #1249.

The moduledoc already opens with "Same shape as `ProcessedEventRepository.execute_atomically/3`,
for the same reason" — it names the duplication but not the decision about it. That decision
(surveyed, deliberately not extracted at N=2, with a stated trigger to revisit) lived only in
the issue tracker, so anyone reading the two repository files saw obvious duplication and no
reason not to collapse it.

Prose only. No behaviour change, no code, no tests touched.

## Review Focus

- The sentence sits in the paragraph that already names the duplication, rather than in a new
  section — the qualification belongs beside the claim it qualifies.
- `ProcessedEventRepository` intentionally gets **no** matching pointer: one place to drift
  rather than two.

## Test Plan

- `MIX_TEST_PARTITION=1249 mix precommit` — green, exit 0, 4095 passed.
- The load-bearing gates for a moduledoc change are `mix compile --warnings-as-errors` (catches a
  malformed heredoc) and `mix format --check-formatted`; both pass.

Refs #1249 — deliberately not "Closes". The issue stays open as the tripwire until a third
genuine instance of the pattern appears.
