### PR TITLE
fix: run a compensation once per job, and never against a resent invite

### DIFF
--- a/lib/klass_hero/enrollment.ex
+++ b/lib/klass_hero/enrollment.ex
@@ -1106,31 +1106,68 @@ defmodule KlassHero.Enrollment do
   `BulkEnrollmentInvite.describe_failure/2`); callers keep logging it themselves for
   diagnostics, which is where an unmapped term belongs.
 
-  `{:error, :already_terminal}` is the expected outcome of compensating twice — inline
-  on a worker's last attempt, then again from the compensation sweep over the same
-  discarded job — and callers translate it to `:ignore` rather than retrying.
+  `{:error, :already_terminal}` means something else already settled this invite, and
+  callers translate it to `:ignore` rather than retrying.
+
+  Use `fail_invite/3` from anything speaking for a dead Oban job; this arity applies no
+  staleness check and is for callers acting on the invite's present, not its past.
   """
   @spec fail_invite(binary(), term()) ::
           {:ok, BulkEnrollmentInvite.t()} | {:error, :not_found | :already_terminal}
   def fail_invite(invite_id, reason) when is_binary(invite_id) do
-    case Repo.get(BulkEnrollmentInvite, invite_id) do
-      nil ->
-        {:error, :not_found}
+    with {:ok, invite} <- fetch_invite_to_fail(invite_id), do: apply_failure(invite, reason)
+  end
 
-      invite ->
-        invite
-        |> BulkEnrollmentInvite.transition_changeset(%{
-          status: :failed,
-          error_details: BulkEnrollmentInvite.describe_failure(invite, reason)
-        })
-        |> Repo.update()
-        |> case do
-          {:ok, failed} -> {:ok, failed}
-          # `@valid_transitions` admits `:failed` only from a live status, so a rejection
-          # here means something already settled this invite. Collapsed rather than
-          # reported field-by-field: no caller can act on the difference.
-          {:error, %Ecto.Changeset{}} -> {:error, :already_terminal}
-        end
+  @doc """
+  Same, but refuses to fail an invite the provider resent after `enqueued_at`.
+
+  A compensation speaks for a job that is already dead, so between that job's death and
+  the compensation running, the provider may have resent the invite — and
+  `@valid_transitions` admits `failed: [:pending]`, so nothing else rejects a second
+  failure. The result was a resend reverting to Failed under a reason copied from the
+  dead job (#1339).
+
+  `enqueued_at` is the job's `inserted_at`. Equality still compensates: a resend and the
+  job it enqueues are written by one transaction, so the invite's own job must not read
+  as stale against it. That relies on `EnqueueInviteEmails` stamping `inserted_at`
+  itself — the column's `now()` default would report transaction start, which precedes
+  the reset in the same transaction.
+  """
+  @spec fail_invite(binary(), term(), DateTime.t()) ::
+          {:ok, BulkEnrollmentInvite.t()} | {:error, :not_found | :already_terminal | :superseded}
+  def fail_invite(invite_id, reason, %DateTime{} = enqueued_at) when is_binary(invite_id) do
+    with {:ok, invite} <- fetch_invite_to_fail(invite_id),
+         :ok <- ensure_not_resent_since(invite, enqueued_at) do
+      apply_failure(invite, reason)
+    end
+  end
+
+  defp fetch_invite_to_fail(invite_id) do
+    case Repo.get(BulkEnrollmentInvite, invite_id) do
+      nil -> {:error, :not_found}
+      invite -> {:ok, invite}
+    end
+  end
+
+  defp ensure_not_resent_since(%BulkEnrollmentInvite{resent_at: nil}, _enqueued_at), do: :ok
+
+  defp ensure_not_resent_since(%BulkEnrollmentInvite{resent_at: resent_at}, enqueued_at) do
+    if DateTime.after?(resent_at, enqueued_at), do: {:error, :superseded}, else: :ok
+  end
+
+  defp apply_failure(invite, reason) do
+    invite
+    |> BulkEnrollmentInvite.transition_changeset(%{
+      status: :failed,
+      error_details: BulkEnrollmentInvite.describe_failure(invite, reason)
+    })
+    |> Repo.update()
+    |> case do
+      {:ok, failed} -> {:ok, failed}
+      # `@valid_transitions` admits `:failed` only from a live status, so a rejection
+      # here means something already settled this invite. Collapsed rather than
+      # reported field-by-field: no caller can act on the difference.
+      {:error, %Ecto.Changeset{}} -> {:error, :already_terminal}
     end
   end
 
@@ -1157,8 +1194,17 @@ defmodule KlassHero.Enrollment do
         {:error, :not_found}
 
       invite ->
+        # `resent_at` is the watermark every compensation for this invite is measured
+        # against, so it must be stamped here — this is the one place the provider
+        # reopens an invite the state machine had settled (#1339).
         invite
-        |> Ecto.Changeset.change(%{status: :pending, invite_token: nil, invite_sent_at: nil, error_details: nil})
+        |> Ecto.Changeset.change(%{
+          status: :pending,
+          invite_token: nil,
+          invite_sent_at: nil,
+          error_details: nil,
+          resent_at: DateTime.utc_now()
+        })
         |> Repo.update()
     end
   end

--- a/lib/klass_hero/enrollment/adapters/driving/workers/send_invite_email_worker.ex
+++ b/lib/klass_hero/enrollment/adapters/driving/workers/send_invite_email_worker.ex
@@ -128,18 +128,25 @@ defmodule KlassHero.Enrollment.Adapters.Driving.Workers.SendInviteEmailWorker do
   # not the missing token, and the token is read off the row, so tagging here cannot
   # mislabel a tokenless invite. It survives the sweep, which arrives with `nil` for a
   # Lifeline discard and could not otherwise tell the two apart.
+  #
+  # `inserted_at` is passed so the invite can reject a compensation it has moved past: a
+  # provider resending between this job's death and the compensation running would
+  # otherwise see their resend revert to Failed under this job's stale reason (#1339).
+  # `:superseded` joins `:already_terminal` in the `:ignore` arm — both are facts a later
+  # sweep cannot improve on.
   @impl true
-  def compensate(%Oban.Job{args: %{"invite_id" => invite_id}}, reason) when is_binary(invite_id) do
-    case Enrollment.fail_invite(invite_id, {:delivery, reason}) do
+  def compensate(%Oban.Job{args: %{"invite_id" => invite_id}, inserted_at: %DateTime{} = enqueued_at}, reason)
+      when is_binary(invite_id) do
+    case Enrollment.fail_invite(invite_id, {:delivery, reason}, enqueued_at) do
       {:ok, _invite} -> :ok
       {:error, _reason} -> :ignore
     end
   end
 
-  # Unreachable from the enqueue path, which only ever writes a binary `invite.id`. Guarded
-  # anyway because the sweep calls this with whatever the job row holds, and a raise here
-  # escapes its `Enum.each` and abandons the rest of the batch — every worker's, not just this
-  # one's.
+  # Unreachable on both counts: the enqueue path only ever writes a binary `invite.id`, and
+  # `oban_jobs.inserted_at` is `null: false`. Guarded anyway because the sweep calls this
+  # with whatever the job row holds, and `:ignore` is the safe direction — it retires the
+  # job without writing a failure this clause has no watermark to justify.
   def compensate(%Oban.Job{}, _reason), do: :ignore
 
   # Reads URL config at runtime — referencing KlassHeroWeb.Endpoint directly would violate boundary rules.

--- a/lib/klass_hero/enrollment/bulk_enrollment_invite.ex
+++ b/lib/klass_hero/enrollment/bulk_enrollment_invite.ex
@@ -51,6 +51,12 @@ defmodule KlassHero.Enrollment.BulkEnrollmentInvite do
     field :enrollment_id, :binary_id
     field :error_details, :string
 
+    # When the provider last reopened this invite. Compared against an Oban job's
+    # `inserted_at` to tell a compensation whether the job it speaks for still describes
+    # this invite — `failed: [:pending]` means a resend can undo a compensation, so a
+    # dead job must not silently redo it (#1339). `nil` means never resent.
+    field :resent_at, :utc_datetime_usec
+
     timestamps()
   end
 
@@ -83,7 +89,7 @@ defmodule KlassHero.Enrollment.BulkEnrollmentInvite do
     failed: [:pending]
   }
 
-  @lifecycle_fields ~w(status invite_token invite_sent_at registered_at enrolled_at enrollment_id error_details)a
+  @lifecycle_fields ~w(status invite_token invite_sent_at registered_at enrolled_at enrollment_id error_details resent_at)a
 
   def valid_transitions, do: @valid_transitions
 

--- a/lib/klass_hero/enrollment/enqueue_invite_emails.ex
+++ b/lib/klass_hero/enrollment/enqueue_invite_emails.ex
@@ -67,12 +67,20 @@ defmodule KlassHero.Enrollment.EnqueueInviteEmails do
 
   defp insert_jobs([]), do: :ok
 
+  # `inserted_at` is set here rather than left to the column's `now()` default, which
+  # Postgres freezes at *transaction start*. A resend resets the invite and enqueues its
+  # email in one transaction (`Enrollment.resend_invite/2`), so the default would stamp
+  # every resend's job as older than the `resent_at` that same transaction goes on to
+  # write — and `fail_invite/3` would then read the resend's own job as superseded and
+  # skip its compensation entirely (#1339). Both clocks have to be the same clock.
   defp insert_jobs(pairs) do
+    enqueued_at = DateTime.utc_now()
+
     jobs =
       Enum.map(pairs, fn {invite_id, program_name} ->
         %{invite_id: invite_id, program_name: program_name}
         |> Context.inject_into_args()
-        |> SendInviteEmailWorker.new()
+        |> SendInviteEmailWorker.new(inserted_at: enqueued_at)
       end)
 
     Oban.insert_all(jobs)

--- a/lib/klass_hero/family/adapters/driving/workers/process_invite_claim_worker.ex
+++ b/lib/klass_hero/family/adapters/driving/workers/process_invite_claim_worker.ex
@@ -42,9 +42,15 @@ defmodule KlassHero.Family.Adapters.Driving.Workers.ProcessInviteClaimWorker do
   # `:already_terminal` is the expected rejection: the invite was enrolled by a retry
   # Lifeline re-ran, or failed by an earlier pass. That is a fact, not a fault, so it
   # reports `:ignore` rather than an error the sweep would keep retrying.
+  #
+  # `inserted_at` is passed so the invite can reject a compensation it has moved past.
+  # A failed claim leaves the invite `:failed`, which the provider may resend from — and
+  # `failed: [:pending]` then makes a second failure legal, so a dead job arriving after
+  # the resend would revert it (#1339). `:superseded` joins `:already_terminal` here.
   @impl true
-  def compensate(%Oban.Job{args: %{"invite_id" => invite_id}}, reason) when is_binary(invite_id) do
-    case Enrollment.fail_invite(invite_id, reason) do
+  def compensate(%Oban.Job{args: %{"invite_id" => invite_id}, inserted_at: %DateTime{} = enqueued_at}, reason)
+      when is_binary(invite_id) do
+    case Enrollment.fail_invite(invite_id, reason, enqueued_at) do
       {:ok, _invite} ->
         :ok
 
@@ -58,6 +64,9 @@ defmodule KlassHero.Family.Adapters.Driving.Workers.ProcessInviteClaimWorker do
     end
   end
 
+  # Unreachable from the enqueue path, and `oban_jobs.inserted_at` is `null: false`.
+  # `:ignore` is the safe direction: it retires the job without writing a failure this
+  # clause has no watermark to justify.
   def compensate(%Oban.Job{}, _reason), do: :ignore
 
   # Oban JSON args use string keys and ISO date strings; convert to atom keys and Date.

--- a/lib/klass_hero/shared/adapters/driven/persistence/repositories/job_compensation_repository.ex
+++ b/lib/klass_hero/shared/adapters/driven/persistence/repositories/job_compensation_repository.ex
@@ -59,11 +59,14 @@ defmodule KlassHero.Shared.Adapters.Driven.Persistence.Repositories.JobCompensat
   @doc """
   Deletes markers compensated before `cutoff`, returning how many went.
 
-  Cutting on `compensated_at` rather than the job's `discarded_at` is deliberate and
-  safe in the conservative direction: a marker can only be written while the sweep's
-  join still sees the `oban_jobs` row, so `compensated_at >= discarded_at` always, and
-  a cutoff measured from it therefore lands no earlier than the same span measured
-  from the job's own clock. The caller owns the span — see `CompensationSweepWorker`.
+  Cutting on `compensated_at` rather than the job's `discarded_at` is deliberate. The
+  two clocks are within milliseconds of each other in both directions: the sweep writes
+  its marker after the job was discarded, while the in-attempt gate writes one just
+  *before* the failing return that discards the job (#1339). Either way the gap is
+  bounded by a single attempt, and the retention span is days — so a cutoff measured
+  from `compensated_at` cannot expire a marker meaningfully earlier than the same span
+  measured from the job's own clock. The caller owns the span, and owns keeping it
+  clear of the Pruner's window — see `CompensationSweepWorker`.
   """
   @spec prune(DateTime.t()) :: non_neg_integer()
   def prune(%DateTime{} = cutoff) do

--- a/lib/klass_hero/shared/tracing/traced_worker.ex
+++ b/lib/klass_hero/shared/tracing/traced_worker.ex
@@ -25,6 +25,7 @@ defmodule KlassHero.Shared.Tracing.TracedWorker do
   The `backoff/1` and `timeout/1` callbacks remain overridable by concrete workers.
   """
 
+  alias KlassHero.Shared.Adapters.Driven.Persistence.Repositories.JobCompensationRepository
   alias KlassHero.Shared.Tracing
 
   @callback execute(Oban.Job.t()) :: :ok | {:ok, term()} | {:error, term()}
@@ -75,10 +76,26 @@ defmodule KlassHero.Shared.Tracing.TracedWorker do
   The in-attempt fast path. A job that dies without reaching it — orphaned, raised,
   or discarded early — is caught later by the sweep over discarded jobs, which calls
   the same `compensate/2`.
+
+  Both routes go through `JobCompensationRepository.compensate_once/3`, so the marker
+  means "this job was compensated" rather than "the sweep compensated this job". It has
+  to: a worker returning `{:error, _}` on its final attempt is marked `discarded` by
+  Oban, so an inline compensation that wrote no marker left the job selectable by the
+  sweep and compensated it a second time (#1339).
+
+  Returns `:ok` for a compensation that ran or had nothing left to do — `compensate_once/3`
+  folds `:ignore` in, because both commit the marker — and `{:error, _}` for one that
+  failed, which rolls the marker back and leaves the job to a later sweep.
   """
-  @spec compensate_if_final(module(), Oban.Job.t(), term()) :: :ok | :ignore | {:error, term()}
+  @spec compensate_if_final(module(), Oban.Job.t(), term()) :: :ok | {:error, term()}
   def compensate_if_final(worker, %Oban.Job{} = job, reason) when is_atom(worker) do
-    if final_attempt?(job), do: worker.compensate(job, reason), else: :ok
+    if final_attempt?(job) do
+      JobCompensationRepository.compensate_once(job.id, job.worker, fn ->
+        worker.compensate(job, reason)
+      end)
+    else
+      :ok
+    end
   end
 
   @doc false

--- a/priv/repo/migrations/20260814150000_add_resent_at_to_bulk_enrollment_invites.exs
+++ b/priv/repo/migrations/20260814150000_add_resent_at_to_bulk_enrollment_invites.exs
@@ -1,0 +1,20 @@
+defmodule KlassHero.Repo.Migrations.AddResentAtToBulkEnrollmentInvites do
+  @moduledoc """
+  When the provider last reopened this invite, so a compensation can tell whether it
+  still describes the invite it was enqueued for.
+
+  Nullable with no backfill on purpose: `nil` already means "never resent", which is
+  true of every existing row, and any value we invented would be a resend that did not
+  happen. `:utc_datetime_usec` to match `oban_jobs.inserted_at`, which is what it gets
+  compared against — a second-precision column would round two events in the same
+  second into a tie (#1339).
+  """
+
+  use Ecto.Migration
+
+  def change do
+    alter table(:bulk_enrollment_invites) do
+      add :resent_at, :utc_datetime_usec
+    end
+  end
+end

--- a/test/klass_hero/enrollment/adapters/driving/workers/send_invite_email_worker_test.exs
+++ b/test/klass_hero/enrollment/adapters/driving/workers/send_invite_email_worker_test.exs
@@ -5,9 +5,11 @@ defmodule KlassHero.Enrollment.Adapters.Driving.Workers.SendInviteEmailWorkerTes
   import KlassHero.Factory
   import Swoosh.TestAssertions
 
+  alias KlassHero.Enrollment
   alias KlassHero.Enrollment.Adapters.Driving.Workers.SendInviteEmailWorker
   alias KlassHero.Enrollment.BulkEnrollmentInvite
   alias KlassHero.Repo
+  alias KlassHero.Shared.Adapters.Driven.Workers.CompensationSweepWorker
   alias KlassHero.Test.StubMailerAdapter
 
   defp create_pending_invite(_context) do
@@ -93,11 +95,17 @@ defmodule KlassHero.Enrollment.Adapters.Driving.Workers.SendInviteEmailWorkerTes
 
     @max_attempts 3
 
-    defp job(invite, program, attempt) do
+    # `id`, `worker` and `inserted_at` are populated because a job reaching the
+    # compensation gate came out of `oban_jobs`: the first two key its compensation
+    # marker, and the third is the watermark a resend is measured against (#1339).
+    defp job(invite, program, attempt, opts \\ []) do
       %Oban.Job{
+        id: System.unique_integer([:positive]),
+        worker: Oban.Worker.to_string(SendInviteEmailWorker),
         args: %{"invite_id" => invite.id, "program_name" => program.title},
         attempt: attempt,
-        max_attempts: @max_attempts
+        max_attempts: @max_attempts,
+        inserted_at: Keyword.get(opts, :inserted_at, DateTime.utc_now())
       }
     end
 
@@ -149,6 +157,123 @@ defmodule KlassHero.Enrollment.Adapters.Driving.Workers.SendInviteEmailWorkerTes
 
       assert {:error, _reason} =
                SendInviteEmailWorker.execute(job(invite, program, @max_attempts))
+    end
+  end
+
+  # #1339. A compensation speaks for a job that is already dead, and between that death
+  # and the compensation running the provider can resend — `failed: [:pending]` reopens
+  # the transition the state machine was otherwise relying on to reject a second failure.
+  describe "compensate/2 after a resend" do
+    setup :create_pending_invite
+
+    test "leaves an invite resent after this job was enqueued alone", %{invite: invite, program: program} do
+      dead = job(invite, program, @max_attempts, inserted_at: minutes_ago(30))
+
+      {:ok, _resent} = Enrollment.reset_invite_for_resend(invite)
+
+      assert :ignore = SendInviteEmailWorker.compensate(dead, {:network, :timeout})
+
+      resent = reload(invite)
+      assert resent.status == :pending, "a dead job re-failed an invite the provider had resent"
+      assert resent.error_details == nil, "a dead job overwrote the reason a resend had cleared"
+    end
+
+    # The other side of the guard: without a resend to supersede it, the compensation is
+    # still the whole point of the mechanism.
+    test "still fails an invite that was never resent", %{invite: invite, program: program} do
+      dead = job(invite, program, @max_attempts, inserted_at: minutes_ago(30))
+
+      assert :ok = SendInviteEmailWorker.compensate(dead, {:network, :timeout})
+      assert reload(invite).status == :failed
+    end
+
+    # The full reported sequence, through the real sweep rather than a direct call:
+    # exhaust the attempts, resend, then let the sweep reach the discarded job.
+    test "survives the compensation sweep after a resend", %{invite: invite, program: program} do
+      StubMailerAdapter.fail_with({:network, :timeout})
+
+      assert {:error, _reason} =
+               SendInviteEmailWorker.execute(job(invite, program, @max_attempts))
+
+      assert reload(invite).status == :failed
+
+      {:ok, _resent} = Enrollment.resend_invite(invite.id, invite.provider_id)
+      assert reload(invite).status == :pending
+
+      discarded_send_job(invite, program)
+      assert :ok = CompensationSweepWorker.perform(%Oban.Job{})
+
+      swept = reload(invite)
+      assert swept.status == :pending, "the sweep re-failed an invite the provider had resent"
+      assert swept.error_details == nil
+    end
+
+    # The guard's sharpest edge. `resent_at` and a job's `inserted_at` are only
+    # comparable if they come from the SAME clock, and left to itself `inserted_at` does
+    # not: the column defaults to Postgres `now()`, which is (a) the database server's
+    # clock, skewed from this VM's by however far the two have drifted, and (b) frozen at
+    # *transaction start* — before the `resent_at` the same transaction goes on to write,
+    # since `resend_invite/2` resets and enqueues together.
+    #
+    # Either alone makes a resend enqueue a job its own guard reads as superseded,
+    # silently disabling compensation for exactly the invites this protects. So the
+    # assertion is on the clock source rather than on an ordering: the window is
+    # microseconds wide, and only a timestamp taken by this VM can land inside it.
+    test "stamps the enqueue time from the application clock, not the database's", %{invite: invite} do
+      before_resend = DateTime.utc_now()
+
+      {:ok, _resent} =
+        Oban.Testing.with_testing_mode(:manual, fn ->
+          Enrollment.resend_invite(invite.id, invite.provider_id)
+        end)
+
+      after_resend = DateTime.utc_now()
+      enqueued_at = resend_job().inserted_at
+
+      assert DateTime.compare(enqueued_at, before_resend) != :lt and
+               DateTime.compare(enqueued_at, after_resend) != :gt,
+             "inserted_at #{inspect(enqueued_at)} fell outside #{inspect(before_resend)}..." <>
+               "#{inspect(after_resend)}, so it came from the database clock, not this one"
+    end
+
+    # The behaviour resting on it: a resend's own job is not superseded by the resend that
+    # enqueued it, so its compensation still lands if that send then fails for good.
+    test "compensates for the job its own resend enqueued", %{invite: invite} do
+      {:ok, _resent} =
+        Oban.Testing.with_testing_mode(:manual, fn ->
+          Enrollment.resend_invite(invite.id, invite.provider_id)
+        end)
+
+      assert :ok = SendInviteEmailWorker.compensate(resend_job(), {:network, :timeout}),
+             "the resend's own job read as superseded by the resend that enqueued it"
+
+      assert reload(invite).status == :failed
+    end
+
+    defp resend_job do
+      Repo.one!(from(j in Oban.Job, where: j.worker == ^Oban.Worker.to_string(SendInviteEmailWorker)))
+    end
+
+    defp minutes_ago(minutes), do: DateTime.add(DateTime.utc_now(), -minutes, :minute)
+
+    # Written straight to the table: `testing: :inline` executes a job at insert, so
+    # Oban's own path cannot leave one sitting in a terminal state.
+    defp discarded_send_job(invite, program) do
+      now = DateTime.utc_now()
+
+      Repo.insert!(%Oban.Job{
+        worker: Oban.Worker.to_string(SendInviteEmailWorker),
+        args: %{"invite_id" => invite.id, "program_name" => program.title},
+        queue: "email",
+        state: "discarded",
+        attempt: @max_attempts,
+        max_attempts: @max_attempts,
+        discarded_at: now,
+        attempted_at: now,
+        inserted_at: minutes_ago(30),
+        scheduled_at: minutes_ago(30),
+        errors: [%{"attempt" => 3, "at" => DateTime.to_iso8601(now), "error" => "boom"}]
+      })
     end
   end
 

--- a/test/klass_hero/enrollment/fail_invite_test.exs
+++ b/test/klass_hero/enrollment/fail_invite_test.exs
@@ -48,10 +48,10 @@ defmodule KlassHero.Enrollment.FailInviteTest do
       assert failed.error_details =~ "no token"
     end
 
-    # This rejection is what keeps compensation idempotent: a worker compensates inline
-    # on its final attempt, and the sweep then re-examines the same discarded job. Both
-    # land here, and `@valid_transitions` (failed: [:pending]) is the only thing that
-    # stops the second one overwriting the first one's reason.
+    # `@valid_transitions` (failed: [:pending]) is what stops a second compensation
+    # overwriting the first one's reason. It is no longer the *only* guard — since #1339
+    # the marker stops a job being compensated twice at all — but it still catches the
+    # cases the marker cannot, such as two different jobs failing the same invite.
     test "refuses to re-fail an invite that is already failed", %{invite: invite} do
       assert {:ok, _} = Enrollment.fail_invite(invite.id, :program_full)
 
@@ -63,6 +63,65 @@ defmodule KlassHero.Enrollment.FailInviteTest do
 
     test "reports a missing invite rather than raising" do
       assert {:error, :not_found} = Enrollment.fail_invite(Ecto.UUID.generate(), :program_full)
+    end
+  end
+
+  # A compensation speaks for a job that is already dead, so it must not describe an
+  # invite the provider has since resent — `failed: [:pending]` reopens the transition
+  # the state machine was otherwise relying on to reject it (#1339).
+  describe "fail_invite/3" do
+    setup :create_invite
+
+    @enqueued_at ~U[2026-08-14 12:00:00.000000Z]
+
+    # Offsets are relative to when the job was enqueued. Equality is the resend's *own*
+    # job and must still compensate: both timestamps come from the one transaction that
+    # reset the invite and enqueued its email.
+    for {label, offset_seconds, outcome} <- [
+          {"was never resent", nil, :fails},
+          {"was resent before the job was enqueued", -60, :fails},
+          {"was resent as the job was enqueued", 0, :fails},
+          {"was resent after the job was enqueued", 60, :superseded}
+        ] do
+      test "an invite that #{label} #{if outcome == :fails, do: "fails", else: "is superseded"}",
+           %{invite: invite} do
+        resent_at =
+          case unquote(offset_seconds) do
+            nil -> nil
+            seconds -> DateTime.add(@enqueued_at, seconds, :second)
+          end
+
+        invite |> Ecto.Changeset.change(%{resent_at: resent_at}) |> Repo.update!()
+
+        result = Enrollment.fail_invite(invite.id, :program_full, @enqueued_at)
+
+        case unquote(outcome) do
+          :fails ->
+            assert {:ok, failed} = result, "expected an invite that #{unquote(label)} to fail"
+            assert failed.status == :failed
+
+          :superseded ->
+            assert {:error, :superseded} = result,
+                   "expected an invite that #{unquote(label)} to be left alone"
+
+            assert Repo.get!(BulkEnrollmentInvite, invite.id).status == :pending
+        end
+      end
+    end
+
+    test "leaves the reason of a superseded invite untouched", %{invite: invite} do
+      invite
+      |> Ecto.Changeset.change(%{resent_at: DateTime.add(@enqueued_at, 60, :second)})
+      |> Repo.update!()
+
+      assert {:error, :superseded} = Enrollment.fail_invite(invite.id, :program_full, @enqueued_at)
+
+      assert Repo.get!(BulkEnrollmentInvite, invite.id).error_details == nil
+    end
+
+    test "reports a missing invite rather than raising" do
+      assert {:error, :not_found} =
+               Enrollment.fail_invite(Ecto.UUID.generate(), :program_full, @enqueued_at)
     end
   end
 end

--- a/test/klass_hero/family/adapters/driving/workers/process_invite_claim_worker_test.exs
+++ b/test/klass_hero/family/adapters/driving/workers/process_invite_claim_worker_test.exs
@@ -121,7 +121,19 @@ defmodule KlassHero.Family.Adapters.Driving.Workers.ProcessInviteClaimWorkerTest
       }
     end
 
-    defp job(args, attempt), do: %Oban.Job{args: args, attempt: attempt, max_attempts: @max_attempts}
+    # `id`, `worker` and `inserted_at` are populated because a job reaching the
+    # compensation gate came out of `oban_jobs`: the first two key its compensation
+    # marker, and the third is the watermark a resend is measured against (#1339).
+    defp job(args, attempt, opts \\ []) do
+      %Oban.Job{
+        id: System.unique_integer([:positive]),
+        worker: Oban.Worker.to_string(ProcessInviteClaimWorker),
+        args: args,
+        attempt: attempt,
+        max_attempts: @max_attempts,
+        inserted_at: Keyword.get(opts, :inserted_at, DateTime.utc_now())
+      }
+    end
 
     defp reload(invite), do: Repo.get!(BulkEnrollmentInvite, invite.id)
 

--- a/test/klass_hero/messaging/adapters/driving/workers/fetch_email_content_worker_test.exs
+++ b/test/klass_hero/messaging/adapters/driving/workers/fetch_email_content_worker_test.exs
@@ -47,6 +47,11 @@ defmodule KlassHero.Messaging.Adapters.Driving.Workers.FetchEmailContentWorkerTe
 
       assert {:error, :not_found} =
                FetchEmailContentWorker.perform(%Oban.Job{
+                 # `id` and `worker` because this attempt reaches the compensation gate,
+                 # which keys its marker on them — a job that gets there came out of
+                 # `oban_jobs` and always has both (#1339).
+                 id: System.unique_integer([:positive]),
+                 worker: Oban.Worker.to_string(FetchEmailContentWorker),
                  args: %{"email_id" => email.id, "resend_id" => email.resend_id},
                  attempt: 3,
                  max_attempts: 3

--- a/test/klass_hero/messaging/adapters/driving/workers/send_email_reply_worker_test.exs
+++ b/test/klass_hero/messaging/adapters/driving/workers/send_email_reply_worker_test.exs
@@ -50,6 +50,11 @@ defmodule KlassHero.Messaging.Adapters.Driving.Workers.SendEmailReplyWorkerTest 
 
       assert {:error, _reason} =
                SendEmailReplyWorker.perform(%Oban.Job{
+                 # `id` and `worker` because this attempt reaches the compensation gate,
+                 # which keys its marker on them — a job that gets there came out of
+                 # `oban_jobs` and always has both (#1339).
+                 id: System.unique_integer([:positive]),
+                 worker: Oban.Worker.to_string(SendEmailReplyWorker),
                  args: %{"reply_id" => reply.id},
                  attempt: 3,
                  max_attempts: 3

--- a/test/klass_hero/shared/adapters/driven/workers/compensation_sweep_worker_test.exs
+++ b/test/klass_hero/shared/adapters/driven/workers/compensation_sweep_worker_test.exs
@@ -11,6 +11,7 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.CompensationSweepWorkerTest d
   use KlassHero.DataCase, async: true
 
   alias KlassHero.Messaging
+  alias KlassHero.Messaging.Adapters.Driving.Workers.SendEmailReplyWorker
   alias KlassHero.MessagingFixtures
   alias KlassHero.Repo
   alias KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializer
@@ -18,6 +19,7 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.CompensationSweepWorkerTest d
   alias KlassHero.Shared.Adapters.Driven.Persistence.Schemas.UndeliveredEvent
   alias KlassHero.Shared.Adapters.Driven.Workers.CompensationSweepWorker
   alias KlassHero.Shared.Domain.Events.Event
+  alias KlassHero.Shared.Tracing.TracedWorker
 
   @registered "KlassHero.Messaging.Adapters.Driving.Workers.SendEmailReplyWorker"
   @unregistered "KlassHero.Messaging.Adapters.Driving.Workers.MessageCleanupWorker"
@@ -57,6 +59,26 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.CompensationSweepWorkerTest d
 
       assert :ok = CompensationSweepWorker.perform(%Oban.Job{})
       assert reply_status(reply) == :sending
+    end
+
+    # The #1339 sequence, with a reply standing in for the invite that surfaced it. A
+    # worker returning `{:error, _}` on its final attempt compensates inline *and* is
+    # marked `discarded`, so before the inline path wrote a marker this sweep found the
+    # job and compensated it a second time — over whatever had happened in between.
+    test "leaves a job that already compensated itself inline alone" do
+      reply = pending_reply()
+      job = discarded_job(@registered, %{"reply_id" => reply.id})
+
+      assert :ok = TracedWorker.compensate_if_final(SendEmailReplyWorker, job, "boom")
+      assert reply_status(reply) == :failed
+
+      # Whoever owns the entity moves it on, exactly as a provider resending does.
+      {:ok, _} = Messaging.update_email_reply_status(reply.id, "sending", %{})
+
+      assert :ok = CompensationSweepWorker.perform(%Oban.Job{})
+
+      assert reply_status(reply) == :sending,
+             "the sweep re-compensated a job that had already compensated itself inline"
     end
 
     test "leaves jobs from unregistered workers alone" do

--- a/test/klass_hero/shared/tracing/traced_worker_test.exs
+++ b/test/klass_hero/shared/tracing/traced_worker_test.exs
@@ -13,9 +13,12 @@ defmodule TracedWorkerContextHelper do
 end
 
 defmodule KlassHero.Shared.Tracing.TracedWorkerTest do
-  use ExUnit.Case, async: false
+  # `async: false` for the OTel exporter, which is process-global. DataCase rather than
+  # a bare ExUnit.Case because `compensate_if_final/3` writes a compensation marker.
+  use KlassHero.DataCase, async: false
   use KlassHero.TracingHelpers
 
+  alias KlassHero.Shared.Adapters.Driven.Persistence.Schemas.JobCompensation
   alias KlassHero.Shared.Tracing.TracedWorker
 
   # Span isolation (flush + drain between tests) is provided by the shared
@@ -31,6 +34,19 @@ defmodule KlassHero.Shared.Tracing.TracedWorkerTest do
     }
 
     struct(defaults, attrs)
+  end
+
+  # A real `id`, because the marker is keyed on it — every job reaching the gate in
+  # production came out of `oban_jobs`. `job_compensations` has no foreign key back, so
+  # the row need not exist.
+  defp compensating_job(opts \\ []) do
+    build_job(%{
+      id: System.unique_integer([:positive]),
+      worker: "KlassHero.Shared.Tracing.TracedWorkerTest.CompensatingWorker",
+      attempt: Keyword.get(opts, :attempt, 3),
+      max_attempts: 3,
+      args: %{"test_pid" => self(), "returns" => Keyword.get(opts, :returns, :ok)}
+    })
   end
 
   # ---- Test workers defined inline ----
@@ -63,6 +79,21 @@ defmodule KlassHero.Shared.Tracing.TracedWorkerTest do
 
     @impl TracedWorker
     def execute(_job), do: {:cancel, "nothing a retry can fix"}
+  end
+
+  # Reports that it ran before returning whatever the test asked for, so a compensation
+  # that gets rolled back can still be distinguished from one that never happened.
+  defmodule CompensatingWorker do
+    use TracedWorker, queue: :test, max_attempts: 3
+
+    @impl TracedWorker
+    def execute(_job), do: {:error, :boom}
+
+    @impl TracedWorker
+    def compensate(%Oban.Job{args: %{"test_pid" => pid, "returns" => returns}}, reason) do
+      send(pid, {:compensated, reason})
+      returns
+    end
   end
 
   # ---- Tests ----
@@ -216,6 +247,62 @@ defmodule KlassHero.Shared.Tracing.TracedWorkerTest do
       # On success, status is either :unset or :ok — never :error
       raw_status = span(worker_span, :status)
       assert raw_status == :undefined or span_status_code(worker_span) != :error
+    end
+  end
+
+  # The in-attempt gate and the sweep both reach the same `compensate/2`, and the marker
+  # is what keeps them from both running it. Before #1339 only the sweep wrote one, so
+  # every inline-compensated job was also swept — harmless until the entity acquired a
+  # legal path back out of the state the compensation had put it in.
+  describe "compensate_if_final/3" do
+    test "records the compensation, so the sweep will not repeat it" do
+      job = compensating_job()
+
+      assert :ok = TracedWorker.compensate_if_final(CompensatingWorker, job, :delivery_failed)
+
+      assert_received {:compensated, :delivery_failed}
+      assert Repo.get_by(JobCompensation, job_id: job.id)
+    end
+
+    test "runs the compensation once when the gate is reached twice" do
+      job = compensating_job()
+
+      assert :ok = TracedWorker.compensate_if_final(CompensatingWorker, job, :delivery_failed)
+      assert :ok = TracedWorker.compensate_if_final(CompensatingWorker, job, :delivery_failed)
+
+      assert_received {:compensated, :delivery_failed}
+      refute_received {:compensated, _reason}
+    end
+
+    # The marker and the compensating write commit together, so a failure must leave
+    # neither — otherwise the sweep skips a job whose compensation never landed.
+    test "records nothing when the compensation fails, leaving the job to a later sweep" do
+      job = compensating_job(returns: {:error, :database_gone})
+
+      assert {:error, :database_gone} =
+               TracedWorker.compensate_if_final(CompensatingWorker, job, :delivery_failed)
+
+      assert_received {:compensated, :delivery_failed}
+      refute Repo.get_by(JobCompensation, job_id: job.id)
+    end
+
+    # `:ignore` means "nothing left to do", which is a completed compensation, not a
+    # failed one — it must commit its marker like any other success.
+    test "records a compensation that reports nothing left to do" do
+      job = compensating_job(returns: :ignore)
+
+      assert :ok = TracedWorker.compensate_if_final(CompensatingWorker, job, :delivery_failed)
+
+      assert Repo.get_by(JobCompensation, job_id: job.id)
+    end
+
+    test "neither compensates nor records while retries remain" do
+      job = compensating_job(attempt: 1)
+
+      assert :ok = TracedWorker.compensate_if_final(CompensatingWorker, job, :delivery_failed)
+
+      refute_received {:compensated, _reason}
+      refute Repo.get_by(JobCompensation, job_id: job.id)
     end
   end
 


### PR DESCRIPTION
Closes #1339

## Summary

The compensation sweep re-failed invites the provider had already resent — the resend silently reverted to **Failed** under a stale reason from a job that died minutes earlier. Two independent defects produce that symptom, and fixing either alone leaves the bug reachable.

**1. The marker only guarded one of two entry points.** `JobCompensationRepository.compensate_once/3` claims a compensation runs at most once per job, but `TracedWorker.compensate_if_final/3` called `compensate/2` directly and wrote no marker. Since a worker returning `{:error, _}` on its final attempt is marked `discarded`, *every* inline-compensated job was also swept — across all five registered workers. Both routes now go through the same gate.

**2. Nothing asked whether the job was still current.** A job that dies without reaching the inline gate (a raise, a Lifeline discard, an early `{:discard, _}`) is legitimately uncompensated, so the marker cannot help it. Invites now carry a `resent_at` watermark and `Enrollment.fail_invite/3` refuses to fail an invite resent after the job it speaks for was enqueued.

## Review focus

**The guard lives at the facade, not in the workers.** `fail_invite/2` is already the single writer of `error_details` (#1290) and the shared call site of *both* compensating workers that fail an invite — `SendInviteEmailWorker` and `ProcessInviteClaimWorker`. `fail_invite/2` stays unguarded for callers acting on the invite's present rather than a dead job's past.

**Scope is two workers, not one.** The issue only names `SendInviteEmailWorker`, but `ProcessInviteClaimWorker.compensate/2` fails the same invite and has the same window. Messaging's two compensating workers were checked and need nothing: their success states are absorbing (`inbound_email.ex`, `email_reply.ex`), so a repeat compensation cannot regress them. `EventDeliveryWorker` has no entity.

**`EnqueueInviteEmails` now stamps `inserted_at` itself — this is load-bearing.** The column defaults to Postgres `now()`, which is (a) the *database server's* clock and (b) frozen at *transaction start*. `resend_invite/2` resets the invite and enqueues its email in one transaction, so left to the default every resend would enqueue a job its own guard read as superseded — silently disabling compensation for exactly the invites this protects. Measured skew between the app and DB clocks in the test environment ranged ±40ms, in both directions.

**Why a timestamp rather than a token or a generation counter.** Both alternatives need a per-attempt identity stamped into job args. `SendInviteEmailWorker` could carry one cheaply, but `ProcessInviteClaimWorker`'s args come from the `:invite_claimed` **event payload** — stamping it would mean widening an event contract to fix a worker bug. A watermark compared against `Oban.Job.inserted_at` needs nothing from either job's args.

## Test plan

- `mix precommit` green (4354 tests), plus `mix lint_read_tables` and `mix lint_acl_boundary`.
- Each regression test was verified to actually **fail** without its fix, not merely pass with it:
  - the sweep test logs `Marked reply ... as permanently failed` **twice** without the marker fix;
  - the clock-source test reports `inserted_at ... came from the database clock` without the enqueue stamp.
- The `fail_invite/3` staleness cases are a table over `resent_at` relative to the job: never resent / before / equal / after. **Equality still compensates** — a resend and the job it enqueues are written by one transaction, so an invite's own job must not read as stale against it.
- Hand-built `%Oban.Job{}` fixtures across four worker test files gained `id`/`worker`/`inserted_at`, which a job reaching the compensation gate always has in production.

## Migration

Additive and nullable, no backfill — `nil` already means "never resent", which is true of every existing row. `:utc_datetime_usec` to match `oban_jobs.inserted_at`.