### PR TITLE
fix: show whole roster in the provider programs staff column

### DIFF
--- a/lib/klass_hero/provider.ex
+++ b/lib/klass_hero/provider.ex
@@ -322,8 +322,11 @@ defmodule KlassHero.Provider do
   @doc "Returns the program's lead instructor as a `%{id, name, headshot_url}` map, or nil."
   defdelegate get_lead_instructor(program_id), to: Assignments
 
-  @doc "Batch lead-instructor read keyed by program_id (avoids N+1 in list views)."
-  defdelegate list_lead_instructors_for_programs(program_ids), to: Assignments
+  @doc """
+  Batch staffing read keyed by program_id — active members plus the lead, in one
+  query (avoids N+1 in list views). Programs nobody staffs are omitted.
+  """
+  defdelegate list_program_staffing(program_ids), to: Assignments
 
   # --- Programs & sessions -------------------------------------------------
 

--- a/lib/klass_hero/provider/assignments.ex
+++ b/lib/klass_hero/provider/assignments.ex
@@ -49,6 +49,7 @@ defmodule KlassHero.Provider.Assignments do
   alias KlassHero.ProgramCatalog
   alias KlassHero.Provider
   alias KlassHero.Provider.Domain.Events.ProviderEvents
+  alias KlassHero.Provider.Domain.ReadModels.ProgramStaffing
   alias KlassHero.Provider.ProgramStaffAssignment
   alias KlassHero.Provider.StaffMember
   alias KlassHero.Repo
@@ -292,18 +293,44 @@ defmodule KlassHero.Provider.Assignments do
   end
 
   @doc """
-  Batch lead-instructor read keyed by `program_id`, for list views that would
-  otherwise N+1. Programs without a lead are omitted from the map.
-  """
-  @spec list_lead_instructors_for_programs([String.t()]) :: %{optional(String.t()) => map()}
-  def list_lead_instructors_for_programs([]), do: %{}
+  Batch staffing read keyed by `program_id`, for list views that would otherwise
+  N+1: every active member of each program plus its lead, in one round-trip.
 
-  def list_lead_instructors_for_programs(program_ids) when is_list(program_ids) do
-    lead_staff_query()
-    |> where([_s, a], a.program_id in ^program_ids)
-    |> select([s, a], {a.program_id, s})
+  Programs nobody staffs are **omitted** rather than mapped to an empty struct —
+  callers default with `ProgramStaffing.empty/1`, or pass the `nil` straight to
+  `ProgramStaffing.staffed_by?/2`, which accepts it.
+
+  Replaced the lead-only batch read this module used to expose: rendering and
+  filtering the provider programs table off the lead alone is what made a
+  staffed-but-leaderless program read as "Unassigned" and made non-lead staff
+  unfindable in the table's filter (#1310).
+  """
+  @spec list_program_staffing([String.t()]) :: %{optional(String.t()) => ProgramStaffing.t()}
+  def list_program_staffing([]), do: %{}
+
+  def list_program_staffing(program_ids) when is_list(program_ids) do
+    from(s in StaffMember,
+      join: a in ProgramStaffAssignment,
+      on: a.staff_member_id == s.id and a.provider_id == s.provider_id,
+      where: a.program_id in ^program_ids and is_nil(a.unassigned_at) and s.active,
+      order_by: [asc: a.assigned_at],
+      select: {a.program_id, s, a.is_lead_instructor}
+    )
     |> Repo.all()
-    |> Map.new(fn {program_id, staff} -> {program_id, to_lead_map(staff)} end)
+    |> Enum.group_by(fn {program_id, _staff, _lead?} -> program_id end)
+    |> Map.new(fn {program_id, rows} -> {program_id, to_staffing(program_id, rows)} end)
+  end
+
+  defp to_staffing(program_id, rows) do
+    lead = Enum.find_value(rows, fn {_program_id, staff, lead?} -> lead? && staff end)
+    member_ids = Enum.map(rows, fn {_program_id, staff, _lead?} -> staff.id end)
+
+    %ProgramStaffing{
+      program_id: program_id,
+      lead: to_lead_map(lead),
+      member_ids: member_ids,
+      member_count: length(member_ids)
+    }
   end
 
   # Active lead assignment(s) for a program (should be at most one via the index),

--- a/lib/klass_hero/provider/domain/read_models/program_staffing.ex
+++ b/lib/klass_hero/provider/domain/read_models/program_staffing.ex
@@ -1,0 +1,64 @@
+defmodule KlassHero.Provider.Domain.ReadModels.ProgramStaffing do
+  @moduledoc """
+  Read-model of who currently staffs one program: the lead (if any) plus every
+  active member.
+
+  Powers the provider programs table (#1310). Before it, that table read the lead
+  alone, so a staffed-but-leaderless program was indistinguishable from an empty
+  one — and, worse, the staff *filter* matched on the rendered lead, which made
+  "who is shown" define "who is findable". This struct is the single answer to
+  both questions: `Presenters.ProgramPresenter` formats it, the LiveView filters
+  through `staffed_by?/2`, and neither re-derives the other's semantics.
+
+  `member_ids` carries **everyone active on the program, the lead included**, so
+  `member_count == length(member_ids)` holds unconditionally and no caller needs
+  a "lead or member?" branch. `lead.id` is therefore always a member of
+  `member_ids` when `lead` is non-nil.
+
+  "Active" means what the assignment reads already mean: the assignment has no
+  `unassigned_at`, and the staff member's `active` flag is set. Display-optimized;
+  the only logic here is the membership predicate.
+  """
+
+  @typedoc "The lead instructor shaped for display, or nil when the program has none."
+  @type lead :: %{id: String.t(), name: String.t(), headshot_url: String.t() | nil} | nil
+
+  @typedoc "Active staffing of one program."
+  @type t :: %__MODULE__{
+          program_id: String.t(),
+          lead: lead(),
+          member_ids: [String.t()],
+          member_count: non_neg_integer()
+        }
+
+  @enforce_keys [:program_id, :member_ids, :member_count]
+
+  defstruct [
+    :program_id,
+    :lead,
+    member_ids: [],
+    member_count: 0
+  ]
+
+  @doc """
+  The zero-staff value. Batch reads omit programs nobody is on, so callers
+  default to this rather than carrying a `nil` through the presenter.
+  """
+  @spec empty(String.t()) :: t()
+  def empty(program_id) when is_binary(program_id) do
+    %__MODULE__{program_id: program_id, lead: nil, member_ids: [], member_count: 0}
+  end
+
+  @doc """
+  Whether `staff_member_id` is currently on this program, leading it or not.
+
+  Accepts `nil` so a caller can pass a batch-read lookup straight through
+  without first defaulting an absent program.
+  """
+  @spec staffed_by?(t() | nil, String.t()) :: boolean()
+  def staffed_by?(nil, _staff_member_id), do: false
+
+  def staffed_by?(%__MODULE__{member_ids: member_ids}, staff_member_id) do
+    staff_member_id in member_ids
+  end
+end

--- a/lib/klass_hero_web/components/provider_components.ex
+++ b/lib/klass_hero_web/components/provider_components.ex
@@ -1376,17 +1376,44 @@ defmodule KlassHeroWeb.ProviderComponents do
                 </div>
               </td>
               <td class="px-4 py-4">
-                <div :if={program.assigned_staff} class="flex items-center gap-2">
+                <%!-- Three distinct states: led, staffed-but-leaderless, empty. Collapsing
+                      the middle one into "Unassigned" is what #1310 was about. --%>
+                <div
+                  :if={program.assigned_staff.lead}
+                  id={"program-staff-lead-#{program.id}"}
+                  class="flex items-center gap-2"
+                >
                   <div class={[
-                    "w-8 h-8 flex items-center justify-center text-white text-xs font-medium",
+                    "w-8 h-8 shrink-0 flex items-center justify-center text-white text-xs font-medium",
                     Theme.rounded(:full),
                     Theme.gradient(:primary)
                   ]}>
-                    {program.assigned_staff.initials}
+                    {program.assigned_staff.lead.initials}
                   </div>
-                  <span class="text-sm text-hero-charcoal">{program.assigned_staff.name}</span>
+                  <span class="text-sm text-hero-charcoal">{program.assigned_staff.lead.name}</span>
+                  <span
+                    :if={program.assigned_staff.others_count > 0}
+                    class="text-sm text-hero-grey-500 whitespace-nowrap"
+                  >
+                    +{program.assigned_staff.others_count}
+                  </span>
                 </div>
-                <span :if={!program.assigned_staff} class="text-sm text-hero-grey-400 italic">
+                <span
+                  :if={!program.assigned_staff.lead and program.assigned_staff.count > 0}
+                  id={"program-staff-leaderless-#{program.id}"}
+                  class="text-sm text-hero-grey-500"
+                >
+                  {ngettext(
+                    "%{count} staff member · no lead",
+                    "%{count} staff · no lead",
+                    program.assigned_staff.count
+                  )}
+                </span>
+                <span
+                  :if={program.assigned_staff.count == 0}
+                  id={"program-staff-empty-#{program.id}"}
+                  class="text-sm text-hero-grey-400 italic"
+                >
                   {gettext("Unassigned")}
                 </span>
               </td>

--- a/lib/klass_hero_web/components/provider_components.ex
+++ b/lib/klass_hero_web/components/provider_components.ex
@@ -1299,8 +1299,13 @@ defmodule KlassHeroWeb.ProviderComponents do
           <h3 class="text-lg font-semibold text-hero-charcoal">
             {gettext("Program Inventory")}
           </h3>
+          <%!-- Each control needs its own <form>: LiveView refuses a phx-change on a
+                bare input ("form events require the input to be inside a form"), so
+                until this wrapper existed neither search nor the staff filter fired
+                in a browser at all — only in tests, where render_change/2 posts to
+                the server directly and never sees the client-side check. --%>
           <div class="flex flex-col sm:flex-row gap-2">
-            <div class="relative">
+            <form phx-change="search_programs" id="programs-search-form" class="relative">
               <.icon
                 name="hero-magnifying-glass-mini"
                 class="w-5 h-5 text-hero-grey-400 absolute left-3 top-1/2 -translate-y-1/2"
@@ -1315,11 +1320,10 @@ defmodule KlassHeroWeb.ProviderComponents do
                   "text-sm placeholder-hero-grey-400 focus:border-hero-cyan focus:ring-1 focus:ring-hero-cyan",
                   Theme.rounded(:lg)
                 ]}
-                phx-change="search_programs"
                 phx-debounce="300"
               />
-            </div>
-            <div class="relative">
+            </form>
+            <form phx-change="filter_by_staff" id="programs-staff-filter-form" class="relative">
               <.icon
                 name="hero-funnel-mini"
                 class="w-5 h-5 text-hero-grey-400 absolute left-3 top-1/2 -translate-y-1/2"
@@ -1331,7 +1335,6 @@ defmodule KlassHeroWeb.ProviderComponents do
                   "text-sm focus:border-hero-cyan focus:ring-1 focus:ring-hero-cyan appearance-none",
                   Theme.rounded(:lg)
                 ]}
-                phx-change="filter_by_staff"
               >
                 <option
                   :for={option <- @staff_options}
@@ -1341,7 +1344,7 @@ defmodule KlassHeroWeb.ProviderComponents do
                   {option.label}
                 </option>
               </select>
-            </div>
+            </form>
           </div>
         </div>
       </div>

--- a/lib/klass_hero_web/live/provider/programs_live.ex
+++ b/lib/klass_hero_web/live/provider/programs_live.ex
@@ -23,6 +23,7 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
   alias KlassHero.Messaging
   alias KlassHero.ProgramCatalog
   alias KlassHero.Provider
+  alias KlassHero.Provider.Domain.ReadModels.ProgramStaffing
   alias KlassHeroWeb.Presenters.ProgramPresenter
   alias KlassHeroWeb.Presenters.ProgramStaffingPresenter
   alias KlassHeroWeb.Presenters.StaffMemberPresenter
@@ -36,7 +37,7 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
 
     domain_programs = ProgramCatalog.list_programs_for_provider(provider.id)
     enrollment_data = build_enrollment_data(domain_programs)
-    programs = to_table_views(domain_programs, enrollment_data)
+    programs = to_table_views(domain_programs, enrollment_data, fetch_staffing(domain_programs))
 
     staff_members = fetch_staff_members(provider.id)
     staff_views = StaffMemberPresenter.to_admin_view_list(staff_members)
@@ -273,6 +274,7 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
         {:noreply,
          socket
          |> refresh_staffing_modal()
+         |> refresh_program_row(program_id)
          |> put_flash(:info, gettext("Staff member added to the program."))}
 
       # The picker excludes them, so this is a stale panel (two tabs, back button)
@@ -298,6 +300,7 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
         {:noreply,
          socket
          |> refresh_staffing_modal()
+         |> refresh_program_row(program_id)
          |> put_flash(:info, gettext("Staff member removed from the program."))}
 
       {:error, :cannot_unassign_lead} ->
@@ -652,7 +655,7 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
         ProgramPresenter.to_table_view(
           program,
           new_enrollment_data,
-          Provider.get_lead_instructor(program.id)
+          Map.get(Provider.list_program_staffing([program.id]), program.id)
         )
 
       {:noreply,
@@ -708,7 +711,7 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
         ProgramPresenter.to_table_view(
           updated,
           enrollment_data,
-          Provider.get_lead_instructor(program_id)
+          Map.get(Provider.list_program_staffing([program_id]), program_id)
         )
 
       {:noreply,
@@ -779,34 +782,39 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
     members
   end
 
+  # Filters run over the DOMAIN programs and their staffing read-model, then the
+  # survivors are presented — never the other way round. Filtering presenter
+  # output is what made the staff filter match on the rendered lead alone, so a
+  # non-lead staff member found none of their programs (#1310).
   defp reset_programs_stream(socket) do
     provider_id = socket.assigns.current_scope.provider.id
     domain_programs = ProgramCatalog.list_programs_for_provider(provider_id)
-    enrollment_data = build_enrollment_data(domain_programs)
+    staffing = fetch_staffing(domain_programs)
 
-    programs =
+    filtered =
       domain_programs
-      |> to_table_views(enrollment_data)
       |> filter_by_search(socket.assigns.search_query)
-      |> filter_by_staff(socket.assigns.selected_staff)
+      |> filter_by_staff(staffing, socket.assigns.selected_staff)
+
+    programs = to_table_views(filtered, build_enrollment_data(filtered), staffing)
 
     socket
     |> stream(:programs, programs, reset: true)
     |> assign(programs_count: length(programs))
   end
 
-  # Batch the lead-instructor read (single query) so the dashboard table avoids an
-  # N+1 across programs. The lead is the single source of truth on
-  # program_staff_assignments; ProgramCatalog no longer carries an instructor snapshot.
-  defp to_table_views(domain_programs, enrollment_data) do
-    leads =
-      domain_programs
-      |> Enum.map(& &1.id)
-      |> Provider.list_lead_instructors_for_programs()
+  # One query for the whole table's staffing, so neither rendering nor filtering
+  # N+1s across programs.
+  defp fetch_staffing(domain_programs) do
+    domain_programs
+    |> Enum.map(& &1.id)
+    |> Provider.list_program_staffing()
+  end
 
+  defp to_table_views(domain_programs, enrollment_data, staffing) do
     Enum.map(
       domain_programs,
-      &ProgramPresenter.to_table_view(&1, enrollment_data, Map.get(leads, &1.id))
+      &ProgramPresenter.to_table_view(&1, enrollment_data, Map.get(staffing, &1.id))
     )
   end
 
@@ -847,24 +855,34 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
     assign(socket, :staffing_modal, build_staffing_modal(program_id, program_name, provider_id))
   end
 
-  # Only a lead change reaches the table: its staff column renders the lead alone
-  # (ProgramPresenter.to_table_view/3), so adding or removing anyone else is invisible there.
+  # Every staffing change reaches the table now that the column renders the whole
+  # roster — adding or removing a non-lead moves the headcount, so those paths
+  # refresh the row too, not just promotion.
   defp refresh_program_row(socket, program_id) do
     provider_id = socket.assigns.current_scope.provider.id
 
     case ProgramCatalog.get_program_for_provider(provider_id, program_id) do
       {:ok, program} ->
-        view =
-          ProgramPresenter.to_table_view(
-            program,
-            build_enrollment_data([program]),
-            Provider.get_lead_instructor(program_id)
-          )
+        staffing = Map.get(Provider.list_program_staffing([program_id]), program_id)
 
-        stream_insert(socket, :programs, view)
+        if row_visible?(socket, staffing) do
+          view = ProgramPresenter.to_table_view(program, build_enrollment_data([program]), staffing)
+          stream_insert(socket, :programs, view)
+        else
+          stream_delete(socket, :programs, %{id: program_id})
+        end
 
       {:error, :not_found} ->
         socket
+    end
+  end
+
+  # Removing the staff member a filter is pinned to must drop the row, not
+  # re-insert it — otherwise the table shows a program that no longer matches.
+  defp row_visible?(socket, staffing) do
+    case socket.assigns.selected_staff do
+      "all" -> true
+      staff_id -> ProgramStaffing.staffed_by?(staffing, staff_id)
     end
   end
 
@@ -890,15 +908,17 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
     query_lower = String.downcase(query)
 
     Enum.filter(programs, fn program ->
-      String.contains?(String.downcase(program.name), query_lower)
+      String.contains?(String.downcase(program.title), query_lower)
     end)
   end
 
-  defp filter_by_staff(programs, "all"), do: programs
+  defp filter_by_staff(programs, _staffing, "all"), do: programs
 
-  defp filter_by_staff(programs, staff_id) do
+  # Matches anyone active on the program, lead or not — the read-model owns that
+  # definition, so the column's rendering can change without moving it.
+  defp filter_by_staff(programs, staffing, staff_id) do
     Enum.filter(programs, fn program ->
-      program.assigned_staff && to_string(program.assigned_staff.id) == staff_id
+      ProgramStaffing.staffed_by?(Map.get(staffing, program.id), staff_id)
     end)
   end
 

--- a/lib/klass_hero_web/presenters/program_presenter.ex
+++ b/lib/klass_hero_web/presenters/program_presenter.ex
@@ -7,6 +7,7 @@ defmodule KlassHeroWeb.Presenters.ProgramPresenter do
 
   alias KlassHero.ProgramCatalog.Program
   alias KlassHero.ProgramCatalog.ProgramListing
+  alias KlassHero.Provider.Domain.ReadModels.ProgramStaffing
   alias KlassHero.Shared.NameUtils
 
   require Logger
@@ -14,24 +15,30 @@ defmodule KlassHeroWeb.Presenters.ProgramPresenter do
   @doc """
   Table view for the provider dashboard. `status` is a placeholder (tracking not yet implemented).
 
-  `lead` is the program's lead instructor as a `%{id, name, headshot_url}` map (or
-  `nil`), read by the caller from `Provider.get_lead_instructor/1` or the batch
-  `Provider.list_lead_instructors_for_programs/1` — the single source of truth now
-  lives on `program_staff_assignments`, not a denormalized program snapshot.
-  """
-  @spec to_table_view(Program.t() | ProgramListing.t(), map(), map() | nil) :: map()
-  def to_table_view(program, enrollment_data \\ %{}, lead \\ nil)
+  `staffing` is the program's `ProgramStaffing` read-model (or `nil` when nobody
+  is on it — the batch read omits those programs), from
+  `Provider.list_program_staffing/1`. The single source of truth lives on
+  `program_staff_assignments`, not a denormalized program snapshot.
 
-  def to_table_view(%Program{} = program, enrollment_data, lead) do
-    to_table_row(program.id, program.title, program.category, program.price, enrollment_data, lead)
+  It carries the whole roster rather than the lead alone because a lead-less but
+  staffed program is a sanctioned state that must not render as "Unassigned"
+  (#1310). Filtering reads the same read-model through
+  `ProgramStaffing.staffed_by?/2` — never this output — so display and
+  findability cannot drift apart.
+  """
+  @spec to_table_view(Program.t() | ProgramListing.t(), map(), ProgramStaffing.t() | nil) :: map()
+  def to_table_view(program, enrollment_data \\ %{}, staffing \\ nil)
+
+  def to_table_view(%Program{} = program, enrollment_data, staffing) do
+    to_table_row(program.id, program.title, program.category, program.price, enrollment_data, staffing)
   end
 
   # ProgramListing is a flat read-model DTO used by other list surfaces.
-  def to_table_view(%ProgramListing{} = listing, enrollment_data, lead) do
-    to_table_row(listing.id, listing.title, listing.category, listing.price, enrollment_data, lead)
+  def to_table_view(%ProgramListing{} = listing, enrollment_data, staffing) do
+    to_table_row(listing.id, listing.title, listing.category, listing.price, enrollment_data, staffing)
   end
 
-  defp to_table_row(id, title, category, price, enrollment_data, lead) do
+  defp to_table_row(id, title, category, price, enrollment_data, staffing) do
     data = Map.get(enrollment_data, id, %{})
 
     %{
@@ -39,7 +46,7 @@ defmodule KlassHeroWeb.Presenters.ProgramPresenter do
       name: title,
       category: humanize_category(category),
       price: format_price(price),
-      assigned_staff: format_lead(lead),
+      assigned_staff: format_staffing(staffing),
       status: :active,
       enrolled: Map.get(data, :enrolled),
       capacity: Map.get(data, :capacity)
@@ -253,6 +260,21 @@ defmodule KlassHeroWeb.Presenters.ProgramPresenter do
 
   defp format_price(nil), do: "0.00"
   defp format_price(price), do: price |> Decimal.round(2) |> Decimal.to_string()
+
+  # The table's staff cell. Always a map, so the template branches on values
+  # rather than on the presence of the key. `count` is everyone active on the
+  # program; `others_count` is everyone who is not the lead — which equals
+  # `count` on a leaderless program, so both render branches read the field that
+  # means what they need. A nil staffing is an unstaffed program, not missing data.
+  defp format_staffing(nil), do: %{lead: nil, count: 0, others_count: 0}
+
+  defp format_staffing(%ProgramStaffing{lead: lead, member_count: count}) do
+    %{
+      lead: format_lead(lead),
+      count: count,
+      others_count: if(lead, do: max(count - 1, 0), else: count)
+    }
+  end
 
   # Lead instructor (single source of truth on program_staff_assignments), shaped
   # for the dashboard table avatar/name. `initials` is derived here for display.

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -137,7 +137,7 @@ msgid "Your Data"
 msgstr "Ihre Daten"
 
 #: lib/klass_hero_web/components/core_components.ex:67
-#: lib/klass_hero_web/components/provider_components.ex:1612
+#: lib/klass_hero_web/components/provider_components.ex:1615
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr "schließen"
@@ -232,7 +232,7 @@ msgstr "Einfache Terminplanung"
 msgid "Enroll Now - %{price}"
 msgstr "Jetzt anmelden - %{price}"
 
-#: lib/klass_hero_web/components/provider_components.ex:1363
+#: lib/klass_hero_web/components/provider_components.ex:1366
 #: lib/klass_hero_web/live/booking_live.ex:285
 #, elixir-autogen, elixir-format
 msgid "Enrollment"
@@ -578,8 +578,8 @@ msgid "Dispute Resolution"
 msgstr "Streitbeilegung"
 
 #: lib/klass_hero_web/components/provider_components.ex:647
-#: lib/klass_hero_web/components/provider_components.ex:2285
-#: lib/klass_hero_web/components/provider_components.ex:2303
+#: lib/klass_hero_web/components/provider_components.ex:2288
+#: lib/klass_hero_web/components/provider_components.ex:2306
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
@@ -878,9 +878,9 @@ msgstr "Speichern..."
 msgid "Select one or both options"
 msgstr "Wählen Sie eine oder beide Optionen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1981
-#: lib/klass_hero_web/components/provider_components.ex:1982
-#: lib/klass_hero_web/components/provider_components.ex:2019
+#: lib/klass_hero_web/components/provider_components.ex:1984
+#: lib/klass_hero_web/components/provider_components.ex:1985
+#: lib/klass_hero_web/components/provider_components.ex:2022
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:446
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:483
@@ -1577,14 +1577,14 @@ msgstr "Profil"
 msgid "Quick Navigation"
 msgstr "Schnellnavigation"
 
-#: lib/klass_hero_web/components/provider_components.ex:1366
-#: lib/klass_hero_web/components/provider_components.ex:1957
-#: lib/klass_hero_web/components/provider_components.ex:2183
+#: lib/klass_hero_web/components/provider_components.ex:1369
+#: lib/klass_hero_web/components/provider_components.ex:1960
+#: lib/klass_hero_web/components/provider_components.ex:2186
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr "Aktionen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1505
+#: lib/klass_hero_web/components/provider_components.ex:1508
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr "Aktiv"
@@ -1600,7 +1600,7 @@ msgstr "Teammitglied hinzufügen"
 msgid "All Staff"
 msgstr "Alle Mitarbeiter"
 
-#: lib/klass_hero_web/components/provider_components.ex:1357
+#: lib/klass_hero_web/components/provider_components.ex:1360
 #, elixir-autogen, elixir-format
 msgid "Assigned Staff"
 msgstr "Zugewiesenes Personal"
@@ -1628,7 +1628,7 @@ msgid "Create profiles for your staff. These will be visible to parents when ass
 msgstr "Erstellen Sie Profile für Ihr Personal. Diese werden für Eltern sichtbar sein, wenn sie Programmen zugewiesen werden."
 
 #: lib/klass_hero_web/components/provider_components.ex:538
-#: lib/klass_hero_web/components/provider_components.ex:1468
+#: lib/klass_hero_web/components/provider_components.ex:1471
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:54
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:81
 #: lib/klass_hero_web/live/settings/children_live.ex:448
@@ -1645,7 +1645,7 @@ msgstr "Bearbeiten"
 msgid "Edit Profile"
 msgstr "Profil bearbeiten"
 
-#: lib/klass_hero_web/components/provider_components.ex:1507
+#: lib/klass_hero_web/components/provider_components.ex:1510
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr "Inaktiv"
@@ -1669,16 +1669,16 @@ msgstr "Übersicht"
 
 #: lib/klass_hero_web/components/provider_components.ex:46
 #: lib/klass_hero_web/components/provider_components.ex:72
-#: lib/klass_hero_web/components/provider_components.ex:1506
-#: lib/klass_hero_web/components/provider_components.ex:2379
-#: lib/klass_hero_web/components/provider_components.ex:2397
+#: lib/klass_hero_web/components/provider_components.ex:1509
+#: lib/klass_hero_web/components/provider_components.ex:2382
+#: lib/klass_hero_web/components/provider_components.ex:2400
 #: lib/klass_hero_web/live/admin/sessions_live.ex:297
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr "Ausstehend"
 
-#: lib/klass_hero_web/components/provider_components.ex:1444
+#: lib/klass_hero_web/components/provider_components.ex:1447
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr "Vorschau"
@@ -1688,7 +1688,7 @@ msgstr "Vorschau"
 msgid "Program Inventory"
 msgstr "Programmübersicht"
 
-#: lib/klass_hero_web/components/provider_components.ex:1354
+#: lib/klass_hero_web/components/provider_components.ex:1357
 #, elixir-autogen, elixir-format
 msgid "Program Name"
 msgstr "Programmname"
@@ -1703,15 +1703,15 @@ msgstr "Anbieter-Dashboard"
 msgid "Save for Later"
 msgstr "Für später speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:1312
+#: lib/klass_hero_web/components/provider_components.ex:1317
 #, elixir-autogen, elixir-format
 msgid "Search by name..."
 msgstr "Nach Namen suchen..."
 
-#: lib/klass_hero_web/components/provider_components.ex:1360
-#: lib/klass_hero_web/components/provider_components.ex:1729
-#: lib/klass_hero_web/components/provider_components.ex:1951
-#: lib/klass_hero_web/components/provider_components.ex:2180
+#: lib/klass_hero_web/components/provider_components.ex:1363
+#: lib/klass_hero_web/components/provider_components.ex:1732
+#: lib/klass_hero_web/components/provider_components.ex:1954
+#: lib/klass_hero_web/components/provider_components.ex:2183
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1735,15 +1735,15 @@ msgstr "Team- & Anbieterprofile"
 msgid "This is your main business identity. Verification is required to list programs."
 msgstr "Dies ist Ihre Hauptgeschäftsidentität. Eine Verifizierung ist erforderlich, um Programme anzubieten."
 
-#: lib/klass_hero_web/components/provider_components.ex:1417
-#: lib/klass_hero_web/components/provider_components.ex:1744
+#: lib/klass_hero_web/components/provider_components.ex:1420
+#: lib/klass_hero_web/components/provider_components.ex:1747
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr "Nicht zugewiesen"
 
 #: lib/klass_hero_web/components/messaging_components.ex:728
 #: lib/klass_hero_web/components/provider_components.ex:49
-#: lib/klass_hero_web/components/provider_components.ex:1508
+#: lib/klass_hero_web/components/provider_components.ex:1511
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:433
 #: lib/klass_hero_web/presenters/provider_presenter.ex:103
 #, elixir-autogen, elixir-format
@@ -1755,7 +1755,7 @@ msgstr "Unbekannt"
 msgid "Verified Business"
 msgstr "Verifiziertes Unternehmen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1455
+#: lib/klass_hero_web/components/provider_components.ex:1458
 #, elixir-autogen, elixir-format
 msgid "View Roster"
 msgstr "Teilnehmerliste"
@@ -1817,7 +1817,7 @@ msgstr "Rundnachricht an %{count} Eltern gesendet"
 #: lib/klass_hero_web/components/participation_components.ex:717
 #: lib/klass_hero_web/components/provider_components.ex:817
 #: lib/klass_hero_web/components/provider_components.ex:1216
-#: lib/klass_hero_web/components/provider_components.ex:2122
+#: lib/klass_hero_web/components/provider_components.ex:2125
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:478
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
@@ -1883,7 +1883,7 @@ msgstr "Kind konnte nicht entfernt werden. Bitte versuchen Sie es erneut."
 msgid "Data sharing consent"
 msgstr "Einwilligung zur Datenweitergabe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2266
+#: lib/klass_hero_web/components/provider_components.ex:2269
 #: lib/klass_hero_web/live/settings/children_live.ex:657
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1931,17 +1931,17 @@ msgstr "Rundnachricht konnte nicht gesendet werden"
 msgid "Failed to submit note"
 msgstr "Notiz konnte nicht eingereicht werden"
 
-#: lib/klass_hero_web/components/provider_components.ex:2260
-#: lib/klass_hero_web/components/provider_components.ex:2289
-#: lib/klass_hero_web/components/provider_components.ex:2305
+#: lib/klass_hero_web/components/provider_components.ex:2263
+#: lib/klass_hero_web/components/provider_components.ex:2292
+#: lib/klass_hero_web/components/provider_components.ex:2308
 #: lib/klass_hero_web/live/settings/children_live.ex:643
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr "Vorname"
 
-#: lib/klass_hero_web/components/provider_components.ex:2261
-#: lib/klass_hero_web/components/provider_components.ex:2290
-#: lib/klass_hero_web/components/provider_components.ex:2306
+#: lib/klass_hero_web/components/provider_components.ex:2264
+#: lib/klass_hero_web/components/provider_components.ex:2293
+#: lib/klass_hero_web/components/provider_components.ex:2309
 #: lib/klass_hero_web/live/settings/children_live.ex:649
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -2080,8 +2080,8 @@ msgstr "Einwilligung zur Datenweitergabe an Anbieter"
 msgid "Save Changes"
 msgstr "Änderungen speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:1590
-#: lib/klass_hero_web/components/provider_components.ex:1591
+#: lib/klass_hero_web/components/provider_components.ex:1593
+#: lib/klass_hero_web/components/provider_components.ex:1594
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:43
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:151
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:252
@@ -2099,7 +2099,7 @@ msgstr "Rundnachricht senden"
 msgid "Send a message to start the conversation"
 msgstr "Senden Sie eine Nachricht, um die Unterhaltung zu beginnen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2360
+#: lib/klass_hero_web/components/provider_components.ex:2363
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:245
 #, elixir-autogen, elixir-format
@@ -2235,7 +2235,7 @@ msgstr "Alter %{min}+"
 msgid "Allowed Genders"
 msgstr "Zulässige Geschlechter"
 
-#: lib/klass_hero_web/components/provider_components.ex:2419
+#: lib/klass_hero_web/components/provider_components.ex:2422
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred during import."
 msgstr "Beim Import ist ein unerwarteter Fehler aufgetreten."
@@ -2335,8 +2335,8 @@ msgstr "Kategorie"
 msgid "Check eligibility at"
 msgstr "Berechtigung prüfen unter"
 
-#: lib/klass_hero_web/components/provider_components.ex:1948
-#: lib/klass_hero_web/components/provider_components.ex:2174
+#: lib/klass_hero_web/components/provider_components.ex:1951
+#: lib/klass_hero_web/components/provider_components.ex:2177
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr "Name des Kindes"
@@ -2381,7 +2381,7 @@ msgstr "Schließen Sie die Geschäftsverifizierung ab, um Programme zu erstellen
 msgid "Confirm rejection"
 msgstr "Ablehnung bestätigen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2380
+#: lib/klass_hero_web/components/provider_components.ex:2383
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr "Bestätigt"
@@ -2430,7 +2430,7 @@ msgstr "Beschreibung"
 msgid "Diverse"
 msgstr "Divers"
 
-#: lib/klass_hero_web/components/provider_components.ex:2517
+#: lib/klass_hero_web/components/provider_components.ex:2520
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr "Dokumenttyp"
@@ -2464,7 +2464,7 @@ msgstr "Dokument abgelehnt."
 msgid "Document uploaded successfully."
 msgstr "Dokument erfolgreich hochgeladen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2141
+#: lib/klass_hero_web/components/provider_components.ex:2144
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr "Vorlage herunterladen"
@@ -2495,14 +2495,14 @@ msgstr "Enddatum"
 msgid "End Time"
 msgstr "Endzeit"
 
-#: lib/klass_hero_web/components/provider_components.ex:1954
-#: lib/klass_hero_web/components/provider_components.ex:2400
+#: lib/klass_hero_web/components/provider_components.ex:1957
+#: lib/klass_hero_web/components/provider_components.ex:2403
 #: lib/klass_hero_web/components/provider_layout_components.ex:644
 #, elixir-autogen, elixir-format
 msgid "Enrolled"
 msgstr "Angemeldet"
 
-#: lib/klass_hero_web/components/provider_components.ex:1636
+#: lib/klass_hero_web/components/provider_components.ex:1639
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr "Angemeldet (%{count})"
@@ -2518,7 +2518,7 @@ msgid "Explain why this document is being rejected..."
 msgstr "Erklären Sie, warum dieses Dokument abgelehnt wird..."
 
 #: lib/klass_hero_web/components/provider_components.ex:70
-#: lib/klass_hero_web/components/provider_components.ex:2401
+#: lib/klass_hero_web/components/provider_components.ex:2404
 #: lib/klass_hero_web/live/admin/emails_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2562,12 +2562,12 @@ msgstr "Weiblich"
 msgid "File"
 msgstr "Datei"
 
-#: lib/klass_hero_web/components/provider_components.ex:2451
+#: lib/klass_hero_web/components/provider_components.ex:2454
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr "Die Datei ist zu groß."
 
-#: lib/klass_hero_web/components/provider_components.ex:2453
+#: lib/klass_hero_web/components/provider_components.ex:2456
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr "Dateityp wird nicht akzeptiert."
@@ -2602,7 +2602,7 @@ msgstr "Klassenstufe %{min}+"
 msgid "Grades %{min} – %{max}"
 msgstr "Klassenstufen %{min} – %{max}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2177
+#: lib/klass_hero_web/components/provider_components.ex:2180
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr "E-Mail des Erziehungsberechtigten"
@@ -2617,7 +2617,7 @@ msgstr "Porträtfoto"
 msgid "ID Document"
 msgstr "Ausweisdokument"
 
-#: lib/klass_hero_web/components/provider_components.ex:2114
+#: lib/klass_hero_web/components/provider_components.ex:2117
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Importieren"
@@ -2642,7 +2642,7 @@ msgstr "Einladung entfernt."
 msgid "Invite resent successfully."
 msgstr "Einladung erfolgreich erneut gesendet."
 
-#: lib/klass_hero_web/components/provider_components.ex:1653
+#: lib/klass_hero_web/components/provider_components.ex:1656
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr "Einladungen (%{count})"
@@ -2743,12 +2743,12 @@ msgstr "Niedrigste Klassenstufe"
 msgid "No approved documents."
 msgstr "Keine genehmigten Dokumente."
 
-#: lib/klass_hero_web/components/provider_components.ex:2479
+#: lib/klass_hero_web/components/provider_components.ex:2482
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr "Noch keine Dokumente hochgeladen."
 
-#: lib/klass_hero_web/components/provider_components.ex:1941
+#: lib/klass_hero_web/components/provider_components.ex:1944
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:425
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
@@ -2764,7 +2764,7 @@ msgstr "Keine Datei ausgewählt."
 msgid "No grade"
 msgstr "Keine Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2165
+#: lib/klass_hero_web/components/provider_components.ex:2168
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr "Noch keine Einladungen. Laden Sie eine CSV-Datei hoch, um Familien einzuladen."
@@ -2827,7 +2827,7 @@ msgstr "Nicht angegeben"
 msgid "Our Story"
 msgstr "Unsere Geschichte"
 
-#: lib/klass_hero_web/components/provider_components.ex:2554
+#: lib/klass_hero_web/components/provider_components.ex:2557
 #: lib/klass_hero_web/live/provider/verification_live.ex:698
 #: lib/klass_hero_web/live/provider/verification_live.ex:770
 #, elixir-autogen, elixir-format
@@ -2925,7 +2925,7 @@ msgid "Read our founding story →"
 msgstr "Lesen Sie unsere Gründungsgeschichte →"
 
 #: lib/klass_hero_web/components/participation_components.ex:805
-#: lib/klass_hero_web/components/provider_components.ex:2399
+#: lib/klass_hero_web/components/provider_components.ex:2402
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Registered"
@@ -3007,16 +3007,16 @@ msgstr "Ablehnungsgrund"
 
 #: lib/klass_hero_web/components/provider_components.ex:767
 #: lib/klass_hero_web/components/provider_components.ex:1166
-#: lib/klass_hero_web/components/provider_components.ex:2221
-#: lib/klass_hero_web/components/provider_components.ex:2573
-#: lib/klass_hero_web/components/provider_components.ex:2652
+#: lib/klass_hero_web/components/provider_components.ex:2224
+#: lib/klass_hero_web/components/provider_components.ex:2576
+#: lib/klass_hero_web/components/provider_components.ex:2655
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:253
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr "Entfernen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2214
+#: lib/klass_hero_web/components/provider_components.ex:2217
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr "Einladung erneut senden"
@@ -3031,7 +3031,7 @@ msgstr "Überprüft"
 msgid "Role"
 msgstr "Rolle"
 
-#: lib/klass_hero_web/components/provider_components.ex:1582
+#: lib/klass_hero_web/components/provider_components.ex:1585
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
@@ -3057,7 +3057,7 @@ msgstr "Zeitplan noch offen"
 msgid "School Grade (optional)"
 msgstr "Klassenstufe (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2551
+#: lib/klass_hero_web/components/provider_components.ex:2554
 #, elixir-autogen, elixir-format
 msgid "Select File"
 msgstr "Datei auswählen"
@@ -3074,7 +3074,7 @@ msgstr "Das ausgewählte Kind erfüllt die Programmanforderungen nicht."
 msgid "Selected instructor could not be found. Please try again."
 msgstr "Der ausgewählte Kursleiter konnte nicht gefunden werden. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2398
+#: lib/klass_hero_web/components/provider_components.ex:2401
 #: lib/klass_hero_web/live/admin/emails_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Sent"
@@ -3184,7 +3184,7 @@ msgstr "Dieses Programm wurde von jemand anderem geändert. Bitte schließen Sie
 msgid "Title"
 msgstr "Titel"
 
-#: lib/klass_hero_web/components/provider_components.ex:2452
+#: lib/klass_hero_web/components/provider_components.ex:2455
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr "Zu viele Dateien."
@@ -3204,32 +3204,32 @@ msgstr "Bis zu %{max}"
 msgid "Up to Grade %{max}"
 msgstr "Bis Klassenstufe %{max}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2100
+#: lib/klass_hero_web/components/provider_components.ex:2103
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr "CSV hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2597
+#: lib/klass_hero_web/components/provider_components.ex:2600
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr "Dokument hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2506
+#: lib/klass_hero_web/components/provider_components.ex:2509
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr "Neues Dokument hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2474
+#: lib/klass_hero_web/components/provider_components.ex:2477
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr "Laden Sie Dokumente hoch, um Ihr Unternehmen zu verifizieren. Die Dokumente werden von unserem Team überprüft."
 
-#: lib/klass_hero_web/components/provider_components.ex:2454
+#: lib/klass_hero_web/components/provider_components.ex:2457
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr "Upload-Fehler."
 
-#: lib/klass_hero_web/components/provider_components.ex:2471
+#: lib/klass_hero_web/components/provider_components.ex:2474
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr "Verifizierungsdokumente"
@@ -3319,7 +3319,7 @@ msgid "Child Safeguarding Training"
 msgstr "Kinderschutzschulung"
 
 #: lib/klass_hero_web/components/marketing_components.ex:1498
-#: lib/klass_hero_web/components/provider_components.ex:2819
+#: lib/klass_hero_web/components/provider_components.ex:2822
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr "Vereinbarung zu Community-Standards"
@@ -3469,7 +3469,7 @@ msgid "Vetted with Care"
 msgstr "Mit Sorgfalt geprüft"
 
 #: lib/klass_hero_web/components/marketing_components.ex:1482
-#: lib/klass_hero_web/components/provider_components.ex:2604
+#: lib/klass_hero_web/components/provider_components.ex:2607
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr "Video-Überprüfung"
@@ -3643,7 +3643,7 @@ msgstr "Eingecheckt"
 msgid "Checked Out"
 msgstr "Ausgecheckt"
 
-#: lib/klass_hero_web/components/provider_components.ex:2257
+#: lib/klass_hero_web/components/provider_components.ex:2260
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Child"
@@ -3696,7 +3696,7 @@ msgstr "Benötige ich ein Konto, um zu buchen?"
 msgid "Download monthly statements for taxes"
 msgstr "Monatliche Abrechnungen für die Steuer herunterladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2018
+#: lib/klass_hero_web/components/provider_components.ex:2021
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Enrollment not confirmed"
@@ -3774,7 +3774,7 @@ msgstr "Keine Änderungen erkannt"
 msgid "No chasing payments or sending invoices"
 msgstr "Kein Nachfassen bei Zahlungen oder Versenden von Rechnungen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1605
+#: lib/klass_hero_web/components/provider_components.ex:1608
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:406
 #, elixir-autogen, elixir-format
 msgid "No enrolled parents"
@@ -3797,7 +3797,7 @@ msgstr "Notizen"
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr "Oder: Jederzeit eine Sofortauszahlung anfordern (mindestens 50 €)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2017
+#: lib/klass_hero_web/components/provider_components.ex:2020
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:481
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -4905,43 +4905,43 @@ msgstr "Ihr Profil ist bereits vollständig."
 msgid "for"
 msgstr "für"
 
-#: lib/klass_hero_web/components/provider_components.ex:1726
+#: lib/klass_hero_web/components/provider_components.ex:1729
 #, elixir-autogen, elixir-format
 msgid "Assigned staff"
 msgstr "Zugewiesenes Personal"
 
-#: lib/klass_hero_web/components/provider_components.ex:1728
+#: lib/klass_hero_web/components/provider_components.ex:1731
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr "Anwesenheit"
 
-#: lib/klass_hero_web/components/provider_components.ex:1710
-#: lib/klass_hero_web/components/provider_components.ex:1799
+#: lib/klass_hero_web/components/provider_components.ex:1713
+#: lib/klass_hero_web/components/provider_components.ex:1802
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr "Schließen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1727
+#: lib/klass_hero_web/components/provider_components.ex:1730
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr "Vertretung"
 
-#: lib/klass_hero_web/components/provider_components.ex:1725
+#: lib/klass_hero_web/components/provider_components.ex:1728
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr "Datum / Uhrzeit"
 
-#: lib/klass_hero_web/components/provider_components.ex:1719
+#: lib/klass_hero_web/components/provider_components.ex:1722
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled yet."
 msgstr "Noch keine Sessions geplant."
 
-#: lib/klass_hero_web/components/provider_components.ex:1708
+#: lib/klass_hero_web/components/provider_components.ex:1711
 #, elixir-autogen, elixir-format
 msgid "Sessions — %{title}"
 msgstr "Sessions — %{title}"
 
-#: lib/klass_hero_web/components/provider_components.ex:1448
+#: lib/klass_hero_web/components/provider_components.ex:1451
 #, elixir-autogen, elixir-format
 msgid "View sessions"
 msgstr "Sessions anzeigen"
@@ -4973,17 +4973,17 @@ msgstr "Abreisezeit ist kein gültiges Datum oder keine gültige Uhrzeit"
 msgid "Failed to update record"
 msgstr "Aktualisieren des Datensatzes fehlgeschlagen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2321
+#: lib/klass_hero_web/components/provider_components.ex:2324
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr "Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2040
+#: lib/klass_hero_web/components/provider_components.ex:2043
 #, elixir-autogen, elixir-format
 msgid "Invite mode"
 msgstr "Einladungsmodus"
 
-#: lib/klass_hero_web/components/provider_components.ex:2059
+#: lib/klass_hero_web/components/provider_components.ex:2062
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr "Einzelperson einladen"
@@ -4998,12 +4998,12 @@ msgstr "Einladung verschickt."
 msgid "Leave blank to keep this child marked as present."
 msgstr "Leer lassen, um dieses Kind als anwesend markiert zu lassen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2334
+#: lib/klass_hero_web/components/provider_components.ex:2337
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr "Gesundheit & Einwilligungen (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2340
+#: lib/klass_hero_web/components/provider_components.ex:2343
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr "Gesundheitliche Besonderheiten"
@@ -5014,17 +5014,17 @@ msgstr "Gesundheitliche Besonderheiten"
 msgid "Nothing to update"
 msgstr "Nichts zu aktualisieren"
 
-#: lib/klass_hero_web/components/provider_components.ex:2342
+#: lib/klass_hero_web/components/provider_components.ex:2345
 #, elixir-autogen, elixir-format
 msgid "Nut allergy"
 msgstr "Nussallergie"
 
-#: lib/klass_hero_web/components/provider_components.ex:2346
+#: lib/klass_hero_web/components/provider_components.ex:2349
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr "Fotos dürfen in Marketingmaterialien verwendet werden"
 
-#: lib/klass_hero_web/components/provider_components.ex:2351
+#: lib/klass_hero_web/components/provider_components.ex:2354
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr "Fotos dürfen in sozialen Medien erscheinen"
@@ -5034,7 +5034,7 @@ msgstr "Fotos dürfen in sozialen Medien erscheinen"
 msgid "Present"
 msgstr "Anwesend"
 
-#: lib/klass_hero_web/components/provider_components.ex:2278
+#: lib/klass_hero_web/components/provider_components.ex:2281
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr "Hauptansprechpartner"
@@ -5061,22 +5061,22 @@ msgstr "Datensatz aktualisiert"
 msgid "Save changes"
 msgstr "Änderungen speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:2315
+#: lib/klass_hero_web/components/provider_components.ex:2318
 #, elixir-autogen, elixir-format
 msgid "School (optional)"
 msgstr "Schule (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2325
+#: lib/klass_hero_web/components/provider_components.ex:2328
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr "Schulname"
 
-#: lib/klass_hero_web/components/provider_components.ex:2299
+#: lib/klass_hero_web/components/provider_components.ex:2302
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr "Zweiter Ansprechpartner (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2368
+#: lib/klass_hero_web/components/provider_components.ex:2371
 #, elixir-autogen, elixir-format
 msgid "Send invite"
 msgstr "Einladung senden"
@@ -5086,7 +5086,7 @@ msgstr "Einladung senden"
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr "Aktualisieren Sie die Notiz für dieses Kind (z. B. um zu klären, was passiert ist)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2077
+#: lib/klass_hero_web/components/provider_components.ex:2080
 #, elixir-autogen, elixir-format
 msgid "Upload a list"
 msgstr "Liste hochladen"
@@ -5186,7 +5186,7 @@ msgstr "Programm oder Session nicht gefunden."
 msgid "Property Damage"
 msgstr "Sachschaden"
 
-#: lib/klass_hero_web/components/provider_components.ex:1478
+#: lib/klass_hero_web/components/provider_components.ex:1481
 #, elixir-autogen, elixir-format
 msgid "Report Incident"
 msgstr "Vorfall melden"
@@ -5868,7 +5868,7 @@ msgstr[1] "%{count} Familien importiert."
 msgid "In 2025, Shane connected with his friend"
 msgstr "2025 tat sich Shane mit seinem Freund zusammen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1487
+#: lib/klass_hero_web/components/provider_components.ex:1490
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:43
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:74
 #, elixir-autogen, elixir-format
@@ -6388,17 +6388,17 @@ msgstr "Umsatz (diese Woche)"
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr "Strenge Überprüfung, damit Familien immer wissen, wer die Gruppe leitet."
 
-#: lib/klass_hero_web/components/provider_components.ex:2407
+#: lib/klass_hero_web/components/provider_components.ex:2410
 #, elixir-autogen, elixir-format
 msgid "Row %{row}"
 msgstr "Zeile %{row}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2407
+#: lib/klass_hero_web/components/provider_components.ex:2410
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr "Zeile —"
 
-#: lib/klass_hero_web/components/provider_components.ex:2153
+#: lib/klass_hero_web/components/provider_components.ex:2156
 #, elixir-autogen, elixir-format
 msgid "Rows with errors"
 msgstr "Zeilen mit Fehlern"
@@ -7157,12 +7157,12 @@ msgstr "Deine Identität ist verifiziert."
 msgid "Experience validation"
 msgstr "Erfahrungsnachweis"
 
-#: lib/klass_hero_web/components/provider_components.ex:2633
+#: lib/klass_hero_web/components/provider_components.ex:2636
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr "MP4, MOV oder WEBM. Max. 100 MB."
 
-#: lib/klass_hero_web/components/provider_components.ex:2607
+#: lib/klass_hero_web/components/provider_components.ex:2610
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr "Nimm ein kurzes Video auf, in dem du dich vorstellst. Unser Team prüft es, um Kommunikationsfähigkeit und Übereinstimmung mit unseren Werten einzuschätzen."
@@ -7172,12 +7172,12 @@ msgstr "Nimm ein kurzes Video auf, in dem du dich vorstellst. Unser Team prüft 
 msgid "Safeguarding certificate"
 msgstr "Kinderschutz-Zertifikat"
 
-#: lib/klass_hero_web/components/provider_components.ex:2630
+#: lib/klass_hero_web/components/provider_components.ex:2633
 #, elixir-autogen, elixir-format
 msgid "Select Video"
 msgstr "Video auswählen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2676
+#: lib/klass_hero_web/components/provider_components.ex:2679
 #, elixir-autogen, elixir-format
 msgid "Upload Video"
 msgstr "Video hochladen"
@@ -7187,7 +7187,7 @@ msgstr "Video hochladen"
 msgid "Your browser does not support video playback."
 msgstr "Dein Browser unterstützt keine Videowiedergabe."
 
-#: lib/klass_hero_web/components/provider_components.ex:2823
+#: lib/klass_hero_web/components/provider_components.ex:2826
 #, elixir-autogen, elixir-format
 msgid "Confirm agreement"
 msgstr "Zustimmung bestätigen"
@@ -7197,12 +7197,12 @@ msgstr "Zustimmung bestätigen"
 msgid "Couldn't record your agreement. Please try again."
 msgstr "Deine Zustimmung konnte nicht gespeichert werden. Bitte versuche es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2846
+#: lib/klass_hero_web/components/provider_components.ex:2849
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr "Vereinbarung herunterladen (PDF)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2822
+#: lib/klass_hero_web/components/provider_components.ex:2825
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr "Ich habe die Klass Hero Community-Richtlinien gelesen und stimme ihnen zu."
@@ -7212,7 +7212,7 @@ msgstr "Ich habe die Klass Hero Community-Richtlinien gelesen und stimme ihnen z
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr "Bitte bestätige, dass du die Community-Richtlinien gelesen hast und ihnen zustimmst."
 
-#: lib/klass_hero_web/components/provider_components.ex:2731
+#: lib/klass_hero_web/components/provider_components.ex:2734
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr "Unterzeichnet von %{name} am %{date} (v%{version})."
@@ -7222,17 +7222,17 @@ msgstr "Unterzeichnet von %{name} am %{date} (v%{version})."
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr "Danke – deine Zustimmung zu den Community-Richtlinien wurde gespeichert."
 
-#: lib/klass_hero_web/components/provider_components.ex:2831
+#: lib/klass_hero_web/components/provider_components.ex:2834
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr "Die Community-Richtlinien wurden seit deiner letzten Zustimmung aktualisiert (v%{old}). Bitte lies sie erneut und stimme erneut zu."
 
-#: lib/klass_hero_web/components/provider_components.ex:2820
+#: lib/klass_hero_web/components/provider_components.ex:2823
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr "Der letzte Schritt: Lies die Klass Hero Community-Richtlinien und stimme ihnen zu."
 
-#: lib/klass_hero_web/components/provider_components.ex:2821
+#: lib/klass_hero_web/components/provider_components.ex:2824
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr "Du hast den Community-Richtlinien zugestimmt."
@@ -7501,12 +7501,12 @@ msgstr "Ihre Versicherungsbescheinigung wird geprüft."
 msgid "Your insurance is verified."
 msgstr "Ihre Versicherung ist verifiziert."
 
-#: lib/klass_hero_web/components/provider_components.ex:2775
+#: lib/klass_hero_web/components/provider_components.ex:2778
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr "Unterzeichnung durch %{name} im Namen des Unternehmens."
 
-#: lib/klass_hero_web/components/provider_components.ex:2878
+#: lib/klass_hero_web/components/provider_components.ex:2881
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr "Bestätige im Namen deines Unternehmens, dass alle Mitarbeitenden gemäß dem deutschen Kinderschutzrecht überprüft sind."
@@ -7516,7 +7516,7 @@ msgstr "Bestätige im Namen deines Unternehmens, dass alle Mitarbeitenden gemä�
 msgid "Couldn't record your declaration. Please try again."
 msgstr "Deine Erklärung konnte nicht gespeichert werden. Bitte versuche es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2884
+#: lib/klass_hero_web/components/provider_components.ex:2887
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr "Ich bestätige im Namen des Unternehmens, dass die obige Erklärung zutrifft und ich zu ihrer Unterzeichnung berechtigt bin."
@@ -7526,17 +7526,17 @@ msgstr "Ich bestätige im Namen des Unternehmens, dass die obige Erklärung zutr
 msgid "Please confirm the declaration before signing."
 msgstr "Bitte bestätige die Erklärung vor der Unterzeichnung."
 
-#: lib/klass_hero_web/components/provider_components.ex:2909
+#: lib/klass_hero_web/components/provider_components.ex:2912
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr "Vorläufiger Text — vor der Freischaltung noch von einer in Deutschland zugelassenen Anwältin bzw. einem Anwalt zu prüfen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2888
+#: lib/klass_hero_web/components/provider_components.ex:2891
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr "Erklärung unterzeichnen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2876
+#: lib/klass_hero_web/components/provider_components.ex:2879
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr "Erklärung zur Mitarbeiter-Compliance"
@@ -7546,12 +7546,12 @@ msgstr "Erklärung zur Mitarbeiter-Compliance"
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr "Danke — deine Erklärung zur Mitarbeiter-Compliance wurde erfasst."
 
-#: lib/klass_hero_web/components/provider_components.ex:2896
+#: lib/klass_hero_web/components/provider_components.ex:2899
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr "Die Erklärung zur Mitarbeiter-Compliance wurde seit deiner letzten Unterzeichnung aktualisiert (v%{old}). Bitte prüfe sie und unterzeichne erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2882
+#: lib/klass_hero_web/components/provider_components.ex:2885
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr "Du hast die Erklärung zur Mitarbeiter-Compliance unterzeichnet."
@@ -7618,12 +7618,12 @@ msgstr "In Prüfung"
 msgid "Undelivered Events"
 msgstr "Nicht zugestellte Ereignisse"
 
-#: lib/klass_hero_web/components/provider_components.ex:1896
+#: lib/klass_hero_web/components/provider_components.ex:1899
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1821
+#: lib/klass_hero_web/components/provider_components.ex:1824
 #, elixir-autogen, elixir-format
 msgid "Lead"
 msgstr "Leitung"
@@ -7633,17 +7633,17 @@ msgstr "Leitung"
 msgid "Lead instructor updated."
 msgstr "Leitender Kursleiter aktualisiert."
 
-#: lib/klass_hero_web/components/provider_components.ex:1832
+#: lib/klass_hero_web/components/provider_components.ex:1835
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor"
 msgstr "Als leitenden Kursleiter festlegen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1462
+#: lib/klass_hero_web/components/provider_components.ex:1465
 #, elixir-autogen, elixir-format
 msgid "Manage Staffing"
 msgstr "Programmteam verwalten"
 
-#: lib/klass_hero_web/components/provider_components.ex:1860
+#: lib/klass_hero_web/components/provider_components.ex:1863
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this program yet."
 msgstr "Diesem Programm ist noch niemand zugewiesen."
@@ -7653,17 +7653,17 @@ msgstr "Diesem Programm ist noch niemand zugewiesen."
 msgid "Pick a staff member to add."
 msgstr "Bitte ein Teammitglied zum Hinzufügen auswählen."
 
-#: lib/klass_hero_web/components/provider_components.ex:1843
+#: lib/klass_hero_web/components/provider_components.ex:1846
 #, elixir-autogen, elixir-format
 msgid "Reassign the lead before removing them"
 msgstr "Vor dem Entfernen einen anderen leitenden Kursleiter festlegen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1844
+#: lib/klass_hero_web/components/provider_components.ex:1847
 #, elixir-autogen, elixir-format
 msgid "Remove from program"
 msgstr "Aus dem Programm entfernen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1878
+#: lib/klass_hero_web/components/provider_components.ex:1881
 #, elixir-autogen, elixir-format
 msgid "Select a staff member…"
 msgstr "Teammitglied auswählen …"
@@ -7678,14 +7678,14 @@ msgstr "Teammitglied zum Programm hinzugefügt."
 msgid "Staff member removed from the program."
 msgstr "Teammitglied aus dem Programm entfernt."
 
-#: lib/klass_hero_web/components/provider_components.ex:1901
+#: lib/klass_hero_web/components/provider_components.ex:1904
 #, elixir-autogen, elixir-format
 msgid "Staff you add can read and reply to this program's parent conversations."
 msgstr ""
 "Hinzugefügte Teammitglieder können die Elterngespräche dieses Programms lesen "
 "und beantworten."
 
-#: lib/klass_hero_web/components/provider_components.ex:1797
+#: lib/klass_hero_web/components/provider_components.ex:1800
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{title}"
 msgstr "Programmteam — %{title}"
@@ -7707,7 +7707,7 @@ msgstr ""
 "Diese Person ist der leitende Kursleiter. Bitte zuerst eine andere Person als "
 "Leitung festlegen."
 
-#: lib/klass_hero_web/components/provider_components.ex:1406
+#: lib/klass_hero_web/components/provider_components.ex:1409
 #, elixir-autogen, elixir-format
 msgid "%{count} staff member · no lead"
 msgid_plural "%{count} staff · no lead"

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -137,7 +137,7 @@ msgid "Your Data"
 msgstr "Ihre Daten"
 
 #: lib/klass_hero_web/components/core_components.ex:67
-#: lib/klass_hero_web/components/provider_components.ex:1585
+#: lib/klass_hero_web/components/provider_components.ex:1612
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr "schließen"
@@ -578,8 +578,8 @@ msgid "Dispute Resolution"
 msgstr "Streitbeilegung"
 
 #: lib/klass_hero_web/components/provider_components.ex:647
-#: lib/klass_hero_web/components/provider_components.ex:2258
-#: lib/klass_hero_web/components/provider_components.ex:2276
+#: lib/klass_hero_web/components/provider_components.ex:2285
+#: lib/klass_hero_web/components/provider_components.ex:2303
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
@@ -878,9 +878,9 @@ msgstr "Speichern..."
 msgid "Select one or both options"
 msgstr "Wählen Sie eine oder beide Optionen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1954
-#: lib/klass_hero_web/components/provider_components.ex:1955
-#: lib/klass_hero_web/components/provider_components.ex:1992
+#: lib/klass_hero_web/components/provider_components.ex:1981
+#: lib/klass_hero_web/components/provider_components.ex:1982
+#: lib/klass_hero_web/components/provider_components.ex:2019
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:446
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:483
@@ -1404,7 +1404,7 @@ msgid "All"
 msgstr "Alle"
 
 #: lib/klass_hero_web/live/programs_live.ex:22
-#: lib/klass_hero_web/presenters/program_presenter.ex:311
+#: lib/klass_hero_web/presenters/program_presenter.ex:333
 #, elixir-autogen, elixir-format
 msgid "Arts"
 msgstr "Kunst"
@@ -1420,7 +1420,7 @@ msgid "Camps"
 msgstr "Camps"
 
 #: lib/klass_hero_web/live/programs_live.ex:24
-#: lib/klass_hero_web/presenters/program_presenter.ex:312
+#: lib/klass_hero_web/presenters/program_presenter.ex:334
 #, elixir-autogen, elixir-format
 msgid "Education"
 msgstr "Bildung"
@@ -1451,7 +1451,7 @@ msgid "Life Skills"
 msgstr "Lebenskompetenzen"
 
 #: lib/klass_hero_web/live/programs_live.ex:23
-#: lib/klass_hero_web/presenters/program_presenter.ex:314
+#: lib/klass_hero_web/presenters/program_presenter.ex:336
 #, elixir-autogen, elixir-format
 msgid "Music"
 msgstr "Musik"
@@ -1478,7 +1478,7 @@ msgid "Set up your teaching profile and list your programs in minutes. Share you
 msgstr "Richten Sie Ihr Kursleiterprofil ein und veröffentlichen Sie Ihre Programme in wenigen Minuten. Teilen Sie Ihr Fachwissen mit Familien, die es brauchen."
 
 #: lib/klass_hero_web/live/programs_live.ex:21
-#: lib/klass_hero_web/presenters/program_presenter.ex:313
+#: lib/klass_hero_web/presenters/program_presenter.ex:335
 #, elixir-autogen, elixir-format
 msgid "Sports"
 msgstr "Sport"
@@ -1578,13 +1578,13 @@ msgid "Quick Navigation"
 msgstr "Schnellnavigation"
 
 #: lib/klass_hero_web/components/provider_components.ex:1366
-#: lib/klass_hero_web/components/provider_components.ex:1930
-#: lib/klass_hero_web/components/provider_components.ex:2156
+#: lib/klass_hero_web/components/provider_components.ex:1957
+#: lib/klass_hero_web/components/provider_components.ex:2183
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr "Aktionen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1478
+#: lib/klass_hero_web/components/provider_components.ex:1505
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr "Aktiv"
@@ -1595,7 +1595,7 @@ msgstr "Aktiv"
 msgid "Add Team Member"
 msgstr "Teammitglied hinzufügen"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:45
+#: lib/klass_hero_web/live/provider/programs_live.ex:46
 #, elixir-autogen, elixir-format
 msgid "All Staff"
 msgstr "Alle Mitarbeiter"
@@ -1628,7 +1628,7 @@ msgid "Create profiles for your staff. These will be visible to parents when ass
 msgstr "Erstellen Sie Profile für Ihr Personal. Diese werden für Eltern sichtbar sein, wenn sie Programmen zugewiesen werden."
 
 #: lib/klass_hero_web/components/provider_components.ex:538
-#: lib/klass_hero_web/components/provider_components.ex:1441
+#: lib/klass_hero_web/components/provider_components.ex:1468
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:54
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:81
 #: lib/klass_hero_web/live/settings/children_live.ex:448
@@ -1645,13 +1645,13 @@ msgstr "Bearbeiten"
 msgid "Edit Profile"
 msgstr "Profil bearbeiten"
 
-#: lib/klass_hero_web/components/provider_components.ex:1480
+#: lib/klass_hero_web/components/provider_components.ex:1507
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr "Inaktiv"
 
 #: lib/klass_hero_web/components/provider_components.ex:112
-#: lib/klass_hero_web/live/provider/programs_live.ex:51
+#: lib/klass_hero_web/live/provider/programs_live.ex:52
 #, elixir-autogen, elixir-format
 msgid "My Programs"
 msgstr "Meine Programme"
@@ -1669,16 +1669,16 @@ msgstr "Übersicht"
 
 #: lib/klass_hero_web/components/provider_components.ex:46
 #: lib/klass_hero_web/components/provider_components.ex:72
-#: lib/klass_hero_web/components/provider_components.ex:1479
-#: lib/klass_hero_web/components/provider_components.ex:2352
-#: lib/klass_hero_web/components/provider_components.ex:2370
+#: lib/klass_hero_web/components/provider_components.ex:1506
+#: lib/klass_hero_web/components/provider_components.ex:2379
+#: lib/klass_hero_web/components/provider_components.ex:2397
 #: lib/klass_hero_web/live/admin/sessions_live.ex:297
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr "Ausstehend"
 
-#: lib/klass_hero_web/components/provider_components.ex:1417
+#: lib/klass_hero_web/components/provider_components.ex:1444
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr "Vorschau"
@@ -1709,9 +1709,9 @@ msgid "Search by name..."
 msgstr "Nach Namen suchen..."
 
 #: lib/klass_hero_web/components/provider_components.ex:1360
-#: lib/klass_hero_web/components/provider_components.ex:1702
-#: lib/klass_hero_web/components/provider_components.ex:1924
-#: lib/klass_hero_web/components/provider_components.ex:2153
+#: lib/klass_hero_web/components/provider_components.ex:1729
+#: lib/klass_hero_web/components/provider_components.ex:1951
+#: lib/klass_hero_web/components/provider_components.ex:2180
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1735,15 +1735,15 @@ msgstr "Team- & Anbieterprofile"
 msgid "This is your main business identity. Verification is required to list programs."
 msgstr "Dies ist Ihre Hauptgeschäftsidentität. Eine Verifizierung ist erforderlich, um Programme anzubieten."
 
-#: lib/klass_hero_web/components/provider_components.ex:1390
-#: lib/klass_hero_web/components/provider_components.ex:1717
+#: lib/klass_hero_web/components/provider_components.ex:1417
+#: lib/klass_hero_web/components/provider_components.ex:1744
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr "Nicht zugewiesen"
 
 #: lib/klass_hero_web/components/messaging_components.ex:728
 #: lib/klass_hero_web/components/provider_components.ex:49
-#: lib/klass_hero_web/components/provider_components.ex:1481
+#: lib/klass_hero_web/components/provider_components.ex:1508
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:433
 #: lib/klass_hero_web/presenters/provider_presenter.ex:103
 #, elixir-autogen, elixir-format
@@ -1755,7 +1755,7 @@ msgstr "Unbekannt"
 msgid "Verified Business"
 msgstr "Verifiziertes Unternehmen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1428
+#: lib/klass_hero_web/components/provider_components.ex:1455
 #, elixir-autogen, elixir-format
 msgid "View Roster"
 msgstr "Teilnehmerliste"
@@ -1817,7 +1817,7 @@ msgstr "Rundnachricht an %{count} Eltern gesendet"
 #: lib/klass_hero_web/components/participation_components.ex:717
 #: lib/klass_hero_web/components/provider_components.ex:817
 #: lib/klass_hero_web/components/provider_components.ex:1216
-#: lib/klass_hero_web/components/provider_components.ex:2095
+#: lib/klass_hero_web/components/provider_components.ex:2122
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:478
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
@@ -1883,7 +1883,7 @@ msgstr "Kind konnte nicht entfernt werden. Bitte versuchen Sie es erneut."
 msgid "Data sharing consent"
 msgstr "Einwilligung zur Datenweitergabe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2239
+#: lib/klass_hero_web/components/provider_components.ex:2266
 #: lib/klass_hero_web/live/settings/children_live.ex:657
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1931,17 +1931,17 @@ msgstr "Rundnachricht konnte nicht gesendet werden"
 msgid "Failed to submit note"
 msgstr "Notiz konnte nicht eingereicht werden"
 
-#: lib/klass_hero_web/components/provider_components.ex:2233
-#: lib/klass_hero_web/components/provider_components.ex:2262
-#: lib/klass_hero_web/components/provider_components.ex:2278
+#: lib/klass_hero_web/components/provider_components.ex:2260
+#: lib/klass_hero_web/components/provider_components.ex:2289
+#: lib/klass_hero_web/components/provider_components.ex:2305
 #: lib/klass_hero_web/live/settings/children_live.ex:643
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr "Vorname"
 
-#: lib/klass_hero_web/components/provider_components.ex:2234
-#: lib/klass_hero_web/components/provider_components.ex:2263
-#: lib/klass_hero_web/components/provider_components.ex:2279
+#: lib/klass_hero_web/components/provider_components.ex:2261
+#: lib/klass_hero_web/components/provider_components.ex:2290
+#: lib/klass_hero_web/components/provider_components.ex:2306
 #: lib/klass_hero_web/live/settings/children_live.ex:649
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -2080,8 +2080,8 @@ msgstr "Einwilligung zur Datenweitergabe an Anbieter"
 msgid "Save Changes"
 msgstr "Änderungen speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:1563
-#: lib/klass_hero_web/components/provider_components.ex:1564
+#: lib/klass_hero_web/components/provider_components.ex:1590
+#: lib/klass_hero_web/components/provider_components.ex:1591
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:43
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:151
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:252
@@ -2099,7 +2099,7 @@ msgstr "Rundnachricht senden"
 msgid "Send a message to start the conversation"
 msgstr "Senden Sie eine Nachricht, um die Unterhaltung zu beginnen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2333
+#: lib/klass_hero_web/components/provider_components.ex:2360
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:245
 #, elixir-autogen, elixir-format
@@ -2235,7 +2235,7 @@ msgstr "Alter %{min}+"
 msgid "Allowed Genders"
 msgstr "Zulässige Geschlechter"
 
-#: lib/klass_hero_web/components/provider_components.ex:2392
+#: lib/klass_hero_web/components/provider_components.ex:2419
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred during import."
 msgstr "Beim Import ist ein unerwarteter Fehler aufgetreten."
@@ -2335,8 +2335,8 @@ msgstr "Kategorie"
 msgid "Check eligibility at"
 msgstr "Berechtigung prüfen unter"
 
-#: lib/klass_hero_web/components/provider_components.ex:1921
-#: lib/klass_hero_web/components/provider_components.ex:2147
+#: lib/klass_hero_web/components/provider_components.ex:1948
+#: lib/klass_hero_web/components/provider_components.ex:2174
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr "Name des Kindes"
@@ -2381,7 +2381,7 @@ msgstr "Schließen Sie die Geschäftsverifizierung ab, um Programme zu erstellen
 msgid "Confirm rejection"
 msgstr "Ablehnung bestätigen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2353
+#: lib/klass_hero_web/components/provider_components.ex:2380
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr "Bestätigt"
@@ -2391,12 +2391,12 @@ msgstr "Bestätigt"
 msgid "Contact Provider"
 msgstr "Anbieter kontaktieren"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:444
+#: lib/klass_hero_web/live/provider/programs_live.ex:447
 #, elixir-autogen, elixir-format
 msgid "Could not read the uploaded file."
 msgstr "Die hochgeladene Datei konnte nicht gelesen werden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:412
+#: lib/klass_hero_web/live/provider/programs_live.ex:415
 #, elixir-autogen, elixir-format
 msgid "Could not remove invite."
 msgstr "Einladung konnte nicht entfernt werden."
@@ -2430,7 +2430,7 @@ msgstr "Beschreibung"
 msgid "Diverse"
 msgstr "Divers"
 
-#: lib/klass_hero_web/components/provider_components.ex:2490
+#: lib/klass_hero_web/components/provider_components.ex:2517
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr "Dokumenttyp"
@@ -2464,7 +2464,7 @@ msgstr "Dokument abgelehnt."
 msgid "Document uploaded successfully."
 msgstr "Dokument erfolgreich hochgeladen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2114
+#: lib/klass_hero_web/components/provider_components.ex:2141
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr "Vorlage herunterladen"
@@ -2495,14 +2495,14 @@ msgstr "Enddatum"
 msgid "End Time"
 msgstr "Endzeit"
 
-#: lib/klass_hero_web/components/provider_components.ex:1927
-#: lib/klass_hero_web/components/provider_components.ex:2373
+#: lib/klass_hero_web/components/provider_components.ex:1954
+#: lib/klass_hero_web/components/provider_components.ex:2400
 #: lib/klass_hero_web/components/provider_layout_components.ex:644
 #, elixir-autogen, elixir-format
 msgid "Enrolled"
 msgstr "Angemeldet"
 
-#: lib/klass_hero_web/components/provider_components.ex:1609
+#: lib/klass_hero_web/components/provider_components.ex:1636
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr "Angemeldet (%{count})"
@@ -2518,7 +2518,7 @@ msgid "Explain why this document is being rejected..."
 msgstr "Erklären Sie, warum dieses Dokument abgelehnt wird..."
 
 #: lib/klass_hero_web/components/provider_components.ex:70
-#: lib/klass_hero_web/components/provider_components.ex:2374
+#: lib/klass_hero_web/components/provider_components.ex:2401
 #: lib/klass_hero_web/live/admin/emails_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2534,7 +2534,7 @@ msgstr "Dokument konnte nicht genehmigt werden."
 msgid "Failed to reject document."
 msgstr "Dokument konnte nicht abgelehnt werden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:394
+#: lib/klass_hero_web/live/provider/programs_live.ex:397
 #, elixir-autogen, elixir-format
 msgid "Failed to resend invite."
 msgstr "Einladung konnte nicht erneut gesendet werden."
@@ -2562,12 +2562,12 @@ msgstr "Weiblich"
 msgid "File"
 msgstr "Datei"
 
-#: lib/klass_hero_web/components/provider_components.ex:2424
+#: lib/klass_hero_web/components/provider_components.ex:2451
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr "Die Datei ist zu groß."
 
-#: lib/klass_hero_web/components/provider_components.ex:2426
+#: lib/klass_hero_web/components/provider_components.ex:2453
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr "Dateityp wird nicht akzeptiert."
@@ -2602,7 +2602,7 @@ msgstr "Klassenstufe %{min}+"
 msgid "Grades %{min} – %{max}"
 msgstr "Klassenstufen %{min} – %{max}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2150
+#: lib/klass_hero_web/components/provider_components.ex:2177
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr "E-Mail des Erziehungsberechtigten"
@@ -2617,7 +2617,7 @@ msgstr "Porträtfoto"
 msgid "ID Document"
 msgstr "Ausweisdokument"
 
-#: lib/klass_hero_web/components/provider_components.ex:2087
+#: lib/klass_hero_web/components/provider_components.ex:2114
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Importieren"
@@ -2627,22 +2627,22 @@ msgstr "Importieren"
 msgid "Insurance Certificate"
 msgstr "Versicherungsnachweis"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:409
+#: lib/klass_hero_web/live/provider/programs_live.ex:412
 #, elixir-autogen, elixir-format
 msgid "Invite not found."
 msgstr "Einladung nicht gefunden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:406
+#: lib/klass_hero_web/live/provider/programs_live.ex:409
 #, elixir-autogen, elixir-format
 msgid "Invite removed."
 msgstr "Einladung entfernt."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:383
+#: lib/klass_hero_web/live/provider/programs_live.ex:386
 #, elixir-autogen, elixir-format
 msgid "Invite resent successfully."
 msgstr "Einladung erfolgreich erneut gesendet."
 
-#: lib/klass_hero_web/components/provider_components.ex:1626
+#: lib/klass_hero_web/components/provider_components.ex:1653
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr "Einladungen (%{count})"
@@ -2743,18 +2743,18 @@ msgstr "Niedrigste Klassenstufe"
 msgid "No approved documents."
 msgstr "Keine genehmigten Dokumente."
 
-#: lib/klass_hero_web/components/provider_components.ex:2452
+#: lib/klass_hero_web/components/provider_components.ex:2479
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr "Noch keine Dokumente hochgeladen."
 
-#: lib/klass_hero_web/components/provider_components.ex:1914
+#: lib/klass_hero_web/components/provider_components.ex:1941
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:425
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
 msgstr "Noch keine Anmeldungen."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:440
+#: lib/klass_hero_web/live/provider/programs_live.ex:443
 #, elixir-autogen, elixir-format
 msgid "No file selected."
 msgstr "Keine Datei ausgewählt."
@@ -2764,7 +2764,7 @@ msgstr "Keine Datei ausgewählt."
 msgid "No grade"
 msgstr "Keine Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2138
+#: lib/klass_hero_web/components/provider_components.ex:2165
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr "Noch keine Einladungen. Laden Sie eine CSV-Datei hoch, um Familien einzuladen."
@@ -2827,7 +2827,7 @@ msgstr "Nicht angegeben"
 msgid "Our Story"
 msgstr "Unsere Geschichte"
 
-#: lib/klass_hero_web/components/provider_components.ex:2527
+#: lib/klass_hero_web/components/provider_components.ex:2554
 #: lib/klass_hero_web/live/provider/verification_live.ex:698
 #: lib/klass_hero_web/live/provider/verification_live.ex:770
 #, elixir-autogen, elixir-format
@@ -2854,8 +2854,8 @@ msgstr "Ausstehende Überprüfung"
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:106
-#: lib/klass_hero_web/live/provider/programs_live.ex:686
-#: lib/klass_hero_web/live/provider/programs_live.ex:752
+#: lib/klass_hero_web/live/provider/programs_live.ex:689
+#: lib/klass_hero_web/live/provider/programs_live.ex:755
 #: lib/klass_hero_web/live/provider/team_live.ex:256
 #: lib/klass_hero_web/live/provider/team_live.ex:299
 #: lib/klass_hero_web/live/provider/team_live.ex:418
@@ -2888,26 +2888,26 @@ msgstr "Profil erfolgreich aktualisiert."
 msgid "Program Start"
 msgstr "Programmbeginn"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1078
+#: lib/klass_hero_web/live/provider/programs_live.ex:1100
 #, elixir-autogen, elixir-format
 msgid "Program created successfully."
 msgstr "Programm erfolgreich erstellt."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1085
+#: lib/klass_hero_web/live/provider/programs_live.ex:1107
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr "Programm erstellt, aber die Anmeldekapazität konnte nicht gespeichert werden. Bearbeiten Sie das Programm, um es erneut zu versuchen."
 
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:54
-#: lib/klass_hero_web/live/provider/programs_live.ex:150
-#: lib/klass_hero_web/live/provider/programs_live.ex:187
-#: lib/klass_hero_web/live/provider/programs_live.ex:251
-#: lib/klass_hero_web/live/provider/programs_live.ex:727
+#: lib/klass_hero_web/live/provider/programs_live.ex:151
+#: lib/klass_hero_web/live/provider/programs_live.ex:188
+#: lib/klass_hero_web/live/provider/programs_live.ex:252
+#: lib/klass_hero_web/live/provider/programs_live.ex:730
 #, elixir-autogen, elixir-format
 msgid "Program not found."
 msgstr "Programm nicht gefunden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:716
+#: lib/klass_hero_web/live/provider/programs_live.ex:719
 #, elixir-autogen, elixir-format
 msgid "Program updated successfully."
 msgstr "Programm erfolgreich aktualisiert."
@@ -2925,7 +2925,7 @@ msgid "Read our founding story →"
 msgstr "Lesen Sie unsere Gründungsgeschichte →"
 
 #: lib/klass_hero_web/components/participation_components.ex:805
-#: lib/klass_hero_web/components/provider_components.ex:2372
+#: lib/klass_hero_web/components/provider_components.ex:2399
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Registered"
@@ -3007,16 +3007,16 @@ msgstr "Ablehnungsgrund"
 
 #: lib/klass_hero_web/components/provider_components.ex:767
 #: lib/klass_hero_web/components/provider_components.ex:1166
-#: lib/klass_hero_web/components/provider_components.ex:2194
-#: lib/klass_hero_web/components/provider_components.ex:2546
-#: lib/klass_hero_web/components/provider_components.ex:2625
+#: lib/klass_hero_web/components/provider_components.ex:2221
+#: lib/klass_hero_web/components/provider_components.ex:2573
+#: lib/klass_hero_web/components/provider_components.ex:2652
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:253
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr "Entfernen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2187
+#: lib/klass_hero_web/components/provider_components.ex:2214
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr "Einladung erneut senden"
@@ -3031,7 +3031,7 @@ msgstr "Überprüft"
 msgid "Role"
 msgstr "Rolle"
 
-#: lib/klass_hero_web/components/provider_components.ex:1555
+#: lib/klass_hero_web/components/provider_components.ex:1582
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
@@ -3057,7 +3057,7 @@ msgstr "Zeitplan noch offen"
 msgid "School Grade (optional)"
 msgstr "Klassenstufe (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2524
+#: lib/klass_hero_web/components/provider_components.ex:2551
 #, elixir-autogen, elixir-format
 msgid "Select File"
 msgstr "Datei auswählen"
@@ -3068,13 +3068,13 @@ msgstr "Datei auswählen"
 msgid "Selected child does not meet the program requirements."
 msgstr "Das ausgewählte Kind erfüllt die Programmanforderungen nicht."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:676
-#: lib/klass_hero_web/live/provider/programs_live.ex:742
+#: lib/klass_hero_web/live/provider/programs_live.ex:679
+#: lib/klass_hero_web/live/provider/programs_live.ex:745
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr "Der ausgewählte Kursleiter konnte nicht gefunden werden. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2371
+#: lib/klass_hero_web/components/provider_components.ex:2398
 #: lib/klass_hero_web/live/admin/emails_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Sent"
@@ -3169,12 +3169,12 @@ msgstr "Erzählen Sie Eltern von Ihrer Organisation..."
 msgid "The Klass Hero Story"
 msgstr "Die Geschichte von Klass Hero"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:386
+#: lib/klass_hero_web/live/provider/programs_live.ex:389
 #, elixir-autogen, elixir-format
 msgid "This invite cannot be resent."
 msgstr "Diese Einladung kann nicht erneut gesendet werden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:734
+#: lib/klass_hero_web/live/provider/programs_live.ex:737
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr "Dieses Programm wurde von jemand anderem geändert. Bitte schließen Sie es und versuchen Sie es erneut."
@@ -3184,7 +3184,7 @@ msgstr "Dieses Programm wurde von jemand anderem geändert. Bitte schließen Sie
 msgid "Title"
 msgstr "Titel"
 
-#: lib/klass_hero_web/components/provider_components.ex:2425
+#: lib/klass_hero_web/components/provider_components.ex:2452
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr "Zu viele Dateien."
@@ -3204,32 +3204,32 @@ msgstr "Bis zu %{max}"
 msgid "Up to Grade %{max}"
 msgstr "Bis Klassenstufe %{max}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2073
+#: lib/klass_hero_web/components/provider_components.ex:2100
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr "CSV hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2570
+#: lib/klass_hero_web/components/provider_components.ex:2597
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr "Dokument hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2479
+#: lib/klass_hero_web/components/provider_components.ex:2506
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr "Neues Dokument hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2447
+#: lib/klass_hero_web/components/provider_components.ex:2474
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr "Laden Sie Dokumente hoch, um Ihr Unternehmen zu verifizieren. Die Dokumente werden von unserem Team überprüft."
 
-#: lib/klass_hero_web/components/provider_components.ex:2427
+#: lib/klass_hero_web/components/provider_components.ex:2454
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr "Upload-Fehler."
 
-#: lib/klass_hero_web/components/provider_components.ex:2444
+#: lib/klass_hero_web/components/provider_components.ex:2471
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr "Verifizierungsdokumente"
@@ -3319,7 +3319,7 @@ msgid "Child Safeguarding Training"
 msgstr "Kinderschutzschulung"
 
 #: lib/klass_hero_web/components/marketing_components.ex:1498
-#: lib/klass_hero_web/components/provider_components.ex:2792
+#: lib/klass_hero_web/components/provider_components.ex:2819
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr "Vereinbarung zu Community-Standards"
@@ -3389,7 +3389,7 @@ msgstr "Zahlung per Bargeld oder Banküberweisung"
 msgid "Program fee:"
 msgstr "Programmgebühr:"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:918
+#: lib/klass_hero_web/live/provider/programs_live.ex:938
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr "Programm gespeichert, aber der Upload des Titelbilds ist fehlgeschlagen. Sie können es erneut hochladen, indem Sie das Programm bearbeiten."
@@ -3469,7 +3469,7 @@ msgid "Vetted with Care"
 msgstr "Mit Sorgfalt geprüft"
 
 #: lib/klass_hero_web/components/marketing_components.ex:1482
-#: lib/klass_hero_web/components/provider_components.ex:2577
+#: lib/klass_hero_web/components/provider_components.ex:2604
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr "Video-Überprüfung"
@@ -3605,7 +3605,7 @@ msgstr "Kann ich meine Programme auf Klass Hero listen und was kostet das?"
 msgid "Cannot check out without a check-in"
 msgstr "Auschecken ohne Einchecken nicht möglich"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:358
+#: lib/klass_hero_web/live/provider/programs_live.ex:361
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:146
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
@@ -3643,7 +3643,7 @@ msgstr "Eingecheckt"
 msgid "Checked Out"
 msgstr "Ausgecheckt"
 
-#: lib/klass_hero_web/components/provider_components.ex:2230
+#: lib/klass_hero_web/components/provider_components.ex:2257
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Child"
@@ -3670,7 +3670,7 @@ msgid "Correct"
 msgstr "Korrigieren"
 
 #: lib/klass_hero_web/live/dashboard_live.ex:301
-#: lib/klass_hero_web/live/provider/programs_live.ex:355
+#: lib/klass_hero_web/live/provider/programs_live.ex:358
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "Could not start conversation. Please try again."
@@ -3696,7 +3696,7 @@ msgstr "Benötige ich ein Konto, um zu buchen?"
 msgid "Download monthly statements for taxes"
 msgstr "Monatliche Abrechnungen für die Steuer herunterladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1991
+#: lib/klass_hero_web/components/provider_components.ex:2018
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Enrollment not confirmed"
@@ -3774,7 +3774,7 @@ msgstr "Keine Änderungen erkannt"
 msgid "No chasing payments or sending invoices"
 msgstr "Kein Nachfassen bei Zahlungen oder Versenden von Rechnungen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1578
+#: lib/klass_hero_web/components/provider_components.ex:1605
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:406
 #, elixir-autogen, elixir-format
 msgid "No enrolled parents"
@@ -3797,7 +3797,7 @@ msgstr "Notizen"
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr "Oder: Jederzeit eine Sofortauszahlung anfordern (mindestens 50 €)"
 
-#: lib/klass_hero_web/components/provider_components.ex:1990
+#: lib/klass_hero_web/components/provider_components.ex:2017
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:481
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -4427,7 +4427,7 @@ msgstr "Absenden"
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:24
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
-#: lib/klass_hero_web/live/provider/programs_live.ex:219
+#: lib/klass_hero_web/live/provider/programs_live.ex:220
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:156
 #, elixir-autogen, elixir-format
 msgid "Program"
@@ -4636,7 +4636,7 @@ msgid "Update your observation..."
 msgstr "Aktualisieren Sie Ihre Beobachtung..."
 
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:138
-#: lib/klass_hero_web/live/provider/programs_live.ex:437
+#: lib/klass_hero_web/live/provider/programs_live.ex:440
 #: lib/klass_hero_web/live/provider/verification_live.ex:240
 #: lib/klass_hero_web/live/provider/verification_live.ex:556
 #: lib/klass_hero_web/live/provider/verification_live.ex:594
@@ -4905,48 +4905,48 @@ msgstr "Ihr Profil ist bereits vollständig."
 msgid "for"
 msgstr "für"
 
-#: lib/klass_hero_web/components/provider_components.ex:1699
+#: lib/klass_hero_web/components/provider_components.ex:1726
 #, elixir-autogen, elixir-format
 msgid "Assigned staff"
 msgstr "Zugewiesenes Personal"
 
-#: lib/klass_hero_web/components/provider_components.ex:1701
+#: lib/klass_hero_web/components/provider_components.ex:1728
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr "Anwesenheit"
 
-#: lib/klass_hero_web/components/provider_components.ex:1683
-#: lib/klass_hero_web/components/provider_components.ex:1772
+#: lib/klass_hero_web/components/provider_components.ex:1710
+#: lib/klass_hero_web/components/provider_components.ex:1799
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr "Schließen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1700
+#: lib/klass_hero_web/components/provider_components.ex:1727
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr "Vertretung"
 
-#: lib/klass_hero_web/components/provider_components.ex:1698
+#: lib/klass_hero_web/components/provider_components.ex:1725
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr "Datum / Uhrzeit"
 
-#: lib/klass_hero_web/components/provider_components.ex:1692
+#: lib/klass_hero_web/components/provider_components.ex:1719
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled yet."
 msgstr "Noch keine Sessions geplant."
 
-#: lib/klass_hero_web/components/provider_components.ex:1681
+#: lib/klass_hero_web/components/provider_components.ex:1708
 #, elixir-autogen, elixir-format
 msgid "Sessions — %{title}"
 msgstr "Sessions — %{title}"
 
-#: lib/klass_hero_web/components/provider_components.ex:1421
+#: lib/klass_hero_web/components/provider_components.ex:1448
 #, elixir-autogen, elixir-format
 msgid "View sessions"
 msgstr "Sessions anzeigen"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:528
+#: lib/klass_hero_web/live/provider/programs_live.ex:531
 #, elixir-autogen, elixir-format
 msgid "Create a program before inviting participants."
 msgstr "Erstellen Sie zuerst ein Programm, bevor Sie Teilnehmer einladen."
@@ -4973,22 +4973,22 @@ msgstr "Abreisezeit ist kein gültiges Datum oder keine gültige Uhrzeit"
 msgid "Failed to update record"
 msgstr "Aktualisieren des Datensatzes fehlgeschlagen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2294
+#: lib/klass_hero_web/components/provider_components.ex:2321
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr "Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2013
+#: lib/klass_hero_web/components/provider_components.ex:2040
 #, elixir-autogen, elixir-format
 msgid "Invite mode"
 msgstr "Einladungsmodus"
 
-#: lib/klass_hero_web/components/provider_components.ex:2032
+#: lib/klass_hero_web/components/provider_components.ex:2059
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr "Einzelperson einladen"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:524
+#: lib/klass_hero_web/live/provider/programs_live.ex:527
 #, elixir-autogen, elixir-format
 msgid "Invite sent."
 msgstr "Einladung verschickt."
@@ -4998,12 +4998,12 @@ msgstr "Einladung verschickt."
 msgid "Leave blank to keep this child marked as present."
 msgstr "Leer lassen, um dieses Kind als anwesend markiert zu lassen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2307
+#: lib/klass_hero_web/components/provider_components.ex:2334
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr "Gesundheit & Einwilligungen (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2313
+#: lib/klass_hero_web/components/provider_components.ex:2340
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr "Gesundheitliche Besonderheiten"
@@ -5014,17 +5014,17 @@ msgstr "Gesundheitliche Besonderheiten"
 msgid "Nothing to update"
 msgstr "Nichts zu aktualisieren"
 
-#: lib/klass_hero_web/components/provider_components.ex:2315
+#: lib/klass_hero_web/components/provider_components.ex:2342
 #, elixir-autogen, elixir-format
 msgid "Nut allergy"
 msgstr "Nussallergie"
 
-#: lib/klass_hero_web/components/provider_components.ex:2319
+#: lib/klass_hero_web/components/provider_components.ex:2346
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr "Fotos dürfen in Marketingmaterialien verwendet werden"
 
-#: lib/klass_hero_web/components/provider_components.ex:2324
+#: lib/klass_hero_web/components/provider_components.ex:2351
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr "Fotos dürfen in sozialen Medien erscheinen"
@@ -5034,7 +5034,7 @@ msgstr "Fotos dürfen in sozialen Medien erscheinen"
 msgid "Present"
 msgstr "Anwesend"
 
-#: lib/klass_hero_web/components/provider_components.ex:2251
+#: lib/klass_hero_web/components/provider_components.ex:2278
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr "Hauptansprechpartner"
@@ -5061,22 +5061,22 @@ msgstr "Datensatz aktualisiert"
 msgid "Save changes"
 msgstr "Änderungen speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:2288
+#: lib/klass_hero_web/components/provider_components.ex:2315
 #, elixir-autogen, elixir-format
 msgid "School (optional)"
 msgstr "Schule (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2298
+#: lib/klass_hero_web/components/provider_components.ex:2325
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr "Schulname"
 
-#: lib/klass_hero_web/components/provider_components.ex:2272
+#: lib/klass_hero_web/components/provider_components.ex:2299
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr "Zweiter Ansprechpartner (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2341
+#: lib/klass_hero_web/components/provider_components.ex:2368
 #, elixir-autogen, elixir-format
 msgid "Send invite"
 msgstr "Einladung senden"
@@ -5086,12 +5086,12 @@ msgstr "Einladung senden"
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr "Aktualisieren Sie die Notiz für dieses Kind (z. B. um zu klären, was passiert ist)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2050
+#: lib/klass_hero_web/components/provider_components.ex:2077
 #, elixir-autogen, elixir-format
 msgid "Upload a list"
 msgstr "Liste hochladen"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:535
+#: lib/klass_hero_web/live/provider/programs_live.ex:538
 #, elixir-autogen, elixir-format
 msgid "An invite for this child and program already exists."
 msgstr "Für dieses Kind und Programm existiert bereits eine Einladung."
@@ -5186,7 +5186,7 @@ msgstr "Programm oder Session nicht gefunden."
 msgid "Property Damage"
 msgstr "Sachschaden"
 
-#: lib/klass_hero_web/components/provider_components.ex:1451
+#: lib/klass_hero_web/components/provider_components.ex:1478
 #, elixir-autogen, elixir-format
 msgid "Report Incident"
 msgstr "Vorfall melden"
@@ -5268,7 +5268,7 @@ msgstr "Ihre Woche mit den Kindern"
 msgid "Go to dashboard"
 msgstr "Zum Dashboard"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:480
+#: lib/klass_hero_web/live/provider/programs_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "%{count} row could not be processed."
 msgid_plural "%{count} rows could not be processed."
@@ -5855,8 +5855,8 @@ msgstr "Wie wir Anbieter überprüfen"
 msgid "I'll be teaching"
 msgstr "Ich werde unterrichten"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:455
-#: lib/klass_hero_web/live/provider/programs_live.ex:477
+#: lib/klass_hero_web/live/provider/programs_live.ex:458
+#: lib/klass_hero_web/live/provider/programs_live.ex:480
 #, elixir-autogen, elixir-format
 msgid "Imported %{count} family."
 msgid_plural "Imported %{count} families."
@@ -5868,7 +5868,7 @@ msgstr[1] "%{count} Familien importiert."
 msgid "In 2025, Shane connected with his friend"
 msgstr "2025 tat sich Shane mit seinem Freund zusammen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1460
+#: lib/klass_hero_web/components/provider_components.ex:1487
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:43
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:74
 #, elixir-autogen, elixir-format
@@ -6145,7 +6145,7 @@ msgstr "Noch keine Programme — fügen Sie Ihr erstes über den Tab „Programm
 msgid "No registered children for this session."
 msgstr "Keine Kinder in dieser Sitzung angemeldet."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:464
+#: lib/klass_hero_web/live/provider/programs_live.ex:467
 #, elixir-autogen, elixir-format
 msgid "No rows imported. %{count} row could not be processed."
 msgid_plural "No rows imported. %{count} rows could not be processed."
@@ -6388,17 +6388,17 @@ msgstr "Umsatz (diese Woche)"
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr "Strenge Überprüfung, damit Familien immer wissen, wer die Gruppe leitet."
 
-#: lib/klass_hero_web/components/provider_components.ex:2380
+#: lib/klass_hero_web/components/provider_components.ex:2407
 #, elixir-autogen, elixir-format
 msgid "Row %{row}"
 msgstr "Zeile %{row}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2380
+#: lib/klass_hero_web/components/provider_components.ex:2407
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr "Zeile —"
 
-#: lib/klass_hero_web/components/provider_components.ex:2126
+#: lib/klass_hero_web/components/provider_components.ex:2153
 #, elixir-autogen, elixir-format
 msgid "Rows with errors"
 msgstr "Zeilen mit Fehlern"
@@ -7157,12 +7157,12 @@ msgstr "Deine Identität ist verifiziert."
 msgid "Experience validation"
 msgstr "Erfahrungsnachweis"
 
-#: lib/klass_hero_web/components/provider_components.ex:2606
+#: lib/klass_hero_web/components/provider_components.ex:2633
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr "MP4, MOV oder WEBM. Max. 100 MB."
 
-#: lib/klass_hero_web/components/provider_components.ex:2580
+#: lib/klass_hero_web/components/provider_components.ex:2607
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr "Nimm ein kurzes Video auf, in dem du dich vorstellst. Unser Team prüft es, um Kommunikationsfähigkeit und Übereinstimmung mit unseren Werten einzuschätzen."
@@ -7172,12 +7172,12 @@ msgstr "Nimm ein kurzes Video auf, in dem du dich vorstellst. Unser Team prüft 
 msgid "Safeguarding certificate"
 msgstr "Kinderschutz-Zertifikat"
 
-#: lib/klass_hero_web/components/provider_components.ex:2603
+#: lib/klass_hero_web/components/provider_components.ex:2630
 #, elixir-autogen, elixir-format
 msgid "Select Video"
 msgstr "Video auswählen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2649
+#: lib/klass_hero_web/components/provider_components.ex:2676
 #, elixir-autogen, elixir-format
 msgid "Upload Video"
 msgstr "Video hochladen"
@@ -7187,7 +7187,7 @@ msgstr "Video hochladen"
 msgid "Your browser does not support video playback."
 msgstr "Dein Browser unterstützt keine Videowiedergabe."
 
-#: lib/klass_hero_web/components/provider_components.ex:2796
+#: lib/klass_hero_web/components/provider_components.ex:2823
 #, elixir-autogen, elixir-format
 msgid "Confirm agreement"
 msgstr "Zustimmung bestätigen"
@@ -7197,12 +7197,12 @@ msgstr "Zustimmung bestätigen"
 msgid "Couldn't record your agreement. Please try again."
 msgstr "Deine Zustimmung konnte nicht gespeichert werden. Bitte versuche es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2819
+#: lib/klass_hero_web/components/provider_components.ex:2846
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr "Vereinbarung herunterladen (PDF)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2795
+#: lib/klass_hero_web/components/provider_components.ex:2822
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr "Ich habe die Klass Hero Community-Richtlinien gelesen und stimme ihnen zu."
@@ -7212,7 +7212,7 @@ msgstr "Ich habe die Klass Hero Community-Richtlinien gelesen und stimme ihnen z
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr "Bitte bestätige, dass du die Community-Richtlinien gelesen hast und ihnen zustimmst."
 
-#: lib/klass_hero_web/components/provider_components.ex:2704
+#: lib/klass_hero_web/components/provider_components.ex:2731
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr "Unterzeichnet von %{name} am %{date} (v%{version})."
@@ -7222,17 +7222,17 @@ msgstr "Unterzeichnet von %{name} am %{date} (v%{version})."
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr "Danke – deine Zustimmung zu den Community-Richtlinien wurde gespeichert."
 
-#: lib/klass_hero_web/components/provider_components.ex:2804
+#: lib/klass_hero_web/components/provider_components.ex:2831
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr "Die Community-Richtlinien wurden seit deiner letzten Zustimmung aktualisiert (v%{old}). Bitte lies sie erneut und stimme erneut zu."
 
-#: lib/klass_hero_web/components/provider_components.ex:2793
+#: lib/klass_hero_web/components/provider_components.ex:2820
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr "Der letzte Schritt: Lies die Klass Hero Community-Richtlinien und stimme ihnen zu."
 
-#: lib/klass_hero_web/components/provider_components.ex:2794
+#: lib/klass_hero_web/components/provider_components.ex:2821
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr "Du hast den Community-Richtlinien zugestimmt."
@@ -7501,12 +7501,12 @@ msgstr "Ihre Versicherungsbescheinigung wird geprüft."
 msgid "Your insurance is verified."
 msgstr "Ihre Versicherung ist verifiziert."
 
-#: lib/klass_hero_web/components/provider_components.ex:2748
+#: lib/klass_hero_web/components/provider_components.ex:2775
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr "Unterzeichnung durch %{name} im Namen des Unternehmens."
 
-#: lib/klass_hero_web/components/provider_components.ex:2851
+#: lib/klass_hero_web/components/provider_components.ex:2878
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr "Bestätige im Namen deines Unternehmens, dass alle Mitarbeitenden gemäß dem deutschen Kinderschutzrecht überprüft sind."
@@ -7516,7 +7516,7 @@ msgstr "Bestätige im Namen deines Unternehmens, dass alle Mitarbeitenden gemä�
 msgid "Couldn't record your declaration. Please try again."
 msgstr "Deine Erklärung konnte nicht gespeichert werden. Bitte versuche es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2857
+#: lib/klass_hero_web/components/provider_components.ex:2884
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr "Ich bestätige im Namen des Unternehmens, dass die obige Erklärung zutrifft und ich zu ihrer Unterzeichnung berechtigt bin."
@@ -7526,17 +7526,17 @@ msgstr "Ich bestätige im Namen des Unternehmens, dass die obige Erklärung zutr
 msgid "Please confirm the declaration before signing."
 msgstr "Bitte bestätige die Erklärung vor der Unterzeichnung."
 
-#: lib/klass_hero_web/components/provider_components.ex:2882
+#: lib/klass_hero_web/components/provider_components.ex:2909
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr "Vorläufiger Text — vor der Freischaltung noch von einer in Deutschland zugelassenen Anwältin bzw. einem Anwalt zu prüfen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2861
+#: lib/klass_hero_web/components/provider_components.ex:2888
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr "Erklärung unterzeichnen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2849
+#: lib/klass_hero_web/components/provider_components.ex:2876
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr "Erklärung zur Mitarbeiter-Compliance"
@@ -7546,12 +7546,12 @@ msgstr "Erklärung zur Mitarbeiter-Compliance"
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr "Danke — deine Erklärung zur Mitarbeiter-Compliance wurde erfasst."
 
-#: lib/klass_hero_web/components/provider_components.ex:2869
+#: lib/klass_hero_web/components/provider_components.ex:2896
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr "Die Erklärung zur Mitarbeiter-Compliance wurde seit deiner letzten Unterzeichnung aktualisiert (v%{old}). Bitte prüfe sie und unterzeichne erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2855
+#: lib/klass_hero_web/components/provider_components.ex:2882
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr "Du hast die Erklärung zur Mitarbeiter-Compliance unterzeichnet."
@@ -7618,91 +7618,98 @@ msgstr "In Prüfung"
 msgid "Undelivered Events"
 msgstr "Nicht zugestellte Ereignisse"
 
-#: lib/klass_hero_web/components/provider_components.ex:1869
+#: lib/klass_hero_web/components/provider_components.ex:1896
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1794
+#: lib/klass_hero_web/components/provider_components.ex:1821
 #, elixir-autogen, elixir-format
 msgid "Lead"
 msgstr "Leitung"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:330
+#: lib/klass_hero_web/live/provider/programs_live.ex:333
 #, elixir-autogen, elixir-format
 msgid "Lead instructor updated."
 msgstr "Leitender Kursleiter aktualisiert."
 
-#: lib/klass_hero_web/components/provider_components.ex:1805
+#: lib/klass_hero_web/components/provider_components.ex:1832
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor"
 msgstr "Als leitenden Kursleiter festlegen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1435
+#: lib/klass_hero_web/components/provider_components.ex:1462
 #, elixir-autogen, elixir-format
 msgid "Manage Staffing"
 msgstr "Programmteam verwalten"
 
-#: lib/klass_hero_web/components/provider_components.ex:1833
+#: lib/klass_hero_web/components/provider_components.ex:1860
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this program yet."
 msgstr "Diesem Programm ist noch niemand zugewiesen."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:262
+#: lib/klass_hero_web/live/provider/programs_live.ex:263
 #, elixir-autogen, elixir-format
 msgid "Pick a staff member to add."
 msgstr "Bitte ein Teammitglied zum Hinzufügen auswählen."
 
-#: lib/klass_hero_web/components/provider_components.ex:1816
+#: lib/klass_hero_web/components/provider_components.ex:1843
 #, elixir-autogen, elixir-format
 msgid "Reassign the lead before removing them"
 msgstr "Vor dem Entfernen einen anderen leitenden Kursleiter festlegen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1817
+#: lib/klass_hero_web/components/provider_components.ex:1844
 #, elixir-autogen, elixir-format
 msgid "Remove from program"
 msgstr "Aus dem Programm entfernen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1851
+#: lib/klass_hero_web/components/provider_components.ex:1878
 #, elixir-autogen, elixir-format
 msgid "Select a staff member…"
 msgstr "Teammitglied auswählen …"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:276
+#: lib/klass_hero_web/live/provider/programs_live.ex:278
 #, elixir-autogen, elixir-format
 msgid "Staff member added to the program."
 msgstr "Teammitglied zum Programm hinzugefügt."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:301
+#: lib/klass_hero_web/live/provider/programs_live.ex:304
 #, elixir-autogen, elixir-format
 msgid "Staff member removed from the program."
 msgstr "Teammitglied aus dem Programm entfernt."
 
-#: lib/klass_hero_web/components/provider_components.ex:1874
+#: lib/klass_hero_web/components/provider_components.ex:1901
 #, elixir-autogen, elixir-format
 msgid "Staff you add can read and reply to this program's parent conversations."
 msgstr ""
 "Hinzugefügte Teammitglieder können die Elterngespräche dieses Programms lesen "
 "und beantworten."
 
-#: lib/klass_hero_web/components/provider_components.ex:1770
+#: lib/klass_hero_web/components/provider_components.ex:1797
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{title}"
 msgstr "Programmteam — %{title}"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:879
+#: lib/klass_hero_web/live/provider/programs_live.ex:897
 #, elixir-autogen, elixir-format
 msgid "That staff member could not be found."
 msgstr "Dieses Teammitglied wurde nicht gefunden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:284
+#: lib/klass_hero_web/live/provider/programs_live.ex:286
 #, elixir-autogen, elixir-format
 msgid "They are already on this program."
 msgstr "Diese Person ist bereits in diesem Programm."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:309
+#: lib/klass_hero_web/live/provider/programs_live.ex:312
 #, elixir-autogen, elixir-format
 msgid "This person is the lead instructor. Make someone else lead before removing them."
 msgstr ""
 "Diese Person ist der leitende Kursleiter. Bitte zuerst eine andere Person als "
 "Leitung festlegen."
+
+#: lib/klass_hero_web/components/provider_components.ex:1406
+#, elixir-autogen, elixir-format
+msgid "%{count} staff member · no lead"
+msgid_plural "%{count} staff · no lead"
+msgstr[0] "%{count} Mitarbeiter*in · keine Leitung"
+msgstr[1] "%{count} Mitarbeitende · keine Leitung"

--- a/priv/gettext/de/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/de/LC_MESSAGES/enrollment.po
@@ -11,62 +11,62 @@ msgstr ""
 "Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:2428
+#: lib/klass_hero_web/components/provider_components.ex:2431
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr "Vorname des Kindes"
 
-#: lib/klass_hero_web/components/provider_components.ex:2429
+#: lib/klass_hero_web/components/provider_components.ex:2432
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr "Nachname des Kindes"
 
-#: lib/klass_hero_web/components/provider_components.ex:2430
+#: lib/klass_hero_web/components/provider_components.ex:2433
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr "Geburtsdatum"
 
-#: lib/klass_hero_web/components/provider_components.ex:2441
+#: lib/klass_hero_web/components/provider_components.ex:2444
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr "Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2431
+#: lib/klass_hero_web/components/provider_components.ex:2434
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr "E-Mail des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2432
+#: lib/klass_hero_web/components/provider_components.ex:2435
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr "Vorname des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2433
+#: lib/klass_hero_web/components/provider_components.ex:2436
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr "Nachname des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2440
+#: lib/klass_hero_web/components/provider_components.ex:2443
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr "Programm"
 
-#: lib/klass_hero_web/components/provider_components.ex:2442
+#: lib/klass_hero_web/components/provider_components.ex:2445
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr "Schule"
 
-#: lib/klass_hero_web/components/provider_components.ex:2434
+#: lib/klass_hero_web/components/provider_components.ex:2437
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr "E-Mail des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2436
+#: lib/klass_hero_web/components/provider_components.ex:2439
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr "Vorname des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2438
+#: lib/klass_hero_web/components/provider_components.ex:2441
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr "Nachname des zweiten Erziehungsberechtigten"

--- a/priv/gettext/de/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/de/LC_MESSAGES/enrollment.po
@@ -11,62 +11,62 @@ msgstr ""
 "Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:2401
+#: lib/klass_hero_web/components/provider_components.ex:2428
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr "Vorname des Kindes"
 
-#: lib/klass_hero_web/components/provider_components.ex:2402
+#: lib/klass_hero_web/components/provider_components.ex:2429
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr "Nachname des Kindes"
 
-#: lib/klass_hero_web/components/provider_components.ex:2403
+#: lib/klass_hero_web/components/provider_components.ex:2430
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr "Geburtsdatum"
 
-#: lib/klass_hero_web/components/provider_components.ex:2414
+#: lib/klass_hero_web/components/provider_components.ex:2441
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr "Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2404
+#: lib/klass_hero_web/components/provider_components.ex:2431
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr "E-Mail des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2405
+#: lib/klass_hero_web/components/provider_components.ex:2432
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr "Vorname des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2406
+#: lib/klass_hero_web/components/provider_components.ex:2433
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr "Nachname des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2413
+#: lib/klass_hero_web/components/provider_components.ex:2440
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr "Programm"
 
-#: lib/klass_hero_web/components/provider_components.ex:2415
+#: lib/klass_hero_web/components/provider_components.ex:2442
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr "Schule"
 
-#: lib/klass_hero_web/components/provider_components.ex:2407
+#: lib/klass_hero_web/components/provider_components.ex:2434
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr "E-Mail des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2409
+#: lib/klass_hero_web/components/provider_components.ex:2436
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr "Vorname des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2411
+#: lib/klass_hero_web/components/provider_components.ex:2438
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr "Nachname des zweiten Erziehungsberechtigten"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -137,7 +137,7 @@ msgid "Your Data"
 msgstr ""
 
 #: lib/klass_hero_web/components/core_components.ex:67
-#: lib/klass_hero_web/components/provider_components.ex:1585
+#: lib/klass_hero_web/components/provider_components.ex:1612
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr ""
@@ -578,8 +578,8 @@ msgid "Dispute Resolution"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:647
-#: lib/klass_hero_web/components/provider_components.ex:2258
-#: lib/klass_hero_web/components/provider_components.ex:2276
+#: lib/klass_hero_web/components/provider_components.ex:2285
+#: lib/klass_hero_web/components/provider_components.ex:2303
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
@@ -878,9 +878,9 @@ msgstr ""
 msgid "Select one or both options"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1954
-#: lib/klass_hero_web/components/provider_components.ex:1955
-#: lib/klass_hero_web/components/provider_components.ex:1992
+#: lib/klass_hero_web/components/provider_components.ex:1981
+#: lib/klass_hero_web/components/provider_components.ex:1982
+#: lib/klass_hero_web/components/provider_components.ex:2019
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:446
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:483
@@ -1404,7 +1404,7 @@ msgid "All"
 msgstr ""
 
 #: lib/klass_hero_web/live/programs_live.ex:22
-#: lib/klass_hero_web/presenters/program_presenter.ex:311
+#: lib/klass_hero_web/presenters/program_presenter.ex:333
 #, elixir-autogen, elixir-format
 msgid "Arts"
 msgstr ""
@@ -1420,7 +1420,7 @@ msgid "Camps"
 msgstr ""
 
 #: lib/klass_hero_web/live/programs_live.ex:24
-#: lib/klass_hero_web/presenters/program_presenter.ex:312
+#: lib/klass_hero_web/presenters/program_presenter.ex:334
 #, elixir-autogen, elixir-format
 msgid "Education"
 msgstr ""
@@ -1451,7 +1451,7 @@ msgid "Life Skills"
 msgstr ""
 
 #: lib/klass_hero_web/live/programs_live.ex:23
-#: lib/klass_hero_web/presenters/program_presenter.ex:314
+#: lib/klass_hero_web/presenters/program_presenter.ex:336
 #, elixir-autogen, elixir-format
 msgid "Music"
 msgstr ""
@@ -1478,7 +1478,7 @@ msgid "Set up your teaching profile and list your programs in minutes. Share you
 msgstr ""
 
 #: lib/klass_hero_web/live/programs_live.ex:21
-#: lib/klass_hero_web/presenters/program_presenter.ex:313
+#: lib/klass_hero_web/presenters/program_presenter.ex:335
 #, elixir-autogen, elixir-format
 msgid "Sports"
 msgstr ""
@@ -1578,13 +1578,13 @@ msgid "Quick Navigation"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1366
-#: lib/klass_hero_web/components/provider_components.ex:1930
-#: lib/klass_hero_web/components/provider_components.ex:2156
+#: lib/klass_hero_web/components/provider_components.ex:1957
+#: lib/klass_hero_web/components/provider_components.ex:2183
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1478
+#: lib/klass_hero_web/components/provider_components.ex:1505
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr ""
@@ -1595,7 +1595,7 @@ msgstr ""
 msgid "Add Team Member"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:45
+#: lib/klass_hero_web/live/provider/programs_live.ex:46
 #, elixir-autogen, elixir-format
 msgid "All Staff"
 msgstr ""
@@ -1628,7 +1628,7 @@ msgid "Create profiles for your staff. These will be visible to parents when ass
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:538
-#: lib/klass_hero_web/components/provider_components.ex:1441
+#: lib/klass_hero_web/components/provider_components.ex:1468
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:54
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:81
 #: lib/klass_hero_web/live/settings/children_live.ex:448
@@ -1645,13 +1645,13 @@ msgstr ""
 msgid "Edit Profile"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1480
+#: lib/klass_hero_web/components/provider_components.ex:1507
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:112
-#: lib/klass_hero_web/live/provider/programs_live.ex:51
+#: lib/klass_hero_web/live/provider/programs_live.ex:52
 #, elixir-autogen, elixir-format
 msgid "My Programs"
 msgstr ""
@@ -1669,16 +1669,16 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:46
 #: lib/klass_hero_web/components/provider_components.ex:72
-#: lib/klass_hero_web/components/provider_components.ex:1479
-#: lib/klass_hero_web/components/provider_components.ex:2352
-#: lib/klass_hero_web/components/provider_components.ex:2370
+#: lib/klass_hero_web/components/provider_components.ex:1506
+#: lib/klass_hero_web/components/provider_components.ex:2379
+#: lib/klass_hero_web/components/provider_components.ex:2397
 #: lib/klass_hero_web/live/admin/sessions_live.ex:297
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1417
+#: lib/klass_hero_web/components/provider_components.ex:1444
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
@@ -1709,9 +1709,9 @@ msgid "Search by name..."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1360
-#: lib/klass_hero_web/components/provider_components.ex:1702
-#: lib/klass_hero_web/components/provider_components.ex:1924
-#: lib/klass_hero_web/components/provider_components.ex:2153
+#: lib/klass_hero_web/components/provider_components.ex:1729
+#: lib/klass_hero_web/components/provider_components.ex:1951
+#: lib/klass_hero_web/components/provider_components.ex:2180
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1735,15 +1735,15 @@ msgstr ""
 msgid "This is your main business identity. Verification is required to list programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1390
-#: lib/klass_hero_web/components/provider_components.ex:1717
+#: lib/klass_hero_web/components/provider_components.ex:1417
+#: lib/klass_hero_web/components/provider_components.ex:1744
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr ""
 
 #: lib/klass_hero_web/components/messaging_components.ex:728
 #: lib/klass_hero_web/components/provider_components.ex:49
-#: lib/klass_hero_web/components/provider_components.ex:1481
+#: lib/klass_hero_web/components/provider_components.ex:1508
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:433
 #: lib/klass_hero_web/presenters/provider_presenter.ex:103
 #, elixir-autogen, elixir-format
@@ -1755,7 +1755,7 @@ msgstr ""
 msgid "Verified Business"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1428
+#: lib/klass_hero_web/components/provider_components.ex:1455
 #, elixir-autogen, elixir-format
 msgid "View Roster"
 msgstr ""
@@ -1817,7 +1817,7 @@ msgstr ""
 #: lib/klass_hero_web/components/participation_components.ex:717
 #: lib/klass_hero_web/components/provider_components.ex:817
 #: lib/klass_hero_web/components/provider_components.ex:1216
-#: lib/klass_hero_web/components/provider_components.ex:2095
+#: lib/klass_hero_web/components/provider_components.ex:2122
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:478
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
@@ -1883,7 +1883,7 @@ msgstr ""
 msgid "Data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2239
+#: lib/klass_hero_web/components/provider_components.ex:2266
 #: lib/klass_hero_web/live/settings/children_live.ex:657
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1931,17 +1931,17 @@ msgstr ""
 msgid "Failed to submit note"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2233
-#: lib/klass_hero_web/components/provider_components.ex:2262
-#: lib/klass_hero_web/components/provider_components.ex:2278
+#: lib/klass_hero_web/components/provider_components.ex:2260
+#: lib/klass_hero_web/components/provider_components.ex:2289
+#: lib/klass_hero_web/components/provider_components.ex:2305
 #: lib/klass_hero_web/live/settings/children_live.ex:643
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2234
-#: lib/klass_hero_web/components/provider_components.ex:2263
-#: lib/klass_hero_web/components/provider_components.ex:2279
+#: lib/klass_hero_web/components/provider_components.ex:2261
+#: lib/klass_hero_web/components/provider_components.ex:2290
+#: lib/klass_hero_web/components/provider_components.ex:2306
 #: lib/klass_hero_web/live/settings/children_live.ex:649
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -2080,8 +2080,8 @@ msgstr ""
 msgid "Save Changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1563
-#: lib/klass_hero_web/components/provider_components.ex:1564
+#: lib/klass_hero_web/components/provider_components.ex:1590
+#: lib/klass_hero_web/components/provider_components.ex:1591
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:43
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:151
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:252
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "Send a message to start the conversation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2333
+#: lib/klass_hero_web/components/provider_components.ex:2360
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:245
 #, elixir-autogen, elixir-format
@@ -2235,7 +2235,7 @@ msgstr ""
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2392
+#: lib/klass_hero_web/components/provider_components.ex:2419
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred during import."
 msgstr ""
@@ -2335,8 +2335,8 @@ msgstr ""
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1921
-#: lib/klass_hero_web/components/provider_components.ex:2147
+#: lib/klass_hero_web/components/provider_components.ex:1948
+#: lib/klass_hero_web/components/provider_components.ex:2174
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2381,7 +2381,7 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2353
+#: lib/klass_hero_web/components/provider_components.ex:2380
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
@@ -2391,12 +2391,12 @@ msgstr ""
 msgid "Contact Provider"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:444
+#: lib/klass_hero_web/live/provider/programs_live.ex:447
 #, elixir-autogen, elixir-format
 msgid "Could not read the uploaded file."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:412
+#: lib/klass_hero_web/live/provider/programs_live.ex:415
 #, elixir-autogen, elixir-format
 msgid "Could not remove invite."
 msgstr ""
@@ -2430,7 +2430,7 @@ msgstr ""
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2490
+#: lib/klass_hero_web/components/provider_components.ex:2517
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2464,7 +2464,7 @@ msgstr ""
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2114
+#: lib/klass_hero_web/components/provider_components.ex:2141
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
@@ -2495,14 +2495,14 @@ msgstr ""
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1927
-#: lib/klass_hero_web/components/provider_components.ex:2373
+#: lib/klass_hero_web/components/provider_components.ex:1954
+#: lib/klass_hero_web/components/provider_components.ex:2400
 #: lib/klass_hero_web/components/provider_layout_components.ex:644
 #, elixir-autogen, elixir-format
 msgid "Enrolled"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1609
+#: lib/klass_hero_web/components/provider_components.ex:1636
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr ""
@@ -2518,7 +2518,7 @@ msgid "Explain why this document is being rejected..."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:70
-#: lib/klass_hero_web/components/provider_components.ex:2374
+#: lib/klass_hero_web/components/provider_components.ex:2401
 #: lib/klass_hero_web/live/admin/emails_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2534,7 +2534,7 @@ msgstr ""
 msgid "Failed to reject document."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:394
+#: lib/klass_hero_web/live/provider/programs_live.ex:397
 #, elixir-autogen, elixir-format
 msgid "Failed to resend invite."
 msgstr ""
@@ -2562,12 +2562,12 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2424
+#: lib/klass_hero_web/components/provider_components.ex:2451
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2426
+#: lib/klass_hero_web/components/provider_components.ex:2453
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
@@ -2602,7 +2602,7 @@ msgstr ""
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2150
+#: lib/klass_hero_web/components/provider_components.ex:2177
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
@@ -2617,7 +2617,7 @@ msgstr ""
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2087
+#: lib/klass_hero_web/components/provider_components.ex:2114
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -2627,22 +2627,22 @@ msgstr ""
 msgid "Insurance Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:409
+#: lib/klass_hero_web/live/provider/programs_live.ex:412
 #, elixir-autogen, elixir-format
 msgid "Invite not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:406
+#: lib/klass_hero_web/live/provider/programs_live.ex:409
 #, elixir-autogen, elixir-format
 msgid "Invite removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:383
+#: lib/klass_hero_web/live/provider/programs_live.ex:386
 #, elixir-autogen, elixir-format
 msgid "Invite resent successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1626
+#: lib/klass_hero_web/components/provider_components.ex:1653
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr ""
@@ -2743,18 +2743,18 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2452
+#: lib/klass_hero_web/components/provider_components.ex:2479
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1914
+#: lib/klass_hero_web/components/provider_components.ex:1941
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:425
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:440
+#: lib/klass_hero_web/live/provider/programs_live.ex:443
 #, elixir-autogen, elixir-format
 msgid "No file selected."
 msgstr ""
@@ -2764,7 +2764,7 @@ msgstr ""
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2138
+#: lib/klass_hero_web/components/provider_components.ex:2165
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
@@ -2827,7 +2827,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2527
+#: lib/klass_hero_web/components/provider_components.ex:2554
 #: lib/klass_hero_web/live/provider/verification_live.ex:698
 #: lib/klass_hero_web/live/provider/verification_live.ex:770
 #, elixir-autogen, elixir-format
@@ -2854,8 +2854,8 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:106
-#: lib/klass_hero_web/live/provider/programs_live.ex:686
-#: lib/klass_hero_web/live/provider/programs_live.ex:752
+#: lib/klass_hero_web/live/provider/programs_live.ex:689
+#: lib/klass_hero_web/live/provider/programs_live.ex:755
 #: lib/klass_hero_web/live/provider/team_live.ex:256
 #: lib/klass_hero_web/live/provider/team_live.ex:299
 #: lib/klass_hero_web/live/provider/team_live.ex:418
@@ -2888,26 +2888,26 @@ msgstr ""
 msgid "Program Start"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1080
+#: lib/klass_hero_web/live/provider/programs_live.ex:1100
 #, elixir-autogen, elixir-format
 msgid "Program created successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1087
+#: lib/klass_hero_web/live/provider/programs_live.ex:1107
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:54
-#: lib/klass_hero_web/live/provider/programs_live.ex:150
-#: lib/klass_hero_web/live/provider/programs_live.ex:187
-#: lib/klass_hero_web/live/provider/programs_live.ex:251
-#: lib/klass_hero_web/live/provider/programs_live.ex:727
+#: lib/klass_hero_web/live/provider/programs_live.ex:151
+#: lib/klass_hero_web/live/provider/programs_live.ex:188
+#: lib/klass_hero_web/live/provider/programs_live.ex:252
+#: lib/klass_hero_web/live/provider/programs_live.ex:730
 #, elixir-autogen, elixir-format
 msgid "Program not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:716
+#: lib/klass_hero_web/live/provider/programs_live.ex:719
 #, elixir-autogen, elixir-format
 msgid "Program updated successfully."
 msgstr ""
@@ -2925,7 +2925,7 @@ msgid "Read our founding story →"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:805
-#: lib/klass_hero_web/components/provider_components.ex:2372
+#: lib/klass_hero_web/components/provider_components.ex:2399
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Registered"
@@ -3007,16 +3007,16 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:767
 #: lib/klass_hero_web/components/provider_components.ex:1166
-#: lib/klass_hero_web/components/provider_components.ex:2194
-#: lib/klass_hero_web/components/provider_components.ex:2546
-#: lib/klass_hero_web/components/provider_components.ex:2625
+#: lib/klass_hero_web/components/provider_components.ex:2221
+#: lib/klass_hero_web/components/provider_components.ex:2573
+#: lib/klass_hero_web/components/provider_components.ex:2652
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:253
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2187
+#: lib/klass_hero_web/components/provider_components.ex:2214
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -3031,7 +3031,7 @@ msgstr ""
 msgid "Role"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1555
+#: lib/klass_hero_web/components/provider_components.ex:1582
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
@@ -3057,7 +3057,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2524
+#: lib/klass_hero_web/components/provider_components.ex:2551
 #, elixir-autogen, elixir-format
 msgid "Select File"
 msgstr ""
@@ -3068,13 +3068,13 @@ msgstr ""
 msgid "Selected child does not meet the program requirements."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:676
-#: lib/klass_hero_web/live/provider/programs_live.ex:742
+#: lib/klass_hero_web/live/provider/programs_live.ex:679
+#: lib/klass_hero_web/live/provider/programs_live.ex:745
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2371
+#: lib/klass_hero_web/components/provider_components.ex:2398
 #: lib/klass_hero_web/live/admin/emails_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Sent"
@@ -3169,12 +3169,12 @@ msgstr ""
 msgid "The Klass Hero Story"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:386
+#: lib/klass_hero_web/live/provider/programs_live.ex:389
 #, elixir-autogen, elixir-format
 msgid "This invite cannot be resent."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:734
+#: lib/klass_hero_web/live/provider/programs_live.ex:737
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
@@ -3184,7 +3184,7 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2425
+#: lib/klass_hero_web/components/provider_components.ex:2452
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -3204,32 +3204,32 @@ msgstr ""
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2073
+#: lib/klass_hero_web/components/provider_components.ex:2100
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2570
+#: lib/klass_hero_web/components/provider_components.ex:2597
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2479
+#: lib/klass_hero_web/components/provider_components.ex:2506
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2447
+#: lib/klass_hero_web/components/provider_components.ex:2474
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2427
+#: lib/klass_hero_web/components/provider_components.ex:2454
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2444
+#: lib/klass_hero_web/components/provider_components.ex:2471
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -3319,7 +3319,7 @@ msgid "Child Safeguarding Training"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1498
-#: lib/klass_hero_web/components/provider_components.ex:2792
+#: lib/klass_hero_web/components/provider_components.ex:2819
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr ""
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Program fee:"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:918
+#: lib/klass_hero_web/live/provider/programs_live.ex:938
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr ""
@@ -3469,7 +3469,7 @@ msgid "Vetted with Care"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1482
-#: lib/klass_hero_web/components/provider_components.ex:2577
+#: lib/klass_hero_web/components/provider_components.ex:2604
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr ""
@@ -3605,7 +3605,7 @@ msgstr ""
 msgid "Cannot check out without a check-in"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:358
+#: lib/klass_hero_web/live/provider/programs_live.ex:361
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:146
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
@@ -3643,7 +3643,7 @@ msgstr ""
 msgid "Checked Out"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2230
+#: lib/klass_hero_web/components/provider_components.ex:2257
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Child"
@@ -3670,7 +3670,7 @@ msgid "Correct"
 msgstr ""
 
 #: lib/klass_hero_web/live/dashboard_live.ex:301
-#: lib/klass_hero_web/live/provider/programs_live.ex:355
+#: lib/klass_hero_web/live/provider/programs_live.ex:358
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "Could not start conversation. Please try again."
@@ -3696,7 +3696,7 @@ msgstr ""
 msgid "Download monthly statements for taxes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1991
+#: lib/klass_hero_web/components/provider_components.ex:2018
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Enrollment not confirmed"
@@ -3774,7 +3774,7 @@ msgstr ""
 msgid "No chasing payments or sending invoices"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1578
+#: lib/klass_hero_web/components/provider_components.ex:1605
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:406
 #, elixir-autogen, elixir-format
 msgid "No enrolled parents"
@@ -3797,7 +3797,7 @@ msgstr ""
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1990
+#: lib/klass_hero_web/components/provider_components.ex:2017
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:481
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -4427,7 +4427,7 @@ msgstr ""
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:24
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
-#: lib/klass_hero_web/live/provider/programs_live.ex:219
+#: lib/klass_hero_web/live/provider/programs_live.ex:220
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:156
 #, elixir-autogen, elixir-format
 msgid "Program"
@@ -4636,7 +4636,7 @@ msgid "Update your observation..."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:138
-#: lib/klass_hero_web/live/provider/programs_live.ex:437
+#: lib/klass_hero_web/live/provider/programs_live.ex:440
 #: lib/klass_hero_web/live/provider/verification_live.ex:240
 #: lib/klass_hero_web/live/provider/verification_live.ex:556
 #: lib/klass_hero_web/live/provider/verification_live.ex:594
@@ -4905,48 +4905,48 @@ msgstr ""
 msgid "for"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1699
+#: lib/klass_hero_web/components/provider_components.ex:1726
 #, elixir-autogen, elixir-format
 msgid "Assigned staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1701
+#: lib/klass_hero_web/components/provider_components.ex:1728
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1683
-#: lib/klass_hero_web/components/provider_components.ex:1772
+#: lib/klass_hero_web/components/provider_components.ex:1710
+#: lib/klass_hero_web/components/provider_components.ex:1799
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1700
+#: lib/klass_hero_web/components/provider_components.ex:1727
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1698
+#: lib/klass_hero_web/components/provider_components.ex:1725
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1692
+#: lib/klass_hero_web/components/provider_components.ex:1719
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1681
+#: lib/klass_hero_web/components/provider_components.ex:1708
 #, elixir-autogen, elixir-format
 msgid "Sessions — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1421
+#: lib/klass_hero_web/components/provider_components.ex:1448
 #, elixir-autogen, elixir-format
 msgid "View sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:528
+#: lib/klass_hero_web/live/provider/programs_live.ex:531
 #, elixir-autogen, elixir-format
 msgid "Create a program before inviting participants."
 msgstr ""
@@ -4973,22 +4973,22 @@ msgstr ""
 msgid "Failed to update record"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2294
+#: lib/klass_hero_web/components/provider_components.ex:2321
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2013
+#: lib/klass_hero_web/components/provider_components.ex:2040
 #, elixir-autogen, elixir-format
 msgid "Invite mode"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2032
+#: lib/klass_hero_web/components/provider_components.ex:2059
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:524
+#: lib/klass_hero_web/live/provider/programs_live.ex:527
 #, elixir-autogen, elixir-format
 msgid "Invite sent."
 msgstr ""
@@ -4998,12 +4998,12 @@ msgstr ""
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2307
+#: lib/klass_hero_web/components/provider_components.ex:2334
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2313
+#: lib/klass_hero_web/components/provider_components.ex:2340
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr ""
@@ -5014,17 +5014,17 @@ msgstr ""
 msgid "Nothing to update"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2315
+#: lib/klass_hero_web/components/provider_components.ex:2342
 #, elixir-autogen, elixir-format
 msgid "Nut allergy"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2319
+#: lib/klass_hero_web/components/provider_components.ex:2346
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2324
+#: lib/klass_hero_web/components/provider_components.ex:2351
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr ""
@@ -5034,7 +5034,7 @@ msgstr ""
 msgid "Present"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2251
+#: lib/klass_hero_web/components/provider_components.ex:2278
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr ""
@@ -5061,22 +5061,22 @@ msgstr ""
 msgid "Save changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2288
+#: lib/klass_hero_web/components/provider_components.ex:2315
 #, elixir-autogen, elixir-format
 msgid "School (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2298
+#: lib/klass_hero_web/components/provider_components.ex:2325
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2272
+#: lib/klass_hero_web/components/provider_components.ex:2299
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2341
+#: lib/klass_hero_web/components/provider_components.ex:2368
 #, elixir-autogen, elixir-format
 msgid "Send invite"
 msgstr ""
@@ -5086,12 +5086,12 @@ msgstr ""
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2050
+#: lib/klass_hero_web/components/provider_components.ex:2077
 #, elixir-autogen, elixir-format
 msgid "Upload a list"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:535
+#: lib/klass_hero_web/live/provider/programs_live.ex:538
 #, elixir-autogen, elixir-format
 msgid "An invite for this child and program already exists."
 msgstr ""
@@ -5186,7 +5186,7 @@ msgstr ""
 msgid "Property Damage"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1451
+#: lib/klass_hero_web/components/provider_components.ex:1478
 #, elixir-autogen, elixir-format
 msgid "Report Incident"
 msgstr ""
@@ -5268,7 +5268,7 @@ msgstr ""
 msgid "Go to dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:480
+#: lib/klass_hero_web/live/provider/programs_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "%{count} row could not be processed."
 msgid_plural "%{count} rows could not be processed."
@@ -5855,8 +5855,8 @@ msgstr ""
 msgid "I'll be teaching"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:455
-#: lib/klass_hero_web/live/provider/programs_live.ex:477
+#: lib/klass_hero_web/live/provider/programs_live.ex:458
+#: lib/klass_hero_web/live/provider/programs_live.ex:480
 #, elixir-autogen, elixir-format
 msgid "Imported %{count} family."
 msgid_plural "Imported %{count} families."
@@ -5868,7 +5868,7 @@ msgstr[1] ""
 msgid "In 2025, Shane connected with his friend"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1460
+#: lib/klass_hero_web/components/provider_components.ex:1487
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:43
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:74
 #, elixir-autogen, elixir-format
@@ -6145,7 +6145,7 @@ msgstr ""
 msgid "No registered children for this session."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:464
+#: lib/klass_hero_web/live/provider/programs_live.ex:467
 #, elixir-autogen, elixir-format
 msgid "No rows imported. %{count} row could not be processed."
 msgid_plural "No rows imported. %{count} rows could not be processed."
@@ -6388,17 +6388,17 @@ msgstr ""
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2380
+#: lib/klass_hero_web/components/provider_components.ex:2407
 #, elixir-autogen, elixir-format
 msgid "Row %{row}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2380
+#: lib/klass_hero_web/components/provider_components.ex:2407
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2126
+#: lib/klass_hero_web/components/provider_components.ex:2153
 #, elixir-autogen, elixir-format
 msgid "Rows with errors"
 msgstr ""
@@ -7157,12 +7157,12 @@ msgstr ""
 msgid "Experience validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2606
+#: lib/klass_hero_web/components/provider_components.ex:2633
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2580
+#: lib/klass_hero_web/components/provider_components.ex:2607
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
@@ -7172,12 +7172,12 @@ msgstr ""
 msgid "Safeguarding certificate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2603
+#: lib/klass_hero_web/components/provider_components.ex:2630
 #, elixir-autogen, elixir-format
 msgid "Select Video"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2649
+#: lib/klass_hero_web/components/provider_components.ex:2676
 #, elixir-autogen, elixir-format
 msgid "Upload Video"
 msgstr ""
@@ -7187,7 +7187,7 @@ msgstr ""
 msgid "Your browser does not support video playback."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2796
+#: lib/klass_hero_web/components/provider_components.ex:2823
 #, elixir-autogen, elixir-format
 msgid "Confirm agreement"
 msgstr ""
@@ -7197,12 +7197,12 @@ msgstr ""
 msgid "Couldn't record your agreement. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2819
+#: lib/klass_hero_web/components/provider_components.ex:2846
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2795
+#: lib/klass_hero_web/components/provider_components.ex:2822
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr ""
@@ -7212,7 +7212,7 @@ msgstr ""
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2704
+#: lib/klass_hero_web/components/provider_components.ex:2731
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr ""
@@ -7222,17 +7222,17 @@ msgstr ""
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2804
+#: lib/klass_hero_web/components/provider_components.ex:2831
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2793
+#: lib/klass_hero_web/components/provider_components.ex:2820
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2794
+#: lib/klass_hero_web/components/provider_components.ex:2821
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
@@ -7501,12 +7501,12 @@ msgstr ""
 msgid "Your insurance is verified."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2748
+#: lib/klass_hero_web/components/provider_components.ex:2775
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2851
+#: lib/klass_hero_web/components/provider_components.ex:2878
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr ""
@@ -7516,7 +7516,7 @@ msgstr ""
 msgid "Couldn't record your declaration. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2857
+#: lib/klass_hero_web/components/provider_components.ex:2884
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr ""
@@ -7526,17 +7526,17 @@ msgstr ""
 msgid "Please confirm the declaration before signing."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2882
+#: lib/klass_hero_web/components/provider_components.ex:2909
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2861
+#: lib/klass_hero_web/components/provider_components.ex:2888
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2849
+#: lib/klass_hero_web/components/provider_components.ex:2876
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr ""
@@ -7546,12 +7546,12 @@ msgstr ""
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2869
+#: lib/klass_hero_web/components/provider_components.ex:2896
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2855
+#: lib/klass_hero_web/components/provider_components.ex:2882
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
@@ -7618,87 +7618,94 @@ msgstr ""
 msgid "Undelivered Events"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1869
+#: lib/klass_hero_web/components/provider_components.ex:1896
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1794
+#: lib/klass_hero_web/components/provider_components.ex:1821
 #, elixir-autogen, elixir-format
 msgid "Lead"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:330
+#: lib/klass_hero_web/live/provider/programs_live.ex:333
 #, elixir-autogen, elixir-format
 msgid "Lead instructor updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1805
+#: lib/klass_hero_web/components/provider_components.ex:1832
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1435
+#: lib/klass_hero_web/components/provider_components.ex:1462
 #, elixir-autogen, elixir-format
 msgid "Manage Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1833
+#: lib/klass_hero_web/components/provider_components.ex:1860
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this program yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:262
+#: lib/klass_hero_web/live/provider/programs_live.ex:263
 #, elixir-autogen, elixir-format
 msgid "Pick a staff member to add."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1816
+#: lib/klass_hero_web/components/provider_components.ex:1843
 #, elixir-autogen, elixir-format
 msgid "Reassign the lead before removing them"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1817
+#: lib/klass_hero_web/components/provider_components.ex:1844
 #, elixir-autogen, elixir-format
 msgid "Remove from program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1851
+#: lib/klass_hero_web/components/provider_components.ex:1878
 #, elixir-autogen, elixir-format
 msgid "Select a staff member…"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:276
+#: lib/klass_hero_web/live/provider/programs_live.ex:278
 #, elixir-autogen, elixir-format
 msgid "Staff member added to the program."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:301
+#: lib/klass_hero_web/live/provider/programs_live.ex:304
 #, elixir-autogen, elixir-format
 msgid "Staff member removed from the program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1874
+#: lib/klass_hero_web/components/provider_components.ex:1901
 #, elixir-autogen, elixir-format
 msgid "Staff you add can read and reply to this program's parent conversations."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1770
+#: lib/klass_hero_web/components/provider_components.ex:1797
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:879
+#: lib/klass_hero_web/live/provider/programs_live.ex:897
 #, elixir-autogen, elixir-format
 msgid "That staff member could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:284
+#: lib/klass_hero_web/live/provider/programs_live.ex:286
 #, elixir-autogen, elixir-format
 msgid "They are already on this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:309
+#: lib/klass_hero_web/live/provider/programs_live.ex:312
 #, elixir-autogen, elixir-format
 msgid "This person is the lead instructor. Make someone else lead before removing them."
 msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1406
+#, elixir-autogen, elixir-format
+msgid "%{count} staff member · no lead"
+msgid_plural "%{count} staff · no lead"
+msgstr[0] ""
+msgstr[1] ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -137,7 +137,7 @@ msgid "Your Data"
 msgstr ""
 
 #: lib/klass_hero_web/components/core_components.ex:67
-#: lib/klass_hero_web/components/provider_components.ex:1612
+#: lib/klass_hero_web/components/provider_components.ex:1615
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr ""
@@ -232,7 +232,7 @@ msgstr ""
 msgid "Enroll Now - %{price}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1363
+#: lib/klass_hero_web/components/provider_components.ex:1366
 #: lib/klass_hero_web/live/booking_live.ex:285
 #, elixir-autogen, elixir-format
 msgid "Enrollment"
@@ -578,8 +578,8 @@ msgid "Dispute Resolution"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:647
-#: lib/klass_hero_web/components/provider_components.ex:2285
-#: lib/klass_hero_web/components/provider_components.ex:2303
+#: lib/klass_hero_web/components/provider_components.ex:2288
+#: lib/klass_hero_web/components/provider_components.ex:2306
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
@@ -878,9 +878,9 @@ msgstr ""
 msgid "Select one or both options"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1981
-#: lib/klass_hero_web/components/provider_components.ex:1982
-#: lib/klass_hero_web/components/provider_components.ex:2019
+#: lib/klass_hero_web/components/provider_components.ex:1984
+#: lib/klass_hero_web/components/provider_components.ex:1985
+#: lib/klass_hero_web/components/provider_components.ex:2022
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:446
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:483
@@ -1577,14 +1577,14 @@ msgstr ""
 msgid "Quick Navigation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1366
-#: lib/klass_hero_web/components/provider_components.ex:1957
-#: lib/klass_hero_web/components/provider_components.ex:2183
+#: lib/klass_hero_web/components/provider_components.ex:1369
+#: lib/klass_hero_web/components/provider_components.ex:1960
+#: lib/klass_hero_web/components/provider_components.ex:2186
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1505
+#: lib/klass_hero_web/components/provider_components.ex:1508
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr ""
@@ -1600,7 +1600,7 @@ msgstr ""
 msgid "All Staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1357
+#: lib/klass_hero_web/components/provider_components.ex:1360
 #, elixir-autogen, elixir-format
 msgid "Assigned Staff"
 msgstr ""
@@ -1628,7 +1628,7 @@ msgid "Create profiles for your staff. These will be visible to parents when ass
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:538
-#: lib/klass_hero_web/components/provider_components.ex:1468
+#: lib/klass_hero_web/components/provider_components.ex:1471
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:54
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:81
 #: lib/klass_hero_web/live/settings/children_live.ex:448
@@ -1645,7 +1645,7 @@ msgstr ""
 msgid "Edit Profile"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1507
+#: lib/klass_hero_web/components/provider_components.ex:1510
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr ""
@@ -1669,16 +1669,16 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:46
 #: lib/klass_hero_web/components/provider_components.ex:72
-#: lib/klass_hero_web/components/provider_components.ex:1506
-#: lib/klass_hero_web/components/provider_components.ex:2379
-#: lib/klass_hero_web/components/provider_components.ex:2397
+#: lib/klass_hero_web/components/provider_components.ex:1509
+#: lib/klass_hero_web/components/provider_components.ex:2382
+#: lib/klass_hero_web/components/provider_components.ex:2400
 #: lib/klass_hero_web/live/admin/sessions_live.ex:297
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1444
+#: lib/klass_hero_web/components/provider_components.ex:1447
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
@@ -1688,7 +1688,7 @@ msgstr ""
 msgid "Program Inventory"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1354
+#: lib/klass_hero_web/components/provider_components.ex:1357
 #, elixir-autogen, elixir-format
 msgid "Program Name"
 msgstr ""
@@ -1703,15 +1703,15 @@ msgstr ""
 msgid "Save for Later"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1312
+#: lib/klass_hero_web/components/provider_components.ex:1317
 #, elixir-autogen, elixir-format
 msgid "Search by name..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1360
-#: lib/klass_hero_web/components/provider_components.ex:1729
-#: lib/klass_hero_web/components/provider_components.ex:1951
-#: lib/klass_hero_web/components/provider_components.ex:2180
+#: lib/klass_hero_web/components/provider_components.ex:1363
+#: lib/klass_hero_web/components/provider_components.ex:1732
+#: lib/klass_hero_web/components/provider_components.ex:1954
+#: lib/klass_hero_web/components/provider_components.ex:2183
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1735,15 +1735,15 @@ msgstr ""
 msgid "This is your main business identity. Verification is required to list programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1417
-#: lib/klass_hero_web/components/provider_components.ex:1744
+#: lib/klass_hero_web/components/provider_components.ex:1420
+#: lib/klass_hero_web/components/provider_components.ex:1747
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr ""
 
 #: lib/klass_hero_web/components/messaging_components.ex:728
 #: lib/klass_hero_web/components/provider_components.ex:49
-#: lib/klass_hero_web/components/provider_components.ex:1508
+#: lib/klass_hero_web/components/provider_components.ex:1511
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:433
 #: lib/klass_hero_web/presenters/provider_presenter.ex:103
 #, elixir-autogen, elixir-format
@@ -1755,7 +1755,7 @@ msgstr ""
 msgid "Verified Business"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1455
+#: lib/klass_hero_web/components/provider_components.ex:1458
 #, elixir-autogen, elixir-format
 msgid "View Roster"
 msgstr ""
@@ -1817,7 +1817,7 @@ msgstr ""
 #: lib/klass_hero_web/components/participation_components.ex:717
 #: lib/klass_hero_web/components/provider_components.ex:817
 #: lib/klass_hero_web/components/provider_components.ex:1216
-#: lib/klass_hero_web/components/provider_components.ex:2122
+#: lib/klass_hero_web/components/provider_components.ex:2125
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:478
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
@@ -1883,7 +1883,7 @@ msgstr ""
 msgid "Data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2266
+#: lib/klass_hero_web/components/provider_components.ex:2269
 #: lib/klass_hero_web/live/settings/children_live.ex:657
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1931,17 +1931,17 @@ msgstr ""
 msgid "Failed to submit note"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2260
-#: lib/klass_hero_web/components/provider_components.ex:2289
-#: lib/klass_hero_web/components/provider_components.ex:2305
+#: lib/klass_hero_web/components/provider_components.ex:2263
+#: lib/klass_hero_web/components/provider_components.ex:2292
+#: lib/klass_hero_web/components/provider_components.ex:2308
 #: lib/klass_hero_web/live/settings/children_live.ex:643
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2261
-#: lib/klass_hero_web/components/provider_components.ex:2290
-#: lib/klass_hero_web/components/provider_components.ex:2306
+#: lib/klass_hero_web/components/provider_components.ex:2264
+#: lib/klass_hero_web/components/provider_components.ex:2293
+#: lib/klass_hero_web/components/provider_components.ex:2309
 #: lib/klass_hero_web/live/settings/children_live.ex:649
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -2080,8 +2080,8 @@ msgstr ""
 msgid "Save Changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1590
-#: lib/klass_hero_web/components/provider_components.ex:1591
+#: lib/klass_hero_web/components/provider_components.ex:1593
+#: lib/klass_hero_web/components/provider_components.ex:1594
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:43
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:151
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:252
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "Send a message to start the conversation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2360
+#: lib/klass_hero_web/components/provider_components.ex:2363
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:245
 #, elixir-autogen, elixir-format
@@ -2235,7 +2235,7 @@ msgstr ""
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2419
+#: lib/klass_hero_web/components/provider_components.ex:2422
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred during import."
 msgstr ""
@@ -2335,8 +2335,8 @@ msgstr ""
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1948
-#: lib/klass_hero_web/components/provider_components.ex:2174
+#: lib/klass_hero_web/components/provider_components.ex:1951
+#: lib/klass_hero_web/components/provider_components.ex:2177
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2381,7 +2381,7 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2380
+#: lib/klass_hero_web/components/provider_components.ex:2383
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
@@ -2430,7 +2430,7 @@ msgstr ""
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2517
+#: lib/klass_hero_web/components/provider_components.ex:2520
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2464,7 +2464,7 @@ msgstr ""
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2141
+#: lib/klass_hero_web/components/provider_components.ex:2144
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
@@ -2495,14 +2495,14 @@ msgstr ""
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1954
-#: lib/klass_hero_web/components/provider_components.ex:2400
+#: lib/klass_hero_web/components/provider_components.ex:1957
+#: lib/klass_hero_web/components/provider_components.ex:2403
 #: lib/klass_hero_web/components/provider_layout_components.ex:644
 #, elixir-autogen, elixir-format
 msgid "Enrolled"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1636
+#: lib/klass_hero_web/components/provider_components.ex:1639
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr ""
@@ -2518,7 +2518,7 @@ msgid "Explain why this document is being rejected..."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:70
-#: lib/klass_hero_web/components/provider_components.ex:2401
+#: lib/klass_hero_web/components/provider_components.ex:2404
 #: lib/klass_hero_web/live/admin/emails_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2562,12 +2562,12 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2451
+#: lib/klass_hero_web/components/provider_components.ex:2454
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2453
+#: lib/klass_hero_web/components/provider_components.ex:2456
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
@@ -2602,7 +2602,7 @@ msgstr ""
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2177
+#: lib/klass_hero_web/components/provider_components.ex:2180
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
@@ -2617,7 +2617,7 @@ msgstr ""
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2114
+#: lib/klass_hero_web/components/provider_components.ex:2117
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -2642,7 +2642,7 @@ msgstr ""
 msgid "Invite resent successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1653
+#: lib/klass_hero_web/components/provider_components.ex:1656
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr ""
@@ -2743,12 +2743,12 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2479
+#: lib/klass_hero_web/components/provider_components.ex:2482
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1941
+#: lib/klass_hero_web/components/provider_components.ex:1944
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:425
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
@@ -2764,7 +2764,7 @@ msgstr ""
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2165
+#: lib/klass_hero_web/components/provider_components.ex:2168
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
@@ -2827,7 +2827,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2554
+#: lib/klass_hero_web/components/provider_components.ex:2557
 #: lib/klass_hero_web/live/provider/verification_live.ex:698
 #: lib/klass_hero_web/live/provider/verification_live.ex:770
 #, elixir-autogen, elixir-format
@@ -2925,7 +2925,7 @@ msgid "Read our founding story →"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:805
-#: lib/klass_hero_web/components/provider_components.ex:2399
+#: lib/klass_hero_web/components/provider_components.ex:2402
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Registered"
@@ -3007,16 +3007,16 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:767
 #: lib/klass_hero_web/components/provider_components.ex:1166
-#: lib/klass_hero_web/components/provider_components.ex:2221
-#: lib/klass_hero_web/components/provider_components.ex:2573
-#: lib/klass_hero_web/components/provider_components.ex:2652
+#: lib/klass_hero_web/components/provider_components.ex:2224
+#: lib/klass_hero_web/components/provider_components.ex:2576
+#: lib/klass_hero_web/components/provider_components.ex:2655
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:253
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2214
+#: lib/klass_hero_web/components/provider_components.ex:2217
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -3031,7 +3031,7 @@ msgstr ""
 msgid "Role"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1582
+#: lib/klass_hero_web/components/provider_components.ex:1585
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
@@ -3057,7 +3057,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2551
+#: lib/klass_hero_web/components/provider_components.ex:2554
 #, elixir-autogen, elixir-format
 msgid "Select File"
 msgstr ""
@@ -3074,7 +3074,7 @@ msgstr ""
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2398
+#: lib/klass_hero_web/components/provider_components.ex:2401
 #: lib/klass_hero_web/live/admin/emails_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Sent"
@@ -3184,7 +3184,7 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2452
+#: lib/klass_hero_web/components/provider_components.ex:2455
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -3204,32 +3204,32 @@ msgstr ""
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2100
+#: lib/klass_hero_web/components/provider_components.ex:2103
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2597
+#: lib/klass_hero_web/components/provider_components.ex:2600
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2506
+#: lib/klass_hero_web/components/provider_components.ex:2509
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2474
+#: lib/klass_hero_web/components/provider_components.ex:2477
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2454
+#: lib/klass_hero_web/components/provider_components.ex:2457
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2471
+#: lib/klass_hero_web/components/provider_components.ex:2474
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -3319,7 +3319,7 @@ msgid "Child Safeguarding Training"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1498
-#: lib/klass_hero_web/components/provider_components.ex:2819
+#: lib/klass_hero_web/components/provider_components.ex:2822
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr ""
@@ -3469,7 +3469,7 @@ msgid "Vetted with Care"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1482
-#: lib/klass_hero_web/components/provider_components.ex:2604
+#: lib/klass_hero_web/components/provider_components.ex:2607
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr ""
@@ -3643,7 +3643,7 @@ msgstr ""
 msgid "Checked Out"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2257
+#: lib/klass_hero_web/components/provider_components.ex:2260
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Child"
@@ -3696,7 +3696,7 @@ msgstr ""
 msgid "Download monthly statements for taxes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2018
+#: lib/klass_hero_web/components/provider_components.ex:2021
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Enrollment not confirmed"
@@ -3774,7 +3774,7 @@ msgstr ""
 msgid "No chasing payments or sending invoices"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1605
+#: lib/klass_hero_web/components/provider_components.ex:1608
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:406
 #, elixir-autogen, elixir-format
 msgid "No enrolled parents"
@@ -3797,7 +3797,7 @@ msgstr ""
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2017
+#: lib/klass_hero_web/components/provider_components.ex:2020
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:481
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -4905,43 +4905,43 @@ msgstr ""
 msgid "for"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1726
+#: lib/klass_hero_web/components/provider_components.ex:1729
 #, elixir-autogen, elixir-format
 msgid "Assigned staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1728
+#: lib/klass_hero_web/components/provider_components.ex:1731
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1710
-#: lib/klass_hero_web/components/provider_components.ex:1799
+#: lib/klass_hero_web/components/provider_components.ex:1713
+#: lib/klass_hero_web/components/provider_components.ex:1802
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1727
+#: lib/klass_hero_web/components/provider_components.ex:1730
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1725
+#: lib/klass_hero_web/components/provider_components.ex:1728
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1719
+#: lib/klass_hero_web/components/provider_components.ex:1722
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1708
+#: lib/klass_hero_web/components/provider_components.ex:1711
 #, elixir-autogen, elixir-format
 msgid "Sessions — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1448
+#: lib/klass_hero_web/components/provider_components.ex:1451
 #, elixir-autogen, elixir-format
 msgid "View sessions"
 msgstr ""
@@ -4973,17 +4973,17 @@ msgstr ""
 msgid "Failed to update record"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2321
+#: lib/klass_hero_web/components/provider_components.ex:2324
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2040
+#: lib/klass_hero_web/components/provider_components.ex:2043
 #, elixir-autogen, elixir-format
 msgid "Invite mode"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2059
+#: lib/klass_hero_web/components/provider_components.ex:2062
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr ""
@@ -4998,12 +4998,12 @@ msgstr ""
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2334
+#: lib/klass_hero_web/components/provider_components.ex:2337
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2340
+#: lib/klass_hero_web/components/provider_components.ex:2343
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr ""
@@ -5014,17 +5014,17 @@ msgstr ""
 msgid "Nothing to update"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2342
+#: lib/klass_hero_web/components/provider_components.ex:2345
 #, elixir-autogen, elixir-format
 msgid "Nut allergy"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2346
+#: lib/klass_hero_web/components/provider_components.ex:2349
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2351
+#: lib/klass_hero_web/components/provider_components.ex:2354
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr ""
@@ -5034,7 +5034,7 @@ msgstr ""
 msgid "Present"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2278
+#: lib/klass_hero_web/components/provider_components.ex:2281
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr ""
@@ -5061,22 +5061,22 @@ msgstr ""
 msgid "Save changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2315
+#: lib/klass_hero_web/components/provider_components.ex:2318
 #, elixir-autogen, elixir-format
 msgid "School (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2325
+#: lib/klass_hero_web/components/provider_components.ex:2328
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2299
+#: lib/klass_hero_web/components/provider_components.ex:2302
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2368
+#: lib/klass_hero_web/components/provider_components.ex:2371
 #, elixir-autogen, elixir-format
 msgid "Send invite"
 msgstr ""
@@ -5086,7 +5086,7 @@ msgstr ""
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2077
+#: lib/klass_hero_web/components/provider_components.ex:2080
 #, elixir-autogen, elixir-format
 msgid "Upload a list"
 msgstr ""
@@ -5186,7 +5186,7 @@ msgstr ""
 msgid "Property Damage"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1478
+#: lib/klass_hero_web/components/provider_components.ex:1481
 #, elixir-autogen, elixir-format
 msgid "Report Incident"
 msgstr ""
@@ -5868,7 +5868,7 @@ msgstr[1] ""
 msgid "In 2025, Shane connected with his friend"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1487
+#: lib/klass_hero_web/components/provider_components.ex:1490
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:43
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:74
 #, elixir-autogen, elixir-format
@@ -6388,17 +6388,17 @@ msgstr ""
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2407
+#: lib/klass_hero_web/components/provider_components.ex:2410
 #, elixir-autogen, elixir-format
 msgid "Row %{row}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2407
+#: lib/klass_hero_web/components/provider_components.ex:2410
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2153
+#: lib/klass_hero_web/components/provider_components.ex:2156
 #, elixir-autogen, elixir-format
 msgid "Rows with errors"
 msgstr ""
@@ -7157,12 +7157,12 @@ msgstr ""
 msgid "Experience validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2633
+#: lib/klass_hero_web/components/provider_components.ex:2636
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2607
+#: lib/klass_hero_web/components/provider_components.ex:2610
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
@@ -7172,12 +7172,12 @@ msgstr ""
 msgid "Safeguarding certificate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2630
+#: lib/klass_hero_web/components/provider_components.ex:2633
 #, elixir-autogen, elixir-format
 msgid "Select Video"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2676
+#: lib/klass_hero_web/components/provider_components.ex:2679
 #, elixir-autogen, elixir-format
 msgid "Upload Video"
 msgstr ""
@@ -7187,7 +7187,7 @@ msgstr ""
 msgid "Your browser does not support video playback."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2823
+#: lib/klass_hero_web/components/provider_components.ex:2826
 #, elixir-autogen, elixir-format
 msgid "Confirm agreement"
 msgstr ""
@@ -7197,12 +7197,12 @@ msgstr ""
 msgid "Couldn't record your agreement. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2846
+#: lib/klass_hero_web/components/provider_components.ex:2849
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2822
+#: lib/klass_hero_web/components/provider_components.ex:2825
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr ""
@@ -7212,7 +7212,7 @@ msgstr ""
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2731
+#: lib/klass_hero_web/components/provider_components.ex:2734
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr ""
@@ -7222,17 +7222,17 @@ msgstr ""
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2831
+#: lib/klass_hero_web/components/provider_components.ex:2834
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2820
+#: lib/klass_hero_web/components/provider_components.ex:2823
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2821
+#: lib/klass_hero_web/components/provider_components.ex:2824
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
@@ -7501,12 +7501,12 @@ msgstr ""
 msgid "Your insurance is verified."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2775
+#: lib/klass_hero_web/components/provider_components.ex:2778
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2878
+#: lib/klass_hero_web/components/provider_components.ex:2881
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr ""
@@ -7516,7 +7516,7 @@ msgstr ""
 msgid "Couldn't record your declaration. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2884
+#: lib/klass_hero_web/components/provider_components.ex:2887
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr ""
@@ -7526,17 +7526,17 @@ msgstr ""
 msgid "Please confirm the declaration before signing."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2909
+#: lib/klass_hero_web/components/provider_components.ex:2912
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2888
+#: lib/klass_hero_web/components/provider_components.ex:2891
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2876
+#: lib/klass_hero_web/components/provider_components.ex:2879
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr ""
@@ -7546,12 +7546,12 @@ msgstr ""
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2896
+#: lib/klass_hero_web/components/provider_components.ex:2899
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2882
+#: lib/klass_hero_web/components/provider_components.ex:2885
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
@@ -7618,12 +7618,12 @@ msgstr ""
 msgid "Undelivered Events"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1896
+#: lib/klass_hero_web/components/provider_components.ex:1899
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1821
+#: lib/klass_hero_web/components/provider_components.ex:1824
 #, elixir-autogen, elixir-format
 msgid "Lead"
 msgstr ""
@@ -7633,17 +7633,17 @@ msgstr ""
 msgid "Lead instructor updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1832
+#: lib/klass_hero_web/components/provider_components.ex:1835
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1462
+#: lib/klass_hero_web/components/provider_components.ex:1465
 #, elixir-autogen, elixir-format
 msgid "Manage Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1860
+#: lib/klass_hero_web/components/provider_components.ex:1863
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this program yet."
 msgstr ""
@@ -7653,17 +7653,17 @@ msgstr ""
 msgid "Pick a staff member to add."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1843
+#: lib/klass_hero_web/components/provider_components.ex:1846
 #, elixir-autogen, elixir-format
 msgid "Reassign the lead before removing them"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1844
+#: lib/klass_hero_web/components/provider_components.ex:1847
 #, elixir-autogen, elixir-format
 msgid "Remove from program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1878
+#: lib/klass_hero_web/components/provider_components.ex:1881
 #, elixir-autogen, elixir-format
 msgid "Select a staff member…"
 msgstr ""
@@ -7678,12 +7678,12 @@ msgstr ""
 msgid "Staff member removed from the program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1901
+#: lib/klass_hero_web/components/provider_components.ex:1904
 #, elixir-autogen, elixir-format
 msgid "Staff you add can read and reply to this program's parent conversations."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1797
+#: lib/klass_hero_web/components/provider_components.ex:1800
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{title}"
 msgstr ""
@@ -7703,7 +7703,7 @@ msgstr ""
 msgid "This person is the lead instructor. Make someone else lead before removing them."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1406
+#: lib/klass_hero_web/components/provider_components.ex:1409
 #, elixir-autogen, elixir-format
 msgid "%{count} staff member · no lead"
 msgid_plural "%{count} staff · no lead"

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -137,7 +137,7 @@ msgid "Your Data"
 msgstr ""
 
 #: lib/klass_hero_web/components/core_components.ex:67
-#: lib/klass_hero_web/components/provider_components.ex:1585
+#: lib/klass_hero_web/components/provider_components.ex:1612
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr ""
@@ -578,8 +578,8 @@ msgid "Dispute Resolution"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:647
-#: lib/klass_hero_web/components/provider_components.ex:2258
-#: lib/klass_hero_web/components/provider_components.ex:2276
+#: lib/klass_hero_web/components/provider_components.ex:2285
+#: lib/klass_hero_web/components/provider_components.ex:2303
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
@@ -878,9 +878,9 @@ msgstr ""
 msgid "Select one or both options"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1954
-#: lib/klass_hero_web/components/provider_components.ex:1955
-#: lib/klass_hero_web/components/provider_components.ex:1992
+#: lib/klass_hero_web/components/provider_components.ex:1981
+#: lib/klass_hero_web/components/provider_components.ex:1982
+#: lib/klass_hero_web/components/provider_components.ex:2019
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:446
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:483
@@ -1404,7 +1404,7 @@ msgid "All"
 msgstr ""
 
 #: lib/klass_hero_web/live/programs_live.ex:22
-#: lib/klass_hero_web/presenters/program_presenter.ex:311
+#: lib/klass_hero_web/presenters/program_presenter.ex:333
 #, elixir-autogen, elixir-format
 msgid "Arts"
 msgstr ""
@@ -1420,7 +1420,7 @@ msgid "Camps"
 msgstr ""
 
 #: lib/klass_hero_web/live/programs_live.ex:24
-#: lib/klass_hero_web/presenters/program_presenter.ex:312
+#: lib/klass_hero_web/presenters/program_presenter.ex:334
 #, elixir-autogen, elixir-format
 msgid "Education"
 msgstr ""
@@ -1451,7 +1451,7 @@ msgid "Life Skills"
 msgstr ""
 
 #: lib/klass_hero_web/live/programs_live.ex:23
-#: lib/klass_hero_web/presenters/program_presenter.ex:314
+#: lib/klass_hero_web/presenters/program_presenter.ex:336
 #, elixir-autogen, elixir-format
 msgid "Music"
 msgstr ""
@@ -1478,7 +1478,7 @@ msgid "Set up your teaching profile and list your programs in minutes. Share you
 msgstr ""
 
 #: lib/klass_hero_web/live/programs_live.ex:21
-#: lib/klass_hero_web/presenters/program_presenter.ex:313
+#: lib/klass_hero_web/presenters/program_presenter.ex:335
 #, elixir-autogen, elixir-format
 msgid "Sports"
 msgstr ""
@@ -1578,13 +1578,13 @@ msgid "Quick Navigation"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1366
-#: lib/klass_hero_web/components/provider_components.ex:1930
-#: lib/klass_hero_web/components/provider_components.ex:2156
+#: lib/klass_hero_web/components/provider_components.ex:1957
+#: lib/klass_hero_web/components/provider_components.ex:2183
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1478
+#: lib/klass_hero_web/components/provider_components.ex:1505
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Active"
 msgstr ""
@@ -1595,7 +1595,7 @@ msgstr ""
 msgid "Add Team Member"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:45
+#: lib/klass_hero_web/live/provider/programs_live.ex:46
 #, elixir-autogen, elixir-format
 msgid "All Staff"
 msgstr ""
@@ -1628,7 +1628,7 @@ msgid "Create profiles for your staff. These will be visible to parents when ass
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:538
-#: lib/klass_hero_web/components/provider_components.ex:1441
+#: lib/klass_hero_web/components/provider_components.ex:1468
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:54
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:81
 #: lib/klass_hero_web/live/settings/children_live.ex:448
@@ -1645,13 +1645,13 @@ msgstr ""
 msgid "Edit Profile"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1480
+#: lib/klass_hero_web/components/provider_components.ex:1507
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:112
-#: lib/klass_hero_web/live/provider/programs_live.ex:51
+#: lib/klass_hero_web/live/provider/programs_live.ex:52
 #, elixir-autogen, elixir-format, fuzzy
 msgid "My Programs"
 msgstr ""
@@ -1669,16 +1669,16 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:46
 #: lib/klass_hero_web/components/provider_components.ex:72
-#: lib/klass_hero_web/components/provider_components.ex:1479
-#: lib/klass_hero_web/components/provider_components.ex:2352
-#: lib/klass_hero_web/components/provider_components.ex:2370
+#: lib/klass_hero_web/components/provider_components.ex:1506
+#: lib/klass_hero_web/components/provider_components.ex:2379
+#: lib/klass_hero_web/components/provider_components.ex:2397
 #: lib/klass_hero_web/live/admin/sessions_live.ex:297
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1417
+#: lib/klass_hero_web/components/provider_components.ex:1444
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
@@ -1709,9 +1709,9 @@ msgid "Search by name..."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1360
-#: lib/klass_hero_web/components/provider_components.ex:1702
-#: lib/klass_hero_web/components/provider_components.ex:1924
-#: lib/klass_hero_web/components/provider_components.ex:2153
+#: lib/klass_hero_web/components/provider_components.ex:1729
+#: lib/klass_hero_web/components/provider_components.ex:1951
+#: lib/klass_hero_web/components/provider_components.ex:2180
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1735,15 +1735,15 @@ msgstr ""
 msgid "This is your main business identity. Verification is required to list programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1390
-#: lib/klass_hero_web/components/provider_components.ex:1717
+#: lib/klass_hero_web/components/provider_components.ex:1417
+#: lib/klass_hero_web/components/provider_components.ex:1744
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr ""
 
 #: lib/klass_hero_web/components/messaging_components.ex:728
 #: lib/klass_hero_web/components/provider_components.ex:49
-#: lib/klass_hero_web/components/provider_components.ex:1481
+#: lib/klass_hero_web/components/provider_components.ex:1508
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:433
 #: lib/klass_hero_web/presenters/provider_presenter.ex:103
 #, elixir-autogen, elixir-format
@@ -1755,7 +1755,7 @@ msgstr ""
 msgid "Verified Business"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1428
+#: lib/klass_hero_web/components/provider_components.ex:1455
 #, elixir-autogen, elixir-format
 msgid "View Roster"
 msgstr ""
@@ -1817,7 +1817,7 @@ msgstr ""
 #: lib/klass_hero_web/components/participation_components.ex:717
 #: lib/klass_hero_web/components/provider_components.ex:817
 #: lib/klass_hero_web/components/provider_components.ex:1216
-#: lib/klass_hero_web/components/provider_components.ex:2095
+#: lib/klass_hero_web/components/provider_components.ex:2122
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:478
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
@@ -1883,7 +1883,7 @@ msgstr ""
 msgid "Data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2239
+#: lib/klass_hero_web/components/provider_components.ex:2266
 #: lib/klass_hero_web/live/settings/children_live.ex:657
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1931,17 +1931,17 @@ msgstr ""
 msgid "Failed to submit note"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2233
-#: lib/klass_hero_web/components/provider_components.ex:2262
-#: lib/klass_hero_web/components/provider_components.ex:2278
+#: lib/klass_hero_web/components/provider_components.ex:2260
+#: lib/klass_hero_web/components/provider_components.ex:2289
+#: lib/klass_hero_web/components/provider_components.ex:2305
 #: lib/klass_hero_web/live/settings/children_live.ex:643
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2234
-#: lib/klass_hero_web/components/provider_components.ex:2263
-#: lib/klass_hero_web/components/provider_components.ex:2279
+#: lib/klass_hero_web/components/provider_components.ex:2261
+#: lib/klass_hero_web/components/provider_components.ex:2290
+#: lib/klass_hero_web/components/provider_components.ex:2306
 #: lib/klass_hero_web/live/settings/children_live.ex:649
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -2080,8 +2080,8 @@ msgstr ""
 msgid "Save Changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1563
-#: lib/klass_hero_web/components/provider_components.ex:1564
+#: lib/klass_hero_web/components/provider_components.ex:1590
+#: lib/klass_hero_web/components/provider_components.ex:1591
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:43
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:151
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:252
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "Send a message to start the conversation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2333
+#: lib/klass_hero_web/components/provider_components.ex:2360
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:245
 #, elixir-autogen, elixir-format, fuzzy
@@ -2235,7 +2235,7 @@ msgstr ""
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2392
+#: lib/klass_hero_web/components/provider_components.ex:2419
 #, elixir-autogen, elixir-format, fuzzy
 msgid "An unexpected error occurred during import."
 msgstr ""
@@ -2335,8 +2335,8 @@ msgstr ""
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1921
-#: lib/klass_hero_web/components/provider_components.ex:2147
+#: lib/klass_hero_web/components/provider_components.ex:1948
+#: lib/klass_hero_web/components/provider_components.ex:2174
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2381,7 +2381,7 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2353
+#: lib/klass_hero_web/components/provider_components.ex:2380
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
@@ -2391,12 +2391,12 @@ msgstr ""
 msgid "Contact Provider"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:444
+#: lib/klass_hero_web/live/provider/programs_live.ex:447
 #, elixir-autogen, elixir-format
 msgid "Could not read the uploaded file."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:412
+#: lib/klass_hero_web/live/provider/programs_live.ex:415
 #, elixir-autogen, elixir-format
 msgid "Could not remove invite."
 msgstr ""
@@ -2430,7 +2430,7 @@ msgstr ""
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2490
+#: lib/klass_hero_web/components/provider_components.ex:2517
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2464,7 +2464,7 @@ msgstr ""
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2114
+#: lib/klass_hero_web/components/provider_components.ex:2141
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
@@ -2495,14 +2495,14 @@ msgstr ""
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1927
-#: lib/klass_hero_web/components/provider_components.ex:2373
+#: lib/klass_hero_web/components/provider_components.ex:1954
+#: lib/klass_hero_web/components/provider_components.ex:2400
 #: lib/klass_hero_web/components/provider_layout_components.ex:644
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrolled"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1609
+#: lib/klass_hero_web/components/provider_components.ex:1636
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr ""
@@ -2518,7 +2518,7 @@ msgid "Explain why this document is being rejected..."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:70
-#: lib/klass_hero_web/components/provider_components.ex:2374
+#: lib/klass_hero_web/components/provider_components.ex:2401
 #: lib/klass_hero_web/live/admin/emails_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2534,7 +2534,7 @@ msgstr ""
 msgid "Failed to reject document."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:394
+#: lib/klass_hero_web/live/provider/programs_live.ex:397
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to resend invite."
 msgstr ""
@@ -2562,12 +2562,12 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2424
+#: lib/klass_hero_web/components/provider_components.ex:2451
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2426
+#: lib/klass_hero_web/components/provider_components.ex:2453
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
@@ -2602,7 +2602,7 @@ msgstr ""
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2150
+#: lib/klass_hero_web/components/provider_components.ex:2177
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
@@ -2617,7 +2617,7 @@ msgstr ""
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2087
+#: lib/klass_hero_web/components/provider_components.ex:2114
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import"
 msgstr ""
@@ -2627,22 +2627,22 @@ msgstr ""
 msgid "Insurance Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:409
+#: lib/klass_hero_web/live/provider/programs_live.ex:412
 #, elixir-autogen, elixir-format
 msgid "Invite not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:406
+#: lib/klass_hero_web/live/provider/programs_live.ex:409
 #, elixir-autogen, elixir-format
 msgid "Invite removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:383
+#: lib/klass_hero_web/live/provider/programs_live.ex:386
 #, elixir-autogen, elixir-format
 msgid "Invite resent successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1626
+#: lib/klass_hero_web/components/provider_components.ex:1653
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr ""
@@ -2743,18 +2743,18 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2452
+#: lib/klass_hero_web/components/provider_components.ex:2479
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1914
+#: lib/klass_hero_web/components/provider_components.ex:1941
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:425
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:440
+#: lib/klass_hero_web/live/provider/programs_live.ex:443
 #, elixir-autogen, elixir-format
 msgid "No file selected."
 msgstr ""
@@ -2764,7 +2764,7 @@ msgstr ""
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2138
+#: lib/klass_hero_web/components/provider_components.ex:2165
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
@@ -2827,7 +2827,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2527
+#: lib/klass_hero_web/components/provider_components.ex:2554
 #: lib/klass_hero_web/live/provider/verification_live.ex:698
 #: lib/klass_hero_web/live/provider/verification_live.ex:770
 #, elixir-autogen, elixir-format
@@ -2854,8 +2854,8 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:106
-#: lib/klass_hero_web/live/provider/programs_live.ex:686
-#: lib/klass_hero_web/live/provider/programs_live.ex:752
+#: lib/klass_hero_web/live/provider/programs_live.ex:689
+#: lib/klass_hero_web/live/provider/programs_live.ex:755
 #: lib/klass_hero_web/live/provider/team_live.ex:256
 #: lib/klass_hero_web/live/provider/team_live.ex:299
 #: lib/klass_hero_web/live/provider/team_live.ex:418
@@ -2888,26 +2888,26 @@ msgstr ""
 msgid "Program Start"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1078
+#: lib/klass_hero_web/live/provider/programs_live.ex:1100
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program created successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1085
+#: lib/klass_hero_web/live/provider/programs_live.ex:1107
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:54
-#: lib/klass_hero_web/live/provider/programs_live.ex:150
-#: lib/klass_hero_web/live/provider/programs_live.ex:187
-#: lib/klass_hero_web/live/provider/programs_live.ex:251
-#: lib/klass_hero_web/live/provider/programs_live.ex:727
+#: lib/klass_hero_web/live/provider/programs_live.ex:151
+#: lib/klass_hero_web/live/provider/programs_live.ex:188
+#: lib/klass_hero_web/live/provider/programs_live.ex:252
+#: lib/klass_hero_web/live/provider/programs_live.ex:730
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:716
+#: lib/klass_hero_web/live/provider/programs_live.ex:719
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program updated successfully."
 msgstr ""
@@ -2925,7 +2925,7 @@ msgid "Read our founding story →"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:805
-#: lib/klass_hero_web/components/provider_components.ex:2372
+#: lib/klass_hero_web/components/provider_components.ex:2399
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registered"
@@ -3007,16 +3007,16 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:767
 #: lib/klass_hero_web/components/provider_components.ex:1166
-#: lib/klass_hero_web/components/provider_components.ex:2194
-#: lib/klass_hero_web/components/provider_components.ex:2546
-#: lib/klass_hero_web/components/provider_components.ex:2625
+#: lib/klass_hero_web/components/provider_components.ex:2221
+#: lib/klass_hero_web/components/provider_components.ex:2573
+#: lib/klass_hero_web/components/provider_components.ex:2652
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:253
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2187
+#: lib/klass_hero_web/components/provider_components.ex:2214
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -3031,7 +3031,7 @@ msgstr ""
 msgid "Role"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1555
+#: lib/klass_hero_web/components/provider_components.ex:1582
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
@@ -3057,7 +3057,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2524
+#: lib/klass_hero_web/components/provider_components.ex:2551
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select File"
 msgstr ""
@@ -3068,13 +3068,13 @@ msgstr ""
 msgid "Selected child does not meet the program requirements."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:676
-#: lib/klass_hero_web/live/provider/programs_live.ex:742
+#: lib/klass_hero_web/live/provider/programs_live.ex:679
+#: lib/klass_hero_web/live/provider/programs_live.ex:745
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2371
+#: lib/klass_hero_web/components/provider_components.ex:2398
 #: lib/klass_hero_web/live/admin/emails_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Sent"
@@ -3169,12 +3169,12 @@ msgstr ""
 msgid "The Klass Hero Story"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:386
+#: lib/klass_hero_web/live/provider/programs_live.ex:389
 #, elixir-autogen, elixir-format
 msgid "This invite cannot be resent."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:734
+#: lib/klass_hero_web/live/provider/programs_live.ex:737
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
@@ -3184,7 +3184,7 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2425
+#: lib/klass_hero_web/components/provider_components.ex:2452
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -3204,32 +3204,32 @@ msgstr ""
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2073
+#: lib/klass_hero_web/components/provider_components.ex:2100
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2570
+#: lib/klass_hero_web/components/provider_components.ex:2597
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2479
+#: lib/klass_hero_web/components/provider_components.ex:2506
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2447
+#: lib/klass_hero_web/components/provider_components.ex:2474
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2427
+#: lib/klass_hero_web/components/provider_components.ex:2454
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2444
+#: lib/klass_hero_web/components/provider_components.ex:2471
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -3319,7 +3319,7 @@ msgid "Child Safeguarding Training"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1498
-#: lib/klass_hero_web/components/provider_components.ex:2792
+#: lib/klass_hero_web/components/provider_components.ex:2819
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr ""
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Program fee:"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:918
+#: lib/klass_hero_web/live/provider/programs_live.ex:938
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr ""
@@ -3469,7 +3469,7 @@ msgid "Vetted with Care"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1482
-#: lib/klass_hero_web/components/provider_components.ex:2577
+#: lib/klass_hero_web/components/provider_components.ex:2604
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr ""
@@ -3605,7 +3605,7 @@ msgstr ""
 msgid "Cannot check out without a check-in"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:358
+#: lib/klass_hero_web/live/provider/programs_live.ex:361
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:146
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
@@ -3643,7 +3643,7 @@ msgstr ""
 msgid "Checked Out"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2230
+#: lib/klass_hero_web/components/provider_components.ex:2257
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Child"
@@ -3670,7 +3670,7 @@ msgid "Correct"
 msgstr ""
 
 #: lib/klass_hero_web/live/dashboard_live.ex:301
-#: lib/klass_hero_web/live/provider/programs_live.ex:355
+#: lib/klass_hero_web/live/provider/programs_live.ex:358
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "Could not start conversation. Please try again."
@@ -3696,7 +3696,7 @@ msgstr ""
 msgid "Download monthly statements for taxes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1991
+#: lib/klass_hero_web/components/provider_components.ex:2018
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:482
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrollment not confirmed"
@@ -3774,7 +3774,7 @@ msgstr ""
 msgid "No chasing payments or sending invoices"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1578
+#: lib/klass_hero_web/components/provider_components.ex:1605
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:406
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No enrolled parents"
@@ -3797,7 +3797,7 @@ msgstr ""
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1990
+#: lib/klass_hero_web/components/provider_components.ex:2017
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:481
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -4427,7 +4427,7 @@ msgstr ""
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:24
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
-#: lib/klass_hero_web/live/provider/programs_live.ex:219
+#: lib/klass_hero_web/live/provider/programs_live.ex:220
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:156
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program"
@@ -4636,7 +4636,7 @@ msgid "Update your observation..."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:138
-#: lib/klass_hero_web/live/provider/programs_live.ex:437
+#: lib/klass_hero_web/live/provider/programs_live.ex:440
 #: lib/klass_hero_web/live/provider/verification_live.ex:240
 #: lib/klass_hero_web/live/provider/verification_live.ex:556
 #: lib/klass_hero_web/live/provider/verification_live.ex:594
@@ -4905,48 +4905,48 @@ msgstr ""
 msgid "for"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1699
+#: lib/klass_hero_web/components/provider_components.ex:1726
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assigned staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1701
+#: lib/klass_hero_web/components/provider_components.ex:1728
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1683
-#: lib/klass_hero_web/components/provider_components.ex:1772
+#: lib/klass_hero_web/components/provider_components.ex:1710
+#: lib/klass_hero_web/components/provider_components.ex:1799
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Close"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1700
+#: lib/klass_hero_web/components/provider_components.ex:1727
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1698
+#: lib/klass_hero_web/components/provider_components.ex:1725
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1692
+#: lib/klass_hero_web/components/provider_components.ex:1719
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No sessions scheduled yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1681
+#: lib/klass_hero_web/components/provider_components.ex:1708
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sessions — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1421
+#: lib/klass_hero_web/components/provider_components.ex:1448
 #, elixir-autogen, elixir-format
 msgid "View sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:528
+#: lib/klass_hero_web/live/provider/programs_live.ex:531
 #, elixir-autogen, elixir-format
 msgid "Create a program before inviting participants."
 msgstr ""
@@ -4973,22 +4973,22 @@ msgstr ""
 msgid "Failed to update record"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2294
+#: lib/klass_hero_web/components/provider_components.ex:2321
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2013
+#: lib/klass_hero_web/components/provider_components.ex:2040
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invite mode"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2032
+#: lib/klass_hero_web/components/provider_components.ex:2059
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:524
+#: lib/klass_hero_web/live/provider/programs_live.ex:527
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invite sent."
 msgstr ""
@@ -4998,12 +4998,12 @@ msgstr ""
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2307
+#: lib/klass_hero_web/components/provider_components.ex:2334
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2313
+#: lib/klass_hero_web/components/provider_components.ex:2340
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr ""
@@ -5014,17 +5014,17 @@ msgstr ""
 msgid "Nothing to update"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2315
+#: lib/klass_hero_web/components/provider_components.ex:2342
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nut allergy"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2319
+#: lib/klass_hero_web/components/provider_components.ex:2346
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2324
+#: lib/klass_hero_web/components/provider_components.ex:2351
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr ""
@@ -5034,7 +5034,7 @@ msgstr ""
 msgid "Present"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2251
+#: lib/klass_hero_web/components/provider_components.ex:2278
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr ""
@@ -5061,22 +5061,22 @@ msgstr ""
 msgid "Save changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2288
+#: lib/klass_hero_web/components/provider_components.ex:2315
 #, elixir-autogen, elixir-format, fuzzy
 msgid "School (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2298
+#: lib/klass_hero_web/components/provider_components.ex:2325
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2272
+#: lib/klass_hero_web/components/provider_components.ex:2299
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2341
+#: lib/klass_hero_web/components/provider_components.ex:2368
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Send invite"
 msgstr ""
@@ -5086,12 +5086,12 @@ msgstr ""
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2050
+#: lib/klass_hero_web/components/provider_components.ex:2077
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload a list"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:535
+#: lib/klass_hero_web/live/provider/programs_live.ex:538
 #, elixir-autogen, elixir-format
 msgid "An invite for this child and program already exists."
 msgstr ""
@@ -5186,7 +5186,7 @@ msgstr ""
 msgid "Property Damage"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1451
+#: lib/klass_hero_web/components/provider_components.ex:1478
 #, elixir-autogen, elixir-format
 msgid "Report Incident"
 msgstr ""
@@ -5268,7 +5268,7 @@ msgstr ""
 msgid "Go to dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:480
+#: lib/klass_hero_web/live/provider/programs_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "%{count} row could not be processed."
 msgid_plural "%{count} rows could not be processed."
@@ -5855,8 +5855,8 @@ msgstr ""
 msgid "I'll be teaching"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:455
-#: lib/klass_hero_web/live/provider/programs_live.ex:477
+#: lib/klass_hero_web/live/provider/programs_live.ex:458
+#: lib/klass_hero_web/live/provider/programs_live.ex:480
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Imported %{count} family."
 msgid_plural "Imported %{count} families."
@@ -5868,7 +5868,7 @@ msgstr[1] ""
 msgid "In 2025, Shane connected with his friend"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1460
+#: lib/klass_hero_web/components/provider_components.ex:1487
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:43
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:74
 #, elixir-autogen, elixir-format
@@ -6145,7 +6145,7 @@ msgstr ""
 msgid "No registered children for this session."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:464
+#: lib/klass_hero_web/live/provider/programs_live.ex:467
 #, elixir-autogen, elixir-format
 msgid "No rows imported. %{count} row could not be processed."
 msgid_plural "No rows imported. %{count} rows could not be processed."
@@ -6388,17 +6388,17 @@ msgstr ""
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2380
+#: lib/klass_hero_web/components/provider_components.ex:2407
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Row %{row}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2380
+#: lib/klass_hero_web/components/provider_components.ex:2407
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2126
+#: lib/klass_hero_web/components/provider_components.ex:2153
 #, elixir-autogen, elixir-format
 msgid "Rows with errors"
 msgstr ""
@@ -7157,12 +7157,12 @@ msgstr ""
 msgid "Experience validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2606
+#: lib/klass_hero_web/components/provider_components.ex:2633
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2580
+#: lib/klass_hero_web/components/provider_components.ex:2607
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
@@ -7172,12 +7172,12 @@ msgstr ""
 msgid "Safeguarding certificate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2603
+#: lib/klass_hero_web/components/provider_components.ex:2630
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select Video"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2649
+#: lib/klass_hero_web/components/provider_components.ex:2676
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload Video"
 msgstr ""
@@ -7187,7 +7187,7 @@ msgstr ""
 msgid "Your browser does not support video playback."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2796
+#: lib/klass_hero_web/components/provider_components.ex:2823
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Confirm agreement"
 msgstr ""
@@ -7197,12 +7197,12 @@ msgstr ""
 msgid "Couldn't record your agreement. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2819
+#: lib/klass_hero_web/components/provider_components.ex:2846
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2795
+#: lib/klass_hero_web/components/provider_components.ex:2822
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr ""
@@ -7212,7 +7212,7 @@ msgstr ""
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2704
+#: lib/klass_hero_web/components/provider_components.ex:2731
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr ""
@@ -7222,17 +7222,17 @@ msgstr ""
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2804
+#: lib/klass_hero_web/components/provider_components.ex:2831
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2793
+#: lib/klass_hero_web/components/provider_components.ex:2820
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2794
+#: lib/klass_hero_web/components/provider_components.ex:2821
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
@@ -7501,12 +7501,12 @@ msgstr ""
 msgid "Your insurance is verified."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2748
+#: lib/klass_hero_web/components/provider_components.ex:2775
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2851
+#: lib/klass_hero_web/components/provider_components.ex:2878
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr ""
@@ -7516,7 +7516,7 @@ msgstr ""
 msgid "Couldn't record your declaration. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2857
+#: lib/klass_hero_web/components/provider_components.ex:2884
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr ""
@@ -7526,17 +7526,17 @@ msgstr ""
 msgid "Please confirm the declaration before signing."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2882
+#: lib/klass_hero_web/components/provider_components.ex:2909
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2861
+#: lib/klass_hero_web/components/provider_components.ex:2888
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2849
+#: lib/klass_hero_web/components/provider_components.ex:2876
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr ""
@@ -7546,12 +7546,12 @@ msgstr ""
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2869
+#: lib/klass_hero_web/components/provider_components.ex:2896
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2855
+#: lib/klass_hero_web/components/provider_components.ex:2882
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
@@ -7618,87 +7618,94 @@ msgstr ""
 msgid "Undelivered Events"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1869
+#: lib/klass_hero_web/components/provider_components.ex:1896
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1794
+#: lib/klass_hero_web/components/provider_components.ex:1821
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Lead"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:330
+#: lib/klass_hero_web/live/provider/programs_live.ex:333
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Lead instructor updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1805
+#: lib/klass_hero_web/components/provider_components.ex:1832
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1435
+#: lib/klass_hero_web/components/provider_components.ex:1462
 #, elixir-autogen, elixir-format
 msgid "Manage Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1833
+#: lib/klass_hero_web/components/provider_components.ex:1860
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this program yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:262
+#: lib/klass_hero_web/live/provider/programs_live.ex:263
 #, elixir-autogen, elixir-format
 msgid "Pick a staff member to add."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1816
+#: lib/klass_hero_web/components/provider_components.ex:1843
 #, elixir-autogen, elixir-format
 msgid "Reassign the lead before removing them"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1817
+#: lib/klass_hero_web/components/provider_components.ex:1844
 #, elixir-autogen, elixir-format
 msgid "Remove from program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1851
+#: lib/klass_hero_web/components/provider_components.ex:1878
 #, elixir-autogen, elixir-format
 msgid "Select a staff member…"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:276
+#: lib/klass_hero_web/live/provider/programs_live.ex:278
 #, elixir-autogen, elixir-format
 msgid "Staff member added to the program."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:301
+#: lib/klass_hero_web/live/provider/programs_live.ex:304
 #, elixir-autogen, elixir-format
 msgid "Staff member removed from the program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1874
+#: lib/klass_hero_web/components/provider_components.ex:1901
 #, elixir-autogen, elixir-format
 msgid "Staff you add can read and reply to this program's parent conversations."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1770
+#: lib/klass_hero_web/components/provider_components.ex:1797
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Staffing — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:879
+#: lib/klass_hero_web/live/provider/programs_live.ex:897
 #, elixir-autogen, elixir-format
 msgid "That staff member could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:284
+#: lib/klass_hero_web/live/provider/programs_live.ex:286
 #, elixir-autogen, elixir-format
 msgid "They are already on this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:309
+#: lib/klass_hero_web/live/provider/programs_live.ex:312
 #, elixir-autogen, elixir-format
 msgid "This person is the lead instructor. Make someone else lead before removing them."
 msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1406
+#, elixir-autogen, elixir-format
+msgid "%{count} staff member · no lead"
+msgid_plural "%{count} staff · no lead"
+msgstr[0] ""
+msgstr[1] ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -137,7 +137,7 @@ msgid "Your Data"
 msgstr ""
 
 #: lib/klass_hero_web/components/core_components.ex:67
-#: lib/klass_hero_web/components/provider_components.ex:1612
+#: lib/klass_hero_web/components/provider_components.ex:1615
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr ""
@@ -232,7 +232,7 @@ msgstr ""
 msgid "Enroll Now - %{price}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1363
+#: lib/klass_hero_web/components/provider_components.ex:1366
 #: lib/klass_hero_web/live/booking_live.ex:285
 #, elixir-autogen, elixir-format
 msgid "Enrollment"
@@ -578,8 +578,8 @@ msgid "Dispute Resolution"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:647
-#: lib/klass_hero_web/components/provider_components.ex:2285
-#: lib/klass_hero_web/components/provider_components.ex:2303
+#: lib/klass_hero_web/components/provider_components.ex:2288
+#: lib/klass_hero_web/components/provider_components.ex:2306
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
@@ -878,9 +878,9 @@ msgstr ""
 msgid "Select one or both options"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1981
-#: lib/klass_hero_web/components/provider_components.ex:1982
-#: lib/klass_hero_web/components/provider_components.ex:2019
+#: lib/klass_hero_web/components/provider_components.ex:1984
+#: lib/klass_hero_web/components/provider_components.ex:1985
+#: lib/klass_hero_web/components/provider_components.ex:2022
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:446
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:483
@@ -1577,14 +1577,14 @@ msgstr ""
 msgid "Quick Navigation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1366
-#: lib/klass_hero_web/components/provider_components.ex:1957
-#: lib/klass_hero_web/components/provider_components.ex:2183
+#: lib/klass_hero_web/components/provider_components.ex:1369
+#: lib/klass_hero_web/components/provider_components.ex:1960
+#: lib/klass_hero_web/components/provider_components.ex:2186
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1505
+#: lib/klass_hero_web/components/provider_components.ex:1508
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Active"
 msgstr ""
@@ -1600,7 +1600,7 @@ msgstr ""
 msgid "All Staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1357
+#: lib/klass_hero_web/components/provider_components.ex:1360
 #, elixir-autogen, elixir-format
 msgid "Assigned Staff"
 msgstr ""
@@ -1628,7 +1628,7 @@ msgid "Create profiles for your staff. These will be visible to parents when ass
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:538
-#: lib/klass_hero_web/components/provider_components.ex:1468
+#: lib/klass_hero_web/components/provider_components.ex:1471
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:54
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:81
 #: lib/klass_hero_web/live/settings/children_live.ex:448
@@ -1645,7 +1645,7 @@ msgstr ""
 msgid "Edit Profile"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1507
+#: lib/klass_hero_web/components/provider_components.ex:1510
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr ""
@@ -1669,16 +1669,16 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:46
 #: lib/klass_hero_web/components/provider_components.ex:72
-#: lib/klass_hero_web/components/provider_components.ex:1506
-#: lib/klass_hero_web/components/provider_components.ex:2379
-#: lib/klass_hero_web/components/provider_components.ex:2397
+#: lib/klass_hero_web/components/provider_components.ex:1509
+#: lib/klass_hero_web/components/provider_components.ex:2382
+#: lib/klass_hero_web/components/provider_components.ex:2400
 #: lib/klass_hero_web/live/admin/sessions_live.ex:297
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1444
+#: lib/klass_hero_web/components/provider_components.ex:1447
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
@@ -1688,7 +1688,7 @@ msgstr ""
 msgid "Program Inventory"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1354
+#: lib/klass_hero_web/components/provider_components.ex:1357
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program Name"
 msgstr ""
@@ -1703,15 +1703,15 @@ msgstr ""
 msgid "Save for Later"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1312
+#: lib/klass_hero_web/components/provider_components.ex:1317
 #, elixir-autogen, elixir-format
 msgid "Search by name..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1360
-#: lib/klass_hero_web/components/provider_components.ex:1729
-#: lib/klass_hero_web/components/provider_components.ex:1951
-#: lib/klass_hero_web/components/provider_components.ex:2180
+#: lib/klass_hero_web/components/provider_components.ex:1363
+#: lib/klass_hero_web/components/provider_components.ex:1732
+#: lib/klass_hero_web/components/provider_components.ex:1954
+#: lib/klass_hero_web/components/provider_components.ex:2183
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1735,15 +1735,15 @@ msgstr ""
 msgid "This is your main business identity. Verification is required to list programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1417
-#: lib/klass_hero_web/components/provider_components.ex:1744
+#: lib/klass_hero_web/components/provider_components.ex:1420
+#: lib/klass_hero_web/components/provider_components.ex:1747
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr ""
 
 #: lib/klass_hero_web/components/messaging_components.ex:728
 #: lib/klass_hero_web/components/provider_components.ex:49
-#: lib/klass_hero_web/components/provider_components.ex:1508
+#: lib/klass_hero_web/components/provider_components.ex:1511
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:433
 #: lib/klass_hero_web/presenters/provider_presenter.ex:103
 #, elixir-autogen, elixir-format
@@ -1755,7 +1755,7 @@ msgstr ""
 msgid "Verified Business"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1455
+#: lib/klass_hero_web/components/provider_components.ex:1458
 #, elixir-autogen, elixir-format
 msgid "View Roster"
 msgstr ""
@@ -1817,7 +1817,7 @@ msgstr ""
 #: lib/klass_hero_web/components/participation_components.ex:717
 #: lib/klass_hero_web/components/provider_components.ex:817
 #: lib/klass_hero_web/components/provider_components.ex:1216
-#: lib/klass_hero_web/components/provider_components.ex:2122
+#: lib/klass_hero_web/components/provider_components.ex:2125
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:478
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
@@ -1883,7 +1883,7 @@ msgstr ""
 msgid "Data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2266
+#: lib/klass_hero_web/components/provider_components.ex:2269
 #: lib/klass_hero_web/live/settings/children_live.ex:657
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1931,17 +1931,17 @@ msgstr ""
 msgid "Failed to submit note"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2260
-#: lib/klass_hero_web/components/provider_components.ex:2289
-#: lib/klass_hero_web/components/provider_components.ex:2305
+#: lib/klass_hero_web/components/provider_components.ex:2263
+#: lib/klass_hero_web/components/provider_components.ex:2292
+#: lib/klass_hero_web/components/provider_components.ex:2308
 #: lib/klass_hero_web/live/settings/children_live.ex:643
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2261
-#: lib/klass_hero_web/components/provider_components.ex:2290
-#: lib/klass_hero_web/components/provider_components.ex:2306
+#: lib/klass_hero_web/components/provider_components.ex:2264
+#: lib/klass_hero_web/components/provider_components.ex:2293
+#: lib/klass_hero_web/components/provider_components.ex:2309
 #: lib/klass_hero_web/live/settings/children_live.ex:649
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -2080,8 +2080,8 @@ msgstr ""
 msgid "Save Changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1590
-#: lib/klass_hero_web/components/provider_components.ex:1591
+#: lib/klass_hero_web/components/provider_components.ex:1593
+#: lib/klass_hero_web/components/provider_components.ex:1594
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:43
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:151
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:252
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "Send a message to start the conversation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2360
+#: lib/klass_hero_web/components/provider_components.ex:2363
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:245
 #, elixir-autogen, elixir-format, fuzzy
@@ -2235,7 +2235,7 @@ msgstr ""
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2419
+#: lib/klass_hero_web/components/provider_components.ex:2422
 #, elixir-autogen, elixir-format, fuzzy
 msgid "An unexpected error occurred during import."
 msgstr ""
@@ -2335,8 +2335,8 @@ msgstr ""
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1948
-#: lib/klass_hero_web/components/provider_components.ex:2174
+#: lib/klass_hero_web/components/provider_components.ex:1951
+#: lib/klass_hero_web/components/provider_components.ex:2177
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2381,7 +2381,7 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2380
+#: lib/klass_hero_web/components/provider_components.ex:2383
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
@@ -2430,7 +2430,7 @@ msgstr ""
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2517
+#: lib/klass_hero_web/components/provider_components.ex:2520
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2464,7 +2464,7 @@ msgstr ""
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2141
+#: lib/klass_hero_web/components/provider_components.ex:2144
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
@@ -2495,14 +2495,14 @@ msgstr ""
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1954
-#: lib/klass_hero_web/components/provider_components.ex:2400
+#: lib/klass_hero_web/components/provider_components.ex:1957
+#: lib/klass_hero_web/components/provider_components.ex:2403
 #: lib/klass_hero_web/components/provider_layout_components.ex:644
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrolled"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1636
+#: lib/klass_hero_web/components/provider_components.ex:1639
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr ""
@@ -2518,7 +2518,7 @@ msgid "Explain why this document is being rejected..."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:70
-#: lib/klass_hero_web/components/provider_components.ex:2401
+#: lib/klass_hero_web/components/provider_components.ex:2404
 #: lib/klass_hero_web/live/admin/emails_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2562,12 +2562,12 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2451
+#: lib/klass_hero_web/components/provider_components.ex:2454
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2453
+#: lib/klass_hero_web/components/provider_components.ex:2456
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
@@ -2602,7 +2602,7 @@ msgstr ""
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2177
+#: lib/klass_hero_web/components/provider_components.ex:2180
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
@@ -2617,7 +2617,7 @@ msgstr ""
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2114
+#: lib/klass_hero_web/components/provider_components.ex:2117
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import"
 msgstr ""
@@ -2642,7 +2642,7 @@ msgstr ""
 msgid "Invite resent successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1653
+#: lib/klass_hero_web/components/provider_components.ex:1656
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr ""
@@ -2743,12 +2743,12 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2479
+#: lib/klass_hero_web/components/provider_components.ex:2482
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1941
+#: lib/klass_hero_web/components/provider_components.ex:1944
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:425
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
@@ -2764,7 +2764,7 @@ msgstr ""
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2165
+#: lib/klass_hero_web/components/provider_components.ex:2168
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
@@ -2827,7 +2827,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2554
+#: lib/klass_hero_web/components/provider_components.ex:2557
 #: lib/klass_hero_web/live/provider/verification_live.ex:698
 #: lib/klass_hero_web/live/provider/verification_live.ex:770
 #, elixir-autogen, elixir-format
@@ -2925,7 +2925,7 @@ msgid "Read our founding story →"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:805
-#: lib/klass_hero_web/components/provider_components.ex:2399
+#: lib/klass_hero_web/components/provider_components.ex:2402
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registered"
@@ -3007,16 +3007,16 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:767
 #: lib/klass_hero_web/components/provider_components.ex:1166
-#: lib/klass_hero_web/components/provider_components.ex:2221
-#: lib/klass_hero_web/components/provider_components.ex:2573
-#: lib/klass_hero_web/components/provider_components.ex:2652
+#: lib/klass_hero_web/components/provider_components.ex:2224
+#: lib/klass_hero_web/components/provider_components.ex:2576
+#: lib/klass_hero_web/components/provider_components.ex:2655
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:253
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2214
+#: lib/klass_hero_web/components/provider_components.ex:2217
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -3031,7 +3031,7 @@ msgstr ""
 msgid "Role"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1582
+#: lib/klass_hero_web/components/provider_components.ex:1585
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
@@ -3057,7 +3057,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2551
+#: lib/klass_hero_web/components/provider_components.ex:2554
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select File"
 msgstr ""
@@ -3074,7 +3074,7 @@ msgstr ""
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2398
+#: lib/klass_hero_web/components/provider_components.ex:2401
 #: lib/klass_hero_web/live/admin/emails_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Sent"
@@ -3184,7 +3184,7 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2452
+#: lib/klass_hero_web/components/provider_components.ex:2455
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -3204,32 +3204,32 @@ msgstr ""
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2100
+#: lib/klass_hero_web/components/provider_components.ex:2103
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2597
+#: lib/klass_hero_web/components/provider_components.ex:2600
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2506
+#: lib/klass_hero_web/components/provider_components.ex:2509
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2474
+#: lib/klass_hero_web/components/provider_components.ex:2477
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2454
+#: lib/klass_hero_web/components/provider_components.ex:2457
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2471
+#: lib/klass_hero_web/components/provider_components.ex:2474
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -3319,7 +3319,7 @@ msgid "Child Safeguarding Training"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1498
-#: lib/klass_hero_web/components/provider_components.ex:2819
+#: lib/klass_hero_web/components/provider_components.ex:2822
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr ""
@@ -3469,7 +3469,7 @@ msgid "Vetted with Care"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1482
-#: lib/klass_hero_web/components/provider_components.ex:2604
+#: lib/klass_hero_web/components/provider_components.ex:2607
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr ""
@@ -3643,7 +3643,7 @@ msgstr ""
 msgid "Checked Out"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2257
+#: lib/klass_hero_web/components/provider_components.ex:2260
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Child"
@@ -3696,7 +3696,7 @@ msgstr ""
 msgid "Download monthly statements for taxes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2018
+#: lib/klass_hero_web/components/provider_components.ex:2021
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:482
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrollment not confirmed"
@@ -3774,7 +3774,7 @@ msgstr ""
 msgid "No chasing payments or sending invoices"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1605
+#: lib/klass_hero_web/components/provider_components.ex:1608
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:406
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No enrolled parents"
@@ -3797,7 +3797,7 @@ msgstr ""
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2017
+#: lib/klass_hero_web/components/provider_components.ex:2020
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:481
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -4905,43 +4905,43 @@ msgstr ""
 msgid "for"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1726
+#: lib/klass_hero_web/components/provider_components.ex:1729
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assigned staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1728
+#: lib/klass_hero_web/components/provider_components.ex:1731
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1710
-#: lib/klass_hero_web/components/provider_components.ex:1799
+#: lib/klass_hero_web/components/provider_components.ex:1713
+#: lib/klass_hero_web/components/provider_components.ex:1802
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Close"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1727
+#: lib/klass_hero_web/components/provider_components.ex:1730
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1725
+#: lib/klass_hero_web/components/provider_components.ex:1728
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1719
+#: lib/klass_hero_web/components/provider_components.ex:1722
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No sessions scheduled yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1708
+#: lib/klass_hero_web/components/provider_components.ex:1711
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sessions — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1448
+#: lib/klass_hero_web/components/provider_components.ex:1451
 #, elixir-autogen, elixir-format
 msgid "View sessions"
 msgstr ""
@@ -4973,17 +4973,17 @@ msgstr ""
 msgid "Failed to update record"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2321
+#: lib/klass_hero_web/components/provider_components.ex:2324
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2040
+#: lib/klass_hero_web/components/provider_components.ex:2043
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invite mode"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2059
+#: lib/klass_hero_web/components/provider_components.ex:2062
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr ""
@@ -4998,12 +4998,12 @@ msgstr ""
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2334
+#: lib/klass_hero_web/components/provider_components.ex:2337
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2340
+#: lib/klass_hero_web/components/provider_components.ex:2343
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr ""
@@ -5014,17 +5014,17 @@ msgstr ""
 msgid "Nothing to update"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2342
+#: lib/klass_hero_web/components/provider_components.ex:2345
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nut allergy"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2346
+#: lib/klass_hero_web/components/provider_components.ex:2349
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2351
+#: lib/klass_hero_web/components/provider_components.ex:2354
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr ""
@@ -5034,7 +5034,7 @@ msgstr ""
 msgid "Present"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2278
+#: lib/klass_hero_web/components/provider_components.ex:2281
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr ""
@@ -5061,22 +5061,22 @@ msgstr ""
 msgid "Save changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2315
+#: lib/klass_hero_web/components/provider_components.ex:2318
 #, elixir-autogen, elixir-format, fuzzy
 msgid "School (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2325
+#: lib/klass_hero_web/components/provider_components.ex:2328
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2299
+#: lib/klass_hero_web/components/provider_components.ex:2302
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2368
+#: lib/klass_hero_web/components/provider_components.ex:2371
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Send invite"
 msgstr ""
@@ -5086,7 +5086,7 @@ msgstr ""
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2077
+#: lib/klass_hero_web/components/provider_components.ex:2080
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload a list"
 msgstr ""
@@ -5186,7 +5186,7 @@ msgstr ""
 msgid "Property Damage"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1478
+#: lib/klass_hero_web/components/provider_components.ex:1481
 #, elixir-autogen, elixir-format
 msgid "Report Incident"
 msgstr ""
@@ -5868,7 +5868,7 @@ msgstr[1] ""
 msgid "In 2025, Shane connected with his friend"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1487
+#: lib/klass_hero_web/components/provider_components.ex:1490
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:43
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:74
 #, elixir-autogen, elixir-format
@@ -6388,17 +6388,17 @@ msgstr ""
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2407
+#: lib/klass_hero_web/components/provider_components.ex:2410
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Row %{row}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2407
+#: lib/klass_hero_web/components/provider_components.ex:2410
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2153
+#: lib/klass_hero_web/components/provider_components.ex:2156
 #, elixir-autogen, elixir-format
 msgid "Rows with errors"
 msgstr ""
@@ -7157,12 +7157,12 @@ msgstr ""
 msgid "Experience validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2633
+#: lib/klass_hero_web/components/provider_components.ex:2636
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2607
+#: lib/klass_hero_web/components/provider_components.ex:2610
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
@@ -7172,12 +7172,12 @@ msgstr ""
 msgid "Safeguarding certificate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2630
+#: lib/klass_hero_web/components/provider_components.ex:2633
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select Video"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2676
+#: lib/klass_hero_web/components/provider_components.ex:2679
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload Video"
 msgstr ""
@@ -7187,7 +7187,7 @@ msgstr ""
 msgid "Your browser does not support video playback."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2823
+#: lib/klass_hero_web/components/provider_components.ex:2826
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Confirm agreement"
 msgstr ""
@@ -7197,12 +7197,12 @@ msgstr ""
 msgid "Couldn't record your agreement. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2846
+#: lib/klass_hero_web/components/provider_components.ex:2849
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2822
+#: lib/klass_hero_web/components/provider_components.ex:2825
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr ""
@@ -7212,7 +7212,7 @@ msgstr ""
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2731
+#: lib/klass_hero_web/components/provider_components.ex:2734
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr ""
@@ -7222,17 +7222,17 @@ msgstr ""
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2831
+#: lib/klass_hero_web/components/provider_components.ex:2834
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2820
+#: lib/klass_hero_web/components/provider_components.ex:2823
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2821
+#: lib/klass_hero_web/components/provider_components.ex:2824
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
@@ -7501,12 +7501,12 @@ msgstr ""
 msgid "Your insurance is verified."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2775
+#: lib/klass_hero_web/components/provider_components.ex:2778
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2878
+#: lib/klass_hero_web/components/provider_components.ex:2881
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr ""
@@ -7516,7 +7516,7 @@ msgstr ""
 msgid "Couldn't record your declaration. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2884
+#: lib/klass_hero_web/components/provider_components.ex:2887
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr ""
@@ -7526,17 +7526,17 @@ msgstr ""
 msgid "Please confirm the declaration before signing."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2909
+#: lib/klass_hero_web/components/provider_components.ex:2912
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2888
+#: lib/klass_hero_web/components/provider_components.ex:2891
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2876
+#: lib/klass_hero_web/components/provider_components.ex:2879
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr ""
@@ -7546,12 +7546,12 @@ msgstr ""
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2896
+#: lib/klass_hero_web/components/provider_components.ex:2899
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2882
+#: lib/klass_hero_web/components/provider_components.ex:2885
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
@@ -7618,12 +7618,12 @@ msgstr ""
 msgid "Undelivered Events"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1896
+#: lib/klass_hero_web/components/provider_components.ex:1899
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1821
+#: lib/klass_hero_web/components/provider_components.ex:1824
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Lead"
 msgstr ""
@@ -7633,17 +7633,17 @@ msgstr ""
 msgid "Lead instructor updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1832
+#: lib/klass_hero_web/components/provider_components.ex:1835
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1462
+#: lib/klass_hero_web/components/provider_components.ex:1465
 #, elixir-autogen, elixir-format
 msgid "Manage Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1860
+#: lib/klass_hero_web/components/provider_components.ex:1863
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this program yet."
 msgstr ""
@@ -7653,17 +7653,17 @@ msgstr ""
 msgid "Pick a staff member to add."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1843
+#: lib/klass_hero_web/components/provider_components.ex:1846
 #, elixir-autogen, elixir-format
 msgid "Reassign the lead before removing them"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1844
+#: lib/klass_hero_web/components/provider_components.ex:1847
 #, elixir-autogen, elixir-format
 msgid "Remove from program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1878
+#: lib/klass_hero_web/components/provider_components.ex:1881
 #, elixir-autogen, elixir-format
 msgid "Select a staff member…"
 msgstr ""
@@ -7678,12 +7678,12 @@ msgstr ""
 msgid "Staff member removed from the program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1901
+#: lib/klass_hero_web/components/provider_components.ex:1904
 #, elixir-autogen, elixir-format
 msgid "Staff you add can read and reply to this program's parent conversations."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1797
+#: lib/klass_hero_web/components/provider_components.ex:1800
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Staffing — %{title}"
 msgstr ""
@@ -7703,7 +7703,7 @@ msgstr ""
 msgid "This person is the lead instructor. Make someone else lead before removing them."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1406
+#: lib/klass_hero_web/components/provider_components.ex:1409
 #, elixir-autogen, elixir-format
 msgid "%{count} staff member · no lead"
 msgid_plural "%{count} staff · no lead"

--- a/priv/gettext/en/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/en/LC_MESSAGES/enrollment.po
@@ -11,62 +11,62 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:2428
+#: lib/klass_hero_web/components/provider_components.ex:2431
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2429
+#: lib/klass_hero_web/components/provider_components.ex:2432
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2430
+#: lib/klass_hero_web/components/provider_components.ex:2433
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2441
+#: lib/klass_hero_web/components/provider_components.ex:2444
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2431
+#: lib/klass_hero_web/components/provider_components.ex:2434
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2432
+#: lib/klass_hero_web/components/provider_components.ex:2435
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2433
+#: lib/klass_hero_web/components/provider_components.ex:2436
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2440
+#: lib/klass_hero_web/components/provider_components.ex:2443
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2442
+#: lib/klass_hero_web/components/provider_components.ex:2445
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2434
+#: lib/klass_hero_web/components/provider_components.ex:2437
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2436
+#: lib/klass_hero_web/components/provider_components.ex:2439
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2438
+#: lib/klass_hero_web/components/provider_components.ex:2441
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/en/LC_MESSAGES/enrollment.po
@@ -11,62 +11,62 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:2401
+#: lib/klass_hero_web/components/provider_components.ex:2428
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2402
+#: lib/klass_hero_web/components/provider_components.ex:2429
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2403
+#: lib/klass_hero_web/components/provider_components.ex:2430
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2414
+#: lib/klass_hero_web/components/provider_components.ex:2441
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2404
+#: lib/klass_hero_web/components/provider_components.ex:2431
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2405
+#: lib/klass_hero_web/components/provider_components.ex:2432
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2406
+#: lib/klass_hero_web/components/provider_components.ex:2433
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2413
+#: lib/klass_hero_web/components/provider_components.ex:2440
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2415
+#: lib/klass_hero_web/components/provider_components.ex:2442
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2407
+#: lib/klass_hero_web/components/provider_components.ex:2434
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2409
+#: lib/klass_hero_web/components/provider_components.ex:2436
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2411
+#: lib/klass_hero_web/components/provider_components.ex:2438
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""

--- a/priv/gettext/enrollment.pot
+++ b/priv/gettext/enrollment.pot
@@ -11,62 +11,62 @@
 msgid ""
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2401
+#: lib/klass_hero_web/components/provider_components.ex:2428
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2402
+#: lib/klass_hero_web/components/provider_components.ex:2429
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2403
+#: lib/klass_hero_web/components/provider_components.ex:2430
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2414
+#: lib/klass_hero_web/components/provider_components.ex:2441
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2404
+#: lib/klass_hero_web/components/provider_components.ex:2431
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2405
+#: lib/klass_hero_web/components/provider_components.ex:2432
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2406
+#: lib/klass_hero_web/components/provider_components.ex:2433
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2413
+#: lib/klass_hero_web/components/provider_components.ex:2440
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2415
+#: lib/klass_hero_web/components/provider_components.ex:2442
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2407
+#: lib/klass_hero_web/components/provider_components.ex:2434
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2409
+#: lib/klass_hero_web/components/provider_components.ex:2436
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2411
+#: lib/klass_hero_web/components/provider_components.ex:2438
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""

--- a/priv/gettext/enrollment.pot
+++ b/priv/gettext/enrollment.pot
@@ -11,62 +11,62 @@
 msgid ""
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2428
+#: lib/klass_hero_web/components/provider_components.ex:2431
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2429
+#: lib/klass_hero_web/components/provider_components.ex:2432
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2430
+#: lib/klass_hero_web/components/provider_components.ex:2433
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2441
+#: lib/klass_hero_web/components/provider_components.ex:2444
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2431
+#: lib/klass_hero_web/components/provider_components.ex:2434
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2432
+#: lib/klass_hero_web/components/provider_components.ex:2435
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2433
+#: lib/klass_hero_web/components/provider_components.ex:2436
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2440
+#: lib/klass_hero_web/components/provider_components.ex:2443
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2442
+#: lib/klass_hero_web/components/provider_components.ex:2445
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2434
+#: lib/klass_hero_web/components/provider_components.ex:2437
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2436
+#: lib/klass_hero_web/components/provider_components.ex:2439
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2438
+#: lib/klass_hero_web/components/provider_components.ex:2441
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""

--- a/test/klass_hero/provider/assignments/lead_instructor_test.exs
+++ b/test/klass_hero/provider/assignments/lead_instructor_test.exs
@@ -140,47 +140,6 @@ defmodule KlassHero.Provider.Assignments.LeadInstructorTest do
     end
   end
 
-  describe "list_lead_instructors_for_programs/1" do
-    test "returns a map keyed by program_id for programs with a lead" do
-      {provider, program_a, staff_a} = setup_provider_program_staff()
-      program_b = insert(:program_schema, provider_id: provider.id)
-      staff_b = insert(:staff_member_schema, provider_id: provider.id)
-      program_c = insert(:program_schema, provider_id: provider.id)
-
-      {:ok, _} = Provider.set_lead_instructor(program_a.id, staff_a.id, program_a.provider_id)
-      {:ok, _} = Provider.set_lead_instructor(program_b.id, staff_b.id, program_b.provider_id)
-
-      result =
-        Provider.list_lead_instructors_for_programs([program_a.id, program_b.id, program_c.id])
-
-      assert result[program_a.id].id == staff_a.id
-      assert result[program_b.id].id == staff_b.id
-      refute Map.has_key?(result, program_c.id)
-    end
-
-    test "returns an empty map for an empty list" do
-      assert Provider.list_lead_instructors_for_programs([]) == %{}
-    end
-
-    # Same invariant as get_lead_instructor/1, asserted separately: the two reads
-    # share lead_staff_query/0 but have their own selects.
-    test "omits programs whose lead has been deactivated" do
-      {provider, program_a, staff_a} = setup_provider_program_staff()
-      program_b = insert(:program_schema, provider_id: provider.id)
-      staff_b = insert(:staff_member_schema, provider_id: provider.id)
-
-      {:ok, _} = Provider.set_lead_instructor(program_a.id, staff_a.id, program_a.provider_id)
-      {:ok, _} = Provider.set_lead_instructor(program_b.id, staff_b.id, program_b.provider_id)
-
-      deactivate(staff_a)
-
-      result = Provider.list_lead_instructors_for_programs([program_a.id, program_b.id])
-
-      refute Map.has_key?(result, program_a.id)
-      assert result[program_b.id].id == staff_b.id
-    end
-  end
-
   defp deactivate(staff) do
     staff
     |> Ecto.Changeset.change(active: false)

--- a/test/klass_hero/provider/assignments/list_program_staffing_test.exs
+++ b/test/klass_hero/provider/assignments/list_program_staffing_test.exs
@@ -1,0 +1,131 @@
+defmodule KlassHero.Provider.Assignments.ListProgramStaffingTest do
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+
+  alias KlassHero.Provider
+  alias KlassHero.Provider.Domain.ReadModels.ProgramStaffing
+  alias KlassHero.Repo
+
+  defp setup_provider_program_staff do
+    provider = insert(:provider_profile_schema)
+    program = insert(:program_schema, provider_id: provider.id)
+    staff = insert(:staff_member_schema, provider_id: provider.id)
+    {provider, program, staff}
+  end
+
+  defp assign(program, staff) do
+    {:ok, assignment} =
+      Provider.assign_staff_to_program(%{
+        provider_id: program.provider_id,
+        program_id: program.id,
+        staff_member_id: staff.id
+      })
+
+    assignment
+  end
+
+  describe "list_program_staffing/1" do
+    test "returns an empty map for an empty list" do
+      assert Provider.list_program_staffing([]) == %{}
+    end
+
+    test "omits programs nobody is assigned to" do
+      {_provider, program, _staff} = setup_provider_program_staff()
+
+      assert Provider.list_program_staffing([program.id]) == %{}
+    end
+
+    test "carries every active member, with the lead among them" do
+      {provider, program, lead_staff} = setup_provider_program_staff()
+      other_staff = insert(:staff_member_schema, provider_id: provider.id)
+
+      assign(program, other_staff)
+      {:ok, _} = Provider.set_lead_instructor(program.id, lead_staff.id, provider.id)
+
+      staffing = Map.fetch!(Provider.list_program_staffing([program.id]), program.id)
+
+      assert %ProgramStaffing{program_id: program_id, member_count: 2} = staffing
+      assert program_id == program.id
+      assert Enum.sort(staffing.member_ids) == Enum.sort([lead_staff.id, other_staff.id])
+      assert staffing.lead.id == lead_staff.id
+      assert staffing.lead.name == "#{lead_staff.first_name} #{lead_staff.last_name}"
+      assert staffing.lead.headshot_url == lead_staff.headshot_url
+    end
+
+    # The state #1310 is about: staffed, but nobody leads. Distinguishable from
+    # the omitted-entirely case above only because member_count is non-zero.
+    test "returns members with a nil lead when the program is leaderless" do
+      {provider, program, staff_a} = setup_provider_program_staff()
+      staff_b = insert(:staff_member_schema, provider_id: provider.id)
+
+      assign(program, staff_a)
+      assign(program, staff_b)
+
+      staffing = Map.fetch!(Provider.list_program_staffing([program.id]), program.id)
+
+      assert staffing.lead == nil
+      assert staffing.member_count == 2
+    end
+
+    test "drops the lead flag but keeps the member when the lead is cleared" do
+      {provider, program, staff} = setup_provider_program_staff()
+      {:ok, _} = Provider.set_lead_instructor(program.id, staff.id, provider.id)
+      :ok = Provider.clear_lead_instructor(program.id, provider.id)
+
+      staffing = Map.fetch!(Provider.list_program_staffing([program.id]), program.id)
+
+      assert staffing.lead == nil
+      assert staffing.member_ids == [staff.id]
+    end
+
+    test "excludes a member who has been unassigned" do
+      {provider, program, staff_a} = setup_provider_program_staff()
+      staff_b = insert(:staff_member_schema, provider_id: provider.id)
+
+      assign(program, staff_a)
+      assign(program, staff_b)
+      {:ok, _} = Provider.unassign_staff_from_program(program.id, staff_b.id, provider.id)
+
+      staffing = Map.fetch!(Provider.list_program_staffing([program.id]), program.id)
+
+      assert staffing.member_ids == [staff_a.id]
+      assert staffing.member_count == 1
+    end
+
+    # Deactivation is how GDPR erasure retires a staff row, and it clears lead
+    # flags without unassigning. A deactivated member must not inflate the count
+    # the table renders as "+1".
+    test "excludes a deactivated member" do
+      {provider, program, staff_a} = setup_provider_program_staff()
+      staff_b = insert(:staff_member_schema, provider_id: provider.id)
+
+      assign(program, staff_a)
+      assign(program, staff_b)
+
+      staff_b |> Ecto.Changeset.change(active: false) |> Repo.update!()
+
+      staffing = Map.fetch!(Provider.list_program_staffing([program.id]), program.id)
+
+      assert staffing.member_ids == [staff_a.id]
+      assert staffing.member_count == 1
+    end
+
+    test "groups members by program across a batch" do
+      {provider, program_a, staff_a} = setup_provider_program_staff()
+      program_b = insert(:program_schema, provider_id: provider.id)
+      program_c = insert(:program_schema, provider_id: provider.id)
+      staff_b = insert(:staff_member_schema, provider_id: provider.id)
+
+      assign(program_a, staff_a)
+      assign(program_b, staff_a)
+      assign(program_b, staff_b)
+
+      result = Provider.list_program_staffing([program_a.id, program_b.id, program_c.id])
+
+      assert result[program_a.id].member_count == 1
+      assert result[program_b.id].member_count == 2
+      refute Map.has_key?(result, program_c.id)
+    end
+  end
+end

--- a/test/klass_hero/provider/domain/read_models/program_staffing_test.exs
+++ b/test/klass_hero/provider/domain/read_models/program_staffing_test.exs
@@ -1,0 +1,56 @@
+defmodule KlassHero.Provider.Domain.ReadModels.ProgramStaffingTest do
+  use ExUnit.Case, async: true
+
+  alias KlassHero.Provider.Domain.ReadModels.ProgramStaffing
+
+  @lead_id "11111111-1111-1111-1111-111111111111"
+  @other_id "22222222-2222-2222-2222-222222222222"
+  @stranger_id "33333333-3333-3333-3333-333333333333"
+
+  defp staffing(member_ids, lead_id) do
+    %ProgramStaffing{
+      program_id: "program-1",
+      lead: lead_id && %{id: lead_id, name: "Lead Person", headshot_url: nil},
+      member_ids: member_ids,
+      member_count: length(member_ids)
+    }
+  end
+
+  describe "staffed_by?/2" do
+    # The lead is one of the members, so the predicate never needs a
+    # "lead or member?" branch — that is the whole point of member_ids
+    # carrying everyone.
+    @cases [
+      {"the lead", [@lead_id, @other_id], @lead_id, @lead_id, true},
+      {"a non-lead member", [@lead_id, @other_id], @lead_id, @other_id, true},
+      {"a member of a leaderless program", [@other_id], nil, @other_id, true},
+      {"someone not on the program", [@lead_id], @lead_id, @stranger_id, false},
+      {"anyone, when nobody is on the program", [], nil, @lead_id, false}
+    ]
+
+    for {label, member_ids, lead_id, queried_id, expected} <- @cases do
+      test "matches #{label}" do
+        actual = ProgramStaffing.staffed_by?(staffing(unquote(member_ids), unquote(lead_id)), unquote(queried_id))
+
+        assert actual == unquote(expected),
+               "expected staffed_by?(#{inspect(unquote(member_ids))}, #{inspect(unquote(queried_id))}) " <>
+                 "to be #{unquote(expected)}, got #{actual}"
+      end
+    end
+
+    test "a nil staffing (program absent from the batch read) is staffed by nobody" do
+      refute ProgramStaffing.staffed_by?(nil, @lead_id)
+    end
+  end
+
+  describe "empty/1" do
+    test "builds the zero-staff value callers default to" do
+      assert %ProgramStaffing{
+               program_id: "program-1",
+               lead: nil,
+               member_ids: [],
+               member_count: 0
+             } = ProgramStaffing.empty("program-1")
+    end
+  end
+end

--- a/test/klass_hero_web/components/provider_components_test.exs
+++ b/test/klass_hero_web/components/provider_components_test.exs
@@ -7,22 +7,7 @@ defmodule KlassHeroWeb.ProviderComponentsTest do
 
   describe "programs_table/1" do
     test "renders a Sessions button per row" do
-      program = %{
-        id: "prog-1",
-        name: "Judo",
-        category: "Sports",
-        price: "120",
-        assigned_staff: nil,
-        status: :active,
-        enrolled: 5,
-        capacity: 10
-      }
-
-      html =
-        render_component(&KlassHeroWeb.ProviderComponents.programs_table/1,
-          programs: [{"programs-prog-1", program}],
-          staff_options: [%{value: "all", label: "All Staff"}]
-        )
+      html = render_table(program_row(id: "prog-1"))
 
       assert html =~ "phx-click=\"view_sessions\""
       assert html =~ "phx-value-program-id=\"prog-1\""
@@ -30,48 +15,93 @@ defmodule KlassHeroWeb.ProviderComponentsTest do
     end
 
     test "renders a Report Incident link per row that targets the new incident page" do
-      program = %{
-        id: "prog-123",
-        name: "Art Club",
-        category: "Arts",
-        price: "50",
-        assigned_staff: nil,
-        status: :active,
-        enrolled: 5,
-        capacity: 10
-      }
-
-      html =
-        render_component(&KlassHeroWeb.ProviderComponents.programs_table/1,
-          programs: [{"programs-prog-123", program}],
-          staff_options: [%{value: "all", label: "All Staff"}]
-        )
+      html = render_table(program_row(id: "prog-123"))
 
       assert html =~ ~s|href="/provider/incidents/new?program_id=prog-123"|
       assert html =~ ~s|aria-label="Report Incident"|
     end
 
     test "renders an Incident Reports link per row that targets the per-program list" do
-      program = %{
-        id: "prog-456",
-        name: "Robotics",
-        category: "STEM",
-        price: "75",
-        assigned_staff: nil,
-        status: :active,
-        enrolled: 3,
-        capacity: 12
-      }
-
-      html =
-        render_component(&KlassHeroWeb.ProviderComponents.programs_table/1,
-          programs: [{"programs-prog-456", program}],
-          staff_options: [%{value: "all", label: "All Staff"}]
-        )
+      html = render_table(program_row(id: "prog-456"))
 
       assert html =~ ~s|href="/provider/programs/prog-456/incidents"|
       assert html =~ ~s|aria-label="Incident Reports"|
     end
+  end
+
+  # The three states the staff column must keep apart (#1310). Before it, the
+  # middle one rendered identically to the last, so a provider could not tell a
+  # leaderless-but-staffed program from an empty one.
+  describe "programs_table/1 assigned staff column" do
+    test "a lead with others shows the lead and an overflow count" do
+      staff = %{
+        lead: %{id: "s-1", name: "Dirk Schreiber", initials: "DS", headshot_url: nil},
+        count: 2,
+        others_count: 1
+      }
+
+      html = render_table(program_row(id: "p1", assigned_staff: staff))
+
+      assert html =~ ~s|id="program-staff-lead-p1"|
+      assert html =~ "Dirk Schreiber"
+      assert html =~ "+1"
+      refute html =~ ~s|id="program-staff-leaderless-p1"|
+      refute html =~ ~s|id="program-staff-empty-p1"|
+    end
+
+    test "a lone lead shows no overflow count" do
+      staff = %{
+        lead: %{id: "s-1", name: "Ada Lovelace", initials: "AL", headshot_url: nil},
+        count: 1,
+        others_count: 0
+      }
+
+      html = render_table(program_row(id: "p2", assigned_staff: staff))
+
+      assert html =~ ~s|id="program-staff-lead-p2"|
+      assert html =~ "Ada Lovelace"
+      refute html =~ "+0"
+    end
+
+    test "a staffed but leaderless program shows its headcount, not Unassigned" do
+      staff = %{lead: nil, count: 2, others_count: 2}
+
+      html = render_table(program_row(id: "p3", assigned_staff: staff))
+
+      assert html =~ ~s|id="program-staff-leaderless-p3"|
+      assert html =~ "2 staff"
+      refute html =~ ~s|id="program-staff-empty-p3"|
+      refute html =~ "Unassigned"
+    end
+
+    test "a program nobody is on shows Unassigned" do
+      html = render_table(program_row(id: "p4"))
+
+      assert html =~ ~s|id="program-staff-empty-p4"|
+      assert html =~ "Unassigned"
+      refute html =~ ~s|id="program-staff-lead-p4"|
+      refute html =~ ~s|id="program-staff-leaderless-p4"|
+    end
+  end
+
+  defp program_row(overrides) do
+    Enum.into(overrides, %{
+      id: "prog-1",
+      name: "Judo",
+      category: "Sports",
+      price: "120",
+      assigned_staff: %{lead: nil, count: 0, others_count: 0},
+      status: :active,
+      enrolled: 5,
+      capacity: 10
+    })
+  end
+
+  defp render_table(program) do
+    render_component(&KlassHeroWeb.ProviderComponents.programs_table/1,
+      programs: [{"programs-#{program.id}", program}],
+      staff_options: [%{value: "all", label: "All Staff"}]
+    )
   end
 
   describe "sessions_modal/1" do

--- a/test/klass_hero_web/live/provider/dashboard_program_staffing_test.exs
+++ b/test/klass_hero_web/live/provider/dashboard_program_staffing_test.exs
@@ -369,10 +369,14 @@ defmodule KlassHeroWeb.Provider.DashboardProgramStaffingTest do
     end
   end
 
+  # Drives the wrapping <form>, not the bare <select>: LiveView rejects a
+  # phx-change on an input outside a form in the browser, and `element/2` +
+  # render_change/2 would happily bypass that check and pass on markup no user
+  # could actually trigger.
   defp filter_by_staff(view, staff) do
     view
-    |> element("select[name=staff_filter]")
-    |> render_change(%{"staff_filter" => staff.id})
+    |> form("#programs-staff-filter-form", %{"staff_filter" => staff.id})
+    |> render_change()
   end
 
   defp open_panel(conn, program) do

--- a/test/klass_hero_web/live/provider/dashboard_program_staffing_test.exs
+++ b/test/klass_hero_web/live/provider/dashboard_program_staffing_test.exs
@@ -264,6 +264,117 @@ defmodule KlassHeroWeb.Provider.DashboardProgramStaffingTest do
     end
   end
 
+  # The table column and the staff filter both read one `ProgramStaffing`
+  # read-model. Before #1310 the column rendered the lead alone and the filter
+  # matched on that rendered lead, so a leaderless-but-staffed program looked
+  # empty and a non-lead staff member found none of their programs.
+  describe "the programs table staff column" do
+    test "a staffed but leaderless program shows its headcount, not Unassigned", %{
+      conn: conn,
+      program: program,
+      ann: ann,
+      bo: bo
+    } do
+      for staff <- [ann, bo], do: assign_staff!(program, staff)
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+
+      assert has_element?(view, "#program-staff-leaderless-#{program.id}", "2 staff")
+      refute has_element?(view, "#program-staff-empty-#{program.id}")
+    end
+
+    test "a led program shows the lead plus an overflow count", %{
+      conn: conn,
+      program: program,
+      ann: ann,
+      bo: bo
+    } do
+      for staff <- [ann, bo], do: assign_staff!(program, staff)
+      promote!(program, ann)
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+
+      assert has_element?(view, "#program-staff-lead-#{program.id}", "Ann Blake")
+      assert has_element?(view, "#program-staff-lead-#{program.id}", "+1")
+    end
+
+    test "a program nobody is on still shows Unassigned", %{conn: conn, program: program} do
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+
+      assert has_element?(view, "#program-staff-empty-#{program.id}")
+    end
+
+    test "adding a non-lead refreshes the row's headcount", %{
+      conn: conn,
+      program: program,
+      ann: ann,
+      bo: bo
+    } do
+      assign_staff!(program, ann)
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+      assert has_element?(view, "#program-staff-leaderless-#{program.id}", "1 staff member")
+
+      view |> element("#manage-staffing-#{program.id}") |> render_click()
+      view |> form("#staffing-add-form", %{"staff-id" => bo.id}) |> render_submit()
+
+      assert has_element?(view, "#program-staff-leaderless-#{program.id}", "2 staff")
+    end
+  end
+
+  describe "filtering the programs table by staff member" do
+    test "finds the programs a NON-LEAD staff member is on", %{
+      conn: conn,
+      program: program,
+      ann: ann,
+      bo: bo
+    } do
+      for staff <- [ann, bo], do: assign_staff!(program, staff)
+      promote!(program, ann)
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+
+      filter_by_staff(view, bo)
+
+      assert has_element?(view, "#programs-#{program.id}")
+    end
+
+    test "hides programs a staff member is not on", %{conn: conn, program: program, ann: ann, cy: cy} do
+      assign_staff!(program, ann)
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+
+      filter_by_staff(view, cy)
+
+      refute has_element?(view, "#programs-#{program.id}")
+    end
+
+    test "drops the row when the staff member the filter is pinned to is removed", %{
+      conn: conn,
+      program: program,
+      ann: ann,
+      bo: bo
+    } do
+      for staff <- [ann, bo], do: assign_staff!(program, staff)
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+
+      filter_by_staff(view, bo)
+      assert has_element?(view, "#programs-#{program.id}")
+
+      view |> element("#manage-staffing-#{program.id}") |> render_click()
+      view |> element("#remove-staff-#{bo.id}") |> render_click()
+
+      refute has_element?(view, "#programs-#{program.id}")
+    end
+  end
+
+  defp filter_by_staff(view, staff) do
+    view
+    |> element("select[name=staff_filter]")
+    |> render_change(%{"staff_filter" => staff.id})
+  end
+
   defp open_panel(conn, program) do
     {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
     view |> element("#manage-staffing-#{program.id}") |> render_click()

--- a/test/klass_hero_web/presenters/program_presenter_test.exs
+++ b/test/klass_hero_web/presenters/program_presenter_test.exs
@@ -4,16 +4,17 @@ defmodule KlassHeroWeb.Presenters.ProgramPresenterTest do
   import ExUnit.CaptureLog
 
   alias KlassHero.ProgramCatalog.Program
+  alias KlassHero.Provider.Domain.ReadModels.ProgramStaffing
   alias KlassHero.Shared.Categories
   alias KlassHeroWeb.Presenters.ProgramPresenter
 
   describe "to_table_view/3" do
-    test "no lead returns nil assigned_staff and nil enrollment fields" do
+    test "no staffing (3rd arg omitted) renders as nobody on the program" do
       program = build_program(%{})
 
       result = ProgramPresenter.to_table_view(program)
 
-      assert result.assigned_staff == nil
+      assert result.assigned_staff == %{lead: nil, count: 0, others_count: 0}
       assert result.status == :active
       assert result.enrolled == nil
       assert result.capacity == nil
@@ -29,17 +30,42 @@ defmodule KlassHeroWeb.Presenters.ProgramPresenterTest do
       assert result.capacity == 20
     end
 
-    test "the lead instructor (3rd arg) populates assigned_staff" do
-      lead = %{id: "instr-1", name: "John Doe", headshot_url: "https://example.com/photo.jpg"}
+    test "a lead plus one other yields the lead map and an others_count of 1" do
+      staffing =
+        staffing(
+          members: ["instr-1", "instr-2"],
+          lead: %{id: "instr-1", name: "John Doe", headshot_url: "https://example.com/photo.jpg"}
+        )
 
-      program = build_program(%{})
+      result = ProgramPresenter.to_table_view(build_program(%{}), %{}, staffing)
 
-      result = ProgramPresenter.to_table_view(program, %{}, lead)
+      assert result.assigned_staff.lead.id == "instr-1"
+      assert result.assigned_staff.lead.name == "John Doe"
+      assert result.assigned_staff.lead.initials == "JD"
+      assert result.assigned_staff.lead.headshot_url == "https://example.com/photo.jpg"
+      assert result.assigned_staff.count == 2
+      assert result.assigned_staff.others_count == 1
+    end
 
-      assert result.assigned_staff.id == "instr-1"
-      assert result.assigned_staff.name == "John Doe"
-      assert result.assigned_staff.initials == "JD"
-      assert result.assigned_staff.headshot_url == "https://example.com/photo.jpg"
+    # The #1310 state: staffed but leaderless. `count` is what separates it from
+    # an empty program, which is the distinction the old lead-only shape lost.
+    test "a leaderless but staffed program keeps its headcount with a nil lead" do
+      staffing = staffing(members: ["a", "b"], lead: nil)
+
+      result = ProgramPresenter.to_table_view(build_program(%{}), %{}, staffing)
+
+      assert result.assigned_staff.lead == nil
+      assert result.assigned_staff.count == 2
+      assert result.assigned_staff.others_count == 2
+    end
+
+    test "a lone lead has no others" do
+      staffing = staffing(members: ["solo"], lead: %{id: "solo", name: "Ada Lovelace", headshot_url: nil})
+
+      result = ProgramPresenter.to_table_view(build_program(%{}), %{}, staffing)
+
+      assert result.assigned_staff.count == 1
+      assert result.assigned_staff.others_count == 0
     end
 
     # {price, expected string} — integer and fractional Decimal values.
@@ -71,10 +97,11 @@ defmodule KlassHeroWeb.Presenters.ProgramPresenterTest do
       @name name
       @expected expected
       test "#{inspect(name)} -> initials #{inspect(expected)}" do
-        lead = %{id: "1", name: @name, headshot_url: nil}
+        staffing = staffing(members: ["1"], lead: %{id: "1", name: @name, headshot_url: nil})
         program = build_program(%{})
 
-        assert ProgramPresenter.to_table_view(program, %{}, lead).assigned_staff.initials == @expected
+        assert ProgramPresenter.to_table_view(program, %{}, staffing).assigned_staff.lead.initials ==
+                 @expected
       end
     end
 
@@ -388,6 +415,17 @@ defmodule KlassHeroWeb.Presenters.ProgramPresenterTest do
       result = ProgramPresenter.format_schedule_brief(program)
       assert result == "Tue & Thu 2:00 - 3:00 PM"
     end
+  end
+
+  defp staffing(opts) do
+    members = Keyword.fetch!(opts, :members)
+
+    %ProgramStaffing{
+      program_id: "prog-1",
+      lead: Keyword.fetch!(opts, :lead),
+      member_ids: members,
+      member_count: length(members)
+    }
   end
 
   defp build_program(overrides) do


### PR DESCRIPTION
## Summary

The **ASSIGNED STAFF** column on `/provider/dashboard/programs` rendered the lead instructor alone, so a program staffed by two people with no lead rendered **"Unassigned"** — identical to a program with nobody on it.

The reported symptom turned out to be one of **three consequences of a single cause**: the table's whole staff axis was lead-only, and `filter_by_staff/2` matched on `program.assigned_staff.id` — *the presenter's own output*. Display and filtering were the same field, so what the column showed defined who could be found.

1. The column collapsed "staffed, leaderless" into "empty" (reported).
2. **Filtering by a non-lead staff member returned zero programs**, even when they were on several.
3. Adding or removing a non-lead never refreshed the row.

## Approach

A `ProgramStaffing` read-model carries the lead plus every active member, read in one batch query. The presenter *formats* it; the LiveView *filters* through `ProgramStaffing.staffed_by?/2`. `reset_programs_stream/1` now filters domain programs **before** presenting them rather than after, so the filter can no longer depend on the render shape.

`member_ids` includes the lead, so `member_count == length(member_ids)` holds unconditionally and no caller needs a "lead or member?" branch.

| State | Renders |
|---|---|
| lead + 1 other | `[DS] Dirk Schreiber +1` |
| 2 staff, no lead | `2 staff · no lead` |
| nobody | `Unassigned` |

## Review focus

- **`assignments.ex`** — the new batch query, and the deletion of `list_lead_instructors_for_programs/1`. Removing the lead-only affordance is deliberate: it turns "remember to update the filter" into a build error.
- **`programs_live.ex`** — the fetch → filter → present reordering is the actual coupling fix. Note `filter_by_search/2` moves from `program.name` (presenter output) to `program.title` (domain).
- **Second commit** wraps the search box and staff filter in `<form>` elements. **This is a separate bug found during browser verification**: LiveView rejects a `phx-change` on an input outside a form (`form events require the input to be inside a form`), so neither control had *ever* fired an event in a browser. LiveView tests missed it because `element/2 |> render_change/2` posts to the server directly and never evaluates that client-side check — the test now drives the form instead. This is why #1310 recorded the filter behaviour as "inconclusive".
- **Beyond the issue:** `refresh_program_row/2` gains a `stream_delete` branch, so removing the staff member an active filter is pinned to drops the row instead of re-inserting a non-matching one.

## Test plan

- `mix precommit` — 4304 passed, credo clean, all five lints pass.
- New: batch-query tests (lead flag, deactivated member excluded, unassigned excluded, multi-program grouping), pure `staffed_by?/2` table tests, three presenter states, three render branches, and LiveView regressions for the filter and row refresh.
- Verified in a browser against seeded data as `katharina.richter@example.com`: Winter Adventure Camp reads `2 staff · no lead`; filtering by **Dirk Schreiber** (a non-lead) returns the program he is on; removing him live drops the row under that filter and clears the `+1` once the filter is cleared. Checked at 375px.

Closes #1310