### PR TITLE
fix: translate invite failure reasons in the reader's locale

### DIFF
--- a/lib/klass_hero/enrollment.ex
+++ b/lib/klass_hero/enrollment.ex
@@ -1097,13 +1097,13 @@ defmodule KlassHero.Enrollment do
   @doc """
   Fails an invite, recording a reason the owning provider can act on.
 
-  The single writer of `error_details`. Before #1290 four call sites across two
+  The single writer of the failure cause. Before #1290 four call sites across two
   contexts each rebuilt this — the `:failed` atom, the refetch-by-id shape, the
   "a rejected transition means already-terminal" rule, and their own wording — and two
   of them wrote raw `inspect/1` output into a field rendered verbatim to providers.
 
-  `reason` is only ever used to *describe* the failure (see
-  `BulkEnrollmentInvite.describe_failure/2`); callers keep logging it themselves for
+  `reason` is only ever used to *classify* the failure (see
+  `BulkEnrollmentInvite.classify_failure/2`); callers keep logging it themselves for
   diagnostics, which is where an unmapped term belongs.
 
   `{:error, :already_terminal}` means something else already settled this invite, and
@@ -1156,10 +1156,13 @@ defmodule KlassHero.Enrollment do
   end
 
   defp apply_failure(invite, reason) do
+    {failure_code, failure_context} = BulkEnrollmentInvite.classify_failure(invite, reason)
+
     invite
     |> BulkEnrollmentInvite.transition_changeset(%{
       status: :failed,
-      error_details: BulkEnrollmentInvite.describe_failure(invite, reason)
+      failure_code: failure_code,
+      failure_context: failure_context
     })
     |> Repo.update()
     |> case do
@@ -1202,6 +1205,10 @@ defmodule KlassHero.Enrollment do
           status: :pending,
           invite_token: nil,
           invite_sent_at: nil,
+          failure_code: nil,
+          failure_context: nil,
+          # Legacy: an invite that failed before #1340 carries its reason here, and a
+          # resend must clear that too or the reopened invite keeps the old sentence.
           error_details: nil,
           resent_at: DateTime.utc_now()
         })

--- a/lib/klass_hero/enrollment/adapters/driving/workers/send_invite_email_worker.ex
+++ b/lib/klass_hero/enrollment/adapters/driving/workers/send_invite_email_worker.ex
@@ -36,8 +36,8 @@ defmodule KlassHero.Enrollment.Adapters.Driving.Workers.SendInviteEmailWorker do
       {:ok, %BulkEnrollmentInvite{invite_token: nil} = invite} ->
         Logger.warning("[SendInviteEmailWorker] Invite has no token", invite_id: invite_id)
 
-        # The reason is not what names this failure — `describe_failure/2` reads the
-        # missing token off the row, so the sweep reaches the same wording later without
+        # The reason is not what names this failure — `classify_failure/2` reads the
+        # missing token off the row, so the sweep reaches the same cause later without
         # a reason to go on.
         invite.id
         |> Enrollment.fail_invite(:tokenless)

--- a/lib/klass_hero/enrollment/bulk_enrollment_invite.ex
+++ b/lib/klass_hero/enrollment/bulk_enrollment_invite.ex
@@ -7,7 +7,7 @@ defmodule KlassHero.Enrollment.BulkEnrollmentInvite do
 
   This module is both the Ecto schema and the struct consumers pattern-match.
   The changesets are the validation gatekeepers; the predicates, `generate_token/0`,
-  `dedup_key/4` and `describe_failure/2` are the functional core. Status follows a
+  `dedup_key/4` and `classify_failure/2` are the functional core. Status follows a
   state machine (see `valid_transitions/0`).
   """
 
@@ -24,6 +24,8 @@ defmodule KlassHero.Enrollment.BulkEnrollmentInvite do
 
   @statuses [:pending, :invite_sent, :registered, :enrolled, :failed]
   @resendable_statuses [:pending, :invite_sent, :failed]
+
+  @failure_codes [:no_token, :program_full, :invalid_date, :delivery_failed, :exhausted, :invalid_details, :generic]
 
   schema "bulk_enrollment_invites" do
     field :program_id, :binary_id
@@ -49,6 +51,15 @@ defmodule KlassHero.Enrollment.BulkEnrollmentInvite do
     field :registered_at, :utc_datetime
     field :enrolled_at, :utc_datetime
     field :enrollment_id, :binary_id
+
+    # Why this invite failed, as a cause rather than a sentence. Every writer is a
+    # background process with no reader's locale in scope, so copy written here would be
+    # frozen in that process's language — the provider translates at render instead (#1340).
+    field :failure_code, Ecto.Enum, values: @failure_codes
+    field :failure_context, :map
+
+    # Superseded by the pair above; kept unwritten so invites that failed before #1340
+    # still read back their original sentence. Nothing may write it again.
     field :error_details, :string
 
     # When the provider last reopened this invite. Compared against an Oban job's
@@ -70,7 +81,7 @@ defmodule KlassHero.Enrollment.BulkEnrollmentInvite do
     school_grade school_name medical_conditions nut_allergy
     consent_photo_marketing consent_photo_social_media
     status invite_token invite_sent_at registered_at enrolled_at
-    enrollment_id error_details
+    enrollment_id
   )a
 
   @import_fields ~w(
@@ -89,7 +100,7 @@ defmodule KlassHero.Enrollment.BulkEnrollmentInvite do
     failed: [:pending]
   }
 
-  @lifecycle_fields ~w(status invite_token invite_sent_at registered_at enrolled_at enrollment_id error_details resent_at)a
+  @lifecycle_fields ~w(status invite_token invite_sent_at registered_at enrolled_at enrollment_id failure_code failure_context resent_at)a
 
   def valid_transitions, do: @valid_transitions
 
@@ -193,64 +204,54 @@ defmodule KlassHero.Enrollment.BulkEnrollmentInvite do
   def ensure_claimable(%__MODULE__{}), do: {:error, :already_claimed}
 
   @doc """
-  The sentence a provider reads under a failed invite's status pill.
+  Why a failed invite failed, as a code the reader turns into a sentence.
 
-  `error_details` is rendered verbatim to providers so the reason is *actionable*
-  (#1221), which means no clause here may emit `inspect/1` output — see #1290, where
-  three of the four writers had each invented their own convention and two emitted raw
-  Elixir terms. Diagnostics belong in the `Logger` calls the writers already make.
+  The provider reads this under the status pill, so the cause has to be *actionable*
+  (#1221) — but every writer is a background process, so a sentence built here would be
+  frozen in that process's locale (#1340). The code plus its context is the whole
+  vocabulary; `KlassHeroWeb.ProviderComponents` owns the wording.
+
+  Context keys and values are JSON-safe scalars, because the map is persisted as jsonb
+  and read back. No clause may put an Elixir term in it — see #1290, where two of the
+  four writers this replaced emitted raw `inspect/1` output. Diagnostics belong in the
+  `Logger` calls the writers already make.
 
   Takes the invite as well as the reason because a missing token is a fact about the
   row that no reason can carry: the compensation sweep hands back `nil` for a Lifeline
   discard, and Oban's own error text otherwise, so by then the original term is gone.
   """
-  @spec describe_failure(t(), term()) :: String.t()
+  @spec classify_failure(t(), term()) :: {atom(), map()}
   # First, because the row outranks the reason: a tokenless invite failed for want of a
   # token whatever the caller believed went wrong, and the resend that mints a new one
   # is different advice from retrying a delivery.
-  def describe_failure(%__MODULE__{invite_token: nil}, _reason) do
-    "Invite link could not be generated (no token). Please resend."
-  end
+  def classify_failure(%__MODULE__{invite_token: nil}, _reason), do: {:no_token, %{}}
 
-  def describe_failure(%__MODULE__{}, %Ecto.Changeset{} = changeset) do
-    case ChangesetErrors.field_list(changeset) do
+  def classify_failure(%__MODULE__{}, %Ecto.Changeset{} = changeset) do
+    case ChangesetErrors.to_payload(changeset) do
       # A changeset can be invalid with its errors on an association rather than a field.
-      # Falling back to the generic sentence loses detail; falling back to `inspect/1`
-      # would lose the provider.
-      [] -> generic_failure()
-      fields -> Enum.map_join(fields, "; ", fn {field, message} -> "#{humanize_field(field)} #{message}" end)
+      # Naming no field is better than naming none convincingly.
+      [] -> {:generic, %{}}
+      fields -> {:invalid_details, %{"fields" => fields}}
     end
   end
 
-  def describe_failure(%__MODULE__{}, :program_full) do
-    "The program is full, so this child could not be enrolled."
+  def classify_failure(%__MODULE__{}, :program_full), do: {:program_full, %{}}
+
+  def classify_failure(%__MODULE__{}, {:invalid_date, value}) when is_binary(value) do
+    {:invalid_date, %{"value" => value}}
   end
 
-  def describe_failure(%__MODULE__{}, {:invalid_date, value}) when is_binary(value) do
-    ~s(Date of birth "#{value}" is not a valid date. Please correct it and resend.)
-  end
-
-  def describe_failure(%__MODULE__{}, {:delivery, _reason}) do
-    "The invitation email could not be delivered. Please check the address and resend."
-  end
+  def classify_failure(%__MODULE__{}, {:delivery, _reason}), do: {:delivery_failed, %{}}
 
   # `nil` is a Lifeline discard, which records no cause at all; a binary is Oban's own
   # error text — `Exception.format/3` output or "... failed with #{inspect(reason)}" —
   # which is developer copy by construction. Both give the provider the fact without a
   # cause rather than a term they cannot act on.
-  def describe_failure(%__MODULE__{}, reason) when is_nil(reason) or is_binary(reason) do
-    "This invite could not be completed and no retries remain. Please resend."
+  def classify_failure(%__MODULE__{}, reason) when is_nil(reason) or is_binary(reason) do
+    {:exhausted, %{}}
   end
 
-  def describe_failure(%__MODULE__{}, _other), do: generic_failure()
-
-  defp generic_failure, do: "This invite could not be completed. Please resend."
-
-  defp humanize_field(field) do
-    field
-    |> Atom.to_string()
-    |> String.replace("_", " ")
-  end
+  def classify_failure(%__MODULE__{}, _other), do: {:generic, %{}}
 
   @doc "Generates a cryptographically secure URL-safe token for invite links."
   @spec generate_token() :: String.t()

--- a/lib/klass_hero/shared/changeset_errors.ex
+++ b/lib/klass_hero/shared/changeset_errors.ex
@@ -6,12 +6,21 @@ defmodule KlassHero.Shared.ChangesetErrors do
   like `"should be at most %{count} character(s)"` don't leak to end users.
 
   Lives in Shared rather than a context because it knows only about Ecto: Enrollment's
-  commands surface it to the LiveView layer, and Family writes it into the reason a
-  provider reads on a failed invite.
+  commands surface it to the LiveView layer, and Enrollment stores it as the context of
+  a failed invite for the provider to read.
+
+  Two shapes, for two moments:
+
+  - `field_list/1` renders now — messages come back expanded, ready to show.
+  - `to_payload/1` renders later — the msgid stays unexpanded so a reader in another
+    locale can still look it up, and the values ride alongside as JSON-safe bindings.
+    `interpolate/2` is the second half, applied after the translation (#1340).
 
   Formatting must never raise — this helper is called on the error path
   where throwing would swallow the real validation errors. Unknown
-  placeholders fall through unchanged.
+  placeholders fall through unchanged, as do placeholders whose opt is `nil`:
+  a visible `%{gap}` says the validator forgot a value, where the empty string
+  this used to render said nothing at all.
   """
 
   @doc """
@@ -26,19 +35,78 @@ defmodule KlassHero.Shared.ChangesetErrors do
     end)
   end
 
-  defp expand({msg, opts}) do
-    Regex.replace(~r"%{(\w+)}", msg, fn match, key -> lookup(opts, key, match) end)
+  @doc """
+  Flatten a changeset's errors into JSON-safe `%{"field", "msg", "bindings"}` maps.
+
+  For errors that are persisted and read back later. The message is the raw gettext
+  msgid, still carrying its `%{...}` placeholders, because the reader translates before
+  interpolating — expanding here would produce a string no catalog contains.
+  """
+  @spec to_payload(Ecto.Changeset.t()) :: [%{String.t() => term()}]
+  def to_payload(%Ecto.Changeset{} = changeset) do
+    changeset
+    |> Ecto.Changeset.traverse_errors(fn {msg, opts} -> {msg, normalize_bindings(opts)} end)
+    |> Enum.flat_map(fn {field, errors} ->
+      for {msg, bindings} <- errors do
+        %{"field" => Atom.to_string(field), "msg" => msg, "bindings" => bindings}
+      end
+    end)
   end
 
-  # Catches only ArgumentError from String.to_existing_atom/1 — other failures surface.
-  defp lookup(opts, key, default) do
-    atom = String.to_existing_atom(key)
+  # Every placeholder the "errors" catalog interpolates — `mix gettext.extract` produces
+  # no others, because these are the only ones Ecto's own validators emit. Closed and
+  # literal on purpose: bindings come back from jsonb, and `String.to_existing_atom/1`
+  # over stored data raises once an atom is deleted in a later release.
+  @gettext_keys %{"count" => :count, "number" => :number}
 
-    case Keyword.fetch(opts, atom) do
-      {:ok, value} -> to_string(value)
-      :error -> default
+  @doc """
+  The subset of stored bindings Gettext can interpolate itself, atom-keyed.
+
+  Gettext logs an error through `handle_missing_bindings/2` for every placeholder it
+  cannot bind, so a translation call must be handed these rather than an empty map —
+  otherwise a single failed invite logs on every render of the table it appears in.
+  `interpolate/2` still runs afterwards and covers any key outside this set.
+  """
+  @spec gettext_bindings(%{String.t() => term()}) :: %{atom() => term()}
+  def gettext_bindings(bindings) when is_map(bindings) do
+    for {key, atom} <- @gettext_keys, {:ok, value} <- [Map.fetch(bindings, key)], into: %{} do
+      {atom, value}
     end
+  end
+
+  @doc """
+  Substitute `%{key}` placeholders from a string-keyed binding map.
+
+  String-keyed on purpose: bindings come back from jsonb, and converting their keys to
+  atoms would tie a render to atoms that may no longer exist.
+  """
+  @spec interpolate(String.t(), %{String.t() => term()}) :: String.t()
+  def interpolate(msg, bindings) when is_binary(msg) and is_map(bindings) do
+    Regex.replace(~r"%{(\w+)}", msg, fn match, key ->
+      case Map.fetch(bindings, key) do
+        {:ok, value} -> to_string(value)
+        :error -> match
+      end
+    end)
+  end
+
+  defp expand({msg, opts}), do: interpolate(msg, normalize_bindings(opts))
+
+  defp normalize_bindings(opts) do
+    for {key, value} <- opts, {:ok, scalar} <- [normalize_value(value)], into: %{} do
+      {Atom.to_string(key), scalar}
+    end
+  end
+
+  defp normalize_value(value) when is_number(value) or is_binary(value) or is_boolean(value), do: {:ok, value}
+  defp normalize_value(nil), do: :drop
+  defp normalize_value(value) when is_atom(value), do: {:ok, Atom.to_string(value)}
+
+  # A custom validator can put any term in opts. Anything with no string form is dropped
+  # rather than left to raise on the render path.
+  defp normalize_value(value) do
+    {:ok, to_string(value)}
   rescue
-    ArgumentError -> default
+    Protocol.UndefinedError -> :drop
   end
 end

--- a/lib/klass_hero_web/components/provider_components.ex
+++ b/lib/klass_hero_web/components/provider_components.ex
@@ -14,6 +14,7 @@ defmodule KlassHeroWeb.ProviderComponents do
   import KlassHeroWeb.ParticipationComponents, only: [participation_status: 1]
   import KlassHeroWeb.UIComponents
 
+  alias KlassHero.Shared.ChangesetErrors
   alias KlassHeroWeb.Presenters.ProviderPresenter
   alias KlassHeroWeb.Theme
 
@@ -2273,11 +2274,11 @@ defmodule KlassHeroWeb.ProviderComponents do
                 <%!-- Written by three places and shown by none until #1221: a red pill with no
                       reason tells a provider that something is wrong but not what to do about it. --%>
                 <p
-                  :if={invite.status == :failed && invite.error_details}
+                  :if={invite.status == :failed && failure_message(invite)}
                   id={"invite-error-#{invite.id}"}
                   class="mt-1 text-xs text-hero-grey-500 break-words"
                 >
-                  {invite.error_details}
+                  {failure_message(invite)}
                 </p>
               </td>
               <td class="px-3 py-3 text-right">
@@ -2498,25 +2499,103 @@ defmodule KlassHeroWeb.ProviderComponents do
     Enum.map_join(errors, ", ", fn {field, msg} -> "#{humanize_field(field)}: #{msg}" end)
   end
 
+  # The sentence a provider reads under a failed invite's status pill.
+  #
+  # `Enrollment` stores the *cause*, not the copy: every writer is a background process,
+  # so a sentence built there would be frozen in that process's locale (#1340). The
+  # wording lives here, where the reader's locale is the one in scope.
+  defp failure_message(%{failure_code: nil, error_details: legacy}), do: legacy
+
+  defp failure_message(%{failure_code: :no_token}),
+    do: dgettext("enrollment", "Invite link could not be generated (no token). Please resend.")
+
+  defp failure_message(%{failure_code: :program_full}),
+    do: dgettext("enrollment", "The program is full, so this child could not be enrolled.")
+
+  defp failure_message(%{failure_code: :invalid_date, failure_context: %{"value" => value}}) do
+    dgettext(
+      "enrollment",
+      "Date of birth \"%{value}\" is not a valid date. Please correct it and resend.",
+      value: value
+    )
+  end
+
+  defp failure_message(%{failure_code: :delivery_failed}),
+    do: dgettext("enrollment", "The invitation email could not be delivered. Please check the address and resend.")
+
+  defp failure_message(%{failure_code: :exhausted}),
+    do: dgettext("enrollment", "This invite could not be completed and no retries remain. Please resend.")
+
+  defp failure_message(%{failure_code: :invalid_details, failure_context: %{"fields" => fields}})
+       when is_list(fields) do
+    Enum.map_join(fields, "; ", &changeset_field_message/1)
+  end
+
+  # Also the landing place for a code whose context did not survive — naming no detail
+  # beats raising on the render path.
+  defp failure_message(%{}), do: dgettext("enrollment", "This invite could not be completed. Please resend.")
+
+  defp changeset_field_message(%{"field" => field, "msg" => msg} = error) do
+    bindings = Map.get(error, "bindings", %{})
+
+    "#{humanize_field(field)} #{translate_changeset_message(msg, bindings)}"
+  end
+
+  # Translate first, interpolate second: the German msgstr carries the placeholders too.
+  # The msgid is a runtime value, so this is `Gettext.d*gettext/4` the function rather
+  # than the macro — the "errors" catalog already holds Ecto's own messages.
+  #
+  # Gettext gets the bindings it can resolve itself, or it logs a missing-binding error
+  # on every render of the row; `interpolate/2` then covers any key outside that set.
+  defp translate_changeset_message(msg, bindings) do
+    msg
+    |> translate_errors_domain(bindings)
+    |> ChangesetErrors.interpolate(bindings)
+  end
+
+  defp translate_errors_domain(msg, %{"count" => count} = bindings) when is_integer(count) do
+    Gettext.dngettext(
+      KlassHeroWeb.Gettext,
+      "errors",
+      msg,
+      msg,
+      count,
+      ChangesetErrors.gettext_bindings(bindings)
+    )
+  end
+
+  defp translate_errors_domain(msg, bindings) do
+    Gettext.dgettext(KlassHeroWeb.Gettext, "errors", msg, ChangesetErrors.gettext_bindings(bindings))
+  end
+
+  # Field names arrive as atoms from a live import failure and as strings from a stored
+  # invite failure (#1340) — one vocabulary serves both, keyed on the string.
+  defp humanize_field(field) when is_atom(field), do: field |> Atom.to_string() |> humanize_field()
+
   # dgettext must run at call-time (not module-attribute time) for i18n to work
-  defp humanize_field(:child_first_name), do: dgettext("enrollment", "Child first name")
-  defp humanize_field(:child_last_name), do: dgettext("enrollment", "Child last name")
-  defp humanize_field(:child_date_of_birth), do: dgettext("enrollment", "Date of birth")
-  defp humanize_field(:guardian_email), do: dgettext("enrollment", "Guardian email")
-  defp humanize_field(:guardian_first_name), do: dgettext("enrollment", "Guardian first name")
-  defp humanize_field(:guardian_last_name), do: dgettext("enrollment", "Guardian last name")
-  defp humanize_field(:guardian2_email), do: dgettext("enrollment", "Second guardian email")
+  defp humanize_field("child_first_name"), do: dgettext("enrollment", "Child first name")
+  defp humanize_field("child_last_name"), do: dgettext("enrollment", "Child last name")
+  defp humanize_field("child_date_of_birth"), do: dgettext("enrollment", "Date of birth")
+  defp humanize_field("guardian_email"), do: dgettext("enrollment", "Guardian email")
+  defp humanize_field("guardian_first_name"), do: dgettext("enrollment", "Guardian first name")
+  defp humanize_field("guardian_last_name"), do: dgettext("enrollment", "Guardian last name")
+  defp humanize_field("guardian2_email"), do: dgettext("enrollment", "Second guardian email")
 
-  defp humanize_field(:guardian2_first_name), do: dgettext("enrollment", "Second guardian first name")
+  defp humanize_field("guardian2_first_name"), do: dgettext("enrollment", "Second guardian first name")
 
-  defp humanize_field(:guardian2_last_name), do: dgettext("enrollment", "Second guardian last name")
+  defp humanize_field("guardian2_last_name"), do: dgettext("enrollment", "Second guardian last name")
 
-  defp humanize_field(:program_name), do: dgettext("enrollment", "Program")
-  defp humanize_field(:school_grade), do: dgettext("enrollment", "Grade")
-  defp humanize_field(:school_name), do: dgettext("enrollment", "School")
+  defp humanize_field("program_name"), do: dgettext("enrollment", "Program")
+  defp humanize_field("school_grade"), do: dgettext("enrollment", "Grade")
+  defp humanize_field("school_name"), do: dgettext("enrollment", "School")
 
-  defp humanize_field(field) do
-    field |> to_string() |> String.replace("_", " ") |> String.capitalize()
+  # A claim failure names the Child's own fields, which the CSV spells differently.
+  defp humanize_field("first_name"), do: dgettext("enrollment", "Child first name")
+  defp humanize_field("last_name"), do: dgettext("enrollment", "Child last name")
+  defp humanize_field("date_of_birth"), do: dgettext("enrollment", "Date of birth")
+
+  defp humanize_field(field) when is_binary(field) do
+    field |> String.replace("_", " ") |> String.capitalize()
   end
 
   @doc """

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -45,7 +45,7 @@ msgstr "Kontakt"
 #: lib/klass_hero_web/components/layouts/app.html.heex:129
 #: lib/klass_hero_web/components/layouts/app.html.heex:204
 #: lib/klass_hero_web/components/layouts/app.html.heex:229
-#: lib/klass_hero_web/components/provider_components.ex:389
+#: lib/klass_hero_web/components/provider_components.ex:390
 #: lib/klass_hero_web/components/ui_components.ex:268
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
@@ -137,7 +137,7 @@ msgid "Your Data"
 msgstr "Ihre Daten"
 
 #: lib/klass_hero_web/components/core_components.ex:67
-#: lib/klass_hero_web/components/provider_components.ex:1686
+#: lib/klass_hero_web/components/provider_components.ex:1687
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr "schließen"
@@ -232,7 +232,7 @@ msgstr "Einfache Terminplanung"
 msgid "Enroll Now - %{price}"
 msgstr "Jetzt anmelden - %{price}"
 
-#: lib/klass_hero_web/components/provider_components.ex:1437
+#: lib/klass_hero_web/components/provider_components.ex:1438
 #: lib/klass_hero_web/live/booking_live.ex:285
 #, elixir-autogen, elixir-format
 msgid "Enrollment"
@@ -577,9 +577,9 @@ msgstr "Wird gelöscht..."
 msgid "Dispute Resolution"
 msgstr "Streitbeilegung"
 
-#: lib/klass_hero_web/components/provider_components.ex:718
-#: lib/klass_hero_web/components/provider_components.ex:2359
-#: lib/klass_hero_web/components/provider_components.ex:2377
+#: lib/klass_hero_web/components/provider_components.ex:719
+#: lib/klass_hero_web/components/provider_components.ex:2360
+#: lib/klass_hero_web/components/provider_components.ex:2378
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
@@ -878,9 +878,9 @@ msgstr "Speichern..."
 msgid "Select one or both options"
 msgstr "Wählen Sie eine oder beide Optionen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2055
 #: lib/klass_hero_web/components/provider_components.ex:2056
-#: lib/klass_hero_web/components/provider_components.ex:2093
+#: lib/klass_hero_web/components/provider_components.ex:2057
+#: lib/klass_hero_web/components/provider_components.ex:2094
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:448
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:484
@@ -1324,7 +1324,7 @@ msgstr "Push-, E-Mail-, SMS-Einstellungen"
 
 #: lib/klass_hero_web/components/composite_components.ex:103
 #: lib/klass_hero_web/components/layouts/admin.html.heex:71
-#: lib/klass_hero_web/components/provider_components.ex:119
+#: lib/klass_hero_web/components/provider_components.ex:120
 #: lib/klass_hero_web/live/admin/sessions_live.ex:26
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:3
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:348
@@ -1456,7 +1456,7 @@ msgstr "Lebenskompetenzen"
 msgid "Music"
 msgstr "Musik"
 
-#: lib/klass_hero_web/components/provider_components.ex:754
+#: lib/klass_hero_web/components/provider_components.ex:755
 #: lib/klass_hero_web/live/for_providers_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "Qualifications"
@@ -1577,19 +1577,19 @@ msgstr "Profil"
 msgid "Quick Navigation"
 msgstr "Schnellnavigation"
 
-#: lib/klass_hero_web/components/provider_components.ex:1440
-#: lib/klass_hero_web/components/provider_components.ex:2031
-#: lib/klass_hero_web/components/provider_components.ex:2257
+#: lib/klass_hero_web/components/provider_components.ex:1441
+#: lib/klass_hero_web/components/provider_components.ex:2032
+#: lib/klass_hero_web/components/provider_components.ex:2258
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr "Aktionen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1579
+#: lib/klass_hero_web/components/provider_components.ex:1580
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr "Aktiv"
 
-#: lib/klass_hero_web/components/provider_components.ex:671
+#: lib/klass_hero_web/components/provider_components.ex:672
 #: lib/klass_hero_web/live/provider/team_live.ex:627
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
@@ -1600,7 +1600,7 @@ msgstr "Teammitglied hinzufügen"
 msgid "All Staff"
 msgstr "Alle Mitarbeiter"
 
-#: lib/klass_hero_web/components/provider_components.ex:1431
+#: lib/klass_hero_web/components/provider_components.ex:1432
 #, elixir-autogen, elixir-format
 msgid "Assigned Staff"
 msgstr "Zugewiesenes Personal"
@@ -1611,7 +1611,7 @@ msgstr "Zugewiesenes Personal"
 msgid "Book Now"
 msgstr "Jetzt buchen"
 
-#: lib/klass_hero_web/components/provider_components.ex:205
+#: lib/klass_hero_web/components/provider_components.ex:206
 #, elixir-autogen, elixir-format
 msgid "Business Profile"
 msgstr "Geschäftsprofil"
@@ -1627,8 +1627,8 @@ msgstr "Gewerbeanmeldung"
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr "Erstellen Sie Profile für Ihr Personal. Diese werden für Eltern sichtbar sein, wenn sie Programmen zugewiesen werden."
 
-#: lib/klass_hero_web/components/provider_components.ex:538
-#: lib/klass_hero_web/components/provider_components.ex:1542
+#: lib/klass_hero_web/components/provider_components.ex:539
+#: lib/klass_hero_web/components/provider_components.ex:1543
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:54
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:81
 #: lib/klass_hero_web/live/settings/children_live.ex:448
@@ -1638,57 +1638,57 @@ msgstr "Erstellen Sie Profile für Ihr Personal. Diese werden für Eltern sichtb
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: lib/klass_hero_web/components/provider_components.ex:223
+#: lib/klass_hero_web/components/provider_components.ex:224
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:31
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "Edit Profile"
 msgstr "Profil bearbeiten"
 
-#: lib/klass_hero_web/components/provider_components.ex:1581
+#: lib/klass_hero_web/components/provider_components.ex:1582
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr "Inaktiv"
 
-#: lib/klass_hero_web/components/provider_components.ex:112
+#: lib/klass_hero_web/components/provider_components.ex:113
 #: lib/klass_hero_web/live/provider/programs_live.ex:54
 #, elixir-autogen, elixir-format
 msgid "My Programs"
 msgstr "Meine Programme"
 
-#: lib/klass_hero_web/components/provider_components.ex:415
-#: lib/klass_hero_web/components/provider_components.ex:929
+#: lib/klass_hero_web/components/provider_components.ex:416
+#: lib/klass_hero_web/components/provider_components.ex:930
 #, elixir-autogen, elixir-format
 msgid "New Program"
 msgstr "Neues Programm"
 
-#: lib/klass_hero_web/components/provider_components.ex:98
+#: lib/klass_hero_web/components/provider_components.ex:99
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr "Übersicht"
 
-#: lib/klass_hero_web/components/provider_components.ex:46
-#: lib/klass_hero_web/components/provider_components.ex:72
-#: lib/klass_hero_web/components/provider_components.ex:1580
-#: lib/klass_hero_web/components/provider_components.ex:2453
-#: lib/klass_hero_web/components/provider_components.ex:2471
+#: lib/klass_hero_web/components/provider_components.ex:47
+#: lib/klass_hero_web/components/provider_components.ex:73
+#: lib/klass_hero_web/components/provider_components.ex:1581
+#: lib/klass_hero_web/components/provider_components.ex:2454
+#: lib/klass_hero_web/components/provider_components.ex:2472
 #: lib/klass_hero_web/live/admin/sessions_live.ex:297
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr "Ausstehend"
 
-#: lib/klass_hero_web/components/provider_components.ex:1518
+#: lib/klass_hero_web/components/provider_components.ex:1519
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr "Vorschau"
 
-#: lib/klass_hero_web/components/provider_components.ex:1371
+#: lib/klass_hero_web/components/provider_components.ex:1372
 #, elixir-autogen, elixir-format
 msgid "Program Inventory"
 msgstr "Programmübersicht"
 
-#: lib/klass_hero_web/components/provider_components.ex:1428
+#: lib/klass_hero_web/components/provider_components.ex:1429
 #, elixir-autogen, elixir-format
 msgid "Program Name"
 msgstr "Programmname"
@@ -1703,15 +1703,15 @@ msgstr "Anbieter-Dashboard"
 msgid "Save for Later"
 msgstr "Für später speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:1388
+#: lib/klass_hero_web/components/provider_components.ex:1389
 #, elixir-autogen, elixir-format
 msgid "Search by name..."
 msgstr "Nach Namen suchen..."
 
-#: lib/klass_hero_web/components/provider_components.ex:1434
-#: lib/klass_hero_web/components/provider_components.ex:1803
-#: lib/klass_hero_web/components/provider_components.ex:2025
-#: lib/klass_hero_web/components/provider_components.ex:2254
+#: lib/klass_hero_web/components/provider_components.ex:1435
+#: lib/klass_hero_web/components/provider_components.ex:1804
+#: lib/klass_hero_web/components/provider_components.ex:2026
+#: lib/klass_hero_web/components/provider_components.ex:2255
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1719,7 +1719,7 @@ msgstr "Nach Namen suchen..."
 msgid "Status"
 msgstr "Status"
 
-#: lib/klass_hero_web/components/provider_components.ex:105
+#: lib/klass_hero_web/components/provider_components.ex:106
 #: lib/klass_hero_web/live/provider/team_live.ex:36
 #, elixir-autogen, elixir-format
 msgid "Team & Profiles"
@@ -1730,32 +1730,32 @@ msgstr "Team & Profile"
 msgid "Team & Provider Profiles"
 msgstr "Team- & Anbieterprofile"
 
-#: lib/klass_hero_web/components/provider_components.ex:208
+#: lib/klass_hero_web/components/provider_components.ex:209
 #, elixir-autogen, elixir-format
 msgid "This is your main business identity. Verification is required to list programs."
 msgstr "Dies ist Ihre Hauptgeschäftsidentität. Eine Verifizierung ist erforderlich, um Programme anzubieten."
 
-#: lib/klass_hero_web/components/provider_components.ex:1491
-#: lib/klass_hero_web/components/provider_components.ex:1818
+#: lib/klass_hero_web/components/provider_components.ex:1492
+#: lib/klass_hero_web/components/provider_components.ex:1819
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr "Nicht zugewiesen"
 
 #: lib/klass_hero_web/components/messaging_components.ex:728
-#: lib/klass_hero_web/components/provider_components.ex:49
-#: lib/klass_hero_web/components/provider_components.ex:1582
+#: lib/klass_hero_web/components/provider_components.ex:50
+#: lib/klass_hero_web/components/provider_components.ex:1583
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:434
 #: lib/klass_hero_web/presenters/provider_presenter.ex:103
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr "Unbekannt"
 
-#: lib/klass_hero_web/components/provider_components.ex:400
+#: lib/klass_hero_web/components/provider_components.ex:401
 #, elixir-autogen, elixir-format
 msgid "Verified Business"
 msgstr "Verifiziertes Unternehmen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1529
+#: lib/klass_hero_web/components/provider_components.ex:1530
 #, elixir-autogen, elixir-format
 msgid "View Roster"
 msgstr "Teilnehmerliste"
@@ -1815,9 +1815,9 @@ msgstr "Rundnachricht an %{count} Eltern gesendet"
 #: lib/klass_hero_web/components/participation_components.ex:441
 #: lib/klass_hero_web/components/participation_components.ex:631
 #: lib/klass_hero_web/components/participation_components.ex:717
-#: lib/klass_hero_web/components/provider_components.ex:888
-#: lib/klass_hero_web/components/provider_components.ex:1287
-#: lib/klass_hero_web/components/provider_components.ex:2196
+#: lib/klass_hero_web/components/provider_components.ex:889
+#: lib/klass_hero_web/components/provider_components.ex:1288
+#: lib/klass_hero_web/components/provider_components.ex:2197
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:478
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
@@ -1883,7 +1883,7 @@ msgstr "Kind konnte nicht entfernt werden. Bitte versuchen Sie es erneut."
 msgid "Data sharing consent"
 msgstr "Einwilligung zur Datenweitergabe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2340
+#: lib/klass_hero_web/components/provider_components.ex:2341
 #: lib/klass_hero_web/live/settings/children_live.ex:657
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1931,17 +1931,17 @@ msgstr "Rundnachricht konnte nicht gesendet werden"
 msgid "Failed to submit note"
 msgstr "Notiz konnte nicht eingereicht werden"
 
-#: lib/klass_hero_web/components/provider_components.ex:2334
-#: lib/klass_hero_web/components/provider_components.ex:2363
-#: lib/klass_hero_web/components/provider_components.ex:2379
+#: lib/klass_hero_web/components/provider_components.ex:2335
+#: lib/klass_hero_web/components/provider_components.ex:2364
+#: lib/klass_hero_web/components/provider_components.ex:2380
 #: lib/klass_hero_web/live/settings/children_live.ex:643
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr "Vorname"
 
-#: lib/klass_hero_web/components/provider_components.ex:2335
-#: lib/klass_hero_web/components/provider_components.ex:2364
-#: lib/klass_hero_web/components/provider_components.ex:2380
+#: lib/klass_hero_web/components/provider_components.ex:2336
+#: lib/klass_hero_web/components/provider_components.ex:2365
+#: lib/klass_hero_web/components/provider_components.ex:2381
 #: lib/klass_hero_web/live/settings/children_live.ex:649
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -2073,15 +2073,15 @@ msgstr "Programm-Rundnachricht"
 msgid "Provider data sharing consent"
 msgstr "Einwilligung zur Datenweitergabe an Anbieter"
 
-#: lib/klass_hero_web/components/provider_components.ex:873
+#: lib/klass_hero_web/components/provider_components.ex:874
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:294
 #: lib/klass_hero_web/live/settings/children_live.ex:754
 #, elixir-autogen, elixir-format
 msgid "Save Changes"
 msgstr "Änderungen speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:1664
 #: lib/klass_hero_web/components/provider_components.ex:1665
+#: lib/klass_hero_web/components/provider_components.ex:1666
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:43
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:151
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:252
@@ -2099,7 +2099,7 @@ msgstr "Rundnachricht senden"
 msgid "Send a message to start the conversation"
 msgstr "Senden Sie eine Nachricht, um die Unterhaltung zu beginnen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2434
+#: lib/klass_hero_web/components/provider_components.ex:2435
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:249
 #, elixir-autogen, elixir-format
@@ -2205,12 +2205,12 @@ msgstr[1] "%{count} Jahre"
 msgid "%{gender} only"
 msgstr "Nur %{gender}"
 
-#: lib/klass_hero_web/components/provider_components.ex:308
+#: lib/klass_hero_web/components/provider_components.ex:309
 #, elixir-autogen, elixir-format
 msgid "Action Required"
 msgstr "Aktion erforderlich"
 
-#: lib/klass_hero_web/components/provider_components.ex:875
+#: lib/klass_hero_web/components/provider_components.ex:876
 #, elixir-autogen, elixir-format
 msgid "Add Member"
 msgstr "Mitglied hinzufügen"
@@ -2230,12 +2230,12 @@ msgstr "Alter %{min} bis %{max}"
 msgid "Ages %{min}+"
 msgstr "Alter %{min}+"
 
-#: lib/klass_hero_web/components/provider_components.ex:1148
+#: lib/klass_hero_web/components/provider_components.ex:1149
 #, elixir-autogen, elixir-format
 msgid "Allowed Genders"
 msgstr "Zulässige Geschlechter"
 
-#: lib/klass_hero_web/components/provider_components.ex:2493
+#: lib/klass_hero_web/components/provider_components.ex:2494
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred during import."
 msgstr "Beim Import ist ein unerwarteter Fehler aufgetreten."
@@ -2248,7 +2248,7 @@ msgid "Approve"
 msgstr "Genehmigen"
 
 #: lib/klass_hero_web/components/participation_components.ex:826
-#: lib/klass_hero_web/components/provider_components.ex:47
+#: lib/klass_hero_web/components/provider_components.ex:48
 #: lib/klass_hero_web/live/admin/sessions_live.ex:294
 #: lib/klass_hero_web/live/admin/verifications_live.ex:202
 #: lib/klass_hero_web/presenters/vetting_checklist_presenter.ex:141
@@ -2278,7 +2278,7 @@ msgstr "Zurück zum Dashboard"
 msgid "Back to verifications"
 msgstr "Zurück zu den Verifizierungen"
 
-#: lib/klass_hero_web/components/provider_components.ex:727
+#: lib/klass_hero_web/components/provider_components.ex:728
 #, elixir-autogen, elixir-format
 msgid "Bio"
 msgstr "Biografie"
@@ -2288,7 +2288,7 @@ msgstr "Biografie"
 msgid "Book a Program"
 msgstr "Programm buchen"
 
-#: lib/klass_hero_web/components/provider_components.ex:728
+#: lib/klass_hero_web/components/provider_components.ex:729
 #, elixir-autogen, elixir-format
 msgid "Brief description of experience and specialties..."
 msgstr "Kurze Beschreibung der Erfahrung und Spezialgebiete..."
@@ -2319,19 +2319,19 @@ msgstr "Geschäftsinformationen"
 msgid "Business Logo"
 msgstr "Firmenlogo"
 
-#: lib/klass_hero_web/components/provider_components.ex:959
+#: lib/klass_hero_web/components/provider_components.ex:960
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "Category"
 msgstr "Kategorie"
 
-#: lib/klass_hero_web/components/provider_components.ex:1097
+#: lib/klass_hero_web/components/provider_components.ex:1098
 #, elixir-autogen, elixir-format
 msgid "Check eligibility at"
 msgstr "Berechtigung prüfen unter"
 
-#: lib/klass_hero_web/components/provider_components.ex:2022
-#: lib/klass_hero_web/components/provider_components.ex:2248
+#: lib/klass_hero_web/components/provider_components.ex:2023
+#: lib/klass_hero_web/components/provider_components.ex:2249
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr "Name des Kindes"
@@ -2346,7 +2346,7 @@ msgstr "Kind erfüllt die Programmanforderungen nicht"
 msgid "Child meets all program requirements"
 msgstr "Kind erfüllt alle Programmanforderungen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1258
+#: lib/klass_hero_web/components/provider_components.ex:1259
 #, elixir-autogen, elixir-format
 msgid "Choose Image"
 msgstr "Bild auswählen"
@@ -2356,17 +2356,17 @@ msgstr "Bild auswählen"
 msgid "Choose Logo"
 msgstr "Logo auswählen"
 
-#: lib/klass_hero_web/components/provider_components.ex:852
+#: lib/klass_hero_web/components/provider_components.ex:853
 #, elixir-autogen, elixir-format
 msgid "Choose Photo"
 msgstr "Foto auswählen"
 
-#: lib/klass_hero_web/components/provider_components.ex:961
+#: lib/klass_hero_web/components/provider_components.ex:962
 #, elixir-autogen, elixir-format
 msgid "Choose a category"
 msgstr "Kategorie auswählen"
 
-#: lib/klass_hero_web/components/provider_components.ex:427
+#: lib/klass_hero_web/components/provider_components.ex:428
 #, elixir-autogen, elixir-format
 msgid "Complete business verification to create programs."
 msgstr "Schließen Sie die Geschäftsverifizierung ab, um Programme zu erstellen."
@@ -2376,7 +2376,7 @@ msgstr "Schließen Sie die Geschäftsverifizierung ab, um Programme zu erstellen
 msgid "Confirm rejection"
 msgstr "Ablehnung bestätigen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2454
+#: lib/klass_hero_web/components/provider_components.ex:2455
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr "Bestätigt"
@@ -2396,22 +2396,22 @@ msgstr "Die hochgeladene Datei konnte nicht gelesen werden."
 msgid "Could not remove invite."
 msgstr "Einladung konnte nicht entfernt werden."
 
-#: lib/klass_hero_web/components/provider_components.ex:1214
+#: lib/klass_hero_web/components/provider_components.ex:1215
 #, elixir-autogen, elixir-format
 msgid "Cover Image"
 msgstr "Titelbild"
 
-#: lib/klass_hero_web/components/provider_components.ex:1091
+#: lib/klass_hero_web/components/provider_components.ex:1092
 #, elixir-autogen, elixir-format
 msgid "Define age, gender, or grade restrictions for eligible participants."
 msgstr "Legen Sie Alters-, Geschlechts- oder Klassenstufenbeschränkungen für teilnahmeberechtigte Teilnehmer fest."
 
-#: lib/klass_hero_web/components/provider_components.ex:1207
+#: lib/klass_hero_web/components/provider_components.ex:1208
 #, elixir-autogen, elixir-format
 msgid "Describe your program..."
 msgstr "Beschreiben Sie Ihr Programm..."
 
-#: lib/klass_hero_web/components/provider_components.ex:1206
+#: lib/klass_hero_web/components/provider_components.ex:1207
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:323
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:285
 #, elixir-autogen, elixir-format
@@ -2419,13 +2419,13 @@ msgid "Description"
 msgstr "Beschreibung"
 
 #: lib/klass_hero_web/components/program_components.ex:684
-#: lib/klass_hero_web/components/provider_components.ex:1159
+#: lib/klass_hero_web/components/provider_components.ex:1160
 #: lib/klass_hero_web/live/settings/children_live.ex:670
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr "Divers"
 
-#: lib/klass_hero_web/components/provider_components.ex:2591
+#: lib/klass_hero_web/components/provider_components.ex:2670
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr "Dokumenttyp"
@@ -2459,7 +2459,7 @@ msgstr "Dokument abgelehnt."
 msgid "Document uploaded successfully."
 msgstr "Dokument erfolgreich hochgeladen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2215
+#: lib/klass_hero_web/components/provider_components.ex:2216
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr "Vorlage herunterladen"
@@ -2469,40 +2469,40 @@ msgstr "Vorlage herunterladen"
 msgid "Download document"
 msgstr "Dokument herunterladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:927
+#: lib/klass_hero_web/components/provider_components.ex:928
 #, elixir-autogen, elixir-format
 msgid "Edit Program"
 msgstr "Programm bearbeiten"
 
-#: lib/klass_hero_web/components/provider_components.ex:669
+#: lib/klass_hero_web/components/provider_components.ex:670
 #, elixir-autogen, elixir-format
 msgid "Edit Team Member"
 msgstr "Teammitglied bearbeiten"
 
-#: lib/klass_hero_web/components/provider_components.ex:1036
+#: lib/klass_hero_web/components/provider_components.ex:1037
 #, elixir-autogen, elixir-format
 msgid "End Date"
 msgstr "Enddatum"
 
-#: lib/klass_hero_web/components/provider_components.ex:1023
+#: lib/klass_hero_web/components/provider_components.ex:1024
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:166
 #, elixir-autogen, elixir-format
 msgid "End Time"
 msgstr "Endzeit"
 
-#: lib/klass_hero_web/components/provider_components.ex:2028
-#: lib/klass_hero_web/components/provider_components.ex:2474
+#: lib/klass_hero_web/components/provider_components.ex:2029
+#: lib/klass_hero_web/components/provider_components.ex:2475
 #: lib/klass_hero_web/components/provider_layout_components.ex:644
 #, elixir-autogen, elixir-format
 msgid "Enrolled"
 msgstr "Angemeldet"
 
-#: lib/klass_hero_web/components/provider_components.ex:1710
+#: lib/klass_hero_web/components/provider_components.ex:1711
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr "Angemeldet (%{count})"
 
-#: lib/klass_hero_web/components/provider_components.ex:1064
+#: lib/klass_hero_web/components/provider_components.ex:1065
 #, elixir-autogen, elixir-format
 msgid "Enrollment Capacity (optional)"
 msgstr "Anmeldekapazität (optional)"
@@ -2512,8 +2512,8 @@ msgstr "Anmeldekapazität (optional)"
 msgid "Explain why this document is being rejected..."
 msgstr "Erklären Sie, warum dieses Dokument abgelehnt wird..."
 
-#: lib/klass_hero_web/components/provider_components.ex:70
-#: lib/klass_hero_web/components/provider_components.ex:2475
+#: lib/klass_hero_web/components/provider_components.ex:71
+#: lib/klass_hero_web/components/provider_components.ex:2476
 #: lib/klass_hero_web/live/admin/emails_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2546,7 +2546,7 @@ msgid "Family Programs"
 msgstr "Familienprogramme"
 
 #: lib/klass_hero_web/components/program_components.ex:682
-#: lib/klass_hero_web/components/provider_components.ex:1158
+#: lib/klass_hero_web/components/provider_components.ex:1159
 #: lib/klass_hero_web/live/settings/children_live.ex:669
 #, elixir-autogen, elixir-format
 msgid "Female"
@@ -2557,22 +2557,22 @@ msgstr "Weiblich"
 msgid "File"
 msgstr "Datei"
 
-#: lib/klass_hero_web/components/provider_components.ex:2525
+#: lib/klass_hero_web/components/provider_components.ex:2604
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr "Die Datei ist zu groß."
 
-#: lib/klass_hero_web/components/provider_components.ex:2527
+#: lib/klass_hero_web/components/provider_components.ex:2606
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr "Dateityp wird nicht akzeptiert."
 
-#: lib/klass_hero_web/components/provider_components.ex:755
+#: lib/klass_hero_web/components/provider_components.ex:756
 #, elixir-autogen, elixir-format
 msgid "First Aid, UEFA B License, Child Care Cert"
 msgstr "Erste Hilfe, UEFA-B-Lizenz, Kinderbetreuungszertifikat"
 
-#: lib/klass_hero_web/components/provider_components.ex:697
+#: lib/klass_hero_web/components/provider_components.ex:698
 #, elixir-autogen, elixir-format
 msgid "First Name"
 msgstr "Vorname"
@@ -2597,12 +2597,12 @@ msgstr "Klassenstufe %{min}+"
 msgid "Grades %{min} – %{max}"
 msgstr "Klassenstufen %{min} – %{max}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2251
+#: lib/klass_hero_web/components/provider_components.ex:2252
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr "E-Mail des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:816
+#: lib/klass_hero_web/components/provider_components.ex:817
 #, elixir-autogen, elixir-format
 msgid "Headshot Photo"
 msgstr "Porträtfoto"
@@ -2612,7 +2612,7 @@ msgstr "Porträtfoto"
 msgid "ID Document"
 msgstr "Ausweisdokument"
 
-#: lib/klass_hero_web/components/provider_components.ex:2188
+#: lib/klass_hero_web/components/provider_components.ex:2189
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Importieren"
@@ -2637,17 +2637,17 @@ msgstr "Einladung entfernt."
 msgid "Invite resent successfully."
 msgstr "Einladung erfolgreich erneut gesendet."
 
-#: lib/klass_hero_web/components/provider_components.ex:1727
+#: lib/klass_hero_web/components/provider_components.ex:1728
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr "Einladungen (%{count})"
 
-#: lib/klass_hero_web/components/provider_components.ex:855
+#: lib/klass_hero_web/components/provider_components.ex:856
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 1MB."
 msgstr "JPG, PNG oder WebP. Max. 1 MB."
 
-#: lib/klass_hero_web/components/provider_components.ex:1261
+#: lib/klass_hero_web/components/provider_components.ex:1262
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:277
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:361
 #, elixir-autogen, elixir-format
@@ -2664,22 +2664,22 @@ msgstr "Klass Hero wurde genau dafür entwickelt. Eine umfassende Betriebsplattf
 msgid "Klasse %{n}"
 msgstr "Klasse %{n}"
 
-#: lib/klass_hero_web/components/provider_components.ex:703
+#: lib/klass_hero_web/components/provider_components.ex:704
 #, elixir-autogen, elixir-format
 msgid "Last Name"
 msgstr "Nachname"
 
-#: lib/klass_hero_web/components/provider_components.ex:1046
+#: lib/klass_hero_web/components/provider_components.ex:1047
 #, elixir-autogen, elixir-format
 msgid "Leave blank for open registration at any time."
 msgstr "Leer lassen für eine jederzeit offene Anmeldung."
 
-#: lib/klass_hero_web/components/provider_components.ex:1151
+#: lib/klass_hero_web/components/provider_components.ex:1152
 #, elixir-autogen, elixir-format
 msgid "Leave unchecked to allow all genders."
 msgstr "Nicht markiert lassen, um alle Geschlechter zuzulassen."
 
-#: lib/klass_hero_web/components/provider_components.ex:979
+#: lib/klass_hero_web/components/provider_components.ex:980
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Location"
@@ -2692,43 +2692,43 @@ msgid "Logo upload failed. Please try again."
 msgstr "Logo-Upload fehlgeschlagen. Bitte versuchen Sie es erneut."
 
 #: lib/klass_hero_web/components/program_components.ex:683
-#: lib/klass_hero_web/components/provider_components.ex:1157
+#: lib/klass_hero_web/components/provider_components.ex:1158
 #: lib/klass_hero_web/live/settings/children_live.ex:668
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr "Männlich"
 
-#: lib/klass_hero_web/components/provider_components.ex:1141
+#: lib/klass_hero_web/components/provider_components.ex:1142
 #, elixir-autogen, elixir-format
 msgid "Maximum Age (months)"
 msgstr "Höchstalter (Monate)"
 
-#: lib/klass_hero_web/components/provider_components.ex:1079
+#: lib/klass_hero_web/components/provider_components.ex:1080
 #, elixir-autogen, elixir-format
 msgid "Maximum Enrollment"
 msgstr "Maximale Anmeldekapazität"
 
-#: lib/klass_hero_web/components/provider_components.ex:1196
+#: lib/klass_hero_web/components/provider_components.ex:1197
 #, elixir-autogen, elixir-format
 msgid "Maximum Grade"
 msgstr "Höchste Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:988
+#: lib/klass_hero_web/components/provider_components.ex:989
 #, elixir-autogen, elixir-format
 msgid "Meeting Days"
 msgstr "Wochentage"
 
-#: lib/klass_hero_web/components/provider_components.ex:1135
+#: lib/klass_hero_web/components/provider_components.ex:1136
 #, elixir-autogen, elixir-format
 msgid "Minimum Age (months)"
 msgstr "Mindestalter (Monate)"
 
-#: lib/klass_hero_web/components/provider_components.ex:1073
+#: lib/klass_hero_web/components/provider_components.ex:1074
 #, elixir-autogen, elixir-format
 msgid "Minimum Enrollment"
 msgstr "Minimale Anmeldekapazität"
 
-#: lib/klass_hero_web/components/provider_components.ex:1189
+#: lib/klass_hero_web/components/provider_components.ex:1190
 #, elixir-autogen, elixir-format
 msgid "Minimum Grade"
 msgstr "Niedrigste Klassenstufe"
@@ -2738,12 +2738,12 @@ msgstr "Niedrigste Klassenstufe"
 msgid "No approved documents."
 msgstr "Keine genehmigten Dokumente."
 
-#: lib/klass_hero_web/components/provider_components.ex:2553
+#: lib/klass_hero_web/components/provider_components.ex:2632
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr "Noch keine Dokumente hochgeladen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2015
+#: lib/klass_hero_web/components/provider_components.ex:2016
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
@@ -2759,17 +2759,17 @@ msgstr "Keine Datei ausgewählt."
 msgid "No grade"
 msgstr "Keine Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2239
+#: lib/klass_hero_web/components/provider_components.ex:2240
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr "Noch keine Einladungen. Laden Sie eine CSV-Datei hoch, um Familien einzuladen."
 
-#: lib/klass_hero_web/components/provider_components.ex:1198
+#: lib/klass_hero_web/components/provider_components.ex:1199
 #, elixir-autogen, elixir-format
 msgid "No maximum"
 msgstr "Kein Maximum"
 
-#: lib/klass_hero_web/components/provider_components.ex:1191
+#: lib/klass_hero_web/components/provider_components.ex:1192
 #, elixir-autogen, elixir-format
 msgid "No minimum"
 msgstr "Kein Minimum"
@@ -2800,18 +2800,18 @@ msgstr "Noch keine Teammitglieder"
 msgid "No verification documents found."
 msgstr "Keine Verifizierungsdokumente gefunden."
 
-#: lib/klass_hero_web/components/provider_components.ex:1273
+#: lib/klass_hero_web/components/provider_components.ex:1274
 #, elixir-autogen, elixir-format
 msgid "None (optional)"
 msgstr "Keine (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:324
+#: lib/klass_hero_web/components/provider_components.ex:325
 #, elixir-autogen, elixir-format
 msgid "Not Verified"
 msgstr "Nicht verifiziert"
 
 #: lib/klass_hero_web/components/program_components.ex:685
-#: lib/klass_hero_web/components/provider_components.ex:1160
+#: lib/klass_hero_web/components/provider_components.ex:1161
 #: lib/klass_hero_web/live/settings/children_live.ex:667
 #, elixir-autogen, elixir-format
 msgid "Not specified"
@@ -2822,7 +2822,7 @@ msgstr "Nicht angegeben"
 msgid "Our Story"
 msgstr "Unsere Geschichte"
 
-#: lib/klass_hero_web/components/provider_components.ex:2628
+#: lib/klass_hero_web/components/provider_components.ex:2707
 #: lib/klass_hero_web/live/provider/verification_live.ex:698
 #: lib/klass_hero_web/live/provider/verification_live.ex:770
 #, elixir-autogen, elixir-format
@@ -2834,13 +2834,13 @@ msgstr "PDF, JPG oder PNG. Max. 10 MB."
 msgid "Participant Requirements"
 msgstr "Teilnahmevoraussetzungen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1088
+#: lib/klass_hero_web/components/provider_components.ex:1089
 #, elixir-autogen, elixir-format
 msgid "Participant Restrictions (optional)"
 msgstr "Teilnahmebeschränkungen (optional)"
 
 #: lib/klass_hero_web/components/participation_components.ex:825
-#: lib/klass_hero_web/components/provider_components.ex:292
+#: lib/klass_hero_web/components/provider_components.ex:293
 #, elixir-autogen, elixir-format
 msgid "Pending Review"
 msgstr "Ausstehende Überprüfung"
@@ -2868,7 +2868,7 @@ msgstr "Bitte geben Sie einen Ablehnungsgrund an."
 msgid "Preview not available for this file type."
 msgstr "Vorschau für diesen Dateityp nicht verfügbar."
 
-#: lib/klass_hero_web/components/provider_components.ex:970
+#: lib/klass_hero_web/components/provider_components.ex:971
 #, elixir-autogen, elixir-format
 msgid "Price (EUR)"
 msgstr "Preis (EUR)"
@@ -2878,7 +2878,7 @@ msgstr "Preis (EUR)"
 msgid "Profile updated successfully."
 msgstr "Profil erfolgreich aktualisiert."
 
-#: lib/klass_hero_web/components/provider_components.ex:1126
+#: lib/klass_hero_web/components/provider_components.ex:1127
 #, elixir-autogen, elixir-format
 msgid "Program Start"
 msgstr "Programmbeginn"
@@ -2920,13 +2920,13 @@ msgid "Read our founding story →"
 msgstr "Lesen Sie unsere Gründungsgeschichte →"
 
 #: lib/klass_hero_web/components/participation_components.ex:805
-#: lib/klass_hero_web/components/provider_components.ex:2473
+#: lib/klass_hero_web/components/provider_components.ex:2474
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Registered"
 msgstr "Registriert"
 
-#: lib/klass_hero_web/components/provider_components.ex:1113
+#: lib/klass_hero_web/components/provider_components.ex:1114
 #, elixir-autogen, elixir-format
 msgid "Registration"
 msgstr "Anmeldung"
@@ -2936,7 +2936,7 @@ msgstr "Anmeldung"
 msgid "Registration Closed"
 msgstr "Anmeldung geschlossen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1057
+#: lib/klass_hero_web/components/provider_components.ex:1058
 #, elixir-autogen, elixir-format
 msgid "Registration Closes"
 msgstr "Anmeldeschluss"
@@ -2946,12 +2946,12 @@ msgstr "Anmeldeschluss"
 msgid "Registration Not Open Yet"
 msgstr "Anmeldung noch nicht geöffnet"
 
-#: lib/klass_hero_web/components/provider_components.ex:1052
+#: lib/klass_hero_web/components/provider_components.ex:1053
 #, elixir-autogen, elixir-format
 msgid "Registration Opens"
 msgstr "Anmeldebeginn"
 
-#: lib/klass_hero_web/components/provider_components.ex:1043
+#: lib/klass_hero_web/components/provider_components.ex:1044
 #, elixir-autogen, elixir-format
 msgid "Registration Period (optional)"
 msgstr "Anmeldezeitraum (optional)"
@@ -2988,7 +2988,7 @@ msgid "Reject"
 msgstr "Ablehnen"
 
 #: lib/klass_hero_web/components/participation_components.ex:827
-#: lib/klass_hero_web/components/provider_components.ex:48
+#: lib/klass_hero_web/components/provider_components.ex:49
 #: lib/klass_hero_web/live/admin/verifications_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Rejected"
@@ -3000,18 +3000,18 @@ msgstr "Abgelehnt"
 msgid "Rejection reason"
 msgstr "Ablehnungsgrund"
 
-#: lib/klass_hero_web/components/provider_components.ex:838
-#: lib/klass_hero_web/components/provider_components.ex:1237
-#: lib/klass_hero_web/components/provider_components.ex:2295
-#: lib/klass_hero_web/components/provider_components.ex:2647
+#: lib/klass_hero_web/components/provider_components.ex:839
+#: lib/klass_hero_web/components/provider_components.ex:1238
+#: lib/klass_hero_web/components/provider_components.ex:2296
 #: lib/klass_hero_web/components/provider_components.ex:2726
+#: lib/klass_hero_web/components/provider_components.ex:2805
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:253
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr "Entfernen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2288
+#: lib/klass_hero_web/components/provider_components.ex:2289
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr "Einladung erneut senden"
@@ -3021,23 +3021,23 @@ msgstr "Einladung erneut senden"
 msgid "Reviewed"
 msgstr "Überprüft"
 
-#: lib/klass_hero_web/components/provider_components.ex:712
+#: lib/klass_hero_web/components/provider_components.ex:713
 #, elixir-autogen, elixir-format
 msgid "Role"
 msgstr "Rolle"
 
-#: lib/klass_hero_web/components/provider_components.ex:1656
+#: lib/klass_hero_web/components/provider_components.ex:1657
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:386
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
 msgstr "Teilnehmerliste: %{name}"
 
-#: lib/klass_hero_web/components/provider_components.ex:1300
+#: lib/klass_hero_web/components/provider_components.ex:1301
 #, elixir-autogen, elixir-format
 msgid "Save Program"
 msgstr "Programm speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:985
+#: lib/klass_hero_web/components/provider_components.ex:986
 #, elixir-autogen, elixir-format
 msgid "Schedule (optional)"
 msgstr "Zeitplan (optional)"
@@ -3052,7 +3052,7 @@ msgstr "Zeitplan noch offen"
 msgid "School Grade (optional)"
 msgstr "Klassenstufe (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2625
+#: lib/klass_hero_web/components/provider_components.ex:2704
 #, elixir-autogen, elixir-format
 msgid "Select File"
 msgstr "Datei auswählen"
@@ -3069,23 +3069,23 @@ msgstr "Das ausgewählte Kind erfüllt die Programmanforderungen nicht."
 msgid "Selected instructor could not be found. Please try again."
 msgstr "Der ausgewählte Kursleiter konnte nicht gefunden werden. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2472
+#: lib/klass_hero_web/components/provider_components.ex:2473
 #: lib/klass_hero_web/live/admin/emails_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Sent"
 msgstr "Gesendet"
 
-#: lib/klass_hero_web/components/provider_components.ex:759
+#: lib/klass_hero_web/components/provider_components.ex:760
 #, elixir-autogen, elixir-format
 msgid "Separate multiple qualifications with commas"
 msgstr "Trennen Sie mehrere Qualifikationen durch Kommas"
 
-#: lib/klass_hero_web/components/provider_components.ex:1067
+#: lib/klass_hero_web/components/provider_components.ex:1068
 #, elixir-autogen, elixir-format
 msgid "Set minimum and maximum enrollment for this program."
 msgstr "Legen Sie die minimale und maximale Anmeldekapazität für dieses Programm fest."
 
-#: lib/klass_hero_web/components/provider_components.ex:733
+#: lib/klass_hero_web/components/provider_components.ex:734
 #, elixir-autogen, elixir-format
 msgid "Specialties"
 msgstr "Spezialisierungen"
@@ -3103,12 +3103,12 @@ msgstr "Der Mitarbeiter existiert nicht mehr."
 msgid "Staff member not found."
 msgstr "Mitarbeiter nicht gefunden."
 
-#: lib/klass_hero_web/components/provider_components.ex:1031
+#: lib/klass_hero_web/components/provider_components.ex:1032
 #, elixir-autogen, elixir-format
 msgid "Start Date"
 msgstr "Startdatum"
 
-#: lib/klass_hero_web/components/provider_components.ex:1018
+#: lib/klass_hero_web/components/provider_components.ex:1019
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Start Time"
@@ -3174,12 +3174,12 @@ msgstr "Diese Einladung kann nicht erneut gesendet werden."
 msgid "This program was modified by someone else. Please close and try again."
 msgstr "Dieses Programm wurde von jemand anderem geändert. Bitte schließen Sie es und versuchen Sie es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:952
+#: lib/klass_hero_web/components/provider_components.ex:953
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr "Titel"
 
-#: lib/klass_hero_web/components/provider_components.ex:2526
+#: lib/klass_hero_web/components/provider_components.ex:2605
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr "Zu viele Dateien."
@@ -3199,32 +3199,32 @@ msgstr "Bis zu %{max}"
 msgid "Up to Grade %{max}"
 msgstr "Bis Klassenstufe %{max}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2174
+#: lib/klass_hero_web/components/provider_components.ex:2175
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr "CSV hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2671
+#: lib/klass_hero_web/components/provider_components.ex:2750
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr "Dokument hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2580
+#: lib/klass_hero_web/components/provider_components.ex:2659
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr "Neues Dokument hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2548
+#: lib/klass_hero_web/components/provider_components.ex:2627
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr "Laden Sie Dokumente hoch, um Ihr Unternehmen zu verifizieren. Die Dokumente werden von unserem Team überprüft."
 
-#: lib/klass_hero_web/components/provider_components.ex:2528
+#: lib/klass_hero_web/components/provider_components.ex:2607
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr "Upload-Fehler."
 
-#: lib/klass_hero_web/components/provider_components.ex:2545
+#: lib/klass_hero_web/components/provider_components.ex:2624
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr "Verifizierungsdokumente"
@@ -3246,7 +3246,7 @@ msgstr "Verifizierungsdokument nicht gefunden."
 msgid "Verifications"
 msgstr "Verifizierungen"
 
-#: lib/klass_hero_web/components/provider_components.ex:276
+#: lib/klass_hero_web/components/provider_components.ex:277
 #: lib/klass_hero_web/components/provider_layout_components.ex:212
 #: lib/klass_hero_web/components/ui_components.ex:1930
 #, elixir-autogen, elixir-format
@@ -3263,32 +3263,32 @@ msgstr "Wir sind Klass Hero — Eltern, Brüder und Partner von Pädagogen — u
 msgid "You don't have access to that page."
 msgstr "Sie haben keinen Zugriff auf diese Seite."
 
-#: lib/klass_hero_web/components/provider_components.ex:713
+#: lib/klass_hero_web/components/provider_components.ex:714
 #, elixir-autogen, elixir-format
 msgid "e.g. Head Coach"
 msgstr "z. B. Cheftrainer"
 
-#: lib/klass_hero_web/components/provider_components.ex:704
+#: lib/klass_hero_web/components/provider_components.ex:705
 #, elixir-autogen, elixir-format
 msgid "e.g. Johnson"
 msgstr "z. B. Johnson"
 
-#: lib/klass_hero_web/components/provider_components.ex:698
+#: lib/klass_hero_web/components/provider_components.ex:699
 #, elixir-autogen, elixir-format
 msgid "e.g. Mike"
 msgstr "z. B. Mike"
 
-#: lib/klass_hero_web/components/provider_components.ex:719
+#: lib/klass_hero_web/components/provider_components.ex:720
 #, elixir-autogen, elixir-format
 msgid "e.g. mike@example.com"
 msgstr "z. B. mike@example.com"
 
-#: lib/klass_hero_web/components/provider_components.ex:953
+#: lib/klass_hero_web/components/provider_components.ex:954
 #, elixir-autogen, elixir-format
 msgid "e.g., Art Adventures"
 msgstr "z. B. Art Adventures"
 
-#: lib/klass_hero_web/components/provider_components.ex:980
+#: lib/klass_hero_web/components/provider_components.ex:981
 #, elixir-autogen, elixir-format
 msgid "e.g., Community Center, Main St"
 msgstr "z. B. Gemeindezentrum, Hauptstraße"
@@ -3314,7 +3314,7 @@ msgid "Child Safeguarding Training"
 msgstr "Kinderschutzschulung"
 
 #: lib/klass_hero_web/components/marketing_components.ex:1498
-#: lib/klass_hero_web/components/provider_components.ex:2893
+#: lib/klass_hero_web/components/provider_components.ex:2972
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr "Vereinbarung zu Community-Standards"
@@ -3464,7 +3464,7 @@ msgid "Vetted with Care"
 msgstr "Mit Sorgfalt geprüft"
 
 #: lib/klass_hero_web/components/marketing_components.ex:1482
-#: lib/klass_hero_web/components/provider_components.ex:2678
+#: lib/klass_hero_web/components/provider_components.ex:2757
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr "Video-Überprüfung"
@@ -3638,7 +3638,7 @@ msgstr "Eingecheckt"
 msgid "Checked Out"
 msgstr "Ausgecheckt"
 
-#: lib/klass_hero_web/components/provider_components.ex:2331
+#: lib/klass_hero_web/components/provider_components.ex:2332
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Child"
@@ -3691,7 +3691,7 @@ msgstr "Benötige ich ein Konto, um zu buchen?"
 msgid "Download monthly statements for taxes"
 msgstr "Monatliche Abrechnungen für die Steuer herunterladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2092
+#: lib/klass_hero_web/components/provider_components.ex:2093
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "Enrollment not confirmed"
@@ -3769,7 +3769,7 @@ msgstr "Keine Änderungen erkannt"
 msgid "No chasing payments or sending invoices"
 msgstr "Kein Nachfassen bei Zahlungen oder Versenden von Rechnungen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1679
+#: lib/klass_hero_web/components/provider_components.ex:1680
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:407
 #, elixir-autogen, elixir-format
 msgid "No enrolled parents"
@@ -3792,7 +3792,7 @@ msgstr "Notizen"
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr "Oder: Jederzeit eine Sofortauszahlung anfordern (mindestens 50 €)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2091
+#: lib/klass_hero_web/components/provider_components.ex:2092
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -4475,7 +4475,7 @@ msgstr "Privates Antworten ist nur für Broadcast-Nachrichten verfügbar"
 msgid "Reply sent successfully"
 msgstr "Antwort erfolgreich gesendet"
 
-#: lib/klass_hero_web/components/provider_components.ex:552
+#: lib/klass_hero_web/components/provider_components.ex:553
 #, elixir-autogen, elixir-format
 msgid "Resend"
 msgstr "Erneut senden"
@@ -4900,43 +4900,43 @@ msgstr "Ihr Profil ist bereits vollständig."
 msgid "for"
 msgstr "für"
 
-#: lib/klass_hero_web/components/provider_components.ex:1800
+#: lib/klass_hero_web/components/provider_components.ex:1801
 #, elixir-autogen, elixir-format
 msgid "Assigned staff"
 msgstr "Zugewiesenes Personal"
 
-#: lib/klass_hero_web/components/provider_components.ex:1802
+#: lib/klass_hero_web/components/provider_components.ex:1803
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr "Anwesenheit"
 
-#: lib/klass_hero_web/components/provider_components.ex:1784
-#: lib/klass_hero_web/components/provider_components.ex:1873
+#: lib/klass_hero_web/components/provider_components.ex:1785
+#: lib/klass_hero_web/components/provider_components.ex:1874
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr "Schließen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1801
+#: lib/klass_hero_web/components/provider_components.ex:1802
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr "Vertretung"
 
-#: lib/klass_hero_web/components/provider_components.ex:1799
+#: lib/klass_hero_web/components/provider_components.ex:1800
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr "Datum / Uhrzeit"
 
-#: lib/klass_hero_web/components/provider_components.ex:1793
+#: lib/klass_hero_web/components/provider_components.ex:1794
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled yet."
 msgstr "Noch keine Sessions geplant."
 
-#: lib/klass_hero_web/components/provider_components.ex:1782
+#: lib/klass_hero_web/components/provider_components.ex:1783
 #, elixir-autogen, elixir-format
 msgid "Sessions — %{title}"
 msgstr "Sessions — %{title}"
 
-#: lib/klass_hero_web/components/provider_components.ex:1522
+#: lib/klass_hero_web/components/provider_components.ex:1523
 #, elixir-autogen, elixir-format
 msgid "View sessions"
 msgstr "Sessions anzeigen"
@@ -4968,17 +4968,17 @@ msgstr "Abreisezeit ist kein gültiges Datum oder keine gültige Uhrzeit"
 msgid "Failed to update record"
 msgstr "Aktualisieren des Datensatzes fehlgeschlagen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2395
+#: lib/klass_hero_web/components/provider_components.ex:2396
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr "Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2114
+#: lib/klass_hero_web/components/provider_components.ex:2115
 #, elixir-autogen, elixir-format
 msgid "Invite mode"
 msgstr "Einladungsmodus"
 
-#: lib/klass_hero_web/components/provider_components.ex:2133
+#: lib/klass_hero_web/components/provider_components.ex:2134
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr "Einzelperson einladen"
@@ -4993,12 +4993,12 @@ msgstr "Einladung verschickt."
 msgid "Leave blank to keep this child marked as present."
 msgstr "Leer lassen, um dieses Kind als anwesend markiert zu lassen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2408
+#: lib/klass_hero_web/components/provider_components.ex:2409
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr "Gesundheit & Einwilligungen (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2414
+#: lib/klass_hero_web/components/provider_components.ex:2415
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr "Gesundheitliche Besonderheiten"
@@ -5009,17 +5009,17 @@ msgstr "Gesundheitliche Besonderheiten"
 msgid "Nothing to update"
 msgstr "Nichts zu aktualisieren"
 
-#: lib/klass_hero_web/components/provider_components.ex:2416
+#: lib/klass_hero_web/components/provider_components.ex:2417
 #, elixir-autogen, elixir-format
 msgid "Nut allergy"
 msgstr "Nussallergie"
 
-#: lib/klass_hero_web/components/provider_components.ex:2420
+#: lib/klass_hero_web/components/provider_components.ex:2421
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr "Fotos dürfen in Marketingmaterialien verwendet werden"
 
-#: lib/klass_hero_web/components/provider_components.ex:2425
+#: lib/klass_hero_web/components/provider_components.ex:2426
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr "Fotos dürfen in sozialen Medien erscheinen"
@@ -5029,7 +5029,7 @@ msgstr "Fotos dürfen in sozialen Medien erscheinen"
 msgid "Present"
 msgstr "Anwesend"
 
-#: lib/klass_hero_web/components/provider_components.ex:2352
+#: lib/klass_hero_web/components/provider_components.ex:2353
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr "Hauptansprechpartner"
@@ -5056,22 +5056,22 @@ msgstr "Datensatz aktualisiert"
 msgid "Save changes"
 msgstr "Änderungen speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:2389
+#: lib/klass_hero_web/components/provider_components.ex:2390
 #, elixir-autogen, elixir-format
 msgid "School (optional)"
 msgstr "Schule (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2399
+#: lib/klass_hero_web/components/provider_components.ex:2400
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr "Schulname"
 
-#: lib/klass_hero_web/components/provider_components.ex:2373
+#: lib/klass_hero_web/components/provider_components.ex:2374
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr "Zweiter Ansprechpartner (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2442
+#: lib/klass_hero_web/components/provider_components.ex:2443
 #, elixir-autogen, elixir-format
 msgid "Send invite"
 msgstr "Einladung senden"
@@ -5081,7 +5081,7 @@ msgstr "Einladung senden"
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr "Aktualisieren Sie die Notiz für dieses Kind (z. B. um zu klären, was passiert ist)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2151
+#: lib/klass_hero_web/components/provider_components.ex:2152
 #, elixir-autogen, elixir-format
 msgid "Upload a list"
 msgstr "Liste hochladen"
@@ -5116,7 +5116,7 @@ msgstr "Foto hierher ziehen oder klicken zum Auswählen"
 msgid "High"
 msgstr "Hoch"
 
-#: lib/klass_hero_web/components/provider_components.ex:786
+#: lib/klass_hero_web/components/provider_components.ex:787
 #, elixir-autogen, elixir-format
 msgid "Hourly"
 msgstr "Stündlich"
@@ -5141,22 +5141,22 @@ msgstr "Niedrig"
 msgid "Medium"
 msgstr "Mittel"
 
-#: lib/klass_hero_web/components/provider_components.ex:776
+#: lib/klass_hero_web/components/provider_components.ex:777
 #, elixir-autogen, elixir-format
 msgid "None"
 msgstr "Keine"
 
-#: lib/klass_hero_web/components/provider_components.ex:765
+#: lib/klass_hero_web/components/provider_components.ex:766
 #, elixir-autogen, elixir-format
 msgid "Pay Rate"
 msgstr "Vergütung"
 
-#: lib/klass_hero_web/components/provider_components.ex:523
+#: lib/klass_hero_web/components/provider_components.ex:524
 #, elixir-autogen, elixir-format
 msgid "Pay rate"
 msgstr "Vergütung"
 
-#: lib/klass_hero_web/components/provider_components.ex:796
+#: lib/klass_hero_web/components/provider_components.ex:797
 #, elixir-autogen, elixir-format
 msgid "Per Session"
 msgstr "Pro Sitzung"
@@ -5181,7 +5181,7 @@ msgstr "Programm oder Session nicht gefunden."
 msgid "Property Damage"
 msgstr "Sachschaden"
 
-#: lib/klass_hero_web/components/provider_components.ex:1552
+#: lib/klass_hero_web/components/provider_components.ex:1553
 #, elixir-autogen, elixir-format
 msgid "Report Incident"
 msgstr "Vorfall melden"
@@ -5863,7 +5863,7 @@ msgstr[1] "%{count} Familien importiert."
 msgid "In 2025, Shane connected with his friend"
 msgstr "2025 tat sich Shane mit seinem Freund zusammen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1561
+#: lib/klass_hero_web/components/provider_components.ex:1562
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:43
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:74
 #, elixir-autogen, elixir-format
@@ -5933,7 +5933,7 @@ msgstr "Klass Hero ist das operative Rückgrat für Berlins Jugendpädagogen. Wi
 msgid "Last 8 weeks"
 msgstr "Letzte 8 Wochen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1271
+#: lib/klass_hero_web/components/provider_components.ex:1272
 #: lib/klass_hero_web/presenters/hero_cards_presenter.ex:27
 #, elixir-autogen, elixir-format
 msgid "Lead Instructor"
@@ -6383,17 +6383,17 @@ msgstr "Umsatz (diese Woche)"
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr "Strenge Überprüfung, damit Familien immer wissen, wer die Gruppe leitet."
 
-#: lib/klass_hero_web/components/provider_components.ex:2481
+#: lib/klass_hero_web/components/provider_components.ex:2482
 #, elixir-autogen, elixir-format
 msgid "Row %{row}"
 msgstr "Zeile %{row}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2481
+#: lib/klass_hero_web/components/provider_components.ex:2482
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr "Zeile —"
 
-#: lib/klass_hero_web/components/provider_components.ex:2227
+#: lib/klass_hero_web/components/provider_components.ex:2228
 #, elixir-autogen, elixir-format
 msgid "Rows with errors"
 msgstr "Zeilen mit Fehlern"
@@ -7005,7 +7005,7 @@ msgstr "Identitäts- und Altersverifizierung"
 msgid "Identity verifications"
 msgstr "Identitätsprüfungen"
 
-#: lib/klass_hero_web/components/provider_components.ex:71
+#: lib/klass_hero_web/components/provider_components.ex:72
 #, elixir-autogen, elixir-format
 msgid "In progress"
 msgstr "In Bearbeitung"
@@ -7035,7 +7035,7 @@ msgstr "Noch keine Identitätsprüfungen."
 msgid "Not started"
 msgstr "Nicht begonnen"
 
-#: lib/klass_hero_web/components/provider_components.ex:69
+#: lib/klass_hero_web/components/provider_components.ex:70
 #, elixir-autogen, elixir-format
 msgid "Passed"
 msgstr "Bestanden"
@@ -7152,12 +7152,12 @@ msgstr "Deine Identität ist verifiziert."
 msgid "Experience validation"
 msgstr "Erfahrungsnachweis"
 
-#: lib/klass_hero_web/components/provider_components.ex:2707
+#: lib/klass_hero_web/components/provider_components.ex:2786
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr "MP4, MOV oder WEBM. Max. 100 MB."
 
-#: lib/klass_hero_web/components/provider_components.ex:2681
+#: lib/klass_hero_web/components/provider_components.ex:2760
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr "Nimm ein kurzes Video auf, in dem du dich vorstellst. Unser Team prüft es, um Kommunikationsfähigkeit und Übereinstimmung mit unseren Werten einzuschätzen."
@@ -7167,12 +7167,12 @@ msgstr "Nimm ein kurzes Video auf, in dem du dich vorstellst. Unser Team prüft 
 msgid "Safeguarding certificate"
 msgstr "Kinderschutz-Zertifikat"
 
-#: lib/klass_hero_web/components/provider_components.ex:2704
+#: lib/klass_hero_web/components/provider_components.ex:2783
 #, elixir-autogen, elixir-format
 msgid "Select Video"
 msgstr "Video auswählen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2750
+#: lib/klass_hero_web/components/provider_components.ex:2829
 #, elixir-autogen, elixir-format
 msgid "Upload Video"
 msgstr "Video hochladen"
@@ -7182,7 +7182,7 @@ msgstr "Video hochladen"
 msgid "Your browser does not support video playback."
 msgstr "Dein Browser unterstützt keine Videowiedergabe."
 
-#: lib/klass_hero_web/components/provider_components.ex:2897
+#: lib/klass_hero_web/components/provider_components.ex:2976
 #, elixir-autogen, elixir-format
 msgid "Confirm agreement"
 msgstr "Zustimmung bestätigen"
@@ -7192,12 +7192,12 @@ msgstr "Zustimmung bestätigen"
 msgid "Couldn't record your agreement. Please try again."
 msgstr "Deine Zustimmung konnte nicht gespeichert werden. Bitte versuche es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2920
+#: lib/klass_hero_web/components/provider_components.ex:2999
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr "Vereinbarung herunterladen (PDF)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2896
+#: lib/klass_hero_web/components/provider_components.ex:2975
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr "Ich habe die Klass Hero Community-Richtlinien gelesen und stimme ihnen zu."
@@ -7207,7 +7207,7 @@ msgstr "Ich habe die Klass Hero Community-Richtlinien gelesen und stimme ihnen z
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr "Bitte bestätige, dass du die Community-Richtlinien gelesen hast und ihnen zustimmst."
 
-#: lib/klass_hero_web/components/provider_components.ex:2805
+#: lib/klass_hero_web/components/provider_components.ex:2884
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr "Unterzeichnet von %{name} am %{date} (v%{version})."
@@ -7217,17 +7217,17 @@ msgstr "Unterzeichnet von %{name} am %{date} (v%{version})."
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr "Danke – deine Zustimmung zu den Community-Richtlinien wurde gespeichert."
 
-#: lib/klass_hero_web/components/provider_components.ex:2905
+#: lib/klass_hero_web/components/provider_components.ex:2984
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr "Die Community-Richtlinien wurden seit deiner letzten Zustimmung aktualisiert (v%{old}). Bitte lies sie erneut und stimme erneut zu."
 
-#: lib/klass_hero_web/components/provider_components.ex:2894
+#: lib/klass_hero_web/components/provider_components.ex:2973
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr "Der letzte Schritt: Lies die Klass Hero Community-Richtlinien und stimme ihnen zu."
 
-#: lib/klass_hero_web/components/provider_components.ex:2895
+#: lib/klass_hero_web/components/provider_components.ex:2974
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr "Du hast den Community-Richtlinien zugestimmt."
@@ -7496,12 +7496,12 @@ msgstr "Ihre Versicherungsbescheinigung wird geprüft."
 msgid "Your insurance is verified."
 msgstr "Ihre Versicherung ist verifiziert."
 
-#: lib/klass_hero_web/components/provider_components.ex:2849
+#: lib/klass_hero_web/components/provider_components.ex:2928
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr "Unterzeichnung durch %{name} im Namen des Unternehmens."
 
-#: lib/klass_hero_web/components/provider_components.ex:2952
+#: lib/klass_hero_web/components/provider_components.ex:3031
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr "Bestätige im Namen deines Unternehmens, dass alle Mitarbeitenden gemäß dem deutschen Kinderschutzrecht überprüft sind."
@@ -7511,7 +7511,7 @@ msgstr "Bestätige im Namen deines Unternehmens, dass alle Mitarbeitenden gemä�
 msgid "Couldn't record your declaration. Please try again."
 msgstr "Deine Erklärung konnte nicht gespeichert werden. Bitte versuche es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2958
+#: lib/klass_hero_web/components/provider_components.ex:3037
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr "Ich bestätige im Namen des Unternehmens, dass die obige Erklärung zutrifft und ich zu ihrer Unterzeichnung berechtigt bin."
@@ -7521,17 +7521,17 @@ msgstr "Ich bestätige im Namen des Unternehmens, dass die obige Erklärung zutr
 msgid "Please confirm the declaration before signing."
 msgstr "Bitte bestätige die Erklärung vor der Unterzeichnung."
 
-#: lib/klass_hero_web/components/provider_components.ex:2983
+#: lib/klass_hero_web/components/provider_components.ex:3062
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr "Vorläufiger Text — vor der Freischaltung noch von einer in Deutschland zugelassenen Anwältin bzw. einem Anwalt zu prüfen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2962
+#: lib/klass_hero_web/components/provider_components.ex:3041
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr "Erklärung unterzeichnen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2950
+#: lib/klass_hero_web/components/provider_components.ex:3029
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr "Erklärung zur Mitarbeiter-Compliance"
@@ -7541,12 +7541,12 @@ msgstr "Erklärung zur Mitarbeiter-Compliance"
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr "Danke — deine Erklärung zur Mitarbeiter-Compliance wurde erfasst."
 
-#: lib/klass_hero_web/components/provider_components.ex:2970
+#: lib/klass_hero_web/components/provider_components.ex:3049
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr "Die Erklärung zur Mitarbeiter-Compliance wurde seit deiner letzten Unterzeichnung aktualisiert (v%{old}). Bitte prüfe sie und unterzeichne erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2956
+#: lib/klass_hero_web/components/provider_components.ex:3035
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr "Du hast die Erklärung zur Mitarbeiter-Compliance unterzeichnet."
@@ -7613,12 +7613,12 @@ msgstr "In Prüfung"
 msgid "Undelivered Events"
 msgstr "Nicht zugestellte Ereignisse"
 
-#: lib/klass_hero_web/components/provider_components.ex:1970
+#: lib/klass_hero_web/components/provider_components.ex:1971
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1895
+#: lib/klass_hero_web/components/provider_components.ex:1896
 #, elixir-autogen, elixir-format
 msgid "Lead"
 msgstr "Leitung"
@@ -7628,17 +7628,17 @@ msgstr "Leitung"
 msgid "Lead instructor updated."
 msgstr "Leitender Kursleiter aktualisiert."
 
-#: lib/klass_hero_web/components/provider_components.ex:1906
+#: lib/klass_hero_web/components/provider_components.ex:1907
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor"
 msgstr "Als leitenden Kursleiter festlegen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1536
+#: lib/klass_hero_web/components/provider_components.ex:1537
 #, elixir-autogen, elixir-format
 msgid "Manage Staffing"
 msgstr "Programmteam verwalten"
 
-#: lib/klass_hero_web/components/provider_components.ex:1934
+#: lib/klass_hero_web/components/provider_components.ex:1935
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this program yet."
 msgstr "Diesem Programm ist noch niemand zugewiesen."
@@ -7648,17 +7648,17 @@ msgstr "Diesem Programm ist noch niemand zugewiesen."
 msgid "Pick a staff member to add."
 msgstr "Bitte ein Teammitglied zum Hinzufügen auswählen."
 
-#: lib/klass_hero_web/components/provider_components.ex:1917
+#: lib/klass_hero_web/components/provider_components.ex:1918
 #, elixir-autogen, elixir-format
 msgid "Reassign the lead before removing them"
 msgstr "Vor dem Entfernen einen anderen leitenden Kursleiter festlegen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1918
+#: lib/klass_hero_web/components/provider_components.ex:1919
 #, elixir-autogen, elixir-format
 msgid "Remove from program"
 msgstr "Aus dem Programm entfernen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1952
+#: lib/klass_hero_web/components/provider_components.ex:1953
 #, elixir-autogen, elixir-format
 msgid "Select a staff member…"
 msgstr "Teammitglied auswählen …"
@@ -7673,14 +7673,14 @@ msgstr "Teammitglied zum Programm hinzugefügt."
 msgid "Staff member removed from the program."
 msgstr "Teammitglied aus dem Programm entfernt."
 
-#: lib/klass_hero_web/components/provider_components.ex:1975
+#: lib/klass_hero_web/components/provider_components.ex:1976
 #, elixir-autogen, elixir-format
 msgid "Staff you add can read and reply to this program's parent conversations."
 msgstr ""
 "Hinzugefügte Teammitglieder können die Elterngespräche dieses Programms lesen "
 "und beantworten."
 
-#: lib/klass_hero_web/components/provider_components.ex:1871
+#: lib/klass_hero_web/components/provider_components.ex:1872
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{title}"
 msgstr "Programmteam — %{title}"
@@ -7702,19 +7702,19 @@ msgstr ""
 "Diese Person ist der leitende Kursleiter. Bitte zuerst eine andere Person als "
 "Leitung festlegen."
 
-#: lib/klass_hero_web/components/provider_components.ex:1480
+#: lib/klass_hero_web/components/provider_components.ex:1481
 #, elixir-autogen, elixir-format
 msgid "%{count} staff member · no lead"
 msgid_plural "%{count} staff · no lead"
 msgstr[0] "%{count} Mitarbeiter*in · keine Leitung"
 msgstr[1] "%{count} Mitarbeitende · keine Leitung"
 
-#: lib/klass_hero_web/components/provider_components.ex:562
+#: lib/klass_hero_web/components/provider_components.ex:563
 #, elixir-autogen, elixir-format
 msgid "%{name} will be unassigned from every program and removed from those conversations. Their history is kept and you can add them back later."
 msgstr "%{name} wird aus allen Programmen und den zugehörigen Unterhaltungen entfernt. Der Verlauf bleibt erhalten und du kannst die Person später wieder hinzufügen."
 
-#: lib/klass_hero_web/components/provider_components.ex:638
+#: lib/klass_hero_web/components/provider_components.ex:639
 #, elixir-autogen, elixir-format
 msgid "Add back to team"
 msgstr "Wieder ins Team aufnehmen"
@@ -7724,7 +7724,7 @@ msgstr "Wieder ins Team aufnehmen"
 msgid "Could not bring this team member back. Please try again."
 msgstr "Teammitglied konnte nicht zurückgeholt werden. Bitte versuche es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:600
+#: lib/klass_hero_web/components/provider_components.ex:601
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr "Eintrag löschen"
@@ -7734,7 +7734,7 @@ msgstr "Eintrag löschen"
 msgid "Former team members"
 msgstr "Ehemalige Teammitglieder"
 
-#: lib/klass_hero_web/components/provider_components.ex:574
+#: lib/klass_hero_web/components/provider_components.ex:575
 #, elixir-autogen, elixir-format
 msgid "Remove from team"
 msgstr "Aus dem Team entfernen"
@@ -7749,7 +7749,7 @@ msgstr "Teammitglied ist zurück. Weise die Person wieder Programmen zu, wenn du
 msgid "Team member removed from the team."
 msgstr "Teammitglied aus dem Team entfernt."
 
-#: lib/klass_hero_web/components/provider_components.ex:590
+#: lib/klass_hero_web/components/provider_components.ex:591
 #, elixir-autogen, elixir-format
 msgid "This deletes %{name} permanently — there's nothing to undo. Use it only for an entry added by mistake."
 msgstr "Damit wird %{name} endgültig gelöscht – das lässt sich nicht rückgängig machen. Nutze das nur für einen versehentlich angelegten Eintrag."

--- a/priv/gettext/de/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/de/LC_MESSAGES/enrollment.po
@@ -11,62 +11,105 @@ msgstr ""
 "Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:2502
+#: lib/klass_hero_web/components/provider_components.ex:2576
+#: lib/klass_hero_web/components/provider_components.ex:2593
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr "Vorname des Kindes"
 
-#: lib/klass_hero_web/components/provider_components.ex:2503
+#: lib/klass_hero_web/components/provider_components.ex:2577
+#: lib/klass_hero_web/components/provider_components.ex:2594
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr "Nachname des Kindes"
 
-#: lib/klass_hero_web/components/provider_components.ex:2504
+#: lib/klass_hero_web/components/provider_components.ex:2578
+#: lib/klass_hero_web/components/provider_components.ex:2595
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr "Geburtsdatum"
 
-#: lib/klass_hero_web/components/provider_components.ex:2515
+#: lib/klass_hero_web/components/provider_components.ex:2589
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr "Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2505
+#: lib/klass_hero_web/components/provider_components.ex:2579
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr "E-Mail des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2506
+#: lib/klass_hero_web/components/provider_components.ex:2580
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr "Vorname des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2507
+#: lib/klass_hero_web/components/provider_components.ex:2581
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr "Nachname des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2514
+#: lib/klass_hero_web/components/provider_components.ex:2588
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr "Programm"
 
-#: lib/klass_hero_web/components/provider_components.ex:2516
+#: lib/klass_hero_web/components/provider_components.ex:2590
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr "Schule"
 
-#: lib/klass_hero_web/components/provider_components.ex:2508
+#: lib/klass_hero_web/components/provider_components.ex:2582
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr "E-Mail des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2510
+#: lib/klass_hero_web/components/provider_components.ex:2584
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr "Vorname des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2512
+#: lib/klass_hero_web/components/provider_components.ex:2586
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr "Nachname des zweiten Erziehungsberechtigten"
+
+#: lib/klass_hero_web/components/provider_components.ex:2516
+#, elixir-autogen, elixir-format
+msgid "Date of birth \"%{value}\" is not a valid date. Please correct it and resend."
+msgstr ""
+"Das Geburtsdatum „%{value}“ ist kein gültiges Datum. Bitte korrigieren Sie es "
+"und senden Sie die Einladung erneut."
+
+#: lib/klass_hero_web/components/provider_components.ex:2510
+#, elixir-autogen, elixir-format
+msgid "Invite link could not be generated (no token). Please resend."
+msgstr ""
+"Der Einladungslink konnte nicht erzeugt werden (kein Token). Bitte erneut "
+"senden."
+
+#: lib/klass_hero_web/components/provider_components.ex:2524
+#, elixir-autogen, elixir-format
+msgid "The invitation email could not be delivered. Please check the address and resend."
+msgstr ""
+"Die Einladungs-E-Mail konnte nicht zugestellt werden. Bitte prüfen Sie die "
+"Adresse und senden Sie die Einladung erneut."
+
+#: lib/klass_hero_web/components/provider_components.ex:2513
+#, elixir-autogen, elixir-format
+msgid "The program is full, so this child could not be enrolled."
+msgstr ""
+"Das Programm ist ausgebucht, daher konnte dieses Kind nicht angemeldet "
+"werden."
+
+#: lib/klass_hero_web/components/provider_components.ex:2527
+#, elixir-autogen, elixir-format
+msgid "This invite could not be completed and no retries remain. Please resend."
+msgstr ""
+"Diese Einladung konnte nicht abgeschlossen werden und es sind keine weiteren "
+"Versuche möglich. Bitte erneut senden."
+
+#: lib/klass_hero_web/components/provider_components.ex:2536
+#, elixir-autogen, elixir-format
+msgid "This invite could not be completed. Please resend."
+msgstr "Diese Einladung konnte nicht abgeschlossen werden. Bitte erneut senden."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -45,7 +45,7 @@ msgstr ""
 #: lib/klass_hero_web/components/layouts/app.html.heex:129
 #: lib/klass_hero_web/components/layouts/app.html.heex:204
 #: lib/klass_hero_web/components/layouts/app.html.heex:229
-#: lib/klass_hero_web/components/provider_components.ex:389
+#: lib/klass_hero_web/components/provider_components.ex:390
 #: lib/klass_hero_web/components/ui_components.ex:268
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
@@ -137,7 +137,7 @@ msgid "Your Data"
 msgstr ""
 
 #: lib/klass_hero_web/components/core_components.ex:67
-#: lib/klass_hero_web/components/provider_components.ex:1686
+#: lib/klass_hero_web/components/provider_components.ex:1687
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr ""
@@ -232,7 +232,7 @@ msgstr ""
 msgid "Enroll Now - %{price}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1437
+#: lib/klass_hero_web/components/provider_components.ex:1438
 #: lib/klass_hero_web/live/booking_live.ex:285
 #, elixir-autogen, elixir-format
 msgid "Enrollment"
@@ -577,9 +577,9 @@ msgstr ""
 msgid "Dispute Resolution"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:718
-#: lib/klass_hero_web/components/provider_components.ex:2359
-#: lib/klass_hero_web/components/provider_components.ex:2377
+#: lib/klass_hero_web/components/provider_components.ex:719
+#: lib/klass_hero_web/components/provider_components.ex:2360
+#: lib/klass_hero_web/components/provider_components.ex:2378
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
@@ -878,9 +878,9 @@ msgstr ""
 msgid "Select one or both options"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2055
 #: lib/klass_hero_web/components/provider_components.ex:2056
-#: lib/klass_hero_web/components/provider_components.ex:2093
+#: lib/klass_hero_web/components/provider_components.ex:2057
+#: lib/klass_hero_web/components/provider_components.ex:2094
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:448
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:484
@@ -1324,7 +1324,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/composite_components.ex:103
 #: lib/klass_hero_web/components/layouts/admin.html.heex:71
-#: lib/klass_hero_web/components/provider_components.ex:119
+#: lib/klass_hero_web/components/provider_components.ex:120
 #: lib/klass_hero_web/live/admin/sessions_live.ex:26
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:3
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:348
@@ -1456,7 +1456,7 @@ msgstr ""
 msgid "Music"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:754
+#: lib/klass_hero_web/components/provider_components.ex:755
 #: lib/klass_hero_web/live/for_providers_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "Qualifications"
@@ -1577,19 +1577,19 @@ msgstr ""
 msgid "Quick Navigation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1440
-#: lib/klass_hero_web/components/provider_components.ex:2031
-#: lib/klass_hero_web/components/provider_components.ex:2257
+#: lib/klass_hero_web/components/provider_components.ex:1441
+#: lib/klass_hero_web/components/provider_components.ex:2032
+#: lib/klass_hero_web/components/provider_components.ex:2258
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1579
+#: lib/klass_hero_web/components/provider_components.ex:1580
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:671
+#: lib/klass_hero_web/components/provider_components.ex:672
 #: lib/klass_hero_web/live/provider/team_live.ex:627
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
@@ -1600,7 +1600,7 @@ msgstr ""
 msgid "All Staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1431
+#: lib/klass_hero_web/components/provider_components.ex:1432
 #, elixir-autogen, elixir-format
 msgid "Assigned Staff"
 msgstr ""
@@ -1611,7 +1611,7 @@ msgstr ""
 msgid "Book Now"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:205
+#: lib/klass_hero_web/components/provider_components.ex:206
 #, elixir-autogen, elixir-format
 msgid "Business Profile"
 msgstr ""
@@ -1627,8 +1627,8 @@ msgstr ""
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:538
-#: lib/klass_hero_web/components/provider_components.ex:1542
+#: lib/klass_hero_web/components/provider_components.ex:539
+#: lib/klass_hero_web/components/provider_components.ex:1543
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:54
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:81
 #: lib/klass_hero_web/live/settings/children_live.ex:448
@@ -1638,57 +1638,57 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:223
+#: lib/klass_hero_web/components/provider_components.ex:224
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:31
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "Edit Profile"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1581
+#: lib/klass_hero_web/components/provider_components.ex:1582
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:112
+#: lib/klass_hero_web/components/provider_components.ex:113
 #: lib/klass_hero_web/live/provider/programs_live.ex:54
 #, elixir-autogen, elixir-format
 msgid "My Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:415
-#: lib/klass_hero_web/components/provider_components.ex:929
+#: lib/klass_hero_web/components/provider_components.ex:416
+#: lib/klass_hero_web/components/provider_components.ex:930
 #, elixir-autogen, elixir-format
 msgid "New Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:98
+#: lib/klass_hero_web/components/provider_components.ex:99
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:46
-#: lib/klass_hero_web/components/provider_components.ex:72
-#: lib/klass_hero_web/components/provider_components.ex:1580
-#: lib/klass_hero_web/components/provider_components.ex:2453
-#: lib/klass_hero_web/components/provider_components.ex:2471
+#: lib/klass_hero_web/components/provider_components.ex:47
+#: lib/klass_hero_web/components/provider_components.ex:73
+#: lib/klass_hero_web/components/provider_components.ex:1581
+#: lib/klass_hero_web/components/provider_components.ex:2454
+#: lib/klass_hero_web/components/provider_components.ex:2472
 #: lib/klass_hero_web/live/admin/sessions_live.ex:297
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1518
+#: lib/klass_hero_web/components/provider_components.ex:1519
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1371
+#: lib/klass_hero_web/components/provider_components.ex:1372
 #, elixir-autogen, elixir-format
 msgid "Program Inventory"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1428
+#: lib/klass_hero_web/components/provider_components.ex:1429
 #, elixir-autogen, elixir-format
 msgid "Program Name"
 msgstr ""
@@ -1703,15 +1703,15 @@ msgstr ""
 msgid "Save for Later"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1388
+#: lib/klass_hero_web/components/provider_components.ex:1389
 #, elixir-autogen, elixir-format
 msgid "Search by name..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1434
-#: lib/klass_hero_web/components/provider_components.ex:1803
-#: lib/klass_hero_web/components/provider_components.ex:2025
-#: lib/klass_hero_web/components/provider_components.ex:2254
+#: lib/klass_hero_web/components/provider_components.ex:1435
+#: lib/klass_hero_web/components/provider_components.ex:1804
+#: lib/klass_hero_web/components/provider_components.ex:2026
+#: lib/klass_hero_web/components/provider_components.ex:2255
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1719,7 +1719,7 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:105
+#: lib/klass_hero_web/components/provider_components.ex:106
 #: lib/klass_hero_web/live/provider/team_live.ex:36
 #, elixir-autogen, elixir-format
 msgid "Team & Profiles"
@@ -1730,32 +1730,32 @@ msgstr ""
 msgid "Team & Provider Profiles"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:208
+#: lib/klass_hero_web/components/provider_components.ex:209
 #, elixir-autogen, elixir-format
 msgid "This is your main business identity. Verification is required to list programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1491
-#: lib/klass_hero_web/components/provider_components.ex:1818
+#: lib/klass_hero_web/components/provider_components.ex:1492
+#: lib/klass_hero_web/components/provider_components.ex:1819
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr ""
 
 #: lib/klass_hero_web/components/messaging_components.ex:728
-#: lib/klass_hero_web/components/provider_components.ex:49
-#: lib/klass_hero_web/components/provider_components.ex:1582
+#: lib/klass_hero_web/components/provider_components.ex:50
+#: lib/klass_hero_web/components/provider_components.ex:1583
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:434
 #: lib/klass_hero_web/presenters/provider_presenter.ex:103
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:400
+#: lib/klass_hero_web/components/provider_components.ex:401
 #, elixir-autogen, elixir-format
 msgid "Verified Business"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1529
+#: lib/klass_hero_web/components/provider_components.ex:1530
 #, elixir-autogen, elixir-format
 msgid "View Roster"
 msgstr ""
@@ -1815,9 +1815,9 @@ msgstr ""
 #: lib/klass_hero_web/components/participation_components.ex:441
 #: lib/klass_hero_web/components/participation_components.ex:631
 #: lib/klass_hero_web/components/participation_components.ex:717
-#: lib/klass_hero_web/components/provider_components.ex:888
-#: lib/klass_hero_web/components/provider_components.ex:1287
-#: lib/klass_hero_web/components/provider_components.ex:2196
+#: lib/klass_hero_web/components/provider_components.ex:889
+#: lib/klass_hero_web/components/provider_components.ex:1288
+#: lib/klass_hero_web/components/provider_components.ex:2197
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:478
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
@@ -1883,7 +1883,7 @@ msgstr ""
 msgid "Data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2340
+#: lib/klass_hero_web/components/provider_components.ex:2341
 #: lib/klass_hero_web/live/settings/children_live.ex:657
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1931,17 +1931,17 @@ msgstr ""
 msgid "Failed to submit note"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2334
-#: lib/klass_hero_web/components/provider_components.ex:2363
-#: lib/klass_hero_web/components/provider_components.ex:2379
+#: lib/klass_hero_web/components/provider_components.ex:2335
+#: lib/klass_hero_web/components/provider_components.ex:2364
+#: lib/klass_hero_web/components/provider_components.ex:2380
 #: lib/klass_hero_web/live/settings/children_live.ex:643
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2335
-#: lib/klass_hero_web/components/provider_components.ex:2364
-#: lib/klass_hero_web/components/provider_components.ex:2380
+#: lib/klass_hero_web/components/provider_components.ex:2336
+#: lib/klass_hero_web/components/provider_components.ex:2365
+#: lib/klass_hero_web/components/provider_components.ex:2381
 #: lib/klass_hero_web/live/settings/children_live.ex:649
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -2073,15 +2073,15 @@ msgstr ""
 msgid "Provider data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:873
+#: lib/klass_hero_web/components/provider_components.ex:874
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:294
 #: lib/klass_hero_web/live/settings/children_live.ex:754
 #, elixir-autogen, elixir-format
 msgid "Save Changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1664
 #: lib/klass_hero_web/components/provider_components.ex:1665
+#: lib/klass_hero_web/components/provider_components.ex:1666
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:43
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:151
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:252
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "Send a message to start the conversation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2434
+#: lib/klass_hero_web/components/provider_components.ex:2435
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:249
 #, elixir-autogen, elixir-format
@@ -2205,12 +2205,12 @@ msgstr[1] ""
 msgid "%{gender} only"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:308
+#: lib/klass_hero_web/components/provider_components.ex:309
 #, elixir-autogen, elixir-format
 msgid "Action Required"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:875
+#: lib/klass_hero_web/components/provider_components.ex:876
 #, elixir-autogen, elixir-format
 msgid "Add Member"
 msgstr ""
@@ -2230,12 +2230,12 @@ msgstr ""
 msgid "Ages %{min}+"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1148
+#: lib/klass_hero_web/components/provider_components.ex:1149
 #, elixir-autogen, elixir-format
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2493
+#: lib/klass_hero_web/components/provider_components.ex:2494
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred during import."
 msgstr ""
@@ -2248,7 +2248,7 @@ msgid "Approve"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:826
-#: lib/klass_hero_web/components/provider_components.ex:47
+#: lib/klass_hero_web/components/provider_components.ex:48
 #: lib/klass_hero_web/live/admin/sessions_live.ex:294
 #: lib/klass_hero_web/live/admin/verifications_live.ex:202
 #: lib/klass_hero_web/presenters/vetting_checklist_presenter.ex:141
@@ -2278,7 +2278,7 @@ msgstr ""
 msgid "Back to verifications"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:727
+#: lib/klass_hero_web/components/provider_components.ex:728
 #, elixir-autogen, elixir-format
 msgid "Bio"
 msgstr ""
@@ -2288,7 +2288,7 @@ msgstr ""
 msgid "Book a Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:728
+#: lib/klass_hero_web/components/provider_components.ex:729
 #, elixir-autogen, elixir-format
 msgid "Brief description of experience and specialties..."
 msgstr ""
@@ -2319,19 +2319,19 @@ msgstr ""
 msgid "Business Logo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:959
+#: lib/klass_hero_web/components/provider_components.ex:960
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "Category"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1097
+#: lib/klass_hero_web/components/provider_components.ex:1098
 #, elixir-autogen, elixir-format
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2022
-#: lib/klass_hero_web/components/provider_components.ex:2248
+#: lib/klass_hero_web/components/provider_components.ex:2023
+#: lib/klass_hero_web/components/provider_components.ex:2249
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2346,7 +2346,7 @@ msgstr ""
 msgid "Child meets all program requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1258
+#: lib/klass_hero_web/components/provider_components.ex:1259
 #, elixir-autogen, elixir-format
 msgid "Choose Image"
 msgstr ""
@@ -2356,17 +2356,17 @@ msgstr ""
 msgid "Choose Logo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:852
+#: lib/klass_hero_web/components/provider_components.ex:853
 #, elixir-autogen, elixir-format
 msgid "Choose Photo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:961
+#: lib/klass_hero_web/components/provider_components.ex:962
 #, elixir-autogen, elixir-format
 msgid "Choose a category"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:427
+#: lib/klass_hero_web/components/provider_components.ex:428
 #, elixir-autogen, elixir-format
 msgid "Complete business verification to create programs."
 msgstr ""
@@ -2376,7 +2376,7 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2454
+#: lib/klass_hero_web/components/provider_components.ex:2455
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
@@ -2396,22 +2396,22 @@ msgstr ""
 msgid "Could not remove invite."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1214
+#: lib/klass_hero_web/components/provider_components.ex:1215
 #, elixir-autogen, elixir-format
 msgid "Cover Image"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1091
+#: lib/klass_hero_web/components/provider_components.ex:1092
 #, elixir-autogen, elixir-format
 msgid "Define age, gender, or grade restrictions for eligible participants."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1207
+#: lib/klass_hero_web/components/provider_components.ex:1208
 #, elixir-autogen, elixir-format
 msgid "Describe your program..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1206
+#: lib/klass_hero_web/components/provider_components.ex:1207
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:323
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:285
 #, elixir-autogen, elixir-format
@@ -2419,13 +2419,13 @@ msgid "Description"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:684
-#: lib/klass_hero_web/components/provider_components.ex:1159
+#: lib/klass_hero_web/components/provider_components.ex:1160
 #: lib/klass_hero_web/live/settings/children_live.ex:670
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2591
+#: lib/klass_hero_web/components/provider_components.ex:2670
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2459,7 +2459,7 @@ msgstr ""
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2215
+#: lib/klass_hero_web/components/provider_components.ex:2216
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
@@ -2469,40 +2469,40 @@ msgstr ""
 msgid "Download document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:927
+#: lib/klass_hero_web/components/provider_components.ex:928
 #, elixir-autogen, elixir-format
 msgid "Edit Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:669
+#: lib/klass_hero_web/components/provider_components.ex:670
 #, elixir-autogen, elixir-format
 msgid "Edit Team Member"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1036
+#: lib/klass_hero_web/components/provider_components.ex:1037
 #, elixir-autogen, elixir-format
 msgid "End Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1023
+#: lib/klass_hero_web/components/provider_components.ex:1024
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:166
 #, elixir-autogen, elixir-format
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2028
-#: lib/klass_hero_web/components/provider_components.ex:2474
+#: lib/klass_hero_web/components/provider_components.ex:2029
+#: lib/klass_hero_web/components/provider_components.ex:2475
 #: lib/klass_hero_web/components/provider_layout_components.ex:644
 #, elixir-autogen, elixir-format
 msgid "Enrolled"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1710
+#: lib/klass_hero_web/components/provider_components.ex:1711
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1064
+#: lib/klass_hero_web/components/provider_components.ex:1065
 #, elixir-autogen, elixir-format
 msgid "Enrollment Capacity (optional)"
 msgstr ""
@@ -2512,8 +2512,8 @@ msgstr ""
 msgid "Explain why this document is being rejected..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:70
-#: lib/klass_hero_web/components/provider_components.ex:2475
+#: lib/klass_hero_web/components/provider_components.ex:71
+#: lib/klass_hero_web/components/provider_components.ex:2476
 #: lib/klass_hero_web/live/admin/emails_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2546,7 +2546,7 @@ msgid "Family Programs"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:682
-#: lib/klass_hero_web/components/provider_components.ex:1158
+#: lib/klass_hero_web/components/provider_components.ex:1159
 #: lib/klass_hero_web/live/settings/children_live.ex:669
 #, elixir-autogen, elixir-format
 msgid "Female"
@@ -2557,22 +2557,22 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2525
+#: lib/klass_hero_web/components/provider_components.ex:2604
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2527
+#: lib/klass_hero_web/components/provider_components.ex:2606
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:755
+#: lib/klass_hero_web/components/provider_components.ex:756
 #, elixir-autogen, elixir-format
 msgid "First Aid, UEFA B License, Child Care Cert"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:697
+#: lib/klass_hero_web/components/provider_components.ex:698
 #, elixir-autogen, elixir-format
 msgid "First Name"
 msgstr ""
@@ -2597,12 +2597,12 @@ msgstr ""
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2251
+#: lib/klass_hero_web/components/provider_components.ex:2252
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:816
+#: lib/klass_hero_web/components/provider_components.ex:817
 #, elixir-autogen, elixir-format
 msgid "Headshot Photo"
 msgstr ""
@@ -2612,7 +2612,7 @@ msgstr ""
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2188
+#: lib/klass_hero_web/components/provider_components.ex:2189
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -2637,17 +2637,17 @@ msgstr ""
 msgid "Invite resent successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1727
+#: lib/klass_hero_web/components/provider_components.ex:1728
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:855
+#: lib/klass_hero_web/components/provider_components.ex:856
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 1MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1261
+#: lib/klass_hero_web/components/provider_components.ex:1262
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:277
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:361
 #, elixir-autogen, elixir-format
@@ -2664,22 +2664,22 @@ msgstr ""
 msgid "Klasse %{n}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:703
+#: lib/klass_hero_web/components/provider_components.ex:704
 #, elixir-autogen, elixir-format
 msgid "Last Name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1046
+#: lib/klass_hero_web/components/provider_components.ex:1047
 #, elixir-autogen, elixir-format
 msgid "Leave blank for open registration at any time."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1151
+#: lib/klass_hero_web/components/provider_components.ex:1152
 #, elixir-autogen, elixir-format
 msgid "Leave unchecked to allow all genders."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:979
+#: lib/klass_hero_web/components/provider_components.ex:980
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Location"
@@ -2692,43 +2692,43 @@ msgid "Logo upload failed. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:683
-#: lib/klass_hero_web/components/provider_components.ex:1157
+#: lib/klass_hero_web/components/provider_components.ex:1158
 #: lib/klass_hero_web/live/settings/children_live.ex:668
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1141
+#: lib/klass_hero_web/components/provider_components.ex:1142
 #, elixir-autogen, elixir-format
 msgid "Maximum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1079
+#: lib/klass_hero_web/components/provider_components.ex:1080
 #, elixir-autogen, elixir-format
 msgid "Maximum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1196
+#: lib/klass_hero_web/components/provider_components.ex:1197
 #, elixir-autogen, elixir-format
 msgid "Maximum Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:988
+#: lib/klass_hero_web/components/provider_components.ex:989
 #, elixir-autogen, elixir-format
 msgid "Meeting Days"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1135
+#: lib/klass_hero_web/components/provider_components.ex:1136
 #, elixir-autogen, elixir-format
 msgid "Minimum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1073
+#: lib/klass_hero_web/components/provider_components.ex:1074
 #, elixir-autogen, elixir-format
 msgid "Minimum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1189
+#: lib/klass_hero_web/components/provider_components.ex:1190
 #, elixir-autogen, elixir-format
 msgid "Minimum Grade"
 msgstr ""
@@ -2738,12 +2738,12 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2553
+#: lib/klass_hero_web/components/provider_components.ex:2632
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2015
+#: lib/klass_hero_web/components/provider_components.ex:2016
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
@@ -2759,17 +2759,17 @@ msgstr ""
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2239
+#: lib/klass_hero_web/components/provider_components.ex:2240
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1198
+#: lib/klass_hero_web/components/provider_components.ex:1199
 #, elixir-autogen, elixir-format
 msgid "No maximum"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1191
+#: lib/klass_hero_web/components/provider_components.ex:1192
 #, elixir-autogen, elixir-format
 msgid "No minimum"
 msgstr ""
@@ -2800,18 +2800,18 @@ msgstr ""
 msgid "No verification documents found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1273
+#: lib/klass_hero_web/components/provider_components.ex:1274
 #, elixir-autogen, elixir-format
 msgid "None (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:324
+#: lib/klass_hero_web/components/provider_components.ex:325
 #, elixir-autogen, elixir-format
 msgid "Not Verified"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:685
-#: lib/klass_hero_web/components/provider_components.ex:1160
+#: lib/klass_hero_web/components/provider_components.ex:1161
 #: lib/klass_hero_web/live/settings/children_live.ex:667
 #, elixir-autogen, elixir-format
 msgid "Not specified"
@@ -2822,7 +2822,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2628
+#: lib/klass_hero_web/components/provider_components.ex:2707
 #: lib/klass_hero_web/live/provider/verification_live.ex:698
 #: lib/klass_hero_web/live/provider/verification_live.ex:770
 #, elixir-autogen, elixir-format
@@ -2834,13 +2834,13 @@ msgstr ""
 msgid "Participant Requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1088
+#: lib/klass_hero_web/components/provider_components.ex:1089
 #, elixir-autogen, elixir-format
 msgid "Participant Restrictions (optional)"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:825
-#: lib/klass_hero_web/components/provider_components.ex:292
+#: lib/klass_hero_web/components/provider_components.ex:293
 #, elixir-autogen, elixir-format
 msgid "Pending Review"
 msgstr ""
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Preview not available for this file type."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:970
+#: lib/klass_hero_web/components/provider_components.ex:971
 #, elixir-autogen, elixir-format
 msgid "Price (EUR)"
 msgstr ""
@@ -2878,7 +2878,7 @@ msgstr ""
 msgid "Profile updated successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1126
+#: lib/klass_hero_web/components/provider_components.ex:1127
 #, elixir-autogen, elixir-format
 msgid "Program Start"
 msgstr ""
@@ -2920,13 +2920,13 @@ msgid "Read our founding story →"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:805
-#: lib/klass_hero_web/components/provider_components.ex:2473
+#: lib/klass_hero_web/components/provider_components.ex:2474
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Registered"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1113
+#: lib/klass_hero_web/components/provider_components.ex:1114
 #, elixir-autogen, elixir-format
 msgid "Registration"
 msgstr ""
@@ -2936,7 +2936,7 @@ msgstr ""
 msgid "Registration Closed"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1057
+#: lib/klass_hero_web/components/provider_components.ex:1058
 #, elixir-autogen, elixir-format
 msgid "Registration Closes"
 msgstr ""
@@ -2946,12 +2946,12 @@ msgstr ""
 msgid "Registration Not Open Yet"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1052
+#: lib/klass_hero_web/components/provider_components.ex:1053
 #, elixir-autogen, elixir-format
 msgid "Registration Opens"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1043
+#: lib/klass_hero_web/components/provider_components.ex:1044
 #, elixir-autogen, elixir-format
 msgid "Registration Period (optional)"
 msgstr ""
@@ -2988,7 +2988,7 @@ msgid "Reject"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:827
-#: lib/klass_hero_web/components/provider_components.ex:48
+#: lib/klass_hero_web/components/provider_components.ex:49
 #: lib/klass_hero_web/live/admin/verifications_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Rejected"
@@ -3000,18 +3000,18 @@ msgstr ""
 msgid "Rejection reason"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:838
-#: lib/klass_hero_web/components/provider_components.ex:1237
-#: lib/klass_hero_web/components/provider_components.ex:2295
-#: lib/klass_hero_web/components/provider_components.ex:2647
+#: lib/klass_hero_web/components/provider_components.ex:839
+#: lib/klass_hero_web/components/provider_components.ex:1238
+#: lib/klass_hero_web/components/provider_components.ex:2296
 #: lib/klass_hero_web/components/provider_components.ex:2726
+#: lib/klass_hero_web/components/provider_components.ex:2805
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:253
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2288
+#: lib/klass_hero_web/components/provider_components.ex:2289
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -3021,23 +3021,23 @@ msgstr ""
 msgid "Reviewed"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:712
+#: lib/klass_hero_web/components/provider_components.ex:713
 #, elixir-autogen, elixir-format
 msgid "Role"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1656
+#: lib/klass_hero_web/components/provider_components.ex:1657
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:386
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1300
+#: lib/klass_hero_web/components/provider_components.ex:1301
 #, elixir-autogen, elixir-format
 msgid "Save Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:985
+#: lib/klass_hero_web/components/provider_components.ex:986
 #, elixir-autogen, elixir-format
 msgid "Schedule (optional)"
 msgstr ""
@@ -3052,7 +3052,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2625
+#: lib/klass_hero_web/components/provider_components.ex:2704
 #, elixir-autogen, elixir-format
 msgid "Select File"
 msgstr ""
@@ -3069,23 +3069,23 @@ msgstr ""
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2472
+#: lib/klass_hero_web/components/provider_components.ex:2473
 #: lib/klass_hero_web/live/admin/emails_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Sent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:759
+#: lib/klass_hero_web/components/provider_components.ex:760
 #, elixir-autogen, elixir-format
 msgid "Separate multiple qualifications with commas"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1067
+#: lib/klass_hero_web/components/provider_components.ex:1068
 #, elixir-autogen, elixir-format
 msgid "Set minimum and maximum enrollment for this program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:733
+#: lib/klass_hero_web/components/provider_components.ex:734
 #, elixir-autogen, elixir-format
 msgid "Specialties"
 msgstr ""
@@ -3103,12 +3103,12 @@ msgstr ""
 msgid "Staff member not found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1031
+#: lib/klass_hero_web/components/provider_components.ex:1032
 #, elixir-autogen, elixir-format
 msgid "Start Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1018
+#: lib/klass_hero_web/components/provider_components.ex:1019
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Start Time"
@@ -3174,12 +3174,12 @@ msgstr ""
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:952
+#: lib/klass_hero_web/components/provider_components.ex:953
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2526
+#: lib/klass_hero_web/components/provider_components.ex:2605
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -3199,32 +3199,32 @@ msgstr ""
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2174
+#: lib/klass_hero_web/components/provider_components.ex:2175
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2671
+#: lib/klass_hero_web/components/provider_components.ex:2750
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2580
+#: lib/klass_hero_web/components/provider_components.ex:2659
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2548
+#: lib/klass_hero_web/components/provider_components.ex:2627
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2528
+#: lib/klass_hero_web/components/provider_components.ex:2607
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2545
+#: lib/klass_hero_web/components/provider_components.ex:2624
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -3246,7 +3246,7 @@ msgstr ""
 msgid "Verifications"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:276
+#: lib/klass_hero_web/components/provider_components.ex:277
 #: lib/klass_hero_web/components/provider_layout_components.ex:212
 #: lib/klass_hero_web/components/ui_components.ex:1930
 #, elixir-autogen, elixir-format
@@ -3263,32 +3263,32 @@ msgstr ""
 msgid "You don't have access to that page."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:713
+#: lib/klass_hero_web/components/provider_components.ex:714
 #, elixir-autogen, elixir-format
 msgid "e.g. Head Coach"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:704
+#: lib/klass_hero_web/components/provider_components.ex:705
 #, elixir-autogen, elixir-format
 msgid "e.g. Johnson"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:698
+#: lib/klass_hero_web/components/provider_components.ex:699
 #, elixir-autogen, elixir-format
 msgid "e.g. Mike"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:719
+#: lib/klass_hero_web/components/provider_components.ex:720
 #, elixir-autogen, elixir-format
 msgid "e.g. mike@example.com"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:953
+#: lib/klass_hero_web/components/provider_components.ex:954
 #, elixir-autogen, elixir-format
 msgid "e.g., Art Adventures"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:980
+#: lib/klass_hero_web/components/provider_components.ex:981
 #, elixir-autogen, elixir-format
 msgid "e.g., Community Center, Main St"
 msgstr ""
@@ -3314,7 +3314,7 @@ msgid "Child Safeguarding Training"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1498
-#: lib/klass_hero_web/components/provider_components.ex:2893
+#: lib/klass_hero_web/components/provider_components.ex:2972
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr ""
@@ -3464,7 +3464,7 @@ msgid "Vetted with Care"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1482
-#: lib/klass_hero_web/components/provider_components.ex:2678
+#: lib/klass_hero_web/components/provider_components.ex:2757
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr ""
@@ -3638,7 +3638,7 @@ msgstr ""
 msgid "Checked Out"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2331
+#: lib/klass_hero_web/components/provider_components.ex:2332
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Child"
@@ -3691,7 +3691,7 @@ msgstr ""
 msgid "Download monthly statements for taxes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2092
+#: lib/klass_hero_web/components/provider_components.ex:2093
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "Enrollment not confirmed"
@@ -3769,7 +3769,7 @@ msgstr ""
 msgid "No chasing payments or sending invoices"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1679
+#: lib/klass_hero_web/components/provider_components.ex:1680
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:407
 #, elixir-autogen, elixir-format
 msgid "No enrolled parents"
@@ -3792,7 +3792,7 @@ msgstr ""
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2091
+#: lib/klass_hero_web/components/provider_components.ex:2092
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -4475,7 +4475,7 @@ msgstr ""
 msgid "Reply sent successfully"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:552
+#: lib/klass_hero_web/components/provider_components.ex:553
 #, elixir-autogen, elixir-format
 msgid "Resend"
 msgstr ""
@@ -4900,43 +4900,43 @@ msgstr ""
 msgid "for"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1800
+#: lib/klass_hero_web/components/provider_components.ex:1801
 #, elixir-autogen, elixir-format
 msgid "Assigned staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1802
+#: lib/klass_hero_web/components/provider_components.ex:1803
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1784
-#: lib/klass_hero_web/components/provider_components.ex:1873
+#: lib/klass_hero_web/components/provider_components.ex:1785
+#: lib/klass_hero_web/components/provider_components.ex:1874
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1801
+#: lib/klass_hero_web/components/provider_components.ex:1802
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1799
+#: lib/klass_hero_web/components/provider_components.ex:1800
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1793
+#: lib/klass_hero_web/components/provider_components.ex:1794
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1782
+#: lib/klass_hero_web/components/provider_components.ex:1783
 #, elixir-autogen, elixir-format
 msgid "Sessions — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1522
+#: lib/klass_hero_web/components/provider_components.ex:1523
 #, elixir-autogen, elixir-format
 msgid "View sessions"
 msgstr ""
@@ -4968,17 +4968,17 @@ msgstr ""
 msgid "Failed to update record"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2395
+#: lib/klass_hero_web/components/provider_components.ex:2396
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2114
+#: lib/klass_hero_web/components/provider_components.ex:2115
 #, elixir-autogen, elixir-format
 msgid "Invite mode"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2133
+#: lib/klass_hero_web/components/provider_components.ex:2134
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr ""
@@ -4993,12 +4993,12 @@ msgstr ""
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2408
+#: lib/klass_hero_web/components/provider_components.ex:2409
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2414
+#: lib/klass_hero_web/components/provider_components.ex:2415
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr ""
@@ -5009,17 +5009,17 @@ msgstr ""
 msgid "Nothing to update"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2416
+#: lib/klass_hero_web/components/provider_components.ex:2417
 #, elixir-autogen, elixir-format
 msgid "Nut allergy"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2420
+#: lib/klass_hero_web/components/provider_components.ex:2421
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2425
+#: lib/klass_hero_web/components/provider_components.ex:2426
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr ""
@@ -5029,7 +5029,7 @@ msgstr ""
 msgid "Present"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2352
+#: lib/klass_hero_web/components/provider_components.ex:2353
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr ""
@@ -5056,22 +5056,22 @@ msgstr ""
 msgid "Save changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2389
+#: lib/klass_hero_web/components/provider_components.ex:2390
 #, elixir-autogen, elixir-format
 msgid "School (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2399
+#: lib/klass_hero_web/components/provider_components.ex:2400
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2373
+#: lib/klass_hero_web/components/provider_components.ex:2374
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2442
+#: lib/klass_hero_web/components/provider_components.ex:2443
 #, elixir-autogen, elixir-format
 msgid "Send invite"
 msgstr ""
@@ -5081,7 +5081,7 @@ msgstr ""
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2151
+#: lib/klass_hero_web/components/provider_components.ex:2152
 #, elixir-autogen, elixir-format
 msgid "Upload a list"
 msgstr ""
@@ -5116,7 +5116,7 @@ msgstr ""
 msgid "High"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:786
+#: lib/klass_hero_web/components/provider_components.ex:787
 #, elixir-autogen, elixir-format
 msgid "Hourly"
 msgstr ""
@@ -5141,22 +5141,22 @@ msgstr ""
 msgid "Medium"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:776
+#: lib/klass_hero_web/components/provider_components.ex:777
 #, elixir-autogen, elixir-format
 msgid "None"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:765
+#: lib/klass_hero_web/components/provider_components.ex:766
 #, elixir-autogen, elixir-format
 msgid "Pay Rate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:523
+#: lib/klass_hero_web/components/provider_components.ex:524
 #, elixir-autogen, elixir-format
 msgid "Pay rate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:796
+#: lib/klass_hero_web/components/provider_components.ex:797
 #, elixir-autogen, elixir-format
 msgid "Per Session"
 msgstr ""
@@ -5181,7 +5181,7 @@ msgstr ""
 msgid "Property Damage"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1552
+#: lib/klass_hero_web/components/provider_components.ex:1553
 #, elixir-autogen, elixir-format
 msgid "Report Incident"
 msgstr ""
@@ -5863,7 +5863,7 @@ msgstr[1] ""
 msgid "In 2025, Shane connected with his friend"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1561
+#: lib/klass_hero_web/components/provider_components.ex:1562
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:43
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:74
 #, elixir-autogen, elixir-format
@@ -5933,7 +5933,7 @@ msgstr ""
 msgid "Last 8 weeks"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1271
+#: lib/klass_hero_web/components/provider_components.ex:1272
 #: lib/klass_hero_web/presenters/hero_cards_presenter.ex:27
 #, elixir-autogen, elixir-format
 msgid "Lead Instructor"
@@ -6383,17 +6383,17 @@ msgstr ""
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2481
+#: lib/klass_hero_web/components/provider_components.ex:2482
 #, elixir-autogen, elixir-format
 msgid "Row %{row}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2481
+#: lib/klass_hero_web/components/provider_components.ex:2482
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2227
+#: lib/klass_hero_web/components/provider_components.ex:2228
 #, elixir-autogen, elixir-format
 msgid "Rows with errors"
 msgstr ""
@@ -7005,7 +7005,7 @@ msgstr ""
 msgid "Identity verifications"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:71
+#: lib/klass_hero_web/components/provider_components.ex:72
 #, elixir-autogen, elixir-format
 msgid "In progress"
 msgstr ""
@@ -7035,7 +7035,7 @@ msgstr ""
 msgid "Not started"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:69
+#: lib/klass_hero_web/components/provider_components.ex:70
 #, elixir-autogen, elixir-format
 msgid "Passed"
 msgstr ""
@@ -7152,12 +7152,12 @@ msgstr ""
 msgid "Experience validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2707
+#: lib/klass_hero_web/components/provider_components.ex:2786
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2681
+#: lib/klass_hero_web/components/provider_components.ex:2760
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
@@ -7167,12 +7167,12 @@ msgstr ""
 msgid "Safeguarding certificate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2704
+#: lib/klass_hero_web/components/provider_components.ex:2783
 #, elixir-autogen, elixir-format
 msgid "Select Video"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2750
+#: lib/klass_hero_web/components/provider_components.ex:2829
 #, elixir-autogen, elixir-format
 msgid "Upload Video"
 msgstr ""
@@ -7182,7 +7182,7 @@ msgstr ""
 msgid "Your browser does not support video playback."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2897
+#: lib/klass_hero_web/components/provider_components.ex:2976
 #, elixir-autogen, elixir-format
 msgid "Confirm agreement"
 msgstr ""
@@ -7192,12 +7192,12 @@ msgstr ""
 msgid "Couldn't record your agreement. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2920
+#: lib/klass_hero_web/components/provider_components.ex:2999
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2896
+#: lib/klass_hero_web/components/provider_components.ex:2975
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr ""
@@ -7207,7 +7207,7 @@ msgstr ""
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2805
+#: lib/klass_hero_web/components/provider_components.ex:2884
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr ""
@@ -7217,17 +7217,17 @@ msgstr ""
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2905
+#: lib/klass_hero_web/components/provider_components.ex:2984
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2894
+#: lib/klass_hero_web/components/provider_components.ex:2973
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2895
+#: lib/klass_hero_web/components/provider_components.ex:2974
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
@@ -7496,12 +7496,12 @@ msgstr ""
 msgid "Your insurance is verified."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2849
+#: lib/klass_hero_web/components/provider_components.ex:2928
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2952
+#: lib/klass_hero_web/components/provider_components.ex:3031
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr ""
@@ -7511,7 +7511,7 @@ msgstr ""
 msgid "Couldn't record your declaration. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2958
+#: lib/klass_hero_web/components/provider_components.ex:3037
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr ""
@@ -7521,17 +7521,17 @@ msgstr ""
 msgid "Please confirm the declaration before signing."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2983
+#: lib/klass_hero_web/components/provider_components.ex:3062
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2962
+#: lib/klass_hero_web/components/provider_components.ex:3041
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2950
+#: lib/klass_hero_web/components/provider_components.ex:3029
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr ""
@@ -7541,12 +7541,12 @@ msgstr ""
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2970
+#: lib/klass_hero_web/components/provider_components.ex:3049
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2956
+#: lib/klass_hero_web/components/provider_components.ex:3035
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
@@ -7613,12 +7613,12 @@ msgstr ""
 msgid "Undelivered Events"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1970
+#: lib/klass_hero_web/components/provider_components.ex:1971
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1895
+#: lib/klass_hero_web/components/provider_components.ex:1896
 #, elixir-autogen, elixir-format
 msgid "Lead"
 msgstr ""
@@ -7628,17 +7628,17 @@ msgstr ""
 msgid "Lead instructor updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1906
+#: lib/klass_hero_web/components/provider_components.ex:1907
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1536
+#: lib/klass_hero_web/components/provider_components.ex:1537
 #, elixir-autogen, elixir-format
 msgid "Manage Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1934
+#: lib/klass_hero_web/components/provider_components.ex:1935
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this program yet."
 msgstr ""
@@ -7648,17 +7648,17 @@ msgstr ""
 msgid "Pick a staff member to add."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1917
+#: lib/klass_hero_web/components/provider_components.ex:1918
 #, elixir-autogen, elixir-format
 msgid "Reassign the lead before removing them"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1918
+#: lib/klass_hero_web/components/provider_components.ex:1919
 #, elixir-autogen, elixir-format
 msgid "Remove from program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1952
+#: lib/klass_hero_web/components/provider_components.ex:1953
 #, elixir-autogen, elixir-format
 msgid "Select a staff member…"
 msgstr ""
@@ -7673,12 +7673,12 @@ msgstr ""
 msgid "Staff member removed from the program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1975
+#: lib/klass_hero_web/components/provider_components.ex:1976
 #, elixir-autogen, elixir-format
 msgid "Staff you add can read and reply to this program's parent conversations."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1871
+#: lib/klass_hero_web/components/provider_components.ex:1872
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{title}"
 msgstr ""
@@ -7698,19 +7698,19 @@ msgstr ""
 msgid "This person is the lead instructor. Make someone else lead before removing them."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1480
+#: lib/klass_hero_web/components/provider_components.ex:1481
 #, elixir-autogen, elixir-format
 msgid "%{count} staff member · no lead"
 msgid_plural "%{count} staff · no lead"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/components/provider_components.ex:562
+#: lib/klass_hero_web/components/provider_components.ex:563
 #, elixir-autogen, elixir-format
 msgid "%{name} will be unassigned from every program and removed from those conversations. Their history is kept and you can add them back later."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:638
+#: lib/klass_hero_web/components/provider_components.ex:639
 #, elixir-autogen, elixir-format
 msgid "Add back to team"
 msgstr ""
@@ -7720,7 +7720,7 @@ msgstr ""
 msgid "Could not bring this team member back. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:600
+#: lib/klass_hero_web/components/provider_components.ex:601
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr ""
@@ -7730,7 +7730,7 @@ msgstr ""
 msgid "Former team members"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:574
+#: lib/klass_hero_web/components/provider_components.ex:575
 #, elixir-autogen, elixir-format
 msgid "Remove from team"
 msgstr ""
@@ -7745,7 +7745,7 @@ msgstr ""
 msgid "Team member removed from the team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:590
+#: lib/klass_hero_web/components/provider_components.ex:591
 #, elixir-autogen, elixir-format
 msgid "This deletes %{name} permanently — there's nothing to undo. Use it only for an entry added by mistake."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -45,7 +45,7 @@ msgstr ""
 #: lib/klass_hero_web/components/layouts/app.html.heex:129
 #: lib/klass_hero_web/components/layouts/app.html.heex:204
 #: lib/klass_hero_web/components/layouts/app.html.heex:229
-#: lib/klass_hero_web/components/provider_components.ex:389
+#: lib/klass_hero_web/components/provider_components.ex:390
 #: lib/klass_hero_web/components/ui_components.ex:268
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
@@ -137,7 +137,7 @@ msgid "Your Data"
 msgstr ""
 
 #: lib/klass_hero_web/components/core_components.ex:67
-#: lib/klass_hero_web/components/provider_components.ex:1686
+#: lib/klass_hero_web/components/provider_components.ex:1687
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr ""
@@ -232,7 +232,7 @@ msgstr ""
 msgid "Enroll Now - %{price}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1437
+#: lib/klass_hero_web/components/provider_components.ex:1438
 #: lib/klass_hero_web/live/booking_live.ex:285
 #, elixir-autogen, elixir-format
 msgid "Enrollment"
@@ -577,9 +577,9 @@ msgstr ""
 msgid "Dispute Resolution"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:718
-#: lib/klass_hero_web/components/provider_components.ex:2359
-#: lib/klass_hero_web/components/provider_components.ex:2377
+#: lib/klass_hero_web/components/provider_components.ex:719
+#: lib/klass_hero_web/components/provider_components.ex:2360
+#: lib/klass_hero_web/components/provider_components.ex:2378
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
@@ -878,9 +878,9 @@ msgstr ""
 msgid "Select one or both options"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2055
 #: lib/klass_hero_web/components/provider_components.ex:2056
-#: lib/klass_hero_web/components/provider_components.ex:2093
+#: lib/klass_hero_web/components/provider_components.ex:2057
+#: lib/klass_hero_web/components/provider_components.ex:2094
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:448
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:484
@@ -1324,7 +1324,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/composite_components.ex:103
 #: lib/klass_hero_web/components/layouts/admin.html.heex:71
-#: lib/klass_hero_web/components/provider_components.ex:119
+#: lib/klass_hero_web/components/provider_components.ex:120
 #: lib/klass_hero_web/live/admin/sessions_live.ex:26
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:3
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:348
@@ -1456,7 +1456,7 @@ msgstr ""
 msgid "Music"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:754
+#: lib/klass_hero_web/components/provider_components.ex:755
 #: lib/klass_hero_web/live/for_providers_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "Qualifications"
@@ -1577,19 +1577,19 @@ msgstr ""
 msgid "Quick Navigation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1440
-#: lib/klass_hero_web/components/provider_components.ex:2031
-#: lib/klass_hero_web/components/provider_components.ex:2257
+#: lib/klass_hero_web/components/provider_components.ex:1441
+#: lib/klass_hero_web/components/provider_components.ex:2032
+#: lib/klass_hero_web/components/provider_components.ex:2258
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1579
+#: lib/klass_hero_web/components/provider_components.ex:1580
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Active"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:671
+#: lib/klass_hero_web/components/provider_components.ex:672
 #: lib/klass_hero_web/live/provider/team_live.ex:627
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
@@ -1600,7 +1600,7 @@ msgstr ""
 msgid "All Staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1431
+#: lib/klass_hero_web/components/provider_components.ex:1432
 #, elixir-autogen, elixir-format
 msgid "Assigned Staff"
 msgstr ""
@@ -1611,7 +1611,7 @@ msgstr ""
 msgid "Book Now"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:205
+#: lib/klass_hero_web/components/provider_components.ex:206
 #, elixir-autogen, elixir-format
 msgid "Business Profile"
 msgstr ""
@@ -1627,8 +1627,8 @@ msgstr ""
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:538
-#: lib/klass_hero_web/components/provider_components.ex:1542
+#: lib/klass_hero_web/components/provider_components.ex:539
+#: lib/klass_hero_web/components/provider_components.ex:1543
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:54
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:81
 #: lib/klass_hero_web/live/settings/children_live.ex:448
@@ -1638,57 +1638,57 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:223
+#: lib/klass_hero_web/components/provider_components.ex:224
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:31
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "Edit Profile"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1581
+#: lib/klass_hero_web/components/provider_components.ex:1582
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:112
+#: lib/klass_hero_web/components/provider_components.ex:113
 #: lib/klass_hero_web/live/provider/programs_live.ex:54
 #, elixir-autogen, elixir-format, fuzzy
 msgid "My Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:415
-#: lib/klass_hero_web/components/provider_components.ex:929
+#: lib/klass_hero_web/components/provider_components.ex:416
+#: lib/klass_hero_web/components/provider_components.ex:930
 #, elixir-autogen, elixir-format, fuzzy
 msgid "New Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:98
+#: lib/klass_hero_web/components/provider_components.ex:99
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:46
-#: lib/klass_hero_web/components/provider_components.ex:72
-#: lib/klass_hero_web/components/provider_components.ex:1580
-#: lib/klass_hero_web/components/provider_components.ex:2453
-#: lib/klass_hero_web/components/provider_components.ex:2471
+#: lib/klass_hero_web/components/provider_components.ex:47
+#: lib/klass_hero_web/components/provider_components.ex:73
+#: lib/klass_hero_web/components/provider_components.ex:1581
+#: lib/klass_hero_web/components/provider_components.ex:2454
+#: lib/klass_hero_web/components/provider_components.ex:2472
 #: lib/klass_hero_web/live/admin/sessions_live.ex:297
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1518
+#: lib/klass_hero_web/components/provider_components.ex:1519
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1371
+#: lib/klass_hero_web/components/provider_components.ex:1372
 #, elixir-autogen, elixir-format
 msgid "Program Inventory"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1428
+#: lib/klass_hero_web/components/provider_components.ex:1429
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program Name"
 msgstr ""
@@ -1703,15 +1703,15 @@ msgstr ""
 msgid "Save for Later"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1388
+#: lib/klass_hero_web/components/provider_components.ex:1389
 #, elixir-autogen, elixir-format
 msgid "Search by name..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1434
-#: lib/klass_hero_web/components/provider_components.ex:1803
-#: lib/klass_hero_web/components/provider_components.ex:2025
-#: lib/klass_hero_web/components/provider_components.ex:2254
+#: lib/klass_hero_web/components/provider_components.ex:1435
+#: lib/klass_hero_web/components/provider_components.ex:1804
+#: lib/klass_hero_web/components/provider_components.ex:2026
+#: lib/klass_hero_web/components/provider_components.ex:2255
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1719,7 +1719,7 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:105
+#: lib/klass_hero_web/components/provider_components.ex:106
 #: lib/klass_hero_web/live/provider/team_live.ex:36
 #, elixir-autogen, elixir-format
 msgid "Team & Profiles"
@@ -1730,32 +1730,32 @@ msgstr ""
 msgid "Team & Provider Profiles"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:208
+#: lib/klass_hero_web/components/provider_components.ex:209
 #, elixir-autogen, elixir-format
 msgid "This is your main business identity. Verification is required to list programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1491
-#: lib/klass_hero_web/components/provider_components.ex:1818
+#: lib/klass_hero_web/components/provider_components.ex:1492
+#: lib/klass_hero_web/components/provider_components.ex:1819
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr ""
 
 #: lib/klass_hero_web/components/messaging_components.ex:728
-#: lib/klass_hero_web/components/provider_components.ex:49
-#: lib/klass_hero_web/components/provider_components.ex:1582
+#: lib/klass_hero_web/components/provider_components.ex:50
+#: lib/klass_hero_web/components/provider_components.ex:1583
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:434
 #: lib/klass_hero_web/presenters/provider_presenter.ex:103
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:400
+#: lib/klass_hero_web/components/provider_components.ex:401
 #, elixir-autogen, elixir-format
 msgid "Verified Business"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1529
+#: lib/klass_hero_web/components/provider_components.ex:1530
 #, elixir-autogen, elixir-format
 msgid "View Roster"
 msgstr ""
@@ -1815,9 +1815,9 @@ msgstr ""
 #: lib/klass_hero_web/components/participation_components.ex:441
 #: lib/klass_hero_web/components/participation_components.ex:631
 #: lib/klass_hero_web/components/participation_components.ex:717
-#: lib/klass_hero_web/components/provider_components.ex:888
-#: lib/klass_hero_web/components/provider_components.ex:1287
-#: lib/klass_hero_web/components/provider_components.ex:2196
+#: lib/klass_hero_web/components/provider_components.ex:889
+#: lib/klass_hero_web/components/provider_components.ex:1288
+#: lib/klass_hero_web/components/provider_components.ex:2197
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:478
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
@@ -1883,7 +1883,7 @@ msgstr ""
 msgid "Data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2340
+#: lib/klass_hero_web/components/provider_components.ex:2341
 #: lib/klass_hero_web/live/settings/children_live.ex:657
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1931,17 +1931,17 @@ msgstr ""
 msgid "Failed to submit note"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2334
-#: lib/klass_hero_web/components/provider_components.ex:2363
-#: lib/klass_hero_web/components/provider_components.ex:2379
+#: lib/klass_hero_web/components/provider_components.ex:2335
+#: lib/klass_hero_web/components/provider_components.ex:2364
+#: lib/klass_hero_web/components/provider_components.ex:2380
 #: lib/klass_hero_web/live/settings/children_live.ex:643
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2335
-#: lib/klass_hero_web/components/provider_components.ex:2364
-#: lib/klass_hero_web/components/provider_components.ex:2380
+#: lib/klass_hero_web/components/provider_components.ex:2336
+#: lib/klass_hero_web/components/provider_components.ex:2365
+#: lib/klass_hero_web/components/provider_components.ex:2381
 #: lib/klass_hero_web/live/settings/children_live.ex:649
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -2073,15 +2073,15 @@ msgstr ""
 msgid "Provider data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:873
+#: lib/klass_hero_web/components/provider_components.ex:874
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:294
 #: lib/klass_hero_web/live/settings/children_live.ex:754
 #, elixir-autogen, elixir-format
 msgid "Save Changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1664
 #: lib/klass_hero_web/components/provider_components.ex:1665
+#: lib/klass_hero_web/components/provider_components.ex:1666
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:43
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:151
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:252
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "Send a message to start the conversation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2434
+#: lib/klass_hero_web/components/provider_components.ex:2435
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:249
 #, elixir-autogen, elixir-format, fuzzy
@@ -2205,12 +2205,12 @@ msgstr[1] ""
 msgid "%{gender} only"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:308
+#: lib/klass_hero_web/components/provider_components.ex:309
 #, elixir-autogen, elixir-format
 msgid "Action Required"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:875
+#: lib/klass_hero_web/components/provider_components.ex:876
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add Member"
 msgstr ""
@@ -2230,12 +2230,12 @@ msgstr ""
 msgid "Ages %{min}+"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1148
+#: lib/klass_hero_web/components/provider_components.ex:1149
 #, elixir-autogen, elixir-format
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2493
+#: lib/klass_hero_web/components/provider_components.ex:2494
 #, elixir-autogen, elixir-format, fuzzy
 msgid "An unexpected error occurred during import."
 msgstr ""
@@ -2248,7 +2248,7 @@ msgid "Approve"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:826
-#: lib/klass_hero_web/components/provider_components.ex:47
+#: lib/klass_hero_web/components/provider_components.ex:48
 #: lib/klass_hero_web/live/admin/sessions_live.ex:294
 #: lib/klass_hero_web/live/admin/verifications_live.ex:202
 #: lib/klass_hero_web/presenters/vetting_checklist_presenter.ex:141
@@ -2278,7 +2278,7 @@ msgstr ""
 msgid "Back to verifications"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:727
+#: lib/klass_hero_web/components/provider_components.ex:728
 #, elixir-autogen, elixir-format
 msgid "Bio"
 msgstr ""
@@ -2288,7 +2288,7 @@ msgstr ""
 msgid "Book a Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:728
+#: lib/klass_hero_web/components/provider_components.ex:729
 #, elixir-autogen, elixir-format
 msgid "Brief description of experience and specialties..."
 msgstr ""
@@ -2319,19 +2319,19 @@ msgstr ""
 msgid "Business Logo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:959
+#: lib/klass_hero_web/components/provider_components.ex:960
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "Category"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1097
+#: lib/klass_hero_web/components/provider_components.ex:1098
 #, elixir-autogen, elixir-format
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2022
-#: lib/klass_hero_web/components/provider_components.ex:2248
+#: lib/klass_hero_web/components/provider_components.ex:2023
+#: lib/klass_hero_web/components/provider_components.ex:2249
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2346,7 +2346,7 @@ msgstr ""
 msgid "Child meets all program requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1258
+#: lib/klass_hero_web/components/provider_components.ex:1259
 #, elixir-autogen, elixir-format
 msgid "Choose Image"
 msgstr ""
@@ -2356,17 +2356,17 @@ msgstr ""
 msgid "Choose Logo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:852
+#: lib/klass_hero_web/components/provider_components.ex:853
 #, elixir-autogen, elixir-format
 msgid "Choose Photo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:961
+#: lib/klass_hero_web/components/provider_components.ex:962
 #, elixir-autogen, elixir-format
 msgid "Choose a category"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:427
+#: lib/klass_hero_web/components/provider_components.ex:428
 #, elixir-autogen, elixir-format
 msgid "Complete business verification to create programs."
 msgstr ""
@@ -2376,7 +2376,7 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2454
+#: lib/klass_hero_web/components/provider_components.ex:2455
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
@@ -2396,22 +2396,22 @@ msgstr ""
 msgid "Could not remove invite."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1214
+#: lib/klass_hero_web/components/provider_components.ex:1215
 #, elixir-autogen, elixir-format
 msgid "Cover Image"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1091
+#: lib/klass_hero_web/components/provider_components.ex:1092
 #, elixir-autogen, elixir-format
 msgid "Define age, gender, or grade restrictions for eligible participants."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1207
+#: lib/klass_hero_web/components/provider_components.ex:1208
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Describe your program..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1206
+#: lib/klass_hero_web/components/provider_components.ex:1207
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:323
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:285
 #, elixir-autogen, elixir-format
@@ -2419,13 +2419,13 @@ msgid "Description"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:684
-#: lib/klass_hero_web/components/provider_components.ex:1159
+#: lib/klass_hero_web/components/provider_components.ex:1160
 #: lib/klass_hero_web/live/settings/children_live.ex:670
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2591
+#: lib/klass_hero_web/components/provider_components.ex:2670
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2459,7 +2459,7 @@ msgstr ""
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2215
+#: lib/klass_hero_web/components/provider_components.ex:2216
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
@@ -2469,40 +2469,40 @@ msgstr ""
 msgid "Download document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:927
+#: lib/klass_hero_web/components/provider_components.ex:928
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:669
+#: lib/klass_hero_web/components/provider_components.ex:670
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit Team Member"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1036
+#: lib/klass_hero_web/components/provider_components.ex:1037
 #, elixir-autogen, elixir-format
 msgid "End Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1023
+#: lib/klass_hero_web/components/provider_components.ex:1024
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:166
 #, elixir-autogen, elixir-format
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2028
-#: lib/klass_hero_web/components/provider_components.ex:2474
+#: lib/klass_hero_web/components/provider_components.ex:2029
+#: lib/klass_hero_web/components/provider_components.ex:2475
 #: lib/klass_hero_web/components/provider_layout_components.ex:644
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrolled"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1710
+#: lib/klass_hero_web/components/provider_components.ex:1711
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1064
+#: lib/klass_hero_web/components/provider_components.ex:1065
 #, elixir-autogen, elixir-format
 msgid "Enrollment Capacity (optional)"
 msgstr ""
@@ -2512,8 +2512,8 @@ msgstr ""
 msgid "Explain why this document is being rejected..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:70
-#: lib/klass_hero_web/components/provider_components.ex:2475
+#: lib/klass_hero_web/components/provider_components.ex:71
+#: lib/klass_hero_web/components/provider_components.ex:2476
 #: lib/klass_hero_web/live/admin/emails_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2546,7 +2546,7 @@ msgid "Family Programs"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:682
-#: lib/klass_hero_web/components/provider_components.ex:1158
+#: lib/klass_hero_web/components/provider_components.ex:1159
 #: lib/klass_hero_web/live/settings/children_live.ex:669
 #, elixir-autogen, elixir-format
 msgid "Female"
@@ -2557,22 +2557,22 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2525
+#: lib/klass_hero_web/components/provider_components.ex:2604
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2527
+#: lib/klass_hero_web/components/provider_components.ex:2606
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:755
+#: lib/klass_hero_web/components/provider_components.ex:756
 #, elixir-autogen, elixir-format
 msgid "First Aid, UEFA B License, Child Care Cert"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:697
+#: lib/klass_hero_web/components/provider_components.ex:698
 #, elixir-autogen, elixir-format, fuzzy
 msgid "First Name"
 msgstr ""
@@ -2597,12 +2597,12 @@ msgstr ""
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2251
+#: lib/klass_hero_web/components/provider_components.ex:2252
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:816
+#: lib/klass_hero_web/components/provider_components.ex:817
 #, elixir-autogen, elixir-format
 msgid "Headshot Photo"
 msgstr ""
@@ -2612,7 +2612,7 @@ msgstr ""
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2188
+#: lib/klass_hero_web/components/provider_components.ex:2189
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import"
 msgstr ""
@@ -2637,17 +2637,17 @@ msgstr ""
 msgid "Invite resent successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1727
+#: lib/klass_hero_web/components/provider_components.ex:1728
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:855
+#: lib/klass_hero_web/components/provider_components.ex:856
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 1MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1261
+#: lib/klass_hero_web/components/provider_components.ex:1262
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:277
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:361
 #, elixir-autogen, elixir-format
@@ -2664,22 +2664,22 @@ msgstr ""
 msgid "Klasse %{n}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:703
+#: lib/klass_hero_web/components/provider_components.ex:704
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Last Name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1046
+#: lib/klass_hero_web/components/provider_components.ex:1047
 #, elixir-autogen, elixir-format
 msgid "Leave blank for open registration at any time."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1151
+#: lib/klass_hero_web/components/provider_components.ex:1152
 #, elixir-autogen, elixir-format
 msgid "Leave unchecked to allow all genders."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:979
+#: lib/klass_hero_web/components/provider_components.ex:980
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:172
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Location"
@@ -2692,43 +2692,43 @@ msgid "Logo upload failed. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:683
-#: lib/klass_hero_web/components/provider_components.ex:1157
+#: lib/klass_hero_web/components/provider_components.ex:1158
 #: lib/klass_hero_web/live/settings/children_live.ex:668
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1141
+#: lib/klass_hero_web/components/provider_components.ex:1142
 #, elixir-autogen, elixir-format
 msgid "Maximum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1079
+#: lib/klass_hero_web/components/provider_components.ex:1080
 #, elixir-autogen, elixir-format
 msgid "Maximum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1196
+#: lib/klass_hero_web/components/provider_components.ex:1197
 #, elixir-autogen, elixir-format
 msgid "Maximum Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:988
+#: lib/klass_hero_web/components/provider_components.ex:989
 #, elixir-autogen, elixir-format
 msgid "Meeting Days"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1135
+#: lib/klass_hero_web/components/provider_components.ex:1136
 #, elixir-autogen, elixir-format
 msgid "Minimum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1073
+#: lib/klass_hero_web/components/provider_components.ex:1074
 #, elixir-autogen, elixir-format
 msgid "Minimum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1189
+#: lib/klass_hero_web/components/provider_components.ex:1190
 #, elixir-autogen, elixir-format
 msgid "Minimum Grade"
 msgstr ""
@@ -2738,12 +2738,12 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2553
+#: lib/klass_hero_web/components/provider_components.ex:2632
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2015
+#: lib/klass_hero_web/components/provider_components.ex:2016
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
@@ -2759,17 +2759,17 @@ msgstr ""
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2239
+#: lib/klass_hero_web/components/provider_components.ex:2240
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1198
+#: lib/klass_hero_web/components/provider_components.ex:1199
 #, elixir-autogen, elixir-format
 msgid "No maximum"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1191
+#: lib/klass_hero_web/components/provider_components.ex:1192
 #, elixir-autogen, elixir-format
 msgid "No minimum"
 msgstr ""
@@ -2800,18 +2800,18 @@ msgstr ""
 msgid "No verification documents found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1273
+#: lib/klass_hero_web/components/provider_components.ex:1274
 #, elixir-autogen, elixir-format
 msgid "None (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:324
+#: lib/klass_hero_web/components/provider_components.ex:325
 #, elixir-autogen, elixir-format
 msgid "Not Verified"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:685
-#: lib/klass_hero_web/components/provider_components.ex:1160
+#: lib/klass_hero_web/components/provider_components.ex:1161
 #: lib/klass_hero_web/live/settings/children_live.ex:667
 #, elixir-autogen, elixir-format
 msgid "Not specified"
@@ -2822,7 +2822,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2628
+#: lib/klass_hero_web/components/provider_components.ex:2707
 #: lib/klass_hero_web/live/provider/verification_live.ex:698
 #: lib/klass_hero_web/live/provider/verification_live.ex:770
 #, elixir-autogen, elixir-format
@@ -2834,13 +2834,13 @@ msgstr ""
 msgid "Participant Requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1088
+#: lib/klass_hero_web/components/provider_components.ex:1089
 #, elixir-autogen, elixir-format
 msgid "Participant Restrictions (optional)"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:825
-#: lib/klass_hero_web/components/provider_components.ex:292
+#: lib/klass_hero_web/components/provider_components.ex:293
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Pending Review"
 msgstr ""
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Preview not available for this file type."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:970
+#: lib/klass_hero_web/components/provider_components.ex:971
 #, elixir-autogen, elixir-format
 msgid "Price (EUR)"
 msgstr ""
@@ -2878,7 +2878,7 @@ msgstr ""
 msgid "Profile updated successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1126
+#: lib/klass_hero_web/components/provider_components.ex:1127
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program Start"
 msgstr ""
@@ -2920,13 +2920,13 @@ msgid "Read our founding story →"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:805
-#: lib/klass_hero_web/components/provider_components.ex:2473
+#: lib/klass_hero_web/components/provider_components.ex:2474
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registered"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1113
+#: lib/klass_hero_web/components/provider_components.ex:1114
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration"
 msgstr ""
@@ -2936,7 +2936,7 @@ msgstr ""
 msgid "Registration Closed"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1057
+#: lib/klass_hero_web/components/provider_components.ex:1058
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration Closes"
 msgstr ""
@@ -2946,12 +2946,12 @@ msgstr ""
 msgid "Registration Not Open Yet"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1052
+#: lib/klass_hero_web/components/provider_components.ex:1053
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration Opens"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1043
+#: lib/klass_hero_web/components/provider_components.ex:1044
 #, elixir-autogen, elixir-format
 msgid "Registration Period (optional)"
 msgstr ""
@@ -2988,7 +2988,7 @@ msgid "Reject"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:827
-#: lib/klass_hero_web/components/provider_components.ex:48
+#: lib/klass_hero_web/components/provider_components.ex:49
 #: lib/klass_hero_web/live/admin/verifications_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Rejected"
@@ -3000,18 +3000,18 @@ msgstr ""
 msgid "Rejection reason"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:838
-#: lib/klass_hero_web/components/provider_components.ex:1237
-#: lib/klass_hero_web/components/provider_components.ex:2295
-#: lib/klass_hero_web/components/provider_components.ex:2647
+#: lib/klass_hero_web/components/provider_components.ex:839
+#: lib/klass_hero_web/components/provider_components.ex:1238
+#: lib/klass_hero_web/components/provider_components.ex:2296
 #: lib/klass_hero_web/components/provider_components.ex:2726
+#: lib/klass_hero_web/components/provider_components.ex:2805
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:253
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2288
+#: lib/klass_hero_web/components/provider_components.ex:2289
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -3021,23 +3021,23 @@ msgstr ""
 msgid "Reviewed"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:712
+#: lib/klass_hero_web/components/provider_components.ex:713
 #, elixir-autogen, elixir-format
 msgid "Role"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1656
+#: lib/klass_hero_web/components/provider_components.ex:1657
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:386
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1300
+#: lib/klass_hero_web/components/provider_components.ex:1301
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Save Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:985
+#: lib/klass_hero_web/components/provider_components.ex:986
 #, elixir-autogen, elixir-format
 msgid "Schedule (optional)"
 msgstr ""
@@ -3052,7 +3052,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2625
+#: lib/klass_hero_web/components/provider_components.ex:2704
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select File"
 msgstr ""
@@ -3069,23 +3069,23 @@ msgstr ""
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2472
+#: lib/klass_hero_web/components/provider_components.ex:2473
 #: lib/klass_hero_web/live/admin/emails_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Sent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:759
+#: lib/klass_hero_web/components/provider_components.ex:760
 #, elixir-autogen, elixir-format
 msgid "Separate multiple qualifications with commas"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1067
+#: lib/klass_hero_web/components/provider_components.ex:1068
 #, elixir-autogen, elixir-format
 msgid "Set minimum and maximum enrollment for this program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:733
+#: lib/klass_hero_web/components/provider_components.ex:734
 #, elixir-autogen, elixir-format
 msgid "Specialties"
 msgstr ""
@@ -3103,12 +3103,12 @@ msgstr ""
 msgid "Staff member not found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1031
+#: lib/klass_hero_web/components/provider_components.ex:1032
 #, elixir-autogen, elixir-format
 msgid "Start Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1018
+#: lib/klass_hero_web/components/provider_components.ex:1019
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:165
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Start Time"
@@ -3174,12 +3174,12 @@ msgstr ""
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:952
+#: lib/klass_hero_web/components/provider_components.ex:953
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2526
+#: lib/klass_hero_web/components/provider_components.ex:2605
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -3199,32 +3199,32 @@ msgstr ""
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2174
+#: lib/klass_hero_web/components/provider_components.ex:2175
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2671
+#: lib/klass_hero_web/components/provider_components.ex:2750
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2580
+#: lib/klass_hero_web/components/provider_components.ex:2659
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2548
+#: lib/klass_hero_web/components/provider_components.ex:2627
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2528
+#: lib/klass_hero_web/components/provider_components.ex:2607
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2545
+#: lib/klass_hero_web/components/provider_components.ex:2624
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -3246,7 +3246,7 @@ msgstr ""
 msgid "Verifications"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:276
+#: lib/klass_hero_web/components/provider_components.ex:277
 #: lib/klass_hero_web/components/provider_layout_components.ex:212
 #: lib/klass_hero_web/components/ui_components.ex:1930
 #, elixir-autogen, elixir-format, fuzzy
@@ -3263,32 +3263,32 @@ msgstr ""
 msgid "You don't have access to that page."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:713
+#: lib/klass_hero_web/components/provider_components.ex:714
 #, elixir-autogen, elixir-format, fuzzy
 msgid "e.g. Head Coach"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:704
+#: lib/klass_hero_web/components/provider_components.ex:705
 #, elixir-autogen, elixir-format
 msgid "e.g. Johnson"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:698
+#: lib/klass_hero_web/components/provider_components.ex:699
 #, elixir-autogen, elixir-format
 msgid "e.g. Mike"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:719
+#: lib/klass_hero_web/components/provider_components.ex:720
 #, elixir-autogen, elixir-format
 msgid "e.g. mike@example.com"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:953
+#: lib/klass_hero_web/components/provider_components.ex:954
 #, elixir-autogen, elixir-format
 msgid "e.g., Art Adventures"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:980
+#: lib/klass_hero_web/components/provider_components.ex:981
 #, elixir-autogen, elixir-format
 msgid "e.g., Community Center, Main St"
 msgstr ""
@@ -3314,7 +3314,7 @@ msgid "Child Safeguarding Training"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1498
-#: lib/klass_hero_web/components/provider_components.ex:2893
+#: lib/klass_hero_web/components/provider_components.ex:2972
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr ""
@@ -3464,7 +3464,7 @@ msgid "Vetted with Care"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1482
-#: lib/klass_hero_web/components/provider_components.ex:2678
+#: lib/klass_hero_web/components/provider_components.ex:2757
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr ""
@@ -3638,7 +3638,7 @@ msgstr ""
 msgid "Checked Out"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2331
+#: lib/klass_hero_web/components/provider_components.ex:2332
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Child"
@@ -3691,7 +3691,7 @@ msgstr ""
 msgid "Download monthly statements for taxes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2092
+#: lib/klass_hero_web/components/provider_components.ex:2093
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:483
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrollment not confirmed"
@@ -3769,7 +3769,7 @@ msgstr ""
 msgid "No chasing payments or sending invoices"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1679
+#: lib/klass_hero_web/components/provider_components.ex:1680
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:407
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No enrolled parents"
@@ -3792,7 +3792,7 @@ msgstr ""
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2091
+#: lib/klass_hero_web/components/provider_components.ex:2092
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -4475,7 +4475,7 @@ msgstr ""
 msgid "Reply sent successfully"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:552
+#: lib/klass_hero_web/components/provider_components.ex:553
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Resend"
 msgstr ""
@@ -4900,43 +4900,43 @@ msgstr ""
 msgid "for"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1800
+#: lib/klass_hero_web/components/provider_components.ex:1801
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assigned staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1802
+#: lib/klass_hero_web/components/provider_components.ex:1803
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1784
-#: lib/klass_hero_web/components/provider_components.ex:1873
+#: lib/klass_hero_web/components/provider_components.ex:1785
+#: lib/klass_hero_web/components/provider_components.ex:1874
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Close"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1801
+#: lib/klass_hero_web/components/provider_components.ex:1802
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1799
+#: lib/klass_hero_web/components/provider_components.ex:1800
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1793
+#: lib/klass_hero_web/components/provider_components.ex:1794
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No sessions scheduled yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1782
+#: lib/klass_hero_web/components/provider_components.ex:1783
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sessions — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1522
+#: lib/klass_hero_web/components/provider_components.ex:1523
 #, elixir-autogen, elixir-format
 msgid "View sessions"
 msgstr ""
@@ -4968,17 +4968,17 @@ msgstr ""
 msgid "Failed to update record"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2395
+#: lib/klass_hero_web/components/provider_components.ex:2396
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2114
+#: lib/klass_hero_web/components/provider_components.ex:2115
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invite mode"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2133
+#: lib/klass_hero_web/components/provider_components.ex:2134
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr ""
@@ -4993,12 +4993,12 @@ msgstr ""
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2408
+#: lib/klass_hero_web/components/provider_components.ex:2409
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2414
+#: lib/klass_hero_web/components/provider_components.ex:2415
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr ""
@@ -5009,17 +5009,17 @@ msgstr ""
 msgid "Nothing to update"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2416
+#: lib/klass_hero_web/components/provider_components.ex:2417
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nut allergy"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2420
+#: lib/klass_hero_web/components/provider_components.ex:2421
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2425
+#: lib/klass_hero_web/components/provider_components.ex:2426
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr ""
@@ -5029,7 +5029,7 @@ msgstr ""
 msgid "Present"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2352
+#: lib/klass_hero_web/components/provider_components.ex:2353
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr ""
@@ -5056,22 +5056,22 @@ msgstr ""
 msgid "Save changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2389
+#: lib/klass_hero_web/components/provider_components.ex:2390
 #, elixir-autogen, elixir-format, fuzzy
 msgid "School (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2399
+#: lib/klass_hero_web/components/provider_components.ex:2400
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2373
+#: lib/klass_hero_web/components/provider_components.ex:2374
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2442
+#: lib/klass_hero_web/components/provider_components.ex:2443
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Send invite"
 msgstr ""
@@ -5081,7 +5081,7 @@ msgstr ""
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2151
+#: lib/klass_hero_web/components/provider_components.ex:2152
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload a list"
 msgstr ""
@@ -5116,7 +5116,7 @@ msgstr ""
 msgid "High"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:786
+#: lib/klass_hero_web/components/provider_components.ex:787
 #, elixir-autogen, elixir-format
 msgid "Hourly"
 msgstr ""
@@ -5141,22 +5141,22 @@ msgstr ""
 msgid "Medium"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:776
+#: lib/klass_hero_web/components/provider_components.ex:777
 #, elixir-autogen, elixir-format
 msgid "None"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:765
+#: lib/klass_hero_web/components/provider_components.ex:766
 #, elixir-autogen, elixir-format
 msgid "Pay Rate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:523
+#: lib/klass_hero_web/components/provider_components.ex:524
 #, elixir-autogen, elixir-format
 msgid "Pay rate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:796
+#: lib/klass_hero_web/components/provider_components.ex:797
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Per Session"
 msgstr ""
@@ -5181,7 +5181,7 @@ msgstr ""
 msgid "Property Damage"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1552
+#: lib/klass_hero_web/components/provider_components.ex:1553
 #, elixir-autogen, elixir-format
 msgid "Report Incident"
 msgstr ""
@@ -5863,7 +5863,7 @@ msgstr[1] ""
 msgid "In 2025, Shane connected with his friend"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1561
+#: lib/klass_hero_web/components/provider_components.ex:1562
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:43
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:74
 #, elixir-autogen, elixir-format
@@ -5933,7 +5933,7 @@ msgstr ""
 msgid "Last 8 weeks"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1271
+#: lib/klass_hero_web/components/provider_components.ex:1272
 #: lib/klass_hero_web/presenters/hero_cards_presenter.ex:27
 #, elixir-autogen, elixir-format
 msgid "Lead Instructor"
@@ -6383,17 +6383,17 @@ msgstr ""
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2481
+#: lib/klass_hero_web/components/provider_components.ex:2482
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Row %{row}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2481
+#: lib/klass_hero_web/components/provider_components.ex:2482
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2227
+#: lib/klass_hero_web/components/provider_components.ex:2228
 #, elixir-autogen, elixir-format
 msgid "Rows with errors"
 msgstr ""
@@ -7005,7 +7005,7 @@ msgstr ""
 msgid "Identity verifications"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:71
+#: lib/klass_hero_web/components/provider_components.ex:72
 #, elixir-autogen, elixir-format, fuzzy
 msgid "In progress"
 msgstr ""
@@ -7035,7 +7035,7 @@ msgstr ""
 msgid "Not started"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:69
+#: lib/klass_hero_web/components/provider_components.ex:70
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Passed"
 msgstr ""
@@ -7152,12 +7152,12 @@ msgstr ""
 msgid "Experience validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2707
+#: lib/klass_hero_web/components/provider_components.ex:2786
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2681
+#: lib/klass_hero_web/components/provider_components.ex:2760
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
@@ -7167,12 +7167,12 @@ msgstr ""
 msgid "Safeguarding certificate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2704
+#: lib/klass_hero_web/components/provider_components.ex:2783
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select Video"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2750
+#: lib/klass_hero_web/components/provider_components.ex:2829
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload Video"
 msgstr ""
@@ -7182,7 +7182,7 @@ msgstr ""
 msgid "Your browser does not support video playback."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2897
+#: lib/klass_hero_web/components/provider_components.ex:2976
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Confirm agreement"
 msgstr ""
@@ -7192,12 +7192,12 @@ msgstr ""
 msgid "Couldn't record your agreement. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2920
+#: lib/klass_hero_web/components/provider_components.ex:2999
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2896
+#: lib/klass_hero_web/components/provider_components.ex:2975
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr ""
@@ -7207,7 +7207,7 @@ msgstr ""
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2805
+#: lib/klass_hero_web/components/provider_components.ex:2884
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr ""
@@ -7217,17 +7217,17 @@ msgstr ""
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2905
+#: lib/klass_hero_web/components/provider_components.ex:2984
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2894
+#: lib/klass_hero_web/components/provider_components.ex:2973
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2895
+#: lib/klass_hero_web/components/provider_components.ex:2974
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
@@ -7496,12 +7496,12 @@ msgstr ""
 msgid "Your insurance is verified."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2849
+#: lib/klass_hero_web/components/provider_components.ex:2928
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2952
+#: lib/klass_hero_web/components/provider_components.ex:3031
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr ""
@@ -7511,7 +7511,7 @@ msgstr ""
 msgid "Couldn't record your declaration. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2958
+#: lib/klass_hero_web/components/provider_components.ex:3037
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr ""
@@ -7521,17 +7521,17 @@ msgstr ""
 msgid "Please confirm the declaration before signing."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2983
+#: lib/klass_hero_web/components/provider_components.ex:3062
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2962
+#: lib/klass_hero_web/components/provider_components.ex:3041
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2950
+#: lib/klass_hero_web/components/provider_components.ex:3029
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr ""
@@ -7541,12 +7541,12 @@ msgstr ""
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2970
+#: lib/klass_hero_web/components/provider_components.ex:3049
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2956
+#: lib/klass_hero_web/components/provider_components.ex:3035
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
@@ -7613,12 +7613,12 @@ msgstr ""
 msgid "Undelivered Events"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1970
+#: lib/klass_hero_web/components/provider_components.ex:1971
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1895
+#: lib/klass_hero_web/components/provider_components.ex:1896
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Lead"
 msgstr ""
@@ -7628,17 +7628,17 @@ msgstr ""
 msgid "Lead instructor updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1906
+#: lib/klass_hero_web/components/provider_components.ex:1907
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1536
+#: lib/klass_hero_web/components/provider_components.ex:1537
 #, elixir-autogen, elixir-format
 msgid "Manage Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1934
+#: lib/klass_hero_web/components/provider_components.ex:1935
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this program yet."
 msgstr ""
@@ -7648,17 +7648,17 @@ msgstr ""
 msgid "Pick a staff member to add."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1917
+#: lib/klass_hero_web/components/provider_components.ex:1918
 #, elixir-autogen, elixir-format
 msgid "Reassign the lead before removing them"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1918
+#: lib/klass_hero_web/components/provider_components.ex:1919
 #, elixir-autogen, elixir-format
 msgid "Remove from program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1952
+#: lib/klass_hero_web/components/provider_components.ex:1953
 #, elixir-autogen, elixir-format
 msgid "Select a staff member…"
 msgstr ""
@@ -7673,12 +7673,12 @@ msgstr ""
 msgid "Staff member removed from the program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1975
+#: lib/klass_hero_web/components/provider_components.ex:1976
 #, elixir-autogen, elixir-format
 msgid "Staff you add can read and reply to this program's parent conversations."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1871
+#: lib/klass_hero_web/components/provider_components.ex:1872
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Staffing — %{title}"
 msgstr ""
@@ -7698,19 +7698,19 @@ msgstr ""
 msgid "This person is the lead instructor. Make someone else lead before removing them."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1480
+#: lib/klass_hero_web/components/provider_components.ex:1481
 #, elixir-autogen, elixir-format
 msgid "%{count} staff member · no lead"
 msgid_plural "%{count} staff · no lead"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/components/provider_components.ex:562
+#: lib/klass_hero_web/components/provider_components.ex:563
 #, elixir-autogen, elixir-format
 msgid "%{name} will be unassigned from every program and removed from those conversations. Their history is kept and you can add them back later."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:638
+#: lib/klass_hero_web/components/provider_components.ex:639
 #, elixir-autogen, elixir-format
 msgid "Add back to team"
 msgstr ""
@@ -7720,7 +7720,7 @@ msgstr ""
 msgid "Could not bring this team member back. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:600
+#: lib/klass_hero_web/components/provider_components.ex:601
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Delete entry"
 msgstr ""
@@ -7730,7 +7730,7 @@ msgstr ""
 msgid "Former team members"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:574
+#: lib/klass_hero_web/components/provider_components.ex:575
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove from team"
 msgstr ""
@@ -7745,7 +7745,7 @@ msgstr ""
 msgid "Team member removed from the team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:590
+#: lib/klass_hero_web/components/provider_components.ex:591
 #, elixir-autogen, elixir-format
 msgid "This deletes %{name} permanently — there's nothing to undo. Use it only for an entry added by mistake."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/en/LC_MESSAGES/enrollment.po
@@ -11,62 +11,95 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:2502
+#: lib/klass_hero_web/components/provider_components.ex:2576
+#: lib/klass_hero_web/components/provider_components.ex:2593
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2503
+#: lib/klass_hero_web/components/provider_components.ex:2577
+#: lib/klass_hero_web/components/provider_components.ex:2594
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2504
+#: lib/klass_hero_web/components/provider_components.ex:2578
+#: lib/klass_hero_web/components/provider_components.ex:2595
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2515
+#: lib/klass_hero_web/components/provider_components.ex:2589
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2505
+#: lib/klass_hero_web/components/provider_components.ex:2579
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2506
+#: lib/klass_hero_web/components/provider_components.ex:2580
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2507
+#: lib/klass_hero_web/components/provider_components.ex:2581
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2514
+#: lib/klass_hero_web/components/provider_components.ex:2588
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2516
+#: lib/klass_hero_web/components/provider_components.ex:2590
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2508
+#: lib/klass_hero_web/components/provider_components.ex:2582
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2510
+#: lib/klass_hero_web/components/provider_components.ex:2584
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2512
+#: lib/klass_hero_web/components/provider_components.ex:2586
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2516
+#, elixir-autogen, elixir-format
+msgid "Date of birth \"%{value}\" is not a valid date. Please correct it and resend."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2510
+#, elixir-autogen, elixir-format
+msgid "Invite link could not be generated (no token). Please resend."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2524
+#, elixir-autogen, elixir-format
+msgid "The invitation email could not be delivered. Please check the address and resend."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2513
+#, elixir-autogen, elixir-format
+msgid "The program is full, so this child could not be enrolled."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2527
+#, elixir-autogen, elixir-format
+msgid "This invite could not be completed and no retries remain. Please resend."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2536
+#, elixir-autogen, elixir-format
+msgid "This invite could not be completed. Please resend."
 msgstr ""

--- a/priv/gettext/enrollment.pot
+++ b/priv/gettext/enrollment.pot
@@ -11,62 +11,95 @@
 msgid ""
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2502
+#: lib/klass_hero_web/components/provider_components.ex:2576
+#: lib/klass_hero_web/components/provider_components.ex:2593
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2503
+#: lib/klass_hero_web/components/provider_components.ex:2577
+#: lib/klass_hero_web/components/provider_components.ex:2594
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2504
+#: lib/klass_hero_web/components/provider_components.ex:2578
+#: lib/klass_hero_web/components/provider_components.ex:2595
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2515
+#: lib/klass_hero_web/components/provider_components.ex:2589
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2505
+#: lib/klass_hero_web/components/provider_components.ex:2579
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2506
+#: lib/klass_hero_web/components/provider_components.ex:2580
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2507
+#: lib/klass_hero_web/components/provider_components.ex:2581
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2514
+#: lib/klass_hero_web/components/provider_components.ex:2588
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2516
+#: lib/klass_hero_web/components/provider_components.ex:2590
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2508
+#: lib/klass_hero_web/components/provider_components.ex:2582
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2510
+#: lib/klass_hero_web/components/provider_components.ex:2584
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2512
+#: lib/klass_hero_web/components/provider_components.ex:2586
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2516
+#, elixir-autogen, elixir-format
+msgid "Date of birth \"%{value}\" is not a valid date. Please correct it and resend."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2510
+#, elixir-autogen, elixir-format
+msgid "Invite link could not be generated (no token). Please resend."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2524
+#, elixir-autogen, elixir-format
+msgid "The invitation email could not be delivered. Please check the address and resend."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2513
+#, elixir-autogen, elixir-format
+msgid "The program is full, so this child could not be enrolled."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2527
+#, elixir-autogen, elixir-format
+msgid "This invite could not be completed and no retries remain. Please resend."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2536
+#, elixir-autogen, elixir-format
+msgid "This invite could not be completed. Please resend."
 msgstr ""

--- a/priv/repo/migrations/20260815074443_add_failure_code_to_bulk_enrollment_invites.exs
+++ b/priv/repo/migrations/20260815074443_add_failure_code_to_bulk_enrollment_invites.exs
@@ -1,0 +1,17 @@
+defmodule KlassHero.Repo.Migrations.AddFailureCodeToBulkEnrollmentInvites do
+  use Ecto.Migration
+
+  # Replaces `error_details`, which held a provider-facing English sentence written by a
+  # background process that has no reader's locale in scope (#1340). The old column stays
+  # so invites that failed before this migration still read back their reason; nothing
+  # writes it any more, and it can be dropped once no live row carries one.
+  #
+  # No check constraint on `failure_code`: `Ecto.Enum` guards the application path, and a
+  # constraint would force a migration for every code added later.
+  def change do
+    alter table(:bulk_enrollment_invites) do
+      add :failure_code, :string
+      add :failure_context, :map
+    end
+  end
+end

--- a/test/klass_hero/enrollment/adapters/driving/workers/send_invite_email_worker_test.exs
+++ b/test/klass_hero/enrollment/adapters/driving/workers/send_invite_email_worker_test.exs
@@ -81,7 +81,7 @@ defmodule KlassHero.Enrollment.Adapters.Driving.Workers.SendInviteEmailWorkerTes
 
       failed = Repo.get!(BulkEnrollmentInvite, invite.id)
       assert failed.status == :failed
-      assert failed.error_details =~ "no token"
+      assert failed.failure_code == :no_token
     end
   end
 
@@ -146,8 +146,10 @@ defmodule KlassHero.Enrollment.Adapters.Driving.Workers.SendInviteEmailWorkerTes
 
       failed = reload(invite)
       assert failed.status == :failed
-      assert failed.error_details =~ "could not be delivered"
-      refute failed.error_details =~ "network", "the mailer's own term reached the provider"
+      assert failed.failure_code == :delivery_failed
+
+      refute inspect(failed.failure_context) =~ "network",
+             "the mailer's own term reached the provider"
     end
 
     # Oban reads retry/discard off the return value; compensating must not look to it
@@ -175,7 +177,7 @@ defmodule KlassHero.Enrollment.Adapters.Driving.Workers.SendInviteEmailWorkerTes
 
       resent = reload(invite)
       assert resent.status == :pending, "a dead job re-failed an invite the provider had resent"
-      assert resent.error_details == nil, "a dead job overwrote the reason a resend had cleared"
+      assert resent.failure_code == nil, "a dead job overwrote the reason a resend had cleared"
     end
 
     # The other side of the guard: without a resend to supersede it, the compensation is
@@ -205,7 +207,7 @@ defmodule KlassHero.Enrollment.Adapters.Driving.Workers.SendInviteEmailWorkerTes
 
       swept = reload(invite)
       assert swept.status == :pending, "the sweep re-failed an invite the provider had resent"
-      assert swept.error_details == nil
+      assert swept.failure_code == nil
     end
 
     # The guard's sharpest edge. `resent_at` and a job's `inserted_at` are only
@@ -320,8 +322,7 @@ defmodule KlassHero.Enrollment.Adapters.Driving.Workers.SendInviteEmailWorkerTes
 
       failed = reload(tokenless)
       assert failed.status == :failed
-      assert failed.error_details =~ "no token"
-      refute failed.error_details =~ "not_found"
+      assert failed.failure_code == :no_token
     end
 
     # Returning the error is what retries it; the log is what makes a write that keeps

--- a/test/klass_hero/enrollment/bulk_enrollment_invite_test.exs
+++ b/test/klass_hero/enrollment/bulk_enrollment_invite_test.exs
@@ -3,11 +3,7 @@ defmodule KlassHero.Enrollment.BulkEnrollmentInviteTest do
 
   alias KlassHero.Enrollment.BulkEnrollmentInvite
 
-  describe "describe_failure/2" do
-    # Everything here is read by a provider in the invites table, so the one property
-    # that must hold for every clause is that no Elixir term survives into it (#1290).
-    @developer_shapes [~r/#Ecto\.Changeset/, ~r/%\{/, ~r/\{:/, ~r/\[\{/]
-
+  describe "classify_failure/2" do
     defp tokenless, do: %BulkEnrollmentInvite{invite_token: nil}
     defp tokenful, do: %BulkEnrollmentInvite{invite_token: "test-token-123"}
 
@@ -17,37 +13,48 @@ defmodule KlassHero.Enrollment.BulkEnrollmentInviteTest do
 
     test "names the missing token whatever the reason says" do
       for reason <- [nil, :program_full, "job died", {:delivery, :timeout}, invalid_changeset()] do
-        assert BulkEnrollmentInvite.describe_failure(tokenless(), reason) =~ "no token",
+        assert {:no_token, %{}} = BulkEnrollmentInvite.classify_failure(tokenless(), reason),
                "a tokenless invite reported #{inspect(reason)} as its cause instead of the missing token"
       end
     end
 
-    test "turns a changeset into the fields the provider has to fix" do
-      details = BulkEnrollmentInvite.describe_failure(tokenful(), invalid_changeset())
-
-      assert details =~ "child date of birth"
-      assert details =~ "can't be blank"
-    end
-
-    test "renders every known reason as a sentence" do
+    test "classifies every known reason, with the detail the provider needs to act" do
       cases = [
-        {:program_full, "full"},
-        {{:invalid_date, "not-a-date"}, "not-a-date"},
-        {{:delivery, {:network, :timeout}}, "deliver"},
-        {nil, "no retries remain"},
-        {"** (Oban.PerformError) ... failed with {:error, :not_found}", "no retries remain"},
-        {:some_unmapped_atom, "could not be completed"}
+        {:program_full, :program_full, %{}},
+        {{:invalid_date, "not-a-date"}, :invalid_date, %{"value" => "not-a-date"}},
+        {{:delivery, {:network, :timeout}}, :delivery_failed, %{}},
+        {nil, :exhausted, %{}},
+        {"** (Oban.PerformError) ... failed with {:error, :not_found}", :exhausted, %{}},
+        {:some_unmapped_atom, :generic, %{}},
+        {{:error, %{nested: [:deeply, {:awkwardly, "shaped"}]}}, :generic, %{}}
       ]
 
-      for {reason, expected} <- cases do
-        assert BulkEnrollmentInvite.describe_failure(tokenful(), reason) =~ expected,
-               "#{inspect(reason)} did not render a reason containing #{inspect(expected)}"
+      for {reason, code, context} <- cases do
+        assert {^code, ^context} = BulkEnrollmentInvite.classify_failure(tokenful(), reason),
+               "#{inspect(reason)} was not classified as #{inspect(code)} carrying #{inspect(context)}"
       end
     end
 
-    # The sweep can only hand back Oban's own error text, which is developer copy by
-    # construction — passing it through would reopen the leak this function closes.
-    test "never leaks a developer term, whatever it is handed" do
+    test "carries a changeset's fields as the details the provider has to fix" do
+      assert {:invalid_details, %{"fields" => fields}} =
+               BulkEnrollmentInvite.classify_failure(tokenful(), invalid_changeset())
+
+      assert %{"field" => "child_date_of_birth", "msg" => "can't be blank"} =
+               Enum.find(fields, &(&1["field"] == "child_date_of_birth"))
+    end
+
+    # A changeset can be invalid with its errors on an association rather than a field.
+    # Naming no field is better than naming none convincingly.
+    test "falls back to the generic cause when a changeset names no field" do
+      empty = Ecto.Changeset.change(%BulkEnrollmentInvite{})
+
+      assert {:generic, %{}} = BulkEnrollmentInvite.classify_failure(tokenful(), empty)
+    end
+
+    # The context is persisted as jsonb and read back by the component, so anything that
+    # does not survive a JSON round trip is a term the provider would eventually read
+    # (#1290) or a decode that would raise on the render path.
+    test "builds a context that survives a JSON round trip unchanged" do
       reasons = [
         nil,
         :program_full,
@@ -60,11 +67,11 @@ defmodule KlassHero.Enrollment.BulkEnrollmentInviteTest do
         invalid_changeset()
       ]
 
-      for reason <- reasons, pattern <- @developer_shapes do
-        details = BulkEnrollmentInvite.describe_failure(tokenful(), reason)
+      for reason <- reasons do
+        {_code, context} = BulkEnrollmentInvite.classify_failure(tokenful(), reason)
 
-        refute details =~ pattern,
-               "#{inspect(reason)} leaked #{inspect(pattern)} into what a provider reads: #{details}"
+        assert context == context |> Jason.encode!() |> Jason.decode!(),
+               "#{inspect(reason)} built a context that changes shape through jsonb: #{inspect(context)}"
       end
     end
   end

--- a/test/klass_hero/enrollment/enqueue_invite_emails_test.exs
+++ b/test/klass_hero/enrollment/enqueue_invite_emails_test.exs
@@ -51,7 +51,7 @@ defmodule KlassHero.Enrollment.EnqueueInviteEmailsTest do
       provider: provider,
       program: program
     } do
-      Repo.update_all(BulkEnrollmentInvite, set: [status: :failed, error_details: "test"])
+      Repo.update_all(BulkEnrollmentInvite, set: [status: :failed])
 
       manual(fn ->
         assert :ok = EnqueueInviteEmails.execute([program.id], provider.id)
@@ -113,7 +113,7 @@ defmodule KlassHero.Enrollment.EnqueueInviteEmailsTest do
       from(s in BulkEnrollmentInvite,
         where: s.program_id != ^orphan_program.id
       )
-      |> Repo.update_all(set: [status: :failed, error_details: "test"])
+      |> Repo.update_all(set: [status: :failed])
 
       manual(fn ->
         assert :ok = EnqueueInviteEmails.execute([orphan_program.id], provider.id)

--- a/test/klass_hero/enrollment/fail_invite_test.exs
+++ b/test/klass_hero/enrollment/fail_invite_test.exs
@@ -31,12 +31,19 @@ defmodule KlassHero.Enrollment.FailInviteTest do
   describe "fail_invite/2" do
     setup :create_invite
 
-    test "fails the invite with a reason a provider can act on", %{invite: invite} do
+    test "fails the invite with a cause a provider can act on", %{invite: invite} do
       assert {:ok, failed} = Enrollment.fail_invite(invite.id, :program_full)
 
       assert failed.status == :failed
-      assert failed.error_details =~ "full"
-      refute failed.error_details =~ ":program_full"
+      assert failed.failure_code == :program_full
+    end
+
+    # The sentence column is superseded, and a writer that still filled it would put the
+    # provider back in front of copy frozen in this process's locale (#1340).
+    test "writes no sentence into the legacy column", %{invite: invite} do
+      assert {:ok, failed} = Enrollment.fail_invite(invite.id, :program_full)
+
+      assert failed.error_details == nil
     end
 
     test "reads the missing token off the row, not off the reason", %{invite: invite} do
@@ -45,7 +52,7 @@ defmodule KlassHero.Enrollment.FailInviteTest do
       # nil is what the compensation sweep hands back for a Lifeline discard — the path
       # on which no reason term survives at all.
       assert {:ok, failed} = Enrollment.fail_invite(invite.id, nil)
-      assert failed.error_details =~ "no token"
+      assert failed.failure_code == :no_token
     end
 
     # `@valid_transitions` (failed: [:pending]) is what stops a second compensation
@@ -57,7 +64,7 @@ defmodule KlassHero.Enrollment.FailInviteTest do
 
       assert {:error, :already_terminal} = Enrollment.fail_invite(invite.id, nil)
 
-      assert Repo.get!(BulkEnrollmentInvite, invite.id).error_details =~ "full",
+      assert Repo.get!(BulkEnrollmentInvite, invite.id).failure_code == :program_full,
              "the second call overwrote the first call's reason"
     end
 
@@ -116,12 +123,40 @@ defmodule KlassHero.Enrollment.FailInviteTest do
 
       assert {:error, :superseded} = Enrollment.fail_invite(invite.id, :program_full, @enqueued_at)
 
-      assert Repo.get!(BulkEnrollmentInvite, invite.id).error_details == nil
+      assert Repo.get!(BulkEnrollmentInvite, invite.id).failure_code == nil
     end
 
     test "reports a missing invite rather than raising" do
       assert {:error, :not_found} =
                Enrollment.fail_invite(Ecto.UUID.generate(), :program_full, @enqueued_at)
+    end
+  end
+
+  describe "reset_invite_for_resend/1" do
+    setup :create_invite
+
+    test "clears the cause so the reopened invite shows no reason", %{invite: invite} do
+      {:ok, failed} = Enrollment.fail_invite(invite.id, {:invalid_date, "not-a-date"})
+      assert failed.failure_code == :invalid_date
+
+      assert {:ok, reset} = Enrollment.reset_invite_for_resend(failed)
+
+      assert reset.status == :pending
+      assert reset.failure_code == nil
+      assert reset.failure_context == nil
+    end
+
+    # An invite that failed before #1340 carries its reason in the old column, and a
+    # resend has to clear that one too or the reopened invite keeps the old sentence.
+    test "clears a legacy sentence as well", %{invite: invite} do
+      failed =
+        invite
+        |> Ecto.Changeset.change(%{status: :failed, error_details: "The program is full."})
+        |> Repo.update!()
+
+      assert {:ok, reset} = Enrollment.reset_invite_for_resend(failed)
+
+      assert reset.error_details == nil
     end
   end
 end

--- a/test/klass_hero/enrollment/invite_claim_saga_test.exs
+++ b/test/klass_hero/enrollment/invite_claim_saga_test.exs
@@ -113,7 +113,8 @@ defmodule KlassHero.Enrollment.InviteClaimSagaTest do
 
         final = Repo.get!(BulkEnrollmentInvite, ctx.invite.id)
         assert final.status == :failed
-        assert final.error_details =~ "first name"
+        assert final.failure_code == :invalid_details
+        assert Enum.any?(final.failure_context["fields"], &(&1["field"] == "first_name"))
 
         # The account is real and stays; only the enrollment never happened.
         assert Accounts.get_user_by_email(ctx.email).id == user.id

--- a/test/klass_hero/family/adapters/driving/workers/process_invite_claim_worker_test.exs
+++ b/test/klass_hero/family/adapters/driving/workers/process_invite_claim_worker_test.exs
@@ -150,19 +150,20 @@ defmodule KlassHero.Family.Adapters.Driving.Workers.ProcessInviteClaimWorkerTest
       end
     end
 
-    # error_details is read by a provider in the invites table, not by a developer in a
-    # log, so a raw inspect/1 of the changeset would be no more actionable than the
-    # silence it replaced.
-    test "fails the invite on the final attempt, recording a readable reason", ctx do
+    # The cause is read by a provider in the invites table, not by a developer in a log,
+    # so it has to name the field they can fix — and carry it as data, since the sentence
+    # is built later in the reader's own language (#1340).
+    test "fails the invite on the final attempt, recording which field it could not accept", ctx do
       args = failing_args(ctx.invite, ctx.program, ctx.user)
 
       assert {:error, _reason} = ProcessInviteClaimWorker.execute(job(args, @max_attempts))
 
       failed = reload(ctx.invite)
       assert failed.status == :failed
-      assert failed.error_details =~ "date of birth"
-      assert failed.error_details =~ "can't be blank"
-      refute failed.error_details =~ "Ecto.Changeset"
+      assert failed.failure_code == :invalid_details
+
+      assert %{"msg" => "can't be blank"} =
+               Enum.find(failed.failure_context["fields"], &(&1["field"] == "date_of_birth"))
     end
 
     test "records a reason for a failure that carries no changeset", ctx do
@@ -173,7 +174,9 @@ defmodule KlassHero.Family.Adapters.Driving.Workers.ProcessInviteClaimWorkerTest
 
       assert {:error, _reason} = ProcessInviteClaimWorker.execute(job(args, @max_attempts))
 
-      assert reload(ctx.invite).error_details =~ "not-a-date"
+      failed = reload(ctx.invite)
+      assert failed.failure_code == :invalid_date
+      assert failed.failure_context == %{"value" => "not-a-date"}
     end
 
     # Oban reads retry/discard off the return value; compensating must not look to it

--- a/test/klass_hero/shared/changeset_errors_test.exs
+++ b/test/klass_hero/shared/changeset_errors_test.exs
@@ -100,4 +100,88 @@ defmodule KlassHero.Shared.ChangesetErrorsTest do
       assert [{:name, "expected 1 to 10"}] = ChangesetErrors.field_list(cs)
     end
   end
+
+  describe "to_payload/1" do
+    test "returns [] for a valid changeset" do
+      assert ChangesetErrors.to_payload(changeset(%{"name" => "ok"})) == []
+    end
+
+    # The msgid is what gettext looks up, so expanding it here would leave the reader
+    # with a string no catalog contains. Interpolation is the caller's second step.
+    test "keeps the msgid unexpanded and hands the values over separately" do
+      payload = ChangesetErrors.to_payload(changeset(%{"name" => "a"}))
+
+      assert %{"msg" => "should be at least %{count} character(s)", "bindings" => %{"count" => 2}} =
+               Enum.find(payload, &(&1["msg"] =~ "at least"))
+    end
+
+    test "names the field as a string so it survives jsonb" do
+      assert [%{"field" => "name"} | _] = ChangesetErrors.to_payload(changeset(%{"name" => ""}))
+    end
+
+    test "round-trips through JSON unchanged" do
+      payload = ChangesetErrors.to_payload(changeset(%{"name" => "a", "quantity" => -1}))
+
+      assert payload == payload |> Jason.encode!() |> Jason.decode!()
+    end
+
+    # Ecto puts its own bookkeeping in opts (`validation: :length`, `kind: :min`), and a
+    # custom validator can put anything there at all. Atoms stringify; a term with no
+    # string form is dropped rather than allowed to break the render path.
+    test "normalizes binding values to JSON-safe scalars" do
+      cs =
+        %Sample{}
+        |> cast(%{"name" => "ok"}, [:name])
+        |> add_error(:name, "bad", validation: :length, count: 3, term: {:awkwardly, "shaped"})
+
+      assert [%{"bindings" => bindings}] = ChangesetErrors.to_payload(cs)
+      assert bindings == %{"validation" => "length", "count" => 3}
+    end
+
+    test "keeps a count binding an integer so a plural lookup still works" do
+      assert [%{"bindings" => %{"count" => count}} | _] =
+               ChangesetErrors.to_payload(changeset(%{"name" => "a"}))
+
+      assert is_integer(count)
+    end
+  end
+
+  describe "gettext_bindings/1" do
+    test "atom-keys the placeholders the errors catalog interpolates" do
+      assert ChangesetErrors.gettext_bindings(%{"count" => 2, "number" => 1}) ==
+               %{count: 2, number: 1}
+    end
+
+    # Gettext logs an error for any placeholder it cannot bind, so a key it does not need
+    # is harmless but a key it does need being absent is not.
+    test "drops keys that are not catalog placeholders" do
+      assert ChangesetErrors.gettext_bindings(%{"validation" => "length", "kind" => "min"}) == %{}
+    end
+
+    test "returns an empty map when there is nothing to bind" do
+      assert ChangesetErrors.gettext_bindings(%{}) == %{}
+    end
+
+    # The keys arrive from jsonb, so the conversion is a closed literal map — never
+    # String.to_existing_atom, which raises once an atom is deleted in a later release.
+    test "ignores a key it has no atom for rather than minting one" do
+      refute Map.has_key?(ChangesetErrors.gettext_bindings(%{"totally_novel_key" => 1}), :totally_novel_key)
+    end
+  end
+
+  describe "interpolate/2" do
+    test "substitutes string-keyed bindings" do
+      assert ChangesetErrors.interpolate("expected %{min} to %{max}", %{"min" => 1, "max" => 10}) ==
+               "expected 1 to 10"
+    end
+
+    test "leaves a placeholder with no binding intact" do
+      assert ChangesetErrors.interpolate("needs %{count} things", %{"validation" => "custom"}) ==
+               "needs %{count} things"
+    end
+
+    test "returns the message untouched when there is nothing to bind" do
+      assert ChangesetErrors.interpolate("can't be blank", %{}) == "can't be blank"
+    end
+  end
 end

--- a/test/klass_hero_web/live/provider/provider_dashboard_test.exs
+++ b/test/klass_hero_web/live/provider/provider_dashboard_test.exs
@@ -508,19 +508,109 @@ defmodule KlassHeroWeb.Provider.ProviderDashboardTest do
       assert has_element?(view, "[phx-click=delete_invite]")
     end
 
-    # #1221: a failed invite showed a red pill and nothing else, so the provider could see
-    # that something broke but not what, nor whether resending could possibly help.
-    test "shows why a failed invite failed", %{conn: conn, program: program} do
-      invite = Repo.one!(BulkEnrollmentInvite)
-
-      invite
-      |> Ecto.Changeset.change(%{status: :failed, error_details: "date of birth can't be blank"})
+    defp fail_invite(attrs) do
+      BulkEnrollmentInvite
+      |> Repo.one!()
+      |> Ecto.Changeset.change(Map.put(attrs, :status, :failed))
       |> Repo.update!()
+    end
 
-      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+    defp open_invites(conn, program, path \\ ~p"/provider/dashboard/programs") do
+      {:ok, view, _html} = live(conn, path)
 
       view |> element("#view-roster-#{program.id}") |> render_click()
       view |> element("#roster-tab-invites") |> render_click()
+
+      view
+    end
+
+    # #1221: a failed invite showed a red pill and nothing else, so the provider could see
+    # that something broke but not what, nor whether resending could possibly help.
+    test "shows why a failed invite failed", %{conn: conn, program: program} do
+      invite = fail_invite(%{failure_code: :delivery_failed})
+
+      view = open_invites(conn, program)
+
+      assert has_element?(view, "#invite-error-#{invite.id}", "could not be delivered")
+    end
+
+    # #1340: the cause is written by an Oban worker, which has no reader's locale — so the
+    # reason has to be translated here, on the render, or the provider reads English.
+    test "shows the reason in the provider's language", %{conn: conn, program: program} do
+      invite = fail_invite(%{failure_code: :delivery_failed})
+
+      view = open_invites(conn, program, ~p"/provider/dashboard/programs?locale=de")
+
+      assert has_element?(view, "#invite-error-#{invite.id}", "konnte nicht zugestellt werden")
+    end
+
+    test "names the field a failed claim could not accept, in the provider's language", %{
+      conn: conn,
+      program: program
+    } do
+      invite =
+        fail_invite(%{
+          failure_code: :invalid_details,
+          failure_context: %{
+            "fields" => [%{"field" => "date_of_birth", "msg" => "can't be blank", "bindings" => %{}}]
+          }
+        })
+
+      view = open_invites(conn, program, ~p"/provider/dashboard/programs?locale=de")
+
+      assert has_element?(view, "#invite-error-#{invite.id}", "Geburtsdatum darf nicht leer sein")
+    end
+
+    # Gettext's default `handle_missing_bindings/2` logs an error and hands back the
+    # un-interpolated string. Calling it with the msgid's placeholders unbound therefore
+    # costs a Logger.error on *every* render of that row — noise the prod-issue sweep
+    # would pick up — even though a second interpolation pass makes the output right.
+    test "renders a message with a value placeholder without logging a missing binding", %{
+      conn: conn,
+      program: program
+    } do
+      invite =
+        fail_invite(%{
+          failure_code: :invalid_details,
+          failure_context: %{
+            "fields" => [
+              %{
+                "field" => "school_grade",
+                "msg" => "must be greater than or equal to %{number}",
+                "bindings" => %{"number" => 1}
+              }
+            ]
+          }
+        })
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          view = open_invites(conn, program, ~p"/provider/dashboard/programs?locale=de")
+
+          assert has_element?(view, "#invite-error-#{invite.id}", "muss größer oder gleich 1 sein")
+        end)
+
+      refute log =~ "missing Gettext bindings"
+    end
+
+    test "interpolates the value a failed date carried", %{conn: conn, program: program} do
+      invite =
+        fail_invite(%{failure_code: :invalid_date, failure_context: %{"value" => "31.02.2016"}})
+
+      view = open_invites(conn, program)
+
+      assert has_element?(view, "#invite-error-#{invite.id}", "31.02.2016")
+    end
+
+    # Invites that failed before #1340 carry a sentence and no code. Nothing backfilled
+    # them, so the render has to keep reading the old column.
+    test "still shows the sentence an invite failed with before the codes existed", %{
+      conn: conn,
+      program: program
+    } do
+      invite = fail_invite(%{error_details: "date of birth can't be blank"})
+
+      view = open_invites(conn, program)
 
       assert has_element?(view, "#invite-error-#{invite.id}", "date of birth can't be blank")
     end


### PR DESCRIPTION
## Summary

A German-locale provider read invite failure reasons in English. `bulk_enrollment_invites.error_details` held a finished English sentence, rendered verbatim under the status pill.

Wrapping the literals in `gettext` cannot fix it. `Gettext.put_locale/2` writes the **calling process's** dictionary, and every writer here is a background process — `SendInviteEmailWorker`, `ProcessInviteClaimWorker`, `InviteFamilyReadyHandler` — none of which has a reader's locale in scope. Copy written at failure time is frozen in whatever locale that process had, which is always `en`. `mix lint_translations` couldn't catch it either: there was no `gettext(...)` call to be missing a translation *for*.

So the seam moves from the rendered sentence to a **classified cause**. Enrollment stores which of seven ways the invite failed plus any interpolation data; the component turns that into a sentence where the reader's locale is the one in scope. Same shape as the Stripe Identity codes already in `verification_live.ex:827-842`.

## Review focus

**Storage shape** — two new nullable columns, `failure_code` (`Ecto.Enum`) and `failure_context` (jsonb). `error_details` is kept, **unwritten**, as a legacy read-only fallback: pre-change rows still render their sentence, so there is no backfill and no migration risk. It can be dropped once no live row carries one. `error_details` was removed from both `@lifecycle_fields` and `@optional_fields` so nothing can write a sentence again.

**The atom trap** — Ecto errors are `{"should be at most %{count} character(s)", [count: 5, validation: :length]}`. Persisting `opts` and rebuilding atom keys at render would raise on an old row once an atom is deleted in a later release. Instead `ChangesetErrors.to_payload/1` stores the raw msgid with **string-keyed** bindings, and the only string→atom conversion is a closed literal map (`gettext_bindings/1`), verified complete against the two placeholders `errors.pot` actually contains. No `String.to_existing_atom/1` touches stored data — in fact the rewrite removed the one that was already there.

**Translate, then interpolate** — the German `msgstr` carries the placeholders too, so the order matters. Gettext must also be handed the bindings it can resolve: its default `handle_missing_bindings/2` is a `Logger.error`, so passing an empty map logged an error on *every render* of any row carrying a `%{number}` message (reachable through `school_grade`'s `validate_number`). Caught by review, now covered by a `capture_log` regression test.

**Reuse over addition** — the field-label vocabulary already existed at `provider_components.ex` `humanize_field/1` with German shipped, built for CSV import errors. A claim failure names `Family.Child`'s fields (`first_name`) where the CSV names its own (`child_first_name`), so three clauses were added reusing the *existing* msgids — zero new translations for those.

## Test plan

- `mix precommit` green: **4380 passed**, credo clean, all five lints including `lint_translations`.
- New coverage: `classify_failure/2` tabular test incl. a JSON-round-trip property on every context; `to_payload/1` / `interpolate/2` / `gettext_bindings/1`; `fail_invite` writes both columns and no sentence; `reset_invite_for_resend` clears both **and** the legacy column; render tests for German output, interpolated values, the missing-binding log, and the legacy-sentence fallback.
- Existing worker/saga assertions re-pointed from English substrings to codes + context.
- Reviewed by `architecture-reviewer` (8/8), `boundary-checker` (5/5), `regression-analyzer` (8/8 after both warnings addressed).

Closes #1340