### PR TITLE
docs: link the StorageIntegrationCase config leak to its issue

### DIFF
--- a/test/klass_hero/shared/adapters/driven/storage/s3_storage_adapter_integration_test.exs
+++ b/test/klass_hero/shared/adapters/driven/storage/s3_storage_adapter_integration_test.exs
@@ -19,7 +19,7 @@ defmodule KlassHero.Shared.Adapters.Driven.Storage.S3StorageAdapterIntegrationTe
   `S3StorageAdapter` against a real S3 backend is developer-run only, and the
   adapter is therefore unverified on every PR.
 
-  Before wiring MinIO into CI, fix `KlassHero.StorageIntegrationCase` first —
+  Before wiring MinIO into CI, fix `KlassHero.StorageIntegrationCase` first (#1276) —
   `setup_minio_buckets/0` overwrites the `:storage` app env and never restores it,
   so these tests would leak the MinIO adapter into every later test that reads it.
   """


### PR DESCRIPTION
Follow-up to #1270, which merged before this one-line change was pushed.

#1270 added a note to the S3 adapter test's moduledoc describing the unrestored
`Application.put_env` in `StorageIntegrationCase.setup_minio_buckets/0` — but at the time
there was no issue to point at. #1276 now exists, so the note links to it.

Comment-only change to one test file. No behaviour change.

## Test plan

- `mix compile --warnings-as-errors` — clean
- `mix format --check-formatted` — clean
- `mix test test/klass_hero/shared/adapters/driven/storage/` — `7 passed, 10 excluded` (unchanged)