### PR TITLE
fix: seed a claimed staff member onto a program conversation

### DIFF
--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -507,6 +507,36 @@ uitest_staff_member
 
 Logger.info("Created UI test staff user: uitest-staff@example.com (Wolf Musik Akademie)")
 
+# A second claimed staff member on the same provider, so a program can render more
+# than one staff user and `AddAssignedStaff`'s "exclude the sender" path has
+# something to exclude. Maria rather than a new synthetic person: she already leads
+# Piano for Beginners and staffs Children's Choir (S9b), both of which the UI test
+# staff is assigned to, so one claim also covers "the lead is a real user".
+#
+# Peter Neumann stays deliberately unclaimed while still assigned — an invite sent
+# and not yet accepted is a real shape, and the one #1309/#1312 were about.
+maria_staff_member = Enum.find(staff_members, &(&1.email == "maria.schulz@example.com"))
+
+maria_staff_user =
+  %User{}
+  |> Ecto.Changeset.change(%{
+    name: "Maria Schulz",
+    email: "maria.schulz@example.com",
+    hashed_password: hashed_pw,
+    confirmed_at: now,
+    intended_roles: [:staff]
+  })
+  |> Repo.insert!()
+
+maria_staff_member
+|> StaffMember.invitation_changeset(%{
+  user_id: maria_staff_user.id,
+  invitation_status: "accepted"
+})
+|> Repo.update!()
+
+Logger.info("Created second claimed staff user: maria.schulz@example.com (Wolf Musik Akademie)")
+
 # ==============================================================================
 # S8: VERIFICATION DOCUMENTS (~12)
 # ==============================================================================
@@ -1556,6 +1586,27 @@ message_count = 0
         |> Repo.insert!()
       end)
 
+    # Mirrors what `AddAssignedStaff.execute/3` does on the real write path
+    # (broadcast_to_program.ex): the program's active, claimed staff become
+    # participants, minus the sender. Derived from the same query rather than
+    # hardcoded, so the fixture cannot drift from that command's eligibility rule —
+    # a staff member seeded without this is invisible in `/staff/messages`, which is
+    # what made the "missing in UI" class of bug hard to see in dev.
+    staff_user_ids =
+      data.program.id
+      |> KlassHero.Provider.list_active_staff_user_ids_for_program()
+      |> Enum.reject(&(&1 == provider_user.id))
+
+    added_staff =
+      for user_id <- staff_user_ids do
+        Participant.create_changeset(%{
+          conversation_id: convo.id,
+          user_id: user_id,
+          joined_at: now
+        })
+        |> Repo.insert!()
+      end
+
     broadcast_messages = [
       "Welcome to the program broadcast channel! Important updates will be shared here.",
       "Reminder: Next session starts at the usual time. Please bring water bottles.",
@@ -1573,7 +1624,7 @@ message_count = 0
         |> Repo.insert!()
       end)
 
-    {pc + 1 + length(added_parents), mc + length(msgs)}
+    {pc + 1 + length(added_parents) + length(added_staff), mc + length(msgs)}
   end)
 
 Logger.info("Created #{participant_count} conversation participants")


### PR DESCRIPTION
Closes #1349

## Summary

Dev seeds produced exactly one claimed staff member, and no seeded conversation gave it a participant row — so `/staff/messages` was empty on a fresh `mix ecto.seed`, and the staff inbox, staff participants on new program conversations, provider-side sender attribution, and the broadcast-reply guard's allow path were all unreachable without hand-building a scenario.

Note DoD item 1 of the issue (uitest staff holding an assignment) already shipped in #1352; this PR closes the remaining two gaps.

## Changes

**1. A second claimed staff member (`priv/repo/seeds.exs`, S7b)**

Adds a `users` row for `maria.schulz@example.com` with `intended_roles: [:staff]` and links it to her **existing** `staff_members` row via `StaffMember.invitation_changeset/2`. She already leads Piano for Beginners and staffs Children's Choir — both programs the UI test staff is assigned to — so one claim covers multi-staff rendering, the "exclude the sender" branch of `AddAssignedStaff`, and "the lead is a real user" attribution, with no new staff row or assignment block to keep in sync.

`peter.neumann@example.com` stays unclaimed-but-assigned. That shape — an invite sent, not yet accepted — is exactly what #1309/#1312 were about and should stay reachable in dev.

**2. Staff participants on broadcast conversations (S17)**

`/staff/messages` resolves through `Messaging.list_conversations_for_user/2` → `ConversationQueries.where_user_is_participant/2`, a write-table query on `conversation_participants`. On the real write path `AddAssignedStaff.execute/3` creates those rows; seeds inserted only the provider user and parents, so staff were invisible.

The fix derives the participant set from `Provider.list_active_staff_user_ids_for_program/1` — the same query the command uses — rather than hardcoding user ids, so the fixture cannot drift from that command's eligibility rule. Elite Soccer Training correctly yields none (Richter's staff are all unclaimed), preserving the provider-only broadcast shape with no special-casing.

Seeds keep using `Repo.insert!` rather than the use cases, per the convention stated at `seeds.exs:973-975`: seeding is not a state transition and must not stage integration events for the outbox to deliver.

## Review Focus

- The derived call sits inside the S17 broadcast reduce, which runs after S9b assignments and after the S7b claim. Ordering matters — `list_active_staff_user_ids_for_program/1` filters on `user_id IS NOT NULL`, so a claim landing later would silently yield `[]`.
- `Enum.reject(&(&1 == provider_user.id))` is a no-op today but mirrors `AddAssignedStaff`'s `excluded_user_id` exactly.

## Test Plan

`mix precommit` green (4411 passed, credo clean). No automated test surface — seeds are uncovered by design — so verification was a fresh seed plus direct facade queries:

| Check | Result |
|---|---|
| `list_active_staff_user_ids_for_program/1` on Piano for Beginners | both claimed users, was `[]` |
| Same on Children's Choir | includes uitest |
| `list_conversations_for_user/2` for uitest | `["Weekly practice tips"]`, was empty |
| Same for Maria | `["Weekly practice tips"]` |
| Unclaimed **and** assigned staff still present | 6, including `peter.neumann@example.com` |
| Seeded conversation participants | 16, up from 14 |
