### PR TITLE
fix: make every programs-table row write respect the active filters

### DIFF
--- a/lib/klass_hero_web/live/provider/programs_live.ex
+++ b/lib/klass_hero_web/live/provider/programs_live.ex
@@ -54,7 +54,6 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
       |> assign(page_title: gettext("My Programs"))
       |> assign(active_nav: :programs)
       |> stream(:programs, programs)
-      |> assign(programs_count: length(programs))
       |> assign(staff_options: staff_options)
       |> assign(search_query: "", selected_staff: "all")
       |> assign(show_program_form: false, editing_program_id: nil)
@@ -660,11 +659,10 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
          participant_policy: participant_result
        )
        |> maybe_flash_cover_warning(cover_result)
-       |> insert_program_row(program, new_enrollment_data)
+       |> reveal_program_row(program, new_enrollment_data)
        |> assign(
          show_program_form: false,
          editing_program_id: nil,
-         programs_count: socket.assigns.programs_count + 1,
          enrollment_form: to_form(Enrollment.new_policy_changeset(), as: "enrollment_policy"),
          participant_policy_form: to_form(Enrollment.new_participant_policy_changeset(), as: "participant_policy")
        )}
@@ -712,7 +710,7 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
          participant_policy: participant_result
        )
        |> maybe_flash_cover_warning(cover_result)
-       |> insert_program_row(updated, enrollment_data)
+       |> sync_program_row(updated, enrollment_data)
        |> assign(
          show_program_form: false,
          editing_program_id: nil,
@@ -792,9 +790,7 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
 
     programs = to_table_views(filtered, build_enrollment_data(filtered), staffing)
 
-    socket
-    |> stream(:programs, programs, reset: true)
-    |> assign(programs_count: length(programs))
+    stream(socket, :programs, programs, reset: true)
   end
 
   # One query for the whole table's staffing, so neither rendering nor filtering
@@ -857,13 +853,7 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
 
     case ProgramCatalog.get_program_for_provider(provider_id, program_id) do
       {:ok, program} ->
-        staffing = fetch_program_staffing(program_id)
-
-        if row_visible?(socket, staffing) do
-          insert_program_row(socket, program, build_enrollment_data([program]), staffing)
-        else
-          stream_delete(socket, :programs, %{id: program_id})
-        end
+        sync_program_row(socket, program, build_enrollment_data([program]), fetch_program_staffing(program_id))
 
       {:error, :not_found} ->
         socket
@@ -877,27 +867,54 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
   #
   # The panel path already holds the staffing it filtered on, so it passes it in
   # rather than paying for the read twice.
-  defp insert_program_row(socket, program, enrollment_data) do
-    insert_program_row(socket, program, enrollment_data, fetch_program_staffing(program.id))
+  #
+  # Whether the row belongs in the table at all is *not* a caller's decision: the
+  # table is filtered, so a write that ignores the filter shows a row contradicting
+  # it. Every path lands here, so a fourth one is correct without knowing that (#1346).
+  defp sync_program_row(socket, program, enrollment_data) do
+    sync_program_row(socket, program, enrollment_data, fetch_program_staffing(program.id))
   end
 
-  defp insert_program_row(socket, program, enrollment_data, staffing) do
-    view = ProgramPresenter.to_table_view(program, enrollment_data, staffing)
+  defp sync_program_row(socket, program, enrollment_data, staffing) do
+    if row_matches_filters?(socket, program, staffing) do
+      stream_insert(socket, :programs, ProgramPresenter.to_table_view(program, enrollment_data, staffing))
+    else
+      stream_delete(socket, :programs, %{id: program.id})
+    end
+  end
 
-    stream_insert(socket, :programs, view)
+  # A program the provider just made is the one row they are certainly looking
+  # for, so a filter that would hide it yields rather than the row — the
+  # alternative is a save that visibly does nothing (#1346).
+  defp reveal_program_row(socket, program, enrollment_data) do
+    staffing = fetch_program_staffing(program.id)
+
+    if row_matches_filters?(socket, program, staffing) do
+      sync_program_row(socket, program, enrollment_data, staffing)
+    else
+      # The re-stream cannot carry the new row: it reads the `program_listings`
+      # projection, which has not caught up with a program created a moment ago.
+      # Only the domain struct the write returned can show it, so the row is
+      # inserted on top of the freshly unfiltered table.
+      socket
+      |> assign(search_query: "", selected_staff: "all")
+      |> reset_programs_stream()
+      |> sync_program_row(program, enrollment_data, staffing)
+    end
   end
 
   defp fetch_program_staffing(program_id) do
     Map.get(Provider.list_program_staffing([program_id]), program_id)
   end
 
-  # Removing the staff member a filter is pinned to must drop the row, not
-  # re-insert it — otherwise the table shows a program that no longer matches.
-  defp row_visible?(socket, staffing) do
-    case socket.assigns.selected_staff do
-      "all" -> true
-      staff_id -> ProgramStaffing.staffed_by?(staffing, staff_id)
-    end
+  # Asks the table's own filters about one row, so "what the list shows" and
+  # "what a row write shows" cannot drift apart — the drift is what let a save
+  # insert a row contradicting the active filter (#1346).
+  defp row_matches_filters?(socket, program, staffing) do
+    [program]
+    |> filter_by_search(socket.assigns.search_query)
+    |> filter_by_staff(%{program.id => staffing}, socket.assigns.selected_staff)
+    |> Enum.any?()
   end
 
   defp staffing_not_found(socket, action, staff_member_id, provider_id) do

--- a/lib/klass_hero_web/live/provider/programs_live.ex
+++ b/lib/klass_hero_web/live/provider/programs_live.ex
@@ -886,6 +886,10 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
   # A program the provider just made is the one row they are certainly looking
   # for, so a filter that would hide it yields rather than the row — the
   # alternative is a save that visibly does nothing (#1346).
+  #
+  # Both axes yield together, even when only one of them hides the row: clearing
+  # per-axis would branch on every combination to spare a search term the row
+  # still matched. Deliberate, and pinned by a test.
   defp reveal_program_row(socket, program, enrollment_data) do
     staffing = fetch_program_staffing(program.id)
 

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -2386,12 +2386,12 @@ msgstr "Bestätigt"
 msgid "Contact Provider"
 msgstr "Anbieter kontaktieren"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:449
+#: lib/klass_hero_web/live/provider/programs_live.ex:448
 #, elixir-autogen, elixir-format
 msgid "Could not read the uploaded file."
 msgstr "Die hochgeladene Datei konnte nicht gelesen werden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:417
+#: lib/klass_hero_web/live/provider/programs_live.ex:416
 #, elixir-autogen, elixir-format
 msgid "Could not remove invite."
 msgstr "Einladung konnte nicht entfernt werden."
@@ -2529,7 +2529,7 @@ msgstr "Dokument konnte nicht genehmigt werden."
 msgid "Failed to reject document."
 msgstr "Dokument konnte nicht abgelehnt werden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:399
+#: lib/klass_hero_web/live/provider/programs_live.ex:398
 #, elixir-autogen, elixir-format
 msgid "Failed to resend invite."
 msgstr "Einladung konnte nicht erneut gesendet werden."
@@ -2622,17 +2622,17 @@ msgstr "Importieren"
 msgid "Insurance Certificate"
 msgstr "Versicherungsnachweis"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:414
+#: lib/klass_hero_web/live/provider/programs_live.ex:413
 #, elixir-autogen, elixir-format
 msgid "Invite not found."
 msgstr "Einladung nicht gefunden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:411
+#: lib/klass_hero_web/live/provider/programs_live.ex:410
 #, elixir-autogen, elixir-format
 msgid "Invite removed."
 msgstr "Einladung entfernt."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:388
+#: lib/klass_hero_web/live/provider/programs_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "Invite resent successfully."
 msgstr "Einladung erfolgreich erneut gesendet."
@@ -2749,7 +2749,7 @@ msgstr "Noch keine Dokumente hochgeladen."
 msgid "No enrollments yet."
 msgstr "Noch keine Anmeldungen."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:445
+#: lib/klass_hero_web/live/provider/programs_live.ex:444
 #, elixir-autogen, elixir-format
 msgid "No file selected."
 msgstr "Keine Datei ausgewählt."
@@ -2849,8 +2849,8 @@ msgstr "Ausstehende Überprüfung"
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:106
-#: lib/klass_hero_web/live/provider/programs_live.ex:687
-#: lib/klass_hero_web/live/provider/programs_live.ex:749
+#: lib/klass_hero_web/live/provider/programs_live.ex:685
+#: lib/klass_hero_web/live/provider/programs_live.ex:747
 #: lib/klass_hero_web/live/provider/team_live.ex:305
 #: lib/klass_hero_web/live/provider/team_live.ex:348
 #: lib/klass_hero_web/live/provider/team_live.ex:467
@@ -2883,26 +2883,26 @@ msgstr "Profil erfolgreich aktualisiert."
 msgid "Program Start"
 msgstr "Programmbeginn"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1130
+#: lib/klass_hero_web/live/provider/programs_live.ex:1151
 #, elixir-autogen, elixir-format
 msgid "Program created successfully."
 msgstr "Programm erfolgreich erstellt."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1134
+#: lib/klass_hero_web/live/provider/programs_live.ex:1155
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr "Programm erstellt, aber die Anmeldekapazität konnte nicht gespeichert werden. Bearbeiten Sie das Programm, um es erneut zu versuchen."
 
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:54
-#: lib/klass_hero_web/live/provider/programs_live.ex:153
-#: lib/klass_hero_web/live/provider/programs_live.ex:190
-#: lib/klass_hero_web/live/provider/programs_live.ex:254
-#: lib/klass_hero_web/live/provider/programs_live.ex:724
+#: lib/klass_hero_web/live/provider/programs_live.ex:152
+#: lib/klass_hero_web/live/provider/programs_live.ex:189
+#: lib/klass_hero_web/live/provider/programs_live.ex:253
+#: lib/klass_hero_web/live/provider/programs_live.ex:722
 #, elixir-autogen, elixir-format
 msgid "Program not found."
 msgstr "Programm nicht gefunden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1131
+#: lib/klass_hero_web/live/provider/programs_live.ex:1152
 #, elixir-autogen, elixir-format
 msgid "Program updated successfully."
 msgstr "Programm erfolgreich aktualisiert."
@@ -3063,8 +3063,8 @@ msgstr "Datei auswählen"
 msgid "Selected child does not meet the program requirements."
 msgstr "Das ausgewählte Kind erfüllt die Programmanforderungen nicht."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:677
-#: lib/klass_hero_web/live/provider/programs_live.ex:739
+#: lib/klass_hero_web/live/provider/programs_live.ex:675
+#: lib/klass_hero_web/live/provider/programs_live.ex:737
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr "Der ausgewählte Kursleiter konnte nicht gefunden werden. Bitte versuchen Sie es erneut."
@@ -3164,12 +3164,12 @@ msgstr "Erzählen Sie Eltern von Ihrer Organisation..."
 msgid "The Klass Hero Story"
 msgstr "Die Geschichte von Klass Hero"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:391
+#: lib/klass_hero_web/live/provider/programs_live.ex:390
 #, elixir-autogen, elixir-format
 msgid "This invite cannot be resent."
 msgstr "Diese Einladung kann nicht erneut gesendet werden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:731
+#: lib/klass_hero_web/live/provider/programs_live.ex:729
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr "Dieses Programm wurde von jemand anderem geändert. Bitte schließen Sie es und versuchen Sie es erneut."
@@ -3384,7 +3384,7 @@ msgstr "Zahlung per Bargeld oder Banküberweisung"
 msgid "Program fee:"
 msgstr "Programmgebühr:"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:952
+#: lib/klass_hero_web/live/provider/programs_live.ex:973
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr "Programm gespeichert, aber der Upload des Titelbilds ist fehlgeschlagen. Sie können es erneut hochladen, indem Sie das Programm bearbeiten."
@@ -3600,7 +3600,7 @@ msgstr "Kann ich meine Programme auf Klass Hero listen und was kostet das?"
 msgid "Cannot check out without a check-in"
 msgstr "Auschecken ohne Einchecken nicht möglich"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:363
+#: lib/klass_hero_web/live/provider/programs_live.ex:362
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
@@ -3665,7 +3665,7 @@ msgid "Correct"
 msgstr "Korrigieren"
 
 #: lib/klass_hero_web/live/dashboard_live.ex:301
-#: lib/klass_hero_web/live/provider/programs_live.ex:360
+#: lib/klass_hero_web/live/provider/programs_live.ex:359
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Could not start conversation. Please try again."
@@ -4422,7 +4422,7 @@ msgstr "Absenden"
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:24
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
-#: lib/klass_hero_web/live/provider/programs_live.ex:222
+#: lib/klass_hero_web/live/provider/programs_live.ex:221
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:156
 #, elixir-autogen, elixir-format
 msgid "Program"
@@ -4631,7 +4631,7 @@ msgid "Update your observation..."
 msgstr "Aktualisieren Sie Ihre Beobachtung..."
 
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:138
-#: lib/klass_hero_web/live/provider/programs_live.ex:442
+#: lib/klass_hero_web/live/provider/programs_live.ex:441
 #: lib/klass_hero_web/live/provider/verification_live.ex:240
 #: lib/klass_hero_web/live/provider/verification_live.ex:556
 #: lib/klass_hero_web/live/provider/verification_live.ex:594
@@ -4941,7 +4941,7 @@ msgstr "Sessions — %{title}"
 msgid "View sessions"
 msgstr "Sessions anzeigen"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:533
+#: lib/klass_hero_web/live/provider/programs_live.ex:532
 #, elixir-autogen, elixir-format
 msgid "Create a program before inviting participants."
 msgstr "Erstellen Sie zuerst ein Programm, bevor Sie Teilnehmer einladen."
@@ -4983,7 +4983,7 @@ msgstr "Einladungsmodus"
 msgid "Invite one person"
 msgstr "Einzelperson einladen"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:529
+#: lib/klass_hero_web/live/provider/programs_live.ex:528
 #, elixir-autogen, elixir-format
 msgid "Invite sent."
 msgstr "Einladung verschickt."
@@ -5086,7 +5086,7 @@ msgstr "Aktualisieren Sie die Notiz für dieses Kind (z. B. um zu klären, was p
 msgid "Upload a list"
 msgstr "Liste hochladen"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:540
+#: lib/klass_hero_web/live/provider/programs_live.ex:539
 #, elixir-autogen, elixir-format
 msgid "An invite for this child and program already exists."
 msgstr "Für dieses Kind und Programm existiert bereits eine Einladung."
@@ -5263,7 +5263,7 @@ msgstr "Ihre Woche mit den Kindern"
 msgid "Go to dashboard"
 msgstr "Zum Dashboard"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:485
+#: lib/klass_hero_web/live/provider/programs_live.ex:484
 #, elixir-autogen, elixir-format
 msgid "%{count} row could not be processed."
 msgid_plural "%{count} rows could not be processed."
@@ -5850,8 +5850,8 @@ msgstr "Wie wir Anbieter überprüfen"
 msgid "I'll be teaching"
 msgstr "Ich werde unterrichten"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:460
-#: lib/klass_hero_web/live/provider/programs_live.ex:482
+#: lib/klass_hero_web/live/provider/programs_live.ex:459
+#: lib/klass_hero_web/live/provider/programs_live.ex:481
 #, elixir-autogen, elixir-format
 msgid "Imported %{count} family."
 msgid_plural "Imported %{count} families."
@@ -6140,7 +6140,7 @@ msgstr "Noch keine Programme — fügen Sie Ihr erstes über den Tab „Programm
 msgid "No registered children for this session."
 msgstr "Keine Kinder in dieser Sitzung angemeldet."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:469
+#: lib/klass_hero_web/live/provider/programs_live.ex:468
 #, elixir-autogen, elixir-format
 msgid "No rows imported. %{count} row could not be processed."
 msgid_plural "No rows imported. %{count} rows could not be processed."
@@ -7623,7 +7623,7 @@ msgstr "Hinzufügen"
 msgid "Lead"
 msgstr "Leitung"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:335
+#: lib/klass_hero_web/live/provider/programs_live.ex:334
 #, elixir-autogen, elixir-format
 msgid "Lead instructor updated."
 msgstr "Leitender Kursleiter aktualisiert."
@@ -7643,7 +7643,7 @@ msgstr "Programmteam verwalten"
 msgid "Nobody is on this program yet."
 msgstr "Diesem Programm ist noch niemand zugewiesen."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:265
+#: lib/klass_hero_web/live/provider/programs_live.ex:264
 #, elixir-autogen, elixir-format
 msgid "Pick a staff member to add."
 msgstr "Bitte ein Teammitglied zum Hinzufügen auswählen."
@@ -7663,12 +7663,12 @@ msgstr "Aus dem Programm entfernen"
 msgid "Select a staff member…"
 msgstr "Teammitglied auswählen …"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:280
+#: lib/klass_hero_web/live/provider/programs_live.ex:279
 #, elixir-autogen, elixir-format
 msgid "Staff member added to the program."
 msgstr "Teammitglied zum Programm hinzugefügt."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:306
+#: lib/klass_hero_web/live/provider/programs_live.ex:305
 #, elixir-autogen, elixir-format
 msgid "Staff member removed from the program."
 msgstr "Teammitglied aus dem Programm entfernt."
@@ -7685,17 +7685,17 @@ msgstr ""
 msgid "Staffing — %{title}"
 msgstr "Programmteam — %{title}"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:911
+#: lib/klass_hero_web/live/provider/programs_live.ex:932
 #, elixir-autogen, elixir-format
 msgid "That staff member could not be found."
 msgstr "Dieses Teammitglied wurde nicht gefunden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:288
+#: lib/klass_hero_web/live/provider/programs_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "They are already on this program."
 msgstr "Diese Person ist bereits in diesem Programm."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:314
+#: lib/klass_hero_web/live/provider/programs_live.ex:313
 #, elixir-autogen, elixir-format
 msgid "This person is the lead instructor. Make someone else lead before removing them."
 msgstr ""
@@ -7759,21 +7759,21 @@ msgstr "Damit wird %{name} endgültig gelöscht – das lässt sich nicht rückg
 msgid "This person has a history here now — use 'Remove from team' instead."
 msgstr "Diese Person hat inzwischen eine Historie – nutze stattdessen „Aus dem Team entfernen“."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1144
+#: lib/klass_hero_web/live/provider/programs_live.ex:1165
 #, elixir-autogen, elixir-format
 msgid "Program created, but some settings could not be saved. Please review the program's limits."
 msgstr ""
 "Programm erstellt, aber einige Einstellungen konnten nicht gespeichert werden. "
 "Bitte überprüfen Sie die Grenzwerte des Programms."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1148
+#: lib/klass_hero_web/live/provider/programs_live.ex:1169
 #, elixir-autogen, elixir-format
 msgid "Program updated, but some settings could not be saved. Please review the program's limits."
 msgstr ""
 "Programm aktualisiert, aber einige Einstellungen konnten nicht gespeichert "
 "werden. Bitte überprüfen Sie die Grenzwerte des Programms."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1138
+#: lib/klass_hero_web/live/provider/programs_live.ex:1159
 #, elixir-autogen, elixir-format
 msgid "Program updated, but the enrollment capacity was rejected. The previous limits still apply."
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -2386,12 +2386,12 @@ msgstr ""
 msgid "Contact Provider"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:449
+#: lib/klass_hero_web/live/provider/programs_live.ex:448
 #, elixir-autogen, elixir-format
 msgid "Could not read the uploaded file."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:417
+#: lib/klass_hero_web/live/provider/programs_live.ex:416
 #, elixir-autogen, elixir-format
 msgid "Could not remove invite."
 msgstr ""
@@ -2529,7 +2529,7 @@ msgstr ""
 msgid "Failed to reject document."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:399
+#: lib/klass_hero_web/live/provider/programs_live.ex:398
 #, elixir-autogen, elixir-format
 msgid "Failed to resend invite."
 msgstr ""
@@ -2622,17 +2622,17 @@ msgstr ""
 msgid "Insurance Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:414
+#: lib/klass_hero_web/live/provider/programs_live.ex:413
 #, elixir-autogen, elixir-format
 msgid "Invite not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:411
+#: lib/klass_hero_web/live/provider/programs_live.ex:410
 #, elixir-autogen, elixir-format
 msgid "Invite removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:388
+#: lib/klass_hero_web/live/provider/programs_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "Invite resent successfully."
 msgstr ""
@@ -2749,7 +2749,7 @@ msgstr ""
 msgid "No enrollments yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:445
+#: lib/klass_hero_web/live/provider/programs_live.ex:444
 #, elixir-autogen, elixir-format
 msgid "No file selected."
 msgstr ""
@@ -2849,8 +2849,8 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:106
-#: lib/klass_hero_web/live/provider/programs_live.ex:687
-#: lib/klass_hero_web/live/provider/programs_live.ex:749
+#: lib/klass_hero_web/live/provider/programs_live.ex:685
+#: lib/klass_hero_web/live/provider/programs_live.ex:747
 #: lib/klass_hero_web/live/provider/team_live.ex:305
 #: lib/klass_hero_web/live/provider/team_live.ex:348
 #: lib/klass_hero_web/live/provider/team_live.ex:467
@@ -2883,26 +2883,26 @@ msgstr ""
 msgid "Program Start"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1130
+#: lib/klass_hero_web/live/provider/programs_live.ex:1151
 #, elixir-autogen, elixir-format
 msgid "Program created successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1134
+#: lib/klass_hero_web/live/provider/programs_live.ex:1155
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:54
-#: lib/klass_hero_web/live/provider/programs_live.ex:153
-#: lib/klass_hero_web/live/provider/programs_live.ex:190
-#: lib/klass_hero_web/live/provider/programs_live.ex:254
-#: lib/klass_hero_web/live/provider/programs_live.ex:724
+#: lib/klass_hero_web/live/provider/programs_live.ex:152
+#: lib/klass_hero_web/live/provider/programs_live.ex:189
+#: lib/klass_hero_web/live/provider/programs_live.ex:253
+#: lib/klass_hero_web/live/provider/programs_live.ex:722
 #, elixir-autogen, elixir-format
 msgid "Program not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1131
+#: lib/klass_hero_web/live/provider/programs_live.ex:1152
 #, elixir-autogen, elixir-format
 msgid "Program updated successfully."
 msgstr ""
@@ -3063,8 +3063,8 @@ msgstr ""
 msgid "Selected child does not meet the program requirements."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:677
-#: lib/klass_hero_web/live/provider/programs_live.ex:739
+#: lib/klass_hero_web/live/provider/programs_live.ex:675
+#: lib/klass_hero_web/live/provider/programs_live.ex:737
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
@@ -3164,12 +3164,12 @@ msgstr ""
 msgid "The Klass Hero Story"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:391
+#: lib/klass_hero_web/live/provider/programs_live.ex:390
 #, elixir-autogen, elixir-format
 msgid "This invite cannot be resent."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:731
+#: lib/klass_hero_web/live/provider/programs_live.ex:729
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
@@ -3384,7 +3384,7 @@ msgstr ""
 msgid "Program fee:"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:952
+#: lib/klass_hero_web/live/provider/programs_live.ex:973
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr ""
@@ -3600,7 +3600,7 @@ msgstr ""
 msgid "Cannot check out without a check-in"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:363
+#: lib/klass_hero_web/live/provider/programs_live.ex:362
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
@@ -3665,7 +3665,7 @@ msgid "Correct"
 msgstr ""
 
 #: lib/klass_hero_web/live/dashboard_live.ex:301
-#: lib/klass_hero_web/live/provider/programs_live.ex:360
+#: lib/klass_hero_web/live/provider/programs_live.ex:359
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Could not start conversation. Please try again."
@@ -4422,7 +4422,7 @@ msgstr ""
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:24
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
-#: lib/klass_hero_web/live/provider/programs_live.ex:222
+#: lib/klass_hero_web/live/provider/programs_live.ex:221
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:156
 #, elixir-autogen, elixir-format
 msgid "Program"
@@ -4631,7 +4631,7 @@ msgid "Update your observation..."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:138
-#: lib/klass_hero_web/live/provider/programs_live.ex:442
+#: lib/klass_hero_web/live/provider/programs_live.ex:441
 #: lib/klass_hero_web/live/provider/verification_live.ex:240
 #: lib/klass_hero_web/live/provider/verification_live.ex:556
 #: lib/klass_hero_web/live/provider/verification_live.ex:594
@@ -4941,7 +4941,7 @@ msgstr ""
 msgid "View sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:533
+#: lib/klass_hero_web/live/provider/programs_live.ex:532
 #, elixir-autogen, elixir-format
 msgid "Create a program before inviting participants."
 msgstr ""
@@ -4983,7 +4983,7 @@ msgstr ""
 msgid "Invite one person"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:529
+#: lib/klass_hero_web/live/provider/programs_live.ex:528
 #, elixir-autogen, elixir-format
 msgid "Invite sent."
 msgstr ""
@@ -5086,7 +5086,7 @@ msgstr ""
 msgid "Upload a list"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:540
+#: lib/klass_hero_web/live/provider/programs_live.ex:539
 #, elixir-autogen, elixir-format
 msgid "An invite for this child and program already exists."
 msgstr ""
@@ -5263,7 +5263,7 @@ msgstr ""
 msgid "Go to dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:485
+#: lib/klass_hero_web/live/provider/programs_live.ex:484
 #, elixir-autogen, elixir-format
 msgid "%{count} row could not be processed."
 msgid_plural "%{count} rows could not be processed."
@@ -5850,8 +5850,8 @@ msgstr ""
 msgid "I'll be teaching"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:460
-#: lib/klass_hero_web/live/provider/programs_live.ex:482
+#: lib/klass_hero_web/live/provider/programs_live.ex:459
+#: lib/klass_hero_web/live/provider/programs_live.ex:481
 #, elixir-autogen, elixir-format
 msgid "Imported %{count} family."
 msgid_plural "Imported %{count} families."
@@ -6140,7 +6140,7 @@ msgstr ""
 msgid "No registered children for this session."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:469
+#: lib/klass_hero_web/live/provider/programs_live.ex:468
 #, elixir-autogen, elixir-format
 msgid "No rows imported. %{count} row could not be processed."
 msgid_plural "No rows imported. %{count} rows could not be processed."
@@ -7623,7 +7623,7 @@ msgstr ""
 msgid "Lead"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:335
+#: lib/klass_hero_web/live/provider/programs_live.ex:334
 #, elixir-autogen, elixir-format
 msgid "Lead instructor updated."
 msgstr ""
@@ -7643,7 +7643,7 @@ msgstr ""
 msgid "Nobody is on this program yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:265
+#: lib/klass_hero_web/live/provider/programs_live.ex:264
 #, elixir-autogen, elixir-format
 msgid "Pick a staff member to add."
 msgstr ""
@@ -7663,12 +7663,12 @@ msgstr ""
 msgid "Select a staff member…"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:280
+#: lib/klass_hero_web/live/provider/programs_live.ex:279
 #, elixir-autogen, elixir-format
 msgid "Staff member added to the program."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:306
+#: lib/klass_hero_web/live/provider/programs_live.ex:305
 #, elixir-autogen, elixir-format
 msgid "Staff member removed from the program."
 msgstr ""
@@ -7683,17 +7683,17 @@ msgstr ""
 msgid "Staffing — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:911
+#: lib/klass_hero_web/live/provider/programs_live.ex:932
 #, elixir-autogen, elixir-format
 msgid "That staff member could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:288
+#: lib/klass_hero_web/live/provider/programs_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "They are already on this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:314
+#: lib/klass_hero_web/live/provider/programs_live.ex:313
 #, elixir-autogen, elixir-format
 msgid "This person is the lead instructor. Make someone else lead before removing them."
 msgstr ""
@@ -7755,17 +7755,17 @@ msgstr ""
 msgid "This person has a history here now — use 'Remove from team' instead."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1144
+#: lib/klass_hero_web/live/provider/programs_live.ex:1165
 #, elixir-autogen, elixir-format
 msgid "Program created, but some settings could not be saved. Please review the program's limits."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1148
+#: lib/klass_hero_web/live/provider/programs_live.ex:1169
 #, elixir-autogen, elixir-format
 msgid "Program updated, but some settings could not be saved. Please review the program's limits."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1138
+#: lib/klass_hero_web/live/provider/programs_live.ex:1159
 #, elixir-autogen, elixir-format
 msgid "Program updated, but the enrollment capacity was rejected. The previous limits still apply."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -2386,12 +2386,12 @@ msgstr ""
 msgid "Contact Provider"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:449
+#: lib/klass_hero_web/live/provider/programs_live.ex:448
 #, elixir-autogen, elixir-format
 msgid "Could not read the uploaded file."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:417
+#: lib/klass_hero_web/live/provider/programs_live.ex:416
 #, elixir-autogen, elixir-format
 msgid "Could not remove invite."
 msgstr ""
@@ -2529,7 +2529,7 @@ msgstr ""
 msgid "Failed to reject document."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:399
+#: lib/klass_hero_web/live/provider/programs_live.ex:398
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to resend invite."
 msgstr ""
@@ -2622,17 +2622,17 @@ msgstr ""
 msgid "Insurance Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:414
+#: lib/klass_hero_web/live/provider/programs_live.ex:413
 #, elixir-autogen, elixir-format
 msgid "Invite not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:411
+#: lib/klass_hero_web/live/provider/programs_live.ex:410
 #, elixir-autogen, elixir-format
 msgid "Invite removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:388
+#: lib/klass_hero_web/live/provider/programs_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "Invite resent successfully."
 msgstr ""
@@ -2749,7 +2749,7 @@ msgstr ""
 msgid "No enrollments yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:445
+#: lib/klass_hero_web/live/provider/programs_live.ex:444
 #, elixir-autogen, elixir-format
 msgid "No file selected."
 msgstr ""
@@ -2849,8 +2849,8 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:106
-#: lib/klass_hero_web/live/provider/programs_live.ex:687
-#: lib/klass_hero_web/live/provider/programs_live.ex:749
+#: lib/klass_hero_web/live/provider/programs_live.ex:685
+#: lib/klass_hero_web/live/provider/programs_live.ex:747
 #: lib/klass_hero_web/live/provider/team_live.ex:305
 #: lib/klass_hero_web/live/provider/team_live.ex:348
 #: lib/klass_hero_web/live/provider/team_live.ex:467
@@ -2883,26 +2883,26 @@ msgstr ""
 msgid "Program Start"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1130
+#: lib/klass_hero_web/live/provider/programs_live.ex:1151
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program created successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1134
+#: lib/klass_hero_web/live/provider/programs_live.ex:1155
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:54
-#: lib/klass_hero_web/live/provider/programs_live.ex:153
-#: lib/klass_hero_web/live/provider/programs_live.ex:190
-#: lib/klass_hero_web/live/provider/programs_live.ex:254
-#: lib/klass_hero_web/live/provider/programs_live.ex:724
+#: lib/klass_hero_web/live/provider/programs_live.ex:152
+#: lib/klass_hero_web/live/provider/programs_live.ex:189
+#: lib/klass_hero_web/live/provider/programs_live.ex:253
+#: lib/klass_hero_web/live/provider/programs_live.ex:722
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1131
+#: lib/klass_hero_web/live/provider/programs_live.ex:1152
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program updated successfully."
 msgstr ""
@@ -3063,8 +3063,8 @@ msgstr ""
 msgid "Selected child does not meet the program requirements."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:677
-#: lib/klass_hero_web/live/provider/programs_live.ex:739
+#: lib/klass_hero_web/live/provider/programs_live.ex:675
+#: lib/klass_hero_web/live/provider/programs_live.ex:737
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
@@ -3164,12 +3164,12 @@ msgstr ""
 msgid "The Klass Hero Story"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:391
+#: lib/klass_hero_web/live/provider/programs_live.ex:390
 #, elixir-autogen, elixir-format
 msgid "This invite cannot be resent."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:731
+#: lib/klass_hero_web/live/provider/programs_live.ex:729
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
@@ -3384,7 +3384,7 @@ msgstr ""
 msgid "Program fee:"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:952
+#: lib/klass_hero_web/live/provider/programs_live.ex:973
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr ""
@@ -3600,7 +3600,7 @@ msgstr ""
 msgid "Cannot check out without a check-in"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:363
+#: lib/klass_hero_web/live/provider/programs_live.ex:362
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
@@ -3665,7 +3665,7 @@ msgid "Correct"
 msgstr ""
 
 #: lib/klass_hero_web/live/dashboard_live.ex:301
-#: lib/klass_hero_web/live/provider/programs_live.ex:360
+#: lib/klass_hero_web/live/provider/programs_live.ex:359
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Could not start conversation. Please try again."
@@ -4422,7 +4422,7 @@ msgstr ""
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:24
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
-#: lib/klass_hero_web/live/provider/programs_live.ex:222
+#: lib/klass_hero_web/live/provider/programs_live.ex:221
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:156
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program"
@@ -4631,7 +4631,7 @@ msgid "Update your observation..."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:138
-#: lib/klass_hero_web/live/provider/programs_live.ex:442
+#: lib/klass_hero_web/live/provider/programs_live.ex:441
 #: lib/klass_hero_web/live/provider/verification_live.ex:240
 #: lib/klass_hero_web/live/provider/verification_live.ex:556
 #: lib/klass_hero_web/live/provider/verification_live.ex:594
@@ -4941,7 +4941,7 @@ msgstr ""
 msgid "View sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:533
+#: lib/klass_hero_web/live/provider/programs_live.ex:532
 #, elixir-autogen, elixir-format
 msgid "Create a program before inviting participants."
 msgstr ""
@@ -4983,7 +4983,7 @@ msgstr ""
 msgid "Invite one person"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:529
+#: lib/klass_hero_web/live/provider/programs_live.ex:528
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invite sent."
 msgstr ""
@@ -5086,7 +5086,7 @@ msgstr ""
 msgid "Upload a list"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:540
+#: lib/klass_hero_web/live/provider/programs_live.ex:539
 #, elixir-autogen, elixir-format
 msgid "An invite for this child and program already exists."
 msgstr ""
@@ -5263,7 +5263,7 @@ msgstr ""
 msgid "Go to dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:485
+#: lib/klass_hero_web/live/provider/programs_live.ex:484
 #, elixir-autogen, elixir-format
 msgid "%{count} row could not be processed."
 msgid_plural "%{count} rows could not be processed."
@@ -5850,8 +5850,8 @@ msgstr ""
 msgid "I'll be teaching"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:460
-#: lib/klass_hero_web/live/provider/programs_live.ex:482
+#: lib/klass_hero_web/live/provider/programs_live.ex:459
+#: lib/klass_hero_web/live/provider/programs_live.ex:481
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Imported %{count} family."
 msgid_plural "Imported %{count} families."
@@ -6140,7 +6140,7 @@ msgstr ""
 msgid "No registered children for this session."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:469
+#: lib/klass_hero_web/live/provider/programs_live.ex:468
 #, elixir-autogen, elixir-format
 msgid "No rows imported. %{count} row could not be processed."
 msgid_plural "No rows imported. %{count} rows could not be processed."
@@ -7623,7 +7623,7 @@ msgstr ""
 msgid "Lead"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:335
+#: lib/klass_hero_web/live/provider/programs_live.ex:334
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Lead instructor updated."
 msgstr ""
@@ -7643,7 +7643,7 @@ msgstr ""
 msgid "Nobody is on this program yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:265
+#: lib/klass_hero_web/live/provider/programs_live.ex:264
 #, elixir-autogen, elixir-format
 msgid "Pick a staff member to add."
 msgstr ""
@@ -7663,12 +7663,12 @@ msgstr ""
 msgid "Select a staff member…"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:280
+#: lib/klass_hero_web/live/provider/programs_live.ex:279
 #, elixir-autogen, elixir-format
 msgid "Staff member added to the program."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:306
+#: lib/klass_hero_web/live/provider/programs_live.ex:305
 #, elixir-autogen, elixir-format
 msgid "Staff member removed from the program."
 msgstr ""
@@ -7683,17 +7683,17 @@ msgstr ""
 msgid "Staffing — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:911
+#: lib/klass_hero_web/live/provider/programs_live.ex:932
 #, elixir-autogen, elixir-format
 msgid "That staff member could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:288
+#: lib/klass_hero_web/live/provider/programs_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "They are already on this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:314
+#: lib/klass_hero_web/live/provider/programs_live.ex:313
 #, elixir-autogen, elixir-format
 msgid "This person is the lead instructor. Make someone else lead before removing them."
 msgstr ""
@@ -7755,17 +7755,17 @@ msgstr ""
 msgid "This person has a history here now — use 'Remove from team' instead."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1144
+#: lib/klass_hero_web/live/provider/programs_live.ex:1165
 #, elixir-autogen, elixir-format
 msgid "Program created, but some settings could not be saved. Please review the program's limits."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1148
+#: lib/klass_hero_web/live/provider/programs_live.ex:1169
 #, elixir-autogen, elixir-format
 msgid "Program updated, but some settings could not be saved. Please review the program's limits."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1138
+#: lib/klass_hero_web/live/provider/programs_live.ex:1159
 #, elixir-autogen, elixir-format
 msgid "Program updated, but the enrollment capacity was rejected. The previous limits still apply."
 msgstr ""

--- a/test/klass_hero_web/live/provider/dashboard_program_filter_sync_test.exs
+++ b/test/klass_hero_web/live/provider/dashboard_program_filter_sync_test.exs
@@ -1,0 +1,217 @@
+defmodule KlassHeroWeb.Provider.DashboardProgramFilterSyncTest do
+  @moduledoc """
+  What saving a program does to a *filtered* programs table.
+
+  Sibling of `dashboard_program_creation_test.exs` (the form itself) and
+  `dashboard_program_staffing_test.exs` (the per-program staffing panel). This one
+  owns the interaction between the two: the table filters on search and staff, so
+  every path that writes a single row has to agree with the filters the table
+  claims to be applying (#1346).
+  """
+  use KlassHeroWeb.ConnCase, async: true
+
+  import KlassHero.Factory
+  import Phoenix.LiveViewTest
+
+  alias KlassHero.ProgramCatalog.Program
+  alias KlassHero.Provider
+  alias KlassHero.Repo
+
+  setup :register_and_log_in_provider
+
+  # "New Program" is disabled for an unverified provider, so every test here
+  # would fail on the button rather than on what it is actually pinning.
+  setup %{provider: provider} do
+    provider
+    |> Ecto.Changeset.change(%{
+      verified: true,
+      verified_at: DateTime.utc_now() |> DateTime.truncate(:second)
+    })
+    |> Repo.update!()
+
+    %{ann: insert_staff(provider, "Ann", "Blake")}
+  end
+
+  describe "creating while a filter is active" do
+    test "shows the new program and clears the staff filter that would hide it", %{
+      conn: conn,
+      provider: provider,
+      ann: ann
+    } do
+      staffed = insert_listed_program(provider, "Ann's Camp")
+      assign_staff!(staffed, ann)
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+
+      filter_by_staff(view, ann)
+      assert has_element?(view, "#programs-#{staffed.id}")
+
+      create_program(view, "Unstaffed Chess Club")
+
+      created = Repo.get_by!(Program, title: "Unstaffed Chess Club")
+
+      assert has_element?(view, "#programs-#{created.id}")
+      assert has_element?(view, "#programs-staff-filter-form option[value=all][selected]")
+    end
+
+    test "shows the new program and clears the search that would hide it", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+
+      search_for(view, "Pottery")
+
+      create_program(view, "Unstaffed Chess Club")
+
+      created = Repo.get_by!(Program, title: "Unstaffed Chess Club")
+
+      assert has_element?(view, "#programs-#{created.id}")
+      assert has_element?(view, ~s(#programs-search-form input[name=search][value=""]))
+    end
+
+    # The filter only yields when it would hide the new row. A provider who
+    # searched for "Chess" and then made a chess program keeps their search.
+    test "keeps a filter the new program already matches", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+
+      search_for(view, "Chess")
+
+      create_program(view, "Unstaffed Chess Club")
+
+      created = Repo.get_by!(Program, title: "Unstaffed Chess Club")
+
+      assert has_element?(view, "#programs-#{created.id}")
+      assert has_element?(view, ~s(#programs-search-form input[name=search][value="Chess"]))
+    end
+  end
+
+  describe "editing while a filter is active" do
+    # The edit is the opposite call from the create: nothing here was just made,
+    # so the row that no longer matches leaves rather than the filter.
+    test "drops the row when the edit renames the program out of the search", %{
+      conn: conn,
+      provider: provider
+    } do
+      program = insert_listed_program(provider, "Chess Club")
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+
+      search_for(view, "Chess")
+      assert has_element?(view, "#programs-#{program.id}")
+
+      edit_program(view, program, "Pottery Basics")
+
+      refute has_element?(view, "#programs-#{program.id}")
+    end
+
+    # The filter controls sit outside the program form, so a provider can change
+    # the filter with the form open and save into a table that no longer wants
+    # the row.
+    test "does not re-insert the row when a staff filter excludes the program", %{
+      conn: conn,
+      provider: provider,
+      ann: ann
+    } do
+      program = insert_listed_program(provider, "Chess Club")
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+
+      view
+      |> element(~s([phx-click="edit_program"][phx-value-id="#{program.id}"]))
+      |> render_click()
+
+      filter_by_staff(view, ann)
+      refute has_element?(view, "#programs-#{program.id}")
+
+      view
+      |> form("#program-form", %{
+        "program_schema" => %{
+          "title" => "Chess Club",
+          "description" => "Saved while a foreign staff filter was active",
+          "category" => "arts",
+          "price" => "25.00"
+        }
+      })
+      |> render_submit()
+
+      refute has_element?(view, "#programs-#{program.id}")
+    end
+  end
+
+  # Drives the wrapping <form>, not the bare <select>: LiveView rejects a
+  # phx-change on an input outside a form in the browser, and `element/2` +
+  # render_change/2 would happily bypass that check (#1310).
+  defp filter_by_staff(view, staff) do
+    view
+    |> form("#programs-staff-filter-form", %{"staff_filter" => staff.id})
+    |> render_change()
+  end
+
+  defp search_for(view, query) do
+    view
+    |> form("#programs-search-form", %{"search" => query})
+    |> render_change()
+  end
+
+  defp create_program(view, title) do
+    view |> element("#new-program-btn") |> render_click()
+
+    view
+    |> form("#program-form", %{
+      "program_schema" => %{
+        "title" => title,
+        "description" => "Created while a filter was active",
+        "category" => "arts",
+        "price" => "25.00"
+      }
+    })
+    |> render_submit()
+  end
+
+  defp edit_program(view, program, new_title) do
+    view
+    |> element(~s([phx-click="edit_program"][phx-value-id="#{program.id}"]))
+    |> render_click()
+
+    view
+    |> form("#program-form", %{
+      "program_schema" => %{
+        "title" => new_title,
+        "description" => "Renamed while a filter was active",
+        "category" => "arts",
+        "price" => "25.00"
+      }
+    })
+    |> render_submit()
+  end
+
+  # The provider programs table renders from the `program_listings` read table, so
+  # a program without a matching listing row is invisible and every row-level
+  # assertion below would fail for an unrelated reason.
+  defp insert_listed_program(provider, title) do
+    program = insert(:program_schema, provider_id: provider.id, title: title)
+
+    insert(:program_listing_schema,
+      id: program.id,
+      provider_id: provider.id,
+      title: program.title,
+      category: program.category,
+      price: program.price
+    )
+
+    program
+  end
+
+  defp insert_staff(provider, first_name, last_name) do
+    insert(:staff_member_schema, provider_id: provider.id, first_name: first_name, last_name: last_name)
+  end
+
+  defp assign_staff!(program, staff) do
+    {:ok, assignment} =
+      Provider.assign_staff_to_program(%{
+        provider_id: program.provider_id,
+        program_id: program.id,
+        staff_member_id: staff.id
+      })
+
+    assignment
+  end
+end

--- a/test/klass_hero_web/live/provider/dashboard_program_filter_sync_test.exs
+++ b/test/klass_hero_web/live/provider/dashboard_program_filter_sync_test.exs
@@ -67,6 +67,32 @@ defmodule KlassHeroWeb.Provider.DashboardProgramFilterSyncTest do
       assert has_element?(view, ~s(#programs-search-form input[name=search][value=""]))
     end
 
+    # Deliberate, not incidental: when one axis hides the new row, *both* yield,
+    # even the one it still matches. Surgical per-axis clearing would buy a
+    # rarely-hit nicety for a branch on every combination.
+    test "clears both axes when only one of them hides the new program", %{
+      conn: conn,
+      provider: provider,
+      ann: ann
+    } do
+      staffed = insert_listed_program(provider, "Ann's Chess Camp")
+      assign_staff!(staffed, ann)
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+
+      search_for(view, "Chess")
+      filter_by_staff(view, ann)
+
+      # Matches the search, but has no staff at all — only the staff axis hides it.
+      create_program(view, "Chess Club")
+
+      created = Repo.get_by!(Program, title: "Chess Club")
+
+      assert has_element?(view, "#programs-#{created.id}")
+      assert has_element?(view, "#programs-staff-filter-form option[value=all][selected]")
+      assert has_element?(view, ~s(#programs-search-form input[name=search][value=""]))
+    end
+
     # The filter only yields when it would hide the new row. A provider who
     # searched for "Chess" and then made a chess program keeps their search.
     test "keeps a filter the new program already matches", %{conn: conn} do
@@ -132,6 +158,62 @@ defmodule KlassHeroWeb.Provider.DashboardProgramFilterSyncTest do
       })
       |> render_submit()
 
+      refute has_element?(view, "#programs-#{program.id}")
+    end
+
+    # The other direction: the same writer has to *add* a row an edit moved into
+    # the filter, not only drop one it moved out.
+    test "shows the row when the edit renames the program into the search", %{
+      conn: conn,
+      provider: provider
+    } do
+      program = insert_listed_program(provider, "Chess Club")
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+
+      view
+      |> element(~s([phx-click="edit_program"][phx-value-id="#{program.id}"]))
+      |> render_click()
+
+      search_for(view, "Pottery")
+      refute has_element?(view, "#programs-#{program.id}")
+
+      view
+      |> form("#program-form", %{
+        "program_schema" => %{
+          "title" => "Pottery Basics",
+          "description" => "Renamed into the active search",
+          "category" => "arts",
+          "price" => "25.00"
+        }
+      })
+      |> render_submit()
+
+      assert has_element?(view, "#programs-#{program.id}")
+    end
+  end
+
+  describe "staffing the program while a filter is active" do
+    # The third write path. #1334 taught it the staff filter; it learned the
+    # search filter only by being folded onto the shared row writer, and nothing
+    # in the staffing suite covers that axis.
+    test "does not re-insert the row when the search no longer matches", %{
+      conn: conn,
+      provider: provider,
+      ann: ann
+    } do
+      program = insert_listed_program(provider, "Chess Club")
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+
+      view |> element("#manage-staffing-#{program.id}") |> render_click()
+
+      search_for(view, "Pottery")
+      refute has_element?(view, "#programs-#{program.id}")
+
+      view |> form("#staffing-add-form", %{"staff-id" => ann.id}) |> render_submit()
+
+      assert has_element?(view, "#staffing-member-#{ann.id}")
       refute has_element?(view, "#programs-#{program.id}")
     end
   end


### PR DESCRIPTION
Closes #1346

## Summary

Saving a program inserted its row into the provider programs table even when the row could not match the active staff filter — the table showed a program contradicting the filter it claimed to be applying, until the next search or filter interaction dropped it again.

The issue reported two unguarded call sites. The cause was one level down: **row visibility was a caller-side decision.** `row_visible?/2` was added in #1334 for the staffing panel alone, and knew only the staff filter — but the table filters on **search and staff**, so all three write paths were also wrong under an active search. That second axis is not in the issue.

## What changed

`lib/klass_hero_web/live/provider/programs_live.ex` only — no context, schema, or migration.

- **`row_matches_filters?/3`** replaces `row_visible?/2`. It runs the table's own `filter_by_search/2` + `filter_by_staff/3` over a one-element list, so "what the list shows" and "what a row write shows" have a single definition.
- **`insert_program_row/3,4` → `sync_program_row/3,4`**, which owns the insert-or-delete decision. A future fourth write path is correct without knowing the table is filtered. (An "insert" that sometimes deletes was worth renaming.)
- **Create reveals the row.** When the new program would not match, the *filters* yield rather than the row — a save that visibly does nothing reads as a failed save. Editing keeps the opposite rule (the row leaves), matching what removing a filtered-on staff member already does.
- **Drops the `programs_count` assign** — assigned in three places, rendered nowhere in this LiveView.

## Review focus

**The one non-obvious line.** In the reveal's else-branch the row is inserted *after* `reset_programs_stream/1`:

```elixir
socket
|> assign(search_query: "", selected_staff: "all")
|> reset_programs_stream()
|> sync_program_row(program, enrollment_data, staffing)
```

The re-stream cannot carry the new row. `ProgramCatalog.list_programs_for_provider/1` reads the **`program_listings` projection**, which has not caught up with a program created a moment ago — only the domain struct the write returned can show it. A test caught this; worth a second pair of eyes on the reasoning.

**Why not simply re-stream on save.** `dashboard_program_creation_test.exs:446` pins that a rejected capacity blanks the row (`0/—`) while the old policy survives at 20. The save paths hand-build enrollment data deliberately; re-streaming re-reads the DB and would show a number the save did not accept.

## Test plan

New `test/klass_hero_web/live/provider/dashboard_program_filter_sync_test.exs`, 5 tests at the rendered-table seam (form submits + filter form changes, never the private helpers):

| scenario | expected |
|---|---|
| create under a foreign staff filter | row shown, filter reset to All Staff |
| create under a non-matching search | row shown, search cleared |
| create under a filter it matches | row shown, filter **unchanged** |
| edit renames out of the active search | row drops |
| edit while a staff filter excludes it | row not re-inserted |

Each was verified capable of failing: removing the search axis fails only the search tests; forcing the predicate true fails only the edit tests.

- `mix precommit` green — 4385 tests, credo --strict clean, 5 lints
- Regression net intact: the rejected-capacity row test, both capacity row tests, and the staffing-panel drop test

Also driven manually against a seeded dev server: created a program with no instructor while filtered to a staff member → row visible, filter reads "All Staff"; then searched "Drum" and renamed that program → row dropped, search retained, "Program updated successfully." No console or server errors.

## Note

The gettext diff is line-reference churn only (`0 new messages, 0 removed`) from shifted source lines.
