### PR TITLE
fix: scope BookingLive price assertions to the summary card

### DIFF
--- a/lib/klass_hero_web/components/booking_components.ex
+++ b/lib/klass_hero_web/components/booking_components.ex
@@ -103,6 +103,12 @@ defmodule KlassHeroWeb.BookingComponents do
   attr :title, :string, default: "Summary"
   attr :class, :string, default: ""
 
+  attr :id, :string,
+    default: nil,
+    doc:
+      "DOM id for the card. Rows carry `data-line-item`/`data-summary-total` so callers " <>
+        "and tests can address the breakdown without scanning the whole document."
+
   slot :line_item, doc: "Regular line item with label and value" do
     attr :label, :string, required: true
     attr :value, :string, required: true
@@ -115,27 +121,29 @@ defmodule KlassHeroWeb.BookingComponents do
 
   def booking_summary(assigns) do
     ~H"""
-    <div class={["bg-white p-6 shadow-lg", Theme.rounded(:xl), @class]}>
+    <div id={@id} class={["bg-white p-6 shadow-lg", Theme.rounded(:xl), @class]}>
       <h3 class={[Theme.typography(:card_title), "text-hero-black mb-4"]}>{@title}</h3>
       <div class="space-y-2">
         <div
           :for={item <- @line_item}
+          data-line-item
           class="flex justify-between text-hero-black-100"
         >
           <span>{item[:label]}</span>
-          <span>{item[:value]}</span>
+          <span data-value>{item[:value]}</span>
         </div>
 
         <!-- Total with emphasis -->
         <div
           :for={total <- @total}
+          data-summary-total
           class={[
             "flex justify-between pt-2 border-t border-hero-grey-300",
             Theme.typography(:card_title)
           ]}
         >
           <span>{total[:label]}</span>
-          <span class={Theme.text_color(:primary)}>{total[:value]}</span>
+          <span data-value class={Theme.text_color(:primary)}>{total[:value]}</span>
         </div>
       </div>
     </div>

--- a/lib/klass_hero_web/live/booking_live.ex
+++ b/lib/klass_hero_web/live/booking_live.ex
@@ -425,7 +425,7 @@ defmodule KlassHeroWeb.BookingLive do
             </fieldset>
           </div>
 
-          <.booking_summary title={gettext("Payment Summary")}>
+          <.booking_summary id="payment-summary" title={gettext("Payment Summary")}>
             <:line_item
               label={gettext("Program fee:")}
               value={ProgramCatalog.format_price(@total_amount)}

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -2336,12 +2336,12 @@ msgstr ""
 msgid "Child Name"
 msgstr ""
 
-#: lib/klass_hero_web/components/booking_components.ex:181
+#: lib/klass_hero_web/components/booking_components.ex:189
 #, elixir-autogen, elixir-format
 msgid "Child does not meet program requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/booking_components.ex:171
+#: lib/klass_hero_web/components/booking_components.ex:179
 #, elixir-autogen, elixir-format
 msgid "Child meets all program requirements"
 msgstr ""

--- a/test/klass_hero_web/live/booking_live_test.exs
+++ b/test/klass_hero_web/live/booking_live_test.exs
@@ -86,28 +86,27 @@ defmodule KlassHeroWeb.BookingLiveTest do
 
     test "displays total matching program price exactly", %{conn: conn} do
       program = insert(:program_schema, price: Decimal.new("149.99"))
-      {:ok, _view, html} = live(conn, ~p"/programs/#{program.id}/booking")
+      {:ok, view, _html} = live(conn, ~p"/programs/#{program.id}/booking")
 
-      assert html =~ "Program fee:"
-      assert html =~ "€149.99"
-      assert html =~ "Total due today:"
-      refute html =~ "Registration fee"
-      refute html =~ "VAT"
-      refute html =~ "Credit card fee"
+      assert has_element?(view, "#payment-summary [data-line-item]", "Program fee:")
+      assert has_element?(view, "#payment-summary [data-summary-total]", "Total due today:")
+      assert summary_total(view) == "€149.99"
+
+      # No hidden fees: the program fee is the only line item.
+      assert line_item_count(view) == 1
     end
 
     test "total is the same regardless of payment method", %{conn: conn} do
       program = insert(:program_schema, price: Decimal.new("75.00"))
       {:ok, view, _html} = live(conn, ~p"/programs/#{program.id}/booking")
 
-      # Switch to transfer — total unchanged
+      # Switch to transfer — total unchanged, still no payment-method surcharge
       view
       |> element("[phx-click='select_payment_method'][phx-value-method='transfer']")
       |> render_click()
 
-      html = render(view)
-      assert html =~ "€75.00"
-      refute html =~ "Credit card fee"
+      assert has_element?(view, "#payment-summary [data-summary-total]", "€75.00")
+      assert line_item_count(view) == 1
     end
 
     test "multi-week program total is still just program price, not multiplied", %{conn: conn} do
@@ -119,10 +118,9 @@ defmodule KlassHeroWeb.BookingLiveTest do
           end_date: ~D[2026-04-26]
         )
 
-      {:ok, _view, html} = live(conn, ~p"/programs/#{program.id}/booking")
+      {:ok, view, _html} = live(conn, ~p"/programs/#{program.id}/booking")
 
-      assert html =~ "€50.00"
-      refute html =~ "€400.00"
+      assert summary_total(view) == "€50.00"
     end
   end
 
@@ -212,5 +210,20 @@ defmodule KlassHeroWeb.BookingLiveTest do
       # No crash, page still renders
       assert has_element?(view, "h1", "Enrollment")
     end
+  end
+
+  # Scope price assertions to the summary card. A `refute html =~ "VAT"` over the whole
+  # document flakes: the page's random base64 blobs (csrf-token, phx-session, phx-static)
+  # occasionally spell short strings. See #1287.
+  defp summary_doc(view) do
+    view |> element("#payment-summary") |> render() |> LazyHTML.from_fragment()
+  end
+
+  defp line_item_count(view) do
+    view |> summary_doc() |> LazyHTML.query("[data-line-item]") |> Enum.count()
+  end
+
+  defp summary_total(view) do
+    view |> summary_doc() |> LazyHTML.query("[data-summary-total] [data-value]") |> LazyHTML.text()
   end
 end


### PR DESCRIPTION
Closes #1287

## Summary

`test/klass_hero_web/live/booking_live_test.exs:95` ran `refute html =~ "VAT"` over an entire `live/2` render. Every full-page LiveView render embeds three crypto-random URL-safe base64 blobs (`csrf-token`, `data-phx-session`, `data-phx-static`), and base64's alphabet covers every letter of `VAT` — so a few times per thousand runs a token spelled it and the test failed with no VAT text on the page. Not reproducible by seed, because the randomness is crypto rather than ExUnit's.

`booking_summary/1` rendered an unaddressable `<div>`, so the test had no handle on the subtree and reached past the seam to the raw document — which `.claude/rules/liveview.md` already forbids. This fixes the seam so the rule becomes followable.

## Changes

- `booking_summary/1` gains an optional `id` attr; rows are marked `data-line-item`, `data-summary-total`, and value spans `data-value`. Markers are deliberately **bare** rather than label-valued — labels are gettext'd, and a translated value would reintroduce the same fragility.
- `booking_live.ex` passes `id="payment-summary"` (sole caller).
- The `BookingLive pricing display` tests assert against those handles. Three private helpers at the bottom of the test module reuse the `Enum.count(LazyHTML.query(...))` idiom already established in `program_card_actions_slot_test.exs:41`.
- `default.pot` line references shift because 8 lines were added above two existing `gettext` calls. No new msgids, no German translation work.

## Review focus

Two things the fix buys beyond de-flaking, both worth a look:

1. **The guard got stronger.** `refute html =~ "VAT"` would have sailed past a German `MwSt.` row. Asserting the summary holds exactly one line item catches any unexpected fee row regardless of wording.
2. **The positive assertions now mean what they claim.** The page renders a *second* price display — an "Activity Summary" card above the Payment Summary. The old `assert html =~ "€50.00"` could have been satisfied entirely by that card while the Payment Summary showed something wrong.

## Test plan

- **Red confirmed first** — tests written before the component change, failing on the missing `#payment-summary` selector, not on a stale expectation.
- **Guard bites** — temporarily injecting `<:line_item label="VAT" value="€0.00" />` fails both count assertions with `left: 2, right: 1`. Caught by count, not by the word.
- **Blob exposure eliminated** — a throwaway probe dumped the scoped fragment: 578 bytes vs the full page's 24,090, containing no `csrf` / `data-phx-session` / `data-phx-static`. The failure mode is structurally out of reach, not merely rarer.
- `mix precommit` green: 4304 tests, credo `--strict` clean, typography + translations pass.

No browser check: the change adds only an `id` and `data-*` attributes, and the fragment dump above confirms the rest of the markup is byte-identical, so there is no possible visual delta.

## Not doing

No suite-wide sweep. The grep for short raw-HTML refutes found other candidates (`login_test.exs:111 "Register"`, `staff_dashboard_live_test.exs:63 "rate-label"`), but the odds scale as positions × (1/64)^n — roughly 1/500 at n=3 versus 1/33,000 at n=4. Only `"VAT"` is genuinely exposed; component-only renders carry no session blobs and are immune outright.