### PR TITLE
feat: surface the provider trust mark on home page featured cards

### DIFF
--- a/lib/klass_hero_web/components/marketing_components.ex
+++ b/lib/klass_hero_web/components/marketing_components.ex
@@ -24,7 +24,15 @@ defmodule KlassHeroWeb.MarketingComponents do
   use Gettext, backend: KlassHeroWeb.Gettext
 
   import KlassHeroWeb.UIComponents,
-    only: [kh_logo: 1, kh_button: 1, kh_card: 1, kh_pill: 1, kh_icon_chip: 1, icon: 1]
+    only: [
+      kh_logo: 1,
+      kh_button: 1,
+      kh_card: 1,
+      kh_pill: 1,
+      kh_icon_chip: 1,
+      kh_trust_mark: 1,
+      icon: 1
+    ]
 
   alias KlassHeroWeb.Theme
   alias Phoenix.HTML.FormField
@@ -365,8 +373,15 @@ defmodule KlassHeroWeb.MarketingComponents do
 
   @doc """
   Program card used inside `mk_featured`. Cover image (or gradient
-  fallback), price + category pills, schedule chip, title, age/period
-  footer with `View →`. Click → existing `phx-click="view_program"`.
+  fallback), price + category pills, schedule chip, title, provider +
+  age/period meta row, footer with `View →`. Click → existing
+  `phx-click="view_program"`.
+
+  The provider appears as a name and a compact trust mark in the meta row —
+  no avatar, no bordered row, unlike `ProgramComponents.program_card/1`. The
+  mark needs an adjacent name to read as a statement about the *provider*
+  rather than about the listing, but the full row truncates the name at mobile
+  width on this narrower card (#1224).
   """
   attr :id, :string, required: true
   attr :program, :map, required: true
@@ -375,6 +390,7 @@ defmodule KlassHeroWeb.MarketingComponents do
     ~H"""
     <.kh_card
       id={@id}
+      data-program-id={@program.id}
       phx-click="view_program"
       phx-value-program-id={@program.id}
       class="overflow-hidden cursor-pointer hover:shadow-xl hover:-translate-y-1"
@@ -415,6 +431,19 @@ defmodule KlassHeroWeb.MarketingComponents do
         <h3 class="font-bold text-lg leading-snug text-hero-black line-clamp-2">
           {@program.title}
         </h3>
+        <%!-- Provider gets its own line rather than joining the meta row below: at 375px
+              the name plus the mark already fills the card, so sharing a line with the
+              age range would wrap unpredictably (#1224). --%>
+        <div
+          :if={Map.get(@program, :provider_name)}
+          class="mt-2 flex items-center gap-2 text-[13px] text-[var(--fg-muted)]"
+        >
+          <span class="truncate">{@program.provider_name}</span>
+          <.kh_trust_mark
+            state={Map.get(@program, :verification_state, :unverified)}
+            variant={:compact}
+          />
+        </div>
         <div class="mt-2 flex items-center gap-2 text-[13px] text-[var(--fg-muted)] flex-wrap">
           <span :if={@program.age_range} class="flex items-center gap-1">
             <.icon name="hero-user" class="w-4 h-4" />

--- a/lib/klass_hero_web/components/program_components.ex
+++ b/lib/klass_hero_web/components/program_components.ex
@@ -213,61 +213,6 @@ defmodule KlassHeroWeb.ProgramComponents do
   end
 
   @doc """
-  Renders a provider's vetting state inline beside their name on a program card.
-
-  Deliberately compact — the roomier `verification_status_badge/1` in
-  `ProviderComponents` is a labelled pill built for the provider's own dashboard
-  header, which is too heavy to sit next to a name in a card.
-
-  `:unverified` renders nothing: a provider who has not completed vetting gets no
-  mark rather than a negative one.
-
-  ## Examples
-
-      <.provider_trust_mark state={:verified} />
-      <.provider_trust_mark state={:in_progress} />
-  """
-  attr :state, :atom, required: true, values: [:verified, :in_progress, :unverified]
-
-  def provider_trust_mark(%{state: :verified} = assigns) do
-    ~H"""
-    <span
-      data-testid="provider-trust-mark"
-      data-trust-state="verified"
-      class={[
-        "inline-flex items-center gap-1 px-1.5 py-0.5 text-xs font-medium flex-shrink-0",
-        Theme.status_badge(:available),
-        Theme.rounded(:full)
-      ]}
-      title={gettext("This provider completed Klass Hero's verification checks")}
-    >
-      <.icon name="hero-check-badge-mini" class="w-3.5 h-3.5" />
-      <span>{gettext("Verified")}</span>
-    </span>
-    """
-  end
-
-  def provider_trust_mark(%{state: :in_progress} = assigns) do
-    ~H"""
-    <span
-      data-testid="provider-trust-mark"
-      data-trust-state="in_progress"
-      class={[
-        "inline-flex items-center gap-1 px-1.5 py-0.5 text-xs font-medium flex-shrink-0",
-        Theme.status_badge(:limited),
-        Theme.rounded(:full)
-      ]}
-      title={gettext("This provider is working through Klass Hero's verification checks")}
-    >
-      <.icon name="hero-clock-mini" class="w-3.5 h-3.5" />
-      <span>{gettext("Verification in progress")}</span>
-    </span>
-    """
-  end
-
-  def provider_trust_mark(assigns), do: ~H""
-
-  @doc """
   Renders a program card with gradient header, favorite button, and program details.
 
   Supports two variants:
@@ -357,7 +302,7 @@ defmodule KlassHeroWeb.ProgramComponents do
               <span class="text-sm font-medium text-hero-black truncate">
                 {@program.provider_name}
               </span>
-              <.provider_trust_mark state={Map.get(@program, :verification_state, :unverified)} />
+              <.kh_trust_mark state={Map.get(@program, :verification_state, :unverified)} />
             </div>
             <div
               :if={Map.get(@program, :provider_location)}

--- a/lib/klass_hero_web/components/ui_components.ex
+++ b/lib/klass_hero_web/components/ui_components.ex
@@ -1847,25 +1847,114 @@ defmodule KlassHeroWeb.UIComponents do
 
       <.kh_pill tone={:success}>Verified</.kh_pill>
       <.kh_pill tone={:dark}>This week</.kh_pill>
+      <.kh_pill tone={:success} size={:xs}>Verified</.kh_pill>
   """
   attr :tone, :atom,
     default: :outline,
-    values: [:primary, :accent, :outline, :success, :warning, :error, :info, :dark, :cream]
+    values: [:primary, :accent, :outline, :success, :warning, :error, :info, :dark, :cream, :none],
+    doc: "`:none` emits no colors — the caller supplies them through `class`"
+
+  attr :size, :atom,
+    default: :default,
+    values: [:default, :xs],
+    doc: "`:xs` is the dense variant for pills sharing a line with other text"
 
   attr :class, :string, default: ""
+  attr :rest, :global
   slot :inner_block, required: true
 
   def kh_pill(assigns) do
     ~H"""
-    <span class={[
-      "inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-semibold",
-      kh_pill_tone_classes(@tone),
-      @class
-    ]}>
+    <span
+      class={[
+        "inline-flex items-center rounded-full",
+        kh_pill_size_classes(@size),
+        kh_pill_tone_classes(@tone),
+        @class
+      ]}
+      {@rest}
+    >
       {render_slot(@inner_block)}
     </span>
     """
   end
+
+  defp kh_pill_size_classes(:default), do: "gap-1.5 px-3 py-1 text-xs font-semibold"
+  defp kh_pill_size_classes(:xs), do: "gap-1 px-1.5 py-0.5 text-xs font-medium flex-shrink-0"
+
+  @doc """
+  Renders a provider's vetting state inline beside their name.
+
+  Lives here rather than with either card because both card families render it:
+  `ProgramComponents.program_card/1` on `/programs` and the parent dashboard, and
+  `MarketingComponents.mk_program_card/1` on the home page. The roomier
+  `ProviderComponents.verification_status_badge/1` stays separate — it is a
+  labelled pill for the provider's own dashboard header, too heavy to sit next to
+  a name in a card.
+
+  `:unverified` renders nothing: a provider who has not completed vetting gets no
+  mark rather than a negative one.
+
+  `variant={:compact}` shortens the in-progress label. The marketing card puts the
+  mark on the same line as the provider name, where the full "Verification in
+  progress" would push that line to wrap at mobile width (#1224).
+
+  Colors come from `Theme.status_badge/1` rather than `kh_pill`'s `:success` /
+  `:warning` tones, which pair a tint background with a mid-tone accent color and
+  measure 2.4:1 and 2.1:1 — below WCAG AA's 4.5:1 for text this size. The
+  `status_badge` pairs measure 6.5:1 and 6.4:1.
+
+  ## Examples
+
+      <.kh_trust_mark state={:verified} />
+      <.kh_trust_mark state={:in_progress} variant={:compact} />
+  """
+  attr :state, :atom, required: true, values: [:verified, :in_progress, :unverified]
+
+  attr :variant, :atom,
+    default: :default,
+    values: [:default, :compact],
+    doc: "`:compact` shortens the in-progress label for dense, shared lines"
+
+  def kh_trust_mark(%{state: :verified} = assigns) do
+    ~H"""
+    <.kh_pill
+      tone={:none}
+      size={:xs}
+      class={Theme.status_badge(:available)}
+      data-testid="provider-trust-mark"
+      data-trust-state="verified"
+      title={gettext("This provider completed Klass Hero's verification checks")}
+    >
+      <.icon name="hero-check-badge-mini" class="w-3.5 h-3.5" />
+      <span>{gettext("Verified")}</span>
+    </.kh_pill>
+    """
+  end
+
+  def kh_trust_mark(%{state: :in_progress} = assigns) do
+    ~H"""
+    <.kh_pill
+      tone={:none}
+      size={:xs}
+      class={Theme.status_badge(:limited)}
+      data-testid="provider-trust-mark"
+      data-trust-state="in_progress"
+      title={gettext("This provider is working through Klass Hero's verification checks")}
+    >
+      <.icon name="hero-clock-mini" class="w-3.5 h-3.5" />
+      <span>
+        <%= if @variant == :compact do %>
+          {gettext("Verifying")}
+        <% else %>
+          {gettext("Verification in progress")}
+        <% end %>
+      </span>
+    </.kh_pill>
+    """
+  end
+
+  def kh_trust_mark(assigns), do: ~H""
 
   defp kh_pill_tone_classes(:primary), do: "bg-[var(--brand-primary)] text-black"
   defp kh_pill_tone_classes(:accent), do: "bg-[var(--hero-yellow-500)] text-black"
@@ -1878,6 +1967,7 @@ defmodule KlassHeroWeb.UIComponents do
   defp kh_pill_tone_classes(:info), do: "bg-[var(--info-bg)] text-[var(--info)]"
   defp kh_pill_tone_classes(:dark), do: "bg-black text-white"
   defp kh_pill_tone_classes(:cream), do: "bg-[var(--hero-cream-100)] text-[var(--fg-body)]"
+  defp kh_pill_tone_classes(:none), do: ""
 
   @doc """
   Renders a heroicon. Convenience alias matching the `Kh*` naming so handoff

--- a/lib/klass_hero_web/live/home_live.ex
+++ b/lib/klass_hero_web/live/home_live.ex
@@ -5,13 +5,15 @@ defmodule KlassHeroWeb.HomeLive do
 
   alias KlassHero.ProgramCatalog
   alias KlassHero.ProgramCatalog.ProgramListing
+  alias KlassHeroWeb.Helpers.ProviderDisplay
   alias KlassHeroWeb.Presenters.ProgramPresenter
   alias KlassHeroWeb.Theme
 
   @impl true
   def mount(_params, _session, socket) do
     featured = ProgramCatalog.list_featured_programs()
-    featured_maps = Enum.map(featured, &listing_to_card_map/1)
+    providers = ProviderDisplay.for_programs(featured)
+    featured_maps = Enum.map(featured, &listing_to_card_map(&1, ProviderDisplay.fetch(providers, &1)))
     trending_tags = ProgramCatalog.trending_searches()
 
     socket =
@@ -52,14 +54,12 @@ defmodule KlassHeroWeb.HomeLive do
     {:noreply, push_navigate(socket, to: ~p"/programs/#{program_id}")}
   end
 
-  # No provider row here on purpose: the home page renders `mk_program_card`, a
-  # marketing card that shows no provider at all. Threading a name and trust state
-  # into it would recreate exactly the write-only data #1195 deleted. Surfacing
-  # verification here needs a design decision about the marketing card first.
-  defp listing_to_card_map(%ProgramListing{} = program) do
+  defp listing_to_card_map(%ProgramListing{} = program, provider) do
     %{
       id: program.id,
       title: program.title,
+      provider_name: provider.name,
+      verification_state: provider.trust,
       description: program.description,
       category: ProgramPresenter.format_category_for_display(program.category),
       age_range: program.age_range,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -13,9 +13,9 @@ msgstr ""
 
 #: lib/klass_hero_web/components/layouts/app.html.heex:44
 #: lib/klass_hero_web/components/layouts/app.html.heex:197
-#: lib/klass_hero_web/components/marketing_components.ex:194
-#: lib/klass_hero_web/components/marketing_components.ex:822
-#: lib/klass_hero_web/components/marketing_components.ex:911
+#: lib/klass_hero_web/components/marketing_components.ex:202
+#: lib/klass_hero_web/components/marketing_components.ex:851
+#: lib/klass_hero_web/components/marketing_components.ex:940
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr "Über uns"
@@ -34,9 +34,9 @@ msgstr "Wählen Sie Ihre bevorzugte Sprache für die Benutzeroberfläche"
 #: lib/klass_hero_web/components/composite_components.ex:468
 #: lib/klass_hero_web/components/layouts/app.html.heex:52
 #: lib/klass_hero_web/components/layouts/app.html.heex:198
-#: lib/klass_hero_web/components/marketing_components.ex:195
-#: lib/klass_hero_web/components/marketing_components.ex:823
-#: lib/klass_hero_web/components/marketing_components.ex:912
+#: lib/klass_hero_web/components/marketing_components.ex:203
+#: lib/klass_hero_web/components/marketing_components.ex:852
+#: lib/klass_hero_web/components/marketing_components.ex:941
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr "Kontakt"
@@ -68,7 +68,7 @@ msgstr "Spracheinstellung konnte nicht aktualisiert werden."
 
 #: lib/klass_hero_web/components/layouts/app.html.heex:28
 #: lib/klass_hero_web/components/layouts/app.html.heex:195
-#: lib/klass_hero_web/components/marketing_components.ex:190
+#: lib/klass_hero_web/components/marketing_components.ex:198
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr "Startseite"
@@ -93,7 +93,7 @@ msgstr "Anmelden"
 #: lib/klass_hero_web/components/composite_components.ex:484
 #: lib/klass_hero_web/components/layouts/app.html.heex:36
 #: lib/klass_hero_web/components/layouts/app.html.heex:196
-#: lib/klass_hero_web/components/marketing_components.ex:191
+#: lib/klass_hero_web/components/marketing_components.ex:199
 #, elixir-autogen, elixir-format
 msgid "Programs"
 msgstr "Programme"
@@ -182,7 +182,7 @@ msgstr "Nach Abschluss der Anmeldung erhalten Sie eine Rechnung per E-Mail"
 msgid "Any allergies, medical conditions, or special instructions..."
 msgstr "Allergien, medizinische Bedingungen oder besondere Hinweise..."
 
-#: lib/klass_hero_web/components/marketing_components.ex:492
+#: lib/klass_hero_web/components/marketing_components.ex:521
 #, elixir-autogen, elixir-format
 msgid "Book camps, tutors, and workshops instantly. Our integrated planner helps you manage your child's busy life."
 msgstr "Buchen Sie Camps, Nachhilfe und Workshops sofort. Unser integrierter Planer hilft Ihnen, den vollen Terminkalender Ihres Kindes zu verwalten."
@@ -197,7 +197,7 @@ msgstr "Bar / Überweisung"
 msgid "Cash/transfer payments will show as \"Pending\" until received"
 msgstr "Bar-/Überweisungszahlungen werden als \"Ausstehend\" angezeigt, bis sie eingegangen sind"
 
-#: lib/klass_hero_web/components/marketing_components.ex:500
+#: lib/klass_hero_web/components/marketing_components.ex:529
 #, elixir-autogen, elixir-format
 msgid "Community Focused"
 msgstr "Gemeinschaftsorientiert"
@@ -222,7 +222,7 @@ msgstr "Kreditkartenzahlungen werden sofort verarbeitet"
 msgid "Duration:"
 msgstr "Dauer:"
 
-#: lib/klass_hero_web/components/marketing_components.ex:490
+#: lib/klass_hero_web/components/marketing_components.ex:519
 #, elixir-autogen, elixir-format
 msgid "Easy Scheduling"
 msgstr "Einfache Terminplanung"
@@ -253,18 +253,18 @@ msgstr "Anmeldung fehlgeschlagen. Bitte versuchen Sie es erneut oder kontaktiere
 msgid "Enrollment successful! You'll receive a confirmation email shortly."
 msgstr "Anmeldung erfolgreich! Sie erhalten in Kürze eine Bestätigungs-E-Mail."
 
-#: lib/klass_hero_web/components/marketing_components.ex:482
+#: lib/klass_hero_web/components/marketing_components.ex:511
 #, elixir-autogen, elixir-format
 msgid "Every provider is rigorously vetted. We prioritize child safety above all else, giving parents peace of mind."
 msgstr "Jeder Anbieter wird sorgfältig geprüft. Wir stellen die Sicherheit der Kinder an erste Stelle und geben Eltern die nötige Sicherheit."
 
-#: lib/klass_hero_web/components/marketing_components.ex:953
+#: lib/klass_hero_web/components/marketing_components.ex:982
 #: lib/klass_hero_web/live/programs_live.ex:35
 #, elixir-autogen, elixir-format
 msgid "Explore Programs"
 msgstr "Programme entdecken"
 
-#: lib/klass_hero_web/components/marketing_components.ex:319
+#: lib/klass_hero_web/components/marketing_components.ex:327
 #, elixir-autogen, elixir-format
 msgid "Featured Programs"
 msgstr "Empfohlene Programme"
@@ -326,7 +326,7 @@ msgstr "Zahlungsinformationen ungültig. Bitte überprüfen Sie Ihre Angaben."
 msgid "Please select a child for enrollment."
 msgstr "Bitte wählen Sie ein Kind für die Anmeldung aus."
 
-#: lib/klass_hero_web/live/home_live.ex:20
+#: lib/klass_hero_web/live/home_live.ex:22
 #, elixir-autogen, elixir-format
 msgid "Klass Hero - Connecting Families with Trusted Youth Educators"
 msgstr "Klass Hero - Wir verbinden Familien mit vertrauenswürdigen Jugendpädagogen"
@@ -343,7 +343,7 @@ msgstr "Programm nicht gefunden"
 msgid "Program not found. It may have been removed or is no longer available."
 msgstr "Programm nicht gefunden. Es wurde möglicherweise entfernt oder ist nicht mehr verfügbar."
 
-#: lib/klass_hero_web/components/marketing_components.ex:480
+#: lib/klass_hero_web/components/marketing_components.ex:509
 #: lib/klass_hero_web/live/about_live.ex:19
 #, elixir-autogen, elixir-format
 msgid "Safety First"
@@ -389,7 +389,7 @@ msgstr "Gesamtpreis:"
 msgid "Total due today:"
 msgstr "Heute fällig:"
 
-#: lib/klass_hero_web/components/marketing_components.ex:338
+#: lib/klass_hero_web/components/marketing_components.ex:346
 #, elixir-autogen, elixir-format
 msgid "View All Programs →"
 msgstr "Alle Programme ansehen →"
@@ -1426,9 +1426,9 @@ msgid "Education"
 msgstr "Bildung"
 
 #: lib/klass_hero_web/components/composite_components.ex:472
-#: lib/klass_hero_web/components/marketing_components.ex:192
-#: lib/klass_hero_web/components/marketing_components.ex:538
-#: lib/klass_hero_web/components/marketing_components.ex:909
+#: lib/klass_hero_web/components/marketing_components.ex:200
+#: lib/klass_hero_web/components/marketing_components.ex:567
+#: lib/klass_hero_web/components/marketing_components.ex:938
 #: lib/klass_hero_web/live/for_providers_live.ex:10
 #: lib/klass_hero_web/live/for_providers_live.ex:39
 #, elixir-autogen, elixir-format
@@ -1440,7 +1440,7 @@ msgstr "Für Anbieter"
 msgid "From sports to arts, technology to languages, we make it easy to discover enriching activities that fit your family's schedule and budget."
 msgstr "Von Sport über Kunst, Technologie bis Sprachen – wir machen es einfach, bereichernde Aktivitäten zu entdecken, die zu Zeitplan und Budget Ihrer Familie passen."
 
-#: lib/klass_hero_web/components/marketing_components.ex:590
+#: lib/klass_hero_web/components/marketing_components.ex:619
 #, elixir-autogen, elixir-format
 msgid "Get Paid & Grow"
 msgstr "Verdienen & Wachsen"
@@ -1467,12 +1467,12 @@ msgstr "Qualifikationen"
 msgid "Ready to join the movement?"
 msgstr "Bereit, Teil der Bewegung zu werden?"
 
-#: lib/klass_hero_web/components/marketing_components.ex:987
+#: lib/klass_hero_web/components/marketing_components.ex:1016
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr "Suche"
 
-#: lib/klass_hero_web/components/marketing_components.ex:574
+#: lib/klass_hero_web/components/marketing_components.ex:603
 #, elixir-autogen, elixir-format
 msgid "Set up your teaching profile and list your programs in minutes. Share your expertise with families who need it."
 msgstr "Richten Sie Ihr Kursleiterprofil ein und veröffentlichen Sie Ihre Programme in wenigen Minuten. Teilen Sie Ihr Fachwissen mit Familien, die es brauchen."
@@ -1488,7 +1488,7 @@ msgstr "Sport"
 msgid "Sustainability"
 msgstr "Nachhaltigkeit"
 
-#: lib/klass_hero_web/components/marketing_components.ex:270
+#: lib/klass_hero_web/components/marketing_components.ex:278
 #, elixir-autogen, elixir-format
 msgid "Trending in Berlin:"
 msgstr "Beliebt in Berlin:"
@@ -2184,23 +2184,23 @@ msgid_plural "%{count} documents"
 msgstr[0] "%{count} Dokument"
 msgstr[1] "%{count} Dokumente"
 
-#: lib/klass_hero_web/components/program_components.ex:619
-#: lib/klass_hero_web/components/program_components.ex:627
+#: lib/klass_hero_web/components/program_components.ex:564
+#: lib/klass_hero_web/components/program_components.ex:572
 #, elixir-autogen, elixir-format
 msgid "%{count} month"
 msgid_plural "%{count} months"
 msgstr[0] "%{count} Monat"
 msgstr[1] "%{count} Monate"
 
-#: lib/klass_hero_web/components/program_components.ex:615
-#: lib/klass_hero_web/components/program_components.ex:626
+#: lib/klass_hero_web/components/program_components.ex:560
+#: lib/klass_hero_web/components/program_components.ex:571
 #, elixir-autogen, elixir-format
 msgid "%{count} year"
 msgid_plural "%{count} years"
 msgstr[0] "%{count} Jahr"
 msgstr[1] "%{count} Jahre"
 
-#: lib/klass_hero_web/components/program_components.ex:637
+#: lib/klass_hero_web/components/program_components.ex:582
 #, elixir-autogen, elixir-format
 msgid "%{gender} only"
 msgstr "Nur %{gender}"
@@ -2220,12 +2220,12 @@ msgstr "Mitglied hinzufügen"
 msgid "Add your first staff member to get started!"
 msgstr "Fügen Sie Ihren ersten Mitarbeiter hinzu, um loszulegen!"
 
-#: lib/klass_hero_web/components/program_components.ex:601
+#: lib/klass_hero_web/components/program_components.ex:546
 #, elixir-autogen, elixir-format
 msgid "Ages %{min} to %{max}"
 msgstr "Alter %{min} bis %{max}"
 
-#: lib/klass_hero_web/components/program_components.ex:605
+#: lib/klass_hero_web/components/program_components.ex:550
 #, elixir-autogen, elixir-format
 msgid "Ages %{min}+"
 msgstr "Alter %{min}+"
@@ -2266,7 +2266,7 @@ msgstr "Möchten Sie dieses Dokument wirklich genehmigen?"
 msgid "Are you sure you want to remove this team member?"
 msgstr "Möchten Sie dieses Teammitglied wirklich entfernen?"
 
-#: lib/klass_hero_web/components/marketing_components.ex:642
+#: lib/klass_hero_web/components/marketing_components.ex:671
 #, elixir-autogen, elixir-format
 msgid "As fathers and partners of teachers in Berlin, we saw and heard firsthand how hard it is to find, book, and manage quality youth activities outside the classroom. Klass Hero is the complete platform connecting Berlin families and schools with trusted, vetted activity providers — offering safe, supervised, and enriching experiences across sports, arts, tutoring, and more. We verify every provider, structure every booking, and support every step — so parents know their child is in good hands, and providers can focus on what they do best: inspiring kids."
 msgstr "Als Väter und Partner von Lehrkräften in Berlin haben wir aus erster Hand erlebt, wie schwer es ist, hochwertige außerschulische Aktivitäten für Kinder zu finden, zu buchen und zu organisieren. Klass Hero ist die umfassende Plattform, die Berliner Familien und Schulen mit vertrauenswürdigen, geprüften Anbietern verbindet — und bietet sichere, betreute und bereichernde Erlebnisse in den Bereichen Sport, Kunst, Nachhilfe und mehr. Wir überprüfen jeden Anbieter, strukturieren jede Buchung und unterstützen bei jedem Schritt — damit Eltern wissen, dass ihr Kind in guten Händen ist, und Anbieter sich auf das konzentrieren können, was sie am besten können: Kinder zu begeistern."
@@ -2303,7 +2303,7 @@ msgstr "Programm buchen"
 msgid "Brief description of experience and specialties..."
 msgstr "Kurze Beschreibung der Erfahrung und Spezialgebiete..."
 
-#: lib/klass_hero_web/components/marketing_components.ex:639
+#: lib/klass_hero_web/components/marketing_components.ex:668
 #, elixir-autogen, elixir-format
 msgid "Built by Parents to Empower Educators."
 msgstr "Von Eltern entwickelt, um Pädagogen zu stärken."
@@ -2428,7 +2428,7 @@ msgstr "Beschreiben Sie Ihr Programm..."
 msgid "Description"
 msgstr "Beschreibung"
 
-#: lib/klass_hero_web/components/program_components.ex:739
+#: lib/klass_hero_web/components/program_components.ex:684
 #: lib/klass_hero_web/components/provider_components.ex:1088
 #: lib/klass_hero_web/live/settings/children_live.ex:670
 #, elixir-autogen, elixir-format
@@ -2555,7 +2555,7 @@ msgstr "Dokument konnte nicht hochgeladen werden."
 msgid "Family Programs"
 msgstr "Familienprogramme"
 
-#: lib/klass_hero_web/components/program_components.ex:737
+#: lib/klass_hero_web/components/program_components.ex:682
 #: lib/klass_hero_web/components/provider_components.ex:1087
 #: lib/klass_hero_web/live/settings/children_live.ex:669
 #, elixir-autogen, elixir-format
@@ -2592,17 +2592,17 @@ msgstr "Vorname"
 msgid "Gender"
 msgstr "Geschlecht"
 
-#: lib/klass_hero_web/components/program_components.ex:746
+#: lib/klass_hero_web/components/program_components.ex:691
 #, elixir-autogen, elixir-format
 msgid "Grade %{grade}"
 msgstr "Klassenstufe %{grade}"
 
-#: lib/klass_hero_web/components/program_components.ex:754
+#: lib/klass_hero_web/components/program_components.ex:699
 #, elixir-autogen, elixir-format
 msgid "Grade %{min}+"
 msgstr "Klassenstufe %{min}+"
 
-#: lib/klass_hero_web/components/program_components.ex:750
+#: lib/klass_hero_web/components/program_components.ex:695
 #, elixir-autogen, elixir-format
 msgid "Grades %{min} – %{max}"
 msgstr "Klassenstufen %{min} – %{max}"
@@ -2701,7 +2701,7 @@ msgstr "Ort"
 msgid "Logo upload failed. Please try again."
 msgstr "Logo-Upload fehlgeschlagen. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/components/program_components.ex:738
+#: lib/klass_hero_web/components/program_components.ex:683
 #: lib/klass_hero_web/components/provider_components.ex:1086
 #: lib/klass_hero_web/live/settings/children_live.ex:668
 #, elixir-autogen, elixir-format
@@ -2820,14 +2820,14 @@ msgstr "Keine (optional)"
 msgid "Not Verified"
 msgstr "Nicht verifiziert"
 
-#: lib/klass_hero_web/components/program_components.ex:740
+#: lib/klass_hero_web/components/program_components.ex:685
 #: lib/klass_hero_web/components/provider_components.ex:1089
 #: lib/klass_hero_web/live/settings/children_live.ex:667
 #, elixir-autogen, elixir-format
 msgid "Not specified"
 msgstr "Nicht angegeben"
 
-#: lib/klass_hero_web/components/marketing_components.ex:636
+#: lib/klass_hero_web/components/marketing_components.ex:665
 #, elixir-autogen, elixir-format
 msgid "Our Story"
 msgstr "Unsere Geschichte"
@@ -2839,7 +2839,7 @@ msgstr "Unsere Geschichte"
 msgid "PDF, JPG or PNG. Max 10MB."
 msgstr "PDF, JPG oder PNG. Max. 10 MB."
 
-#: lib/klass_hero_web/components/program_components.ex:564
+#: lib/klass_hero_web/components/program_components.ex:509
 #, elixir-autogen, elixir-format
 msgid "Participant Requirements"
 msgstr "Teilnahmevoraussetzungen"
@@ -2923,7 +2923,7 @@ msgstr "Programm erfolgreich aktualisiert."
 msgid "Provider profile not found."
 msgstr "Anbieterprofil nicht gefunden."
 
-#: lib/klass_hero_web/components/marketing_components.ex:649
+#: lib/klass_hero_web/components/marketing_components.ex:678
 #, elixir-autogen, elixir-format
 msgid "Read our founding story →"
 msgstr "Lesen Sie unsere Gründungsgeschichte →"
@@ -3198,12 +3198,12 @@ msgstr "Zu viele Dateien."
 msgid "Unable to load document preview."
 msgstr "Die Dokumentvorschau konnte nicht geladen werden."
 
-#: lib/klass_hero_web/components/program_components.ex:609
+#: lib/klass_hero_web/components/program_components.ex:554
 #, elixir-autogen, elixir-format
 msgid "Up to %{max}"
 msgstr "Bis zu %{max}"
 
-#: lib/klass_hero_web/components/program_components.ex:758
+#: lib/klass_hero_web/components/program_components.ex:703
 #, elixir-autogen, elixir-format
 msgid "Up to Grade %{max}"
 msgstr "Bis Klassenstufe %{max}"
@@ -3255,9 +3255,9 @@ msgstr "Verifizierungsdokument nicht gefunden."
 msgid "Verifications"
 msgstr "Verifizierungen"
 
-#: lib/klass_hero_web/components/program_components.ex:245
 #: lib/klass_hero_web/components/provider_components.ex:276
 #: lib/klass_hero_web/components/provider_layout_components.ex:212
+#: lib/klass_hero_web/components/ui_components.ex:1930
 #, elixir-autogen, elixir-format
 msgid "Verified"
 msgstr "Verifiziert"
@@ -3302,12 +3302,12 @@ msgstr "z. B. Art Adventures"
 msgid "e.g., Community Center, Main St"
 msgstr "z. B. Gemeindezentrum, Hauptstraße"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1463
+#: lib/klass_hero_web/components/marketing_components.ex:1492
 #, elixir-autogen, elixir-format
 msgid "All Heroes must hold or complete a recognized child safeguarding course, ensuring up-to-date knowledge."
 msgstr "Alle Heroes müssen einen anerkannten Kinderschutzkurs absolviert haben oder absolvieren, um stets aktuelles Wissen sicherzustellen."
 
-#: lib/klass_hero_web/components/marketing_components.ex:1431
+#: lib/klass_hero_web/components/marketing_components.ex:1460
 #, elixir-autogen, elixir-format
 msgid "All providers must be 18 years or older, ensuring legal accountability and professional responsibility."
 msgstr "Alle Anbieter müssen mindestens 18 Jahre alt sein, um rechtliche Verantwortlichkeit und professionelle Verlässlichkeit zu gewährleisten."
@@ -3317,12 +3317,12 @@ msgstr "Alle Anbieter müssen mindestens 18 Jahre alt sein, um rechtliche Verant
 msgid "And at Klass Hero, both come standard."
 msgstr "Und bei Klass Hero sind beide selbstverständlich."
 
-#: lib/klass_hero_web/components/marketing_components.ex:1461
+#: lib/klass_hero_web/components/marketing_components.ex:1490
 #, elixir-autogen, elixir-format
 msgid "Child Safeguarding Training"
 msgstr "Kinderschutzschulung"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1469
+#: lib/klass_hero_web/components/marketing_components.ex:1498
 #: lib/klass_hero_web/components/provider_components.ex:2616
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
@@ -3333,7 +3333,7 @@ msgstr "Vereinbarung zu Community-Standards"
 msgid "Create long-term trust across our community"
 msgstr "Langfristiges Vertrauen in unserer Community aufbauen"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1447
+#: lib/klass_hero_web/components/marketing_components.ex:1476
 #, elixir-autogen, elixir-format
 msgid "Each provider submits an extended police background check, confirming their eligibility to work safely with minors."
 msgstr "Jeder Anbieter reicht ein erweitertes polizeiliches Führungszeugnis ein, das seine Eignung bestätigt, sicher mit Minderjährigen zu arbeiten."
@@ -3343,17 +3343,17 @@ msgstr "Jeder Anbieter reicht ein erweitertes polizeiliches Führungszeugnis ein
 msgid "Enforcing platform standards and guidelines"
 msgstr "Durchsetzung von Plattformstandards und -richtlinien"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1471
+#: lib/klass_hero_web/components/marketing_components.ex:1500
 #, elixir-autogen, elixir-format
 msgid "Every provider agrees to follow our Community Guidelines, defining expectations around professionalism."
 msgstr "Jeder Anbieter verpflichtet sich, unsere Community-Richtlinien einzuhalten, die die Erwartungen an Professionalität festlegen."
 
-#: lib/klass_hero_web/components/marketing_components.ex:1437
+#: lib/klass_hero_web/components/marketing_components.ex:1466
 #, elixir-autogen, elixir-format
 msgid "Experience Validation"
 msgstr "Erfahrungsprüfung"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1445
+#: lib/klass_hero_web/components/marketing_components.ex:1474
 #, elixir-autogen, elixir-format
 msgid "Extended Background Checks"
 msgstr "Erweiterte Führungszeugnisprüfungen"
@@ -3363,12 +3363,12 @@ msgstr "Erweiterte Führungszeugnisprüfungen"
 msgid "From academic tutoring to sports, arts, and enrichment programs, every provider on Klass Hero is carefully reviewed to ensure they meet our high standards for child safety, professionalism, and educational quality."
 msgstr "Von akademischer Nachhilfe über Sport und Kunst bis hin zu Förderprogrammen wird jeder Anbieter auf Klass Hero sorgfältig geprüft, um sicherzustellen, dass er unseren hohen Standards für Kindersicherheit, Professionalität und pädagogische Qualität entspricht."
 
-#: lib/klass_hero_web/components/marketing_components.ex:1491
+#: lib/klass_hero_web/components/marketing_components.ex:1520
 #, elixir-autogen, elixir-format
 msgid "How We Verify Providers"
 msgstr "Wie wir Anbieter verifizieren"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1429
+#: lib/klass_hero_web/components/marketing_components.ex:1458
 #, elixir-autogen, elixir-format
 msgid "Identity & Age Verification"
 msgstr "Identitäts- und Altersverifizierung"
@@ -3403,7 +3403,7 @@ msgstr "Programm gespeichert, aber der Upload des Titelbilds ist fehlgeschlagen.
 msgid "Protect children and families"
 msgstr "Kinder und Familien schützen"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1439
+#: lib/klass_hero_web/components/marketing_components.ex:1468
 #, elixir-autogen, elixir-format
 msgid "Providers must demonstrate at least one year of experience working with children in their area of expertise."
 msgstr "Anbieter müssen mindestens ein Jahr Erfahrung in der Arbeit mit Kindern in ihrem Fachgebiet nachweisen."
@@ -3443,9 +3443,9 @@ msgstr "Dieses Kind ist bereits für dieses Programm angemeldet."
 #: lib/klass_hero_web/components/composite_components.ex:546
 #: lib/klass_hero_web/components/layouts/app.html.heex:60
 #: lib/klass_hero_web/components/layouts/app.html.heex:199
-#: lib/klass_hero_web/components/marketing_components.ex:193
-#: lib/klass_hero_web/components/marketing_components.ex:806
-#: lib/klass_hero_web/components/marketing_components.ex:910
+#: lib/klass_hero_web/components/marketing_components.ex:201
+#: lib/klass_hero_web/components/marketing_components.ex:835
+#: lib/klass_hero_web/components/marketing_components.ex:939
 #: lib/klass_hero_web/live/for_providers_live.ex:136
 #: lib/klass_hero_web/live/trust_safety_live.ex:10
 #, elixir-autogen, elixir-format
@@ -3467,12 +3467,12 @@ msgstr "Vertrauen muss man sich verdienen. Sicherheit ist nicht verhandelbar."
 msgid "Uphold professional and ethical teaching practices"
 msgstr "Professionelle und ethische Lehrpraktiken einhalten"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1388
+#: lib/klass_hero_web/components/marketing_components.ex:1417
 #, elixir-autogen, elixir-format
 msgid "Vetted with Care"
 msgstr "Mit Sorgfalt geprüft"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1453
+#: lib/klass_hero_web/components/marketing_components.ex:1482
 #: lib/klass_hero_web/components/provider_components.ex:2401
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
@@ -3843,7 +3843,7 @@ msgid "Private lessons and tutoring"
 msgstr "Privatunterricht und Nachhilfe"
 
 #: lib/klass_hero_web/components/layouts/admin.html.heex:31
-#: lib/klass_hero_web/components/marketing_components.ex:811
+#: lib/klass_hero_web/components/marketing_components.ex:840
 #, elixir-autogen, elixir-format
 msgid "Providers"
 msgstr "Anbieter"
@@ -4732,7 +4732,7 @@ msgstr "+1234567890"
 msgid "About the Provider"
 msgstr "Über den Anbieter"
 
-#: lib/klass_hero_web/components/marketing_components.ex:502
+#: lib/klass_hero_web/components/marketing_components.ex:531
 #, elixir-autogen, elixir-format
 msgid "Built for the Berlin international community. Integrated secure encrypted messaging to connect with local families and trusted educators nearby."
 msgstr "Entwickelt für die internationale Berliner Gemeinschaft. Integriertes sicheres verschlüsseltes Messaging, um sich mit lokalen Familien und vertrauenswürdigen Pädagogen in Ihrer Nähe zu verbinden."
@@ -5265,8 +5265,8 @@ msgstr "Guten Abend"
 msgid "Your week with the kids"
 msgstr "Ihre Woche mit den Kindern"
 
-#: lib/klass_hero_web/components/marketing_components.ex:92
-#: lib/klass_hero_web/components/marketing_components.ex:160
+#: lib/klass_hero_web/components/marketing_components.ex:100
+#: lib/klass_hero_web/components/marketing_components.ex:168
 #, elixir-autogen, elixir-format
 msgid "Go to dashboard"
 msgstr "Zum Dashboard"
@@ -5293,7 +5293,7 @@ msgstr ", Max' Bruder, kam als CFO dazu und brachte die finanzielle Sorgfalt und
 msgid ", a full-stack developer who shared a unique perspective. Both Shane and Max are partners of teachers who wanted to extend their expertise beyond the classroom — but without the time to manage the operational side on their own."
 msgstr ", ein Full-Stack-Entwickler, der eine besondere Perspektive einbrachte. Sowohl Shane als auch Max sind Partner von Lehrkräften, die ihre Expertise über den Unterricht hinaus erweitern wollten — jedoch ohne die Zeit, die operative Seite selbst zu verwalten."
 
-#: lib/klass_hero_web/components/marketing_components.ex:959
+#: lib/klass_hero_web/components/marketing_components.ex:988
 #, elixir-autogen, elixir-format
 msgid ", camps & classes for your child"
 msgstr ", Camps & Kurse für Ihr Kind"
@@ -5350,7 +5350,7 @@ msgstr "Fügen Sie 3+ Fotos hinzu, um Buchungen um ~40% zu steigern."
 msgid "Add a child"
 msgstr "Ein Kind hinzufügen"
 
-#: lib/klass_hero_web/components/marketing_components.ex:322
+#: lib/klass_hero_web/components/marketing_components.ex:330
 #, elixir-autogen, elixir-format
 msgid "Afterschool Adventures Await"
 msgstr "Nachmittagsabenteuer erwarten Sie"
@@ -5365,7 +5365,7 @@ msgstr "Alter & Identität"
 msgid "All instructors are background-checked and verified."
 msgstr "Alle Lehrkräfte sind hintergrundgeprüft und verifiziert."
 
-#: lib/klass_hero_web/components/marketing_components.ex:549
+#: lib/klass_hero_web/components/marketing_components.ex:578
 #, elixir-autogen, elixir-format
 msgid "Are you an educator, coach, or artist?"
 msgstr "Sind Sie Pädagog:in, Coach oder Künstler:in?"
@@ -5385,13 +5385,13 @@ msgstr "Foto anhängen"
 msgid "Back to Programs"
 msgstr "Zurück zu den Programmen"
 
-#: lib/klass_hero_web/components/marketing_components.ex:891
-#: lib/klass_hero_web/components/marketing_components.ex:901
+#: lib/klass_hero_web/components/marketing_components.ex:920
+#: lib/klass_hero_web/components/marketing_components.ex:930
 #, elixir-autogen, elixir-format
 msgid "Become a Hero"
 msgstr "Werden Sie ein Hero"
 
-#: lib/klass_hero_web/components/marketing_components.ex:859
+#: lib/klass_hero_web/components/marketing_components.ex:888
 #, elixir-autogen, elixir-format
 msgid "Become a Hero →"
 msgstr "Werden Sie ein Hero →"
@@ -5406,17 +5406,17 @@ msgstr "Anbieter werden"
 msgid "Berlin parents come to Klass Hero looking for trusted programs. You focus on teaching — we handle the funnel."
 msgstr "Berliner Eltern kommen zu Klass Hero auf der Suche nach vertrauenswürdigen Programmen. Sie konzentrieren sich aufs Unterrichten — wir übernehmen die Akquise."
 
-#: lib/klass_hero_web/components/marketing_components.ex:227
+#: lib/klass_hero_web/components/marketing_components.ex:235
 #, elixir-autogen, elixir-format
 msgid "Berlin's #1 network for youth educators"
 msgstr "Berlins Nr. 1-Netzwerk für Jugendpädagogen"
 
-#: lib/klass_hero_web/components/marketing_components.ex:241
+#: lib/klass_hero_web/components/marketing_components.ex:249
 #, elixir-autogen, elixir-format
 msgid "Berlin's leading network for tutors, coaches, and camp providers — every one verified by our team."
 msgstr "Berlins führendes Netzwerk für Nachhilfelehrer, Trainer und Camp-Anbieter — jeder Einzelne von unserem Team verifiziert."
 
-#: lib/klass_hero_web/components/marketing_components.ex:795
+#: lib/klass_hero_web/components/marketing_components.ex:824
 #, elixir-autogen, elixir-format
 msgid "Berlin's network for trusted youth educators. Built by parents, for parents."
 msgstr "Berlins Netzwerk für vertrauenswürdige Jugendpädagogen. Von Eltern für Eltern entwickelt."
@@ -5436,16 +5436,16 @@ msgstr "Buchungen, Teilnehmerlisten, Zeitpläne, Anwesenheit, Elternkommunikatio
 msgid "Brings the financial rigour and strategic planning needed for the German market and long-term provider stability."
 msgstr "Bringt die finanzielle Sorgfalt und strategische Planung mit, die für den deutschen Markt und langfristige Stabilität der Anbieter nötig sind."
 
-#: lib/klass_hero_web/components/marketing_components.ex:804
-#: lib/klass_hero_web/components/marketing_components.ex:908
+#: lib/klass_hero_web/components/marketing_components.ex:833
+#: lib/klass_hero_web/components/marketing_components.ex:937
 #, elixir-autogen, elixir-format
 msgid "Browse Programs"
 msgstr "Programme durchsuchen"
 
-#: lib/klass_hero_web/components/marketing_components.ex:869
-#: lib/klass_hero_web/components/marketing_components.ex:879
-#: lib/klass_hero_web/components/marketing_components.ex:889
-#: lib/klass_hero_web/components/marketing_components.ex:899
+#: lib/klass_hero_web/components/marketing_components.ex:898
+#: lib/klass_hero_web/components/marketing_components.ex:908
+#: lib/klass_hero_web/components/marketing_components.ex:918
+#: lib/klass_hero_web/components/marketing_components.ex:928
 #, elixir-autogen, elixir-format
 msgid "Browse Programs →"
 msgstr "Programme durchsuchen →"
@@ -5505,7 +5505,7 @@ msgstr "Schauen Sie in unsere FAQ — die meisten Fragen werden dort beantwortet
 msgid "Children"
 msgstr "Kinder"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1246
+#: lib/klass_hero_web/components/marketing_components.ex:1275
 #, elixir-autogen, elixir-format
 msgid "Clear filters"
 msgstr "Filter zurücksetzen"
@@ -5544,7 +5544,7 @@ msgstr "Kommunikation"
 msgid "Community Standards"
 msgstr "Gemeinschaftsstandards"
 
-#: lib/klass_hero_web/components/marketing_components.ex:820
+#: lib/klass_hero_web/components/marketing_components.ex:849
 #, elixir-autogen, elixir-format
 msgid "Company"
 msgstr "Unternehmen"
@@ -5564,7 +5564,7 @@ msgstr "Bestätigen"
 msgid "Confirm your account to finish signing up."
 msgstr "Bestätigen Sie Ihr Konto, um die Registrierung abzuschließen."
 
-#: lib/klass_hero_web/components/marketing_components.ex:233
+#: lib/klass_hero_web/components/marketing_components.ex:241
 #, elixir-autogen, elixir-format
 msgid "Connecting Families with"
 msgstr "Familien verbinden mit"
@@ -5619,7 +5619,7 @@ msgstr "Direktnachrichten und Rundnachrichten"
 msgid "Direct messaging, broadcast announcements, incident reports. Keep parents informed, automatically."
 msgstr "Direktnachrichten, Rundschreiben, Vorfallberichte. Halten Sie Eltern automatisch auf dem Laufenden."
 
-#: lib/klass_hero_web/components/marketing_components.ex:957
+#: lib/klass_hero_web/components/marketing_components.ex:986
 #, elixir-autogen, elixir-format
 msgid "Discover"
 msgstr "Entdecken"
@@ -5694,7 +5694,7 @@ msgstr "Jede Lehrkraft und jede pädagogische Fachkraft durchläuft vor der Gene
 msgid "Every feature included. No subscription, no setup fees."
 msgstr "Alle Funktionen inklusive. Kein Abo, keine Einrichtungsgebühren."
 
-#: lib/klass_hero_web/components/marketing_components.ex:473
+#: lib/klass_hero_web/components/marketing_components.ex:502
 #, elixir-autogen, elixir-format
 msgid "Everything parents need, nothing they don't"
 msgstr "Alles, was Eltern brauchen – nichts, was sie nicht brauchen"
@@ -5709,7 +5709,7 @@ msgstr "Alles, was Sie über Klass Hero wissen müssen."
 msgid "Extended Police Check"
 msgstr "Erweitertes Führungszeugnis"
 
-#: lib/klass_hero_web/components/marketing_components.ex:677
+#: lib/klass_hero_web/components/marketing_components.ex:706
 #: lib/klass_hero_web/live/for_providers_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "FAQ"
@@ -5720,17 +5720,17 @@ msgstr "FAQ"
 msgid "Failed to approve"
 msgstr "Genehmigung fehlgeschlagen"
 
-#: lib/klass_hero_web/components/marketing_components.ex:802
+#: lib/klass_hero_web/components/marketing_components.ex:831
 #, elixir-autogen, elixir-format
 msgid "Families"
 msgstr "Familien"
 
-#: lib/klass_hero_web/components/marketing_components.ex:261
+#: lib/klass_hero_web/components/marketing_components.ex:269
 #, elixir-autogen, elixir-format
 msgid "Find Programs"
 msgstr "Programme finden"
 
-#: lib/klass_hero_web/components/marketing_components.ex:765
+#: lib/klass_hero_web/components/marketing_components.ex:794
 #, elixir-autogen, elixir-format
 msgid "Footer mobile"
 msgstr "Fußzeile (mobil)"
@@ -5760,7 +5760,7 @@ msgstr "Vom Eintrag bis zur ersten Auszahlung in weniger als einer Woche"
 msgid "Full-stack developer. Partner of a teacher who saw the gap between great educators and good infrastructure."
 msgstr "Full-Stack-Entwickler. Partner einer Lehrerin, die die Lücke zwischen großartigen Pädagogen und guter Infrastruktur erkannte."
 
-#: lib/klass_hero_web/components/marketing_components.ex:581
+#: lib/klass_hero_web/components/marketing_components.ex:610
 #, elixir-autogen, elixir-format
 msgid "Get Bookings"
 msgstr "Buchungen erhalten"
@@ -5787,17 +5787,17 @@ msgstr "Wöchentlich bezahlt werden"
 msgid "Get verified"
 msgstr "Lassen Sie sich verifizieren"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1100
+#: lib/klass_hero_web/components/marketing_components.ex:1129
 #, elixir-autogen, elixir-format
 msgid "Grid"
 msgstr "Raster"
 
-#: lib/klass_hero_web/components/marketing_components.ex:325
+#: lib/klass_hero_web/components/marketing_components.ex:333
 #, elixir-autogen, elixir-format
 msgid "Hand-picked programs this week across Berlin."
 msgstr "Handverlesene Programme diese Woche in ganz Berlin."
 
-#: lib/klass_hero_web/components/marketing_components.ex:963
+#: lib/klass_hero_web/components/marketing_components.ex:992
 #, elixir-autogen, elixir-format
 msgid "Hand-picked, vetted programs across Berlin — filter by category, age, or schedule."
 msgstr "Handverlesene, geprüfte Programme in ganz Berlin — filtern Sie nach Kategorie, Alter oder Zeitplan."
@@ -5812,8 +5812,8 @@ msgstr "Haben Sie Fragen?"
 msgid "Head of Trust & Quality (joining)"
 msgstr "Leitung Vertrauen & Qualität (kommt bald dazu)"
 
-#: lib/klass_hero_web/components/marketing_components.ex:815
-#: lib/klass_hero_web/components/marketing_components.ex:913
+#: lib/klass_hero_web/components/marketing_components.ex:844
+#: lib/klass_hero_web/components/marketing_components.ex:942
 #, elixir-autogen, elixir-format
 msgid "Help Center"
 msgstr "Hilfezentrum"
@@ -5823,7 +5823,7 @@ msgstr "Hilfezentrum"
 msgid "How and when do I get paid?"
 msgstr "Wie und wann werde ich bezahlt?"
 
-#: lib/klass_hero_web/components/marketing_components.ex:805
+#: lib/klass_hero_web/components/marketing_components.ex:834
 #, elixir-autogen, elixir-format
 msgid "How it Works"
 msgstr "So funktioniert's"
@@ -5843,12 +5843,12 @@ msgstr "Wie viel kostet Klass Hero?"
 msgid "How quickly can I start accepting bookings?"
 msgstr "Wie schnell kann ich Buchungen annehmen?"
 
-#: lib/klass_hero_web/components/marketing_components.ex:541
+#: lib/klass_hero_web/components/marketing_components.ex:570
 #, elixir-autogen, elixir-format
 msgid "How to Grow Your Youth Program"
 msgstr "So bringen Sie Ihr Jugendprogramm zum Wachsen"
 
-#: lib/klass_hero_web/components/marketing_components.ex:871
+#: lib/klass_hero_web/components/marketing_components.ex:900
 #, elixir-autogen, elixir-format
 msgid "How we vet providers"
 msgstr "Wie wir Anbieter überprüfen"
@@ -5899,7 +5899,7 @@ msgstr "Das ist der Hero-Standard: Identitäts- und Altersprüfung, Erfahrungsna
 msgid "Join Berlin's growing network of trusted educators. Free to list. No setup fees."
 msgstr "Werden Sie Teil von Berlins wachsendem Netzwerk vertrauenswürdiger Pädagogen. Kostenlos eintragen. Keine Einrichtungsgebühren."
 
-#: lib/klass_hero_web/components/marketing_components.ex:544
+#: lib/klass_hero_web/components/marketing_components.ex:573
 #, elixir-autogen, elixir-format
 msgid "Join Berlin's trusted network of educators. We handle payments, scheduling, and discovery — you focus on teaching."
 msgstr "Werden Sie Teil von Berlins vertrauenswürdigem Netzwerk von Pädagogen. Wir kümmern uns um Zahlungen, Terminplanung und Sichtbarkeit — Sie konzentrieren sich aufs Unterrichten."
@@ -5946,12 +5946,12 @@ msgstr "Letzte 8 Wochen"
 msgid "Lead Instructor"
 msgstr "Leitender Kursleiter"
 
-#: lib/klass_hero_web/components/marketing_components.ex:554
+#: lib/klass_hero_web/components/marketing_components.ex:583
 #, elixir-autogen, elixir-format
 msgid "Learn How to Become a Hero →"
 msgstr "Werde zum Hero →"
 
-#: lib/klass_hero_web/components/marketing_components.ex:861
+#: lib/klass_hero_web/components/marketing_components.ex:890
 #, elixir-autogen, elixir-format
 msgid "Learn how vetting works"
 msgstr "Erfahren Sie, wie die Überprüfung funktioniert"
@@ -5981,12 +5981,12 @@ msgstr "Verknüpfen Sie diese Einladung mit Ihrem Konto %{email}."
 msgid "Linking..."
 msgstr "Wird verknüpft..."
 
-#: lib/klass_hero_web/components/marketing_components.ex:1116
+#: lib/klass_hero_web/components/marketing_components.ex:1145
 #, elixir-autogen, elixir-format
 msgid "List"
 msgstr "Liste"
 
-#: lib/klass_hero_web/components/marketing_components.ex:572
+#: lib/klass_hero_web/components/marketing_components.ex:601
 #, elixir-autogen, elixir-format
 msgid "List Your Program"
 msgstr "Ihr Programm eintragen"
@@ -6022,7 +6022,7 @@ msgstr "Melden Sie sich an und öffnen Sie diese Einladung erneut, um dem Team b
 msgid "Log out"
 msgstr "Abmelden"
 
-#: lib/klass_hero_web/components/marketing_components.ex:868
+#: lib/klass_hero_web/components/marketing_components.ex:897
 #, elixir-autogen, elixir-format
 msgid "Looking for programs for your child?"
 msgstr "Suchen Sie Programme für Ihr Kind?"
@@ -6072,7 +6072,7 @@ msgstr "Als anwesend markieren"
 msgid "Minimum one year working with children, validated."
 msgstr "Mindestens ein Jahr Erfahrung in der Arbeit mit Kindern, nachgewiesen."
 
-#: lib/klass_hero_web/components/marketing_components.ex:136
+#: lib/klass_hero_web/components/marketing_components.ex:144
 #, elixir-autogen, elixir-format
 msgid "Mobile primary"
 msgstr "Primäre mobile Navigation"
@@ -6097,7 +6097,7 @@ msgstr "Neue Unterhaltung"
 msgid "New program"
 msgstr "Neues Programm"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1127
+#: lib/klass_hero_web/components/marketing_components.ex:1156
 #, elixir-autogen, elixir-format
 msgid "Newest"
 msgstr "Neueste"
@@ -6112,7 +6112,7 @@ msgstr "Weiter"
 msgid "No credit card required"
 msgstr "Keine Kreditkarte erforderlich"
 
-#: lib/klass_hero_web/components/marketing_components.ex:353
+#: lib/klass_hero_web/components/marketing_components.ex:361
 #, elixir-autogen, elixir-format
 msgid "No featured programs available right now. Check back soon."
 msgstr "Derzeit keine empfohlenen Programme verfügbar. Schauen Sie bald wieder vorbei."
@@ -6179,7 +6179,7 @@ msgstr "Bieten Sie Ihre eigenen Programme auf Klass Hero an — zusätzlich zu I
 msgid "Once your listing is live and you've completed Hero verification (typically 3–5 business days), parents can book immediately. Most providers receive their first inquiry within the first week."
 msgstr "Sobald Ihr Eintrag live ist und Sie die Hero-Verifizierung abgeschlossen haben (in der Regel 3–5 Werktage), können Eltern sofort buchen. Die meisten Anbieter erhalten ihre erste Anfrage innerhalb der ersten Woche."
 
-#: lib/klass_hero_web/components/marketing_components.ex:1539
+#: lib/klass_hero_web/components/marketing_components.ex:1568
 #, elixir-autogen, elixir-format
 msgid "Ongoing Quality"
 msgstr "Laufende Qualität"
@@ -6199,12 +6199,12 @@ msgstr "Kontomenü öffnen"
 msgid "Open inbox"
 msgstr "Posteingang öffnen"
 
-#: lib/klass_hero_web/components/marketing_components.ex:111
+#: lib/klass_hero_web/components/marketing_components.ex:119
 #, elixir-autogen, elixir-format
 msgid "Open menu"
 msgstr "Menü öffnen"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1367
+#: lib/klass_hero_web/components/marketing_components.ex:1396
 #, elixir-autogen, elixir-format
 msgid "Our Commitment"
 msgstr "Unser Engagement"
@@ -6239,7 +6239,7 @@ msgstr "Elternteil: %{name}"
 msgid "Parents discover you on Klass Hero. Approve manually or auto-accept — your call."
 msgstr "Eltern entdecken Sie auf Klass Hero. Genehmigen Sie manuell oder automatisch — Sie entscheiden."
 
-#: lib/klass_hero_web/components/marketing_components.ex:583
+#: lib/klass_hero_web/components/marketing_components.ex:612
 #, elixir-autogen, elixir-format
 msgid "Parents find you through Klass Hero. Approve or auto-accept bookings with secure messaging built in."
 msgstr "Eltern finden Sie über Klass Hero. Genehmigen Sie Buchungen manuell oder automatisch — inklusive sicherer Nachrichtenfunktion."
@@ -6270,29 +6270,29 @@ msgstr "Ausstehende Anmeldungen"
 msgid "Predictable income"
 msgstr "Planbares Einkommen"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1129
+#: lib/klass_hero_web/components/marketing_components.ex:1158
 #, elixir-autogen, elixir-format
 msgid "Price: high to low"
 msgstr "Preis: hoch zu niedrig"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1128
+#: lib/klass_hero_web/components/marketing_components.ex:1157
 #, elixir-autogen, elixir-format
 msgid "Price: low to high"
 msgstr "Preis: niedrig zu hoch"
 
-#: lib/klass_hero_web/components/marketing_components.ex:814
+#: lib/klass_hero_web/components/marketing_components.ex:843
 #: lib/klass_hero_web/live/for_providers_live.ex:167
 #, elixir-autogen, elixir-format
 msgid "Pricing"
 msgstr "Preise"
 
-#: lib/klass_hero_web/components/marketing_components.ex:66
+#: lib/klass_hero_web/components/marketing_components.ex:74
 #, elixir-autogen, elixir-format
 msgid "Primary"
 msgstr "Primär"
 
-#: lib/klass_hero_web/components/marketing_components.ex:777
-#: lib/klass_hero_web/components/marketing_components.ex:824
+#: lib/klass_hero_web/components/marketing_components.ex:806
+#: lib/klass_hero_web/components/marketing_components.ex:853
 #: lib/klass_hero_web/live/privacy_policy_live.ex:238
 #, elixir-autogen, elixir-format
 msgid "Privacy"
@@ -6333,7 +6333,7 @@ msgstr "Qualität & Verantwortung — jederzeit aktiv."
 msgid "Questions about programs, bookings, or becoming a Hero — we read every message."
 msgstr "Fragen zu Programmen, Buchungen oder wie Sie ein Hero werden — wir lesen jede Nachricht."
 
-#: lib/klass_hero_web/components/marketing_components.ex:680
+#: lib/klass_hero_web/components/marketing_components.ex:709
 #, elixir-autogen, elixir-format
 msgid "Questions, answered."
 msgstr "Fragen, beantwortet."
@@ -6348,8 +6348,8 @@ msgstr "Bewertung"
 msgid "Ready to be a Hero?"
 msgstr "Bereit, ein Hero zu werden?"
 
-#: lib/klass_hero_web/components/marketing_components.ex:878
-#: lib/klass_hero_web/components/marketing_components.ex:898
+#: lib/klass_hero_web/components/marketing_components.ex:907
+#: lib/klass_hero_web/components/marketing_components.ex:927
 #, elixir-autogen, elixir-format
 msgid "Ready to find your child's next adventure?"
 msgstr "Bereit, das nächste Abenteuer für Ihr Kind zu finden?"
@@ -6364,8 +6364,8 @@ msgstr "Buchungen erhalten"
 msgid "Recent messages"
 msgstr "Neueste Nachrichten"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1126
-#: lib/klass_hero_web/components/marketing_components.ex:1138
+#: lib/klass_hero_web/components/marketing_components.ex:1155
+#: lib/klass_hero_web/components/marketing_components.ex:1167
 #, elixir-autogen, elixir-format
 msgid "Recommended"
 msgstr "Empfohlen"
@@ -6415,12 +6415,12 @@ msgstr "Kinderschutzschulung"
 msgid "Safety"
 msgstr "Sicherheit"
 
-#: lib/klass_hero_web/components/marketing_components.ex:983
+#: lib/klass_hero_web/components/marketing_components.ex:1012
 #, elixir-autogen, elixir-format
 msgid "Search programs, providers, neighborhoods..."
 msgstr "Programme, Anbieter, Stadtteile durchsuchen..."
 
-#: lib/klass_hero_web/components/marketing_components.ex:256
+#: lib/klass_hero_web/components/marketing_components.ex:264
 #, elixir-autogen, elixir-format
 msgid "Search: coding, football, art..."
 msgstr "Suche: Programmieren, Fußball, Kunst..."
@@ -6435,7 +6435,7 @@ msgstr "Sichere SEPA-Auszahlungen jeden Montag. Rechnungen und Mehrwertsteuer we
 msgid "Secure payments, invoicing, and VAT handling"
 msgstr "Sichere Zahlungen, Rechnungsstellung und Umsatzsteuer-Abwicklung"
 
-#: lib/klass_hero_web/components/marketing_components.ex:592
+#: lib/klass_hero_web/components/marketing_components.ex:621
 #, elixir-autogen, elixir-format
 msgid "Secure weekly payouts. Insights into your business and opportunities to expand your impact."
 msgstr "Sichere wöchentliche Auszahlungen. Einblicke in Ihr Geschäft und Möglichkeiten, Ihre Wirkung auszubauen."
@@ -6450,7 +6450,7 @@ msgstr "Sicherheit"
 msgid "See pricing"
 msgstr "Preise ansehen"
 
-#: lib/klass_hero_web/components/marketing_components.ex:563
+#: lib/klass_hero_web/components/marketing_components.ex:592
 #, elixir-autogen, elixir-format
 msgid "See provider plans"
 msgstr "Anbieter-Tarife ansehen"
@@ -6480,8 +6480,8 @@ msgstr "Schreiben Sie uns eine Nachricht"
 msgid "Setting up..."
 msgstr "Wird eingerichtet..."
 
-#: lib/klass_hero_web/components/marketing_components.ex:96
-#: lib/klass_hero_web/components/marketing_components.ex:168
+#: lib/klass_hero_web/components/marketing_components.ex:104
+#: lib/klass_hero_web/components/marketing_components.ex:176
 #: lib/klass_hero_web/live/user_live/login.ex:12
 #, elixir-autogen, elixir-format
 msgid "Sign in"
@@ -6492,8 +6492,8 @@ msgstr "Anmelden"
 msgid "Sign in to continue. Don't have an account?"
 msgstr "Melden Sie sich an, um fortzufahren. Sie haben noch kein Konto?"
 
-#: lib/klass_hero_web/components/marketing_components.ex:99
-#: lib/klass_hero_web/components/marketing_components.ex:173
+#: lib/klass_hero_web/components/marketing_components.ex:107
+#: lib/klass_hero_web/components/marketing_components.ex:181
 #: lib/klass_hero_web/live/user_live/registration.ex:12
 #, elixir-autogen, elixir-format
 msgid "Sign up"
@@ -6504,7 +6504,7 @@ msgstr "Registrieren"
 msgid "Signed agreement on conduct and quality bar."
 msgstr "Unterzeichnete Vereinbarung zu Verhalten und Qualitätsstandards."
 
-#: lib/klass_hero_web/components/marketing_components.ex:155
+#: lib/klass_hero_web/components/marketing_components.ex:163
 #: lib/klass_hero_web/components/ui_components.ex:193
 #, elixir-autogen, elixir-format
 msgid "Signed in as"
@@ -6515,12 +6515,12 @@ msgstr "Angemeldet als"
 msgid "Six checks. No shortcuts."
 msgstr "Sechs Prüfungen. Keine Abkürzungen."
 
-#: lib/klass_hero_web/components/marketing_components.ex:1053
+#: lib/klass_hero_web/components/marketing_components.ex:1082
 #, elixir-autogen, elixir-format
 msgid "Sort:"
 msgstr "Sortieren:"
 
-#: lib/klass_hero_web/components/marketing_components.ex:813
+#: lib/klass_hero_web/components/marketing_components.ex:842
 #, elixir-autogen, elixir-format
 msgid "Start Teaching"
 msgstr "Unterrichten beginnen"
@@ -6571,7 +6571,7 @@ msgstr "Unternehmen wechseln"
 msgid "Talk to our team →"
 msgstr "Sprechen Sie mit unserem Team →"
 
-#: lib/klass_hero_web/components/marketing_components.ex:881
+#: lib/klass_hero_web/components/marketing_components.ex:910
 #: lib/klass_hero_web/live/about_live.ex:164
 #: lib/klass_hero_web/live/for_providers_live.ex:269
 #, elixir-autogen, elixir-format
@@ -6588,7 +6588,7 @@ msgstr "Mehr unterrichten."
 msgid "Teaching Experience"
 msgstr "Unterrichtserfahrung"
 
-#: lib/klass_hero_web/components/marketing_components.ex:858
+#: lib/klass_hero_web/components/marketing_components.ex:887
 #, elixir-autogen, elixir-format
 msgid "Teaching kids is your thing? Join as a Hero."
 msgstr "Unterrichten von Kindern ist Ihr Ding? Werden Sie ein Hero."
@@ -6598,8 +6598,8 @@ msgstr "Unterrichten von Kindern ist Ihr Ding? Werden Sie ein Hero."
 msgid "Tell us a bit about what you need — we'll route you to the right person."
 msgstr "Erzählen Sie uns kurz, was Sie brauchen — wir leiten Sie an die richtige Person weiter."
 
-#: lib/klass_hero_web/components/marketing_components.ex:778
-#: lib/klass_hero_web/components/marketing_components.ex:825
+#: lib/klass_hero_web/components/marketing_components.ex:807
+#: lib/klass_hero_web/components/marketing_components.ex:854
 #: lib/klass_hero_web/live/terms_of_service_live.ex:259
 #, elixir-autogen, elixir-format
 msgid "Terms"
@@ -6650,7 +6650,7 @@ msgstr "Verfolgen Sie Anmeldungen, Bindung, Nichterscheinen und Umsatz. Erkennen
 msgid "Trust &"
 msgstr "Vertrauen &"
 
-#: lib/klass_hero_web/components/marketing_components.ex:235
+#: lib/klass_hero_web/components/marketing_components.ex:243
 #, elixir-autogen, elixir-format
 msgid "Trusted Heroes"
 msgstr "Vertrauenswürdige Heroes"
@@ -6690,7 +6690,7 @@ msgstr "Diese Woche anstehend"
 msgid "Vetted"
 msgstr "Geprüft"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1213
+#: lib/klass_hero_web/components/marketing_components.ex:1242
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr "Ansehen"
@@ -6700,7 +6700,7 @@ msgstr "Ansehen"
 msgid "View all"
 msgstr "Alle anzeigen"
 
-#: lib/klass_hero_web/components/marketing_components.ex:432
+#: lib/klass_hero_web/components/marketing_components.ex:461
 #, elixir-autogen, elixir-format
 msgid "View →"
 msgstr "Ansehen →"
@@ -6781,12 +6781,12 @@ msgstr "Was beschäftigt Sie?"
 msgid "What's the verification process like?"
 msgstr "Wie läuft der Verifizierungsprozess ab?"
 
-#: lib/klass_hero_web/components/marketing_components.ex:888
+#: lib/klass_hero_web/components/marketing_components.ex:917
 #, elixir-autogen, elixir-format
 msgid "While you're here — explore programs."
 msgstr "Wo Sie schon mal hier sind — entdecken Sie Programme."
 
-#: lib/klass_hero_web/components/marketing_components.ex:470
+#: lib/klass_hero_web/components/marketing_components.ex:499
 #: lib/klass_hero_web/live/for_providers_live.ex:72
 #, elixir-autogen, elixir-format
 msgid "Why Klass Hero"
@@ -6867,7 +6867,7 @@ msgstr "Konto"
 msgid "active"
 msgstr "Aktiv"
 
-#: lib/klass_hero_web/components/marketing_components.ex:958
+#: lib/klass_hero_web/components/marketing_components.ex:987
 #, elixir-autogen, elixir-format
 msgid "activities"
 msgstr "Aktivitäten"
@@ -6892,7 +6892,7 @@ msgstr "Kinderprogramme entdecken und nutzen"
 msgid "families"
 msgstr "Familien"
 
-#: lib/klass_hero_web/components/marketing_components.ex:237
+#: lib/klass_hero_web/components/marketing_components.ex:245
 #, elixir-autogen, elixir-format
 msgid "for Our Youth"
 msgstr "für unsere Jugend"
@@ -6902,12 +6902,12 @@ msgstr "für unsere Jugend"
 msgid "help"
 msgstr "Hilfe"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1041
+#: lib/klass_hero_web/components/marketing_components.ex:1070
 #, elixir-autogen, elixir-format
 msgid "in"
 msgstr "in"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1045
+#: lib/klass_hero_web/components/marketing_components.ex:1074
 #, elixir-autogen, elixir-format
 msgid "matching"
 msgstr "Passend"
@@ -6918,7 +6918,7 @@ msgstr "Passend"
 msgid "pending"
 msgstr "Ausstehend"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1039
+#: lib/klass_hero_web/components/marketing_components.ex:1068
 #, elixir-autogen, elixir-format
 msgid "program"
 msgid_plural "programs"
@@ -7239,7 +7239,7 @@ msgstr "Der letzte Schritt: Lies die Klass Hero Community-Richtlinien und stimme
 msgid "You have agreed to the Community Guidelines."
 msgstr "Du hast den Community-Richtlinien zugestimmt."
 
-#: lib/klass_hero_web/components/marketing_components.ex:1455
+#: lib/klass_hero_web/components/marketing_components.ex:1484
 #, elixir-autogen, elixir-format
 msgid "Applicants submit a short recorded video (max 2 minutes) so we can assess communication skills and alignment with our values before approving their profile."
 msgstr "Bewerber reichen ein kurzes aufgezeichnetes Video (max. 2 Minuten) ein, damit wir vor der Freigabe ihres Profils Kommunikationsfähigkeiten und die Übereinstimmung mit unseren Werten beurteilen können."
@@ -7595,17 +7595,22 @@ msgid_plural "%{count} children enrolled"
 msgstr[0] "%{count} Kind angemeldet"
 msgstr[1] "%{count} Kinder angemeldet"
 
-#: lib/klass_hero_web/components/program_components.ex:242
+#: lib/klass_hero_web/components/ui_components.ex:1927
 #, elixir-autogen, elixir-format
 msgid "This provider completed Klass Hero's verification checks"
 msgstr "Dieser Anbieter hat alle Prüfungen von Klass Hero bestanden"
 
-#: lib/klass_hero_web/components/program_components.ex:260
+#: lib/klass_hero_web/components/ui_components.ex:1943
 #, elixir-autogen, elixir-format
 msgid "This provider is working through Klass Hero's verification checks"
 msgstr "Dieser Anbieter durchläuft gerade die Prüfungen von Klass Hero"
 
-#: lib/klass_hero_web/components/program_components.ex:263
+#: lib/klass_hero_web/components/ui_components.ex:1950
 #, elixir-autogen, elixir-format
 msgid "Verification in progress"
 msgstr "Verifizierung läuft"
+
+#: lib/klass_hero_web/components/ui_components.ex:1948
+#, elixir-autogen, elixir-format
+msgid "Verifying"
+msgstr "In Prüfung"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -13,9 +13,9 @@ msgstr ""
 
 #: lib/klass_hero_web/components/layouts/app.html.heex:44
 #: lib/klass_hero_web/components/layouts/app.html.heex:197
-#: lib/klass_hero_web/components/marketing_components.ex:194
-#: lib/klass_hero_web/components/marketing_components.ex:822
-#: lib/klass_hero_web/components/marketing_components.ex:911
+#: lib/klass_hero_web/components/marketing_components.ex:202
+#: lib/klass_hero_web/components/marketing_components.ex:851
+#: lib/klass_hero_web/components/marketing_components.ex:940
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr ""
@@ -34,9 +34,9 @@ msgstr ""
 #: lib/klass_hero_web/components/composite_components.ex:468
 #: lib/klass_hero_web/components/layouts/app.html.heex:52
 #: lib/klass_hero_web/components/layouts/app.html.heex:198
-#: lib/klass_hero_web/components/marketing_components.ex:195
-#: lib/klass_hero_web/components/marketing_components.ex:823
-#: lib/klass_hero_web/components/marketing_components.ex:912
+#: lib/klass_hero_web/components/marketing_components.ex:203
+#: lib/klass_hero_web/components/marketing_components.ex:852
+#: lib/klass_hero_web/components/marketing_components.ex:941
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr ""
@@ -68,7 +68,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/layouts/app.html.heex:28
 #: lib/klass_hero_web/components/layouts/app.html.heex:195
-#: lib/klass_hero_web/components/marketing_components.ex:190
+#: lib/klass_hero_web/components/marketing_components.ex:198
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr ""
@@ -93,7 +93,7 @@ msgstr ""
 #: lib/klass_hero_web/components/composite_components.ex:484
 #: lib/klass_hero_web/components/layouts/app.html.heex:36
 #: lib/klass_hero_web/components/layouts/app.html.heex:196
-#: lib/klass_hero_web/components/marketing_components.ex:191
+#: lib/klass_hero_web/components/marketing_components.ex:199
 #, elixir-autogen, elixir-format
 msgid "Programs"
 msgstr ""
@@ -182,7 +182,7 @@ msgstr ""
 msgid "Any allergies, medical conditions, or special instructions..."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:492
+#: lib/klass_hero_web/components/marketing_components.ex:521
 #, elixir-autogen, elixir-format
 msgid "Book camps, tutors, and workshops instantly. Our integrated planner helps you manage your child's busy life."
 msgstr ""
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Cash/transfer payments will show as \"Pending\" until received"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:500
+#: lib/klass_hero_web/components/marketing_components.ex:529
 #, elixir-autogen, elixir-format
 msgid "Community Focused"
 msgstr ""
@@ -222,7 +222,7 @@ msgstr ""
 msgid "Duration:"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:490
+#: lib/klass_hero_web/components/marketing_components.ex:519
 #, elixir-autogen, elixir-format
 msgid "Easy Scheduling"
 msgstr ""
@@ -253,18 +253,18 @@ msgstr ""
 msgid "Enrollment successful! You'll receive a confirmation email shortly."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:482
+#: lib/klass_hero_web/components/marketing_components.ex:511
 #, elixir-autogen, elixir-format
 msgid "Every provider is rigorously vetted. We prioritize child safety above all else, giving parents peace of mind."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:953
+#: lib/klass_hero_web/components/marketing_components.ex:982
 #: lib/klass_hero_web/live/programs_live.ex:35
 #, elixir-autogen, elixir-format
 msgid "Explore Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:319
+#: lib/klass_hero_web/components/marketing_components.ex:327
 #, elixir-autogen, elixir-format
 msgid "Featured Programs"
 msgstr ""
@@ -326,7 +326,7 @@ msgstr ""
 msgid "Please select a child for enrollment."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:20
+#: lib/klass_hero_web/live/home_live.ex:22
 #, elixir-autogen, elixir-format
 msgid "Klass Hero - Connecting Families with Trusted Youth Educators"
 msgstr ""
@@ -343,7 +343,7 @@ msgstr ""
 msgid "Program not found. It may have been removed or is no longer available."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:480
+#: lib/klass_hero_web/components/marketing_components.ex:509
 #: lib/klass_hero_web/live/about_live.ex:19
 #, elixir-autogen, elixir-format
 msgid "Safety First"
@@ -389,7 +389,7 @@ msgstr ""
 msgid "Total due today:"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:338
+#: lib/klass_hero_web/components/marketing_components.ex:346
 #, elixir-autogen, elixir-format
 msgid "View All Programs →"
 msgstr ""
@@ -1426,9 +1426,9 @@ msgid "Education"
 msgstr ""
 
 #: lib/klass_hero_web/components/composite_components.ex:472
-#: lib/klass_hero_web/components/marketing_components.ex:192
-#: lib/klass_hero_web/components/marketing_components.ex:538
-#: lib/klass_hero_web/components/marketing_components.ex:909
+#: lib/klass_hero_web/components/marketing_components.ex:200
+#: lib/klass_hero_web/components/marketing_components.ex:567
+#: lib/klass_hero_web/components/marketing_components.ex:938
 #: lib/klass_hero_web/live/for_providers_live.ex:10
 #: lib/klass_hero_web/live/for_providers_live.ex:39
 #, elixir-autogen, elixir-format
@@ -1440,7 +1440,7 @@ msgstr ""
 msgid "From sports to arts, technology to languages, we make it easy to discover enriching activities that fit your family's schedule and budget."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:590
+#: lib/klass_hero_web/components/marketing_components.ex:619
 #, elixir-autogen, elixir-format
 msgid "Get Paid & Grow"
 msgstr ""
@@ -1467,12 +1467,12 @@ msgstr ""
 msgid "Ready to join the movement?"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:987
+#: lib/klass_hero_web/components/marketing_components.ex:1016
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:574
+#: lib/klass_hero_web/components/marketing_components.ex:603
 #, elixir-autogen, elixir-format
 msgid "Set up your teaching profile and list your programs in minutes. Share your expertise with families who need it."
 msgstr ""
@@ -1488,7 +1488,7 @@ msgstr ""
 msgid "Sustainability"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:270
+#: lib/klass_hero_web/components/marketing_components.ex:278
 #, elixir-autogen, elixir-format
 msgid "Trending in Berlin:"
 msgstr ""
@@ -2184,23 +2184,23 @@ msgid_plural "%{count} documents"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/components/program_components.ex:619
-#: lib/klass_hero_web/components/program_components.ex:627
+#: lib/klass_hero_web/components/program_components.ex:564
+#: lib/klass_hero_web/components/program_components.ex:572
 #, elixir-autogen, elixir-format
 msgid "%{count} month"
 msgid_plural "%{count} months"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/components/program_components.ex:615
-#: lib/klass_hero_web/components/program_components.ex:626
+#: lib/klass_hero_web/components/program_components.ex:560
+#: lib/klass_hero_web/components/program_components.ex:571
 #, elixir-autogen, elixir-format
 msgid "%{count} year"
 msgid_plural "%{count} years"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/components/program_components.ex:637
+#: lib/klass_hero_web/components/program_components.ex:582
 #, elixir-autogen, elixir-format
 msgid "%{gender} only"
 msgstr ""
@@ -2220,12 +2220,12 @@ msgstr ""
 msgid "Add your first staff member to get started!"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:601
+#: lib/klass_hero_web/components/program_components.ex:546
 #, elixir-autogen, elixir-format
 msgid "Ages %{min} to %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:605
+#: lib/klass_hero_web/components/program_components.ex:550
 #, elixir-autogen, elixir-format
 msgid "Ages %{min}+"
 msgstr ""
@@ -2266,7 +2266,7 @@ msgstr ""
 msgid "Are you sure you want to remove this team member?"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:642
+#: lib/klass_hero_web/components/marketing_components.ex:671
 #, elixir-autogen, elixir-format
 msgid "As fathers and partners of teachers in Berlin, we saw and heard firsthand how hard it is to find, book, and manage quality youth activities outside the classroom. Klass Hero is the complete platform connecting Berlin families and schools with trusted, vetted activity providers — offering safe, supervised, and enriching experiences across sports, arts, tutoring, and more. We verify every provider, structure every booking, and support every step — so parents know their child is in good hands, and providers can focus on what they do best: inspiring kids."
 msgstr ""
@@ -2303,7 +2303,7 @@ msgstr ""
 msgid "Brief description of experience and specialties..."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:639
+#: lib/klass_hero_web/components/marketing_components.ex:668
 #, elixir-autogen, elixir-format
 msgid "Built by Parents to Empower Educators."
 msgstr ""
@@ -2428,7 +2428,7 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:739
+#: lib/klass_hero_web/components/program_components.ex:684
 #: lib/klass_hero_web/components/provider_components.ex:1088
 #: lib/klass_hero_web/live/settings/children_live.ex:670
 #, elixir-autogen, elixir-format
@@ -2555,7 +2555,7 @@ msgstr ""
 msgid "Family Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:737
+#: lib/klass_hero_web/components/program_components.ex:682
 #: lib/klass_hero_web/components/provider_components.ex:1087
 #: lib/klass_hero_web/live/settings/children_live.ex:669
 #, elixir-autogen, elixir-format
@@ -2592,17 +2592,17 @@ msgstr ""
 msgid "Gender"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:746
+#: lib/klass_hero_web/components/program_components.ex:691
 #, elixir-autogen, elixir-format
 msgid "Grade %{grade}"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:754
+#: lib/klass_hero_web/components/program_components.ex:699
 #, elixir-autogen, elixir-format
 msgid "Grade %{min}+"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:750
+#: lib/klass_hero_web/components/program_components.ex:695
 #, elixir-autogen, elixir-format
 msgid "Grades %{min} – %{max}"
 msgstr ""
@@ -2701,7 +2701,7 @@ msgstr ""
 msgid "Logo upload failed. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:738
+#: lib/klass_hero_web/components/program_components.ex:683
 #: lib/klass_hero_web/components/provider_components.ex:1086
 #: lib/klass_hero_web/live/settings/children_live.ex:668
 #, elixir-autogen, elixir-format
@@ -2820,14 +2820,14 @@ msgstr ""
 msgid "Not Verified"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:740
+#: lib/klass_hero_web/components/program_components.ex:685
 #: lib/klass_hero_web/components/provider_components.ex:1089
 #: lib/klass_hero_web/live/settings/children_live.ex:667
 #, elixir-autogen, elixir-format
 msgid "Not specified"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:636
+#: lib/klass_hero_web/components/marketing_components.ex:665
 #, elixir-autogen, elixir-format
 msgid "Our Story"
 msgstr ""
@@ -2839,7 +2839,7 @@ msgstr ""
 msgid "PDF, JPG or PNG. Max 10MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:564
+#: lib/klass_hero_web/components/program_components.ex:509
 #, elixir-autogen, elixir-format
 msgid "Participant Requirements"
 msgstr ""
@@ -2923,7 +2923,7 @@ msgstr ""
 msgid "Provider profile not found."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:649
+#: lib/klass_hero_web/components/marketing_components.ex:678
 #, elixir-autogen, elixir-format
 msgid "Read our founding story →"
 msgstr ""
@@ -3198,12 +3198,12 @@ msgstr ""
 msgid "Unable to load document preview."
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:609
+#: lib/klass_hero_web/components/program_components.ex:554
 #, elixir-autogen, elixir-format
 msgid "Up to %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:758
+#: lib/klass_hero_web/components/program_components.ex:703
 #, elixir-autogen, elixir-format
 msgid "Up to Grade %{max}"
 msgstr ""
@@ -3255,9 +3255,9 @@ msgstr ""
 msgid "Verifications"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:245
 #: lib/klass_hero_web/components/provider_components.ex:276
 #: lib/klass_hero_web/components/provider_layout_components.ex:212
+#: lib/klass_hero_web/components/ui_components.ex:1930
 #, elixir-autogen, elixir-format
 msgid "Verified"
 msgstr ""
@@ -3302,12 +3302,12 @@ msgstr ""
 msgid "e.g., Community Center, Main St"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1463
+#: lib/klass_hero_web/components/marketing_components.ex:1492
 #, elixir-autogen, elixir-format
 msgid "All Heroes must hold or complete a recognized child safeguarding course, ensuring up-to-date knowledge."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1431
+#: lib/klass_hero_web/components/marketing_components.ex:1460
 #, elixir-autogen, elixir-format
 msgid "All providers must be 18 years or older, ensuring legal accountability and professional responsibility."
 msgstr ""
@@ -3317,12 +3317,12 @@ msgstr ""
 msgid "And at Klass Hero, both come standard."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1461
+#: lib/klass_hero_web/components/marketing_components.ex:1490
 #, elixir-autogen, elixir-format
 msgid "Child Safeguarding Training"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1469
+#: lib/klass_hero_web/components/marketing_components.ex:1498
 #: lib/klass_hero_web/components/provider_components.ex:2616
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
@@ -3333,7 +3333,7 @@ msgstr ""
 msgid "Create long-term trust across our community"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1447
+#: lib/klass_hero_web/components/marketing_components.ex:1476
 #, elixir-autogen, elixir-format
 msgid "Each provider submits an extended police background check, confirming their eligibility to work safely with minors."
 msgstr ""
@@ -3343,17 +3343,17 @@ msgstr ""
 msgid "Enforcing platform standards and guidelines"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1471
+#: lib/klass_hero_web/components/marketing_components.ex:1500
 #, elixir-autogen, elixir-format
 msgid "Every provider agrees to follow our Community Guidelines, defining expectations around professionalism."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1437
+#: lib/klass_hero_web/components/marketing_components.ex:1466
 #, elixir-autogen, elixir-format
 msgid "Experience Validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1445
+#: lib/klass_hero_web/components/marketing_components.ex:1474
 #, elixir-autogen, elixir-format
 msgid "Extended Background Checks"
 msgstr ""
@@ -3363,12 +3363,12 @@ msgstr ""
 msgid "From academic tutoring to sports, arts, and enrichment programs, every provider on Klass Hero is carefully reviewed to ensure they meet our high standards for child safety, professionalism, and educational quality."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1491
+#: lib/klass_hero_web/components/marketing_components.ex:1520
 #, elixir-autogen, elixir-format
 msgid "How We Verify Providers"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1429
+#: lib/klass_hero_web/components/marketing_components.ex:1458
 #, elixir-autogen, elixir-format
 msgid "Identity & Age Verification"
 msgstr ""
@@ -3403,7 +3403,7 @@ msgstr ""
 msgid "Protect children and families"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1439
+#: lib/klass_hero_web/components/marketing_components.ex:1468
 #, elixir-autogen, elixir-format
 msgid "Providers must demonstrate at least one year of experience working with children in their area of expertise."
 msgstr ""
@@ -3443,9 +3443,9 @@ msgstr ""
 #: lib/klass_hero_web/components/composite_components.ex:546
 #: lib/klass_hero_web/components/layouts/app.html.heex:60
 #: lib/klass_hero_web/components/layouts/app.html.heex:199
-#: lib/klass_hero_web/components/marketing_components.ex:193
-#: lib/klass_hero_web/components/marketing_components.ex:806
-#: lib/klass_hero_web/components/marketing_components.ex:910
+#: lib/klass_hero_web/components/marketing_components.ex:201
+#: lib/klass_hero_web/components/marketing_components.ex:835
+#: lib/klass_hero_web/components/marketing_components.ex:939
 #: lib/klass_hero_web/live/for_providers_live.ex:136
 #: lib/klass_hero_web/live/trust_safety_live.ex:10
 #, elixir-autogen, elixir-format
@@ -3467,12 +3467,12 @@ msgstr ""
 msgid "Uphold professional and ethical teaching practices"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1388
+#: lib/klass_hero_web/components/marketing_components.ex:1417
 #, elixir-autogen, elixir-format
 msgid "Vetted with Care"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1453
+#: lib/klass_hero_web/components/marketing_components.ex:1482
 #: lib/klass_hero_web/components/provider_components.ex:2401
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
@@ -3843,7 +3843,7 @@ msgid "Private lessons and tutoring"
 msgstr ""
 
 #: lib/klass_hero_web/components/layouts/admin.html.heex:31
-#: lib/klass_hero_web/components/marketing_components.ex:811
+#: lib/klass_hero_web/components/marketing_components.ex:840
 #, elixir-autogen, elixir-format
 msgid "Providers"
 msgstr ""
@@ -4732,7 +4732,7 @@ msgstr ""
 msgid "About the Provider"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:502
+#: lib/klass_hero_web/components/marketing_components.ex:531
 #, elixir-autogen, elixir-format
 msgid "Built for the Berlin international community. Integrated secure encrypted messaging to connect with local families and trusted educators nearby."
 msgstr ""
@@ -5265,8 +5265,8 @@ msgstr ""
 msgid "Your week with the kids"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:92
-#: lib/klass_hero_web/components/marketing_components.ex:160
+#: lib/klass_hero_web/components/marketing_components.ex:100
+#: lib/klass_hero_web/components/marketing_components.ex:168
 #, elixir-autogen, elixir-format
 msgid "Go to dashboard"
 msgstr ""
@@ -5293,7 +5293,7 @@ msgstr ""
 msgid ", a full-stack developer who shared a unique perspective. Both Shane and Max are partners of teachers who wanted to extend their expertise beyond the classroom — but without the time to manage the operational side on their own."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:959
+#: lib/klass_hero_web/components/marketing_components.ex:988
 #, elixir-autogen, elixir-format
 msgid ", camps & classes for your child"
 msgstr ""
@@ -5350,7 +5350,7 @@ msgstr ""
 msgid "Add a child"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:322
+#: lib/klass_hero_web/components/marketing_components.ex:330
 #, elixir-autogen, elixir-format
 msgid "Afterschool Adventures Await"
 msgstr ""
@@ -5365,7 +5365,7 @@ msgstr ""
 msgid "All instructors are background-checked and verified."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:549
+#: lib/klass_hero_web/components/marketing_components.ex:578
 #, elixir-autogen, elixir-format
 msgid "Are you an educator, coach, or artist?"
 msgstr ""
@@ -5385,13 +5385,13 @@ msgstr ""
 msgid "Back to Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:891
-#: lib/klass_hero_web/components/marketing_components.ex:901
+#: lib/klass_hero_web/components/marketing_components.ex:920
+#: lib/klass_hero_web/components/marketing_components.ex:930
 #, elixir-autogen, elixir-format
 msgid "Become a Hero"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:859
+#: lib/klass_hero_web/components/marketing_components.ex:888
 #, elixir-autogen, elixir-format
 msgid "Become a Hero →"
 msgstr ""
@@ -5406,17 +5406,17 @@ msgstr ""
 msgid "Berlin parents come to Klass Hero looking for trusted programs. You focus on teaching — we handle the funnel."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:227
+#: lib/klass_hero_web/components/marketing_components.ex:235
 #, elixir-autogen, elixir-format
 msgid "Berlin's #1 network for youth educators"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:241
+#: lib/klass_hero_web/components/marketing_components.ex:249
 #, elixir-autogen, elixir-format
 msgid "Berlin's leading network for tutors, coaches, and camp providers — every one verified by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:795
+#: lib/klass_hero_web/components/marketing_components.ex:824
 #, elixir-autogen, elixir-format
 msgid "Berlin's network for trusted youth educators. Built by parents, for parents."
 msgstr ""
@@ -5436,16 +5436,16 @@ msgstr ""
 msgid "Brings the financial rigour and strategic planning needed for the German market and long-term provider stability."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:804
-#: lib/klass_hero_web/components/marketing_components.ex:908
+#: lib/klass_hero_web/components/marketing_components.ex:833
+#: lib/klass_hero_web/components/marketing_components.ex:937
 #, elixir-autogen, elixir-format
 msgid "Browse Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:869
-#: lib/klass_hero_web/components/marketing_components.ex:879
-#: lib/klass_hero_web/components/marketing_components.ex:889
-#: lib/klass_hero_web/components/marketing_components.ex:899
+#: lib/klass_hero_web/components/marketing_components.ex:898
+#: lib/klass_hero_web/components/marketing_components.ex:908
+#: lib/klass_hero_web/components/marketing_components.ex:918
+#: lib/klass_hero_web/components/marketing_components.ex:928
 #, elixir-autogen, elixir-format
 msgid "Browse Programs →"
 msgstr ""
@@ -5505,7 +5505,7 @@ msgstr ""
 msgid "Children"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1246
+#: lib/klass_hero_web/components/marketing_components.ex:1275
 #, elixir-autogen, elixir-format
 msgid "Clear filters"
 msgstr ""
@@ -5544,7 +5544,7 @@ msgstr ""
 msgid "Community Standards"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:820
+#: lib/klass_hero_web/components/marketing_components.ex:849
 #, elixir-autogen, elixir-format
 msgid "Company"
 msgstr ""
@@ -5564,7 +5564,7 @@ msgstr ""
 msgid "Confirm your account to finish signing up."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:233
+#: lib/klass_hero_web/components/marketing_components.ex:241
 #, elixir-autogen, elixir-format
 msgid "Connecting Families with"
 msgstr ""
@@ -5619,7 +5619,7 @@ msgstr ""
 msgid "Direct messaging, broadcast announcements, incident reports. Keep parents informed, automatically."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:957
+#: lib/klass_hero_web/components/marketing_components.ex:986
 #, elixir-autogen, elixir-format
 msgid "Discover"
 msgstr ""
@@ -5694,7 +5694,7 @@ msgstr ""
 msgid "Every feature included. No subscription, no setup fees."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:473
+#: lib/klass_hero_web/components/marketing_components.ex:502
 #, elixir-autogen, elixir-format
 msgid "Everything parents need, nothing they don't"
 msgstr ""
@@ -5709,7 +5709,7 @@ msgstr ""
 msgid "Extended Police Check"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:677
+#: lib/klass_hero_web/components/marketing_components.ex:706
 #: lib/klass_hero_web/live/for_providers_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "FAQ"
@@ -5720,17 +5720,17 @@ msgstr ""
 msgid "Failed to approve"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:802
+#: lib/klass_hero_web/components/marketing_components.ex:831
 #, elixir-autogen, elixir-format
 msgid "Families"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:261
+#: lib/klass_hero_web/components/marketing_components.ex:269
 #, elixir-autogen, elixir-format
 msgid "Find Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:765
+#: lib/klass_hero_web/components/marketing_components.ex:794
 #, elixir-autogen, elixir-format
 msgid "Footer mobile"
 msgstr ""
@@ -5760,7 +5760,7 @@ msgstr ""
 msgid "Full-stack developer. Partner of a teacher who saw the gap between great educators and good infrastructure."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:581
+#: lib/klass_hero_web/components/marketing_components.ex:610
 #, elixir-autogen, elixir-format
 msgid "Get Bookings"
 msgstr ""
@@ -5787,17 +5787,17 @@ msgstr ""
 msgid "Get verified"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1100
+#: lib/klass_hero_web/components/marketing_components.ex:1129
 #, elixir-autogen, elixir-format
 msgid "Grid"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:325
+#: lib/klass_hero_web/components/marketing_components.ex:333
 #, elixir-autogen, elixir-format
 msgid "Hand-picked programs this week across Berlin."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:963
+#: lib/klass_hero_web/components/marketing_components.ex:992
 #, elixir-autogen, elixir-format
 msgid "Hand-picked, vetted programs across Berlin — filter by category, age, or schedule."
 msgstr ""
@@ -5812,8 +5812,8 @@ msgstr ""
 msgid "Head of Trust & Quality (joining)"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:815
-#: lib/klass_hero_web/components/marketing_components.ex:913
+#: lib/klass_hero_web/components/marketing_components.ex:844
+#: lib/klass_hero_web/components/marketing_components.ex:942
 #, elixir-autogen, elixir-format
 msgid "Help Center"
 msgstr ""
@@ -5823,7 +5823,7 @@ msgstr ""
 msgid "How and when do I get paid?"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:805
+#: lib/klass_hero_web/components/marketing_components.ex:834
 #, elixir-autogen, elixir-format
 msgid "How it Works"
 msgstr ""
@@ -5843,12 +5843,12 @@ msgstr ""
 msgid "How quickly can I start accepting bookings?"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:541
+#: lib/klass_hero_web/components/marketing_components.ex:570
 #, elixir-autogen, elixir-format
 msgid "How to Grow Your Youth Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:871
+#: lib/klass_hero_web/components/marketing_components.ex:900
 #, elixir-autogen, elixir-format
 msgid "How we vet providers"
 msgstr ""
@@ -5899,7 +5899,7 @@ msgstr ""
 msgid "Join Berlin's growing network of trusted educators. Free to list. No setup fees."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:544
+#: lib/klass_hero_web/components/marketing_components.ex:573
 #, elixir-autogen, elixir-format
 msgid "Join Berlin's trusted network of educators. We handle payments, scheduling, and discovery — you focus on teaching."
 msgstr ""
@@ -5946,12 +5946,12 @@ msgstr ""
 msgid "Lead Instructor"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:554
+#: lib/klass_hero_web/components/marketing_components.ex:583
 #, elixir-autogen, elixir-format
 msgid "Learn How to Become a Hero →"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:861
+#: lib/klass_hero_web/components/marketing_components.ex:890
 #, elixir-autogen, elixir-format
 msgid "Learn how vetting works"
 msgstr ""
@@ -5981,12 +5981,12 @@ msgstr ""
 msgid "Linking..."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1116
+#: lib/klass_hero_web/components/marketing_components.ex:1145
 #, elixir-autogen, elixir-format
 msgid "List"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:572
+#: lib/klass_hero_web/components/marketing_components.ex:601
 #, elixir-autogen, elixir-format
 msgid "List Your Program"
 msgstr ""
@@ -6022,7 +6022,7 @@ msgstr ""
 msgid "Log out"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:868
+#: lib/klass_hero_web/components/marketing_components.ex:897
 #, elixir-autogen, elixir-format
 msgid "Looking for programs for your child?"
 msgstr ""
@@ -6072,7 +6072,7 @@ msgstr ""
 msgid "Minimum one year working with children, validated."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:136
+#: lib/klass_hero_web/components/marketing_components.ex:144
 #, elixir-autogen, elixir-format
 msgid "Mobile primary"
 msgstr ""
@@ -6097,7 +6097,7 @@ msgstr ""
 msgid "New program"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1127
+#: lib/klass_hero_web/components/marketing_components.ex:1156
 #, elixir-autogen, elixir-format
 msgid "Newest"
 msgstr ""
@@ -6112,7 +6112,7 @@ msgstr ""
 msgid "No credit card required"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:353
+#: lib/klass_hero_web/components/marketing_components.ex:361
 #, elixir-autogen, elixir-format
 msgid "No featured programs available right now. Check back soon."
 msgstr ""
@@ -6179,7 +6179,7 @@ msgstr ""
 msgid "Once your listing is live and you've completed Hero verification (typically 3–5 business days), parents can book immediately. Most providers receive their first inquiry within the first week."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1539
+#: lib/klass_hero_web/components/marketing_components.ex:1568
 #, elixir-autogen, elixir-format
 msgid "Ongoing Quality"
 msgstr ""
@@ -6199,12 +6199,12 @@ msgstr ""
 msgid "Open inbox"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:111
+#: lib/klass_hero_web/components/marketing_components.ex:119
 #, elixir-autogen, elixir-format
 msgid "Open menu"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1367
+#: lib/klass_hero_web/components/marketing_components.ex:1396
 #, elixir-autogen, elixir-format
 msgid "Our Commitment"
 msgstr ""
@@ -6239,7 +6239,7 @@ msgstr ""
 msgid "Parents discover you on Klass Hero. Approve manually or auto-accept — your call."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:583
+#: lib/klass_hero_web/components/marketing_components.ex:612
 #, elixir-autogen, elixir-format
 msgid "Parents find you through Klass Hero. Approve or auto-accept bookings with secure messaging built in."
 msgstr ""
@@ -6270,29 +6270,29 @@ msgstr ""
 msgid "Predictable income"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1129
+#: lib/klass_hero_web/components/marketing_components.ex:1158
 #, elixir-autogen, elixir-format
 msgid "Price: high to low"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1128
+#: lib/klass_hero_web/components/marketing_components.ex:1157
 #, elixir-autogen, elixir-format
 msgid "Price: low to high"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:814
+#: lib/klass_hero_web/components/marketing_components.ex:843
 #: lib/klass_hero_web/live/for_providers_live.ex:167
 #, elixir-autogen, elixir-format
 msgid "Pricing"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:66
+#: lib/klass_hero_web/components/marketing_components.ex:74
 #, elixir-autogen, elixir-format
 msgid "Primary"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:777
-#: lib/klass_hero_web/components/marketing_components.ex:824
+#: lib/klass_hero_web/components/marketing_components.ex:806
+#: lib/klass_hero_web/components/marketing_components.ex:853
 #: lib/klass_hero_web/live/privacy_policy_live.ex:238
 #, elixir-autogen, elixir-format
 msgid "Privacy"
@@ -6333,7 +6333,7 @@ msgstr ""
 msgid "Questions about programs, bookings, or becoming a Hero — we read every message."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:680
+#: lib/klass_hero_web/components/marketing_components.ex:709
 #, elixir-autogen, elixir-format
 msgid "Questions, answered."
 msgstr ""
@@ -6348,8 +6348,8 @@ msgstr ""
 msgid "Ready to be a Hero?"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:878
-#: lib/klass_hero_web/components/marketing_components.ex:898
+#: lib/klass_hero_web/components/marketing_components.ex:907
+#: lib/klass_hero_web/components/marketing_components.ex:927
 #, elixir-autogen, elixir-format
 msgid "Ready to find your child's next adventure?"
 msgstr ""
@@ -6364,8 +6364,8 @@ msgstr ""
 msgid "Recent messages"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1126
-#: lib/klass_hero_web/components/marketing_components.ex:1138
+#: lib/klass_hero_web/components/marketing_components.ex:1155
+#: lib/klass_hero_web/components/marketing_components.ex:1167
 #, elixir-autogen, elixir-format
 msgid "Recommended"
 msgstr ""
@@ -6415,12 +6415,12 @@ msgstr ""
 msgid "Safety"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:983
+#: lib/klass_hero_web/components/marketing_components.ex:1012
 #, elixir-autogen, elixir-format
 msgid "Search programs, providers, neighborhoods..."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:256
+#: lib/klass_hero_web/components/marketing_components.ex:264
 #, elixir-autogen, elixir-format
 msgid "Search: coding, football, art..."
 msgstr ""
@@ -6435,7 +6435,7 @@ msgstr ""
 msgid "Secure payments, invoicing, and VAT handling"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:592
+#: lib/klass_hero_web/components/marketing_components.ex:621
 #, elixir-autogen, elixir-format
 msgid "Secure weekly payouts. Insights into your business and opportunities to expand your impact."
 msgstr ""
@@ -6450,7 +6450,7 @@ msgstr ""
 msgid "See pricing"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:563
+#: lib/klass_hero_web/components/marketing_components.ex:592
 #, elixir-autogen, elixir-format
 msgid "See provider plans"
 msgstr ""
@@ -6480,8 +6480,8 @@ msgstr ""
 msgid "Setting up..."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:96
-#: lib/klass_hero_web/components/marketing_components.ex:168
+#: lib/klass_hero_web/components/marketing_components.ex:104
+#: lib/klass_hero_web/components/marketing_components.ex:176
 #: lib/klass_hero_web/live/user_live/login.ex:12
 #, elixir-autogen, elixir-format
 msgid "Sign in"
@@ -6492,8 +6492,8 @@ msgstr ""
 msgid "Sign in to continue. Don't have an account?"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:99
-#: lib/klass_hero_web/components/marketing_components.ex:173
+#: lib/klass_hero_web/components/marketing_components.ex:107
+#: lib/klass_hero_web/components/marketing_components.ex:181
 #: lib/klass_hero_web/live/user_live/registration.ex:12
 #, elixir-autogen, elixir-format
 msgid "Sign up"
@@ -6504,7 +6504,7 @@ msgstr ""
 msgid "Signed agreement on conduct and quality bar."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:155
+#: lib/klass_hero_web/components/marketing_components.ex:163
 #: lib/klass_hero_web/components/ui_components.ex:193
 #, elixir-autogen, elixir-format
 msgid "Signed in as"
@@ -6515,12 +6515,12 @@ msgstr ""
 msgid "Six checks. No shortcuts."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1053
+#: lib/klass_hero_web/components/marketing_components.ex:1082
 #, elixir-autogen, elixir-format
 msgid "Sort:"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:813
+#: lib/klass_hero_web/components/marketing_components.ex:842
 #, elixir-autogen, elixir-format
 msgid "Start Teaching"
 msgstr ""
@@ -6571,7 +6571,7 @@ msgstr ""
 msgid "Talk to our team →"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:881
+#: lib/klass_hero_web/components/marketing_components.ex:910
 #: lib/klass_hero_web/live/about_live.ex:164
 #: lib/klass_hero_web/live/for_providers_live.ex:269
 #, elixir-autogen, elixir-format
@@ -6588,7 +6588,7 @@ msgstr ""
 msgid "Teaching Experience"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:858
+#: lib/klass_hero_web/components/marketing_components.ex:887
 #, elixir-autogen, elixir-format
 msgid "Teaching kids is your thing? Join as a Hero."
 msgstr ""
@@ -6598,8 +6598,8 @@ msgstr ""
 msgid "Tell us a bit about what you need — we'll route you to the right person."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:778
-#: lib/klass_hero_web/components/marketing_components.ex:825
+#: lib/klass_hero_web/components/marketing_components.ex:807
+#: lib/klass_hero_web/components/marketing_components.ex:854
 #: lib/klass_hero_web/live/terms_of_service_live.ex:259
 #, elixir-autogen, elixir-format
 msgid "Terms"
@@ -6650,7 +6650,7 @@ msgstr ""
 msgid "Trust &"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:235
+#: lib/klass_hero_web/components/marketing_components.ex:243
 #, elixir-autogen, elixir-format
 msgid "Trusted Heroes"
 msgstr ""
@@ -6690,7 +6690,7 @@ msgstr ""
 msgid "Vetted"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1213
+#: lib/klass_hero_web/components/marketing_components.ex:1242
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr ""
@@ -6700,7 +6700,7 @@ msgstr ""
 msgid "View all"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:432
+#: lib/klass_hero_web/components/marketing_components.ex:461
 #, elixir-autogen, elixir-format
 msgid "View →"
 msgstr ""
@@ -6781,12 +6781,12 @@ msgstr ""
 msgid "What's the verification process like?"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:888
+#: lib/klass_hero_web/components/marketing_components.ex:917
 #, elixir-autogen, elixir-format
 msgid "While you're here — explore programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:470
+#: lib/klass_hero_web/components/marketing_components.ex:499
 #: lib/klass_hero_web/live/for_providers_live.ex:72
 #, elixir-autogen, elixir-format
 msgid "Why Klass Hero"
@@ -6867,7 +6867,7 @@ msgstr ""
 msgid "active"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:958
+#: lib/klass_hero_web/components/marketing_components.ex:987
 #, elixir-autogen, elixir-format
 msgid "activities"
 msgstr ""
@@ -6892,7 +6892,7 @@ msgstr ""
 msgid "families"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:237
+#: lib/klass_hero_web/components/marketing_components.ex:245
 #, elixir-autogen, elixir-format
 msgid "for Our Youth"
 msgstr ""
@@ -6902,12 +6902,12 @@ msgstr ""
 msgid "help"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1041
+#: lib/klass_hero_web/components/marketing_components.ex:1070
 #, elixir-autogen, elixir-format
 msgid "in"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1045
+#: lib/klass_hero_web/components/marketing_components.ex:1074
 #, elixir-autogen, elixir-format
 msgid "matching"
 msgstr ""
@@ -6918,7 +6918,7 @@ msgstr ""
 msgid "pending"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1039
+#: lib/klass_hero_web/components/marketing_components.ex:1068
 #, elixir-autogen, elixir-format
 msgid "program"
 msgid_plural "programs"
@@ -7239,7 +7239,7 @@ msgstr ""
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1455
+#: lib/klass_hero_web/components/marketing_components.ex:1484
 #, elixir-autogen, elixir-format
 msgid "Applicants submit a short recorded video (max 2 minutes) so we can assess communication skills and alignment with our values before approving their profile."
 msgstr ""
@@ -7595,17 +7595,22 @@ msgid_plural "%{count} children enrolled"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/components/program_components.ex:242
+#: lib/klass_hero_web/components/ui_components.ex:1927
 #, elixir-autogen, elixir-format
 msgid "This provider completed Klass Hero's verification checks"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:260
+#: lib/klass_hero_web/components/ui_components.ex:1943
 #, elixir-autogen, elixir-format
 msgid "This provider is working through Klass Hero's verification checks"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:263
+#: lib/klass_hero_web/components/ui_components.ex:1950
 #, elixir-autogen, elixir-format
 msgid "Verification in progress"
+msgstr ""
+
+#: lib/klass_hero_web/components/ui_components.ex:1948
+#, elixir-autogen, elixir-format
+msgid "Verifying"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -13,9 +13,9 @@ msgstr ""
 
 #: lib/klass_hero_web/components/layouts/app.html.heex:44
 #: lib/klass_hero_web/components/layouts/app.html.heex:197
-#: lib/klass_hero_web/components/marketing_components.ex:194
-#: lib/klass_hero_web/components/marketing_components.ex:822
-#: lib/klass_hero_web/components/marketing_components.ex:911
+#: lib/klass_hero_web/components/marketing_components.ex:202
+#: lib/klass_hero_web/components/marketing_components.ex:851
+#: lib/klass_hero_web/components/marketing_components.ex:940
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr ""
@@ -34,9 +34,9 @@ msgstr ""
 #: lib/klass_hero_web/components/composite_components.ex:468
 #: lib/klass_hero_web/components/layouts/app.html.heex:52
 #: lib/klass_hero_web/components/layouts/app.html.heex:198
-#: lib/klass_hero_web/components/marketing_components.ex:195
-#: lib/klass_hero_web/components/marketing_components.ex:823
-#: lib/klass_hero_web/components/marketing_components.ex:912
+#: lib/klass_hero_web/components/marketing_components.ex:203
+#: lib/klass_hero_web/components/marketing_components.ex:852
+#: lib/klass_hero_web/components/marketing_components.ex:941
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr ""
@@ -68,7 +68,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/layouts/app.html.heex:28
 #: lib/klass_hero_web/components/layouts/app.html.heex:195
-#: lib/klass_hero_web/components/marketing_components.ex:190
+#: lib/klass_hero_web/components/marketing_components.ex:198
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr ""
@@ -93,7 +93,7 @@ msgstr ""
 #: lib/klass_hero_web/components/composite_components.ex:484
 #: lib/klass_hero_web/components/layouts/app.html.heex:36
 #: lib/klass_hero_web/components/layouts/app.html.heex:196
-#: lib/klass_hero_web/components/marketing_components.ex:191
+#: lib/klass_hero_web/components/marketing_components.ex:199
 #, elixir-autogen, elixir-format
 msgid "Programs"
 msgstr ""
@@ -182,7 +182,7 @@ msgstr ""
 msgid "Any allergies, medical conditions, or special instructions..."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:492
+#: lib/klass_hero_web/components/marketing_components.ex:521
 #, elixir-autogen, elixir-format
 msgid "Book camps, tutors, and workshops instantly. Our integrated planner helps you manage your child's busy life."
 msgstr ""
@@ -197,7 +197,7 @@ msgstr ""
 msgid "Cash/transfer payments will show as \"Pending\" until received"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:500
+#: lib/klass_hero_web/components/marketing_components.ex:529
 #, elixir-autogen, elixir-format
 msgid "Community Focused"
 msgstr ""
@@ -222,7 +222,7 @@ msgstr ""
 msgid "Duration:"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:490
+#: lib/klass_hero_web/components/marketing_components.ex:519
 #, elixir-autogen, elixir-format
 msgid "Easy Scheduling"
 msgstr ""
@@ -253,18 +253,18 @@ msgstr ""
 msgid "Enrollment successful! You'll receive a confirmation email shortly."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:482
+#: lib/klass_hero_web/components/marketing_components.ex:511
 #, elixir-autogen, elixir-format
 msgid "Every provider is rigorously vetted. We prioritize child safety above all else, giving parents peace of mind."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:953
+#: lib/klass_hero_web/components/marketing_components.ex:982
 #: lib/klass_hero_web/live/programs_live.ex:35
 #, elixir-autogen, elixir-format
 msgid "Explore Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:319
+#: lib/klass_hero_web/components/marketing_components.ex:327
 #, elixir-autogen, elixir-format
 msgid "Featured Programs"
 msgstr ""
@@ -326,7 +326,7 @@ msgstr ""
 msgid "Please select a child for enrollment."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:20
+#: lib/klass_hero_web/live/home_live.ex:22
 #, elixir-autogen, elixir-format
 msgid "Klass Hero - Connecting Families with Trusted Youth Educators"
 msgstr ""
@@ -343,7 +343,7 @@ msgstr ""
 msgid "Program not found. It may have been removed or is no longer available."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:480
+#: lib/klass_hero_web/components/marketing_components.ex:509
 #: lib/klass_hero_web/live/about_live.ex:19
 #, elixir-autogen, elixir-format
 msgid "Safety First"
@@ -389,7 +389,7 @@ msgstr ""
 msgid "Total due today:"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:338
+#: lib/klass_hero_web/components/marketing_components.ex:346
 #, elixir-autogen, elixir-format
 msgid "View All Programs →"
 msgstr ""
@@ -1426,9 +1426,9 @@ msgid "Education"
 msgstr ""
 
 #: lib/klass_hero_web/components/composite_components.ex:472
-#: lib/klass_hero_web/components/marketing_components.ex:192
-#: lib/klass_hero_web/components/marketing_components.ex:538
-#: lib/klass_hero_web/components/marketing_components.ex:909
+#: lib/klass_hero_web/components/marketing_components.ex:200
+#: lib/klass_hero_web/components/marketing_components.ex:567
+#: lib/klass_hero_web/components/marketing_components.ex:938
 #: lib/klass_hero_web/live/for_providers_live.ex:10
 #: lib/klass_hero_web/live/for_providers_live.ex:39
 #, elixir-autogen, elixir-format
@@ -1440,7 +1440,7 @@ msgstr ""
 msgid "From sports to arts, technology to languages, we make it easy to discover enriching activities that fit your family's schedule and budget."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:590
+#: lib/klass_hero_web/components/marketing_components.ex:619
 #, elixir-autogen, elixir-format
 msgid "Get Paid & Grow"
 msgstr ""
@@ -1467,12 +1467,12 @@ msgstr ""
 msgid "Ready to join the movement?"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:987
+#: lib/klass_hero_web/components/marketing_components.ex:1016
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:574
+#: lib/klass_hero_web/components/marketing_components.ex:603
 #, elixir-autogen, elixir-format
 msgid "Set up your teaching profile and list your programs in minutes. Share your expertise with families who need it."
 msgstr ""
@@ -1488,7 +1488,7 @@ msgstr ""
 msgid "Sustainability"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:270
+#: lib/klass_hero_web/components/marketing_components.ex:278
 #, elixir-autogen, elixir-format
 msgid "Trending in Berlin:"
 msgstr ""
@@ -2184,23 +2184,23 @@ msgid_plural "%{count} documents"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/components/program_components.ex:619
-#: lib/klass_hero_web/components/program_components.ex:627
+#: lib/klass_hero_web/components/program_components.ex:564
+#: lib/klass_hero_web/components/program_components.ex:572
 #, elixir-autogen, elixir-format
 msgid "%{count} month"
 msgid_plural "%{count} months"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/components/program_components.ex:615
-#: lib/klass_hero_web/components/program_components.ex:626
+#: lib/klass_hero_web/components/program_components.ex:560
+#: lib/klass_hero_web/components/program_components.ex:571
 #, elixir-autogen, elixir-format
 msgid "%{count} year"
 msgid_plural "%{count} years"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/components/program_components.ex:637
+#: lib/klass_hero_web/components/program_components.ex:582
 #, elixir-autogen, elixir-format
 msgid "%{gender} only"
 msgstr ""
@@ -2220,12 +2220,12 @@ msgstr ""
 msgid "Add your first staff member to get started!"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:601
+#: lib/klass_hero_web/components/program_components.ex:546
 #, elixir-autogen, elixir-format
 msgid "Ages %{min} to %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:605
+#: lib/klass_hero_web/components/program_components.ex:550
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Ages %{min}+"
 msgstr ""
@@ -2266,7 +2266,7 @@ msgstr ""
 msgid "Are you sure you want to remove this team member?"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:642
+#: lib/klass_hero_web/components/marketing_components.ex:671
 #, elixir-autogen, elixir-format
 msgid "As fathers and partners of teachers in Berlin, we saw and heard firsthand how hard it is to find, book, and manage quality youth activities outside the classroom. Klass Hero is the complete platform connecting Berlin families and schools with trusted, vetted activity providers — offering safe, supervised, and enriching experiences across sports, arts, tutoring, and more. We verify every provider, structure every booking, and support every step — so parents know their child is in good hands, and providers can focus on what they do best: inspiring kids."
 msgstr ""
@@ -2303,7 +2303,7 @@ msgstr ""
 msgid "Brief description of experience and specialties..."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:639
+#: lib/klass_hero_web/components/marketing_components.ex:668
 #, elixir-autogen, elixir-format
 msgid "Built by Parents to Empower Educators."
 msgstr ""
@@ -2428,7 +2428,7 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:739
+#: lib/klass_hero_web/components/program_components.ex:684
 #: lib/klass_hero_web/components/provider_components.ex:1088
 #: lib/klass_hero_web/live/settings/children_live.ex:670
 #, elixir-autogen, elixir-format
@@ -2555,7 +2555,7 @@ msgstr ""
 msgid "Family Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:737
+#: lib/klass_hero_web/components/program_components.ex:682
 #: lib/klass_hero_web/components/provider_components.ex:1087
 #: lib/klass_hero_web/live/settings/children_live.ex:669
 #, elixir-autogen, elixir-format
@@ -2592,17 +2592,17 @@ msgstr ""
 msgid "Gender"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:746
+#: lib/klass_hero_web/components/program_components.ex:691
 #, elixir-autogen, elixir-format
 msgid "Grade %{grade}"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:754
+#: lib/klass_hero_web/components/program_components.ex:699
 #, elixir-autogen, elixir-format
 msgid "Grade %{min}+"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:750
+#: lib/klass_hero_web/components/program_components.ex:695
 #, elixir-autogen, elixir-format
 msgid "Grades %{min} – %{max}"
 msgstr ""
@@ -2701,7 +2701,7 @@ msgstr ""
 msgid "Logo upload failed. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:738
+#: lib/klass_hero_web/components/program_components.ex:683
 #: lib/klass_hero_web/components/provider_components.ex:1086
 #: lib/klass_hero_web/live/settings/children_live.ex:668
 #, elixir-autogen, elixir-format
@@ -2820,14 +2820,14 @@ msgstr ""
 msgid "Not Verified"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:740
+#: lib/klass_hero_web/components/program_components.ex:685
 #: lib/klass_hero_web/components/provider_components.ex:1089
 #: lib/klass_hero_web/live/settings/children_live.ex:667
 #, elixir-autogen, elixir-format
 msgid "Not specified"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:636
+#: lib/klass_hero_web/components/marketing_components.ex:665
 #, elixir-autogen, elixir-format
 msgid "Our Story"
 msgstr ""
@@ -2839,7 +2839,7 @@ msgstr ""
 msgid "PDF, JPG or PNG. Max 10MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:564
+#: lib/klass_hero_web/components/program_components.ex:509
 #, elixir-autogen, elixir-format
 msgid "Participant Requirements"
 msgstr ""
@@ -2923,7 +2923,7 @@ msgstr ""
 msgid "Provider profile not found."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:649
+#: lib/klass_hero_web/components/marketing_components.ex:678
 #, elixir-autogen, elixir-format
 msgid "Read our founding story →"
 msgstr ""
@@ -3198,12 +3198,12 @@ msgstr ""
 msgid "Unable to load document preview."
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:609
+#: lib/klass_hero_web/components/program_components.ex:554
 #, elixir-autogen, elixir-format
 msgid "Up to %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:758
+#: lib/klass_hero_web/components/program_components.ex:703
 #, elixir-autogen, elixir-format
 msgid "Up to Grade %{max}"
 msgstr ""
@@ -3255,9 +3255,9 @@ msgstr ""
 msgid "Verifications"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:245
 #: lib/klass_hero_web/components/provider_components.ex:276
 #: lib/klass_hero_web/components/provider_layout_components.ex:212
+#: lib/klass_hero_web/components/ui_components.ex:1930
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Verified"
 msgstr ""
@@ -3302,12 +3302,12 @@ msgstr ""
 msgid "e.g., Community Center, Main St"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1463
+#: lib/klass_hero_web/components/marketing_components.ex:1492
 #, elixir-autogen, elixir-format
 msgid "All Heroes must hold or complete a recognized child safeguarding course, ensuring up-to-date knowledge."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1431
+#: lib/klass_hero_web/components/marketing_components.ex:1460
 #, elixir-autogen, elixir-format
 msgid "All providers must be 18 years or older, ensuring legal accountability and professional responsibility."
 msgstr ""
@@ -3317,12 +3317,12 @@ msgstr ""
 msgid "And at Klass Hero, both come standard."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1461
+#: lib/klass_hero_web/components/marketing_components.ex:1490
 #, elixir-autogen, elixir-format
 msgid "Child Safeguarding Training"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1469
+#: lib/klass_hero_web/components/marketing_components.ex:1498
 #: lib/klass_hero_web/components/provider_components.ex:2616
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
@@ -3333,7 +3333,7 @@ msgstr ""
 msgid "Create long-term trust across our community"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1447
+#: lib/klass_hero_web/components/marketing_components.ex:1476
 #, elixir-autogen, elixir-format
 msgid "Each provider submits an extended police background check, confirming their eligibility to work safely with minors."
 msgstr ""
@@ -3343,17 +3343,17 @@ msgstr ""
 msgid "Enforcing platform standards and guidelines"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1471
+#: lib/klass_hero_web/components/marketing_components.ex:1500
 #, elixir-autogen, elixir-format
 msgid "Every provider agrees to follow our Community Guidelines, defining expectations around professionalism."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1437
+#: lib/klass_hero_web/components/marketing_components.ex:1466
 #, elixir-autogen, elixir-format
 msgid "Experience Validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1445
+#: lib/klass_hero_web/components/marketing_components.ex:1474
 #, elixir-autogen, elixir-format
 msgid "Extended Background Checks"
 msgstr ""
@@ -3363,12 +3363,12 @@ msgstr ""
 msgid "From academic tutoring to sports, arts, and enrichment programs, every provider on Klass Hero is carefully reviewed to ensure they meet our high standards for child safety, professionalism, and educational quality."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1491
+#: lib/klass_hero_web/components/marketing_components.ex:1520
 #, elixir-autogen, elixir-format
 msgid "How We Verify Providers"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1429
+#: lib/klass_hero_web/components/marketing_components.ex:1458
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Identity & Age Verification"
 msgstr ""
@@ -3403,7 +3403,7 @@ msgstr ""
 msgid "Protect children and families"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1439
+#: lib/klass_hero_web/components/marketing_components.ex:1468
 #, elixir-autogen, elixir-format
 msgid "Providers must demonstrate at least one year of experience working with children in their area of expertise."
 msgstr ""
@@ -3443,9 +3443,9 @@ msgstr ""
 #: lib/klass_hero_web/components/composite_components.ex:546
 #: lib/klass_hero_web/components/layouts/app.html.heex:60
 #: lib/klass_hero_web/components/layouts/app.html.heex:199
-#: lib/klass_hero_web/components/marketing_components.ex:193
-#: lib/klass_hero_web/components/marketing_components.ex:806
-#: lib/klass_hero_web/components/marketing_components.ex:910
+#: lib/klass_hero_web/components/marketing_components.ex:201
+#: lib/klass_hero_web/components/marketing_components.ex:835
+#: lib/klass_hero_web/components/marketing_components.ex:939
 #: lib/klass_hero_web/live/for_providers_live.ex:136
 #: lib/klass_hero_web/live/trust_safety_live.ex:10
 #, elixir-autogen, elixir-format
@@ -3467,12 +3467,12 @@ msgstr ""
 msgid "Uphold professional and ethical teaching practices"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1388
+#: lib/klass_hero_web/components/marketing_components.ex:1417
 #, elixir-autogen, elixir-format
 msgid "Vetted with Care"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1453
+#: lib/klass_hero_web/components/marketing_components.ex:1482
 #: lib/klass_hero_web/components/provider_components.ex:2401
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
@@ -3843,7 +3843,7 @@ msgid "Private lessons and tutoring"
 msgstr ""
 
 #: lib/klass_hero_web/components/layouts/admin.html.heex:31
-#: lib/klass_hero_web/components/marketing_components.ex:811
+#: lib/klass_hero_web/components/marketing_components.ex:840
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Providers"
 msgstr ""
@@ -4732,7 +4732,7 @@ msgstr ""
 msgid "About the Provider"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:502
+#: lib/klass_hero_web/components/marketing_components.ex:531
 #, elixir-autogen, elixir-format
 msgid "Built for the Berlin international community. Integrated secure encrypted messaging to connect with local families and trusted educators nearby."
 msgstr ""
@@ -5265,8 +5265,8 @@ msgstr ""
 msgid "Your week with the kids"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:92
-#: lib/klass_hero_web/components/marketing_components.ex:160
+#: lib/klass_hero_web/components/marketing_components.ex:100
+#: lib/klass_hero_web/components/marketing_components.ex:168
 #, elixir-autogen, elixir-format
 msgid "Go to dashboard"
 msgstr ""
@@ -5293,7 +5293,7 @@ msgstr ""
 msgid ", a full-stack developer who shared a unique perspective. Both Shane and Max are partners of teachers who wanted to extend their expertise beyond the classroom — but without the time to manage the operational side on their own."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:959
+#: lib/klass_hero_web/components/marketing_components.ex:988
 #, elixir-autogen, elixir-format
 msgid ", camps & classes for your child"
 msgstr ""
@@ -5350,7 +5350,7 @@ msgstr ""
 msgid "Add a child"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:322
+#: lib/klass_hero_web/components/marketing_components.ex:330
 #, elixir-autogen, elixir-format
 msgid "Afterschool Adventures Await"
 msgstr ""
@@ -5365,7 +5365,7 @@ msgstr ""
 msgid "All instructors are background-checked and verified."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:549
+#: lib/klass_hero_web/components/marketing_components.ex:578
 #, elixir-autogen, elixir-format
 msgid "Are you an educator, coach, or artist?"
 msgstr ""
@@ -5385,13 +5385,13 @@ msgstr ""
 msgid "Back to Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:891
-#: lib/klass_hero_web/components/marketing_components.ex:901
+#: lib/klass_hero_web/components/marketing_components.ex:920
+#: lib/klass_hero_web/components/marketing_components.ex:930
 #, elixir-autogen, elixir-format
 msgid "Become a Hero"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:859
+#: lib/klass_hero_web/components/marketing_components.ex:888
 #, elixir-autogen, elixir-format
 msgid "Become a Hero →"
 msgstr ""
@@ -5406,17 +5406,17 @@ msgstr ""
 msgid "Berlin parents come to Klass Hero looking for trusted programs. You focus on teaching — we handle the funnel."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:227
+#: lib/klass_hero_web/components/marketing_components.ex:235
 #, elixir-autogen, elixir-format
 msgid "Berlin's #1 network for youth educators"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:241
+#: lib/klass_hero_web/components/marketing_components.ex:249
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Berlin's leading network for tutors, coaches, and camp providers — every one verified by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:795
+#: lib/klass_hero_web/components/marketing_components.ex:824
 #, elixir-autogen, elixir-format
 msgid "Berlin's network for trusted youth educators. Built by parents, for parents."
 msgstr ""
@@ -5436,16 +5436,16 @@ msgstr ""
 msgid "Brings the financial rigour and strategic planning needed for the German market and long-term provider stability."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:804
-#: lib/klass_hero_web/components/marketing_components.ex:908
+#: lib/klass_hero_web/components/marketing_components.ex:833
+#: lib/klass_hero_web/components/marketing_components.ex:937
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Browse Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:869
-#: lib/klass_hero_web/components/marketing_components.ex:879
-#: lib/klass_hero_web/components/marketing_components.ex:889
-#: lib/klass_hero_web/components/marketing_components.ex:899
+#: lib/klass_hero_web/components/marketing_components.ex:898
+#: lib/klass_hero_web/components/marketing_components.ex:908
+#: lib/klass_hero_web/components/marketing_components.ex:918
+#: lib/klass_hero_web/components/marketing_components.ex:928
 #, elixir-autogen, elixir-format
 msgid "Browse Programs →"
 msgstr ""
@@ -5505,7 +5505,7 @@ msgstr ""
 msgid "Children"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1246
+#: lib/klass_hero_web/components/marketing_components.ex:1275
 #, elixir-autogen, elixir-format
 msgid "Clear filters"
 msgstr ""
@@ -5544,7 +5544,7 @@ msgstr ""
 msgid "Community Standards"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:820
+#: lib/klass_hero_web/components/marketing_components.ex:849
 #, elixir-autogen, elixir-format
 msgid "Company"
 msgstr ""
@@ -5564,7 +5564,7 @@ msgstr ""
 msgid "Confirm your account to finish signing up."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:233
+#: lib/klass_hero_web/components/marketing_components.ex:241
 #, elixir-autogen, elixir-format
 msgid "Connecting Families with"
 msgstr ""
@@ -5619,7 +5619,7 @@ msgstr ""
 msgid "Direct messaging, broadcast announcements, incident reports. Keep parents informed, automatically."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:957
+#: lib/klass_hero_web/components/marketing_components.ex:986
 #, elixir-autogen, elixir-format
 msgid "Discover"
 msgstr ""
@@ -5694,7 +5694,7 @@ msgstr ""
 msgid "Every feature included. No subscription, no setup fees."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:473
+#: lib/klass_hero_web/components/marketing_components.ex:502
 #, elixir-autogen, elixir-format
 msgid "Everything parents need, nothing they don't"
 msgstr ""
@@ -5709,7 +5709,7 @@ msgstr ""
 msgid "Extended Police Check"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:677
+#: lib/klass_hero_web/components/marketing_components.ex:706
 #: lib/klass_hero_web/live/for_providers_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "FAQ"
@@ -5720,17 +5720,17 @@ msgstr ""
 msgid "Failed to approve"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:802
+#: lib/klass_hero_web/components/marketing_components.ex:831
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Families"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:261
+#: lib/klass_hero_web/components/marketing_components.ex:269
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Find Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:765
+#: lib/klass_hero_web/components/marketing_components.ex:794
 #, elixir-autogen, elixir-format
 msgid "Footer mobile"
 msgstr ""
@@ -5760,7 +5760,7 @@ msgstr ""
 msgid "Full-stack developer. Partner of a teacher who saw the gap between great educators and good infrastructure."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:581
+#: lib/klass_hero_web/components/marketing_components.ex:610
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Get Bookings"
 msgstr ""
@@ -5787,17 +5787,17 @@ msgstr ""
 msgid "Get verified"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1100
+#: lib/klass_hero_web/components/marketing_components.ex:1129
 #, elixir-autogen, elixir-format
 msgid "Grid"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:325
+#: lib/klass_hero_web/components/marketing_components.ex:333
 #, elixir-autogen, elixir-format
 msgid "Hand-picked programs this week across Berlin."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:963
+#: lib/klass_hero_web/components/marketing_components.ex:992
 #, elixir-autogen, elixir-format
 msgid "Hand-picked, vetted programs across Berlin — filter by category, age, or schedule."
 msgstr ""
@@ -5812,8 +5812,8 @@ msgstr ""
 msgid "Head of Trust & Quality (joining)"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:815
-#: lib/klass_hero_web/components/marketing_components.ex:913
+#: lib/klass_hero_web/components/marketing_components.ex:844
+#: lib/klass_hero_web/components/marketing_components.ex:942
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Help Center"
 msgstr ""
@@ -5823,7 +5823,7 @@ msgstr ""
 msgid "How and when do I get paid?"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:805
+#: lib/klass_hero_web/components/marketing_components.ex:834
 #, elixir-autogen, elixir-format
 msgid "How it Works"
 msgstr ""
@@ -5843,12 +5843,12 @@ msgstr ""
 msgid "How quickly can I start accepting bookings?"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:541
+#: lib/klass_hero_web/components/marketing_components.ex:570
 #, elixir-autogen, elixir-format, fuzzy
 msgid "How to Grow Your Youth Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:871
+#: lib/klass_hero_web/components/marketing_components.ex:900
 #, elixir-autogen, elixir-format
 msgid "How we vet providers"
 msgstr ""
@@ -5899,7 +5899,7 @@ msgstr ""
 msgid "Join Berlin's growing network of trusted educators. Free to list. No setup fees."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:544
+#: lib/klass_hero_web/components/marketing_components.ex:573
 #, elixir-autogen, elixir-format
 msgid "Join Berlin's trusted network of educators. We handle payments, scheduling, and discovery — you focus on teaching."
 msgstr ""
@@ -5946,12 +5946,12 @@ msgstr ""
 msgid "Lead Instructor"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:554
+#: lib/klass_hero_web/components/marketing_components.ex:583
 #, elixir-autogen, elixir-format
 msgid "Learn How to Become a Hero →"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:861
+#: lib/klass_hero_web/components/marketing_components.ex:890
 #, elixir-autogen, elixir-format
 msgid "Learn how vetting works"
 msgstr ""
@@ -5981,12 +5981,12 @@ msgstr ""
 msgid "Linking..."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1116
+#: lib/klass_hero_web/components/marketing_components.ex:1145
 #, elixir-autogen, elixir-format
 msgid "List"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:572
+#: lib/klass_hero_web/components/marketing_components.ex:601
 #, elixir-autogen, elixir-format
 msgid "List Your Program"
 msgstr ""
@@ -6022,7 +6022,7 @@ msgstr ""
 msgid "Log out"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:868
+#: lib/klass_hero_web/components/marketing_components.ex:897
 #, elixir-autogen, elixir-format
 msgid "Looking for programs for your child?"
 msgstr ""
@@ -6072,7 +6072,7 @@ msgstr ""
 msgid "Minimum one year working with children, validated."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:136
+#: lib/klass_hero_web/components/marketing_components.ex:144
 #, elixir-autogen, elixir-format
 msgid "Mobile primary"
 msgstr ""
@@ -6097,7 +6097,7 @@ msgstr ""
 msgid "New program"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1127
+#: lib/klass_hero_web/components/marketing_components.ex:1156
 #, elixir-autogen, elixir-format
 msgid "Newest"
 msgstr ""
@@ -6112,7 +6112,7 @@ msgstr ""
 msgid "No credit card required"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:353
+#: lib/klass_hero_web/components/marketing_components.ex:361
 #, elixir-autogen, elixir-format
 msgid "No featured programs available right now. Check back soon."
 msgstr ""
@@ -6179,7 +6179,7 @@ msgstr ""
 msgid "Once your listing is live and you've completed Hero verification (typically 3–5 business days), parents can book immediately. Most providers receive their first inquiry within the first week."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1539
+#: lib/klass_hero_web/components/marketing_components.ex:1568
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Ongoing Quality"
 msgstr ""
@@ -6199,12 +6199,12 @@ msgstr ""
 msgid "Open inbox"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:111
+#: lib/klass_hero_web/components/marketing_components.ex:119
 #, elixir-autogen, elixir-format
 msgid "Open menu"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1367
+#: lib/klass_hero_web/components/marketing_components.ex:1396
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Our Commitment"
 msgstr ""
@@ -6239,7 +6239,7 @@ msgstr ""
 msgid "Parents discover you on Klass Hero. Approve manually or auto-accept — your call."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:583
+#: lib/klass_hero_web/components/marketing_components.ex:612
 #, elixir-autogen, elixir-format
 msgid "Parents find you through Klass Hero. Approve or auto-accept bookings with secure messaging built in."
 msgstr ""
@@ -6270,29 +6270,29 @@ msgstr ""
 msgid "Predictable income"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1129
+#: lib/klass_hero_web/components/marketing_components.ex:1158
 #, elixir-autogen, elixir-format
 msgid "Price: high to low"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1128
+#: lib/klass_hero_web/components/marketing_components.ex:1157
 #, elixir-autogen, elixir-format
 msgid "Price: low to high"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:814
+#: lib/klass_hero_web/components/marketing_components.ex:843
 #: lib/klass_hero_web/live/for_providers_live.ex:167
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Pricing"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:66
+#: lib/klass_hero_web/components/marketing_components.ex:74
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Primary"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:777
-#: lib/klass_hero_web/components/marketing_components.ex:824
+#: lib/klass_hero_web/components/marketing_components.ex:806
+#: lib/klass_hero_web/components/marketing_components.ex:853
 #: lib/klass_hero_web/live/privacy_policy_live.ex:238
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Privacy"
@@ -6333,7 +6333,7 @@ msgstr ""
 msgid "Questions about programs, bookings, or becoming a Hero — we read every message."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:680
+#: lib/klass_hero_web/components/marketing_components.ex:709
 #, elixir-autogen, elixir-format
 msgid "Questions, answered."
 msgstr ""
@@ -6348,8 +6348,8 @@ msgstr ""
 msgid "Ready to be a Hero?"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:878
-#: lib/klass_hero_web/components/marketing_components.ex:898
+#: lib/klass_hero_web/components/marketing_components.ex:907
+#: lib/klass_hero_web/components/marketing_components.ex:927
 #, elixir-autogen, elixir-format
 msgid "Ready to find your child's next adventure?"
 msgstr ""
@@ -6364,8 +6364,8 @@ msgstr ""
 msgid "Recent messages"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1126
-#: lib/klass_hero_web/components/marketing_components.ex:1138
+#: lib/klass_hero_web/components/marketing_components.ex:1155
+#: lib/klass_hero_web/components/marketing_components.ex:1167
 #, elixir-autogen, elixir-format
 msgid "Recommended"
 msgstr ""
@@ -6415,12 +6415,12 @@ msgstr ""
 msgid "Safety"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:983
+#: lib/klass_hero_web/components/marketing_components.ex:1012
 #, elixir-autogen, elixir-format
 msgid "Search programs, providers, neighborhoods..."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:256
+#: lib/klass_hero_web/components/marketing_components.ex:264
 #, elixir-autogen, elixir-format
 msgid "Search: coding, football, art..."
 msgstr ""
@@ -6435,7 +6435,7 @@ msgstr ""
 msgid "Secure payments, invoicing, and VAT handling"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:592
+#: lib/klass_hero_web/components/marketing_components.ex:621
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Secure weekly payouts. Insights into your business and opportunities to expand your impact."
 msgstr ""
@@ -6450,7 +6450,7 @@ msgstr ""
 msgid "See pricing"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:563
+#: lib/klass_hero_web/components/marketing_components.ex:592
 #, elixir-autogen, elixir-format
 msgid "See provider plans"
 msgstr ""
@@ -6480,8 +6480,8 @@ msgstr ""
 msgid "Setting up..."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:96
-#: lib/klass_hero_web/components/marketing_components.ex:168
+#: lib/klass_hero_web/components/marketing_components.ex:104
+#: lib/klass_hero_web/components/marketing_components.ex:176
 #: lib/klass_hero_web/live/user_live/login.ex:12
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sign in"
@@ -6492,8 +6492,8 @@ msgstr ""
 msgid "Sign in to continue. Don't have an account?"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:99
-#: lib/klass_hero_web/components/marketing_components.ex:173
+#: lib/klass_hero_web/components/marketing_components.ex:107
+#: lib/klass_hero_web/components/marketing_components.ex:181
 #: lib/klass_hero_web/live/user_live/registration.ex:12
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sign up"
@@ -6504,7 +6504,7 @@ msgstr ""
 msgid "Signed agreement on conduct and quality bar."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:155
+#: lib/klass_hero_web/components/marketing_components.ex:163
 #: lib/klass_hero_web/components/ui_components.ex:193
 #, elixir-autogen, elixir-format
 msgid "Signed in as"
@@ -6515,12 +6515,12 @@ msgstr ""
 msgid "Six checks. No shortcuts."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1053
+#: lib/klass_hero_web/components/marketing_components.ex:1082
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sort:"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:813
+#: lib/klass_hero_web/components/marketing_components.ex:842
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Start Teaching"
 msgstr ""
@@ -6571,7 +6571,7 @@ msgstr ""
 msgid "Talk to our team →"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:881
+#: lib/klass_hero_web/components/marketing_components.ex:910
 #: lib/klass_hero_web/live/about_live.ex:164
 #: lib/klass_hero_web/live/for_providers_live.ex:269
 #, elixir-autogen, elixir-format
@@ -6588,7 +6588,7 @@ msgstr ""
 msgid "Teaching Experience"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:858
+#: lib/klass_hero_web/components/marketing_components.ex:887
 #, elixir-autogen, elixir-format
 msgid "Teaching kids is your thing? Join as a Hero."
 msgstr ""
@@ -6598,8 +6598,8 @@ msgstr ""
 msgid "Tell us a bit about what you need — we'll route you to the right person."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:778
-#: lib/klass_hero_web/components/marketing_components.ex:825
+#: lib/klass_hero_web/components/marketing_components.ex:807
+#: lib/klass_hero_web/components/marketing_components.ex:854
 #: lib/klass_hero_web/live/terms_of_service_live.ex:259
 #, elixir-autogen, elixir-format
 msgid "Terms"
@@ -6650,7 +6650,7 @@ msgstr ""
 msgid "Trust &"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:235
+#: lib/klass_hero_web/components/marketing_components.ex:243
 #, elixir-autogen, elixir-format
 msgid "Trusted Heroes"
 msgstr ""
@@ -6690,7 +6690,7 @@ msgstr ""
 msgid "Vetted"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1213
+#: lib/klass_hero_web/components/marketing_components.ex:1242
 #, elixir-autogen, elixir-format, fuzzy
 msgid "View"
 msgstr ""
@@ -6700,7 +6700,7 @@ msgstr ""
 msgid "View all"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:432
+#: lib/klass_hero_web/components/marketing_components.ex:461
 #, elixir-autogen, elixir-format, fuzzy
 msgid "View →"
 msgstr ""
@@ -6781,12 +6781,12 @@ msgstr ""
 msgid "What's the verification process like?"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:888
+#: lib/klass_hero_web/components/marketing_components.ex:917
 #, elixir-autogen, elixir-format
 msgid "While you're here — explore programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:470
+#: lib/klass_hero_web/components/marketing_components.ex:499
 #: lib/klass_hero_web/live/for_providers_live.ex:72
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Why Klass Hero"
@@ -6867,7 +6867,7 @@ msgstr ""
 msgid "active"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:958
+#: lib/klass_hero_web/components/marketing_components.ex:987
 #, elixir-autogen, elixir-format, fuzzy
 msgid "activities"
 msgstr ""
@@ -6892,7 +6892,7 @@ msgstr ""
 msgid "families"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:237
+#: lib/klass_hero_web/components/marketing_components.ex:245
 #, elixir-autogen, elixir-format
 msgid "for Our Youth"
 msgstr ""
@@ -6902,12 +6902,12 @@ msgstr ""
 msgid "help"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1041
+#: lib/klass_hero_web/components/marketing_components.ex:1070
 #, elixir-autogen, elixir-format
 msgid "in"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1045
+#: lib/klass_hero_web/components/marketing_components.ex:1074
 #, elixir-autogen, elixir-format
 msgid "matching"
 msgstr ""
@@ -6918,7 +6918,7 @@ msgstr ""
 msgid "pending"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1039
+#: lib/klass_hero_web/components/marketing_components.ex:1068
 #, elixir-autogen, elixir-format, fuzzy
 msgid "program"
 msgid_plural "programs"
@@ -7239,7 +7239,7 @@ msgstr ""
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1455
+#: lib/klass_hero_web/components/marketing_components.ex:1484
 #, elixir-autogen, elixir-format
 msgid "Applicants submit a short recorded video (max 2 minutes) so we can assess communication skills and alignment with our values before approving their profile."
 msgstr ""
@@ -7595,17 +7595,22 @@ msgid_plural "%{count} children enrolled"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/components/program_components.ex:242
+#: lib/klass_hero_web/components/ui_components.ex:1927
 #, elixir-autogen, elixir-format
 msgid "This provider completed Klass Hero's verification checks"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:260
+#: lib/klass_hero_web/components/ui_components.ex:1943
 #, elixir-autogen, elixir-format
 msgid "This provider is working through Klass Hero's verification checks"
 msgstr ""
 
-#: lib/klass_hero_web/components/program_components.ex:263
+#: lib/klass_hero_web/components/ui_components.ex:1950
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Verification in progress"
+msgstr ""
+
+#: lib/klass_hero_web/components/ui_components.ex:1948
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Verifying"
 msgstr ""

--- a/test/klass_hero_web/live/program_card_trust_mark_test.exs
+++ b/test/klass_hero_web/live/program_card_trust_mark_test.exs
@@ -1,9 +1,12 @@
 defmodule KlassHeroWeb.ProgramCardTrustMarkTest do
   @moduledoc """
-  The provider row on a program card, across all three trust states (#1195).
+  The provider trust mark on both program cards, across all three states (#1195, #1224).
 
-  Scoped to `/programs`: the home page renders `mk_program_card`, a marketing
-  card with no provider row, so verification does not surface there yet.
+  Two cards, two densities, one mark. `/programs` and the parent dashboard render
+  `<.program_card>`, whose provider row carries an avatar, the name and a location.
+  The home page renders `mk_program_card`, a sparser marketing card that shows the
+  name and mark as plain text under the title and nothing else — the compact
+  variant, with the shorter in-progress label that keeps it on one line at 375px.
   """
   use KlassHeroWeb.ConnCase, async: true
 
@@ -63,6 +66,49 @@ defmodule KlassHeroWeb.ProgramCardTrustMarkTest do
       program = insert(:program_listing_schema, provider_id: Ecto.UUID.generate())
 
       html = card_html(conn, ~p"/programs", program.id)
+
+      refute html =~ ~s(data-testid="provider-trust-mark")
+    end
+  end
+
+  describe "home page featured cards" do
+    for {trust, expected} <- [verified: "verified", in_progress: "in_progress"] do
+      test "renders the #{trust} trust mark beside the provider name", %{conn: conn} do
+        provider = provider_with(unquote(trust))
+        program = insert(:program_listing_schema, provider_id: provider.id)
+
+        html = card_html(conn, ~p"/", program.id)
+
+        assert html =~ ~s(data-testid="provider-trust-mark")
+        assert html =~ ~s(data-trust-state="#{unquote(expected)}")
+        assert html =~ "Acme Activities"
+      end
+    end
+
+    test "uses the short in-progress label, not the listing page's long one", %{conn: conn} do
+      provider = provider_with(:in_progress)
+      program = insert(:program_listing_schema, provider_id: provider.id)
+
+      html = card_html(conn, ~p"/", program.id)
+
+      assert html =~ "Verifying"
+      refute html =~ "Verification in progress"
+    end
+
+    test "renders the provider name but no trust mark when unverified", %{conn: conn} do
+      provider = provider_with(:unverified)
+      program = insert(:program_listing_schema, provider_id: provider.id)
+
+      html = card_html(conn, ~p"/", program.id)
+
+      assert html =~ "Acme Activities"
+      refute html =~ ~s(data-testid="provider-trust-mark")
+    end
+
+    test "omits the provider entirely when the provider no longer exists", %{conn: conn} do
+      program = insert(:program_listing_schema, provider_id: Ecto.UUID.generate())
+
+      html = card_html(conn, ~p"/", program.id)
 
       refute html =~ ~s(data-testid="provider-trust-mark")
     end


### PR DESCRIPTION
Closes #1224.

## What this decides

#1224 was a decision ticket: the home page renders `mk_program_card`, a marketing card with no provider row, so #1218 deliberately left verification off it. Three options were on the table — nothing, a bare badge, or the full provider row from `program_card`. Both a design-system pass and a rendered UI pass were run before writing code.

**Result: none of the three.** What ships is the provider name plus a compact trust mark as plain text under the title — no avatar, no bordered row.

| Option | Why not |
|---|---|
| Nothing | Home is the first surface a prospective parent sees, and `TrustSafetyLive` already promises "Six checks. No shortcuts." |
| Bare badge, no name | With no adjacent name it sits among the price/category/schedule pills and reads as *listing* metadata, not a provider signal |
| Full provider row | At 375px the card is 327px wide; avatar + name + "Verification in progress" overflows, and `truncate` clips the name to "Studio Muel…" — in the state where identity matters most |

## Review focus

**The accessibility call is the one worth checking.** The static pass recommended rebuilding the mark on `kh_pill`'s `:success`/`:warning` tones, and there is shipped precedent for that (`provider_layout_components.ex:211`). Measured on the rendered node, those tones pair a tint background with a mid-tone accent color:

| | contrast | WCAG AA (4.5:1, 12px text) |
|---|---|---|
| `kh_pill` `:success` | 2.41:1 | fail |
| `kh_pill` `:warning` | 2.07:1 | fail |
| `Theme.status_badge(:available)` | 5.92:1 | pass |
| `Theme.status_badge(:limited)` | 5.30:1 | pass |

So the mark keeps `status_badge`'s colors and `kh_pill` gains a `:none` tone for callers supplying their own. Reconciling the two color systems — `Theme.status_badge/1`'s raw Tailwind pairs vs `kh_pill`'s CSS vars — is real but wider than this PR; filing separately.

**`/programs` should be pixel-identical.** `kh_pill`'s new `:xs` size reproduces the mark's previous geometry exactly (`gap-1 px-1.5 py-0.5 text-xs font-medium flex-shrink-0`), verified as `padding: 2px 6px`, `font-weight: 500` on the live node before and after.

## Changes

- `provider_trust_mark/1` → `UIComponents.kh_trust_mark/1`. It moved because `MarketingComponents` imports `UIComponents` through an explicit `only:` allowlist and importing a domain component module instead would break that discipline — nothing else in the codebase does it. No cycle: `UIComponents` is a leaf.
- `kh_pill` gains `size` (`:default` | `:xs`) and a `:none` tone. The `:xs` size also removes the need for a third `!`-override call site.
- `variant={:compact}` shortens the in-progress label to "Verifying" (`In Prüfung`), which keeps name + mark on one line on the narrower card.
- `HomeLive` re-adds `ProviderDisplay.for_programs/1` — two batched queries per render, no new denormalisation, consistent with `ProgramListing`'s documented decision to keep provider facts out of the read table.

## Test plan

- `mix precommit` green: 4089 passed, credo `--strict` clean, typography/translations/read-table lints pass.
- `program_card_trust_mark_test.exs` extended with a `home page featured cards` describe mirroring the `/programs` one: both trust states, unverified renders name but no mark, missing provider renders neither, plus an assertion that the home card uses the short label and not the long one.
- Verified in-browser at 375px and 1280px against seeded verified + in-progress providers: provider row is 20px (one line) on both, `name_truncated: false` even for a 30-character business name.

## Follow-ups worth filing

1. Reconcile `Theme.status_badge/1` and `kh_pill` tones — two token systems answering the same question, one of them failing AA.
2. Five other "verified" renderings exist across the codebase at four visual weights; this consolidates one of them.
3. Dev seed gaps found on the way: featured listings point at non-existent provider profiles, and all 133 listings have `age_range`/`pricing_period` null, so the meta row never renders in dev.