### PR TITLE
test: clear the test suite's compile warnings and gate them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,8 +167,10 @@ jobs:
       # ecto.create --quiet + ecto.migrate --quiet automatically.
       # --include slow opts the 5k-row CSV smoke test into CI so
       # chunk-boundary correctness at scale is exercised on every PR.
+      # --warnings-as-errors covers the test files themselves; the
+      # compile job's gate runs in dev env and never sees them.
       - name: Run tests
-        run: mix test --include slow
+        run: mix test --warnings-as-errors --include slow
 
   # Skip condition mirrors `test` above — see the rationale there.
   e2e:

--- a/mix.exs
+++ b/mix.exs
@@ -154,7 +154,10 @@ defmodule KlassHero.MixProject do
         "lint_typography",
         "lint_translations",
         "credo --strict",
-        "cmd env MIX_ENV=test mix test --include slow"
+        # Two halves on purpose: `test --warnings-as-errors` only covers test
+        # files, and `test/support/*.ex` compiles solely in the test env — so
+        # the dev-env `compile --warnings-as-errors` above never sees it.
+        "cmd env MIX_ENV=test mix do compile --warnings-as-errors + test --warnings-as-errors --include slow"
       ]
     ]
   end

--- a/test/klass_hero/enrollment/confirm_enrollment_test.exs
+++ b/test/klass_hero/enrollment/confirm_enrollment_test.exs
@@ -1,7 +1,6 @@
 defmodule KlassHero.Enrollment.ConfirmEnrollmentTest do
   use KlassHero.DataCase, async: true
 
-  import KlassHero.EventTestHelper
   import KlassHero.Factory
 
   alias KlassHero.Enrollment.Enrollment

--- a/test/klass_hero/participation/submit_session_note_test.exs
+++ b/test/klass_hero/participation/submit_session_note_test.exs
@@ -5,7 +5,6 @@ defmodule KlassHero.Participation.SubmitSessionNoteTest do
 
   use KlassHero.DataCase, async: true
 
-  import KlassHero.EventTestHelper
   import KlassHero.Factory
 
   alias KlassHero.Participation

--- a/test/klass_hero/shared/adapters/driven/persistence/repositories/processed_event_repository_test.exs
+++ b/test/klass_hero/shared/adapters/driven/persistence/repositories/processed_event_repository_test.exs
@@ -7,7 +7,6 @@ defmodule KlassHero.Shared.Adapters.Driven.Persistence.Repositories.ProcessedEve
   alias KlassHero.Repo
   alias KlassHero.Shared.Adapters.Driven.Persistence.Repositories.ProcessedEventRepository
   alias KlassHero.Shared.Adapters.Driven.Persistence.Schemas.ProcessedEvent
-  alias KlassHero.Shared.Domain.Events.Event
 
   describe "execute_atomically/3" do
     test "runs handler and inserts row on success" do

--- a/test/klass_hero_web/live/provider/sessions_live_test.exs
+++ b/test/klass_hero_web/live/provider/sessions_live_test.exs
@@ -1,14 +1,10 @@
 defmodule KlassHeroWeb.Provider.SessionsLiveTest do
   use KlassHeroWeb.ConnCase, async: true
 
-  import KlassHero.EventTestHelper
   import KlassHero.Factory
   import Phoenix.LiveViewTest
 
   alias KlassHero.Participation
-  alias KlassHero.Participation.Domain.Events.ParticipationEvents
-  alias KlassHero.Participation.ParticipationRecord
-  alias KlassHero.Participation.ProgramSession
 
   describe "authentication and authorization" do
     test "redirects unauthenticated users to login", %{conn: conn} do
@@ -562,7 +558,7 @@ defmodule KlassHeroWeb.Provider.SessionsLiveTest do
 
     test "an unrelated participation event does not crash the view", %{conn: conn, provider: provider} do
       listing = insert(:program_listing_schema, provider_id: provider.id)
-      program = insert(:program_schema, id: listing.id, provider_id: provider.id)
+      _program = insert(:program_schema, id: listing.id, provider_id: provider.id)
 
       {:ok, view, _html} = live(conn, ~p"/provider/sessions")
 

--- a/test/klass_hero_web/live/staff/staff_sessions_live_test.exs
+++ b/test/klass_hero_web/live/staff/staff_sessions_live_test.exs
@@ -1,12 +1,10 @@
 defmodule KlassHeroWeb.Staff.StaffSessionsLiveTest do
   use KlassHeroWeb.ConnCase, async: true
 
-  import KlassHero.EventTestHelper
   import KlassHero.Factory
   import Phoenix.LiveViewTest
 
   alias KlassHero.Participation
-  alias KlassHero.Participation.Domain.Events.ParticipationEvents
 
   describe "authentication and authorization" do
     test "redirects unauthenticated users to login", %{conn: conn} do


### PR DESCRIPTION
## Summary

Clears ten compile warnings across five test files, then closes the gap that let them
accumulate unnoticed.

**The warnings.** Four orphaned `import KlassHero.EventTestHelper`, five unused aliases, one
unused binding. #1208 ("deliver UI updates as tagged tuples, not domain events") converted the
event-bus assertions to tagged-tuple and outbox assertions, and #1213 deleted the domain event
bus. Both left the names behind. Checked the #1208 diff per file: the assertions were
**converted, not dropped** — `confirm_enrollment_test.exs`, for instance, came out stronger
(it now also asserts no cross-provider leak). Nothing is lost with the imports.
`KlassHero.EventTestHelper` itself stays; 25 test files still call its assertions.

**Why they survived.** `precommit` runs `compile --warnings-as-errors` in the **dev** env,
which compiles `lib/` only. Test `.exs` files compile during `mix test`, which carried no such
flag — so `mix test` returned **0** on a file with a compile warning, and has done since #1208
landed. The zero-warnings rule has never actually applied to the test suite.

**The gate.** `--warnings-as-errors` on the test run, in `precommit` and in CI. The paired
`do compile + test` form in the alias also covers `test/support/*.ex`, which compiles solely in
the test env and was equally unguarded.

## Review Focus

- `mix.exs` — the two-half form is deliberate and commented. `mix help test` documents that
  `test --warnings-as-errors` applies to test files only.
- The one unused binding becomes `_program` rather than losing its `insert/2` call: the insert
  is setup the view reads. `_name = insert(...)` is the established shape in that same file.
- `mix test.e2e` intentionally gets no flag — it compiles the same test files, so the unit-test
  gate already covers them.

## Test Plan

- `MIX_TEST_PARTITION=1249 mix precommit` — green, exit 0, 4095 passed, no warning output. With
  the flag wired in, green *is* the assertion that no warnings remain.
- Gate verified to actually fail, not just to be configured: re-introduced one removed alias and
  ran the single file both ways — `mix test` exit **0**, `mix test --warnings-as-errors` exit
  **1**. Reverted after.

Follow-up to #1263.
