### PR TITLE
fix: derive the dev database name per checkout

### DIFF
--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -5,7 +5,9 @@
 ### Development Database
 
 - PostgreSQL (default: user `postgres`, password `postgres`, host `localhost`, port `5432`)
-- Database: `klass_hero_dev`
+- Database: `klass_hero_dev` on the main checkout; a worktree derives its own
+  (`klass_hero_dev_<checkout>`) so migrations cannot escape into main's schema.
+  Override either with `LOCAL_DEV_DATABASE`. See `.claude/rules/worktrees.md`.
 
 ### Test Database
 

--- a/.claude/rules/worktrees.md
+++ b/.claude/rules/worktrees.md
@@ -39,11 +39,18 @@ mix deps.get
 MIX_TEST_PARTITION=<n> mix compile
 MIX_TEST_PARTITION=<n> MIX_ENV=test mix ecto.create
 MIX_TEST_PARTITION=<n> MIX_ENV=test mix ecto.migrate
+mix ecto.setup     # this worktree's OWN dev DB — create + migrate
+mix ecto.seed      # skip if you only need the test suite
 bin/setup-mcp      # allocate this worktree's dev port + Tidewave endpoint
 ```
 
 `bin/setup-mcp` writes `.mcp.json`, which Claude Code reads **at session start** —
 so restart the session in the worktree afterwards. See the Tidewave section below.
+
+The two `ecto` lines are the dev DB, which is separate from the test DB above and
+needs no `MIX_TEST_PARTITION` — see the next section. Skipping them is safe: the
+first dev-env command fails loudly on a missing database rather than falling back
+to main's.
 
 ## Test DB isolation — always set MIX_TEST_PARTITION in a worktree
 
@@ -81,6 +88,41 @@ TEST_PORT=4242 MIX_TEST_PARTITION=1060 mix test.e2e
 
 `TEST_PORT` feeds both the endpoint and Wallaby's `base_url` from one binding, so the
 two can't drift apart.
+
+## Dev DB isolation — automatic, nothing to remember
+
+Unlike the test DB, the dev DB needs no env var from you. `config/dev.exs` derives the
+name from the checkout itself:
+
+| Checkout | Dev database |
+|---|---|
+| main | `klass_hero_dev` |
+| worktree `.claude/worktrees/kh-1257` | `klass_hero_dev_kh_1257` |
+| anything, with `LOCAL_DEV_DATABASE` set | whatever you set |
+
+The slug is the checkout **directory basename**, downcased with non-alphanumerics
+folded to `_`. Deliberately not the branch name, which changes under the checkout on
+`git switch` and would silently repoint the DB mid-session.
+
+Override either way with `LOCAL_DEV_DATABASE` — to point a worktree at main's data
+for a read-only comparison, or to give main a scratch DB:
+
+```bash
+LOCAL_DEV_DATABASE=klass_hero_dev mix phx.server   # worktree, on main's data
+LOCAL_DEV_DATABASE=kh_scratch mix ecto.setup       # a throwaway
+```
+
+**Why this is derived in `config/dev.exs` and not in `bin/dev`:** every `mix`
+invocation in a checkout reads its own `config/dev.exs`, so a bare `mix ecto.migrate`
+is covered — and that is the command that actually caused the damage (#1253: a
+migration run from a worktree dropped a column in main's dev schema, breaking main
+until it was restored by hand). A default exported from a launcher script would not
+have been in that process's environment. `mix`, `iex -S mix`, `bin/dev`, and a
+Tidewave `execute_sql_query` all land on the same DB with no cooperation from the
+caller.
+
+Each app boot logs `Dev database: <name>` so a worktree session can see at a glance
+which schema it is about to touch.
 
 ## Tidewave / dev server per worktree (separate axis from the test partition)
 
@@ -135,11 +177,14 @@ ignored until a workspace is trusted, which a fresh worktree isn't yet.
   symptom if it regresses.)
 - **live_debugger** binds its own endpoint and defaults to 4007. Before ports were
   derived, a second concurrent `mix phx.server` died on `:eaddrinuse` here.
-- **Shared dev DB caveat:** `klass_hero_dev` is shared across all checkouts and is
-  **not** partitioned like the test DB. A worktree server reads/writes the same
-  dev DB as main — fine for reads, but running migrations from a worktree mutates
-  shared dev schema. For schema-diverging work, point the worktree at its own dev
-  DB (override `database:` via env) rather than migrating the shared one.
+- **A fresh worktree has no dev DB yet.** Isolation is automatic (see the dev DB
+  section above), so the first dev-env command in a new worktree hits a database that
+  does not exist until `mix ecto.setup` has run. That failure is the design: it is
+  loud, immediate, and local, where the old shared-DB behaviour was silent and
+  surfaced later in a *different* checkout.
+- **`LOCAL_DEV_DATABASE` is per-command, not per-checkout.** Exporting it in a shell
+  profile re-creates the exact trap the derivation removes — every worktree in that
+  shell would share one DB again. Set it inline on the command that needs it.
 
 ## Recovery
 

--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,11 @@
 # PostgreSQL Database
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
-POSTGRES_DB=klass_hero_dev
+
+# Override this checkout's dev database. Unset, the name is derived per checkout:
+# klass_hero_dev on main, klass_hero_dev_<checkout> in a worktree.
+# See .claude/rules/worktrees.md.
+# LOCAL_DEV_DATABASE=klass_hero_dev
 
 # Phoenix Application
 SECRET_KEY_BASE=your-secret-key-base-here

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -6,11 +6,34 @@ alias KlassHero.Shared.Adapters.Driven.Storage.S3StorageAdapter
 # main's. See .claude/rules/worktrees.md.
 dev_port = String.to_integer(System.get_env("PORT") || "4000")
 
+# __DIR__ is <root>/config no matter which directory mix was invoked from.
+checkout_root = Path.dirname(__DIR__)
+
+# The dev DB is per-checkout for the same reason the port is, but derived here rather
+# than in bin/dev: every mix invocation reads this file, so a bare `mix ecto.migrate`
+# in a worktree cannot reach main's schema (#1257). A linked worktree has `.git` as a
+# file; the main checkout has a directory, and a checkout with neither (tarball,
+# container build) keeps the shared default.
+dev_database =
+  System.get_env("LOCAL_DEV_DATABASE") ||
+    if File.regular?(Path.join(checkout_root, ".git")) do
+      slug =
+        checkout_root
+        |> Path.basename()
+        |> String.downcase()
+        |> String.replace(~r/[^a-z0-9]+/, "_")
+
+      # 63 is the Postgres identifier limit.
+      String.slice("klass_hero_dev_#{slug}", 0, 63)
+    else
+      "klass_hero_dev"
+    end
+
 config :klass_hero, KlassHero.Repo,
   username: "postgres",
   password: "postgres",
   hostname: "localhost",
-  database: "klass_hero_dev",
+  database: dev_database,
   stacktrace: true,
   # In order to use HTTPS in development, a self-signed
   #     https: [

--- a/lib/klass_hero/application.ex
+++ b/lib/klass_hero/application.ex
@@ -3,8 +3,12 @@ defmodule KlassHero.Application do
 
   use Application
 
+  require Logger
+
   @impl true
   def start(_type, _args) do
+    log_dev_database()
+
     children = infrastructure_children() ++ projections() ++ [KlassHeroWeb.Endpoint]
 
     opts = [strategy: :one_for_one, name: KlassHero.Supervisor]
@@ -15,6 +19,16 @@ defmodule KlassHero.Application do
   def config_change(changed, _new, removed) do
     KlassHeroWeb.Endpoint.config_change(changed, removed)
     :ok
+  end
+
+  # The dev DB name is derived per checkout (config/dev.exs), so boot names it: a
+  # migration run from a worktree otherwise gives no clue which schema it is about
+  # to touch — this one or main's (#1257).
+  defp log_dev_database do
+    if Application.get_env(:klass_hero, :env) == :dev do
+      database = Application.get_env(:klass_hero, KlassHero.Repo)[:database]
+      Logger.info("Dev database: #{database}")
+    end
   end
 
   defp infrastructure_children do


### PR DESCRIPTION
Closes #1257

## Summary

`config/dev.exs:13` hardcoded `database: "klass_hero_dev"`, so main and every worktree shared one dev database. `.claude/rules/worktrees.md` instructed you to "point the worktree at its own dev DB (override `database:` via env)" — no such env existed, so following the documented rule meant hand-editing config and remembering to revert it.

The name is now derived from the checkout:

| Checkout | Dev database |
|---|---|
| main | `klass_hero_dev` |
| worktree `.claude/worktrees/kh-1257` | `klass_hero_dev_kh_1257` |
| anything, with `LOCAL_DEV_DATABASE` set | whatever you set |

## Review focus

**Why `config/dev.exs` and not `bin/dev`.** The command that caused the damage in #1253 was a bare `mix ecto.migrate` run from a worktree, which dropped a column in main's dev schema and broke main until it was restored by hand. That command never passes through `bin/dev`, so a default exported from a launcher script would not have been in its environment. Every `mix` invocation reads its own checkout's `config/dev.exs`, which is why the derivation lives there.

**Worktree detection is `.git` being a *file*.** Verified across real worktrees: `.git` is a directory in main, a file in a linked worktree. Keying on *file* means a checkout with neither — tarball, container build, CI edge cases — falls back to the shared default rather than inventing a name.

**Slug is the directory basename, not the branch name.** A branch name changes under the checkout on `git switch`, which would silently repoint the database mid-session.

**No test covers the derivation, deliberately.** Config `.exs` is evaluated before compilation, so it cannot live in a `lib/` module, and `config/dev.exs` never loads under `MIX_ENV=test`. Test machinery here would cost more than the five lines it guards. The CI `Fresh Seed` job is the regression guard for the default path.

**One item beyond the issue's DoD:** a dev-only boot log naming the database (`lib/klass_hero/application.ex`). The issue's sharpest point is that *nothing signals* which schema a command is about to touch; deriving the name closes the trap, logging it makes the closure visible. Happy to drop it if you'd rather keep the diff config-only.

## Test plan

Verified from this worktree (`kh-1257`) against the shared Postgres:

- Derived name with no env: `klass_hero_dev_kh_1257`; with `LOCAL_DEV_DATABASE=scratch_db`: `scratch_db` (both via `mix run --no-start`, so the Repo never connects).
- Main takes the `else` branch — `.git` is a directory there, confirmed empirically.
- **Isolation proven directly, not inferred:** created a probe table through the app's Repo from the worktree, then checked both databases — present in `klass_hero_dev_kh_1257`, absent from `klass_hero_dev`. Probe dropped afterwards.
- Boot log fires: `[info] Dev database: klass_hero_dev_kh_1257`.
- Documented hydration path works end to end: `mix ecto.setup && mix ecto.seed` against a fresh worktree database.
- `MIX_TEST_PARTITION=1257 mix precommit` — 4079 passed, 2 skipped.

CI's `Fresh Seed` job is the check that matters for the default path: it runs `MIX_ENV=dev mix ecto.create` on an `actions/checkout` working copy, which has a real `.git` directory and must still land on `klass_hero_dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)