### PR TITLE
feat: make staff deactivation a real domain operation

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -105,8 +105,13 @@ _Avoid_: Teacher, Coach, Trainer (those are **Roles**, not the lead responsibili
 A **Staff Member**'s specific job title — freeform text such as "Coach" or "Teacher". Distinct from **Instructor**, which is the lead responsibility for a Program/Session, not a title.
 _Avoid_: Position, Title, Type
 
+**Deactivation**:
+Ending a **Staff Member**'s employment link — they no longer work for that **Provider**. Reversible (*reactivation*), and deliberately narrow: any **Instructor** role they held is cleared and an outstanding invitation is revoked, but their **Program Staff Assignments** and conversation membership survive, because unassigning would destroy access that reactivation cannot give back. Reactivation restores only the employment: the Instructor role and the invitation stay gone.
+Distinct from two neighbours that land on the same `active` column: **removal** (a hard delete of the row, the Team tab's "remove member") and **erasure** (GDPR, which deactivates *and* scrubs PII). Deactivation alone says nothing about why.
+_Avoid_: Disable, Archive, Soft-delete, Suspend, Terminate
+
 **Program Staff Assignment**:
-The link recording that a **Staff Member** works on a **Program**. Many Staff Members may be assigned to one Program because a class can need several people.
+The link recording that a **Staff Member** works on a **Program**. Many Staff Members may be assigned to one Program because a class can need several people. Survives the Staff Member's **deactivation**.
 _Avoid_: Membership, Posting
 
 ## Families & Accounts

--- a/config/config.exs
+++ b/config/config.exs
@@ -262,6 +262,12 @@ config :klass_hero, :event_consumers, %{
     {StaffAssignmentHandler, :handle_event},
     {ProviderSessionDetails, :project}
   ],
+  # Deliberately NOT routed to StaffAssignmentHandler: deactivation ends the
+  # employment link but leaves assignments standing, so conversation membership
+  # survives — reactivating cannot give it back (#1237).
+  "integration:provider:staff_member_deactivated" => [
+    {ProviderSessionDetails, :project}
+  ],
   # `integration:provider:provider_verified` / `provider_unverified` have no consumers
   # since #1195: program cards read trust state from Provider's facade per render rather
   # than from a denormalised column. The events are still produced (the `verified` fact

--- a/lib/klass_hero/provider.ex
+++ b/lib/klass_hero/provider.ex
@@ -208,6 +208,12 @@ defmodule KlassHero.Provider do
   @doc "Deletes a staff member owned by `provider_id`; foreign ≡ missing."
   defdelegate delete_staff_member(staff_id, provider_id), to: Staff
 
+  @doc "Ends a staff member's employment link: clears their lead flags, revokes any invitation, stages the event."
+  defdelegate deactivate_staff_member(staff_member), to: Staff
+
+  @doc "Reinstates a staff member's employment link; does not restore lead flags or invitations."
+  defdelegate reactivate_staff_member(staff_member), to: Staff
+
   @doc "Resends a staff invitation for a `:failed`/`:expired` member owned by `provider_id`."
   defdelegate resend_staff_invitation(provider_id, staff_member_id), to: Staff
 

--- a/lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex
+++ b/lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex
@@ -361,21 +361,34 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
 
   defp warn_if_missing(_result, _event_name, _metadata), do: :ok
 
+  # Deliberately the same LATERAL shape as bootstrap_session_details/0, not a
+  # second spelling of it: both answer "which staff member is currently assigned
+  # to this program", and the two must agree or a rebuild silently rewrites what
+  # the incremental path wrote.
+  #
+  # `sm.active` is inside the LATERAL, so a deactivated staff member is skipped
+  # rather than selected-then-blanked. Deactivation leaves assignments standing on
+  # purpose, so a departed staff member stays the earliest-assigned row forever —
+  # filtering on the join alone would still pick their assignment and merely lose
+  # their name.
   defp resolve_program_context(program_id) do
     sql = """
     SELECT p.title,
            p.provider_id,
-           psa.staff_member_id,
-           sm.first_name,
-           sm.last_name
+           staff.staff_member_id,
+           staff.first_name,
+           staff.last_name
     FROM programs p
-    LEFT JOIN program_staff_assignments psa
-           ON psa.program_id = p.id
-          AND psa.unassigned_at IS NULL
-    LEFT JOIN staff_members sm ON sm.id = psa.staff_member_id
+    LEFT JOIN LATERAL (
+      SELECT psa.staff_member_id, sm.first_name, sm.last_name
+      FROM program_staff_assignments psa
+      JOIN staff_members sm ON sm.id = psa.staff_member_id AND sm.active
+      WHERE psa.program_id = p.id
+        AND psa.unassigned_at IS NULL
+      ORDER BY psa.assigned_at ASC
+      LIMIT 1
+    ) staff ON TRUE
     WHERE p.id = $1
-    ORDER BY psa.assigned_at ASC NULLS LAST
-    LIMIT 1
     """
 
     case Repo.query(sql, [Ecto.UUID.dump!(program_id)]) do

--- a/lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex
+++ b/lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex
@@ -39,7 +39,8 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
       "integration:participation:child_checked_out",
       "integration:participation:child_marked_absent",
       "integration:provider:staff_assigned_to_program",
-      "integration:provider:staff_unassigned_from_program"
+      "integration:provider:staff_unassigned_from_program",
+      "integration:provider:staff_member_deactivated"
     ]
 
   use KlassHero.Shared.Projection.WithBootstrapRetry
@@ -149,6 +150,29 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
     )
   end
 
+  # Scoped by staff member, not by program: deactivation ends the employment link
+  # itself, so it reaches every program they were on. Historical rows keep their
+  # attribution, matching :staff_unassigned_from_program.
+  #
+  # This clause is why the event exists. The other staff-name consumers can filter
+  # `s.active` on read; this one cannot, because the name is a stored column — so
+  # without it a deactivated (or erased) staff member stays named here until a
+  # restart rebuilds the projection.
+  def handle_event(:staff_member_deactivated, %Event{payload: %{staff_member_id: staff_member_id}}) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    from(d in SessionDetail,
+      where: d.current_assigned_staff_id == ^staff_member_id and d.status == :scheduled
+    )
+    |> Repo.update_all(
+      set: [
+        current_assigned_staff_id: nil,
+        current_assigned_staff_name: nil,
+        updated_at: now
+      ]
+    )
+  end
+
   # Rebuilds from programs + program_sessions + staff assignments + participation counts.
   # Design notes:
   # * UUIDs cast to ::text so Postgrex returns strings (Ecto :binary_id accepts them on insert).
@@ -159,6 +183,11 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
     # LATERAL subquery picks exactly one active staff assignment (earliest-assigned wins, matching
     # resolve_program_context/1). Without LIMIT 1 a program with N staff would produce N rows per
     # session and break the ON CONFLICT target.
+    #
+    # `sm.active` is an inner join, not a filter on a LEFT JOIN: a deactivated staff member must not
+    # win the LIMIT 1 and shadow a still-active colleague. Without it a rebuild would resurrect the
+    # attribution the :staff_member_deactivated clause cleared — an erased user's name reappearing
+    # in a read table on the next restart (#1237).
     sql = """
     SELECT
       ps.id::text                            AS session_id,
@@ -179,7 +208,7 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
     LEFT JOIN LATERAL (
       SELECT psa.staff_member_id, sm.first_name, sm.last_name
       FROM program_staff_assignments psa
-      LEFT JOIN staff_members sm ON sm.id = psa.staff_member_id
+      JOIN staff_members sm ON sm.id = psa.staff_member_id AND sm.active
       WHERE psa.program_id = ps.program_id
         AND psa.unassigned_at IS NULL
       ORDER BY psa.assigned_at ASC

--- a/lib/klass_hero/provider/anonymize_user_data.ex
+++ b/lib/klass_hero/provider/anonymize_user_data.ex
@@ -17,6 +17,7 @@ defmodule KlassHero.Provider.AnonymizeUserData do
   import Ecto.Query, only: [from: 2]
 
   alias KlassHero.Provider.IncidentReport
+  alias KlassHero.Provider.Staff
   alias KlassHero.Provider.StaffMember
   alias KlassHero.Repo
 
@@ -60,9 +61,21 @@ defmodule KlassHero.Provider.AnonymizeUserData do
 
       _ ->
         Enum.each(reports, &update!(IncidentReport.anonymize_changeset(&1)))
-        Enum.each(staff, &update!(StaffMember.anonymize_changeset(&1)))
+        Enum.each(staff, &erase_staff_member/1)
 
         %{incident_reports: length(reports), staff_members: length(staff)}
+    end
+  end
+
+  # Erasure is an ending of employment plus a scrub, and the ordering is
+  # load-bearing: deactivate_staff_member/1 short-circuits on an already-inactive
+  # row, so scrubbing first (which sets active: false) would silently skip the
+  # lead-instructor clearing and the event that clears the erased name from read
+  # tables. Deactivate, then scrub.
+  defp erase_staff_member(staff) do
+    case Staff.deactivate_staff_member(staff) do
+      {:ok, deactivated} -> update!(StaffMember.anonymize_changeset(deactivated))
+      {:error, reason} -> Repo.rollback(reason)
     end
   end
 

--- a/lib/klass_hero/provider/domain/events/provider_events.ex
+++ b/lib/klass_hero/provider/domain/events/provider_events.ex
@@ -14,6 +14,9 @@ defmodule KlassHero.Provider.Domain.Events.ProviderEvents do
   - `staff_assigned_to_program` / `staff_unassigned_from_program` - A staff
     member's program assignment changed (critical). Messaging reacts by adding
     or removing the staff member from the program's conversation.
+  - `staff_member_deactivated` - A staff member's employment link ended
+    (critical). Read tables holding a denormalised staff name clear it; a read
+    filter cannot, because the name is a stored column.
 
   The staff assignment events carry the **staff member** as their entity, not
   the assignment row: consumers key on who was assigned, not on which row
@@ -87,6 +90,32 @@ defmodule KlassHero.Provider.Domain.Events.ProviderEvents do
           Event.t()
   def staff_unassigned_from_program(%ProgramStaffAssignment{} = assignment, %StaffMember{} = staff_member, opts \\ []) do
     assignment_event(:staff_unassigned_from_program, assignment, staff_member, opts)
+  end
+
+  @doc """
+  Creates a `staff_member_deactivated` event (critical).
+
+  Carries no `program_ids`: consumers hold `staff_member_id` on their own rows,
+  so scoping by the staff member is both narrower and immune to the assignment
+  set changing between staging and delivery. No timestamp either — a payload
+  `DateTime` does not survive the durable round trip (#1010).
+  """
+  @spec staff_member_deactivated(StaffMember.t(), keyword()) :: Event.t()
+  def staff_member_deactivated(%StaffMember{} = staff_member, opts \\ []) do
+    payload = %{
+      provider_id: staff_member.provider_id,
+      staff_member_id: staff_member.id,
+      staff_user_id: staff_member.user_id
+    }
+
+    Event.new(
+      :staff_member_deactivated,
+      @source_context,
+      @staff_entity_type,
+      staff_member.id,
+      payload,
+      Keyword.put_new(opts, :criticality, :critical)
+    )
   end
 
   # assigned_at/unassigned_at are deliberately absent: no consumer reads them, and

--- a/lib/klass_hero/provider/staff.ex
+++ b/lib/klass_hero/provider/staff.ex
@@ -15,6 +15,7 @@ defmodule KlassHero.Provider.Staff do
   alias KlassHero.Provider.Domain.Events.ProviderEvents
   alias KlassHero.Provider.Domain.ReadModels.StaffMembership
   alias KlassHero.Provider.Profiles
+  alias KlassHero.Provider.ProgramStaffAssignment
   alias KlassHero.Provider.ProviderProfile
   alias KlassHero.Provider.StaffMember
   alias KlassHero.Repo
@@ -39,7 +40,11 @@ defmodule KlassHero.Provider.Staff do
     "invitation_sent_at"
   ]
 
-  @staff_updatable_fields ~w(first_name last_name role email bio headshot_url tags qualifications active
+  # `active` is deliberately absent: ending an employment link is
+  # deactivate_staff_member/1, which clears lead flags, revokes the invitation and
+  # stages an event. A profile edit that flipped the same boolean would skip all
+  # three (#1237).
+  @staff_updatable_fields ~w(first_name last_name role email bio headshot_url tags qualifications
                              pay_rate rate_type rate_amount rate_currency)a
 
   @doc """
@@ -132,6 +137,78 @@ defmodule KlassHero.Provider.Staff do
           {:error, :not_found}
       end
     end
+  end
+
+  @doc """
+  Ends a staff member's employment link — the single definition of deactivation.
+
+  Before this existed, `active` was flipped by a bare cast from four places and
+  every consequence had to be remembered at each call site; forgetting one is
+  what left a deactivated staff member showing as lead instructor on the public
+  program page (#1236). The consequences now live here, in one transaction:
+
+    * the lead-instructor flag on their active assignments is cleared,
+    * an outstanding invitation is revoked (it is a live credential), and
+    * a `staff_member_deactivated` event is staged, so read tables holding a
+      denormalised staff name can clear it — a read filter cannot, because the
+      name is a stored column.
+
+  Program Staff Assignments deliberately **survive**: unassigning would strip
+  Messaging conversation membership, which reactivation cannot give back.
+
+  Idempotent — an already-inactive member is returned unchanged with nothing
+  staged. Takes the struct, so provider-initiated callers scope first through
+  `get_staff_member/2`; foreign ≡ missing is that function's guarantee.
+  """
+  @spec deactivate_staff_member(StaffMember.t()) :: {:ok, StaffMember.t()} | {:error, term()}
+  def deactivate_staff_member(%StaffMember{active: false} = staff), do: {:ok, staff}
+
+  def deactivate_staff_member(%StaffMember{} = staff) do
+    context_span entity: "staff_member" do
+      deactivate_with_event(staff)
+    end
+  end
+
+  @doc """
+  Reinstates a staff member's employment link.
+
+  Deliberately not the mirror image of deactivation: lead-instructor flags stay
+  cleared (leading a program is a promotion, not a property of employment) and a
+  revoked invitation is not reissued — use `resend_staff_invitation/2`.
+
+  No event is staged, so a read table whose staff name was cleared on
+  deactivation stays cleared until the staff member's assignments next change or
+  the projection rebuilds. Recomputing "who is currently assigned" incrementally
+  would have to re-run the bootstrap's earliest-active-assignment resolution and
+  could disagree with it; leaving the field empty is the safe direction.
+  """
+  @spec reactivate_staff_member(StaffMember.t()) :: {:ok, StaffMember.t()} | {:error, term()}
+  def reactivate_staff_member(%StaffMember{active: true} = staff), do: {:ok, staff}
+
+  def reactivate_staff_member(%StaffMember{} = staff) do
+    context_span entity: "staff_member" do
+      Repo.update(StaffMember.reactivate_changeset(staff))
+    end
+  end
+
+  defp deactivate_with_event(staff) do
+    Outbox.transact(@context, fn ->
+      clear_lead_instructor_flags(staff)
+
+      with {:ok, deactivated} <- Repo.update(StaffMember.deactivate_changeset(staff)) do
+        {:ok, deactivated, [ProviderEvents.staff_member_deactivated(deactivated)]}
+      end
+    end)
+  end
+
+  # Scoped to the staff member's own active assignments, so a program whose lead
+  # is someone else is untouched. Leaves `unassigned_at` alone — the assignment
+  # survives, only the lead responsibility ends.
+  defp clear_lead_instructor_flags(%StaffMember{id: staff_id}) do
+    from(a in ProgramStaffAssignment,
+      where: a.staff_member_id == ^staff_id and a.is_lead_instructor and is_nil(a.unassigned_at)
+    )
+    |> Repo.update_all(set: [is_lead_instructor: false])
   end
 
   @doc """

--- a/lib/klass_hero/provider/staff_member.ex
+++ b/lib/klass_hero/provider/staff_member.ex
@@ -162,7 +162,6 @@ defmodule KlassHero.Provider.StaffMember do
       :headshot_url,
       :tags,
       :qualifications,
-      :active,
       :invitation_status,
       :invitation_token_hash,
       :invitation_sent_at,
@@ -184,14 +183,42 @@ defmodule KlassHero.Provider.StaffMember do
   end
 
   @doc """
-  Admin changeset for Backpex dashboard edits.
+  Admin changeset satisfying Backpex's `adapter_config` contract.
 
-  Only allows toggling `active` — all other fields are provider-owned. Accepts
-  the Backpex 3-arg signature; metadata is unused (no audit fields for the toggle).
+  Inert since #1237: the admin dashboard denies `:edit` and toggles `active`
+  through `Provider.deactivate_staff_member/1` item actions instead, so Backpex
+  never calls this. It stays because `adapter_config` requires the key.
   """
   def admin_changeset(schema, attrs, _metadata) do
     cast(schema, attrs, [:active])
   end
+
+  @doc """
+  Ends a staff member's employment link.
+
+  Deactivation is the reversible end of an employment link (`CONTEXT.md`), so it
+  scrubs no PII — that is erasure's job, via `anonymize_changeset/1`. It does
+  revoke an outstanding invitation for the same reason erasure does: the invite
+  link is a live credential and `get_staff_member_by_token_hash/1` does not check
+  `active`.
+  """
+  @spec deactivate_changeset(t()) :: Ecto.Changeset.t()
+  def deactivate_changeset(%__MODULE__{} = staff) do
+    staff
+    |> change(%{active: false})
+    |> revoke_invitation()
+  end
+
+  @doc """
+  Reinstates a staff member's employment link.
+
+  Deliberately narrow: a revoked invitation is not reissued (use
+  `resend_staff_invitation/2`) and lead-instructor flags cleared on deactivation
+  are not restored — leading a program is a deliberate promotion, not a property
+  of being employed.
+  """
+  @spec reactivate_changeset(t()) :: Ecto.Changeset.t()
+  def reactivate_changeset(%__MODULE__{} = staff), do: change(staff, %{active: true})
 
   @doc """
   Changeset for updating invitation-specific fields.

--- a/lib/klass_hero/release/dedup_active_staff_memberships.ex
+++ b/lib/klass_hero/release/dedup_active_staff_memberships.ex
@@ -13,6 +13,22 @@ defmodule KlassHero.Release.DedupActiveStaffMemberships do
   Lives outside the migration so the transform is unit-testable (the #966
   pattern); the migration's `up/0` calls `run/1` before creating the index.
   Idempotent: re-running finds no duplicates and deactivates zero rows.
+
+  ## Why this bypasses `Provider.deactivate_staff_member/1`
+
+  #1237 made deactivation a domain operation and routed every other writer of
+  `active` through it. This one is a deliberate exemption, not an oversight:
+
+    * It runs inside a migration's `up/0`, where staging an event would deliver
+      it on the next boot against a schema that was mid-migration when the event
+      was written.
+    * It is a one-shot historical cleanup that has already run in production, so
+      routing it changes no live behaviour while adding migration-time risk.
+    * The rows it touches are duplicates that should never have existed; they
+      hold no lead-instructor role and no outstanding invitation worth revoking.
+
+  Do not copy this exemption. A new writer of `active` belongs on
+  `Provider.deactivate_staff_member/1`.
   """
 
   alias Ecto.Adapters.SQL

--- a/lib/klass_hero_web/live/admin/actions/activate_staff_action.ex
+++ b/lib/klass_hero_web/live/admin/actions/activate_staff_action.ex
@@ -1,0 +1,49 @@
+defmodule KlassHeroWeb.Admin.Actions.ActivateStaffAction do
+  @moduledoc """
+  Backpex item action reinstating a staff member's employment link.
+
+  Not a full undo of `DeactivateStaffAction`: lead-instructor roles cleared on
+  deactivation stay cleared, and a revoked invitation is not reissued — see
+  `KlassHero.Provider.Staff.reactivate_staff_member/1`.
+
+  `StaffLive.can?/3` shows this only for a staff member who is currently inactive.
+  """
+
+  use BackpexWeb, :item_action
+
+  alias KlassHero.Provider
+  alias KlassHeroWeb.Admin.Actions.StaffEmployment
+
+  require KlassHeroWeb.BackpexCompat
+
+  @impl Backpex.ItemAction
+  def icon(assigns, _item) do
+    ~H"""
+    <Backpex.HTML.CoreComponents.icon name="hero-user-plus" class="h-5 w-5 text-green-600" />
+    """
+  end
+
+  @impl Backpex.ItemAction
+  def label(_assigns, _item), do: "Activate"
+
+  @impl Backpex.ItemAction
+  def confirm(_assigns) do
+    "This restores their employment. Any lead-instructor role they held is not " <>
+      "restored, and a revoked invitation is not reissued. Are you sure?"
+  end
+
+  # See the note in DeactivateStaffAction — Backpex appends a default confirm_label/1.
+  KlassHeroWeb.BackpexCompat.override :confirm_label, 1 do
+    @impl Backpex.ItemAction
+    def confirm_label(_assigns), do: "Activate"
+  end
+
+  @impl Backpex.ItemAction
+  def handle(socket, items, _data) do
+    StaffEmployment.apply_to(socket, items, &Provider.reactivate_staff_member/1,
+      done: "activated",
+      failed: "activate",
+      log: "ActivateStaffAction"
+    )
+  end
+end

--- a/lib/klass_hero_web/live/admin/actions/deactivate_staff_action.ex
+++ b/lib/klass_hero_web/live/admin/actions/deactivate_staff_action.ex
@@ -1,0 +1,52 @@
+defmodule KlassHeroWeb.Admin.Actions.DeactivateStaffAction do
+  @moduledoc """
+  Backpex item action ending a staff member's employment link.
+
+  Replaces the editable `active` checkbox the admin form used to carry. That
+  checkbox went straight to `Repo` through `StaffMember.admin_changeset/3`, so
+  none of deactivation's consequences ran — see
+  `KlassHero.Provider.Staff.deactivate_staff_member/1` (#1237).
+
+  `StaffLive.can?/3` shows this only for a staff member who is currently active.
+  """
+
+  use BackpexWeb, :item_action
+
+  alias KlassHero.Provider
+  alias KlassHeroWeb.Admin.Actions.StaffEmployment
+
+  require KlassHeroWeb.BackpexCompat
+
+  @impl Backpex.ItemAction
+  def icon(assigns, _item) do
+    ~H"""
+    <Backpex.HTML.CoreComponents.icon name="hero-user-minus" class="h-5 w-5 text-red-600" />
+    """
+  end
+
+  @impl Backpex.ItemAction
+  def label(_assigns, _item), do: "Deactivate"
+
+  @impl Backpex.ItemAction
+  def confirm(_assigns) do
+    "This ends their employment: they lose any lead-instructor role and stop appearing " <>
+      "on upcoming sessions. Their program assignments and messages are kept, and this " <>
+      "can be undone. Are you sure?"
+  end
+
+  # Backpex's @before_compile appends a default confirm_label/1; Elixir 1.20's type
+  # checker flags it as redundant. BackpexCompat re-emits ours after Backpex's.
+  KlassHeroWeb.BackpexCompat.override :confirm_label, 1 do
+    @impl Backpex.ItemAction
+    def confirm_label(_assigns), do: "Deactivate"
+  end
+
+  @impl Backpex.ItemAction
+  def handle(socket, items, _data) do
+    StaffEmployment.apply_to(socket, items, &Provider.deactivate_staff_member/1,
+      done: "deactivated",
+      failed: "deactivate",
+      log: "DeactivateStaffAction"
+    )
+  end
+end

--- a/lib/klass_hero_web/live/admin/actions/staff_employment.ex
+++ b/lib/klass_hero_web/live/admin/actions/staff_employment.ex
@@ -1,0 +1,58 @@
+defmodule KlassHeroWeb.Admin.Actions.StaffEmployment do
+  @moduledoc """
+  Shared execution for the admin's staff employment item actions.
+
+  `DeactivateStaffAction` and `ActivateStaffAction` differ only in which domain
+  command they run and what the flash says, so the apply-and-summarise loop lives
+  here rather than twice.
+
+  Both go through `KlassHero.Provider`'s public API instead of Backpex's direct
+  `Repo` write. That is the whole point of #1237: the admin toggle used to cast
+  `active` with no consequences attached, so a deactivated staff member kept
+  their lead-instructor flag and stayed named in read tables.
+  """
+
+  alias KlassHero.Provider.StaffMember
+  alias Phoenix.LiveView.Socket
+
+  require Logger
+
+  @doc """
+  Runs `command` over each selected staff member and puts a summarising flash.
+
+  `copy` supplies the verbs: `:done` for the success flash ("deactivated"),
+  `:failed` for the failure one, and `:log` for the warning label.
+  """
+  @spec apply_to(Socket.t(), [StaffMember.t()], (StaffMember.t() -> {:ok, term()} | {:error, term()}), keyword()) ::
+          {:ok, Socket.t()}
+  def apply_to(socket, items, command, copy) do
+    results = Enum.map(items, fn item -> {item.id, command.(item)} end)
+    failures = Enum.reject(results, fn {_id, result} -> match?({:ok, _}, result) end)
+
+    Enum.each(failures, fn {id, error} ->
+      Logger.warning("[Admin.#{copy[:log]}] Failed to update staff employment",
+        staff_member_id: id,
+        error: inspect(error)
+      )
+    end)
+
+    {:ok, Phoenix.LiveView.put_flash(socket, level(failures, items), message(failures, items, copy))}
+  end
+
+  defp level([], _items), do: :info
+  defp level(failures, items) when length(failures) == length(items), do: :error
+  defp level(_failures, _items), do: :warning
+
+  defp message([], items, copy), do: "#{length(items)} staff member(s) #{copy[:done]}."
+
+  defp message(failures, items, copy) when length(failures) == length(items) do
+    "Could not #{copy[:failed]} #{length(items)} staff member(s)."
+  end
+
+  defp message(failures, items, copy) do
+    ok_count = length(items) - length(failures)
+
+    "#{ok_count} of #{length(items)} staff member(s) #{copy[:done]}. " <>
+      "#{length(failures)} could not be #{copy[:done]}."
+  end
+end

--- a/lib/klass_hero_web/live/admin/staff_live.ex
+++ b/lib/klass_hero_web/live/admin/staff_live.ex
@@ -2,12 +2,14 @@ defmodule KlassHeroWeb.Admin.StaffLive do
   @moduledoc """
   Backpex LiveResource for managing staff members in the admin dashboard.
 
-  Provides index, show, and edit views. Only `active` status is editable —
-  all other fields are provider-owned.
+  Read-only (index and show): every field is provider-owned.
 
-  Note: Backpex operates directly on Ecto schemas and Repo, bypassing
-  the Ports & Adapters layering used elsewhere. This is a pragmatic
-  exception scoped to admin-only read + limited edit operations.
+  Employment status is changed through the `Deactivate` / `Activate` item
+  actions, which call `KlassHero.Provider`'s commands. Backpex otherwise writes
+  straight to `Repo`, and that is exactly what #1237 removed here: the old
+  editable `active` checkbox cast the column with none of deactivation's
+  consequences — no lead-instructor clearing, no event, so read tables kept
+  naming the departed staff member.
   """
 
   # Backpex requires FQ refs in `use` args — alias can't precede `use` per formatter rules
@@ -26,19 +28,33 @@ defmodule KlassHeroWeb.Admin.StaffLive do
   alias Backpex.Fields.Boolean
   alias Backpex.Fields.Text
   alias Backpex.Fields.Textarea
+  alias KlassHeroWeb.Admin.Actions.ActivateStaffAction
+  alias KlassHeroWeb.Admin.Actions.DeactivateStaffAction
   alias KlassHeroWeb.Admin.Filters.ActiveFilter
 
   @impl Backpex.LiveResource
   def layout(_assigns), do: {KlassHeroWeb.Layouts, :admin}
 
   # Staff members are created/deleted by their providers — hides "New" button, denies create/delete.
+  # `:edit` is denied too since #1237: `active` was the only editable field, and it now
+  # moves through Provider's domain command, so the form has nothing left to write.
+  # The two employment actions are opposite-gated, so exactly one shows per row.
   @impl Backpex.LiveResource
   def can?(_assigns, :new, _item), do: false
   def can?(_assigns, :delete, _item), do: false
+  def can?(_assigns, :edit, _item), do: false
   def can?(_assigns, :index, _item), do: true
   def can?(_assigns, :show, _item), do: true
-  def can?(_assigns, :edit, _item), do: true
+  def can?(_assigns, :deactivate_staff, item), do: item.active
+  def can?(_assigns, :activate_staff, item), do: not item.active
   def can?(_assigns, _action, _item), do: false
+
+  @impl Backpex.LiveResource
+  def item_actions(default_actions) do
+    default_actions
+    |> Keyword.put(:deactivate_staff, %{module: DeactivateStaffAction, only: [:row, :show]})
+    |> Keyword.put(:activate_staff, %{module: ActivateStaffAction, only: [:row, :show]})
+  end
 
   @impl Backpex.LiveResource
   def filters do
@@ -89,6 +105,8 @@ defmodule KlassHeroWeb.Admin.StaffLive do
         searchable: true,
         readonly: true
       },
+      # No `readonly:` — Backpex.Fields.Boolean rejects the option, and it would be
+      # redundant: can?(:edit) is false, so no form ever renders this field.
       active: %{
         module: Boolean,
         label: "Active",

--- a/test/klass_hero/provider/adapters/driven/projections/provider_session_details_bootstrap_test.exs
+++ b/test/klass_hero/provider/adapters/driven/projections/provider_session_details_bootstrap_test.exs
@@ -160,4 +160,53 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetailsB
     assert row.current_assigned_staff_id == first_staff.id
     assert row.current_assigned_staff_name == "Grace Hopper"
   end
+
+  @tag :bootstrap
+  test "bootstrap skips a deactivated staff member and picks the next active one" do
+    # Trigger: the earliest-assigned staff member has been deactivated, a later
+    #          one is still active. Both assignments remain live — deactivation
+    #          ends the employment link, it does not unassign (#1237).
+    # Why: the incremental path clears a deactivated staff member on
+    #      :staff_member_deactivated, so a rebuild that re-named them would
+    #      resurrect the stale attribution — and on the GDPR path that is an
+    #      erased user's real name reappearing in a read table.
+    # Outcome: the LATERAL picks the earliest *active* assignment.
+    provider = insert(:provider_profile_schema)
+    program = insert(:program_schema, provider_id: provider.id, title: "Fencing")
+
+    departed =
+      insert(:staff_member_schema, provider_id: provider.id, first_name: "Gone", last_name: "Away", active: false)
+
+    current =
+      insert(:staff_member_schema, provider_id: provider.id, first_name: "Still", last_name: "Here")
+
+    for {staff, assigned_at} <- [{departed, ~U[2026-04-01 09:00:00Z]}, {current, ~U[2026-04-02 09:00:00Z]}] do
+      {:ok, _} =
+        %ProgramStaffAssignment{}
+        |> ProgramStaffAssignment.create_changeset(%{
+          provider_id: provider.id,
+          staff_member_id: staff.id,
+          program_id: program.id,
+          assigned_at: assigned_at
+        })
+        |> Repo.insert()
+    end
+
+    session_schema =
+      insert(:program_session_schema,
+        program_id: program.id,
+        session_date: ~D[2026-05-11],
+        start_time: ~T[09:00:00],
+        end_time: ~T[10:00:00],
+        status: "scheduled"
+      )
+
+    start_supervised!({ProviderSessionDetails, name: :bootstrap_test_inactive_staff})
+    :ok = ProviderSessionDetails.rebuild(:bootstrap_test_inactive_staff)
+
+    row = Repo.get(SessionDetail, session_schema.id)
+
+    assert row.current_assigned_staff_id == current.id
+    assert row.current_assigned_staff_name == "Still Here"
+  end
 end

--- a/test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs
+++ b/test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs
@@ -6,8 +6,10 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetailsT
   import KlassHero.Factory
 
   alias KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails
+  alias KlassHero.Provider.Domain.Events.ProviderEvents
   alias KlassHero.Provider.ProgramStaffAssignment
   alias KlassHero.Provider.SessionDetail
+  alias KlassHero.Provider.StaffMember
   alias KlassHero.Repo
   alias KlassHero.Shared.Domain.Events.Event
 
@@ -421,6 +423,83 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetailsT
       assert scheduled.current_assigned_staff_name == nil
       assert completed.current_assigned_staff_id == staff.id
       assert completed.current_assigned_staff_name == "Bob Jones"
+    end
+  end
+
+  describe "staff deactivation (#1237)" do
+    # Built from the real ProviderEvents constructor rather than the local
+    # Event.new/5 helpers: the suite runs on TestOutbox, so nothing else in this
+    # file pairs a producer with its consumer, and a hand-rolled payload would
+    # hide drift between the two.
+    setup do
+      provider = insert(:provider_profile_schema)
+
+      staff =
+        insert(:staff_member_schema,
+          provider_id: provider.id,
+          first_name: "Carol",
+          last_name: "Dane"
+        )
+
+      %{provider: provider, staff: staff}
+    end
+
+    defp deactivate(staff) do
+      staff
+      |> ProviderEvents.staff_member_deactivated()
+      |> ProviderSessionDetails.project()
+    end
+
+    defp session_assigned_to(provider, staff, status) do
+      program = insert(:program_schema, provider_id: provider.id)
+      session_id = Ecto.UUID.generate()
+
+      insert_program_session(
+        session_id: session_id,
+        program_id: program.id,
+        provider_id: provider.id,
+        status: status,
+        current_assigned_staff_id: staff.id,
+        current_assigned_staff_name: StaffMember.full_name(staff)
+      )
+
+      session_id
+    end
+
+    test "clears the staff member from scheduled sessions across every program", ctx do
+      # Deactivation is not per-program, so unlike :staff_unassigned_from_program
+      # this clause must reach every program the staff member was assigned to.
+      first = session_assigned_to(ctx.provider, ctx.staff, :scheduled)
+      second = session_assigned_to(ctx.provider, ctx.staff, :scheduled)
+
+      deactivate(ctx.staff)
+
+      for session_id <- [first, second] do
+        row = reload(session_id)
+        assert is_nil(row.current_assigned_staff_id), "expected #{session_id} to be cleared"
+        assert is_nil(row.current_assigned_staff_name), "expected #{session_id} to be cleared"
+      end
+    end
+
+    test "leaves historical rows attributed", ctx do
+      completed = session_assigned_to(ctx.provider, ctx.staff, :completed)
+
+      deactivate(ctx.staff)
+
+      row = reload(completed)
+      assert row.current_assigned_staff_id == ctx.staff.id
+      assert row.current_assigned_staff_name == "Carol Dane"
+    end
+
+    test "does not clear another staff member's sessions", ctx do
+      other = insert(:staff_member_schema, provider_id: ctx.provider.id, first_name: "Dee", last_name: "Ell")
+      mine = session_assigned_to(ctx.provider, ctx.staff, :scheduled)
+      theirs = session_assigned_to(ctx.provider, other, :scheduled)
+
+      deactivate(ctx.staff)
+
+      assert is_nil(reload(mine).current_assigned_staff_id)
+      assert reload(theirs).current_assigned_staff_id == other.id
     end
   end
 

--- a/test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs
+++ b/test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs
@@ -97,6 +97,48 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetailsT
       assert row.current_assigned_staff_name == "Ada Lovelace"
     end
 
+    test "skips a deactivated staff member when resolving the assigned staff" do
+      # The incremental twin of the bootstrap's active-staff filter. Deactivation
+      # leaves ProgramStaffAssignment rows standing on purpose, so a departed staff
+      # member can stay the earliest-assigned row forever — and a session created
+      # afterwards would be attributed to them over their active colleague. Unlike
+      # bootstrap, this path never self-heals: the row is written wrong and stays wrong.
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id, title: "Judo")
+
+      departed =
+        insert(:staff_member_schema, provider_id: provider.id, first_name: "Gone", last_name: "Away", active: false)
+
+      current = insert(:staff_member_schema, provider_id: provider.id, first_name: "Still", last_name: "Here")
+
+      for {staff, assigned_at} <- [{departed, ~U[2026-04-01 09:00:00Z]}, {current, ~U[2026-04-02 09:00:00Z]}] do
+        {:ok, _} =
+          %ProgramStaffAssignment{}
+          |> ProgramStaffAssignment.create_changeset(%{
+            provider_id: provider.id,
+            staff_member_id: staff.id,
+            program_id: program.id,
+            assigned_at: assigned_at
+          })
+          |> Repo.insert()
+      end
+
+      session_id = Ecto.UUID.generate()
+
+      broadcast(:session_created, session_id, %{
+        session_id: session_id,
+        program_id: program.id,
+        session_date: ~D[2026-05-04],
+        start_time: ~T[09:00:00],
+        end_time: ~T[10:00:00]
+      })
+
+      row = Repo.get(SessionDetail, session_id)
+
+      assert row.current_assigned_staff_id == current.id
+      assert row.current_assigned_staff_name == "Still Here"
+    end
+
     test "duplicate delivery preserves evolved state written by other handlers" do
       # session_created must be a no-op on duplicate (at-least-once) delivery — it
       # must NOT stomp status/counts/cover_staff_* that other handlers evolved

--- a/test/klass_hero/provider/anonymize_user_data_test.exs
+++ b/test/klass_hero/provider/anonymize_user_data_test.exs
@@ -5,12 +5,18 @@ defmodule KlassHero.Provider.AnonymizeUserDataTest do
   use KlassHero.DataCase, async: true
 
   import KlassHero.AccountsFixtures
+  import KlassHero.EventTestHelper
   import KlassHero.Factory
   import KlassHero.ProviderFixtures
 
   alias KlassHero.Provider
   alias KlassHero.Provider.IncidentReport
+  alias KlassHero.Provider.ProgramStaffAssignment
   alias KlassHero.Provider.StaffMember
+
+  setup do
+    setup_test_integration_events()
+  end
 
   describe "anonymize_data_for_user/1" do
     test "scrubs both PII surfaces and reports what it touched" do
@@ -59,6 +65,24 @@ defmodule KlassHero.Provider.AnonymizeUserDataTest do
 
       assert Repo.get(StaffMember, staff.id).email == nil
     end
+
+    test "ends the employment link with its consequences, not just the PII" do
+      # Erasure goes through deactivate_staff_member/1 rather than flipping `active`
+      # itself, so it inherits every consequence instead of having to remember them:
+      # the lead-instructor flag goes, and the event that clears the erased name from
+      # read tables is staged (#1237).
+      %{user: user, provider: provider, program: program, staff: staff} = user_with_provider_data()
+
+      {:ok, lead} = Provider.set_lead_instructor(program.id, staff.id, provider.id)
+      assert lead.is_lead_instructor
+
+      clear_integration_events()
+
+      assert {:ok, _} = Provider.anonymize_data_for_user(user.id)
+
+      refute Repo.get(ProgramStaffAssignment, lead.id).is_lead_instructor
+      assert_integration_event_published(:staff_member_deactivated, %{staff_member_id: staff.id})
+    end
   end
 
   defp user_with_provider_data(staff_attrs \\ []) do
@@ -89,6 +113,6 @@ defmodule KlassHero.Provider.AnonymizeUserDataTest do
         program_id: program.id
       )
 
-    %{user: user, provider: provider, staff: staff, report: report}
+    %{user: user, provider: provider, program: program, staff: staff, report: report}
   end
 end

--- a/test/klass_hero/provider/staff/deactivate_staff_member_test.exs
+++ b/test/klass_hero/provider/staff/deactivate_staff_member_test.exs
@@ -1,0 +1,154 @@
+defmodule KlassHero.Provider.Staff.DeactivateStaffMemberTest do
+  @moduledoc """
+  `deactivate_staff_member/1` — the single definition of ending a Staff Member's
+  employment link (#1237).
+
+  Before this command existed, `active` was flipped by a bare cast from four
+  places and every consequence had to be remembered at each call site. The
+  consequences are now: the lead-instructor flag is cleared, an outstanding
+  invitation is revoked, and a `staff_member_deactivated` event is staged so
+  read tables holding a denormalised staff name can clear it.
+
+  Program Staff Assignments deliberately **survive** — deactivation ends the
+  employment, it does not rewrite the roster history, and unassignment would
+  strip conversation membership that reactivation cannot give back.
+  """
+
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.EventTestHelper
+  import KlassHero.Factory
+
+  alias KlassHero.Provider
+  alias KlassHero.Provider.ProgramStaffAssignment
+  alias KlassHero.Provider.StaffMember
+  alias KlassHero.Repo
+
+  setup do
+    setup_test_integration_events()
+
+    provider = insert(:provider_profile_schema)
+    program = insert(:program_schema, provider_id: provider.id)
+    staff = insert(:staff_member_schema, provider_id: provider.id)
+
+    clear_integration_events()
+
+    %{provider: provider, program: program, staff: staff}
+  end
+
+  defp lead_assignment(program, staff) do
+    {:ok, lead} = Provider.set_lead_instructor(program.id, staff.id, program.provider_id)
+    lead
+  end
+
+  defp reload(%StaffMember{id: id}), do: Repo.get!(StaffMember, id)
+  defp reload(%ProgramStaffAssignment{id: id}), do: Repo.get!(ProgramStaffAssignment, id)
+
+  describe "deactivate_staff_member/1" do
+    test "ends the employment link", %{staff: staff} do
+      assert {:ok, deactivated} = Provider.deactivate_staff_member(staff)
+
+      assert deactivated.active == false
+      assert reload(staff).active == false
+    end
+
+    test "clears the lead-instructor flag the staff member held", %{program: program, staff: staff} do
+      lead = lead_assignment(program, staff)
+      assert lead.is_lead_instructor
+
+      {:ok, _} = Provider.deactivate_staff_member(staff)
+
+      refute reload(lead).is_lead_instructor
+    end
+
+    test "leaves the assignment itself active", %{program: program, staff: staff} do
+      lead = lead_assignment(program, staff)
+
+      {:ok, _} = Provider.deactivate_staff_member(staff)
+
+      assert is_nil(reload(lead).unassigned_at),
+             "deactivation must not unassign — that would strip conversation membership"
+    end
+
+    test "does not touch another staff member's lead flag", %{provider: provider, program: program, staff: staff} do
+      other_program = insert(:program_schema, provider_id: provider.id)
+      other_staff = insert(:staff_member_schema, provider_id: provider.id)
+
+      lead = lead_assignment(program, staff)
+      other_lead = lead_assignment(other_program, other_staff)
+
+      {:ok, _} = Provider.deactivate_staff_member(staff)
+
+      refute reload(lead).is_lead_instructor
+      assert reload(other_lead).is_lead_instructor
+      assert reload(other_staff).active
+    end
+
+    test "revokes an outstanding invitation", %{provider: provider} do
+      invited =
+        insert(:staff_member_schema,
+          provider_id: provider.id,
+          invitation_status: :sent,
+          invitation_token_hash: :crypto.hash(:sha256, "token"),
+          invitation_sent_at: DateTime.utc_now()
+        )
+
+      {:ok, _} = Provider.deactivate_staff_member(invited)
+
+      revoked = reload(invited)
+      assert is_nil(revoked.invitation_token_hash)
+      assert revoked.invitation_status == :expired
+    end
+
+    test "leaves an accepted invitation intact", %{provider: provider} do
+      accepted = insert(:staff_member_schema, provider_id: provider.id, invitation_status: :accepted)
+
+      {:ok, _} = Provider.deactivate_staff_member(accepted)
+
+      assert reload(accepted).invitation_status == :accepted
+    end
+
+    test "stages a staff_member_deactivated event on the provider topic", %{provider: provider, staff: staff} do
+      {:ok, _} = Provider.deactivate_staff_member(staff)
+
+      event =
+        assert_integration_published_to(
+          :staff_member_deactivated,
+          "integration:provider:staff_member_deactivated"
+        )
+
+      assert event.payload.staff_member_id == staff.id
+      assert event.payload.provider_id == provider.id
+    end
+
+    test "is idempotent and stages nothing for an already-inactive member", %{provider: provider} do
+      inactive = insert(:staff_member_schema, provider_id: provider.id, active: false)
+
+      assert {:ok, unchanged} = Provider.deactivate_staff_member(inactive)
+
+      assert unchanged.active == false
+      assert_no_integration_events_published()
+    end
+  end
+
+  describe "reactivate_staff_member/1" do
+    test "restores the employment link", %{staff: staff} do
+      {:ok, deactivated} = Provider.deactivate_staff_member(staff)
+
+      assert {:ok, reactivated} = Provider.reactivate_staff_member(deactivated)
+
+      assert reactivated.active
+      assert reload(staff).active
+    end
+
+    test "does not restore the lead-instructor flag", %{program: program, staff: staff} do
+      lead = lead_assignment(program, staff)
+      {:ok, deactivated} = Provider.deactivate_staff_member(staff)
+
+      {:ok, _} = Provider.reactivate_staff_member(deactivated)
+
+      refute reload(lead).is_lead_instructor,
+             "lead is a deliberate promotion — reinstating employment must not re-confer it"
+    end
+  end
+end

--- a/test/klass_hero/provider/staff/update_staff_member_test.exs
+++ b/test/klass_hero/provider/staff/update_staff_member_test.exs
@@ -46,9 +46,13 @@ defmodule KlassHero.Provider.Staff.UpdateStaffMemberTest do
       assert updated.qualifications == ["First Aid"]
     end
 
-    test "deactivates a staff member", %{staff: staff} do
+    test "ignores :active — ending an employment link is its own operation", %{staff: staff} do
+      # The profile-edit path must not be a back door into deactivation: it stages
+      # no event and clears no lead-instructor flag, so a staff member deactivated
+      # this way would leave every consequence unapplied (#1237).
       assert {:ok, updated} = Provider.update_staff_member(staff.provider_id, staff.id, %{active: false})
-      assert updated.active == false
+
+      assert updated.active, "update_staff_member/3 must not flip :active"
     end
 
     test "preserves unmodified fields", %{staff: staff} do

--- a/test/klass_hero/provider/staff_deactivation_cascade_test.exs
+++ b/test/klass_hero/provider/staff_deactivation_cascade_test.exs
@@ -1,0 +1,85 @@
+defmodule KlassHero.Provider.StaffDeactivationCascadeTest do
+  @moduledoc """
+  End-to-end proof that deactivating a staff member actually reaches the read
+  table that names them (#1237).
+
+  The projection tests call `project/1` directly. This one starts at
+  `Provider.deactivate_staff_member/1` and lets the real machinery run: staged
+  event → Oban job → consumer registry → `ProviderSessionDetails`. It is the test
+  that would have caught the original gap, where deactivation wrote `active`
+  and told nobody.
+  """
+  # async: false — swaps the :outbox adapter in application env, which every
+  # other test reads (see outbox_test.exs for the same constraint).
+  use KlassHero.DataCase, async: false
+
+  import KlassHero.Factory
+
+  alias KlassHero.Provider
+  alias KlassHero.Provider.SessionDetail
+  alias KlassHero.Shared.Adapters.Driven.Events.ObanOutbox
+
+  test "deactivating a staff member clears their name from upcoming sessions" do
+    provider = insert(:provider_profile_schema)
+    program = insert(:program_schema, provider_id: provider.id, title: "Judo")
+    staff = insert(:staff_member_schema, provider_id: provider.id, first_name: "Jane", last_name: "Doe")
+
+    scheduled = insert_session_detail(provider, program, staff, :scheduled)
+    completed = insert_session_detail(provider, program, staff, :completed)
+
+    # The real outbox is swapped in around the act only. Doing it in `setup`
+    # makes the fixtures above collide on providers_identity_id_index: with
+    # ObanOutbox live, building a provider drives :user_registered through the
+    # real handler, which creates a second profile for the same identity.
+    with_real_outbox(fn ->
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        assert {:ok, _} = Provider.deactivate_staff_member(staff)
+
+        # Nothing has consumed the event yet — the job is staged, not run.
+        assert Repo.get(SessionDetail, scheduled).current_assigned_staff_name == "Jane Doe"
+
+        Oban.drain_queue(queue: :critical_events, with_recursion: true)
+      end)
+    end)
+
+    cleared = Repo.get(SessionDetail, scheduled)
+    assert is_nil(cleared.current_assigned_staff_id)
+    assert is_nil(cleared.current_assigned_staff_name)
+
+    # Historical attribution is audit trail and survives.
+    assert Repo.get(SessionDetail, completed).current_assigned_staff_name == "Jane Doe"
+  end
+
+  defp with_real_outbox(fun) do
+    original = Application.get_env(:klass_hero, :outbox)
+    Application.put_env(:klass_hero, :outbox, module: ObanOutbox)
+
+    try do
+      fun.()
+    after
+      Application.put_env(:klass_hero, :outbox, original)
+    end
+  end
+
+  defp insert_session_detail(provider, program, staff, status) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    session_id = Ecto.UUID.generate()
+
+    Repo.insert!(%SessionDetail{
+      session_id: session_id,
+      program_id: program.id,
+      program_title: program.title,
+      provider_id: provider.id,
+      session_date: ~D[2026-09-01],
+      start_time: ~T[15:00:00],
+      end_time: ~T[16:00:00],
+      status: status,
+      current_assigned_staff_id: staff.id,
+      current_assigned_staff_name: "Jane Doe",
+      inserted_at: now,
+      updated_at: now
+    })
+
+    session_id
+  end
+end

--- a/test/klass_hero/provider/staff_member_integration_test.exs
+++ b/test/klass_hero/provider/staff_member_integration_test.exs
@@ -72,7 +72,7 @@ defmodule KlassHero.Provider.StaffMemberIntegrationTest do
         )
 
       # Deactivate the second staff member
-      {:ok, _} = Provider.update_staff_member(inactive.provider_id, inactive.id, %{active: false})
+      {:ok, _} = Provider.deactivate_staff_member(inactive)
 
       assert {:ok, members} = Provider.list_active_staff_members(provider.id)
       assert length(members) == 1
@@ -88,7 +88,7 @@ defmodule KlassHero.Provider.StaffMemberIntegrationTest do
           first_name: "Inactive"
         )
 
-      {:ok, _} = Provider.update_staff_member(staff.provider_id, staff.id, %{active: false})
+      {:ok, _} = Provider.deactivate_staff_member(staff)
 
       assert {:ok, []} = Provider.list_active_staff_members(provider.id)
     end

--- a/test/klass_hero_web/live/admin/staff_live_test.exs
+++ b/test/klass_hero_web/live/admin/staff_live_test.exs
@@ -5,6 +5,11 @@ defmodule KlassHeroWeb.Admin.StaffLiveTest do
   import Phoenix.LiveViewTest
 
   alias KlassHero.Provider.StaffMember
+  alias KlassHero.Repo
+  alias KlassHeroWeb.Admin.Actions.ActivateStaffAction
+  alias KlassHeroWeb.Admin.Actions.DeactivateStaffAction
+  alias KlassHeroWeb.Admin.StaffLive
+  alias Phoenix.LiveView.Socket
 
   describe "admin access control" do
     setup :register_and_log_in_admin
@@ -60,62 +65,76 @@ defmodule KlassHeroWeb.Admin.StaffLiveTest do
     end
   end
 
-  describe "edit staff member" do
-    setup :register_and_log_in_admin
+  describe "can?/3 employment-action gating" do
+    # Deactivate and Activate are opposite-gated on the same row, so Backpex renders
+    # exactly one of them per staff member. Tested as plain functions, matching
+    # BookingLive's cancel_booking gates — no item-action modal is driven anywhere
+    # in this suite.
+    @employment_cases [
+      {:deactivate_staff, true, true},
+      {:deactivate_staff, false, false},
+      {:activate_staff, true, false},
+      {:activate_staff, false, true}
+    ]
 
-    test "admin can toggle active status to false", %{conn: conn} do
-      provider = provider_profile_fixture()
-
-      staff =
-        staff_member_fixture(provider_id: provider.id, first_name: "Bob", last_name: "Jones")
-
-      {:ok, view, _html} = live(conn, ~p"/admin/staff/#{staff.id}/edit")
-
-      view
-      |> form("#resource-form", %{change: %{active: false}})
-      |> render_submit(%{"save-type" => "save"})
-
-      schema =
-        KlassHero.Repo.get!(
-          StaffMember,
-          staff.id
-        )
-
-      assert schema.active == false
+    test "offers deactivate only for active staff and activate only for inactive" do
+      for {action, active?, expected} <- @employment_cases do
+        assert StaffLive.can?(%{}, action, %{active: active?}) == expected,
+               "can?(#{inspect(action)}, active: #{active?}) should be #{expected}"
+      end
     end
 
-    test "admin cannot edit provider-owned fields", %{conn: conn} do
-      provider = provider_profile_fixture()
+    @fixed_cases [{:new, false}, {:delete, false}, {:edit, false}, {:index, true}, {:show, true}]
 
-      staff =
-        staff_member_fixture(
-          provider_id: provider.id,
-          first_name: "Original",
-          last_name: "Name",
-          role: "Instructor"
-        )
+    test "denies create, delete and edit; permits index and show" do
+      # :edit is denied since #1237 — `active` was the only editable field, and it
+      # now moves through the domain command, so the form has nothing left to write.
+      for {action, expected} <- @fixed_cases do
+        assert StaffLive.can?(%{}, action, %{}) == expected,
+               "can?(#{inspect(action)}) should be #{expected}"
+      end
+    end
 
-      {:ok, view, _html} = live(conn, ~p"/admin/staff/#{staff.id}/edit")
-
-      # Trigger: admin submits the edit form with only the active toggle changed
-      # Why: admin_changeset only casts :active; readonly fields (first_name, role)
-      #      are not rendered as editable inputs, so they can't be submitted at all
-      # Outcome: first_name, role remain unchanged in the database
-      view
-      |> form("#resource-form", %{
-        change: %{active: false}
-      })
-      |> render_submit(%{"save-type" => "save"})
-
-      schema =
-        KlassHero.Repo.get!(
-          StaffMember,
-          staff.id
-        )
-
-      assert schema.first_name == "Original"
-      assert schema.role == "Instructor"
-      assert schema.active == false
+    test "denies unknown actions" do
+      refute StaffLive.can?(%{}, :unknown_action, %{active: true})
     end
   end
+
+  describe "employment item actions" do
+    setup :register_and_log_in_admin
+
+    test "deactivating ends the employment link through the domain command" do
+      provider = provider_profile_fixture()
+      staff = staff_member_fixture(provider_id: provider.id, first_name: "Bob", last_name: "Jones")
+
+      assert {:ok, _socket} = DeactivateStaffAction.handle(bare_socket(), [staff], %{})
+
+      reloaded = Repo.get!(StaffMember, staff.id)
+      refute reloaded.active
+      assert reloaded.first_name == "Bob", "the action must not touch provider-owned fields"
+    end
+
+    test "activating reinstates the employment link" do
+      provider = provider_profile_fixture()
+      staff = staff_member_fixture(provider_id: provider.id, active: false)
+
+      assert {:ok, _socket} = ActivateStaffAction.handle(bare_socket(), [staff], %{})
+
+      assert Repo.get!(StaffMember, staff.id).active
+    end
+
+    test "the edit route is no longer reachable", %{conn: conn} do
+      # Backpex raises rather than redirecting when can?/3 denies a form mount, so
+      # the URL cannot be used as a back door around the item actions.
+      provider = provider_profile_fixture()
+      staff = staff_member_fixture(provider_id: provider.id)
+
+      assert_raise Backpex.ForbiddenError, fn -> live(conn, ~p"/admin/staff/#{staff.id}/edit") end
+    end
+  end
+
+  # The actions only put a flash on the socket, so a bare one exercises handle/3
+  # directly. Driving the confirm modal through LiveViewTest has no precedent in
+  # this suite — BookingLive's action is tested the same way.
+  defp bare_socket, do: %Socket{assigns: %{flash: %{}, __changed__: %{}}}
 end


### PR DESCRIPTION
Closes #1237.

## Summary

`staff_members.active` was flipped by a bare cast from four places, with no definition and no consequences attached. Every consequence of deactivation had to be remembered independently at each call site — which is why a deactivated staff member kept showing as lead instructor on the public program page (#1236, the fixed half of this).

Adds `Provider.deactivate_staff_member/1` and `reactivate_staff_member/1`. In one transaction: set `active`, clear the lead-instructor flag on the staff member's active assignments, revoke an outstanding invitation, stage a `staff_member_deactivated` event.

Program Staff Assignments deliberately **survive**. Unassigning would emit `staff_unassigned_from_program`, which strips Messaging conversation membership that reactivation cannot give back — so deactivation ends the employment link without rewriting roster history.

## Review focus

**Why an event at all, when five read paths already filter `s.active`.** Because two cases a read filter structurally cannot reach:

1. `ProviderSessionDetails` denormalises the staff name into `current_assigned_staff_name`. It is a stored column, so no filter clears it — a deactivated (or erased) staff member stayed named on every `:scheduled` session row until a restart rebuilt the projection. Visible in the provider sessions modal.
2. The bootstrap SQL joined `program_staff_assignments → staff_members` with no `active` filter, so a rebuild would have resurrected exactly what the new handler clears.

**The second commit is a review finding, not a follow-up.** The regression pass caught that `resolve_program_context/1` — the incremental twin of the bootstrap query — still had no `active` filter, so a session created *after* someone left was attributed to them over their active colleague. Unlike the bootstrap case it never self-heals. Fixed by rewriting it into the same LATERAL shape the bootstrap uses, rather than adding a second spelling of the rule. The filter has to sit inside the LATERAL: on the join alone it would still pick the departed staff member's assignment and merely lose their name.

**Ordering in `AnonymizeUserData` is load-bearing.** Deactivate runs before the PII scrub, because scrubbing sets `active: false` and would make the command short-circuit — silently skipping the lead-instructor clearing and the event.

## All four writers migrated

| Writer | Change |
|---|---|
| Admin toggle | Editable `active` checkbox → Deactivate/Activate item actions calling the domain command. `can?(:edit)` is now `false` — `active` was the only editable field, so the form has nothing left to write, and the edit route raises rather than acting as a back door. |
| GDPR erasure | `AnonymizeUserData` deactivates, then scrubs. |
| `update_staff_member/3` | `:active` dropped from `@staff_updatable_fields` and from `edit_changeset` — an undocumented fourth path, one form param from being reachable. |
| `DedupActiveStaffMemberships` | Documented exemption. It runs inside a migration's `up/0`, where staging an event would deliver against a mid-migration schema, and it is a one-shot cleanup that has already run in production. |

`CONTEXT.md` gains the missing term: the domain had no word for this. Deactivation ends an employment link, and is distinct from removal (hard delete) and erasure (GDPR) — all three of which land on the same `active` boolean.

## Test plan

- `deactivate_staff_member_test.exs` — lead flags cleared, invitation revoked (and `:accepted` left intact), assignments survive, idempotent on an already-inactive member with nothing staged, another staff member's lead untouched. Event asserted via `assert_integration_published_to/2`, which derives the topic through the same `Event.topic/1` the delivery job uses.
- `staff_deactivation_cascade_test.exs` — end-to-end through the real outbox: `with_testing_mode(:manual)`, assert the pre-drain state, `drain_queue(with_recursion: true)`, assert the projection row cleared. The pre-drain assertion is what stops it passing vacuously. The outbox swap wraps the act only — doing it in `setup` collides the fixtures on `providers_identity_id_index`.
- Projection tests build their event from the real `ProviderEvents` constructor rather than a hand-rolled `Event.new/5`, since the suite runs on `TestOutbox` and nothing else pairs this producer with its consumer.
- Bootstrap and `session_created` each get a test proving a deactivated staff member loses to an active colleague.
- Admin: tabular `can?/3` gating, plus `handle/3` driven directly — matching how `BookingLive`'s item action is tested, since no confirm-modal LiveViewTest precedent exists in this repo.

`mix precommit`: 4116 passed, 2 skipped.

## Known gap

Reactivation stages no event, so a read table whose staff name was cleared stays cleared until the staff member's assignments next change or the projection rebuilds. Recomputing "who is currently assigned" incrementally would have to re-run the earliest-active-assignment resolution and could disagree with it; leaving the field empty is the safe direction. Documented on `reactivate_staff_member/1`.

## Follow-up

`Provider.delete_staff_member/2` shares this root cause and is worse: `program_staff_assignments.staff_member_id` is `on_delete: :delete_all`, so the Team tab's "remove member" button — the only user-facing removal control — lets Postgres vaporise every assignment with no `staff_unassigned_from_program` event, leaving Messaging conversation participants stale. Filed separately; it needs its own design gate (soft-delete, or emit unassign events first).