### PR TITLE
refactor: drop the transitional :critical_events queue entry

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -145,14 +145,7 @@ config :klass_hero, Oban,
   # email: 1 — serialized to stay under Resend's 2 req/sec rate limit (per-node;
   #   add a rate limiter if scaling to multiple Oban nodes)
   # events: 5 — every event goes here; since ADR-0014 there is no other kind.
-  # critical_events: 5 — transitional (#1357), and the only reason jobs staged before the
-  #   rename still run. `oban_jobs.queue` is data, so those rows still say "critical_events";
-  #   they execute fine because the `worker` column still resolves to EventDeliveryWorker, but
-  #   only while a producer is running for the queue they name. Removing this line does not
-  #   fail them — it leaves them sitting, and nothing alerts on a merely unattended queue.
-  #   Drop it via #1362, once `SELECT count(*) FROM oban_jobs WHERE queue = 'critical_events'`
-  #   is 0 in prod — gate on the count, not on elapsed time.
-  queues: [default: 10, messaging: 5, cleanup: 2, email: 1, family: 1, events: 5, critical_events: 5]
+  queues: [default: 10, messaging: 5, cleanup: 2, email: 1, family: 1, events: 5]
 
 # Base URL for constructing links in emails and event handlers
 # (avoids boundary violations from referencing KlassHeroWeb.Endpoint in domain code)

--- a/test/klass_hero/shared/adapters/driven/workers/event_delivery_worker_test.exs
+++ b/test/klass_hero/shared/adapters/driven/workers/event_delivery_worker_test.exs
@@ -269,46 +269,11 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorkerTest do
     end
   end
 
-  # #1357 moved this worker from `:critical_events` to `:events`. A queue rename is not a
-  # rename: `oban_jobs.queue` is data, so every row staged before the deploy still says
-  # "critical_events" — including anything mid-retry across the ~4.5h ladder. Both halves
-  # of why those rows are still safe are pinned here, because they are different facts and
-  # only one of them is behaviour.
-  describe "the legacy :critical_events queue" do
-    test "still executes its rows, because the worker column is what resolves the module", ctx do
-      route([{Recorder, :first}], ctx)
-
-      # `:manual` because `testing: :inline` would run the job at insert and never consult
-      # the queue at all, which is the one thing this test is here to exercise.
-      Oban.Testing.with_testing_mode(:manual, fn ->
-        Oban.insert!(
-          EventDeliveryWorker.new(%{"events" => [EventSerializer.serialize(event("thing-1"))]},
-            queue: :critical_events
-          )
-        )
-
-        Oban.drain_queue(queue: :critical_events, with_recursion: true)
-      end)
-
-      assert [{:first, "thing-1"}] = Recorder.calls()
-    end
-
-    # `drain_queue/2` above executes by queue name in the calling process and never consults
-    # the `queues:` list, so it proves the code path and NOT that anything drains this queue
-    # in production. That guarantee is a config fact, and this is the only thing asserting it.
-    test "stays configured, or every row staged before #1357 is stranded" do
-      queues = Application.get_env(:klass_hero, Oban)[:queues]
-
-      assert Keyword.has_key?(queues, :critical_events),
-             "dropping :critical_events strands every job staged before #1357 — confirm " <>
-               "`SELECT count(*) FROM oban_jobs WHERE queue = 'critical_events'` is 0 in prod " <>
-               "first. That is #1362, which removes this test along with the queue entry."
-    end
-
-    # The same failure from the other end: staging into a queue no producer is running for
-    # strands the job just as quietly, and a typo in the worker's `queue:` would do it to
+  describe "queue wiring" do
+    # Staging into a queue no producer is running for strands the job quietly — nothing
+    # errors, the row simply sits — and a typo in the worker's `queue:` would do it to
     # every event at once.
-    test "the queue this worker now stages into is one that is actually configured" do
+    test "the queue this worker stages into is one that is actually configured" do
       queues = Application.get_env(:klass_hero, Oban)[:queues]
       staged_queue = EventDeliveryWorker.new(%{"events" => []}).changes.queue
 


### PR DESCRIPTION
Closes #1362. Second half of the queue rename started in #1357 / PR #1363.

## Why this was a separate release

`oban_jobs.queue` is a column, not a code reference. Every row staged before #1363 deployed still carries `queue = 'critical_events'`. Oban dispatches on `queue` but executes on `worker`, so those rows run fine under the renamed code — but only while a producer is polling the name they carry. Dropping the entry does not fail them; it parks them, and nothing alerts on a merely unattended queue.

## The gate — and a correction to how the issue phrased it

#1362 says to gate on `SELECT count(*) FROM oban_jobs WHERE queue = 'critical_events'` returning 0. Measured in production:

| Query | Result |
|---|---|
| `count(*) where queue='critical_events'` | 107 (105 `completed`, 2 `discarded`) |
| same, restricted to `available`/`scheduled`/`retryable`/`executing` | **0** |
| last `critical_events` insert | 2026-08-14 06:13 (pre-deploy) |
| last `events` insert | 2026-08-16 07:59 (live) |

**The literal gate is not met; the invariant it was protecting is.** All 107 rows are terminal and can never be dispatched again — they are waiting on `Oban.Plugins.Pruner` (`max_age: 604_800`), which reaches the 2026-08-14 batch around 2026-08-21. Waiting for the count to hit zero would delay a safe change by five days and change nothing about the diff.

Recording this explicitly because the next person to run the issue's query will see 107 and reasonably wonder whether the gate was skipped.

Two facts close the rest of the risk:

- Nothing has staged into the old queue since the deploy — its last insert predates the rename commit, while `events` is actively producing.
- The two `discarded` rows are unaffected. `CompensationSweepWorker.uncompensated_jobs/0` filters on `job.worker` and `state == "discarded"` and never reads `queue`, so compensation stays reachable with the producer gone.

## Review focus

- `config/config.exs` — entry plus its six-line explanatory comment removed; the `events: 5` comment above stands correctly on its own.
- `event_delivery_worker_test.exs` — the two transitional tests are deleted, including the tripwire (`"stays configured, or every row staged before #1357 is stranded"`) that existed to fail this change until the gate was confirmed.
- The surviving test stays in the worker file rather than moving to `ObanConfigTest`: it asserts a *pairing* — that the worker stages into `"events"` **and** that `:events` is configured. `ObanConfigTest` is scoped to Oban plugin facts, and moving it there would drop the half that catches a typo in the worker's own `queue:` option. Its `describe` is renamed from `"the legacy :critical_events queue"`, which no longer describes anything.

## Test plan

- `mix precommit` green: 4408 passed, 2 skipped. Credo clean, all five lints pass.
- Configured queues verified as `[default, messaging, cleanup, email, family, events]` — no `:critical_events`.
- Prod runnable-row count re-checked at 0 immediately before push.