### PR TITLE
fix: deny broadcast replies from staff whose employment ended

### DIFF
--- a/lib/klass_hero/messaging/send_message.ex
+++ b/lib/klass_hero/messaging/send_message.ex
@@ -14,7 +14,6 @@ defmodule KlassHero.Messaging.SendMessage do
   alias KlassHero.Messaging.Message
   alias KlassHero.Messaging.Notifications
   alias KlassHero.Messaging.Shared
-  alias KlassHero.Messaging.StaffParticipants
   alias KlassHero.Shared.Outbox
   alias KlassHero.Shared.Storage
 
@@ -223,8 +222,9 @@ defmodule KlassHero.Messaging.SendMessage do
     |> String.slice(0, 255)
   end
 
-  # Broadcast conversations are one-way: only the provider owner and assigned staff may send.
-  # Parents replying would expose messages to all other participants (privacy breach).
+  # Broadcast conversations are one-way: only the provider owner and their currently
+  # employed staff may send. Parents replying would expose messages to all other
+  # participants (privacy breach).
   defp verify_broadcast_send_permission(conversation_id, sender_id, conversation) do
     # Validates conversation.id matches conversation_id to prevent a mismatched
     # pre-fetched struct from bypassing broadcast guards.
@@ -234,8 +234,8 @@ defmodule KlassHero.Messaging.SendMessage do
         else: KlassHero.Messaging.get_conversation_by_id(conversation_id)
 
     case result do
-      {:ok, %{type: :program_broadcast, provider_id: provider_id, program_id: program_id}} ->
-        check_broadcast_reply_permission(provider_id, program_id, sender_id)
+      {:ok, %{type: :program_broadcast, provider_id: provider_id}} ->
+        check_broadcast_reply_permission(provider_id, sender_id)
 
       {:ok, _direct_conversation} ->
         :ok
@@ -245,13 +245,10 @@ defmodule KlassHero.Messaging.SendMessage do
     end
   end
 
-  defp check_broadcast_reply_permission(provider_id, program_id, sender_id) do
-    cond do
-      provider_owner?(provider_id, sender_id) -> :ok
-      staff_assigned?(program_id, sender_id) -> :ok
-      active_staff_for_provider?(provider_id, sender_id) -> :ok
-      true -> {:error, :broadcast_reply_not_allowed}
-    end
+  defp check_broadcast_reply_permission(provider_id, sender_id) do
+    if provider_owner?(provider_id, sender_id) or active_staff_for_provider?(provider_id, sender_id),
+      do: :ok,
+      else: {:error, :broadcast_reply_not_allowed}
   end
 
   defp provider_owner?(provider_id, sender_id) do
@@ -261,16 +258,13 @@ defmodule KlassHero.Messaging.SendMessage do
     end
   end
 
-  defp staff_assigned?(nil, _sender_id), do: false
-
-  defp staff_assigned?(program_id, sender_id) do
-    staff_user_ids = StaffParticipants.get_active_staff_user_ids(program_id)
-    sender_id in staff_user_ids
-  end
-
-  # `program_staff_participants` projection covers only explicit program assignments;
-  # provider-level staff are also authorised to broadcast for any program of their
-  # provider (see `StaffBroadcastLive.mount/3`). The two checks must agree — bug #669.
+  # Current employment at the provider is the whole authorization fact — staff may
+  # follow up on any program of their provider (bug #669), so a per-program check
+  # against `program_staff_participants` would only ever narrow this for people the
+  # mirror has drifted on. That is exactly what it did: the mirror is never told
+  # about deactivation (#1237) or hard removal (#1292), so it kept authorizing both
+  # (#1320). Deriving from `staff_members.active` also means reactivation restores
+  # access with no event, replay, or backfill.
   defp active_staff_for_provider?(provider_id, sender_id) do
     ProviderStaffResolver.active_staff_for_provider?(provider_id, sender_id)
   end

--- a/test/klass_hero/messaging/send_message_test.exs
+++ b/test/klass_hero/messaging/send_message_test.exs
@@ -147,6 +147,12 @@ defmodule KlassHero.Messaging.SendMessageTest do
       staff_user = AccountsFixtures.user_fixture()
       broadcast = insert_broadcast(provider, program)
 
+      insert(:staff_member_schema,
+        provider_id: provider.id,
+        user_id: staff_user.id,
+        active: true
+      )
+
       insert(:participant_schema, conversation_id: broadcast.id, user_id: staff_user.id)
 
       StaffParticipants.upsert_active(%{
@@ -172,6 +178,48 @@ defmodule KlassHero.Messaging.SendMessageTest do
 
       assert {:error, :broadcast_reply_not_allowed} =
                SendMessage.execute(broadcast.id, non_staff_user.id, "Sneaky reply")
+    end
+
+    # #1320: nothing tells the mirror that an employment ended. Deactivation
+    # deliberately leaves the assignment and the conversation membership standing
+    # and is not routed to the mirror's writer (#1237); hard removal destroys the
+    # assignment with no event at all (#1292). Either way the participant row and
+    # an `active: true` mirror row survive, so `staff_members` — the row's `active`
+    # flag, or its absence — is the only thing left that can tell these senders
+    # apart from staff who may still reply.
+    test "rejects staff whose employment ended, despite an active mirror row" do
+      for {label, employed_row?} <- [{"deactivated", true}, {"hard-removed", false}] do
+        provider = insert(:provider_profile_schema)
+        program = insert(:program_schema, provider_id: provider.id)
+        staff_user = AccountsFixtures.user_fixture()
+        broadcast = insert_broadcast(provider, program)
+
+        if employed_row? do
+          insert(:staff_member_schema,
+            provider_id: provider.id,
+            user_id: staff_user.id,
+            active: false
+          )
+        end
+
+        insert(:participant_schema, conversation_id: broadcast.id, user_id: staff_user.id)
+
+        StaffParticipants.upsert_active(%{
+          provider_id: provider.id,
+          program_id: program.id,
+          staff_user_id: staff_user.id
+        })
+
+        # Pin the precondition: the mirror still lists them, and that list is
+        # exactly what the deleted guard branch consulted. Without this the
+        # assertion below could go green for the wrong reason.
+        assert staff_user.id in StaffParticipants.get_active_staff_user_ids(program.id),
+               "#{label}: the mirror row must survive, or this stops being a regression test"
+
+        assert SendMessage.execute(broadcast.id, staff_user.id, "Still here") ==
+                 {:error, :broadcast_reply_not_allowed},
+               "expected a #{label} staff member to be denied"
+      end
     end
 
     # Bug #669: a staff_member of the provider should be able to follow up in a


### PR DESCRIPTION
Closes #1320

## Summary

The broadcast-reply guard authorized staff against `program_staff_participants`, a mirror that is never told an employment ended:

- **Deactivation** deliberately leaves the assignment and the conversation membership standing, and `staff_member_deactivated` is not routed to the mirror's writer (#1237).
- **Hard removal** destroys the assignment with no event at all (#1292).

Conversation membership surviving deactivation is by design, and `/messages/:id` sits in the plain `:authenticated` live_session rather than `:require_staff` — so a deactivated staff member kept a reachable UI path to the broadcast and still passed the guard.

## Why this is a deletion rather than a new facade read

The issue suggested replacing the mirror read with a Provider facade read. That turned out to be unnecessary: the branch was already **redundant**.

```elixir
provider_owner?(provider_id, sender_id)             -> :ok   # 1
staff_assigned?(program_id, sender_id)              -> :ok   # 2 — the mirror
active_staff_for_provider?(provider_id, sender_id)  -> :ok   # 3
```

A mirror row's `provider_id` comes from `build_assignment_attrs/2` off an ownership-proven `StaffMember`, never from caller input — so a row can only exist for someone the provider had already proven active. Branch 2 was therefore a subset of branch 3 for every *active* staff member, and its only unique contribution was authorizing the people whose employment had ended.

Deleting it fixes the defect exactly, with no behaviour change for active staff. Because the surviving check derives from `staff_members.active`, reactivation now restores access with no event, replay, or backfill — which is what the #1237 decision could not offer.

## Review Focus

- **The subset claim** is what the whole change rests on. The question to attack: is there any state where the deleted branch returned true but `active_staff_for_provider?/2` returns false, for a staff member still employed? Program transfer between providers, re-hire under a new `StaffMember` row, multi-provider staff, and reactivation were all checked and none produce it.
- Removing a disjunct from an OR-chain can only **narrow** authorization, so the failure mode to look for is a legitimate sender losing access, never the reverse.
- `check_broadcast_reply_permission/3` → `/2`: the `program_id` binding existed only to feed the deleted branch.

## Test Plan

- New table-driven regression test covering both **deactivated** and **hard-removed** staff. It pins the precondition (`assert staff_user.id in StaffParticipants.get_active_staff_user_ids(program.id)`) before asserting the rejection, so it cannot pass for the wrong reason once the mirror stops being consulted.
- `"allows assigned staff to send in broadcast"` needed a real active `StaffMember`. It previously faked staffing with `StaffParticipants.upsert_active/1` and no `staff_members` row — a state production cannot reach — which is precisely how the bug read as expected behaviour.
- `mix precommit`: 4208 passed, credo clean, `lint_acl_boundary` and `lint_read_tables` pass.

## Notes

- Shrinks #1321 (delete the mirror): three mirror readers become two.
- Filed #1323 while tracing this — staff `tags` are the de-facto program assignment model across four surfaces, which is why the compose/reply tag asymmetry is a product decision rather than a guard tweak, and is deliberately not addressed here.
- Pre-existing, untouched: `ProviderStaffResolver` / `ProviderUserResolver` are pure forwarders sitting in `adapters/driven/provider/` where other contexts use `adapters/driven/acl/`. This change makes the first the sole authorization path, so it may be worth a cleanup issue.
