### PR TITLE
ci: gate test-file compile warnings and stop Release PRs reverting merged work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,9 +100,70 @@ jobs:
       - name: Projection read-table convention
         run: mix lint_read_tables
 
-  # Release-please's Release PR only ever touches .release-please-manifest.json,
-  # CHANGELOG.md and mix.exs's `version:` — content already tested on main. Running the
-  # full suite plus a browser E2E pass for a version bump costs ~9 billable minutes.
+  # The counterpart to the skip documented on `test` below: that skip is only safe while a
+  # Release PR's diff really is a version bump over content already tested on main. This job
+  # is what makes that true rather than assumed. Runs only on the Release PR (~20s), so it
+  # costs nothing on ordinary PRs.
+  #
+  # When it fails, the Release PR is carrying someone else's reverted work. Do not "fix" the
+  # diff by hand — close the PR and delete the release-please--branches--main branch; the
+  # next push to main regenerates it from current content.
+  release-pr-guard:
+    name: Release PR Diff Shape
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.head_ref == 'release-please--branches--main'
+
+    steps:
+      # fetch-depth: 0 because the check is a diff against the merge base, which a depth-1
+      # checkout cannot reach.
+      # actions/checkout@v7.0.1
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 0
+
+      # BASE_REF goes through env rather than inline `${{ }}` in run: — a ref name is
+      # attacker-influenced input and inline interpolation is a shell-injection sink.
+      - name: Release PR changes only release files
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          changed=$(git diff --name-only "origin/${BASE_REF}...HEAD")
+          unexpected=$(echo "$changed" | grep -vxE 'mix\.exs|CHANGELOG\.md|\.release-please-manifest\.json' || true)
+          if [ -n "$unexpected" ]; then
+            echo "::error::Release PR touches files it does not own:"
+            echo "$unexpected"
+            exit 1
+          fi
+
+      - name: Release PR changes only mix.exs's version
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          # --unified=0 so no context line is mistaken for a change.
+          extra=$(git diff --unified=0 "origin/${BASE_REF}...HEAD" -- mix.exs \
+            | grep -E '^[-+][^-+]' \
+            | grep -vE '^[-+][[:space:]]*version: "[0-9]+\.[0-9]+\.[0-9]+",$' || true)
+          if [ -n "$extra" ]; then
+            echo "::error::Release PR changes mix.exs beyond version: — it is reverting merged work."
+            echo "$extra"
+            exit 1
+          fi
+
+  # Release-please rebuilds mix.exs from a SNAPSHOT taken when it first opened the Release
+  # PR, then re-parents the branch onto latest main without re-reading the file. So a
+  # Release PR can revert any mix.exs change merged while it was open, even though its
+  # branch is perfectly up to date. #1266 reverted the precommit warning gate #1265 added
+  # 81 minutes earlier that way: its head commit was parented on #1265's merge, yet its
+  # mix.exs was byte-identical to main from before #1265 apart from `version:`.
+  #
+  # `release-pr-guard` below re-checks that premise on every Release PR, so this skip stays
+  # honest: the Release PR touches .release-please-manifest.json, CHANGELOG.md and mix.exs's
+  # `version:` and nothing else — content already tested on main. Running the full suite
+  # plus a browser E2E pass for a version bump costs ~9 billable minutes.
   # `quality` deliberately still runs: format and credo over a bumped mix.exs are cheap and
   # catch a malformed version.
   #

--- a/mix.exs
+++ b/mix.exs
@@ -155,7 +155,14 @@ defmodule KlassHero.MixProject do
         "lint_translations",
         "lint_read_tables",
         "credo --strict",
-        "cmd env MIX_ENV=test mix test --include slow"
+        # Two halves on purpose: `test --warnings-as-errors` only covers test
+        # files, and `test/support/*.ex` compiles solely in the test env — so
+        # the dev-env `compile --warnings-as-errors` above never sees it.
+        #
+        # Restored after release-please reverted it (#1265 landed it, the #1266
+        # Release PR replayed a pre-#1265 snapshot of this file over it). The
+        # `release-pr-guard` job in ci.yml exists to stop that recurring.
+        "cmd env MIX_ENV=test mix do compile --warnings-as-errors + test --warnings-as-errors --include slow"
       ]
     ]
   end


### PR DESCRIPTION
Closes #1230.

## Summary

Two halves. #1230's own work — clean the 10 test-file warnings, gate them in
precommit and CI — landed in #1265. Then #1266, a release-please Release PR,
reverted the precommit half 81 minutes later. This restores it and closes the
hole that let it happen.

**1. Restore the precommit gate** (`mix.exs`)

`elixirc_paths(:test)` is `["lib", "test/support", "test/e2e/support"]`, so the
dev-env `compile --warnings-as-errors` never sees `test/**/*_test.exs`. The
paired `mix do compile --warnings-as-errors + test --warnings-as-errors` form
covers both halves — the `.exs` files and `test/support/*.ex`, which compiles
only in the test env. CI's equivalent (`ci.yml`) was untouched by the revert,
so this was a local-only weakening.

**2. Fail a Release PR that carries a revert** (`.github/workflows/ci.yml`)

Release-please rebuilds `mix.exs` from a snapshot taken when it first opened
the Release PR, then re-parents the branch onto latest main *without re-reading
the file*. So its branch is up to date while its content is not.

Evidence from #1266:

| | |
|---|---|
| Release PR head | `d88867b9` |
| Its parent | `b00a838e` — #1265's merge commit |
| Its `mix.exs` | byte-identical to `main@9ca3f17a` (before #1265) apart from `version:` |

Nothing caught it: `test`, `e2e` and `seed` skip on the Release PR, on the
premise that its diff is a version bump over content already tested on main.
The new `release-pr-guard` job checks that premise rather than assuming it —
the changed file set is the three release-owned files, and `mix.exs`'s diff is
the `version:` line and nothing else. It runs only on the Release PR, so it
costs nothing on ordinary PRs.

Rejected alternatives, both of which would have missed #1266:
- **Require branches up to date** — this branch *was* up to date. Also adds a
  rebase round-trip to every PR.
- **Un-skip `test`/`e2e` on Release PRs** — ~9 billable minutes per release,
  and no test asserts the content of a mix alias.

## Review focus

- The guard's grep in `ci.yml`. `--unified=0` is load-bearing: with context
  lines, a `version:` line appearing as context in an unrelated hunk would
  widen what the allow-pattern forgives.
- `BASE_REF` goes through `env:` rather than inline `${{ }}` in `run:` — a ref
  name is attacker-influenced input and inline interpolation is a shell
  injection sink.
- The recovery instruction in the job comment: when the guard fires, close the
  Release PR and delete `release-please--branches--main` rather than hand-editing
  the diff. The next push to main regenerates it from current content.

## Test plan

- `mix precommit` green with the restored flag — 4084 passed, 2 skipped. This
  also confirms no test-file warnings have regressed since #1265.
- Guard logic replayed against real history:
  - `b00a838e...d88867b9` (the #1266 clobber) → **fails**, as it must
  - `#1261` release → passes
  - `#1275` release → passes
- `ci.yml` parses; `release-pr-guard` resolves to the expected `if:` and steps.

## Follow-up (not in this PR)

`Release PR Diff Shape` is not yet a required status check on the `main`
ruleset (currently: `Code Quality`, `Tests`, `E2E Tests`). Until it is added,
the guard reports red but does not block the merge. Safe to add — an
`if:`-skipped job still emits a check run, which satisfies a required check, the
same property the existing `Tests`/`E2E Tests` skips already rely on.