### PR TITLE
chore: provision every checkout automatically so Tidewave is always up

### DIFF
--- a/.claude/hooks/session_start_worktree.sh
+++ b/.claude/hooks/session_start_worktree.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# SessionStart(startup|resume) hook: make sure this checkout has a dev server and a
+# Tidewave endpoint that belong to it, before the session does any work.
+#
+# This is the load-bearing path. WorktreeCreate is an accelerator that only fires for
+# harness-created worktrees; this fires for every session in every checkout, however
+# that checkout came to exist, so a session can never quietly begin against a dead or
+# foreign Tidewave.
+#
+# Fast when there is nothing to do (a status check is two lsof calls and a curl), so
+# the common case costs nothing. Provisioning only runs when the check fails, and is
+# detached so a cold compile cannot hold up the session.
+#
+# Exit 0 always: a provisioning problem is worth reporting, never worth refusing to
+# start a session over.
+set -uo pipefail
+
+cd "$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+[[ -x bin/worktree-status ]] || exit 0
+
+if bin/worktree-status >/dev/null 2>&1; then
+  exit 0
+fi
+
+STATUS=$(bin/worktree-status 2>&1 || true)
+
+# Detached: a cold checkout needs deps + compile, which can outlast any hook budget.
+# The session starts now and the server catches up.
+mkdir -p .claude/run
+nohup bin/worktree-up --quiet >>.claude/run/boot.log 2>&1 &
+disown
+
+cat >&2 <<EOF
+Dev server / Tidewave was not ready for this checkout — provisioning started in the
+background (log: .claude/run/boot.log). Check with: bin/worktree-status
+
+$STATUS
+
+Until it reports READY, do not rely on Tidewave: follow the Unavailability Alert
+Protocol in .claude/rules/mcp-integration.md rather than silently falling back to bash.
+If .mcp.json was only just written, this session cannot pick it up at all — it is read
+at session start. Restart the session here once bin/worktree-status says READY.
+EOF
+
+exit 0

--- a/.claude/hooks/worktree_create.sh
+++ b/.claude/hooks/worktree_create.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# WorktreeCreate hook: create the worktree AND provision it, so the session that
+# lands in it already has its own databases and its own Tidewave port.
+#
+# This event replaces Claude Code's default `git worktree add`, so this script owns
+# creation entirely. Its output contract is unusual and unforgiving:
+#
+#   * stdout must end with the absolute path of the created worktree, and nothing
+#     else may be printed there. Every diagnostic goes to stderr.
+#   * any non-zero exit aborts worktree creation.
+#
+# Provisioning uses --fast (databases and .mcp.json, no seeds, no server) to stay well
+# inside the hook budget. The SessionStart hook finishes the job — seeds and the dev
+# server — once a session actually opens here.
+#
+# Deliberate deviation from "fail closed": a *provisioning* failure warns and still
+# returns the path, because bin/worktree-up is convergent and SessionStart re-runs it.
+# Only a failure to create the worktree itself aborts. Destroying a freshly created
+# worktree over a transient docker hiccup would cost real work; a half-provisioned one
+# costs a retry.
+set -uo pipefail
+
+PAYLOAD=$(cat | tr -d '\000-\037')
+NAME=$(jq -r '.name // empty' <<<"$PAYLOAD" 2>/dev/null)
+
+if [[ -z "$NAME" ]]; then
+  echo "worktree_create: no .name in the hook payload" >&2
+  exit 1
+fi
+
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  echo "worktree_create: not in a git repository" >&2
+  exit 1
+}
+cd "$ROOT"
+
+DEST="${ROOT}/.claude/worktrees/${NAME}"
+BRANCH="worktree-${NAME}"
+
+if [[ -d "$DEST" ]]; then
+  echo "worktree_create: ${DEST} already exists" >&2
+  exit 1
+fi
+
+git fetch origin --quiet 2>/dev/null || true
+
+# Reuse the branch if it already exists; otherwise cut a fresh one from origin/main.
+if git show-ref --verify --quiet "refs/heads/${BRANCH}"; then
+  git worktree add "$DEST" "$BRANCH" >&2 || exit 1
+else
+  git worktree add "$DEST" -b "$BRANCH" origin/main >&2 || exit 1
+fi
+
+if ! (cd "$DEST" && bin/worktree-up --fast >&2); then
+  cat >&2 <<EOF
+worktree_create: ${NAME} was created but provisioning did not finish.
+                 The worktree is usable; run bin/worktree-up inside it, or just start
+                 a session there — the SessionStart hook retries automatically.
+EOF
+fi
+
+# The contract: the path, alone, last.
+echo "$DEST"

--- a/.claude/hooks/worktree_remove.sh
+++ b/.claude/hooks/worktree_remove.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# WorktreeRemove hook: tear down what the worktree was using before its directory
+# disappears — its dev server, its dev database, its test database.
+#
+# This is what stops the next orphan. A dev server outlives `git worktree remove`
+# perfectly happily: it keeps its port and keeps answering /tidewave/mcp for a
+# checkout that no longer exists, which is worse than being down, because it looks
+# healthy. One such process (a deleted kh-1321 worktree, still serving 4010) is what
+# prompted this whole change.
+#
+# The event cannot block removal and its failures are only logged in debug mode, so
+# this is best-effort by design. bin/worktree-up's reaper is the backstop for anything
+# that slips through.
+set -uo pipefail
+
+PAYLOAD=$(cat | tr -d '\000-\037')
+WORKTREE=$(jq -r '.worktree_path // empty' <<<"$PAYLOAD" 2>/dev/null)
+
+[[ -n "$WORKTREE" && -d "$WORKTREE" ]] || exit 0
+[[ -x "$WORKTREE/bin/worktree-down" ]] || exit 0
+
+(cd "$WORKTREE" && bin/worktree-down >&2) || true
+
+exit 0

--- a/.claude/rules/mcp-integration.md
+++ b/.claude/rules/mcp-integration.md
@@ -54,10 +54,17 @@ When Tidewave is not connected or fails to respond:
    [Next step: suggest remedial action]
    ```
 
-2. **Investigation required**: Tidewave unavailability suggests:
-   - Phoenix server not running (`mix phx.server` needed)
-   - MCP connection issue requiring restart
-   - Development environment misconfiguration
+2. **Investigation required**: run `bin/worktree-status` first — it answers the two
+   questions that matter in one shot: is a server answering on this checkout's port,
+   and does that server actually *live in this checkout*. Its verdict maps to a cause:
+
+   | Verdict | Cause |
+   |---|---|
+   | `NOT RUNNING` | no dev server — run `bin/worktree-up` |
+   | `NOT CONFIGURED` | no `.mcp.json` — run `bin/worktree-up` |
+   | `ORPHAN` | a server from a deleted checkout is answering; `bin/worktree-up` reaps it |
+   | `WRONG CHECKOUT` | another live checkout holds the port; **do not use Tidewave from here** |
+   | `READY` | the server is fine, so this is an MCP client issue — the session started before the server was up, and `.mcp.json` is read at session start. Reconnect via `/mcp`, or restart the session in this directory |
 
 3. **Never silently degrade**: Do not fall back to bash/shell evaluation without explicitly notifying the user that Tidewave is unavailable
 

--- a/.claude/rules/worktrees.md
+++ b/.claude/rules/worktrees.md
@@ -26,52 +26,86 @@ Skip the worktree only when the user explicitly asks to work in the current
 checkout, or for read-only / throwaway actions (answering a question, a quick
 `git log`, inspecting a file) where no branch or edit is produced.
 
-After entering a native worktree, hydrate it once and set `MIX_TEST_PARTITION`
-per the sections below before running any format/credo/test hook.
+Provisioning is automatic — see the next section. You do not set
+`MIX_TEST_PARTITION` by hand any more; it is derived from the checkout.
 
-## First-run setup (fresh checkout has no deps/_build)
+## Provisioning: `bin/worktree-up` does all of it
 
-A native worktree starts empty of build artifacts, so the format/credo/test hooks
-fail until you hydrate it once:
-
-```bash
-mix deps.get
-MIX_TEST_PARTITION=<n> mix compile
-MIX_TEST_PARTITION=<n> MIX_ENV=test mix ecto.create
-MIX_TEST_PARTITION=<n> MIX_ENV=test mix ecto.migrate
-mix ecto.setup     # this worktree's OWN dev DB — create + migrate
-mix ecto.seed      # skip if you only need the test suite
-bin/setup-mcp      # allocate this worktree's dev port + Tidewave endpoint
-```
-
-`bin/setup-mcp` writes `.mcp.json`, which Claude Code reads **at session start** —
-so restart the session in the worktree afterwards. See the Tidewave section below.
-
-The two `ecto` lines are the dev DB, which is separate from the test DB above and
-needs no `MIX_TEST_PARTITION` — see the next section. Skipping them is safe: the
-first dev-env command fails loudly on a missing database rather than falling back
-to main's.
-
-## Test DB isolation — always set MIX_TEST_PARTITION in a worktree
-
-All parallel checkouts share **one** Docker Postgres test container. The test DB
-name is suffixed by `MIX_TEST_PARTITION` (`config/test.exs`:
-`database: "klass_hero_test#{System.get_env("MIX_TEST_PARTITION")}"`). Without it,
-every worktree targets the same `klass_hero_test` DB and steps on each other —
-the classic symptom is a phantom missing/extra column error where one branch's
-migrations disagree with another's schema.
-
-So in a worktree, prefix **every** test/DB command with a partition unique to that
-worktree (e.g. the issue number):
+**Before any work in a checkout, it must be provisioned.** One command, idempotent,
+safe to run any number of times in any checkout including main:
 
 ```bash
-MIX_TEST_PARTITION=1060 mix test
-MIX_TEST_PARTITION=1060 mix precommit
+bin/worktree-up        # containers, deps, compile, dev DB (+seeds), test DB,
+                       # .mcp.json, detached dev server, verified Tidewave
+bin/worktree-status    # read-only: is Tidewave up AND is it *this* checkout's?
+bin/worktree-down      # stop the server, drop this checkout's two databases
 ```
 
-`mix precommit` runs the full suite, so it needs the partition too. The container
-itself is shared and started once (`mix test.setup`); only the DB *name* is
-per-partition, so no extra container management is required.
+You normally never type these. Three hooks in `.claude/settings.json` run them:
+
+| Hook | What it does |
+|---|---|
+| `WorktreeCreate` | creates the worktree and provisions it (`--fast`: DBs + `.mcp.json`, no seeds, no server) |
+| `SessionStart` | converges the checkout on every session start/resume — the load-bearing path |
+| `WorktreeRemove` | tears the checkout down before its directory disappears |
+
+A cold worktree reaches a verified Tidewave in about 30 seconds, seeds included,
+because `bin/worktree-up` copies `deps/` and `_build/` from the main checkout
+first — a worktree materializes only *tracked* files, so those start empty, and
+the copy turns a full compile into an incremental one. It copies rather than
+symlinks: a shared `_build` would serve one checkout's beam files to another.
+
+### "Tidewave is up" is not the property you want
+
+`bin/worktree-status` verifies something stronger: that the process answering
+`/tidewave/mcp` on this checkout's port has **this checkout as its working
+directory**. A dev server outlives `git worktree remove` happily and keeps
+answering perfectly for a checkout that no longer exists — which is worse than
+being down, because it looks healthy, and `project_eval` against it silently
+evaluates code that is gone. `bin/worktree-up` reaps such a listener (and only
+such a listener: one whose own directory is gone). A port held by a *different
+live* checkout is reported, never taken.
+
+### The one thing no script can fix
+
+`.mcp.json` is read **at session start**, and `EnterWorktree` does not restart the
+session — it changes the working directory the way `/cd` does, and does not
+re-fire `SessionStart`. So **a worktree entered mid-session keeps pointing at the
+previous checkout's Tidewave.**
+
+Do not call `project_eval` after a mid-session `EnterWorktree`; you would be
+evaluating against the wrong tree. Start the task's session *in* the worktree
+instead (`cd <worktree> && claude`). If Tidewave is missing where it should be
+present, say so and follow the Unavailability Alert Protocol in
+`.claude/rules/mcp-integration.md` — never silently fall back to bash.
+
+## Test DB isolation — derived, not remembered
+
+All parallel checkouts share **one** Docker Postgres container. Isolation is by
+database *name*, and both names are derived in config from the checkout directory,
+so every `mix` invocation gets them for free:
+
+| Checkout | dev DB (`config/dev.exs`) | test DB (`config/test.exs`) |
+|---|---|---|
+| main | `klass_hero_dev` | `klass_hero_test` |
+| worktree `kh-1257` | `klass_hero_dev_kh_1257` | `klass_hero_test_kh_1257` |
+
+`MIX_TEST_PARTITION` still wins when set explicitly — CI sets it per partition,
+and you can set it by hand to run two logically separate suites in one checkout.
+What changed is that you no longer *have to*:
+
+```bash
+mix test          # already isolated
+mix precommit     # already isolated
+```
+
+This used to be a rule you had to remember, and a rule cannot bind an automated
+caller: `.claude/hooks/tests.sh` runs `mix test` on every edit and never set the
+variable, so every worktree's edit-triggered suite was writing to the shared
+`klass_hero_test`. Same failure as #1257 on the dev side, fixed the same way — in
+config, which every `mix` invocation reads, rather than in a launcher a hook can
+bypass. The container is still shared and started once (`mix test.setup`); only
+the DB name is per-checkout, so no extra container management is required.
 
 `mix test` binds **no** HTTP port, so worktree suites can run concurrently — only the
 `MIX_TEST_PARTITION` DB isolation above is required. `config/test.exs` sets
@@ -91,8 +125,8 @@ two can't drift apart.
 
 ## Dev DB isolation — automatic, nothing to remember
 
-Unlike the test DB, the dev DB needs no env var from you. `config/dev.exs` derives the
-name from the checkout itself:
+The dev DB needs no env var from you. `config/dev.exs` derives the name from the
+checkout itself (and `config/test.exs` now does the same for the test DB):
 
 | Checkout | Dev database |
 |---|---|
@@ -132,12 +166,20 @@ Tidewave endpoint on that port, so several can run at once.
 
 ### Setup
 
+`bin/worktree-up` does this for you, and the `SessionStart` hook runs it. The
+pieces, when you need them individually:
+
 ```bash
-bin/setup-mcp   # once per checkout — writes .mcp.json, then restart Claude Code here
-bin/dev         # starts the server on that checkout's port
+bin/setup-mcp    # allocate/repair this checkout's port in .mcp.json
+bin/dev          # foreground server with an IEx shell
+bin/dev --detach # background server, waits until Tidewave answers
+bin/dev --port   # print this checkout's port
 ```
 
-`bin/setup-mcp` runs in **every** checkout, main included. Main takes 4000; a worktree
+`bin/setup-mcp` runs in **every** checkout, main included. It is *convergent*, not
+write-once: an existing `.mcp.json` is re-validated rather than trusted, because a
+port can stop being yours between runs — another checkout claims it, or an orphaned
+server keeps answering on it. Main takes 4000; a worktree
 takes the lowest free port in **4010–4039**. It writes `.mcp.json` declaring an MCP
 server named `tidewave` at `http://localhost:<port>/tidewave/mcp`, and `bin/dev` reads
 the port back out of that same file — so the client and the server it talks to cannot

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,39 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/session_start_worktree.sh",
+            "timeout": 20
+          }
+        ]
+      }
+    ],
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/worktree_create.sh",
+            "timeout": 600
+          }
+        ]
+      }
+    ],
+    "WorktreeRemove": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/worktree_remove.sh",
+            "timeout": 120
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write",

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,9 @@ npm-debug.log
 .claude/worktrees/
 .superpowers/
 
+# Per-checkout dev server runtime state (pidfile + logs), written by bin/worktree-up
+.claude/run/
+
 # Override global gitignore to track Claude config
 !CLAUDE.md
 !.claude/

--- a/bin/dev
+++ b/bin/dev
@@ -6,15 +6,18 @@
 # checkout's Tidewave endpoint — so the MCP client and the server it talks to can
 # never drift apart. Falls back to 4000 if the file is missing.
 #
-# Run bin/setup-mcp once per checkout to create it.
+# Run bin/worktree-up once per checkout to create it (it calls bin/setup-mcp).
 #
 # Usage:
-#   bin/dev            start the server
+#   bin/dev            start the server in the foreground, with an IEx shell
 #   bin/dev --port     print the port and exit
+#   bin/dev --detach   start it in the background, then wait until Tidewave answers
 
 set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
+# shellcheck source=bin/lib/worktree-common.sh
+source bin/lib/worktree-common.sh
 
 port=4000
 
@@ -42,5 +45,50 @@ if [[ "${1:-}" == "--port" ]]; then
   exit 0
 fi
 
-echo "Starting dev server on http://localhost:${port} (live_debugger on $((port + 100)))"
-exec env PORT="$port" iex -S mix phx.server
+if [[ "${1:-}" != "--detach" ]]; then
+  echo "Starting dev server on http://localhost:${port} (live_debugger on $((port + 100)))"
+  exec env PORT="$port" iex -S mix phx.server
+fi
+
+# --- detached ---------------------------------------------------------------
+#
+# `mix phx.server`, not `iex -S mix`: a background process must not expect a TTY.
+# The pidfile records the pid that ends up *listening*, found via lsof once the
+# server is up — not $! from the launch, which is the mix wrapper and not the beam
+# that owns the socket.
+
+if [[ "$(port_owner "$port")" == "mine" ]] && tidewave_alive "$port"; then
+  echo "Dev server already running for this checkout on ${port}." >&2
+  exit 0
+fi
+
+reap_dead_listener "$port" || true
+
+case "$(port_owner "$port")" in
+  foreign)
+    pid=$(listener_pid "$port")
+    echo "bin/dev: port ${port} is held by pid ${pid} from $(listener_cwd "$pid")." >&2
+    echo "         That is a different live checkout — refusing to take its port." >&2
+    exit 1
+    ;;
+esac
+
+mkdir -p "$RUN_DIR"
+: >"$LOG_FILE"
+
+echo "Starting dev server on http://localhost:${port} (live_debugger on $((port + 100)))" >&2
+PORT="$port" nohup mix phx.server >>"$LOG_FILE" 2>&1 &
+disown
+
+for _ in $(seq 1 120); do
+  if tidewave_alive "$port"; then
+    listener_pid "$port" >"$PID_FILE"
+    echo "Tidewave up at $(tidewave_url "$port") (pid $(cat "$PID_FILE"))." >&2
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "bin/dev: server did not answer on ${port} within 120s. Last 30 lines of ${LOG_FILE}:" >&2
+tail -30 "$LOG_FILE" >&2
+exit 1

--- a/bin/lib/worktree-common.sh
+++ b/bin/lib/worktree-common.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+#
+# Shared helpers for the per-checkout dev environment: which slug this checkout
+# has, which databases it owns, which port it may bind, and whether the process
+# already holding that port is actually ours.
+#
+# Sourced, never executed. Callers set their own `set -euo pipefail`; a library
+# that sets shell options changes its caller's behaviour behind its back.
+#
+# Used by: bin/setup-mcp, bin/worktree-up, bin/worktree-down, bin/worktree-status,
+# and the .claude/hooks/worktree_*.sh hooks.
+
+MAIN_PORT=4000
+PORT_MIN=4010
+PORT_MAX=4039
+
+# Where a detached dev server records itself. Gitignored; per checkout.
+RUN_DIR=".claude/run"
+PID_FILE="${RUN_DIR}/dev.pid"
+LOG_FILE="${RUN_DIR}/dev.log"
+
+# ---------------------------------------------------------------------------
+# Checkout identity
+# ---------------------------------------------------------------------------
+
+repo_root() {
+  git rev-parse --show-toplevel
+}
+
+# A linked worktree has .git as a FILE ("gitdir: ..."); the main checkout has a
+# directory. Same test config/dev.exs uses to decide the database name.
+linked_worktree() {
+  [[ -f "$(repo_root)/.git" ]]
+}
+
+# The slug config/dev.exs derives in Elixir, derived identically in bash:
+#   basename |> downcase |> replace(~r/[^a-z0-9]+/, "_")
+# The two MUST agree — the script provisions the database the app then opens.
+checkout_slug() {
+  basename "$(repo_root)" |
+    tr '[:upper:]' '[:lower:]' |
+    sed -E 's/[^a-z0-9]+/_/g'
+}
+
+# Mirrors config/dev.exs, including the 63-char Postgres identifier limit.
+dev_database() {
+  if [[ -n "${LOCAL_DEV_DATABASE:-}" ]]; then
+    echo "$LOCAL_DEV_DATABASE"
+  elif linked_worktree; then
+    local name="klass_hero_dev_$(checkout_slug)"
+    echo "${name:0:63}"
+  else
+    echo "klass_hero_dev"
+  fi
+}
+
+# Mirrors config/test.exs. The main checkout keeps the bare name so CI, which
+# checks out a normal repo, is unaffected.
+test_partition() {
+  if [[ -n "${MIX_TEST_PARTITION:-}" ]]; then
+    echo "$MIX_TEST_PARTITION"
+  elif linked_worktree; then
+    echo "_$(checkout_slug)"
+  else
+    echo ""
+  fi
+}
+
+test_database() {
+  local name="klass_hero_test$(test_partition)"
+  echo "${name:0:63}"
+}
+
+# ---------------------------------------------------------------------------
+# Ports
+# ---------------------------------------------------------------------------
+
+# The port a .mcp.json names, or nothing if it has no tidewave entry.
+port_from() {
+  jq -r '.mcpServers.tidewave.url // empty' "$1" 2>/dev/null |
+    sed -n 's#.*localhost:\([0-9][0-9]*\)/.*#\1#p'
+}
+
+# Ports already written into some checkout's .mcp.json. Stale entries self-clean:
+# a deleted worktree stops appearing in `git worktree list`.
+claimed_ports() {
+  local worktree
+  while read -r worktree; do
+    [[ "$worktree" == "$(repo_root)" ]] && continue
+    if [[ -f "$worktree/.mcp.json" ]]; then
+      port_from "$worktree/.mcp.json"
+    fi
+  done < <(git worktree list --porcelain | awk '/^worktree /{print $2}')
+}
+
+bound_ports() {
+  lsof -nP -iTCP -sTCP:LISTEN 2>/dev/null |
+    sed -n 's/.*:\([0-9][0-9]*\) (LISTEN).*/\1/p'
+}
+
+listener_pid() {
+  lsof -t -nP -iTCP:"$1" -sTCP:LISTEN 2>/dev/null | head -1
+}
+
+# The working directory of a running process. This is what lets us tell "Tidewave
+# is up" apart from "Tidewave is up FOR THIS CODE" — the distinction the whole
+# per-checkout setup rests on.
+listener_cwd() {
+  lsof -a -p "$1" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | tail -1
+}
+
+# Who owns $1, from this checkout's point of view:
+#   free    nothing is listening
+#   mine    a process whose cwd is this checkout
+#   dead    a process whose cwd no longer exists on disk (an orphan; safe to kill)
+#   foreign a process belonging to another live checkout (never kill this)
+port_owner() {
+  local port="$1" pid cwd
+  pid=$(listener_pid "$port")
+
+  if [[ -z "$pid" ]]; then
+    echo "free"
+    return
+  fi
+
+  cwd=$(listener_cwd "$pid")
+
+  if [[ "$cwd" == "$(repo_root)" ]]; then
+    echo "mine"
+  elif [[ -z "$cwd" || ! -d "$cwd" ]]; then
+    echo "dead"
+  else
+    echo "foreign"
+  fi
+}
+
+# Kill an orphan — and only an orphan. A listener whose own directory is gone
+# cannot have anything depending on it, which is what makes this unambiguous.
+# A `foreign` port belongs to a live checkout and is never touched: that is the
+# #1253 lesson (one checkout reaching into another's state) in process form.
+reap_dead_listener() {
+  local port="$1" pid cwd
+
+  [[ "$(port_owner "$port")" == "dead" ]] || return 1
+
+  pid=$(listener_pid "$port")
+  cwd=$(listener_cwd "$pid")
+
+  echo "Reaping orphaned server on port ${port}: pid ${pid}, former checkout ${cwd:-unknown} (gone)." >&2
+  kill "$pid" 2>/dev/null || true
+
+  for _ in $(seq 1 20); do
+    kill -0 "$pid" 2>/dev/null || return 0
+    sleep 0.5
+  done
+
+  kill -9 "$pid" 2>/dev/null || true
+  return 0
+}
+
+# Lowest free port in the range. Claimed ports keep two worktrees off the same
+# number even while their servers are down; bound ports additionally dodge an
+# unrelated process squatting in the range.
+allocate_port() {
+  local taken port
+  taken=$(
+    {
+      claimed_ports
+      bound_ports
+    } | sort -u
+  )
+
+  for ((port = PORT_MIN; port <= PORT_MAX; port++)); do
+    if ! grep -qx "$port" <<<"$taken"; then
+      echo "$port"
+      return 0
+    fi
+  done
+
+  echo "No free port in ${PORT_MIN}-${PORT_MAX}." >&2
+  echo "Run bin/worktree-down in a checkout you are finished with, or widen the range in bin/lib/worktree-common.sh." >&2
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Tidewave
+# ---------------------------------------------------------------------------
+
+tidewave_url() {
+  echo "http://localhost:$1/tidewave/mcp"
+}
+
+# The endpoint is POST-only JSON-RPC, so a bare GET returning 405 is the healthy
+# answer. curl prints 000 itself when it cannot connect, so swallow its exit
+# status rather than echoing a second 000 after it.
+tidewave_status() {
+  curl -s -o /dev/null -m 3 -w '%{http_code}' "$(tidewave_url "$1")" 2>/dev/null || true
+}
+
+tidewave_alive() {
+  local code
+  code=$(tidewave_status "$1")
+  [[ "$code" == "405" || "$code" == "200" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Postgres
+# ---------------------------------------------------------------------------
+
+# Ask Postgres directly rather than parsing `mix ecto.create`'s output, whose
+# wording is an Ecto implementation detail. Used to decide whether seeding is
+# safe: priv/repo/seeds.exs is Repo.insert! throughout, so re-seeding a populated
+# database raises on a unique constraint.
+database_exists() {
+  PGPASSWORD=postgres psql -h localhost -U postgres -tAc \
+    "SELECT 1 FROM pg_database WHERE datname = '$1'" 2>/dev/null | grep -qx 1
+}

--- a/bin/setup-mcp
+++ b/bin/setup-mcp
@@ -1,93 +1,102 @@
 #!/usr/bin/env bash
 #
 # Give this checkout its own dev-server port and Tidewave MCP endpoint by writing
-# .mcp.json. Run once per checkout — the main one included.
+# .mcp.json.
 #
 # The main checkout takes 4000; each worktree takes the lowest free port in
 # PORT_MIN..PORT_MAX, so several dev servers can run at once and each Claude Code
 # session talks to the server for the code it is actually looking at.
+#
+# Convergent, not write-once: an existing .mcp.json is re-validated, not trusted.
+# A port can stop being ours between runs — another checkout claims it, or an
+# orphaned server from a deleted worktree keeps answering on it. That orphan case
+# is the dangerous one, because it answers /tidewave/mcp *correctly* for the wrong
+# code. Re-validation is what turns that from a silent wrong answer into a fix.
 #
 # .mcp.json is *project* scope, which outranks user scope and replaces the entry
 # wholesale (scopes match by name; fields are never merged). Keeping the name
 # `tidewave` is deliberate: MCP tool permissions are keyed on the server name, so a
 # per-worktree name would need its own mcp__<name>__* grants in settings.
 #
-# .mcp.json is gitignored, so every checkout needs this run once.
+# .mcp.json is gitignored, so every checkout needs this run once. bin/worktree-up
+# calls it for you.
 #
-# Usage: bin/setup-mcp
+# Usage:
+#   bin/setup-mcp            write or repair .mcp.json
+#   bin/setup-mcp --quiet    same, but only speak up on a change or a problem
 
 set -euo pipefail
 
-MAIN_PORT=4000
-PORT_MIN=4010
-PORT_MAX=4039
-
 cd "$(git rev-parse --show-toplevel)"
+# shellcheck source=bin/lib/worktree-common.sh
+source bin/lib/worktree-common.sh
+
+QUIET=false
+[[ "${1:-}" == "--quiet" ]] && QUIET=true
 
 if ! command -v jq >/dev/null 2>&1; then
   echo "setup-mcp: jq is required" >&2
   exit 1
 fi
 
-# Extract the port from a .mcp.json, or nothing if it has no tidewave entry.
-port_from() {
-  jq -r '.mcpServers.tidewave.url // empty' "$1" 2>/dev/null |
-    sed -n 's#.*localhost:\([0-9][0-9]*\)/.*#\1#p'
+say() { $QUIET || echo "$@"; }
+
+root=$(repo_root)
+
+# Is $1 a port this checkout may still call its own?
+port_still_ours() {
+  local port="$1"
+
+  # Right neighbourhood for this kind of checkout?
+  if linked_worktree; then
+    ((port >= PORT_MIN && port <= PORT_MAX)) || return 1
+  else
+    ((port == MAIN_PORT)) || return 1
+  fi
+
+  # Written into another live checkout's .mcp.json since we last looked?
+  grep -qx "$port" <<<"$(claimed_ports)" && return 1
+
+  # An orphan holding it is reapable, so try that before judging.
+  reap_dead_listener "$port" >/dev/null 2>&1 || true
+
+  case "$(port_owner "$port")" in
+    free | mine) return 0 ;;
+    *) return 1 ;;
+  esac
 }
 
-if [[ -f .mcp.json ]]; then
-  echo "Already configured: port $(port_from .mcp.json). Nothing to do."
+existing=""
+[[ -f .mcp.json ]] && existing=$(port_from .mcp.json)
+
+if [[ -n "$existing" ]] && port_still_ours "$existing"; then
+  say "Port ${existing} is still this checkout's. Nothing to do."
   exit 0
 fi
 
-# Ports already written into some checkout's .mcp.json. Stale entries self-clean:
-# a deleted worktree stops appearing in `git worktree list`.
-claimed_ports() {
-  local worktree
-  while read -r worktree; do
-    if [[ -f "$worktree/.mcp.json" ]]; then
-      port_from "$worktree/.mcp.json"
-    fi
-  done < <(git worktree list --porcelain | awk '/^worktree /{print $2}')
-}
+if [[ -n "$existing" ]]; then
+  pid=$(listener_pid "$existing")
+  owner=$(port_owner "$existing")
+  echo "Port ${existing} in .mcp.json is no longer usable here (${owner}${pid:+, held by pid ${pid} at $(listener_cwd "$pid")})." >&2
+  echo "Reallocating." >&2
+fi
 
-# Ports currently bound by any listening process on this machine.
-bound_ports() {
-  lsof -nP -iTCP -sTCP:LISTEN 2>/dev/null |
-    sed -n 's/.*:\([0-9][0-9]*\) (LISTEN).*/\1/p'
-}
-
-# Lowest free port in the range. Claimed ports keep two worktrees off the same
-# number even while their servers are down; bound ports additionally dodge an
-# unrelated process squatting in the range.
-allocate_port() {
-  local taken port
-  taken=$(
-    {
-      claimed_ports
-      bound_ports
-    } | sort -u
-  )
-
-  for ((port = PORT_MIN; port <= PORT_MAX; port++)); do
-    if ! grep -qx "$port" <<<"$taken"; then
-      echo "$port"
-      return 0
-    fi
-  done
-
-  echo "setup-mcp: no free port in ${PORT_MIN}-${PORT_MAX}." >&2
-  echo "Prune a stale worktree, or widen the range at the top of this script." >&2
-  return 1
-}
-
-# A linked worktree has .git as a file ("gitdir: ..."); the main checkout has a directory.
-if [[ -d .git ]]; then
-  port=$MAIN_PORT
-  where="main checkout"
-else
+if linked_worktree; then
   port=$(allocate_port)
   where=$(git branch --show-current)
+else
+  port=$MAIN_PORT
+  where="main checkout"
+
+  reap_dead_listener "$port" >/dev/null 2>&1 || true
+
+  if [[ "$(port_owner "$port")" == "foreign" ]]; then
+    pid=$(listener_pid "$port")
+    echo "setup-mcp: port ${MAIN_PORT} belongs to the main checkout, but pid ${pid} is holding it" >&2
+    echo "           from $(listener_cwd "$pid")." >&2
+    echo "           Stop that server (bin/worktree-down there) and re-run." >&2
+    exit 1
+  fi
 fi
 
 cat >.mcp.json <<EOF
@@ -101,11 +110,9 @@ cat >.mcp.json <<EOF
 }
 EOF
 
-cat <<EOF
-Configured port ${port} for ${where}.
-
-  wrote .mcp.json  -> tidewave at http://localhost:${port}/tidewave/mcp
-  bin/dev          -> starts the server on ${port} (live_debugger on $((port + 100)))
-
-Restart Claude Code here — .mcp.json is read at session start.
-EOF
+say "Configured port ${port} for ${where}."
+say ""
+say "  wrote .mcp.json  -> tidewave at $(tidewave_url "$port")"
+say "  bin/worktree-up  -> provisions and starts the server on ${port} (live_debugger on $((port + 100)))"
+say ""
+say "Restart Claude Code here — .mcp.json is read at session start."

--- a/bin/worktree-down
+++ b/bin/worktree-down
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# Tear down what bin/worktree-up provisioned for THIS checkout: stop its dev
+# server, drop its dev and test databases, forget its port.
+#
+# Scoped to this checkout only. It never stops the shared Postgres/MinIO
+# containers and never runs `docker-compose down -v`, which would destroy every
+# other checkout's data along with this one's.
+#
+# Refuses to run in the main checkout without --force: dropping klass_hero_dev is
+# exactly the damage the per-checkout database derivation exists to prevent.
+#
+# Usage:
+#   bin/worktree-down             stop the server, drop this checkout's databases
+#   bin/worktree-down --keep-db   stop the server only
+#   bin/worktree-down --force     allow this in the main checkout
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+# shellcheck source=bin/lib/worktree-common.sh
+source bin/lib/worktree-common.sh
+
+DROP_DB=true
+FORCE=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --keep-db) DROP_DB=false ;;
+    --force) FORCE=true ;;
+    *)
+      echo "worktree-down: unknown option $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+root=$(repo_root)
+dev_db=$(dev_database)
+test_db=$(test_database)
+
+if ! linked_worktree && ! $FORCE; then
+  echo "worktree-down: this is the main checkout — dropping ${dev_db} would take the whole" >&2
+  echo "               machine's dev data with it. Pass --force if you really mean it." >&2
+  exit 1
+fi
+
+export MIX_TEST_PARTITION="$(test_partition)"
+
+# --- server -----------------------------------------------------------------
+# Prefer the pid that actually holds the socket over the pidfile: the pidfile can
+# be stale, and the listener is what matters. Only ever stop a server that lives
+# in this checkout.
+port=$(bin/dev --port 2>/dev/null || echo "")
+
+if [[ -n "$port" ]]; then
+  case "$(port_owner "$port")" in
+    mine)
+      pid=$(listener_pid "$port")
+      echo "Stopping dev server on ${port} (pid ${pid})." >&2
+      kill "$pid" 2>/dev/null || true
+      for _ in $(seq 1 20); do
+        kill -0 "$pid" 2>/dev/null || break
+        sleep 0.5
+      done
+      kill -9 "$pid" 2>/dev/null || true
+      ;;
+    dead)
+      reap_dead_listener "$port" || true
+      ;;
+    foreign)
+      echo "Port ${port} is held by another live checkout — leaving it alone." >&2
+      ;;
+  esac
+fi
+
+rm -rf "$RUN_DIR"
+
+# --- databases --------------------------------------------------------------
+if $DROP_DB; then
+  echo "Dropping ${dev_db}." >&2
+  mix ecto.drop >/dev/null 2>&1 || echo "  (already gone)" >&2
+
+  echo "Dropping ${test_db}." >&2
+  MIX_ENV=test mix ecto.drop >/dev/null 2>&1 || echo "  (already gone)" >&2
+fi
+
+rm -f .mcp.json
+
+echo "DOWN  ${root}" >&2

--- a/bin/worktree-status
+++ b/bin/worktree-status
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Report whether this checkout has a dev server and a Tidewave endpoint that
+# actually belong to it. Read-only and instant — nothing here starts, stops, or
+# provisions anything.
+#
+# Use it to answer "can I trust project_eval right now?" before relying on
+# Tidewave, and to diagnose the case that looks fine but is not: an endpoint that
+# answers, from a server running in a different checkout.
+#
+# Exit status: 0 when Tidewave is up and verified to be this checkout's, 1 otherwise
+# — so it composes: `bin/worktree-status >/dev/null || bin/worktree-up`.
+#
+# Usage: bin/worktree-status
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+# shellcheck source=bin/lib/worktree-common.sh
+source bin/lib/worktree-common.sh
+
+root=$(repo_root)
+
+echo "checkout   ${root}"
+echo "kind       $(linked_worktree && echo "worktree ($(git branch --show-current))" || echo "main checkout")"
+echo "dev db     $(dev_database) $(database_exists "$(dev_database)" && echo "(exists)" || echo "(MISSING)")"
+echo "test db    $(test_database) $(database_exists "$(test_database)" && echo "(exists)" || echo "(MISSING)")"
+
+if [[ ! -f .mcp.json ]]; then
+  echo "tidewave   NOT CONFIGURED — no .mcp.json. Run bin/worktree-up."
+  exit 1
+fi
+
+port=$(bin/dev --port)
+owner=$(port_owner "$port")
+code=$(tidewave_status "$port")
+
+echo "port       ${port}"
+echo "endpoint   $(tidewave_url "$port")  (HTTP ${code}; 405 is healthy — it is POST-only)"
+
+case "$owner" in
+  mine)
+    if tidewave_alive "$port"; then
+      echo "verdict    READY — served by pid $(listener_pid "$port"), which lives in this checkout"
+      exit 0
+    fi
+    echo "verdict    NOT READY — the port is ours but nothing is answering yet. Still booting? See ${LOG_FILE}."
+    exit 1
+    ;;
+  free)
+    echo "verdict    NOT RUNNING — nothing is listening on ${port}. Run bin/worktree-up."
+    exit 1
+    ;;
+  dead)
+    pid=$(listener_pid "$port")
+    echo "verdict    ORPHAN — pid ${pid} answers on ${port} but its checkout ($(listener_cwd "$pid")) is gone."
+    echo "           Anything you ask it runs against code that no longer exists. Run bin/worktree-up to reap it."
+    exit 1
+    ;;
+  foreign)
+    pid=$(listener_pid "$port")
+    echo "verdict    WRONG CHECKOUT — pid ${pid} answers on ${port} but lives in $(listener_cwd "$pid")."
+    echo "           Do not use Tidewave from this session: project_eval would run against that tree, not this one."
+    exit 1
+    ;;
+esac

--- a/bin/worktree-up
+++ b/bin/worktree-up
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+#
+# Bring this checkout to a working state: containers up, dependencies fetched,
+# code compiled, its own dev and test databases migrated, its own Tidewave port
+# written, and its own dev server running and *verified to be its own*.
+#
+# Idempotent and convergent — safe to run any number of times, in any checkout,
+# including the main one. Every step asks before it acts; nothing assumes.
+#
+# All progress goes to stderr. That is not cosmetic: .claude/hooks/worktree_create.sh
+# calls this script and must keep stdout clean for the worktree path it has to
+# return to Claude Code.
+#
+# Usage:
+#   bin/worktree-up              full converge (default)
+#   bin/worktree-up --fast       databases and .mcp.json only; no seeds, no server
+#   bin/worktree-up --no-seed    converge, but never seed
+#   bin/worktree-up --reseed     seed even if the database already existed
+#   bin/worktree-up --no-server  converge, but do not start the dev server
+#   bin/worktree-up --quiet      only report the final verdict and any problem
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+# shellcheck source=bin/lib/worktree-common.sh
+source bin/lib/worktree-common.sh
+
+SEED_MODE=auto # auto | never | always
+START_SERVER=true
+QUIET=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --fast)
+      SEED_MODE=never
+      START_SERVER=false
+      ;;
+    --no-seed) SEED_MODE=never ;;
+    --reseed) SEED_MODE=always ;;
+    --no-server) START_SERVER=false ;;
+    --quiet) QUIET=true ;;
+    *)
+      echo "worktree-up: unknown option $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+step() { $QUIET || echo "→ $*" >&2; }
+note() { echo "  $*" >&2; }
+fail() {
+  echo "worktree-up: $*" >&2
+  exit 1
+}
+
+root=$(repo_root)
+slug=$(checkout_slug)
+dev_db=$(dev_database)
+test_db=$(test_database)
+
+# Explicit rather than relying on config/test.exs deriving the same value. The two
+# agree by construction (both read this slug), and being explicit means the script
+# behaves identically on a checkout that predates that config change.
+export MIX_TEST_PARTITION="$(test_partition)"
+
+# --- 1. containers ----------------------------------------------------------
+# mix dev.setup is already idempotent: docker-compose up -d, then health-polls
+# klass_hero_postgres and klass_hero_minio. Reused rather than reimplemented.
+step "Docker services"
+mix dev.setup >/dev/null 2>&1 || fail "mix dev.setup failed — run it directly to see why"
+
+# --- 2. warm the build ------------------------------------------------------
+# A fresh worktree materialises only *tracked* files, so deps/ and _build/ start
+# empty and a cold fetch-and-compile is by far the slowest step here — the one
+# thing that could exhaust the WorktreeCreate hook's budget. Same mix.lock and
+# same toolchain mean main's artefacts are valid input, and Elixir's compile
+# manifests sort out what is actually stale, so this becomes an incremental
+# compile instead of a full one.
+#
+# Copy, never symlink: a shared _build would serve one checkout's beam files to
+# another, which is the same class of mistake as a shared dev database.
+if linked_worktree; then
+  main_root=$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")
+
+  if [[ -d "$main_root/deps" && ! -d deps ]]; then
+    step "Warming deps/ from ${main_root}"
+    cp -R "$main_root/deps" deps
+  fi
+
+  if [[ -d "$main_root/_build" && ! -d _build ]]; then
+    step "Warming _build/ from ${main_root}"
+    cp -R "$main_root/_build" _build
+  fi
+fi
+
+# --- 3. dependencies + compile ---------------------------------------------
+step "Dependencies"
+mix deps.get >/dev/null || fail "mix deps.get failed"
+
+step "Compile"
+mix compile >/dev/null || fail "mix compile failed — run it directly to see the errors"
+
+# --- 4. dev database --------------------------------------------------------
+# Whether to seed is decided *before* creating, by asking Postgres. Parsing
+# `mix ecto.create`'s output would work today and break on an Ecto wording change.
+dev_db_existed=false
+database_exists "$dev_db" && dev_db_existed=true
+
+step "Dev database ${dev_db}"
+mix ecto.create >/dev/null || fail "mix ecto.create failed for ${dev_db}"
+mix ecto.migrate >/dev/null || fail "mix ecto.migrate failed for ${dev_db}"
+
+should_seed=false
+case "$SEED_MODE" in
+  always) should_seed=true ;;
+  auto) $dev_db_existed || should_seed=true ;;
+esac
+
+if $should_seed; then
+  step "Seeding ${dev_db}"
+  mix ecto.seed >/dev/null || fail "mix ecto.seed failed — see the output of 'mix ecto.seed'"
+elif [[ "$SEED_MODE" == "auto" ]] && $dev_db_existed; then
+  # priv/repo/seeds.exs is Repo.insert! throughout with no on_conflict guards, so
+  # re-running it against a populated database raises on a unique constraint.
+  # Skipping is the correct convergent behaviour, not a shortcut.
+  note "${dev_db} already existed — skipping seeds (seeds.exs is not idempotent; --reseed forces)"
+fi
+
+# --- 5. test database -------------------------------------------------------
+step "Test database ${test_db}"
+MIX_ENV=test mix ecto.create >/dev/null || fail "test-env ecto.create failed for ${test_db}"
+MIX_ENV=test mix ecto.migrate >/dev/null || fail "test-env ecto.migrate failed for ${test_db}"
+
+# --- 6. MCP endpoint --------------------------------------------------------
+step "Tidewave endpoint"
+bin/setup-mcp --quiet >&2 || fail "bin/setup-mcp failed"
+port=$(bin/dev --port)
+
+# --- 7. dev server ----------------------------------------------------------
+if $START_SERVER; then
+  step "Dev server on ${port}"
+  bin/dev --detach || fail "dev server did not come up on ${port}"
+
+  # --- 8. identity gate ----------------------------------------------------
+  # The point of the whole exercise. "Tidewave answers" is not the property we
+  # need; "Tidewave answers *for this checkout*" is. An orphaned server from a
+  # deleted worktree answers the first check perfectly and would have the agent
+  # evaluating code against a tree that no longer exists.
+  owner=$(port_owner "$port")
+  if [[ "$owner" != "mine" ]]; then
+    pid=$(listener_pid "$port")
+    fail "port ${port} answers, but from ${owner} process ${pid} at $(listener_cwd "$pid") — not ${root}"
+  fi
+
+  tidewave_alive "$port" || fail "no Tidewave at $(tidewave_url "$port")"
+
+  echo "READY  ${root}" >&2
+  echo "       tidewave  $(tidewave_url "$port")  (verified: pid $(listener_pid "$port") lives here)" >&2
+  echo "       dev db    ${dev_db}" >&2
+  echo "       test db   ${test_db}" >&2
+else
+  echo "PROVISIONED  ${root}  (no server started)" >&2
+  echo "             tidewave port ${port}, dev db ${dev_db}, test db ${test_db}" >&2
+  echo "             run bin/worktree-up to start the server" >&2
+fi

--- a/bin/worktree-up
+++ b/bin/worktree-up
@@ -63,13 +63,7 @@ test_db=$(test_database)
 # behaves identically on a checkout that predates that config change.
 export MIX_TEST_PARTITION="$(test_partition)"
 
-# --- 1. containers ----------------------------------------------------------
-# mix dev.setup is already idempotent: docker-compose up -d, then health-polls
-# klass_hero_postgres and klass_hero_minio. Reused rather than reimplemented.
-step "Docker services"
-mix dev.setup >/dev/null 2>&1 || fail "mix dev.setup failed — run it directly to see why"
-
-# --- 2. warm the build ------------------------------------------------------
+# --- 1. warm the build ------------------------------------------------------
 # A fresh worktree materialises only *tracked* files, so deps/ and _build/ start
 # empty and a cold fetch-and-compile is by far the slowest step here — the one
 # thing that could exhaust the WorktreeCreate hook's budget. Same mix.lock and
@@ -93,12 +87,21 @@ if linked_worktree; then
   fi
 fi
 
-# --- 3. dependencies + compile ---------------------------------------------
+# --- 2. dependencies + compile ---------------------------------------------
 step "Dependencies"
 mix deps.get >/dev/null || fail "mix deps.get failed"
 
 step "Compile"
 mix compile >/dev/null || fail "mix compile failed — run it directly to see the errors"
+
+# --- 3. containers ----------------------------------------------------------
+# After compiling, not before: dev.setup is a Mix task defined in this project
+# (lib/mix/tasks/dev.setup.ex), so it cannot run until the project's dependencies
+# are fetched and compiled. It is itself idempotent — docker-compose up -d, then
+# health-polls klass_hero_postgres and klass_hero_minio — so it is reused rather
+# than reimplemented here.
+step "Docker services"
+mix dev.setup >/dev/null 2>&1 || fail "mix dev.setup failed — run it directly to see why"
 
 # --- 4. dev database --------------------------------------------------------
 # Whether to seed is decided *before* creating, by asking Postgres. Parsing

--- a/config/test.exs
+++ b/config/test.exs
@@ -12,6 +12,35 @@ alias KlassHero.Test.StubMailerAdapter
 # unrelated project on the same machine).
 test_port = String.to_integer(System.get_env("TEST_PORT") || "4002")
 
+# The test DB is per-checkout for the same reason the dev DB is (config/dev.exs), and
+# derived the same way. MIX_TEST_PARTITION still wins when set explicitly — CI sets it
+# per partition, and you can set it by hand to run two logically separate suites in one
+# checkout.
+#
+# The default matters because nothing enforces the env var on an automated caller:
+# .claude/hooks/tests.sh runs `mix test` on every edit and never set it, so every
+# worktree's edit-triggered suite was writing to the one shared klass_hero_test. That is
+# the same failure #1257 fixed on the dev side, and it is fixed the same way — in config,
+# where every mix invocation reads it, rather than in a launcher a hook can bypass.
+#
+# A linked worktree has `.git` as a file; the main checkout has a directory and keeps the
+# bare `klass_hero_test`, so CI (a normal checkout) is unaffected.
+checkout_root = Path.dirname(__DIR__)
+
+test_partition =
+  System.get_env("MIX_TEST_PARTITION") ||
+    if File.regular?(Path.join(checkout_root, ".git")) do
+      slug =
+        checkout_root
+        |> Path.basename()
+        |> String.downcase()
+        |> String.replace(~r/[^a-z0-9]+/, "_")
+
+      "_#{slug}"
+    else
+      ""
+    end
+
 # Only in tests, remove the complexity from the password hashing algorithm
 config :bcrypt_elixir, :log_rounds, 1
 
@@ -31,7 +60,7 @@ config :klass_hero, KlassHero.Repo,
   username: "postgres",
   password: "postgres",
   hostname: "localhost",
-  database: "klass_hero_test#{System.get_env("MIX_TEST_PARTITION")}",
+  database: String.slice("klass_hero_test#{test_partition}", 0, 63),
   pool: Ecto.Adapters.SQL.Sandbox,
   pool_size: System.schedulers_online() * 2
 


### PR DESCRIPTION
## Summary

Tidewave was never running, so sessions silently degraded to bash.

The cause was not broken infrastructure — Postgres and MinIO were healthy the whole time. It was that provisioning a checkout was a six-command manual sequence documented in `.claude/rules/worktrees.md`, and a sequence a human runs is a sequence a human skips. **7 of 9 worktrees on this machine had no `.mcp.json` at all**, so `bin/dev` there fell back to port 4000 and collided with main.

This replaces the checklist with one idempotent command and three hooks that run it.

```
bin/worktree-up        # containers, deps, compile, dev DB (+seeds), test DB,
                       # .mcp.json, detached dev server, verified Tidewave
bin/worktree-status    # read-only: is Tidewave up AND is it *this* checkout's?
bin/worktree-down      # stop the server, drop this checkout's two databases
```

| Hook | Runs |
|---|---|
| `WorktreeCreate` | creates + provisions (`--fast`) |
| `SessionStart` | converges on every start/resume — the load-bearing path |
| `WorktreeRemove` | tears down before the directory disappears |

## Review focus

**The identity gate is the point of the change.** "Tidewave answers" is not the property we need; "Tidewave answers *for this checkout*" is. A dev server outlives `git worktree remove` happily and keeps answering `/tidewave/mcp` perfectly for a checkout that no longer exists — worse than being down, because it looks healthy, and `project_eval` against it evaluates code that is gone. There was one on port 4010 from a deleted `kh-1321` worktree, answering HTTP 405, for weeks.

`port_owner/1` classifies a listener via its cwd as `mine`, `free`, `dead` or `foreign`. Only `dead` — a listener whose own directory no longer exists, so nothing can depend on it — is ever killed. A `foreign` port belongs to a live checkout and is reported, never taken.

**Seeding is decided by asking Postgres, not by parsing mix output.** `priv/repo/seeds.exs` is `Repo.insert!` throughout with no `on_conflict` guards, so re-seeding a populated database raises. A script that runs on every `SessionStart` cannot seed unconditionally.

**`config/test.exs` is the one behaviour change worth scrutiny** (its own commit). `.claude/hooks/tests.sh` runs `mix test` on every edit and never set `MIX_TEST_PARTITION`, so every worktree's edit-triggered suite was writing to the shared `klass_hero_test`. Same failure as #1257 on the dev side, fixed the same way — in config, which every `mix` invocation reads, rather than in a launcher a hook can bypass. The main checkout keeps the bare name, so CI is unaffected.

**The constraint the docs now state plainly:** `.mcp.json` is read at session start, and `EnterWorktree` does not restart the session or re-fire `SessionStart`. A worktree entered mid-session keeps pointing at the previous checkout's Tidewave. The workflow routes around this rather than pretending otherwise.

## Test plan

Verified on this machine:

- `bin/worktree-up` in main: cold to READY in **11.5s**; second run starts no second server.
- Cold worktree via the `WorktreeCreate` payload: **31.8s** to a verified Tidewave, seeds included — well inside the hook's 600s budget. Own port 4022, own `klass_hero_dev_kh_provision_probe`, own `klass_hero_test_kh_provision_probe`.
- `WorktreeRemove` payload: server stopped, both databases dropped, port freed.
- `WorktreeCreate` stdout contract: the absolute path alone; all diagnostics on stderr.
- Provisioning failure path exercised for real (worktree branched off `origin/main`, which lacks the scripts): warned, still returned the path, worktree intact.
- `config/test.exs`: main resolves `klass_hero_test`; `MIX_TEST_PARTITION=99` still resolves `klass_hero_test99`.
- `mix precommit`: **4362 passed**, 0 failures; credo, typography, translations, read-table and ACL lints clean.

Also reaped the `kh-1321` orphan and removed four directories git no longer tracked (all three with content had closed issues and their files on `origin/main`) — 248MB.

## Follow-up, not in this PR

~120 orphaned `klass_hero_test<number>` databases from months of hand-typed partitions. The derivation ends the growth — the partition is now bounded by checkouts rather than by whatever number someone typed — but the existing ones need a deliberate sweep.