### PR TITLE
docs: repair the staff_member_deactivated moduledoc bullet

### DIFF
--- a/lib/klass_hero/provider/domain/events/provider_events.ex
+++ b/lib/klass_hero/provider/domain/events/provider_events.ex
@@ -17,9 +17,9 @@ defmodule KlassHero.Provider.Domain.Events.ProviderEvents do
     `staff_assigned_to_program` is **also replayed on invite acceptance**, once per
     standing assignment: a program assigned before the invite was claimed announced
     a nil `staff_user_id`, which consumers skip (#1312).
-  - `staff_member_deactivated` - A staff member's employment link ended
-   . Read tables holding a denormalised staff name clear it; a read
-    filter cannot, because the name is a stored column.
+  - `staff_member_deactivated` - A staff member's employment link ended. Read
+    tables holding a denormalised staff name clear it; a read filter cannot,
+    because the name is a stored column.
 
   The staff assignment events carry the **staff member** as their entity, not
   the assignment row: consumers key on who was assigned, not on which row


### PR DESCRIPTION
Follow-up to #1354, which merged while the review pass was still running.

#1354 stripped the 19 bare `(critical)` doc markers with a `sed` rule. Where the marker sat mid-sentence rather than at the end, removing it left the sentence's period stranded on its own line:

```
- `staff_member_deactivated` - A staff member's employment link ended
 . Read tables holding a denormalised staff name clear it; a read
  filter cannot, because the name is a stored column.
```

Rewraps the bullet. No code change, no behaviour change.

Caught independently by both the architecture and regression review agents on #1354's branch, after that PR had already merged.

## Test plan

`MIX_TEST_PARTITION=1326 mix precommit` — 4337 passed, credo clean, all linters pass, zero warnings (run on the same tree before the branch was recreated off main).