### PR TITLE
refactor: enforce traced cross-context table reads

### DIFF
--- a/.claude/agents/boundary-checker.md
+++ b/.claude/agents/boundary-checker.md
@@ -94,12 +94,18 @@ is fine (schema-as-struct: the context module is the data-access API).
 
 **Exceptions:**
 - `KlassHero.Accounts.User` — commonly used for `belongs_to` associations (known exception)
+- **A raw-string table read (`from(p in "programs", ...)`) that carries an `acl_span`.**
+  ADR 0015 lists cycle-breaking direct table access as legitimate — ProgramCatalog
+  depends on Enrollment, so Enrollment cannot call its facade — and requires only that
+  the hop stay visible in traces. `mix lint_acl_boundary` enforces that in CI, per
+  function. Do not hand-report this class; the lint already owns it, and reporting a
+  traced read as a violation is a false finding (it produced #1274).
 
 **How to verify:**
 1. For each changed module, extract schema modules referenced in queries
    (`from`, `join`, `preload`) and any `Repo` calls
 2. Determine each schema's owning context
-3. Flag references to another context's schemas/tables (except the allowed exception)
+3. Flag references to another context's schemas/tables (except the allowed exceptions)
 4. Do NOT flag a context using `Repo` on its own schemas — that is the convention now
 
 ## Check 3: Event handlers must use facade APIs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,9 @@ jobs:
       - name: Projection read-table convention
         run: mix lint_read_tables
 
+      - name: Cross-context table reads are traced
+        run: mix lint_acl_boundary
+
   # The counterpart to the skip documented on `test` below: that skip is only safe while a
   # Release PR's diff really is a version bump over content already tested on main. This job
   # is what makes that true rather than assumed. Runs only on the Release PR (~20s), so it

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,7 @@ These checks run automatically on every PR — don't manually recheck what CI ca
 | `mix lint_typography` | Font/typography usage violations |
 | `mix lint_translations` | Stale `.pot` templates, empty/fuzzy German `msgstr` |
 | `mix lint_read_tables` | Projection read-table convention: a context-root schema that is neither an entity nor a declared read table, a read table carrying a changeset, or a read table outside the context root |
+| `mix lint_acl_boundary` | A function reading another context's table (`in "<table>"`) without an `acl_span` — ADR 0015 permits the direct read but requires the hop stay visible in traces |
 | `mix test` | Functional regressions (full suite with PostgreSQL) |
 | Sobelow | Common Phoenix security vulnerabilities |
 | `mix deps.audit` | Known dependency vulnerabilities (community advisory DB) |

--- a/docs/adr/0015-cross-context-reads-call-the-facade-directly.md
+++ b/docs/adr/0015-cross-context-reads-call-the-facade-directly.md
@@ -71,6 +71,10 @@ An ACL whose every function forwards a call is not one of these. Fold it into it
   where renaming an instrumented module silently moved its span. At the time of writing the
   `live` environment has no `acl.*` columns at all, so nothing queries these attributes yet;
   that is why #1269's renames were safe, and it is not a general licence.
+  **Update (#1274):** `acl.source`, `acl.target` and `acl.operation` now exist in `live`. The
+  second half still holds — both live triggers filter on `context.name` + `error`, not `acl.*`
+  — but the "no columns at all" premise is spent, so a future rename needs the board and
+  trigger check rather than this exemption.
 - **A facade read is strongly consistent; a projection is not.** That is sometimes the reason to
   choose it. `provider/assignments.ex:307` reads `ProgramCatalog.get_program_for_provider/2`
   rather than the `provider_programs` projection precisely because an ownership guard cannot

--- a/docs/adr/0015-cross-context-reads-call-the-facade-directly.md
+++ b/docs/adr/0015-cross-context-reads-call-the-facade-directly.md
@@ -79,6 +79,12 @@ An ACL whose every function forwards a call is not one of these. Fold it into it
   ADR narrows when an *ACL* is warranted; it does not change CQRS.
 - **`boundary-checker` flags the inverse.** It previously reported "a missing ACL where one should
   exist" as a Warning — a false finding against this decision. It now flags an *unnecessary* ACL.
+- **`mix lint_acl_boundary` enforces the observability clause** (added for #1274). Review alone did
+  not hold it: four of the eight raw-table reads in the tree had drifted untraced, including
+  `provider/…/acl/participation_session_stats_acl.ex` — cited by name above as a legitimate ACL —
+  and `enrollment.ex`, whose untraced `programs` join hid behind the six `acl_span`s that file
+  already carried for its Family hops. That last one is why the lint checks per *function*, not
+  per file.
 
 ## Precedents in the tree
 

--- a/lib/klass_hero/admin/queries.ex
+++ b/lib/klass_hero/admin/queries.ex
@@ -4,7 +4,13 @@ defmodule KlassHero.Admin.Queries do
 
   Returns plain maps for select/dropdown options. No domain logic.
   Located in the data layer because it executes Ecto/Repo queries directly.
+
+  Admin owns no tables, so every read here is cross-context by construction — which is
+  the point of the module, not a smell. Each still carries an `acl_span` so the hops
+  show up in traces like any other; `mix lint_acl_boundary` enforces it.
   """
+
+  use KlassHero.Shared.Tracing
 
   import Ecto.Query
 
@@ -15,11 +21,13 @@ defmodule KlassHero.Admin.Queries do
   sorted alphabetically by business name.
   """
   def list_providers_for_select do
-    from(p in "providers",
-      select: %{id: type(p.id, :binary_id), label: p.business_name},
-      order_by: [asc: p.business_name]
-    )
-    |> Repo.all()
+    acl_span source: "admin", target: "provider" do
+      from(p in "providers",
+        select: %{id: type(p.id, :binary_id), label: p.business_name},
+        order_by: [asc: p.business_name]
+      )
+      |> Repo.all()
+    end
   end
 
   @doc """
@@ -30,14 +38,16 @@ defmodule KlassHero.Admin.Queries do
   when a provider is selected (cascading dropdown).
   """
   def list_programs_for_select do
-    from(p in "programs",
-      select: %{
-        id: type(p.id, :binary_id),
-        label: p.title,
-        provider_id: type(p.provider_id, :binary_id)
-      },
-      order_by: [asc: p.title]
-    )
-    |> Repo.all()
+    acl_span source: "admin", target: "program_catalog" do
+      from(p in "programs",
+        select: %{
+          id: type(p.id, :binary_id),
+          label: p.title,
+          provider_id: type(p.provider_id, :binary_id)
+        },
+        order_by: [asc: p.title]
+      )
+      |> Repo.all()
+    end
   end
 end

--- a/lib/klass_hero/enrollment.ex
+++ b/lib/klass_hero/enrollment.ex
@@ -563,31 +563,36 @@ defmodule KlassHero.Enrollment do
 
   # One trip for enrollments + program titles. Querying `programs` directly avoids a
   # ProgramCatalog↔Enrollment dependency cycle (ProgramCatalog already depends on
-  # Enrollment for capacity ACL).
+  # Enrollment for capacity ACL) — ADR 0015's cycle-breaking case, which is why the
+  # join stays here rather than moving behind ProgramCatalogACL: it attaches to
+  # Enrollment's own query, so an adapter could only serve it by handing back a
+  # composable fragment.
   #
   # The two arities filter deliberately different sides of the join: the program_ids
   # arity filters the enrollment's program_id, the provider_id arity the program's
   # provider_id — the only place that link lives.
   defp list_pending(filter_fun) do
-    query =
-      Enrollment
-      |> join(:left, [e], p in "programs", on: type(p.id, :binary_id) == e.program_id)
-      |> where([e], e.status == :pending)
-      |> select([e, p], {e, p.title})
+    acl_span source: "enrollment", target: "program_catalog" do
+      query =
+        Enrollment
+        |> join(:left, [e], p in "programs", on: type(p.id, :binary_id) == e.program_id)
+        |> where([e], e.status == :pending)
+        |> select([e, p], {e, p.title})
 
-    query
-    |> filter_fun.()
-    |> Repo.all()
-    |> case do
-      [] ->
-        []
+      query
+      |> filter_fun.()
+      |> Repo.all()
+      |> case do
+        [] ->
+          []
 
-      rows ->
-        child_map = rows |> Enum.map(fn {enrollment, _title} -> enrollment end) |> child_map_for()
+        rows ->
+          child_map = rows |> Enum.map(fn {enrollment, _title} -> enrollment end) |> child_map_for()
 
-        Enum.map(rows, fn {enrollment, title} ->
-          build_pending_entry(enrollment, title, child_map)
-        end)
+          Enum.map(rows, fn {enrollment, title} ->
+            build_pending_entry(enrollment, title, child_map)
+          end)
+      end
     end
   end
 

--- a/lib/klass_hero/enrollment.ex
+++ b/lib/klass_hero/enrollment.ex
@@ -3,7 +3,10 @@ defmodule KlassHero.Enrollment do
   Public API for the Enrollment bounded context.
 
   Manages program enrollments, capacity policies, participant eligibility, and bulk invite flows.
-  Follows Ports & Adapters: this module delegates to use cases in the application layer.
+
+  Conventional Phoenix since the flatten (#986–#1002): this module is the imperative shell
+  that other contexts call, over schema-as-struct entities. There is no application layer
+  and there are no ports.
   """
 
   use KlassHero.Shared.Tracing
@@ -572,27 +575,29 @@ defmodule KlassHero.Enrollment do
   # arity filters the enrollment's program_id, the provider_id arity the program's
   # provider_id — the only place that link lives.
   defp list_pending(filter_fun) do
-    acl_span source: "enrollment", target: "program_catalog" do
-      query =
+    # Span covers the foreign query alone. Widening it over the rest would nest
+    # child_map_for/1's own family-targeted span inside a program_catalog one and
+    # bill that hop's time to Program Catalog.
+    rows =
+      acl_span source: "enrollment", target: "program_catalog" do
         Enrollment
         |> join(:left, [e], p in "programs", on: type(p.id, :binary_id) == e.program_id)
         |> where([e], e.status == :pending)
         |> select([e, p], {e, p.title})
-
-      query
-      |> filter_fun.()
-      |> Repo.all()
-      |> case do
-        [] ->
-          []
-
-        rows ->
-          child_map = rows |> Enum.map(fn {enrollment, _title} -> enrollment end) |> child_map_for()
-
-          Enum.map(rows, fn {enrollment, title} ->
-            build_pending_entry(enrollment, title, child_map)
-          end)
+        |> filter_fun.()
+        |> Repo.all()
       end
+
+    case rows do
+      [] ->
+        []
+
+      rows ->
+        child_map = rows |> Enum.map(fn {enrollment, _title} -> enrollment end) |> child_map_for()
+
+        Enum.map(rows, fn {enrollment, title} ->
+          build_pending_entry(enrollment, title, child_map)
+        end)
     end
   end
 

--- a/lib/klass_hero/messaging/adapters/driven/projections/enrolled_children.ex
+++ b/lib/klass_hero/messaging/adapters/driven/projections/enrolled_children.ex
@@ -35,18 +35,18 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildren do
     looks up `children.first_name` because the `enrollment_created` integration
     event payload does not carry the child's name.
 
-  These are **pragmatic cross-context couplings** at the adapter layer: raw
-  string table references (rather than schema-module aliases) sidestep
-  Boundary's compile-time isolation, but Messaging still gains runtime
-  knowledge of Enrollment's and Family's physical schema — a rename in those
-  contexts will silently break these paths.
+  These are **pragmatic cross-context couplings** at the adapter layer, and the cost is
+  real: Messaging holds runtime knowledge of Enrollment's and Family's physical schema,
+  so a rename in those contexts breaks these paths with nothing at compile time to say
+  so. What ADR 0015 requires in exchange is that the hop stays visible — hence the
+  `acl_span` on each, enforced by `mix lint_acl_boundary`.
 
   Both paths mirror the precedent set by
   `Family.Adapters.Driven.ACL.ChildEnrollmentACL` and
-  `Enrollment.Adapters.Driven.ACL.ProgramCatalogACL`, which adopt the same
-  raw-string workaround to avoid hard Boundary dependencies. Issue #685
-  tracks replacing all of these with dedicated cross-context ports.
+  `Enrollment.Adapters.Driven.ACL.ProgramCatalogACL`.
   """
+
+  use KlassHero.Shared.Tracing
 
   use KlassHero.Shared.Projection,
     topics: [
@@ -86,20 +86,22 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildren do
 
   defp bootstrap_from_write_tables do
     entries =
-      from(e in "enrollments",
-        join: c in "children",
-        on: c.id == e.child_id,
-        join: pp in "parents",
-        on: pp.id == e.parent_id,
-        where: e.status in ["pending", "confirmed"],
-        select: %{
-          parent_user_id: type(pp.identity_id, :binary_id),
-          program_id: type(e.program_id, :binary_id),
-          child_id: type(e.child_id, :binary_id),
-          child_first_name: c.first_name
-        }
-      )
-      |> Repo.all()
+      acl_span source: "messaging", target: "enrollment" do
+        from(e in "enrollments",
+          join: c in "children",
+          on: c.id == e.child_id,
+          join: pp in "parents",
+          on: pp.id == e.parent_id,
+          where: e.status in ["pending", "confirmed"],
+          select: %{
+            parent_user_id: type(pp.identity_id, :binary_id),
+            program_id: type(e.program_id, :binary_id),
+            child_id: type(e.child_id, :binary_id),
+            child_first_name: c.first_name
+          }
+        )
+        |> Repo.all()
+      end
 
     if entries == [] do
       0
@@ -154,12 +156,14 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildren do
 
   defp resolve_child_first_name(child_id) do
     name =
-      Repo.one(
-        from(c in "children",
-          where: c.id == type(^child_id, :binary_id),
-          select: c.first_name
+      acl_span source: "messaging", target: "family" do
+        Repo.one(
+          from(c in "children",
+            where: c.id == type(^child_id, :binary_id),
+            select: c.first_name
+          )
         )
-      )
+      end
 
     if is_nil(name) do
       Logger.warning("EnrolledChildren: child row not found when resolving first_name",

--- a/lib/klass_hero/provider/adapters/driven/acl/participation_session_stats_acl.ex
+++ b/lib/klass_hero/provider/adapters/driven/acl/participation_session_stats_acl.ex
@@ -8,27 +8,33 @@ defmodule KlassHero.Provider.Adapters.Driven.ACL.ParticipationSessionStatsACL do
   Used exclusively during ProviderSessionStats projection bootstrap.
   """
 
+  use KlassHero.Shared.Tracing
+
   import Ecto.Query
 
   alias KlassHero.Repo
 
   require Logger
 
+  # Two foreign contexts, one span on the `FROM` table's — the shape
+  # `family/…/acl/child_enrollment_acl.ex` already uses for its two-table join.
   def list_completed_session_counts do
     results =
-      from(s in "program_sessions",
-        join: p in "programs",
-        on: s.program_id == p.id,
-        where: s.status == "completed",
-        group_by: [p.provider_id, p.id, p.title],
-        select: %{
-          provider_id: type(p.provider_id, :binary_id),
-          program_id: type(p.id, :binary_id),
-          program_title: p.title,
-          sessions_completed_count: count(s.id)
-        }
-      )
-      |> Repo.all()
+      acl_span source: "provider", target: "participation" do
+        from(s in "program_sessions",
+          join: p in "programs",
+          on: s.program_id == p.id,
+          where: s.status == "completed",
+          group_by: [p.provider_id, p.id, p.title],
+          select: %{
+            provider_id: type(p.provider_id, :binary_id),
+            program_id: type(p.id, :binary_id),
+            program_title: p.title,
+            sessions_completed_count: count(s.id)
+          }
+        )
+        |> Repo.all()
+      end
 
     {:ok, results}
   rescue

--- a/lib/klass_hero/provider/adapters/driven/acl/participation_session_stats_acl.ex
+++ b/lib/klass_hero/provider/adapters/driven/acl/participation_session_stats_acl.ex
@@ -6,6 +6,13 @@ defmodule KlassHero.Provider.Adapters.Driven.ACL.ParticipationSessionStatsACL do
   Program Catalog's `programs` to compute counts grouped by (provider_id, program_id).
 
   Used exclusively during ProviderSessionStats projection bootstrap.
+
+  ## Why an ACL rather than facade calls
+
+  ADR 0015's fourth justification — a query no facade expresses. The grouped count spans
+  two foreign contexts in one aggregation; serving it through facades would mean fetching
+  every session and every program and counting in Elixir, on the bootstrap path. Naming
+  the justification is a requirement of that ADR, not a courtesy.
   """
 
   use KlassHero.Shared.Tracing

--- a/lib/mix/tasks/lint_acl_boundary.ex
+++ b/lib/mix/tasks/lint_acl_boundary.ex
@@ -1,0 +1,202 @@
+defmodule Mix.Tasks.LintAclBoundary do
+  @shortdoc "Check that cross-context table reads stay visible in traces"
+  @moduledoc """
+  Enforces ADR 0015's call-site observability rule.
+
+  A bounded context may query another context's table directly — ADR 0015 lists
+  cycle-breaking direct table access as one of the four things that earns an ACL its
+  place, and `.claude/rules/domain-architecture.md` allows the same read inline. What
+  it may not do is make that hop invisible: *"Observability is preserved at the call
+  site, not by the adapter."*
+
+  So the rule is one line — **a file that reads another context's table must contain
+  an `acl_span`** — and this task checks it.
+
+  ## Ownership is derived, not configured
+
+  Every table in the tree declares itself exactly once, via `schema "<table>"`. The
+  context that owns a table is the context directory that declaration sits in, so the
+  map needs no maintenance and cannot drift from the schemas. It also means a quoted
+  string that is not a table name — `invite_family_ready_handler.ex` says `in
+  "registered" status` in its moduledoc — is ignored for free rather than needing a
+  pattern to exclude it.
+
+  ## Granularity: one `acl_span` per reading function, not per table or per file
+
+  A cross-context query frequently spans three tables and two foreign contexts.
+  `family/…/acl/child_enrollment_acl.ex` joins `enrollments` and `programs` under a
+  single `target: "enrollment"` — the `FROM` table's context — and that is the
+  established shape. Requiring a span per foreign table would flag code that follows
+  the precedent.
+
+  Per *file* is too coarse in the other direction, and not hypothetically:
+  `enrollment.ex` carries six `acl_span`s for its Family hops while its `programs`
+  join went untraced for three weeks (#1274). A file-level check passes that file.
+
+  So a reference counts as traced when an `acl_span` appears between it and its
+  enclosing `def`/`defp` — which is where every span in the tree already sits, at the
+  top of the function body.
+
+  Text-based on purpose: this runs in the `quality` CI job, which must keep its
+  `mix compile --warnings-as-errors` step first (see `.github/workflows/ci.yml`).
+
+  ## Escape hatch
+
+  A file-wide `# acl-boundary-lint-ignore: <reason>` comment exempts a file. Nothing
+  in the tree uses it today — `admin/queries.ex` is a cross-cutting read surface that
+  owns no tables, and it carries real spans rather than an exemption. It exists for a
+  future read that genuinely cannot be traced.
+
+  ## Usage
+
+      mix lint_acl_boundary
+  """
+  use Mix.Task
+
+  @contexts_dir "lib/klass_hero"
+
+  # Quotes `schema "provider_programs"` in its own moduledoc, which would register a
+  # phantom second owner for a table Provider already declares.
+  @excluded_files ["read_table.ex"]
+
+  @suppression_marker "acl-boundary-lint-ignore"
+
+  @schema ~r/^\s*schema\s+"(?<table>\w+)"/m
+
+  # The Ecto binding form — `from(p in "programs", ...)` and `join: p in "programs"`.
+  # Schemaless queries are the only way to reach a foreign table without aliasing its
+  # module, which is itself a boundary violation the boundary-checker agent covers.
+  @table_reference ~r/\bin\s+"(?<table>\w+)"/
+
+  @acl_span ~r/\bacl_span\b/
+
+  @def ~r/^\s*defp?\s/m
+
+  @impl true
+  def run(_args) do
+    violations = violations(@contexts_dir)
+
+    if violations == [] do
+      Mix.shell().info("ACL boundary lint passed — every cross-context table read is traced.")
+    else
+      Mix.shell().error("Untraced cross-context table reads:\n")
+
+      Enum.each(violations, fn {file, message} ->
+        Mix.shell().error("  #{file}: #{message}")
+      end)
+
+      Mix.shell().error("""
+
+      See `docs/adr/0015-cross-context-reads-call-the-facade-directly.md`.
+      Wrap the read so the hop stays visible in traces:
+
+          use KlassHero.Shared.Tracing
+
+          def my_read do
+            acl_span source: "<this context>", target: "<owning context>" do
+              # the query
+            end
+          end
+
+      For a read that genuinely cannot be traced, add:
+
+          # acl-boundary-lint-ignore: <why this hop is invisible>
+      """)
+
+      Mix.raise("ACL boundary lint failed — #{length(violations)} violation(s) found")
+    end
+  end
+
+  @doc """
+  Returns `[{file, message}]` for every untraced cross-context table read under
+  `contexts_dir`.
+
+  Takes the directory rather than hard-coding it so the test suite can drive the real
+  globbing — and, because ownership is derived from the same tree, so a fixture can
+  declare its own owners.
+  """
+  @spec violations(Path.t()) :: [{Path.t(), String.t()}]
+  def violations(contexts_dir) do
+    files =
+      contexts_dir
+      |> Path.join("**/*.ex")
+      |> Path.wildcard()
+      |> Enum.reject(&(Path.basename(&1) in @excluded_files))
+      |> Enum.map(&{&1, File.read!(&1)})
+
+    owners = owners(files, contexts_dir)
+
+    files
+    |> Enum.reject(fn {_file, content} -> exempt?(content) end)
+    |> Enum.flat_map(fn {file, content} ->
+      case foreign_reads(content, owners, context_of(file, contexts_dir)) do
+        [] -> []
+        reads -> [{file, message(reads)}]
+      end
+    end)
+  end
+
+  # File-wide, unlike the span check: a file can hold several reads and these violations
+  # have no single offending line for a marker to sit beside — same reasoning as
+  # `mix lint_read_tables`.
+  defp exempt?(content), do: String.contains?(content, @suppression_marker)
+
+  # A table declared twice would resolve to whichever context sorts last. Only
+  # `read_table.ex` ever did that, by quoting an example in its moduledoc, and it is
+  # excluded above — so in practice every table has exactly one owner.
+  defp owners(files, contexts_dir) do
+    for {file, content} <- files,
+        [_full, table] <- Regex.scan(@schema, content),
+        into: %{},
+        do: {table, context_of(file, contexts_dir)}
+  end
+
+  defp foreign_reads(content, owners, context) do
+    defs = offsets(content, @def)
+    spans = offsets(content, @acl_span)
+
+    for {offset, table} <- table_references(content),
+        owner = owners[table],
+        owner != nil and owner != context,
+        not traced?(offset, defs, spans),
+        uniq: true,
+        do: {owner, table}
+  end
+
+  defp table_references(content) do
+    for [_full, {at, len}] <- Regex.scan(@table_reference, content, return: :index),
+        do: {at, binary_part(content, at, len)}
+  end
+
+  # Traced when a span opens after the enclosing function head and before the reference.
+  # A reference above the first `def` has no enclosing function, so offset 0 stands in.
+  defp traced?(offset, defs, spans) do
+    enclosing_def = defs |> Enum.take_while(&(&1 < offset)) |> List.last() || 0
+
+    Enum.any?(spans, &(&1 > enclosing_def and &1 < offset))
+  end
+
+  defp offsets(content, regex) do
+    for [{at, _len}] <- Regex.scan(regex, content, return: :index), do: at
+  end
+
+  defp message(reads) do
+    reads
+    |> Enum.sort()
+    |> Enum.map_join(", ", fn {owner, table} -> "#{owner}'s `#{table}`" end)
+    |> then(
+      &("reads #{&1} with no acl_span — ADR 0015 keeps the cross-context hop visible at the " <>
+          "call site, not in the adapter")
+    )
+  end
+
+  # `lib/klass_hero/enrollment.ex` and `lib/klass_hero/enrollment/**/*.ex` are both
+  # Enrollment; the facade is a file where every other context is a directory.
+  defp context_of(file, contexts_dir) do
+    file
+    |> Path.relative_to(contexts_dir)
+    |> Path.split()
+    |> hd()
+    |> Path.basename(".ex")
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -154,6 +154,7 @@ defmodule KlassHero.MixProject do
         "lint_typography",
         "lint_translations",
         "lint_read_tables",
+        "lint_acl_boundary",
         "credo --strict",
         # Two halves on purpose: `test --warnings-as-errors` only covers test
         # files, and `test/support/*.ex` compiles solely in the test env — so

--- a/test/mix/tasks/lint_acl_boundary_test.exs
+++ b/test/mix/tasks/lint_acl_boundary_test.exs
@@ -1,0 +1,175 @@
+defmodule Mix.Tasks.LintAclBoundaryTest do
+  @moduledoc """
+  Drives `Mix.Tasks.LintAclBoundary.violations/1` against a fixture tree.
+
+  The tree is the point twice over: table ownership is *derived* from the
+  `schema "..."` declarations found under the same directory, so a test that fed
+  strings to a matcher could not express "this table belongs to that context" at
+  all — and the context of a file is a property of its path.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Mix.Tasks.LintAclBoundary
+
+  describe "violations/1" do
+    @tag :tmp_dir
+    test "flags a foreign table read with no acl_span", %{tmp_dir: dir} do
+      write(dir, "program_catalog/program.ex", schema("programs"))
+      write(dir, "enrollment.ex", query_over("programs"))
+
+      assert [{path, message}] = LintAclBoundary.violations(dir)
+      assert Path.basename(path) == "enrollment.ex"
+      assert message =~ "program_catalog's `programs`"
+      assert message =~ "acl_span"
+    end
+
+    # One behaviour — classifying a quoted name in a query — under the four inputs that
+    # decide it. Only the first is a violation; the other three are the ways a match on
+    # `in "..."` legitimately means nothing.
+    @tag :tmp_dir
+    test "classifies a quoted table reference", %{tmp_dir: dir} do
+      cases = [
+        {"a foreign table with no span", "enrollment", query_over("programs"), 1},
+        {"the context's own table", "program_catalog", query_over("programs"), 0},
+        {"a foreign table inside an acl_span", "enrollment", traced_query_over("programs"), 0},
+        {"a quoted word that is not a table", "enrollment", query_over("registered"), 0}
+      ]
+
+      for {label, context, content, expected} <- cases do
+        case_dir = Path.join(dir, String.replace(label, " ", "-"))
+        write(case_dir, "program_catalog/program.ex", schema("programs"))
+        write(case_dir, "#{context}/reader.ex", content)
+
+        assert length(LintAclBoundary.violations(case_dir)) == expected,
+               "#{label}: expected #{expected} violation(s)"
+      end
+    end
+
+    @tag :tmp_dir
+    test "names every foreign table a file reads", %{tmp_dir: dir} do
+      write(dir, "enrollment/enrollment.ex", schema("enrollments"))
+      write(dir, "family/child.ex", schema("children"))
+      write(dir, "messaging/reader.ex", query_over("enrollments", "children"))
+
+      assert [{_path, message}] = LintAclBoundary.violations(dir)
+      assert message =~ "enrollment's `enrollments`"
+      assert message =~ "family's `children`"
+    end
+
+    @tag :tmp_dir
+    test "the ignore comment exempts a file", %{tmp_dir: dir} do
+      write(dir, "program_catalog/program.ex", schema("programs"))
+
+      write(dir, "enrollment/reader.ex", """
+      # acl-boundary-lint-ignore: this read cannot be traced because <reason>
+      #{query_over("programs")}
+      """)
+
+      assert LintAclBoundary.violations(dir) == []
+    end
+
+    # read_table.ex quotes `schema "provider_programs"` in its own moduledoc. Without the
+    # exclusion that quote registers Shared as the owner of a table Provider declares, and
+    # every Provider read of its OWN table starts reading as cross-context. The paired
+    # assertion is what makes this non-vacuous: identical content under any other basename
+    # does mis-assign ownership, so the exclusion is doing the work.
+    @tag :tmp_dir
+    test "read_table.ex is excluded so its usage example does not claim ownership", %{tmp_dir: dir} do
+      write(dir, "shared/read_table.ex", schema_in_moduledoc("provider_programs"))
+      write(dir, "provider/provider_program.ex", schema("provider_programs"))
+      write(dir, "provider/reader.ex", query_over("provider_programs"))
+
+      assert LintAclBoundary.violations(dir) == []
+
+      write(dir, "shared/impostor.ex", schema_in_moduledoc("provider_programs"))
+
+      assert [{path, message}] = LintAclBoundary.violations(dir)
+      assert Path.basename(path) == "reader.ex"
+      assert message =~ "shared's `provider_programs`"
+    end
+
+    test "the real tree satisfies the convention" do
+      assert LintAclBoundary.violations("lib/klass_hero") == []
+    end
+  end
+
+  defp write(dir, relative_path, content) do
+    path = Path.join(dir, relative_path)
+    File.mkdir_p!(Path.dirname(path))
+    File.write!(path, content)
+  end
+
+  defp schema(table) do
+    """
+    defmodule KlassHero.Fixture do
+      use Ecto.Schema
+
+      schema "#{table}" do
+        field :title, :string
+      end
+    end
+    """
+  end
+
+  defp schema_in_moduledoc(table) do
+    """
+    defmodule KlassHero.Fixture.Marker do
+      @moduledoc \"\"\"
+          defmodule Example do
+            use Ecto.Schema
+
+            schema "#{table}" do
+              field :title, :string
+            end
+          end
+      \"\"\"
+    end
+    """
+  end
+
+  defp query_over(table) do
+    """
+    defmodule KlassHero.Fixture.Reader do
+      import Ecto.Query
+
+      def run do
+        from(t in "#{table}", select: t.title) |> Repo.all()
+      end
+    end
+    """
+  end
+
+  defp query_over(from_table, join_table) do
+    """
+    defmodule KlassHero.Fixture.Reader do
+      import Ecto.Query
+
+      def run do
+        from(t in "#{from_table}",
+          join: j in "#{join_table}",
+          on: j.id == t.child_id,
+          select: t.id
+        )
+        |> Repo.all()
+      end
+    end
+    """
+  end
+
+  defp traced_query_over(table) do
+    """
+    defmodule KlassHero.Fixture.Reader do
+      use KlassHero.Shared.Tracing
+
+      import Ecto.Query
+
+      def run do
+        acl_span source: "enrollment", target: "program_catalog" do
+          from(t in "#{table}", select: t.title) |> Repo.all()
+        end
+      end
+    end
+    """
+  end
+end


### PR DESCRIPTION
Closes #1274.

## What the issue asked, and what was actually there

#1274 reports that `Enrollment.list_pending/1` joins ProgramCatalog's `programs` inline instead of going through `ProgramCatalogACL`, on three grounds. Two did not hold:

- **"justification is not written down at the call site"** — `enrollment.ex` has carried a 7-line comment naming the cycle *and* the two-sided filter since #1103 (2026-07-17), three weeks before the issue was filed.
- **"not covered by the ACL's tests"** — covered by `list_pending_enrollments_for_provider_test.exs`, 6 tests including provider isolation.

The third ground is real, and larger than the issue framed it.

## Root cause

ADR 0015 permits cycle-breaking direct table access and requires one thing in exchange: *"Observability is preserved at the call site, not by the adapter."* Nothing checked that. A census of every raw-string table read found **four of eight untraced**:

| Site | Foreign tables | `acl_span` before |
|---|---|---|
| `enrollment.ex` (#1274) | `programs` | ❌ |
| `provider/…/acl/participation_session_stats_acl.ex` | `program_sessions`, `programs` | ❌ |
| `messaging/…/projections/enrolled_children.ex` | `enrollments`, `children`, `parents` | ❌ |
| `admin/queries.ex` | `providers`, `programs` | ❌ |
| the four other ACLs | — | ✅ |

The untraced set includes the module ADR 0015 cites **by name** as a legitimate ACL. #1274 surfaced only because `boundary-checker` happened to run on an unrelated PR.

## What this does

Adds `mix lint_acl_boundary`, wired into `precommit` and the CI `quality` job, and traces all four sites.

Two design points worth review attention:

- **Ownership is derived, not configured.** The lint maps each table to the context whose directory holds its `schema "..."` declaration. The map cannot drift from the schemas, and a quoted word that is not a table (`in "registered" status`, in a moduledoc) is ignored for free.
- **The check is per function, not per file.** This was not the original plan — the real-tree test caught it. File-level granularity *passes* `enrollment.ex`, because its untraced `programs` join hides behind the six `acl_span`s that file already carries for its Family hops. That is exactly how #1274 survived three weeks.

## Rejected: moving the join into ProgramCatalogACL

The issue's primary proposal. The join attaches `programs` to Enrollment's **own** query, and the two arities filter opposite sides of it (`e.program_id` vs `p.provider_id`). An ACL could only serve that by reverting #1103's single-query consolidation to two round trips, or by handing back a composable query fragment for the caller to `join` onto — an adapter leaking Ecto bindings, which is not an anti-corruption layer.

## Review focus

- `traced?/3` in the lint is an offset comparison: nearest preceding `def`, any `acl_span` between it and the reference. Text-based because the `quality` job must keep `mix compile --warnings-as-errors` as its first compile.
- Every query is **unchanged in shape**. The only functional edit is `list_pending/1`, where the span was narrowed after review so it no longer nests `child_map_for/1`'s Family span inside a `program_catalog`-tagged one.
- The `# acl-boundary-lint-ignore:` escape hatch ships with **no consumer** — Admin is traced rather than exempted.

## Test plan

- `mix lint_acl_boundary` passes on the real tree; its 6 tests drive a fixture tree covering ownership derivation, own-table reads, traced reads, non-table strings, the `read_table.ex` exclusion (with an impostor pairing so the exclusion is proven to do the work), and the real tree itself.
- The real-tree test is the load-bearing one: it went red naming all four sites, then green once each was traced.
- `mix precommit` green — 4122 passed, all five lints, credo clean.
- `/review-architecture`: 21/21 checks passed across architecture-reviewer, boundary-checker, and regression-analyzer, 0 violations. Regression's one `info` (span scope too wide in `list_pending`) is fixed in the second commit.

## Also in here

Stale prose the review surfaced, in files already being touched:

- `enrolled_children.ex` claimed raw strings "sidestep Boundary's compile-time isolation" — that library is gone — and pointed at #685's cross-context ports, deleted in the flatten.
- `enrollment.ex` claimed "Follows Ports & Adapters: delegates to use cases in the application layer".
- `participation_session_stats_acl.ex` never named *why* it bypasses the facade, which ADR 0015 requires — the same defect #1274 was filed about.
- ADR 0015 claimed `live` has no `acl.*` columns. It does, since 2026-08-05. Nothing queries them (both live triggers filter `context.name` + `error`), but the premise a future rename would lean on is spent.
- `boundary-checker` now treats a traced raw-table read as a documented exception instead of hand-reporting it — reporting one is what produced #1274.

🤖 Generated with [Claude Code](https://claude.com/claude-code)