### PR TITLE
fix: retry a tokenless invite's failing write instead of cancelling

### DIFF
--- a/lib/klass_hero/enrollment/adapters/driving/workers/send_invite_email_worker.ex
+++ b/lib/klass_hero/enrollment/adapters/driving/workers/send_invite_email_worker.ex
@@ -30,23 +30,53 @@ defmodule KlassHero.Enrollment.Adapters.Driving.Workers.SendInviteEmailWorker do
 
         :ok
 
-      # Every retry re-reads the same nil token, so the remaining attempts are
-      # guaranteed waste — cancel rather than spend them. Failing the invite here is
-      # what makes it visible: left :pending it would sit forever with no email sent
-      # and nothing to show the provider. A resend mints a fresh token.
+      # Failing the invite here is what makes it visible: left :pending it would sit
+      # forever with no email sent and nothing to show the provider. A resend mints a
+      # fresh token.
       {:ok, %BulkEnrollmentInvite{invite_token: nil} = invite} ->
         Logger.warning("[SendInviteEmailWorker] Invite has no token", invite_id: invite_id)
 
-        Enrollment.transition_invite(invite, %{
+        invite
+        |> Enrollment.transition_invite(%{
           status: :failed,
           error_details: "Invite link could not be generated (no token). Please resend."
         })
-
-        {:cancel, "invite has no token"}
+        |> resolve_tokenless(job)
 
       {:ok, %BulkEnrollmentInvite{} = invite} ->
         send_and_transition(invite, program_name, job)
     end
+  end
+
+  @doc """
+  The Oban outcome a tokenless invite deserves, given whether failing it stuck.
+
+  Split from the branch it serves because no fixture can reach the error arm: the
+  non-pending guard in `execute/1` catches every invite that is not `:pending` before
+  the branch runs, and `transition_changeset/2` validates against the refetched row,
+  so `pending -> :failed` is legal by the time we get here. Injecting the result is
+  the only way this decision goes red.
+  """
+  @spec resolve_tokenless({:ok, BulkEnrollmentInvite.t()} | {:error, term()}, Oban.Job.t()) ::
+          {:cancel, String.t()} | {:error, term()}
+  # The nil token is beyond retry — every attempt re-reads it — so once the invite is
+  # marked failed there is nothing left worth spending attempts on.
+  def resolve_tokenless({:ok, _invite}, %Oban.Job{}), do: {:cancel, "invite has no token"}
+
+  # The token is beyond retry; this write is not. `{:cancel, _}` would land the job in
+  # `cancelled`, which the compensation sweep does not scan — cancelling is a decision
+  # the code made rather than a death it failed to observe — so a lost write would
+  # leave the invite :pending forever with nothing to retry it (#1248). Erroring hands
+  # it back to Oban, and the final attempt to the sweep.
+  def resolve_tokenless({:error, reason}, %Oban.Job{} = job) do
+    Logger.critical("[SendInviteEmailWorker] Could not fail a tokenless invite",
+      invite_id: job.args["invite_id"],
+      reason: inspect(reason)
+    )
+
+    TracedWorker.compensate_if_final(__MODULE__, job, reason)
+
+    {:error, reason}
   end
 
   defp send_and_transition(invite, program_name, job) do

--- a/lib/klass_hero/shared/adapters/driven/workers/compensation_sweep_worker.ex
+++ b/lib/klass_hero/shared/adapters/driven/workers/compensation_sweep_worker.ex
@@ -15,6 +15,14 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.CompensationSweepWorker do
   The job row is the only durable trace — Lifeline's telemetry carries ids and
   nothing else — so reconciliation reads the table rather than listening for events.
 
+  `cancelled` is deliberately **not** swept. A cancel is a decision the worker made,
+  not a death it failed to observe, and re-deciding it here would override the one
+  branch that had the context to judge. The obligation that falls out: a worker
+  returning `{:cancel, _}` after a compensating write of its own must resolve that
+  write itself, because nothing downstream will. `SendInviteEmailWorker`'s tokenless
+  branch is the only such site — it returns `{:error, _}` when its write fails, so the
+  retry machinery and then this sweep still apply (#1248).
+
   Scope is the `CompensatingWorkerRegistry` list, filtered in SQL. Without that, a
   discarded job from a worker that never compensates would be re-examined on every
   tick for as long as the Pruner keeps its row.

--- a/test/klass_hero/enrollment/adapters/driving/workers/send_invite_email_worker_test.exs
+++ b/test/klass_hero/enrollment/adapters/driving/workers/send_invite_email_worker_test.exs
@@ -1,6 +1,7 @@
 defmodule KlassHero.Enrollment.Adapters.Driving.Workers.SendInviteEmailWorkerTest do
   use KlassHero.DataCase, async: true
 
+  import ExUnit.CaptureLog
   import KlassHero.Factory
   import Swoosh.TestAssertions
 
@@ -147,6 +148,62 @@ defmodule KlassHero.Enrollment.Adapters.Driving.Workers.SendInviteEmailWorkerTes
 
       assert {:error, _reason} =
                SendInviteEmailWorker.execute(job(invite, program, @max_attempts))
+    end
+  end
+
+  # #1248: the tokenless branch used to discard this transition's result and return
+  # {:cancel, _} regardless. A cancelled job is out of the compensation sweep's scope
+  # on purpose, so a failed write left the invite :pending forever with nothing to
+  # retry it and nothing logged.
+  #
+  # The result is injected because no fixture can produce it: the non-pending guard in
+  # execute/1 catches every invite that is not :pending before this branch, and
+  # transition_changeset validates against the refetched row — so by the time the
+  # branch runs, pending -> :failed is always legal.
+  describe "resolve_tokenless/2" do
+    setup :create_pending_invite
+
+    test "cancels once the invite is marked failed", %{invite: invite, program: program} do
+      assert {:cancel, "invite has no token"} =
+               SendInviteEmailWorker.resolve_tokenless({:ok, invite}, job(invite, program, 1))
+
+      assert reload(invite).status == :pending,
+             "resolve_tokenless/2 should not write; the caller already did"
+    end
+
+    test "retries a failed write while attempts remain", %{invite: invite, program: program} do
+      assert {:error, :not_found} =
+               SendInviteEmailWorker.resolve_tokenless({:error, :not_found}, job(invite, program, 1))
+
+      assert reload(invite).status == :pending,
+             "compensated while retries remained, destroying the write the next attempt makes"
+    end
+
+    test "compensates a failed write on the final attempt", %{invite: invite, program: program} do
+      assert {:error, :not_found} =
+               SendInviteEmailWorker.resolve_tokenless(
+                 {:error, :not_found},
+                 job(invite, program, @max_attempts)
+               )
+
+      # The reason reads "Email delivery failed" because compensate/2 is shared with the
+      # delivery path, and the sweep that also calls it has only the job row to go on.
+      # Imprecise, but the provider still sees Failed rather than a silent :pending.
+      failed = reload(invite)
+      assert failed.status == :failed
+      assert failed.error_details =~ "not_found"
+    end
+
+    # Returning the error is what retries it; the log is what makes a write that keeps
+    # failing visible before the retries run out.
+    test "logs the failed write at :critical", %{invite: invite, program: program} do
+      log =
+        capture_log(fn ->
+          SendInviteEmailWorker.resolve_tokenless({:error, :not_found}, job(invite, program, 1))
+        end)
+
+      assert log =~ "[critical]"
+      assert log =~ "tokenless invite"
     end
   end
 end


### PR DESCRIPTION
Closes #1248.

## Summary

`SendInviteEmailWorker`'s tokenless branch discarded the result of the transition that marks the invite `:failed`, then returned `{:cancel, _}` regardless. A cancelled job is out of `CompensationSweepWorker`'s scope on purpose, so a failed write left the invite `:pending` forever — no email sent, nothing to show the provider, nothing to retry it, and nothing logged.

The branch applied the token's verdict to the write. *"No retry can help"* is true of the `nil` token, which every attempt re-reads, but false of the write, which is exactly what a retry heals. This splits them: `{:ok, _}` → cancel, `{:error, _}` → log at `:critical`, `compensate_if_final`, and return the error so Oban retries and the last attempt reaches the sweep.

Retrying is provably harmless: if the transition *did* succeed, status is `:failed` and the non-pending guard returns `:ok` on re-entry.

## Review focus

**Why a new public function rather than an inline `case`.** The error arm cannot be reached by any fixture: the non-pending guard catches every invite that is not `:pending` *before* the branch runs, and `transition_changeset/2` validates against the **refetched** row — so `pending -> :failed` is always legal by the time we get there. Injecting the result is the only way the decision goes red. `CompensationSweepWorker.reason_from/1` is the in-repo precedent for a small public documented function on a worker.

**Two premise corrections to the issue**, both verified:

- It says *"every `{:cancel, _}` compensation across the codebase is unbackstopped"* — there is exactly **one** `{:cancel, _}` in `lib/` (this one). The only other hit is `TracedWorker.record_result/2` handling the atom.
- It says the *"inline comment added in #1244 naming this as an accepted gap should be updated"* — no such comment existed. #1244 added `compensate/2` + `compensate_if_final`; the comment there argued cancel-over-retry and never mentioned the sweep. So this **adds** the statement, in the sweep's moduledoc where it covers every future caller rather than this one site.

**Reachability, for sizing the risk.** The branch is near-unreachable in the first place: `EnqueueInviteEmails` commits token assignment and job insert in one transaction, and `resend_invite/2` wraps reset-then-re-token in an `Ecto.Multi`, so no observer sees `pending` + `nil` token. This hardens a defensive guard; it is not a live-bug fix.

One known imprecision, left alone deliberately: on the compensated path the provider sees `"Email delivery failed: …"` even though the cause was a missing token, because `compensate/2` is shared with the delivery path and the sweep that also calls it has only the job row to go on. Noted at the assertion rather than widened into this PR.

## Test plan

- `mix precommit` — 4091 passed, credo `--strict` 0 issues, typography/translation/read-table lints clean
- 4 new tests in `send_invite_email_worker_test.exs`, each confirmed to fail first with `UndefinedFunctionError` before the implementation landed: cancel on `{:ok, _}`; error + invite still `:pending` while attempts remain; error + invite `:failed` on the final attempt; `:critical` log on the failing write
- The pre-existing end-to-end `perform/1` test for this branch is unchanged and still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)