### PR TITLE
refactor: rename the Critical* event modules and the :critical_events queue

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -144,7 +144,14 @@ config :klass_hero, Oban,
   ],
   # email: 1 — serialized to stay under Resend's 2 req/sec rate limit (per-node;
   #   add a rate limiter if scaling to multiple Oban nodes)
-  queues: [default: 10, messaging: 5, cleanup: 2, email: 1, family: 1, critical_events: 5]
+  # events: 5 — every event goes here; since ADR-0014 there is no other kind.
+  # critical_events: 5 — transitional (#1357), and the only reason jobs staged before the
+  #   rename still run. `oban_jobs.queue` is data, so those rows still say "critical_events";
+  #   they execute fine because the `worker` column still resolves to EventDeliveryWorker, but
+  #   only while a producer is running for the queue they name. Removing this line does not
+  #   fail them — it leaves them sitting, and nothing alerts on a merely unattended queue.
+  #   Drop it once `SELECT count(*) FROM oban_jobs WHERE queue = 'critical_events'` is 0 in prod.
+  queues: [default: 10, messaging: 5, cleanup: 2, email: 1, family: 1, events: 5, critical_events: 5]
 
 # Base URL for constructing links in emails and event handlers
 # (avoids boundary violations from referencing KlassHeroWeb.Endpoint in domain code)

--- a/config/config.exs
+++ b/config/config.exs
@@ -150,7 +150,8 @@ config :klass_hero, Oban,
   #   they execute fine because the `worker` column still resolves to EventDeliveryWorker, but
   #   only while a producer is running for the queue they name. Removing this line does not
   #   fail them — it leaves them sitting, and nothing alerts on a merely unattended queue.
-  #   Drop it once `SELECT count(*) FROM oban_jobs WHERE queue = 'critical_events'` is 0 in prod.
+  #   Drop it via #1362, once `SELECT count(*) FROM oban_jobs WHERE queue = 'critical_events'`
+  #   is 0 in prod — gate on the count, not on elapsed time.
   queues: [default: 10, messaging: 5, cleanup: 2, email: 1, family: 1, events: 5, critical_events: 5]
 
 # Base URL for constructing links in emails and event handlers

--- a/lib/klass_hero/provider/adapters/driving/workers/replay_standing_assignments_worker.ex
+++ b/lib/klass_hero/provider/adapters/driving/workers/replay_standing_assignments_worker.ex
@@ -10,8 +10,8 @@ defmodule KlassHero.Provider.Adapters.Driving.Workers.ReplayStandingAssignmentsW
       Oban.insert(ReplayStandingAssignmentsWorker.new(%{}))
 
   Runs on `:default` rather than `:messaging`: the work here is Provider staging
-  events, and the Messaging-side effect happens later, on `:critical_events`,
-  once `EventDeliveryWorker` picks each one up.
+  events, and the Messaging-side effect happens later, on `:events`, once
+  `EventDeliveryWorker` picks each one up.
 
   Safe to run more than once — see `Provider.replay_standing_assignments/0` for
   why every consumer absorbs a repeat.

--- a/lib/klass_hero/shared/adapters/driven/events/event_serializer.ex
+++ b/lib/klass_hero/shared/adapters/driven/events/event_serializer.ex
@@ -1,4 +1,4 @@
-defmodule KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializer do
+defmodule KlassHero.Shared.Adapters.Driven.Events.EventSerializer do
   @moduledoc """
   Serializes and deserializes event structs for Oban job args.
 

--- a/lib/klass_hero/shared/adapters/driven/events/oban_outbox.ex
+++ b/lib/klass_hero/shared/adapters/driven/events/oban_outbox.ex
@@ -14,13 +14,13 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.ObanOutbox do
 
   @behaviour KlassHero.Shared.ForStagingEvents
 
-  alias KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializer
+  alias KlassHero.Shared.Adapters.Driven.Events.EventSerializer
   alias KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorker
   alias KlassHero.Shared.Tracing.Context
 
   @impl true
   def stage(events) when is_list(events) do
-    args = Context.inject_into_args(%{"events" => Enum.map(events, &CriticalEventSerializer.serialize/1)})
+    args = Context.inject_into_args(%{"events" => Enum.map(events, &EventSerializer.serialize/1)})
 
     # insert! on purpose: a caller inside a transaction must not be able to ignore
     # a staging failure and commit the state change without its events.

--- a/lib/klass_hero/shared/adapters/driven/persistence/schemas/processed_event.ex
+++ b/lib/klass_hero/shared/adapters/driven/persistence/schemas/processed_event.ex
@@ -2,7 +2,7 @@ defmodule KlassHero.Shared.Adapters.Driven.Persistence.Schemas.ProcessedEvent do
   @moduledoc """
   Ecto schema for the processed_events idempotency table.
 
-  Internal to CriticalEventDispatcher — not a domain model. Each row records
+  Internal to EventDispatcher — not a domain model. Each row records
   that a specific handler has processed a specific event, preventing duplicate
   execution across PubSub and Oban delivery paths.
   """

--- a/lib/klass_hero/shared/adapters/driven/workers/event_delivery_worker.ex
+++ b/lib/klass_hero/shared/adapters/driven/workers/event_delivery_worker.ex
@@ -2,10 +2,10 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorker do
   @moduledoc """
   Delivers one transaction's integration events to every consumer of each.
 
-  Generalizes `CriticalEventWorker`, which carried one event to one handler. This
-  carries N events to all their registered consumers — cross-context handlers and
+  Carries N events to all their registered consumers — cross-context handlers and
   projections alike, because `EventConsumerRegistry` makes them the same kind of
-  entry.
+  entry. ADR-0014 replaced a per-event, per-handler worker with this one, which is
+  why nothing downstream distinguishes a handler from a projection any more.
 
   ## Why the job invokes consumers rather than broadcasting to them
 
@@ -16,7 +16,7 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorker do
   recovery. PubSub keeps only the LiveView broadcast, where a dropped refresh is
   the one loss this system is allowed to take.
 
-  Each consumer runs through `CriticalEventDispatcher`, so at-least-once delivery
+  Each consumer runs through `EventDispatcher`, so at-least-once delivery
   does not become at-least-once *effects*: a consumer that already succeeded is a
   no-op on retry, and only the ones that failed run again.
 
@@ -32,15 +32,15 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorker do
   # this bound doubles as the window in which an orphaned event stays recoverable. 10 spans roughly
   # 4.5 hours under Oban's default backoff.
   use KlassHero.Shared.Tracing.TracedWorker,
-    queue: :critical_events,
+    queue: :events,
     max_attempts: 10
 
-  alias KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializer
   alias KlassHero.Shared.Adapters.Driven.Events.EventConsumerRegistry
+  alias KlassHero.Shared.Adapters.Driven.Events.EventSerializer
   alias KlassHero.Shared.Adapters.Driven.Persistence.Repositories.ProcessedEventRepository
   alias KlassHero.Shared.Adapters.Driven.Persistence.Repositories.UndeliveredEventRepository
-  alias KlassHero.Shared.CriticalEventDispatcher
   alias KlassHero.Shared.Domain.Events.Event
+  alias KlassHero.Shared.EventDispatcher
   alias KlassHero.Shared.Tracing.Context
 
   require Logger
@@ -48,7 +48,7 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorker do
   @impl true
   def execute(%Oban.Job{args: %{"events" => raw_events}} = job) do
     raw_events
-    |> Enum.map(&CriticalEventSerializer.deserialize/1)
+    |> Enum.map(&EventSerializer.deserialize/1)
     |> Enum.map(&deliver(&1, job))
     |> first_error()
   end
@@ -67,9 +67,9 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorker do
   end
 
   defp run_consumer({module, function} = consumer, event, topic, job) do
-    handler_ref = CriticalEventDispatcher.handler_ref(consumer)
+    handler_ref = EventDispatcher.handler_ref(consumer)
 
-    case CriticalEventDispatcher.execute(event.event_id, handler_ref, fn -> apply(module, function, [event]) end) do
+    case EventDispatcher.execute(event.event_id, handler_ref, fn -> apply(module, function, [event]) end) do
       :ok ->
         :ok
 
@@ -129,7 +129,7 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorker do
   @impl true
   def compensate(%Oban.Job{args: %{"events" => raw_events}} = job, _reason) do
     raw_events
-    |> Enum.map(&CriticalEventSerializer.deserialize/1)
+    |> Enum.map(&EventSerializer.deserialize/1)
     |> Enum.flat_map(&undelivered_row(&1, job))
     |> record()
   end
@@ -152,7 +152,7 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorker do
           %{
             event_id: event.event_id,
             topic: topic,
-            payload: CriticalEventSerializer.serialize(event),
+            payload: EventSerializer.serialize(event),
             missed_consumers: missed,
             job_id: job.id,
             discarded_at: job.discarded_at,
@@ -168,7 +168,7 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorker do
     delivered = MapSet.new(processed)
 
     for consumer <- EventConsumerRegistry.consumers_for(topic),
-        ref = CriticalEventDispatcher.handler_ref(consumer),
+        ref = EventDispatcher.handler_ref(consumer),
         not MapSet.member?(delivered, ref),
         do: ref
   end

--- a/lib/klass_hero/shared/domain/events/event.ex
+++ b/lib/klass_hero/shared/domain/events/event.ex
@@ -9,7 +9,7 @@ defmodule KlassHero.Shared.Domain.Events.Event do
   - Use `entity_type`/`entity_id` instead of `aggregate_type`/`aggregate_id`
   - Carry a `version` field for schema evolution and forward compatibility
   - Carry a `payload` of JSON scalars, plus atoms and `Date`/`Time`/`DateTime`/
-    `NaiveDateTime`/`Decimal`, which `CriticalEventSerializer` round-trips with their
+    `NaiveDateTime`/`Decimal`, which `EventSerializer` round-trips with their
     types intact (#1311, #1317). Anything else loses its type in `oban_jobs.args`, so
     `EventMetadata.validate_payload!/1` rejects it at construction —
     `PayloadCodec` is the one list of what survives.

--- a/lib/klass_hero/shared/domain/events/payload_codec.ex
+++ b/lib/klass_hero/shared/domain/events/payload_codec.ex
@@ -10,7 +10,7 @@ defmodule KlassHero.Shared.Domain.Events.PayloadCodec do
 
   - `EventMetadata.validate_payload!/1` asks `encodable?/1` at `Event.new/6`, so an
     unencodable value fails where a developer caused it rather than in a worker.
-  - `CriticalEventSerializer` calls `encode/1` on the way out and `decode/2` on the
+  - `EventSerializer` calls `encode/1` on the way out and `decode/2` on the
     way back, walking the payload and mirroring the tags into a `payload_types`
     sidecar beside it.
 

--- a/lib/klass_hero/shared/event_dispatcher.ex
+++ b/lib/klass_hero/shared/event_dispatcher.ex
@@ -1,10 +1,11 @@
-defmodule KlassHero.Shared.CriticalEventDispatcher do
+defmodule KlassHero.Shared.EventDispatcher do
   @moduledoc """
-  Exactly-once dispatch for critical events.
+  Exactly-once dispatch for events.
 
   Owns the idempotency invariant: a given event-handler pair is processed at
-  most once, regardless of how many delivery paths attempt it. Both the PubSub
-  real-time path and the Oban durable path funnel through this module.
+  most once, however many times delivery is attempted. Since ADR-0014 there is
+  one delivery path — `EventDeliveryWorker` — and Oban's at-least-once retry is
+  what makes this gate load-bearing rather than defensive.
 
   Delegates persistence and transactional atomicity to the
   `ForTrackingProcessedEvents` port — this domain service contains no

--- a/lib/klass_hero/shared/for_tracking_processed_events.ex
+++ b/lib/klass_hero/shared/for_tracking_processed_events.ex
@@ -3,7 +3,7 @@ defmodule KlassHero.Shared.ForTrackingProcessedEvents do
   Port for tracking which event-handler pairs have been processed.
 
   Provides the persistence and durable retry infrastructure behind
-  `CriticalEventDispatcher`. Implementations own the transactional
+  `EventDispatcher`. Implementations own the transactional
   atomicity guarantees — the domain service only sees `:ok` or
   `{:error, reason}`.
   """

--- a/test/klass_hero/accounts/registration_confirmation_integration_test.exs
+++ b/test/klass_hero/accounts/registration_confirmation_integration_test.exs
@@ -31,7 +31,7 @@ defmodule KlassHero.Accounts.RegistrationProfileCreationIntegrationTest do
   # inside the registration's own transaction. Production runs it after the commit.
   defp register_and_deliver(attrs) do
     {:ok, user} = Oban.Testing.with_testing_mode(:manual, fn -> Accounts.register_user(attrs) end)
-    Oban.drain_queue(queue: :critical_events, with_recursion: true)
+    Oban.drain_queue(queue: :events, with_recursion: true)
     user
   end
 

--- a/test/klass_hero/enrollment/invite_claim_saga_test.exs
+++ b/test/klass_hero/enrollment/invite_claim_saga_test.exs
@@ -65,9 +65,9 @@ defmodule KlassHero.Enrollment.InviteClaimSagaTest do
   # hop staged in turn. `with_scheduled` drives a failing job through its retries instead
   # of stopping at the first backoff.
   defp run_saga do
-    Oban.drain_queue(queue: :critical_events, with_recursion: true)
+    Oban.drain_queue(queue: :events, with_recursion: true)
     Oban.drain_queue(queue: :family, with_recursion: true, with_scheduled: true)
-    Oban.drain_queue(queue: :critical_events, with_recursion: true)
+    Oban.drain_queue(queue: :events, with_recursion: true)
   end
 
   describe "full invite claim saga" do

--- a/test/klass_hero/family/adapters/driving/events/family_event_handler_test.exs
+++ b/test/klass_hero/family/adapters/driving/events/family_event_handler_test.exs
@@ -139,7 +139,7 @@ defmodule KlassHero.Family.Adapters.Driving.Events.FamilyEventHandlerTest do
     # Regression for #1065. Unlike the "idempotent" test above (which calls the
     # handler directly, exercising the safe out-of-transaction path), this drives
     # the handler through the exactly-once wrapper the way production does
-    # (EventSubscriber / CriticalEventWorker → ProcessedEventRepository.execute_atomically),
+    # (EventDeliveryWorker → EventDispatcher → ProcessedEventRepository.execute_atomically),
     # i.e. INSIDE a Repo.transaction. Before the `mode: :savepoint` fix, the
     # duplicate-identity insert poisoned that transaction and execute_atomically
     # returned {:error, :rollback}, so the dedup marker never committed and the

--- a/test/klass_hero/messaging/archive_conversations_delivery_test.exs
+++ b/test/klass_hero/messaging/archive_conversations_delivery_test.exs
@@ -79,7 +79,7 @@ defmodule KlassHero.Messaging.ArchiveConversationsDeliveryTest do
         Application.put_env(:klass_hero, :outbox, original_outbox)
       end
 
-    Oban.drain_queue(queue: :critical_events, with_recursion: true)
+    Oban.drain_queue(queue: :events, with_recursion: true)
 
     result
   end

--- a/test/klass_hero/program_catalog/program_listing_delivery_test.exs
+++ b/test/klass_hero/program_catalog/program_listing_delivery_test.exs
@@ -62,7 +62,7 @@ defmodule KlassHero.ProgramCatalog.ProgramListingDeliveryTest do
         Application.put_env(:klass_hero, :outbox, original_outbox)
       end
 
-    Oban.drain_queue(queue: :critical_events, with_recursion: true)
+    Oban.drain_queue(queue: :events, with_recursion: true)
 
     result
   end

--- a/test/klass_hero/provider/erasure_cascade_test.exs
+++ b/test/klass_hero/provider/erasure_cascade_test.exs
@@ -66,7 +66,7 @@ defmodule KlassHero.Provider.ErasureCascadeTest do
       # Nothing has consumed the event yet — the job is staged, not run.
       assert Repo.get(StaffMember, staff.id).email == "jane@example.com"
 
-      Oban.drain_queue(queue: :critical_events, with_recursion: true)
+      Oban.drain_queue(queue: :events, with_recursion: true)
     end)
 
     scrubbed_staff = Repo.get(StaffMember, staff.id)

--- a/test/klass_hero/provider/staff_assignment_durability_test.exs
+++ b/test/klass_hero/provider/staff_assignment_durability_test.exs
@@ -13,7 +13,7 @@ defmodule KlassHero.Provider.StaffAssignmentDurabilityTest do
 
   2. **Serialization safety** — the payload carries only string/UUID fields
      (the `assigned_at`/`unassigned_at` `DateTime`s are never put in it), so it
-     round-trips through `CriticalEventSerializer` losslessly.
+     round-trips through `EventSerializer` losslessly.
   """
   use ExUnit.Case, async: true
 
@@ -21,8 +21,8 @@ defmodule KlassHero.Provider.StaffAssignmentDurabilityTest do
   alias KlassHero.Provider.Domain.Events.ProviderEvents
   alias KlassHero.Provider.ProgramStaffAssignment
   alias KlassHero.Provider.StaffMember
-  alias KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializer
   alias KlassHero.Shared.Adapters.Driven.Events.EventConsumerRegistry
+  alias KlassHero.Shared.Adapters.Driven.Events.EventSerializer
   alias KlassHero.Shared.Domain.Events.Event
 
   @assignment %ProgramStaffAssignment{
@@ -64,9 +64,9 @@ defmodule KlassHero.Provider.StaffAssignmentDurabilityTest do
 
       round_tripped =
         event
-        |> CriticalEventSerializer.serialize()
+        |> EventSerializer.serialize()
         |> jsonify()
-        |> CriticalEventSerializer.deserialize()
+        |> EventSerializer.deserialize()
 
       # Trimmed at the promotion boundary — no DateTime crosses the boundary.
       refute Map.has_key?(round_tripped.payload, :assigned_at)
@@ -84,9 +84,9 @@ defmodule KlassHero.Provider.StaffAssignmentDurabilityTest do
 
       round_tripped =
         event
-        |> CriticalEventSerializer.serialize()
+        |> EventSerializer.serialize()
         |> jsonify()
-        |> CriticalEventSerializer.deserialize()
+        |> EventSerializer.deserialize()
 
       refute Map.has_key?(round_tripped.payload, :unassigned_at)
 

--- a/test/klass_hero/provider/staff_deactivation_cascade_test.exs
+++ b/test/klass_hero/provider/staff_deactivation_cascade_test.exs
@@ -38,7 +38,7 @@ defmodule KlassHero.Provider.StaffDeactivationCascadeTest do
         # Nothing has consumed the event yet — the job is staged, not run.
         assert Repo.get(SessionDetail, scheduled).current_assigned_staff_name == "Jane Doe"
 
-        Oban.drain_queue(queue: :critical_events, with_recursion: true)
+        Oban.drain_queue(queue: :events, with_recursion: true)
       end)
     end)
 

--- a/test/klass_hero/provider/staff_invite_accept_messaging_test.exs
+++ b/test/klass_hero/provider/staff_invite_accept_messaging_test.exs
@@ -80,7 +80,7 @@ defmodule KlassHero.Provider.StaffInviteAcceptMessagingTest do
         # The participant row is the half that still needs the replay to land.
         refute participant?(conversation.id, user.id)
 
-        Oban.drain_queue(queue: :critical_events, with_recursion: true)
+        Oban.drain_queue(queue: :events, with_recursion: true)
       end)
     end)
 

--- a/test/klass_hero/provider/staff_offboarding_cascade_test.exs
+++ b/test/klass_hero/provider/staff_offboarding_cascade_test.exs
@@ -71,7 +71,7 @@ defmodule KlassHero.Provider.StaffOffboardingCascadeTest do
     refute Messaging.participant?(conversation.id, staff_user.id)
   end
 
-  defp drain, do: Oban.drain_queue(queue: :critical_events, with_recursion: true)
+  defp drain, do: Oban.drain_queue(queue: :events, with_recursion: true)
 
   defp with_real_outbox(fun) do
     original = Application.get_env(:klass_hero, :outbox)

--- a/test/klass_hero/shared/adapters/driven/events/event_serializer_test.exs
+++ b/test/klass_hero/shared/adapters/driven/events/event_serializer_test.exs
@@ -1,8 +1,8 @@
-defmodule KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializerTest do
+defmodule KlassHero.Shared.Adapters.Driven.Events.EventSerializerTest do
   use ExUnit.Case, async: true
   use ExUnitProperties
 
-  alias KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializer
+  alias KlassHero.Shared.Adapters.Driven.Events.EventSerializer
   alias KlassHero.Shared.Domain.Events.Event
 
   # Payload keys must survive String.to_existing_atom/1, so the generator draws from
@@ -24,8 +24,8 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializerTest do
           version: 2
         )
 
-      serialized = CriticalEventSerializer.serialize(event)
-      deserialized = CriticalEventSerializer.deserialize(serialized)
+      serialized = EventSerializer.serialize(event)
+      deserialized = EventSerializer.deserialize(serialized)
 
       assert deserialized.event_id == event.event_id
       assert deserialized.event_type == :child_data_anonymized
@@ -40,7 +40,7 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializerTest do
       event =
         Event.new(:test, :enrollment, :invite, "id", %{}, version: 3)
 
-      serialized = CriticalEventSerializer.serialize(event)
+      serialized = EventSerializer.serialize(event)
 
       assert serialized["source_context"] == "enrollment"
       assert serialized["version"] == 3
@@ -50,30 +50,30 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializerTest do
   describe "payload key atomization" do
     test "restores atom keys after JSON round-trip" do
       event = Event.new(:test, :test_context, :test, "id", %{user_id: 1, name: "Alice"})
-      serialized = CriticalEventSerializer.serialize(event)
+      serialized = EventSerializer.serialize(event)
 
       # Simulate JSON round-trip (keys become strings)
       json_cycled = Jason.decode!(Jason.encode!(serialized))
 
-      deserialized = CriticalEventSerializer.deserialize(json_cycled)
+      deserialized = EventSerializer.deserialize(json_cycled)
 
       assert deserialized.payload == %{user_id: 1, name: "Alice"}
     end
 
     test "handles nested payload maps" do
       event = Event.new(:test, :test_context, :test, "id", %{address: %{city: "Berlin", zip: "10115"}})
-      serialized = CriticalEventSerializer.serialize(event)
+      serialized = EventSerializer.serialize(event)
       json_cycled = Jason.decode!(Jason.encode!(serialized))
-      deserialized = CriticalEventSerializer.deserialize(json_cycled)
+      deserialized = EventSerializer.deserialize(json_cycled)
 
       assert deserialized.payload == %{address: %{city: "Berlin", zip: "10115"}}
     end
 
     test "atomizes keys inside maps nested in lists" do
       event = Event.new(:test, :test_context, :test, "id", %{items: [%{name: "Alice"}, %{name: "Bob"}]})
-      serialized = CriticalEventSerializer.serialize(event)
+      serialized = EventSerializer.serialize(event)
       json_cycled = Jason.decode!(Jason.encode!(serialized))
-      deserialized = CriticalEventSerializer.deserialize(json_cycled)
+      deserialized = EventSerializer.deserialize(json_cycled)
 
       assert deserialized.payload == %{items: [%{name: "Alice"}, %{name: "Bob"}]}
     end
@@ -129,7 +129,7 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializerTest do
     test "leaves values alone when payload_types is absent" do
       legacy = serialize(%{alpha: ~D[2026-08-12]}) |> Map.delete("payload_types")
 
-      assert CriticalEventSerializer.deserialize(legacy).payload == %{alpha: "2026-08-12"}
+      assert EventSerializer.deserialize(legacy).payload == %{alpha: "2026-08-12"}
     end
 
     test "raises on a struct it cannot restore" do
@@ -144,7 +144,7 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializerTest do
       }
 
       assert_raise ArgumentError, ~r/cannot cross the Oban jsonb boundary/, fn ->
-        CriticalEventSerializer.serialize(event)
+        EventSerializer.serialize(event)
       end
     end
   end
@@ -157,9 +157,9 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializerTest do
           causation_id: "cause-1"
         )
 
-      serialized = CriticalEventSerializer.serialize(event)
+      serialized = EventSerializer.serialize(event)
       json_cycled = Jason.decode!(Jason.encode!(serialized))
-      deserialized = CriticalEventSerializer.deserialize(json_cycled)
+      deserialized = EventSerializer.deserialize(json_cycled)
 
       assert deserialized.metadata == %{correlation_id: "corr-1", causation_id: "cause-1"}
     end
@@ -178,9 +178,9 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializerTest do
               })
         }
 
-      serialized = CriticalEventSerializer.serialize(event_with_trace)
+      serialized = EventSerializer.serialize(event_with_trace)
       json_cycled = Jason.decode!(Jason.encode!(serialized))
-      deserialized = CriticalEventSerializer.deserialize(json_cycled)
+      deserialized = EventSerializer.deserialize(json_cycled)
 
       assert Map.fetch(deserialized.metadata, "traceparent") == {:ok, "00-abc123-def456-01"}
       assert Map.fetch(deserialized.metadata, "tracestate") == {:ok, ""}
@@ -201,7 +201,7 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializerTest do
       test "drops #{key}, which the format does not define" do
         args = legacy_args(%{unquote(key) => "critical"})
 
-        assert CriticalEventSerializer.deserialize(args).metadata == %{}
+        assert EventSerializer.deserialize(args).metadata == %{}
       end
     end
   end
@@ -211,7 +211,7 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializerTest do
   defp legacy_args(metadata) do
     :test
     |> Event.new(:test_context, :test, "id", %{})
-    |> CriticalEventSerializer.serialize()
+    |> EventSerializer.serialize()
     |> Map.put("metadata", metadata)
     |> Jason.encode!()
     |> Jason.decode!()
@@ -224,14 +224,14 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializerTest do
     |> serialize()
     |> Jason.encode!()
     |> Jason.decode!()
-    |> CriticalEventSerializer.deserialize()
+    |> EventSerializer.deserialize()
     |> Map.fetch!(:payload)
   end
 
   defp serialize(payload) do
     :test
     |> Event.new(:test_context, :test, "id", payload)
-    |> CriticalEventSerializer.serialize()
+    |> EventSerializer.serialize()
   end
 
   defp payload_generator do

--- a/test/klass_hero/shared/adapters/driven/workers/compensation_sweep_worker_test.exs
+++ b/test/klass_hero/shared/adapters/driven/workers/compensation_sweep_worker_test.exs
@@ -14,7 +14,7 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.CompensationSweepWorkerTest d
   alias KlassHero.Messaging.Adapters.Driving.Workers.SendEmailReplyWorker
   alias KlassHero.MessagingFixtures
   alias KlassHero.Repo
-  alias KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializer
+  alias KlassHero.Shared.Adapters.Driven.Events.EventSerializer
   alias KlassHero.Shared.Adapters.Driven.Persistence.Schemas.JobCompensation
   alias KlassHero.Shared.Adapters.Driven.Persistence.Schemas.UndeliveredEvent
   alias KlassHero.Shared.Adapters.Driven.Workers.CompensationSweepWorker
@@ -120,7 +120,7 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.CompensationSweepWorkerTest d
   describe "undelivered events" do
     test "dead-letters an event delivery that gave up permanently" do
       event = Event.new(:user_registered, :accounts, :user, Ecto.UUID.generate(), %{})
-      job = discarded_job(@delivery, %{"events" => [CriticalEventSerializer.serialize(event)]})
+      job = discarded_job(@delivery, %{"events" => [EventSerializer.serialize(event)]})
 
       assert :ok = CompensationSweepWorker.perform(%Oban.Job{})
 

--- a/test/klass_hero/shared/adapters/driven/workers/event_delivery_worker_test.exs
+++ b/test/klass_hero/shared/adapters/driven/workers/event_delivery_worker_test.exs
@@ -3,12 +3,12 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorkerTest do
 
   import ExUnit.CaptureLog
 
-  alias KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializer
+  alias KlassHero.Shared.Adapters.Driven.Events.EventSerializer
   alias KlassHero.Shared.Adapters.Driven.Persistence.Schemas.ProcessedEvent
   alias KlassHero.Shared.Adapters.Driven.Persistence.Schemas.UndeliveredEvent
   alias KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorker
-  alias KlassHero.Shared.CriticalEventDispatcher
   alias KlassHero.Shared.Domain.Events.Event
+  alias KlassHero.Shared.EventDispatcher
 
   @topic "integration:test_context:thing_happened"
 
@@ -47,7 +47,7 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorkerTest do
   defp job(events, attempt \\ 1) do
     %Oban.Job{
       id: 4242,
-      args: %{"events" => Enum.map(events, &CriticalEventSerializer.serialize/1)},
+      args: %{"events" => Enum.map(events, &EventSerializer.serialize/1)},
       attempt: attempt,
       max_attempts: 10,
       discarded_at: DateTime.utc_now()
@@ -66,7 +66,7 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorkerTest do
     %{job | args: %{"events" => staged}}
   end
 
-  defp handler_ref(consumer), do: CriticalEventDispatcher.handler_ref(consumer)
+  defp handler_ref(consumer), do: EventDispatcher.handler_ref(consumer)
 
   defp mark_processed(event, consumer) do
     Repo.insert!(%ProcessedEvent{
@@ -115,7 +115,7 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorkerTest do
 
     assert Repo.get_by(ProcessedEvent,
              event_id: event.event_id,
-             handler_ref: CriticalEventDispatcher.handler_ref({Recorder, :first})
+             handler_ref: EventDispatcher.handler_ref({Recorder, :first})
            )
   end
 
@@ -200,7 +200,7 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorkerTest do
 
       assert :ok = EventDeliveryWorker.compensate(job([event]), nil)
 
-      assert undelivered(event).payload == CriticalEventSerializer.serialize(event)
+      assert undelivered(event).payload == EventSerializer.serialize(event)
     end
 
     # The loss is partial: `processed_events` keeps the consumers that did run, and a
@@ -256,6 +256,53 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorkerTest do
       assert :ok = EventDeliveryWorker.compensate(job, "boom")
 
       assert [_one] = Repo.all(from(u in UndeliveredEvent, where: u.event_id == ^event.event_id))
+    end
+  end
+
+  # #1357 moved this worker from `:critical_events` to `:events`. A queue rename is not a
+  # rename: `oban_jobs.queue` is data, so every row staged before the deploy still says
+  # "critical_events" — including anything mid-retry across the ~4.5h ladder. Both halves
+  # of why those rows are still safe are pinned here, because they are different facts and
+  # only one of them is behaviour.
+  describe "the legacy :critical_events queue" do
+    test "still executes its rows, because the worker column is what resolves the module", ctx do
+      route([{Recorder, :first}], ctx)
+
+      # `:manual` because `testing: :inline` would run the job at insert and never consult
+      # the queue at all, which is the one thing this test is here to exercise.
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        Oban.insert!(
+          EventDeliveryWorker.new(%{"events" => [EventSerializer.serialize(event("thing-1"))]},
+            queue: :critical_events
+          )
+        )
+
+        Oban.drain_queue(queue: :critical_events, with_recursion: true)
+      end)
+
+      assert [{:first, "thing-1"}] = Recorder.calls()
+    end
+
+    # `drain_queue/2` above executes by queue name in the calling process and never consults
+    # the `queues:` list, so it proves the code path and NOT that anything drains this queue
+    # in production. That guarantee is a config fact, and this is the only thing asserting it.
+    test "stays configured, or every row staged before #1357 is stranded" do
+      queues = Application.get_env(:klass_hero, Oban)[:queues]
+
+      assert Keyword.has_key?(queues, :critical_events),
+             "dropping :critical_events strands every job staged before #1357 — confirm " <>
+               "`SELECT count(*) FROM oban_jobs WHERE queue = 'critical_events'` is 0 in prod first"
+    end
+
+    # The same failure from the other end: staging into a queue no producer is running for
+    # strands the job just as quietly, and a typo in the worker's `queue:` would do it to
+    # every event at once.
+    test "the queue this worker now stages into is one that is actually configured" do
+      queues = Application.get_env(:klass_hero, Oban)[:queues]
+      staged_queue = EventDeliveryWorker.new(%{"events" => []}).changes.queue
+
+      assert staged_queue == "events"
+      assert Keyword.has_key?(queues, String.to_existing_atom(staged_queue))
     end
   end
 end

--- a/test/klass_hero/shared/adapters/driven/workers/event_delivery_worker_test.exs
+++ b/test/klass_hero/shared/adapters/driven/workers/event_delivery_worker_test.exs
@@ -291,7 +291,8 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorkerTest do
 
       assert Keyword.has_key?(queues, :critical_events),
              "dropping :critical_events strands every job staged before #1357 — confirm " <>
-               "`SELECT count(*) FROM oban_jobs WHERE queue = 'critical_events'` is 0 in prod first"
+               "`SELECT count(*) FROM oban_jobs WHERE queue = 'critical_events'` is 0 in prod " <>
+               "first. That is #1362, which removes this test along with the queue entry."
     end
 
     # The same failure from the other end: staging into a queue no producer is running for

--- a/test/klass_hero/shared/domain/events/payload_codec_test.exs
+++ b/test/klass_hero/shared/domain/events/payload_codec_test.exs
@@ -3,7 +3,7 @@ defmodule KlassHero.Shared.Domain.Events.PayloadCodecTest do
   The one list of what an event payload leaf may be, and how it crosses jsonb.
 
   Both walkers ask this module: `EventMetadata` before construction, to reject a
-  payload at its source, and `CriticalEventSerializer` on the way out and back.
+  payload at its source, and `EventSerializer` on the way out and back.
   Keeping that list in one place is the point — it lived in two before #1317, and
   both #1316 and this change had to edit both halves in lockstep.
   """

--- a/test/klass_hero/shared/domain/events/payload_guard_test.exs
+++ b/test/klass_hero/shared/domain/events/payload_guard_test.exs
@@ -21,7 +21,7 @@ defmodule KlassHero.Shared.Domain.Events.PayloadGuardTest do
     {"a struct nested in a list", %{items: ["ok", %URI{host: "x"}]}, "items.1"}
   ]
 
-  # CriticalEventSerializer records these on the way out and rebuilds them on the
+  # EventSerializer records these on the way out and rebuilds them on the
   # way in, so the consumer gets what the producer sent.
   @restorable [
     {"an atom", %{status: :pending}},

--- a/test/klass_hero/shared/event_dispatcher_test.exs
+++ b/test/klass_hero/shared/event_dispatcher_test.exs
@@ -1,21 +1,21 @@
-defmodule KlassHero.Shared.CriticalEventDispatcherTest do
+defmodule KlassHero.Shared.EventDispatcherTest do
   use KlassHero.DataCase, async: true
 
   import ExUnit.CaptureLog
 
   alias KlassHero.Repo
   alias KlassHero.Shared.Adapters.Driven.Persistence.Schemas.ProcessedEvent
-  alias KlassHero.Shared.CriticalEventDispatcher
+  alias KlassHero.Shared.EventDispatcher
 
   describe "handler_ref/1" do
     test "produces canonical string from {module, function} tuple" do
-      ref = CriticalEventDispatcher.handler_ref({MyApp.SomeHandler, :handle_event})
+      ref = EventDispatcher.handler_ref({MyApp.SomeHandler, :handle_event})
       assert ref == "Elixir.MyApp.SomeHandler:handle_event"
     end
 
     test "produces different refs for different functions on same module" do
-      ref_a = CriticalEventDispatcher.handler_ref({MyApp.Handler, :handle})
-      ref_b = CriticalEventDispatcher.handler_ref({MyApp.Handler, :handle_event})
+      ref_a = EventDispatcher.handler_ref({MyApp.Handler, :handle})
+      ref_b = EventDispatcher.handler_ref({MyApp.Handler, :handle_event})
       assert ref_a != ref_b
     end
   end
@@ -27,7 +27,7 @@ defmodule KlassHero.Shared.CriticalEventDispatcherTest do
       test_pid = self()
 
       result =
-        CriticalEventDispatcher.execute(event_id, handler_ref, fn ->
+        EventDispatcher.execute(event_id, handler_ref, fn ->
           send(test_pid, :handler_called)
           :ok
         end)
@@ -46,7 +46,7 @@ defmodule KlassHero.Shared.CriticalEventDispatcherTest do
 
       # First call processes normally
       :ok =
-        CriticalEventDispatcher.execute(event_id, handler_ref, fn ->
+        EventDispatcher.execute(event_id, handler_ref, fn ->
           send(test_pid, :first_call)
           :ok
         end)
@@ -55,7 +55,7 @@ defmodule KlassHero.Shared.CriticalEventDispatcherTest do
 
       # Second call is idempotent — handler not called
       :ok =
-        CriticalEventDispatcher.execute(event_id, handler_ref, fn ->
+        EventDispatcher.execute(event_id, handler_ref, fn ->
           send(test_pid, :second_call)
           :ok
         end)
@@ -68,7 +68,7 @@ defmodule KlassHero.Shared.CriticalEventDispatcherTest do
       handler_ref = "Elixir.TestModule:handle"
 
       result =
-        CriticalEventDispatcher.execute(event_id, handler_ref, fn ->
+        EventDispatcher.execute(event_id, handler_ref, fn ->
           {:error, :something_went_wrong}
         end)
 
@@ -83,7 +83,7 @@ defmodule KlassHero.Shared.CriticalEventDispatcherTest do
       handler_ref = "Elixir.TestModule:handle"
 
       result =
-        CriticalEventDispatcher.execute(event_id, handler_ref, fn ->
+        EventDispatcher.execute(event_id, handler_ref, fn ->
           raise "boom"
         end)
 
@@ -98,7 +98,7 @@ defmodule KlassHero.Shared.CriticalEventDispatcherTest do
       handler_ref = "Elixir.TestModule:handle"
 
       result =
-        CriticalEventDispatcher.execute(event_id, handler_ref, fn ->
+        EventDispatcher.execute(event_id, handler_ref, fn ->
           :ignore
         end)
 
@@ -112,7 +112,7 @@ defmodule KlassHero.Shared.CriticalEventDispatcherTest do
 
       log =
         capture_log([level: :error], fn ->
-          CriticalEventDispatcher.execute(event_id, handler_ref, fn ->
+          EventDispatcher.execute(event_id, handler_ref, fn ->
             raise "kaboom"
           end)
         end)
@@ -128,13 +128,13 @@ defmodule KlassHero.Shared.CriticalEventDispatcherTest do
 
       # First attempt fails
       {:error, _} =
-        CriticalEventDispatcher.execute(event_id, handler_ref, fn ->
+        EventDispatcher.execute(event_id, handler_ref, fn ->
           {:error, :transient}
         end)
 
       # Retry succeeds — row was not left behind
       :ok =
-        CriticalEventDispatcher.execute(event_id, handler_ref, fn ->
+        EventDispatcher.execute(event_id, handler_ref, fn ->
           send(test_pid, :retry_succeeded)
           :ok
         end)

--- a/test/klass_hero/shared/payload_jsonb_delivery_test.exs
+++ b/test/klass_hero/shared/payload_jsonb_delivery_test.exs
@@ -15,7 +15,7 @@ defmodule KlassHero.Shared.PayloadJsonbDeliveryTest do
 
   use KlassHero.DataCase, async: false
 
-  alias KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializer
+  alias KlassHero.Shared.Adapters.Driven.Events.EventSerializer
   alias KlassHero.Shared.Adapters.Driven.Events.ObanOutbox
   alias KlassHero.Shared.Domain.Events.Event
   alias KlassHero.Shared.Outbox
@@ -45,7 +45,7 @@ defmodule KlassHero.Shared.PayloadJsonbDeliveryTest do
 
     args = stage_and_read_args(event)
 
-    assert CriticalEventSerializer.deserialize(args).payload == @payload
+    assert EventSerializer.deserialize(args).payload == @payload
   end
 
   test "the stored payload is still plain JSON, with the types beside it" do

--- a/test/support/event_test_helper.ex
+++ b/test/support/event_test_helper.ex
@@ -20,7 +20,7 @@ defmodule KlassHero.EventTestHelper do
 
   import ExUnit.Assertions
 
-  alias KlassHero.Shared.Adapters.Driven.Events.CriticalEventSerializer
+  alias KlassHero.Shared.Adapters.Driven.Events.EventSerializer
   alias KlassHero.Shared.Adapters.Driven.Events.TestOutbox
   alias KlassHero.Shared.Domain.Events.Event
 
@@ -41,10 +41,10 @@ defmodule KlassHero.EventTestHelper do
   @spec through_outbox(Event.t()) :: Event.t()
   def through_outbox(%Event{} = event) do
     event
-    |> CriticalEventSerializer.serialize()
+    |> EventSerializer.serialize()
     |> Jason.encode!()
     |> Jason.decode!()
-    |> CriticalEventSerializer.deserialize()
+    |> EventSerializer.deserialize()
   end
 
   @doc """


### PR DESCRIPTION
Closes #1357.

## Summary

Since ADR-0014 there is one event delivery path: `EventDeliveryWorker` carries every event, one dispatcher gates every consumer, one serializer encodes every job's args. "Critical" stopped naming a distinction. #1326 removed the `criticality` field and its 19 doc markers; this removes the last artifact claiming the distinction survives.

- `Shared.CriticalEventDispatcher` → `Shared.EventDispatcher`
- `...Driven.Events.CriticalEventSerializer` → `...Driven.Events.EventSerializer`
- `EventDeliveryWorker` moves from `:critical_events` to `:events`

No behaviour changes. Arities, return shapes and module placement are all identical.

## Review focus

**The queue half is not a rename — it is an in-flight-job migration.** `oban_jobs.queue` is data, so every row staged before this deploys still says `critical_events`, including anything mid-retry across the ~4.5h backoff ladder. Those rows do not *fail* if their queue goes unattended. They sit, and nothing alerts on a merely unattended queue.

So **both queues stay configured for one release**. Legacy rows keep executing because Oban dispatches on the `queue` column but executes the `worker` column, and `EventDeliveryWorker`'s module name is unchanged — `oban_jobs.args` names no modules at all. #1362 drops the transitional entry once the prod count reaches zero, gated on the count and not on elapsed time.

The alternative was rejected on a concrete race: `fly.toml` sets `release_command = "/app/bin/migrate"`, which runs **before** the new machines take over. An `UPDATE oban_jobs SET queue = ...` there leaves old machines still live and still staging into the old queue afterwards, and `executing` rows land in `retryable` on the old queue when they fail.

**Two rollout tests, deliberately separate** — they prove different things and one is weaker than it looks:

- *"still executes its rows"* drives a real `critical_events` row through `drain_queue/2`. This proves the **code path** (args parse, worker resolves, consumers fire under the renamed modules).
- *"stays configured"* is a plain config assertion, and it is the **only** thing pinning the production guarantee — `drain_queue/2` executes by queue name in the calling process and never consults the `queues:` list, so the first test would pass even with the queue unconfigured.

A third test pins the same failure from the other end: the queue this worker now *stages into* is one that is actually configured. A typo in `queue:` would strand every event at once, just as quietly.

**ADRs 0006/0014 and CHANGELOG keep the old names** and are untouched. An ADR stating the module was called `CriticalEventDispatcher` is correct about the date it records; rewriting it would falsify the record.

Two already-stale references were corrected while in the same files: `EventDispatcher`'s moduledoc claimed "Both the PubSub real-time path and the Oban durable path funnel through this module" (the PubSub path died with ADR-0014), and two test/moduledoc comments named `CriticalEventWorker` and `EventSubscriber`, both long-deleted modules a reader would grep for and never find.

## Test plan

- `mix precommit` — 4362 passed, 2 skipped. Credo, format, typography, translations, `lint_read_tables` and `lint_acl_boundary` all clean.
- Both new queue tests were verified red before the config change and green after.
- Confirmed no stale identifier survives outside the historical record:

  ```
  rg "CriticalEvent" -g '!CHANGELOG.md' -g '!docs/adr/**'    # no hits
  rg "critical_events" -g '!CHANGELOG.md' -g '!docs/adr/**'  # config/config.exs + the legacy-queue tests only
  ```

## After merge

Do not drop `critical_events: 5` in a follow-up sweep without running the count query from #1362 first. The guard test fails until you do, and its failure message says why.