### PR TITLE
fix: record message attribution at send time

### DIFF
--- a/lib/klass_hero/messaging.ex
+++ b/lib/klass_hero/messaging.ex
@@ -692,15 +692,28 @@ defmodule KlassHero.Messaging do
   Returns the user IDs of staff currently active on a program, read from
   Provider (#1321) rather than from a mirror Messaging maintained itself.
 
-  Two callers, and the second is why this is not display-only: the web layer
-  decides which senders render provider-side ("Business via Staff Name"), and
-  `AddAssignedStaff` seeds these users as participants when a conversation is
-  created. The first is cosmetic; the second grants access.
+  Access-granting, and only that: `AddAssignedStaff` seeds these users as
+  participants when a conversation is created. The render path used to share it to
+  decide which senders show branded attribution, which is how deactivating a staff
+  member restyled every message they had ever sent (#1348) — attribution now comes
+  from `messages.sender_role`, so a change here can no longer reach the past.
   """
   @spec get_active_staff_user_ids(String.t()) :: [String.t()]
   defdelegate get_active_staff_user_ids(program_id),
     to: ProviderStaffResolver,
     as: :list_active_staff_user_ids
+
+  @doc """
+  User IDs of everyone who has ever been staff at the provider.
+
+  Renders attribution for messages predating `messages.sender_role` (#1348) and
+  nothing else — it must never gate access, because it deliberately includes people
+  whose employment has ended.
+  """
+  @spec get_provider_staff_user_ids(String.t()) :: [String.t()]
+  defdelegate get_provider_staff_user_ids(provider_id),
+    to: ProviderStaffResolver,
+    as: :list_staff_user_ids
 
   @doc """
   Returns the PubSub topic for a conversation.
@@ -1095,7 +1108,8 @@ defmodule KlassHero.Messaging do
   @spec create_message(map()) :: {:ok, Message.t()} | {:error, Ecto.Changeset.t()}
   def create_message(attrs) do
     context_span entity: "message" do
-      create_attrs = Map.take(attrs, [:conversation_id, :sender_id, :content, :message_type])
+      create_attrs =
+        Map.take(attrs, [:conversation_id, :sender_id, :sender_role, :content, :message_type])
 
       %Message{}
       |> Message.create_changeset(create_attrs)

--- a/lib/klass_hero/messaging/adapters/driven/provider/provider_staff_resolver.ex
+++ b/lib/klass_hero/messaging/adapters/driven/provider/provider_staff_resolver.ex
@@ -27,4 +27,19 @@ defmodule KlassHero.Messaging.Adapters.Driven.Provider.ProviderStaffResolver do
       KlassHero.Provider.list_active_staff_user_ids_for_program(program_id)
     end
   end
+
+  @doc """
+  User IDs of everyone who has ever been staff at the provider.
+
+  Only the render path wants this, and only for messages written before
+  `messages.sender_role` existed (#1348). Employment *ever* is the closest available
+  approximation of who was provider-side at send time; employment *now* — which is
+  what `list_active_staff_user_ids/1` answers — is the question that rewrote history.
+  """
+  @spec list_staff_user_ids(String.t()) :: [String.t()]
+  def list_staff_user_ids(provider_id) do
+    acl_span source: "messaging", target: "provider" do
+      KlassHero.Provider.list_staff_user_ids_for_provider(provider_id)
+    end
+  end
 end

--- a/lib/klass_hero/messaging/message.ex
+++ b/lib/klass_hero/messaging/message.ex
@@ -28,6 +28,7 @@ defmodule KlassHero.Messaging.Message do
     field :sender_id, :binary_id
     field :content, :string
     field :message_type, Ecto.Enum, values: [:text, :system], default: :text
+    field :sender_role, Ecto.Enum, values: [:provider, :staff, :parent]
     field :deleted_at, :utc_datetime
 
     belongs_to :conversation, Conversation, define_field: false
@@ -38,6 +39,7 @@ defmodule KlassHero.Messaging.Message do
   end
 
   @type message_type :: :text | :system
+  @type sender_role :: :provider | :staff | :parent
 
   @type t :: %__MODULE__{
           id: String.t(),
@@ -45,13 +47,14 @@ defmodule KlassHero.Messaging.Message do
           sender_id: String.t(),
           content: String.t() | nil,
           message_type: message_type() | nil,
+          sender_role: sender_role() | nil,
           deleted_at: DateTime.t() | nil,
           inserted_at: DateTime.t() | nil,
           updated_at: DateTime.t() | nil
         }
 
   @required_fields ~w(conversation_id sender_id)a
-  @optional_fields ~w(content message_type deleted_at)a
+  @optional_fields ~w(content message_type sender_role deleted_at)a
 
   @doc "Changeset for creating a message."
   def create_changeset(schema \\ %__MODULE__{}, attrs) do
@@ -69,4 +72,29 @@ defmodule KlassHero.Messaging.Message do
     |> cast(attrs, [:deleted_at])
     |> validate_required([:deleted_at])
   end
+
+  @doc """
+  Whether the message was sent from the provider's side, i.e. whether it renders
+  with branded attribution ("Business via Staff Name").
+
+  Answered from `sender_role`, recorded when the message was written, so it stays
+  true to the moment of sending: deactivating or unassigning a staff member cannot
+  restyle messages they sent while employed (#1348).
+
+  `sender_role` is `nil` on rows written before that column existed. Those fall
+  back to `fallback_provider_user_ids` — the live provider-side set the render path
+  used before #1348 — which is the only signal available for them. The fallback
+  expires with the rows: `EnforceRetentionPolicy` deletes messages past retention,
+  so both it and the set can go once none survive.
+  """
+  @spec provider_side?(t(), MapSet.t(String.t()) | nil) :: boolean()
+  def provider_side?(message, fallback_provider_user_ids \\ nil)
+
+  def provider_side?(%__MODULE__{sender_role: role}, _fallback) when role in [:provider, :staff], do: true
+
+  def provider_side?(%__MODULE__{sender_role: role}, _fallback) when not is_nil(role), do: false
+
+  def provider_side?(%__MODULE__{sender_id: sender_id}, %MapSet{} = fallback), do: MapSet.member?(fallback, sender_id)
+
+  def provider_side?(%__MODULE__{}, _fallback), do: false
 end

--- a/lib/klass_hero/messaging/send_message.ex
+++ b/lib/klass_hero/messaging/send_message.ex
@@ -2,9 +2,10 @@ defmodule KlassHero.Messaging.SendMessage do
   @moduledoc """
   Use case for sending a message in a conversation.
 
-  Validates content/attachments, checks participant and broadcast-send permissions,
-  uploads files to S3, persists message + attachments (cleaning up S3 on DB failure),
-  updates sender's last_read_at, and publishes a message_sent event.
+  Validates content/attachments, resolves the sender's role relative to the
+  conversation's provider (which both authorizes the send and is recorded on the
+  message), uploads files to S3, persists message + attachments (cleaning up S3 on
+  DB failure), updates sender's last_read_at, and publishes a message_sent event.
   """
 
   alias KlassHero.Messaging.Adapters.Driven.Provider.ProviderStaffResolver
@@ -27,7 +28,7 @@ defmodule KlassHero.Messaging.SendMessage do
   ## Options
   - `:message_type` — `:text` (default) or `:system`
   - `:conversation` — pre-fetched `%Conversation{}` for the same `conversation_id`
-    (skips DB round-trip in broadcast permission check; ignored if ID doesn't match)
+    (skips the DB round-trip taken to authorize; ignored if ID doesn't match)
   - `:attachments` — list of `%{binary: <<>>, filename: "x.jpg", content_type: "image/jpeg", size: 1000}`
 
   ## Returns
@@ -54,12 +55,14 @@ defmodule KlassHero.Messaging.SendMessage do
     with :ok <- validate_message_content(trimmed_content, attachment_files),
          :ok <- validate_attachment_files(attachment_files),
          :ok <- Shared.verify_participant(conversation_id, sender_id),
-         :ok <- verify_broadcast_send_permission(conversation_id, sender_id, conversation),
+         {:ok, loaded_conversation} <- load_conversation(conversation_id, conversation),
+         {:ok, sender_role} <- authorize_sender(loaded_conversation, sender_id),
          {:ok, uploaded_files} <- upload_files(attachment_files, conversation_id),
          {:ok, message_with_attachments} <-
            persist_message_and_attachments(
              conversation_id,
              sender_id,
+             sender_role,
              trimmed_content,
              message_type,
              uploaded_files
@@ -154,10 +157,11 @@ defmodule KlassHero.Messaging.SendMessage do
     end
   end
 
-  defp persist_message_and_attachments(conversation_id, sender_id, content, message_type, uploaded_files) do
+  defp persist_message_and_attachments(conversation_id, sender_id, sender_role, content, message_type, uploaded_files) do
     message_attrs = %{
       conversation_id: conversation_id,
       sender_id: sender_id,
+      sender_role: sender_role,
       content: content,
       message_type: message_type
     }
@@ -222,33 +226,36 @@ defmodule KlassHero.Messaging.SendMessage do
     |> String.slice(0, 255)
   end
 
-  # Broadcast conversations are one-way: only the provider owner and their currently
-  # employed staff may send. Parents replying would expose messages to all other
-  # participants (privacy breach).
-  defp verify_broadcast_send_permission(conversation_id, sender_id, conversation) do
-    # Validates conversation.id matches conversation_id to prevent a mismatched
-    # pre-fetched struct from bypassing broadcast guards.
-    result =
-      if conversation && conversation.id == conversation_id,
-        do: {:ok, conversation},
-        else: KlassHero.Messaging.get_conversation_by_id(conversation_id)
+  # Validates conversation.id matches conversation_id to prevent a mismatched
+  # pre-fetched struct from bypassing the broadcast guard below.
+  defp load_conversation(conversation_id, prefetched) do
+    if prefetched && prefetched.id == conversation_id,
+      do: {:ok, prefetched},
+      else: KlassHero.Messaging.get_conversation_by_id(conversation_id)
+  end
 
-    case result do
-      {:ok, %{type: :program_broadcast, provider_id: provider_id}} ->
-        check_broadcast_reply_permission(provider_id, sender_id)
-
-      {:ok, _direct_conversation} ->
-        :ok
-
-      {:error, :not_found} ->
-        {:error, :not_found}
+  # Resolves the sender's role once and authorizes from it, so attribution and
+  # permission can never disagree. They used to be separate computations over
+  # different staff sets — provider-wide here, program-scoped in the renderer —
+  # which is how an unassigned staff member came to be allowed to send a message
+  # that rendered as if a parent had sent it (#1348).
+  #
+  # Broadcast conversations are one-way: only the provider owner and their
+  # currently employed staff may send. Parents replying would expose messages to
+  # all other participants (privacy breach).
+  defp authorize_sender(conversation, sender_id) do
+    case {conversation.type, resolve_sender_role(conversation.provider_id, sender_id)} do
+      {:program_broadcast, :parent} -> {:error, :broadcast_reply_not_allowed}
+      {_type, role} -> {:ok, role}
     end
   end
 
-  defp check_broadcast_reply_permission(provider_id, sender_id) do
-    if provider_owner?(provider_id, sender_id) or active_staff_for_provider?(provider_id, sender_id),
-      do: :ok,
-      else: {:error, :broadcast_reply_not_allowed}
+  defp resolve_sender_role(provider_id, sender_id) do
+    cond do
+      provider_owner?(provider_id, sender_id) -> :provider
+      active_staff_for_provider?(provider_id, sender_id) -> :staff
+      true -> :parent
+    end
   end
 
   defp provider_owner?(provider_id, sender_id) do

--- a/lib/klass_hero/provider.ex
+++ b/lib/klass_hero/provider.ex
@@ -274,6 +274,9 @@ defmodule KlassHero.Provider do
   @doc "Returns true if the user has any active staff row for the given provider."
   defdelegate active_staff_for_provider?(provider_id, user_id), to: Staff
 
+  @doc "User IDs of everyone who has ever been staff at the provider — active or not, claimed only."
+  defdelegate list_staff_user_ids_for_provider(provider_id), to: Staff
+
   @doc "Returns the staff member matching the given invitation token hash (status :sent)."
   defdelegate get_staff_member_by_token_hash(token_hash), to: Staff
 

--- a/lib/klass_hero/provider/staff.ex
+++ b/lib/klass_hero/provider/staff.ex
@@ -518,6 +518,26 @@ defmodule KlassHero.Provider.Staff do
   end
 
   @doc """
+  User IDs of everyone who has ever held a staff row at the provider, active or not.
+
+  The counterpart to `active_staff_for_provider?/2`: that one answers "may this user
+  act now", this one answers "was this user ever one of ours" — the question a reader
+  of *past* messages is really asking (#1348). Rows with no `user_id` are unclaimed
+  invitations and can never have sent anything.
+
+  Deliberately narrower than `list_staff_members/1`, which returns full structs and
+  loads a pay rate per row.
+  """
+  @spec list_staff_user_ids_for_provider(String.t()) :: [String.t()]
+  def list_staff_user_ids_for_provider(provider_id) when is_binary(provider_id) do
+    from(s in StaffMember,
+      where: s.provider_id == ^provider_id and not is_nil(s.user_id),
+      select: s.user_id
+    )
+    |> Repo.all()
+  end
+
+  @doc """
   Returns the staff member matching the given invitation token hash,
   only if invitation_status is :sent. Used by the invitation registration flow.
   """

--- a/lib/klass_hero_web/components/messaging_components.ex
+++ b/lib/klass_hero_web/components/messaging_components.ex
@@ -183,6 +183,8 @@ defmodule KlassHeroWeb.MessagingComponents do
       ]}>
         <p
           :if={!@is_own && @message.message_type != :system}
+          id={"#{@id}-attribution"}
+          data-provider-side={to_string(@is_provider_side)}
           class={["text-xs font-medium mb-1", Theme.text_color(:muted)]}
         >
           <%= if @is_provider_side && @provider_name do %>
@@ -653,10 +655,7 @@ defmodule KlassHeroWeb.MessagingComponents do
           is_own={MessagingLiveHelper.own_message?(message, @current_user_id)}
           sender_name={MessagingLiveHelper.get_sender_name(@sender_names, message.sender_id)}
           provider_name={@provider_name}
-          is_provider_side={
-            @provider_user_ids != nil &&
-              MapSet.member?(@provider_user_ids, message.sender_id)
-          }
+          is_provider_side={MessagingLiveHelper.provider_side?(message, @provider_user_ids)}
         />
       </div>
       <.messages_empty_state :if={@messages_empty?} />

--- a/lib/klass_hero_web/live/messaging_live_helper.ex
+++ b/lib/klass_hero_web/live/messaging_live_helper.ex
@@ -35,6 +35,7 @@ defmodule KlassHeroWeb.MessagingLiveHelper do
 
   alias KlassHero.Messaging
   alias KlassHero.Messaging.Attachment
+  alias KlassHero.Messaging.Message
   alias Phoenix.LiveView.Socket
 
   require Logger
@@ -339,6 +340,16 @@ defmodule KlassHeroWeb.MessagingLiveHelper do
     message.sender_id == user_id
   end
 
+  @doc """
+  Whether the message renders with branded attribution ("Business via Staff Name").
+
+  `provider_user_ids` is consulted only for messages predating `sender_role` — see
+  `KlassHero.Messaging.Message.provider_side?/2`.
+  """
+  def provider_side?(message, provider_user_ids) do
+    Message.provider_side?(message, provider_user_ids)
+  end
+
   def get_sender_name(sender_names, sender_id) do
     Map.get(sender_names, sender_id, "Unknown")
   end
@@ -358,14 +369,14 @@ defmodule KlassHeroWeb.MessagingLiveHelper do
     Messaging.get_conversation_context(conversation_id, user_id)
   end
 
+  # The returned set only renders messages written before `messages.sender_role`
+  # existed (#1348); anything newer answers for itself. So it asks who has *ever*
+  # been staff at the provider, not who staffs this program today — the latter both
+  # rewrote history and disagreed with the send guard, which is provider-wide (#669).
+  #
   # Single fetch avoids separate round-trips for identity_id and business_name.
   defp resolve_provider_info(conversation) do
-    staff_ids =
-      if conversation.program_id do
-        Messaging.get_active_staff_user_ids(conversation.program_id)
-      else
-        []
-      end
+    staff_ids = Messaging.get_provider_staff_user_ids(conversation.provider_id)
 
     case KlassHero.Provider.get_provider_profile(conversation.provider_id) do
       {:ok, provider} ->

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -1741,7 +1741,7 @@ msgstr "Dies ist Ihre Hauptgeschäftsidentität. Eine Verifizierung ist erforder
 msgid "Unassigned"
 msgstr "Nicht zugewiesen"
 
-#: lib/klass_hero_web/components/messaging_components.ex:728
+#: lib/klass_hero_web/components/messaging_components.ex:727
 #: lib/klass_hero_web/components/provider_components.ex:50
 #: lib/klass_hero_web/components/provider_components.ex:1583
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:434
@@ -1765,7 +1765,7 @@ msgstr "Teilnehmerliste"
 msgid "%{age} years old"
 msgstr "%{age} Jahre alt"
 
-#: lib/klass_hero_web/components/messaging_components.ex:738
+#: lib/klass_hero_web/components/messaging_components.ex:737
 #, elixir-autogen, elixir-format
 msgid "%{n}m ago"
 msgstr "vor %{n} Min."
@@ -1863,12 +1863,12 @@ msgid "Child updated, but consent update failed. Please try again."
 msgstr "Kind aktualisiert, aber Einwilligungsaktualisierung fehlgeschlagen. Bitte versuchen Sie es erneut."
 
 #: lib/klass_hero_web/live/dashboard_live.ex:196
-#: lib/klass_hero_web/live/messaging_live_helper.ex:335
+#: lib/klass_hero_web/live/messaging_live_helper.ex:336
 #, elixir-autogen, elixir-format
 msgid "Conversation"
 msgstr "Unterhaltung"
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:155
+#: lib/klass_hero_web/live/messaging_live_helper.ex:156
 #, elixir-autogen, elixir-format
 msgid "Conversation not found"
 msgstr "Unterhaltung nicht gefunden"
@@ -1969,10 +1969,10 @@ msgid "Message content is required"
 msgstr "Nachrichteninhalt ist erforderlich"
 
 #: lib/klass_hero_web/components/layouts/app.html.heex:212
-#: lib/klass_hero_web/components/messaging_components.ex:494
-#: lib/klass_hero_web/components/messaging_components.ex:517
+#: lib/klass_hero_web/components/messaging_components.ex:496
+#: lib/klass_hero_web/components/messaging_components.ex:519
 #: lib/klass_hero_web/live/messages_live/index.ex:19
-#: lib/klass_hero_web/live/messaging_live_helper.ex:287
+#: lib/klass_hero_web/live/messaging_live_helper.ex:288
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr "Nachrichten"
@@ -1983,14 +1983,14 @@ msgstr "Nachrichten"
 msgid "No children yet"
 msgstr "Noch keine Kinder"
 
-#: lib/klass_hero_web/components/messaging_components.ex:464
+#: lib/klass_hero_web/components/messaging_components.ex:466
 #, elixir-autogen, elixir-format
 msgid "No conversations yet"
 msgstr "Noch keine Unterhaltungen"
 
-#: lib/klass_hero_web/components/messaging_components.ex:433
-#: lib/klass_hero_web/components/messaging_components.ex:748
-#: lib/klass_hero_web/components/messaging_components.ex:759
+#: lib/klass_hero_web/components/messaging_components.ex:435
+#: lib/klass_hero_web/components/messaging_components.ex:747
+#: lib/klass_hero_web/components/messaging_components.ex:758
 #, elixir-autogen, elixir-format
 msgid "No messages yet"
 msgstr "Noch keine Nachrichten"
@@ -2022,7 +2022,7 @@ msgstr "Notiz abgelehnt"
 msgid "Note resubmitted for review"
 msgstr "Notiz erneut zur Überprüfung eingereicht"
 
-#: lib/klass_hero_web/components/messaging_components.ex:737
+#: lib/klass_hero_web/components/messaging_components.ex:736
 #, elixir-autogen, elixir-format
 msgid "Now"
 msgstr "Jetzt"
@@ -2062,8 +2062,8 @@ msgstr "Bitte authentifizieren Sie sich erneut, um Ihr Konto zu löschen."
 msgid "Please set up your parent profile to manage children."
 msgstr "Bitte richten Sie Ihr Elternprofil ein, um Kinder zu verwalten."
 
-#: lib/klass_hero_web/components/messaging_components.ex:721
-#: lib/klass_hero_web/live/messaging_live_helper.ex:331
+#: lib/klass_hero_web/components/messaging_components.ex:720
+#: lib/klass_hero_web/live/messaging_live_helper.ex:332
 #, elixir-autogen, elixir-format
 msgid "Program Broadcast"
 msgstr "Programm-Rundnachricht"
@@ -2094,7 +2094,7 @@ msgstr "Änderungen speichern"
 msgid "Send Broadcast"
 msgstr "Rundnachricht senden"
 
-#: lib/klass_hero_web/components/messaging_components.ex:436
+#: lib/klass_hero_web/components/messaging_components.ex:438
 #, elixir-autogen, elixir-format
 msgid "Send a message to start the conversation"
 msgstr "Senden Sie eine Nachricht, um die Unterhaltung zu beginnen"
@@ -2118,7 +2118,7 @@ msgstr "Unterstützungsbedarf"
 msgid "This message will be sent to all parents with active enrollments in this program."
 msgstr "Diese Nachricht wird an alle Eltern mit aktiven Anmeldungen in diesem Programm gesendet."
 
-#: lib/klass_hero_web/components/messaging_components.ex:387
+#: lib/klass_hero_web/components/messaging_components.ex:389
 #, elixir-autogen, elixir-format
 msgid "Type a message..."
 msgstr "Nachricht eingeben..."
@@ -2140,7 +2140,7 @@ msgstr "Schreiben Sie Ihre Nachricht an alle angemeldeten Eltern..."
 msgid "You already submitted a note for this record"
 msgstr "Sie haben bereits eine Notiz für diesen Eintrag eingereicht"
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:161
+#: lib/klass_hero_web/live/messaging_live_helper.ex:162
 #, elixir-autogen, elixir-format
 msgid "You don't have access to this conversation"
 msgstr "Sie haben keinen Zugriff auf diese Unterhaltung"
@@ -2155,12 +2155,12 @@ msgstr "Sie haben keine Berechtigung, dieses Kind zu löschen."
 msgid "You don't have permission to edit this child."
 msgstr "Sie haben keine Berechtigung, dieses Kind zu bearbeiten."
 
-#: lib/klass_hero_web/components/messaging_components.ex:473
+#: lib/klass_hero_web/components/messaging_components.ex:475
 #, elixir-autogen, elixir-format
 msgid "Your conversations with parents will appear here"
 msgstr "Ihre Unterhaltungen mit Eltern werden hier angezeigt"
 
-#: lib/klass_hero_web/components/messaging_components.ex:475
+#: lib/klass_hero_web/components/messaging_components.ex:477
 #, elixir-autogen, elixir-format
 msgid "Your conversations with providers will appear here"
 msgstr "Ihre Unterhaltungen mit Anbietern werden hier angezeigt"
@@ -2381,7 +2381,7 @@ msgstr "Ablehnung bestätigen"
 msgid "Confirmed"
 msgstr "Bestätigt"
 
-#: lib/klass_hero_web/components/messaging_components.ex:811
+#: lib/klass_hero_web/components/messaging_components.ex:810
 #, elixir-autogen, elixir-format
 msgid "Contact Provider"
 msgstr "Anbieter kontaktieren"
@@ -4045,7 +4045,7 @@ msgstr "Zurück zu Sitzungen"
 msgid "Back to emails"
 msgstr "Zurück zu E-Mails"
 
-#: lib/klass_hero_web/components/messaging_components.ex:688
+#: lib/klass_hero_web/components/messaging_components.ex:687
 #, elixir-autogen, elixir-format
 msgid "Broadcast messages are one-way"
 msgstr "Broadcast-Nachrichten sind einseitig"
@@ -4137,7 +4137,7 @@ msgstr "Inhalt wird erneut abgerufen..."
 msgid "Content is being fetched..."
 msgstr "Inhalt wird abgerufen..."
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:222
+#: lib/klass_hero_web/live/messaging_live_helper.ex:223
 #, elixir-autogen, elixir-format
 msgid "Could not start private conversation"
 msgstr "Private Unterhaltung konnte nicht gestartet werden"
@@ -4460,12 +4460,12 @@ msgstr "Grund für die Ablehnung (optional)"
 msgid "Reply"
 msgstr "Antworten"
 
-#: lib/klass_hero_web/components/messaging_components.ex:699
+#: lib/klass_hero_web/components/messaging_components.ex:698
 #, elixir-autogen, elixir-format
 msgid "Reply privately"
 msgstr "Privat antworten"
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:229
+#: lib/klass_hero_web/live/messaging_live_helper.ex:230
 #, elixir-autogen, elixir-format
 msgid "Reply privately is only available for broadcast messages"
 msgstr "Privates Antworten ist nur für Broadcast-Nachrichten verfügbar"
@@ -4769,22 +4769,22 @@ msgstr "Vervollständigen Sie Ihr Anbieterprofil"
 msgid "Drag and drop or click to upload"
 msgstr "Ziehen und ablegen oder klicken zum Hochladen"
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:438
+#: lib/klass_hero_web/live/messaging_live_helper.ex:449
 #, elixir-autogen, elixir-format
 msgid "Failed to upload files. Please try again."
 msgstr "Hochladen der Dateien fehlgeschlagen. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/components/messaging_components.ex:763
+#: lib/klass_hero_web/components/messaging_components.ex:762
 #, elixir-autogen, elixir-format
 msgid "File is too large (max %{mb} MB)"
 msgstr "Datei ist zu groß (max. %{mb} MB)"
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:436
+#: lib/klass_hero_web/live/messaging_live_helper.ex:447
 #, elixir-autogen, elixir-format
 msgid "File is too large (max %{mb} MB)."
 msgstr "Datei ist zu groß (max. %{mb} MB)."
 
-#: lib/klass_hero_web/components/messaging_components.ex:766
+#: lib/klass_hero_web/components/messaging_components.ex:765
 #, elixir-autogen, elixir-format
 msgid "File type not accepted (images only)"
 msgstr "Dateityp nicht akzeptiert (nur Bilder)"
@@ -4804,18 +4804,18 @@ msgstr "Geben Sie Ihre Unternehmensdaten ein. Ihr Profil wird von Klass Hero gep
 msgid "Manage your business"
 msgstr "Ihr Unternehmen verwalten"
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:433
+#: lib/klass_hero_web/live/messaging_live_helper.ex:444
 #, elixir-autogen, elixir-format
 msgid "Only images are accepted (JPG, PNG, GIF, WebP)."
 msgstr "Nur Bilder werden akzeptiert (JPG, PNG, GIF, WebP)."
 
-#: lib/klass_hero_web/components/messaging_components.ex:751
-#: lib/klass_hero_web/components/messaging_components.ex:755
+#: lib/klass_hero_web/components/messaging_components.ex:750
+#: lib/klass_hero_web/components/messaging_components.ex:754
 #, elixir-autogen, elixir-format
 msgid "Photo"
 msgstr "Foto"
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:428
+#: lib/klass_hero_web/live/messaging_live_helper.ex:439
 #, elixir-autogen, elixir-format
 msgid "Please enter a message or attach a photo."
 msgstr "Bitte geben Sie eine Nachricht ein oder fügen Sie ein Foto hinzu."
@@ -4830,14 +4830,14 @@ msgstr "Profil vervollständigt! Klass Hero wird Ihr Profil in Kürze prüfen."
 msgid "Provider not found"
 msgstr "Anbieter nicht gefunden"
 
-#: lib/klass_hero_web/components/messaging_components.ex:276
-#: lib/klass_hero_web/components/messaging_components.ex:344
+#: lib/klass_hero_web/components/messaging_components.ex:278
+#: lib/klass_hero_web/components/messaging_components.ex:346
 #, elixir-autogen, elixir-format
 msgid "Remove attachment"
 msgstr "Anhang entfernen"
 
 #: lib/klass_hero_web/controllers/invite_claim_controller.ex:67
-#: lib/klass_hero_web/live/messaging_live_helper.ex:439
+#: lib/klass_hero_web/live/messaging_live_helper.ex:450
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:132
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:110
 #, elixir-autogen, elixir-format
@@ -4849,22 +4849,22 @@ msgstr "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut."
 msgid "Tell parents about your organization and what makes you unique..."
 msgstr "Erzählen Sie Eltern von Ihrer Organisation und was Sie einzigartig macht..."
 
-#: lib/klass_hero_web/components/messaging_components.ex:770
+#: lib/klass_hero_web/components/messaging_components.ex:769
 #, elixir-autogen, elixir-format
 msgid "Too many files (max %{max})"
 msgstr "Zu viele Dateien (max. %{max})"
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:431
+#: lib/klass_hero_web/live/messaging_live_helper.ex:442
 #, elixir-autogen, elixir-format
 msgid "Too many files (max %{max})."
 msgstr "Zu viele Dateien (max. %{max})."
 
-#: lib/klass_hero_web/components/messaging_components.ex:774
+#: lib/klass_hero_web/components/messaging_components.ex:773
 #, elixir-autogen, elixir-format
 msgid "Upload error"
 msgstr "Upload-Fehler"
 
-#: lib/klass_hero_web/components/messaging_components.ex:773
+#: lib/klass_hero_web/components/messaging_components.ex:772
 #, elixir-autogen, elixir-format
 msgid "Upload failed"
 msgstr "Hochladen fehlgeschlagen"
@@ -4895,7 +4895,7 @@ msgid "Your profile is already complete."
 msgstr "Ihr Profil ist bereits vollständig."
 
 #: lib/klass_hero_web/components/messaging_components.ex:92
-#: lib/klass_hero_web/live/messaging_live_helper.ex:319
+#: lib/klass_hero_web/live/messaging_live_helper.ex:320
 #, elixir-autogen, elixir-format
 msgid "for"
 msgstr "für"
@@ -5367,7 +5367,7 @@ msgstr "Sind Sie Pädagog:in, Coach oder Künstler:in?"
 msgid "At Klass Hero, trust isn't a feature — it's the foundation of everything we do. We connect families, schools, and organizations with qualified, vetted, and safety-verified educators."
 msgstr "Bei Klass Hero ist Vertrauen kein Feature — es ist das Fundament von allem, was wir tun. Wir verbinden Familien, Schulen und Organisationen mit qualifizierten, geprüften und sicherheitsverifizierten Pädagogen."
 
-#: lib/klass_hero_web/components/messaging_components.ex:294
+#: lib/klass_hero_web/components/messaging_components.ex:296
 #, elixir-autogen, elixir-format
 msgid "Attach photo"
 msgstr "Foto anhängen"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -1741,7 +1741,7 @@ msgstr ""
 msgid "Unassigned"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:728
+#: lib/klass_hero_web/components/messaging_components.ex:727
 #: lib/klass_hero_web/components/provider_components.ex:50
 #: lib/klass_hero_web/components/provider_components.ex:1583
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:434
@@ -1765,7 +1765,7 @@ msgstr ""
 msgid "%{age} years old"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:738
+#: lib/klass_hero_web/components/messaging_components.ex:737
 #, elixir-autogen, elixir-format
 msgid "%{n}m ago"
 msgstr ""
@@ -1863,12 +1863,12 @@ msgid "Child updated, but consent update failed. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/live/dashboard_live.ex:196
-#: lib/klass_hero_web/live/messaging_live_helper.ex:335
+#: lib/klass_hero_web/live/messaging_live_helper.ex:336
 #, elixir-autogen, elixir-format
 msgid "Conversation"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:155
+#: lib/klass_hero_web/live/messaging_live_helper.ex:156
 #, elixir-autogen, elixir-format
 msgid "Conversation not found"
 msgstr ""
@@ -1969,10 +1969,10 @@ msgid "Message content is required"
 msgstr ""
 
 #: lib/klass_hero_web/components/layouts/app.html.heex:212
-#: lib/klass_hero_web/components/messaging_components.ex:494
-#: lib/klass_hero_web/components/messaging_components.ex:517
+#: lib/klass_hero_web/components/messaging_components.ex:496
+#: lib/klass_hero_web/components/messaging_components.ex:519
 #: lib/klass_hero_web/live/messages_live/index.ex:19
-#: lib/klass_hero_web/live/messaging_live_helper.ex:287
+#: lib/klass_hero_web/live/messaging_live_helper.ex:288
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr ""
@@ -1983,14 +1983,14 @@ msgstr ""
 msgid "No children yet"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:464
+#: lib/klass_hero_web/components/messaging_components.ex:466
 #, elixir-autogen, elixir-format
 msgid "No conversations yet"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:433
-#: lib/klass_hero_web/components/messaging_components.ex:748
-#: lib/klass_hero_web/components/messaging_components.ex:759
+#: lib/klass_hero_web/components/messaging_components.ex:435
+#: lib/klass_hero_web/components/messaging_components.ex:747
+#: lib/klass_hero_web/components/messaging_components.ex:758
 #, elixir-autogen, elixir-format
 msgid "No messages yet"
 msgstr ""
@@ -2022,7 +2022,7 @@ msgstr ""
 msgid "Note resubmitted for review"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:737
+#: lib/klass_hero_web/components/messaging_components.ex:736
 #, elixir-autogen, elixir-format
 msgid "Now"
 msgstr ""
@@ -2062,8 +2062,8 @@ msgstr ""
 msgid "Please set up your parent profile to manage children."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:721
-#: lib/klass_hero_web/live/messaging_live_helper.ex:331
+#: lib/klass_hero_web/components/messaging_components.ex:720
+#: lib/klass_hero_web/live/messaging_live_helper.ex:332
 #, elixir-autogen, elixir-format
 msgid "Program Broadcast"
 msgstr ""
@@ -2094,7 +2094,7 @@ msgstr ""
 msgid "Send Broadcast"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:436
+#: lib/klass_hero_web/components/messaging_components.ex:438
 #, elixir-autogen, elixir-format
 msgid "Send a message to start the conversation"
 msgstr ""
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "This message will be sent to all parents with active enrollments in this program."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:387
+#: lib/klass_hero_web/components/messaging_components.ex:389
 #, elixir-autogen, elixir-format
 msgid "Type a message..."
 msgstr ""
@@ -2140,7 +2140,7 @@ msgstr ""
 msgid "You already submitted a note for this record"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:161
+#: lib/klass_hero_web/live/messaging_live_helper.ex:162
 #, elixir-autogen, elixir-format
 msgid "You don't have access to this conversation"
 msgstr ""
@@ -2155,12 +2155,12 @@ msgstr ""
 msgid "You don't have permission to edit this child."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:473
+#: lib/klass_hero_web/components/messaging_components.ex:475
 #, elixir-autogen, elixir-format
 msgid "Your conversations with parents will appear here"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:475
+#: lib/klass_hero_web/components/messaging_components.ex:477
 #, elixir-autogen, elixir-format
 msgid "Your conversations with providers will appear here"
 msgstr ""
@@ -2381,7 +2381,7 @@ msgstr ""
 msgid "Confirmed"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:811
+#: lib/klass_hero_web/components/messaging_components.ex:810
 #, elixir-autogen, elixir-format
 msgid "Contact Provider"
 msgstr ""
@@ -4045,7 +4045,7 @@ msgstr ""
 msgid "Back to emails"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:688
+#: lib/klass_hero_web/components/messaging_components.ex:687
 #, elixir-autogen, elixir-format
 msgid "Broadcast messages are one-way"
 msgstr ""
@@ -4137,7 +4137,7 @@ msgstr ""
 msgid "Content is being fetched..."
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:222
+#: lib/klass_hero_web/live/messaging_live_helper.ex:223
 #, elixir-autogen, elixir-format
 msgid "Could not start private conversation"
 msgstr ""
@@ -4460,12 +4460,12 @@ msgstr ""
 msgid "Reply"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:699
+#: lib/klass_hero_web/components/messaging_components.ex:698
 #, elixir-autogen, elixir-format
 msgid "Reply privately"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:229
+#: lib/klass_hero_web/live/messaging_live_helper.ex:230
 #, elixir-autogen, elixir-format
 msgid "Reply privately is only available for broadcast messages"
 msgstr ""
@@ -4769,22 +4769,22 @@ msgstr ""
 msgid "Drag and drop or click to upload"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:438
+#: lib/klass_hero_web/live/messaging_live_helper.ex:449
 #, elixir-autogen, elixir-format
 msgid "Failed to upload files. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:763
+#: lib/klass_hero_web/components/messaging_components.ex:762
 #, elixir-autogen, elixir-format
 msgid "File is too large (max %{mb} MB)"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:436
+#: lib/klass_hero_web/live/messaging_live_helper.ex:447
 #, elixir-autogen, elixir-format
 msgid "File is too large (max %{mb} MB)."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:766
+#: lib/klass_hero_web/components/messaging_components.ex:765
 #, elixir-autogen, elixir-format
 msgid "File type not accepted (images only)"
 msgstr ""
@@ -4804,18 +4804,18 @@ msgstr ""
 msgid "Manage your business"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:433
+#: lib/klass_hero_web/live/messaging_live_helper.ex:444
 #, elixir-autogen, elixir-format
 msgid "Only images are accepted (JPG, PNG, GIF, WebP)."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:751
-#: lib/klass_hero_web/components/messaging_components.ex:755
+#: lib/klass_hero_web/components/messaging_components.ex:750
+#: lib/klass_hero_web/components/messaging_components.ex:754
 #, elixir-autogen, elixir-format
 msgid "Photo"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:428
+#: lib/klass_hero_web/live/messaging_live_helper.ex:439
 #, elixir-autogen, elixir-format
 msgid "Please enter a message or attach a photo."
 msgstr ""
@@ -4830,14 +4830,14 @@ msgstr ""
 msgid "Provider not found"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:276
-#: lib/klass_hero_web/components/messaging_components.ex:344
+#: lib/klass_hero_web/components/messaging_components.ex:278
+#: lib/klass_hero_web/components/messaging_components.ex:346
 #, elixir-autogen, elixir-format
 msgid "Remove attachment"
 msgstr ""
 
 #: lib/klass_hero_web/controllers/invite_claim_controller.ex:67
-#: lib/klass_hero_web/live/messaging_live_helper.ex:439
+#: lib/klass_hero_web/live/messaging_live_helper.ex:450
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:132
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:110
 #, elixir-autogen, elixir-format
@@ -4849,22 +4849,22 @@ msgstr ""
 msgid "Tell parents about your organization and what makes you unique..."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:770
+#: lib/klass_hero_web/components/messaging_components.ex:769
 #, elixir-autogen, elixir-format
 msgid "Too many files (max %{max})"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:431
+#: lib/klass_hero_web/live/messaging_live_helper.ex:442
 #, elixir-autogen, elixir-format
 msgid "Too many files (max %{max})."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:774
+#: lib/klass_hero_web/components/messaging_components.ex:773
 #, elixir-autogen, elixir-format
 msgid "Upload error"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:773
+#: lib/klass_hero_web/components/messaging_components.ex:772
 #, elixir-autogen, elixir-format
 msgid "Upload failed"
 msgstr ""
@@ -4895,7 +4895,7 @@ msgid "Your profile is already complete."
 msgstr ""
 
 #: lib/klass_hero_web/components/messaging_components.ex:92
-#: lib/klass_hero_web/live/messaging_live_helper.ex:319
+#: lib/klass_hero_web/live/messaging_live_helper.ex:320
 #, elixir-autogen, elixir-format
 msgid "for"
 msgstr ""
@@ -5367,7 +5367,7 @@ msgstr ""
 msgid "At Klass Hero, trust isn't a feature — it's the foundation of everything we do. We connect families, schools, and organizations with qualified, vetted, and safety-verified educators."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:294
+#: lib/klass_hero_web/components/messaging_components.ex:296
 #, elixir-autogen, elixir-format
 msgid "Attach photo"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -1741,7 +1741,7 @@ msgstr ""
 msgid "Unassigned"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:728
+#: lib/klass_hero_web/components/messaging_components.ex:727
 #: lib/klass_hero_web/components/provider_components.ex:50
 #: lib/klass_hero_web/components/provider_components.ex:1583
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:434
@@ -1765,7 +1765,7 @@ msgstr ""
 msgid "%{age} years old"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:738
+#: lib/klass_hero_web/components/messaging_components.ex:737
 #, elixir-autogen, elixir-format
 msgid "%{n}m ago"
 msgstr ""
@@ -1863,12 +1863,12 @@ msgid "Child updated, but consent update failed. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/live/dashboard_live.ex:196
-#: lib/klass_hero_web/live/messaging_live_helper.ex:335
+#: lib/klass_hero_web/live/messaging_live_helper.ex:336
 #, elixir-autogen, elixir-format
 msgid "Conversation"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:155
+#: lib/klass_hero_web/live/messaging_live_helper.ex:156
 #, elixir-autogen, elixir-format
 msgid "Conversation not found"
 msgstr ""
@@ -1969,10 +1969,10 @@ msgid "Message content is required"
 msgstr ""
 
 #: lib/klass_hero_web/components/layouts/app.html.heex:212
-#: lib/klass_hero_web/components/messaging_components.ex:494
-#: lib/klass_hero_web/components/messaging_components.ex:517
+#: lib/klass_hero_web/components/messaging_components.ex:496
+#: lib/klass_hero_web/components/messaging_components.ex:519
 #: lib/klass_hero_web/live/messages_live/index.ex:19
-#: lib/klass_hero_web/live/messaging_live_helper.ex:287
+#: lib/klass_hero_web/live/messaging_live_helper.ex:288
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Messages"
 msgstr ""
@@ -1983,14 +1983,14 @@ msgstr ""
 msgid "No children yet"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:464
+#: lib/klass_hero_web/components/messaging_components.ex:466
 #, elixir-autogen, elixir-format
 msgid "No conversations yet"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:433
-#: lib/klass_hero_web/components/messaging_components.ex:748
-#: lib/klass_hero_web/components/messaging_components.ex:759
+#: lib/klass_hero_web/components/messaging_components.ex:435
+#: lib/klass_hero_web/components/messaging_components.ex:747
+#: lib/klass_hero_web/components/messaging_components.ex:758
 #, elixir-autogen, elixir-format
 msgid "No messages yet"
 msgstr ""
@@ -2022,7 +2022,7 @@ msgstr ""
 msgid "Note resubmitted for review"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:737
+#: lib/klass_hero_web/components/messaging_components.ex:736
 #, elixir-autogen, elixir-format
 msgid "Now"
 msgstr ""
@@ -2062,8 +2062,8 @@ msgstr ""
 msgid "Please set up your parent profile to manage children."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:721
-#: lib/klass_hero_web/live/messaging_live_helper.ex:331
+#: lib/klass_hero_web/components/messaging_components.ex:720
+#: lib/klass_hero_web/live/messaging_live_helper.ex:332
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program Broadcast"
 msgstr ""
@@ -2094,7 +2094,7 @@ msgstr ""
 msgid "Send Broadcast"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:436
+#: lib/klass_hero_web/components/messaging_components.ex:438
 #, elixir-autogen, elixir-format
 msgid "Send a message to start the conversation"
 msgstr ""
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "This message will be sent to all parents with active enrollments in this program."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:387
+#: lib/klass_hero_web/components/messaging_components.ex:389
 #, elixir-autogen, elixir-format
 msgid "Type a message..."
 msgstr ""
@@ -2140,7 +2140,7 @@ msgstr ""
 msgid "You already submitted a note for this record"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:161
+#: lib/klass_hero_web/live/messaging_live_helper.ex:162
 #, elixir-autogen, elixir-format
 msgid "You don't have access to this conversation"
 msgstr ""
@@ -2155,12 +2155,12 @@ msgstr ""
 msgid "You don't have permission to edit this child."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:473
+#: lib/klass_hero_web/components/messaging_components.ex:475
 #, elixir-autogen, elixir-format
 msgid "Your conversations with parents will appear here"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:475
+#: lib/klass_hero_web/components/messaging_components.ex:477
 #, elixir-autogen, elixir-format
 msgid "Your conversations with providers will appear here"
 msgstr ""
@@ -2381,7 +2381,7 @@ msgstr ""
 msgid "Confirmed"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:811
+#: lib/klass_hero_web/components/messaging_components.ex:810
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Contact Provider"
 msgstr ""
@@ -4045,7 +4045,7 @@ msgstr ""
 msgid "Back to emails"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:688
+#: lib/klass_hero_web/components/messaging_components.ex:687
 #, elixir-autogen, elixir-format
 msgid "Broadcast messages are one-way"
 msgstr ""
@@ -4137,7 +4137,7 @@ msgstr ""
 msgid "Content is being fetched..."
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:222
+#: lib/klass_hero_web/live/messaging_live_helper.ex:223
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Could not start private conversation"
 msgstr ""
@@ -4460,12 +4460,12 @@ msgstr ""
 msgid "Reply"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:699
+#: lib/klass_hero_web/components/messaging_components.ex:698
 #, elixir-autogen, elixir-format
 msgid "Reply privately"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:229
+#: lib/klass_hero_web/live/messaging_live_helper.ex:230
 #, elixir-autogen, elixir-format
 msgid "Reply privately is only available for broadcast messages"
 msgstr ""
@@ -4769,22 +4769,22 @@ msgstr ""
 msgid "Drag and drop or click to upload"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:438
+#: lib/klass_hero_web/live/messaging_live_helper.ex:449
 #, elixir-autogen, elixir-format
 msgid "Failed to upload files. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:763
+#: lib/klass_hero_web/components/messaging_components.ex:762
 #, elixir-autogen, elixir-format, fuzzy
 msgid "File is too large (max %{mb} MB)"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:436
+#: lib/klass_hero_web/live/messaging_live_helper.ex:447
 #, elixir-autogen, elixir-format, fuzzy
 msgid "File is too large (max %{mb} MB)."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:766
+#: lib/klass_hero_web/components/messaging_components.ex:765
 #, elixir-autogen, elixir-format, fuzzy
 msgid "File type not accepted (images only)"
 msgstr ""
@@ -4804,18 +4804,18 @@ msgstr ""
 msgid "Manage your business"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:433
+#: lib/klass_hero_web/live/messaging_live_helper.ex:444
 #, elixir-autogen, elixir-format
 msgid "Only images are accepted (JPG, PNG, GIF, WebP)."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:751
-#: lib/klass_hero_web/components/messaging_components.ex:755
+#: lib/klass_hero_web/components/messaging_components.ex:750
+#: lib/klass_hero_web/components/messaging_components.ex:754
 #, elixir-autogen, elixir-format
 msgid "Photo"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:428
+#: lib/klass_hero_web/live/messaging_live_helper.ex:439
 #, elixir-autogen, elixir-format
 msgid "Please enter a message or attach a photo."
 msgstr ""
@@ -4830,14 +4830,14 @@ msgstr ""
 msgid "Provider not found"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:276
-#: lib/klass_hero_web/components/messaging_components.ex:344
+#: lib/klass_hero_web/components/messaging_components.ex:278
+#: lib/klass_hero_web/components/messaging_components.ex:346
 #, elixir-autogen, elixir-format
 msgid "Remove attachment"
 msgstr ""
 
 #: lib/klass_hero_web/controllers/invite_claim_controller.ex:67
-#: lib/klass_hero_web/live/messaging_live_helper.ex:439
+#: lib/klass_hero_web/live/messaging_live_helper.ex:450
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:132
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:110
 #, elixir-autogen, elixir-format, fuzzy
@@ -4849,22 +4849,22 @@ msgstr ""
 msgid "Tell parents about your organization and what makes you unique..."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:770
+#: lib/klass_hero_web/components/messaging_components.ex:769
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Too many files (max %{max})"
 msgstr ""
 
-#: lib/klass_hero_web/live/messaging_live_helper.ex:431
+#: lib/klass_hero_web/live/messaging_live_helper.ex:442
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Too many files (max %{max})."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:774
+#: lib/klass_hero_web/components/messaging_components.ex:773
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload error"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:773
+#: lib/klass_hero_web/components/messaging_components.ex:772
 #, elixir-autogen, elixir-format
 msgid "Upload failed"
 msgstr ""
@@ -4895,7 +4895,7 @@ msgid "Your profile is already complete."
 msgstr ""
 
 #: lib/klass_hero_web/components/messaging_components.ex:92
-#: lib/klass_hero_web/live/messaging_live_helper.ex:319
+#: lib/klass_hero_web/live/messaging_live_helper.ex:320
 #, elixir-autogen, elixir-format, fuzzy
 msgid "for"
 msgstr ""
@@ -5367,7 +5367,7 @@ msgstr ""
 msgid "At Klass Hero, trust isn't a feature — it's the foundation of everything we do. We connect families, schools, and organizations with qualified, vetted, and safety-verified educators."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:294
+#: lib/klass_hero_web/components/messaging_components.ex:296
 #, elixir-autogen, elixir-format
 msgid "Attach photo"
 msgstr ""

--- a/priv/repo/migrations/20260816065500_add_sender_role_to_messages.exs
+++ b/priv/repo/migrations/20260816065500_add_sender_role_to_messages.exs
@@ -1,0 +1,20 @@
+defmodule KlassHero.Repo.Migrations.AddSenderRoleToMessages do
+  use Ecto.Migration
+
+  # Attribution ("Business via Staff Name") was a live staffing lookup at render time, so
+  # deactivating a staff member rewrote every message they had ever sent (#1348). The role is
+  # a fact about the sender at send time; `SendMessage` already resolves it to authorize the
+  # send, so it is recorded here instead of discarded.
+  #
+  # Nullable, with no backfill: the live lookup is the only signal available for existing
+  # rows, so backfilling would freeze today's answer as history rather than recover the true
+  # one. Those rows read `nil` and fall back to the old lookup until retention deletes them.
+  #
+  # No check constraint: `Ecto.Enum` guards the application path, and a constraint would force
+  # a migration for every role added later.
+  def change do
+    alter table(:messages) do
+      add :sender_role, :string
+    end
+  end
+end

--- a/test/klass_hero/messaging/message_test.exs
+++ b/test/klass_hero/messaging/message_test.exs
@@ -54,6 +54,44 @@ defmodule KlassHero.Messaging.MessageTest do
 
       assert %{message_type: ["is invalid"]} = errors_on(changeset)
     end
+
+    test "rejects a sender_role outside the enum" do
+      changeset =
+        Message.create_changeset(%{
+          conversation_id: Ecto.UUID.generate(),
+          sender_id: Ecto.UUID.generate(),
+          sender_role: :landlord
+        })
+
+      assert %{sender_role: ["is invalid"]} = errors_on(changeset)
+    end
+  end
+
+  describe "provider_side?/2" do
+    @sender_id "11111111-1111-1111-1111-111111111111"
+    @other_id "22222222-2222-2222-2222-222222222222"
+
+    # {sender_role, fallback set, expected, why}
+    @cases [
+      {:provider, nil, true, "the provider owner is provider-side"},
+      {:staff, nil, true, "staff are provider-side"},
+      {:parent, nil, false, "parents are not"},
+      {:parent, [@sender_id], false, "a persisted role wins over the live set"},
+      {:staff, [@other_id], true, "a persisted role wins even when the set disagrees"},
+      {nil, [@sender_id], true, "pre-#1348 rows fall back to the live set"},
+      {nil, [@other_id], false, "fallback says no when the sender is absent"},
+      {nil, nil, false, "no role and no set renders plainly"}
+    ]
+
+    for {role, ids, expected, why} <- @cases do
+      test "#{why} (role: #{inspect(role)})" do
+        message = %Message{sender_id: @sender_id, sender_role: unquote(role)}
+        fallback = unquote(ids) && MapSet.new(unquote(ids))
+
+        assert Message.provider_side?(message, fallback) == unquote(expected),
+               "expected provider_side? to be #{unquote(expected)} because #{unquote(why)}"
+      end
+    end
   end
 
   describe "create_message/1" do

--- a/test/klass_hero/messaging/send_message_test.exs
+++ b/test/klass_hero/messaging/send_message_test.exs
@@ -7,6 +7,7 @@ defmodule KlassHero.Messaging.SendMessageTest do
   alias KlassHero.Messaging.Conversation
   alias KlassHero.Messaging.Message
   alias KlassHero.Messaging.SendMessage
+  alias KlassHero.Provider
 
   describe "execute/4" do
     test "sends message successfully for participant" do
@@ -371,6 +372,75 @@ defmodule KlassHero.Messaging.SendMessageTest do
 
   # A direct conversation with one enrolled participant (backed by a real user).
   # Extra participant attrs (e.g. last_read_at:, left_at:) override the defaults.
+  # #1348: attribution used to be a live staffing lookup at render time, so it
+  # rewrote itself whenever employment changed. The role is resolved here, from the
+  # same predicate that authorizes the send, and recorded on the row.
+  describe "sender_role" do
+    test "records :provider for the provider owner" do
+      provider_user = AccountsFixtures.user_fixture()
+      provider = insert(:provider_profile_schema, identity_id: provider_user.id)
+      program = insert(:program_schema, provider_id: provider.id)
+      broadcast = insert_broadcast(provider, program)
+      insert(:participant_schema, conversation_id: broadcast.id, user_id: provider_user.id)
+
+      assert {:ok, message} = SendMessage.execute(broadcast.id, provider_user.id, "Announcement")
+      assert message.sender_role == :provider
+    end
+
+    test "records :staff for a staff member assigned to the program" do
+      %{provider: provider, program: program, staff_user: staff_user, staff: staff, broadcast: broadcast} =
+        broadcast_with_staff()
+
+      insert(:program_staff_assignment_schema,
+        provider_id: provider.id,
+        program_id: program.id,
+        staff_member_id: staff.id
+      )
+
+      assert {:ok, message} = SendMessage.execute(broadcast.id, staff_user.id, "From staff")
+      assert message.sender_role == :staff
+    end
+
+    # The defect the issue did not name: send authorization is provider-wide
+    # (#669), but rendering used a program-scoped set, so an active staff member
+    # with no assignment to *this* program rendered parent-side immediately — no
+    # departure required. Resolving the role from the authorization predicate is
+    # what makes the two agree.
+    test "records :staff for active staff with no assignment to this program" do
+      %{staff_user: staff_user, broadcast: broadcast} = broadcast_with_staff()
+
+      assert {:ok, message} = SendMessage.execute(broadcast.id, staff_user.id, "From staff")
+      assert message.sender_role == :staff
+    end
+
+    test "records :parent for a participant who is neither owner nor staff" do
+      %{conversation: conversation, user: user} = conversation_with_participant()
+
+      assert {:ok, message} = SendMessage.execute(conversation.id, user.id, "From a parent")
+      assert message.sender_role == :parent
+    end
+
+    test "the recorded role survives the sender's deactivation" do
+      %{staff_user: staff_user, staff: staff, broadcast: broadcast} = broadcast_with_staff()
+
+      assert {:ok, message} = SendMessage.execute(broadcast.id, staff_user.id, "While employed")
+      assert {:ok, _} = Provider.deactivate_staff_member(staff)
+
+      assert KlassHero.Repo.get!(Message, message.id).sender_role == :staff
+    end
+  end
+
+  defp broadcast_with_staff do
+    provider = insert(:provider_profile_schema)
+    program = insert(:program_schema, provider_id: provider.id)
+    staff_user = AccountsFixtures.user_fixture()
+    staff = insert(:staff_member_schema, provider_id: provider.id, user_id: staff_user.id, active: true)
+    broadcast = insert_broadcast(provider, program)
+    insert(:participant_schema, conversation_id: broadcast.id, user_id: staff_user.id)
+
+    %{provider: provider, program: program, staff_user: staff_user, staff: staff, broadcast: broadcast}
+  end
+
   defp conversation_with_participant(participant_attrs \\ []) do
     conversation = insert(:conversation_schema)
     user = AccountsFixtures.user_fixture()

--- a/test/klass_hero/provider/staff_member_integration_test.exs
+++ b/test/klass_hero/provider/staff_member_integration_test.exs
@@ -94,6 +94,33 @@ defmodule KlassHero.Provider.StaffMemberIntegrationTest do
     end
   end
 
+  # Reading *past* attribution, not present authorization: a message sent by someone
+  # who has since left must keep rendering as it did (#1348), so employment ever —
+  # not employment now — is the question. Unclaimed invitations have no user_id and
+  # can never have sent anything.
+  describe "list_staff_user_ids_for_provider/1" do
+    test "includes deactivated staff and excludes unclaimed invitations" do
+      provider = ProviderFixtures.provider_profile_fixture()
+      other_provider = ProviderFixtures.provider_profile_fixture()
+      active_user = KlassHero.AccountsFixtures.user_fixture()
+      departed_user = KlassHero.AccountsFixtures.user_fixture()
+      other_user = KlassHero.AccountsFixtures.user_fixture()
+
+      ProviderFixtures.staff_member_fixture(provider_id: provider.id, user_id: active_user.id)
+      ProviderFixtures.staff_member_fixture(provider_id: provider.id, first_name: "Unclaimed")
+      ProviderFixtures.staff_member_fixture(provider_id: other_provider.id, user_id: other_user.id)
+
+      departed =
+        ProviderFixtures.staff_member_fixture(provider_id: provider.id, user_id: departed_user.id)
+
+      {:ok, _} = Provider.deactivate_staff_member(departed)
+
+      ids = Provider.list_staff_user_ids_for_provider(provider.id)
+
+      assert Enum.sort(ids) == Enum.sort([active_user.id, departed_user.id])
+    end
+  end
+
   describe "update_staff_member/3" do
     test "updates allowed fields" do
       staff = ProviderFixtures.staff_member_fixture(first_name: "Old", role: "Assistant")

--- a/test/klass_hero_web/live/messages_live/show_test.exs
+++ b/test/klass_hero_web/live/messages_live/show_test.exs
@@ -263,6 +263,90 @@ defmodule KlassHeroWeb.MessagesLive.ShowTest do
     end
   end
 
+  # #1348: a parent re-reading a thread must see the conversation they saw a month
+  # ago. Attribution used to be a live staffing lookup, so a staff member leaving
+  # restyled every message they had ever sent.
+  describe "provider-side attribution" do
+    setup :register_and_log_in_user
+
+    setup %{conn: conn, user: user} do
+      provider_user = AccountsFixtures.user_fixture()
+      provider = insert(:provider_profile_schema, identity_id: provider_user.id)
+      program = insert(:program_schema, provider_id: provider.id)
+      staff_user = AccountsFixtures.user_fixture()
+
+      staff =
+        insert(:staff_member_schema,
+          provider_id: provider.id,
+          user_id: staff_user.id,
+          active: true
+        )
+
+      conversation =
+        insert(:conversation_schema,
+          type: "program_broadcast",
+          provider_id: provider.id,
+          program_id: program.id,
+          subject: "Update"
+        )
+
+      for participant_id <- [user.id, staff_user.id] do
+        insert(:participant_schema, conversation_id: conversation.id, user_id: participant_id)
+      end
+
+      %{conn: conn, conversation: conversation, staff: staff, staff_user: staff_user}
+    end
+
+    test "survives the sender's deactivation", ctx do
+      {:ok, message} =
+        KlassHero.Messaging.send_message(ctx.conversation.id, ctx.staff_user.id, "While employed")
+
+      {:ok, _} = KlassHero.Provider.deactivate_staff_member(ctx.staff)
+
+      {:ok, view, _html} = live(ctx.conn, ~p"/messages/#{ctx.conversation.id}")
+
+      assert has_element?(view, "#messages-#{message.id}-attribution[data-provider-side='true']")
+    end
+
+    # Rows written before `sender_role` existed fall back to the live set, which is
+    # why that set asks about employment *ever* rather than employment *now*.
+    test "holds for a pre-#1348 message with no recorded role", ctx do
+      {:ok, message} =
+        KlassHero.Messaging.create_message(%{
+          conversation_id: ctx.conversation.id,
+          sender_id: ctx.staff_user.id,
+          content: "Sent before the column existed"
+        })
+
+      assert message.sender_role == nil
+      {:ok, _} = KlassHero.Provider.deactivate_staff_member(ctx.staff)
+
+      {:ok, view, _html} = live(ctx.conn, ~p"/messages/#{ctx.conversation.id}")
+
+      assert has_element?(view, "#messages-#{message.id}-attribution[data-provider-side='true']")
+    end
+
+    test "is absent for a message from another parent", ctx do
+      other_parent = AccountsFixtures.user_fixture()
+
+      insert(:participant_schema,
+        conversation_id: ctx.conversation.id,
+        user_id: other_parent.id
+      )
+
+      {:ok, message} =
+        KlassHero.Messaging.create_message(%{
+          conversation_id: ctx.conversation.id,
+          sender_id: other_parent.id,
+          content: "Just a parent"
+        })
+
+      {:ok, view, _html} = live(ctx.conn, ~p"/messages/#{ctx.conversation.id}")
+
+      assert has_element?(view, "#messages-#{message.id}-attribution[data-provider-side='false']")
+    end
+  end
+
   describe "page title" do
     setup :register_and_log_in_user
 


### PR DESCRIPTION
Closes #1348

## Summary

Whether a message bubble renders provider-side (`Business via Staff Name`) was decided by a **live staffing lookup at mount**, not by a fact about the sender. `messaging_live_helper.ex` built a `provider_user_ids` MapSet from the provider's `identity_id` plus the program's *currently active* staff, and each bubble was rendered by `MapSet.member?` on it. `messages` carried no role field, so there was nothing else to consult.

Two defects fell out of that one seam:

1. **#1348 — history was rewritten.** Deactivate or unassign a staff member and every message they had ever sent silently flipped to non-provider attribution. A parent re-reading a thread saw a different conversation than they saw a month ago.
2. **A live mismatch the issue did not name.** Send authorization asks `active_staff_for_provider?/2` — provider-wide, deliberately, per #669. Rendering asked `list_active_staff_user_ids_for_program/1` — program-scoped, joined through `program_staff_assignments`. So an active staff member **not assigned to that program** could legally send in a broadcast and have it render parent-side *immediately*, no departure required.

These were not two bugs. They were one seam asked two different questions.

## Approach

`SendMessage` already resolved the sender's role to authorize the send (`provider_owner?/2`, `active_staff_for_provider?/2`) and threw the answer away. It now resolves it **once**, authorizes **from** it, and records it on the row as `sender_role` (`:provider | :staff | :parent`).

```elixir
defp authorize_sender(conversation, sender_id) do
  case {conversation.type, resolve_sender_role(conversation.provider_id, sender_id)} do
    {:program_broadcast, :parent} -> {:error, :broadcast_reply_not_allowed}
    {_type, role} -> {:ok, role}
  end
end
```

Authorization is now a *consequence* of the role rather than a parallel computation, so defect 2 becomes unrepresentable rather than merely fixed.

### Why a column and not a facade read

This cuts against "call the facade, don't denormalise", and #1321 just deleted a denormalised staff copy — so, explicitly: `program_staff_participants` was a **mirror**, a copy of a mutable fact obliged to track its source forever, which drifted three times (#1309/#1312/#1320). `sender_role` is a **historical record**, like an invoice storing the price at purchase. It is *supposed* to stop tracking its source.

### Pre-migration rows

Nullable, **no backfill**. The live lookup is the only signal available for existing rows, so backfilling would freeze today's answer as history rather than recover the true one. Those rows fall back to the live set — which now asks who has *ever* been staff at the provider, not who staffs this program today, so defect 2 is fixed for them too. `EnforceRetentionPolicy` hard-deletes messages past retention, so the fallback branch expires with the rows it serves and can be deleted later.

## Review focus

- **`send_message.ex`** — the `with` restructure. `load_conversation/2` keeps the guard that a pre-fetched `%Conversation{}`'s id must match, which existed to stop a mismatched struct bypassing the broadcast guard. Every pre-existing authorization test (#669, #1320 deactivated/hard-removed, parent rejection) passes unchanged.
- **Cost:** direct conversations previously skipped both resolver calls and now pay up to two indexed lookups per send. Broadcast sends are unchanged. In exchange the render path loses a cross-context query and ACL hop per conversation mount.
- **`Messaging.get_active_staff_user_ids/1`** is now authorization-only (seeding participants in `AddAssignedStaff`); its moduledoc previously warned it was dual-purpose. The new `get_provider_staff_user_ids/1` is render-only and must never gate access — it deliberately includes people whose employment has ended. Both docstrings say so.
- **No event-payload change.** `message_sent_event/1` passes explicit args, not the struct, so none of the #1316/#1325 payload-format window applies.
- **Migration is additive and nullable**, so the pre-deploy release keeps serving correctly while `release_command` runs it (#1347).

## Test plan

Nothing in `test/` asserted this attribution before — grep for the branded render returned zero hits. All coverage here is net-new.

- `message_test.exs` — tabular `provider_side?/2`: persisted roles, and `nil` × {in set, not in set, no set}. Two rows deliberately pair a persisted role with a *disagreeing* MapSet to pin precedence, so reordering the clauses fails.
- `send_message_test.exs` — role recorded as `:provider` / `:staff` / `:parent`; **`:staff` for active staff with no assignment to this program** (defect 2); and the role surviving `deactivate_staff_member/1` (defect 1).
- `staff_member_integration_test.exs` — the new Provider read includes deactivated staff, excludes unclaimed invitations and other providers.
- `messages_live/show_test.exs` — from the parent's view: attribution survives deactivation, holds for a `nil`-role row via the fallback, and is absent for another parent. Asserted on `#messages-<id>-attribution[data-provider-side=...]`, an element added for the purpose, so the negative case can't pass vacuously.

`mix precommit` green: **4411 passed**, all six lints including `lint_acl_boundary` (the new cross-context read is `acl_span`-wrapped).

Not verified in a browser or against Tidewave — this branch was created mid-session, so its `.mcp.json` was never loaded. Worth a manual pass on a program conversation before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)