### PR TITLE
fix: model staff removal as offboarding so conversations tear down

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -107,11 +107,20 @@ _Avoid_: Position, Title, Type
 
 **Deactivation**:
 Ending a **Staff Member**'s employment link — they no longer work for that **Provider**. Reversible (*reactivation*), and deliberately narrow: any **Instructor** role they held is cleared and an outstanding invitation is revoked, but their **Program Staff Assignments** and conversation membership survive, because unassigning would destroy access that reactivation cannot give back. Reactivation restores only the employment: the Instructor role and the invitation stay gone.
-Distinct from two neighbours that land on the same `active` column: **removal** (a hard delete of the row, the Team tab's "remove member") and **erasure** (GDPR, which deactivates *and* scrubs PII). Deactivation alone says nothing about why.
+Distinct from two neighbours that land on the same `active` column: **offboarding** (below) and **erasure** (GDPR, which offboards *and* scrubs PII). Deactivation alone says nothing about why.
 _Avoid_: Disable, Archive, Soft-delete, Suspend, Terminate
 
+**Offboarding**:
+**Deactivation** plus the roster teardown: every live **Program Staff Assignment** is retired, which is what removes the person from those Programs' **Conversations**. This is what the Team tab's "Remove from team" does, and what **erasure** does before scrubbing. The employment can be reinstated, but the assignments cannot — reinstating gives back an employee with no Programs, so re-assign deliberately.
+The distinction from deactivation is the whole point: deactivation keeps assignments alive so a reversible pause does not destroy conversation access; offboarding is the person leaving, so the access has to go.
+_Avoid_: Remove, Delete, Fire (removal now means the erase below)
+
+**Removal (erase)**:
+Destroying a **Staff Member** row outright. Legal only for a row that never became anything — no linked **User**, no invitation ever sent, no **Program Staff Assignment** ever created — i.e. a roster entry typed in by mistake. Anything else is **offboarded** instead, because events and audit records name that `staff_member_id` and deleting the row would leave them pointing at nothing.
+_Avoid_: using this word for an employee leaving — that is **offboarding**
+
 **Program Staff Assignment**:
-The link recording that a **Staff Member** works on a **Program**. Many Staff Members may be assigned to one Program because a class can need several people. Survives the Staff Member's **deactivation**.
+The link recording that a **Staff Member** works on a **Program**. Many Staff Members may be assigned to one Program because a class can need several people. Survives the Staff Member's **deactivation**, but not their **offboarding**.
 _Avoid_: Membership, Posting
 
 ## Families & Accounts

--- a/lib/klass_hero/accounts.ex
+++ b/lib/klass_hero/accounts.ex
@@ -135,17 +135,51 @@ defmodule KlassHero.Accounts do
   end
 
   @doc """
-  Deletes a staff member row, atomically tearing down the now-backing-less
+  Ends a staff member's employment, atomically tearing down the now-backing-less
   `:staff` role (ADR-0005, #972).
 
+  Provider offboards the person — retiring every program assignment so Messaging
+  drops them from those conversations (#1292) — and Accounts settles the persona.
   `:staff` is removed from the linked user only when no other active linked staff
   row remains for them; multi-employer users keep it, and unlinked display-only
   rows never touch roles.
 
-  Returns `{:ok, %StaffMember{}}` (the deleted row) or `{:error, :not_found}`.
+  Returns `{:ok, %StaffMember{}}` (the offboarded row) or `{:error, :not_found}`.
+  """
+  @spec offboard_staff_member(String.t(), String.t()) ::
+          {:ok, StaffMember.t()} | {:error, :not_found}
+  def offboard_staff_member(provider_id, staff_id) when is_binary(provider_id) and is_binary(staff_id) do
+    context_span entity: "user" do
+      Repo.transaction(fn ->
+        # The fetch is the provider-scoping step — foreign ≡ missing — and supplies
+        # the struct the offboard command takes.
+        with {:ok, staff} <- Provider.get_staff_member(staff_id, provider_id),
+             {:ok, %{staff_member: offboarded}} <- Provider.offboard_staff_member(staff),
+             # Runs after the `active` flip, in the same transaction, so the
+             # "any employment left?" query already sees this one as ended.
+             :ok <- maybe_revoke_staff_role(offboarded) do
+          offboarded
+        else
+          {:error, reason} -> Repo.rollback(reason)
+        end
+      end)
+    end
+  end
+
+  @doc """
+  Erases a staff row that never became anything — the narrow counterpart to
+  `offboard_staff_member/2` (#1292).
+
+  Refuses with `{:error, :has_history}` unless the row has no linked user, no
+  invitation ever sent, and no program assignment ever created; `Provider` owns
+  that precondition. Use it for a roster entry typed in by mistake, never to
+  remove someone who worked here.
+
+  Returns `{:ok, %StaffMember{}}` (the deleted row) or
+  `{:error, :not_found | :has_history}`.
   """
   @spec remove_staff_member(String.t(), String.t()) ::
-          {:ok, StaffMember.t()} | {:error, :not_found}
+          {:ok, StaffMember.t()} | {:error, :not_found | :has_history}
   def remove_staff_member(provider_id, staff_id) when is_binary(provider_id) and is_binary(staff_id) do
     context_span entity: "user" do
       Repo.transaction(fn ->
@@ -167,7 +201,7 @@ defmodule KlassHero.Accounts do
   defp maybe_revoke_staff_role(%StaffMember{user_id: nil}), do: :ok
 
   defp maybe_revoke_staff_role(%StaffMember{user_id: user_id}) do
-    # Queried after the delete (same txn): :not_found means this was the last active employment
+    # Queried after the employment ended (same txn): :not_found means this was the last one
     case Provider.get_active_staff_member_by_user(user_id) do
       {:ok, _still_employed} -> :ok
       {:error, :not_found} -> revoke_staff(user_id)

--- a/lib/klass_hero/provider.ex
+++ b/lib/klass_hero/provider.ex
@@ -27,6 +27,7 @@ defmodule KlassHero.Provider do
   alias KlassHero.Provider.AnonymizeUserData
   alias KlassHero.Provider.Assignments
   alias KlassHero.Provider.Incidents
+  alias KlassHero.Provider.OffboardStaffMember
   alias KlassHero.Provider.Profiles
   alias KlassHero.Provider.Programs
   alias KlassHero.Provider.ProviderProfile
@@ -205,11 +206,23 @@ defmodule KlassHero.Provider do
   @doc "Updates an existing staff member."
   defdelegate update_staff_member(provider_id, staff_id, attrs), to: Staff
 
-  @doc "Deletes a staff member owned by `provider_id`; foreign ≡ missing."
+  @doc "Erases a staff row with no history; `{:error, :has_history}` otherwise. Foreign ≡ missing."
   defdelegate delete_staff_member(staff_id, provider_id), to: Staff
+
+  @doc "Ids of the provider's staff rows `delete_staff_member/2` would accept — the same predicate."
+  defdelegate erasable_staff_ids(provider_id), to: Staff
 
   @doc "Ends a staff member's employment link: clears their lead flags, revokes any invitation, stages the event."
   defdelegate deactivate_staff_member(staff_member), to: Staff
+
+  @doc """
+  Offboards a staff member: retires every live program assignment (one
+  `staff_unassigned_from_program` each, so Messaging drops them from the
+  programs' conversations), then ends the employment link.
+
+  Wider than `deactivate_staff_member/1`, which keeps assignments alive on purpose.
+  """
+  defdelegate offboard_staff_member(staff_member), to: OffboardStaffMember, as: :execute
 
   @doc "Reinstates a staff member's employment link; does not restore lead flags or invitations."
   defdelegate reactivate_staff_member(staff_member), to: Staff

--- a/lib/klass_hero/provider/anonymize_user_data.ex
+++ b/lib/klass_hero/provider/anonymize_user_data.ex
@@ -17,7 +17,7 @@ defmodule KlassHero.Provider.AnonymizeUserData do
   import Ecto.Query, only: [from: 2]
 
   alias KlassHero.Provider.IncidentReport
-  alias KlassHero.Provider.Staff
+  alias KlassHero.Provider.OffboardStaffMember
   alias KlassHero.Provider.StaffMember
   alias KlassHero.Repo
 
@@ -67,14 +67,18 @@ defmodule KlassHero.Provider.AnonymizeUserData do
     end
   end
 
-  # Erasure is an ending of employment plus a scrub, and the ordering is
-  # load-bearing: deactivate_staff_member/1 short-circuits on an already-inactive
-  # row, so scrubbing first (which sets active: false) would silently skip the
-  # lead-instructor clearing and the event that clears the erased name from read
-  # tables. Deactivate, then scrub.
+  # Erasure is an offboarding plus a scrub, and the ordering is load-bearing: the
+  # employment write short-circuits on an already-inactive row, so scrubbing first
+  # (which sets active: false) would silently skip the event that clears the
+  # erased name from read tables. Offboard, then scrub.
+  #
+  # Offboarding rather than deactivating (#1292): deactivation deliberately keeps
+  # Program Staff Assignments alive, which for an erased person means their
+  # account stays an active participant in the programs' conversations. Retiring
+  # each assignment is what stages the event Messaging listens to.
   defp erase_staff_member(staff) do
-    case Staff.deactivate_staff_member(staff) do
-      {:ok, deactivated} -> update!(StaffMember.anonymize_changeset(deactivated))
+    case OffboardStaffMember.execute(staff) do
+      {:ok, %{staff_member: offboarded}} -> update!(StaffMember.anonymize_changeset(offboarded))
       {:error, reason} -> Repo.rollback(reason)
     end
   end

--- a/lib/klass_hero/provider/offboard_staff_member.ex
+++ b/lib/klass_hero/provider/offboard_staff_member.ex
@@ -1,0 +1,106 @@
+defmodule KlassHero.Provider.OffboardStaffMember do
+  @moduledoc """
+  Ends a staff member's employment **and** takes them off every program (#1292).
+
+  The sibling of `Provider.Staff.deactivate_staff_member/1`, and deliberately not
+  the same operation:
+
+    * **Deactivation** pauses the employment link. Program Staff Assignments
+      survive on purpose, because unassigning would strip Messaging conversation
+      membership that reactivation cannot give back.
+    * **Offboarding** is the provider saying the person no longer works here. The
+      assignments have to go, and going through the assignment rows is what
+      stages `staff_unassigned_from_program` — the event Messaging listens to in
+      order to deactivate the `program_staff_participant` row and soft-leave the
+      person from the program's conversations.
+
+  It replaces a bare `Repo.delete` whose assignments were destroyed by an
+  `on_delete: :delete_all` FK: Postgres removed the rows, no changeset ran, and
+  so nothing was ever staged. The removed staff member stayed a conversation
+  participant indefinitely.
+
+  Lives at the context root rather than in `staff.ex` because it spans two
+  entities under one transaction — the same reason `AnonymizeUserData` does.
+
+  Ordering is load-bearing: the assignments are retired **before** the employment
+  write, so the `active` flip cannot short-circuit the teardown on a re-run.
+  """
+
+  use KlassHero.Shared.Tracing
+
+  alias KlassHero.Provider.Assignments
+  alias KlassHero.Provider.Domain.Events.ProviderEvents
+  alias KlassHero.Provider.ProgramStaffAssignment
+  alias KlassHero.Provider.StaffMember
+  alias KlassHero.Repo
+  alias KlassHero.Shared.Outbox
+
+  @context KlassHero.Provider
+
+  @doc """
+  Offboards a staff member, in one transaction.
+
+  Retires every live Program Staff Assignment (staging one
+  `staff_unassigned_from_program` per program), then ends the employment link and
+  stages `staff_member_deactivated`. All of it commits together, and the outbox
+  turns the batch into a single ordered delivery job.
+
+  Takes the struct, so provider-initiated callers scope through
+  `Provider.get_staff_member/2` first — foreign ≡ missing is that function's
+  guarantee, and re-deriving it here would give the guard a second home.
+
+  Idempotent: an already-offboarded member with no live assignments comes back
+  with `unassigned_count: 0` and nothing staged.
+  """
+  @spec execute(StaffMember.t()) ::
+          {:ok, %{staff_member: StaffMember.t(), unassigned_count: non_neg_integer()}}
+          | {:error, term()}
+  def execute(%StaffMember{} = staff) do
+    context_span entity: "staff_member" do
+      Outbox.transact(@context, fn -> offboard(staff) end)
+    end
+  end
+
+  defp offboard(staff) do
+    with {:ok, unassigned, unassignment_events} <- retire_assignments(staff),
+         {:ok, ended, employment_events} <- end_employment(staff) do
+      result = %{staff_member: ended, unassigned_count: length(unassigned)}
+
+      {:ok, result, unassignment_events ++ employment_events}
+    end
+  end
+
+  # `unassign_changeset/1` clears `is_lead_instructor` as it retires the row, so
+  # leading a program is not an obstacle here. The public
+  # `Assignments.unassign_staff_from_program/3` is deliberately not reused: it
+  # refuses to retire a lead (a rail on the interactive one-program detach), and
+  # it would open its own transaction per program — N delivery jobs instead of one.
+  defp retire_assignments(%StaffMember{} = staff) do
+    staff.id
+    |> Assignments.list_active_assignments_for_staff_member()
+    |> Enum.reduce_while({:ok, [], []}, fn assignment, {:ok, retired, events} ->
+      case Repo.update(ProgramStaffAssignment.unassign_changeset(assignment)) do
+        {:ok, unassigned} ->
+          event = ProviderEvents.staff_unassigned_from_program(unassigned, staff)
+          {:cont, {:ok, [unassigned | retired], [event | events]}}
+
+        {:error, reason} ->
+          {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, retired, events} -> {:ok, Enum.reverse(retired), Enum.reverse(events)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  # Already inactive: the employment link is where it should be, and re-staging
+  # `staff_member_deactivated` would announce a change that did not happen.
+  defp end_employment(%StaffMember{active: false} = staff), do: {:ok, staff, []}
+
+  defp end_employment(%StaffMember{} = staff) do
+    with {:ok, ended} <- Repo.update(StaffMember.deactivate_changeset(staff)) do
+      {:ok, ended, [ProviderEvents.staff_member_deactivated(ended)]}
+    end
+  end
+end

--- a/lib/klass_hero/provider/staff.ex
+++ b/lib/klass_hero/provider/staff.ex
@@ -120,22 +120,76 @@ defmodule KlassHero.Provider.Staff do
   end
 
   @doc """
-  Deletes a staff member owned by `provider_id`.
+  Erases a staff member owned by `provider_id` — the narrow hard delete (#1292).
 
-  Scoped like `get_staff_member/2`, so a foreign row is unreachable rather than
-  fetched and then rejected — the guard cannot be skipped by a caller.
+  Removing someone who actually worked here is `offboard_staff_member/1`. This is
+  for a row that is provably a data-entry mistake, and it refuses anything else
+  with `{:error, :has_history}`. A row qualifies only when it has **no linked
+  user**, **no invitation was ever sent**, and **no assignment row ever existed**:
+
+    * an invitation means a real person was told they have a role at this
+      business, and
+    * an assignment means `staff_assigned_to_program` / `staff_unassigned_from_program`
+      events exist naming this `staff_member_id`.
+
+  Deleting under either would leave those pointing at nothing — silently, because
+  `program_staff_assignments.staff_member_id` is `on_delete: :delete_all` and a
+  cascade runs no changeset and stages no event. That silence *was* #1292.
+
+  The predicate and the delete are one statement, so an invitation sent or an
+  assignment created concurrently cannot slip between check and delete. Scoped
+  like `get_staff_member/2`, so a foreign row is unreachable rather than fetched
+  and then rejected.
   """
-  @spec delete_staff_member(String.t(), String.t()) :: :ok | {:error, :not_found}
+  @spec delete_staff_member(String.t(), String.t()) :: :ok | {:error, :not_found | :has_history}
   def delete_staff_member(staff_id, provider_id) when is_binary(staff_id) and is_binary(provider_id) do
     context_span entity: "staff_member" do
-      case get_staff_member(staff_id, provider_id) do
-        {:ok, staff} ->
-          {:ok, _} = Repo.delete(staff)
-          :ok
-
-        {:error, :not_found} ->
-          {:error, :not_found}
+      case Repo.delete_all(erasable_scope(staff_id, provider_id)) do
+        {1, _} -> :ok
+        {0, _} -> classify_refusal(staff_id, provider_id)
       end
+    end
+  end
+
+  @doc """
+  Ids of the provider's staff members that `delete_staff_member/2` would accept.
+
+  Shares the predicate with the delete itself, so the Team tab can only offer the
+  action where it would succeed — a UI copy of the rule would drift from it.
+  """
+  @spec erasable_staff_ids(String.t()) :: MapSet.t(String.t())
+  def erasable_staff_ids(provider_id) when is_binary(provider_id) do
+    provider_id
+    |> erasable_scope()
+    |> select([s], s.id)
+    |> Repo.all()
+    |> MapSet.new()
+  end
+
+  defp erasable_scope(staff_id, provider_id) do
+    from [staff: s] in erasable_scope(provider_id), where: s.id == ^staff_id
+  end
+
+  defp erasable_scope(provider_id) do
+    from s in StaffMember,
+      as: :staff,
+      where: s.provider_id == ^provider_id,
+      where: is_nil(s.user_id) and is_nil(s.invitation_status),
+      where:
+        not exists(
+          from a in ProgramStaffAssignment,
+            where: a.staff_member_id == parent_as(:staff).id,
+            select: 1
+        )
+  end
+
+  # The delete matched nothing for one of two reasons. Re-reading tells them
+  # apart for the caller's error, and goes through the scoped getter so a foreign
+  # row still reports as missing rather than as a row that exists but is protected.
+  defp classify_refusal(staff_id, provider_id) do
+    case get_staff_member(staff_id, provider_id) do
+      {:ok, _protected} -> {:error, :has_history}
+      {:error, :not_found} -> {:error, :not_found}
     end
   end
 

--- a/lib/klass_hero_web/components/provider_components.ex
+++ b/lib/klass_hero_web/components/provider_components.ex
@@ -551,21 +551,92 @@ defmodule KlassHeroWeb.ProviderComponents do
           >
             {gettext("Resend")}
           </button>
+          <%!-- Ending employment is routine and reversible, so it reads as an
+                ordinary action rather than a red destructive one. --%>
           <button
             type="button"
-            phx-click="delete_member"
+            id={"end-employment-#{@member.id}"}
+            phx-click="end_employment"
             phx-value-id={@member.id}
-            data-confirm={gettext("Are you sure you want to remove this team member?")}
+            data-confirm={
+              gettext(
+                "%{name} will be unassigned from every program and removed from those conversations. Their history is kept and you can add them back later.",
+                name: @member.full_name
+              )
+            }
             class={[
-              "p-2 text-red-500 hover:bg-red-50",
+              "px-3 py-2 border border-hero-grey-300 bg-white",
+              "hover:bg-hero-grey-50 text-hero-charcoal text-sm font-medium",
               Theme.rounded(:lg),
               Theme.transition(:normal)
             ]}
           >
-            <.icon name="hero-x-mark-mini" class="w-5 h-5" />
+            {gettext("Remove from team")}
           </button>
         </div>
+
+        <%!-- Only rendered where the context would actually accept it: no linked
+              account, no invitation ever sent, no program assignment ever. Absent
+              rather than disabled — explaining a refusal for an action nobody was
+              trying to take is clutter, and "Remove from team" is the answer for
+              everyone else. --%>
+        <button
+          :if={@member.can_delete?}
+          type="button"
+          id={"delete-member-#{@member.id}"}
+          phx-click="delete_member"
+          phx-value-id={@member.id}
+          data-confirm={
+            gettext(
+              "This deletes %{name} permanently — there's nothing to undo. Use it only for an entry added by mistake.",
+              name: @member.full_name
+            )
+          }
+          class={[
+            "mt-2 text-xs text-hero-grey-500 underline hover:text-red-600",
+            Theme.transition(:normal)
+          ]}
+        >
+          {gettext("Delete entry")}
+        </button>
       </div>
+    </div>
+    """
+  end
+
+  @doc """
+  A team member whose employment has ended.
+
+  Deliberately not the active card greyed out: the only action is bringing them
+  back. Editing, resending an invitation or deleting all belong to someone who
+  currently works here, so reinstate first and act after.
+  """
+  attr :member, :map, required: true
+
+  def former_member_card(assigns) do
+    ~H"""
+    <div class={[
+      "flex items-center justify-between gap-3 bg-white border border-hero-grey-200 px-4 py-3",
+      Theme.rounded(:xl)
+    ]}>
+      <div class="min-w-0">
+        <p class="font-medium text-hero-charcoal truncate">{@member.full_name}</p>
+        <p :if={@member.role} class="text-xs text-hero-grey-500 truncate">{@member.role}</p>
+      </div>
+      <button
+        type="button"
+        id={"reactivate-member-#{@member.id}"}
+        phx-click="reactivate_member"
+        phx-value-id={@member.id}
+        class={[
+          "shrink-0 px-3 py-2 border border-hero-grey-300 bg-white",
+          "hover:bg-hero-grey-50 text-hero-charcoal text-sm font-medium",
+          Theme.rounded(:lg),
+          Theme.transition(:normal)
+        ]}
+      >
+        {gettext("Add back to team")}
+      </button>
     </div>
     """
   end

--- a/lib/klass_hero_web/live/provider/programs_live.ex
+++ b/lib/klass_hero_web/live/provider/programs_live.ex
@@ -42,9 +42,11 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
     staff_members = fetch_staff_members(provider.id)
     staff_views = StaffMemberPresenter.to_admin_view_list(staff_members)
 
+    # Current team only: a former member has no active assignment left, so
+    # filtering by them would always come back empty — a dead option (#1292).
     staff_options =
       [%{value: "all", label: gettext("All Staff")}] ++
-        Enum.map(staff_views, &%{value: &1.id, label: &1.full_name})
+        for member <- staff_views, member.active, do: %{value: member.id, label: member.full_name}
 
     socket =
       socket

--- a/lib/klass_hero_web/live/provider/team_live.ex
+++ b/lib/klass_hero_web/live/provider/team_live.ex
@@ -28,7 +28,7 @@ defmodule KlassHeroWeb.Provider.TeamLive do
     scope = socket.assigns.current_scope
 
     staff_members = fetch_staff_members(provider.id)
-    staff_views = StaffMemberPresenter.to_admin_view_list(staff_members)
+    {current_views, former_views} = roster_views(staff_members, provider.id)
 
     socket =
       socket
@@ -37,8 +37,10 @@ defmodule KlassHeroWeb.Provider.TeamLive do
       |> assign(active_nav: :home)
       |> assign(:self_staffed?, self_staffed?(staff_members, scope))
       |> assign(:self_staffing?, false)
-      |> stream(:team_members, staff_views)
-      |> update_staff_count(length(staff_views))
+      |> stream(:team_members, current_views)
+      |> stream(:former_members, former_views)
+      |> update_staff_count(length(current_views))
+      |> assign(former_count: length(former_views))
       |> assign(show_staff_form: false, editing_staff_id: nil)
       |> assign(staff_form: to_form(Provider.new_staff_member_changeset(), as: :staff_member_schema))
       |> assign(categories: ProgramCatalog.program_categories())
@@ -147,12 +149,55 @@ defmodule KlassHeroWeb.Provider.TeamLive do
   end
 
   @impl true
+  def handle_event("end_employment", %{"id" => staff_id}, socket) do
+    provider_id = socket.assigns.current_scope.provider.id
+
+    # Accounts orchestrates: Provider offboards (every program assignment retired,
+    # which is what takes them out of the programs' conversations — #1292) and
+    # Accounts durably drops :staff when no other active employment remains (#972),
+    # atomically. It also enforces provider ownership — a foreign staff_id comes
+    # back as :not_found.
+    case Accounts.offboard_staff_member(provider_id, staff_id) do
+      {:ok, offboarded} ->
+        {:noreply,
+         socket
+         |> move_to_former(offboarded)
+         |> heal_after_self_delete({:ok, offboarded})
+         |> clear_flash(:error)
+         |> put_flash(:info, gettext("Team member removed from the team."))}
+
+      {:error, :not_found} ->
+        {:noreply, staff_not_found(socket, "offboard", staff_id, provider_id)}
+    end
+  end
+
+  @impl true
+  def handle_event("reactivate_member", %{"id" => staff_id}, socket) do
+    provider_id = socket.assigns.current_scope.provider.id
+
+    with {:ok, staff} <- Provider.get_staff_member(staff_id, provider_id),
+         {:ok, reactivated} <- Provider.reactivate_staff_member(staff) do
+      {:noreply,
+       socket
+       |> move_to_current(reactivated)
+       |> heal_after_self_reactivate(reactivated)
+       |> clear_flash(:error)
+       # Employment only: assignments retired on offboarding do not come back,
+       # so say so rather than let "reactivated" imply their programs returned.
+       |> put_flash(:info, gettext("Team member is back. Assign them to programs again when you're ready."))}
+    else
+      {:error, :not_found} ->
+        {:noreply, staff_not_found(socket, "reactivate", staff_id, provider_id)}
+
+      {:error, _reason} ->
+        {:noreply, put_flash(socket, :error, gettext("Could not bring this team member back. Please try again."))}
+    end
+  end
+
+  @impl true
   def handle_event("delete_member", %{"id" => staff_id}, socket) do
     provider_id = socket.assigns.current_scope.provider.id
 
-    # Accounts orchestrates: it deletes the Provider row AND durably drops :staff
-    # when no other active linked row remains (#972), atomically. It also enforces
-    # provider ownership — a foreign staff_id comes back as :not_found.
     case Accounts.remove_staff_member(provider_id, staff_id) do
       {:ok, deleted} ->
         {:noreply,
@@ -163,14 +208,18 @@ defmodule KlassHeroWeb.Provider.TeamLive do
          |> clear_flash(:error)
          |> put_flash(:info, gettext("Team member removed."))}
 
-      {:error, :not_found} ->
-        # Log the attempt so an enumeration attack is visible.
-        Logger.warning("[TeamLive] Staff delete returned not_found",
-          staff_member_id: staff_id,
-          provider_id: provider_id
-        )
+      # The card only offers Delete on a row with no history, so this is a stale
+      # tab: someone was invited or assigned since the page loaded.
+      {:error, :has_history} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           gettext("This person has a history here now — use 'Remove from team' instead.")
+         )}
 
-        {:noreply, put_flash(socket, :error, gettext("Staff member not found."))}
+      {:error, :not_found} ->
+        {:noreply, staff_not_found(socket, "delete", staff_id, provider_id)}
     end
   end
 
@@ -273,15 +322,15 @@ defmodule KlassHeroWeb.Provider.TeamLive do
       {:error, :already_staffed} ->
         # Stale tab: they self-staffed elsewhere. The row exists but isn't in
         # this tab's memory, so converge the whole page: flags, nav, roster.
-        staff_views =
-          socket.assigns.current_scope.provider.id
-          |> fetch_staff_members()
-          |> StaffMemberPresenter.to_admin_view_list()
+        provider_id = socket.assigns.current_scope.provider.id
+        {current_views, former_views} = roster_views(fetch_staff_members(provider_id), provider_id)
 
         {:noreply,
          socket
-         |> stream(:team_members, staff_views, reset: true)
-         |> update_staff_count(length(staff_views))
+         |> stream(:team_members, current_views, reset: true)
+         |> stream(:former_members, former_views, reset: true)
+         |> update_staff_count(length(current_views))
+         |> assign(former_count: length(former_views))
          |> assign(show_staff_form: false, self_staffing?: false)
          |> assign(self_staffed?: true, dual_role?: true)
          |> put_flash(:info, gettext("You're already on your team."))}
@@ -429,9 +478,58 @@ defmodule KlassHeroWeb.Provider.TeamLive do
     assign(socket, staff_count: count)
   end
 
+  # Log the attempt so an enumeration attack is visible.
+  defp staff_not_found(socket, action, staff_id, provider_id) do
+    Logger.warning("[TeamLive] Staff #{action} returned not_found",
+      staff_member_id: staff_id,
+      provider_id: provider_id
+    )
+
+    put_flash(socket, :error, gettext("Staff member not found."))
+  end
+
   defp fetch_staff_members(provider_id) do
     {:ok, members} = Provider.list_staff_members(provider_id)
     members
+  end
+
+  # The roster read is not active-filtered, so the tab splits it: people who work
+  # here, and former team members kept for their history (and for Reactivate).
+  # `staff_count` counts the current team only.
+  defp roster_views(staff_members, provider_id) do
+    erasable = Provider.erasable_staff_ids(provider_id)
+    {current, former} = Enum.split_with(staff_members, & &1.active)
+
+    {StaffMemberPresenter.to_admin_view_list(current, erasable),
+     StaffMemberPresenter.to_admin_view_list(former, erasable)}
+  end
+
+  defp move_to_former(socket, staff) do
+    socket
+    |> stream_delete_by_dom_id(:team_members, "team_members-#{staff.id}")
+    |> stream_insert(:former_members, StaffMemberPresenter.to_admin_view(staff))
+    |> update_staff_count(max(0, socket.assigns.staff_count - 1))
+    |> assign(former_count: socket.assigns.former_count + 1)
+  end
+
+  defp move_to_current(socket, staff) do
+    erasable = Provider.erasable_staff_ids(staff.provider_id)
+
+    socket
+    |> stream_delete_by_dom_id(:former_members, "former_members-#{staff.id}")
+    |> stream_insert(:team_members, StaffMemberPresenter.to_admin_view(staff, erasable))
+    |> update_staff_count(socket.assigns.staff_count + 1)
+    |> assign(former_count: max(0, socket.assigns.former_count - 1))
+  end
+
+  # Mirror of heal_after_self_delete/2: reinstating their own row restores the
+  # self-staff state and the staff-dashboard cross-nav.
+  defp heal_after_self_reactivate(socket, %{user_id: user_id}) do
+    if user_id == socket.assigns.current_scope.user.id do
+      assign(socket, self_staffed?: true, dual_role?: true)
+    else
+      socket
+    end
   end
 
   defp upload_headshot(socket, provider_id) do
@@ -555,6 +653,19 @@ defmodule KlassHeroWeb.Provider.TeamLive do
           </div>
           <div :for={{id, member} <- @streams.team_members} id={id}>
             <.team_member_card member={member} rate_label={member.rate_label} />
+          </div>
+        </div>
+
+        <%!-- Streams cannot report their own size, so the section is gated on a
+              counted assign rather than on the stream (see LiveView streams). --%>
+        <div :if={@former_count > 0} id="former-members-section" class="space-y-3">
+          <h3 id="former-members-heading" class={KlassHeroWeb.Theme.typography(:card_title)}>
+            {gettext("Former team members")}
+          </h3>
+          <div id="former-members" phx-update="stream" class="space-y-3">
+            <div :for={{id, member} <- @streams.former_members} id={id}>
+              <.former_member_card member={member} />
+            </div>
           </div>
         </div>
       </div>

--- a/lib/klass_hero_web/presenters/staff_member_presenter.ex
+++ b/lib/klass_hero_web/presenters/staff_member_presenter.ex
@@ -69,13 +69,21 @@ defmodule KlassHeroWeb.Presenters.StaffMemberPresenter do
 
   @doc """
   Business-owner-facing view. Extends the card view with pay_rate + formatted rate_label.
-  """
-  @spec to_admin_view(StaffMember.t()) :: map()
-  def to_admin_view(%StaffMember{} = staff), do: with_pay_rate(staff)
 
-  @spec to_admin_view_list([StaffMember.t()]) :: [map()]
-  def to_admin_view_list(staff_members) when is_list(staff_members) do
-    Enum.map(staff_members, &to_admin_view/1)
+  `erasable_ids` comes from `Provider.erasable_staff_ids/1` and decides `can_delete?`
+  — whether the Team tab offers the hard delete on this row. It defaults to none,
+  so a caller that does not ask about erasability never renders the action.
+  """
+  @spec to_admin_view(StaffMember.t(), MapSet.t(String.t())) :: map()
+  def to_admin_view(%StaffMember{} = staff, erasable_ids \\ MapSet.new()) do
+    staff
+    |> with_pay_rate()
+    |> Map.put(:can_delete?, MapSet.member?(erasable_ids, staff.id))
+  end
+
+  @spec to_admin_view_list([StaffMember.t()], MapSet.t(String.t())) :: [map()]
+  def to_admin_view_list(staff_members, erasable_ids \\ MapSet.new()) when is_list(staff_members) do
+    Enum.map(staff_members, &to_admin_view(&1, erasable_ids))
   end
 
   @doc """

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -137,7 +137,7 @@ msgid "Your Data"
 msgstr "Ihre Daten"
 
 #: lib/klass_hero_web/components/core_components.ex:67
-#: lib/klass_hero_web/components/provider_components.ex:1615
+#: lib/klass_hero_web/components/provider_components.ex:1686
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr "schließen"
@@ -232,7 +232,7 @@ msgstr "Einfache Terminplanung"
 msgid "Enroll Now - %{price}"
 msgstr "Jetzt anmelden - %{price}"
 
-#: lib/klass_hero_web/components/provider_components.ex:1366
+#: lib/klass_hero_web/components/provider_components.ex:1437
 #: lib/klass_hero_web/live/booking_live.ex:285
 #, elixir-autogen, elixir-format
 msgid "Enrollment"
@@ -577,9 +577,9 @@ msgstr "Wird gelöscht..."
 msgid "Dispute Resolution"
 msgstr "Streitbeilegung"
 
-#: lib/klass_hero_web/components/provider_components.ex:647
-#: lib/klass_hero_web/components/provider_components.ex:2288
-#: lib/klass_hero_web/components/provider_components.ex:2306
+#: lib/klass_hero_web/components/provider_components.ex:718
+#: lib/klass_hero_web/components/provider_components.ex:2359
+#: lib/klass_hero_web/components/provider_components.ex:2377
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
@@ -878,9 +878,9 @@ msgstr "Speichern..."
 msgid "Select one or both options"
 msgstr "Wählen Sie eine oder beide Optionen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1984
-#: lib/klass_hero_web/components/provider_components.ex:1985
-#: lib/klass_hero_web/components/provider_components.ex:2022
+#: lib/klass_hero_web/components/provider_components.ex:2055
+#: lib/klass_hero_web/components/provider_components.ex:2056
+#: lib/klass_hero_web/components/provider_components.ex:2093
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:446
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:483
@@ -1456,7 +1456,7 @@ msgstr "Lebenskompetenzen"
 msgid "Music"
 msgstr "Musik"
 
-#: lib/klass_hero_web/components/provider_components.ex:683
+#: lib/klass_hero_web/components/provider_components.ex:754
 #: lib/klass_hero_web/live/for_providers_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "Qualifications"
@@ -1577,30 +1577,30 @@ msgstr "Profil"
 msgid "Quick Navigation"
 msgstr "Schnellnavigation"
 
-#: lib/klass_hero_web/components/provider_components.ex:1369
-#: lib/klass_hero_web/components/provider_components.ex:1960
-#: lib/klass_hero_web/components/provider_components.ex:2186
+#: lib/klass_hero_web/components/provider_components.ex:1440
+#: lib/klass_hero_web/components/provider_components.ex:2031
+#: lib/klass_hero_web/components/provider_components.ex:2257
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr "Aktionen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1508
+#: lib/klass_hero_web/components/provider_components.ex:1579
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr "Aktiv"
 
-#: lib/klass_hero_web/components/provider_components.ex:600
-#: lib/klass_hero_web/live/provider/team_live.ex:529
+#: lib/klass_hero_web/components/provider_components.ex:671
+#: lib/klass_hero_web/live/provider/team_live.ex:627
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
 msgstr "Teammitglied hinzufügen"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:46
+#: lib/klass_hero_web/live/provider/programs_live.ex:48
 #, elixir-autogen, elixir-format
 msgid "All Staff"
 msgstr "Alle Mitarbeiter"
 
-#: lib/klass_hero_web/components/provider_components.ex:1360
+#: lib/klass_hero_web/components/provider_components.ex:1431
 #, elixir-autogen, elixir-format
 msgid "Assigned Staff"
 msgstr "Zugewiesenes Personal"
@@ -1622,13 +1622,13 @@ msgstr "Geschäftsprofil"
 msgid "Business Registration"
 msgstr "Gewerbeanmeldung"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:506
+#: lib/klass_hero_web/live/provider/team_live.ex:604
 #, elixir-autogen, elixir-format
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr "Erstellen Sie Profile für Ihr Personal. Diese werden für Eltern sichtbar sein, wenn sie Programmen zugewiesen werden."
 
 #: lib/klass_hero_web/components/provider_components.ex:538
-#: lib/klass_hero_web/components/provider_components.ex:1471
+#: lib/klass_hero_web/components/provider_components.ex:1542
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:54
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:81
 #: lib/klass_hero_web/live/settings/children_live.ex:448
@@ -1645,19 +1645,19 @@ msgstr "Bearbeiten"
 msgid "Edit Profile"
 msgstr "Profil bearbeiten"
 
-#: lib/klass_hero_web/components/provider_components.ex:1510
+#: lib/klass_hero_web/components/provider_components.ex:1581
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr "Inaktiv"
 
 #: lib/klass_hero_web/components/provider_components.ex:112
-#: lib/klass_hero_web/live/provider/programs_live.ex:52
+#: lib/klass_hero_web/live/provider/programs_live.ex:54
 #, elixir-autogen, elixir-format
 msgid "My Programs"
 msgstr "Meine Programme"
 
 #: lib/klass_hero_web/components/provider_components.ex:415
-#: lib/klass_hero_web/components/provider_components.ex:858
+#: lib/klass_hero_web/components/provider_components.ex:929
 #, elixir-autogen, elixir-format
 msgid "New Program"
 msgstr "Neues Programm"
@@ -1669,26 +1669,26 @@ msgstr "Übersicht"
 
 #: lib/klass_hero_web/components/provider_components.ex:46
 #: lib/klass_hero_web/components/provider_components.ex:72
-#: lib/klass_hero_web/components/provider_components.ex:1509
-#: lib/klass_hero_web/components/provider_components.ex:2382
-#: lib/klass_hero_web/components/provider_components.ex:2400
+#: lib/klass_hero_web/components/provider_components.ex:1580
+#: lib/klass_hero_web/components/provider_components.ex:2453
+#: lib/klass_hero_web/components/provider_components.ex:2471
 #: lib/klass_hero_web/live/admin/sessions_live.ex:297
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr "Ausstehend"
 
-#: lib/klass_hero_web/components/provider_components.ex:1447
+#: lib/klass_hero_web/components/provider_components.ex:1518
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr "Vorschau"
 
-#: lib/klass_hero_web/components/provider_components.ex:1300
+#: lib/klass_hero_web/components/provider_components.ex:1371
 #, elixir-autogen, elixir-format
 msgid "Program Inventory"
 msgstr "Programmübersicht"
 
-#: lib/klass_hero_web/components/provider_components.ex:1357
+#: lib/klass_hero_web/components/provider_components.ex:1428
 #, elixir-autogen, elixir-format
 msgid "Program Name"
 msgstr "Programmname"
@@ -1703,15 +1703,15 @@ msgstr "Anbieter-Dashboard"
 msgid "Save for Later"
 msgstr "Für später speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:1317
+#: lib/klass_hero_web/components/provider_components.ex:1388
 #, elixir-autogen, elixir-format
 msgid "Search by name..."
 msgstr "Nach Namen suchen..."
 
-#: lib/klass_hero_web/components/provider_components.ex:1363
-#: lib/klass_hero_web/components/provider_components.ex:1732
-#: lib/klass_hero_web/components/provider_components.ex:1954
-#: lib/klass_hero_web/components/provider_components.ex:2183
+#: lib/klass_hero_web/components/provider_components.ex:1434
+#: lib/klass_hero_web/components/provider_components.ex:1803
+#: lib/klass_hero_web/components/provider_components.ex:2025
+#: lib/klass_hero_web/components/provider_components.ex:2254
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1725,7 +1725,7 @@ msgstr "Status"
 msgid "Team & Profiles"
 msgstr "Team & Profile"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:503
+#: lib/klass_hero_web/live/provider/team_live.ex:601
 #, elixir-autogen, elixir-format
 msgid "Team & Provider Profiles"
 msgstr "Team- & Anbieterprofile"
@@ -1735,15 +1735,15 @@ msgstr "Team- & Anbieterprofile"
 msgid "This is your main business identity. Verification is required to list programs."
 msgstr "Dies ist Ihre Hauptgeschäftsidentität. Eine Verifizierung ist erforderlich, um Programme anzubieten."
 
-#: lib/klass_hero_web/components/provider_components.ex:1420
-#: lib/klass_hero_web/components/provider_components.ex:1747
+#: lib/klass_hero_web/components/provider_components.ex:1491
+#: lib/klass_hero_web/components/provider_components.ex:1818
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr "Nicht zugewiesen"
 
 #: lib/klass_hero_web/components/messaging_components.ex:728
 #: lib/klass_hero_web/components/provider_components.ex:49
-#: lib/klass_hero_web/components/provider_components.ex:1511
+#: lib/klass_hero_web/components/provider_components.ex:1582
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:433
 #: lib/klass_hero_web/presenters/provider_presenter.ex:103
 #, elixir-autogen, elixir-format
@@ -1755,7 +1755,7 @@ msgstr "Unbekannt"
 msgid "Verified Business"
 msgstr "Verifiziertes Unternehmen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1458
+#: lib/klass_hero_web/components/provider_components.ex:1529
 #, elixir-autogen, elixir-format
 msgid "View Roster"
 msgstr "Teilnehmerliste"
@@ -1815,9 +1815,9 @@ msgstr "Rundnachricht an %{count} Eltern gesendet"
 #: lib/klass_hero_web/components/participation_components.ex:441
 #: lib/klass_hero_web/components/participation_components.ex:631
 #: lib/klass_hero_web/components/participation_components.ex:717
-#: lib/klass_hero_web/components/provider_components.ex:817
-#: lib/klass_hero_web/components/provider_components.ex:1216
-#: lib/klass_hero_web/components/provider_components.ex:2125
+#: lib/klass_hero_web/components/provider_components.ex:888
+#: lib/klass_hero_web/components/provider_components.ex:1287
+#: lib/klass_hero_web/components/provider_components.ex:2196
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:478
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
@@ -1883,7 +1883,7 @@ msgstr "Kind konnte nicht entfernt werden. Bitte versuchen Sie es erneut."
 msgid "Data sharing consent"
 msgstr "Einwilligung zur Datenweitergabe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2269
+#: lib/klass_hero_web/components/provider_components.ex:2340
 #: lib/klass_hero_web/live/settings/children_live.ex:657
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1931,17 +1931,17 @@ msgstr "Rundnachricht konnte nicht gesendet werden"
 msgid "Failed to submit note"
 msgstr "Notiz konnte nicht eingereicht werden"
 
-#: lib/klass_hero_web/components/provider_components.ex:2263
-#: lib/klass_hero_web/components/provider_components.ex:2292
-#: lib/klass_hero_web/components/provider_components.ex:2308
+#: lib/klass_hero_web/components/provider_components.ex:2334
+#: lib/klass_hero_web/components/provider_components.ex:2363
+#: lib/klass_hero_web/components/provider_components.ex:2379
 #: lib/klass_hero_web/live/settings/children_live.ex:643
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr "Vorname"
 
-#: lib/klass_hero_web/components/provider_components.ex:2264
-#: lib/klass_hero_web/components/provider_components.ex:2293
-#: lib/klass_hero_web/components/provider_components.ex:2309
+#: lib/klass_hero_web/components/provider_components.ex:2335
+#: lib/klass_hero_web/components/provider_components.ex:2364
+#: lib/klass_hero_web/components/provider_components.ex:2380
 #: lib/klass_hero_web/live/settings/children_live.ex:649
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -2073,15 +2073,15 @@ msgstr "Programm-Rundnachricht"
 msgid "Provider data sharing consent"
 msgstr "Einwilligung zur Datenweitergabe an Anbieter"
 
-#: lib/klass_hero_web/components/provider_components.ex:802
+#: lib/klass_hero_web/components/provider_components.ex:873
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:294
 #: lib/klass_hero_web/live/settings/children_live.ex:754
 #, elixir-autogen, elixir-format
 msgid "Save Changes"
 msgstr "Änderungen speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:1593
-#: lib/klass_hero_web/components/provider_components.ex:1594
+#: lib/klass_hero_web/components/provider_components.ex:1664
+#: lib/klass_hero_web/components/provider_components.ex:1665
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:43
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:151
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:252
@@ -2099,7 +2099,7 @@ msgstr "Rundnachricht senden"
 msgid "Send a message to start the conversation"
 msgstr "Senden Sie eine Nachricht, um die Unterhaltung zu beginnen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2363
+#: lib/klass_hero_web/components/provider_components.ex:2434
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:245
 #, elixir-autogen, elixir-format
@@ -2210,12 +2210,12 @@ msgstr "Nur %{gender}"
 msgid "Action Required"
 msgstr "Aktion erforderlich"
 
-#: lib/klass_hero_web/components/provider_components.ex:804
+#: lib/klass_hero_web/components/provider_components.ex:875
 #, elixir-autogen, elixir-format
 msgid "Add Member"
 msgstr "Mitglied hinzufügen"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:553
+#: lib/klass_hero_web/live/provider/team_live.ex:651
 #, elixir-autogen, elixir-format
 msgid "Add your first staff member to get started!"
 msgstr "Fügen Sie Ihren ersten Mitarbeiter hinzu, um loszulegen!"
@@ -2230,12 +2230,12 @@ msgstr "Alter %{min} bis %{max}"
 msgid "Ages %{min}+"
 msgstr "Alter %{min}+"
 
-#: lib/klass_hero_web/components/provider_components.ex:1077
+#: lib/klass_hero_web/components/provider_components.ex:1148
 #, elixir-autogen, elixir-format
 msgid "Allowed Genders"
 msgstr "Zulässige Geschlechter"
 
-#: lib/klass_hero_web/components/provider_components.ex:2422
+#: lib/klass_hero_web/components/provider_components.ex:2493
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred during import."
 msgstr "Beim Import ist ein unerwarteter Fehler aufgetreten."
@@ -2261,11 +2261,6 @@ msgstr "Genehmigt"
 msgid "Are you sure you want to approve this document?"
 msgstr "Möchten Sie dieses Dokument wirklich genehmigen?"
 
-#: lib/klass_hero_web/components/provider_components.ex:558
-#, elixir-autogen, elixir-format
-msgid "Are you sure you want to remove this team member?"
-msgstr "Möchten Sie dieses Teammitglied wirklich entfernen?"
-
 #: lib/klass_hero_web/components/marketing_components.ex:671
 #, elixir-autogen, elixir-format
 msgid "As fathers and partners of teachers in Berlin, we saw and heard firsthand how hard it is to find, book, and manage quality youth activities outside the classroom. Klass Hero is the complete platform connecting Berlin families and schools with trusted, vetted activity providers — offering safe, supervised, and enriching experiences across sports, arts, tutoring, and more. We verify every provider, structure every booking, and support every step — so parents know their child is in good hands, and providers can focus on what they do best: inspiring kids."
@@ -2283,7 +2278,7 @@ msgstr "Zurück zum Dashboard"
 msgid "Back to verifications"
 msgstr "Zurück zu den Verifizierungen"
 
-#: lib/klass_hero_web/components/provider_components.ex:656
+#: lib/klass_hero_web/components/provider_components.ex:727
 #, elixir-autogen, elixir-format
 msgid "Bio"
 msgstr "Biografie"
@@ -2293,7 +2288,7 @@ msgstr "Biografie"
 msgid "Book a Program"
 msgstr "Programm buchen"
 
-#: lib/klass_hero_web/components/provider_components.ex:657
+#: lib/klass_hero_web/components/provider_components.ex:728
 #, elixir-autogen, elixir-format
 msgid "Brief description of experience and specialties..."
 msgstr "Kurze Beschreibung der Erfahrung und Spezialgebiete..."
@@ -2324,19 +2319,19 @@ msgstr "Geschäftsinformationen"
 msgid "Business Logo"
 msgstr "Firmenlogo"
 
-#: lib/klass_hero_web/components/provider_components.ex:888
+#: lib/klass_hero_web/components/provider_components.ex:959
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "Category"
 msgstr "Kategorie"
 
-#: lib/klass_hero_web/components/provider_components.ex:1026
+#: lib/klass_hero_web/components/provider_components.ex:1097
 #, elixir-autogen, elixir-format
 msgid "Check eligibility at"
 msgstr "Berechtigung prüfen unter"
 
-#: lib/klass_hero_web/components/provider_components.ex:1951
-#: lib/klass_hero_web/components/provider_components.ex:2177
+#: lib/klass_hero_web/components/provider_components.ex:2022
+#: lib/klass_hero_web/components/provider_components.ex:2248
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr "Name des Kindes"
@@ -2351,7 +2346,7 @@ msgstr "Kind erfüllt die Programmanforderungen nicht"
 msgid "Child meets all program requirements"
 msgstr "Kind erfüllt alle Programmanforderungen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1187
+#: lib/klass_hero_web/components/provider_components.ex:1258
 #, elixir-autogen, elixir-format
 msgid "Choose Image"
 msgstr "Bild auswählen"
@@ -2361,12 +2356,12 @@ msgstr "Bild auswählen"
 msgid "Choose Logo"
 msgstr "Logo auswählen"
 
-#: lib/klass_hero_web/components/provider_components.ex:781
+#: lib/klass_hero_web/components/provider_components.ex:852
 #, elixir-autogen, elixir-format
 msgid "Choose Photo"
 msgstr "Foto auswählen"
 
-#: lib/klass_hero_web/components/provider_components.ex:890
+#: lib/klass_hero_web/components/provider_components.ex:961
 #, elixir-autogen, elixir-format
 msgid "Choose a category"
 msgstr "Kategorie auswählen"
@@ -2381,7 +2376,7 @@ msgstr "Schließen Sie die Geschäftsverifizierung ab, um Programme zu erstellen
 msgid "Confirm rejection"
 msgstr "Ablehnung bestätigen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2383
+#: lib/klass_hero_web/components/provider_components.ex:2454
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr "Bestätigt"
@@ -2391,32 +2386,32 @@ msgstr "Bestätigt"
 msgid "Contact Provider"
 msgstr "Anbieter kontaktieren"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:447
+#: lib/klass_hero_web/live/provider/programs_live.ex:449
 #, elixir-autogen, elixir-format
 msgid "Could not read the uploaded file."
 msgstr "Die hochgeladene Datei konnte nicht gelesen werden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:415
+#: lib/klass_hero_web/live/provider/programs_live.ex:417
 #, elixir-autogen, elixir-format
 msgid "Could not remove invite."
 msgstr "Einladung konnte nicht entfernt werden."
 
-#: lib/klass_hero_web/components/provider_components.ex:1143
+#: lib/klass_hero_web/components/provider_components.ex:1214
 #, elixir-autogen, elixir-format
 msgid "Cover Image"
 msgstr "Titelbild"
 
-#: lib/klass_hero_web/components/provider_components.ex:1020
+#: lib/klass_hero_web/components/provider_components.ex:1091
 #, elixir-autogen, elixir-format
 msgid "Define age, gender, or grade restrictions for eligible participants."
 msgstr "Legen Sie Alters-, Geschlechts- oder Klassenstufenbeschränkungen für teilnahmeberechtigte Teilnehmer fest."
 
-#: lib/klass_hero_web/components/provider_components.ex:1136
+#: lib/klass_hero_web/components/provider_components.ex:1207
 #, elixir-autogen, elixir-format
 msgid "Describe your program..."
 msgstr "Beschreiben Sie Ihr Programm..."
 
-#: lib/klass_hero_web/components/provider_components.ex:1135
+#: lib/klass_hero_web/components/provider_components.ex:1206
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:323
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:285
 #, elixir-autogen, elixir-format
@@ -2424,13 +2419,13 @@ msgid "Description"
 msgstr "Beschreibung"
 
 #: lib/klass_hero_web/components/program_components.ex:684
-#: lib/klass_hero_web/components/provider_components.ex:1088
+#: lib/klass_hero_web/components/provider_components.ex:1159
 #: lib/klass_hero_web/live/settings/children_live.ex:670
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr "Divers"
 
-#: lib/klass_hero_web/components/provider_components.ex:2520
+#: lib/klass_hero_web/components/provider_components.ex:2591
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr "Dokumenttyp"
@@ -2464,7 +2459,7 @@ msgstr "Dokument abgelehnt."
 msgid "Document uploaded successfully."
 msgstr "Dokument erfolgreich hochgeladen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2144
+#: lib/klass_hero_web/components/provider_components.ex:2215
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr "Vorlage herunterladen"
@@ -2474,40 +2469,40 @@ msgstr "Vorlage herunterladen"
 msgid "Download document"
 msgstr "Dokument herunterladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:856
+#: lib/klass_hero_web/components/provider_components.ex:927
 #, elixir-autogen, elixir-format
 msgid "Edit Program"
 msgstr "Programm bearbeiten"
 
-#: lib/klass_hero_web/components/provider_components.ex:598
+#: lib/klass_hero_web/components/provider_components.ex:669
 #, elixir-autogen, elixir-format
 msgid "Edit Team Member"
 msgstr "Teammitglied bearbeiten"
 
-#: lib/klass_hero_web/components/provider_components.ex:965
+#: lib/klass_hero_web/components/provider_components.ex:1036
 #, elixir-autogen, elixir-format
 msgid "End Date"
 msgstr "Enddatum"
 
-#: lib/klass_hero_web/components/provider_components.ex:952
+#: lib/klass_hero_web/components/provider_components.ex:1023
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:166
 #, elixir-autogen, elixir-format
 msgid "End Time"
 msgstr "Endzeit"
 
-#: lib/klass_hero_web/components/provider_components.ex:1957
-#: lib/klass_hero_web/components/provider_components.ex:2403
+#: lib/klass_hero_web/components/provider_components.ex:2028
+#: lib/klass_hero_web/components/provider_components.ex:2474
 #: lib/klass_hero_web/components/provider_layout_components.ex:644
 #, elixir-autogen, elixir-format
 msgid "Enrolled"
 msgstr "Angemeldet"
 
-#: lib/klass_hero_web/components/provider_components.ex:1639
+#: lib/klass_hero_web/components/provider_components.ex:1710
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr "Angemeldet (%{count})"
 
-#: lib/klass_hero_web/components/provider_components.ex:993
+#: lib/klass_hero_web/components/provider_components.ex:1064
 #, elixir-autogen, elixir-format
 msgid "Enrollment Capacity (optional)"
 msgstr "Anmeldekapazität (optional)"
@@ -2518,7 +2513,7 @@ msgid "Explain why this document is being rejected..."
 msgstr "Erklären Sie, warum dieses Dokument abgelehnt wird..."
 
 #: lib/klass_hero_web/components/provider_components.ex:70
-#: lib/klass_hero_web/components/provider_components.ex:2404
+#: lib/klass_hero_web/components/provider_components.ex:2475
 #: lib/klass_hero_web/live/admin/emails_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2534,7 +2529,7 @@ msgstr "Dokument konnte nicht genehmigt werden."
 msgid "Failed to reject document."
 msgstr "Dokument konnte nicht abgelehnt werden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:397
+#: lib/klass_hero_web/live/provider/programs_live.ex:399
 #, elixir-autogen, elixir-format
 msgid "Failed to resend invite."
 msgstr "Einladung konnte nicht erneut gesendet werden."
@@ -2551,7 +2546,7 @@ msgid "Family Programs"
 msgstr "Familienprogramme"
 
 #: lib/klass_hero_web/components/program_components.ex:682
-#: lib/klass_hero_web/components/provider_components.ex:1087
+#: lib/klass_hero_web/components/provider_components.ex:1158
 #: lib/klass_hero_web/live/settings/children_live.ex:669
 #, elixir-autogen, elixir-format
 msgid "Female"
@@ -2562,22 +2557,22 @@ msgstr "Weiblich"
 msgid "File"
 msgstr "Datei"
 
-#: lib/klass_hero_web/components/provider_components.ex:2454
+#: lib/klass_hero_web/components/provider_components.ex:2525
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr "Die Datei ist zu groß."
 
-#: lib/klass_hero_web/components/provider_components.ex:2456
+#: lib/klass_hero_web/components/provider_components.ex:2527
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr "Dateityp wird nicht akzeptiert."
 
-#: lib/klass_hero_web/components/provider_components.ex:684
+#: lib/klass_hero_web/components/provider_components.ex:755
 #, elixir-autogen, elixir-format
 msgid "First Aid, UEFA B License, Child Care Cert"
 msgstr "Erste Hilfe, UEFA-B-Lizenz, Kinderbetreuungszertifikat"
 
-#: lib/klass_hero_web/components/provider_components.ex:626
+#: lib/klass_hero_web/components/provider_components.ex:697
 #, elixir-autogen, elixir-format
 msgid "First Name"
 msgstr "Vorname"
@@ -2602,12 +2597,12 @@ msgstr "Klassenstufe %{min}+"
 msgid "Grades %{min} – %{max}"
 msgstr "Klassenstufen %{min} – %{max}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2180
+#: lib/klass_hero_web/components/provider_components.ex:2251
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr "E-Mail des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:745
+#: lib/klass_hero_web/components/provider_components.ex:816
 #, elixir-autogen, elixir-format
 msgid "Headshot Photo"
 msgstr "Porträtfoto"
@@ -2617,7 +2612,7 @@ msgstr "Porträtfoto"
 msgid "ID Document"
 msgstr "Ausweisdokument"
 
-#: lib/klass_hero_web/components/provider_components.ex:2117
+#: lib/klass_hero_web/components/provider_components.ex:2188
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Importieren"
@@ -2627,32 +2622,32 @@ msgstr "Importieren"
 msgid "Insurance Certificate"
 msgstr "Versicherungsnachweis"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:412
+#: lib/klass_hero_web/live/provider/programs_live.ex:414
 #, elixir-autogen, elixir-format
 msgid "Invite not found."
 msgstr "Einladung nicht gefunden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:409
+#: lib/klass_hero_web/live/provider/programs_live.ex:411
 #, elixir-autogen, elixir-format
 msgid "Invite removed."
 msgstr "Einladung entfernt."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:386
+#: lib/klass_hero_web/live/provider/programs_live.ex:388
 #, elixir-autogen, elixir-format
 msgid "Invite resent successfully."
 msgstr "Einladung erfolgreich erneut gesendet."
 
-#: lib/klass_hero_web/components/provider_components.ex:1656
+#: lib/klass_hero_web/components/provider_components.ex:1727
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr "Einladungen (%{count})"
 
-#: lib/klass_hero_web/components/provider_components.ex:784
+#: lib/klass_hero_web/components/provider_components.ex:855
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 1MB."
 msgstr "JPG, PNG oder WebP. Max. 1 MB."
 
-#: lib/klass_hero_web/components/provider_components.ex:1190
+#: lib/klass_hero_web/components/provider_components.ex:1261
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:277
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:361
 #, elixir-autogen, elixir-format
@@ -2669,22 +2664,22 @@ msgstr "Klass Hero wurde genau dafür entwickelt. Eine umfassende Betriebsplattf
 msgid "Klasse %{n}"
 msgstr "Klasse %{n}"
 
-#: lib/klass_hero_web/components/provider_components.ex:632
+#: lib/klass_hero_web/components/provider_components.ex:703
 #, elixir-autogen, elixir-format
 msgid "Last Name"
 msgstr "Nachname"
 
-#: lib/klass_hero_web/components/provider_components.ex:975
+#: lib/klass_hero_web/components/provider_components.ex:1046
 #, elixir-autogen, elixir-format
 msgid "Leave blank for open registration at any time."
 msgstr "Leer lassen für eine jederzeit offene Anmeldung."
 
-#: lib/klass_hero_web/components/provider_components.ex:1080
+#: lib/klass_hero_web/components/provider_components.ex:1151
 #, elixir-autogen, elixir-format
 msgid "Leave unchecked to allow all genders."
 msgstr "Nicht markiert lassen, um alle Geschlechter zuzulassen."
 
-#: lib/klass_hero_web/components/provider_components.ex:908
+#: lib/klass_hero_web/components/provider_components.ex:979
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Location"
@@ -2697,43 +2692,43 @@ msgid "Logo upload failed. Please try again."
 msgstr "Logo-Upload fehlgeschlagen. Bitte versuchen Sie es erneut."
 
 #: lib/klass_hero_web/components/program_components.ex:683
-#: lib/klass_hero_web/components/provider_components.ex:1086
+#: lib/klass_hero_web/components/provider_components.ex:1157
 #: lib/klass_hero_web/live/settings/children_live.ex:668
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr "Männlich"
 
-#: lib/klass_hero_web/components/provider_components.ex:1070
+#: lib/klass_hero_web/components/provider_components.ex:1141
 #, elixir-autogen, elixir-format
 msgid "Maximum Age (months)"
 msgstr "Höchstalter (Monate)"
 
-#: lib/klass_hero_web/components/provider_components.ex:1008
+#: lib/klass_hero_web/components/provider_components.ex:1079
 #, elixir-autogen, elixir-format
 msgid "Maximum Enrollment"
 msgstr "Maximale Anmeldekapazität"
 
-#: lib/klass_hero_web/components/provider_components.ex:1125
+#: lib/klass_hero_web/components/provider_components.ex:1196
 #, elixir-autogen, elixir-format
 msgid "Maximum Grade"
 msgstr "Höchste Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:917
+#: lib/klass_hero_web/components/provider_components.ex:988
 #, elixir-autogen, elixir-format
 msgid "Meeting Days"
 msgstr "Wochentage"
 
-#: lib/klass_hero_web/components/provider_components.ex:1064
+#: lib/klass_hero_web/components/provider_components.ex:1135
 #, elixir-autogen, elixir-format
 msgid "Minimum Age (months)"
 msgstr "Mindestalter (Monate)"
 
-#: lib/klass_hero_web/components/provider_components.ex:1002
+#: lib/klass_hero_web/components/provider_components.ex:1073
 #, elixir-autogen, elixir-format
 msgid "Minimum Enrollment"
 msgstr "Minimale Anmeldekapazität"
 
-#: lib/klass_hero_web/components/provider_components.ex:1118
+#: lib/klass_hero_web/components/provider_components.ex:1189
 #, elixir-autogen, elixir-format
 msgid "Minimum Grade"
 msgstr "Niedrigste Klassenstufe"
@@ -2743,18 +2738,18 @@ msgstr "Niedrigste Klassenstufe"
 msgid "No approved documents."
 msgstr "Keine genehmigten Dokumente."
 
-#: lib/klass_hero_web/components/provider_components.ex:2482
+#: lib/klass_hero_web/components/provider_components.ex:2553
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr "Noch keine Dokumente hochgeladen."
 
-#: lib/klass_hero_web/components/provider_components.ex:1944
+#: lib/klass_hero_web/components/provider_components.ex:2015
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:425
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
 msgstr "Noch keine Anmeldungen."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:443
+#: lib/klass_hero_web/live/provider/programs_live.ex:445
 #, elixir-autogen, elixir-format
 msgid "No file selected."
 msgstr "Keine Datei ausgewählt."
@@ -2764,17 +2759,17 @@ msgstr "Keine Datei ausgewählt."
 msgid "No grade"
 msgstr "Keine Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2168
+#: lib/klass_hero_web/components/provider_components.ex:2239
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr "Noch keine Einladungen. Laden Sie eine CSV-Datei hoch, um Familien einzuladen."
 
-#: lib/klass_hero_web/components/provider_components.ex:1127
+#: lib/klass_hero_web/components/provider_components.ex:1198
 #, elixir-autogen, elixir-format
 msgid "No maximum"
 msgstr "Kein Maximum"
 
-#: lib/klass_hero_web/components/provider_components.ex:1120
+#: lib/klass_hero_web/components/provider_components.ex:1191
 #, elixir-autogen, elixir-format
 msgid "No minimum"
 msgstr "Kein Minimum"
@@ -2794,7 +2789,7 @@ msgstr "Noch keine Programme gebucht"
 msgid "No rejected documents."
 msgstr "Keine abgelehnten Dokumente."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:552
+#: lib/klass_hero_web/live/provider/team_live.ex:650
 #, elixir-autogen, elixir-format
 msgid "No team members yet"
 msgstr "Noch keine Teammitglieder"
@@ -2805,7 +2800,7 @@ msgstr "Noch keine Teammitglieder"
 msgid "No verification documents found."
 msgstr "Keine Verifizierungsdokumente gefunden."
 
-#: lib/klass_hero_web/components/provider_components.ex:1202
+#: lib/klass_hero_web/components/provider_components.ex:1273
 #, elixir-autogen, elixir-format
 msgid "None (optional)"
 msgstr "Keine (optional)"
@@ -2816,7 +2811,7 @@ msgid "Not Verified"
 msgstr "Nicht verifiziert"
 
 #: lib/klass_hero_web/components/program_components.ex:685
-#: lib/klass_hero_web/components/provider_components.ex:1089
+#: lib/klass_hero_web/components/provider_components.ex:1160
 #: lib/klass_hero_web/live/settings/children_live.ex:667
 #, elixir-autogen, elixir-format
 msgid "Not specified"
@@ -2827,7 +2822,7 @@ msgstr "Nicht angegeben"
 msgid "Our Story"
 msgstr "Unsere Geschichte"
 
-#: lib/klass_hero_web/components/provider_components.ex:2557
+#: lib/klass_hero_web/components/provider_components.ex:2628
 #: lib/klass_hero_web/live/provider/verification_live.ex:698
 #: lib/klass_hero_web/live/provider/verification_live.ex:770
 #, elixir-autogen, elixir-format
@@ -2839,7 +2834,7 @@ msgstr "PDF, JPG oder PNG. Max. 10 MB."
 msgid "Participant Requirements"
 msgstr "Teilnahmevoraussetzungen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1017
+#: lib/klass_hero_web/components/provider_components.ex:1088
 #, elixir-autogen, elixir-format
 msgid "Participant Restrictions (optional)"
 msgstr "Teilnahmebeschränkungen (optional)"
@@ -2854,11 +2849,11 @@ msgstr "Ausstehende Überprüfung"
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:106
-#: lib/klass_hero_web/live/provider/programs_live.ex:689
-#: lib/klass_hero_web/live/provider/programs_live.ex:755
-#: lib/klass_hero_web/live/provider/team_live.ex:256
-#: lib/klass_hero_web/live/provider/team_live.ex:299
-#: lib/klass_hero_web/live/provider/team_live.ex:418
+#: lib/klass_hero_web/live/provider/programs_live.ex:691
+#: lib/klass_hero_web/live/provider/programs_live.ex:757
+#: lib/klass_hero_web/live/provider/team_live.ex:305
+#: lib/klass_hero_web/live/provider/team_live.ex:348
+#: lib/klass_hero_web/live/provider/team_live.ex:467
 #, elixir-autogen, elixir-format
 msgid "Please fix the errors below."
 msgstr "Bitte korrigieren Sie die Fehler unten."
@@ -2873,7 +2868,7 @@ msgstr "Bitte geben Sie einen Ablehnungsgrund an."
 msgid "Preview not available for this file type."
 msgstr "Vorschau für diesen Dateityp nicht verfügbar."
 
-#: lib/klass_hero_web/components/provider_components.ex:899
+#: lib/klass_hero_web/components/provider_components.ex:970
 #, elixir-autogen, elixir-format
 msgid "Price (EUR)"
 msgstr "Preis (EUR)"
@@ -2883,31 +2878,31 @@ msgstr "Preis (EUR)"
 msgid "Profile updated successfully."
 msgstr "Profil erfolgreich aktualisiert."
 
-#: lib/klass_hero_web/components/provider_components.ex:1055
+#: lib/klass_hero_web/components/provider_components.ex:1126
 #, elixir-autogen, elixir-format
 msgid "Program Start"
 msgstr "Programmbeginn"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1100
+#: lib/klass_hero_web/live/provider/programs_live.ex:1102
 #, elixir-autogen, elixir-format
 msgid "Program created successfully."
 msgstr "Programm erfolgreich erstellt."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1107
+#: lib/klass_hero_web/live/provider/programs_live.ex:1109
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr "Programm erstellt, aber die Anmeldekapazität konnte nicht gespeichert werden. Bearbeiten Sie das Programm, um es erneut zu versuchen."
 
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:54
-#: lib/klass_hero_web/live/provider/programs_live.ex:151
-#: lib/klass_hero_web/live/provider/programs_live.ex:188
-#: lib/klass_hero_web/live/provider/programs_live.ex:252
-#: lib/klass_hero_web/live/provider/programs_live.ex:730
+#: lib/klass_hero_web/live/provider/programs_live.ex:153
+#: lib/klass_hero_web/live/provider/programs_live.ex:190
+#: lib/klass_hero_web/live/provider/programs_live.ex:254
+#: lib/klass_hero_web/live/provider/programs_live.ex:732
 #, elixir-autogen, elixir-format
 msgid "Program not found."
 msgstr "Programm nicht gefunden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:719
+#: lib/klass_hero_web/live/provider/programs_live.ex:721
 #, elixir-autogen, elixir-format
 msgid "Program updated successfully."
 msgstr "Programm erfolgreich aktualisiert."
@@ -2925,13 +2920,13 @@ msgid "Read our founding story →"
 msgstr "Lesen Sie unsere Gründungsgeschichte →"
 
 #: lib/klass_hero_web/components/participation_components.ex:805
-#: lib/klass_hero_web/components/provider_components.ex:2402
+#: lib/klass_hero_web/components/provider_components.ex:2473
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Registered"
 msgstr "Registriert"
 
-#: lib/klass_hero_web/components/provider_components.ex:1042
+#: lib/klass_hero_web/components/provider_components.ex:1113
 #, elixir-autogen, elixir-format
 msgid "Registration"
 msgstr "Anmeldung"
@@ -2941,7 +2936,7 @@ msgstr "Anmeldung"
 msgid "Registration Closed"
 msgstr "Anmeldung geschlossen"
 
-#: lib/klass_hero_web/components/provider_components.ex:986
+#: lib/klass_hero_web/components/provider_components.ex:1057
 #, elixir-autogen, elixir-format
 msgid "Registration Closes"
 msgstr "Anmeldeschluss"
@@ -2951,12 +2946,12 @@ msgstr "Anmeldeschluss"
 msgid "Registration Not Open Yet"
 msgstr "Anmeldung noch nicht geöffnet"
 
-#: lib/klass_hero_web/components/provider_components.ex:981
+#: lib/klass_hero_web/components/provider_components.ex:1052
 #, elixir-autogen, elixir-format
 msgid "Registration Opens"
 msgstr "Anmeldebeginn"
 
-#: lib/klass_hero_web/components/provider_components.ex:972
+#: lib/klass_hero_web/components/provider_components.ex:1043
 #, elixir-autogen, elixir-format
 msgid "Registration Period (optional)"
 msgstr "Anmeldezeitraum (optional)"
@@ -3005,18 +3000,18 @@ msgstr "Abgelehnt"
 msgid "Rejection reason"
 msgstr "Ablehnungsgrund"
 
-#: lib/klass_hero_web/components/provider_components.ex:767
-#: lib/klass_hero_web/components/provider_components.ex:1166
-#: lib/klass_hero_web/components/provider_components.ex:2224
-#: lib/klass_hero_web/components/provider_components.ex:2576
-#: lib/klass_hero_web/components/provider_components.ex:2655
+#: lib/klass_hero_web/components/provider_components.ex:838
+#: lib/klass_hero_web/components/provider_components.ex:1237
+#: lib/klass_hero_web/components/provider_components.ex:2295
+#: lib/klass_hero_web/components/provider_components.ex:2647
+#: lib/klass_hero_web/components/provider_components.ex:2726
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:253
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr "Entfernen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2217
+#: lib/klass_hero_web/components/provider_components.ex:2288
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr "Einladung erneut senden"
@@ -3026,23 +3021,23 @@ msgstr "Einladung erneut senden"
 msgid "Reviewed"
 msgstr "Überprüft"
 
-#: lib/klass_hero_web/components/provider_components.ex:641
+#: lib/klass_hero_web/components/provider_components.ex:712
 #, elixir-autogen, elixir-format
 msgid "Role"
 msgstr "Rolle"
 
-#: lib/klass_hero_web/components/provider_components.ex:1585
+#: lib/klass_hero_web/components/provider_components.ex:1656
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
 msgstr "Teilnehmerliste: %{name}"
 
-#: lib/klass_hero_web/components/provider_components.ex:1229
+#: lib/klass_hero_web/components/provider_components.ex:1300
 #, elixir-autogen, elixir-format
 msgid "Save Program"
 msgstr "Programm speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:914
+#: lib/klass_hero_web/components/provider_components.ex:985
 #, elixir-autogen, elixir-format
 msgid "Schedule (optional)"
 msgstr "Zeitplan (optional)"
@@ -3057,7 +3052,7 @@ msgstr "Zeitplan noch offen"
 msgid "School Grade (optional)"
 msgstr "Klassenstufe (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2554
+#: lib/klass_hero_web/components/provider_components.ex:2625
 #, elixir-autogen, elixir-format
 msgid "Select File"
 msgstr "Datei auswählen"
@@ -3068,52 +3063,52 @@ msgstr "Datei auswählen"
 msgid "Selected child does not meet the program requirements."
 msgstr "Das ausgewählte Kind erfüllt die Programmanforderungen nicht."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:679
-#: lib/klass_hero_web/live/provider/programs_live.ex:745
+#: lib/klass_hero_web/live/provider/programs_live.ex:681
+#: lib/klass_hero_web/live/provider/programs_live.ex:747
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr "Der ausgewählte Kursleiter konnte nicht gefunden werden. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2401
+#: lib/klass_hero_web/components/provider_components.ex:2472
 #: lib/klass_hero_web/live/admin/emails_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Sent"
 msgstr "Gesendet"
 
-#: lib/klass_hero_web/components/provider_components.ex:688
+#: lib/klass_hero_web/components/provider_components.ex:759
 #, elixir-autogen, elixir-format
 msgid "Separate multiple qualifications with commas"
 msgstr "Trennen Sie mehrere Qualifikationen durch Kommas"
 
-#: lib/klass_hero_web/components/provider_components.ex:996
+#: lib/klass_hero_web/components/provider_components.ex:1067
 #, elixir-autogen, elixir-format
 msgid "Set minimum and maximum enrollment for this program."
 msgstr "Legen Sie die minimale und maximale Anmeldekapazität für dieses Programm fest."
 
-#: lib/klass_hero_web/components/provider_components.ex:662
+#: lib/klass_hero_web/components/provider_components.ex:733
 #, elixir-autogen, elixir-format
 msgid "Specialties"
 msgstr "Spezialisierungen"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:398
-#: lib/klass_hero_web/live/provider/team_live.ex:424
+#: lib/klass_hero_web/live/provider/team_live.ex:447
+#: lib/klass_hero_web/live/provider/team_live.ex:473
 #, elixir-autogen, elixir-format
 msgid "Staff member no longer exists."
 msgstr "Der Mitarbeiter existiert nicht mehr."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:101
-#: lib/klass_hero_web/live/provider/team_live.ex:173
-#: lib/klass_hero_web/live/provider/team_live.ex:197
+#: lib/klass_hero_web/live/provider/team_live.ex:103
+#: lib/klass_hero_web/live/provider/team_live.ex:246
+#: lib/klass_hero_web/live/provider/team_live.ex:488
 #, elixir-autogen, elixir-format
 msgid "Staff member not found."
 msgstr "Mitarbeiter nicht gefunden."
 
-#: lib/klass_hero_web/components/provider_components.ex:960
+#: lib/klass_hero_web/components/provider_components.ex:1031
 #, elixir-autogen, elixir-format
 msgid "Start Date"
 msgstr "Startdatum"
 
-#: lib/klass_hero_web/components/provider_components.ex:947
+#: lib/klass_hero_web/components/provider_components.ex:1018
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Start Time"
@@ -3134,27 +3129,27 @@ msgstr "Noch offen"
 msgid "Tax Certificate"
 msgstr "Steuerbescheinigung"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:352
+#: lib/klass_hero_web/live/provider/team_live.ex:401
 #, elixir-autogen, elixir-format
 msgid "Team member added, but headshot upload failed."
 msgstr "Teammitglied hinzugefügt, aber der Upload des Profilfotos ist fehlgeschlagen."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:353
+#: lib/klass_hero_web/live/provider/team_live.ex:402
 #, elixir-autogen, elixir-format
 msgid "Team member added."
 msgstr "Teammitglied hinzugefügt."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:164
+#: lib/klass_hero_web/live/provider/team_live.ex:209
 #, elixir-autogen, elixir-format
 msgid "Team member removed."
 msgstr "Teammitglied entfernt."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:378
+#: lib/klass_hero_web/live/provider/team_live.ex:427
 #, elixir-autogen, elixir-format
 msgid "Team member updated, but headshot upload failed."
 msgstr "Teammitglied aktualisiert, aber der Upload des Profilfotos ist fehlgeschlagen."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:379
+#: lib/klass_hero_web/live/provider/team_live.ex:428
 #, elixir-autogen, elixir-format
 msgid "Team member updated."
 msgstr "Teammitglied aktualisiert."
@@ -3169,22 +3164,22 @@ msgstr "Erzählen Sie Eltern von Ihrer Organisation..."
 msgid "The Klass Hero Story"
 msgstr "Die Geschichte von Klass Hero"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:389
+#: lib/klass_hero_web/live/provider/programs_live.ex:391
 #, elixir-autogen, elixir-format
 msgid "This invite cannot be resent."
 msgstr "Diese Einladung kann nicht erneut gesendet werden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:737
+#: lib/klass_hero_web/live/provider/programs_live.ex:739
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr "Dieses Programm wurde von jemand anderem geändert. Bitte schließen Sie es und versuchen Sie es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:881
+#: lib/klass_hero_web/components/provider_components.ex:952
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr "Titel"
 
-#: lib/klass_hero_web/components/provider_components.ex:2455
+#: lib/klass_hero_web/components/provider_components.ex:2526
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr "Zu viele Dateien."
@@ -3204,32 +3199,32 @@ msgstr "Bis zu %{max}"
 msgid "Up to Grade %{max}"
 msgstr "Bis Klassenstufe %{max}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2103
+#: lib/klass_hero_web/components/provider_components.ex:2174
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr "CSV hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2600
+#: lib/klass_hero_web/components/provider_components.ex:2671
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr "Dokument hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2509
+#: lib/klass_hero_web/components/provider_components.ex:2580
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr "Neues Dokument hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2477
+#: lib/klass_hero_web/components/provider_components.ex:2548
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr "Laden Sie Dokumente hoch, um Ihr Unternehmen zu verifizieren. Die Dokumente werden von unserem Team überprüft."
 
-#: lib/klass_hero_web/components/provider_components.ex:2457
+#: lib/klass_hero_web/components/provider_components.ex:2528
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr "Upload-Fehler."
 
-#: lib/klass_hero_web/components/provider_components.ex:2474
+#: lib/klass_hero_web/components/provider_components.ex:2545
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr "Verifizierungsdokumente"
@@ -3268,32 +3263,32 @@ msgstr "Wir sind Klass Hero — Eltern, Brüder und Partner von Pädagogen — u
 msgid "You don't have access to that page."
 msgstr "Sie haben keinen Zugriff auf diese Seite."
 
-#: lib/klass_hero_web/components/provider_components.ex:642
+#: lib/klass_hero_web/components/provider_components.ex:713
 #, elixir-autogen, elixir-format
 msgid "e.g. Head Coach"
 msgstr "z. B. Cheftrainer"
 
-#: lib/klass_hero_web/components/provider_components.ex:633
+#: lib/klass_hero_web/components/provider_components.ex:704
 #, elixir-autogen, elixir-format
 msgid "e.g. Johnson"
 msgstr "z. B. Johnson"
 
-#: lib/klass_hero_web/components/provider_components.ex:627
+#: lib/klass_hero_web/components/provider_components.ex:698
 #, elixir-autogen, elixir-format
 msgid "e.g. Mike"
 msgstr "z. B. Mike"
 
-#: lib/klass_hero_web/components/provider_components.ex:648
+#: lib/klass_hero_web/components/provider_components.ex:719
 #, elixir-autogen, elixir-format
 msgid "e.g. mike@example.com"
 msgstr "z. B. mike@example.com"
 
-#: lib/klass_hero_web/components/provider_components.ex:882
+#: lib/klass_hero_web/components/provider_components.ex:953
 #, elixir-autogen, elixir-format
 msgid "e.g., Art Adventures"
 msgstr "z. B. Art Adventures"
 
-#: lib/klass_hero_web/components/provider_components.ex:909
+#: lib/klass_hero_web/components/provider_components.ex:980
 #, elixir-autogen, elixir-format
 msgid "e.g., Community Center, Main St"
 msgstr "z. B. Gemeindezentrum, Hauptstraße"
@@ -3319,7 +3314,7 @@ msgid "Child Safeguarding Training"
 msgstr "Kinderschutzschulung"
 
 #: lib/klass_hero_web/components/marketing_components.ex:1498
-#: lib/klass_hero_web/components/provider_components.ex:2822
+#: lib/klass_hero_web/components/provider_components.ex:2893
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr "Vereinbarung zu Community-Standards"
@@ -3389,7 +3384,7 @@ msgstr "Zahlung per Bargeld oder Banküberweisung"
 msgid "Program fee:"
 msgstr "Programmgebühr:"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:938
+#: lib/klass_hero_web/live/provider/programs_live.ex:940
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr "Programm gespeichert, aber der Upload des Titelbilds ist fehlgeschlagen. Sie können es erneut hochladen, indem Sie das Programm bearbeiten."
@@ -3469,7 +3464,7 @@ msgid "Vetted with Care"
 msgstr "Mit Sorgfalt geprüft"
 
 #: lib/klass_hero_web/components/marketing_components.ex:1482
-#: lib/klass_hero_web/components/provider_components.ex:2607
+#: lib/klass_hero_web/components/provider_components.ex:2678
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr "Video-Überprüfung"
@@ -3605,7 +3600,7 @@ msgstr "Kann ich meine Programme auf Klass Hero listen und was kostet das?"
 msgid "Cannot check out without a check-in"
 msgstr "Auschecken ohne Einchecken nicht möglich"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:361
+#: lib/klass_hero_web/live/provider/programs_live.ex:363
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:146
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
@@ -3643,7 +3638,7 @@ msgstr "Eingecheckt"
 msgid "Checked Out"
 msgstr "Ausgecheckt"
 
-#: lib/klass_hero_web/components/provider_components.ex:2260
+#: lib/klass_hero_web/components/provider_components.ex:2331
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Child"
@@ -3670,7 +3665,7 @@ msgid "Correct"
 msgstr "Korrigieren"
 
 #: lib/klass_hero_web/live/dashboard_live.ex:301
-#: lib/klass_hero_web/live/provider/programs_live.ex:358
+#: lib/klass_hero_web/live/provider/programs_live.ex:360
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "Could not start conversation. Please try again."
@@ -3696,7 +3691,7 @@ msgstr "Benötige ich ein Konto, um zu buchen?"
 msgid "Download monthly statements for taxes"
 msgstr "Monatliche Abrechnungen für die Steuer herunterladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2021
+#: lib/klass_hero_web/components/provider_components.ex:2092
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Enrollment not confirmed"
@@ -3774,7 +3769,7 @@ msgstr "Keine Änderungen erkannt"
 msgid "No chasing payments or sending invoices"
 msgstr "Kein Nachfassen bei Zahlungen oder Versenden von Rechnungen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1608
+#: lib/klass_hero_web/components/provider_components.ex:1679
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:406
 #, elixir-autogen, elixir-format
 msgid "No enrolled parents"
@@ -3797,7 +3792,7 @@ msgstr "Notizen"
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr "Oder: Jederzeit eine Sofortauszahlung anfordern (mindestens 50 €)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2020
+#: lib/klass_hero_web/components/provider_components.ex:2091
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:481
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -4233,7 +4228,7 @@ msgstr "E-Mail-Inhalt konnte nicht abgerufen werden."
 msgid "Failed to mark email as unread"
 msgstr "E-Mail konnte nicht als ungelesen markiert werden"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:213
+#: lib/klass_hero_web/live/provider/team_live.ex:262
 #, elixir-autogen, elixir-format
 msgid "Failed to resend invitation. Please try again."
 msgstr "Einladung konnte nicht erneut gesendet werden. Bitte versuchen Sie es erneut."
@@ -4281,32 +4276,32 @@ msgid "Invalid time format"
 msgstr "Ungültiges Zeitformat"
 
 #: lib/klass_hero_web/live/user_live/staff_invitation.ex:27
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:107
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:115
 #, elixir-autogen, elixir-format
 msgid "Invitation Expired"
 msgstr "Einladung abgelaufen"
 
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:105
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:113
 #, elixir-autogen, elixir-format
 msgid "Invitation Failed"
 msgstr "Einladung fehlgeschlagen"
 
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:103
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:111
 #, elixir-autogen, elixir-format
 msgid "Invitation Pending"
 msgstr "Einladung ausstehend"
 
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:104
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:112
 #, elixir-autogen, elixir-format
 msgid "Invitation Sent"
 msgstr "Einladung gesendet"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:188
+#: lib/klass_hero_web/live/provider/team_live.ex:237
 #, elixir-autogen, elixir-format
 msgid "Invitation resent successfully."
 msgstr "Einladung erfolgreich erneut gesendet."
 
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:106
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:114
 #, elixir-autogen, elixir-format
 msgid "Joined"
 msgstr "Beigetreten"
@@ -4427,7 +4422,7 @@ msgstr "Absenden"
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:24
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
-#: lib/klass_hero_web/live/provider/programs_live.ex:220
+#: lib/klass_hero_web/live/provider/programs_live.ex:222
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:156
 #, elixir-autogen, elixir-format
 msgid "Program"
@@ -4574,7 +4569,7 @@ msgstr "Unterstützung: %{details}"
 msgid "The business associated with your account could not be found."
 msgstr "Das mit Ihrem Konto verknüpfte Unternehmen konnte nicht gefunden werden."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:204
+#: lib/klass_hero_web/live/provider/team_live.ex:253
 #, elixir-autogen, elixir-format
 msgid "This invitation cannot be resent in its current state."
 msgstr "Diese Einladung kann in ihrem aktuellen Status nicht erneut gesendet werden."
@@ -4636,7 +4631,7 @@ msgid "Update your observation..."
 msgstr "Aktualisieren Sie Ihre Beobachtung..."
 
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:138
-#: lib/klass_hero_web/live/provider/programs_live.ex:440
+#: lib/klass_hero_web/live/provider/programs_live.ex:442
 #: lib/klass_hero_web/live/provider/verification_live.ex:240
 #: lib/klass_hero_web/live/provider/verification_live.ex:556
 #: lib/klass_hero_web/live/provider/verification_live.ex:594
@@ -4905,48 +4900,48 @@ msgstr "Ihr Profil ist bereits vollständig."
 msgid "for"
 msgstr "für"
 
-#: lib/klass_hero_web/components/provider_components.ex:1729
+#: lib/klass_hero_web/components/provider_components.ex:1800
 #, elixir-autogen, elixir-format
 msgid "Assigned staff"
 msgstr "Zugewiesenes Personal"
 
-#: lib/klass_hero_web/components/provider_components.ex:1731
+#: lib/klass_hero_web/components/provider_components.ex:1802
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr "Anwesenheit"
 
-#: lib/klass_hero_web/components/provider_components.ex:1713
-#: lib/klass_hero_web/components/provider_components.ex:1802
+#: lib/klass_hero_web/components/provider_components.ex:1784
+#: lib/klass_hero_web/components/provider_components.ex:1873
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr "Schließen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1730
+#: lib/klass_hero_web/components/provider_components.ex:1801
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr "Vertretung"
 
-#: lib/klass_hero_web/components/provider_components.ex:1728
+#: lib/klass_hero_web/components/provider_components.ex:1799
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr "Datum / Uhrzeit"
 
-#: lib/klass_hero_web/components/provider_components.ex:1722
+#: lib/klass_hero_web/components/provider_components.ex:1793
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled yet."
 msgstr "Noch keine Sessions geplant."
 
-#: lib/klass_hero_web/components/provider_components.ex:1711
+#: lib/klass_hero_web/components/provider_components.ex:1782
 #, elixir-autogen, elixir-format
 msgid "Sessions — %{title}"
 msgstr "Sessions — %{title}"
 
-#: lib/klass_hero_web/components/provider_components.ex:1451
+#: lib/klass_hero_web/components/provider_components.ex:1522
 #, elixir-autogen, elixir-format
 msgid "View sessions"
 msgstr "Sessions anzeigen"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:531
+#: lib/klass_hero_web/live/provider/programs_live.ex:533
 #, elixir-autogen, elixir-format
 msgid "Create a program before inviting participants."
 msgstr "Erstellen Sie zuerst ein Programm, bevor Sie Teilnehmer einladen."
@@ -4973,22 +4968,22 @@ msgstr "Abreisezeit ist kein gültiges Datum oder keine gültige Uhrzeit"
 msgid "Failed to update record"
 msgstr "Aktualisieren des Datensatzes fehlgeschlagen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2324
+#: lib/klass_hero_web/components/provider_components.ex:2395
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr "Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2043
+#: lib/klass_hero_web/components/provider_components.ex:2114
 #, elixir-autogen, elixir-format
 msgid "Invite mode"
 msgstr "Einladungsmodus"
 
-#: lib/klass_hero_web/components/provider_components.ex:2062
+#: lib/klass_hero_web/components/provider_components.ex:2133
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr "Einzelperson einladen"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:527
+#: lib/klass_hero_web/live/provider/programs_live.ex:529
 #, elixir-autogen, elixir-format
 msgid "Invite sent."
 msgstr "Einladung verschickt."
@@ -4998,12 +4993,12 @@ msgstr "Einladung verschickt."
 msgid "Leave blank to keep this child marked as present."
 msgstr "Leer lassen, um dieses Kind als anwesend markiert zu lassen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2337
+#: lib/klass_hero_web/components/provider_components.ex:2408
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr "Gesundheit & Einwilligungen (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2343
+#: lib/klass_hero_web/components/provider_components.ex:2414
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr "Gesundheitliche Besonderheiten"
@@ -5014,17 +5009,17 @@ msgstr "Gesundheitliche Besonderheiten"
 msgid "Nothing to update"
 msgstr "Nichts zu aktualisieren"
 
-#: lib/klass_hero_web/components/provider_components.ex:2345
+#: lib/klass_hero_web/components/provider_components.ex:2416
 #, elixir-autogen, elixir-format
 msgid "Nut allergy"
 msgstr "Nussallergie"
 
-#: lib/klass_hero_web/components/provider_components.ex:2349
+#: lib/klass_hero_web/components/provider_components.ex:2420
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr "Fotos dürfen in Marketingmaterialien verwendet werden"
 
-#: lib/klass_hero_web/components/provider_components.ex:2354
+#: lib/klass_hero_web/components/provider_components.ex:2425
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr "Fotos dürfen in sozialen Medien erscheinen"
@@ -5034,7 +5029,7 @@ msgstr "Fotos dürfen in sozialen Medien erscheinen"
 msgid "Present"
 msgstr "Anwesend"
 
-#: lib/klass_hero_web/components/provider_components.ex:2281
+#: lib/klass_hero_web/components/provider_components.ex:2352
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr "Hauptansprechpartner"
@@ -5061,22 +5056,22 @@ msgstr "Datensatz aktualisiert"
 msgid "Save changes"
 msgstr "Änderungen speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:2318
+#: lib/klass_hero_web/components/provider_components.ex:2389
 #, elixir-autogen, elixir-format
 msgid "School (optional)"
 msgstr "Schule (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2328
+#: lib/klass_hero_web/components/provider_components.ex:2399
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr "Schulname"
 
-#: lib/klass_hero_web/components/provider_components.ex:2302
+#: lib/klass_hero_web/components/provider_components.ex:2373
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr "Zweiter Ansprechpartner (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2371
+#: lib/klass_hero_web/components/provider_components.ex:2442
 #, elixir-autogen, elixir-format
 msgid "Send invite"
 msgstr "Einladung senden"
@@ -5086,12 +5081,12 @@ msgstr "Einladung senden"
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr "Aktualisieren Sie die Notiz für dieses Kind (z. B. um zu klären, was passiert ist)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2080
+#: lib/klass_hero_web/components/provider_components.ex:2151
 #, elixir-autogen, elixir-format
 msgid "Upload a list"
 msgstr "Liste hochladen"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:538
+#: lib/klass_hero_web/live/provider/programs_live.ex:540
 #, elixir-autogen, elixir-format
 msgid "An invite for this child and program already exists."
 msgstr "Für dieses Kind und Programm existiert bereits eine Einladung."
@@ -5121,7 +5116,7 @@ msgstr "Foto hierher ziehen oder klicken zum Auswählen"
 msgid "High"
 msgstr "Hoch"
 
-#: lib/klass_hero_web/components/provider_components.ex:715
+#: lib/klass_hero_web/components/provider_components.ex:786
 #, elixir-autogen, elixir-format
 msgid "Hourly"
 msgstr "Stündlich"
@@ -5146,12 +5141,12 @@ msgstr "Niedrig"
 msgid "Medium"
 msgstr "Mittel"
 
-#: lib/klass_hero_web/components/provider_components.ex:705
+#: lib/klass_hero_web/components/provider_components.ex:776
 #, elixir-autogen, elixir-format
 msgid "None"
 msgstr "Keine"
 
-#: lib/klass_hero_web/components/provider_components.ex:694
+#: lib/klass_hero_web/components/provider_components.ex:765
 #, elixir-autogen, elixir-format
 msgid "Pay Rate"
 msgstr "Vergütung"
@@ -5161,7 +5156,7 @@ msgstr "Vergütung"
 msgid "Pay rate"
 msgstr "Vergütung"
 
-#: lib/klass_hero_web/components/provider_components.ex:725
+#: lib/klass_hero_web/components/provider_components.ex:796
 #, elixir-autogen, elixir-format
 msgid "Per Session"
 msgstr "Pro Sitzung"
@@ -5186,7 +5181,7 @@ msgstr "Programm oder Session nicht gefunden."
 msgid "Property Damage"
 msgstr "Sachschaden"
 
-#: lib/klass_hero_web/components/provider_components.ex:1481
+#: lib/klass_hero_web/components/provider_components.ex:1552
 #, elixir-autogen, elixir-format
 msgid "Report Incident"
 msgstr "Vorfall melden"
@@ -5232,12 +5227,12 @@ msgstr "Bericht absenden"
 msgid "Your pay rate"
 msgstr "Ihre Vergütung"
 
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:99
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:107
 #, elixir-autogen, elixir-format
 msgid "hour"
 msgstr "Stunde"
 
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:100
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:108
 #, elixir-autogen, elixir-format
 msgid "session"
 msgstr "Sitzung"
@@ -5268,7 +5263,7 @@ msgstr "Ihre Woche mit den Kindern"
 msgid "Go to dashboard"
 msgstr "Zum Dashboard"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:483
+#: lib/klass_hero_web/live/provider/programs_live.ex:485
 #, elixir-autogen, elixir-format
 msgid "%{count} row could not be processed."
 msgid_plural "%{count} rows could not be processed."
@@ -5571,7 +5566,7 @@ msgstr "Familien verbinden mit"
 msgid "Contact Us →"
 msgstr "Kontakt →"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:307
+#: lib/klass_hero_web/live/provider/team_live.ex:356
 #, elixir-autogen, elixir-format
 msgid "Could not add you to the team. Please try again."
 msgstr "Sie konnten nicht zum Team hinzugefügt werden. Bitte versuchen Sie es erneut."
@@ -5850,13 +5845,13 @@ msgstr "So bringen Sie Ihr Jugendprogramm zum Wachsen"
 msgid "How we vet providers"
 msgstr "Wie wir Anbieter überprüfen"
 
-#: lib/klass_hero_web/live/provider/team_live.ex:520
+#: lib/klass_hero_web/live/provider/team_live.ex:618
 #, elixir-autogen, elixir-format
 msgid "I'll be teaching"
 msgstr "Ich werde unterrichten"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:458
-#: lib/klass_hero_web/live/provider/programs_live.ex:480
+#: lib/klass_hero_web/live/provider/programs_live.ex:460
+#: lib/klass_hero_web/live/provider/programs_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Imported %{count} family."
 msgid_plural "Imported %{count} families."
@@ -5868,7 +5863,7 @@ msgstr[1] "%{count} Familien importiert."
 msgid "In 2025, Shane connected with his friend"
 msgstr "2025 tat sich Shane mit seinem Freund zusammen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1490
+#: lib/klass_hero_web/components/provider_components.ex:1561
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:43
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:74
 #, elixir-autogen, elixir-format
@@ -5938,7 +5933,7 @@ msgstr "Klass Hero ist das operative Rückgrat für Berlins Jugendpädagogen. Wi
 msgid "Last 8 weeks"
 msgstr "Letzte 8 Wochen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1200
+#: lib/klass_hero_web/components/provider_components.ex:1271
 #: lib/klass_hero_web/presenters/hero_cards_presenter.ex:27
 #, elixir-autogen, elixir-format
 msgid "Lead Instructor"
@@ -6145,7 +6140,7 @@ msgstr "Noch keine Programme — fügen Sie Ihr erstes über den Tab „Programm
 msgid "No registered children for this session."
 msgstr "Keine Kinder in dieser Sitzung angemeldet."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:467
+#: lib/klass_hero_web/live/provider/programs_live.ex:469
 #, elixir-autogen, elixir-format
 msgid "No rows imported. %{count} row could not be processed."
 msgid_plural "No rows imported. %{count} rows could not be processed."
@@ -6388,17 +6383,17 @@ msgstr "Umsatz (diese Woche)"
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr "Strenge Überprüfung, damit Familien immer wissen, wer die Gruppe leitet."
 
-#: lib/klass_hero_web/components/provider_components.ex:2410
+#: lib/klass_hero_web/components/provider_components.ex:2481
 #, elixir-autogen, elixir-format
 msgid "Row %{row}"
 msgstr "Zeile %{row}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2410
+#: lib/klass_hero_web/components/provider_components.ex:2481
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr "Zeile —"
 
-#: lib/klass_hero_web/components/provider_components.ex:2156
+#: lib/klass_hero_web/components/provider_components.ex:2227
 #, elixir-autogen, elixir-format
 msgid "Rows with errors"
 msgstr "Zeilen mit Fehlern"
@@ -6820,7 +6815,7 @@ msgstr "Sie haben bereits ein Konto für %{email}."
 msgid "You'll get your own provider profile to fill in, and your account will open on your business dashboard from now on. You stay on %{business}'s team."
 msgstr "Sie erhalten Ihr eigenes Anbieterprofil zum Ausfüllen, und Ihr Konto öffnet sich ab sofort auf Ihrem Geschäfts-Dashboard. Sie bleiben im Team von %{business}."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:287
+#: lib/klass_hero_web/live/provider/team_live.ex:336
 #, elixir-autogen, elixir-format
 msgid "You're already on your team."
 msgstr "Sie sind bereits in Ihrem Team."
@@ -6840,12 +6835,12 @@ msgstr "Sie sind nicht mehr in diesem Team."
 msgid "You're now part of the team."
 msgstr "Sie sind jetzt Teil des Teams."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:335
+#: lib/klass_hero_web/live/provider/team_live.ex:384
 #, elixir-autogen, elixir-format
 msgid "You're on the team — you can now be assigned to programs."
 msgstr "Sie sind im Team — Sie können nun Programmen zugewiesen werden."
 
-#: lib/klass_hero_web/live/provider/team_live.ex:334
+#: lib/klass_hero_web/live/provider/team_live.ex:383
 #, elixir-autogen, elixir-format
 msgid "You're on the team, but the headshot upload failed."
 msgstr "Sie sind im Team, aber der Upload des Profilfotos ist fehlgeschlagen."
@@ -7157,12 +7152,12 @@ msgstr "Deine Identität ist verifiziert."
 msgid "Experience validation"
 msgstr "Erfahrungsnachweis"
 
-#: lib/klass_hero_web/components/provider_components.ex:2636
+#: lib/klass_hero_web/components/provider_components.ex:2707
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr "MP4, MOV oder WEBM. Max. 100 MB."
 
-#: lib/klass_hero_web/components/provider_components.ex:2610
+#: lib/klass_hero_web/components/provider_components.ex:2681
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr "Nimm ein kurzes Video auf, in dem du dich vorstellst. Unser Team prüft es, um Kommunikationsfähigkeit und Übereinstimmung mit unseren Werten einzuschätzen."
@@ -7172,12 +7167,12 @@ msgstr "Nimm ein kurzes Video auf, in dem du dich vorstellst. Unser Team prüft 
 msgid "Safeguarding certificate"
 msgstr "Kinderschutz-Zertifikat"
 
-#: lib/klass_hero_web/components/provider_components.ex:2633
+#: lib/klass_hero_web/components/provider_components.ex:2704
 #, elixir-autogen, elixir-format
 msgid "Select Video"
 msgstr "Video auswählen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2679
+#: lib/klass_hero_web/components/provider_components.ex:2750
 #, elixir-autogen, elixir-format
 msgid "Upload Video"
 msgstr "Video hochladen"
@@ -7187,7 +7182,7 @@ msgstr "Video hochladen"
 msgid "Your browser does not support video playback."
 msgstr "Dein Browser unterstützt keine Videowiedergabe."
 
-#: lib/klass_hero_web/components/provider_components.ex:2826
+#: lib/klass_hero_web/components/provider_components.ex:2897
 #, elixir-autogen, elixir-format
 msgid "Confirm agreement"
 msgstr "Zustimmung bestätigen"
@@ -7197,12 +7192,12 @@ msgstr "Zustimmung bestätigen"
 msgid "Couldn't record your agreement. Please try again."
 msgstr "Deine Zustimmung konnte nicht gespeichert werden. Bitte versuche es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2849
+#: lib/klass_hero_web/components/provider_components.ex:2920
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr "Vereinbarung herunterladen (PDF)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2825
+#: lib/klass_hero_web/components/provider_components.ex:2896
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr "Ich habe die Klass Hero Community-Richtlinien gelesen und stimme ihnen zu."
@@ -7212,7 +7207,7 @@ msgstr "Ich habe die Klass Hero Community-Richtlinien gelesen und stimme ihnen z
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr "Bitte bestätige, dass du die Community-Richtlinien gelesen hast und ihnen zustimmst."
 
-#: lib/klass_hero_web/components/provider_components.ex:2734
+#: lib/klass_hero_web/components/provider_components.ex:2805
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr "Unterzeichnet von %{name} am %{date} (v%{version})."
@@ -7222,17 +7217,17 @@ msgstr "Unterzeichnet von %{name} am %{date} (v%{version})."
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr "Danke – deine Zustimmung zu den Community-Richtlinien wurde gespeichert."
 
-#: lib/klass_hero_web/components/provider_components.ex:2834
+#: lib/klass_hero_web/components/provider_components.ex:2905
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr "Die Community-Richtlinien wurden seit deiner letzten Zustimmung aktualisiert (v%{old}). Bitte lies sie erneut und stimme erneut zu."
 
-#: lib/klass_hero_web/components/provider_components.ex:2823
+#: lib/klass_hero_web/components/provider_components.ex:2894
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr "Der letzte Schritt: Lies die Klass Hero Community-Richtlinien und stimme ihnen zu."
 
-#: lib/klass_hero_web/components/provider_components.ex:2824
+#: lib/klass_hero_web/components/provider_components.ex:2895
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr "Du hast den Community-Richtlinien zugestimmt."
@@ -7501,12 +7496,12 @@ msgstr "Ihre Versicherungsbescheinigung wird geprüft."
 msgid "Your insurance is verified."
 msgstr "Ihre Versicherung ist verifiziert."
 
-#: lib/klass_hero_web/components/provider_components.ex:2778
+#: lib/klass_hero_web/components/provider_components.ex:2849
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr "Unterzeichnung durch %{name} im Namen des Unternehmens."
 
-#: lib/klass_hero_web/components/provider_components.ex:2881
+#: lib/klass_hero_web/components/provider_components.ex:2952
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr "Bestätige im Namen deines Unternehmens, dass alle Mitarbeitenden gemäß dem deutschen Kinderschutzrecht überprüft sind."
@@ -7516,7 +7511,7 @@ msgstr "Bestätige im Namen deines Unternehmens, dass alle Mitarbeitenden gemä�
 msgid "Couldn't record your declaration. Please try again."
 msgstr "Deine Erklärung konnte nicht gespeichert werden. Bitte versuche es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2887
+#: lib/klass_hero_web/components/provider_components.ex:2958
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr "Ich bestätige im Namen des Unternehmens, dass die obige Erklärung zutrifft und ich zu ihrer Unterzeichnung berechtigt bin."
@@ -7526,17 +7521,17 @@ msgstr "Ich bestätige im Namen des Unternehmens, dass die obige Erklärung zutr
 msgid "Please confirm the declaration before signing."
 msgstr "Bitte bestätige die Erklärung vor der Unterzeichnung."
 
-#: lib/klass_hero_web/components/provider_components.ex:2912
+#: lib/klass_hero_web/components/provider_components.ex:2983
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr "Vorläufiger Text — vor der Freischaltung noch von einer in Deutschland zugelassenen Anwältin bzw. einem Anwalt zu prüfen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2891
+#: lib/klass_hero_web/components/provider_components.ex:2962
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr "Erklärung unterzeichnen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2879
+#: lib/klass_hero_web/components/provider_components.ex:2950
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr "Erklärung zur Mitarbeiter-Compliance"
@@ -7546,12 +7541,12 @@ msgstr "Erklärung zur Mitarbeiter-Compliance"
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr "Danke — deine Erklärung zur Mitarbeiter-Compliance wurde erfasst."
 
-#: lib/klass_hero_web/components/provider_components.ex:2899
+#: lib/klass_hero_web/components/provider_components.ex:2970
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr "Die Erklärung zur Mitarbeiter-Compliance wurde seit deiner letzten Unterzeichnung aktualisiert (v%{old}). Bitte prüfe sie und unterzeichne erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2885
+#: lib/klass_hero_web/components/provider_components.ex:2956
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr "Du hast die Erklärung zur Mitarbeiter-Compliance unterzeichnet."
@@ -7618,98 +7613,148 @@ msgstr "In Prüfung"
 msgid "Undelivered Events"
 msgstr "Nicht zugestellte Ereignisse"
 
-#: lib/klass_hero_web/components/provider_components.ex:1899
+#: lib/klass_hero_web/components/provider_components.ex:1970
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1824
+#: lib/klass_hero_web/components/provider_components.ex:1895
 #, elixir-autogen, elixir-format
 msgid "Lead"
 msgstr "Leitung"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:333
+#: lib/klass_hero_web/live/provider/programs_live.ex:335
 #, elixir-autogen, elixir-format
 msgid "Lead instructor updated."
 msgstr "Leitender Kursleiter aktualisiert."
 
-#: lib/klass_hero_web/components/provider_components.ex:1835
+#: lib/klass_hero_web/components/provider_components.ex:1906
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor"
 msgstr "Als leitenden Kursleiter festlegen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1465
+#: lib/klass_hero_web/components/provider_components.ex:1536
 #, elixir-autogen, elixir-format
 msgid "Manage Staffing"
 msgstr "Programmteam verwalten"
 
-#: lib/klass_hero_web/components/provider_components.ex:1863
+#: lib/klass_hero_web/components/provider_components.ex:1934
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this program yet."
 msgstr "Diesem Programm ist noch niemand zugewiesen."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:263
+#: lib/klass_hero_web/live/provider/programs_live.ex:265
 #, elixir-autogen, elixir-format
 msgid "Pick a staff member to add."
 msgstr "Bitte ein Teammitglied zum Hinzufügen auswählen."
 
-#: lib/klass_hero_web/components/provider_components.ex:1846
+#: lib/klass_hero_web/components/provider_components.ex:1917
 #, elixir-autogen, elixir-format
 msgid "Reassign the lead before removing them"
 msgstr "Vor dem Entfernen einen anderen leitenden Kursleiter festlegen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1847
+#: lib/klass_hero_web/components/provider_components.ex:1918
 #, elixir-autogen, elixir-format
 msgid "Remove from program"
 msgstr "Aus dem Programm entfernen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1881
+#: lib/klass_hero_web/components/provider_components.ex:1952
 #, elixir-autogen, elixir-format
 msgid "Select a staff member…"
 msgstr "Teammitglied auswählen …"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:278
+#: lib/klass_hero_web/live/provider/programs_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Staff member added to the program."
 msgstr "Teammitglied zum Programm hinzugefügt."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:304
+#: lib/klass_hero_web/live/provider/programs_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "Staff member removed from the program."
 msgstr "Teammitglied aus dem Programm entfernt."
 
-#: lib/klass_hero_web/components/provider_components.ex:1904
+#: lib/klass_hero_web/components/provider_components.ex:1975
 #, elixir-autogen, elixir-format
 msgid "Staff you add can read and reply to this program's parent conversations."
 msgstr ""
 "Hinzugefügte Teammitglieder können die Elterngespräche dieses Programms lesen "
 "und beantworten."
 
-#: lib/klass_hero_web/components/provider_components.ex:1800
+#: lib/klass_hero_web/components/provider_components.ex:1871
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{title}"
 msgstr "Programmteam — %{title}"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:897
+#: lib/klass_hero_web/live/provider/programs_live.ex:899
 #, elixir-autogen, elixir-format
 msgid "That staff member could not be found."
 msgstr "Dieses Teammitglied wurde nicht gefunden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:286
+#: lib/klass_hero_web/live/provider/programs_live.ex:288
 #, elixir-autogen, elixir-format
 msgid "They are already on this program."
 msgstr "Diese Person ist bereits in diesem Programm."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:312
+#: lib/klass_hero_web/live/provider/programs_live.ex:314
 #, elixir-autogen, elixir-format
 msgid "This person is the lead instructor. Make someone else lead before removing them."
 msgstr ""
 "Diese Person ist der leitende Kursleiter. Bitte zuerst eine andere Person als "
 "Leitung festlegen."
 
-#: lib/klass_hero_web/components/provider_components.ex:1409
+#: lib/klass_hero_web/components/provider_components.ex:1480
 #, elixir-autogen, elixir-format
 msgid "%{count} staff member · no lead"
 msgid_plural "%{count} staff · no lead"
 msgstr[0] "%{count} Mitarbeiter*in · keine Leitung"
 msgstr[1] "%{count} Mitarbeitende · keine Leitung"
+
+#: lib/klass_hero_web/components/provider_components.ex:562
+#, elixir-autogen, elixir-format
+msgid "%{name} will be unassigned from every program and removed from those conversations. Their history is kept and you can add them back later."
+msgstr "%{name} wird aus allen Programmen und den zugehörigen Unterhaltungen entfernt. Der Verlauf bleibt erhalten und du kannst die Person später wieder hinzufügen."
+
+#: lib/klass_hero_web/components/provider_components.ex:638
+#, elixir-autogen, elixir-format
+msgid "Add back to team"
+msgstr "Wieder ins Team aufnehmen"
+
+#: lib/klass_hero_web/live/provider/team_live.ex:193
+#, elixir-autogen, elixir-format
+msgid "Could not bring this team member back. Please try again."
+msgstr "Teammitglied konnte nicht zurückgeholt werden. Bitte versuche es erneut."
+
+#: lib/klass_hero_web/components/provider_components.ex:600
+#, elixir-autogen, elixir-format
+msgid "Delete entry"
+msgstr "Eintrag löschen"
+
+#: lib/klass_hero_web/live/provider/team_live.ex:663
+#, elixir-autogen, elixir-format
+msgid "Former team members"
+msgstr "Ehemalige Teammitglieder"
+
+#: lib/klass_hero_web/components/provider_components.ex:574
+#, elixir-autogen, elixir-format
+msgid "Remove from team"
+msgstr "Aus dem Team entfernen"
+
+#: lib/klass_hero_web/live/provider/team_live.ex:187
+#, elixir-autogen, elixir-format
+msgid "Team member is back. Assign them to programs again when you're ready."
+msgstr "Teammitglied ist zurück. Weise die Person wieder Programmen zu, wenn du so weit bist."
+
+#: lib/klass_hero_web/live/provider/team_live.ex:167
+#, elixir-autogen, elixir-format
+msgid "Team member removed from the team."
+msgstr "Teammitglied aus dem Team entfernt."
+
+#: lib/klass_hero_web/components/provider_components.ex:590
+#, elixir-autogen, elixir-format
+msgid "This deletes %{name} permanently — there's nothing to undo. Use it only for an entry added by mistake."
+msgstr "Damit wird %{name} endgültig gelöscht – das lässt sich nicht rückgängig machen. Nutze das nur für einen versehentlich angelegten Eintrag."
+
+#: lib/klass_hero_web/live/provider/team_live.ex:218
+#, elixir-autogen, elixir-format
+msgid "This person has a history here now — use 'Remove from team' instead."
+msgstr "Diese Person hat inzwischen eine Historie – nutze stattdessen „Aus dem Team entfernen“."

--- a/priv/gettext/de/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/de/LC_MESSAGES/enrollment.po
@@ -11,62 +11,62 @@ msgstr ""
 "Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:2431
+#: lib/klass_hero_web/components/provider_components.ex:2502
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr "Vorname des Kindes"
 
-#: lib/klass_hero_web/components/provider_components.ex:2432
+#: lib/klass_hero_web/components/provider_components.ex:2503
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr "Nachname des Kindes"
 
-#: lib/klass_hero_web/components/provider_components.ex:2433
+#: lib/klass_hero_web/components/provider_components.ex:2504
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr "Geburtsdatum"
 
-#: lib/klass_hero_web/components/provider_components.ex:2444
+#: lib/klass_hero_web/components/provider_components.ex:2515
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr "Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2434
+#: lib/klass_hero_web/components/provider_components.ex:2505
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr "E-Mail des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2435
+#: lib/klass_hero_web/components/provider_components.ex:2506
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr "Vorname des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2436
+#: lib/klass_hero_web/components/provider_components.ex:2507
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr "Nachname des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2443
+#: lib/klass_hero_web/components/provider_components.ex:2514
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr "Programm"
 
-#: lib/klass_hero_web/components/provider_components.ex:2445
+#: lib/klass_hero_web/components/provider_components.ex:2516
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr "Schule"
 
-#: lib/klass_hero_web/components/provider_components.ex:2437
+#: lib/klass_hero_web/components/provider_components.ex:2508
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr "E-Mail des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2439
+#: lib/klass_hero_web/components/provider_components.ex:2510
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr "Vorname des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2441
+#: lib/klass_hero_web/components/provider_components.ex:2512
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr "Nachname des zweiten Erziehungsberechtigten"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -137,7 +137,7 @@ msgid "Your Data"
 msgstr ""
 
 #: lib/klass_hero_web/components/core_components.ex:67
-#: lib/klass_hero_web/components/provider_components.ex:1615
+#: lib/klass_hero_web/components/provider_components.ex:1686
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr ""
@@ -232,7 +232,7 @@ msgstr ""
 msgid "Enroll Now - %{price}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1366
+#: lib/klass_hero_web/components/provider_components.ex:1437
 #: lib/klass_hero_web/live/booking_live.ex:285
 #, elixir-autogen, elixir-format
 msgid "Enrollment"
@@ -577,9 +577,9 @@ msgstr ""
 msgid "Dispute Resolution"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:647
-#: lib/klass_hero_web/components/provider_components.ex:2288
-#: lib/klass_hero_web/components/provider_components.ex:2306
+#: lib/klass_hero_web/components/provider_components.ex:718
+#: lib/klass_hero_web/components/provider_components.ex:2359
+#: lib/klass_hero_web/components/provider_components.ex:2377
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
@@ -878,9 +878,9 @@ msgstr ""
 msgid "Select one or both options"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1984
-#: lib/klass_hero_web/components/provider_components.ex:1985
-#: lib/klass_hero_web/components/provider_components.ex:2022
+#: lib/klass_hero_web/components/provider_components.ex:2055
+#: lib/klass_hero_web/components/provider_components.ex:2056
+#: lib/klass_hero_web/components/provider_components.ex:2093
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:446
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:483
@@ -1456,7 +1456,7 @@ msgstr ""
 msgid "Music"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:683
+#: lib/klass_hero_web/components/provider_components.ex:754
 #: lib/klass_hero_web/live/for_providers_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "Qualifications"
@@ -1577,30 +1577,30 @@ msgstr ""
 msgid "Quick Navigation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1369
-#: lib/klass_hero_web/components/provider_components.ex:1960
-#: lib/klass_hero_web/components/provider_components.ex:2186
+#: lib/klass_hero_web/components/provider_components.ex:1440
+#: lib/klass_hero_web/components/provider_components.ex:2031
+#: lib/klass_hero_web/components/provider_components.ex:2257
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1508
+#: lib/klass_hero_web/components/provider_components.ex:1579
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:600
-#: lib/klass_hero_web/live/provider/team_live.ex:529
+#: lib/klass_hero_web/components/provider_components.ex:671
+#: lib/klass_hero_web/live/provider/team_live.ex:627
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:46
+#: lib/klass_hero_web/live/provider/programs_live.ex:48
 #, elixir-autogen, elixir-format
 msgid "All Staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1360
+#: lib/klass_hero_web/components/provider_components.ex:1431
 #, elixir-autogen, elixir-format
 msgid "Assigned Staff"
 msgstr ""
@@ -1622,13 +1622,13 @@ msgstr ""
 msgid "Business Registration"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:506
+#: lib/klass_hero_web/live/provider/team_live.ex:604
 #, elixir-autogen, elixir-format
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:538
-#: lib/klass_hero_web/components/provider_components.ex:1471
+#: lib/klass_hero_web/components/provider_components.ex:1542
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:54
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:81
 #: lib/klass_hero_web/live/settings/children_live.ex:448
@@ -1645,19 +1645,19 @@ msgstr ""
 msgid "Edit Profile"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1510
+#: lib/klass_hero_web/components/provider_components.ex:1581
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:112
-#: lib/klass_hero_web/live/provider/programs_live.ex:52
+#: lib/klass_hero_web/live/provider/programs_live.ex:54
 #, elixir-autogen, elixir-format
 msgid "My Programs"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:415
-#: lib/klass_hero_web/components/provider_components.ex:858
+#: lib/klass_hero_web/components/provider_components.ex:929
 #, elixir-autogen, elixir-format
 msgid "New Program"
 msgstr ""
@@ -1669,26 +1669,26 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:46
 #: lib/klass_hero_web/components/provider_components.ex:72
-#: lib/klass_hero_web/components/provider_components.ex:1509
-#: lib/klass_hero_web/components/provider_components.ex:2382
-#: lib/klass_hero_web/components/provider_components.ex:2400
+#: lib/klass_hero_web/components/provider_components.ex:1580
+#: lib/klass_hero_web/components/provider_components.ex:2453
+#: lib/klass_hero_web/components/provider_components.ex:2471
 #: lib/klass_hero_web/live/admin/sessions_live.ex:297
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1447
+#: lib/klass_hero_web/components/provider_components.ex:1518
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1300
+#: lib/klass_hero_web/components/provider_components.ex:1371
 #, elixir-autogen, elixir-format
 msgid "Program Inventory"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1357
+#: lib/klass_hero_web/components/provider_components.ex:1428
 #, elixir-autogen, elixir-format
 msgid "Program Name"
 msgstr ""
@@ -1703,15 +1703,15 @@ msgstr ""
 msgid "Save for Later"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1317
+#: lib/klass_hero_web/components/provider_components.ex:1388
 #, elixir-autogen, elixir-format
 msgid "Search by name..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1363
-#: lib/klass_hero_web/components/provider_components.ex:1732
-#: lib/klass_hero_web/components/provider_components.ex:1954
-#: lib/klass_hero_web/components/provider_components.ex:2183
+#: lib/klass_hero_web/components/provider_components.ex:1434
+#: lib/klass_hero_web/components/provider_components.ex:1803
+#: lib/klass_hero_web/components/provider_components.ex:2025
+#: lib/klass_hero_web/components/provider_components.ex:2254
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1725,7 +1725,7 @@ msgstr ""
 msgid "Team & Profiles"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:503
+#: lib/klass_hero_web/live/provider/team_live.ex:601
 #, elixir-autogen, elixir-format
 msgid "Team & Provider Profiles"
 msgstr ""
@@ -1735,15 +1735,15 @@ msgstr ""
 msgid "This is your main business identity. Verification is required to list programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1420
-#: lib/klass_hero_web/components/provider_components.ex:1747
+#: lib/klass_hero_web/components/provider_components.ex:1491
+#: lib/klass_hero_web/components/provider_components.ex:1818
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr ""
 
 #: lib/klass_hero_web/components/messaging_components.ex:728
 #: lib/klass_hero_web/components/provider_components.ex:49
-#: lib/klass_hero_web/components/provider_components.ex:1511
+#: lib/klass_hero_web/components/provider_components.ex:1582
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:433
 #: lib/klass_hero_web/presenters/provider_presenter.ex:103
 #, elixir-autogen, elixir-format
@@ -1755,7 +1755,7 @@ msgstr ""
 msgid "Verified Business"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1458
+#: lib/klass_hero_web/components/provider_components.ex:1529
 #, elixir-autogen, elixir-format
 msgid "View Roster"
 msgstr ""
@@ -1815,9 +1815,9 @@ msgstr ""
 #: lib/klass_hero_web/components/participation_components.ex:441
 #: lib/klass_hero_web/components/participation_components.ex:631
 #: lib/klass_hero_web/components/participation_components.ex:717
-#: lib/klass_hero_web/components/provider_components.ex:817
-#: lib/klass_hero_web/components/provider_components.ex:1216
-#: lib/klass_hero_web/components/provider_components.ex:2125
+#: lib/klass_hero_web/components/provider_components.ex:888
+#: lib/klass_hero_web/components/provider_components.ex:1287
+#: lib/klass_hero_web/components/provider_components.ex:2196
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:478
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
@@ -1883,7 +1883,7 @@ msgstr ""
 msgid "Data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2269
+#: lib/klass_hero_web/components/provider_components.ex:2340
 #: lib/klass_hero_web/live/settings/children_live.ex:657
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1931,17 +1931,17 @@ msgstr ""
 msgid "Failed to submit note"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2263
-#: lib/klass_hero_web/components/provider_components.ex:2292
-#: lib/klass_hero_web/components/provider_components.ex:2308
+#: lib/klass_hero_web/components/provider_components.ex:2334
+#: lib/klass_hero_web/components/provider_components.ex:2363
+#: lib/klass_hero_web/components/provider_components.ex:2379
 #: lib/klass_hero_web/live/settings/children_live.ex:643
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2264
-#: lib/klass_hero_web/components/provider_components.ex:2293
-#: lib/klass_hero_web/components/provider_components.ex:2309
+#: lib/klass_hero_web/components/provider_components.ex:2335
+#: lib/klass_hero_web/components/provider_components.ex:2364
+#: lib/klass_hero_web/components/provider_components.ex:2380
 #: lib/klass_hero_web/live/settings/children_live.ex:649
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -2073,15 +2073,15 @@ msgstr ""
 msgid "Provider data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:802
+#: lib/klass_hero_web/components/provider_components.ex:873
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:294
 #: lib/klass_hero_web/live/settings/children_live.ex:754
 #, elixir-autogen, elixir-format
 msgid "Save Changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1593
-#: lib/klass_hero_web/components/provider_components.ex:1594
+#: lib/klass_hero_web/components/provider_components.ex:1664
+#: lib/klass_hero_web/components/provider_components.ex:1665
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:43
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:151
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:252
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "Send a message to start the conversation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2363
+#: lib/klass_hero_web/components/provider_components.ex:2434
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:245
 #, elixir-autogen, elixir-format
@@ -2210,12 +2210,12 @@ msgstr ""
 msgid "Action Required"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:804
+#: lib/klass_hero_web/components/provider_components.ex:875
 #, elixir-autogen, elixir-format
 msgid "Add Member"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:553
+#: lib/klass_hero_web/live/provider/team_live.ex:651
 #, elixir-autogen, elixir-format
 msgid "Add your first staff member to get started!"
 msgstr ""
@@ -2230,12 +2230,12 @@ msgstr ""
 msgid "Ages %{min}+"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1077
+#: lib/klass_hero_web/components/provider_components.ex:1148
 #, elixir-autogen, elixir-format
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2422
+#: lib/klass_hero_web/components/provider_components.ex:2493
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred during import."
 msgstr ""
@@ -2261,11 +2261,6 @@ msgstr ""
 msgid "Are you sure you want to approve this document?"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:558
-#, elixir-autogen, elixir-format
-msgid "Are you sure you want to remove this team member?"
-msgstr ""
-
 #: lib/klass_hero_web/components/marketing_components.ex:671
 #, elixir-autogen, elixir-format
 msgid "As fathers and partners of teachers in Berlin, we saw and heard firsthand how hard it is to find, book, and manage quality youth activities outside the classroom. Klass Hero is the complete platform connecting Berlin families and schools with trusted, vetted activity providers — offering safe, supervised, and enriching experiences across sports, arts, tutoring, and more. We verify every provider, structure every booking, and support every step — so parents know their child is in good hands, and providers can focus on what they do best: inspiring kids."
@@ -2283,7 +2278,7 @@ msgstr ""
 msgid "Back to verifications"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:656
+#: lib/klass_hero_web/components/provider_components.ex:727
 #, elixir-autogen, elixir-format
 msgid "Bio"
 msgstr ""
@@ -2293,7 +2288,7 @@ msgstr ""
 msgid "Book a Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:657
+#: lib/klass_hero_web/components/provider_components.ex:728
 #, elixir-autogen, elixir-format
 msgid "Brief description of experience and specialties..."
 msgstr ""
@@ -2324,19 +2319,19 @@ msgstr ""
 msgid "Business Logo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:888
+#: lib/klass_hero_web/components/provider_components.ex:959
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "Category"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1026
+#: lib/klass_hero_web/components/provider_components.ex:1097
 #, elixir-autogen, elixir-format
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1951
-#: lib/klass_hero_web/components/provider_components.ex:2177
+#: lib/klass_hero_web/components/provider_components.ex:2022
+#: lib/klass_hero_web/components/provider_components.ex:2248
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2351,7 +2346,7 @@ msgstr ""
 msgid "Child meets all program requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1187
+#: lib/klass_hero_web/components/provider_components.ex:1258
 #, elixir-autogen, elixir-format
 msgid "Choose Image"
 msgstr ""
@@ -2361,12 +2356,12 @@ msgstr ""
 msgid "Choose Logo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:781
+#: lib/klass_hero_web/components/provider_components.ex:852
 #, elixir-autogen, elixir-format
 msgid "Choose Photo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:890
+#: lib/klass_hero_web/components/provider_components.ex:961
 #, elixir-autogen, elixir-format
 msgid "Choose a category"
 msgstr ""
@@ -2381,7 +2376,7 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2383
+#: lib/klass_hero_web/components/provider_components.ex:2454
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
@@ -2391,32 +2386,32 @@ msgstr ""
 msgid "Contact Provider"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:447
+#: lib/klass_hero_web/live/provider/programs_live.ex:449
 #, elixir-autogen, elixir-format
 msgid "Could not read the uploaded file."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:415
+#: lib/klass_hero_web/live/provider/programs_live.ex:417
 #, elixir-autogen, elixir-format
 msgid "Could not remove invite."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1143
+#: lib/klass_hero_web/components/provider_components.ex:1214
 #, elixir-autogen, elixir-format
 msgid "Cover Image"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1020
+#: lib/klass_hero_web/components/provider_components.ex:1091
 #, elixir-autogen, elixir-format
 msgid "Define age, gender, or grade restrictions for eligible participants."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1136
+#: lib/klass_hero_web/components/provider_components.ex:1207
 #, elixir-autogen, elixir-format
 msgid "Describe your program..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1135
+#: lib/klass_hero_web/components/provider_components.ex:1206
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:323
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:285
 #, elixir-autogen, elixir-format
@@ -2424,13 +2419,13 @@ msgid "Description"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:684
-#: lib/klass_hero_web/components/provider_components.ex:1088
+#: lib/klass_hero_web/components/provider_components.ex:1159
 #: lib/klass_hero_web/live/settings/children_live.ex:670
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2520
+#: lib/klass_hero_web/components/provider_components.ex:2591
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2464,7 +2459,7 @@ msgstr ""
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2144
+#: lib/klass_hero_web/components/provider_components.ex:2215
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
@@ -2474,40 +2469,40 @@ msgstr ""
 msgid "Download document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:856
+#: lib/klass_hero_web/components/provider_components.ex:927
 #, elixir-autogen, elixir-format
 msgid "Edit Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:598
+#: lib/klass_hero_web/components/provider_components.ex:669
 #, elixir-autogen, elixir-format
 msgid "Edit Team Member"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:965
+#: lib/klass_hero_web/components/provider_components.ex:1036
 #, elixir-autogen, elixir-format
 msgid "End Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:952
+#: lib/klass_hero_web/components/provider_components.ex:1023
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:166
 #, elixir-autogen, elixir-format
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1957
-#: lib/klass_hero_web/components/provider_components.ex:2403
+#: lib/klass_hero_web/components/provider_components.ex:2028
+#: lib/klass_hero_web/components/provider_components.ex:2474
 #: lib/klass_hero_web/components/provider_layout_components.ex:644
 #, elixir-autogen, elixir-format
 msgid "Enrolled"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1639
+#: lib/klass_hero_web/components/provider_components.ex:1710
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:993
+#: lib/klass_hero_web/components/provider_components.ex:1064
 #, elixir-autogen, elixir-format
 msgid "Enrollment Capacity (optional)"
 msgstr ""
@@ -2518,7 +2513,7 @@ msgid "Explain why this document is being rejected..."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:70
-#: lib/klass_hero_web/components/provider_components.ex:2404
+#: lib/klass_hero_web/components/provider_components.ex:2475
 #: lib/klass_hero_web/live/admin/emails_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2534,7 +2529,7 @@ msgstr ""
 msgid "Failed to reject document."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:397
+#: lib/klass_hero_web/live/provider/programs_live.ex:399
 #, elixir-autogen, elixir-format
 msgid "Failed to resend invite."
 msgstr ""
@@ -2551,7 +2546,7 @@ msgid "Family Programs"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:682
-#: lib/klass_hero_web/components/provider_components.ex:1087
+#: lib/klass_hero_web/components/provider_components.ex:1158
 #: lib/klass_hero_web/live/settings/children_live.ex:669
 #, elixir-autogen, elixir-format
 msgid "Female"
@@ -2562,22 +2557,22 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2454
+#: lib/klass_hero_web/components/provider_components.ex:2525
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2456
+#: lib/klass_hero_web/components/provider_components.ex:2527
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:684
+#: lib/klass_hero_web/components/provider_components.ex:755
 #, elixir-autogen, elixir-format
 msgid "First Aid, UEFA B License, Child Care Cert"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:626
+#: lib/klass_hero_web/components/provider_components.ex:697
 #, elixir-autogen, elixir-format
 msgid "First Name"
 msgstr ""
@@ -2602,12 +2597,12 @@ msgstr ""
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2180
+#: lib/klass_hero_web/components/provider_components.ex:2251
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:745
+#: lib/klass_hero_web/components/provider_components.ex:816
 #, elixir-autogen, elixir-format
 msgid "Headshot Photo"
 msgstr ""
@@ -2617,7 +2612,7 @@ msgstr ""
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2117
+#: lib/klass_hero_web/components/provider_components.ex:2188
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -2627,32 +2622,32 @@ msgstr ""
 msgid "Insurance Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:412
+#: lib/klass_hero_web/live/provider/programs_live.ex:414
 #, elixir-autogen, elixir-format
 msgid "Invite not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:409
+#: lib/klass_hero_web/live/provider/programs_live.ex:411
 #, elixir-autogen, elixir-format
 msgid "Invite removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:386
+#: lib/klass_hero_web/live/provider/programs_live.ex:388
 #, elixir-autogen, elixir-format
 msgid "Invite resent successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1656
+#: lib/klass_hero_web/components/provider_components.ex:1727
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:784
+#: lib/klass_hero_web/components/provider_components.ex:855
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 1MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1190
+#: lib/klass_hero_web/components/provider_components.ex:1261
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:277
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:361
 #, elixir-autogen, elixir-format
@@ -2669,22 +2664,22 @@ msgstr ""
 msgid "Klasse %{n}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:632
+#: lib/klass_hero_web/components/provider_components.ex:703
 #, elixir-autogen, elixir-format
 msgid "Last Name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:975
+#: lib/klass_hero_web/components/provider_components.ex:1046
 #, elixir-autogen, elixir-format
 msgid "Leave blank for open registration at any time."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1080
+#: lib/klass_hero_web/components/provider_components.ex:1151
 #, elixir-autogen, elixir-format
 msgid "Leave unchecked to allow all genders."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:908
+#: lib/klass_hero_web/components/provider_components.ex:979
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Location"
@@ -2697,43 +2692,43 @@ msgid "Logo upload failed. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:683
-#: lib/klass_hero_web/components/provider_components.ex:1086
+#: lib/klass_hero_web/components/provider_components.ex:1157
 #: lib/klass_hero_web/live/settings/children_live.ex:668
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1070
+#: lib/klass_hero_web/components/provider_components.ex:1141
 #, elixir-autogen, elixir-format
 msgid "Maximum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1008
+#: lib/klass_hero_web/components/provider_components.ex:1079
 #, elixir-autogen, elixir-format
 msgid "Maximum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1125
+#: lib/klass_hero_web/components/provider_components.ex:1196
 #, elixir-autogen, elixir-format
 msgid "Maximum Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:917
+#: lib/klass_hero_web/components/provider_components.ex:988
 #, elixir-autogen, elixir-format
 msgid "Meeting Days"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1064
+#: lib/klass_hero_web/components/provider_components.ex:1135
 #, elixir-autogen, elixir-format
 msgid "Minimum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1002
+#: lib/klass_hero_web/components/provider_components.ex:1073
 #, elixir-autogen, elixir-format
 msgid "Minimum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1118
+#: lib/klass_hero_web/components/provider_components.ex:1189
 #, elixir-autogen, elixir-format
 msgid "Minimum Grade"
 msgstr ""
@@ -2743,18 +2738,18 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2482
+#: lib/klass_hero_web/components/provider_components.ex:2553
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1944
+#: lib/klass_hero_web/components/provider_components.ex:2015
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:425
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:443
+#: lib/klass_hero_web/live/provider/programs_live.ex:445
 #, elixir-autogen, elixir-format
 msgid "No file selected."
 msgstr ""
@@ -2764,17 +2759,17 @@ msgstr ""
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2168
+#: lib/klass_hero_web/components/provider_components.ex:2239
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1127
+#: lib/klass_hero_web/components/provider_components.ex:1198
 #, elixir-autogen, elixir-format
 msgid "No maximum"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1120
+#: lib/klass_hero_web/components/provider_components.ex:1191
 #, elixir-autogen, elixir-format
 msgid "No minimum"
 msgstr ""
@@ -2794,7 +2789,7 @@ msgstr ""
 msgid "No rejected documents."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:552
+#: lib/klass_hero_web/live/provider/team_live.ex:650
 #, elixir-autogen, elixir-format
 msgid "No team members yet"
 msgstr ""
@@ -2805,7 +2800,7 @@ msgstr ""
 msgid "No verification documents found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1202
+#: lib/klass_hero_web/components/provider_components.ex:1273
 #, elixir-autogen, elixir-format
 msgid "None (optional)"
 msgstr ""
@@ -2816,7 +2811,7 @@ msgid "Not Verified"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:685
-#: lib/klass_hero_web/components/provider_components.ex:1089
+#: lib/klass_hero_web/components/provider_components.ex:1160
 #: lib/klass_hero_web/live/settings/children_live.ex:667
 #, elixir-autogen, elixir-format
 msgid "Not specified"
@@ -2827,7 +2822,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2557
+#: lib/klass_hero_web/components/provider_components.ex:2628
 #: lib/klass_hero_web/live/provider/verification_live.ex:698
 #: lib/klass_hero_web/live/provider/verification_live.ex:770
 #, elixir-autogen, elixir-format
@@ -2839,7 +2834,7 @@ msgstr ""
 msgid "Participant Requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1017
+#: lib/klass_hero_web/components/provider_components.ex:1088
 #, elixir-autogen, elixir-format
 msgid "Participant Restrictions (optional)"
 msgstr ""
@@ -2854,11 +2849,11 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:106
-#: lib/klass_hero_web/live/provider/programs_live.ex:689
-#: lib/klass_hero_web/live/provider/programs_live.ex:755
-#: lib/klass_hero_web/live/provider/team_live.ex:256
-#: lib/klass_hero_web/live/provider/team_live.ex:299
-#: lib/klass_hero_web/live/provider/team_live.ex:418
+#: lib/klass_hero_web/live/provider/programs_live.ex:691
+#: lib/klass_hero_web/live/provider/programs_live.ex:757
+#: lib/klass_hero_web/live/provider/team_live.ex:305
+#: lib/klass_hero_web/live/provider/team_live.ex:348
+#: lib/klass_hero_web/live/provider/team_live.ex:467
 #, elixir-autogen, elixir-format
 msgid "Please fix the errors below."
 msgstr ""
@@ -2873,7 +2868,7 @@ msgstr ""
 msgid "Preview not available for this file type."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:899
+#: lib/klass_hero_web/components/provider_components.ex:970
 #, elixir-autogen, elixir-format
 msgid "Price (EUR)"
 msgstr ""
@@ -2883,31 +2878,31 @@ msgstr ""
 msgid "Profile updated successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1055
+#: lib/klass_hero_web/components/provider_components.ex:1126
 #, elixir-autogen, elixir-format
 msgid "Program Start"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1100
+#: lib/klass_hero_web/live/provider/programs_live.ex:1102
 #, elixir-autogen, elixir-format
 msgid "Program created successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1107
+#: lib/klass_hero_web/live/provider/programs_live.ex:1109
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:54
-#: lib/klass_hero_web/live/provider/programs_live.ex:151
-#: lib/klass_hero_web/live/provider/programs_live.ex:188
-#: lib/klass_hero_web/live/provider/programs_live.ex:252
-#: lib/klass_hero_web/live/provider/programs_live.ex:730
+#: lib/klass_hero_web/live/provider/programs_live.ex:153
+#: lib/klass_hero_web/live/provider/programs_live.ex:190
+#: lib/klass_hero_web/live/provider/programs_live.ex:254
+#: lib/klass_hero_web/live/provider/programs_live.ex:732
 #, elixir-autogen, elixir-format
 msgid "Program not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:719
+#: lib/klass_hero_web/live/provider/programs_live.ex:721
 #, elixir-autogen, elixir-format
 msgid "Program updated successfully."
 msgstr ""
@@ -2925,13 +2920,13 @@ msgid "Read our founding story →"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:805
-#: lib/klass_hero_web/components/provider_components.ex:2402
+#: lib/klass_hero_web/components/provider_components.ex:2473
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Registered"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1042
+#: lib/klass_hero_web/components/provider_components.ex:1113
 #, elixir-autogen, elixir-format
 msgid "Registration"
 msgstr ""
@@ -2941,7 +2936,7 @@ msgstr ""
 msgid "Registration Closed"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:986
+#: lib/klass_hero_web/components/provider_components.ex:1057
 #, elixir-autogen, elixir-format
 msgid "Registration Closes"
 msgstr ""
@@ -2951,12 +2946,12 @@ msgstr ""
 msgid "Registration Not Open Yet"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:981
+#: lib/klass_hero_web/components/provider_components.ex:1052
 #, elixir-autogen, elixir-format
 msgid "Registration Opens"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:972
+#: lib/klass_hero_web/components/provider_components.ex:1043
 #, elixir-autogen, elixir-format
 msgid "Registration Period (optional)"
 msgstr ""
@@ -3005,18 +3000,18 @@ msgstr ""
 msgid "Rejection reason"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:767
-#: lib/klass_hero_web/components/provider_components.ex:1166
-#: lib/klass_hero_web/components/provider_components.ex:2224
-#: lib/klass_hero_web/components/provider_components.ex:2576
-#: lib/klass_hero_web/components/provider_components.ex:2655
+#: lib/klass_hero_web/components/provider_components.ex:838
+#: lib/klass_hero_web/components/provider_components.ex:1237
+#: lib/klass_hero_web/components/provider_components.ex:2295
+#: lib/klass_hero_web/components/provider_components.ex:2647
+#: lib/klass_hero_web/components/provider_components.ex:2726
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:253
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2217
+#: lib/klass_hero_web/components/provider_components.ex:2288
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -3026,23 +3021,23 @@ msgstr ""
 msgid "Reviewed"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:641
+#: lib/klass_hero_web/components/provider_components.ex:712
 #, elixir-autogen, elixir-format
 msgid "Role"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1585
+#: lib/klass_hero_web/components/provider_components.ex:1656
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1229
+#: lib/klass_hero_web/components/provider_components.ex:1300
 #, elixir-autogen, elixir-format
 msgid "Save Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:914
+#: lib/klass_hero_web/components/provider_components.ex:985
 #, elixir-autogen, elixir-format
 msgid "Schedule (optional)"
 msgstr ""
@@ -3057,7 +3052,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2554
+#: lib/klass_hero_web/components/provider_components.ex:2625
 #, elixir-autogen, elixir-format
 msgid "Select File"
 msgstr ""
@@ -3068,52 +3063,52 @@ msgstr ""
 msgid "Selected child does not meet the program requirements."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:679
-#: lib/klass_hero_web/live/provider/programs_live.ex:745
+#: lib/klass_hero_web/live/provider/programs_live.ex:681
+#: lib/klass_hero_web/live/provider/programs_live.ex:747
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2401
+#: lib/klass_hero_web/components/provider_components.ex:2472
 #: lib/klass_hero_web/live/admin/emails_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Sent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:688
+#: lib/klass_hero_web/components/provider_components.ex:759
 #, elixir-autogen, elixir-format
 msgid "Separate multiple qualifications with commas"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:996
+#: lib/klass_hero_web/components/provider_components.ex:1067
 #, elixir-autogen, elixir-format
 msgid "Set minimum and maximum enrollment for this program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:662
+#: lib/klass_hero_web/components/provider_components.ex:733
 #, elixir-autogen, elixir-format
 msgid "Specialties"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:398
-#: lib/klass_hero_web/live/provider/team_live.ex:424
+#: lib/klass_hero_web/live/provider/team_live.ex:447
+#: lib/klass_hero_web/live/provider/team_live.ex:473
 #, elixir-autogen, elixir-format
 msgid "Staff member no longer exists."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:101
-#: lib/klass_hero_web/live/provider/team_live.ex:173
-#: lib/klass_hero_web/live/provider/team_live.ex:197
+#: lib/klass_hero_web/live/provider/team_live.ex:103
+#: lib/klass_hero_web/live/provider/team_live.ex:246
+#: lib/klass_hero_web/live/provider/team_live.ex:488
 #, elixir-autogen, elixir-format
 msgid "Staff member not found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:960
+#: lib/klass_hero_web/components/provider_components.ex:1031
 #, elixir-autogen, elixir-format
 msgid "Start Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:947
+#: lib/klass_hero_web/components/provider_components.ex:1018
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Start Time"
@@ -3134,27 +3129,27 @@ msgstr ""
 msgid "Tax Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:352
+#: lib/klass_hero_web/live/provider/team_live.ex:401
 #, elixir-autogen, elixir-format
 msgid "Team member added, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:353
+#: lib/klass_hero_web/live/provider/team_live.ex:402
 #, elixir-autogen, elixir-format
 msgid "Team member added."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:164
+#: lib/klass_hero_web/live/provider/team_live.ex:209
 #, elixir-autogen, elixir-format
 msgid "Team member removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:378
+#: lib/klass_hero_web/live/provider/team_live.ex:427
 #, elixir-autogen, elixir-format
 msgid "Team member updated, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:379
+#: lib/klass_hero_web/live/provider/team_live.ex:428
 #, elixir-autogen, elixir-format
 msgid "Team member updated."
 msgstr ""
@@ -3169,22 +3164,22 @@ msgstr ""
 msgid "The Klass Hero Story"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:389
+#: lib/klass_hero_web/live/provider/programs_live.ex:391
 #, elixir-autogen, elixir-format
 msgid "This invite cannot be resent."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:737
+#: lib/klass_hero_web/live/provider/programs_live.ex:739
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:881
+#: lib/klass_hero_web/components/provider_components.ex:952
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2455
+#: lib/klass_hero_web/components/provider_components.ex:2526
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -3204,32 +3199,32 @@ msgstr ""
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2103
+#: lib/klass_hero_web/components/provider_components.ex:2174
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2600
+#: lib/klass_hero_web/components/provider_components.ex:2671
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2509
+#: lib/klass_hero_web/components/provider_components.ex:2580
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2477
+#: lib/klass_hero_web/components/provider_components.ex:2548
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2457
+#: lib/klass_hero_web/components/provider_components.ex:2528
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2474
+#: lib/klass_hero_web/components/provider_components.ex:2545
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -3268,32 +3263,32 @@ msgstr ""
 msgid "You don't have access to that page."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:642
+#: lib/klass_hero_web/components/provider_components.ex:713
 #, elixir-autogen, elixir-format
 msgid "e.g. Head Coach"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:633
+#: lib/klass_hero_web/components/provider_components.ex:704
 #, elixir-autogen, elixir-format
 msgid "e.g. Johnson"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:627
+#: lib/klass_hero_web/components/provider_components.ex:698
 #, elixir-autogen, elixir-format
 msgid "e.g. Mike"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:648
+#: lib/klass_hero_web/components/provider_components.ex:719
 #, elixir-autogen, elixir-format
 msgid "e.g. mike@example.com"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:882
+#: lib/klass_hero_web/components/provider_components.ex:953
 #, elixir-autogen, elixir-format
 msgid "e.g., Art Adventures"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:909
+#: lib/klass_hero_web/components/provider_components.ex:980
 #, elixir-autogen, elixir-format
 msgid "e.g., Community Center, Main St"
 msgstr ""
@@ -3319,7 +3314,7 @@ msgid "Child Safeguarding Training"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1498
-#: lib/klass_hero_web/components/provider_components.ex:2822
+#: lib/klass_hero_web/components/provider_components.ex:2893
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr ""
@@ -3389,7 +3384,7 @@ msgstr ""
 msgid "Program fee:"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:938
+#: lib/klass_hero_web/live/provider/programs_live.ex:940
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr ""
@@ -3469,7 +3464,7 @@ msgid "Vetted with Care"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1482
-#: lib/klass_hero_web/components/provider_components.ex:2607
+#: lib/klass_hero_web/components/provider_components.ex:2678
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr ""
@@ -3605,7 +3600,7 @@ msgstr ""
 msgid "Cannot check out without a check-in"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:361
+#: lib/klass_hero_web/live/provider/programs_live.ex:363
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:146
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
@@ -3643,7 +3638,7 @@ msgstr ""
 msgid "Checked Out"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2260
+#: lib/klass_hero_web/components/provider_components.ex:2331
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Child"
@@ -3670,7 +3665,7 @@ msgid "Correct"
 msgstr ""
 
 #: lib/klass_hero_web/live/dashboard_live.ex:301
-#: lib/klass_hero_web/live/provider/programs_live.ex:358
+#: lib/klass_hero_web/live/provider/programs_live.ex:360
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "Could not start conversation. Please try again."
@@ -3696,7 +3691,7 @@ msgstr ""
 msgid "Download monthly statements for taxes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2021
+#: lib/klass_hero_web/components/provider_components.ex:2092
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Enrollment not confirmed"
@@ -3774,7 +3769,7 @@ msgstr ""
 msgid "No chasing payments or sending invoices"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1608
+#: lib/klass_hero_web/components/provider_components.ex:1679
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:406
 #, elixir-autogen, elixir-format
 msgid "No enrolled parents"
@@ -3797,7 +3792,7 @@ msgstr ""
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2020
+#: lib/klass_hero_web/components/provider_components.ex:2091
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:481
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -4233,7 +4228,7 @@ msgstr ""
 msgid "Failed to mark email as unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:213
+#: lib/klass_hero_web/live/provider/team_live.ex:262
 #, elixir-autogen, elixir-format
 msgid "Failed to resend invitation. Please try again."
 msgstr ""
@@ -4281,32 +4276,32 @@ msgid "Invalid time format"
 msgstr ""
 
 #: lib/klass_hero_web/live/user_live/staff_invitation.ex:27
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:107
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:115
 #, elixir-autogen, elixir-format
 msgid "Invitation Expired"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:105
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:113
 #, elixir-autogen, elixir-format
 msgid "Invitation Failed"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:103
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:111
 #, elixir-autogen, elixir-format
 msgid "Invitation Pending"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:104
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:112
 #, elixir-autogen, elixir-format
 msgid "Invitation Sent"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:188
+#: lib/klass_hero_web/live/provider/team_live.ex:237
 #, elixir-autogen, elixir-format
 msgid "Invitation resent successfully."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:106
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:114
 #, elixir-autogen, elixir-format
 msgid "Joined"
 msgstr ""
@@ -4427,7 +4422,7 @@ msgstr ""
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:24
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
-#: lib/klass_hero_web/live/provider/programs_live.ex:220
+#: lib/klass_hero_web/live/provider/programs_live.ex:222
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:156
 #, elixir-autogen, elixir-format
 msgid "Program"
@@ -4574,7 +4569,7 @@ msgstr ""
 msgid "The business associated with your account could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:204
+#: lib/klass_hero_web/live/provider/team_live.ex:253
 #, elixir-autogen, elixir-format
 msgid "This invitation cannot be resent in its current state."
 msgstr ""
@@ -4636,7 +4631,7 @@ msgid "Update your observation..."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:138
-#: lib/klass_hero_web/live/provider/programs_live.ex:440
+#: lib/klass_hero_web/live/provider/programs_live.ex:442
 #: lib/klass_hero_web/live/provider/verification_live.ex:240
 #: lib/klass_hero_web/live/provider/verification_live.ex:556
 #: lib/klass_hero_web/live/provider/verification_live.ex:594
@@ -4905,48 +4900,48 @@ msgstr ""
 msgid "for"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1729
+#: lib/klass_hero_web/components/provider_components.ex:1800
 #, elixir-autogen, elixir-format
 msgid "Assigned staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1731
+#: lib/klass_hero_web/components/provider_components.ex:1802
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1713
-#: lib/klass_hero_web/components/provider_components.ex:1802
+#: lib/klass_hero_web/components/provider_components.ex:1784
+#: lib/klass_hero_web/components/provider_components.ex:1873
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1730
+#: lib/klass_hero_web/components/provider_components.ex:1801
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1728
+#: lib/klass_hero_web/components/provider_components.ex:1799
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1722
+#: lib/klass_hero_web/components/provider_components.ex:1793
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1711
+#: lib/klass_hero_web/components/provider_components.ex:1782
 #, elixir-autogen, elixir-format
 msgid "Sessions — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1451
+#: lib/klass_hero_web/components/provider_components.ex:1522
 #, elixir-autogen, elixir-format
 msgid "View sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:531
+#: lib/klass_hero_web/live/provider/programs_live.ex:533
 #, elixir-autogen, elixir-format
 msgid "Create a program before inviting participants."
 msgstr ""
@@ -4973,22 +4968,22 @@ msgstr ""
 msgid "Failed to update record"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2324
+#: lib/klass_hero_web/components/provider_components.ex:2395
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2043
+#: lib/klass_hero_web/components/provider_components.ex:2114
 #, elixir-autogen, elixir-format
 msgid "Invite mode"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2062
+#: lib/klass_hero_web/components/provider_components.ex:2133
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:527
+#: lib/klass_hero_web/live/provider/programs_live.ex:529
 #, elixir-autogen, elixir-format
 msgid "Invite sent."
 msgstr ""
@@ -4998,12 +4993,12 @@ msgstr ""
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2337
+#: lib/klass_hero_web/components/provider_components.ex:2408
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2343
+#: lib/klass_hero_web/components/provider_components.ex:2414
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr ""
@@ -5014,17 +5009,17 @@ msgstr ""
 msgid "Nothing to update"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2345
+#: lib/klass_hero_web/components/provider_components.ex:2416
 #, elixir-autogen, elixir-format
 msgid "Nut allergy"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2349
+#: lib/klass_hero_web/components/provider_components.ex:2420
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2354
+#: lib/klass_hero_web/components/provider_components.ex:2425
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr ""
@@ -5034,7 +5029,7 @@ msgstr ""
 msgid "Present"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2281
+#: lib/klass_hero_web/components/provider_components.ex:2352
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr ""
@@ -5061,22 +5056,22 @@ msgstr ""
 msgid "Save changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2318
+#: lib/klass_hero_web/components/provider_components.ex:2389
 #, elixir-autogen, elixir-format
 msgid "School (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2328
+#: lib/klass_hero_web/components/provider_components.ex:2399
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2302
+#: lib/klass_hero_web/components/provider_components.ex:2373
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2371
+#: lib/klass_hero_web/components/provider_components.ex:2442
 #, elixir-autogen, elixir-format
 msgid "Send invite"
 msgstr ""
@@ -5086,12 +5081,12 @@ msgstr ""
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2080
+#: lib/klass_hero_web/components/provider_components.ex:2151
 #, elixir-autogen, elixir-format
 msgid "Upload a list"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:538
+#: lib/klass_hero_web/live/provider/programs_live.ex:540
 #, elixir-autogen, elixir-format
 msgid "An invite for this child and program already exists."
 msgstr ""
@@ -5121,7 +5116,7 @@ msgstr ""
 msgid "High"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:715
+#: lib/klass_hero_web/components/provider_components.ex:786
 #, elixir-autogen, elixir-format
 msgid "Hourly"
 msgstr ""
@@ -5146,12 +5141,12 @@ msgstr ""
 msgid "Medium"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:705
+#: lib/klass_hero_web/components/provider_components.ex:776
 #, elixir-autogen, elixir-format
 msgid "None"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:694
+#: lib/klass_hero_web/components/provider_components.ex:765
 #, elixir-autogen, elixir-format
 msgid "Pay Rate"
 msgstr ""
@@ -5161,7 +5156,7 @@ msgstr ""
 msgid "Pay rate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:725
+#: lib/klass_hero_web/components/provider_components.ex:796
 #, elixir-autogen, elixir-format
 msgid "Per Session"
 msgstr ""
@@ -5186,7 +5181,7 @@ msgstr ""
 msgid "Property Damage"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1481
+#: lib/klass_hero_web/components/provider_components.ex:1552
 #, elixir-autogen, elixir-format
 msgid "Report Incident"
 msgstr ""
@@ -5232,12 +5227,12 @@ msgstr ""
 msgid "Your pay rate"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:99
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:107
 #, elixir-autogen, elixir-format
 msgid "hour"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:100
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:108
 #, elixir-autogen, elixir-format
 msgid "session"
 msgstr ""
@@ -5268,7 +5263,7 @@ msgstr ""
 msgid "Go to dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:483
+#: lib/klass_hero_web/live/provider/programs_live.ex:485
 #, elixir-autogen, elixir-format
 msgid "%{count} row could not be processed."
 msgid_plural "%{count} rows could not be processed."
@@ -5571,7 +5566,7 @@ msgstr ""
 msgid "Contact Us →"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:307
+#: lib/klass_hero_web/live/provider/team_live.ex:356
 #, elixir-autogen, elixir-format
 msgid "Could not add you to the team. Please try again."
 msgstr ""
@@ -5850,13 +5845,13 @@ msgstr ""
 msgid "How we vet providers"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:520
+#: lib/klass_hero_web/live/provider/team_live.ex:618
 #, elixir-autogen, elixir-format
 msgid "I'll be teaching"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:458
-#: lib/klass_hero_web/live/provider/programs_live.ex:480
+#: lib/klass_hero_web/live/provider/programs_live.ex:460
+#: lib/klass_hero_web/live/provider/programs_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Imported %{count} family."
 msgid_plural "Imported %{count} families."
@@ -5868,7 +5863,7 @@ msgstr[1] ""
 msgid "In 2025, Shane connected with his friend"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1490
+#: lib/klass_hero_web/components/provider_components.ex:1561
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:43
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:74
 #, elixir-autogen, elixir-format
@@ -5938,7 +5933,7 @@ msgstr ""
 msgid "Last 8 weeks"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1200
+#: lib/klass_hero_web/components/provider_components.ex:1271
 #: lib/klass_hero_web/presenters/hero_cards_presenter.ex:27
 #, elixir-autogen, elixir-format
 msgid "Lead Instructor"
@@ -6145,7 +6140,7 @@ msgstr ""
 msgid "No registered children for this session."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:467
+#: lib/klass_hero_web/live/provider/programs_live.ex:469
 #, elixir-autogen, elixir-format
 msgid "No rows imported. %{count} row could not be processed."
 msgid_plural "No rows imported. %{count} rows could not be processed."
@@ -6388,17 +6383,17 @@ msgstr ""
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2410
+#: lib/klass_hero_web/components/provider_components.ex:2481
 #, elixir-autogen, elixir-format
 msgid "Row %{row}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2410
+#: lib/klass_hero_web/components/provider_components.ex:2481
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2156
+#: lib/klass_hero_web/components/provider_components.ex:2227
 #, elixir-autogen, elixir-format
 msgid "Rows with errors"
 msgstr ""
@@ -6820,7 +6815,7 @@ msgstr ""
 msgid "You'll get your own provider profile to fill in, and your account will open on your business dashboard from now on. You stay on %{business}'s team."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:287
+#: lib/klass_hero_web/live/provider/team_live.ex:336
 #, elixir-autogen, elixir-format
 msgid "You're already on your team."
 msgstr ""
@@ -6840,12 +6835,12 @@ msgstr ""
 msgid "You're now part of the team."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:335
+#: lib/klass_hero_web/live/provider/team_live.ex:384
 #, elixir-autogen, elixir-format
 msgid "You're on the team — you can now be assigned to programs."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:334
+#: lib/klass_hero_web/live/provider/team_live.ex:383
 #, elixir-autogen, elixir-format
 msgid "You're on the team, but the headshot upload failed."
 msgstr ""
@@ -7157,12 +7152,12 @@ msgstr ""
 msgid "Experience validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2636
+#: lib/klass_hero_web/components/provider_components.ex:2707
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2610
+#: lib/klass_hero_web/components/provider_components.ex:2681
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
@@ -7172,12 +7167,12 @@ msgstr ""
 msgid "Safeguarding certificate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2633
+#: lib/klass_hero_web/components/provider_components.ex:2704
 #, elixir-autogen, elixir-format
 msgid "Select Video"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2679
+#: lib/klass_hero_web/components/provider_components.ex:2750
 #, elixir-autogen, elixir-format
 msgid "Upload Video"
 msgstr ""
@@ -7187,7 +7182,7 @@ msgstr ""
 msgid "Your browser does not support video playback."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2826
+#: lib/klass_hero_web/components/provider_components.ex:2897
 #, elixir-autogen, elixir-format
 msgid "Confirm agreement"
 msgstr ""
@@ -7197,12 +7192,12 @@ msgstr ""
 msgid "Couldn't record your agreement. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2849
+#: lib/klass_hero_web/components/provider_components.ex:2920
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2825
+#: lib/klass_hero_web/components/provider_components.ex:2896
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr ""
@@ -7212,7 +7207,7 @@ msgstr ""
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2734
+#: lib/klass_hero_web/components/provider_components.ex:2805
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr ""
@@ -7222,17 +7217,17 @@ msgstr ""
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2834
+#: lib/klass_hero_web/components/provider_components.ex:2905
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2823
+#: lib/klass_hero_web/components/provider_components.ex:2894
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2824
+#: lib/klass_hero_web/components/provider_components.ex:2895
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
@@ -7501,12 +7496,12 @@ msgstr ""
 msgid "Your insurance is verified."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2778
+#: lib/klass_hero_web/components/provider_components.ex:2849
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2881
+#: lib/klass_hero_web/components/provider_components.ex:2952
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr ""
@@ -7516,7 +7511,7 @@ msgstr ""
 msgid "Couldn't record your declaration. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2887
+#: lib/klass_hero_web/components/provider_components.ex:2958
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr ""
@@ -7526,17 +7521,17 @@ msgstr ""
 msgid "Please confirm the declaration before signing."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2912
+#: lib/klass_hero_web/components/provider_components.ex:2983
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2891
+#: lib/klass_hero_web/components/provider_components.ex:2962
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2879
+#: lib/klass_hero_web/components/provider_components.ex:2950
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr ""
@@ -7546,12 +7541,12 @@ msgstr ""
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2899
+#: lib/klass_hero_web/components/provider_components.ex:2970
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2885
+#: lib/klass_hero_web/components/provider_components.ex:2956
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
@@ -7618,94 +7613,144 @@ msgstr ""
 msgid "Undelivered Events"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1899
+#: lib/klass_hero_web/components/provider_components.ex:1970
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1824
+#: lib/klass_hero_web/components/provider_components.ex:1895
 #, elixir-autogen, elixir-format
 msgid "Lead"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:333
+#: lib/klass_hero_web/live/provider/programs_live.ex:335
 #, elixir-autogen, elixir-format
 msgid "Lead instructor updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1835
+#: lib/klass_hero_web/components/provider_components.ex:1906
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1465
+#: lib/klass_hero_web/components/provider_components.ex:1536
 #, elixir-autogen, elixir-format
 msgid "Manage Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1863
+#: lib/klass_hero_web/components/provider_components.ex:1934
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this program yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:263
+#: lib/klass_hero_web/live/provider/programs_live.ex:265
 #, elixir-autogen, elixir-format
 msgid "Pick a staff member to add."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1846
+#: lib/klass_hero_web/components/provider_components.ex:1917
 #, elixir-autogen, elixir-format
 msgid "Reassign the lead before removing them"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1847
+#: lib/klass_hero_web/components/provider_components.ex:1918
 #, elixir-autogen, elixir-format
 msgid "Remove from program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1881
+#: lib/klass_hero_web/components/provider_components.ex:1952
 #, elixir-autogen, elixir-format
 msgid "Select a staff member…"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:278
+#: lib/klass_hero_web/live/provider/programs_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Staff member added to the program."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:304
+#: lib/klass_hero_web/live/provider/programs_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "Staff member removed from the program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1904
+#: lib/klass_hero_web/components/provider_components.ex:1975
 #, elixir-autogen, elixir-format
 msgid "Staff you add can read and reply to this program's parent conversations."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1800
+#: lib/klass_hero_web/components/provider_components.ex:1871
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:897
+#: lib/klass_hero_web/live/provider/programs_live.ex:899
 #, elixir-autogen, elixir-format
 msgid "That staff member could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:286
+#: lib/klass_hero_web/live/provider/programs_live.ex:288
 #, elixir-autogen, elixir-format
 msgid "They are already on this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:312
+#: lib/klass_hero_web/live/provider/programs_live.ex:314
 #, elixir-autogen, elixir-format
 msgid "This person is the lead instructor. Make someone else lead before removing them."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1409
+#: lib/klass_hero_web/components/provider_components.ex:1480
 #, elixir-autogen, elixir-format
 msgid "%{count} staff member · no lead"
 msgid_plural "%{count} staff · no lead"
 msgstr[0] ""
 msgstr[1] ""
+
+#: lib/klass_hero_web/components/provider_components.ex:562
+#, elixir-autogen, elixir-format
+msgid "%{name} will be unassigned from every program and removed from those conversations. Their history is kept and you can add them back later."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:638
+#, elixir-autogen, elixir-format
+msgid "Add back to team"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/team_live.ex:193
+#, elixir-autogen, elixir-format
+msgid "Could not bring this team member back. Please try again."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:600
+#, elixir-autogen, elixir-format
+msgid "Delete entry"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/team_live.ex:663
+#, elixir-autogen, elixir-format
+msgid "Former team members"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:574
+#, elixir-autogen, elixir-format
+msgid "Remove from team"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/team_live.ex:187
+#, elixir-autogen, elixir-format
+msgid "Team member is back. Assign them to programs again when you're ready."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/team_live.ex:167
+#, elixir-autogen, elixir-format
+msgid "Team member removed from the team."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:590
+#, elixir-autogen, elixir-format
+msgid "This deletes %{name} permanently — there's nothing to undo. Use it only for an entry added by mistake."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/team_live.ex:218
+#, elixir-autogen, elixir-format
+msgid "This person has a history here now — use 'Remove from team' instead."
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -137,7 +137,7 @@ msgid "Your Data"
 msgstr ""
 
 #: lib/klass_hero_web/components/core_components.ex:67
-#: lib/klass_hero_web/components/provider_components.ex:1615
+#: lib/klass_hero_web/components/provider_components.ex:1686
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr ""
@@ -232,7 +232,7 @@ msgstr ""
 msgid "Enroll Now - %{price}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1366
+#: lib/klass_hero_web/components/provider_components.ex:1437
 #: lib/klass_hero_web/live/booking_live.ex:285
 #, elixir-autogen, elixir-format
 msgid "Enrollment"
@@ -577,9 +577,9 @@ msgstr ""
 msgid "Dispute Resolution"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:647
-#: lib/klass_hero_web/components/provider_components.ex:2288
-#: lib/klass_hero_web/components/provider_components.ex:2306
+#: lib/klass_hero_web/components/provider_components.ex:718
+#: lib/klass_hero_web/components/provider_components.ex:2359
+#: lib/klass_hero_web/components/provider_components.ex:2377
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
@@ -878,9 +878,9 @@ msgstr ""
 msgid "Select one or both options"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1984
-#: lib/klass_hero_web/components/provider_components.ex:1985
-#: lib/klass_hero_web/components/provider_components.ex:2022
+#: lib/klass_hero_web/components/provider_components.ex:2055
+#: lib/klass_hero_web/components/provider_components.ex:2056
+#: lib/klass_hero_web/components/provider_components.ex:2093
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:446
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:483
@@ -1456,7 +1456,7 @@ msgstr ""
 msgid "Music"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:683
+#: lib/klass_hero_web/components/provider_components.ex:754
 #: lib/klass_hero_web/live/for_providers_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "Qualifications"
@@ -1577,30 +1577,30 @@ msgstr ""
 msgid "Quick Navigation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1369
-#: lib/klass_hero_web/components/provider_components.ex:1960
-#: lib/klass_hero_web/components/provider_components.ex:2186
+#: lib/klass_hero_web/components/provider_components.ex:1440
+#: lib/klass_hero_web/components/provider_components.ex:2031
+#: lib/klass_hero_web/components/provider_components.ex:2257
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1508
+#: lib/klass_hero_web/components/provider_components.ex:1579
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Active"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:600
-#: lib/klass_hero_web/live/provider/team_live.ex:529
+#: lib/klass_hero_web/components/provider_components.ex:671
+#: lib/klass_hero_web/live/provider/team_live.ex:627
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:46
+#: lib/klass_hero_web/live/provider/programs_live.ex:48
 #, elixir-autogen, elixir-format
 msgid "All Staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1360
+#: lib/klass_hero_web/components/provider_components.ex:1431
 #, elixir-autogen, elixir-format
 msgid "Assigned Staff"
 msgstr ""
@@ -1622,13 +1622,13 @@ msgstr ""
 msgid "Business Registration"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:506
+#: lib/klass_hero_web/live/provider/team_live.ex:604
 #, elixir-autogen, elixir-format
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:538
-#: lib/klass_hero_web/components/provider_components.ex:1471
+#: lib/klass_hero_web/components/provider_components.ex:1542
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:54
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:81
 #: lib/klass_hero_web/live/settings/children_live.ex:448
@@ -1645,19 +1645,19 @@ msgstr ""
 msgid "Edit Profile"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1510
+#: lib/klass_hero_web/components/provider_components.ex:1581
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:112
-#: lib/klass_hero_web/live/provider/programs_live.ex:52
+#: lib/klass_hero_web/live/provider/programs_live.ex:54
 #, elixir-autogen, elixir-format, fuzzy
 msgid "My Programs"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:415
-#: lib/klass_hero_web/components/provider_components.ex:858
+#: lib/klass_hero_web/components/provider_components.ex:929
 #, elixir-autogen, elixir-format, fuzzy
 msgid "New Program"
 msgstr ""
@@ -1669,26 +1669,26 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:46
 #: lib/klass_hero_web/components/provider_components.ex:72
-#: lib/klass_hero_web/components/provider_components.ex:1509
-#: lib/klass_hero_web/components/provider_components.ex:2382
-#: lib/klass_hero_web/components/provider_components.ex:2400
+#: lib/klass_hero_web/components/provider_components.ex:1580
+#: lib/klass_hero_web/components/provider_components.ex:2453
+#: lib/klass_hero_web/components/provider_components.ex:2471
 #: lib/klass_hero_web/live/admin/sessions_live.ex:297
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1447
+#: lib/klass_hero_web/components/provider_components.ex:1518
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1300
+#: lib/klass_hero_web/components/provider_components.ex:1371
 #, elixir-autogen, elixir-format
 msgid "Program Inventory"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1357
+#: lib/klass_hero_web/components/provider_components.ex:1428
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program Name"
 msgstr ""
@@ -1703,15 +1703,15 @@ msgstr ""
 msgid "Save for Later"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1317
+#: lib/klass_hero_web/components/provider_components.ex:1388
 #, elixir-autogen, elixir-format
 msgid "Search by name..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1363
-#: lib/klass_hero_web/components/provider_components.ex:1732
-#: lib/klass_hero_web/components/provider_components.ex:1954
-#: lib/klass_hero_web/components/provider_components.ex:2183
+#: lib/klass_hero_web/components/provider_components.ex:1434
+#: lib/klass_hero_web/components/provider_components.ex:1803
+#: lib/klass_hero_web/components/provider_components.ex:2025
+#: lib/klass_hero_web/components/provider_components.ex:2254
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1725,7 +1725,7 @@ msgstr ""
 msgid "Team & Profiles"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:503
+#: lib/klass_hero_web/live/provider/team_live.ex:601
 #, elixir-autogen, elixir-format
 msgid "Team & Provider Profiles"
 msgstr ""
@@ -1735,15 +1735,15 @@ msgstr ""
 msgid "This is your main business identity. Verification is required to list programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1420
-#: lib/klass_hero_web/components/provider_components.ex:1747
+#: lib/klass_hero_web/components/provider_components.ex:1491
+#: lib/klass_hero_web/components/provider_components.ex:1818
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr ""
 
 #: lib/klass_hero_web/components/messaging_components.ex:728
 #: lib/klass_hero_web/components/provider_components.ex:49
-#: lib/klass_hero_web/components/provider_components.ex:1511
+#: lib/klass_hero_web/components/provider_components.ex:1582
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:433
 #: lib/klass_hero_web/presenters/provider_presenter.ex:103
 #, elixir-autogen, elixir-format
@@ -1755,7 +1755,7 @@ msgstr ""
 msgid "Verified Business"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1458
+#: lib/klass_hero_web/components/provider_components.ex:1529
 #, elixir-autogen, elixir-format
 msgid "View Roster"
 msgstr ""
@@ -1815,9 +1815,9 @@ msgstr ""
 #: lib/klass_hero_web/components/participation_components.ex:441
 #: lib/klass_hero_web/components/participation_components.ex:631
 #: lib/klass_hero_web/components/participation_components.ex:717
-#: lib/klass_hero_web/components/provider_components.ex:817
-#: lib/klass_hero_web/components/provider_components.ex:1216
-#: lib/klass_hero_web/components/provider_components.ex:2125
+#: lib/klass_hero_web/components/provider_components.ex:888
+#: lib/klass_hero_web/components/provider_components.ex:1287
+#: lib/klass_hero_web/components/provider_components.ex:2196
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:478
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
@@ -1883,7 +1883,7 @@ msgstr ""
 msgid "Data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2269
+#: lib/klass_hero_web/components/provider_components.ex:2340
 #: lib/klass_hero_web/live/settings/children_live.ex:657
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1931,17 +1931,17 @@ msgstr ""
 msgid "Failed to submit note"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2263
-#: lib/klass_hero_web/components/provider_components.ex:2292
-#: lib/klass_hero_web/components/provider_components.ex:2308
+#: lib/klass_hero_web/components/provider_components.ex:2334
+#: lib/klass_hero_web/components/provider_components.ex:2363
+#: lib/klass_hero_web/components/provider_components.ex:2379
 #: lib/klass_hero_web/live/settings/children_live.ex:643
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2264
-#: lib/klass_hero_web/components/provider_components.ex:2293
-#: lib/klass_hero_web/components/provider_components.ex:2309
+#: lib/klass_hero_web/components/provider_components.ex:2335
+#: lib/klass_hero_web/components/provider_components.ex:2364
+#: lib/klass_hero_web/components/provider_components.ex:2380
 #: lib/klass_hero_web/live/settings/children_live.ex:649
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -2073,15 +2073,15 @@ msgstr ""
 msgid "Provider data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:802
+#: lib/klass_hero_web/components/provider_components.ex:873
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:294
 #: lib/klass_hero_web/live/settings/children_live.ex:754
 #, elixir-autogen, elixir-format
 msgid "Save Changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1593
-#: lib/klass_hero_web/components/provider_components.ex:1594
+#: lib/klass_hero_web/components/provider_components.ex:1664
+#: lib/klass_hero_web/components/provider_components.ex:1665
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:43
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:151
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:252
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "Send a message to start the conversation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2363
+#: lib/klass_hero_web/components/provider_components.ex:2434
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:245
 #, elixir-autogen, elixir-format, fuzzy
@@ -2210,12 +2210,12 @@ msgstr ""
 msgid "Action Required"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:804
+#: lib/klass_hero_web/components/provider_components.ex:875
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add Member"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:553
+#: lib/klass_hero_web/live/provider/team_live.ex:651
 #, elixir-autogen, elixir-format
 msgid "Add your first staff member to get started!"
 msgstr ""
@@ -2230,12 +2230,12 @@ msgstr ""
 msgid "Ages %{min}+"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1077
+#: lib/klass_hero_web/components/provider_components.ex:1148
 #, elixir-autogen, elixir-format
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2422
+#: lib/klass_hero_web/components/provider_components.ex:2493
 #, elixir-autogen, elixir-format, fuzzy
 msgid "An unexpected error occurred during import."
 msgstr ""
@@ -2261,11 +2261,6 @@ msgstr ""
 msgid "Are you sure you want to approve this document?"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:558
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Are you sure you want to remove this team member?"
-msgstr ""
-
 #: lib/klass_hero_web/components/marketing_components.ex:671
 #, elixir-autogen, elixir-format
 msgid "As fathers and partners of teachers in Berlin, we saw and heard firsthand how hard it is to find, book, and manage quality youth activities outside the classroom. Klass Hero is the complete platform connecting Berlin families and schools with trusted, vetted activity providers — offering safe, supervised, and enriching experiences across sports, arts, tutoring, and more. We verify every provider, structure every booking, and support every step — so parents know their child is in good hands, and providers can focus on what they do best: inspiring kids."
@@ -2283,7 +2278,7 @@ msgstr ""
 msgid "Back to verifications"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:656
+#: lib/klass_hero_web/components/provider_components.ex:727
 #, elixir-autogen, elixir-format
 msgid "Bio"
 msgstr ""
@@ -2293,7 +2288,7 @@ msgstr ""
 msgid "Book a Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:657
+#: lib/klass_hero_web/components/provider_components.ex:728
 #, elixir-autogen, elixir-format
 msgid "Brief description of experience and specialties..."
 msgstr ""
@@ -2324,19 +2319,19 @@ msgstr ""
 msgid "Business Logo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:888
+#: lib/klass_hero_web/components/provider_components.ex:959
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "Category"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1026
+#: lib/klass_hero_web/components/provider_components.ex:1097
 #, elixir-autogen, elixir-format
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1951
-#: lib/klass_hero_web/components/provider_components.ex:2177
+#: lib/klass_hero_web/components/provider_components.ex:2022
+#: lib/klass_hero_web/components/provider_components.ex:2248
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2351,7 +2346,7 @@ msgstr ""
 msgid "Child meets all program requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1187
+#: lib/klass_hero_web/components/provider_components.ex:1258
 #, elixir-autogen, elixir-format
 msgid "Choose Image"
 msgstr ""
@@ -2361,12 +2356,12 @@ msgstr ""
 msgid "Choose Logo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:781
+#: lib/klass_hero_web/components/provider_components.ex:852
 #, elixir-autogen, elixir-format
 msgid "Choose Photo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:890
+#: lib/klass_hero_web/components/provider_components.ex:961
 #, elixir-autogen, elixir-format
 msgid "Choose a category"
 msgstr ""
@@ -2381,7 +2376,7 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2383
+#: lib/klass_hero_web/components/provider_components.ex:2454
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
@@ -2391,32 +2386,32 @@ msgstr ""
 msgid "Contact Provider"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:447
+#: lib/klass_hero_web/live/provider/programs_live.ex:449
 #, elixir-autogen, elixir-format
 msgid "Could not read the uploaded file."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:415
+#: lib/klass_hero_web/live/provider/programs_live.ex:417
 #, elixir-autogen, elixir-format
 msgid "Could not remove invite."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1143
+#: lib/klass_hero_web/components/provider_components.ex:1214
 #, elixir-autogen, elixir-format
 msgid "Cover Image"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1020
+#: lib/klass_hero_web/components/provider_components.ex:1091
 #, elixir-autogen, elixir-format
 msgid "Define age, gender, or grade restrictions for eligible participants."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1136
+#: lib/klass_hero_web/components/provider_components.ex:1207
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Describe your program..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1135
+#: lib/klass_hero_web/components/provider_components.ex:1206
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:323
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:285
 #, elixir-autogen, elixir-format
@@ -2424,13 +2419,13 @@ msgid "Description"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:684
-#: lib/klass_hero_web/components/provider_components.ex:1088
+#: lib/klass_hero_web/components/provider_components.ex:1159
 #: lib/klass_hero_web/live/settings/children_live.ex:670
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2520
+#: lib/klass_hero_web/components/provider_components.ex:2591
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2464,7 +2459,7 @@ msgstr ""
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2144
+#: lib/klass_hero_web/components/provider_components.ex:2215
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
@@ -2474,40 +2469,40 @@ msgstr ""
 msgid "Download document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:856
+#: lib/klass_hero_web/components/provider_components.ex:927
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:598
+#: lib/klass_hero_web/components/provider_components.ex:669
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit Team Member"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:965
+#: lib/klass_hero_web/components/provider_components.ex:1036
 #, elixir-autogen, elixir-format
 msgid "End Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:952
+#: lib/klass_hero_web/components/provider_components.ex:1023
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:166
 #, elixir-autogen, elixir-format
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1957
-#: lib/klass_hero_web/components/provider_components.ex:2403
+#: lib/klass_hero_web/components/provider_components.ex:2028
+#: lib/klass_hero_web/components/provider_components.ex:2474
 #: lib/klass_hero_web/components/provider_layout_components.ex:644
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrolled"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1639
+#: lib/klass_hero_web/components/provider_components.ex:1710
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:993
+#: lib/klass_hero_web/components/provider_components.ex:1064
 #, elixir-autogen, elixir-format
 msgid "Enrollment Capacity (optional)"
 msgstr ""
@@ -2518,7 +2513,7 @@ msgid "Explain why this document is being rejected..."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:70
-#: lib/klass_hero_web/components/provider_components.ex:2404
+#: lib/klass_hero_web/components/provider_components.ex:2475
 #: lib/klass_hero_web/live/admin/emails_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2534,7 +2529,7 @@ msgstr ""
 msgid "Failed to reject document."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:397
+#: lib/klass_hero_web/live/provider/programs_live.ex:399
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to resend invite."
 msgstr ""
@@ -2551,7 +2546,7 @@ msgid "Family Programs"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:682
-#: lib/klass_hero_web/components/provider_components.ex:1087
+#: lib/klass_hero_web/components/provider_components.ex:1158
 #: lib/klass_hero_web/live/settings/children_live.ex:669
 #, elixir-autogen, elixir-format
 msgid "Female"
@@ -2562,22 +2557,22 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2454
+#: lib/klass_hero_web/components/provider_components.ex:2525
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2456
+#: lib/klass_hero_web/components/provider_components.ex:2527
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:684
+#: lib/klass_hero_web/components/provider_components.ex:755
 #, elixir-autogen, elixir-format
 msgid "First Aid, UEFA B License, Child Care Cert"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:626
+#: lib/klass_hero_web/components/provider_components.ex:697
 #, elixir-autogen, elixir-format, fuzzy
 msgid "First Name"
 msgstr ""
@@ -2602,12 +2597,12 @@ msgstr ""
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2180
+#: lib/klass_hero_web/components/provider_components.ex:2251
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:745
+#: lib/klass_hero_web/components/provider_components.ex:816
 #, elixir-autogen, elixir-format
 msgid "Headshot Photo"
 msgstr ""
@@ -2617,7 +2612,7 @@ msgstr ""
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2117
+#: lib/klass_hero_web/components/provider_components.ex:2188
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import"
 msgstr ""
@@ -2627,32 +2622,32 @@ msgstr ""
 msgid "Insurance Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:412
+#: lib/klass_hero_web/live/provider/programs_live.ex:414
 #, elixir-autogen, elixir-format
 msgid "Invite not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:409
+#: lib/klass_hero_web/live/provider/programs_live.ex:411
 #, elixir-autogen, elixir-format
 msgid "Invite removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:386
+#: lib/klass_hero_web/live/provider/programs_live.ex:388
 #, elixir-autogen, elixir-format
 msgid "Invite resent successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1656
+#: lib/klass_hero_web/components/provider_components.ex:1727
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:784
+#: lib/klass_hero_web/components/provider_components.ex:855
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 1MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1190
+#: lib/klass_hero_web/components/provider_components.ex:1261
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:277
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:361
 #, elixir-autogen, elixir-format
@@ -2669,22 +2664,22 @@ msgstr ""
 msgid "Klasse %{n}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:632
+#: lib/klass_hero_web/components/provider_components.ex:703
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Last Name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:975
+#: lib/klass_hero_web/components/provider_components.ex:1046
 #, elixir-autogen, elixir-format
 msgid "Leave blank for open registration at any time."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1080
+#: lib/klass_hero_web/components/provider_components.ex:1151
 #, elixir-autogen, elixir-format
 msgid "Leave unchecked to allow all genders."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:908
+#: lib/klass_hero_web/components/provider_components.ex:979
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:172
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Location"
@@ -2697,43 +2692,43 @@ msgid "Logo upload failed. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:683
-#: lib/klass_hero_web/components/provider_components.ex:1086
+#: lib/klass_hero_web/components/provider_components.ex:1157
 #: lib/klass_hero_web/live/settings/children_live.ex:668
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1070
+#: lib/klass_hero_web/components/provider_components.ex:1141
 #, elixir-autogen, elixir-format
 msgid "Maximum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1008
+#: lib/klass_hero_web/components/provider_components.ex:1079
 #, elixir-autogen, elixir-format
 msgid "Maximum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1125
+#: lib/klass_hero_web/components/provider_components.ex:1196
 #, elixir-autogen, elixir-format
 msgid "Maximum Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:917
+#: lib/klass_hero_web/components/provider_components.ex:988
 #, elixir-autogen, elixir-format
 msgid "Meeting Days"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1064
+#: lib/klass_hero_web/components/provider_components.ex:1135
 #, elixir-autogen, elixir-format
 msgid "Minimum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1002
+#: lib/klass_hero_web/components/provider_components.ex:1073
 #, elixir-autogen, elixir-format
 msgid "Minimum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1118
+#: lib/klass_hero_web/components/provider_components.ex:1189
 #, elixir-autogen, elixir-format
 msgid "Minimum Grade"
 msgstr ""
@@ -2743,18 +2738,18 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2482
+#: lib/klass_hero_web/components/provider_components.ex:2553
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1944
+#: lib/klass_hero_web/components/provider_components.ex:2015
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:425
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:443
+#: lib/klass_hero_web/live/provider/programs_live.ex:445
 #, elixir-autogen, elixir-format
 msgid "No file selected."
 msgstr ""
@@ -2764,17 +2759,17 @@ msgstr ""
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2168
+#: lib/klass_hero_web/components/provider_components.ex:2239
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1127
+#: lib/klass_hero_web/components/provider_components.ex:1198
 #, elixir-autogen, elixir-format
 msgid "No maximum"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1120
+#: lib/klass_hero_web/components/provider_components.ex:1191
 #, elixir-autogen, elixir-format
 msgid "No minimum"
 msgstr ""
@@ -2794,7 +2789,7 @@ msgstr ""
 msgid "No rejected documents."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:552
+#: lib/klass_hero_web/live/provider/team_live.ex:650
 #, elixir-autogen, elixir-format
 msgid "No team members yet"
 msgstr ""
@@ -2805,7 +2800,7 @@ msgstr ""
 msgid "No verification documents found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1202
+#: lib/klass_hero_web/components/provider_components.ex:1273
 #, elixir-autogen, elixir-format
 msgid "None (optional)"
 msgstr ""
@@ -2816,7 +2811,7 @@ msgid "Not Verified"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:685
-#: lib/klass_hero_web/components/provider_components.ex:1089
+#: lib/klass_hero_web/components/provider_components.ex:1160
 #: lib/klass_hero_web/live/settings/children_live.ex:667
 #, elixir-autogen, elixir-format
 msgid "Not specified"
@@ -2827,7 +2822,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2557
+#: lib/klass_hero_web/components/provider_components.ex:2628
 #: lib/klass_hero_web/live/provider/verification_live.ex:698
 #: lib/klass_hero_web/live/provider/verification_live.ex:770
 #, elixir-autogen, elixir-format
@@ -2839,7 +2834,7 @@ msgstr ""
 msgid "Participant Requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1017
+#: lib/klass_hero_web/components/provider_components.ex:1088
 #, elixir-autogen, elixir-format
 msgid "Participant Restrictions (optional)"
 msgstr ""
@@ -2854,11 +2849,11 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:106
-#: lib/klass_hero_web/live/provider/programs_live.ex:689
-#: lib/klass_hero_web/live/provider/programs_live.ex:755
-#: lib/klass_hero_web/live/provider/team_live.ex:256
-#: lib/klass_hero_web/live/provider/team_live.ex:299
-#: lib/klass_hero_web/live/provider/team_live.ex:418
+#: lib/klass_hero_web/live/provider/programs_live.ex:691
+#: lib/klass_hero_web/live/provider/programs_live.ex:757
+#: lib/klass_hero_web/live/provider/team_live.ex:305
+#: lib/klass_hero_web/live/provider/team_live.ex:348
+#: lib/klass_hero_web/live/provider/team_live.ex:467
 #, elixir-autogen, elixir-format
 msgid "Please fix the errors below."
 msgstr ""
@@ -2873,7 +2868,7 @@ msgstr ""
 msgid "Preview not available for this file type."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:899
+#: lib/klass_hero_web/components/provider_components.ex:970
 #, elixir-autogen, elixir-format
 msgid "Price (EUR)"
 msgstr ""
@@ -2883,31 +2878,31 @@ msgstr ""
 msgid "Profile updated successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1055
+#: lib/klass_hero_web/components/provider_components.ex:1126
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program Start"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1100
+#: lib/klass_hero_web/live/provider/programs_live.ex:1102
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program created successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1107
+#: lib/klass_hero_web/live/provider/programs_live.ex:1109
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:54
-#: lib/klass_hero_web/live/provider/programs_live.ex:151
-#: lib/klass_hero_web/live/provider/programs_live.ex:188
-#: lib/klass_hero_web/live/provider/programs_live.ex:252
-#: lib/klass_hero_web/live/provider/programs_live.ex:730
+#: lib/klass_hero_web/live/provider/programs_live.ex:153
+#: lib/klass_hero_web/live/provider/programs_live.ex:190
+#: lib/klass_hero_web/live/provider/programs_live.ex:254
+#: lib/klass_hero_web/live/provider/programs_live.ex:732
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:719
+#: lib/klass_hero_web/live/provider/programs_live.ex:721
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program updated successfully."
 msgstr ""
@@ -2925,13 +2920,13 @@ msgid "Read our founding story →"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:805
-#: lib/klass_hero_web/components/provider_components.ex:2402
+#: lib/klass_hero_web/components/provider_components.ex:2473
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registered"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1042
+#: lib/klass_hero_web/components/provider_components.ex:1113
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration"
 msgstr ""
@@ -2941,7 +2936,7 @@ msgstr ""
 msgid "Registration Closed"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:986
+#: lib/klass_hero_web/components/provider_components.ex:1057
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration Closes"
 msgstr ""
@@ -2951,12 +2946,12 @@ msgstr ""
 msgid "Registration Not Open Yet"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:981
+#: lib/klass_hero_web/components/provider_components.ex:1052
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration Opens"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:972
+#: lib/klass_hero_web/components/provider_components.ex:1043
 #, elixir-autogen, elixir-format
 msgid "Registration Period (optional)"
 msgstr ""
@@ -3005,18 +3000,18 @@ msgstr ""
 msgid "Rejection reason"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:767
-#: lib/klass_hero_web/components/provider_components.ex:1166
-#: lib/klass_hero_web/components/provider_components.ex:2224
-#: lib/klass_hero_web/components/provider_components.ex:2576
-#: lib/klass_hero_web/components/provider_components.ex:2655
+#: lib/klass_hero_web/components/provider_components.ex:838
+#: lib/klass_hero_web/components/provider_components.ex:1237
+#: lib/klass_hero_web/components/provider_components.ex:2295
+#: lib/klass_hero_web/components/provider_components.ex:2647
+#: lib/klass_hero_web/components/provider_components.ex:2726
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:253
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2217
+#: lib/klass_hero_web/components/provider_components.ex:2288
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -3026,23 +3021,23 @@ msgstr ""
 msgid "Reviewed"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:641
+#: lib/klass_hero_web/components/provider_components.ex:712
 #, elixir-autogen, elixir-format
 msgid "Role"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1585
+#: lib/klass_hero_web/components/provider_components.ex:1656
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1229
+#: lib/klass_hero_web/components/provider_components.ex:1300
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Save Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:914
+#: lib/klass_hero_web/components/provider_components.ex:985
 #, elixir-autogen, elixir-format
 msgid "Schedule (optional)"
 msgstr ""
@@ -3057,7 +3052,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2554
+#: lib/klass_hero_web/components/provider_components.ex:2625
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select File"
 msgstr ""
@@ -3068,52 +3063,52 @@ msgstr ""
 msgid "Selected child does not meet the program requirements."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:679
-#: lib/klass_hero_web/live/provider/programs_live.ex:745
+#: lib/klass_hero_web/live/provider/programs_live.ex:681
+#: lib/klass_hero_web/live/provider/programs_live.ex:747
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2401
+#: lib/klass_hero_web/components/provider_components.ex:2472
 #: lib/klass_hero_web/live/admin/emails_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Sent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:688
+#: lib/klass_hero_web/components/provider_components.ex:759
 #, elixir-autogen, elixir-format
 msgid "Separate multiple qualifications with commas"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:996
+#: lib/klass_hero_web/components/provider_components.ex:1067
 #, elixir-autogen, elixir-format
 msgid "Set minimum and maximum enrollment for this program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:662
+#: lib/klass_hero_web/components/provider_components.ex:733
 #, elixir-autogen, elixir-format
 msgid "Specialties"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:398
-#: lib/klass_hero_web/live/provider/team_live.ex:424
+#: lib/klass_hero_web/live/provider/team_live.ex:447
+#: lib/klass_hero_web/live/provider/team_live.ex:473
 #, elixir-autogen, elixir-format
 msgid "Staff member no longer exists."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:101
-#: lib/klass_hero_web/live/provider/team_live.ex:173
-#: lib/klass_hero_web/live/provider/team_live.ex:197
+#: lib/klass_hero_web/live/provider/team_live.ex:103
+#: lib/klass_hero_web/live/provider/team_live.ex:246
+#: lib/klass_hero_web/live/provider/team_live.ex:488
 #, elixir-autogen, elixir-format
 msgid "Staff member not found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:960
+#: lib/klass_hero_web/components/provider_components.ex:1031
 #, elixir-autogen, elixir-format
 msgid "Start Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:947
+#: lib/klass_hero_web/components/provider_components.ex:1018
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:165
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Start Time"
@@ -3134,27 +3129,27 @@ msgstr ""
 msgid "Tax Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:352
+#: lib/klass_hero_web/live/provider/team_live.ex:401
 #, elixir-autogen, elixir-format
 msgid "Team member added, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:353
+#: lib/klass_hero_web/live/provider/team_live.ex:402
 #, elixir-autogen, elixir-format
 msgid "Team member added."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:164
+#: lib/klass_hero_web/live/provider/team_live.ex:209
 #, elixir-autogen, elixir-format
 msgid "Team member removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:378
+#: lib/klass_hero_web/live/provider/team_live.ex:427
 #, elixir-autogen, elixir-format
 msgid "Team member updated, but headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:379
+#: lib/klass_hero_web/live/provider/team_live.ex:428
 #, elixir-autogen, elixir-format
 msgid "Team member updated."
 msgstr ""
@@ -3169,22 +3164,22 @@ msgstr ""
 msgid "The Klass Hero Story"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:389
+#: lib/klass_hero_web/live/provider/programs_live.ex:391
 #, elixir-autogen, elixir-format
 msgid "This invite cannot be resent."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:737
+#: lib/klass_hero_web/live/provider/programs_live.ex:739
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:881
+#: lib/klass_hero_web/components/provider_components.ex:952
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2455
+#: lib/klass_hero_web/components/provider_components.ex:2526
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -3204,32 +3199,32 @@ msgstr ""
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2103
+#: lib/klass_hero_web/components/provider_components.ex:2174
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2600
+#: lib/klass_hero_web/components/provider_components.ex:2671
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2509
+#: lib/klass_hero_web/components/provider_components.ex:2580
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2477
+#: lib/klass_hero_web/components/provider_components.ex:2548
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2457
+#: lib/klass_hero_web/components/provider_components.ex:2528
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2474
+#: lib/klass_hero_web/components/provider_components.ex:2545
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -3268,32 +3263,32 @@ msgstr ""
 msgid "You don't have access to that page."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:642
+#: lib/klass_hero_web/components/provider_components.ex:713
 #, elixir-autogen, elixir-format, fuzzy
 msgid "e.g. Head Coach"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:633
+#: lib/klass_hero_web/components/provider_components.ex:704
 #, elixir-autogen, elixir-format
 msgid "e.g. Johnson"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:627
+#: lib/klass_hero_web/components/provider_components.ex:698
 #, elixir-autogen, elixir-format
 msgid "e.g. Mike"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:648
+#: lib/klass_hero_web/components/provider_components.ex:719
 #, elixir-autogen, elixir-format
 msgid "e.g. mike@example.com"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:882
+#: lib/klass_hero_web/components/provider_components.ex:953
 #, elixir-autogen, elixir-format
 msgid "e.g., Art Adventures"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:909
+#: lib/klass_hero_web/components/provider_components.ex:980
 #, elixir-autogen, elixir-format
 msgid "e.g., Community Center, Main St"
 msgstr ""
@@ -3319,7 +3314,7 @@ msgid "Child Safeguarding Training"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1498
-#: lib/klass_hero_web/components/provider_components.ex:2822
+#: lib/klass_hero_web/components/provider_components.ex:2893
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr ""
@@ -3389,7 +3384,7 @@ msgstr ""
 msgid "Program fee:"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:938
+#: lib/klass_hero_web/live/provider/programs_live.ex:940
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr ""
@@ -3469,7 +3464,7 @@ msgid "Vetted with Care"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1482
-#: lib/klass_hero_web/components/provider_components.ex:2607
+#: lib/klass_hero_web/components/provider_components.ex:2678
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr ""
@@ -3605,7 +3600,7 @@ msgstr ""
 msgid "Cannot check out without a check-in"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:361
+#: lib/klass_hero_web/live/provider/programs_live.ex:363
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:146
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
@@ -3643,7 +3638,7 @@ msgstr ""
 msgid "Checked Out"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2260
+#: lib/klass_hero_web/components/provider_components.ex:2331
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Child"
@@ -3670,7 +3665,7 @@ msgid "Correct"
 msgstr ""
 
 #: lib/klass_hero_web/live/dashboard_live.ex:301
-#: lib/klass_hero_web/live/provider/programs_live.ex:358
+#: lib/klass_hero_web/live/provider/programs_live.ex:360
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "Could not start conversation. Please try again."
@@ -3696,7 +3691,7 @@ msgstr ""
 msgid "Download monthly statements for taxes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2021
+#: lib/klass_hero_web/components/provider_components.ex:2092
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:482
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrollment not confirmed"
@@ -3774,7 +3769,7 @@ msgstr ""
 msgid "No chasing payments or sending invoices"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1608
+#: lib/klass_hero_web/components/provider_components.ex:1679
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:406
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No enrolled parents"
@@ -3797,7 +3792,7 @@ msgstr ""
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2020
+#: lib/klass_hero_web/components/provider_components.ex:2091
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:481
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -4233,7 +4228,7 @@ msgstr ""
 msgid "Failed to mark email as unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:213
+#: lib/klass_hero_web/live/provider/team_live.ex:262
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to resend invitation. Please try again."
 msgstr ""
@@ -4281,32 +4276,32 @@ msgid "Invalid time format"
 msgstr ""
 
 #: lib/klass_hero_web/live/user_live/staff_invitation.ex:27
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:107
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:115
 #, elixir-autogen, elixir-format
 msgid "Invitation Expired"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:105
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:113
 #, elixir-autogen, elixir-format
 msgid "Invitation Failed"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:103
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:111
 #, elixir-autogen, elixir-format
 msgid "Invitation Pending"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:104
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:112
 #, elixir-autogen, elixir-format
 msgid "Invitation Sent"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:188
+#: lib/klass_hero_web/live/provider/team_live.ex:237
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invitation resent successfully."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:106
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:114
 #, elixir-autogen, elixir-format
 msgid "Joined"
 msgstr ""
@@ -4427,7 +4422,7 @@ msgstr ""
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:24
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
-#: lib/klass_hero_web/live/provider/programs_live.ex:220
+#: lib/klass_hero_web/live/provider/programs_live.ex:222
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:156
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program"
@@ -4574,7 +4569,7 @@ msgstr ""
 msgid "The business associated with your account could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:204
+#: lib/klass_hero_web/live/provider/team_live.ex:253
 #, elixir-autogen, elixir-format
 msgid "This invitation cannot be resent in its current state."
 msgstr ""
@@ -4636,7 +4631,7 @@ msgid "Update your observation..."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:138
-#: lib/klass_hero_web/live/provider/programs_live.ex:440
+#: lib/klass_hero_web/live/provider/programs_live.ex:442
 #: lib/klass_hero_web/live/provider/verification_live.ex:240
 #: lib/klass_hero_web/live/provider/verification_live.ex:556
 #: lib/klass_hero_web/live/provider/verification_live.ex:594
@@ -4905,48 +4900,48 @@ msgstr ""
 msgid "for"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1729
+#: lib/klass_hero_web/components/provider_components.ex:1800
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assigned staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1731
+#: lib/klass_hero_web/components/provider_components.ex:1802
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1713
-#: lib/klass_hero_web/components/provider_components.ex:1802
+#: lib/klass_hero_web/components/provider_components.ex:1784
+#: lib/klass_hero_web/components/provider_components.ex:1873
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Close"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1730
+#: lib/klass_hero_web/components/provider_components.ex:1801
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1728
+#: lib/klass_hero_web/components/provider_components.ex:1799
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1722
+#: lib/klass_hero_web/components/provider_components.ex:1793
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No sessions scheduled yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1711
+#: lib/klass_hero_web/components/provider_components.ex:1782
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sessions — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1451
+#: lib/klass_hero_web/components/provider_components.ex:1522
 #, elixir-autogen, elixir-format
 msgid "View sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:531
+#: lib/klass_hero_web/live/provider/programs_live.ex:533
 #, elixir-autogen, elixir-format
 msgid "Create a program before inviting participants."
 msgstr ""
@@ -4973,22 +4968,22 @@ msgstr ""
 msgid "Failed to update record"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2324
+#: lib/klass_hero_web/components/provider_components.ex:2395
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2043
+#: lib/klass_hero_web/components/provider_components.ex:2114
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invite mode"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2062
+#: lib/klass_hero_web/components/provider_components.ex:2133
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:527
+#: lib/klass_hero_web/live/provider/programs_live.ex:529
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invite sent."
 msgstr ""
@@ -4998,12 +4993,12 @@ msgstr ""
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2337
+#: lib/klass_hero_web/components/provider_components.ex:2408
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2343
+#: lib/klass_hero_web/components/provider_components.ex:2414
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr ""
@@ -5014,17 +5009,17 @@ msgstr ""
 msgid "Nothing to update"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2345
+#: lib/klass_hero_web/components/provider_components.ex:2416
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nut allergy"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2349
+#: lib/klass_hero_web/components/provider_components.ex:2420
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2354
+#: lib/klass_hero_web/components/provider_components.ex:2425
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr ""
@@ -5034,7 +5029,7 @@ msgstr ""
 msgid "Present"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2281
+#: lib/klass_hero_web/components/provider_components.ex:2352
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr ""
@@ -5061,22 +5056,22 @@ msgstr ""
 msgid "Save changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2318
+#: lib/klass_hero_web/components/provider_components.ex:2389
 #, elixir-autogen, elixir-format, fuzzy
 msgid "School (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2328
+#: lib/klass_hero_web/components/provider_components.ex:2399
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2302
+#: lib/klass_hero_web/components/provider_components.ex:2373
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2371
+#: lib/klass_hero_web/components/provider_components.ex:2442
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Send invite"
 msgstr ""
@@ -5086,12 +5081,12 @@ msgstr ""
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2080
+#: lib/klass_hero_web/components/provider_components.ex:2151
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload a list"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:538
+#: lib/klass_hero_web/live/provider/programs_live.ex:540
 #, elixir-autogen, elixir-format
 msgid "An invite for this child and program already exists."
 msgstr ""
@@ -5121,7 +5116,7 @@ msgstr ""
 msgid "High"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:715
+#: lib/klass_hero_web/components/provider_components.ex:786
 #, elixir-autogen, elixir-format
 msgid "Hourly"
 msgstr ""
@@ -5146,12 +5141,12 @@ msgstr ""
 msgid "Medium"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:705
+#: lib/klass_hero_web/components/provider_components.ex:776
 #, elixir-autogen, elixir-format
 msgid "None"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:694
+#: lib/klass_hero_web/components/provider_components.ex:765
 #, elixir-autogen, elixir-format
 msgid "Pay Rate"
 msgstr ""
@@ -5161,7 +5156,7 @@ msgstr ""
 msgid "Pay rate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:725
+#: lib/klass_hero_web/components/provider_components.ex:796
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Per Session"
 msgstr ""
@@ -5186,7 +5181,7 @@ msgstr ""
 msgid "Property Damage"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1481
+#: lib/klass_hero_web/components/provider_components.ex:1552
 #, elixir-autogen, elixir-format
 msgid "Report Incident"
 msgstr ""
@@ -5232,12 +5227,12 @@ msgstr ""
 msgid "Your pay rate"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:99
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:107
 #, elixir-autogen, elixir-format
 msgid "hour"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/staff_member_presenter.ex:100
+#: lib/klass_hero_web/presenters/staff_member_presenter.ex:108
 #, elixir-autogen, elixir-format, fuzzy
 msgid "session"
 msgstr ""
@@ -5268,7 +5263,7 @@ msgstr ""
 msgid "Go to dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:483
+#: lib/klass_hero_web/live/provider/programs_live.ex:485
 #, elixir-autogen, elixir-format
 msgid "%{count} row could not be processed."
 msgid_plural "%{count} rows could not be processed."
@@ -5571,7 +5566,7 @@ msgstr ""
 msgid "Contact Us →"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:307
+#: lib/klass_hero_web/live/provider/team_live.ex:356
 #, elixir-autogen, elixir-format
 msgid "Could not add you to the team. Please try again."
 msgstr ""
@@ -5850,13 +5845,13 @@ msgstr ""
 msgid "How we vet providers"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:520
+#: lib/klass_hero_web/live/provider/team_live.ex:618
 #, elixir-autogen, elixir-format
 msgid "I'll be teaching"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:458
-#: lib/klass_hero_web/live/provider/programs_live.ex:480
+#: lib/klass_hero_web/live/provider/programs_live.ex:460
+#: lib/klass_hero_web/live/provider/programs_live.ex:482
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Imported %{count} family."
 msgid_plural "Imported %{count} families."
@@ -5868,7 +5863,7 @@ msgstr[1] ""
 msgid "In 2025, Shane connected with his friend"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1490
+#: lib/klass_hero_web/components/provider_components.ex:1561
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:43
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:74
 #, elixir-autogen, elixir-format
@@ -5938,7 +5933,7 @@ msgstr ""
 msgid "Last 8 weeks"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1200
+#: lib/klass_hero_web/components/provider_components.ex:1271
 #: lib/klass_hero_web/presenters/hero_cards_presenter.ex:27
 #, elixir-autogen, elixir-format
 msgid "Lead Instructor"
@@ -6145,7 +6140,7 @@ msgstr ""
 msgid "No registered children for this session."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:467
+#: lib/klass_hero_web/live/provider/programs_live.ex:469
 #, elixir-autogen, elixir-format
 msgid "No rows imported. %{count} row could not be processed."
 msgid_plural "No rows imported. %{count} rows could not be processed."
@@ -6388,17 +6383,17 @@ msgstr ""
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2410
+#: lib/klass_hero_web/components/provider_components.ex:2481
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Row %{row}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2410
+#: lib/klass_hero_web/components/provider_components.ex:2481
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2156
+#: lib/klass_hero_web/components/provider_components.ex:2227
 #, elixir-autogen, elixir-format
 msgid "Rows with errors"
 msgstr ""
@@ -6820,7 +6815,7 @@ msgstr ""
 msgid "You'll get your own provider profile to fill in, and your account will open on your business dashboard from now on. You stay on %{business}'s team."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:287
+#: lib/klass_hero_web/live/provider/team_live.ex:336
 #, elixir-autogen, elixir-format
 msgid "You're already on your team."
 msgstr ""
@@ -6840,12 +6835,12 @@ msgstr ""
 msgid "You're now part of the team."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:335
+#: lib/klass_hero_web/live/provider/team_live.ex:384
 #, elixir-autogen, elixir-format
 msgid "You're on the team — you can now be assigned to programs."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/team_live.ex:334
+#: lib/klass_hero_web/live/provider/team_live.ex:383
 #, elixir-autogen, elixir-format
 msgid "You're on the team, but the headshot upload failed."
 msgstr ""
@@ -7157,12 +7152,12 @@ msgstr ""
 msgid "Experience validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2636
+#: lib/klass_hero_web/components/provider_components.ex:2707
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2610
+#: lib/klass_hero_web/components/provider_components.ex:2681
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
@@ -7172,12 +7167,12 @@ msgstr ""
 msgid "Safeguarding certificate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2633
+#: lib/klass_hero_web/components/provider_components.ex:2704
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select Video"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2679
+#: lib/klass_hero_web/components/provider_components.ex:2750
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload Video"
 msgstr ""
@@ -7187,7 +7182,7 @@ msgstr ""
 msgid "Your browser does not support video playback."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2826
+#: lib/klass_hero_web/components/provider_components.ex:2897
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Confirm agreement"
 msgstr ""
@@ -7197,12 +7192,12 @@ msgstr ""
 msgid "Couldn't record your agreement. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2849
+#: lib/klass_hero_web/components/provider_components.ex:2920
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2825
+#: lib/klass_hero_web/components/provider_components.ex:2896
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr ""
@@ -7212,7 +7207,7 @@ msgstr ""
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2734
+#: lib/klass_hero_web/components/provider_components.ex:2805
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr ""
@@ -7222,17 +7217,17 @@ msgstr ""
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2834
+#: lib/klass_hero_web/components/provider_components.ex:2905
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2823
+#: lib/klass_hero_web/components/provider_components.ex:2894
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2824
+#: lib/klass_hero_web/components/provider_components.ex:2895
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
@@ -7501,12 +7496,12 @@ msgstr ""
 msgid "Your insurance is verified."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2778
+#: lib/klass_hero_web/components/provider_components.ex:2849
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2881
+#: lib/klass_hero_web/components/provider_components.ex:2952
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr ""
@@ -7516,7 +7511,7 @@ msgstr ""
 msgid "Couldn't record your declaration. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2887
+#: lib/klass_hero_web/components/provider_components.ex:2958
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr ""
@@ -7526,17 +7521,17 @@ msgstr ""
 msgid "Please confirm the declaration before signing."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2912
+#: lib/klass_hero_web/components/provider_components.ex:2983
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2891
+#: lib/klass_hero_web/components/provider_components.ex:2962
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2879
+#: lib/klass_hero_web/components/provider_components.ex:2950
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr ""
@@ -7546,12 +7541,12 @@ msgstr ""
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2899
+#: lib/klass_hero_web/components/provider_components.ex:2970
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2885
+#: lib/klass_hero_web/components/provider_components.ex:2956
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
@@ -7618,94 +7613,144 @@ msgstr ""
 msgid "Undelivered Events"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1899
+#: lib/klass_hero_web/components/provider_components.ex:1970
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1824
+#: lib/klass_hero_web/components/provider_components.ex:1895
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Lead"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:333
+#: lib/klass_hero_web/live/provider/programs_live.ex:335
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Lead instructor updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1835
+#: lib/klass_hero_web/components/provider_components.ex:1906
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1465
+#: lib/klass_hero_web/components/provider_components.ex:1536
 #, elixir-autogen, elixir-format
 msgid "Manage Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1863
+#: lib/klass_hero_web/components/provider_components.ex:1934
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this program yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:263
+#: lib/klass_hero_web/live/provider/programs_live.ex:265
 #, elixir-autogen, elixir-format
 msgid "Pick a staff member to add."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1846
+#: lib/klass_hero_web/components/provider_components.ex:1917
 #, elixir-autogen, elixir-format
 msgid "Reassign the lead before removing them"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1847
+#: lib/klass_hero_web/components/provider_components.ex:1918
 #, elixir-autogen, elixir-format
 msgid "Remove from program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1881
+#: lib/klass_hero_web/components/provider_components.ex:1952
 #, elixir-autogen, elixir-format
 msgid "Select a staff member…"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:278
+#: lib/klass_hero_web/live/provider/programs_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Staff member added to the program."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:304
+#: lib/klass_hero_web/live/provider/programs_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "Staff member removed from the program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1904
+#: lib/klass_hero_web/components/provider_components.ex:1975
 #, elixir-autogen, elixir-format
 msgid "Staff you add can read and reply to this program's parent conversations."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1800
+#: lib/klass_hero_web/components/provider_components.ex:1871
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Staffing — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:897
+#: lib/klass_hero_web/live/provider/programs_live.ex:899
 #, elixir-autogen, elixir-format
 msgid "That staff member could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:286
+#: lib/klass_hero_web/live/provider/programs_live.ex:288
 #, elixir-autogen, elixir-format
 msgid "They are already on this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:312
+#: lib/klass_hero_web/live/provider/programs_live.ex:314
 #, elixir-autogen, elixir-format
 msgid "This person is the lead instructor. Make someone else lead before removing them."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1409
+#: lib/klass_hero_web/components/provider_components.ex:1480
 #, elixir-autogen, elixir-format
 msgid "%{count} staff member · no lead"
 msgid_plural "%{count} staff · no lead"
 msgstr[0] ""
 msgstr[1] ""
+
+#: lib/klass_hero_web/components/provider_components.ex:562
+#, elixir-autogen, elixir-format
+msgid "%{name} will be unassigned from every program and removed from those conversations. Their history is kept and you can add them back later."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:638
+#, elixir-autogen, elixir-format
+msgid "Add back to team"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/team_live.ex:193
+#, elixir-autogen, elixir-format
+msgid "Could not bring this team member back. Please try again."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:600
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Delete entry"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/team_live.ex:663
+#, elixir-autogen, elixir-format
+msgid "Former team members"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:574
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Remove from team"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/team_live.ex:187
+#, elixir-autogen, elixir-format
+msgid "Team member is back. Assign them to programs again when you're ready."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/team_live.ex:167
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Team member removed from the team."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:590
+#, elixir-autogen, elixir-format
+msgid "This deletes %{name} permanently — there's nothing to undo. Use it only for an entry added by mistake."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/team_live.ex:218
+#, elixir-autogen, elixir-format
+msgid "This person has a history here now — use 'Remove from team' instead."
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/en/LC_MESSAGES/enrollment.po
@@ -11,62 +11,62 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:2431
+#: lib/klass_hero_web/components/provider_components.ex:2502
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2432
+#: lib/klass_hero_web/components/provider_components.ex:2503
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2433
+#: lib/klass_hero_web/components/provider_components.ex:2504
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2444
+#: lib/klass_hero_web/components/provider_components.ex:2515
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2434
+#: lib/klass_hero_web/components/provider_components.ex:2505
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2435
+#: lib/klass_hero_web/components/provider_components.ex:2506
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2436
+#: lib/klass_hero_web/components/provider_components.ex:2507
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2443
+#: lib/klass_hero_web/components/provider_components.ex:2514
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2445
+#: lib/klass_hero_web/components/provider_components.ex:2516
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2437
+#: lib/klass_hero_web/components/provider_components.ex:2508
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2439
+#: lib/klass_hero_web/components/provider_components.ex:2510
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2441
+#: lib/klass_hero_web/components/provider_components.ex:2512
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""

--- a/priv/gettext/enrollment.pot
+++ b/priv/gettext/enrollment.pot
@@ -11,62 +11,62 @@
 msgid ""
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2431
+#: lib/klass_hero_web/components/provider_components.ex:2502
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2432
+#: lib/klass_hero_web/components/provider_components.ex:2503
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2433
+#: lib/klass_hero_web/components/provider_components.ex:2504
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2444
+#: lib/klass_hero_web/components/provider_components.ex:2515
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2434
+#: lib/klass_hero_web/components/provider_components.ex:2505
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2435
+#: lib/klass_hero_web/components/provider_components.ex:2506
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2436
+#: lib/klass_hero_web/components/provider_components.ex:2507
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2443
+#: lib/klass_hero_web/components/provider_components.ex:2514
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2445
+#: lib/klass_hero_web/components/provider_components.ex:2516
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2437
+#: lib/klass_hero_web/components/provider_components.ex:2508
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2439
+#: lib/klass_hero_web/components/provider_components.ex:2510
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2441
+#: lib/klass_hero_web/components/provider_components.ex:2512
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""

--- a/test/klass_hero/accounts/offboard_staff_member_test.exs
+++ b/test/klass_hero/accounts/offboard_staff_member_test.exs
@@ -1,0 +1,117 @@
+defmodule KlassHero.Accounts.OffboardStaffMemberTest do
+  @moduledoc """
+  Durable `:staff` teardown when someone's last employment ends (#972, #1292).
+
+  Offboarding a linked StaffMember removes `:staff` from the owning user's
+  `intended_roles` ONLY when no other **active** linked row remains for them at
+  any provider. Multi-employer users keep the role (ADR-0005); unlinked
+  display-only rows never touch roles. The employment write, the assignment
+  teardown and the role removal are one atomic transaction.
+
+  This replaced a hard delete. The role check keys on
+  `Provider.get_active_staff_member_by_user/1`, which reads `active` rather than
+  row existence, so it kept working unchanged when the row started surviving.
+  """
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.AccountsFixtures
+  import KlassHero.ProviderFixtures
+
+  alias KlassHero.Accounts
+  alias KlassHero.Accounts.User
+  alias KlassHero.Provider
+
+  defp reload_roles(user_id), do: Repo.get!(User, user_id).intended_roles
+
+  defp linked_staff_row(user, business_name) do
+    provider = provider_profile_fixture(%{business_name: business_name})
+
+    staff_member_fixture(%{
+      provider_id: provider.id,
+      user_id: user.id,
+      active: true,
+      invitation_status: :accepted
+    })
+  end
+
+  describe "offboard_staff_member/2 — last active linked row" do
+    test "ends the employment and removes :staff from the user" do
+      user = user_fixture(intended_roles: [:staff])
+      staff = linked_staff_row(user, "Only Employer")
+
+      assert {:ok, offboarded} = Accounts.offboard_staff_member(staff.provider_id, staff.id)
+
+      refute offboarded.active
+      assert {:ok, %{active: false}} = Provider.get_staff_member(staff.id)
+      assert reload_roles(user.id) == []
+    end
+
+    test "keeps the row so the roster history survives" do
+      user = user_fixture(intended_roles: [:staff])
+      staff = linked_staff_row(user, "Only Employer")
+
+      {:ok, _} = Accounts.offboard_staff_member(staff.provider_id, staff.id)
+
+      assert {:ok, kept} = Provider.get_staff_member(staff.id)
+      assert kept.first_name == staff.first_name
+    end
+
+    test "keeps the user's other roles (provider founder offboarding their self-row)" do
+      user = user_fixture(intended_roles: [:provider, :staff])
+      staff = linked_staff_row(user, "Their Business")
+
+      assert {:ok, _} = Accounts.offboard_staff_member(staff.provider_id, staff.id)
+
+      assert reload_roles(user.id) == [:provider]
+    end
+  end
+
+  describe "offboard_staff_member/2 — one of several active rows" do
+    test "keeps :staff because another active employment remains" do
+      user = user_fixture(intended_roles: [:staff])
+      staff_a = linked_staff_row(user, "Alpha Sports")
+      _staff_b = linked_staff_row(user, "Beta Camps")
+
+      assert {:ok, _} = Accounts.offboard_staff_member(staff_a.provider_id, staff_a.id)
+
+      assert {:ok, %{active: false}} = Provider.get_staff_member(staff_a.id)
+      assert reload_roles(user.id) == [:staff]
+    end
+  end
+
+  describe "offboard_staff_member/2 — unlinked display-only row" do
+    test "ends the employment and never touches roles" do
+      provider = provider_profile_fixture(%{business_name: "Some Studio"})
+      staff = staff_member_fixture(%{provider_id: provider.id, user_id: nil})
+
+      owner = user_fixture(intended_roles: [:provider, :staff])
+      owner_roles_before = reload_roles(owner.id)
+
+      assert {:ok, %{active: false}} = Accounts.offboard_staff_member(staff.provider_id, staff.id)
+
+      assert reload_roles(owner.id) == owner_roles_before
+    end
+  end
+
+  describe "offboard_staff_member/2 — guards" do
+    test "returns :not_found and changes no roles" do
+      user = user_fixture(intended_roles: [:staff])
+
+      assert {:error, :not_found} =
+               Accounts.offboard_staff_member(Ecto.UUID.generate(), Ecto.UUID.generate())
+
+      assert reload_roles(user.id) == [:staff]
+    end
+
+    test "a foreign provider_id offboards nothing and revokes no role" do
+      user = user_fixture(intended_roles: [:staff])
+      staff = linked_staff_row(user, "Victim Employer")
+      other = provider_profile_fixture(%{business_name: "Attacker"})
+
+      assert {:error, :not_found} = Accounts.offboard_staff_member(other.id, staff.id)
+
+      assert {:ok, %{active: true}} = Provider.get_staff_member(staff.id)
+      assert reload_roles(user.id) == [:staff]
+    end
+  end
+end

--- a/test/klass_hero/accounts/remove_staff_member_test.exs
+++ b/test/klass_hero/accounts/remove_staff_member_test.exs
@@ -1,11 +1,15 @@
 defmodule KlassHero.Accounts.RemoveStaffMemberTest do
   @moduledoc """
-  Durable `:staff` teardown when the last linked staff row is deleted (#972).
+  `remove_staff_member/2` — the narrow erase of a mis-typed roster entry (#1292).
 
-  Deleting a linked StaffMember row removes `:staff` from the owning user's
-  `intended_roles` ONLY when no other active linked row remains for them at any
-  provider. Multi-employer users keep the role; unlinked display-only rows never
-  touch roles. The delete and the role removal are one atomic transaction.
+  Ending a real employment is `offboard_staff_member/2`, which keeps the row and
+  tears the person out of their programs' conversations. This one destroys the
+  row, so it only accepts a row with no history to destroy: no linked user, no
+  invitation ever sent, no assignment ever created.
+
+  The `:staff` role teardown it inherited from #972 is now unreachable by
+  construction — a row eligible for erasure has no `user_id` — but the branch
+  stays, because a future relaxation of the precondition would need it back.
   """
   use KlassHero.DataCase, async: true
 
@@ -18,55 +22,9 @@ defmodule KlassHero.Accounts.RemoveStaffMemberTest do
 
   defp reload_roles(user_id), do: Repo.get!(User, user_id).intended_roles
 
-  defp linked_staff_row(user, business_name) do
-    provider = provider_profile_fixture(%{business_name: business_name})
-
-    staff_member_fixture(%{
-      provider_id: provider.id,
-      user_id: user.id,
-      active: true,
-      invitation_status: :accepted
-    })
-  end
-
-  describe "remove_staff_member/1 — last active linked row" do
-    test "deletes the row and removes :staff from the user" do
-      user = user_fixture(intended_roles: [:staff])
-      staff = linked_staff_row(user, "Only Employer")
-
-      assert {:ok, _deleted} = Accounts.remove_staff_member(staff.provider_id, staff.id)
-
-      assert {:error, :not_found} = Provider.get_staff_member(staff.id)
-      assert reload_roles(user.id) == []
-    end
-
-    test "keeps the user's other roles (provider founder deleting their self-row)" do
-      user = user_fixture(intended_roles: [:provider, :staff])
-      staff = linked_staff_row(user, "Their Business")
-
-      assert {:ok, _deleted} = Accounts.remove_staff_member(staff.provider_id, staff.id)
-
-      assert reload_roles(user.id) == [:provider]
-    end
-  end
-
-  describe "remove_staff_member/1 — one of several active rows" do
-    test "keeps :staff because another active employment remains" do
-      user = user_fixture(intended_roles: [:staff])
-      staff_a = linked_staff_row(user, "Alpha Sports")
-      _staff_b = linked_staff_row(user, "Beta Camps")
-
-      assert {:ok, _deleted} = Accounts.remove_staff_member(staff_a.provider_id, staff_a.id)
-
-      assert {:error, :not_found} = Provider.get_staff_member(staff_a.id)
-      assert reload_roles(user.id) == [:staff]
-    end
-  end
-
-  describe "remove_staff_member/1 — unlinked display-only row" do
+  describe "remove_staff_member/2 — unlinked display-only row" do
     test "deletes the row and never touches roles" do
-      # No user_id: an invited-but-unaccepted / email-less staff entry. The
-      # provider who created it keeps their own roles untouched.
+      # No user_id, no invitation: a roster entry typed in by hand and regretted.
       provider = provider_profile_fixture(%{business_name: "Some Studio"})
       staff = staff_member_fixture(%{provider_id: provider.id, user_id: nil})
 
@@ -80,7 +38,27 @@ defmodule KlassHero.Accounts.RemoveStaffMemberTest do
     end
   end
 
-  describe "remove_staff_member/2 — not found" do
+  describe "remove_staff_member/2 — a row with history" do
+    test "refuses a linked row and leaves the user's roles alone" do
+      user = user_fixture(intended_roles: [:staff])
+      provider = provider_profile_fixture(%{business_name: "Real Employer"})
+
+      staff =
+        staff_member_fixture(%{
+          provider_id: provider.id,
+          user_id: user.id,
+          active: true,
+          invitation_status: :accepted
+        })
+
+      assert {:error, :has_history} = Accounts.remove_staff_member(provider.id, staff.id)
+
+      assert {:ok, %{active: true}} = Provider.get_staff_member(staff.id)
+      assert reload_roles(user.id) == [:staff]
+    end
+  end
+
+  describe "remove_staff_member/2 — guards" do
     test "returns :not_found and changes no roles" do
       user = user_fixture(intended_roles: [:staff])
 
@@ -89,20 +67,16 @@ defmodule KlassHero.Accounts.RemoveStaffMemberTest do
 
       assert reload_roles(user.id) == [:staff]
     end
-  end
 
-  describe "remove_staff_member/2 — foreign provider (IDOR guard)" do
-    test "returns :not_found, deletes nothing, and revokes no role" do
-      user = user_fixture(intended_roles: [:staff])
-      staff = linked_staff_row(user, "Victim Employer")
+    test "a foreign provider_id deletes nothing (IDOR guard)" do
+      provider = provider_profile_fixture(%{business_name: "Victim Studio"})
+      staff = staff_member_fixture(%{provider_id: provider.id, user_id: nil})
       other = provider_profile_fixture(%{business_name: "Attacker"})
 
-      # A foreign provider_id must not delete the row — indistinguishable from a
-      # genuine miss (no existence leak), and the role stays intact.
+      # Indistinguishable from a genuine miss — no existence leak.
       assert {:error, :not_found} = Accounts.remove_staff_member(other.id, staff.id)
 
       assert {:ok, _still_there} = Provider.get_staff_member(staff.id)
-      assert reload_roles(user.id) == [:staff]
     end
   end
 end

--- a/test/klass_hero/provider/anonymize_user_data_test.exs
+++ b/test/klass_hero/provider/anonymize_user_data_test.exs
@@ -67,7 +67,7 @@ defmodule KlassHero.Provider.AnonymizeUserDataTest do
     end
 
     test "ends the employment link with its consequences, not just the PII" do
-      # Erasure goes through deactivate_staff_member/1 rather than flipping `active`
+      # Erasure goes through offboard_staff_member/1 rather than flipping `active`
       # itself, so it inherits every consequence instead of having to remember them:
       # the lead-instructor flag goes, and the event that clears the erased name from
       # read tables is staged (#1237).
@@ -82,6 +82,33 @@ defmodule KlassHero.Provider.AnonymizeUserDataTest do
 
       refute Repo.get(ProgramStaffAssignment, lead.id).is_lead_instructor
       assert_integration_event_published(:staff_member_deactivated, %{staff_member_id: staff.id})
+    end
+
+    test "takes the erased person out of their programs' conversations" do
+      # An erased user who stays an active conversation participant is the #1292
+      # defect wearing a different trigger: the name renders as "Deleted User", but
+      # the account is still in the thread. Erasure offboards rather than
+      # deactivates, so each assignment is retired through the event path Messaging
+      # listens to.
+      %{user: user, provider: provider, program: program, staff: staff} = user_with_provider_data()
+
+      {:ok, assignment} =
+        Provider.assign_staff_to_program(%{
+          provider_id: provider.id,
+          program_id: program.id,
+          staff_member_id: staff.id
+        })
+
+      clear_integration_events()
+
+      assert {:ok, _} = Provider.anonymize_data_for_user(user.id)
+
+      assert %DateTime{} = Repo.get(ProgramStaffAssignment, assignment.id).unassigned_at
+
+      assert_integration_event_published(:staff_unassigned_from_program, %{
+        program_id: program.id,
+        staff_user_id: user.id
+      })
     end
   end
 

--- a/test/klass_hero/provider/assignments/employment_guard_test.exs
+++ b/test/klass_hero/provider/assignments/employment_guard_test.exs
@@ -112,7 +112,13 @@ defmodule KlassHero.Provider.Assignments.EmploymentGuardTest do
                Repo.get_by(ProgramStaffAssignment, program_id: ctx.program.id, staff_member_id: ctx.staff.id)
     end
 
-    test "delete still reaches a deactivated member (offboarding, GDPR erasure)", ctx do
+    test "offboarding still reaches a deactivated member (GDPR erasure)", ctx do
+      # Erasure arrives after someone already left, so the command must not refuse
+      # an inactive row — it still has assignments to retire.
+      assert {:ok, %{staff_member: %{active: false}}} = Provider.offboard_staff_member(ctx.deactivated)
+    end
+
+    test "erasing a historyless row still reaches a deactivated member", ctx do
       assert :ok = Provider.delete_staff_member(ctx.deactivated.id, ctx.provider.id)
       assert {:error, :not_found} = Provider.get_staff_member(ctx.deactivated.id, ctx.provider.id)
     end

--- a/test/klass_hero/provider/offboard_staff_member_test.exs
+++ b/test/klass_hero/provider/offboard_staff_member_test.exs
@@ -1,0 +1,144 @@
+defmodule KlassHero.Provider.OffboardStaffMemberTest do
+  @moduledoc """
+  `offboard_staff_member/1` — ending an employment link *and* taking the person
+  off every program they were on (#1292).
+
+  The sibling of `deactivate_staff_member/1`, and deliberately not the same
+  operation. Deactivation is a reversible pause that keeps Program Staff
+  Assignments alive so Messaging membership survives reactivation. Offboarding is
+  the provider saying "this person no longer works here", which has to reach the
+  read side: each unassignment stages a `staff_unassigned_from_program` event,
+  and that event is the only thing that removes the person from the program's
+  conversations.
+
+  Before this command existed, the provider-facing removal was a bare
+  `Repo.delete` whose assignments were destroyed by an `on_delete: :delete_all`
+  FK — so Postgres vaporised the rows, no event was staged, and the removed staff
+  member stayed a conversation participant forever.
+  """
+
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.EventTestHelper
+  import KlassHero.Factory
+
+  alias KlassHero.Provider
+  alias KlassHero.Provider.ProgramStaffAssignment
+  alias KlassHero.Provider.StaffMember
+  alias KlassHero.Repo
+  alias KlassHero.Shared.Domain.Events.Event
+
+  setup do
+    setup_test_integration_events()
+
+    provider = insert(:provider_profile_schema)
+    judo = insert(:program_schema, provider_id: provider.id)
+    chess = insert(:program_schema, provider_id: provider.id)
+    staff = insert(:staff_member_schema, provider_id: provider.id)
+
+    clear_integration_events()
+
+    %{provider: provider, judo: judo, chess: chess, staff: staff}
+  end
+
+  defp assign(program, staff) do
+    {:ok, assignment} =
+      Provider.assign_staff_to_program(%{
+        provider_id: program.provider_id,
+        program_id: program.id,
+        staff_member_id: staff.id
+      })
+
+    assignment
+  end
+
+  defp reload(%StaffMember{id: id}), do: Repo.get!(StaffMember, id)
+  defp reload(%ProgramStaffAssignment{id: id}), do: Repo.get!(ProgramStaffAssignment, id)
+
+  defp staged(event_type) do
+    get_published_integration_events()
+    |> Enum.filter(&(&1.event_type == event_type))
+  end
+
+  describe "offboard_staff_member/1" do
+    test "ends the employment link", %{staff: staff} do
+      assert {:ok, %{staff_member: offboarded}} = Provider.offboard_staff_member(staff)
+
+      assert offboarded.active == false
+      assert reload(staff).active == false
+    end
+
+    test "unassigns every program the staff member was on", ctx do
+      judo = assign(ctx.judo, ctx.staff)
+      chess = assign(ctx.chess, ctx.staff)
+
+      assert {:ok, %{unassigned_count: 2}} = Provider.offboard_staff_member(ctx.staff)
+
+      assert %DateTime{} = reload(judo).unassigned_at
+      assert %DateTime{} = reload(chess).unassigned_at
+    end
+
+    test "stages one unassignment event per program, plus the deactivation", ctx do
+      assign(ctx.judo, ctx.staff)
+      assign(ctx.chess, ctx.staff)
+      clear_integration_events()
+
+      {:ok, _} = Provider.offboard_staff_member(ctx.staff)
+
+      unassignments = staged(:staff_unassigned_from_program)
+
+      assert length(unassignments) == 2
+      assert Enum.map(unassignments, & &1.payload.program_id) |> Enum.sort() == Enum.sort([ctx.judo.id, ctx.chess.id])
+
+      assert_integration_event_published(:staff_member_deactivated, %{staff_member_id: ctx.staff.id})
+    end
+
+    test "the unassignment events carry the program conversations' teardown key", ctx do
+      user = KlassHero.AccountsFixtures.user_fixture()
+      staff = insert(:staff_member_schema, provider_id: ctx.provider.id, user_id: user.id)
+      assign(ctx.judo, staff)
+      clear_integration_events()
+
+      {:ok, _} = Provider.offboard_staff_member(staff)
+
+      # Messaging skips an event whose staff_user_id is nil, so an unclaimed
+      # invite tears down nothing — a claimed one must carry the id.
+      assert %Event{payload: %{staff_user_id: staff_user_id}} =
+               assert_integration_event_published(:staff_unassigned_from_program)
+
+      assert staff_user_id == user.id
+    end
+
+    test "succeeds when the staff member leads a program", ctx do
+      {:ok, lead} = Provider.set_lead_instructor(ctx.judo.id, ctx.staff.id, ctx.provider.id)
+      assert lead.is_lead_instructor
+
+      assert {:ok, %{unassigned_count: 1}} = Provider.offboard_staff_member(ctx.staff)
+
+      unassigned = reload(lead)
+      refute unassigned.is_lead_instructor
+      assert %DateTime{} = unassigned.unassigned_at
+    end
+
+    test "leaves another staff member's assignments alone", ctx do
+      colleague = insert(:staff_member_schema, provider_id: ctx.provider.id)
+      theirs = assign(ctx.judo, colleague)
+      assign(ctx.chess, ctx.staff)
+
+      {:ok, _} = Provider.offboard_staff_member(ctx.staff)
+
+      assert is_nil(reload(theirs).unassigned_at)
+      assert reload(colleague).active
+    end
+
+    test "is idempotent — re-offboarding stages nothing", ctx do
+      assign(ctx.judo, ctx.staff)
+      {:ok, %{staff_member: offboarded}} = Provider.offboard_staff_member(ctx.staff)
+      clear_integration_events()
+
+      assert {:ok, %{unassigned_count: 0}} = Provider.offboard_staff_member(offboarded)
+
+      assert get_published_integration_events() == []
+    end
+  end
+end

--- a/test/klass_hero/provider/staff/delete_staff_member_test.exs
+++ b/test/klass_hero/provider/staff/delete_staff_member_test.exs
@@ -1,5 +1,19 @@
 defmodule KlassHero.Provider.Staff.DeleteStaffMemberTest do
+  @moduledoc """
+  `delete_staff_member/2` — the narrow hard delete that survives #1292.
+
+  Removing a real employee is `offboard_staff_member/1`; this is the eraser for a
+  row that is provably a data-entry mistake. The precondition is what makes the
+  destruction safe: no linked user, no invitation ever sent, and no assignment
+  row ever created. Anything else has left a trace somewhere — an event naming
+  this `staff_member_id`, or an email that told a real person they had a role at
+  this business — and deleting the row would leave those pointing at nothing,
+  which is the class of defect #1292 was.
+  """
+
   use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
 
   alias KlassHero.Provider
   alias KlassHero.Provider.StaffMember
@@ -7,29 +21,59 @@ defmodule KlassHero.Provider.Staff.DeleteStaffMemberTest do
 
   setup do
     provider = ProviderFixtures.provider_profile_fixture()
-    staff = ProviderFixtures.staff_member_fixture(provider_id: provider.id)
+    staff = insert(:staff_member_schema, provider_id: provider.id)
     %{provider: provider, staff: staff}
   end
 
-  describe "delete_staff_member/2" do
-    test "deletes a staff member owned by the provider", ctx do
+  describe "delete_staff_member/2 on a row with no history" do
+    test "deletes it", ctx do
       assert :ok = Provider.delete_staff_member(ctx.staff.id, ctx.provider.id)
       assert {:error, :not_found} = Provider.get_staff_member(ctx.staff.id)
     end
 
-    test "returns not_found for a staff member that does not exist", ctx do
-      assert {:error, :not_found} =
-               Provider.delete_staff_member(Ecto.UUID.generate(), ctx.provider.id)
-    end
-
     test "does not affect other staff members", ctx do
-      other_staff = ProviderFixtures.staff_member_fixture(provider_id: ctx.provider.id)
+      other = insert(:staff_member_schema, provider_id: ctx.provider.id)
 
       assert :ok = Provider.delete_staff_member(ctx.staff.id, ctx.provider.id)
 
-      assert {:ok, _} = Provider.get_staff_member(other_staff.id)
+      assert {:ok, _} = Provider.get_staff_member(other.id)
     end
 
+    test "returns not_found for a staff member that does not exist", ctx do
+      assert {:error, :not_found} = Provider.delete_staff_member(Ecto.UUID.generate(), ctx.provider.id)
+    end
+  end
+
+  describe "delete_staff_member/2 on a row with history" do
+    setup ctx do
+      user = KlassHero.AccountsFixtures.user_fixture()
+      program = insert(:program_schema, provider_id: ctx.provider.id)
+
+      %{user: user, program: program}
+    end
+
+    # Each trace is independently disqualifying, so they are proven one at a
+    # time rather than on one maximally-dirty row — a single fixture carrying all
+    # three would pass even if only one of the checks were implemented.
+    for {trace, description} <- [
+          {:linked, "a linked user account"},
+          {:invited, "an invitation that was sent"},
+          {:expired_invite, "an invitation that expired unclaimed"},
+          {:assigned, "a live program assignment"},
+          {:unassigned, "a program assignment that was later retired"}
+        ] do
+      test "refuses a row carrying #{description}", ctx do
+        staff = dirty_staff(unquote(trace), ctx)
+
+        assert {:error, :has_history} = Provider.delete_staff_member(staff.id, ctx.provider.id),
+               "expected #{unquote(description)} to disqualify the row from hard deletion"
+
+        assert %StaffMember{} = Repo.get(StaffMember, staff.id)
+      end
+    end
+  end
+
+  describe "delete_staff_member/2 IDOR guards" do
     test "leaves another provider's staff member intact", ctx do
       attacker = ProviderFixtures.provider_profile_fixture()
 
@@ -46,5 +90,33 @@ defmodule KlassHero.Provider.Staff.DeleteStaffMemberTest do
 
       assert foreign == missing
     end
+  end
+
+  defp dirty_staff(:linked, ctx), do: insert(:staff_member_schema, provider_id: ctx.provider.id, user_id: ctx.user.id)
+
+  defp dirty_staff(:invited, ctx),
+    do: insert(:staff_member_schema, provider_id: ctx.provider.id, invitation_status: :sent)
+
+  defp dirty_staff(:expired_invite, ctx),
+    do: insert(:staff_member_schema, provider_id: ctx.provider.id, invitation_status: :expired)
+
+  defp dirty_staff(:assigned, ctx) do
+    staff = insert(:staff_member_schema, provider_id: ctx.provider.id)
+
+    {:ok, _} =
+      Provider.assign_staff_to_program(%{
+        provider_id: ctx.provider.id,
+        program_id: ctx.program.id,
+        staff_member_id: staff.id
+      })
+
+    staff
+  end
+
+  defp dirty_staff(:unassigned, ctx) do
+    staff = dirty_staff(:assigned, ctx)
+    {:ok, _} = Provider.unassign_staff_from_program(ctx.program.id, staff.id, ctx.provider.id)
+
+    staff
   end
 end

--- a/test/klass_hero/provider/staff_offboarding_cascade_test.exs
+++ b/test/klass_hero/provider/staff_offboarding_cascade_test.exs
@@ -1,0 +1,86 @@
+defmodule KlassHero.Provider.StaffOffboardingCascadeTest do
+  @moduledoc """
+  End-to-end proof that offboarding a staff member actually removes them from the
+  programs' conversations (#1292).
+
+  The unit tests assert the events are staged. This one starts at
+  `Provider.offboard_staff_member/1` and lets the real machinery run: staged
+  events → Oban job → consumer registry → `Messaging.StaffAssignmentHandler`.
+
+  It is the test the old code could not have passed. Removal was a bare
+  `Repo.delete`, and `program_staff_assignments.staff_member_id` is
+  `on_delete: :delete_all` — so Postgres destroyed the assignment rows, no
+  changeset ran, nothing was staged, and the removed staff member stayed an
+  active participant in every one of the program's conversations.
+  """
+  # async: false — swaps the :outbox adapter in application env, which every
+  # other test reads (see outbox_test.exs for the same constraint).
+  use KlassHero.DataCase, async: false
+
+  import KlassHero.Factory
+
+  alias KlassHero.Messaging
+  alias KlassHero.Messaging.ProgramStaffParticipant
+  alias KlassHero.Provider
+  alias KlassHero.Shared.Adapters.Driven.Events.ObanOutbox
+
+  test "offboarding removes the staff member from the program's conversations" do
+    provider = insert(:provider_profile_schema)
+    program = insert(:program_schema, provider_id: provider.id)
+    staff_user = KlassHero.AccountsFixtures.user_fixture()
+    parent_user = KlassHero.AccountsFixtures.user_fixture()
+    staff = insert(:staff_member_schema, provider_id: provider.id, user_id: staff_user.id)
+
+    conversation =
+      insert(:conversation_schema, provider_id: provider.id, type: "direct", program_id: program.id)
+
+    insert(:participant_schema, conversation_id: conversation.id, user_id: parent_user.id)
+
+    # The real outbox is swapped in around the act only. Doing it in `setup`
+    # makes the fixtures above collide on providers_identity_id_index: with
+    # ObanOutbox live, building a provider drives :user_registered through the
+    # real handler, which creates a second profile for the same identity.
+    with_real_outbox(fn ->
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        {:ok, _} =
+          Provider.assign_staff_to_program(%{
+            provider_id: provider.id,
+            program_id: program.id,
+            staff_member_id: staff.id
+          })
+
+        drain()
+
+        # Precondition: assignment put them in the conversation and the mirror.
+        assert Messaging.participant?(conversation.id, staff_user.id)
+        assert mirror(program, staff_user).active
+
+        {:ok, %{unassigned_count: 1}} = Provider.offboard_staff_member(staff)
+
+        # Nothing has consumed the unassignment yet — it is staged, not run.
+        assert Messaging.participant?(conversation.id, staff_user.id)
+
+        drain()
+      end)
+    end)
+
+    refute Messaging.participant?(conversation.id, staff_user.id)
+    refute mirror(program, staff_user).active
+  end
+
+  defp drain, do: Oban.drain_queue(queue: :critical_events, with_recursion: true)
+
+  defp mirror(program, staff_user),
+    do: Repo.get_by!(ProgramStaffParticipant, program_id: program.id, staff_user_id: staff_user.id)
+
+  defp with_real_outbox(fun) do
+    original = Application.get_env(:klass_hero, :outbox)
+    Application.put_env(:klass_hero, :outbox, module: ObanOutbox)
+
+    try do
+      fun.()
+    after
+      Application.put_env(:klass_hero, :outbox, original)
+    end
+  end
+end

--- a/test/klass_hero_web/live/provider/dashboard_self_staff_test.exs
+++ b/test/klass_hero_web/live/provider/dashboard_self_staff_test.exs
@@ -170,7 +170,7 @@ defmodule KlassHeroWeb.Provider.DashboardSelfStaffTest do
     end
   end
 
-  describe "deleting the own self row" do
+  describe "ending the own self row's employment" do
     test "heals the page: button returns, cross-nav goes (single employer)", %{conn: conn} do
       %{conn: conn, user: user, provider: provider} = log_in_named_provider(conn, "Maxi Founder")
 
@@ -186,7 +186,7 @@ defmodule KlassHeroWeb.Provider.DashboardSelfStaffTest do
       refute has_element?(view, "#self-staff-btn")
 
       view
-      |> element(~s(button[phx-click="delete_member"][phx-value-id="#{staff.id}"]))
+      |> element("#end-employment-#{staff.id}")
       |> render_click()
 
       assert has_element?(view, "#self-staff-btn")
@@ -216,7 +216,7 @@ defmodule KlassHeroWeb.Provider.DashboardSelfStaffTest do
       {:ok, view, _html} = live(conn, ~p"/provider/dashboard/team")
 
       view
-      |> element(~s(button[phx-click="delete_member"][phx-value-id="#{own_row.id}"]))
+      |> element("#end-employment-#{own_row.id}")
       |> render_click()
 
       assert has_element?(view, "#self-staff-btn")
@@ -225,7 +225,7 @@ defmodule KlassHeroWeb.Provider.DashboardSelfStaffTest do
   end
 
   describe "durable :staff teardown (#972)" do
-    test "deleting the last linked row removes :staff from intended_roles", %{conn: conn} do
+    test "offboarding the last linked row removes :staff from intended_roles", %{conn: conn} do
       %{conn: conn, user: user, provider: provider} = log_in_provider_also_staff(conn)
 
       staff =
@@ -241,14 +241,14 @@ defmodule KlassHeroWeb.Provider.DashboardSelfStaffTest do
       {:ok, view, _html} = live(conn, ~p"/provider/dashboard/team")
 
       view
-      |> element(~s(button[phx-click="delete_member"][phx-value-id="#{staff.id}"]))
+      |> element("#end-employment-#{staff.id}")
       |> render_click()
 
       # Durable: survives a fresh DB read, not just the in-session heal.
       assert reload_roles(user.id) == [:provider]
     end
 
-    test "deleting one of several linked rows keeps :staff", %{conn: conn} do
+    test "offboarding one of several linked rows keeps :staff", %{conn: conn} do
       %{conn: conn, user: user, provider: provider} = log_in_provider_also_staff(conn)
 
       employer = provider_profile_fixture()
@@ -271,7 +271,7 @@ defmodule KlassHeroWeb.Provider.DashboardSelfStaffTest do
       {:ok, view, _html} = live(conn, ~p"/provider/dashboard/team")
 
       view
-      |> element(~s(button[phx-click="delete_member"][phx-value-id="#{own_row.id}"]))
+      |> element("#end-employment-#{own_row.id}")
       |> render_click()
 
       assert :staff in reload_roles(user.id)

--- a/test/klass_hero_web/live/provider/dashboard_team_test.exs
+++ b/test/klass_hero_web/live/provider/dashboard_team_test.exs
@@ -184,8 +184,8 @@ defmodule KlassHeroWeb.Provider.DashboardTeamTest do
     end
   end
 
-  describe "delete member" do
-    test "deleting a member shows success flash", %{conn: conn, provider: provider} do
+  describe "end employment" do
+    setup %{provider: provider} do
       staff =
         ProviderFixtures.staff_member_fixture(
           provider_id: provider.id,
@@ -193,16 +193,79 @@ defmodule KlassHeroWeb.Provider.DashboardTeamTest do
           last_name: "Smith"
         )
 
+      %{staff: staff}
+    end
+
+    test "moves the member out of the roster and into former team members", ctx do
+      {:ok, view, _html} = live(ctx.conn, ~p"/provider/dashboard/team")
+
+      assert has_element?(view, "#team_members-#{ctx.staff.id}")
+
+      view |> element("#end-employment-#{ctx.staff.id}") |> render_click()
+
+      refute has_element?(view, "#team_members-#{ctx.staff.id}")
+      assert has_element?(view, "#former_members-#{ctx.staff.id}")
+    end
+
+    test "survives a reload — the roster read, not just the stream, excludes them", ctx do
+      {:ok, view, _html} = live(ctx.conn, ~p"/provider/dashboard/team")
+      view |> element("#end-employment-#{ctx.staff.id}") |> render_click()
+
+      {:ok, reloaded, _html} = live(ctx.conn, ~p"/provider/dashboard/team")
+
+      refute has_element?(reloaded, "#team_members-#{ctx.staff.id}")
+      assert has_element?(reloaded, "#former_members-#{ctx.staff.id}")
+    end
+
+    test "keeps the employment row rather than destroying it", ctx do
+      {:ok, view, _html} = live(ctx.conn, ~p"/provider/dashboard/team")
+
+      view |> element("#end-employment-#{ctx.staff.id}") |> render_click()
+
+      assert {:ok, %{active: false}} = Provider.get_staff_member(ctx.staff.id)
+    end
+
+    test "reactivating puts them back on the roster", ctx do
+      {:ok, view, _html} = live(ctx.conn, ~p"/provider/dashboard/team")
+      view |> element("#end-employment-#{ctx.staff.id}") |> render_click()
+
+      view |> element("#reactivate-member-#{ctx.staff.id}") |> render_click()
+
+      assert has_element?(view, "#team_members-#{ctx.staff.id}")
+      refute has_element?(view, "#former_members-#{ctx.staff.id}")
+      assert {:ok, %{active: true}} = Provider.get_staff_member(ctx.staff.id)
+    end
+  end
+
+  describe "delete member" do
+    test "offers deletion for a roster entry with no history", %{conn: conn, provider: provider} do
+      typo = ProviderFixtures.staff_member_fixture(provider_id: provider.id, first_name: "Jhon")
+
       {:ok, view, _html} = live(conn, ~p"/provider/dashboard/team")
 
-      html = render(view)
-      assert html =~ "Alice Smith"
+      assert has_element?(view, "#delete-member-#{typo.id}")
 
-      view
-      |> element(~s(button[phx-click="delete_member"][phx-value-id="#{staff.id}"]))
-      |> render_click()
+      view |> element("#delete-member-#{typo.id}") |> render_click()
 
       assert render(view) =~ "Team member removed."
+      assert {:error, :not_found} = Provider.get_staff_member(typo.id)
+    end
+
+    test "does not offer deletion once the person has history", %{conn: conn, provider: provider} do
+      # An invitation went out: a real person was told they work here, so the row
+      # is no longer a typo to erase. Absent rather than disabled — the answer for
+      # this member is End employment, and the UI should not suggest otherwise.
+      invited =
+        ProviderFixtures.staff_member_fixture(
+          provider_id: provider.id,
+          first_name: "Real",
+          invitation_status: :sent
+        )
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/team")
+
+      assert has_element?(view, "#end-employment-#{invited.id}")
+      refute has_element?(view, "#delete-member-#{invited.id}")
     end
   end
 


### PR DESCRIPTION
Closes #1292

## Summary

Removing a staff member was a bare `Repo.delete`. Because `program_staff_assignments.staff_member_id` is `on_delete: :delete_all`, Postgres destroyed every assignment row without running a changeset, so no `staff_unassigned_from_program` event was ever staged. `Messaging.StaffAssignmentHandler` therefore never ran: the removed person stayed an **active participant in every program conversation**, and their `program_staff_participants` row stayed `active`. This is the only removal control providers have.

Removal is now a modelled domain operation, split from the eraser it was doing double duty as.

| | before | after |
|---|---|---|
| Remove an employee | hard delete, FK cascade, no events | `offboard_staff_member/1`: retires every assignment (one event each) + ends employment, one transaction |
| Erase a typo row | same hard delete | `delete_staff_member/2`, refusing `{:error, :has_history}` on anything with a trace |
| GDPR erasure | deactivated, assignments kept → erased user stayed in conversations | offboards, then scrubs |

## Review focus

- **`lib/klass_hero/provider/offboard_staff_member.ex`** — the new use case. It does the writes itself rather than looping the public `Assignments.unassign_staff_from_program/3`, for two reasons worth checking: that function refuses to retire a lead, and it would open one transaction (and one Oban job) per program. Ordering is load-bearing — assignments are retired *before* the employment write, so the `active` flip cannot short-circuit the teardown on a re-run.
- **The `:has_history` predicate** (`staff.ex`) — legal only when `user_id IS NULL AND invitation_status IS NULL AND no assignment row ever existed`. Predicate and delete are one statement, so a concurrent invite or assignment cannot slip between check and delete. `Provider.erasable_staff_ids/1` reuses the same scope, so the Team tab can only offer the action where it would succeed.
- **`deactivate_staff_member/1` is untouched.** It still keeps assignments alive on purpose, and the Backpex confirm copy that promises exactly that stays true. Offboarding is a different operation, not deactivation with a flag.
- **Reversibility is partial and the copy says so** — reactivating restores the employment, not the assignments.

## Test plan

- `test/klass_hero/provider/staff_offboarding_cascade_test.exs` — the one that would have caught this: real `ObanOutbox`, manual Oban mode, `drain_queue`, asserting the conversation participant is soft-left and the `program_staff_participants` mirror goes inactive. It also asserts the membership is *still* intact between the offboard and the drain, so it proves the event does the work rather than the write.
- `offboard_staff_member_test.exs` (Provider + Accounts) — per-program events, lead instructor, idempotence, `:staff` persona teardown across multi-employer staff.
- `delete_staff_member_test.exs` — the `:has_history` matrix as a tabular comprehension (linked / invited / expired invite / assigned / since-unassigned), plus both IDOR guards kept verbatim.
- `dashboard_team_test.exs` — the former-members section, reactivation, and that Delete is absent (not disabled) once a person has history. Includes a reload assertion, because the previous test only checked the flash and would not have caught a member lingering in the roster.
- `mix precommit` green: 4329 tests, credo `--strict` clean, `lint_translations` complete (German shipped in-PR).

Not driven through a browser: this worktree would need its own dev server and MCP endpoint to exercise the branch's code rather than main's. The cascade test covers the same path end to end, Oban delivery included.
