### PR TITLE
fix: archive conversations in the read table, and drop the producer-less archive path

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -311,9 +311,6 @@ config :klass_hero, :event_consumers, %{
   "integration:messaging:messages_read" => [
     {ConversationSummaries, :project}
   ],
-  "integration:messaging:conversation_archived" => [
-    {ConversationSummaries, :project}
-  ],
   "integration:messaging:conversations_archived" => [
     {ConversationSummaries, :project}
   ],

--- a/lib/klass_hero/messaging.ex
+++ b/lib/klass_hero/messaging.ex
@@ -742,39 +742,6 @@ defmodule KlassHero.Messaging do
     end
   end
 
-  @doc """
-  Archives a conversation, setting a 30-day retention window.
-
-  Re-fetches the row before updating (ignoring the caller's in-memory `lock_version`)
-  so the optimistic lock only guards the narrow get/update window.
-  """
-  @spec archive_conversation(Conversation.t()) ::
-          {:ok, Conversation.t()} | {:error, :not_found | Ecto.Changeset.t()}
-  def archive_conversation(conversation) do
-    context_span entity: "conversation" do
-      now = DateTime.utc_now()
-      retention_until = DateTime.add(now, 30, :day)
-
-      case Repo.get(Conversation, conversation.id) do
-        nil ->
-          {:error, :not_found}
-
-        schema ->
-          schema
-          |> Conversation.archive_changeset(%{archived_at: now, retention_until: retention_until})
-          |> Repo.update()
-          |> case do
-            {:ok, updated} ->
-              Logger.info("Archived conversation", conversation_id: conversation.id)
-              {:ok, updated}
-
-            error ->
-              error
-          end
-      end
-    end
-  end
-
   @doc "Hard-deletes archived conversations whose retention window expired before `before`."
   @spec delete_expired_conversations(DateTime.t()) :: {:ok, non_neg_integer()}
   def delete_expired_conversations(before) do

--- a/lib/klass_hero/messaging.ex
+++ b/lib/klass_hero/messaging.ex
@@ -790,12 +790,26 @@ defmodule KlassHero.Messaging do
     end
   end
 
-  @doc "Archives conversations for programs that ended before `cutoff_date`."
+  @doc """
+  Archives conversations for programs that ended before `cutoff_date`.
+
+  Returns the `archived_at` it wrote so the caller can put it on the
+  `conversations_archived` event: the read-side projection stores that timestamp
+  verbatim, and re-deriving it there would drift from the write table.
+  """
   @spec archive_ended_program_conversations(DateTime.t(), non_neg_integer()) ::
-          {:ok, %{count: non_neg_integer(), conversation_ids: [String.t()]}}
+          {:ok,
+           %{
+             count: non_neg_integer(),
+             conversation_ids: [String.t()],
+             archived_at: DateTime.t() | nil
+           }}
   def archive_ended_program_conversations(cutoff_date, retention_days) do
     context_span entity: "conversation" do
-      now = DateTime.utc_now()
+      # Truncated because both `conversations.archived_at` and the read table's column are
+      # `:utc_datetime` — keeping microseconds here would make the value on the event differ
+      # from the value in the row it describes.
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
       retention_until = DateTime.add(now, retention_days, :day)
 
       conversation_ids =
@@ -805,7 +819,7 @@ defmodule KlassHero.Messaging do
         |> Repo.all()
 
       if conversation_ids == [] do
-        {:ok, %{count: 0, conversation_ids: []}}
+        {:ok, %{count: 0, conversation_ids: [], archived_at: nil}}
       else
         {count, _} =
           from(c in Conversation, where: c.id in ^conversation_ids)
@@ -817,7 +831,7 @@ defmodule KlassHero.Messaging do
           retention_days: retention_days
         )
 
-        {:ok, %{count: count, conversation_ids: conversation_ids}}
+        {:ok, %{count: count, conversation_ids: conversation_ids, archived_at: now}}
       end
     end
   end

--- a/lib/klass_hero/messaging/adapters/driven/projections/conversation_summaries.ex
+++ b/lib/klass_hero/messaging/adapters/driven/projections/conversation_summaries.ex
@@ -522,10 +522,16 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries 
 
   defp project_conversations_archived(event) do
     # Destructured, not `Map.get`-ed: `project/1` discards this function's return, so a
-    # defaulting read of a key the producer stopped sending would write `archived_at: nil`
-    # and silently leave archived conversations in every inbox. A MatchError here surfaces
-    # as a retried delivery job instead.
-    %{conversation_ids: conversation_ids, archived_at: archived_at} = event.payload
+    # defaulting read would write `archived_at: nil` and silently leave archived
+    # conversations in every inbox — the bug #1216 fixed.
+    %{conversation_ids: conversation_ids} = event.payload
+
+    # Both values arrive as ISO8601 *strings*, not %DateTime{}: the outbox stores the
+    # event as Oban jsonb and `CriticalEventSerializer.deserialize/1` atomizes keys only.
+    # Safe here because `update_all` casts them into the `:utc_datetime` column; a
+    # consumer doing DateTime arithmetic on them would not be.
+    archived_at = legacy_archived_at(event)
+
     now = DateTime.utc_now() |> DateTime.truncate(:second)
 
     if conversation_ids != [] do
@@ -539,6 +545,22 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries 
         ]
       )
     end
+  end
+
+  # Producers before #1216 staged this event without `archived_at`. Such an event can only
+  # be delivered in the window between that deploy and the queue draining, and its
+  # `occurred_at` was stamped in the archiving transaction itself — close enough to the
+  # value the row got, and far better than dropping the event into the dead-letter table
+  # and leaving the conversation in every inbox. Delete this clause once no pre-#1216
+  # event can still be queued.
+  defp legacy_archived_at(%Event{payload: %{archived_at: archived_at}}), do: archived_at
+
+  defp legacy_archived_at(%Event{} = event) do
+    Logger.warning("conversations_archived carried no archived_at; falling back to occurred_at",
+      event_id: event.event_id
+    )
+
+    event.occurred_at
   end
 
   defp project_message_data_anonymized(event) do

--- a/lib/klass_hero/messaging/adapters/driven/projections/conversation_summaries.ex
+++ b/lib/klass_hero/messaging/adapters/driven/projections/conversation_summaries.ex
@@ -311,7 +311,7 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries 
           # fields (latest_message_*, has_attachments, system_notes,
           # enrolled_child_names) and archived_at MUST be preserved —
           # those are owned by other event handlers (:message_sent,
-          # :messages_read, :conversation_archived).
+          # :messages_read, :conversations_archived).
           on_conflict:
             {:replace,
              [

--- a/lib/klass_hero/messaging/adapters/driven/projections/conversation_summaries.ex
+++ b/lib/klass_hero/messaging/adapters/driven/projections/conversation_summaries.ex
@@ -27,8 +27,7 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries 
   - `:message_sent` — updates latest_message fields, increments unread_count
     for non-sender participants
   - `:messages_read` — resets unread_count to 0, updates last_read_at
-  - `:conversation_archived` — sets archived_at for all rows of a conversation
-  - `:conversations_archived` — same as above but for multiple conversations
+  - `:conversations_archived` — sets archived_at for all rows of the archived conversations
   - `:message_data_anonymized` — updates other_participant_name to "Deleted User"
     for rows where the anonymized user was the other participant
   """
@@ -38,7 +37,6 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries 
       "integration:messaging:conversation_created",
       "integration:messaging:message_sent",
       "integration:messaging:messages_read",
-      "integration:messaging:conversation_archived",
       "integration:messaging:conversations_archived",
       "integration:messaging:message_data_anonymized",
       "integration:messaging:participant_added",
@@ -92,15 +90,6 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries 
     )
 
     project_messages_read(event)
-  end
-
-  def handle_event(:conversation_archived, %Event{} = event) do
-    Logger.debug("ConversationSummaries projecting conversation_archived",
-      conversation_id: event.entity_id,
-      event_id: event.event_id
-    )
-
-    project_conversation_archived(event)
   end
 
   def handle_event(:conversations_archived, %Event{} = event) do
@@ -526,23 +515,6 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries 
       set: [
         unread_count: 0,
         last_read_at: read_at,
-        updated_at: now
-      ]
-    )
-  end
-
-  defp project_conversation_archived(event) do
-    payload = event.payload
-    conversation_id = payload.conversation_id
-    archived_at = Map.get(payload, :archived_at)
-    now = DateTime.utc_now() |> DateTime.truncate(:second)
-
-    from(s in ConversationSummary,
-      where: s.conversation_id == ^conversation_id
-    )
-    |> Repo.update_all(
-      set: [
-        archived_at: archived_at,
         updated_at: now
       ]
     )

--- a/lib/klass_hero/messaging/adapters/driven/projections/conversation_summaries.ex
+++ b/lib/klass_hero/messaging/adapters/driven/projections/conversation_summaries.ex
@@ -549,9 +549,11 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries 
   end
 
   defp project_conversations_archived(event) do
-    payload = event.payload
-    conversation_ids = Map.get(payload, :conversation_ids, [])
-    archived_at = Map.get(payload, :archived_at)
+    # Destructured, not `Map.get`-ed: `project/1` discards this function's return, so a
+    # defaulting read of a key the producer stopped sending would write `archived_at: nil`
+    # and silently leave archived conversations in every inbox. A MatchError here surfaces
+    # as a retried delivery job instead.
+    %{conversation_ids: conversation_ids, archived_at: archived_at} = event.payload
     now = DateTime.utc_now() |> DateTime.truncate(:second)
 
     if conversation_ids != [] do

--- a/lib/klass_hero/messaging/archive_ended_program_conversations.ex
+++ b/lib/klass_hero/messaging/archive_ended_program_conversations.ex
@@ -78,8 +78,8 @@ defmodule KlassHero.Messaging.ArchiveEndedProgramConversations do
   # delivery job a job with no work in it.
   defp archived_events(%{count: 0}), do: []
 
-  defp archived_events(%{count: count, conversation_ids: ids}) do
-    [MessagingEvents.conversations_archived(ids, :program_ended, count)]
+  defp archived_events(%{count: count, conversation_ids: ids, archived_at: archived_at}) do
+    [MessagingEvents.conversations_archived(ids, :program_ended, count, archived_at)]
   end
 
   defp default_days_after_program_end do

--- a/lib/klass_hero/messaging/conversation.ex
+++ b/lib/klass_hero/messaging/conversation.ex
@@ -74,14 +74,6 @@ defmodule KlassHero.Messaging.Conversation do
     |> optimistic_lock(:lock_version)
   end
 
-  @doc "Changeset for archiving a conversation."
-  def archive_changeset(schema, attrs) do
-    schema
-    |> cast(attrs, [:archived_at, :retention_until, :lock_version])
-    |> validate_required([:archived_at, :retention_until])
-    |> optimistic_lock(:lock_version)
-  end
-
   defp validate_broadcast_program_id(changeset) do
     type = get_field(changeset, :type)
     program_id = get_field(changeset, :program_id)

--- a/lib/klass_hero/messaging/domain/events/messaging_events.ex
+++ b/lib/klass_hero/messaging/domain/events/messaging_events.ex
@@ -104,23 +104,6 @@ defmodule KlassHero.Messaging.Domain.Events.MessagingEvents do
   end
 
   @doc """
-  Creates a conversation_archived event (single conversation).
-  """
-  @spec conversation_archived(
-          conversation_id :: String.t(),
-          reason :: :program_ended | :manual
-        ) :: Event.t()
-  def conversation_archived(conversation_id, reason) do
-    Event.new(
-      :conversation_archived,
-      @source_context,
-      @entity_type,
-      conversation_id,
-      %{conversation_id: conversation_id, reason: reason}
-    )
-  end
-
-  @doc """
   Creates a conversations_archived event for bulk archive operations.
 
   Published when multiple conversations are archived at once (e.g. program

--- a/lib/klass_hero/messaging/domain/events/messaging_events.ex
+++ b/lib/klass_hero/messaging/domain/events/messaging_events.ex
@@ -126,19 +126,29 @@ defmodule KlassHero.Messaging.Domain.Events.MessagingEvents do
   Published when multiple conversations are archived at once (e.g. program
   ended). Its entity id is a bulk-operation identifier rather than any one
   conversation.
+
+  `archived_at` is the timestamp the producer wrote to the conversation rows, not
+  the moment the event was built: the read-side projection copies it verbatim, so
+  the two tables agree.
   """
   @spec conversations_archived(
           conversation_ids :: [String.t()],
           reason :: :program_ended | :retention_policy,
-          count :: non_neg_integer()
+          count :: non_neg_integer(),
+          archived_at :: DateTime.t()
         ) :: Event.t()
-  def conversations_archived(conversation_ids, reason, count) do
+  def conversations_archived(conversation_ids, reason, count, archived_at) do
     Event.new(
       :conversations_archived,
       @source_context,
       @entity_type,
       "bulk_archive_#{DateTime.to_unix(DateTime.utc_now())}",
-      %{conversation_ids: conversation_ids, reason: reason, count: count}
+      %{
+        conversation_ids: conversation_ids,
+        reason: reason,
+        count: count,
+        archived_at: archived_at
+      }
     )
   end
 

--- a/test/klass_hero/messaging/adapters/driven/projections/conversation_summaries_test.exs
+++ b/test/klass_hero/messaging/adapters/driven/projections/conversation_summaries_test.exs
@@ -724,42 +724,6 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummariesT
     end
   end
 
-  describe "handle conversation_archived event" do
-    test "sets archived_at for all participants of the conversation" do
-      user_1 = user_fixture(name: "Alice Smith")
-      user_2 = user_fixture(name: "Bob Jones")
-
-      conversation_id = Ecto.UUID.generate()
-      provider_id = Ecto.UUID.generate()
-      archived_at = now()
-
-      # Create conversation first
-      dispatch(:conversation_created, %{
-        conversation_id: conversation_id,
-        type: :direct,
-        provider_id: provider_id,
-        participant_ids: [user_1.id, user_2.id]
-      })
-
-      # Now archive it
-      dispatch(:conversation_archived, %{
-        conversation_id: conversation_id,
-        archived_at: archived_at
-      })
-
-      # Both participants' summary rows should have archived_at set
-      summaries =
-        Repo.all(
-          from(s in ConversationSummary,
-            where: s.conversation_id == ^conversation_id
-          )
-        )
-
-      assert length(summaries) == 2
-      assert Enum.all?(summaries, fn s -> s.archived_at == archived_at end)
-    end
-  end
-
   describe "handle conversations_archived event" do
     test "sets archived_at for all participants across multiple conversations" do
       user_1 = user_fixture(name: "Alice Smith")

--- a/test/klass_hero/messaging/adapters/driven/projections/conversation_summaries_test.exs
+++ b/test/klass_hero/messaging/adapters/driven/projections/conversation_summaries_test.exs
@@ -762,6 +762,33 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummariesT
       assert length(summaries) == 4
       assert Enum.all?(summaries, fn s -> s.archived_at == archived_at end)
     end
+
+    test "falls back to occurred_at for an event staged before archived_at was on the payload" do
+      user = user_fixture(name: "Alice Smith")
+      conversation_id = Ecto.UUID.generate()
+
+      dispatch(:conversation_created, %{
+        conversation_id: conversation_id,
+        type: :direct,
+        provider_id: Ecto.UUID.generate(),
+        participant_ids: [user.id]
+      })
+
+      # The pre-#1216 payload shape, which can still be sitting in the queue across the
+      # deploy. A literal map is right here: the point is a payload the constructor can
+      # no longer build.
+      event =
+        event(:conversations_archived, %{conversation_ids: [conversation_id], reason: :program_ended, count: 1},
+          entity_id: "bulk_archive_#{System.unique_integer([:positive])}"
+        )
+
+      dispatch(event)
+
+      summary = Repo.one(from(s in ConversationSummary, where: s.conversation_id == ^conversation_id))
+
+      assert summary.archived_at == DateTime.truncate(event.occurred_at, :second),
+             "a legacy event must still archive the row rather than dead-letter the job"
+    end
   end
 
   describe "handle message_data_anonymized event" do

--- a/test/klass_hero/messaging/adapters/driven/projections/conversation_summaries_test.exs
+++ b/test/klass_hero/messaging/adapters/driven/projections/conversation_summaries_test.exs
@@ -8,6 +8,7 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummariesT
   alias KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries
   alias KlassHero.Messaging.Conversation
   alias KlassHero.Messaging.ConversationSummary
+  alias KlassHero.Messaging.Domain.Events.MessagingEvents
   alias KlassHero.Messaging.EnrolledChild
   alias KlassHero.Messaging.Message
   alias KlassHero.Messaging.Participant
@@ -744,15 +745,11 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummariesT
         })
       end
 
-      # Bulk archive both conversations
-      dispatch(
-        :conversations_archived,
-        %{
-          conversation_ids: [conv_1_id, conv_2_id],
-          archived_at: archived_at
-        },
-        entity_id: "bulk_archive_#{System.unique_integer([:positive])}"
-      )
+      # Built through the real constructor, not a literal payload: a hand-written map
+      # here is what let the producer stop sending archived_at without any test noticing.
+      [conv_1_id, conv_2_id]
+      |> MessagingEvents.conversations_archived(:program_ended, 2, archived_at)
+      |> dispatch()
 
       # All 4 summary rows (2 per conversation) should have archived_at set
       summaries =

--- a/test/klass_hero/messaging/archive_conversations_delivery_test.exs
+++ b/test/klass_hero/messaging/archive_conversations_delivery_test.exs
@@ -1,0 +1,86 @@
+defmodule KlassHero.Messaging.ArchiveConversationsDeliveryTest do
+  @moduledoc """
+  Integration test for the bulk archive flow end to end: the nightly archive stages
+  `conversations_archived` in the same transaction as the write, and the delivery job
+  then invokes `ConversationSummaries.project/1`, which is what removes the conversation
+  from every participant's inbox.
+
+  The rest of the messaging suite runs against `TestOutbox`, which records staged events
+  instead of enqueueing them — so it can assert what a producer emitted, but never what
+  its consumers did with the payload. This test swaps in the real `ObanOutbox` for its
+  duration to cover that gap, following
+  `test/klass_hero/accounts/registration_confirmation_integration_test.exs`.
+  """
+
+  use KlassHero.DataCase, async: false
+
+  import KlassHero.Factory
+
+  alias KlassHero.Messaging
+  alias KlassHero.Messaging.ArchiveEndedProgramConversations
+  alias KlassHero.Shared.Adapters.Driven.Events.ObanOutbox
+
+  describe "archiving conversations for ended programs" do
+    test "archives the read-table rows, so the conversation leaves the inbox" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, end_date: DateTime.utc_now() |> DateTime.add(-40, :day))
+
+      conversation =
+        insert(:conversation_schema,
+          type: "program_broadcast",
+          provider_id: provider.id,
+          program_id: program.id
+        )
+
+      # conversation_summaries has no FKs (see the factory), so a bare id stands in
+      # for the participant whose inbox we are asserting on.
+      user_id = Ecto.UUID.generate()
+
+      insert(:conversation_summary_schema,
+        conversation_id: conversation.id,
+        user_id: user_id,
+        conversation_type: "program_broadcast",
+        provider_id: provider.id,
+        program_id: program.id,
+        archived_at: nil
+      )
+
+      archive_and_deliver()
+
+      {:ok, archived_conversation} = Messaging.get_conversation_by_id(conversation.id)
+      summary = Repo.get_by!(Messaging.ConversationSummary, conversation_id: conversation.id, user_id: user_id)
+
+      assert summary.archived_at != nil,
+             "the write table archived the conversation but the read table kept archived_at nil"
+
+      assert DateTime.compare(summary.archived_at, archived_conversation.archived_at) == :eq
+
+      assert {:ok, [], false} = Messaging.list_conversation_summaries_for_user(user_id, [])
+    end
+  end
+
+  # The real outbox is swapped in around the act alone, not in `setup`: under `ObanOutbox`
+  # the user fixtures would also deliver their own `user_registered`, which creates a
+  # provider profile and collides with the one the factory inserts.
+  #
+  # Manual mode, then drain: `testing: :inline` would run the delivery job at insert,
+  # inside the archive's own transaction. Production runs it after the commit.
+  defp archive_and_deliver do
+    original_outbox = Application.get_env(:klass_hero, :outbox)
+    Application.put_env(:klass_hero, :outbox, module: ObanOutbox)
+
+    result =
+      try do
+        {:ok, result} =
+          Oban.Testing.with_testing_mode(:manual, fn -> ArchiveEndedProgramConversations.execute() end)
+
+        result
+      after
+        Application.put_env(:klass_hero, :outbox, original_outbox)
+      end
+
+    Oban.drain_queue(queue: :critical_events, with_recursion: true)
+
+    result
+  end
+end

--- a/test/klass_hero/messaging/conversation_test.exs
+++ b/test/klass_hero/messaging/conversation_test.exs
@@ -104,26 +104,13 @@ defmodule KlassHero.Messaging.ConversationTest do
     end
   end
 
-  describe "archive_conversation/1" do
-    test "sets archived_at, a retention window, and bumps lock_version" do
-      conversation = insert(:conversation_schema)
-
-      assert {:ok, archived} = Messaging.archive_conversation(conversation)
-      assert archived.archived_at != nil
-      assert archived.retention_until != nil
-      assert archived.lock_version == conversation.lock_version + 1
-    end
-
-    test "returns :not_found for an unknown conversation" do
-      assert {:error, :not_found} =
-               Messaging.archive_conversation(%Conversation{id: Ecto.UUID.generate()})
-    end
-  end
-
   describe "delete_expired_conversations/1" do
     test "deletes archived conversations past their retention window" do
-      conversation = insert(:conversation_schema)
-      {:ok, _} = Messaging.archive_conversation(conversation)
+      conversation =
+        insert(:conversation_schema,
+          archived_at: DateTime.utc_now() |> DateTime.add(-31, :day) |> DateTime.truncate(:second),
+          retention_until: DateTime.utc_now() |> DateTime.add(-1, :day) |> DateTime.truncate(:second)
+        )
 
       future = DateTime.add(DateTime.utc_now(), 60, :day)
 

--- a/test/klass_hero/messaging/domain/events/messaging_events_test.exs
+++ b/test/klass_hero/messaging/domain/events/messaging_events_test.exs
@@ -102,17 +102,19 @@ defmodule KlassHero.Messaging.Domain.Events.MessagingEventsTest do
     end
   end
 
-  describe "conversations_archived/3" do
+  describe "conversations_archived/4" do
     test "creates event with correct type and payload" do
       ids = [Ecto.UUID.generate(), Ecto.UUID.generate()]
+      archived_at = DateTime.utc_now() |> DateTime.truncate(:second)
 
-      event = MessagingEvents.conversations_archived(ids, :retention_policy, 2)
+      event = MessagingEvents.conversations_archived(ids, :retention_policy, 2, archived_at)
 
       assert event.event_type == :conversations_archived
       assert event.entity_type == :conversation
       assert event.payload.conversation_ids == ids
       assert event.payload.reason == :retention_policy
       assert event.payload.count == 2
+      assert event.payload.archived_at == archived_at
     end
   end
 

--- a/test/klass_hero/messaging/domain/events/messaging_events_test.exs
+++ b/test/klass_hero/messaging/domain/events/messaging_events_test.exs
@@ -89,19 +89,6 @@ defmodule KlassHero.Messaging.Domain.Events.MessagingEventsTest do
     end
   end
 
-  describe "conversation_archived/2" do
-    test "creates event with correct type and payload" do
-      conversation_id = Ecto.UUID.generate()
-
-      event = MessagingEvents.conversation_archived(conversation_id, :program_ended)
-
-      assert event.event_type == :conversation_archived
-      assert event.entity_id == conversation_id
-      assert event.entity_type == :conversation
-      assert event.payload.reason == :program_ended
-    end
-  end
-
   describe "conversations_archived/4" do
     test "creates event with correct type and payload" do
       ids = [Ecto.UUID.generate(), Ecto.UUID.generate()]

--- a/test/klass_hero/messaging/message_test.exs
+++ b/test/klass_hero/messaging/message_test.exs
@@ -130,11 +130,15 @@ defmodule KlassHero.Messaging.MessageTest do
     end
 
     test "delete_messages_for_expired_conversations removes messages of expired conversations" do
-      conversation = insert(:conversation_schema)
+      conversation =
+        insert(:conversation_schema,
+          archived_at: DateTime.utc_now() |> DateTime.add(-31, :day) |> DateTime.truncate(:second),
+          retention_until: DateTime.utc_now() |> DateTime.add(-1, :day) |> DateTime.truncate(:second)
+        )
+
       user = AccountsFixtures.user_fixture()
       insert(:participant_schema, conversation_id: conversation.id, user_id: user.id)
       {:ok, message} = Messaging.create_message(%{conversation_id: conversation.id, sender_id: user.id, content: "x"})
-      {:ok, _} = Messaging.archive_conversation(conversation)
 
       future = DateTime.add(DateTime.utc_now(), 60, :day)
 


### PR DESCRIPTION
Closes #1216.

## Summary

#1216 reported `:conversation_archived` as a consumer with no producer. Scoping it turned up two things the issue did not have:

1. **`Messaging.archive_conversation/1` was dead too.** The issue assumed the single-conversation write path needed adding; it already existed, with zero `lib/` callers and no UI — only three tests used it as fixture setup.

2. **The sibling bulk path was broken in production.** `conversations_archived`'s payload carried no `archived_at`, while `project_conversations_archived/1` read it with `Map.get/3` — so the nightly `MessageCleanupWorker` archived conversations in the write table while `conversation_summaries.archived_at` stayed `nil`. Since `list_conversation_summaries_for_user/2` filters on `is_nil(archived_at)`, archived conversations kept showing in every participant's inbox until a deploy re-bootstrapped the projection from the write table. The projection test passed only because it hand-built a payload containing a key no constructor produced.

The root cause behind both: nothing checks that an event constructor's payload and its consumer's reads agree. `Outbox.stage/2` catches a producer with no consumer; the inverse, and payload-key drift, is invisible to it and to the compiler.

## Review focus

- **`project_conversations_archived/1`** — `conversation_ids` is destructured, `archived_at` goes through `legacy_archived_at/1`. That split is deliberate: an event staged before this deploy has no `archived_at` key, and a strict read there would have cost 10 Oban retries plus a dead-letter row while leaving the conversation in every inbox. It falls back to `occurred_at` (stamped in the archiving transaction) and logs. The clause is marked for deletion once no pre-#1216 event can be queued.
- **The drift guard is the test, not the runtime.** The projection test now builds its event via `MessagingEvents.conversations_archived/4`; that is what fails if the two sides disagree again.
- **`archive_conversations_delivery_test.exs`** — the suite runs against `TestOutbox`, which records what a producer staged but never runs its consumers, which is precisely why this bug survived. This test swaps in the real `ObanOutbox` around the act alone (doing it in `setup` makes the user fixtures deliver their own `user_registered` and collide on `providers_identity_id_index`) and drains the queue.
- **`Conversation.archive_changeset/2` is deleted too.** Its only caller was `archive_conversation/1`; the bulk path writes through `update_all`, so it validated nothing that still runs.

## Test plan

- `mix precommit` green: 4082 passed, 2 skipped (includes `--include slow`, credo `--strict`, format, warnings-as-errors).
- The delivery test was red before the fix with the intended failure (`archived_at` nil, conversation still listed) and green after.
- The legacy-payload test was proven red by removing the fallback clause (`FunctionClauseError`), then restored.
- `/review-architecture`: 21 checks, 0 violations. The two advisory findings — deploy-window strictness and the `DateTime`-becomes-ISO8601-string round-trip — are both addressed in the final commit.

## Follow-up filed

#1280 — `EventMetadata`'s moduledoc still says non-critical events "dispatch in-memory only (never serialized)". Under the unified outbox every event round-trips through Oban's jsonb, so any `DateTime` in any payload reaches its consumer as a string while the `@spec` claims `DateTime.t()`. Harmless here because the value lands in an Ecto `:utc_datetime` column, but the next consumer doing date arithmetic on one would break.