### PR TITLE
chore: prune job_compensations after 14 days

### DIFF
--- a/lib/klass_hero/shared/adapters/driven/persistence/repositories/job_compensation_repository.ex
+++ b/lib/klass_hero/shared/adapters/driven/persistence/repositories/job_compensation_repository.ex
@@ -22,6 +22,8 @@ defmodule KlassHero.Shared.Adapters.Driven.Persistence.Repositories.JobCompensat
 
   use KlassHero.Shared.Interaction
 
+  import Ecto.Query
+
   alias KlassHero.Repo
   alias KlassHero.Shared.Adapters.Driven.Persistence.Schemas.JobCompensation
 
@@ -51,6 +53,25 @@ defmodule KlassHero.Shared.Adapters.Driven.Persistence.Repositories.JobCompensat
         end
       end)
       |> unwrap_transaction_result()
+    end
+  end
+
+  @doc """
+  Deletes markers compensated before `cutoff`, returning how many went.
+
+  Cutting on `compensated_at` rather than the job's `discarded_at` is deliberate and
+  safe in the conservative direction: a marker can only be written while the sweep's
+  join still sees the `oban_jobs` row, so `compensated_at >= discarded_at` always, and
+  a cutoff measured from it therefore lands no earlier than the same span measured
+  from the job's own clock. The caller owns the span — see `CompensationSweepWorker`.
+  """
+  @spec prune(DateTime.t()) :: non_neg_integer()
+  def prune(%DateTime{} = cutoff) do
+    db_interaction operation: :prune, entity: "job_compensation" do
+      {deleted, _returning} =
+        Repo.delete_all(from(compensation in JobCompensation, where: compensation.compensated_at < ^cutoff))
+
+      deleted
     end
   end
 

--- a/lib/klass_hero/shared/adapters/driven/workers/compensation_sweep_worker.ex
+++ b/lib/klass_hero/shared/adapters/driven/workers/compensation_sweep_worker.ex
@@ -49,6 +49,23 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.CompensationSweepWorker do
   # realistic "what did we lose?" investigation still finds the payload.
   @undelivered_retention_days 90
 
+  # A marker carries no personal data; it only has to outlive the `oban_jobs` row it guards,
+  # which the Pruner deletes at 7 days. Everything past that is margin for the Pruner running
+  # behind — it prunes only while a node is up, and 10_000 rows at a time. Shortening this
+  # below the Pruner window deletes a marker whose job is still discardable and hands the same
+  # job back to the sweep for a second compensation; `KlassHero.ObanConfigTest` is what stops
+  # that going unnoticed.
+  @job_compensation_retention_days 14
+
+  @doc """
+  How long a compensation marker is kept, in days.
+
+  Public because the coupling to `Oban.Plugins.Pruner`'s window is asserted in
+  `KlassHero.ObanConfigTest`, which reads config rather than module attributes.
+  """
+  @spec job_compensation_retention_days() :: pos_integer()
+  def job_compensation_retention_days, do: @job_compensation_retention_days
+
   @impl true
   def execute(%Oban.Job{}) do
     pending = uncompensated_jobs()
@@ -59,11 +76,12 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.CompensationSweepWorker do
 
     Enum.each(pending, &compensate_job/1)
     prune_undelivered_events()
+    prune_job_compensations()
     :ok
   end
 
-  # Rides the 5-minute tick rather than a cron of its own: an indexed delete over a
-  # table that is empty in the healthy case costs nothing, and the alternative is a
+  # Both prunes ride the 5-minute tick rather than a cron of their own: an indexed delete
+  # over a table that is empty in the healthy case costs nothing, and the alternative is a
   # second schedule to keep in agreement with this one.
   defp prune_undelivered_events do
     cutoff = DateTime.add(DateTime.utc_now(), -@undelivered_retention_days, :day)
@@ -71,6 +89,17 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.CompensationSweepWorker do
     case UndeliveredEventRepository.prune(cutoff) do
       0 -> :ok
       pruned -> Logger.info("Pruned #{pruned} undelivered event(s) past #{@undelivered_retention_days} days")
+    end
+  end
+
+  # After the compensation pass, not before: pruning first could delete a marker and hand
+  # its job straight back to `uncompensated_jobs/0` in the same tick.
+  defp prune_job_compensations do
+    cutoff = DateTime.add(DateTime.utc_now(), -@job_compensation_retention_days, :day)
+
+    case JobCompensationRepository.prune(cutoff) do
+      0 -> :ok
+      pruned -> Logger.info("Pruned #{pruned} compensation marker(s) past #{@job_compensation_retention_days} days")
     end
   end
 

--- a/priv/repo/migrations/20260802090000_create_job_compensations.exs
+++ b/priv/repo/migrations/20260802090000_create_job_compensations.exs
@@ -10,6 +10,13 @@ defmodule KlassHero.Repo.Migrations.CreateJobCompensations do
   `job_id` is unique because that uniqueness *is* the exactly-once guarantee —
   the sweep inserts the marker and runs the compensation in one transaction, so
   a duplicate is refused by the database rather than by careful code.
+
+  Rows are pruned after 14 days by `CompensationSweepWorker` (#1246). A marker
+  stops being load-bearing the moment the `oban_jobs` row it guards is gone, so
+  the rule is the Pruner's 7-day window plus margin — long enough that the marker
+  always outlives its job, short enough that the table has an owner. Shortening it
+  under the Pruner window re-compensates a job that already was; `oban_config_test`
+  fails if anyone tries.
   """
 
   use Ecto.Migration

--- a/priv/repo/migrations/20260805070000_index_job_compensations_compensated_at.exs
+++ b/priv/repo/migrations/20260805070000_index_job_compensations_compensated_at.exs
@@ -1,0 +1,15 @@
+defmodule KlassHero.Repo.Migrations.IndexJobCompensationsCompensatedAt do
+  @moduledoc """
+  The access path for the retention prune added in #1246.
+
+  Every other read of `job_compensations` is either the exactly-once lookup on the
+  unique `job_id` or a human looking at a handful of rows, so this is the only
+  other index worth its write cost.
+  """
+
+  use Ecto.Migration
+
+  def change do
+    create index(:job_compensations, [:compensated_at])
+  end
+end

--- a/test/config/oban_config_test.exs
+++ b/test/config/oban_config_test.exs
@@ -51,6 +51,20 @@ defmodule KlassHero.ObanConfigTest do
       assert max_age > 3600,
              "Pruner max_age (#{max_age}s) leaves too little room for the sweep at #{expression}"
     end
+
+    # The other end of the same coupling. A marker exists to stop the sweep reaching a job it
+    # already compensated; delete it while that job row survives and the sweep compensates the
+    # job a second time. Neither side can see the other — the retention is a module attribute,
+    # the window is config — so this is the only place the two are compared.
+    test "keeps compensation markers longer than the job rows they guard" do
+      retention = CompensationSweepWorker.job_compensation_retention_days() * 86_400
+      max_age = Oban.Plugins.Pruner |> plugin_opts() |> Keyword.get(:max_age, 60)
+
+      assert retention > max_age,
+             "job_compensations retention (#{retention}s) is shorter than the Pruner window " <>
+               "(#{max_age}s) — a marker can be deleted while its job row is still discardable, " <>
+               "and the next sweep compensates that job twice"
+    end
   end
 
   # config/test.exs adds only `testing: :inline` and Config.Reader deep-merges, so the plugin list

--- a/test/klass_hero/shared/adapters/driven/workers/compensation_sweep_worker_test.exs
+++ b/test/klass_hero/shared/adapters/driven/workers/compensation_sweep_worker_test.exs
@@ -121,6 +121,35 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.CompensationSweepWorkerTest d
     end
   end
 
+  # 14 days, against the Pruner's 7. `oban_config_test` guards that ordering; these two guard
+  # that the prune runs at all and cuts where it says it does.
+  describe "compensation markers" do
+    for {age_days, kept?} <- [{13, true}, {15, false}] do
+      test "a marker written #{age_days} days ago is #{if kept?, do: "kept", else: "pruned"}" do
+        job_id = stale_marker(unquote(age_days))
+
+        assert :ok = CompensationSweepWorker.perform(%Oban.Job{})
+
+        assert Repo.get_by(JobCompensation, job_id: job_id) != nil == unquote(kept?),
+               "expected a #{unquote(age_days)}-day-old marker to be #{unquote(if kept?, do: "kept", else: "pruned")}"
+      end
+    end
+
+    # Pins where the safety actually comes from. The prune has no join back to `oban_jobs`, so
+    # an expired marker goes whether or not its job survives; nothing but the retention being
+    # longer than the Pruner window keeps the two from overlapping.
+    test "prunes an expired marker even while its job row survives" do
+      reply = pending_reply()
+      job = discarded_job(@registered, %{"reply_id" => reply.id})
+      stale_marker(15, job.id)
+
+      assert :ok = CompensationSweepWorker.perform(%Oban.Job{})
+
+      refute Repo.get_by(JobCompensation, job_id: job.id)
+      assert reply_status(reply) == :sending, "the marker should have excluded this job from the sweep"
+    end
+  end
+
   describe "reason_from/1" do
     test "returns the last recorded error string" do
       job = %Oban.Job{
@@ -168,6 +197,21 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.CompensationSweepWorkerTest d
     ])
 
     event_id
+  end
+
+  # Same shortcut as `stale_record/1`. The default `job_id` deliberately matches no
+  # `oban_jobs` row, so a marker staged this way cannot be re-created by the same sweep —
+  # `uncompensated_jobs/0` joins *from* the job table.
+  defp stale_marker(age_days, job_id \\ 999_999) do
+    Repo.insert_all(JobCompensation, [
+      %{
+        job_id: job_id,
+        worker: @registered,
+        compensated_at: DateTime.add(DateTime.utc_now(), -age_days, :day)
+      }
+    ])
+
+    job_id
   end
 
   # Written straight to the table: Oban's own insert path cannot leave a row in a


### PR DESCRIPTION
## Summary

`job_compensations` (added in #1244) had no deleter. This gives it one: rows are pruned 14 days after `compensated_at`, by the sweep that already runs every 5 minutes.

**Why 14, and why measured from `compensated_at`:**

A marker's only job is to stop the sweep re-compensating a job it can no longer see. It stops being load-bearing the moment `Oban.Plugins.Pruner` deletes the `oban_jobs` row it guards — 7 days here. So the correctness floor is 7 days; 14 is that plus margin for the Pruner running behind (it prunes only while a node is up, 10 000 rows at a time).

Cutting on `compensated_at` rather than the job's `discarded_at` is conservative in the safe direction: a marker can only be written while the sweep's join still sees the job row, so `compensated_at >= discarded_at` always, and the cutoff therefore lands no earlier than the same span measured from the job's own clock.

Deliberately **not** 90 days like the sibling `undelivered_events`. That number is a GDPR-shaped rule — its payload carries personal data. A marker carries `job_id`/`worker`/`compensated_at`, so its retention is purely mechanical.

## Review Focus

**The one-directional coupling.** Retention shorter than the Pruner window deletes a marker whose job is still discardable, and the next sweep compensates that job a second time. Neither side can see the other — the retention is a module attribute, the window is config — so `test/config/oban_config_test.exs` now compares them directly, next to the existing Pruner/crontab guards. That is the assertion worth scrutinising.

**Ordering inside `execute/1`.** The prune runs *after* the compensation pass. Reversed, a tick could delete an expired marker and hand the very same job back to `uncompensated_jobs/0` within that same run.

**No join back to `oban_jobs`.** The prune is unconditional; all the safety comes from the retention exceeding the Pruner window. `"prunes an expired marker even while its job row survives"` pins that deliberately, so nobody later mistakes the ordering guarantee for a query guarantee.

## Test Plan

Full suite green (4091 passed) on `--seed 495890`.

Both new guards were mutation-proved rather than assumed:

- retention → `5`: the `oban_config_test` guard fails, as designed
- retention → `20`: both 15-day cases fail — confirming the "even while its job row survives" test is not vacuous

New coverage:

- `{13, true}` / `{15, false}` boundary pair over the prune, matching the shape used for `undelivered_events`
- the expired-marker-with-surviving-job case above
- the config-level coupling guard

Migration is an additive index on `job_compensations(compensated_at)` — the prune's access path, and the only read of that table that is not the unique `job_id` lookup or a human.

Closes #1246
