### PR TITLE
refactor: make conversation_type an Ecto.Enum end to end

### DIFF
--- a/lib/klass_hero/messaging.ex
+++ b/lib/klass_hero/messaging.ex
@@ -1057,7 +1057,7 @@ defmodule KlassHero.Messaging do
               id: Ecto.UUID.generate(),
               conversation_id: conversation_id,
               user_id: user_id,
-              conversation_type: to_string(conversation.type),
+              conversation_type: conversation.type,
               provider_id: conversation.provider_id,
               subject: conversation.subject,
               system_notes: token_json,

--- a/lib/klass_hero/messaging/adapters/driven/projections/conversation_summaries.ex
+++ b/lib/klass_hero/messaging/adapters/driven/projections/conversation_summaries.ex
@@ -226,10 +226,10 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries 
     participant_count = length(active_participants)
 
     other_name =
-      resolve_other_participant_name(
+      resolve_other_name(
         conversation.type,
         participant.user_id,
-        active_participants,
+        Enum.map(active_participants, & &1.user_id),
         user_names
       )
 
@@ -242,7 +242,7 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries 
       id: Ecto.UUID.generate(),
       conversation_id: conversation.id,
       user_id: participant.user_id,
-      conversation_type: to_string(conversation.type),
+      conversation_type: conversation.type,
       provider_id: conversation.provider_id,
       program_id: conversation.program_id,
       subject: conversation.subject,
@@ -269,7 +269,7 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries 
     payload = event.payload
     conversation_id = payload.conversation_id
     participant_ids = Map.get(payload, :participant_ids, [])
-    conversation_type = payload |> Map.get(:type, "direct") |> to_string()
+    conversation_type = Map.get(payload, :type, :direct)
     provider_id = Map.get(payload, :provider_id)
     program_id = Map.get(payload, :program_id)
     subject = Map.get(payload, :subject)
@@ -282,7 +282,7 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries 
     Repo.transaction(fn ->
       Enum.each(participant_ids, fn user_id ->
         other_name =
-          resolve_other_name_from_ids(
+          resolve_other_name(
             conversation_type,
             user_id,
             participant_ids,
@@ -591,7 +591,7 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries 
   # Private Functions — System Note Projection
 
   defp maybe_project_system_note(%{message_type: message_type, content: content} = payload)
-       when message_type in [:system, "system"] do
+       when message_type == :system do
     conversation_id = payload.conversation_id
 
     case Regex.run(@broadcast_token_regex, content || "") do
@@ -666,29 +666,23 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries 
     ProgramCatalog.get_titles(program_ids)
   end
 
-  defp resolve_program_name("program_broadcast", program_id) when not is_nil(program_id) do
+  defp resolve_program_name(:program_broadcast, program_id) when not is_nil(program_id) do
     [program_id] |> fetch_program_names() |> Map.get(program_id)
   end
 
   defp resolve_program_name(_type, _program_id), do: nil
 
-  defp resolve_other_participant_name(:direct, user_id, participants, user_names) do
-    case Enum.find(participants, fn p -> p.user_id != user_id end) do
-      nil -> nil
-      other -> Map.get(user_names, other.user_id)
-    end
-  end
-
-  defp resolve_other_participant_name(_type, _user_id, _participants, _user_names), do: nil
-
-  defp resolve_other_name_from_ids("direct", user_id, participant_ids, user_names) do
+  # Both the bootstrap and the event path land here. They used to be two functions
+  # keyed on different spellings of the same value — `:direct` from `conversation.type`,
+  # `"direct"` from the payload — which is the duplication #1327 removes.
+  defp resolve_other_name(:direct, user_id, participant_ids, user_names) do
     case Enum.find(participant_ids, fn id -> id != user_id end) do
       nil -> nil
       other_id -> Map.get(user_names, other_id)
     end
   end
 
-  defp resolve_other_name_from_ids(_type, _user_id, _participant_ids, _user_names), do: nil
+  defp resolve_other_name(_type, _user_id, _participant_ids, _user_names), do: nil
 
   # Subquery avoids loading N×M rows via :messages preload.
   defp fetch_latest_messages(conversation_ids) when conversation_ids != [] do

--- a/lib/klass_hero/messaging/adapters/driven/projections/enrolled_children.ex
+++ b/lib/klass_hero/messaging/adapters/driven/projections/enrolled_children.ex
@@ -227,9 +227,8 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildren do
   defp project_conversation_created(event) do
     payload = event.payload
     program_id = Map.get(payload, :program_id)
-    conversation_type = payload |> Map.get(:type, "direct") |> to_string()
 
-    if conversation_type == "direct" and program_id do
+    if Map.get(payload, :type, :direct) == :direct and program_id do
       emit_enrolled_children_for_direct_participants(
         payload.conversation_id,
         Map.get(payload, :participant_ids, []),
@@ -256,7 +255,7 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildren do
         where:
           s.user_id == ^parent_user_id and
             s.program_id == ^program_id and
-            s.conversation_type == "direct",
+            s.conversation_type == ^:direct,
         select: s.conversation_id,
         distinct: true
       )

--- a/lib/klass_hero/messaging/conversation_summary.ex
+++ b/lib/klass_hero/messaging/conversation_summary.ex
@@ -17,7 +17,7 @@ defmodule KlassHero.Messaging.ConversationSummary do
   schema "conversation_summaries" do
     field :conversation_id, :binary_id
     field :user_id, :binary_id
-    field :conversation_type, :string
+    field :conversation_type, Ecto.Enum, values: [:direct, :program_broadcast]
     field :provider_id, :binary_id
     field :program_id, :binary_id
     field :subject, :string
@@ -41,7 +41,7 @@ defmodule KlassHero.Messaging.ConversationSummary do
           id: String.t(),
           conversation_id: String.t(),
           user_id: String.t(),
-          conversation_type: String.t() | nil,
+          conversation_type: :direct | :program_broadcast | nil,
           provider_id: String.t(),
           program_id: String.t() | nil,
           subject: String.t() | nil,

--- a/lib/klass_hero/messaging/list_conversations.ex
+++ b/lib/klass_hero/messaging/list_conversations.ex
@@ -52,7 +52,7 @@ defmodule KlassHero.Messaging.ListConversations do
     %{
       conversation: %{
         id: summary.conversation_id,
-        type: parse_conversation_type(summary.conversation_type),
+        type: summary.conversation_type,
         provider_id: summary.provider_id,
         program_id: summary.program_id,
         subject: summary.subject
@@ -64,17 +64,6 @@ defmodule KlassHero.Messaging.ListConversations do
       program_name: summary.program_name,
       enrolled_child_names: summary.enrolled_child_names
     }
-  end
-
-  defp parse_conversation_type("direct"), do: :direct
-  defp parse_conversation_type("program_broadcast"), do: :program_broadcast
-
-  defp parse_conversation_type(unknown) do
-    Logger.warning("[ListConversations] Unknown conversation_type in read model",
-      conversation_type: unknown
-    )
-
-    :direct
   end
 
   defp build_latest_message(%{latest_message_content: nil, has_attachments: false}), do: nil

--- a/test/klass_hero/messaging/adapters/driven/projections/conversation_summaries_test.exs
+++ b/test/klass_hero/messaging/adapters/driven/projections/conversation_summaries_test.exs
@@ -739,6 +739,50 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummariesT
     end
   end
 
+  # `:conversation_created` was the one event with no outbox round-trip: every other
+  # call site here builds the %Event{} in memory, so `:type` crossing serialization was
+  # never exercised. Both denormalised names are asserted alongside the type because a
+  # resolver keyed on the wrong form of `:type` falls to its catch-all and returns nil
+  # rather than failing — that is bug #892's shape.
+  @created_type_cases [
+    {:direct, nil, "Bob Jones"},
+    {:program_broadcast, "Forest Friends", nil}
+  ]
+
+  describe "conversation_created crossing the outbox boundary" do
+    for {type, expected_program_name, expected_other_name} <- @created_type_cases do
+      test "#{type} survives serialization and still resolves its names" do
+        type = unquote(type)
+        expected_program_name = unquote(expected_program_name)
+        expected_other_name = unquote(expected_other_name)
+
+        provider = insert(:provider_profile_schema)
+        program = insert(:program_schema, provider_id: provider.id, title: "Forest Friends")
+        user_1 = user_fixture(name: "Alice Smith")
+        user_2 = user_fixture(name: "Bob Jones")
+        conversation_id = Ecto.UUID.generate()
+
+        MessagingEvents.conversation_created(
+          conversation_id,
+          type,
+          provider.id,
+          [user_1.id, user_2.id],
+          program.id
+        )
+        |> through_outbox()
+        |> dispatch()
+
+        summary = summary_for(conversation_id, user_1.id)
+
+        assert summary.conversation_type == type,
+               "expected #{inspect(type)} to survive the outbox, got #{inspect(summary.conversation_type)}"
+
+        assert summary.program_name == expected_program_name
+        assert summary.other_participant_name == expected_other_name
+      end
+    end
+  end
+
   describe "handle messages_read event" do
     test "sets unread_count to 0 and updates last_read_at for the user" do
       user_1 = user_fixture(name: "Alice Smith")

--- a/test/klass_hero/messaging/adapters/driven/projections/conversation_summaries_test.exs
+++ b/test/klass_hero/messaging/adapters/driven/projections/conversation_summaries_test.exs
@@ -63,7 +63,7 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummariesT
         )
 
       assert summary_1 != nil
-      assert summary_1.conversation_type == "direct"
+      assert summary_1.conversation_type == :direct
       assert summary_1.provider_id == provider.id
       assert summary_1.other_participant_name == "Bob Jones"
       assert summary_1.participant_count == 2
@@ -209,7 +209,7 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummariesT
         Repo.all(from(s in ConversationSummary, where: s.conversation_id == ^conversation_id))
 
       assert length(summaries) == 2
-      assert Enum.all?(summaries, &(&1.conversation_type == "program_broadcast"))
+      assert Enum.all?(summaries, &(&1.conversation_type == :program_broadcast))
       assert Enum.all?(summaries, &(&1.program_name == "Science Explorers"))
     end
   end
@@ -250,7 +250,7 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummariesT
       assert length(summaries) == 2
 
       summary_1 = Enum.find(summaries, &(&1.user_id == user_1.id))
-      assert summary_1.conversation_type == "direct"
+      assert summary_1.conversation_type == :direct
       assert summary_1.other_participant_name == "Bob Rebuild"
     end
   end
@@ -281,7 +281,7 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummariesT
         )
 
       assert summary_1 != nil
-      assert summary_1.conversation_type == "direct"
+      assert summary_1.conversation_type == :direct
       assert summary_1.provider_id == provider_id
       assert summary_1.other_participant_name == "Bob Jones"
       assert summary_1.participant_count == 2
@@ -328,7 +328,7 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummariesT
         )
 
       assert summary != nil
-      assert summary.conversation_type == "program_broadcast"
+      assert summary.conversation_type == :program_broadcast
       assert summary.program_name == nil
     end
 
@@ -359,7 +359,7 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummariesT
         Repo.all(from(s in ConversationSummary, where: s.conversation_id == ^conversation_id))
 
       assert length(summaries) == 2
-      assert Enum.all?(summaries, &(&1.conversation_type == "program_broadcast"))
+      assert Enum.all?(summaries, &(&1.conversation_type == :program_broadcast))
       assert Enum.all?(summaries, &(&1.program_name == "Forest Friends"))
     end
 
@@ -413,7 +413,7 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummariesT
              "unread_count must survive a :conversation_created replay"
 
       # Meta fields should still be in sync with the event payload
-      assert summary_1.conversation_type == "direct"
+      assert summary_1.conversation_type == :direct
       assert summary_1.provider_id == provider_id
       assert summary_1.other_participant_name == "Bob Jones"
       assert summary_1.participant_count == 2
@@ -997,7 +997,7 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummariesT
       assert length(staff_summaries) == 1
       staff_summary = hd(staff_summaries)
       assert staff_summary.conversation_id == conversation_id
-      assert staff_summary.conversation_type == "direct"
+      assert staff_summary.conversation_type == :direct
       assert staff_summary.participant_count == 3
 
       # Owner should have a summary row
@@ -1078,7 +1078,7 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummariesT
         )
 
       assert summary != nil, "staff summary row must exist after :participant_added"
-      assert summary.conversation_type == "direct"
+      assert summary.conversation_type == :direct
       assert summary.provider_id == provider.id
       assert summary.participant_count == 3
       assert summary.latest_message_content == "Hi there"
@@ -1175,7 +1175,7 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummariesT
 
       assert length(summaries) == 2
       assert Enum.all?(summaries, &(&1.participant_count == 3))
-      assert Enum.all?(summaries, &(&1.conversation_type == "direct"))
+      assert Enum.all?(summaries, &(&1.conversation_type == :direct))
     end
 
     test "inserts row for broadcast conversation with nil other_participant_name" do
@@ -1203,7 +1203,7 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummariesT
         )
 
       assert summary != nil
-      assert summary.conversation_type == "program_broadcast"
+      assert summary.conversation_type == :program_broadcast
       assert summary.other_participant_name == nil
     end
   end

--- a/test/klass_hero/messaging/adapters/driven/projections/enrolled_children_test.exs
+++ b/test/klass_hero/messaging/adapters/driven/projections/enrolled_children_test.exs
@@ -3,9 +3,12 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildrenTest d
 
   import Ecto.Query
   import ExUnit.CaptureLog
+  import KlassHero.EventTestHelper, only: [through_outbox: 1]
   import KlassHero.Factory
 
   alias KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildren
+  alias KlassHero.Messaging.ConversationSummary
+  alias KlassHero.Messaging.Domain.Events.MessagingEvents
   alias KlassHero.Messaging.EnrolledChild
   alias KlassHero.Repo
   alias KlassHero.Shared.Domain.Events.Event
@@ -114,6 +117,48 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildrenTest d
       assert row.child_first_name == "Emma"
     end
 
+    test "re-derivation stamps the names onto that parent's direct conversation summaries" do
+      # re_derive_and_emit/2 selects the summaries to stamp by conversation_type, and
+      # nothing asserted that hop before #1327 — the three callers all stopped at the
+      # messaging_enrolled_children rows.
+      user = user_fixture(name: "Sarah Johnson")
+      parent = insert(:parent_profile_schema, identity_id: user.id)
+      child = insert(:child_schema, first_name: "Emma", last_name: "Johnson")
+      insert(:child_guardian_schema, child_id: child.id, guardian_id: parent.id)
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+
+      direct_id = Ecto.UUID.generate()
+      broadcast_id = Ecto.UUID.generate()
+
+      for {conversation_id, type} <- [{direct_id, "direct"}, {broadcast_id, "program_broadcast"}] do
+        insert(:conversation_summary_schema,
+          conversation_id: conversation_id,
+          user_id: user.id,
+          program_id: program.id,
+          conversation_type: type,
+          enrolled_child_names: []
+        )
+      end
+
+      enrollment_id = Ecto.UUID.generate()
+
+      Event.new(:enrollment_created, :enrollment, :enrollment, enrollment_id, %{
+        enrollment_id: enrollment_id,
+        child_id: child.id,
+        parent_id: parent.id,
+        parent_user_id: user.id,
+        program_id: program.id,
+        status: "confirmed"
+      })
+      |> EnrolledChildren.project()
+
+      assert names_for(direct_id) == ["Emma"]
+
+      assert names_for(broadcast_id) == [],
+             "broadcasts carry :program_name, not per-parent child names"
+    end
+
     test "inserts row with nil child_first_name and logs warning when child row is missing" do
       user = user_fixture(name: "Unknown Parent")
       parent = insert(:parent_profile_schema, identity_id: user.id)
@@ -155,6 +200,56 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildrenTest d
 
       assert row != nil
       assert row.child_first_name == nil
+    end
+  end
+
+  # `project_conversation_created/1` had no test at all before #1327, and it branches on
+  # the payload's `:type` — the one field that changed form when atoms started surviving
+  # the outbox (#1317). Crossing the real serializer is the point: an in-memory %Event{}
+  # would not prove the branch still fires.
+  @conversation_type_cases [
+    {:direct, ["Emma"]},
+    {:program_broadcast, []}
+  ]
+
+  describe "handle conversation_created event" do
+    for {type, expected_names} <- @conversation_type_cases do
+      test "#{type} conversation stamps enrolled_child_names as #{inspect(expected_names)}" do
+        type = unquote(type)
+        expected_names = unquote(expected_names)
+
+        user = user_fixture(name: "Sarah Johnson")
+        provider = insert(:provider_profile_schema)
+        program = insert(:program_schema, provider_id: provider.id)
+        conversation_id = Ecto.UUID.generate()
+
+        Repo.insert!(%EnrolledChild{
+          parent_user_id: user.id,
+          program_id: program.id,
+          child_id: Ecto.UUID.generate(),
+          child_first_name: "Emma"
+        })
+
+        insert(:conversation_summary_schema,
+          conversation_id: conversation_id,
+          user_id: user.id,
+          program_id: program.id,
+          enrolled_child_names: []
+        )
+
+        MessagingEvents.conversation_created(
+          conversation_id,
+          type,
+          provider.id,
+          [user.id],
+          program.id
+        )
+        |> through_outbox()
+        |> EnrolledChildren.project()
+
+        assert names_for(conversation_id) == expected_names,
+               "#{inspect(type)} took the wrong branch in project_conversation_created/1"
+      end
     end
   end
 
@@ -206,5 +301,14 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildrenTest d
   # Helper to create users with specific names
   defp user_fixture(attrs) do
     KlassHero.AccountsFixtures.user_fixture(attrs)
+  end
+
+  defp names_for(conversation_id) do
+    Repo.one!(
+      from(s in ConversationSummary,
+        where: s.conversation_id == ^conversation_id,
+        select: s.enrolled_child_names
+      )
+    )
   end
 end

--- a/test/klass_hero/messaging/adapters/driven/projections/enrolled_children_test.exs
+++ b/test/klass_hero/messaging/adapters/driven/projections/enrolled_children_test.exs
@@ -131,7 +131,7 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildrenTest d
       direct_id = Ecto.UUID.generate()
       broadcast_id = Ecto.UUID.generate()
 
-      for {conversation_id, type} <- [{direct_id, "direct"}, {broadcast_id, "program_broadcast"}] do
+      for {conversation_id, type} <- [{direct_id, :direct}, {broadcast_id, :program_broadcast}] do
         insert(:conversation_summary_schema,
           conversation_id: conversation_id,
           user_id: user.id,

--- a/test/klass_hero/messaging/archive_conversations_delivery_test.exs
+++ b/test/klass_hero/messaging/archive_conversations_delivery_test.exs
@@ -39,7 +39,7 @@ defmodule KlassHero.Messaging.ArchiveConversationsDeliveryTest do
       insert(:conversation_summary_schema,
         conversation_id: conversation.id,
         user_id: user_id,
-        conversation_type: "program_broadcast",
+        conversation_type: :program_broadcast,
         provider_id: provider.id,
         program_id: program.id,
         archived_at: nil

--- a/test/klass_hero/messaging/get_total_unread_count_test.exs
+++ b/test/klass_hero/messaging/get_total_unread_count_test.exs
@@ -11,7 +11,7 @@ defmodule KlassHero.Messaging.GetTotalUnreadCountTest do
       id: Ecto.UUID.generate(),
       conversation_id: Ecto.UUID.generate(),
       user_id: Ecto.UUID.generate(),
-      conversation_type: "direct",
+      conversation_type: :direct,
       provider_id: Ecto.UUID.generate(),
       program_id: nil,
       subject: nil,

--- a/test/klass_hero/messaging/list_conversations_test.exs
+++ b/test/klass_hero/messaging/list_conversations_test.exs
@@ -11,7 +11,7 @@ defmodule KlassHero.Messaging.ListConversationsTest do
       id: Ecto.UUID.generate(),
       conversation_id: Ecto.UUID.generate(),
       user_id: Ecto.UUID.generate(),
-      conversation_type: "direct",
+      conversation_type: :direct,
       provider_id: Ecto.UUID.generate(),
       program_id: nil,
       subject: nil,

--- a/test/klass_hero/messaging/messaging_integration_test.exs
+++ b/test/klass_hero/messaging/messaging_integration_test.exs
@@ -70,7 +70,7 @@ defmodule KlassHero.Messaging.MessagingIntegrationTest do
       insert_conversation_summary(%{
         conversation_id: conversation.id,
         user_id: parent_user.id,
-        conversation_type: "direct",
+        conversation_type: :direct,
         provider_id: provider.id,
         other_participant_name: "Test Provider",
         latest_message_content: msg3.content,
@@ -111,7 +111,7 @@ defmodule KlassHero.Messaging.MessagingIntegrationTest do
       insert_conversation_summary(%{
         conversation_id: conversation.id,
         user_id: parent_user.id,
-        conversation_type: "direct",
+        conversation_type: :direct,
         provider_id: provider.id,
         other_participant_name: "Test Provider",
         latest_message_content: "Hello parent!",
@@ -177,7 +177,7 @@ defmodule KlassHero.Messaging.MessagingIntegrationTest do
         insert_conversation_summary(%{
           conversation_id: conversation.id,
           user_id: parent_identity_id,
-          conversation_type: "program_broadcast",
+          conversation_type: :program_broadcast,
           provider_id: provider.id,
           program_id: program.id,
           subject: "Schedule Update",
@@ -219,7 +219,7 @@ defmodule KlassHero.Messaging.MessagingIntegrationTest do
       id: Ecto.UUID.generate(),
       conversation_id: Ecto.UUID.generate(),
       user_id: Ecto.UUID.generate(),
-      conversation_type: "direct",
+      conversation_type: :direct,
       provider_id: Ecto.UUID.generate(),
       program_id: nil,
       subject: nil,

--- a/test/klass_hero_web/live/messages_live/index_test.exs
+++ b/test/klass_hero_web/live/messages_live/index_test.exs
@@ -122,7 +122,7 @@ defmodule KlassHeroWeb.MessagesLive.IndexTest do
       id: Ecto.UUID.generate(),
       conversation_id: Ecto.UUID.generate(),
       user_id: Ecto.UUID.generate(),
-      conversation_type: "direct",
+      conversation_type: :direct,
       provider_id: Ecto.UUID.generate(),
       program_id: nil,
       subject: nil,

--- a/test/klass_hero_web/live/provider/messages_live/index_test.exs
+++ b/test/klass_hero_web/live/provider/messages_live/index_test.exs
@@ -88,7 +88,7 @@ defmodule KlassHeroWeb.Provider.MessagesLive.IndexTest do
       id: Ecto.UUID.generate(),
       conversation_id: Ecto.UUID.generate(),
       user_id: Ecto.UUID.generate(),
-      conversation_type: "direct",
+      conversation_type: :direct,
       provider_id: Ecto.UUID.generate(),
       program_id: nil,
       subject: nil,

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1230,7 +1230,7 @@ defmodule KlassHero.Factory do
       id: Ecto.UUID.generate(),
       conversation_id: Ecto.UUID.generate(),
       user_id: Ecto.UUID.generate(),
-      conversation_type: "direct",
+      conversation_type: :direct,
       provider_id: Ecto.UUID.generate(),
       program_id: nil,
       subject: nil,


### PR DESCRIPTION
Closes #1327.

## Summary

#1327 asked to delete two dual-form payload matches in `ConversationSummaries` that #1317 made dead. One of them turned out to be load-bearing, and tracing why led one layer down to the actual cause.

`conversation_summaries.conversation_type` was declared `:string`, while the domain, the event payload, and `ListConversations`' output all spoke `:direct` / `:program_broadcast`. Every translation around it existed to bridge that one declaration:

- two `to_string/1` calls on the write side (the projection's event path and bootstrap, plus `write_system_note_token/2`'s seed insert), and
- `ListConversations.parse_conversation_type/1` converting it straight back — with a catch-all that degraded an unrecognised value to `:direct`, so a broadcast would have rendered as a direct conversation.

Declaring the field `Ecto.Enum, values: [:direct, :program_broadcast]` moves the dump/load to the column, where the form actually changes, and all of them go.

**No migration.** The column stays `varchar`, matching `Conversation.type`, which has always been a string-backed `Ecto.Enum` over the same column type.

## Review focus

**Why `:272`'s `to_string/1` could not simply be deleted** — the issue's step 2. It was doing two jobs, and dropping it would have shipped one crash plus two silent regressions:

| Consequence | Failure mode |
|---|---|
| atom into a `:string` field via `Changeset.change/2` + `insert!` (`change/2` does not cast) | `Ecto.ChangeError` |
| `resolve_program_name("program_broadcast", …)` never matches an atom | `program_name: nil` on every broadcast — **silent** |
| `resolve_other_name_from_ids("direct", …)` never matches an atom | `other_participant_name: nil` on every direct — **silent**, a #892 regression |

**The resolver fold.** With the atom reaching the resolvers, `resolve_other_participant_name/4` (bootstrap, atom-keyed, participant structs) and `resolve_other_name_from_ids/4` (event path, string-keyed, bare ids) become one `resolve_other_name/4`. They were the same decision spelled twice — which is how the two spellings drifted in the first place.

**`^:direct` in `enrolled_children.ex`.** Ecto does not cast a bare string literal against an `Ecto.Enum` field in a query; it raises `Ecto.QueryError` and tells you to interpolate. The new `re_derive_and_emit/2` test is what surfaced this.

**Safety of the load.** Prod holds exactly `direct` (60) and `program_broadcast` (59) — no stray values, so the `Ecto.Enum` load cannot raise on existing rows. Losing `parse_conversation_type/1`'s fallback is deliberate: only `Conversation.type` (itself `Ecto.Enum`-constrained) ever feeds this column, so the fallback was unreachable, and its silent-default behaviour was worse than failing.

Commit 3 (`test: spell conversation_type as an atom`) is mechanical churn forced by the field type — safe to skim.

## Test plan

Coverage gaps closed **first**, before the change:

- `:conversation_created` was never dispatched through `through_outbox/1` anywhere in the suite — every call site built the `%Event{}` in memory, so `:type` crossing serialization had no coverage. Two new cases assert the type **and** both denormalised names, since a resolver missing its match returns `nil` rather than failing.
- `project_conversation_created/1` in `EnrolledChildren` had no test at all.
- `re_derive_and_emit/2`'s hop onto `conversation_summaries` was unasserted from all three of its callers.

The two `conversation_summaries` cases fail on the pre-change schema (commit 1), which is the red this was driven from.

- `mix precommit` green: 4345 tests, credo clean, `lint_read_tables` confirms the `Ecto.Enum` field does not trip the read-table no-changeset rule.
- Browser-verified on seeded data (a user with one direct + two broadcasts): the direct row renders `other_participant_name`, both broadcasts render `program_name` and the Broadcast badge. Those are exactly the fields a wrongly-keyed resolver would blank, and the badge proves the atom still reaches the component through `ListConversations`.

## Out of scope

`ListConversations.to_enriched_map/1` is a mapper over a read table, which bends `Shared.ReadTable` rule 2. This removes the type translation from it but not the nested `%{conversation: %{…}}` reshape — worth its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
