### PR TITLE
fix: give invite error_details a single owner

### DIFF
--- a/lib/klass_hero/enrollment.ex
+++ b/lib/klass_hero/enrollment.ex
@@ -1094,6 +1094,46 @@ defmodule KlassHero.Enrollment do
     end
   end
 
+  @doc """
+  Fails an invite, recording a reason the owning provider can act on.
+
+  The single writer of `error_details`. Before #1290 four call sites across two
+  contexts each rebuilt this — the `:failed` atom, the refetch-by-id shape, the
+  "a rejected transition means already-terminal" rule, and their own wording — and two
+  of them wrote raw `inspect/1` output into a field rendered verbatim to providers.
+
+  `reason` is only ever used to *describe* the failure (see
+  `BulkEnrollmentInvite.describe_failure/2`); callers keep logging it themselves for
+  diagnostics, which is where an unmapped term belongs.
+
+  `{:error, :already_terminal}` is the expected outcome of compensating twice — inline
+  on a worker's last attempt, then again from the compensation sweep over the same
+  discarded job — and callers translate it to `:ignore` rather than retrying.
+  """
+  @spec fail_invite(binary(), term()) ::
+          {:ok, BulkEnrollmentInvite.t()} | {:error, :not_found | :already_terminal}
+  def fail_invite(invite_id, reason) when is_binary(invite_id) do
+    case Repo.get(BulkEnrollmentInvite, invite_id) do
+      nil ->
+        {:error, :not_found}
+
+      invite ->
+        invite
+        |> BulkEnrollmentInvite.transition_changeset(%{
+          status: :failed,
+          error_details: BulkEnrollmentInvite.describe_failure(invite, reason)
+        })
+        |> Repo.update()
+        |> case do
+          {:ok, failed} -> {:ok, failed}
+          # `@valid_transitions` admits `:failed` only from a live status, so a rejection
+          # here means something already settled this invite. Collapsed rather than
+          # reported field-by-field: no caller can act on the difference.
+          {:error, %Ecto.Changeset{}} -> {:error, :already_terminal}
+        end
+    end
+  end
+
   @doc "Applies a validated status transition to an invite (refetched by id)."
   def transition_invite(%{id: id}, attrs) when is_map(attrs) do
     case Repo.get(BulkEnrollmentInvite, id) do

--- a/lib/klass_hero/enrollment/adapters/driving/events/invite_family_ready_handler.ex
+++ b/lib/klass_hero/enrollment/adapters/driving/events/invite_family_ready_handler.ex
@@ -68,7 +68,7 @@ defmodule KlassHero.Enrollment.Adapters.Driving.Events.InviteFamilyReadyHandler 
           reason: inspect(reason)
         )
 
-        transition_to_failed(invite_id, reason)
+        Enrollment.fail_invite(invite_id, reason)
         {:error, reason}
     end
   end
@@ -129,19 +129,6 @@ defmodule KlassHero.Enrollment.Adapters.Driving.Events.InviteFamilyReadyHandler 
 
       _ ->
         :ok
-    end
-  end
-
-  defp transition_to_failed(invite_id, reason) do
-    case Enrollment.get_invite(invite_id) do
-      {:error, :not_found} ->
-        :ok
-
-      {:ok, invite} ->
-        Enrollment.transition_invite(invite, %{
-          status: :failed,
-          error_details: inspect(reason)
-        })
     end
   end
 end

--- a/lib/klass_hero/enrollment/adapters/driving/workers/send_invite_email_worker.ex
+++ b/lib/klass_hero/enrollment/adapters/driving/workers/send_invite_email_worker.ex
@@ -36,11 +36,11 @@ defmodule KlassHero.Enrollment.Adapters.Driving.Workers.SendInviteEmailWorker do
       {:ok, %BulkEnrollmentInvite{invite_token: nil} = invite} ->
         Logger.warning("[SendInviteEmailWorker] Invite has no token", invite_id: invite_id)
 
-        invite
-        |> Enrollment.transition_invite(%{
-          status: :failed,
-          error_details: "Invite link could not be generated (no token). Please resend."
-        })
+        # The reason is not what names this failure — `describe_failure/2` reads the
+        # missing token off the row, so the sweep reaches the same wording later without
+        # a reason to go on.
+        invite.id
+        |> Enrollment.fail_invite(:tokenless)
         |> resolve_tokenless(job)
 
       {:ok, %BulkEnrollmentInvite{} = invite} ->
@@ -123,21 +123,24 @@ defmodule KlassHero.Enrollment.Adapters.Driving.Workers.SendInviteEmailWorker do
   # A rejected transition means the invite is already terminal — sent by a duplicate
   # attempt, or failed by an earlier pass — which is a fact rather than something a later
   # sweep could fix, so it reports `:ignore`.
+  #
+  # `{:delivery, _}` unconditionally: delivery is this worker's only failure mode that is
+  # not the missing token, and the token is read off the row, so tagging here cannot
+  # mislabel a tokenless invite. It survives the sweep, which arrives with `nil` for a
+  # Lifeline discard and could not otherwise tell the two apart.
   @impl true
-  def compensate(%Oban.Job{args: %{"invite_id" => invite_id}}, reason) do
-    case Enrollment.transition_invite(%{id: invite_id}, %{
-           status: :failed,
-           error_details: describe(reason)
-         }) do
+  def compensate(%Oban.Job{args: %{"invite_id" => invite_id}}, reason) when is_binary(invite_id) do
+    case Enrollment.fail_invite(invite_id, {:delivery, reason}) do
       {:ok, _invite} -> :ok
       {:error, _reason} -> :ignore
     end
   end
 
-  # The sweep cannot recover the failing attempt's reason — a Lifeline discard records
-  # none — so the provider gets the fact without a cause rather than "nil".
-  defp describe(nil), do: "Email delivery failed and no retries remain"
-  defp describe(reason), do: "Email delivery failed: #{inspect(reason)}"
+  # Unreachable from the enqueue path, which only ever writes a binary `invite.id`. Guarded
+  # anyway because the sweep calls this with whatever the job row holds, and a raise here
+  # escapes its `Enum.each` and abandons the rest of the batch — every worker's, not just this
+  # one's.
+  def compensate(%Oban.Job{}, _reason), do: :ignore
 
   # Reads URL config at runtime — referencing KlassHeroWeb.Endpoint directly would violate boundary rules.
   defp base_url do

--- a/lib/klass_hero/enrollment/bulk_enrollment_invite.ex
+++ b/lib/klass_hero/enrollment/bulk_enrollment_invite.ex
@@ -6,9 +6,9 @@ defmodule KlassHero.Enrollment.BulkEnrollmentInvite do
   Child, Enrollment, Consents) are created from this data.
 
   This module is both the Ecto schema and the struct consumers pattern-match.
-  The changesets are the validation gatekeepers; the predicates, `generate_token/0`
-  and `dedup_key/4` are the functional core. Status follows a state machine
-  (see `valid_transitions/0`).
+  The changesets are the validation gatekeepers; the predicates, `generate_token/0`,
+  `dedup_key/4` and `describe_failure/2` are the functional core. Status follows a
+  state machine (see `valid_transitions/0`).
   """
 
   use Ecto.Schema
@@ -16,6 +16,7 @@ defmodule KlassHero.Enrollment.BulkEnrollmentInvite do
   import Ecto.Changeset
 
   alias KlassHero.Enrollment.Domain.Services.InviteFieldValidations
+  alias KlassHero.Shared.ChangesetErrors
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
@@ -184,6 +185,66 @@ defmodule KlassHero.Enrollment.BulkEnrollmentInvite do
   @spec ensure_claimable(t()) :: {:ok, t()} | {:error, :already_claimed}
   def ensure_claimable(%__MODULE__{status: :invite_sent} = invite), do: {:ok, invite}
   def ensure_claimable(%__MODULE__{}), do: {:error, :already_claimed}
+
+  @doc """
+  The sentence a provider reads under a failed invite's status pill.
+
+  `error_details` is rendered verbatim to providers so the reason is *actionable*
+  (#1221), which means no clause here may emit `inspect/1` output — see #1290, where
+  three of the four writers had each invented their own convention and two emitted raw
+  Elixir terms. Diagnostics belong in the `Logger` calls the writers already make.
+
+  Takes the invite as well as the reason because a missing token is a fact about the
+  row that no reason can carry: the compensation sweep hands back `nil` for a Lifeline
+  discard, and Oban's own error text otherwise, so by then the original term is gone.
+  """
+  @spec describe_failure(t(), term()) :: String.t()
+  # First, because the row outranks the reason: a tokenless invite failed for want of a
+  # token whatever the caller believed went wrong, and the resend that mints a new one
+  # is different advice from retrying a delivery.
+  def describe_failure(%__MODULE__{invite_token: nil}, _reason) do
+    "Invite link could not be generated (no token). Please resend."
+  end
+
+  def describe_failure(%__MODULE__{}, %Ecto.Changeset{} = changeset) do
+    case ChangesetErrors.field_list(changeset) do
+      # A changeset can be invalid with its errors on an association rather than a field.
+      # Falling back to the generic sentence loses detail; falling back to `inspect/1`
+      # would lose the provider.
+      [] -> generic_failure()
+      fields -> Enum.map_join(fields, "; ", fn {field, message} -> "#{humanize_field(field)} #{message}" end)
+    end
+  end
+
+  def describe_failure(%__MODULE__{}, :program_full) do
+    "The program is full, so this child could not be enrolled."
+  end
+
+  def describe_failure(%__MODULE__{}, {:invalid_date, value}) when is_binary(value) do
+    ~s(Date of birth "#{value}" is not a valid date. Please correct it and resend.)
+  end
+
+  def describe_failure(%__MODULE__{}, {:delivery, _reason}) do
+    "The invitation email could not be delivered. Please check the address and resend."
+  end
+
+  # `nil` is a Lifeline discard, which records no cause at all; a binary is Oban's own
+  # error text — `Exception.format/3` output or "... failed with #{inspect(reason)}" —
+  # which is developer copy by construction. Both give the provider the fact without a
+  # cause rather than a term they cannot act on.
+  def describe_failure(%__MODULE__{}, reason) when is_nil(reason) or is_binary(reason) do
+    "This invite could not be completed and no retries remain. Please resend."
+  end
+
+  def describe_failure(%__MODULE__{}, _other), do: generic_failure()
+
+  defp generic_failure, do: "This invite could not be completed. Please resend."
+
+  defp humanize_field(field) do
+    field
+    |> Atom.to_string()
+    |> String.replace("_", " ")
+  end
 
   @doc "Generates a cryptographically secure URL-safe token for invite links."
   @spec generate_token() :: String.t()

--- a/lib/klass_hero/family/adapters/driving/workers/process_invite_claim_worker.ex
+++ b/lib/klass_hero/family/adapters/driving/workers/process_invite_claim_worker.ex
@@ -19,7 +19,6 @@ defmodule KlassHero.Family.Adapters.Driving.Workers.ProcessInviteClaimWorker do
 
   alias KlassHero.Enrollment
   alias KlassHero.Family.ProcessInviteClaim
-  alias KlassHero.Shared.ChangesetErrors
 
   require Logger
 
@@ -38,22 +37,19 @@ defmodule KlassHero.Family.Adapters.Driving.Workers.ProcessInviteClaimWorker do
     end
   end
 
-  # The invite belongs to Enrollment, so this goes through its facade rather than touching
-  # the schema. A rejected transition means the invite is already terminal — enrolled by a
-  # retry Lifeline re-ran, or failed by an earlier pass — which is a fact, not a fault, so
-  # it reports `:ignore` rather than an error the sweep would keep retrying.
+  # The invite belongs to Enrollment, so this goes through its facade — which also owns
+  # the wording a provider reads, rather than this worker inventing its own (#1290).
+  # `:already_terminal` is the expected rejection: the invite was enrolled by a retry
+  # Lifeline re-ran, or failed by an earlier pass. That is a fact, not a fault, so it
+  # reports `:ignore` rather than an error the sweep would keep retrying.
   @impl true
-  def compensate(%Oban.Job{args: args}, reason) do
-    fail_invite(args["invite_id"], reason)
-  end
-
-  defp fail_invite(invite_id, reason) when is_binary(invite_id) do
-    case Enrollment.transition_invite(%{id: invite_id}, %{status: :failed, error_details: describe(reason)}) do
+  def compensate(%Oban.Job{args: %{"invite_id" => invite_id}}, reason) when is_binary(invite_id) do
+    case Enrollment.fail_invite(invite_id, reason) do
       {:ok, _invite} ->
         :ok
 
       {:error, transition_error} ->
-        Logger.warning("[ProcessInviteClaimWorker] Invite already past :registered, not failing it",
+        Logger.warning("[ProcessInviteClaimWorker] Invite not failed",
           invite_id: invite_id,
           reason: inspect(transition_error)
         )
@@ -62,30 +58,7 @@ defmodule KlassHero.Family.Adapters.Driving.Workers.ProcessInviteClaimWorker do
     end
   end
 
-  defp fail_invite(_invite_id, _reason), do: :ignore
-
-  # A provider reads this in the invites table, so it has to name what is wrong with the
-  # row they uploaded. `inspect/1` of a changeset names it only to a developer.
-  defp describe(%Ecto.Changeset{} = changeset) do
-    case ChangesetErrors.field_list(changeset) do
-      # A changeset can be invalid with its errors on an association rather than a field,
-      # and an empty string here would render as a blank reason line rather than none.
-      [] -> inspect(changeset)
-      fields -> Enum.map_join(fields, "; ", fn {field, message} -> "#{humanize_field(field)} #{message}" end)
-    end
-  end
-
-  # The sweep cannot recover the failing attempt's reason — a Lifeline discard records
-  # none — so the provider gets the fact without a cause rather than the string "nil".
-  defp describe(nil), do: "Processing failed and no retries remain"
-
-  defp describe(reason), do: inspect(reason)
-
-  defp humanize_field(field) do
-    field
-    |> Atom.to_string()
-    |> String.replace("_", " ")
-  end
+  def compensate(%Oban.Job{}, _reason), do: :ignore
 
   # Oban JSON args use string keys and ISO date strings; convert to atom keys and Date.
   defp deserialize_args(args) do

--- a/test/klass_hero/enrollment/adapters/driving/workers/send_invite_email_worker_test.exs
+++ b/test/klass_hero/enrollment/adapters/driving/workers/send_invite_email_worker_test.exs
@@ -138,7 +138,8 @@ defmodule KlassHero.Enrollment.Adapters.Driving.Workers.SendInviteEmailWorkerTes
 
       failed = reload(invite)
       assert failed.status == :failed
-      assert failed.error_details =~ "Email delivery failed"
+      assert failed.error_details =~ "could not be delivered"
+      refute failed.error_details =~ "network", "the mailer's own term reached the provider"
     end
 
     # Oban reads retry/discard off the return value; compensating must not look to it
@@ -179,19 +180,23 @@ defmodule KlassHero.Enrollment.Adapters.Driving.Workers.SendInviteEmailWorkerTes
              "compensated while retries remained, destroying the write the next attempt makes"
     end
 
-    test "compensates a failed write on the final attempt", %{invite: invite, program: program} do
+    # The token is nilled to match the only state that reaches this branch in
+    # production. It is also what makes the reason right: compensate/2 is shared with
+    # the delivery path, so before #1290 a missing token was reported to the provider as
+    # an email delivery problem — different advice from the resend that mints a new one.
+    test "compensates a failed write, naming the missing token", %{invite: invite, program: program} do
+      tokenless = invite |> Ecto.Changeset.change(%{invite_token: nil}) |> Repo.update!()
+
       assert {:error, :not_found} =
                SendInviteEmailWorker.resolve_tokenless(
                  {:error, :not_found},
-                 job(invite, program, @max_attempts)
+                 job(tokenless, program, @max_attempts)
                )
 
-      # The reason reads "Email delivery failed" because compensate/2 is shared with the
-      # delivery path, and the sweep that also calls it has only the job row to go on.
-      # Imprecise, but the provider still sees Failed rather than a silent :pending.
-      failed = reload(invite)
+      failed = reload(tokenless)
       assert failed.status == :failed
-      assert failed.error_details =~ "not_found"
+      assert failed.error_details =~ "no token"
+      refute failed.error_details =~ "not_found"
     end
 
     # Returning the error is what retries it; the log is what makes a write that keeps

--- a/test/klass_hero/enrollment/bulk_enrollment_invite_test.exs
+++ b/test/klass_hero/enrollment/bulk_enrollment_invite_test.exs
@@ -1,0 +1,71 @@
+defmodule KlassHero.Enrollment.BulkEnrollmentInviteTest do
+  use ExUnit.Case, async: true
+
+  alias KlassHero.Enrollment.BulkEnrollmentInvite
+
+  describe "describe_failure/2" do
+    # Everything here is read by a provider in the invites table, so the one property
+    # that must hold for every clause is that no Elixir term survives into it (#1290).
+    @developer_shapes [~r/#Ecto\.Changeset/, ~r/%\{/, ~r/\{:/, ~r/\[\{/]
+
+    defp tokenless, do: %BulkEnrollmentInvite{invite_token: nil}
+    defp tokenful, do: %BulkEnrollmentInvite{invite_token: "test-token-123"}
+
+    defp invalid_changeset do
+      BulkEnrollmentInvite.import_changeset(%{"child_first_name" => "Emma"})
+    end
+
+    test "names the missing token whatever the reason says" do
+      for reason <- [nil, :program_full, "job died", {:delivery, :timeout}, invalid_changeset()] do
+        assert BulkEnrollmentInvite.describe_failure(tokenless(), reason) =~ "no token",
+               "a tokenless invite reported #{inspect(reason)} as its cause instead of the missing token"
+      end
+    end
+
+    test "turns a changeset into the fields the provider has to fix" do
+      details = BulkEnrollmentInvite.describe_failure(tokenful(), invalid_changeset())
+
+      assert details =~ "child date of birth"
+      assert details =~ "can't be blank"
+    end
+
+    test "renders every known reason as a sentence" do
+      cases = [
+        {:program_full, "full"},
+        {{:invalid_date, "not-a-date"}, "not-a-date"},
+        {{:delivery, {:network, :timeout}}, "deliver"},
+        {nil, "no retries remain"},
+        {"** (Oban.PerformError) ... failed with {:error, :not_found}", "no retries remain"},
+        {:some_unmapped_atom, "could not be completed"}
+      ]
+
+      for {reason, expected} <- cases do
+        assert BulkEnrollmentInvite.describe_failure(tokenful(), reason) =~ expected,
+               "#{inspect(reason)} did not render a reason containing #{inspect(expected)}"
+      end
+    end
+
+    # The sweep can only hand back Oban's own error text, which is developer copy by
+    # construction — passing it through would reopen the leak this function closes.
+    test "never leaks a developer term, whatever it is handed" do
+      reasons = [
+        nil,
+        :program_full,
+        :some_unmapped_atom,
+        {:invalid_date, "not-a-date"},
+        {:invalid_date_type, %{}},
+        {:delivery, {:network, :timeout}},
+        {:error, %{nested: [:deeply, {:awkwardly, "shaped"}]}},
+        "** (Oban.PerformError) MyWorker failed with {:error, %Ecto.Changeset{}}",
+        invalid_changeset()
+      ]
+
+      for reason <- reasons, pattern <- @developer_shapes do
+        details = BulkEnrollmentInvite.describe_failure(tokenful(), reason)
+
+        refute details =~ pattern,
+               "#{inspect(reason)} leaked #{inspect(pattern)} into what a provider reads: #{details}"
+      end
+    end
+  end
+end

--- a/test/klass_hero/enrollment/fail_invite_test.exs
+++ b/test/klass_hero/enrollment/fail_invite_test.exs
@@ -1,0 +1,68 @@
+defmodule KlassHero.Enrollment.FailInviteTest do
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+
+  alias KlassHero.Enrollment
+  alias KlassHero.Enrollment.BulkEnrollmentInvite
+  alias KlassHero.Repo
+
+  defp create_invite(_context) do
+    provider = insert(:provider_profile_schema)
+    program = insert(:program_schema, provider_id: provider.id, title: "Dance Class")
+
+    {:ok, _} =
+      Enrollment.create_invite(%{
+        program_id: program.id,
+        provider_id: provider.id,
+        child_first_name: "Emma",
+        child_last_name: "Schmidt",
+        child_date_of_birth: ~D[2016-03-15],
+        guardian_email: "parent@example.com",
+        guardian_first_name: "Hans"
+      })
+
+    invite = Repo.one!(BulkEnrollmentInvite)
+    invite = invite |> Ecto.Changeset.change(%{invite_token: "test-token-123"}) |> Repo.update!()
+
+    %{invite: invite, program: program}
+  end
+
+  describe "fail_invite/2" do
+    setup :create_invite
+
+    test "fails the invite with a reason a provider can act on", %{invite: invite} do
+      assert {:ok, failed} = Enrollment.fail_invite(invite.id, :program_full)
+
+      assert failed.status == :failed
+      assert failed.error_details =~ "full"
+      refute failed.error_details =~ ":program_full"
+    end
+
+    test "reads the missing token off the row, not off the reason", %{invite: invite} do
+      invite |> Ecto.Changeset.change(%{invite_token: nil}) |> Repo.update!()
+
+      # nil is what the compensation sweep hands back for a Lifeline discard — the path
+      # on which no reason term survives at all.
+      assert {:ok, failed} = Enrollment.fail_invite(invite.id, nil)
+      assert failed.error_details =~ "no token"
+    end
+
+    # This rejection is what keeps compensation idempotent: a worker compensates inline
+    # on its final attempt, and the sweep then re-examines the same discarded job. Both
+    # land here, and `@valid_transitions` (failed: [:pending]) is the only thing that
+    # stops the second one overwriting the first one's reason.
+    test "refuses to re-fail an invite that is already failed", %{invite: invite} do
+      assert {:ok, _} = Enrollment.fail_invite(invite.id, :program_full)
+
+      assert {:error, :already_terminal} = Enrollment.fail_invite(invite.id, nil)
+
+      assert Repo.get!(BulkEnrollmentInvite, invite.id).error_details =~ "full",
+             "the second call overwrote the first call's reason"
+    end
+
+    test "reports a missing invite rather than raising" do
+      assert {:error, :not_found} = Enrollment.fail_invite(Ecto.UUID.generate(), :program_full)
+    end
+  end
+end


### PR DESCRIPTION
Closes #1290.

## Summary

`bulk_enrollment_invites.error_details` is rendered verbatim to providers under a failed invite's status pill, so the reason has to be actionable (#1221). It had no owner: four call sites across two contexts filled it by local convention, and two wrote raw `inspect/1` output.

Verified leaks on `main`, three of which the issue did not name:

| Site | What a provider could read |
|---|---|
| `invite_family_ready_handler.ex` | an `#Ecto.Changeset<...>` dump, or the literal `":program_full"` |
| `send_invite_email_worker.ex` `describe/1` | `"Email delivery failed: {:network, :timeout}"` |
| `send_invite_email_worker.ex` `compensate/2` | `"Email delivery failed"` for an invite that failed for a *missing token* (#1288) |
| `send_invite_email_worker_test.exs:194` | a test asserting the leak (`=~ "not_found"`), with a comment conceding it was imprecise |

Now: `Enrollment.fail_invite/2` is the single writer, and `BulkEnrollmentInvite.describe_failure/2` is the single formatter. No clause emits `inspect/1`. Both private `describe/1` copies are deleted.

## Review Focus

**Why `describe_failure/2` takes the invite and not just the reason.** `CompensationSweepWorker.reason_from/1` returns Oban's own error *text* or `nil` — its docs say "the original term is gone by the time it lands here", and a Lifeline discard yields `nil`. So the tokenless-vs-delivery cause cannot ride the reason term on every path. The only discriminator that survives is `invite_token` on the row, which is why the tokenless clause matches on the invite and is ordered first.

**Why the sweep's error string is dropped rather than rendered.** It is `Exception.format/3` output or `"... failed with #{inspect(reason)}"` — developer copy by construction. Rendering it would reopen the exact leak this closes. Diagnostics stay in the `Logger` calls every producer already makes.

**One tagged reason, not a taxonomy.** `SendInviteEmailWorker.compensate/2` passes `{:delivery, reason}` because delivery is its only failure mode that is not the missing token — that keeps "email could not be delivered" as actionable advice, which a flat catch-all would have lost. Tagging cannot mislabel a tokenless invite, since the row-state clause is matched first.

**`Enrollment` vocabulary leaves Family.** `ProcessInviteClaimWorker` previously constructed Enrollment's `:failed` atom and its own provider-facing copy; it now passes an opaque reason.

## Test Plan

- `mix precommit` green: 4312 tests, credo clean, all five lints
- New: `bulk_enrollment_invite_test.exs` (tabular over every clause, plus a blanket assertion that no clause leaks a developer term) and `fail_invite_test.exs`
- `send_invite_email_worker_test.exs:194` flips from asserting the leak to asserting the fix — and its fixture now nils the token, so it actually simulates the tokenless path it claimed to test
- `process_invite_claim_worker_test.exs` and `invite_claim_saga_test.exs` unchanged and green — they are the contract the new formatter had to preserve
- `/review-architecture`: 21/21 checks, 0 violations across structure, boundaries and behaviour

## Follow-ups filed, deliberately not in scope

- #1339 — the compensation sweep re-fails an invite the provider has already resent. Pre-existing; this change inherits it unchanged.
- #1340 — a German-locale provider reads these reasons in English. Needs a stored-code-plus-render-time-translation shape, since `gettext` at write time would freeze a background job's locale. This PR is the precondition: one function to change instead of four sites.
