### PR TITLE
fix: replay program assignments when a staff invite is accepted

### DIFF
--- a/lib/klass_hero/messaging/adapters/driving/events/staff_assignment_handler.ex
+++ b/lib/klass_hero/messaging/adapters/driving/events/staff_assignment_handler.ex
@@ -10,6 +10,11 @@ defmodule KlassHero.Messaging.Adapters.Driving.Events.StaffAssignmentHandler do
      inside a single transaction, so the delivery job reaches the
      `ConversationSummaries` projection only after the rows it describes commit.
 
+  A nil `staff_user_id` means the invite is unclaimed, and the assignment is
+  skipped rather than mirrored — there is no user to make a participant yet. That
+  is not a dropped assignment: Provider replays the event on acceptance, once the
+  user exists (#1312).
+
   On unassignment:
   1. Deactivates the projection entry (sets active=false).
   2. Delegates to `RemoveAssignedStaff` to soft-leave the staff in every

--- a/lib/klass_hero/provider/domain/events/provider_events.ex
+++ b/lib/klass_hero/provider/domain/events/provider_events.ex
@@ -14,6 +14,9 @@ defmodule KlassHero.Provider.Domain.Events.ProviderEvents do
   - `staff_assigned_to_program` / `staff_unassigned_from_program` - A staff
     member's program assignment changed (critical). Messaging reacts by adding
     or removing the staff member from the program's conversation.
+    `staff_assigned_to_program` is **also replayed on invite acceptance**, once per
+    standing assignment: a program assigned before the invite was claimed announced
+    a nil `staff_user_id`, which consumers skip (#1312).
   - `staff_member_deactivated` - A staff member's employment link ended
     (critical). Read tables holding a denormalised staff name clear it; a read
     filter cannot, because the name is a stored column.

--- a/lib/klass_hero/provider/staff.ex
+++ b/lib/klass_hero/provider/staff.ex
@@ -264,6 +264,9 @@ defmodule KlassHero.Provider.Staff do
   Links a User to a StaffMember and accepts the invitation (synchronous).
 
   Used by the one-click accept flow (#967). Idempotent for the same user.
+
+  Stages a `staff_assigned_to_program` per standing assignment (#1312) — see
+  `assignment_replay_events/1`. The link and that announcement commit together.
   """
   @spec accept_staff_invitation(StaffMember.t(), String.t()) ::
           {:ok, StaffMember.t()} | {:error, term()}
@@ -501,12 +504,32 @@ defmodule KlassHero.Provider.Staff do
   end
 
   defp accept_staff_invitation_fresh(%StaffMember{} = staff, user_id) do
-    with {:ok, _transitioned} <- StaffMember.transition_invitation(staff, :accepted),
-         {:ok, linked} <-
-           persist_staff_invitation_fields(staff, %{invitation_status: :accepted, user_id: user_id}),
-         {:ok, :selected} <- touch_staff_last_selected(user_id, linked.provider_id) do
-      {:ok, linked}
-    end
+    Outbox.transact(@context, fn ->
+      with {:ok, _transitioned} <- StaffMember.transition_invitation(staff, :accepted),
+           {:ok, linked} <-
+             persist_staff_invitation_fields(staff, %{invitation_status: :accepted, user_id: user_id}),
+           {:ok, :selected} <- touch_staff_last_selected(user_id, linked.provider_id) do
+        {:ok, linked, assignment_replay_events(linked)}
+      end
+    end)
+  end
+
+  # A program assigned before the invite was claimed emitted its
+  # staff_assigned_to_program with a nil staff_user_id, which Messaging skips —
+  # leaving the staff member out of that program's conversations for good.
+  # Acceptance is when those assignments become addressable, so replay them
+  # (#1312). Consumers are idempotent under replay: Messaging upserts on
+  # {program_id, staff_user_id}, and ProviderSessionDetails re-resolves from
+  # program_staff_assignments rather than trusting the payload.
+  #
+  # Queried here rather than through Assignments: Staff -> Assignments would
+  # close a cycle against the existing Assignments -> Provider -> Staff.
+  defp assignment_replay_events(%StaffMember{id: staff_id} = linked) do
+    from(a in ProgramStaffAssignment,
+      where: a.staff_member_id == ^staff_id and is_nil(a.unassigned_at)
+    )
+    |> Repo.all()
+    |> Enum.map(&ProviderEvents.staff_assigned_to_program(&1, linked))
   end
 
   defp insert_invited_staff(attrs, provider, raw_token) do

--- a/test/klass_hero/accounts/link_staff_invitation_test.exs
+++ b/test/klass_hero/accounts/link_staff_invitation_test.exs
@@ -2,11 +2,18 @@ defmodule KlassHero.Accounts.LinkStaffInvitationTest do
   use KlassHero.DataCase, async: true
 
   import KlassHero.AccountsFixtures
+  import KlassHero.EventTestHelper
+  import KlassHero.Factory
   import KlassHero.ProviderFixtures
 
   alias KlassHero.Accounts
   alias KlassHero.Accounts.User
   alias KlassHero.Provider
+
+  setup do
+    setup_test_integration_events()
+    :ok
+  end
 
   defp sent_staff_for(provider, email) do
     staff_member_fixture(%{
@@ -99,6 +106,32 @@ defmodule KlassHero.Accounts.LinkStaffInvitationTest do
       assert {:ok, db} = Provider.get_staff_member(staff.id)
       assert db.invitation_status == :expired
       assert is_nil(db.user_id)
+    end
+  end
+
+  # This path never emits :staff_user_registered — the user already exists, so
+  # there is no registration to announce. Any backfill hung off that event would
+  # miss it entirely; replaying from the accept itself is what covers both (#1312).
+  describe "link_staff_invitation/2 (pre-claim program assignments)" do
+    test "replays assignments made before the invite was claimed" do
+      user = user_fixture(intended_roles: [:parent])
+      provider = provider_profile_fixture()
+      staff = sent_staff_for(provider, user.email)
+      program = insert(:program_schema, provider_id: provider.id)
+
+      insert(:program_staff_assignment_schema,
+        provider_id: provider.id,
+        program_id: program.id,
+        staff_member_id: staff.id
+      )
+
+      assert {:ok, _updated} = Accounts.link_staff_invitation(user, staff)
+
+      assert_integration_event_published(:staff_assigned_to_program, %{
+        program_id: program.id,
+        staff_member_id: staff.id,
+        staff_user_id: user.id
+      })
     end
   end
 end

--- a/test/klass_hero/provider/staff/accept_staff_invitation_test.exs
+++ b/test/klass_hero/provider/staff/accept_staff_invitation_test.exs
@@ -2,9 +2,17 @@ defmodule KlassHero.Provider.Staff.AcceptStaffInvitationTest do
   use KlassHero.DataCase, async: true
 
   import KlassHero.AccountsFixtures
+  import KlassHero.EventTestHelper
+  import KlassHero.Factory
   import KlassHero.ProviderFixtures
 
   alias KlassHero.Provider
+  alias KlassHero.Provider.StaffMember
+
+  setup do
+    setup_test_integration_events()
+    :ok
+  end
 
   defp sent_staff(provider, opts \\ []) do
     staff_member_fixture(
@@ -109,5 +117,111 @@ defmodule KlassHero.Provider.Staff.AcceptStaffInvitationTest do
       assert db.invitation_status == :expired
       assert is_nil(db.user_id)
     end
+  end
+
+  # A program assigned before the invite was claimed emitted a
+  # staff_assigned_to_program carrying a nil staff_user_id, which Messaging
+  # skipped. Acceptance is the moment those assignments become addressable, so
+  # it replays them — otherwise the staff member is cut out of that program's
+  # messaging permanently (#1312).
+  describe "replaying assignments made before the invite was claimed" do
+    test "stages one staff_assigned_to_program per active assignment, carrying the linked user" do
+      provider = provider_profile_fixture()
+      staff = sent_staff(provider)
+      user_id = user_fixture().id
+
+      program_a = insert(:program_schema, provider_id: provider.id)
+      program_b = insert(:program_schema, provider_id: provider.id)
+
+      for program <- [program_a, program_b] do
+        insert(:program_staff_assignment_schema,
+          provider_id: provider.id,
+          program_id: program.id,
+          staff_member_id: staff.id
+        )
+      end
+
+      assert {:ok, _accepted} = Provider.accept_staff_invitation(staff, user_id)
+
+      for program <- [program_a, program_b] do
+        assert_integration_event_published(:staff_assigned_to_program, %{
+          provider_id: provider.id,
+          program_id: program.id,
+          staff_member_id: staff.id,
+          staff_user_id: user_id
+        })
+      end
+
+      assert length(assignment_events()) == 2
+    end
+
+    @replay_cases [
+      {"no assignment at all", nil, 0},
+      {"an assignment already removed", :unassigned_program_staff_assignment_schema, 0},
+      {"a standing assignment", :program_staff_assignment_schema, 1}
+    ]
+
+    test "only standing assignments replay" do
+      for {label, factory, expected} <- @replay_cases do
+        provider = provider_profile_fixture()
+        staff = sent_staff(provider)
+        user_id = user_fixture().id
+
+        if factory do
+          insert(factory,
+            provider_id: provider.id,
+            program_id: insert(:program_schema, provider_id: provider.id).id,
+            staff_member_id: staff.id
+          )
+        end
+
+        clear_integration_events()
+        assert {:ok, _accepted} = Provider.accept_staff_invitation(staff, user_id)
+
+        assert length(assignment_events()) == expected,
+               "with #{label}, expected #{expected} replayed event(s), got #{length(assignment_events())}"
+      end
+    end
+
+    test "re-accepting does not replay — the short circuit stages nothing" do
+      provider = provider_profile_fixture()
+      staff = sent_staff(provider)
+      user_id = user_fixture().id
+
+      insert(:program_staff_assignment_schema,
+        provider_id: provider.id,
+        program_id: insert(:program_schema, provider_id: provider.id).id,
+        staff_member_id: staff.id
+      )
+
+      assert {:ok, accepted} = Provider.accept_staff_invitation(staff, user_id)
+      assert length(assignment_events()) == 1
+
+      clear_integration_events()
+      assert {:ok, _again} = Provider.accept_staff_invitation(accepted, user_id)
+      assert assignment_events() == []
+    end
+
+    test "a failed selection bump rolls the whole acceptance back" do
+      # Staging the replay puts acceptance in a transaction, so the link no
+      # longer survives a later step failing. Half-accepted — user linked but
+      # never selectable — is not a state worth keeping.
+      provider = provider_profile_fixture()
+      staff = sent_staff(provider)
+      user_id = user_fixture().id
+
+      Repo.update_all(from(s in StaffMember, where: s.id == ^staff.id), set: [active: false])
+
+      assert {:error, :not_staffed} = Provider.accept_staff_invitation(staff, user_id)
+
+      assert {:ok, db} = Provider.get_staff_member(staff.id)
+      assert is_nil(db.user_id)
+      assert db.invitation_status == :sent
+      assert assignment_events() == []
+    end
+  end
+
+  defp assignment_events do
+    Enum.filter(get_published_integration_events(), &(&1.event_type == :staff_assigned_to_program))
   end
 end

--- a/test/klass_hero/provider/staff_invite_accept_messaging_test.exs
+++ b/test/klass_hero/provider/staff_invite_accept_messaging_test.exs
@@ -1,0 +1,99 @@
+defmodule KlassHero.Provider.StaffInviteAcceptMessagingTest do
+  @moduledoc """
+  End-to-end proof that accepting an invitation grants messaging access to
+  programs assigned *before* the invite was claimed (#1312).
+
+  A program assigned at invite time emits `staff_assigned_to_program` with a nil
+  `staff_user_id`, which Messaging skips — and nothing re-announced when the user
+  later appeared, so `program_staff_participants` stayed empty forever. Since
+  that mirror is the only source of broadcast recipients, the staff member was
+  cut out of every future broadcast, not just the historical ones.
+
+  This starts at `Provider.accept_staff_invitation/2` and lets the real machinery
+  run: staged events → Oban job → consumer registry → `StaffAssignmentHandler`.
+  The unit tests assert what was staged; only this one proves it lands.
+  """
+  # async: false — swaps the :outbox adapter in application env, which every
+  # other test reads (see outbox_test.exs for the same constraint).
+  use KlassHero.DataCase, async: false
+
+  import Ecto.Query
+  import KlassHero.AccountsFixtures
+  import KlassHero.Factory
+  import KlassHero.ProviderFixtures
+
+  alias KlassHero.Messaging.Participant
+  alias KlassHero.Messaging.ProgramStaffParticipant
+  alias KlassHero.Provider
+  alias KlassHero.Shared.Adapters.Driven.Events.ObanOutbox
+
+  test "accepting an invitation backfills messaging for a program assigned before the claim" do
+    provider = insert(:provider_profile_schema)
+    program = insert(:program_schema, provider_id: provider.id)
+    user = user_fixture()
+
+    # Invited, not yet claimed: user_id is nil, so the assignment below announces
+    # a nil staff_user_id and Messaging skips it.
+    staff =
+      staff_member_fixture(%{
+        provider_id: provider.id,
+        email: "invited-#{System.unique_integer([:positive])}@example.com",
+        invitation_status: :sent,
+        invitation_token_hash: :crypto.hash(:sha256, "tok-#{System.unique_integer([:positive])}"),
+        invitation_sent_at: DateTime.utc_now()
+      })
+
+    assert is_nil(staff.user_id)
+
+    insert(:program_staff_assignment_schema,
+      provider_id: provider.id,
+      program_id: program.id,
+      staff_member_id: staff.id
+    )
+
+    # A broadcast that already exists — the history the staff member is missing.
+    conversation =
+      insert(:conversation_schema,
+        provider_id: provider.id,
+        program_id: program.id,
+        type: :program_broadcast
+      )
+
+    with_real_outbox(fn ->
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        assert {:ok, accepted} = Provider.accept_staff_invitation(staff, user.id)
+        assert accepted.user_id == user.id
+
+        # Nothing has consumed the events yet — the job is staged, not run.
+        assert staff_participants(user.id) == []
+
+        Oban.drain_queue(queue: :critical_events, with_recursion: true)
+      end)
+    end)
+
+    assert [%ProgramStaffParticipant{active: true} = mirrored] = staff_participants(user.id)
+    assert mirrored.program_id == program.id
+    assert mirrored.provider_id == provider.id
+
+    assert Repo.exists?(
+             from(p in Participant,
+               where: p.conversation_id == ^conversation.id and p.user_id == ^user.id and is_nil(p.left_at)
+             )
+           )
+  end
+
+  defp staff_participants(user_id) do
+    Repo.all(from(p in ProgramStaffParticipant, where: p.staff_user_id == ^user_id))
+  end
+
+  defp with_real_outbox(fun) do
+    original = Application.get_env(:klass_hero, :outbox)
+    Application.put_env(:klass_hero, :outbox, module: ObanOutbox)
+
+    try do
+      fun.()
+    after
+      Application.put_env(:klass_hero, :outbox, original)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

A program assigned to a staff member **before** they claimed their invite announced
`staff_assigned_to_program` with a nil `staff_user_id`. Messaging skips that — there is no
user to make a participant yet — and nothing re-announced once the user appeared, so
`program_staff_participants` stayed empty for good.

That mirror is the only source of broadcast recipients (`broadcast_to_program.ex:133` via
`AddAssignedStaff`, and `send_message.ex:267`), so the staff member was cut out of **every
future broadcast** on that program, not just the history they missed. Invite-then-register
is the standard onboarding flow, so this is the common case, not an edge.

Acceptance is the moment those assignments become addressable. `accept_staff_invitation/2`
now stages one `staff_assigned_to_program` per standing assignment, inside the same
transaction that links the user.

Closes #1312

## Review Focus

**Why the fix lives in Provider, not Messaging.** The issue suggested Messaging subscribe to
`:staff_user_registered`. That would cover only one of two accept paths:

| Path | Trigger | Emits `:staff_user_registered`? |
|---|---|---|
| new account | `StaffInvitation` LiveView `"save"` → `Accounts.emit_staff_user_registered/3` | yes |
| existing logged-in user (#967) | LiveView `"link"` → `Accounts.link_staff_invitation/2` | **no** |

Both funnel through `accept_staff_invitation/2`, so that is where the fix goes. Messaging is
unchanged apart from a moduledoc.

**Why replaying is safe.** Every consumer of the event is idempotent under replay:
- `StaffParticipants.upsert_active/1` conflicts on `{program_id, staff_user_id}`
- `Messaging.add_user_to_conversations/2` only targets conversations the user is *not* in,
  and its on-conflict clears `left_at` while preserving `joined_at`
- `ProviderSessionDetails` re-resolves from `program_staff_assignments` and never reads
  `staff_user_id` from the payload

**Two judgement calls worth a second opinion:**

1. **Local query instead of `Assignments.list_active_assignments_for_staff_member/1`.**
   Calling it would close a `Staff → Assignments → Provider → Staff` cycle that does not
   exist today. The cost is duplicating the `is_nil(unassigned_at)` scope.
2. **Acceptance is now transactional.** Previously a `touch_staff_last_selected` failure left
   the `user_id` link committed; now the whole accept rolls back. More correct — half-accepted
   invitations are not a state worth keeping — but it is a behaviour change, covered by its
   own test.

## Test Plan

- `test/klass_hero/provider/staff_invite_accept_messaging_test.exs` (new) — end-to-end through
  the real machinery: staged events → Oban job → consumer registry → `StaffAssignmentHandler`.
  **Verified non-vacuous**: with the replay neutered it fails on exactly the reported symptom
  (`program_staff_participants` empty after acceptance).
- `accept_staff_invitation_test.exs` — tabular case over no / removed / standing assignment,
  plus per-program fan-out with payload, the re-accept short circuit, and the rollback.
- `link_staff_invitation_test.exs` — the existing-user path, which emits no
  `:staff_user_registered` and would have been missed by a fix hung off that event.
- `mix precommit` green: 4174 passed, credo/format/typography/translations/read-table/ACL
  lints clean.

## Follow-up

#1309 (the unassign clause crashing on the same nil `staff_user_id`) is untouched here — a
6-line nil-guard in the same handler, deliberately left to its own PR.
