### PR TITLE
refactor: fold the program-row rebuild paths in ProgramsLive

### DIFF
--- a/lib/klass_hero_web/live/provider/programs_live.ex
+++ b/lib/klass_hero_web/live/provider/programs_live.ex
@@ -653,18 +653,11 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
         program.id => %{enrolled: 0, capacity: capacity}
       }
 
-      view =
-        ProgramPresenter.to_table_view(
-          program,
-          new_enrollment_data,
-          Map.get(Provider.list_program_staffing([program.id]), program.id)
-        )
-
       {:noreply,
        socket
        |> flash_for_policy_result(policy_result)
        |> maybe_flash_cover_warning(cover_result)
-       |> stream_insert(:programs, view)
+       |> insert_program_row(program, new_enrollment_data)
        |> assign(
          show_program_form: false,
          editing_program_id: nil,
@@ -709,18 +702,11 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
       enrolled = Map.get(active_counts, program_id, 0)
       enrollment_data = %{program_id => %{enrolled: enrolled, capacity: capacity}}
 
-      view =
-        ProgramPresenter.to_table_view(
-          updated,
-          enrollment_data,
-          Map.get(Provider.list_program_staffing([program_id]), program_id)
-        )
-
       {:noreply,
        socket
        |> put_flash(:info, gettext("Program updated successfully."))
        |> maybe_flash_cover_warning(cover_result)
-       |> stream_insert(:programs, view)
+       |> insert_program_row(updated, enrollment_data)
        |> assign(
          show_program_form: false,
          editing_program_id: nil,
@@ -865,11 +851,10 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
 
     case ProgramCatalog.get_program_for_provider(provider_id, program_id) do
       {:ok, program} ->
-        staffing = Map.get(Provider.list_program_staffing([program_id]), program_id)
+        staffing = fetch_program_staffing(program_id)
 
         if row_visible?(socket, staffing) do
-          view = ProgramPresenter.to_table_view(program, build_enrollment_data([program]), staffing)
-          stream_insert(socket, :programs, view)
+          insert_program_row(socket, program, build_enrollment_data([program]), staffing)
         else
           stream_delete(socket, :programs, %{id: program_id})
         end
@@ -877,6 +862,27 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
       {:error, :not_found} ->
         socket
     end
+  end
+
+  # The three write paths differ only in where the enrollment numbers come from:
+  # the save paths hand-build them so a rejected capacity blanks the cell instead
+  # of showing the surviving old policy, while the staffing panel re-reads. That
+  # decision stays with each caller; everything after it is this one rebuild (#1307).
+  #
+  # The panel path already holds the staffing it filtered on, so it passes it in
+  # rather than paying for the read twice.
+  defp insert_program_row(socket, program, enrollment_data) do
+    insert_program_row(socket, program, enrollment_data, fetch_program_staffing(program.id))
+  end
+
+  defp insert_program_row(socket, program, enrollment_data, staffing) do
+    view = ProgramPresenter.to_table_view(program, enrollment_data, staffing)
+
+    stream_insert(socket, :programs, view)
+  end
+
+  defp fetch_program_staffing(program_id) do
+    Map.get(Provider.list_program_staffing([program_id]), program_id)
   end
 
   # Removing the staff member a filter is pinned to must drop the row, not

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -2336,12 +2336,12 @@ msgstr "Berechtigung prüfen unter"
 msgid "Child Name"
 msgstr "Name des Kindes"
 
-#: lib/klass_hero_web/components/booking_components.ex:181
+#: lib/klass_hero_web/components/booking_components.ex:189
 #, elixir-autogen, elixir-format
 msgid "Child does not meet program requirements"
 msgstr "Kind erfüllt die Programmanforderungen nicht"
 
-#: lib/klass_hero_web/components/booking_components.ex:171
+#: lib/klass_hero_web/components/booking_components.ex:179
 #, elixir-autogen, elixir-format
 msgid "Child meets all program requirements"
 msgstr "Kind erfüllt alle Programmanforderungen"
@@ -2849,8 +2849,8 @@ msgstr "Ausstehende Überprüfung"
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:106
-#: lib/klass_hero_web/live/provider/programs_live.ex:691
-#: lib/klass_hero_web/live/provider/programs_live.ex:757
+#: lib/klass_hero_web/live/provider/programs_live.ex:684
+#: lib/klass_hero_web/live/provider/programs_live.ex:743
 #: lib/klass_hero_web/live/provider/team_live.ex:305
 #: lib/klass_hero_web/live/provider/team_live.ex:348
 #: lib/klass_hero_web/live/provider/team_live.ex:467
@@ -2883,12 +2883,12 @@ msgstr "Profil erfolgreich aktualisiert."
 msgid "Program Start"
 msgstr "Programmbeginn"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1102
+#: lib/klass_hero_web/live/provider/programs_live.ex:1108
 #, elixir-autogen, elixir-format
 msgid "Program created successfully."
 msgstr "Programm erfolgreich erstellt."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1109
+#: lib/klass_hero_web/live/provider/programs_live.ex:1115
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr "Programm erstellt, aber die Anmeldekapazität konnte nicht gespeichert werden. Bearbeiten Sie das Programm, um es erneut zu versuchen."
@@ -2897,12 +2897,12 @@ msgstr "Programm erstellt, aber die Anmeldekapazität konnte nicht gespeichert w
 #: lib/klass_hero_web/live/provider/programs_live.ex:153
 #: lib/klass_hero_web/live/provider/programs_live.ex:190
 #: lib/klass_hero_web/live/provider/programs_live.ex:254
-#: lib/klass_hero_web/live/provider/programs_live.ex:732
+#: lib/klass_hero_web/live/provider/programs_live.ex:718
 #, elixir-autogen, elixir-format
 msgid "Program not found."
 msgstr "Programm nicht gefunden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:721
+#: lib/klass_hero_web/live/provider/programs_live.ex:707
 #, elixir-autogen, elixir-format
 msgid "Program updated successfully."
 msgstr "Programm erfolgreich aktualisiert."
@@ -3063,8 +3063,8 @@ msgstr "Datei auswählen"
 msgid "Selected child does not meet the program requirements."
 msgstr "Das ausgewählte Kind erfüllt die Programmanforderungen nicht."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:681
-#: lib/klass_hero_web/live/provider/programs_live.ex:747
+#: lib/klass_hero_web/live/provider/programs_live.ex:674
+#: lib/klass_hero_web/live/provider/programs_live.ex:733
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr "Der ausgewählte Kursleiter konnte nicht gefunden werden. Bitte versuchen Sie es erneut."
@@ -3169,7 +3169,7 @@ msgstr "Die Geschichte von Klass Hero"
 msgid "This invite cannot be resent."
 msgstr "Diese Einladung kann nicht erneut gesendet werden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:739
+#: lib/klass_hero_web/live/provider/programs_live.ex:725
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr "Dieses Programm wurde von jemand anderem geändert. Bitte schließen Sie es und versuchen Sie es erneut."
@@ -3384,7 +3384,7 @@ msgstr "Zahlung per Bargeld oder Banküberweisung"
 msgid "Program fee:"
 msgstr "Programmgebühr:"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:940
+#: lib/klass_hero_web/live/provider/programs_live.ex:946
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr "Programm gespeichert, aber der Upload des Titelbilds ist fehlgeschlagen. Sie können es erneut hochladen, indem Sie das Programm bearbeiten."
@@ -7685,7 +7685,7 @@ msgstr ""
 msgid "Staffing — %{title}"
 msgstr "Programmteam — %{title}"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:899
+#: lib/klass_hero_web/live/provider/programs_live.ex:905
 #, elixir-autogen, elixir-format
 msgid "That staff member could not be found."
 msgstr "Dieses Teammitglied wurde nicht gefunden."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -2849,8 +2849,8 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:106
-#: lib/klass_hero_web/live/provider/programs_live.ex:691
-#: lib/klass_hero_web/live/provider/programs_live.ex:757
+#: lib/klass_hero_web/live/provider/programs_live.ex:684
+#: lib/klass_hero_web/live/provider/programs_live.ex:743
 #: lib/klass_hero_web/live/provider/team_live.ex:305
 #: lib/klass_hero_web/live/provider/team_live.ex:348
 #: lib/klass_hero_web/live/provider/team_live.ex:467
@@ -2883,12 +2883,12 @@ msgstr ""
 msgid "Program Start"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1102
+#: lib/klass_hero_web/live/provider/programs_live.ex:1108
 #, elixir-autogen, elixir-format
 msgid "Program created successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1109
+#: lib/klass_hero_web/live/provider/programs_live.ex:1115
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr ""
@@ -2897,12 +2897,12 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/programs_live.ex:153
 #: lib/klass_hero_web/live/provider/programs_live.ex:190
 #: lib/klass_hero_web/live/provider/programs_live.ex:254
-#: lib/klass_hero_web/live/provider/programs_live.ex:732
+#: lib/klass_hero_web/live/provider/programs_live.ex:718
 #, elixir-autogen, elixir-format
 msgid "Program not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:721
+#: lib/klass_hero_web/live/provider/programs_live.ex:707
 #, elixir-autogen, elixir-format
 msgid "Program updated successfully."
 msgstr ""
@@ -3063,8 +3063,8 @@ msgstr ""
 msgid "Selected child does not meet the program requirements."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:681
-#: lib/klass_hero_web/live/provider/programs_live.ex:747
+#: lib/klass_hero_web/live/provider/programs_live.ex:674
+#: lib/klass_hero_web/live/provider/programs_live.ex:733
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
@@ -3169,7 +3169,7 @@ msgstr ""
 msgid "This invite cannot be resent."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:739
+#: lib/klass_hero_web/live/provider/programs_live.ex:725
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
@@ -3384,7 +3384,7 @@ msgstr ""
 msgid "Program fee:"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:940
+#: lib/klass_hero_web/live/provider/programs_live.ex:946
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr ""
@@ -7683,7 +7683,7 @@ msgstr ""
 msgid "Staffing — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:899
+#: lib/klass_hero_web/live/provider/programs_live.ex:905
 #, elixir-autogen, elixir-format
 msgid "That staff member could not be found."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -2336,12 +2336,12 @@ msgstr ""
 msgid "Child Name"
 msgstr ""
 
-#: lib/klass_hero_web/components/booking_components.ex:181
+#: lib/klass_hero_web/components/booking_components.ex:189
 #, elixir-autogen, elixir-format
 msgid "Child does not meet program requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/booking_components.ex:171
+#: lib/klass_hero_web/components/booking_components.ex:179
 #, elixir-autogen, elixir-format
 msgid "Child meets all program requirements"
 msgstr ""
@@ -2849,8 +2849,8 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:106
-#: lib/klass_hero_web/live/provider/programs_live.ex:691
-#: lib/klass_hero_web/live/provider/programs_live.ex:757
+#: lib/klass_hero_web/live/provider/programs_live.ex:684
+#: lib/klass_hero_web/live/provider/programs_live.ex:743
 #: lib/klass_hero_web/live/provider/team_live.ex:305
 #: lib/klass_hero_web/live/provider/team_live.ex:348
 #: lib/klass_hero_web/live/provider/team_live.ex:467
@@ -2883,12 +2883,12 @@ msgstr ""
 msgid "Program Start"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1102
+#: lib/klass_hero_web/live/provider/programs_live.ex:1108
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program created successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1109
+#: lib/klass_hero_web/live/provider/programs_live.ex:1115
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr ""
@@ -2897,12 +2897,12 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/programs_live.ex:153
 #: lib/klass_hero_web/live/provider/programs_live.ex:190
 #: lib/klass_hero_web/live/provider/programs_live.ex:254
-#: lib/klass_hero_web/live/provider/programs_live.ex:732
+#: lib/klass_hero_web/live/provider/programs_live.ex:718
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:721
+#: lib/klass_hero_web/live/provider/programs_live.ex:707
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program updated successfully."
 msgstr ""
@@ -3063,8 +3063,8 @@ msgstr ""
 msgid "Selected child does not meet the program requirements."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:681
-#: lib/klass_hero_web/live/provider/programs_live.ex:747
+#: lib/klass_hero_web/live/provider/programs_live.ex:674
+#: lib/klass_hero_web/live/provider/programs_live.ex:733
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
@@ -3169,7 +3169,7 @@ msgstr ""
 msgid "This invite cannot be resent."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:739
+#: lib/klass_hero_web/live/provider/programs_live.ex:725
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
@@ -3384,7 +3384,7 @@ msgstr ""
 msgid "Program fee:"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:940
+#: lib/klass_hero_web/live/provider/programs_live.ex:946
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr ""
@@ -7683,7 +7683,7 @@ msgstr ""
 msgid "Staffing — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:899
+#: lib/klass_hero_web/live/provider/programs_live.ex:905
 #, elixir-autogen, elixir-format
 msgid "That staff member could not be found."
 msgstr ""

--- a/test/klass_hero_web/live/provider/dashboard_program_creation_test.exs
+++ b/test/klass_hero_web/live/provider/dashboard_program_creation_test.exs
@@ -3,6 +3,7 @@ defmodule KlassHeroWeb.Provider.DashboardProgramCreationTest do
 
   import Phoenix.LiveViewTest
 
+  alias KlassHero.Enrollment.EnrollmentPolicy
   alias KlassHero.ProgramCatalog.Program
   alias KlassHero.ProgramCatalog.ProgramListing
   alias KlassHero.ProviderFixtures
@@ -410,6 +411,120 @@ defmodule KlassHeroWeb.Provider.DashboardProgramCreationTest do
       html = render(view)
       assert html =~ "Program created successfully."
       refute html =~ "enrollment capacity could not be saved"
+    end
+  end
+
+  # The row a save inserts shows the capacity that was just typed, not what an
+  # enrollment read would return — the two save paths hand-build their
+  # `enrollment_data` for exactly that reason, and the staffing panel's refresh
+  # deliberately does not (#1307). Nothing pinned that divergence before, so a
+  # naive fold of the three row-rebuild paths would have landed green.
+  describe "the saved row reflects just-submitted capacity" do
+    defp seed_program_with_listing(provider_id, title) do
+      id = Ecto.UUID.generate()
+
+      attrs = %{
+        id: id,
+        title: title,
+        description: "Seeded for a capacity row assertion",
+        category: "arts",
+        price: Decimal.new("50.00"),
+        provider_id: provider_id
+      }
+
+      program = Repo.insert!(struct!(Program, Map.put(attrs, :origin, :self_posted)))
+      Repo.insert!(struct!(ProgramListing, attrs))
+
+      program
+    end
+
+    # The one case where the two sources actually disagree. A rejected capacity
+    # leaves `enrollment_policies` holding the old 20, but `resolve_capacity/2`
+    # answers `nil` for the failed write — so the row blanks to "—" rather than
+    # showing a number the save did not accept. Fold the save path onto
+    # `build_enrollment_data/1` and this is the test that goes red.
+    test "a rejected capacity blanks the row while the old policy survives", %{
+      conn: conn,
+      provider: provider
+    } do
+      program = seed_program_with_listing(provider.id, "Kept Policy Program")
+
+      {:ok, _policy} =
+        KlassHero.Enrollment.set_enrollment_policy(%{program_id: program.id, max_enrollment: 20})
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+
+      assert view |> element("#programs-#{program.id}") |> render() =~ "0/20"
+
+      view
+      |> element(~s([phx-click="edit_program"][phx-value-id="#{program.id}"]))
+      |> render_click()
+
+      view
+      |> form("#program-form", %{
+        "program_schema" => %{
+          "title" => "Kept Policy Program",
+          "description" => "Submitting a capacity the policy will reject",
+          "category" => "arts",
+          "price" => "50.00"
+        },
+        "enrollment_policy" => %{"min_enrollment" => "50", "max_enrollment" => "10"}
+      })
+      |> render_submit()
+
+      # No warning flash here: `flash_for_policy_result/2` is wired into the create
+      # path only, so an update silently drops a rejected capacity. Filed separately;
+      # this test pins the row, not the (missing) flash.
+      assert view |> element("#programs-#{program.id}") |> render() =~ "0/—"
+
+      assert %{max_enrollment: 20} =
+               Repo.get_by!(EnrollmentPolicy, program_id: program.id)
+    end
+
+    test "a created program's row shows the capacity from the form", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+
+      view |> element("#new-program-btn") |> render_click()
+
+      view
+      |> form("#program-form", %{
+        "program_schema" => %{
+          "title" => "Capacity Row Program",
+          "description" => "The new row must show the typed capacity",
+          "category" => "arts",
+          "price" => "25.00"
+        },
+        "enrollment_policy" => %{"max_enrollment" => "42"}
+      })
+      |> render_submit()
+
+      program = Repo.get_by!(Program, title: "Capacity Row Program")
+
+      assert view |> element("#programs-#{program.id}") |> render() =~ "0/42"
+    end
+
+    test "an edited program's row shows the raised capacity", %{conn: conn, provider: provider} do
+      program = seed_program_with_listing(provider.id, "Raise My Capacity")
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+
+      view
+      |> element(~s([phx-click="edit_program"][phx-value-id="#{program.id}"]))
+      |> render_click()
+
+      view
+      |> form("#program-form", %{
+        "program_schema" => %{
+          "title" => "Raise My Capacity",
+          "description" => "The rebuilt row must show the raised capacity",
+          "category" => "arts",
+          "price" => "50.00"
+        },
+        "enrollment_policy" => %{"max_enrollment" => "60"}
+      })
+      |> render_submit()
+
+      assert view |> element("#programs-#{program.id}") |> render() =~ "0/60"
     end
   end
 


### PR DESCRIPTION
Closes #1307.

## Summary

`ProgramsLive` rebuilt a single program's table row from three places, each ending
in the same staffing-read → `to_table_view/3` → `stream_insert` tail. That tail now
lives in `insert_program_row/3,4`; each caller keeps owning where its
`enrollment_data` comes from, which is exactly where #1307 wants that decision to
stay visible.

A 4-arity clause exists so `refresh_program_row/2` can pass the staffing it already
read for `row_visible?/2` instead of paying for the read twice — query counts are
unchanged on all three paths.

## Two corrections to the issue body

The issue was written when #1300 landed; #1334 has since changed the row path.

1. The shared call is `Provider.list_program_staffing/1`, **not**
   `Provider.get_lead_instructor/1`. The latter now survives only in
   `build_staffing_modal/3`.
2. There are **three** sites, not two — `create_new_program/4` builds the same
   triple with a literal `%{id => %{enrolled: 0, capacity: capacity}}`. The issue's
   own trigger ("worth doing when a third row-rebuild appears") was already met.

## Review focus

The issue's stated rationale for the divergence — "the row reflects the capacity the
user just typed, which a policy read would not yet show" — does not hold as written.
`Enrollment.get_enrollment_summary_batch/1` reads the same write table, and
`maybe_set_enrollment_policy/2` commits before the row rebuild, so on valid input
the two sources are identical.

The divergence is real but narrower: it shows only when the policy write is
**rejected**. `resolve_capacity({:error, _}, _)` answers `nil`, so the row blanks to
`—` while `enrollment_policies` still holds the old value. That single case is what
the new test pins, and it was verified by mutation — folding the save path onto
`build_enrollment_data/1` turns it red.

## Test plan

- New: `dashboard_program_creation_test.exs` → `describe "the saved row reflects
  just-submitted capacity"` — three tests covering the create row, the edited row,
  and the rejected-capacity divergence, all asserting the rendered `#programs-<id>`
  cell.
- Verified the divergence test fails against a naive fold before shipping the real one.
- `MIX_TEST_PARTITION=1307 mix precommit` → 4340 passed, credo clean.

## Follow-up found while testing (not fixed here)

`flash_for_policy_result/2` is wired into `create_new_program/4` but **not**
`update_existing_program/5` — editing a program with an invalid capacity silently
drops it, with only a `Logger.warning` server-side. Happy to file this separately.

The gettext diff is line-reference churn only (`0 new messages, 0 removed`) caused by
the shifted line numbers.