### PR TITLE
refactor: retire the dead metadata, version, and opts plumbing from the event envelope

### DIFF
--- a/docs/adr/0006-flatten-shared-context-preserve-swap-seams.md
+++ b/docs/adr/0006-flatten-shared-context-preserve-swap-seams.md
@@ -12,6 +12,8 @@ A behaviour module + config-selected impl is **idiomatic Elixir dependency injec
 
 The conventional-Phoenix target tree also *keeps* `domain/events/` (event structs) and all of `adapters/driven/**` (driven adapters). So Shared's event-envelope structs (`DomainEvent`/`IntegrationEvent`/`EventMetadata`) and every driven adapter stay exactly where they are. The flatten is therefore a **namespace collapse of the ports/services/types/validation/models modules only**, not a rewrite.
 
+> **Amended by #1358.** None of those three module names survives. `DomainEvent` and `IntegrationEvent` collapsed into one `Event` struct in ADR-0014, which this line predates. `EventMetadata` is gone too: #1358 retired the `metadata` field it was named for, leaving only a UUID mint (inlined into `Event.new/5`) and a jsonb guard (now `PayloadGuard`, beside `PayloadCodec`). The claim this paragraph was actually making — that `domain/events/` and `adapters/driven/**` keep their shape through the flatten — still holds.
+
 ## Decision
 
 Collapse the `Domain.Ports` / `Domain.Services` / `Domain.Types` namespaces; keep each swap behaviour as a **standalone slim behaviour module** at the context root. Modules keep their identity — only their path shortens. (The deeper "inline each `@callback` into its facade" variant was rejected: more edits, more risk, no payoff for a behaviour-preserving refactor.)

--- a/docs/adr/0014-events-are-delivered-by-a-transactional-outbox-not-by-pubsub.md
+++ b/docs/adr/0014-events-are-delivered-by-a-transactional-outbox-not-by-pubsub.md
@@ -58,6 +58,16 @@ error propagation into the caller's `with`). What actually needs to be asynchron
   > allowlist and drops what the format does not define — an open `String.to_existing_atom/1`
   > would have raised on every one of them, in `execute/1` and again in `compensate/2`.
 
+  > **Amended by #1358.** `metadata` and `version` are both gone from the struct and the wire.
+  > No producer ever set `correlation_id`/`causation_id`, nothing branched on `version`, and the
+  > trace context that `metadata` was shaped to carry propagates through `oban_jobs.args`
+  > (`Tracing.Context.inject_into_args/1` → `TracedWorker.perform/1` → `attach_from_args/1`) —
+  > per-event propagation was not merely unused but wrong, reattaching inside an already-open
+  > worker span with no restore token. The closed allowlist above went with them: `deserialize/1`
+  > reads named keys and never walks the map, so a pre-#1358 row's leftover keys are inert
+  > without any allowlist to list them. Re-add `version` when a payload contract actually needs
+  > to evolve; a row lacking it deserializes the way a pre-`payload_types` row does.
+
 - **The `DomainEventBus` is deleted, not made async.** Its 7 surviving handlers are same-context and
   become direct calls, which restores compile-time checking, `xref` visibility, natural error
   propagation, and line-order sequencing. The runtime `subscribe/4` API — with its owner scoping,

--- a/lib/klass_hero/accounts/domain/events/accounts_events.ex
+++ b/lib/klass_hero/accounts/domain/events/accounts_events.ex
@@ -148,14 +148,13 @@ defmodule KlassHero.Accounts.Domain.Events.AccountsEvents do
   """
   def staff_user_registered(user_id, payload \\ %{}, opts \\ [])
 
-  def staff_user_registered(user_id, payload, opts) when is_binary(user_id) and byte_size(user_id) > 0 do
+  def staff_user_registered(user_id, payload, _opts) when is_binary(user_id) and byte_size(user_id) > 0 do
     Event.new(
       :staff_user_registered,
       @source_context,
       @entity_type,
       user_id,
-      Map.put(payload, :user_id, user_id),
-      opts
+      Map.put(payload, :user_id, user_id)
     )
   end
 
@@ -166,25 +165,23 @@ defmodule KlassHero.Accounts.Domain.Events.AccountsEvents do
 
   # Caller-supplied payload overrides the derived fields, but never the identity:
   # `user_id` is what consumers key on, so it is put last.
-  defp build(event_type, user_id, base_payload, payload, opts) do
+  defp build(event_type, user_id, base_payload, payload, _opts) do
     Event.new(
       event_type,
       @source_context,
       @entity_type,
       user_id,
-      base_payload |> Map.merge(payload) |> Map.put(:user_id, user_id),
-      opts
+      base_payload |> Map.merge(payload) |> Map.put(:user_id, user_id)
     )
   end
 
-  defp staff_event(event_type, staff_member_id, payload, opts) do
+  defp staff_event(event_type, staff_member_id, payload, _opts) do
     Event.new(
       event_type,
       @source_context,
       @staff_entity_type,
       staff_member_id,
-      Map.put(payload, :staff_member_id, staff_member_id),
-      opts
+      Map.put(payload, :staff_member_id, staff_member_id)
     )
   end
 

--- a/lib/klass_hero/enrollment/domain/events/enrollment_events.ex
+++ b/lib/klass_hero/enrollment/domain/events/enrollment_events.ex
@@ -76,15 +76,14 @@ defmodule KlassHero.Enrollment.Domain.Events.EnrollmentEvents do
           "enrollment_cancelled/3 requires a non-empty enrollment_id string, got: #{inspect(enrollment_id)}"
   end
 
-  defp build(event_type, entity_type, id_key, id, payload, opts) do
+  defp build(event_type, entity_type, id_key, id, payload, _opts) do
     Event.new(
       event_type,
       @source_context,
       entity_type,
       id,
       # Overwrites rather than merges: the id argument wins over any caller-supplied one.
-      Map.put(payload, id_key, id),
-      opts
+      Map.put(payload, id_key, id)
     )
   end
 end

--- a/lib/klass_hero/family/domain/events/family_events.ex
+++ b/lib/klass_hero/family/domain/events/family_events.ex
@@ -15,9 +15,8 @@ defmodule KlassHero.Family.Domain.Events.FamilyEvents do
     invite claim. Downstream contexts (e.g. Enrollment) react to auto-enroll
     the child.
 
-  Each factory takes the entity id, an optional payload, and metadata opts
-  (`correlation_id`, `causation_id`), and raises `ArgumentError`
-  on a nil or blank id.
+  Each factory takes the entity id and an optional payload, and raises
+  `ArgumentError` on a nil or blank id.
   """
 
   alias KlassHero.Shared.Domain.Events.Event
@@ -124,15 +123,14 @@ defmodule KlassHero.Family.Domain.Events.FamilyEvents do
     raise_blank_id(:invite_family_ready, :invite_id, invite_id)
   end
 
-  defp build(event_type, entity_type, id_key, id, payload, opts) do
+  defp build(event_type, entity_type, id_key, id, payload, _opts) do
     Event.new(
       event_type,
       @source_context,
       entity_type,
       id,
       # Overwrites rather than merges: the id argument wins over any caller-supplied one.
-      Map.put(payload, id_key, id),
-      opts
+      Map.put(payload, id_key, id)
     )
   end
 

--- a/lib/klass_hero/messaging/adapters/driven/projections/conversation_summaries.ex
+++ b/lib/klass_hero/messaging/adapters/driven/projections/conversation_summaries.ex
@@ -528,7 +528,6 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries 
 
     # Arrives as the %DateTime{} the producer sent: since #1311 the serializer records
     # typed payload values and rebuilds them, so DateTime arithmetic on this is safe.
-    # (`reason` is still a string — atoms are not restored; see EventMetadata.)
     archived_at = legacy_archived_at(event)
 
     now = DateTime.utc_now() |> DateTime.truncate(:second)

--- a/lib/klass_hero/participation/domain/events/participation_events.ex
+++ b/lib/klass_hero/participation/domain/events/participation_events.ex
@@ -285,8 +285,8 @@ defmodule KlassHero.Participation.Domain.Events.ParticipationEvents do
   # Builds the event, deriving entity_type from the registry so no call site
   # hand-writes it.
   @spec new_event(atom(), String.t(), map(), keyword()) :: Event.t()
-  defp new_event(event_type, entity_id, payload, opts) do
-    Event.new(event_type, @source_context, entity_type_for(event_type), entity_id, payload, opts)
+  defp new_event(event_type, entity_id, payload, _opts) do
+    Event.new(event_type, @source_context, entity_type_for(event_type), entity_id, payload)
   end
 
   @spec session_note_payload(SessionNote.t()) :: session_note_payload()

--- a/lib/klass_hero/program_catalog/domain/events/program_events.ex
+++ b/lib/klass_hero/program_catalog/domain/events/program_events.ex
@@ -36,15 +36,14 @@ defmodule KlassHero.ProgramCatalog.Domain.Events.ProgramEvents do
           "program_updated/3 requires a non-empty program_id string, got: #{inspect(program_id)}"
   end
 
-  defp build(event_type, program_id, payload, opts) do
+  defp build(event_type, program_id, payload, _opts) do
     Event.new(
       event_type,
       @source_context,
       @entity_type,
       program_id,
       # Overwrites rather than merges: the id argument wins over any caller-supplied :program_id.
-      Map.put(payload, :program_id, program_id),
-      opts
+      Map.put(payload, :program_id, program_id)
     )
   end
 end

--- a/lib/klass_hero/provider/domain/events/provider_events.ex
+++ b/lib/klass_hero/provider/domain/events/provider_events.ex
@@ -64,15 +64,14 @@ defmodule KlassHero.Provider.Domain.Events.ProviderEvents do
   """
   def staff_member_invited(staff_member_id, payload \\ %{}, opts \\ [])
 
-  def staff_member_invited(staff_member_id, payload, opts)
+  def staff_member_invited(staff_member_id, payload, _opts)
       when is_binary(staff_member_id) and byte_size(staff_member_id) > 0 do
     Event.new(
       :staff_member_invited,
       @source_context,
       @staff_entity_type,
       staff_member_id,
-      Map.put(payload, :staff_member_id, staff_member_id),
-      opts
+      Map.put(payload, :staff_member_id, staff_member_id)
     )
   end
 
@@ -104,7 +103,7 @@ defmodule KlassHero.Provider.Domain.Events.ProviderEvents do
   reads one.
   """
   @spec staff_member_deactivated(StaffMember.t(), keyword()) :: Event.t()
-  def staff_member_deactivated(%StaffMember{} = staff_member, opts \\ []) do
+  def staff_member_deactivated(%StaffMember{} = staff_member, _opts \\ []) do
     payload = %{
       provider_id: staff_member.provider_id,
       staff_member_id: staff_member.id,
@@ -116,13 +115,12 @@ defmodule KlassHero.Provider.Domain.Events.ProviderEvents do
       @source_context,
       @staff_entity_type,
       staff_member.id,
-      payload,
-      opts
+      payload
     )
   end
 
   # assigned_at/unassigned_at are deliberately absent: no consumer reads them.
-  defp assignment_event(event_type, assignment, staff_member, opts) do
+  defp assignment_event(event_type, assignment, staff_member, _opts) do
     payload = %{
       provider_id: assignment.provider_id,
       program_id: assignment.program_id,
@@ -135,8 +133,7 @@ defmodule KlassHero.Provider.Domain.Events.ProviderEvents do
       @source_context,
       @staff_entity_type,
       assignment.staff_member_id,
-      payload,
-      opts
+      payload
     )
   end
 end

--- a/lib/klass_hero/shared/adapters/driven/events/event_serializer.ex
+++ b/lib/klass_hero/shared/adapters/driven/events/event_serializer.ex
@@ -51,14 +51,13 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.EventSerializer do
   stay strings — the pre-#1311 behaviour, which is what the jobs already in the queue
   at deploy need.
 
-  ## Metadata is a closed format, and that is what makes a key retirable
+  ## A key this format does not define is ignored, which is what makes one retirable
 
-  `deserialize_metadata/1` restores only the keys the format defines and drops the
-  rest, rather than atomizing whatever arrives. The asymmetry is deliberate: an open
-  `String.to_existing_atom/1` makes deleting a metadata key a breaking change, because
-  every row an earlier release staged still carries it and no module holds the atom any
-  more. #1326 retired `criticality` through this door; whatever is retired next needs
-  no shim.
+  `deserialize/1` reads named keys out of the map and never walks it, so a key an
+  earlier release staged and this one no longer knows is inert rather than fatal — no
+  shim, no dated migration. #1326 retired `criticality` this way through a closed
+  metadata allowlist; #1358 retired `metadata` and `version` themselves, which needed
+  no allowlist at all because there is no field left to receive them into.
 
   The reverse direction needs more care than it used to. "Older code ignores the extra
   key" was true only of the pre-#1311 serializer, which never read `payload_types`;
@@ -87,9 +86,7 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.EventSerializer do
       "entity_id" => event.entity_id,
       "occurred_at" => DateTime.to_iso8601(event.occurred_at),
       "payload" => payload,
-      "payload_types" => payload_types || %{},
-      "metadata" => serialize_metadata(event.metadata),
-      "version" => event.version
+      "payload_types" => payload_types || %{}
     }
   end
 
@@ -108,9 +105,7 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.EventSerializer do
       entity_type: to_existing_atom(data["entity_type"]),
       entity_id: data["entity_id"],
       occurred_at: parse_datetime!(data["occurred_at"]),
-      payload: decode_payload(data["payload"], data["payload_types"]),
-      metadata: deserialize_metadata(data["metadata"]),
-      version: data["version"]
+      payload: decode_payload(data["payload"], data["payload_types"])
     }
   end
 
@@ -178,36 +173,6 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.EventSerializer do
 
   defp type_for(types, key) when is_map(types), do: Map.get(types, key)
   defp type_for(_types, _key), do: nil
-
-  defp serialize_metadata(metadata) when is_map(metadata) do
-    Map.new(metadata, fn
-      {k, v} when is_atom(k) and is_atom(v) ->
-        {Atom.to_string(k), Atom.to_string(v)}
-
-      {k, v} when is_atom(k) ->
-        {Atom.to_string(k), v}
-
-      {k, v} ->
-        {to_string(k), v}
-    end)
-  end
-
-  # Keys restored to the atom the producer used.
-  @atom_metadata_keys ~w(correlation_id causation_id)
-
-  # Keys that stay binary strings — W3C Trace Context headers, which the Erlang
-  # propagator wants as `{binary(), binary()}` pairs.
-  @string_metadata_keys ~w(traceparent tracestate baggage)
-
-  defp deserialize_metadata(metadata) when is_map(metadata) do
-    for {key, value} <- metadata, entry = restore_entry(to_string(key), value), into: %{}, do: entry
-  end
-
-  defp deserialize_metadata(nil), do: %{}
-
-  defp restore_entry(key, value) when key in @atom_metadata_keys, do: {String.to_existing_atom(key), value}
-  defp restore_entry(key, value) when key in @string_metadata_keys, do: {key, value}
-  defp restore_entry(_key, _value), do: nil
 
   defp parse_datetime!(iso_string) when is_binary(iso_string) do
     {:ok, dt, _offset} = DateTime.from_iso8601(iso_string)

--- a/lib/klass_hero/shared/adapters/driven/events/event_serializer.ex
+++ b/lib/klass_hero/shared/adapters/driven/events/event_serializer.ex
@@ -37,7 +37,7 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.EventSerializer do
 
   **What each leaf may be is `PayloadCodec`'s to say, not this module's.** This one
   walks the payload and mirrors the tags into the sidecar; the codec turns one leaf
-  into `{scalar, tag}` and back. `EventMetadata.validate_payload!/1` asks that same
+  into `{scalar, tag}` and back. `PayloadGuard.validate_payload!/1` asks that same
   codec at construction, which is what keeps the two ends from drifting — they were
   separate lists until #1317, and each of #1316 and #1317 had to edit both.
 

--- a/lib/klass_hero/shared/adapters/driven/workers/event_delivery_worker.ex
+++ b/lib/klass_hero/shared/adapters/driven/workers/event_delivery_worker.ex
@@ -41,7 +41,6 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorker do
   alias KlassHero.Shared.Adapters.Driven.Persistence.Repositories.UndeliveredEventRepository
   alias KlassHero.Shared.Domain.Events.Event
   alias KlassHero.Shared.EventDispatcher
-  alias KlassHero.Shared.Tracing.Context
 
   require Logger
 
@@ -57,7 +56,6 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorker do
   # subscribing in PR 3, and no LiveView ever did — those now receive tagged
   # tuples from whoever wrote the data they read.
   defp deliver(%Event{} = event, job) do
-    Context.attach_from_event(event)
     topic = Event.topic(event)
 
     topic

--- a/lib/klass_hero/shared/domain/events/event.ex
+++ b/lib/klass_hero/shared/domain/events/event.ex
@@ -7,12 +7,18 @@ defmodule KlassHero.Shared.Domain.Events.Event do
 
   - Use `source_context` to identify the publishing bounded context
   - Use `entity_type`/`entity_id` instead of `aggregate_type`/`aggregate_id`
-  - Carry a `version` field for schema evolution and forward compatibility
   - Carry a `payload` of JSON scalars, plus atoms and `Date`/`Time`/`DateTime`/
     `NaiveDateTime`/`Decimal`, which `EventSerializer` round-trips with their
     types intact (#1311, #1317). Anything else loses its type in `oban_jobs.args`, so
-    `EventMetadata.validate_payload!/1` rejects it at construction —
+    `PayloadGuard.validate_payload!/1` rejects it at construction —
     `PayloadCodec` is the one list of what survives.
+
+  The envelope carries only what something writes. A `metadata` map (`correlation_id`,
+  `causation_id`, W3C trace headers) and a `version` field were both retired in #1358:
+  no producer ever set either, nothing branched on them, and trace context propagates
+  through `oban_jobs.args`, not per-event metadata. Re-add `version` when a payload
+  contract actually needs to evolve — a row written without it deserializes fine, the
+  same way one written before `payload_types` existed does.
 
   ## Topic Naming Convention
 
@@ -35,7 +41,7 @@ defmodule KlassHero.Shared.Domain.Events.Event do
   condition that decides anything.
   """
 
-  alias KlassHero.Shared.Domain.Events.EventMetadata
+  alias KlassHero.Shared.Domain.Events.PayloadGuard
 
   @type t :: %__MODULE__{
           event_id: String.t(),
@@ -44,9 +50,7 @@ defmodule KlassHero.Shared.Domain.Events.Event do
           entity_type: atom(),
           entity_id: String.t() | integer(),
           occurred_at: DateTime.t(),
-          payload: map(),
-          metadata: map(),
-          version: pos_integer()
+          payload: map()
         }
 
   @enforce_keys [
@@ -65,9 +69,7 @@ defmodule KlassHero.Shared.Domain.Events.Event do
     :entity_type,
     :entity_id,
     :occurred_at,
-    :payload,
-    metadata: %{},
-    version: 1
+    :payload
   ]
 
   @doc """
@@ -80,13 +82,6 @@ defmodule KlassHero.Shared.Domain.Events.Event do
   - `entity_type` - Public-facing entity name (e.g., `:child`)
   - `entity_id` - Public-facing entity ID
   - `payload` - Event data map (primitive types only for stable contract)
-  - `opts` - Metadata options
-
-  ## Options
-
-  - `:correlation_id` - ID to correlate related events
-  - `:causation_id` - ID of the event that caused this event
-  - `:version` - Schema version (default: 1)
 
   ## Examples
 
@@ -96,22 +91,18 @@ defmodule KlassHero.Shared.Domain.Events.Event do
       iex> event.source_context
       :identity
   """
-  @spec new(atom(), atom(), atom(), String.t() | integer(), map(), keyword()) :: t()
-  def new(event_type, source_context, entity_type, entity_id, payload, opts \\ []) do
-    metadata = EventMetadata.build_metadata(opts)
-    version = Keyword.get(opts, :version, 1)
-    EventMetadata.validate_payload!(payload)
+  @spec new(atom(), atom(), atom(), String.t() | integer(), map()) :: t()
+  def new(event_type, source_context, entity_type, entity_id, payload) do
+    PayloadGuard.validate_payload!(payload)
 
     %__MODULE__{
-      event_id: EventMetadata.generate_event_id(),
+      event_id: Ecto.UUID.generate(),
       event_type: event_type,
       source_context: source_context,
       entity_type: entity_type,
       entity_id: entity_id,
       occurred_at: DateTime.utc_now(),
-      payload: payload,
-      metadata: metadata,
-      version: version
+      payload: payload
     }
   end
 
@@ -127,16 +118,4 @@ defmodule KlassHero.Shared.Domain.Events.Event do
   def topic(%__MODULE__{source_context: source_context, event_type: event_type}) do
     "integration:#{source_context}:#{event_type}"
   end
-
-  @doc """
-  Returns the correlation_id from metadata if present.
-  """
-  @spec correlation_id(t()) :: String.t() | nil
-  defdelegate correlation_id(event), to: EventMetadata
-
-  @doc """
-  Returns the causation_id from metadata if present.
-  """
-  @spec causation_id(t()) :: String.t() | nil
-  defdelegate causation_id(event), to: EventMetadata
 end

--- a/lib/klass_hero/shared/domain/events/payload_codec.ex
+++ b/lib/klass_hero/shared/domain/events/payload_codec.ex
@@ -8,7 +8,7 @@ defmodule KlassHero.Shared.Domain.Events.PayloadCodec do
 
   Two callers ask, at two different moments:
 
-  - `EventMetadata.validate_payload!/1` asks `encodable?/1` at `Event.new/6`, so an
+  - `PayloadGuard.validate_payload!/1` asks `encodable?/1` at `Event.new/5`, so an
     unencodable value fails where a developer caused it rather than in a worker.
   - `EventSerializer` calls `encode/1` on the way out and `decode/2` on the
     way back, walking the payload and mirroring the tags into a `payload_types`
@@ -16,7 +16,7 @@ defmodule KlassHero.Shared.Domain.Events.PayloadCodec do
 
   ## Why the list lives here and not in either caller
 
-  It lived in both. `EventMetadata` knew which types were *legal* and the serializer
+  It lived in both. `PayloadGuard` knew which types were *legal* and the serializer
   knew how each one *crossed*, and the two had to agree by hand — #1316 (typed value
   support) and #1317 (atoms) each had to edit both halves in lockstep, and the gap
   between them is exactly where #1311's two production bugs sat. Adding a type is now

--- a/lib/klass_hero/shared/domain/events/payload_guard.ex
+++ b/lib/klass_hero/shared/domain/events/payload_guard.ex
@@ -1,49 +1,17 @@
-defmodule KlassHero.Shared.Domain.Events.EventMetadata do
+defmodule KlassHero.Shared.Domain.Events.PayloadGuard do
   @moduledoc """
-  Shared metadata accessors and builders for domain and integration events.
+  Rejects, at construction, any event payload that cannot survive Oban's jsonb column.
 
-  Both event structs carry a `:metadata` map with optional fields like
-  `:correlation_id` and `:causation_id`.
-  This module centralises the accessor functions and the metadata construction
-  logic so that both event structs stay in sync without duplicating code.
+  Pairs with `PayloadCodec`: the codec decides *what* survives, this walks a payload
+  and reports *where* something does not. Keeping them side by side is what stopped
+  them drifting — they were separate lists until #1317, and each of #1316 and #1317
+  had to edit both.
+
+  Lived in `EventMetadata` until #1358 retired the `metadata` field, which left that
+  module named after a concept it no longer held.
   """
 
   alias KlassHero.Shared.Domain.Events.PayloadCodec
-
-  @spec correlation_id(%{metadata: map()}) :: String.t() | nil
-  def correlation_id(%{metadata: %{correlation_id: id}}), do: id
-  def correlation_id(%{metadata: _}), do: nil
-
-  @spec causation_id(%{metadata: map()}) :: String.t() | nil
-  def causation_id(%{metadata: %{causation_id: id}}), do: id
-  def causation_id(%{metadata: _}), do: nil
-
-  @doc """
-  Generates a unique event ID (UUID v4).
-  """
-  @spec generate_event_id() :: String.t()
-  def generate_event_id, do: Ecto.UUID.generate()
-
-  @doc """
-  Builds a metadata map from keyword options.
-
-  Includes `:correlation_id` and `:causation_id` when present, and is empty
-  otherwise — which is what every event carries today, since no producer passes
-  either.
-  """
-  @spec build_metadata(keyword()) :: map()
-  def build_metadata(opts) do
-    %{}
-    |> maybe_add(:correlation_id, opts)
-    |> maybe_add(:causation_id, opts)
-  end
-
-  defp maybe_add(map, key, opts) do
-    case Keyword.get(opts, key) do
-      nil -> map
-      value -> Map.put(map, key, value)
-    end
-  end
 
   @doc """
   Raises if an event carries a payload value that cannot survive Oban's jsonb column.

--- a/lib/klass_hero/shared/tracing/context.ex
+++ b/lib/klass_hero/shared/tracing/context.ex
@@ -1,21 +1,21 @@
 defmodule KlassHero.Shared.Tracing.Context do
   @moduledoc """
-  Trace context propagation across process boundaries.
+  Trace context propagation across the one process boundary that has one.
 
-  Provides helpers to serialize/deserialize W3C Trace Context
-  into event metadata maps and Oban job args. Uses
-  `:otel_propagator_text_map` under the hood.
+  Serializes W3C Trace Context into Oban job args and restores it in the worker
+  process, over `:otel_propagator_text_map`.
 
-  ## Process boundaries requiring propagation
+  Oban is the only boundary that needs this. An integration event crosses process
+  boundaries *as* job args — ADR-0014 replaced the PubSub delivery path with a single
+  `EventDeliveryWorker` job, so an event's trace context is its job's trace context.
+  A same-context reaction runs inside the producer's own process and needs no
+  propagation at all.
 
-  1. **Integration events** — PubSub messages cross processes
-  2. **Oban workers** — jobs execute in new processes
-
-  Domain events dispatch synchronously in the caller's process
-  and do NOT need explicit propagation.
+  Propagating per-event instead was tried and removed in #1358: `TracedWorker` attaches
+  the job's context before opening the worker span, so a second attach inside that span
+  — once per event, with no restore token — would reparent later consumers' spans to an
+  earlier event's producer.
   """
-
-  require Logger
 
   @trace_context_key "trace_context"
 
@@ -29,36 +29,14 @@ defmodule KlassHero.Shared.Tracing.Context do
 
   @spec attach(map()) :: :ok
   def attach(context) when is_map(context) and map_size(context) > 0 do
-    # W3C Trace Context keys are always binary strings. Filter out any atom-keyed
-    # entries (e.g. :correlation_id from event metadata) before handing to the
-    # Erlang propagator, which expects {binary(), binary()} 2-tuples.
-    headers = Enum.filter(context, fn {k, _} -> is_binary(k) end)
-
-    if headers == [] do
-      Logger.debug("[Tracing.Context] No binary keys in context map, skipping attach: #{inspect(Map.keys(context))}")
-    else
-      # extract/1 both deserializes the W3C Trace Context headers and attaches
-      # the resulting context to the current process, returning the old token.
-      :otel_propagator_text_map.extract(headers)
-    end
+    # extract/1 both deserializes the W3C Trace Context headers and attaches
+    # the resulting context to the current process, returning the old token.
+    :otel_propagator_text_map.extract(Map.to_list(context))
 
     :ok
   end
 
   def attach(_empty), do: :ok
-
-  @spec inject_into_event(struct()) :: struct()
-  def inject_into_event(%{metadata: metadata} = event) do
-    trace_context = inject()
-    %{event | metadata: Map.merge(metadata, trace_context)}
-  end
-
-  @spec attach_from_event(struct()) :: :ok
-  def attach_from_event(%{metadata: metadata}) do
-    attach(metadata)
-  end
-
-  def attach_from_event(_event), do: :ok
 
   @spec inject_into_args(map()) :: map()
   def inject_into_args(args) when is_map(args) do

--- a/test/klass_hero/provider/adapters/driven/projections/provider_programs_test.exs
+++ b/test/klass_hero/provider/adapters/driven/projections/provider_programs_test.exs
@@ -19,9 +19,7 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderProgramsTest do
       entity_type: :program,
       entity_id: payload.program_id,
       occurred_at: DateTime.utc_now(),
-      payload: payload,
-      metadata: %{},
-      version: 1
+      payload: payload
     }
   end
 

--- a/test/klass_hero/provider/adapters/driven/projections/provider_session_stats_test.exs
+++ b/test/klass_hero/provider/adapters/driven/projections/provider_session_stats_test.exs
@@ -24,9 +24,7 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionStatsTes
         program_id: attrs[:program_id] || Ecto.UUID.generate(),
         provider_id: attrs[:provider_id] || Ecto.UUID.generate(),
         program_title: attrs[:program_title] || "Test Program"
-      },
-      metadata: %{},
-      version: 1
+      }
     }
   end
 

--- a/test/klass_hero/shared/adapters/driven/events/event_serializer_test.exs
+++ b/test/klass_hero/shared/adapters/driven/events/event_serializer_test.exs
@@ -20,8 +20,7 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.EventSerializerTest do
           :family,
           :child,
           "child-uuid",
-          %{child_id: "child-uuid", reason: "gdpr_request"},
-          version: 2
+          %{child_id: "child-uuid", reason: "gdpr_request"}
         )
 
       serialized = EventSerializer.serialize(event)
@@ -33,17 +32,37 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.EventSerializerTest do
       assert deserialized.entity_type == :child
       assert deserialized.entity_id == "child-uuid"
       assert deserialized.payload == %{child_id: "child-uuid", reason: "gdpr_request"}
-      assert deserialized.version == 2
     end
 
-    test "serialized form includes version and source_context" do
-      event =
-        Event.new(:test, :enrollment, :invite, "id", %{}, version: 3)
-
-      serialized = EventSerializer.serialize(event)
+    test "serialized form includes source_context" do
+      serialized = EventSerializer.serialize(Event.new(:test, :enrollment, :invite, "id", %{}))
 
       assert serialized["source_context"] == "enrollment"
-      assert serialized["version"] == 3
+    end
+  end
+
+  describe "metadata and version were retired (#1358)" do
+    test "the serialized envelope carries neither key" do
+      keys = EventSerializer.serialize(Event.new(:test, :test_context, :test, "id", %{})) |> Map.keys()
+
+      refute "metadata" in keys
+      refute "version" in keys
+    end
+
+    # A row staged before #1358 still carries both in `oban_jobs.args`. They are ignored
+    # structurally now — there is no field to receive them into — rather than by the
+    # closed allowlist that retired `criticality` in #1326. Same guarantee, one fewer
+    # mechanism. `legacy_job/1` in EventDeliveryWorkerTest proves the same thing through
+    # the worker; this is the unit-level half.
+    test "a row staged before the retirement still deserializes" do
+      legacy =
+        Event.new(:test, :test_context, :test, "id", %{})
+        |> EventSerializer.serialize()
+        |> Map.merge(%{"metadata" => %{"criticality" => "critical"}, "version" => 2})
+        |> Jason.encode!()
+        |> Jason.decode!()
+
+      assert %Event{event_type: :test, entity_id: "id"} = EventSerializer.deserialize(legacy)
     end
   end
 
@@ -147,74 +166,6 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.EventSerializerTest do
         EventSerializer.serialize(event)
       end
     end
-  end
-
-  describe "metadata round-trip" do
-    test "restores metadata atom keys after JSON round-trip" do
-      event =
-        Event.new(:test, :test_context, :test, "id", %{},
-          correlation_id: "corr-1",
-          causation_id: "cause-1"
-        )
-
-      serialized = EventSerializer.serialize(event)
-      json_cycled = Jason.decode!(Jason.encode!(serialized))
-      deserialized = EventSerializer.deserialize(json_cycled)
-
-      assert deserialized.metadata == %{correlation_id: "corr-1", causation_id: "cause-1"}
-    end
-
-    test "preserves string keys for trace context fields after round-trip" do
-      event =
-        Event.new(:test_event, :enrollment, :invite, "id-1", %{})
-
-      event_with_trace =
-        %{
-          event
-          | metadata:
-              Map.merge(event.metadata, %{
-                "traceparent" => "00-abc123-def456-01",
-                "tracestate" => ""
-              })
-        }
-
-      serialized = EventSerializer.serialize(event_with_trace)
-      json_cycled = Jason.decode!(Jason.encode!(serialized))
-      deserialized = EventSerializer.deserialize(json_cycled)
-
-      assert Map.fetch(deserialized.metadata, "traceparent") == {:ok, "00-abc123-def456-01"}
-      assert Map.fetch(deserialized.metadata, "tracestate") == {:ok, ""}
-      refute Map.has_key?(deserialized.metadata, :traceparent)
-      refute Map.has_key?(deserialized.metadata, :tracestate)
-    end
-
-    # Dropping is what makes a retired key safe. `criticality` was removed in #1326
-    # and no module holds that atom any more, so atomizing whatever arrives would
-    # raise on every row an earlier release staged — in `execute/1` and again in
-    # `compensate/2`, losing the event with no `undelivered_events` row to find it by.
-    # Whatever is retired next is covered without a second shim.
-    #
-    # These strings are load-bearing: an atom literal anywhere in the suite creates
-    # the atom for the whole run, and these would then pass for a reason production
-    # does not have.
-    for key <- ["criticality", "some_future_retired_key"] do
-      test "drops #{key}, which the format does not define" do
-        args = legacy_args(%{unquote(key) => "critical"})
-
-        assert EventSerializer.deserialize(args).metadata == %{}
-      end
-    end
-  end
-
-  # A serialized event whose metadata is replaced wholesale, then pushed through JSON
-  # — the shape `EventDeliveryWorker` reads out of `oban_jobs.args`.
-  defp legacy_args(metadata) do
-    :test
-    |> Event.new(:test_context, :test, "id", %{})
-    |> EventSerializer.serialize()
-    |> Map.put("metadata", metadata)
-    |> Jason.encode!()
-    |> Jason.decode!()
   end
 
   # Jason.encode!/decode! is not ceremony: without it the test compares two in-memory

--- a/test/klass_hero/shared/adapters/driven/events/event_serializer_test.exs
+++ b/test/klass_hero/shared/adapters/driven/events/event_serializer_test.exs
@@ -42,6 +42,13 @@ defmodule KlassHero.Shared.Adapters.Driven.Events.EventSerializerTest do
   end
 
   describe "metadata and version were retired (#1358)" do
+    test "the envelope struct carries neither field" do
+      fields = Event.new(:test, :test_context, :test, "id", %{}) |> Map.from_struct() |> Map.keys()
+
+      refute :metadata in fields
+      refute :version in fields
+    end
+
     test "the serialized envelope carries neither key" do
       keys = EventSerializer.serialize(Event.new(:test, :test_context, :test, "id", %{})) |> Map.keys()
 

--- a/test/klass_hero/shared/adapters/driven/workers/event_delivery_worker_test.exs
+++ b/test/klass_hero/shared/adapters/driven/workers/event_delivery_worker_test.exs
@@ -54,14 +54,24 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorkerTest do
     }
   end
 
-  # A row staged before #1326: its metadata still carries `"criticality"`. No module
-  # holds that atom any more, so a serializer that atomized whatever arrived would
-  # raise on this — here, and again in `compensate/2`, losing the event with no
-  # `undelivered_events` row to find it by. Both routes are covered because the
-  # second is the one nothing else would have caught.
+  # A row staged before #1326 *and* before #1358: it carries a `"metadata"` map holding
+  # `"criticality"`, plus a `"version"`. No module holds the `criticality` atom any more,
+  # and neither top-level key has a field to land in since #1358 — so a serializer that
+  # atomized whatever arrived would raise here, and again in `compensate/2`, losing the
+  # event with no `undelivered_events` row to find it by. Both routes are covered because
+  # the second is the one nothing else would have caught.
+  #
+  # The assertions deliberately say nothing about the retired keys. What is being proved
+  # is that an old row still *delivers*, which is the guarantee that has to survive every
+  # future retirement, not the mechanism any one of them used.
   defp legacy_job(events) do
     job = job(events)
-    staged = Enum.map(job.args["events"], &Map.put(&1, "metadata", %{"criticality" => "critical"}))
+
+    staged =
+      Enum.map(
+        job.args["events"],
+        &Map.merge(&1, %{"metadata" => %{"criticality" => "critical"}, "version" => 1})
+      )
 
     %{job | args: %{"events" => staged}}
   end

--- a/test/klass_hero/shared/domain/events/payload_codec_test.exs
+++ b/test/klass_hero/shared/domain/events/payload_codec_test.exs
@@ -2,7 +2,7 @@ defmodule KlassHero.Shared.Domain.Events.PayloadCodecTest do
   @moduledoc """
   The one list of what an event payload leaf may be, and how it crosses jsonb.
 
-  Both walkers ask this module: `EventMetadata` before construction, to reject a
+  Both walkers ask this module: `PayloadGuard` before construction, to reject a
   payload at its source, and `EventSerializer` on the way out and back.
   Keeping that list in one place is the point — it lived in two before #1317, and
   both #1316 and this change had to edit both halves in lockstep.

--- a/test/klass_hero/shared/domain/events/payload_guard_test.exs
+++ b/test/klass_hero/shared/domain/events/payload_guard_test.exs
@@ -1,7 +1,7 @@
 defmodule KlassHero.Shared.Domain.Events.PayloadGuardTest do
   @moduledoc """
   Guards what an event payload may carry across jsonb (#1010, #1311, #1317).
-  The guard lives in `EventMetadata.validate_payload!/1`, invoked from `Event.new/6`.
+  The guard lives in `PayloadGuard.validate_payload!/1`, invoked from `Event.new/5`.
 
   One rule, and the difference it draws is the whole point: a value `PayloadCodec`
   can restore is allowed, a value that would silently arrive as something else is
@@ -98,7 +98,7 @@ defmodule KlassHero.Shared.Domain.Events.PayloadGuardTest do
     end
   end
 
-  defp build(payload, opts \\ []) do
-    Event.new(:test_event, :test_context, :test, "agg-1", payload, opts)
+  defp build(payload) do
+    Event.new(:test_event, :test_context, :test, "agg-1", payload)
   end
 end

--- a/test/klass_hero/shared/payload_jsonb_delivery_test.exs
+++ b/test/klass_hero/shared/payload_jsonb_delivery_test.exs
@@ -67,6 +67,18 @@ defmodule KlassHero.Shared.PayloadJsonbDeliveryTest do
     refute Map.has_key?(args["payload_types"], "active")
   end
 
+  # The row Postgres actually holds, which is the only place the envelope's shape is
+  # observable end to end. #1358 retired both keys; asserting it here rather than only
+  # against `serialize/1` is what would catch a producer path that reintroduced either.
+  test "the stored envelope carries no metadata or version" do
+    event = Event.new(:conversation_created, :messaging, :conversation, Ecto.UUID.generate(), @payload)
+
+    keys = event |> stage_and_read_args() |> Map.keys()
+
+    refute "metadata" in keys
+    refute "version" in keys
+  end
+
   # Manual mode so the job is inserted and left alone: this asserts what Postgres
   # stored, not what a consumer did with it. The real outbox is swapped in around
   # the stage alone, per archive_conversations_delivery_test.exs.

--- a/test/klass_hero/shared/projection_test.exs
+++ b/test/klass_hero/shared/projection_test.exs
@@ -131,9 +131,7 @@ defmodule KlassHero.Shared.ProjectionTest do
       entity_type: :thing,
       entity_id: "id-1",
       occurred_at: DateTime.utc_now(),
-      payload: %{},
-      metadata: %{},
-      version: 1
+      payload: %{}
     }
   end
 

--- a/test/klass_hero/shared/tracing/context_test.exs
+++ b/test/klass_hero/shared/tracing/context_test.exs
@@ -3,7 +3,6 @@
 defmodule KlassHero.Shared.Tracing.ContextTest.Helpers do
   use KlassHero.Shared.Tracing
 
-  alias KlassHero.Shared.Domain.Events.Event
   alias KlassHero.Shared.Tracing.Context
 
   def inject_in_span do
@@ -16,57 +15,6 @@ defmodule KlassHero.Shared.Tracing.ContextTest.Helpers do
 
           span "child.operation" do
             :child_result
-          end
-        end)
-
-      Task.await(task)
-      context
-    end
-  end
-
-  def inject_into_domain_event do
-    span "test.operation" do
-      event = Event.new(:test_event, :test_context, :test, "123", %{})
-      Context.inject_into_event(event)
-    end
-  end
-
-  def inject_into_integration_event do
-    span "test.operation" do
-      event = Event.new(:test_event, :test, :entity, "123", %{})
-      Context.inject_into_event(event)
-    end
-  end
-
-  def attach_from_event_in_child_span do
-    span "publisher.span" do
-      event = Event.new(:test_event, :test_context, :test, "123", %{})
-      enriched = Context.inject_into_event(event)
-
-      task =
-        Task.async(fn ->
-          Context.attach_from_event(enriched)
-
-          span "subscriber.span" do
-            :ok
-          end
-        end)
-
-      Task.await(task)
-    end
-  end
-
-  def attach_with_mixed_keys_in_child_span do
-    span "parent.operation" do
-      context = Context.inject()
-      mixed = Map.put(context, :correlation_id, "corr-1")
-
-      task =
-        Task.async(fn ->
-          Context.attach(mixed)
-
-          span "child.operation" do
-            :ok
           end
         end)
 
@@ -117,44 +65,11 @@ defmodule KlassHero.Shared.Tracing.ContextTest do
 
       assert span(parent_span, :trace_id) == span(child_span, :trace_id)
     end
-
-    test "filters atom keys and attaches only binary-keyed trace context" do
-      Helpers.attach_with_mixed_keys_in_child_span()
-
-      parent_span = assert_span("parent.operation")
-      child_span = assert_span("child.operation")
-
-      assert span(parent_span, :trace_id) == span(child_span, :trace_id)
-    end
   end
 
   describe "inject/0 when no active span" do
     test "returns empty map" do
       assert Context.inject() == %{}
-    end
-  end
-
-  describe "inject_into_event/1" do
-    test "merges trace context into DomainEvent metadata" do
-      enriched = Helpers.inject_into_domain_event()
-
-      assert Map.has_key?(enriched.metadata, "traceparent")
-      assert enriched.event_type == :test_event
-    end
-
-    test "merges trace context into Event metadata" do
-      enriched = Helpers.inject_into_integration_event()
-
-      assert Map.has_key?(enriched.metadata, "traceparent")
-    end
-  end
-
-  describe "attach_from_event/1" do
-    test "restores context from event metadata" do
-      Helpers.attach_from_event_in_child_span()
-
-      subscriber_span = assert_span("subscriber.span")
-      assert span(subscriber_span, :parent_span_id) != :undefined
     end
   end
 


### PR DESCRIPTION
## Summary

#1358 reported that `Tracing.Context.inject_into_event/1` has no production caller. Verification showed the symptom was narrower than the disease: **the whole non-payload half of the event envelope is dead.**

- No producer ever set `correlation_id`/`causation_id`, so `%Event{}.metadata` was `%{}` for every production event — `build_metadata/1`'s own moduledoc already said so.
- `Event.correlation_id/1` and `causation_id/1` had **zero callers repo-wide** — no producers *and* no consumers.
- `version` was written and read back by the serializer and nothing else. No consumer ever matched `%Event{version: _}`.
- `Event.new/6`'s `opts` therefore carried nothing: of 69 call sites, 55 were already 5-arg, and the 14 passing opts all forwarded a variable that was always `[]`.

Two findings made deletion the right call rather than leaving a seam:

**`attach_from_event/1` was a latent bug, not neutral dead code.** `TracedWorker.perform` attaches the job's trace context *before* opening the worker span. `EventDeliveryWorker.deliver/2` then called `attach_from_event(event)` *inside* that span, once per event in a loop, and `Context.attach/1` discards `extract/1`'s restore token. Had metadata ever carried a `traceparent`, consumer spans for events 2..N would have reparented to event 1's producer and never restored — fragmenting the trace the args path builds correctly.

**Metadata propagation was an approach that lost, not intent never wired.** `context_test.exs` still had `inject_into_domain_event/0` and `inject_into_integration_event/0` as byte-identical duplicates — a fossil of the pre-ADR-0014 two-tier event model. ADR-0014 collapsed that to one struct on one Oban route, and `inject_into_args/1` won.

## What changed

| | |
|---|---|
| `Tracing.Context` | `inject_into_event/1`, `attach_from_event/1`, and `attach/1`'s atom-key filter deleted |
| `Event` | `:metadata` and `:version` dropped; `new/6` → `new/5`; both dead accessors removed |
| `EventSerializer` | stops reading and writing `"metadata"` / `"version"`; the closed metadata allowlist goes with them |
| `EventMetadata` | dissolved — UUID mint inlined into `Event.new/5`, jsonb guard extracted to `PayloadGuard` |
| six constructor modules | private forwarders drop the trailing `opts` argument; public heads untouched |

`EventMetadata` was dissolved rather than left named after the field it no longer held. Its test file was **already** called `payload_guard_test.exs` — the codebase had been calling the concept "payload guard" for a while, and only the module name disagreed.

## Review focus

**No migration, no backfill, and rollback-safe both directions.** `deserialize/1` reads named keys with bracket access and never walks the map, so a row staged before this deploy carries both retired keys inertly, and a rollback reads rows lacking them through the same nil-defaulting path. This is the door #1326/#1354 used to retire `criticality`, one level up. `undelivered_events.payload` needs no backfill: the repository exposes only `record_all/1` and `prune/1`, and the admin LiveView renders the column as raw JSON, never through `deserialize/1`.

**The two #1354 regression tests pass unmodified.** `legacy_job/1`'s tests assert `Recorder.calls()` and `missed_consumers`, never `.metadata` — so their guarantee ("an old row still delivers") survives and gets stronger: leftover keys are now ignored *structurally* rather than by an allowlist. Only their comment changed, to say the guarantee is what matters and not the mechanism any one retirement used.

**`ParticipationEvents` keeps its `opts` on purpose.** `participation.ex:997` really does call `session_completed(session, extra_payload: ...)`, and the function pops that before forwarding the (always empty) remainder. That is why the public `opts \\ []` heads stay across all six modules — removing them would make Participation a deliberate exception for zero behaviour gain.

**One consequence worth a look:** those public `opts` params are now accepted and discarded outright, where before they at least reached `Event.new`. Nothing passes them, so behaviour is unchanged, but the ~30 heads are now inert in a stronger sense. Left out of this PR deliberately (see below).

## Test plan

- `mix precommit` green: `compile --warnings-as-errors`, `format`, `credo --strict` (826 files, no issues), `lint_typography`, `lint_translations`, `lint_read_tables`, `lint_acl_boundary`, and **4358 tests** including `--include slow`.
- New coverage, red-green driven:
  - `event_serializer_test.exs` — the envelope struct carries neither field; the serialized envelope carries neither key; a row staged before the retirement still deserializes.
  - `payload_jsonb_delivery_test.exs` — the row Postgres actually stores after `Outbox.stage/2` carries no `metadata` or `version`. This is the end-to-end pin: it is what would catch a producer path reintroducing either.
- Retired coverage: the metadata round-trip and closed-allowlist tests, whose mechanism no longer exists. Their guarantee is subsumed by the legacy-row tests above and by `legacy_job/1`.

## Follow-up left out

The ~30 public `opts \\ []` heads on the six constructor modules. Inert after this change but harmless, and removing them touches five contexts for no behaviour change. Happy to file it if you want it tracked.

Closes #1358
