### PR TITLE
refactor: remove criticality from the event envelope

### DIFF
--- a/docs/adr/0014-events-are-delivered-by-a-transactional-outbox-not-by-pubsub.md
+++ b/docs/adr/0014-events-are-delivered-by-a-transactional-outbox-not-by-pubsub.md
@@ -51,6 +51,13 @@ error propagation into the caller's `with`). What actually needs to be asynchron
   `validate_critical_payload!`, which guards Oban's jsonb round-trip (#1010); it moves onto the
   single struct.
 
+  > **Amended by #1326.** That guard was the last reader of the `criticality` field, and PR #1325
+  > ungated it (`validate_payload!/1`, no criticality argument) once #1317 taught the codec to
+  > record atoms. With nothing left consulting it, `criticality` is gone. Rows staged before that
+  > deploy still carry the key, so `CriticalEventSerializer` reads metadata through a closed
+  > allowlist and drops what the format does not define — an open `String.to_existing_atom/1`
+  > would have raised on every one of them, in `execute/1` and again in `compensate/2`.
+
 - **The `DomainEventBus` is deleted, not made async.** Its 7 surviving handlers are same-context and
   become direct calls, which restores compile-time checking, `xref` visibility, natural error
   propagation, and line-order sequencing. The runtime `subscribe/4` API — with its owner scoping,

--- a/lib/klass_hero/accounts/domain/events/accounts_events.ex
+++ b/lib/klass_hero/accounts/domain/events/accounts_events.ex
@@ -5,23 +5,23 @@ defmodule KlassHero.Accounts.Domain.Events.AccountsEvents do
 
   ## Events
 
-  - `:user_registered` - Emitted when a new user registers (critical).
+  - `:user_registered` - Emitted when a new user registers.
     Downstream contexts react to create profiles.
 
-  - `:user_confirmed` - Emitted when a user confirms their email (critical).
+  - `:user_confirmed` - Emitted when a user confirms their email.
     Downstream contexts use this as a compensation path to ensure profiles exist
     before first login.
 
-  - `:user_anonymized` - Emitted when a user is anonymized for GDPR (critical).
+  - `:user_anonymized` - Emitted when a user is anonymized for GDPR.
     Downstream contexts (Family, Messaging) react to anonymize their data.
 
-  - `:staff_invitation_sent` - Emitted when a staff invitation email was sent (critical).
+  - `:staff_invitation_sent` - Emitted when a staff invitation email was sent.
     The Provider context reacts to update the staff member's invitation status.
 
-  - `:staff_invitation_failed` - Emitted when a staff invitation email failed (critical).
+  - `:staff_invitation_failed` - Emitted when a staff invitation email failed.
     The Provider context reacts to update the staff member's invitation status.
 
-  - `:staff_user_registered` - Emitted to link a user to their staff membership (critical).
+  - `:staff_user_registered` - Emitted to link a user to their staff membership.
     The Provider context reacts to set `StaffMember.user_id` and accept the invitation —
     no provider profile is created (ADR-0005).
 
@@ -56,7 +56,7 @@ defmodule KlassHero.Accounts.Domain.Events.AccountsEvents do
   @staff_entity_type :staff_member
 
   @doc """
-  Creates a `user_registered` event (critical). Payload includes `email`, `name`, `intended_roles`.
+  Creates a `user_registered` event. Payload includes `email`, `name`, `intended_roles`.
   """
   def user_registered(%{id: _, email: _, name: _} = user, payload \\ %{}, opts \\ []) do
     validate_user_for_registration!(user)
@@ -67,11 +67,11 @@ defmodule KlassHero.Accounts.Domain.Events.AccountsEvents do
       intended_roles: Enum.map(Map.get(user, :intended_roles) || [], &Atom.to_string/1)
     }
 
-    build(:user_registered, user.id, base_payload, payload, Keyword.put_new(opts, :criticality, :critical))
+    build(:user_registered, user.id, base_payload, payload, opts)
   end
 
   @doc """
-  Creates a `user_confirmed` event (critical). Payload includes `email`, `name`, `confirmed_at`, `intended_roles`.
+  Creates a `user_confirmed` event. Payload includes `email`, `name`, `confirmed_at`, `intended_roles`.
   """
   def user_confirmed(%{id: _, email: _, confirmed_at: _} = user, payload \\ %{}, opts \\ []) do
     validate_user_for_confirmation!(user)
@@ -79,17 +79,17 @@ defmodule KlassHero.Accounts.Domain.Events.AccountsEvents do
     base_payload = %{
       email: user.email,
       name: Map.get(user, :name),
-      # Critical events serialize to jsonb; ISO8601 string keeps this a scalar
+      # Events serialize to jsonb; ISO8601 string keeps this a scalar
       # so it round-trips with its type intact (see #1010).
       confirmed_at: encode_timestamp(user.confirmed_at),
       intended_roles: Enum.map(Map.get(user, :intended_roles) || [], &Atom.to_string/1)
     }
 
-    build(:user_confirmed, user.id, base_payload, payload, Keyword.put_new(opts, :criticality, :critical))
+    build(:user_confirmed, user.id, base_payload, payload, opts)
   end
 
   @doc """
-  Creates a `user_anonymized` event (critical — GDPR cascade must not be lost).
+  Creates a `user_anonymized` event (GDPR cascade must not be lost).
   Requires `previous_email` in payload for audit trail.
   """
   def user_anonymized(user, payload, opts \\ [])
@@ -98,14 +98,14 @@ defmodule KlassHero.Accounts.Domain.Events.AccountsEvents do
       when is_binary(previous_email) and byte_size(previous_email) > 0 do
     validate_user_for_anonymization!(user)
 
-    # Critical events serialize to jsonb; carry the timestamp as an ISO8601
+    # Events serialize to jsonb; carry the timestamp as an ISO8601
     # string so it survives the round trip as a scalar (see #1010).
     base_payload = %{
       anonymized_email: Map.get(user, :email),
       anonymized_at: DateTime.to_iso8601(DateTime.utc_now())
     }
 
-    build(:user_anonymized, user.id, base_payload, payload, Keyword.put_new(opts, :criticality, :critical))
+    build(:user_anonymized, user.id, base_payload, payload, opts)
   end
 
   def user_anonymized(%{id: _}, payload, _opts) do
@@ -114,7 +114,7 @@ defmodule KlassHero.Accounts.Domain.Events.AccountsEvents do
   end
 
   @doc """
-  Creates a `staff_invitation_sent` event (critical — Provider must update staff status).
+  Creates a `staff_invitation_sent` event (Provider must update staff status).
   """
   def staff_invitation_sent(staff_member_id, payload \\ %{}, opts \\ [])
 
@@ -129,7 +129,7 @@ defmodule KlassHero.Accounts.Domain.Events.AccountsEvents do
   end
 
   @doc """
-  Creates a `staff_invitation_failed` event (critical — Provider must update staff status).
+  Creates a `staff_invitation_failed` event (Provider must update staff status).
   """
   def staff_invitation_failed(staff_member_id, payload \\ %{}, opts \\ [])
 
@@ -144,7 +144,7 @@ defmodule KlassHero.Accounts.Domain.Events.AccountsEvents do
   end
 
   @doc """
-  Creates a `staff_user_registered` event (critical — Provider must activate the staff member).
+  Creates a `staff_user_registered` event (Provider must activate the staff member).
   """
   def staff_user_registered(user_id, payload \\ %{}, opts \\ [])
 
@@ -155,7 +155,7 @@ defmodule KlassHero.Accounts.Domain.Events.AccountsEvents do
       @entity_type,
       user_id,
       Map.put(payload, :user_id, user_id),
-      Keyword.put_new(opts, :criticality, :critical)
+      opts
     )
   end
 
@@ -184,7 +184,7 @@ defmodule KlassHero.Accounts.Domain.Events.AccountsEvents do
       @staff_entity_type,
       staff_member_id,
       Map.put(payload, :staff_member_id, staff_member_id),
-      Keyword.put_new(opts, :criticality, :critical)
+      opts
     )
   end
 
@@ -226,7 +226,7 @@ defmodule KlassHero.Accounts.Domain.Events.AccountsEvents do
   defp validate_field!(_field, _value, :list_or_nil, _event_name), do: :ok
 
   # Encodes a timestamp as an ISO8601 string so it stays a JSON scalar through
-  # critical-event serialization (see #1010). Accepts nil defensively — the
+  # event serialization (see #1010). Accepts nil defensively — the
   # confirmation validator already rejects a nil `confirmed_at` upstream.
   defp encode_timestamp(%DateTime{} = timestamp), do: DateTime.to_iso8601(timestamp)
   defp encode_timestamp(nil), do: nil

--- a/lib/klass_hero/family/domain/events/family_events.ex
+++ b/lib/klass_hero/family/domain/events/family_events.ex
@@ -9,14 +9,14 @@ defmodule KlassHero.Family.Domain.Events.FamilyEvents do
   - `:child_updated` - Emitted when an existing child record is updated.
     Downstream contexts (e.g. Messaging) react to refresh local child name lookups.
   - `:child_data_anonymized` - Emitted when a child's PII is anonymized during
-    GDPR account deletion (critical). Downstream contexts (e.g. Participation)
+    GDPR account deletion. Downstream contexts (e.g. Participation)
     react to anonymize their own child-related data.
   - `:invite_family_ready` - Emitted after creating parent + child from an
     invite claim. Downstream contexts (e.g. Enrollment) react to auto-enroll
     the child.
 
   Each factory takes the entity id, an optional payload, and metadata opts
-  (`correlation_id`, `causation_id`, `criticality`), and raises `ArgumentError`
+  (`correlation_id`, `causation_id`), and raises `ArgumentError`
   on a nil or blank id.
   """
 
@@ -87,16 +87,16 @@ defmodule KlassHero.Family.Domain.Events.FamilyEvents do
   @doc """
   Creates a `child_data_anonymized` event.
 
-  Critical by default: it is part of the GDPR deletion cascade and must not be lost.
+  Part of the GDPR deletion cascade, so it must not be lost — which every staged
+  event is guaranteed since ADR-0014, not something this factory opts into.
 
       iex> event = FamilyEvents.child_data_anonymized("child-uuid")
-      iex> Event.critical?(event)
-      true
+      iex> event.event_type
+      :child_data_anonymized
   """
   def child_data_anonymized(child_id, payload \\ %{}, opts \\ [])
 
   def child_data_anonymized(child_id, payload, opts) when is_binary(child_id) and byte_size(child_id) > 0 do
-    opts = Keyword.put_new(opts, :criticality, :critical)
     build(:child_data_anonymized, @entity_type, :child_id, child_id, payload, opts)
   end
 

--- a/lib/klass_hero/messaging/domain/events/messaging_events.ex
+++ b/lib/klass_hero/messaging/domain/events/messaging_events.ex
@@ -7,9 +7,11 @@ defmodule KlassHero.Messaging.Domain.Events.MessagingEvents do
   field a consumer needs.
 
   `:participant_added`, `:participant_removed` and `:message_data_anonymized`
-  are critical: without durable delivery, late participants would be missing
-  from read-model summaries until a restart re-derived them, removed ones would
-  linger, and the GDPR cascade could be lost.
+  are the ones durable delivery is load-bearing for: without it, late
+  participants would be missing from read-model summaries until a restart
+  re-derived them, removed ones would linger, and the GDPR cascade could be
+  lost. Since ADR-0014 every staged event gets that guarantee, so there is
+  nothing here to opt into.
   """
 
   alias KlassHero.Shared.Domain.Events.Event
@@ -134,7 +136,7 @@ defmodule KlassHero.Messaging.Domain.Events.MessagingEvents do
   end
 
   @doc """
-  Creates a message_data_anonymized event (critical).
+  Creates a message_data_anonymized event.
 
   Published after anonymizing a user's messaging data (content replaced,
   participations ended). Part of the GDPR deletion cascade, so it must not be
@@ -147,8 +149,7 @@ defmodule KlassHero.Messaging.Domain.Events.MessagingEvents do
       @source_context,
       :user,
       user_id,
-      %{user_id: user_id},
-      criticality: :critical
+      %{user_id: user_id}
     )
   end
 
@@ -161,7 +162,7 @@ defmodule KlassHero.Messaging.Domain.Events.MessagingEvents do
   @type participant_added_source :: :initial_staff | :later_assignment | :broadcast_setup
 
   @doc """
-  Creates a participant_added event (critical).
+  Creates a participant_added event.
 
   Published after one or more users are inserted into a conversation's
   `participants` table. Consumed by CQRS projections.
@@ -183,7 +184,7 @@ defmodule KlassHero.Messaging.Domain.Events.MessagingEvents do
   @type participant_removed_source :: :staff_unassignment
 
   @doc """
-  Creates a participant_removed event (critical).
+  Creates a participant_removed event.
 
   Published after one or more users are removed from a conversation's
   `participants` table. Consumed by CQRS projections, which soft-archive the
@@ -212,8 +213,7 @@ defmodule KlassHero.Messaging.Domain.Events.MessagingEvents do
         conversation_id: conversation_id,
         participant_user_ids: participant_user_ids,
         source: source
-      },
-      criticality: :critical
+      }
     )
   end
 end

--- a/lib/klass_hero/provider/domain/events/provider_events.ex
+++ b/lib/klass_hero/provider/domain/events/provider_events.ex
@@ -10,15 +10,15 @@ defmodule KlassHero.Provider.Domain.Events.ProviderEvents do
     projection used to subscribe, but program cards now read verification through
     `Provider.get_trust_states/1` per render. They are still built here so that
     registering a consumer in `config/config.exs` is all it takes to revive delivery.
-  - `staff_member_invited` - A staff invitation was created (critical).
+  - `staff_member_invited` - A staff invitation was created.
   - `staff_assigned_to_program` / `staff_unassigned_from_program` - A staff
-    member's program assignment changed (critical). Messaging reacts by adding
+    member's program assignment changed. Messaging reacts by adding
     or removing the staff member from the program's conversation.
     `staff_assigned_to_program` is **also replayed on invite acceptance**, once per
     standing assignment: a program assigned before the invite was claimed announced
     a nil `staff_user_id`, which consumers skip (#1312).
   - `staff_member_deactivated` - A staff member's employment link ended
-    (critical). Read tables holding a denormalised staff name clear it; a read
+   . Read tables holding a denormalised staff name clear it; a read
     filter cannot, because the name is a stored column.
 
   The staff assignment events carry the **staff member** as their entity, not
@@ -57,7 +57,7 @@ defmodule KlassHero.Provider.Domain.Events.ProviderEvents do
   end
 
   @doc """
-  Creates a `staff_member_invited` event (critical).
+  Creates a `staff_member_invited` event.
 
   Accounts reacts by sending the invitation email, so a lost event is a staff
   member who never hears they were invited.
@@ -72,7 +72,7 @@ defmodule KlassHero.Provider.Domain.Events.ProviderEvents do
       @staff_entity_type,
       staff_member_id,
       Map.put(payload, :staff_member_id, staff_member_id),
-      Keyword.put_new(opts, :criticality, :critical)
+      opts
     )
   end
 
@@ -81,14 +81,14 @@ defmodule KlassHero.Provider.Domain.Events.ProviderEvents do
           "staff_member_invited/3 requires a non-empty staff_member_id string, got: #{inspect(staff_member_id)}"
   end
 
-  @doc "Creates a staff_assigned_to_program event (critical)."
+  @doc "Creates a staff_assigned_to_program event."
   @spec staff_assigned_to_program(ProgramStaffAssignment.t(), StaffMember.t(), keyword()) ::
           Event.t()
   def staff_assigned_to_program(%ProgramStaffAssignment{} = assignment, %StaffMember{} = staff_member, opts \\ []) do
     assignment_event(:staff_assigned_to_program, assignment, staff_member, opts)
   end
 
-  @doc "Creates a staff_unassigned_from_program event (critical)."
+  @doc "Creates a staff_unassigned_from_program event."
   @spec staff_unassigned_from_program(ProgramStaffAssignment.t(), StaffMember.t(), keyword()) ::
           Event.t()
   def staff_unassigned_from_program(%ProgramStaffAssignment{} = assignment, %StaffMember{} = staff_member, opts \\ []) do
@@ -96,7 +96,7 @@ defmodule KlassHero.Provider.Domain.Events.ProviderEvents do
   end
 
   @doc """
-  Creates a `staff_member_deactivated` event (critical).
+  Creates a `staff_member_deactivated` event.
 
   Carries no `program_ids`: consumers hold `staff_member_id` on their own rows,
   so scoping by the staff member is both narrower and immune to the assignment
@@ -117,7 +117,7 @@ defmodule KlassHero.Provider.Domain.Events.ProviderEvents do
       @staff_entity_type,
       staff_member.id,
       payload,
-      Keyword.put_new(opts, :criticality, :critical)
+      opts
     )
   end
 
@@ -136,7 +136,7 @@ defmodule KlassHero.Provider.Domain.Events.ProviderEvents do
       @staff_entity_type,
       assignment.staff_member_id,
       payload,
-      Keyword.put_new(opts, :criticality, :critical)
+      opts
     )
   end
 end

--- a/lib/klass_hero/shared/adapters/driven/events/critical_event_serializer.ex
+++ b/lib/klass_hero/shared/adapters/driven/events/critical_event_serializer.ex
@@ -51,6 +51,15 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializer do
   stay strings — the pre-#1311 behaviour, which is what the jobs already in the queue
   at deploy need.
 
+  ## Metadata is a closed format, and that is what makes a key retirable
+
+  `deserialize_metadata/1` restores only the keys the format defines and drops the
+  rest, rather than atomizing whatever arrives. The asymmetry is deliberate: an open
+  `String.to_existing_atom/1` makes deleting a metadata key a breaking change, because
+  every row an earlier release staged still carries it and no module holds the atom any
+  more. #1326 retired `criticality` through this door; whatever is retired next needs
+  no shim.
+
   The reverse direction needs more care than it used to. "Older code ignores the extra
   key" was true only of the pre-#1311 serializer, which never read `payload_types`;
   #1316's does read it, and until #1317 it had no fallback for a tag it did not know.
@@ -183,29 +192,22 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializer do
     end)
   end
 
-  @atom_metadata_values ~w(criticality)
+  # Keys restored to the atom the producer used.
+  @atom_metadata_keys ~w(correlation_id causation_id)
 
-  # Keys that remain as binary strings after deserialization — they are
-  # string-keyed by design (W3C Trace Context headers) and must not be atomized.
-  @string_passthrough_keys ["traceparent", "tracestate", "baggage"]
+  # Keys that stay binary strings — W3C Trace Context headers, which the Erlang
+  # propagator wants as `{binary(), binary()}` pairs.
+  @string_metadata_keys ~w(traceparent tracestate baggage)
 
   defp deserialize_metadata(metadata) when is_map(metadata) do
-    Map.new(metadata, fn
-      {k, v} when is_binary(k) and k in @atom_metadata_values ->
-        {String.to_existing_atom(k), String.to_existing_atom(v)}
-
-      {k, v} when is_binary(k) and k in @string_passthrough_keys ->
-        {k, v}
-
-      {k, v} when is_binary(k) ->
-        {String.to_existing_atom(k), v}
-
-      {k, v} when is_atom(k) ->
-        {k, v}
-    end)
+    for {key, value} <- metadata, entry = restore_entry(to_string(key), value), into: %{}, do: entry
   end
 
   defp deserialize_metadata(nil), do: %{}
+
+  defp restore_entry(key, value) when key in @atom_metadata_keys, do: {String.to_existing_atom(key), value}
+  defp restore_entry(key, value) when key in @string_metadata_keys, do: {key, value}
+  defp restore_entry(_key, _value), do: nil
 
   defp parse_datetime!(iso_string) when is_binary(iso_string) do
     {:ok, dt, _offset} = DateTime.from_iso8601(iso_string)

--- a/lib/klass_hero/shared/adapters/driven/events/event_consumer_registry.ex
+++ b/lib/klass_hero/shared/adapters/driven/events/event_consumer_registry.ex
@@ -7,8 +7,8 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.EventConsumerRegistry do
   (`{ProgramListings, :project}`) are the same kind of thing here, because the
   delivery job calls them the same way.
 
-  Replaces the pair of switches that used to decide durability — per-event
-  `Event.critical?` metadata and a per-topic handler map — which had to
+  Replaces the pair of switches that used to decide durability — a per-event
+  criticality level in metadata and a per-topic handler map — which had to
   *both* be on for an Oban fallback to exist, and which nothing kept in agreement.
   Being in this table is now the only condition, so a consumer either gets durable
   at-least-once delivery or is visibly absent from `config/config.exs`.

--- a/lib/klass_hero/shared/domain/events/event.ex
+++ b/lib/klass_hero/shared/domain/events/event.ex
@@ -26,16 +26,16 @@ defmodule KlassHero.Shared.Domain.Events.Event do
 
   Subscribers receive: `{:integration_event, %Event{}}`
 
-  ## Event Criticality
+  ## Delivery is not a per-event choice
 
-  Events can be marked with a criticality level via metadata:
-  - `:critical` - Must not be lost (durable delivery via CriticalEventDispatcher + Oban)
-  - `:normal` - Standard fire-and-forget (default)
+  Every staged event takes the same durable Outbox → Oban → `EventDeliveryWorker`
+  route. Events used to carry a criticality level that was meant to select between
+  durable and fire-and-forget delivery; ADR-0014 collapsed the two tiers into one,
+  and #1326 removed the field. Being in `EventConsumerRegistry` is the only
+  condition that decides anything.
   """
 
   alias KlassHero.Shared.Domain.Events.EventMetadata
-
-  @type criticality :: :critical | :normal
 
   @type t :: %__MODULE__{
           event_id: String.t(),
@@ -84,7 +84,6 @@ defmodule KlassHero.Shared.Domain.Events.Event do
 
   ## Options
 
-  - `:criticality` - Event criticality level (:critical or :normal, default: :normal)
   - `:correlation_id` - ID to correlate related events
   - `:causation_id` - ID of the event that caused this event
   - `:version` - Schema version (default: 1)
@@ -96,10 +95,6 @@ defmodule KlassHero.Shared.Domain.Events.Event do
       :child_data_anonymized
       iex> event.source_context
       :identity
-
-      iex> event = Event.new(:child_data_anonymized, :identity, :child, "uuid", %{}, criticality: :critical)
-      iex> Event.critical?(event)
-      true
   """
   @spec new(atom(), atom(), atom(), String.t() | integer(), map(), keyword()) :: t()
   def new(event_type, source_context, entity_type, entity_id, payload, opts \\ []) do
@@ -132,18 +127,6 @@ defmodule KlassHero.Shared.Domain.Events.Event do
   def topic(%__MODULE__{source_context: source_context, event_type: event_type}) do
     "integration:#{source_context}:#{event_type}"
   end
-
-  @doc """
-  Returns the criticality level of the event (defaults to :normal).
-  """
-  @spec criticality(t()) :: criticality()
-  defdelegate criticality(event), to: EventMetadata
-
-  @doc """
-  Returns true if this is a critical event.
-  """
-  @spec critical?(t()) :: boolean()
-  defdelegate critical?(event), to: EventMetadata
 
   @doc """
   Returns the correlation_id from metadata if present.

--- a/lib/klass_hero/shared/domain/events/event_metadata.ex
+++ b/lib/klass_hero/shared/domain/events/event_metadata.ex
@@ -2,22 +2,13 @@ defmodule KlassHero.Shared.Domain.Events.EventMetadata do
   @moduledoc """
   Shared metadata accessors and builders for domain and integration events.
 
-  Both event structs carry a `:metadata` map with
-  optional fields like `:criticality`, `:correlation_id`, and `:causation_id`.
+  Both event structs carry a `:metadata` map with optional fields like
+  `:correlation_id` and `:causation_id`.
   This module centralises the accessor functions and the metadata construction
   logic so that both event structs stay in sync without duplicating code.
   """
 
   alias KlassHero.Shared.Domain.Events.PayloadCodec
-
-  @type criticality :: :critical | :normal
-
-  @spec criticality(%{metadata: map()}) :: criticality()
-  def criticality(%{metadata: %{criticality: level}}), do: level
-  def criticality(%{metadata: _}), do: :normal
-
-  @spec critical?(%{metadata: map()}) :: boolean()
-  def critical?(event), do: criticality(event) == :critical
 
   @spec correlation_id(%{metadata: map()}) :: String.t() | nil
   def correlation_id(%{metadata: %{correlation_id: id}}), do: id
@@ -36,12 +27,13 @@ defmodule KlassHero.Shared.Domain.Events.EventMetadata do
   @doc """
   Builds a metadata map from keyword options.
 
-  Always includes `:criticality` (defaulting to `:normal`), plus
-  `:correlation_id` and `:causation_id` when present.
+  Includes `:correlation_id` and `:causation_id` when present, and is empty
+  otherwise — which is what every event carries today, since no producer passes
+  either.
   """
   @spec build_metadata(keyword()) :: map()
   def build_metadata(opts) do
-    %{criticality: Keyword.get(opts, :criticality, :normal)}
+    %{}
     |> maybe_add(:correlation_id, opts)
     |> maybe_add(:causation_id, opts)
   end
@@ -67,14 +59,15 @@ defmodule KlassHero.Shared.Domain.Events.EventMetadata do
 
   ## Why this runs for every event
 
-  It used to run for `:critical` events only, on the reasoning that "non-critical
+  It used to run for events marked critical only, on the reasoning that "non-critical
   events dispatch in-memory only (never serialized)". ADR-0014 ended that: every
-  staged event now takes the same Outbox → Oban → `EventDeliveryWorker` path, and
-  `criticality` selects nothing. Both of #1311's production bugs sat in the gap.
+  staged event takes the same Outbox → Oban → `EventDeliveryWorker` path. Both of
+  #1311's production bugs sat in the gap that left, and being this guard's last
+  reader was the only thing keeping the criticality field alive — #1326 removed it.
 
-  Ungating it was blocked on atoms, which `:normal` payloads carry as a matter of
-  course (`type: :direct`, `message_type: :text`, `status: :pending`). #1317 taught
-  the codec to record them, so there is nothing left to exempt.
+  Ungating it was blocked on atoms, which payloads carry as a matter of course
+  (`type: :direct`, `message_type: :text`, `status: :pending`). #1317 taught the
+  codec to record them, so there is nothing left to exempt.
 
   Returns `:ok` or raises `ArgumentError`.
   """

--- a/lib/klass_hero/shared/tracing/context.ex
+++ b/lib/klass_hero/shared/tracing/context.ex
@@ -30,7 +30,7 @@ defmodule KlassHero.Shared.Tracing.Context do
   @spec attach(map()) :: :ok
   def attach(context) when is_map(context) and map_size(context) > 0 do
     # W3C Trace Context keys are always binary strings. Filter out any atom-keyed
-    # entries (e.g. :criticality from event metadata) before handing to the
+    # entries (e.g. :correlation_id from event metadata) before handing to the
     # Erlang propagator, which expects {binary(), binary()} 2-tuples.
     headers = Enum.filter(context, fn {k, _} -> is_binary(k) end)
 

--- a/test/klass_hero/accounts/domain/events/accounts_events_test.exs
+++ b/test/klass_hero/accounts/domain/events/accounts_events_test.exs
@@ -5,10 +5,10 @@ defmodule KlassHero.Accounts.Domain.Events.AccountsEventsTest do
   alias KlassHero.Shared.Domain.Events.Event
 
   # The staff factories take an id, because their producers hold one and not a
-  # user. They share one contract: build a critical event with stable identity
-  # fields, let the id argument win over any caller-supplied id (while
-  # preserving extras), allow criticality to be lowered via opts, and raise on
-  # a blank id. Rows vary only by the id field name and entity_type.
+  # user. They share one contract: build an event with stable identity fields,
+  # let the id argument win over any caller-supplied id (while preserving
+  # extras), and raise on a blank id. Rows vary only by the id field name and
+  # entity_type.
   @staff_factories [
     %{fun: :staff_invitation_sent, id: :staff_member_id, entity: :staff_member},
     %{fun: :staff_invitation_failed, id: :staff_member_id, entity: :staff_member},
@@ -21,7 +21,7 @@ defmodule KlassHero.Accounts.Domain.Events.AccountsEventsTest do
       @id id
       @entity entity
 
-      test "builds a critical event with stable identity fields" do
+      test "builds an event with stable identity fields" do
         event = apply(AccountsEvents, @fun, ["id-1"])
 
         assert %Event{} = event
@@ -30,7 +30,6 @@ defmodule KlassHero.Accounts.Domain.Events.AccountsEventsTest do
         assert event.entity_type == @entity
         assert event.entity_id == "id-1"
         assert Map.get(event.payload, @id) == "id-1"
-        assert Event.critical?(event)
       end
 
       test "the id argument wins over a caller-supplied one and preserves extras" do
@@ -39,12 +38,6 @@ defmodule KlassHero.Accounts.Domain.Events.AccountsEventsTest do
 
         assert Map.get(event.payload, @id) == "real-id"
         assert event.payload.extra == "data"
-      end
-
-      test "allows overriding criticality via opts" do
-        event = apply(AccountsEvents, @fun, ["id-1", %{}, [criticality: :normal]])
-
-        refute Event.critical?(event)
       end
 
       test "raises for a nil or blank id" do
@@ -95,7 +88,6 @@ defmodule KlassHero.Accounts.Domain.Events.AccountsEventsTest do
       assert event.payload.user_id == 1
       assert event.payload.email == "test@example.com"
       assert event.payload.name == "Test User"
-      assert event.metadata.criticality == :critical
     end
 
     test "succeeds with valid user and custom payload" do
@@ -224,7 +216,6 @@ defmodule KlassHero.Accounts.Domain.Events.AccountsEventsTest do
       assert event.payload.anonymized_email == "deleted_1@anonymized.local"
       assert event.payload.previous_email == "old@example.com"
       assert event.payload.anonymized_at
-      assert event.metadata.criticality == :critical
     end
 
     test "succeeds with valid user and additional payload fields" do

--- a/test/klass_hero/family/domain/events/family_events_test.exs
+++ b/test/klass_hero/family/domain/events/family_events_test.exs
@@ -9,23 +9,21 @@ defmodule KlassHero.Family.Domain.Events.FamilyEventsTest do
   # Every family event factory shares one contract: build a :family event with
   # stable identity fields, let the id argument win over any caller-supplied
   # one (while preserving extras), and raise on a blank id. The table drives
-  # that shape; rows vary only by the id field name, the entity_type, and
-  # (for child_data_anonymized) default criticality.
+  # that shape; rows vary only by the id field name and the entity_type.
   @factories [
-    %{fun: :child_created, id: :child_id, entity_type: :child, critical: false},
-    %{fun: :child_updated, id: :child_id, entity_type: :child, critical: false},
-    %{fun: :child_data_anonymized, id: :child_id, entity_type: :child, critical: true},
-    %{fun: :invite_family_ready, id: :invite_id, entity_type: :invite, critical: false}
+    %{fun: :child_created, id: :child_id, entity_type: :child},
+    %{fun: :child_updated, id: :child_id, entity_type: :child},
+    %{fun: :child_data_anonymized, id: :child_id, entity_type: :child},
+    %{fun: :invite_family_ready, id: :invite_id, entity_type: :invite}
   ]
 
-  for %{fun: fun, id: id, entity_type: entity_type, critical: critical} <- @factories do
+  for %{fun: fun, id: id, entity_type: entity_type} <- @factories do
     describe "#{fun}/3" do
       @fun fun
       @id id
       @entity_type entity_type
-      @critical critical
 
-      test "builds an event with the right type, entity, and criticality" do
+      test "builds an event with the right type and entity" do
         event = apply(FamilyEvents, @fun, ["id-1"])
 
         assert %Event{} = event
@@ -34,7 +32,6 @@ defmodule KlassHero.Family.Domain.Events.FamilyEventsTest do
         assert event.entity_id == "id-1"
         assert event.entity_type == @entity_type
         assert Map.get(event.payload, @id) == "id-1"
-        assert Event.critical?(event) == @critical
       end
 
       test "the id argument wins over a caller-supplied one and preserves extras" do

--- a/test/klass_hero/messaging/domain/events/messaging_events_test.exs
+++ b/test/klass_hero/messaging/domain/events/messaging_events_test.exs
@@ -6,7 +6,6 @@ defmodule KlassHero.Messaging.Domain.Events.MessagingEventsTest do
   use ExUnit.Case, async: true
 
   alias KlassHero.Messaging.Domain.Events.MessagingEvents
-  alias KlassHero.Shared.Domain.Events.Event
 
   describe "conversation_created/4" do
     test "creates event with correct type and payload" do
@@ -106,11 +105,10 @@ defmodule KlassHero.Messaging.Domain.Events.MessagingEventsTest do
   end
 
   describe "message_data_anonymized/1" do
-    test "creates a critical event with correct type and payload" do
+    test "creates an event with correct type and payload" do
       user_id = Ecto.UUID.generate()
       event = MessagingEvents.message_data_anonymized(user_id)
 
-      assert Event.critical?(event)
       assert event.event_type == :message_data_anonymized
       assert event.entity_id == user_id
       assert event.entity_type == :user

--- a/test/klass_hero/participation/adapters/driving/events/participation_event_handler_test.exs
+++ b/test/klass_hero/participation/adapters/driving/events/participation_event_handler_test.exs
@@ -25,8 +25,7 @@ defmodule KlassHero.Participation.Adapters.Driving.Events.ParticipationEventHand
           :identity,
           :child,
           note.child_id,
-          %{child_id: note.child_id},
-          criticality: :critical
+          %{child_id: note.child_id}
         )
 
       assert :ok == ParticipationEventHandler.handle_event(event)
@@ -46,8 +45,7 @@ defmodule KlassHero.Participation.Adapters.Driving.Events.ParticipationEventHand
           :identity,
           :child,
           child_id,
-          %{child_id: child_id},
-          criticality: :critical
+          %{child_id: child_id}
         )
 
       assert :ok == ParticipationEventHandler.handle_event(event)

--- a/test/klass_hero/provider/domain/events/provider_integration_events_staff_test.exs
+++ b/test/klass_hero/provider/domain/events/provider_integration_events_staff_test.exs
@@ -8,13 +8,12 @@ defmodule KlassHero.Provider.Domain.Events.ProviderEventsTest do
   alias KlassHero.Provider.Domain.Events.ProviderEvents
   alias KlassHero.Shared.Domain.Events.Event
 
-  # The provider integration-event factories share one contract: build a
-  # critical event with stable identity fields, let the base payload's id win
-  # over any caller-supplied id (while preserving extras), allow criticality
-  # to be lowered via opts, and raise on a blank id. The table drives that
-  # shape; rows vary only by the factory function, id field name, and
-  # entity_type. Factory-specific payload passthrough is covered by the
-  # hand-written tests below.
+  # The provider integration-event factories share one contract: build an event
+  # with stable identity fields, let the base payload's id win over any
+  # caller-supplied id (while preserving extras), and raise on a blank id. The
+  # table drives that shape; rows vary only by the factory function, id field
+  # name, and entity_type. Factory-specific payload passthrough is covered by
+  # the hand-written tests below.
   @factories [
     %{fun: :staff_member_invited, id: :staff_member_id, entity: :staff_member}
   ]
@@ -41,18 +40,6 @@ defmodule KlassHero.Provider.Domain.Events.ProviderEventsTest do
 
         assert Map.get(event.payload, @id) == "real-id"
         assert event.payload.extra == "data"
-      end
-
-      test "marks event as critical by default" do
-        event = apply(ProviderEvents, @fun, ["id-1"])
-
-        assert Event.critical?(event)
-      end
-
-      test "allows overriding criticality via opts" do
-        event = apply(ProviderEvents, @fun, ["id-1", %{}, [criticality: :normal]])
-
-        refute Event.critical?(event)
       end
 
       test "raises for a nil or blank id" do

--- a/test/klass_hero/shared/adapters/driven/events/critical_event_serializer_test.exs
+++ b/test/klass_hero/shared/adapters/driven/events/critical_event_serializer_test.exs
@@ -21,7 +21,6 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializerTest do
           :child,
           "child-uuid",
           %{child_id: "child-uuid", reason: "gdpr_request"},
-          criticality: :critical,
           version: 2
         )
 
@@ -34,7 +33,6 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializerTest do
       assert deserialized.entity_type == :child
       assert deserialized.entity_id == "child-uuid"
       assert deserialized.payload == %{child_id: "child-uuid", reason: "gdpr_request"}
-      assert deserialized.metadata.criticality == :critical
       assert deserialized.version == 2
     end
 
@@ -155,7 +153,6 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializerTest do
     test "restores metadata atom keys after JSON round-trip" do
       event =
         Event.new(:test, :test_context, :test, "id", %{},
-          criticality: :critical,
           correlation_id: "corr-1",
           causation_id: "cause-1"
         )
@@ -164,14 +161,12 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializerTest do
       json_cycled = Jason.decode!(Jason.encode!(serialized))
       deserialized = CriticalEventSerializer.deserialize(json_cycled)
 
-      assert deserialized.metadata.criticality == :critical
-      assert deserialized.metadata.correlation_id == "corr-1"
-      assert deserialized.metadata.causation_id == "cause-1"
+      assert deserialized.metadata == %{correlation_id: "corr-1", causation_id: "cause-1"}
     end
 
     test "preserves string keys for trace context fields after round-trip" do
       event =
-        Event.new(:test_event, :enrollment, :invite, "id-1", %{}, criticality: :normal)
+        Event.new(:test_event, :enrollment, :invite, "id-1", %{})
 
       event_with_trace =
         %{
@@ -192,6 +187,34 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializerTest do
       refute Map.has_key?(deserialized.metadata, :traceparent)
       refute Map.has_key?(deserialized.metadata, :tracestate)
     end
+
+    # Dropping is what makes a retired key safe. `criticality` was removed in #1326
+    # and no module holds that atom any more, so atomizing whatever arrives would
+    # raise on every row an earlier release staged — in `execute/1` and again in
+    # `compensate/2`, losing the event with no `undelivered_events` row to find it by.
+    # Whatever is retired next is covered without a second shim.
+    #
+    # These strings are load-bearing: an atom literal anywhere in the suite creates
+    # the atom for the whole run, and these would then pass for a reason production
+    # does not have.
+    for key <- ["criticality", "some_future_retired_key"] do
+      test "drops #{key}, which the format does not define" do
+        args = legacy_args(%{unquote(key) => "critical"})
+
+        assert CriticalEventSerializer.deserialize(args).metadata == %{}
+      end
+    end
+  end
+
+  # A serialized event whose metadata is replaced wholesale, then pushed through JSON
+  # — the shape `EventDeliveryWorker` reads out of `oban_jobs.args`.
+  defp legacy_args(metadata) do
+    :test
+    |> Event.new(:test_context, :test, "id", %{})
+    |> CriticalEventSerializer.serialize()
+    |> Map.put("metadata", metadata)
+    |> Jason.encode!()
+    |> Jason.decode!()
   end
 
   # Jason.encode!/decode! is not ceremony: without it the test compares two in-memory

--- a/test/klass_hero/shared/adapters/driven/workers/event_delivery_worker_test.exs
+++ b/test/klass_hero/shared/adapters/driven/workers/event_delivery_worker_test.exs
@@ -54,6 +54,18 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorkerTest do
     }
   end
 
+  # A row staged before #1326: its metadata still carries `"criticality"`. No module
+  # holds that atom any more, so a serializer that atomized whatever arrived would
+  # raise on this — here, and again in `compensate/2`, losing the event with no
+  # `undelivered_events` row to find it by. Both routes are covered because the
+  # second is the one nothing else would have caught.
+  defp legacy_job(events) do
+    job = job(events)
+    staged = Enum.map(job.args["events"], &Map.put(&1, "metadata", %{"criticality" => "critical"}))
+
+    %{job | args: %{"events" => staged}}
+  end
+
   defp handler_ref(consumer), do: CriticalEventDispatcher.handler_ref(consumer)
 
   defp mark_processed(event, consumer) do
@@ -74,6 +86,14 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorkerTest do
     assert :ok = EventDeliveryWorker.perform(job([event("thing-1")]))
 
     assert [{:first, "thing-1"}, {:second, "thing-1"}] = Recorder.calls()
+  end
+
+  test "delivers a job staged before the criticality field was removed", ctx do
+    route([{Recorder, :first}], ctx)
+
+    assert :ok = EventDeliveryWorker.perform(legacy_job([event("thing-1")]))
+
+    assert [{:first, "thing-1"}] = Recorder.calls()
   end
 
   test "delivers a job's events in the order they were staged", ctx do
@@ -161,6 +181,15 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorkerTest do
       assert row.job_id == 4242
       assert row.discarded_at
       assert row.missed_consumers == [handler_ref({Recorder, :first}), handler_ref({Recorder, :second})]
+    end
+
+    test "records a job staged before the criticality field was removed", ctx do
+      route([{Recorder, :first}], ctx)
+      event = event("thing-1")
+
+      assert :ok = EventDeliveryWorker.compensate(legacy_job([event]), "boom")
+
+      assert undelivered(event).missed_consumers == [handler_ref({Recorder, :first})]
     end
 
     # Replay hands these args straight back to the worker, so the whole envelope has

--- a/test/klass_hero/shared/domain/events/payload_guard_test.exs
+++ b/test/klass_hero/shared/domain/events/payload_guard_test.exs
@@ -85,20 +85,13 @@ defmodule KlassHero.Shared.Domain.Events.PayloadGuardTest do
     end
   end
 
-  # The guard used to run for `:critical` events only, on the reasoning that a
-  # `:normal` event was never serialized. ADR-0014 ended that — every staged event
-  # takes the same Outbox → Oban → EventDeliveryWorker path — and both of #1311's
-  # production bugs sat in the gap it left.
-  describe "the guard runs regardless of criticality" do
-    for criticality <- [:critical, :normal] do
-      test "rejects an unencodable value on a #{criticality} event" do
-        assert_raise ArgumentError, ~r/cannot survive jsonb serialization/, fn ->
-          build(%{coord: {1, 2}}, criticality: unquote(criticality))
-        end
-      end
-    end
-
-    test "rejects an unencodable value when criticality is unset" do
+  # The guard used to run for events marked critical only, on the reasoning that an
+  # unmarked one was never serialized. ADR-0014 ended that — every staged event takes
+  # the same Outbox → Oban → EventDeliveryWorker path — and both of #1311's production
+  # bugs sat in the gap it left. #1326 then removed the marker itself, so there is one
+  # kind of event and one rule for it.
+  describe "the guard is ungated" do
+    test "rejects an unencodable value on any event" do
       assert_raise ArgumentError, ~r/cannot survive jsonb serialization/, fn ->
         Event.new(:test_event, :test_context, :test, "agg-1", %{coord: {1, 2}})
       end

--- a/test/klass_hero/shared/tracing/context_test.exs
+++ b/test/klass_hero/shared/tracing/context_test.exs
@@ -59,7 +59,7 @@ defmodule KlassHero.Shared.Tracing.ContextTest.Helpers do
   def attach_with_mixed_keys_in_child_span do
     span "parent.operation" do
       context = Context.inject()
-      mixed = Map.put(context, :criticality, :critical)
+      mixed = Map.put(context, :correlation_id, "corr-1")
 
       task =
         Task.async(fn ->


### PR DESCRIPTION
Closes #1326.

## What

`criticality` stopped selecting anything when ADR-0014 collapsed the two-tier event model — every staged event takes the same Outbox → Oban → `EventDeliveryWorker` route. Its last reader was the payload guard, which PR #1325 ungated once #1317 taught the codec to record atoms. Verified: no production code called `criticality/1` or `critical?/1`.

## Review focus — the part the issue did not scope

`criticality` was on the wire, not just in memory. `serialize_metadata/1` wrote `"criticality" => "critical"` into `oban_jobs.args` for **every** staged event.

Deleting `@atom_metadata_values ~w(criticality)` as the issue described would make a legacy row fall through to the generic clause, `String.to_existing_atom("criticality")` — which raises once no module holds that atom. That hits two call sites:

- `EventDeliveryWorker.execute/1` — job raises, retries 10× (~4.5h), discards. Event never delivered.
- `EventDeliveryWorker.compensate/2` — same args, same raise, so it cannot even dead-letter the row into `undelivered_events`.

Window: any job staged pre-deploy, plus anything mid-retry across the backoff ladder.

So `deserialize_metadata/1` is now a **closed allowlist** — `correlation_id`/`causation_id` restored to atoms, W3C trace headers passed through as strings, everything else dropped. A legacy `"criticality"` key is handled by not being on either list. No dated shim, no follow-up ticket, and whatever is retired next is covered for free.

Rejected alternatives: a dated `@retired_metadata_keys` shim (needs a second PR to delete) and an atomize-if-known-else-keep-binary fallback (never signals wire drift).

## Also

Strips the 19 bare `(critical)` doc markers across the four factory modules — they asserted a distinction that no longer exists. Prose that carries real meaning is kept (e.g. "Part of the GDPR deletion cascade, so it must not be lost"). ADR-0014 gets an amendment note.

## Test plan

- `MIX_TEST_PARTITION=1326 mix precommit` — **4337 passed**, credo clean, all five linters pass, zero warnings.
- New regression tests, both routes of the deploy-window failure:
  - `critical_event_serializer_test.exs` — tabular test that an undefined metadata key is dropped
  - `event_delivery_worker_test.exs` — a job whose args carry pre-#1326 metadata both **delivers** (`perform/1`) and **compensates** (`compensate/2`)
- **Non-vacuity checks**, because these tests could silently pass for the wrong reason:
  - `grep -rn ":criticality" lib test priv config` returns nothing — an atom literal anywhere in the suite would create the atom for the whole run
  - confirmed at runtime in the loaded app that `String.to_existing_atom("criticality")` raises, so the pre-fix serializer really would have failed on every legacy row

## Not in scope

- Renaming `CriticalEventDispatcher` / `CriticalEventSerializer` / the `:critical_events` queue — the queue rename is its own in-flight-job migration.
- `Tracing.Context.inject_into_event/1`, which this work found has no production caller.