### PR TITLE
fix: block deactivated staff from new program attachments

### DIFF
--- a/lib/klass_hero/provider.ex
+++ b/lib/klass_hero/provider.ex
@@ -234,6 +234,12 @@ defmodule KlassHero.Provider do
   """
   defdelegate get_staff_member(staff_id, provider_id), to: Staff
 
+  @doc """
+  Retrieves an active staff member owned by `provider_id`; deactivated ≡ foreign ≡
+  missing. Use for new program attachments; `get_staff_member/2` for lifecycle work.
+  """
+  defdelegate get_active_staff_member(staff_id, provider_id), to: Staff
+
   @doc "Retrieves a single staff member by ID, unscoped (no provider in scope)."
   defdelegate get_staff_member(staff_id), to: Staff
 

--- a/lib/klass_hero/provider/assignments.ex
+++ b/lib/klass_hero/provider/assignments.ex
@@ -9,7 +9,7 @@ defmodule KlassHero.Provider.Assignments do
   ## Tenancy
 
   Every write takes a `provider_id` and enforces it uniformly (#1134): the staff
-  member comes from the scoped `Provider.get_staff_member/2`, the program from the
+  member comes from a scoped getter (see ## Employment below), the program from the
   scoped `ProgramCatalog.get_program_for_provider/2` (via `ensure_program_owned/2`), and
   every UPDATE is narrowed by `ProgramStaffAssignment.owned_by/2`. Ownership is a
   property of the queries, not a caller convention, so no UPDATE can reach a
@@ -21,6 +21,21 @@ defmodule KlassHero.Provider.Assignments do
 
   Foreign and missing are deliberately indistinguishable throughout — both
   `{:error, :not_found}`, leaking no existence oracle.
+
+  ## Employment
+
+  Which scoped getter a write uses depends on whether it *creates* an attachment
+  (#1306). `assign_staff_to_program/1` and `set_lead_instructor/3` take
+  `Provider.get_active_staff_member/2`, so a deactivated member cannot be newly
+  attached — the read side filters them out, and a write the reads then hide is a
+  silent no-op with a real row behind it.
+
+  `unassign_staff_from_program/3` uses the tenancy-only `Provider.get_staff_member/2`
+  on purpose: deactivation leaves existing assignments alive, so detaching someone
+  after they were offboarded has to stay possible.
+
+  Deactivated collapses into the same `{:error, :not_found}` as foreign and missing,
+  so this adds no third error branch for callers.
 
   Reads are intentionally *not* provider-scoped: `get_lead_instructor/1` and its
   batch sibling feed publicly-rendered program pages.
@@ -54,14 +69,15 @@ defmodule KlassHero.Provider.Assignments do
   Returns:
   - `{:ok, ProgramStaffAssignment.t()}` on success
   - `{:error, :already_assigned}` if the staff member is already assigned
-  - `{:error, :not_found}` if the staff member or program is missing or foreign
+  - `{:error, :not_found}` if the staff member or program is missing or foreign, or
+    the staff member is deactivated (#1306 — deactivated ≡ foreign ≡ missing)
   """
   @spec assign_staff_to_program(map()) ::
           {:ok, ProgramStaffAssignment.t()}
           | {:error, :already_assigned | :not_found | term()}
   def assign_staff_to_program(%{provider_id: provider_id} = attrs) do
     context_span entity: "program_staff_assignment" do
-      with {:ok, staff_member} <- Provider.get_staff_member(attrs.staff_member_id, provider_id),
+      with {:ok, staff_member} <- Provider.get_active_staff_member(attrs.staff_member_id, provider_id),
            :ok <- ensure_program_owned(attrs.program_id, provider_id),
            assignment_attrs = build_assignment_attrs(attrs, staff_member),
            {:ok, assignment} <-
@@ -221,14 +237,16 @@ defmodule KlassHero.Provider.Assignments do
   Returns `{:ok, ProgramStaffAssignment.t()}`, or `{:error, :not_found}` when the
   staff member **or the program** is missing or foreign — both sides are checked,
   so a competitor's staff can never attach to this program, nor this provider's
-  staff to theirs.
+  staff to theirs. A **deactivated** staff member is `{:error, :not_found}` too:
+  promoting someone the read side filters out would flag a lead that
+  `get_lead_instructor/1` reports as absent (#1306).
   """
   @spec set_lead_instructor(String.t(), String.t(), String.t()) ::
           {:ok, ProgramStaffAssignment.t()} | {:error, :not_found | term()}
   def set_lead_instructor(program_id, staff_member_id, provider_id)
       when is_binary(program_id) and is_binary(staff_member_id) and is_binary(provider_id) do
     context_span entity: "program_staff_assignment" do
-      with {:ok, staff_member} <- Provider.get_staff_member(staff_member_id, provider_id),
+      with {:ok, staff_member} <- Provider.get_active_staff_member(staff_member_id, provider_id),
            :ok <- ensure_program_owned(program_id, provider_id) do
         Multi.new()
         |> Multi.update_all(

--- a/lib/klass_hero/provider/staff.ex
+++ b/lib/klass_hero/provider/staff.ex
@@ -317,11 +317,42 @@ defmodule KlassHero.Provider.Staff do
   Scoped via `StaffMember.owned_by/2` (see its docs for why). Prefer this over
   `get_staff_member/1` on every provider-initiated path. A malformed `staff_id`
   is `{:error, :not_found}`, not a raise.
+
+  Answers tenancy only, so a **deactivated** member is still returned — which is
+  what the employment lifecycle needs (edit, delete, unassign, GDPR erasure all
+  target offboarded people). To gate a *new* attachment, use
+  `get_active_staff_member/2` instead.
   """
   @spec get_staff_member(String.t(), String.t()) :: {:ok, StaffMember.t()} | {:error, :not_found}
   def get_staff_member(staff_id, provider_id) when is_binary(staff_id) and is_binary(provider_id) do
     provider_id
     |> StaffMember.owned_by()
+    |> RepositoryHelpers.get_schema_by_uuid(staff_id)
+    |> case do
+      {:ok, staff} -> {:ok, StaffMember.load_pay_rate(staff)}
+      {:error, :not_found} -> {:error, :not_found}
+    end
+  end
+
+  @doc """
+  Retrieves an **active** staff member owned by `provider_id`; deactivated ≡
+  foreign ≡ missing.
+
+  The getter for paths that create a *new* attachment between a staff member and
+  a program — `assign_staff_to_program/1`, `set_lead_instructor/3`, and the
+  program form's lead pick. Deactivation deliberately leaves existing assignments
+  alive (see `deactivate_staff_member/1`) so Messaging membership survives
+  reactivation; this blocks new ones without disturbing those.
+
+  Collapsing deactivated into `:not_found` rather than a distinct error is what
+  keeps the callers' existing not-found branches correct, and leaks nothing about
+  which ids are real. `get_staff_member/2` is the counterpart for lifecycle work.
+  """
+  @spec get_active_staff_member(String.t(), String.t()) :: {:ok, StaffMember.t()} | {:error, :not_found}
+  def get_active_staff_member(staff_id, provider_id) when is_binary(staff_id) and is_binary(provider_id) do
+    provider_id
+    |> StaffMember.owned_by()
+    |> StaffMember.active()
     |> RepositoryHelpers.get_schema_by_uuid(staff_id)
     |> case do
       {:ok, staff} -> {:ok, StaffMember.load_pay_rate(staff)}

--- a/lib/klass_hero/provider/staff_member.ex
+++ b/lib/klass_hero/provider/staff_member.ex
@@ -375,6 +375,24 @@ defmodule KlassHero.Provider.StaffMember do
     from s in query, where: s.provider_id == ^provider_id
   end
 
+  @doc """
+  Narrows a query to staff whose employment is still live.
+
+  Deliberately separate from `owned_by/2`: tenancy ("is this row mine?") and
+  employment ("is this person still on staff?") are different questions, and the
+  callers that need them differ. Composing both is right for a *new* attachment —
+  assigning to a program, promoting to lead. Composing only `owned_by/2` is right
+  for the employment lifecycle itself — editing, deleting, unassigning, GDPR
+  erasure — all of which must still reach an offboarded member.
+
+  Fusing the two into one getter looks like a simplification and is not: it makes
+  offboarding and erasure fail to find their own targets (#1306).
+  """
+  @spec active(Ecto.Queryable.t()) :: Ecto.Query.t()
+  def active(query \\ __MODULE__) do
+    from s in query, where: s.active == true
+  end
+
   # ── Functional core (ported domain validator + helpers) ──────────────────
 
   @doc """

--- a/lib/klass_hero_web/live/provider/programs_live.ex
+++ b/lib/klass_hero_web/live/provider/programs_live.ex
@@ -921,19 +921,21 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
 
   defp maybe_flash_cover_warning(socket, _cover_result), do: socket
 
-  # Validates the instructor exists AND belongs to this provider (IDOR guard) —
-  # the pre-write gate that keeps apply_lead_instructor's bang-match safe.
+  # Validates the instructor exists, belongs to this provider (IDOR guard), and is
+  # still employed (#1306) — the pre-write gate that keeps apply_lead_instructor's
+  # bang-match safe. It must refuse on exactly the conditions set_lead_instructor/3
+  # refuses on, or the bang below matches an {:error, :not_found} and crashes.
   defp resolve_instructor(id, _socket) when id in [nil, ""], do: {:ok, nil}
 
   defp resolve_instructor(instructor_id, socket) do
     provider_id = socket.assigns.current_scope.provider.id
 
-    case Provider.get_staff_member(instructor_id, provider_id) do
+    case Provider.get_active_staff_member(instructor_id, provider_id) do
       {:ok, _staff} ->
         {:ok, instructor_id}
 
-      _not_found_or_foreign ->
-        Logger.warning("Instructor not found or not owned by provider during program save",
+      _not_found_foreign_or_deactivated ->
+        Logger.warning("Instructor not found, not owned by provider, or deactivated during program save",
           instructor_id: instructor_id,
           provider_id: provider_id
         )

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -2888,12 +2888,12 @@ msgstr ""
 msgid "Program Start"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1078
+#: lib/klass_hero_web/live/provider/programs_live.ex:1080
 #, elixir-autogen, elixir-format
 msgid "Program created successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1085
+#: lib/klass_hero_web/live/provider/programs_live.ex:1087
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr ""

--- a/test/klass_hero/provider/assignments/employment_guard_test.exs
+++ b/test/klass_hero/provider/assignments/employment_guard_test.exs
@@ -1,0 +1,131 @@
+defmodule KlassHero.Provider.Assignments.EmploymentGuardTest do
+  @moduledoc """
+  The module-wide employment policy for `Provider.Assignments` (#1306).
+
+  Sibling to `OwnershipGuardTest`, and deliberately a separate policy: tenancy
+  asks "is this row mine?", employment asks "is this person still on staff?".
+  They gate different writes, so proving them in one place would hide the split
+  that is the whole point.
+
+  The rule has two halves, and the second is the load-bearing one:
+
+    * a **new attachment** (assign, promote to lead) refuses a deactivated member
+      and writes no row — previously it succeeded and then rendered nowhere,
+      because the read side filters `active`;
+    * the **employment lifecycle** (unassign, delete, update) still reaches one —
+      offboarding and GDPR erasure target exactly the people the first half
+      refuses, so fusing the two getters breaks them.
+  """
+  use KlassHero.DataCase, async: true
+
+  import Ecto.Query
+  import KlassHero.Factory
+
+  alias KlassHero.Provider
+  alias KlassHero.Provider.ProgramStaffAssignment
+
+  setup do
+    provider = insert(:provider_profile_schema)
+    staff = insert(:staff_member_schema, provider_id: provider.id)
+
+    %{
+      provider: provider,
+      program: insert(:program_schema, provider_id: provider.id),
+      staff: staff,
+      deactivated: insert(:staff_member_schema, provider_id: provider.id, active: false)
+    }
+  end
+
+  describe "new attachments" do
+    test "every row-creating write refuses a deactivated staff member", ctx do
+      writes = [
+        {"assign_staff_to_program",
+         fn ->
+           Provider.assign_staff_to_program(%{
+             provider_id: ctx.provider.id,
+             program_id: ctx.program.id,
+             staff_member_id: ctx.deactivated.id
+           })
+         end},
+        {"set_lead_instructor",
+         fn -> Provider.set_lead_instructor(ctx.program.id, ctx.deactivated.id, ctx.provider.id) end}
+      ]
+
+      for {label, call} <- writes do
+        assert call.() == {:error, :not_found}, "#{label}: expected {:error, :not_found}"
+
+        # The bug was a write that *succeeded* invisibly, so the error tuple alone
+        # would not have caught it — assert the row is absent.
+        refute assignments_for?(ctx.deactivated.id),
+               "#{label}: an assignment row was written for a deactivated staff member"
+      end
+    end
+
+    test "deactivated is indistinguishable from foreign and missing", ctx do
+      other = insert(:provider_profile_schema)
+      foreign_staff = insert(:staff_member_schema, provider_id: other.id)
+
+      deactivated = Provider.set_lead_instructor(ctx.program.id, ctx.deactivated.id, ctx.provider.id)
+      foreign = Provider.set_lead_instructor(ctx.program.id, foreign_staff.id, ctx.provider.id)
+      missing = Provider.set_lead_instructor(ctx.program.id, Ecto.UUID.generate(), ctx.provider.id)
+
+      assert deactivated == foreign
+      assert foreign == missing
+    end
+
+    test "a member deactivated after assignment keeps the assignment but cannot be re-promoted", ctx do
+      {:ok, _} =
+        Provider.assign_staff_to_program(%{
+          provider_id: ctx.provider.id,
+          program_id: ctx.program.id,
+          staff_member_id: ctx.staff.id
+        })
+
+      {:ok, _} = Provider.deactivate_staff_member(ctx.staff)
+
+      # Deactivation deliberately leaves the assignment alive so Messaging
+      # membership survives reactivation — only *new* attachments are blocked.
+      assert %ProgramStaffAssignment{unassigned_at: nil} =
+               Repo.get_by(ProgramStaffAssignment, program_id: ctx.program.id, staff_member_id: ctx.staff.id)
+
+      assert {:error, :not_found} =
+               Provider.set_lead_instructor(ctx.program.id, ctx.staff.id, ctx.provider.id)
+    end
+  end
+
+  describe "employment lifecycle" do
+    # The regression guard. If someone later "simplifies" get_staff_member/2 and
+    # get_active_staff_member/2 into one getter, these fail — which is the point.
+    test "unassign still reaches a member deactivated after assignment", ctx do
+      {:ok, _} =
+        Provider.assign_staff_to_program(%{
+          provider_id: ctx.provider.id,
+          program_id: ctx.program.id,
+          staff_member_id: ctx.staff.id
+        })
+
+      {:ok, _} = Provider.deactivate_staff_member(ctx.staff)
+
+      assert {:ok, _} = Provider.unassign_staff_from_program(ctx.program.id, ctx.staff.id, ctx.provider.id)
+
+      assert %ProgramStaffAssignment{unassigned_at: %DateTime{}} =
+               Repo.get_by(ProgramStaffAssignment, program_id: ctx.program.id, staff_member_id: ctx.staff.id)
+    end
+
+    test "delete still reaches a deactivated member (offboarding, GDPR erasure)", ctx do
+      assert :ok = Provider.delete_staff_member(ctx.deactivated.id, ctx.provider.id)
+      assert {:error, :not_found} = Provider.get_staff_member(ctx.deactivated.id, ctx.provider.id)
+    end
+
+    test "update still reaches a deactivated member", ctx do
+      assert {:ok, updated} =
+               Provider.update_staff_member(ctx.provider.id, ctx.deactivated.id, %{role: "Retired Coach"})
+
+      assert updated.role == "Retired Coach"
+    end
+  end
+
+  defp assignments_for?(staff_member_id) do
+    Repo.exists?(from a in ProgramStaffAssignment, where: a.staff_member_id == ^staff_member_id)
+  end
+end

--- a/test/klass_hero/provider/staff/get_staff_member_scoped_test.exs
+++ b/test/klass_hero/provider/staff/get_staff_member_scoped_test.exs
@@ -47,5 +47,69 @@ defmodule KlassHero.Provider.Staff.GetStaffMemberScopedTest do
 
       assert foreign == missing
     end
+
+    # The division of labour with get_active_staff_member/2 below: this getter
+    # answers tenancy only, so the lifecycle paths built on it (edit, delete,
+    # unassign, GDPR erasure) keep reaching an offboarded member. #1306.
+    test "still returns a deactivated staff member", ctx do
+      deactivated = insert(:staff_member_schema, provider_id: ctx.provider.id, active: false)
+
+      assert {:ok, %StaffMember{id: id}} = Provider.get_staff_member(deactivated.id, ctx.provider.id)
+      assert id == deactivated.id
+    end
+  end
+
+  describe "get_active_staff_member/2 (provider-scoped + employed)" do
+    setup do
+      provider = insert(:provider_profile_schema)
+      other_provider = insert(:provider_profile_schema)
+      staff = insert(:staff_member_schema, provider_id: provider.id)
+
+      %{provider: provider, other_provider: other_provider, staff: staff}
+    end
+
+    test "returns the staff member when owned by the provider and active", ctx do
+      assert {:ok, %StaffMember{id: id}} = Provider.get_active_staff_member(ctx.staff.id, ctx.provider.id)
+      assert id == ctx.staff.id
+    end
+
+    # `deactivated` is the #1306 case: the attach paths accepted such a member,
+    # wrote a real row, and the read side then filtered them out of every render.
+    # A malformed id reaches here straight from phx-value, so it must not raise.
+    test "returns not_found for every unattachable id", ctx do
+      deactivated = insert(:staff_member_schema, provider_id: ctx.provider.id, active: false)
+
+      cases = [
+        {"deactivated", deactivated.id, ctx.provider.id},
+        {"foreign", ctx.staff.id, ctx.other_provider.id},
+        {"missing", Ecto.UUID.generate(), ctx.provider.id},
+        {"malformed", "not-a-uuid", ctx.provider.id}
+      ]
+
+      for {label, staff_id, provider_id} <- cases do
+        assert Provider.get_active_staff_member(staff_id, provider_id) == {:error, :not_found},
+               "#{label}: expected {:error, :not_found}"
+      end
+    end
+
+    test "loads the pay rate, matching the tenancy-only getter", ctx do
+      assert {:ok, active_only} = Provider.get_active_staff_member(ctx.staff.id, ctx.provider.id)
+      assert {:ok, scoped} = Provider.get_staff_member(ctx.staff.id, ctx.provider.id)
+
+      assert active_only.pay_rate == scoped.pay_rate
+    end
+
+    # Deactivated collapses into the same answer as foreign and missing, so no
+    # caller learns that the id was real — and none needs a third error branch.
+    test "deactivated, foreign and missing are indistinguishable", ctx do
+      deactivated = insert(:staff_member_schema, provider_id: ctx.provider.id, active: false)
+
+      inactive = Provider.get_active_staff_member(deactivated.id, ctx.provider.id)
+      foreign = Provider.get_active_staff_member(ctx.staff.id, ctx.other_provider.id)
+      missing = Provider.get_active_staff_member(Ecto.UUID.generate(), ctx.provider.id)
+
+      assert inactive == foreign
+      assert foreign == missing
+    end
   end
 end

--- a/test/klass_hero_web/live/provider/dashboard_program_creation_test.exs
+++ b/test/klass_hero_web/live/provider/dashboard_program_creation_test.exs
@@ -111,6 +111,36 @@ defmodule KlassHeroWeb.Provider.DashboardProgramCreationTest do
       assert staff_id == staff.id
     end
 
+    # The select only lists active staff, so this needs a crafted param — but
+    # resolve_instructor/2 is also what keeps apply_lead_instructor's bang-match
+    # safe, so a deactivated pick must be refused there rather than reaching the
+    # context and blowing up mid-save (#1306).
+    test "refuses a deactivated instructor without creating the program", %{conn: conn, provider: provider} do
+      staff = ProviderFixtures.staff_member_fixture(provider_id: provider.id, first_name: "Del", last_name: "Gone")
+      {:ok, _} = KlassHero.Provider.deactivate_staff_member(staff)
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+
+      view |> element("#new-program-btn") |> render_click()
+
+      # Dispatched directly: the select never renders a deactivated option, so
+      # form/3 would reject the value before it ever reached the LiveView.
+      html =
+        render_submit(view, "save_program", %{
+          "program_schema" => %{
+            "title" => "Ghost Camp",
+            "description" => "Nobody leads this",
+            "category" => "sports",
+            "price" => "75.00",
+            "location" => "Sports Park",
+            "instructor_id" => staff.id
+          }
+        })
+
+      assert html =~ "instructor"
+      refute Repo.get_by(Program, title: "Ghost Camp")
+    end
+
     test "closes form on cancel", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
 

--- a/test/klass_hero_web/live/provider/dashboard_program_staffing_test.exs
+++ b/test/klass_hero_web/live/provider/dashboard_program_staffing_test.exs
@@ -208,6 +208,62 @@ defmodule KlassHeroWeb.Provider.DashboardProgramStaffingTest do
     end
   end
 
+  # The picker filters deactivated staff, so these are only reachable by a crafted
+  # phx-value — or a stale panel left open in another tab across a deactivation.
+  # Before #1306 they wrote a real row that then rendered nowhere.
+  describe "deactivated staff" do
+    setup %{provider: provider} do
+      former = insert_staff(provider, "Del", "Gone")
+      {:ok, _} = Provider.deactivate_staff_member(former)
+
+      %{former: former}
+    end
+
+    test "the picker does not offer them", %{conn: conn, program: program, former: former} do
+      view = open_panel(conn, program)
+
+      refute has_element?(view, ~s(#staffing-add-form option[value="#{former.id}"]))
+    end
+
+    test "a deactivated staff member cannot be added to my program", %{
+      conn: conn,
+      program: program,
+      former: former
+    } do
+      view = open_panel(conn, program)
+
+      html = render_click(view, "assign_staff_member", %{"staff-id" => former.id})
+
+      assert html =~ "could not be found"
+      assert active_staff_ids(program) == MapSet.new()
+    end
+
+    test "a deactivated staff member cannot be promoted on my program", %{
+      conn: conn,
+      program: program,
+      former: former
+    } do
+      view = open_panel(conn, program)
+
+      html = render_click(view, "promote_to_lead", %{"staff-id" => former.id})
+
+      assert html =~ "could not be found"
+      assert Provider.get_lead_instructor(program.id) == nil
+    end
+
+    test "the panel stays usable afterwards", %{conn: conn, program: program, former: former, ann: ann} do
+      view = open_panel(conn, program)
+
+      render_click(view, "assign_staff_member", %{"staff-id" => former.id})
+
+      assert has_element?(view, "#program-staffing-modal")
+
+      view |> form("#staffing-add-form", %{"staff-id" => ann.id}) |> render_submit()
+
+      assert has_element?(view, "#staffing-member-#{ann.id}")
+    end
+  end
+
   defp open_panel(conn, program) do
     {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
     view |> element("#manage-staffing-#{program.id}") |> render_click()


### PR DESCRIPTION
Closes #1306

## Summary

`Provider.get_staff_member/2` scoped only by tenancy, so a **deactivated** staff member was still retrievable and every write gating on it accepted them. `assign_staff_to_program/1` created an active assignment row and `set_lead_instructor/3` flagged them lead — while the read side (`list_assignable_staff_for_program/2`, `get_lead_instructor/1`) filters `active`. The write succeeded, the person rendered nowhere, and `program_staff_assignments` held a row claiming a lead the whole system reported as absent.

**Root cause:** tenancy ("is this row mine?") and employment ("is this person still on staff?") shared one getter. Nothing named the second on the write side, so each attach path had to remember it independently — and `resolve_instructor/2` already forgot, pre-dating #1300.

## Approach

Split the two questions:

- `StaffMember.active/1` — a query scope beside `owned_by/2`
- `Staff.get_active_staff_member/2` — composes both

The three paths that create a *new* attachment use it: `assign_staff_to_program/1`, `set_lead_instructor/3`, and the program form's `resolve_instructor/2`.

Deactivated collapses into the same `{:error, :not_found}` as foreign and missing. That is what keeps the web layer unchanged — `staffing_not_found/4` and `resolve_instructor/2`'s catch-all already handle it — and it introduces no existence oracle and no new user-facing strings (so no gettext/translation work).

## Review focus

**`get_staff_member/2` is deliberately unchanged.** Filtering it would have been the tempting one-line fix, and it breaks 8 of its 11 callers — all of which legitimately target offboarded people:

| Caller | Why it needs deactivated staff |
|---|---|
| `Staff.update_staff_member/3` | editing an offboarded member |
| `Staff.delete_staff_member/2` | offboarding |
| `Staff.resend_staff_invitation/2` | invitation lifecycle |
| `Accounts.remove_staff_member/2` | GDPR erasure — must never 404 on its own target |
| `Assignments.unassign_staff_from_program/3` | detaching someone you just deactivated |
| `TeamLive` edit / validate / rehydrate | the staff form |

`EmploymentGuardTest` pins **both** halves — the refusals and the still-permitted lifecycle writes — so a later "simplification" merging the two getters fails loudly rather than silently breaking offboarding.

**The `resolve_instructor/2` swap is load-bearing, not cosmetic.** It is the pre-write gate for `apply_lead_instructor/3`'s `{:ok, _} = ` bang-match. Once `set_lead_instructor/3` refuses deactivated staff, the gate must refuse on exactly the same conditions or the LiveView crashes mid-save. A red test in `dashboard_program_creation_test.exs` reproduced that `MatchError` before the fix.

## Test plan

- `test/klass_hero/provider/staff/get_staff_member_scoped_test.exs` — new `get_active_staff_member/2` block (tabular rejection cases, pay-rate parity, indistinguishability), plus a pin that `get_staff_member/2` *still* returns a deactivated member
- `test/klass_hero/provider/assignments/employment_guard_test.exs` — new module-wide employment policy, sibling to `OwnershipGuardTest`; asserts **no row is written**, not just the error tuple, since the bug was an invisible success
- `dashboard_program_staffing_test.exs` — crafted `phx-value` for assign/promote, picker exclusion, panel still usable afterwards
- `dashboard_program_creation_test.exs` — crafted `save_program` with a deactivated instructor; no program created

`mix precommit` green: 4278 passed, credo clean, all four custom lints pass.

## Note on the issue text

The repro's step 1 says to deactivate from `/provider/dashboard/team`. `active` is not in `@staff_updatable_fields`, so deactivation is admin (Backpex) + anonymize only. The bug itself is real and unaffected.
