### PR TITLE
fix: surface rejected policy writes on the program update path

### DIFF
--- a/lib/klass_hero_web/live/provider/programs_live.ex
+++ b/lib/klass_hero_web/live/provider/programs_live.ex
@@ -646,7 +646,7 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
          {:ok, program} <- ProgramCatalog.create_program(attrs) do
       :ok = apply_lead_instructor(program.id, instructor_id, socket.assigns.current_scope.provider.id)
       policy_result = maybe_set_enrollment_policy(program.id, enrollment_params)
-      set_participant_policy_on_create(program.id, participant_policy_params)
+      participant_result = set_participant_policy_on_create(program.id, participant_policy_params)
       capacity = resolve_capacity(policy_result, enrollment_params)
 
       new_enrollment_data = %{
@@ -655,7 +655,10 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
 
       {:noreply,
        socket
-       |> flash_for_policy_result(policy_result)
+       |> flash_for_save(:created,
+         enrollment_policy: policy_result,
+         participant_policy: participant_result
+       )
        |> maybe_flash_cover_warning(cover_result)
        |> insert_program_row(program, new_enrollment_data)
        |> assign(
@@ -695,7 +698,7 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
          {:ok, updated} <- ProgramCatalog.update_program(provider_id, program_id, attrs) do
       :ok = apply_lead_instructor(program_id, instructor_id, provider_id)
       policy_result = maybe_set_enrollment_policy(program_id, enrollment_params)
-      set_participant_policy_on_update(program_id, participant_policy_params)
+      participant_result = set_participant_policy_on_update(program_id, participant_policy_params)
 
       capacity = resolve_capacity(policy_result, enrollment_params)
       active_counts = Enrollment.count_active_enrollments_batch([program_id])
@@ -704,7 +707,10 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
 
       {:noreply,
        socket
-       |> put_flash(:info, gettext("Program updated successfully."))
+       |> flash_for_save(:updated,
+         enrollment_policy: policy_result,
+         participant_policy: participant_result
+       )
        |> maybe_flash_cover_warning(cover_result)
        |> insert_program_row(updated, enrollment_data)
        |> assign(
@@ -1102,18 +1108,44 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
 
   defp resolve_capacity({:error, _}, _enrollment_params), do: nil
 
-  defp flash_for_policy_result(socket, :ok) do
-    socket
-    |> clear_flash(:error)
-    |> put_flash(:info, gettext("Program created successfully."))
+  # The program row is already written by the time the policy sub-writes run, so a
+  # rejected one is reported, never rolled back. Flash is keyed by kind, so a second
+  # put_flash of the same kind erases the first — every failure merges into ONE
+  # :warning, which also keeps it clear of a real :error (#1345).
+  defp flash_for_save(socket, action, results) do
+    failed_sources = for {source, {:error, _reason}} <- results, do: source
+
+    case failed_sources do
+      [] ->
+        socket
+        |> clear_flash(:error)
+        |> clear_flash(:warning)
+        |> put_flash(:info, save_success_message(action))
+
+      _ ->
+        put_flash(socket, :warning, save_failure_message(action, failed_sources))
+    end
   end
 
-  defp flash_for_policy_result(socket, {:error, :enrollment_policy_failed}) do
-    socket
-    |> put_flash(
-      :error,
-      gettext("Program created, but enrollment capacity could not be saved. Edit the program to retry.")
-    )
+  defp save_success_message(:created), do: gettext("Program created successfully.")
+  defp save_success_message(:updated), do: gettext("Program updated successfully.")
+
+  defp save_failure_message(:created, [:enrollment_policy]) do
+    gettext("Program created, but enrollment capacity could not be saved. Edit the program to retry.")
+  end
+
+  defp save_failure_message(:updated, [:enrollment_policy]) do
+    gettext("Program updated, but the enrollment capacity was rejected. The previous limits still apply.")
+  end
+
+  # A rejected participant policy is a should-never-happen (the form only submits
+  # shapes the changeset accepts), so it shares one message rather than earning its own.
+  defp save_failure_message(:created, _failed_sources) do
+    gettext("Program created, but some settings could not be saved. Please review the program's limits.")
+  end
+
+  defp save_failure_message(:updated, _failed_sources) do
+    gettext("Program updated, but some settings could not be saved. Please review the program's limits.")
   end
 
   defp lead_instructor_id(program_id) do

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -2849,8 +2849,8 @@ msgstr "Ausstehende Überprüfung"
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:106
-#: lib/klass_hero_web/live/provider/programs_live.ex:684
-#: lib/klass_hero_web/live/provider/programs_live.ex:743
+#: lib/klass_hero_web/live/provider/programs_live.ex:687
+#: lib/klass_hero_web/live/provider/programs_live.ex:749
 #: lib/klass_hero_web/live/provider/team_live.ex:305
 #: lib/klass_hero_web/live/provider/team_live.ex:348
 #: lib/klass_hero_web/live/provider/team_live.ex:467
@@ -2883,12 +2883,12 @@ msgstr "Profil erfolgreich aktualisiert."
 msgid "Program Start"
 msgstr "Programmbeginn"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1108
+#: lib/klass_hero_web/live/provider/programs_live.ex:1130
 #, elixir-autogen, elixir-format
 msgid "Program created successfully."
 msgstr "Programm erfolgreich erstellt."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1115
+#: lib/klass_hero_web/live/provider/programs_live.ex:1134
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr "Programm erstellt, aber die Anmeldekapazität konnte nicht gespeichert werden. Bearbeiten Sie das Programm, um es erneut zu versuchen."
@@ -2897,12 +2897,12 @@ msgstr "Programm erstellt, aber die Anmeldekapazität konnte nicht gespeichert w
 #: lib/klass_hero_web/live/provider/programs_live.ex:153
 #: lib/klass_hero_web/live/provider/programs_live.ex:190
 #: lib/klass_hero_web/live/provider/programs_live.ex:254
-#: lib/klass_hero_web/live/provider/programs_live.ex:718
+#: lib/klass_hero_web/live/provider/programs_live.ex:724
 #, elixir-autogen, elixir-format
 msgid "Program not found."
 msgstr "Programm nicht gefunden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:707
+#: lib/klass_hero_web/live/provider/programs_live.ex:1131
 #, elixir-autogen, elixir-format
 msgid "Program updated successfully."
 msgstr "Programm erfolgreich aktualisiert."
@@ -3063,8 +3063,8 @@ msgstr "Datei auswählen"
 msgid "Selected child does not meet the program requirements."
 msgstr "Das ausgewählte Kind erfüllt die Programmanforderungen nicht."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:674
-#: lib/klass_hero_web/live/provider/programs_live.ex:733
+#: lib/klass_hero_web/live/provider/programs_live.ex:677
+#: lib/klass_hero_web/live/provider/programs_live.ex:739
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr "Der ausgewählte Kursleiter konnte nicht gefunden werden. Bitte versuchen Sie es erneut."
@@ -3169,7 +3169,7 @@ msgstr "Die Geschichte von Klass Hero"
 msgid "This invite cannot be resent."
 msgstr "Diese Einladung kann nicht erneut gesendet werden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:725
+#: lib/klass_hero_web/live/provider/programs_live.ex:731
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr "Dieses Programm wurde von jemand anderem geändert. Bitte schließen Sie es und versuchen Sie es erneut."
@@ -3384,7 +3384,7 @@ msgstr "Zahlung per Bargeld oder Banküberweisung"
 msgid "Program fee:"
 msgstr "Programmgebühr:"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:946
+#: lib/klass_hero_web/live/provider/programs_live.ex:952
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr "Programm gespeichert, aber der Upload des Titelbilds ist fehlgeschlagen. Sie können es erneut hochladen, indem Sie das Programm bearbeiten."
@@ -7685,7 +7685,7 @@ msgstr ""
 msgid "Staffing — %{title}"
 msgstr "Programmteam — %{title}"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:905
+#: lib/klass_hero_web/live/provider/programs_live.ex:911
 #, elixir-autogen, elixir-format
 msgid "That staff member could not be found."
 msgstr "Dieses Teammitglied wurde nicht gefunden."
@@ -7758,3 +7758,24 @@ msgstr "Damit wird %{name} endgültig gelöscht – das lässt sich nicht rückg
 #, elixir-autogen, elixir-format
 msgid "This person has a history here now — use 'Remove from team' instead."
 msgstr "Diese Person hat inzwischen eine Historie – nutze stattdessen „Aus dem Team entfernen“."
+
+#: lib/klass_hero_web/live/provider/programs_live.ex:1144
+#, elixir-autogen, elixir-format
+msgid "Program created, but some settings could not be saved. Please review the program's limits."
+msgstr ""
+"Programm erstellt, aber einige Einstellungen konnten nicht gespeichert werden. "
+"Bitte überprüfen Sie die Grenzwerte des Programms."
+
+#: lib/klass_hero_web/live/provider/programs_live.ex:1148
+#, elixir-autogen, elixir-format
+msgid "Program updated, but some settings could not be saved. Please review the program's limits."
+msgstr ""
+"Programm aktualisiert, aber einige Einstellungen konnten nicht gespeichert "
+"werden. Bitte überprüfen Sie die Grenzwerte des Programms."
+
+#: lib/klass_hero_web/live/provider/programs_live.ex:1138
+#, elixir-autogen, elixir-format
+msgid "Program updated, but the enrollment capacity was rejected. The previous limits still apply."
+msgstr ""
+"Programm aktualisiert, aber die Anmeldekapazität wurde abgelehnt. Es gelten "
+"weiterhin die bisherigen Grenzwerte."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -2849,8 +2849,8 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:106
-#: lib/klass_hero_web/live/provider/programs_live.ex:684
-#: lib/klass_hero_web/live/provider/programs_live.ex:743
+#: lib/klass_hero_web/live/provider/programs_live.ex:687
+#: lib/klass_hero_web/live/provider/programs_live.ex:749
 #: lib/klass_hero_web/live/provider/team_live.ex:305
 #: lib/klass_hero_web/live/provider/team_live.ex:348
 #: lib/klass_hero_web/live/provider/team_live.ex:467
@@ -2883,12 +2883,12 @@ msgstr ""
 msgid "Program Start"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1108
+#: lib/klass_hero_web/live/provider/programs_live.ex:1130
 #, elixir-autogen, elixir-format
 msgid "Program created successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1115
+#: lib/klass_hero_web/live/provider/programs_live.ex:1134
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr ""
@@ -2897,12 +2897,12 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/programs_live.ex:153
 #: lib/klass_hero_web/live/provider/programs_live.ex:190
 #: lib/klass_hero_web/live/provider/programs_live.ex:254
-#: lib/klass_hero_web/live/provider/programs_live.ex:718
+#: lib/klass_hero_web/live/provider/programs_live.ex:724
 #, elixir-autogen, elixir-format
 msgid "Program not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:707
+#: lib/klass_hero_web/live/provider/programs_live.ex:1131
 #, elixir-autogen, elixir-format
 msgid "Program updated successfully."
 msgstr ""
@@ -3063,8 +3063,8 @@ msgstr ""
 msgid "Selected child does not meet the program requirements."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:674
-#: lib/klass_hero_web/live/provider/programs_live.ex:733
+#: lib/klass_hero_web/live/provider/programs_live.ex:677
+#: lib/klass_hero_web/live/provider/programs_live.ex:739
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
@@ -3169,7 +3169,7 @@ msgstr ""
 msgid "This invite cannot be resent."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:725
+#: lib/klass_hero_web/live/provider/programs_live.ex:731
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
@@ -3384,7 +3384,7 @@ msgstr ""
 msgid "Program fee:"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:946
+#: lib/klass_hero_web/live/provider/programs_live.ex:952
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr ""
@@ -7683,7 +7683,7 @@ msgstr ""
 msgid "Staffing — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:905
+#: lib/klass_hero_web/live/provider/programs_live.ex:911
 #, elixir-autogen, elixir-format
 msgid "That staff member could not be found."
 msgstr ""
@@ -7753,4 +7753,19 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/team_live.ex:218
 #, elixir-autogen, elixir-format
 msgid "This person has a history here now — use 'Remove from team' instead."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/programs_live.ex:1144
+#, elixir-autogen, elixir-format
+msgid "Program created, but some settings could not be saved. Please review the program's limits."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/programs_live.ex:1148
+#, elixir-autogen, elixir-format
+msgid "Program updated, but some settings could not be saved. Please review the program's limits."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/programs_live.ex:1138
+#, elixir-autogen, elixir-format
+msgid "Program updated, but the enrollment capacity was rejected. The previous limits still apply."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -2849,8 +2849,8 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:106
-#: lib/klass_hero_web/live/provider/programs_live.ex:684
-#: lib/klass_hero_web/live/provider/programs_live.ex:743
+#: lib/klass_hero_web/live/provider/programs_live.ex:687
+#: lib/klass_hero_web/live/provider/programs_live.ex:749
 #: lib/klass_hero_web/live/provider/team_live.ex:305
 #: lib/klass_hero_web/live/provider/team_live.ex:348
 #: lib/klass_hero_web/live/provider/team_live.ex:467
@@ -2883,12 +2883,12 @@ msgstr ""
 msgid "Program Start"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1108
+#: lib/klass_hero_web/live/provider/programs_live.ex:1130
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program created successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1115
+#: lib/klass_hero_web/live/provider/programs_live.ex:1134
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr ""
@@ -2897,12 +2897,12 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/programs_live.ex:153
 #: lib/klass_hero_web/live/provider/programs_live.ex:190
 #: lib/klass_hero_web/live/provider/programs_live.ex:254
-#: lib/klass_hero_web/live/provider/programs_live.ex:718
+#: lib/klass_hero_web/live/provider/programs_live.ex:724
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:707
+#: lib/klass_hero_web/live/provider/programs_live.ex:1131
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program updated successfully."
 msgstr ""
@@ -3063,8 +3063,8 @@ msgstr ""
 msgid "Selected child does not meet the program requirements."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:674
-#: lib/klass_hero_web/live/provider/programs_live.ex:733
+#: lib/klass_hero_web/live/provider/programs_live.ex:677
+#: lib/klass_hero_web/live/provider/programs_live.ex:739
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
@@ -3169,7 +3169,7 @@ msgstr ""
 msgid "This invite cannot be resent."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:725
+#: lib/klass_hero_web/live/provider/programs_live.ex:731
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
@@ -3384,7 +3384,7 @@ msgstr ""
 msgid "Program fee:"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:946
+#: lib/klass_hero_web/live/provider/programs_live.ex:952
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr ""
@@ -7683,7 +7683,7 @@ msgstr ""
 msgid "Staffing — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:905
+#: lib/klass_hero_web/live/provider/programs_live.ex:911
 #, elixir-autogen, elixir-format
 msgid "That staff member could not be found."
 msgstr ""
@@ -7753,4 +7753,19 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/team_live.ex:218
 #, elixir-autogen, elixir-format
 msgid "This person has a history here now — use 'Remove from team' instead."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/programs_live.ex:1144
+#, elixir-autogen, elixir-format
+msgid "Program created, but some settings could not be saved. Please review the program's limits."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/programs_live.ex:1148
+#, elixir-autogen, elixir-format
+msgid "Program updated, but some settings could not be saved. Please review the program's limits."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/programs_live.ex:1138
+#, elixir-autogen, elixir-format
+msgid "Program updated, but the enrollment capacity was rejected. The previous limits still apply."
 msgstr ""

--- a/test/klass_hero_web/live/provider/dashboard_program_creation_test.exs
+++ b/test/klass_hero_web/live/provider/dashboard_program_creation_test.exs
@@ -412,6 +412,112 @@ defmodule KlassHeroWeb.Provider.DashboardProgramCreationTest do
       assert html =~ "Program created successfully."
       refute html =~ "enrollment capacity could not be saved"
     end
+
+    # The regression #1345 reports: the update path reported success while the
+    # policy write was rejected and the old limits stayed in force.
+    test "warns when an edit's capacity is rejected", %{conn: conn, provider: provider} do
+      program = seed_program_with_listing(provider.id, "Rejected Capacity Program")
+
+      {:ok, _policy} =
+        KlassHero.Enrollment.set_enrollment_policy(%{program_id: program.id, max_enrollment: 20})
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+
+      open_edit_form(view, program)
+
+      submit_program_form(view, "Rejected Capacity Program", %{
+        "enrollment_policy" => %{"min_enrollment" => "50", "max_enrollment" => "10"}
+      })
+
+      assert_flash(
+        view,
+        :warning,
+        "Program updated, but the enrollment capacity was rejected. The previous limits still apply."
+      )
+
+      refute_flash(view, :info)
+    end
+
+    # Every edit outcome is the same submit under a different policy payload, so the
+    # only axis that matters is which sub-writes were rejected. A rejected capacity
+    # names itself; anything else shares the generic message.
+    for {label, policy_params, kind, message} <- [
+          {"accepted capacity and restrictions",
+           %{
+             "enrollment_policy" => %{"min_enrollment" => "5", "max_enrollment" => "20"},
+             "participant_policy" => %{"min_grade" => "1", "max_grade" => "4"}
+           }, :info, "Program updated successfully."},
+          {"rejected participant restrictions",
+           %{
+             "enrollment_policy" => %{"max_enrollment" => "20"},
+             "participant_policy" => %{"min_grade" => "10", "max_grade" => "2"}
+           }, :warning, "Program updated, but some settings could not be saved. Please review the program's limits."},
+          {"both rejected",
+           %{
+             "enrollment_policy" => %{"min_enrollment" => "50", "max_enrollment" => "10"},
+             "participant_policy" => %{"min_grade" => "10", "max_grade" => "2"}
+           }, :warning, "Program updated, but some settings could not be saved. Please review the program's limits."}
+        ] do
+      @edit_case %{params: policy_params, kind: kind, message: message}
+
+      test "editing with #{label} flashes the matching outcome", %{conn: conn, provider: provider} do
+        program = seed_program_with_listing(provider.id, "Outcome Program")
+
+        {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+
+        open_edit_form(view, program)
+        submit_program_form(view, "Outcome Program", @edit_case.params)
+
+        assert_flash(view, @edit_case.kind, @edit_case.message)
+        refute_flash(view, opposite_kind(@edit_case.kind))
+      end
+    end
+
+    # A partial failure is a :warning, never an :error — flash is keyed by kind, so
+    # an :error here would be erased by (or erase) a genuine error from elsewhere.
+    test "a rejected capacity on create is a warning, not an error", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+
+      view |> element("#new-program-btn") |> render_click()
+
+      submit_program_form(view, "Capacity Kind Program", %{
+        "enrollment_policy" => %{"min_enrollment" => "20", "max_enrollment" => "5"}
+      })
+
+      assert_flash(
+        view,
+        :warning,
+        "Program created, but enrollment capacity could not be saved. Edit the program to retry."
+      )
+
+      refute_flash(view, :error)
+    end
+
+    defp opposite_kind(:info), do: :warning
+    defp opposite_kind(:warning), do: :info
+
+    defp open_edit_form(view, program) do
+      view
+      |> element(~s([phx-click="edit_program"][phx-value-id="#{program.id}"]))
+      |> render_click()
+    end
+
+    defp submit_program_form(view, title, policy_params) do
+      params =
+        Map.merge(
+          %{
+            "program_schema" => %{
+              "title" => title,
+              "description" => "Exercising a program save outcome",
+              "category" => "arts",
+              "price" => "50.00"
+            }
+          },
+          policy_params
+        )
+
+      view |> form("#program-form", params) |> render_submit()
+    end
   end
 
   # The row a save inserts shows the capacity that was just typed, not what an
@@ -472,9 +578,8 @@ defmodule KlassHeroWeb.Provider.DashboardProgramCreationTest do
       })
       |> render_submit()
 
-      # No warning flash here: `flash_for_policy_result/2` is wired into the create
-      # path only, so an update silently drops a rejected capacity. Filed separately;
-      # this test pins the row, not the (missing) flash.
+      # The cell blanks rather than showing the surviving 20, so the warning flash
+      # is what tells the provider the capacity was refused, not cleared (#1345).
       assert view |> element("#programs-#{program.id}") |> render() =~ "0/—"
 
       assert %{max_enrollment: 20} =

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -83,6 +83,22 @@ defmodule KlassHeroWeb.ConnCase do
   end
 
   @doc """
+  Asserts a LiveView has no flash message of the given kind.
+
+  ## Examples
+
+      refute_flash(lv, :warning)
+  """
+  def refute_flash(lv, kind) do
+    flash = :sys.get_state(lv.pid).socket.assigns.flash
+
+    case Phoenix.Flash.get(flash, kind) do
+      nil -> true
+      actual -> flunk("Expected no flash #{inspect(kind)}, but got: #{inspect(actual)}")
+    end
+  end
+
+  @doc """
   Asserts a cross-tenant (IDOR) ownership guard.
 
   Triggers `event` on the LiveView with a foreign resource `id` and asserts the


### PR DESCRIPTION
## Summary

Editing a program with an invalid enrollment capacity (`min_enrollment` > `max_enrollment`) failed the policy write but told the provider **"Program updated successfully."** The rejection survived only as a `Logger.warning`; the row's capacity cell blanked to `—`, which reads as *capacity cleared* rather than *capacity refused*, while `enrollment_policies` still held the old value.

`update_existing_program/5` already computed `policy_result` — it fed `resolve_capacity/2` and was never rendered. The create path did it correctly via `flash_for_policy_result/2`.

Investigating turned up the same silence one layer over: `save_participant_policy/2` returns `{:error, :participant_policy_failed}` and **neither** save path bound it, so a rejected participant policy was invisible on create *and* update.

### What changed

`flash_for_policy_result/2` — create-only, with `"Program created successfully."` hardcoded in its `:ok` clause — is replaced by:

```elixir
flash_for_save(socket, action, enrollment_policy: r1, participant_policy: r2)
# action :: :created | :updated
```

One function now owns *what the provider sees after a save*. Two constraints shaped it:

- **Phoenix flash is a map keyed by kind** — a second `put_flash(:error, …)` silently erases the first. Folding participant-policy failure in as another `:error` would have wiped the capacity message, so every failure merges into a **single** message.
- Partial failures move to **`:warning`**, matching `maybe_flash_cover_warning/2` ("Program saved, but the cover image upload failed"). That also keeps them clear of a genuine `:error` from elsewhere.

The create path's capacity copy is **unchanged**; only its kind moved `:error` → `:warning`.

The row cell still blanks on a rejected capacity — that's the deliberate #1307 decision, and the new warning is what explains it. Deciding to show the surviving old value instead would be a separate call.

## Review Focus

- **`programs_live.ex` — `flash_for_save/3` and the message clauses.** The `[:enrollment_policy]` clause matches a single-element list on purpose: a capacity rejection names itself, anything else (participant policy, or both) shares the generic copy. Adding a third sub-write later means deciding whether it deserves its own message or falls through.
- **The `:error` → `:warning` move on the create path.** No existing test caught it, because they all assert on rendered text rather than kind — which is why this adds `refute_flash/2` next to `assert_flash/3` in `conn_case.ex`.
- **German copy.** Three new `msgstr` entries, formal *Sie*, reusing the established "Anmeldekapazität". Worth a native read.

## Test Plan

- `mix precommit` green: **4385 passed**, credo `--strict` clean, all five lints pass (including `lint_translations`, which would fail on an empty German `msgstr`).
- New coverage in `dashboard_program_creation_test.exs`:
  - the #1345 regression itself — edit a program holding `max_enrollment: 20`, submit `min: 50 / max: 10`, assert the `:warning` and `refute_flash(:info)`;
  - a 3-row table over edit outcomes: accepted / rejected participant restrictions / both rejected;
  - a create-path test pinning that a rejected capacity is a `:warning`, not an `:error`.
- `provider_dashboard_test.exs:1202,1266,1314` submit `"enrollment_policy" => %{}` and still assert `:info` "Program updated successfully." — untouched and green, confirming *nothing to write* isn't treated as a failure.

## Follow-up

A third symptom of the same root cause is left out deliberately and needs its own issue: **clearing both capacity fields on the edit form is a silent no-op.** `maybe_set_enrollment_policy/2` short-circuits on `nil, nil` (create semantics), so the old policy survives while the flash reports success — exactly the bug #795 fixed for participant policy. It needs a `KlassHero.Enrollment` decision on what "clear" means (delete the row, or upsert nils?), which doesn't belong in a flash fix.

Closes #1345
