### PR TITLE
fix: preserve typed payload values across the Oban jsonb boundary

### DIFF
--- a/lib/klass_hero/messaging/adapters/driven/projections/conversation_summaries.ex
+++ b/lib/klass_hero/messaging/adapters/driven/projections/conversation_summaries.ex
@@ -526,10 +526,9 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries 
     # conversations in every inbox — the bug #1216 fixed.
     %{conversation_ids: conversation_ids} = event.payload
 
-    # Both values arrive as ISO8601 *strings*, not %DateTime{}: the outbox stores the
-    # event as Oban jsonb and `CriticalEventSerializer.deserialize/1` atomizes keys only.
-    # Safe here because `update_all` casts them into the `:utc_datetime` column; a
-    # consumer doing DateTime arithmetic on them would not be.
+    # Arrives as the %DateTime{} the producer sent: since #1311 the serializer records
+    # typed payload values and rebuilds them, so DateTime arithmetic on this is safe.
+    # (`reason` is still a string — atoms are not restored; see EventMetadata.)
     archived_at = legacy_archived_at(event)
 
     now = DateTime.utc_now() |> DateTime.truncate(:second)

--- a/lib/klass_hero/shared/adapters/driven/events/critical_event_serializer.ex
+++ b/lib/klass_hero/shared/adapters/driven/events/critical_event_serializer.ex
@@ -17,6 +17,41 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializer do
   Stated because the opposite was assumed once — handlers carried their own
   shallow `normalize_keys/1` long after this became the single normalization
   point, and it read as load-bearing (#1256).
+
+  ## Payload values keep their types, and that is also only here
+
+  `jsonb` has no date, time or decimal. A `%Date{}` a producer put in a payload
+  would arrive as `"2026-08-12"`, and a consumer written against the `@spec` would
+  raise on it — which is what #1311 was, in two contexts at once.
+
+  So `serialize/1` writes a second map beside the payload recording what each typed
+  value was, and `deserialize/1` uses it to rebuild them:
+
+      %{
+        "payload"       => %{"start_date" => "2026-08-12", "title" => "Chess"},
+        "payload_types" => %{"start_date" => "date"}
+      }
+
+  A consumer therefore receives what the producer sent and needs to know nothing
+  about the wire. Supported: `Date`, `Time`, `DateTime`, `NaiveDateTime`, `Decimal`.
+  Any other struct raises here — `EventMetadata.validate_payload!/1` rejects it at
+  construction, so reaching that raise means something bypassed `Event.new/6`.
+
+  The sidecar mirrors the payload's shape rather than tagging values inline
+  (`{"__type__": ...}`) so the payload stays plain JSON in `oban_jobs.args` and
+  `undelivered_events.payload` — both get read in SQL and in Honeycomb, where a
+  wrapped scalar is materially worse. Branches with nothing typed in them are
+  pruned, so an all-scalar payload carries `%{}`.
+
+  Two properties worth knowing:
+
+  - **Args written before this existed** carry no `"payload_types"`, so their values
+    stay strings — the pre-#1311 behaviour, which is what in-flight jobs need at
+    deploy. The reverse holds too: older code ignores the extra key, so a rollback
+    is safe.
+  - **A `DateTime` comes back in UTC.** `DateTime.from_iso8601/1` returns the instant
+    plus a separate offset, and only the instant is kept. Every producer here builds
+    UTC, so nothing observes the difference.
   """
 
   alias KlassHero.Shared.Domain.Events.Event
@@ -26,6 +61,8 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializer do
   """
   @spec serialize(Event.t()) :: map()
   def serialize(%Event{} = event) do
+    {payload, payload_types} = encode_payload(event.payload)
+
     %{
       "event_id" => event.event_id,
       "event_type" => Atom.to_string(event.event_type),
@@ -33,7 +70,8 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializer do
       "entity_type" => Atom.to_string(event.entity_type),
       "entity_id" => event.entity_id,
       "occurred_at" => DateTime.to_iso8601(event.occurred_at),
-      "payload" => stringify_keys(event.payload),
+      "payload" => payload,
+      "payload_types" => payload_types || %{},
       "metadata" => serialize_metadata(event.metadata),
       "version" => event.version
     }
@@ -54,37 +92,99 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializer do
       entity_type: to_existing_atom(data["entity_type"]),
       entity_id: data["entity_id"],
       occurred_at: parse_datetime!(data["occurred_at"]),
-      payload: atomize_keys(data["payload"]),
+      payload: decode_payload(data["payload"], data["payload_types"]),
       metadata: deserialize_metadata(data["metadata"]),
       version: data["version"]
     }
   end
 
-  defp stringify_keys(%_{} = struct), do: struct
+  # Each walker returns {encoded_value, types} where types mirrors the value's shape
+  # and holds a type name at every typed leaf, or nil where there is nothing to
+  # remember. nil is what prunes the sidecar: it propagates up through maps and
+  # lists, so an all-scalar payload contributes no sidecar at all.
 
-  defp stringify_keys(map) when is_map(map) do
-    Map.new(map, fn
-      {k, v} when is_atom(k) -> {Atom.to_string(k), stringify_keys(v)}
-      {k, v} -> {k, stringify_keys(v)}
+  defp encode_payload(payload) when is_map(payload), do: encode_value(payload)
+
+  defp encode_value(%Date{} = value), do: {Date.to_iso8601(value), "date"}
+  defp encode_value(%Time{} = value), do: {Time.to_iso8601(value), "time"}
+  defp encode_value(%DateTime{} = value), do: {DateTime.to_iso8601(value), "datetime"}
+  defp encode_value(%NaiveDateTime{} = value), do: {NaiveDateTime.to_iso8601(value), "naive_datetime"}
+  defp encode_value(%Decimal{} = value), do: {Decimal.to_string(value), "decimal"}
+
+  defp encode_value(%struct{} = value) do
+    raise ArgumentError,
+          "Event payload value of type #{inspect(struct)} cannot cross the Oban jsonb " <>
+            "boundary: #{inspect(value)}. Supported structs are Date, Time, DateTime, " <>
+            "NaiveDateTime and Decimal; encode anything else as a JSON scalar in the " <>
+            "producer. Event.new/6 rejects this too, so reaching here means the event " <>
+            "was built some other way."
+  end
+
+  defp encode_value(map) when is_map(map) do
+    {encoded, types} =
+      Enum.map_reduce(map, %{}, fn {key, value}, types ->
+        string_key = stringify_key(key)
+        {encoded_value, value_types} = encode_value(value)
+
+        {{string_key, encoded_value}, put_type(types, string_key, value_types)}
+      end)
+
+    {Map.new(encoded), prune(types)}
+  end
+
+  defp encode_value(list) when is_list(list) do
+    {encoded, types} = list |> Enum.map(&encode_value/1) |> Enum.unzip()
+
+    {encoded, prune(types)}
+  end
+
+  defp encode_value(value), do: {value, nil}
+
+  defp stringify_key(key) when is_atom(key), do: Atom.to_string(key)
+  defp stringify_key(key), do: key
+
+  defp put_type(types, _key, nil), do: types
+  defp put_type(types, key, value_types), do: Map.put(types, key, value_types)
+
+  # An empty container carries no type information, so it collapses to nil and its
+  # parent drops the entry entirely.
+  defp prune(types) when types == %{}, do: nil
+  defp prune(types) when is_list(types), do: if(!Enum.all?(types, &is_nil/1), do: types)
+  defp prune(types), do: types
+
+  defp decode_payload(payload, types) when is_map(payload), do: decode_value(payload, types)
+
+  defp decode_value(value, type) when is_binary(type), do: revive(type, value)
+
+  defp decode_value(map, types) when is_map(map) do
+    Map.new(map, fn {key, value} ->
+      {atomize_key(key), decode_value(value, type_for(types, key))}
     end)
   end
 
-  defp stringify_keys(list) when is_list(list), do: Enum.map(list, &stringify_keys/1)
+  defp decode_value(list, types) when is_list(list) do
+    types = if is_list(types) and length(types) == length(list), do: types, else: List.duplicate(nil, length(list))
 
-  defp stringify_keys(value), do: value
-
-  defp atomize_keys(%_{} = struct), do: struct
-
-  defp atomize_keys(map) when is_map(map) do
-    Map.new(map, fn
-      {k, v} when is_binary(k) -> {String.to_existing_atom(k), atomize_keys(v)}
-      {k, v} -> {k, atomize_keys(v)}
-    end)
+    for {value, value_types} <- Enum.zip(list, types), do: decode_value(value, value_types)
   end
 
-  defp atomize_keys(list) when is_list(list), do: Enum.map(list, &atomize_keys/1)
+  defp decode_value(value, _types), do: value
 
-  defp atomize_keys(value), do: value
+  defp atomize_key(key) when is_binary(key), do: String.to_existing_atom(key)
+  defp atomize_key(key), do: key
+
+  defp type_for(types, key) when is_map(types), do: Map.get(types, key)
+  defp type_for(_types, _key), do: nil
+
+  defp revive("date", value), do: Date.from_iso8601!(value)
+  defp revive("time", value), do: Time.from_iso8601!(value)
+  defp revive("naive_datetime", value), do: NaiveDateTime.from_iso8601!(value)
+  defp revive("decimal", value), do: Decimal.new(value)
+
+  defp revive("datetime", value) do
+    {:ok, datetime, _utc_offset} = DateTime.from_iso8601(value)
+    datetime
+  end
 
   defp serialize_metadata(metadata) when is_map(metadata) do
     Map.new(metadata, fn

--- a/lib/klass_hero/shared/domain/events/event.ex
+++ b/lib/klass_hero/shared/domain/events/event.ex
@@ -8,7 +8,10 @@ defmodule KlassHero.Shared.Domain.Events.Event do
   - Use `source_context` to identify the publishing bounded context
   - Use `entity_type`/`entity_id` instead of `aggregate_type`/`aggregate_id`
   - Carry a `version` field for schema evolution and forward compatibility
-  - Contain only primitive types in `payload` for a stable cross-context contract
+  - Carry a `payload` of JSON scalars, plus `Date`/`Time`/`DateTime`/`NaiveDateTime`/
+    `Decimal`, which `CriticalEventSerializer` round-trips with their types intact
+    (#1311). Anything else loses its type in `oban_jobs.args`; for `:critical` events
+    `EventMetadata.validate_critical_payload!/2` rejects it at construction.
 
   ## Topic Naming Convention
 

--- a/lib/klass_hero/shared/domain/events/event_metadata.ex
+++ b/lib/klass_hero/shared/domain/events/event_metadata.ex
@@ -52,22 +52,34 @@ defmodule KlassHero.Shared.Domain.Events.EventMetadata do
   end
 
   @doc """
-  Raises if a `:critical` event carries a payload value that is not a JSON
-  scalar.
+  Raises if a `:critical` event carries a payload value that cannot survive Oban's
+  jsonb column.
 
-  Critical events are serialized to Oban's jsonb `args` column for durable,
-  at-least-once delivery. Non-scalar payload *values* — a `%DateTime{}`, an
-  atom, a tuple — silently lose their type across the `serialize → jsonb →
-  deserialize` round trip (a `DateTime` comes back a string, an atom comes
-  back a string) with no error (see issue #1010). Guarding at construction
-  makes the failure loud at the publish site instead of latent three systems
-  downstream.
+  Payloads are serialized to `oban_jobs.args`, so a value that loses its type there
+  — an atom, a tuple, a schema struct — reaches consumers as something else, with no
+  error at the publish site (#1010). Guarding at construction makes that loud where
+  it is caused.
 
-  Nested maps and lists are allowed as *containers* — they are walked
-  recursively, and only their leaf values must be scalars.
+  `Date`, `Time`, `DateTime`, `NaiveDateTime` and `Decimal` are exempt: since #1311
+  `CriticalEventSerializer` records them on the way out and rebuilds them on the way
+  in, so they arrive as what the producer sent. Nested maps and lists are containers
+  — walked recursively, only their leaves are checked.
 
-  Non-critical events dispatch in-memory only (never serialized), so they may
-  carry any term and are exempt.
+  ## Why this still only runs for `:critical`
+
+  The original reason for the exemption is stale. It read "non-critical events
+  dispatch in-memory only (never serialized)", which ADR-0014 ended: every staged
+  event now takes the same Outbox → Oban → `EventDeliveryWorker` path, and
+  `criticality` selects nothing. #1311's two bugs both hid in that gap.
+
+  It stays gated anyway, because ungating it today raises on 137 existing tests:
+  `:normal` payloads carry atoms as a matter of course (`type: :direct`,
+  `message_type: :text`, `status: :pending`), and their consumers already cope with
+  the string that arrives — `conversation_summaries.ex` matches
+  `message_type in [:system, "system"]` for exactly this reason. Closing that needs
+  either atom support in the serializer or an encode-at-the-producer pass across ~9
+  producers, and it is tracked separately. #1311 was about type loss the envelope can
+  fix without changing what any consumer receives.
 
   Returns `:ok` or raises `ArgumentError`.
   """
@@ -93,16 +105,26 @@ defmodule KlassHero.Shared.Domain.Events.EventMetadata do
   end
 
   defp scan_payload(value, path) do
-    if !json_scalar?(value) do
+    if !json_scalar?(value) and !typed_scalar?(value) do
       location = path |> Enum.reverse() |> Enum.join(".")
 
       raise ArgumentError,
-            "Critical event payload value at #{inspect(location)} is not a JSON scalar: " <>
-              "#{inspect(value)}. Critical payloads must carry only strings, numbers, " <>
-              "booleans, or nil (nested in maps/lists) so they survive jsonb serialization. " <>
-              "Encode DateTimes as ISO8601 strings and atoms as strings before publishing."
+            "Critical event payload value at #{inspect(location)} cannot survive jsonb " <>
+              "serialization: #{inspect(value)}. Critical payloads may carry strings, numbers, " <>
+              "booleans, nil, and Date/Time/DateTime/NaiveDateTime/Decimal structs (nested in " <>
+              "maps/lists). Encode anything else — an atom, a tuple, a schema struct — as a " <>
+              "JSON scalar before publishing."
     end
   end
+
+  # CriticalEventSerializer records these on the way out and rebuilds them on the way
+  # in, so unlike a bare atom they arrive as what the producer sent (#1311).
+  defp typed_scalar?(%Date{}), do: true
+  defp typed_scalar?(%Time{}), do: true
+  defp typed_scalar?(%DateTime{}), do: true
+  defp typed_scalar?(%NaiveDateTime{}), do: true
+  defp typed_scalar?(%Decimal{}), do: true
+  defp typed_scalar?(_value), do: false
 
   # A JSON scalar is a value that survives a jsonb round trip with its type
   # intact: strings, numbers, booleans, and nil. `nil`/`true`/`false` are

--- a/test/klass_hero/messaging/adapters/driven/projections/conversation_summaries_test.exs
+++ b/test/klass_hero/messaging/adapters/driven/projections/conversation_summaries_test.exs
@@ -2,6 +2,7 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummariesT
   use KlassHero.DataCase, async: false
 
   import Ecto.Query
+  import KlassHero.EventTestHelper, only: [through_outbox: 1]
   import KlassHero.Factory
 
   alias KlassHero.Messaging
@@ -669,6 +670,75 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummariesT
     end
   end
 
+  # Same gap as #1311, different context: the tests above hand a native %Event{} to
+  # the projection, while production stages it into oban_jobs.args first. These use
+  # the real constructors and cross that boundary, so a %DateTime{} arriving as an
+  # ISO string fails here instead of in prod.
+  describe "events crossing the outbox boundary" do
+    setup do
+      user_1 = user_fixture(name: "Alice Smith")
+      user_2 = user_fixture(name: "Bob Jones")
+      conversation_id = Ecto.UUID.generate()
+
+      dispatch(:conversation_created, %{
+        conversation_id: conversation_id,
+        type: :direct,
+        provider_id: Ecto.UUID.generate(),
+        participant_ids: [user_1.id, user_2.id]
+      })
+
+      {:ok, conversation_id: conversation_id, user_1: user_1, user_2: user_2}
+    end
+
+    test "message_sent keeps sent_at a DateTime for latest_message_at", ctx do
+      sent_at = now()
+
+      MessagingEvents.message_sent(
+        ctx.conversation_id,
+        Ecto.UUID.generate(),
+        ctx.user_1.id,
+        "Hello Bob!",
+        :text,
+        sent_at
+      )
+      |> through_outbox()
+      |> dispatch()
+
+      summary = summary_for(ctx.conversation_id, ctx.user_2.id)
+      assert summary.latest_message_at == sent_at
+    end
+
+    test "message_sent with a broadcast token stamps system_notes", ctx do
+      token = "[broadcast:#{Ecto.UUID.generate()}]"
+
+      MessagingEvents.message_sent(
+        ctx.conversation_id,
+        Ecto.UUID.generate(),
+        ctx.user_1.id,
+        "System note #{token}",
+        :system,
+        now()
+      )
+      |> through_outbox()
+      |> dispatch()
+
+      summary = summary_for(ctx.conversation_id, ctx.user_2.id)
+      assert Map.has_key?(summary.system_notes, token)
+    end
+
+    test "messages_read keeps read_at a DateTime for last_read_at", ctx do
+      read_at = now()
+
+      MessagingEvents.messages_read(ctx.conversation_id, ctx.user_2.id, read_at)
+      |> through_outbox()
+      |> dispatch()
+
+      summary = summary_for(ctx.conversation_id, ctx.user_2.id)
+      assert summary.last_read_at == read_at
+      assert summary.unread_count == 0
+    end
+  end
+
   describe "handle messages_read event" do
     test "sets unread_count to 0 and updates last_read_at for the user" do
       user_1 = user_fixture(name: "Alice Smith")
@@ -1265,6 +1335,14 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummariesT
   # ── Seed + dispatch helpers ────────────────────────────────────────────────
 
   defp now, do: DateTime.utc_now() |> DateTime.truncate(:second)
+
+  defp summary_for(conversation_id, user_id) do
+    Repo.one!(
+      from(s in ConversationSummary,
+        where: s.conversation_id == ^conversation_id and s.user_id == ^user_id
+      )
+    )
+  end
 
   defp insert_conversation(attrs) do
     Repo.insert!(struct!(Conversation, Keyword.put_new(attrs, :id, Ecto.UUID.generate())))

--- a/test/klass_hero/program_catalog/adapters/driven/projections/program_listings_test.exs
+++ b/test/klass_hero/program_catalog/adapters/driven/projections/program_listings_test.exs
@@ -1,9 +1,11 @@
 defmodule KlassHero.ProgramCatalog.Adapters.Driven.Projections.ProgramListingsTest do
   use KlassHero.DataCase, async: false
 
+  import KlassHero.EventTestHelper, only: [through_outbox: 1]
   import KlassHero.Factory
 
   alias KlassHero.ProgramCatalog.Adapters.Driven.Projections.ProgramListings
+  alias KlassHero.ProgramCatalog.Domain.Events.ProgramEvents
   alias KlassHero.ProgramCatalog.ProgramListing
   alias KlassHero.Repo
   alias KlassHero.Shared.Domain.Events.Event
@@ -258,6 +260,65 @@ defmodule KlassHero.ProgramCatalog.Adapters.Driven.Projections.ProgramListingsTe
       assert listing.category == "education"
       assert listing.provider_id == provider_id
       assert listing.season == nil
+    end
+  end
+
+  # The tests above hand a native %Event{} to the projection. Production does not:
+  # the event is staged into oban_jobs.args and read back out first, which is where
+  # #1311's %Date{} became "2026-03-01". These use the real event constructors and
+  # cross that boundary.
+  describe "events crossing the outbox boundary" do
+    test "projects a program_created carrying dates, times and a price" do
+      program_id = Ecto.UUID.generate()
+      provider_id = Ecto.UUID.generate()
+
+      ProgramEvents.program_created(program_id, %{
+        provider_id: provider_id,
+        title: "Soccer Camp",
+        category: "sports",
+        meeting_days: ["Monday"],
+        meeting_start_time: ~T[15:00:00],
+        meeting_end_time: ~T[17:00:00],
+        start_date: ~D[2026-08-12],
+        end_date: ~D[2026-09-30]
+      })
+      |> through_outbox()
+      |> dispatch()
+
+      listing = Repo.get!(ProgramListing, program_id)
+      assert listing.start_date == ~D[2026-08-12]
+      assert listing.end_date == ~D[2026-09-30]
+      assert listing.meeting_start_time == ~T[15:00:00]
+      assert listing.meeting_end_time == ~T[17:00:00]
+    end
+
+    test "projects a program_updated carrying every typed field" do
+      program_id = Ecto.UUID.generate()
+      provider_id = Ecto.UUID.generate()
+
+      ProgramEvents.program_updated(program_id, %{
+        provider_id: provider_id,
+        title: "Updated Soccer Camp",
+        category: "sports",
+        price: Decimal.new("200.00"),
+        meeting_days: ["Tuesday"],
+        meeting_start_time: ~T[16:00:00],
+        meeting_end_time: ~T[18:00:00],
+        start_date: ~D[2026-08-12],
+        end_date: ~D[2026-09-30],
+        registration_start_date: ~D[2026-07-01],
+        registration_end_date: ~D[2026-07-31]
+      })
+      |> through_outbox()
+      |> dispatch()
+
+      listing = Repo.get!(ProgramListing, program_id)
+      assert listing.price == Decimal.new("200.00")
+      assert listing.start_date == ~D[2026-08-12]
+      assert listing.end_date == ~D[2026-09-30]
+      assert listing.meeting_start_time == ~T[16:00:00]
+      assert listing.registration_start_date == ~D[2026-07-01]
+      assert listing.registration_end_date == ~D[2026-07-31]
     end
   end
 

--- a/test/klass_hero/program_catalog/program_listing_delivery_test.exs
+++ b/test/klass_hero/program_catalog/program_listing_delivery_test.exs
@@ -1,0 +1,69 @@
+defmodule KlassHero.ProgramCatalog.ProgramListingDeliveryTest do
+  @moduledoc """
+  Integration test for #1311, at the level the bug actually lived: creating a program
+  stages `program_created` in the write's transaction, and the delivery job reads it
+  back out of `oban_jobs.args` before invoking `ProgramListings.project/1`.
+
+  Every other test of this path either hands the projection a native `%Event{}` or
+  asserts on `TestOutbox`, which records structs rather than enqueueing them. Neither
+  crosses the jsonb boundary, which is why a `%Date{}` arriving as `"2026-08-12"` —
+  raising `Ecto.ChangeError` on every program create and update in production — passed
+  CI for two months. This test swaps in the real `ObanOutbox`, following
+  `test/klass_hero/messaging/archive_conversations_delivery_test.exs`.
+  """
+
+  use KlassHero.DataCase, async: false
+
+  alias KlassHero.ProgramCatalog
+  alias KlassHero.ProgramCatalog.ProgramListing
+  alias KlassHero.ProviderFixtures
+  alias KlassHero.Shared.Adapters.Driven.Events.ObanOutbox
+
+  describe "creating a program" do
+    test "projects its dates and price into the catalog read table" do
+      provider = ProviderFixtures.provider_profile_fixture()
+
+      {:ok, program} =
+        create_and_deliver(%{
+          provider_id: provider.id,
+          title: "Soccer Camp",
+          description: "Outdoor soccer for beginners",
+          category: "sports",
+          price: Decimal.new("150.00"),
+          start_date: ~D[2026-08-12],
+          end_date: ~D[2026-09-30],
+          meeting_start_time: ~T[15:00:00],
+          meeting_end_time: ~T[17:00:00]
+        })
+
+      listing = Repo.get(ProgramListing, program.id)
+
+      assert listing != nil,
+             "program_created was staged but never reached program_listings — the delivery job failed"
+
+      assert listing.start_date == ~D[2026-08-12]
+      assert listing.end_date == ~D[2026-09-30]
+      assert listing.meeting_start_time == ~T[15:00:00]
+      assert listing.meeting_end_time == ~T[17:00:00]
+    end
+  end
+
+  # Swapped around the act alone, and manual-mode-then-drain rather than the suite's
+  # `testing: :inline`, which would run delivery inside the producer's own transaction.
+  # See archive_conversations_delivery_test.exs for both reasons in full.
+  defp create_and_deliver(attrs) do
+    original_outbox = Application.get_env(:klass_hero, :outbox)
+    Application.put_env(:klass_hero, :outbox, module: ObanOutbox)
+
+    result =
+      try do
+        Oban.Testing.with_testing_mode(:manual, fn -> ProgramCatalog.create_program(attrs) end)
+      after
+        Application.put_env(:klass_hero, :outbox, original_outbox)
+      end
+
+    Oban.drain_queue(queue: :critical_events, with_recursion: true)
+
+    result
+  end
+end

--- a/test/klass_hero/shared/adapters/driven/events/critical_event_serializer_test.exs
+++ b/test/klass_hero/shared/adapters/driven/events/critical_event_serializer_test.exs
@@ -1,8 +1,16 @@
 defmodule KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializerTest do
   use ExUnit.Case, async: true
+  use ExUnitProperties
 
   alias KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializer
   alias KlassHero.Shared.Domain.Events.Event
+
+  # Payload keys must survive String.to_existing_atom/1, so the generator draws from
+  # atoms this module has already created. The space is deliberately wider than
+  # @max_keys: map_of/3 needs unique keys, and asking for as many as exist starves it
+  # into StreamData.TooManyDuplicatesError.
+  @keys [:alpha, :beta, :gamma, :delta, :epsilon, :zeta, :eta, :theta]
+  @max_keys 3
 
   describe "round-trip" do
     test "serialize then deserialize produces equivalent struct" do
@@ -73,6 +81,69 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializerTest do
     end
   end
 
+  describe "typed payload values" do
+    # The invariant the sidecar exists for. #1311 was one instance of it failing;
+    # this covers the whole space rather than the fields that happened to break.
+    property "any payload survives the jsonb round-trip unchanged" do
+      check all(payload <- payload_generator()) do
+        assert round_trip(payload) == payload
+      end
+    end
+
+    for {label, payload} <- [
+          {"a Date", %{alpha: ~D[2026-08-12]}},
+          {"a Time", %{alpha: ~T[15:00:00]}},
+          {"a DateTime", %{alpha: ~U[2026-08-12 10:00:00Z]}},
+          {"a DateTime with microseconds", %{alpha: ~U[2026-08-12 10:00:00.123456Z]}},
+          {"a NaiveDateTime", %{alpha: ~N[2026-08-12 10:00:00]}},
+          {"a Decimal", %{alpha: Decimal.new("12.50")}},
+          {"a typed value nested in a map", %{alpha: %{beta: ~D[2026-08-12]}}},
+          {"a typed value nested in a list", %{alpha: ["x", ~T[09:00:00]]}},
+          {"typed values beside scalars and nils", %{alpha: ~D[2026-08-12], beta: "x", gamma: nil}}
+        ] do
+      test "restores #{label}" do
+        payload = unquote(Macro.escape(payload))
+
+        assert round_trip(payload) == payload
+      end
+    end
+
+    test "keeps the payload plain JSON and puts the types beside it" do
+      serialized = serialize(%{alpha: ~D[2026-08-12], beta: "Chess"})
+
+      assert serialized["payload"] == %{"alpha" => "2026-08-12", "beta" => "Chess"}
+      assert serialized["payload_types"] == %{"alpha" => "date"}
+    end
+
+    test "records no types for an all-scalar payload" do
+      assert serialize(%{alpha: "x", beta: %{gamma: 1}, delta: ["a"]})["payload_types"] == %{}
+    end
+
+    # Args staged before the sidecar existed. Values stay strings, which is the
+    # pre-#1311 behaviour — the in-flight jobs at deploy need exactly that.
+    test "leaves values alone when payload_types is absent" do
+      legacy = serialize(%{alpha: ~D[2026-08-12]}) |> Map.delete("payload_types")
+
+      assert CriticalEventSerializer.deserialize(legacy).payload == %{alpha: "2026-08-12"}
+    end
+
+    test "raises on a struct it cannot restore" do
+      event = %Event{
+        event_id: "id",
+        event_type: :test,
+        source_context: :test_context,
+        entity_type: :test,
+        entity_id: "id",
+        occurred_at: DateTime.utc_now(),
+        payload: %{alpha: %URI{host: "example.com"}}
+      }
+
+      assert_raise ArgumentError, ~r/cannot cross the Oban jsonb boundary/, fn ->
+        CriticalEventSerializer.serialize(event)
+      end
+    end
+  end
+
   describe "metadata round-trip" do
     test "restores metadata atom keys after JSON round-trip" do
       event =
@@ -114,5 +185,49 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializerTest do
       refute Map.has_key?(deserialized.metadata, :traceparent)
       refute Map.has_key?(deserialized.metadata, :tracestate)
     end
+  end
+
+  # Jason.encode!/decode! is not ceremony: without it the test compares two in-memory
+  # maps and never crosses the boundary that loses the type.
+  defp round_trip(payload) do
+    payload
+    |> serialize()
+    |> Jason.encode!()
+    |> Jason.decode!()
+    |> CriticalEventSerializer.deserialize()
+    |> Map.fetch!(:payload)
+  end
+
+  defp serialize(payload) do
+    :test
+    |> Event.new(:test_context, :test, "id", payload)
+    |> CriticalEventSerializer.serialize()
+  end
+
+  defp payload_generator do
+    StreamData.map_of(member_of(@keys), nested_value(), max_length: @max_keys)
+  end
+
+  defp nested_value do
+    StreamData.tree(leaf_value(), fn child ->
+      one_of([
+        StreamData.list_of(child, max_length: 3),
+        StreamData.map_of(member_of(@keys), child, max_length: @max_keys)
+      ])
+    end)
+  end
+
+  defp leaf_value do
+    one_of([
+      string(:printable),
+      integer(),
+      boolean(),
+      constant(nil),
+      map(integer(0..36_500), &Date.add(~D[1990-01-01], &1)),
+      map(integer(0..86_399), &Time.add(~T[00:00:00], &1)),
+      map(integer(0..2_000_000_000), &DateTime.from_unix!/1),
+      map(integer(0..2_000_000_000), &(&1 |> DateTime.from_unix!() |> DateTime.to_naive())),
+      map(integer(-1_000_000..1_000_000), &Decimal.new/1)
+    ])
   end
 end

--- a/test/klass_hero/shared/domain/events/critical_payload_guard_test.exs
+++ b/test/klass_hero/shared/domain/events/critical_payload_guard_test.exs
@@ -1,72 +1,75 @@
 defmodule KlassHero.Shared.Domain.Events.CriticalPayloadGuardTest do
   @moduledoc """
-  Guards that `:critical` event payloads carry only JSON scalars so they
-  survive jsonb serialization intact (see #1010). The guard lives in
-  `EventMetadata.validate_critical_payload!/2` and is invoked from both
-  `DomainEvent.new/5` and `Event.new/6`.
+  Guards what a `:critical` event payload may carry across jsonb (#1010, #1311).
+  The guard lives in `EventMetadata.validate_critical_payload!/2`, invoked from
+  `Event.new/6`.
+
+  Two rules, and the difference between them is the whole point: a value the
+  serializer can restore is allowed, a value that would silently arrive as
+  something else is not.
   """
   use ExUnit.Case, async: true
 
   alias KlassHero.Shared.Domain.Events.Event
 
-  defp new_domain(payload, opts \\ [criticality: :critical]) do
-    Event.new(:test_event, :test_context, :test, "agg-1", payload, opts)
-  end
+  # Type is lost across jsonb with nothing recording what it was, so the consumer
+  # receives a string it did not ask for. Each case pins the path in the message —
+  # the point of the guard is saying *where*.
+  @rejected [
+    {"a bare atom", %{status: :pending}, "status"},
+    {"a tuple", %{coord: {1, 2}}, "coord"},
+    {"an atom nested in a map", %{outer: %{inner: :atom_value}}, "outer.inner"},
+    {"an atom nested in a list", %{items: ["ok", :nope]}, "items.1"},
+    {"a schema struct", %{ref: %URI{host: "example.com"}}, "ref"}
+  ]
 
-  defp new_integration(payload, opts \\ [criticality: :critical]) do
-    Event.new(:test_event, :test_ctx, :test, "id-1", payload, opts)
-  end
+  # CriticalEventSerializer records these on the way out and rebuilds them on the
+  # way in (#1311), so the consumer gets what the producer sent.
+  @restorable [
+    {"a Date", %{on: ~D[2026-08-12]}},
+    {"a Time", %{at: ~T[15:00:00]}},
+    {"a DateTime", %{happened_at: ~U[2026-08-12 10:00:00Z]}},
+    {"a NaiveDateTime", %{naive: ~N[2026-08-12 10:00:00]}},
+    {"a Decimal", %{price: Decimal.new("12.50")}}
+  ]
 
-  describe "critical events reject non-scalar payload values" do
-    test "raises on a DateTime payload value" do
-      assert_raise ArgumentError, ~r/not a JSON scalar/, fn ->
-        new_domain(%{happened_at: DateTime.utc_now()})
-      end
-    end
+  describe "critical payloads reject values that lose their type" do
+    for {label, payload, path} <- @rejected do
+      test "rejects #{label}" do
+        error =
+          assert_raise ArgumentError, fn ->
+            critical(unquote(Macro.escape(payload)))
+          end
 
-    test "raises on a bare atom payload value" do
-      assert_raise ArgumentError, ~r/not a JSON scalar/, fn ->
-        new_domain(%{status: :pending})
-      end
-    end
+        assert error.message =~ "cannot survive jsonb serialization",
+               "expected the guard's message, got: #{error.message}"
 
-    test "raises on a tuple payload value" do
-      assert_raise ArgumentError, ~r/not a JSON scalar/, fn ->
-        new_domain(%{coord: {1, 2}})
-      end
-    end
-
-    test "raises on a non-scalar nested inside a map" do
-      assert_raise ArgumentError, ~r/not a JSON scalar/, fn ->
-        new_domain(%{outer: %{inner: :atom_value}})
-      end
-    end
-
-    test "raises on a non-scalar nested inside a list" do
-      assert_raise ArgumentError, ~r/not a JSON scalar/, fn ->
-        new_domain(%{items: ["ok", DateTime.utc_now()]})
-      end
-    end
-
-    test "error message names the offending path" do
-      error =
-        assert_raise ArgumentError, fn ->
-          new_domain(%{outer: %{when: DateTime.utc_now()}})
-        end
-
-      assert error.message =~ "outer.when"
-    end
-
-    test "applies to Event too" do
-      assert_raise ArgumentError, ~r/not a JSON scalar/, fn ->
-        new_integration(%{happened_at: DateTime.utc_now()})
+        assert error.message =~ unquote(path),
+               "expected the message to name the path #{unquote(path)}, got: #{error.message}"
       end
     end
   end
 
-  describe "critical events accept JSON scalars and containers" do
+  describe "critical payloads accept what the serializer can restore" do
+    for {label, payload} <- @restorable do
+      test "accepts #{label}" do
+        payload = unquote(Macro.escape(payload))
+
+        assert critical(payload).payload == payload
+      end
+    end
+
+    test "accepts a restorable value nested in a map and a list" do
+      payload = %{outer: %{on: ~D[2026-08-12]}, items: ["ok", Decimal.new("1.00")]}
+
+      assert critical(payload).payload == payload
+    end
+  end
+
+  describe "critical payloads accept JSON scalars and containers" do
     test "allows strings, numbers, booleans, and nil" do
-      event = new_domain(%{name: "Alice", age: 7, ratio: 1.5, active: true, deleted: nil})
+      event = critical(%{name: "Alice", age: 7, ratio: 1.5, active: true, deleted: nil})
+
       assert event.payload.name == "Alice"
       assert event.payload.active == true
       assert event.payload.deleted == nil
@@ -74,24 +77,36 @@ defmodule KlassHero.Shared.Domain.Events.CriticalPayloadGuardTest do
 
     test "allows scalars nested in maps and lists" do
       payload = %{address: %{city: "Berlin"}, tags: ["a", "b"], items: [%{n: 1}, %{n: 2}]}
-      event = new_domain(payload)
-      assert event.payload == payload
+
+      assert critical(payload).payload == payload
     end
 
     test "allows an empty payload" do
-      assert %Event{} = new_domain(%{})
+      assert %Event{} = critical(%{})
     end
   end
 
+  # The exemption is stale — ADR-0014 made every event serialize — but ungating it
+  # raises on the atoms `:normal` payloads carry throughout, so it stands until those
+  # are encoded. See `EventMetadata`'s moduledoc.
   describe "non-critical events are exempt" do
-    test "allows a DateTime payload value on a :normal event" do
-      event = new_domain(%{happened_at: ~U[2026-07-06 12:00:00Z]}, criticality: :normal)
-      assert %DateTime{} = event.payload.happened_at
+    test "allows an atom payload value on a :normal event" do
+      event = normal(%{status: :pending})
+
+      assert event.payload.status == :pending
     end
 
     test "defaults to :normal (exempt) when criticality is unset" do
       event = Event.new(:test_event, :test_context, :test, "agg-1", %{status: :pending})
+
       assert event.payload.status == :pending
     end
+  end
+
+  defp critical(payload), do: build(payload, criticality: :critical)
+  defp normal(payload), do: build(payload, criticality: :normal)
+
+  defp build(payload, opts) do
+    Event.new(:test_event, :test_context, :test, "agg-1", payload, opts)
   end
 end

--- a/test/support/event_test_helper.ex
+++ b/test/support/event_test_helper.ex
@@ -20,8 +20,32 @@ defmodule KlassHero.EventTestHelper do
 
   import ExUnit.Assertions
 
+  alias KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializer
   alias KlassHero.Shared.Adapters.Driven.Events.TestOutbox
   alias KlassHero.Shared.Domain.Events.Event
+
+  @doc """
+  Puts an event through the Oban `jsonb` boundary its delivery job crosses.
+
+  A consumer test that hands a freshly built `%Event{}` straight to the consumer
+  exercises a path production does not have: since ADR-0014 every event is staged
+  into `oban_jobs.args` and read back out before any consumer sees it. `TestOutbox`
+  records native structs, so nothing else in the suite crosses that boundary —
+  which is why #1311 (a `%Date{}` arriving as `"2026-08-12"`) passed CI and failed
+  in prod.
+
+      event
+      |> KlassHero.EventTestHelper.through_outbox()
+      |> ProgramListings.project()
+  """
+  @spec through_outbox(Event.t()) :: Event.t()
+  def through_outbox(%Event{} = event) do
+    event
+    |> CriticalEventSerializer.serialize()
+    |> Jason.encode!()
+    |> Jason.decode!()
+    |> CriticalEventSerializer.deserialize()
+  end
 
   @doc """
   Initializes integration event collection for the current test.


### PR DESCRIPTION
Closes #1311

## Summary

Since ADR-0014 every integration event round-trips through `oban_jobs.args`.
`CriticalEventSerializer` atomized payload **keys** but left **values** untouched, so a
`%Date{}` a producer staged arrived at its consumer as `"2026-08-12"`.

Two consumers broke on that in production:

1. **`ProgramListings`** (the reported bug) — `Ecto.Changeset.change/2` does not cast, so
   every `program_created`/`program_updated` raised `Ecto.ChangeError` and the job was
   discarded after 10 attempts. The catalog read table only ever updated at deploy, via
   projection bootstrap — which is also what hid the bug for two months.
2. **`ConversationSummaries`** (found while scoping, not in the issue) — `sent_at` reached
   `DateTime.truncate/2` on the system-note path, and a `rescue` swallowed the
   `FunctionClauseError`. Silent data loss, no error_tracker signal at all.

`serialize/1` now records what each typed value was in a shape-mirroring `payload_types`
map beside the payload, and `deserialize/1` rebuilds them:

```elixir
%{
  "payload"       => %{"start_date" => "2026-08-12", "title" => "Chess"},
  "payload_types" => %{"start_date" => "date"}
}
```

`Date`, `Time`, `DateTime`, `NaiveDateTime` and `Decimal` are supported; any other struct
raises at serialize.

## Review focus

**No consumer changed.** `ProgramListings` keeps `change/2`, `ConversationSummaries` keeps
`update_all` — the envelope owns wire fidelity, so both bugs are fixed with zero edits to
any projection. That was the design's own check: a consumer needing an edit would have meant
the seam was in the wrong place. The only `lib` diff outside the serializer is the guard
widening and a comment that asserted the old behaviour.

**The sidecar is a parallel map, not inline `{"__type__": ...}` tags.** `oban_jobs.args` and
`undelivered_events.payload` get read in SQL and in Honeycomb, and a wrapped scalar is
materially worse there. The payload stays plain JSON.

**Deploy and rollback are both safe.** Args written before this carry no `payload_types`, so
their values stay strings — today's behaviour, which is what in-flight jobs need. Older code
reads named keys and ignores the extra one.

**`validate_critical_payload!/2` now permits those five structs** instead of rejecting them,
but stays gated on criticality. Its exemption ("non-critical events dispatch in-memory only")
has been stale since ADR-0014, and #1311 hid in that gap — but ungating it raises on 137
existing tests, because `:normal` payloads carry atoms as a matter of course (`type: :direct`,
`message_type: :text`, `status: :pending`) and their consumers already cope with the string
that arrives. Closing that needs atom support or an encode pass across ~9 producers; filed
separately rather than smuggled into a `priority:high` fix.

**One correction to the issue's analysis:** `latest_message_at` and `last_read_at` were never
broken. Ecto casts values in `update_all(set: ...)`, so an ISO string lands in a
`:utc_datetime` column intact. Only code calling a `DateTime`/`Date` function on a payload
value breaks. The red tests established that, not reasoning.

## Test plan

- `KlassHero.EventTestHelper.through_outbox/1` — puts an event through `serialize |> JSON |>
  deserialize`, so a consumer test crosses the boundary production crosses. `TestOutbox`
  records native structs, which is why nothing in the suite did (#1216).
- Round-trip **identity property** (`stream_data`) over generated payloads of scalars, all
  five typed structs, and nested maps/lists — plus example tests pinning each type, µs
  precision, and legacy args with no sidecar.
- Regressions at both live sites, built through the real event constructors.
- `program_listing_delivery_test.exs` — true end-to-end: `create_program` → real `ObanOutbox`
  → `drain_queue` → `program_listings` row. The test that would have caught this.
- Guard tests folded into rejected/restorable tables.
- **Mutation-checked:** disabling the sidecar fails 15 of these (property + 14 tests),
  including the end-to-end one.

`mix precommit`: 4198 passed, credo clean, all lints green.

## Not in this PR

Prod repair happens at the next deploy via projection bootstrap. The `undelivered_events`
rows already recorded for discarded jobs 3023/3025 stay as they are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)