### PR TITLE
test: stop the 5k import test running 5000 Oban jobs in one transaction

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -84,3 +84,16 @@ Assert what the change *did*:
 
 An `assert_receive` still belongs on the UI notifications (`Participation.Notifications` and
 friends), which are plain `Phoenix.PubSub` broadcasts carrying tagged tuples.
+
+## Bulk Enqueues Also Need Manual Mode
+
+The sequencing above is not the only cost. `Oban.insert_all` inside a `Repo.transaction` under
+`testing: :inline` runs *every* job's DB work on the producer's connection, inside its
+transaction. At N jobs × k queries that crosses the connection timeout on a slow runner and
+surfaces as `DBConnection.ConnectionError` from a worker line that looks unrelated to the test
+(#1282: 5000 jobs × 3 queries, CI-only, ~2 failures in 6 runs).
+
+So a test driving a bulk enqueue wraps the call in `with_testing_mode(:manual, ...)` and asserts
+the job rows — see the 5k CSV import tests in
+`test/klass_hero_web/controllers/provider/enrollment_import_controller_test.exs` and
+`test/klass_hero/enrollment/import_enrollment_csv_test.exs`.

--- a/test/klass_hero_web/controllers/provider/enrollment_import_controller_test.exs
+++ b/test/klass_hero_web/controllers/provider/enrollment_import_controller_test.exs
@@ -219,10 +219,10 @@ defmodule KlassHeroWeb.Provider.EnrollmentImportControllerTest do
     end
   end
 
-  # 5k rows costs ~8s, hence :slow. See test/test_helper.exs for what opts it back in.
+  # 5k rows is :slow even in manual mode. See test/test_helper.exs for what opts it back in.
   describe "POST /provider/enrollment/import (5k rows)" do
     @tag :slow
-    test "imports 5000 rows in a single transaction" do
+    test "imports 5000 rows and enqueues one invite email each" do
       %{conn: conn, provider: provider} = register_and_log_in_provider(%{conn: build_conn()})
       insert(:program_schema, provider_id: provider.id, title: "Ballsports & Parkour")
 
@@ -238,10 +238,17 @@ defmodule KlassHeroWeb.Provider.EnrollmentImportControllerTest do
 
       path = rows |> build_csv() |> write_temp()
 
-      conn = post(conn, ~p"/provider/enrollment/import", %{"file" => upload(path)})
+      # `testing: :inline` would run all 5000 SendInviteEmailWorker jobs inside the enqueue's
+      # own transaction — ~15k serialized queries on one connection, which crosses the
+      # connection timeout on a slow runner (#1282). Manual mode inserts them as rows instead.
+      conn =
+        Oban.Testing.with_testing_mode(:manual, fn ->
+          post(conn, ~p"/provider/enrollment/import", %{"file" => upload(path)})
+        end)
 
       assert json_response(conn, 201) == %{"created" => 5_000, "failed" => []}
       assert KlassHero.Repo.aggregate(BulkEnrollmentInvite, :count) == 5_000
+      assert KlassHero.Repo.aggregate(Oban.Job, :count) == 5_000
     end
   end
 end


### PR DESCRIPTION
Closes #1282

## Summary

`config/test.exs` sets `Oban, testing: :inline`, which executes a job **at insert**, on the caller's connection. `EnqueueInviteEmails` calls `Oban.insert_all` inside its own `Repo.transaction` (deliberately — a token written without its job is an invite nobody is ever told about). So the 5k import test ran all 5000 `SendInviteEmailWorker` jobs inside that one transaction: each does `get_invite` plus `transition_invite` (`Repo.get` + `Repo.update`), roughly **15,000 serialized queries on one connection** against the 15s default timeout. On CI's slower runner that was a coin flip — ~2 failures in 6 runs on byte-identical commits.

Production is unaffected: Oban is not inline there, so `insert_all` writes 5000 rows and the workers drain off the `:email` queue later. **No lib code changes.**

## What changed

- Wrap the request in `Oban.Testing.with_testing_mode(:manual, ...)` — the idiom `.claude/rules/testing.md` already prescribes, and which the sibling 5k test (`import_enrollment_csv_test.exs`) already uses at the same scale. This one was simply missed.
- Add `assert Repo.aggregate(Oban.Job, :count) == 5_000`. Not decoration: it replaces the coverage inline mode gave implicitly (emails actually sending). Without it, switching modes would silently drop all evidence the enqueue happened.
- Rename the test. The import inserts row-by-row through chunked `Enum.reduce_while` with no wrapping transaction, so "in a single transaction" described only the enqueue transaction it accidentally stressed.
- Document the failure shape in `.claude/rules/testing.md`. The existing section covers inline mode's *sequencing* cost; this adds the *scale* cost, which is a different symptom (a timeout from a worker line that looks unrelated to the test).

## Review focus

Whether the job-count assertion is the right replacement for what inline execution covered implicitly. The alternative was `use Oban.Testing` + `assert_enqueued`, which is awkward at 5000 jobs.

## Test plan

Red → green, then the mechanism proven directly by lowering the Repo timeout locally (probe reverted, not committed):

| | pre-fix | post-fix |
|---|---|---|
| job-count assertion, default timeout | fails `0 == 5000` | passes |
| **6s** `timeout`/`ownership_timeout` | dies at `Inline.execute_job -> SendInviteEmailWorker.execute/1 -> get_invite` with the issue's exact `DBConnection.ConnectionError` | passes in 2.4s |

Same config, same data — only the Oban mode differs, which isolates the 15k in-transaction queries as the whole cost. (At a 2s budget it dies earlier, in `process_invites`: the budget is consumed by the transaction as a whole, so which query holds the connection when it expires is arbitrary. That is why the CI stack shows `transition_invite` and the probe shows `get_invite`.)

- Controller test file: **9.8s → 3.1s** for all three affected files together (42 tests, both 5k tests included)
- Sibling `import_enrollment_csv_test.exs` untouched and green — its two small-N tests rely on inline execution deliberately
- `MIX_TEST_PARTITION=1282 mix precommit`: **4082 passed**, credo/typography/translations/read-tables clean