### PR TITLE
ci: serialize release-please so concurrent runs stop losing updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,14 +153,19 @@ jobs:
             exit 1
           fi
 
-  # Release-please rebuilds mix.exs from a SNAPSHOT taken when it first opened the Release
-  # PR, then re-parents the branch onto latest main without re-reading the file. So a
-  # Release PR can revert any mix.exs change merged while it was open, even though its
-  # branch is perfectly up to date. #1266 reverted the precommit warning gate #1265 added
-  # 81 minutes earlier that way: its head commit was parented on #1265's merge, yet its
-  # mix.exs was byte-identical to main from before #1265 apart from `version:`.
+  # A Release PR can carry a REVERT of someone's merged mix.exs change. #1266 reverted the
+  # precommit warning gate #1265 had added 81 minutes earlier: its head commit was parented
+  # on #1265's merge, yet its mix.exs was byte-identical to main from before #1265 apart
+  # from `version:`.
   #
-  # `release-pr-guard` below re-checks that premise on every Release PR, so this skip stays
+  # The cause is concurrent workflow runs, not a stale branch. Each run of release-please.yml
+  # force-pushes the Release PR from its own read of main; #1264 and #1265 merged 11s apart,
+  # so two ran at once and the older one finished last and overwrote the newer. That is fixed
+  # at source by the `concurrency` group in release-please.yml — release-please does re-read
+  # main on every regeneration, which #1281 shows: opened before #1279, it regenerated after
+  # it and carried #1279's mix.exs correctly.
+  #
+  # `release-pr-guard` below is the backstop for that prevention, and what keeps this skip
   # honest: the Release PR touches .release-please-manifest.json, CHANGELOG.md and mix.exs's
   # `version:` and nothing else — content already tested on main. Running the full suite
   # plus a browser E2E pass for a version bump costs ~9 billable minutes.

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,25 @@ on:
   push:
     branches: [main]
 
+# Two pushes to main close together used to run this workflow twice at once, and each run
+# force-pushes the Release PR branch from its own read of main. The older run finishing last
+# then overwrites the newer one's content — a lost update. #1266 is the case: #1264 (08:07:34Z)
+# and #1265 (08:07:45Z) merged 11s apart, and the Release PR that came out carried a mix.exs
+# read before #1265, silently reverting the precommit warning gate #1265 had just added.
+#
+# Serialising fixes it because a queued run re-reads main when it finally starts, so the last
+# run to finish is also the one with the freshest content.
+#
+# cancel-in-progress MUST stay false. This workflow also creates the GitHub Release and
+# dispatches the production deploy when a Release PR merges (see `release_created` below), so
+# cancelling an in-flight run to make way for an ordinary push would silently skip a
+# production release. Queuing buys the same freshness without that failure mode.
+#
+# `release-pr-guard` in ci.yml is the backstop if this prevention ever fails.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
## Summary

Follow-up to #1279. That PR shipped `release-pr-guard`, which fails a Release PR whose
`mix.exs` diff is more than the `version:` line. This fixes the thing the guard was
catching, and corrects the mechanism #1279 documented.

**#1279's explanation was wrong.** It said release-please replays a file snapshot taken
when the Release PR opened. Release PR #1281 disproves that:

| | |
|---|---|
| #1281 opened | 2026-08-04T19:21:49Z — before #1279 existed |
| #1279 merged | 2026-08-05T03:53:00Z |
| #1281 regenerated | 03:53:19Z, parented on #1279's merge |
| Its `mix.exs` | **carries #1279's restored precommit line** |

So release-please re-reads main on every regeneration.

**The actual cause is a lost update between concurrent runs.** Each run force-pushes the
Release PR branch from its own read of main, and `release-please.yml` had no `concurrency:`
group. #1264 (08:07:34Z) and #1265 (08:07:45Z) merged 11 seconds apart, so two runs
overlapped; the one that had read main before #1265 finished last and overwrote the other.
That produced #1266 — parented on #1265's merge, yet carrying a pre-#1265 `mix.exs`, which
reverted the precommit warning gate #1265 had just added.

#1281 is the control case: single push, no race, correct content.

## Changes

- `.github/workflows/release-please.yml` — add a `concurrency` group so runs queue instead
  of racing. A queued run re-reads main when it starts, so the last run to finish is also
  the one with the freshest content.
- `.github/workflows/ci.yml` — replace the snapshot explanation added in #1279 with this
  one, and point at where the prevention now lives.

## Review focus

**`cancel-in-progress: false` is deliberate and load-bearing.** `true` looks right — newest
content wins — but this same workflow creates the GitHub Release and dispatches the
production deploy when a Release PR merges (`release_created` → `Dispatch production
deploy`). With `true`, an ordinary push landing seconds after a Release PR merge would
cancel that run and silently skip a production release. Queuing gets the same freshness
without that failure mode.

The group is `${{ github.workflow }}` with no `-${{ github.ref }}` suffix, unlike `ci.yml`'s.
That is intentional: this workflow only triggers on push to main, and every one of those
pushes must serialise against every other. Adding the ref would defeat the fix.

## Test plan

- Both workflow files parse (`ruby -ryaml -e 'YAML.load_file(...)'`); `ci.yml` still
  resolves all 7 jobs and its own per-ref concurrency group is untouched.
- No Elixir changed, so no suite run — this is workflow config and comments.
- Post-merge: two pushes to main landing close together should show the second Release
  Please run **queued** behind the first rather than running alongside it.
- Post-merge: the next Release PR regenerates with `Release PR Diff Shape` green.

## Related

`Release PR Diff Shape` is now a required status check on the `main` ruleset (added
alongside this PR), so the guard blocks rather than merely reports.