### PR TITLE
refactor: drop the program_staff_participants table

### DIFF
--- a/priv/repo/migrations/20260816071028_drop_program_staff_participants.exs
+++ b/priv/repo/migrations/20260816071028_drop_program_staff_participants.exs
@@ -1,0 +1,31 @@
+defmodule KlassHero.Repo.Migrations.DropProgramStaffParticipants do
+  use Ecto.Migration
+
+  # Messaging's mirror of Provider's program staffing, unread and unwritten since
+  # #1321 (Release A, PR #1351, rolled out 2026-08-14). Provider's
+  # `program_staff_assignments` is the source of truth; Messaging reads it through
+  # the facade.
+  #
+  # up/down rather than change: Ecto cannot reverse a table drop. `down` recreates
+  # the empty table so a rollback leaves a valid schema. It cannot restore rows —
+  # acceptable, because nothing has written since Release A and nothing reads it.
+  def up do
+    drop table(:program_staff_participants)
+  end
+
+  def down do
+    create table(:program_staff_participants, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :provider_id, :binary_id, null: false
+      add :program_id, :binary_id, null: false
+      add :staff_user_id, :binary_id, null: false
+      add :active, :boolean, null: false, default: true
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create unique_index(:program_staff_participants, [:program_id, :staff_user_id])
+    create index(:program_staff_participants, [:provider_id])
+    create index(:program_staff_participants, [:staff_user_id])
+  end
+end


### PR DESCRIPTION
Closes #1347. Release B of #1321 — the one-way half.

## Summary

One migration. Drops `program_staff_participants`, Messaging's denormalised mirror of Provider's program staffing. It has been unread and unwritten since Release A (#1351, merged 2026-08-14, tag v0.72.1), which cut Messaging over to reading Provider's facade.

Three bugs (#1309, #1312, #1320) were drift between that copy and its source. Dropping it keeps `.claude/rules/domain-architecture.md`'s "the third read-side kind has no instance, and that is a warning" true.

## Review focus

**Why this is a separate PR from #1351.** Fly runs migrations as a `release_command` (`fly.toml:9`) — before new machines take traffic. A `drop table` therefore executes while the *previous* release is still serving. Folding it into #1351, as an architecture review of that PR recommended, would have raised `Postgrex.Error: undefined_table` at three call sites for the length of the rollout.

**Why `up`/`down` and not `change`.** Ecto cannot reverse a table drop; `change/0` would raise `Ecto.MigrationError` on rollback, and CI never runs one. `down` recreates the empty table with the same three indexes so a rollback leaves a valid schema. It cannot restore rows — acceptable, because nothing has written since Release A.

**Correction to the issue's DoD.** #1347 states "a non-zero count means Release A did not fully roll out." That criterion is unsound: Release A stopped reading and writing but never deleted, so pre-A rows are expected to survive. Prod holds 12 rows with `max(updated_at) = 2026-08-12 10:23:52` — two days *before* Release A merged. The sound check is `max(updated_at) < Release-A rollout`, which holds.

## Prerequisite verification (2026-08-16)

| Check | Result |
|---|---|
| Release A rolled out | prod `klass-hero-live` on v151, both `fra` machines; v147 (Aug 14 12:36 UTC) already post-#1351 |
| Live code references | zero — `grep -rn program_staff_participant lib test` returns 7 prose comments, 0 code lines |
| Schema module | already deleted in #1321 |
| Prod rows / last write | 12 / 2026-08-12, i.e. pre-Release-A |

## Test plan

- `mix ecto.migrate` → `mix ecto.rollback --step 1` → `mix ecto.migrate` round-trip run locally. `down` recreated the table and all three indexes under the same generated names as `20260401090000`; `to_regclass('program_staff_participants')` is `(null)` after the final forward pass.
- `mix precommit` green — 4393 passed (3 doctests, 37 properties), credo clean, 0 warnings.
- Deliberately unchanged: the 7 moduledoc/test-docstring references to the old table name. They record why the facade read exists and guard against someone re-adding the mirror.

## Post-merge

After rollout, confirm `bin/prod-db -c "select to_regclass('program_staff_participants');"` returns `(null)`.