### PR TITLE
fix: follow the real transaction context when isolating an insert

### DIFF
--- a/lib/klass_hero/family.ex
+++ b/lib/klass_hero/family.ex
@@ -32,6 +32,7 @@ defmodule KlassHero.Family do
   alias KlassHero.Family.ParentProfile
   alias KlassHero.Repo
   alias KlassHero.Shared.Adapters.Driven.Persistence.EctoErrorHelpers
+  alias KlassHero.Shared.Adapters.Driven.Persistence.RepositoryHelpers
   alias KlassHero.Shared.Outbox
 
   @context __MODULE__
@@ -47,13 +48,9 @@ defmodule KlassHero.Family do
   """
   def create_parent_profile(attrs) when is_map(attrs) do
     context_span entity: "parent" do
-      # `mode: :savepoint` so a unique-constraint hit rolls back only to a savepoint
-      # instead of poisoning an outer transaction — this runs inside
-      # `ProcessedEventRepository.execute_atomically`'s txn on the
-      # `:user_registered`/`:user_confirmed` compensation path (issue #1065).
       %ParentProfile{}
       |> ParentProfile.changeset(attrs)
-      |> Repo.insert(mode: :savepoint)
+      |> RepositoryHelpers.insert_isolated()
       |> case do
         {:ok, parent} ->
           {:ok, parent}
@@ -214,10 +211,7 @@ defmodule KlassHero.Family do
 
       %Consent{}
       |> Consent.changeset(attrs)
-      # `mode: :savepoint` because callers run this inside a transaction (ProcessInviteClaim
-      # grants invite consents inside its Outbox.transact). Without it the constraint hit
-      # below aborts the enclosing transaction instead of being caught here — issue #1065.
-      |> Repo.insert(mode: :savepoint)
+      |> RepositoryHelpers.insert_isolated()
       |> case do
         {:ok, consent} ->
           {:ok, consent}

--- a/lib/klass_hero/provider/profiles.ex
+++ b/lib/klass_hero/provider/profiles.ex
@@ -15,6 +15,7 @@ defmodule KlassHero.Provider.Profiles do
   alias KlassHero.Provider.ProviderProfile
   alias KlassHero.Repo
   alias KlassHero.Shared.Adapters.Driven.Persistence.EctoErrorHelpers
+  alias KlassHero.Shared.Adapters.Driven.Persistence.RepositoryHelpers
   alias KlassHero.Shared.CommandResult
   alias KlassHero.Shared.Outbox
 
@@ -197,13 +198,9 @@ defmodule KlassHero.Provider.Profiles do
   # unique-identity violation back to the frozen :duplicate_resource contract
   # (ProviderEventHandler/Accounts depend on that literal atom).
   defp insert_provider_profile(attrs) do
-    # `mode: :savepoint` so a unique-identity violation rolls back only to a
-    # savepoint instead of poisoning an outer transaction — this runs inside
-    # `ProcessedEventRepository.execute_atomically`'s txn on the
-    # `:user_registered`/`:user_confirmed` compensation path (issue #1065).
     %ProviderProfile{}
     |> ProviderProfile.changeset(attrs)
-    |> Repo.insert(mode: :savepoint)
+    |> RepositoryHelpers.insert_isolated()
     |> case do
       {:ok, profile} ->
         {:ok, profile}

--- a/lib/klass_hero/shared/adapters/driven/persistence/repository_helpers.ex
+++ b/lib/klass_hero/shared/adapters/driven/persistence/repository_helpers.ex
@@ -1,16 +1,18 @@
 defmodule KlassHero.Shared.Adapters.Driven.Persistence.RepositoryHelpers do
   @moduledoc """
-  Two small conveniences shared by persistence-adapter code.
+  Small conveniences shared by persistence-adapter code.
 
   The mapper-taking fetch-and-map variants were removed post-flatten (#986→#1002)
   once every schema became its own domain struct. What remains is unrelated:
 
     * `get_schema_by_uuid/2` — a UUID-safe `Repo.get` that returns
       `{:error, :not_found}` for a malformed id instead of raising.
+    * `insert_isolated/2` — an insert whose constraint violation stays
+      recoverable whether or not a transaction is open.
     * `log_validation_error/2` — canonical changeset-failure logging.
 
-  Neither emits telemetry spans; callers wrap their own `span` so traces
-  attribute to the repository, not this module.
+  None emit telemetry spans; callers wrap their own `span` so traces attribute
+  to the repository, not this module.
   """
 
   alias KlassHero.Repo
@@ -39,6 +41,33 @@ defmodule KlassHero.Shared.Adapters.Driven.Persistence.RepositoryHelpers do
       :error ->
         {:error, :not_found}
     end
+  end
+
+  @doc """
+  Inserts a changeset whose constraint violation must come back as
+  `{:error, changeset}` without damaging anything around it.
+
+  Inside a transaction that means `mode: :savepoint`: without it the constraint
+  hit aborts the *enclosing* transaction instead of being caught by the caller
+  (#1065). Outside one it means the opposite — `mode: :savepoint` has no
+  transaction to open a savepoint against, so Postgrex refuses and DBConnection
+  raises `TransactionError` (#1322, a crash on the add-a-child flow).
+
+  So the mode follows the actual context rather than assuming one. Note this
+  cannot be tested under the SQL sandbox, which proxies every statement through
+  its own savepoint and hides both failure modes — see
+  `test/klass_hero/family/consents_unboxed_test.exs`.
+  """
+  @spec insert_isolated(Ecto.Changeset.t(), keyword()) ::
+          {:ok, struct()} | {:error, Ecto.Changeset.t()}
+  def insert_isolated(%Ecto.Changeset{} = changeset, opts \\ []) do
+    # Merge, not `++`: a keyword lookup takes the first match, so appending would
+    # let the derived mode silently outrank a caller's explicit one.
+    Repo.insert(changeset, Keyword.merge(isolation_opts(), opts))
+  end
+
+  defp isolation_opts do
+    if Repo.in_transaction?(), do: [mode: :savepoint], else: []
   end
 
   @doc """

--- a/test/klass_hero/family/consents_unboxed_test.exs
+++ b/test/klass_hero/family/consents_unboxed_test.exs
@@ -1,0 +1,86 @@
+defmodule KlassHero.Family.ConsentsUnboxedTest do
+  @moduledoc """
+  The one consent test that runs *outside* the SQL sandbox.
+
+  `Ecto.Adapters.SQL.Sandbox.Connection` proxies every statement and injects
+  `mode: :savepoint` itself whenever no user-level transaction is open, so a
+  sandboxed connection is never idle. That makes `mode: :savepoint` succeed in
+  tests no matter how it is called — which is exactly how #1322 shipped green:
+  `grant_consent/1` hardcoded the option, crashed on the LiveView path in
+  production, and every test kept passing.
+
+  `unboxed_run/2` checks out with `sandbox: false`, so there is no proxy and the
+  connection really is idle. That is the only place this class of bug is visible.
+
+  Consequences, all deliberate:
+
+  - `async: false` and no `DataCase` — there is no sandbox to own, and the real
+    test database is shared with no isolation.
+  - Fixtures are built inside the block; rows created by a sandboxed process are
+    invisible on this connection.
+  - Nothing rolls back, so the block cleans up after itself.
+
+  If you find yourself "fixing" this file back onto `DataCase`, read #1322 first:
+  under the sandbox this test passes against the broken code.
+  """
+
+  use ExUnit.Case, async: false
+
+  import Ecto.Query
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias KlassHero.Accounts.User
+  alias KlassHero.Family
+  alias KlassHero.Family.Child
+  alias KlassHero.Family.Consent
+  alias KlassHero.Family.ParentProfile
+  alias KlassHero.Repo
+
+  @consent_type "photo_marketing"
+
+  test "grant_consent/1 succeeds when the caller holds no transaction" do
+    Sandbox.unboxed_run(Repo, fn ->
+      # Pins the precondition. Without it the test would still pass inside a
+      # transaction and prove nothing — the exact trap #1322 fell into.
+      refute Repo.in_transaction?()
+
+      {parent, child} = insert_fixtures()
+
+      try do
+        assert {:ok, %Consent{} = consent} =
+                 Family.grant_consent(%{
+                   parent_id: parent.id,
+                   child_id: child.id,
+                   consent_type: @consent_type
+                 })
+
+        assert consent.child_id == child.id
+        assert consent.parent_id == parent.id
+        assert is_nil(consent.withdrawn_at)
+      after
+        cleanup(parent, child)
+      end
+    end)
+  end
+
+  defp insert_fixtures do
+    user =
+      Repo.insert!(%User{
+        email: "consent-unboxed-#{System.unique_integer([:positive])}@example.com",
+        name: "Unboxed Test User"
+      })
+
+    parent = Repo.insert!(%ParentProfile{identity_id: user.id, display_name: "Unboxed Parent"})
+    child = Repo.insert!(%Child{first_name: "Unboxed", last_name: "Child"})
+
+    {parent, child}
+  end
+
+  # FK order: consents restrict both parents and children, parents restricts users.
+  defp cleanup(parent, child) do
+    Repo.delete_all(from(c in Consent, where: c.child_id == ^child.id))
+    Repo.delete_all(from(c in Child, where: c.id == ^child.id))
+    Repo.delete_all(from(p in ParentProfile, where: p.id == ^parent.id))
+    Repo.delete_all(from(u in User, where: u.id == ^parent.identity_id))
+  end
+end


### PR DESCRIPTION
Closes #1322

## Summary

A guardian who ticks the photo-consent box while adding a child at `/settings/children/new` crashed the LiveView with `DBConnection.TransactionError: transaction is not started`. The child row was written first, so the visible result was: child appears, LiveView dies, page reloads, consent never recorded. Retrying reproduced it — the guardian could not grant consent at all. 0 consent rows in the last 30 days against 20 all-time.

`Family.grant_consent/1` hardcoded `Repo.insert(mode: :savepoint)`. That option is only valid *inside* a transaction: `Postgrex.Protocol.handle_begin/2` returns a bare `{:idle, state}` when the connection is idle, which DBConnection turns into a raise.

The option was correct for the caller it was added for (#1220, fixing #1065) — `ProcessInviteClaim` runs inside `Outbox.transact`, where the savepoint keeps a unique-constraint hit from aborting the enclosing transaction. The defect is that this became an **unstated precondition on every caller**, absent from the signature, spec, and docs. `ChildrenLive` holds no transaction.

## Review Focus

**The mode now follows the actual context** — `insert_isolated/2` in `RepositoryHelpers`, guarded by `Repo.in_transaction?/0`:

|  | in `Outbox.transact` | no transaction |
|---|---|---|
| **prod** | `true` → savepoint (#1065 preserved) | `false` → plain insert (#1322 fixed) |
| **sandbox** | `true` → savepoint | `false` → plain insert; sandbox savepoints it anyway |

`Repo.in_transaction?/0` is process-local (reads the process dictionary, set only by `Repo.transaction`). All six caller paths were traced: none crosses a process boundary between opening the transaction and the insert, so every caller that previously got a savepoint still gets one.

**All three savepoint sites are converted**, not just the crashing one. `create_parent_profile/1` and `insert_provider_profile/1` were safe only by luck of caller and carried the same unstated precondition.

**Why the existing tests never caught this.** `Ecto.Adapters.SQL.Sandbox.Connection` proxies every statement and injects `mode: :savepoint` itself when no user-level transaction is open, so a sandboxed connection is never idle and the fatal branch is unreachable. Both tests that would "cover" this **already existed and were green against the broken code**:

- `consents_test.exs:22` — direct facade call, no enclosing transaction
- `children_live_test.exs:365-389` — saves via `#child-form` with consent ticked, asserts the consent exists

So the new `consents_unboxed_test.exs` uses `Sandbox.unboxed_run/2` to get a genuinely idle connection. Its `refute Repo.in_transaction?()` is load-bearing — it stops the file silently degrading into another vacuous test if someone moves it back onto `DataCase`.

## Test Plan

- [x] **Red before green** — on the unfixed code the new test raises `DBConnection.TransactionError` from `family.ex:220`, matching the production stack trace; passes after
- [x] `mix precommit` — 4263 passed, credo clean, all lints
- [x] **#1065 regression suite** (consents, process_invite_claim, both event handlers, children_live) — 66 passed
- [x] **Real dev environment, no sandbox** — outside a transaction returns `{:ok, %Consent{}}`; inside one a duplicate returns `{:error, :already_active}` **and the transaction stays usable** (subsequent query and commit both succeed)
- [x] **Browser** — logged in as a parent, added a child with the consent box ticked: flash reads "Child added successfully." (not the consent-failed variant), and the `provider_data_sharing` consent row is present with `withdrawn_at` null
- [x] `architecture-reviewer` 8/8, `regression-analyzer` 8/8

## Not in scope

Children added since 2026-07-31 may be missing consents their guardians actually granted (4 named in the issue). The intent was never written to the DB, so it cannot be reconstructed — that needs re-asking the guardians, a product decision rather than a migration. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)