### PR TITLE
feat: surface undelivered events in the admin dashboard

### DIFF
--- a/lib/klass_hero/shared/adapters/driven/persistence/schemas/undelivered_event.ex
+++ b/lib/klass_hero/shared/adapters/driven/persistence/schemas/undelivered_event.ex
@@ -2,19 +2,30 @@ defmodule KlassHero.Shared.Adapters.Driven.Persistence.Schemas.UndeliveredEvent 
   @moduledoc """
   Ecto schema for the `undelivered_events` dead-letter table.
 
-  Internal to `UndeliveredEventRepository` — not a domain model. Each row records
-  one integration event that delivery gave up on permanently, together with the
-  consumers that never received it and the serialized envelope needed to replay it.
+  Not a domain model. Each row records one integration event that delivery gave up
+  on permanently, together with the consumers that never received it and the
+  serialized envelope needed to replay it.
+
+  Written and pruned only through `UndeliveredEventRepository`. It is also read
+  directly by `KlassHeroWeb.Admin.UndeliveredEventLive`, which is a Backpex
+  LiveResource and so operates on the schema and Repo by design — the same
+  admin-only exception the other admin resources take.
 
   Identity is `event_id`; there is no synthetic primary key and no association to
   `oban_jobs`, whose rows the Pruner deletes on a schedule of its own.
+
+  `event_id` is declared `:binary_id` rather than `Ecto.UUID` — the same value at
+  the database, but Backpex only special-cases `:id` and `:binary_id` when casting
+  a URL segment into the show query. Under any other type a typo'd admin link
+  reaches the catch-all and raises `Ecto.Query.CastError` (a 500) where it should
+  simply not be found.
   """
 
   use Ecto.Schema
 
   @primary_key false
   schema "undelivered_events" do
-    field :event_id, Ecto.UUID
+    field :event_id, :binary_id
     field :topic, :string
     field :payload, :map
     field :missed_consumers, {:array, :string}

--- a/lib/klass_hero_web/components/layouts/admin.html.heex
+++ b/lib/klass_hero_web/components/layouts/admin.html.heex
@@ -50,6 +50,14 @@
         "Incidents"
       )}
     </Backpex.HTML.Layout.sidebar_item>
+    <Backpex.HTML.Layout.sidebar_item
+      current_url={@current_url}
+      navigate={~p"/admin/undelivered-events"}
+    >
+      <Backpex.HTML.CoreComponents.icon name="hero-inbox-arrow-down" class="h-5 w-5" /> {gettext(
+        "Undelivered Events"
+      )}
+    </Backpex.HTML.Layout.sidebar_item>
     <Backpex.HTML.Layout.sidebar_item current_url={@current_url} navigate={~p"/admin/emails"}>
       <Backpex.HTML.CoreComponents.icon name="hero-envelope" class="h-5 w-5" /> {gettext("Emails")}
       <span

--- a/lib/klass_hero_web/live/admin/undelivered_event_live.ex
+++ b/lib/klass_hero_web/live/admin/undelivered_event_live.ex
@@ -1,0 +1,158 @@
+defmodule KlassHeroWeb.Admin.UndeliveredEventLive do
+  @moduledoc """
+  Backpex LiveResource for viewing integration events that were never delivered.
+
+  Strictly read-only — no create, edit, or delete. A row here is a terminal
+  record: `EventDeliveryWorker.compensate/2` writes it once delivery has given up
+  permanently, and nothing but the 90-day prune touches it again.
+
+  Note: Backpex operates directly on Ecto schemas and Repo, bypassing
+  the Ports & Adapters layering used elsewhere. This is a pragmatic
+  exception scoped to admin-only read operations.
+
+  ## Reads, not events
+
+  There is no projection and no event behind this view. The failure it reports is
+  the one place in the system where delivery has already stopped being reliable —
+  making the record itself reliable is what PR #1250 did; this only shows it.
+
+  ## Access
+
+  Every admin (`is_admin: true`) can read every envelope, including whatever
+  personal data the event carried — the same data `ErrorContextFilter` redacts
+  from ErrorTracker. That exposure is deliberate rather than accidental: the
+  envelope is what a replay would be built from, so redacting it here would leave
+  the page unable to answer the question it exists for. There are no admin
+  sub-roles to scope this to, and no record is kept of which admin read which
+  envelope — identical to `KlassHeroWeb.Admin.IncidentLive`.
+  """
+
+  # Backpex requires FQ refs in `use` args — alias can't precede `use` per formatter rules
+  # credo:disable-for-lines:10 Credo.Check.Design.AliasUsage
+  use Backpex.LiveResource,
+    adapter_config: [
+      schema: KlassHero.Shared.Adapters.Driven.Persistence.Schemas.UndeliveredEvent,
+      repo: KlassHero.Repo
+    ],
+    # Identity is `event_id`; the schema is `@primary_key false`. Backpex defaults this
+    # to `:id` and threads it through URL building, row DOM ids, and the show query.
+    primary_key: :event_id,
+    pubsub: [server: KlassHero.PubSub],
+    init_order: %{by: :discarded_at, direction: :desc}
+
+  alias Backpex.Fields.Text
+
+  @impl Backpex.LiveResource
+  def layout(_assigns), do: {KlassHeroWeb.Layouts, :admin}
+
+  # Written by the compensation sweep, pruned on a schedule — admins read only.
+  @impl Backpex.LiveResource
+  def can?(_assigns, :index, _item), do: true
+  def can?(_assigns, :show, _item), do: true
+  def can?(_assigns, _action, _item), do: false
+
+  @impl Backpex.LiveResource
+  def singular_name, do: "Undelivered Event"
+
+  @impl Backpex.LiveResource
+  def plural_name, do: "Undelivered Events"
+
+  @impl Backpex.LiveResource
+  def render_resource_slot(assigns, :index, :before_main) do
+    ~H"""
+    <div class="mb-4 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
+      Reactions that never ran. Each row is one integration event delivery gave up on —
+      replaying it means re-inserting its delivery job, and records are pruned 90 days
+      after they are recorded.
+    </div>
+    """
+  end
+
+  @impl Backpex.LiveResource
+  def fields do
+    [
+      topic: %{
+        module: Text,
+        label: "Topic",
+        searchable: true,
+        orderable: true
+      },
+      # Registry order is delivery order, and `EventDeliveryWorker` preserves it —
+      # the list tells you which consumer ran last and where the failure stopped.
+      # One per line, because a joined cell squeezed the timestamp column to nothing.
+      missed_consumers: %{
+        module: Text,
+        label: "Missed Consumers",
+        orderable: false,
+        # The wrapping <div> is required, not cosmetic: Backpex.Fields.Text is a
+        # stateful LiveComponent, so its root must be a single static HTML tag.
+        render: fn assigns ->
+          ~H"""
+          <div class="font-mono text-xs">
+            <div :for={consumer <- @value}>{short_consumer(consumer)}</div>
+          </div>
+          """
+        end
+      },
+      # Age is rendered here rather than added as a virtual column. Backpex's
+      # `orderable` default is `true` and it validates `order_by` against the
+      # orderable list, so a virtual `age` would let `?order_by=age` through to
+      # `ORDER BY u0."age"` — a column that does not exist (42703).
+      discarded_at: %{
+        module: Text,
+        label: "Discarded At",
+        orderable: true,
+        render: fn assigns ->
+          ~H"""
+          <div>
+            {Calendar.strftime(@value, "%Y-%m-%d %H:%M UTC")}
+            <span class="text-gray-400">({age(@value)})</span>
+          </div>
+          """
+        end
+      },
+      job_id: %{
+        module: Text,
+        label: "Oban Job",
+        only: [:show],
+        orderable: false
+      },
+      payload: %{
+        module: Text,
+        label: "Envelope",
+        only: [:show],
+        orderable: false,
+        render: fn assigns ->
+          ~H"""
+          <div>
+            <pre
+              phx-no-curly-interpolation
+              class="overflow-x-auto rounded bg-gray-50 p-3 text-xs"
+            ><%= Jason.encode!(@value, pretty: true) %></pre>
+          </div>
+          """
+        end
+      }
+    ]
+  end
+
+  # `EventDeliveryWorker` stores a fully-qualified handler ref
+  # ("Elixir.KlassHero.Family.Adapters.Driving.Events.FamilyEventHandler:handle_event").
+  # The context and the handler name are the signal; the fixed `Adapters.Driving.Events`
+  # path in between is boilerplate that pushed every other column off the table.
+  defp short_consumer(ref) when is_binary(ref) do
+    ref
+    |> String.replace_prefix("Elixir.KlassHero.", "")
+    |> String.replace(".Adapters.Driving.Events.", ".")
+  end
+
+  # No relative-time helper exists app-wide, and the only consumer is this column.
+  # Days are the unit that matters: the record is pruned at 90 of them.
+  defp age(%DateTime{} = discarded_at) do
+    case DateTime.diff(DateTime.utc_now(), discarded_at, :second) do
+      seconds when seconds < 3600 -> "#{div(seconds, 60)}m ago"
+      seconds when seconds < 86_400 -> "#{div(seconds, 3600)}h ago"
+      seconds -> "#{div(seconds, 86_400)}d ago"
+    end
+  end
+end

--- a/lib/klass_hero_web/router.ex
+++ b/lib/klass_hero_web/router.ex
@@ -223,6 +223,7 @@ defmodule KlassHeroWeb.Router do
         live_resources("/bookings", BookingLive, only: [:index, :show])
         live_resources("/consents", ConsentLive, only: [:index, :show])
         live_resources("/incidents", IncidentLive, only: [:index, :show])
+        live_resources("/undelivered-events", UndeliveredEventLive, only: [:index, :show])
       end
     end
 

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -1323,7 +1323,7 @@ msgid "Push, email, SMS settings"
 msgstr "Push-, E-Mail-, SMS-Einstellungen"
 
 #: lib/klass_hero_web/components/composite_components.ex:103
-#: lib/klass_hero_web/components/layouts/admin.html.heex:63
+#: lib/klass_hero_web/components/layouts/admin.html.heex:71
 #: lib/klass_hero_web/components/provider_components.ex:119
 #: lib/klass_hero_web/live/admin/sessions_live.ex:26
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:3
@@ -4194,7 +4194,7 @@ msgstr "E-Mail als ungelesen markiert"
 msgid "Email not found"
 msgstr "E-Mail nicht gefunden"
 
-#: lib/klass_hero_web/components/layouts/admin.html.heex:54
+#: lib/klass_hero_web/components/layouts/admin.html.heex:62
 #: lib/klass_hero_web/live/admin/emails_live.ex:21
 #: lib/klass_hero_web/live/admin/emails_live.ex:41
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:4
@@ -7614,3 +7614,8 @@ msgstr "Verifizierung läuft"
 #, elixir-autogen, elixir-format
 msgid "Verifying"
 msgstr "In Prüfung"
+
+#: lib/klass_hero_web/components/layouts/admin.html.heex:57
+#, elixir-autogen, elixir-format
+msgid "Undelivered Events"
+msgstr "Nicht zugestellte Ereignisse"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -1323,7 +1323,7 @@ msgid "Push, email, SMS settings"
 msgstr ""
 
 #: lib/klass_hero_web/components/composite_components.ex:103
-#: lib/klass_hero_web/components/layouts/admin.html.heex:63
+#: lib/klass_hero_web/components/layouts/admin.html.heex:71
 #: lib/klass_hero_web/components/provider_components.ex:119
 #: lib/klass_hero_web/live/admin/sessions_live.ex:26
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:3
@@ -4194,7 +4194,7 @@ msgstr ""
 msgid "Email not found"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/admin.html.heex:54
+#: lib/klass_hero_web/components/layouts/admin.html.heex:62
 #: lib/klass_hero_web/live/admin/emails_live.ex:21
 #: lib/klass_hero_web/live/admin/emails_live.ex:41
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:4
@@ -7613,4 +7613,9 @@ msgstr ""
 #: lib/klass_hero_web/components/ui_components.ex:1948
 #, elixir-autogen, elixir-format
 msgid "Verifying"
+msgstr ""
+
+#: lib/klass_hero_web/components/layouts/admin.html.heex:57
+#, elixir-autogen, elixir-format
+msgid "Undelivered Events"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -1323,7 +1323,7 @@ msgid "Push, email, SMS settings"
 msgstr ""
 
 #: lib/klass_hero_web/components/composite_components.ex:103
-#: lib/klass_hero_web/components/layouts/admin.html.heex:63
+#: lib/klass_hero_web/components/layouts/admin.html.heex:71
 #: lib/klass_hero_web/components/provider_components.ex:119
 #: lib/klass_hero_web/live/admin/sessions_live.ex:26
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:3
@@ -4194,7 +4194,7 @@ msgstr ""
 msgid "Email not found"
 msgstr ""
 
-#: lib/klass_hero_web/components/layouts/admin.html.heex:54
+#: lib/klass_hero_web/components/layouts/admin.html.heex:62
 #: lib/klass_hero_web/live/admin/emails_live.ex:21
 #: lib/klass_hero_web/live/admin/emails_live.ex:41
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:4
@@ -7613,4 +7613,9 @@ msgstr ""
 #: lib/klass_hero_web/components/ui_components.ex:1948
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Verifying"
+msgstr ""
+
+#: lib/klass_hero_web/components/layouts/admin.html.heex:57
+#, elixir-autogen, elixir-format
+msgid "Undelivered Events"
 msgstr ""

--- a/test/klass_hero_web/live/admin/undelivered_event_live_test.exs
+++ b/test/klass_hero_web/live/admin/undelivered_event_live_test.exs
@@ -1,0 +1,163 @@
+defmodule KlassHeroWeb.Admin.UndeliveredEventLiveTest do
+  use KlassHeroWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias KlassHero.Repo
+  alias KlassHero.Shared.Adapters.Driven.Persistence.Schemas.UndeliveredEvent
+
+  describe "admin access control" do
+    setup :register_and_log_in_admin
+
+    test "admin can access /admin/undelivered-events", %{conn: conn} do
+      {:ok, _view, html} = live(conn, ~p"/admin/undelivered-events")
+      assert html =~ "Undelivered Events"
+    end
+
+    test "no new button is shown on index", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/admin/undelivered-events")
+      refute has_element?(view, "a", "New")
+    end
+  end
+
+  describe "non-admin access control" do
+    setup :register_and_log_in_user
+
+    test "non-admin is redirected from /admin/undelivered-events", %{conn: conn} do
+      assert {:error, {:redirect, %{to: "/", flash: flash}}} =
+               live(conn, ~p"/admin/undelivered-events")
+
+      assert flash["error"] =~ "access"
+    end
+  end
+
+  describe "unauthenticated access control" do
+    test "unauthenticated user is redirected from /admin/undelivered-events", %{conn: conn} do
+      assert {:error, {:redirect, %{to: "/users/log-in"}}} =
+               live(conn, ~p"/admin/undelivered-events")
+    end
+  end
+
+  describe "show view" do
+    setup :register_and_log_in_admin
+
+    # The row's identity is `event_id` on a `@primary_key false` schema. Backpex
+    # defaults `primary_key` to `:id`, so without the explicit option this route
+    # resolves against a column that does not exist.
+    test "resolves a record by its event_id", %{conn: conn} do
+      event_id = record(topic: "integration:accounts:user_registered")
+
+      {:ok, _view, html} = live(conn, ~p"/admin/undelivered-events/#{event_id}/show")
+
+      assert html =~ "integration:accounts:user_registered"
+    end
+
+    # Backpex casts the URL segment against the primary key's declared type. Only its
+    # `:id` and `:binary_id` clauses raise `NoResultsError` (a 404); anything else falls
+    # to a catch-all that compares raw and blows up as a 500 on a typo'd link.
+    test "treats an unparseable id as not found rather than a server error", %{conn: conn} do
+      assert_raise Ecto.NoResultsError, fn ->
+        live(conn, ~p"/admin/undelivered-events/not-a-uuid/show")
+      end
+    end
+
+    test "renders the full serialized envelope", %{conn: conn} do
+      event_id =
+        record(
+          topic: "integration:enrollment:invite_claimed",
+          payload: %{"event_type" => "invite_claimed", "payload" => %{"invite_id" => "inv-4711"}}
+        )
+
+      {:ok, view, html} = live(conn, ~p"/admin/undelivered-events/#{event_id}/show")
+
+      assert has_element?(view, "pre")
+      assert html =~ "inv-4711"
+    end
+  end
+
+  describe "index view" do
+    setup :register_and_log_in_admin
+
+    # The stored refs are fully qualified. Only the context and the handler name are
+    # worth a table cell — the fixed `Adapters.Driving.Events` path in between is
+    # boilerplate wide enough to squeeze every other column off the page.
+    test "lists the consumers that never received the event, minus the boilerplate path",
+         %{conn: conn} do
+      record(
+        topic: "integration:accounts:user_registered",
+        missed_consumers: [
+          "Elixir.KlassHero.Family.Adapters.Driving.Events.FamilyEventHandler:handle_event",
+          "Elixir.KlassHero.Provider.Adapters.Driving.Events.ProviderEventHandler:handle_event"
+        ]
+      )
+
+      {:ok, _view, html} = live(conn, ~p"/admin/undelivered-events")
+
+      assert html =~ "Family.FamilyEventHandler:handle_event"
+      assert html =~ "Provider.ProviderEventHandler:handle_event"
+      refute html =~ "Adapters.Driving.Events"
+    end
+
+    # Ages are offset well clear of the 1h/24h boundaries: the column is rendered
+    # against `utc_now/0`, so a value sitting exactly on one would flip on the
+    # milliseconds between seeding and rendering.
+    @age_cases [
+      {300, "5m ago"},
+      {3_540, "59m ago"},
+      {10_800, "3h ago"},
+      {345_600, "4d ago"}
+    ]
+
+    test "renders each discard's age beside its timestamp", %{conn: conn} do
+      now = DateTime.utc_now()
+
+      for {seconds_ago, _expected} <- @age_cases do
+        record(topic: "topic:#{seconds_ago}", discarded_at: DateTime.add(now, -seconds_ago))
+      end
+
+      {:ok, _view, html} = live(conn, ~p"/admin/undelivered-events")
+
+      for {seconds_ago, expected} <- @age_cases do
+        assert html =~ expected,
+               "expected a discard #{seconds_ago}s old to render as #{expected}"
+      end
+    end
+
+    test "orders the newest discard first", %{conn: conn} do
+      now = DateTime.utc_now()
+
+      record(topic: "topic:older", discarded_at: DateTime.add(now, -2, :day))
+      record(topic: "topic:newer", discarded_at: now)
+
+      {:ok, _view, html} = live(conn, ~p"/admin/undelivered-events")
+
+      assert index_of(html, "topic:newer") < index_of(html, "topic:older")
+    end
+  end
+
+  defp index_of(html, needle) do
+    [{position, _length}] = :binary.matches(html, needle)
+    position
+  end
+
+  # Written straight to the table: producing one by its real route means discarding an
+  # Oban job through the compensation sweep, which this view knows nothing about.
+  defp record(attrs) do
+    event_id = Ecto.UUID.generate()
+    discarded_at = Keyword.get(attrs, :discarded_at, DateTime.utc_now())
+
+    Repo.insert_all(UndeliveredEvent, [
+      %{
+        event_id: event_id,
+        topic: Keyword.fetch!(attrs, :topic),
+        payload: Keyword.get(attrs, :payload, %{}),
+        missed_consumers: Keyword.get(attrs, :missed_consumers, ["Elixir.KlassHero.Whoever:handle_event"]),
+        job_id: 1,
+        discarded_at: discarded_at,
+        inserted_at: discarded_at
+      }
+    ])
+
+    event_id
+  end
+end


### PR DESCRIPTION
Closes #1251.

## Summary

PR #1250 added the `undelivered_events` dead-letter table but nothing read it — a permanently-lost integration event was discoverable only by someone who already knew the table existed and ran SQL against production, and the record deletes itself after 90 days. #1247 made the loss durable; this makes it visible in time to act on.

Read-only Backpex LiveResource at `/admin/undelivered-events`: topic, the consumers that never ran, and the discard time with its age, newest first. The detail view renders the full serialized envelope a replay would be built from.

## Review Focus

**`primary_key: :event_id` is load-bearing.** The schema is `@primary_key false` and Backpex defaults to `:id`, threading it through URL building (`router.ex:192`), row DOM ids (`html/resource.ex:118`), and the show query (`adapters/ecto.ex:364`). Without it the *index still renders fine* and only the detail page 500s — so the show test is the one that matters.

**`event_id` moves from `Ecto.UUID` to `:binary_id`** (`undelivered_event.ex`). Same value at the database, but Backpex only special-cases `:id` and `:binary_id` when casting a URL segment into the show query; anything else falls to a catch-all that compares raw. Under `Ecto.UUID` a typo'd admin link raised `Ecto.Query.CastError` — a 500 where the sibling admin resources return a 404. This is also the repo's dominant convention (`Ecto.UUID` appears only in the two Shared event-infra schemas).

**No `update_changeset` / `create_changeset` in `adapter_config`.** Every other admin resource passes an `admin_changeset` because it needs `:edit`; this one is read-only and the schema has no changeset at all. Backpex defaults both to a bare `cast(item, attrs, [])`.

**Age is rendered inside the real `discarded_at` column, not added as a virtual one.** Backpex's `orderable` default is `true` and it validates `order_by` against the orderable list, so a virtual `age` would let `?order_by=age` through to `ORDER BY u0."age"` (42703 → 500). Reading the AC's "discarded-at, and age" as one column removes that class rather than guarding it.

**PII is deliberate.** The envelope carries whatever personal data its event carried — the same data `ErrorContextFilter` redacts from ErrorTracker. Redacting it here would leave the page unable to answer the question it exists for. Exposure matches `IncidentLive`: every admin reads everything, no sub-roles, no view audit. Stated in the moduledoc.

**Consumer refs are shortened on display.** Stored refs are fully qualified; the fixed `Adapters.Driving.Events` path in between was wide enough to squeeze the timestamp column off the table (caught in the browser, not by tests — `html =~ "5m ago"` passes on a visually clipped cell).

## Test Plan

10 tests in `test/klass_hero_web/live/admin/undelivered_event_live_test.exs`. No factory exists for this table, so rows are seeded with `Repo.insert_all/2`, copying `compensation_sweep_worker_test.exs:187`.

- Access control: admin reaches index; non-admin → `/`; unauthenticated → `/users/log-in`; no New button
- Show resolves by `event_id`; renders the envelope; unparseable id raises `NoResultsError` not `CastError`
- Index: consumer refs shortened, ordering newest-first, age rendered (tabular over 4 offsets)

Two assertions were checked for vacuity by reverting the production code and confirming red: without `primary_key` the show query raises `field \`id\` ... does not exist`; without `init_order` the ordering test fails.

`mix precommit` green — 4126 passed, credo clean, typography/translations/read-table lints pass. Walked in the browser at desktop and 375px: index, detail, sidebar highlight, JSON rendering, and the malformed-UUID route.

## Not in scope

A replay button (#1251 defers it), and a test factory for `undelivered_event`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)