### PR TITLE
feat: point Tidewave at the checkout the session is actually in

### DIFF
--- a/.claude/hooks/cwd_changed.sh
+++ b/.claude/hooks/cwd_changed.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# CwdChanged hook: when the session moves into a different checkout, make sure THAT
+# checkout has a dev server, because it is the one bin/tidewave-router will forward to
+# from now on.
+#
+# The router resolves its target from the session's current root on every call, so a
+# mid-session EnterWorktree already repoints Tidewave correctly — nothing here has to
+# fix the pointer. What it cannot do is start a server that was never started. This
+# hook closes that gap: entering an existing, idle worktree brings it up.
+#
+# Deliberately does NOT export LOCAL_DEV_DATABASE or MIX_TEST_PARTITION into the
+# session (via CLAUDE_ENV_FILE). config/dev.exs and config/test.exs derive both from
+# the config file's own directory, so mix already resolves them correctly inside the
+# worktree — and an export would outlive the move back to main, pointing main's mix at
+# a worktree database. That is #1257 exactly, re-created by hand.
+#
+# Exit 0 always: a directory change is not worth failing.
+set -uo pipefail
+
+PAYLOAD=$(cat | tr -d '\000-\037')
+NEW_CWD=$(jq -r '.new_cwd // empty' <<<"$PAYLOAD" 2>/dev/null)
+OLD_CWD=$(jq -r '.old_cwd // empty' <<<"$PAYLOAD" 2>/dev/null)
+
+[[ -d "$NEW_CWD" ]] || exit 0
+
+checkout_of() {
+  git -C "$1" rev-parse --show-toplevel 2>/dev/null
+}
+
+NEW_ROOT=$(checkout_of "$NEW_CWD")
+OLD_ROOT=$(checkout_of "${OLD_CWD:-$NEW_CWD}")
+
+# Moving around inside one checkout changes nothing about which server serves it.
+[[ -n "$NEW_ROOT" && "$NEW_ROOT" != "$OLD_ROOT" ]] || exit 0
+[[ -x "$NEW_ROOT/bin/worktree-status" ]] || exit 0
+
+cd "$NEW_ROOT" || exit 0
+
+if bin/worktree-status >/dev/null 2>&1; then
+  exit 0
+fi
+
+mkdir -p .claude/run
+nohup bin/worktree-up --quiet >>.claude/run/boot.log 2>&1 &
+disown
+
+jq -n --arg root "$NEW_ROOT" '{
+  systemMessage: (
+    "Entered \($root), which had no running dev server — provisioning started in the "
+    + "background (log: .claude/run/boot.log). Tidewave already points here (the router "
+    + "resolves the target per call); it will answer once the server is up. Check with "
+    + "bin/worktree-status."
+  )
+}'
+
+exit 0

--- a/.claude/hooks/session_start_worktree.sh
+++ b/.claude/hooks/session_start_worktree.sh
@@ -30,6 +30,22 @@ mkdir -p .claude/run
 nohup bin/worktree-up --quiet >>.claude/run/boot.log 2>&1 &
 disown
 
+# A short bounded wait, well inside the hook budget. Since WorktreeCreate now provisions
+# fully, the usual reason to land here is a checkout whose server merely needs restarting
+# — seconds, not a cold compile. Catching that case here means the session's first turn
+# already has Tidewave, instead of spending a turn discovering it does not.
+source bin/lib/worktree-common.sh
+port=$(my_port)
+
+if [[ -n "$port" ]]; then
+  for _ in $(seq 1 12); do
+    if tidewave_alive "$port"; then
+      exit 0
+    fi
+    sleep 1
+  done
+fi
+
 cat >&2 <<EOF
 Dev server / Tidewave was not ready for this checkout — provisioning started in the
 background (log: .claude/run/boot.log). Check with: bin/worktree-status
@@ -38,8 +54,9 @@ $STATUS
 
 Until it reports READY, do not rely on Tidewave: follow the Unavailability Alert
 Protocol in .claude/rules/mcp-integration.md rather than silently falling back to bash.
-If .mcp.json was only just written, this session cannot pick it up at all — it is read
-at session start. Restart the session here once bin/worktree-status says READY.
+No restart is needed once it is up — .mcp.json names bin/tidewave-router, which resolves
+the target checkout on every call, so this session will start working as soon as the
+server answers.
 EOF
 
 exit 0

--- a/.claude/hooks/worktree_create.sh
+++ b/.claude/hooks/worktree_create.sh
@@ -9,9 +9,11 @@
 #     else may be printed there. Every diagnostic goes to stderr.
 #   * any non-zero exit aborts worktree creation.
 #
-# Provisioning uses --fast (databases and .mcp.json, no seeds, no server) to stay well
-# inside the hook budget. The SessionStart hook finishes the job — seeds and the dev
-# server — once a session actually opens here.
+# Provisioning is FULL — databases, seeds, and a running dev server — not --fast.
+# --fast left the worktree without a server, which meant the first session to open here
+# raced its own MCP connection: bin/tidewave-router would resolve the right checkout and
+# find nothing listening. The hook budget is 600s and a warm worktree converges in ~30s,
+# because bin/worktree-up copies deps/ and _build/ from the main checkout first.
 #
 # Deliberate deviation from "fail closed": a *provisioning* failure warns and still
 # returns the path, because bin/worktree-up is convergent and SessionStart re-runs it.
@@ -51,7 +53,7 @@ else
   git worktree add "$DEST" -b "$BRANCH" origin/main >&2 || exit 1
 fi
 
-if ! (cd "$DEST" && bin/worktree-up --fast >&2); then
+if ! (cd "$DEST" && bin/worktree-up >&2); then
   cat >&2 <<EOF
 worktree_create: ${NAME} was created but provisioning did not finish.
                  The worktree is usable; run bin/worktree-up inside it, or just start

--- a/.claude/rules/mcp-integration.md
+++ b/.claude/rules/mcp-integration.md
@@ -61,10 +61,10 @@ When Tidewave is not connected or fails to respond:
    | Verdict | Cause |
    |---|---|
    | `NOT RUNNING` | no dev server — run `bin/worktree-up` |
-   | `NOT CONFIGURED` | no `.mcp.json` — run `bin/worktree-up` |
+   | `NOT CONFIGURED` | no port claimed in `.claude/run/port` — run `bin/worktree-up` |
    | `ORPHAN` | a server from a deleted checkout is answering; `bin/worktree-up` reaps it |
    | `WRONG CHECKOUT` | another live checkout holds the port; **do not use Tidewave from here** |
-   | `READY` | the server is fine, so this is an MCP client issue — the session started before the server was up, and `.mcp.json` is read at session start. Reconnect via `/mcp`, or restart the session in this directory |
+   | `READY` | the server is fine. Tidewave calls resolve the target per request via `bin/tidewave-router`, so no restart is needed — retry the call. If it still fails, check `claude mcp get tidewave` reports `Connected` (a missing `node` leaves the session with no Tidewave tools) |
 
 3. **Never silently degrade**: Do not fall back to bash/shell evaluation without explicitly notifying the user that Tidewave is unavailable
 

--- a/.claude/rules/worktrees.md
+++ b/.claude/rules/worktrees.md
@@ -45,7 +45,8 @@ You normally never type these. Three hooks in `.claude/settings.json` run them:
 
 | Hook | What it does |
 |---|---|
-| `WorktreeCreate` | creates the worktree and provisions it (`--fast`: DBs + `.mcp.json`, no seeds, no server) |
+| `WorktreeCreate` | creates the worktree and provisions it **fully** — DBs, seeds, and a running dev server, so the first session here finds Tidewave already answering |
+| `CwdChanged` | converges the checkout the session just moved into, so the router has a server to forward to |
 | `SessionStart` | converges the checkout on every session start/resume — the load-bearing path |
 | `WorktreeRemove` | tears the checkout down before its directory disappears |
 
@@ -66,18 +67,45 @@ evaluates code that is gone. `bin/worktree-up` reaps such a listener (and only
 such a listener: one whose own directory is gone). A port held by a *different
 live* checkout is reported, never taken.
 
-### The one thing no script can fix
+### Tidewave follows the session — `bin/tidewave-router`
 
-`.mcp.json` is read **at session start**, and `EnterWorktree` does not restart the
-session — it changes the working directory the way `/cd` does, and does not
-re-fire `SessionStart`. So **a worktree entered mid-session keeps pointing at the
-previous checkout's Tidewave.**
+**A worktree entered mid-session now works.** It did not used to, and the reason is
+worth keeping: `.mcp.json` is read **once, at session start**, and `EnterWorktree`
+does not restart the session or re-fire `SessionStart`. So any per-checkout value
+baked into that file — which is what a `http://localhost:<port>/tidewave/mcp` URL is
+— is frozen at launch and goes stale the moment the session moves. No hook can repair
+it: no hook event carries an MCP field, `/mcp reconnect` only reconnects a server it
+already knows, and `/reload-plugins` is plugin-scoped.
 
-Do not call `project_eval` after a mid-session `EnterWorktree`; you would be
-evaluating against the wrong tree. Start the task's session *in* the worktree
-instead (`cd <worktree> && claude`). If Tidewave is missing where it should be
-present, say so and follow the Unavailability Alert Protocol in
-`.claude/rules/mcp-integration.md` — never silently fall back to bash.
+The fix is to stop encoding the target in config. `.mcp.json` now names a stdio
+server, `bin/tidewave-router`, identical in every checkout — which is why it is
+**committed** rather than generated, and why a fresh worktree has one immediately.
+On each request the router asks Claude Code `roots/list`, which reports the session's
+*current* directory, resolves that to a checkout and its port
+(`.claude/run/port`), and forwards the JSON-RPC call there.
+
+Two behaviours of that design are load-bearing:
+
+- **It re-queries; it does not subscribe.** Claude Code advertises
+  `roots.listChanged: true` but sends no `notifications/roots/list_changed` on
+  `EnterWorktree` (verified empirically — the docs describe roots only in terms of
+  `--add-dir`). A router that waited to be told would never fire.
+- **It never falls back to another checkout.** A target with no running server
+  produces a JSON-RPC error naming the checkout and the fix, because answering from
+  the wrong tree — correctly, and therefore invisibly — is the entire failure this
+  replaced. The one exception is `tools/list`, which serves a cached list when the
+  target is down: that call happens once at session start, and failing it would
+  register no Tidewave tools at all, turning a loud per-call error into a silent
+  session-wide outage.
+
+So `project_eval` after a mid-session `EnterWorktree` is safe. If Tidewave reports no
+server for a checkout, that is a provisioning problem, not a pointer problem — run
+`bin/worktree-up` there. Never silently fall back to bash; follow the Unavailability
+Alert Protocol in `.claude/rules/mcp-integration.md`.
+
+The port lives in `.claude/run/port`, not in `.mcp.json`. That relocation is what
+lets `.mcp.json` be identical everywhere, and it is what `bin/worktree-down` clears
+to release a port.
 
 ## Test DB isolation — derived, not remembered
 
@@ -170,20 +198,31 @@ Tidewave endpoint on that port, so several can run at once.
 pieces, when you need them individually:
 
 ```bash
-bin/setup-mcp    # allocate/repair this checkout's port in .mcp.json
+bin/setup-mcp    # allocate/repair this checkout's port claim
 bin/dev          # foreground server with an IEx shell
 bin/dev --detach # background server, waits until Tidewave answers
 bin/dev --port   # print this checkout's port
+bin/worktree-gc  # list stale worktrees (--prune to remove them and free their ports)
 ```
 
 `bin/setup-mcp` runs in **every** checkout, main included. It is *convergent*, not
-write-once: an existing `.mcp.json` is re-validated rather than trusted, because a
-port can stop being yours between runs — another checkout claims it, or an orphaned
-server keeps answering on it. Main takes 4000; a worktree
-takes the lowest free port in **4010–4039**. It writes `.mcp.json` declaring an MCP
-server named `tidewave` at `http://localhost:<port>/tidewave/mcp`, and `bin/dev` reads
-the port back out of that same file — so the client and the server it talks to cannot
-drift. `.mcp.json` is gitignored, which is why each checkout needs its own run.
+write-once: an existing claim is re-validated rather than trusted, because a port can
+stop being yours between runs — another checkout claims it, or an orphaned server
+keeps answering on it. Main takes 4000; a worktree takes the lowest free port in
+**4010–4089**. The ceiling matters: `live_debugger` binds `PORT + 100`, so a range
+reaching 4090 or beyond would put one checkout's debugger on another's server port.
+
+The port is written to `.claude/run/port`, and `bin/dev` and `bin/tidewave-router`
+both read it from there — so the client and the server it talks to cannot drift.
+`.mcp.json` holds no port at all and is committed, so every checkout has a working
+one the moment it is created.
+
+Ports are a finite pool, and a checkout holds its claim for as long as it exists.
+`bin/worktree-gc` is how you get them back; it reports state and removes nothing
+unless you pass `--prune`, and it never proposes a worktree with uncommitted changes.
+It decides "merged" with `git cherry`, which compares patch-ids rather than commit
+ids — necessary because every PR here is squash-merged, so a fully merged branch
+still looks unmerged to `git log origin/main..branch`.
 
 Ports derive from `PORT` in `config/dev.exs`: the endpoint binds it, `url:` and
 `:app_base_url` follow it (so generated links point at the right server), and
@@ -217,6 +256,20 @@ ignored until a workspace is trusted, which a fresh worktree isn't yet.
   `Project config`. (A parent `.mcp.json` overriding a nested worktree's was reported in
   anthropics/claude-code#42465; verified not to reproduce on 2.1.220, but this is the
   symptom if it regresses.)
+- **`.mcp.json` does not expand `${CLAUDE_PROJECT_DIR}`.** Claude Code parses the file
+  before that variable exists in its own environment and reports `Missing environment
+  variables: CLAUDE_PROJECT_DIR`, then fails to spawn with `ENOENT`. The router is
+  therefore declared with the **relative** command `bin/tidewave-router`, resolved
+  against the session's directory. Do not "fix" it by making the path absolute — that
+  is what breaks it, and it would also make the file per-checkout again.
+- **`bin/tidewave-router` needs `node` on PATH.** It is a stdio MCP server; without
+  node the session starts with no Tidewave tools at all. `bin/setup-mcp` checks for it.
+- **Migration, one time only.** `.mcp.json` used to be gitignored, so every checkout
+  that predates the router holds an *untracked* copy. Git refuses to check out a
+  tracked file over an untracked one, so rebasing such a worktree onto main fails with
+  "untracked working tree files would be overwritten". Delete it first
+  (`rm .mcp.json && git rebase origin/main`), or retire the worktree with
+  `bin/worktree-gc --prune`. Checkouts created after this landed are unaffected.
 - **live_debugger** binds its own endpoint and defaults to 4007. Before ports were
   derived, a second concurrent `mix phx.server` died on `:eaddrinuse` here.
 - **A fresh worktree has no dev DB yet.** Isolation is automatic (see the dev DB

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,6 +12,17 @@
         ]
       }
     ],
+    "CwdChanged": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/cwd_changed.sh",
+            "timeout": 20
+          }
+        ]
+      }
+    ],
     "WorktreeCreate": [
       {
         "hooks": [

--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,6 @@ npm-debug.log
 
 # IDE
 .idea/
-.mcp.json
 
 # specify
 .specify/results/
@@ -58,7 +57,9 @@ npm-debug.log
 .claude/worktrees/
 .superpowers/
 
-# Per-checkout dev server runtime state (pidfile + logs), written by bin/worktree-up
+# Per-checkout dev server runtime state (pidfile, logs, and the allocated port),
+# written by bin/worktree-up. The port lives here rather than in .mcp.json so that
+# .mcp.json can be identical everywhere and therefore committed.
 .claude/run/
 
 # Override global gitignore to track Claude config

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "tidewave": {
+      "type": "stdio",
+      "command": "bin/tidewave-router"
+    }
+  }
+}

--- a/bin/dev
+++ b/bin/dev
@@ -2,9 +2,10 @@
 #
 # Start the dev server on this checkout's port.
 #
-# The port is read from .mcp.json — the same file that points Claude Code at this
-# checkout's Tidewave endpoint — so the MCP client and the server it talks to can
-# never drift apart. Falls back to 4000 if the file is missing.
+# The port is read from .claude/run/port, the single record of what this checkout
+# claimed — the same file bin/tidewave-router resolves when it forwards an MCP call
+# here, so the client and the server it talks to cannot drift apart. Falls back to
+# 4000 when no claim has been recorded yet.
 #
 # Run bin/worktree-up once per checkout to create it (it calls bin/setup-mcp).
 #
@@ -19,25 +20,13 @@ cd "$(git rev-parse --show-toplevel)"
 # shellcheck source=bin/lib/worktree-common.sh
 source bin/lib/worktree-common.sh
 
-port=4000
+port=$(my_port)
+port="${port:-4000}"
 
-if [[ -f .mcp.json ]]; then
-  if ! command -v jq >/dev/null 2>&1; then
-    echo "bin/dev: .mcp.json exists but jq is not installed — cannot read the port." >&2
-    exit 1
-  fi
-
-  url=$(jq -r '.mcpServers.tidewave.url // empty' .mcp.json)
-
-  if [[ -n "$url" ]]; then
-    port="${url##*:}"  # http://localhost:4010/tidewave/mcp -> 4010/tidewave/mcp
-    port="${port%%/*}" # 4010/tidewave/mcp                  -> 4010
-  fi
-
-  if ! [[ "$port" =~ ^[0-9]+$ ]]; then
-    echo "bin/dev: could not parse a port out of .mcp.json (url: ${url:-none})" >&2
-    exit 1
-  fi
+if ! [[ "$port" =~ ^[0-9]+$ ]]; then
+  echo "bin/dev: ${PORT_FILE} does not contain a port (got: ${port})." >&2
+  echo "         Run bin/setup-mcp to allocate one." >&2
+  exit 1
 fi
 
 if [[ "${1:-}" == "--port" ]]; then

--- a/bin/lib/worktree-common.sh
+++ b/bin/lib/worktree-common.sh
@@ -12,12 +12,18 @@
 
 MAIN_PORT=4000
 PORT_MIN=4010
-PORT_MAX=4039
+# live_debugger binds PORT + 100 (config/dev.exs), so the ceiling must stay below
+# PORT_MIN + 100 or a debugger would land on another checkout's server port.
+PORT_MAX=4089
 
 # Where a detached dev server records itself. Gitignored; per checkout.
 RUN_DIR=".claude/run"
 PID_FILE="${RUN_DIR}/dev.pid"
 LOG_FILE="${RUN_DIR}/dev.log"
+# This checkout's allocated port. It lives here, not in .mcp.json, because .mcp.json
+# is now byte-identical in every checkout (it names bin/tidewave-router, which resolves
+# the port at request time) and is therefore committed rather than generated.
+PORT_FILE="${RUN_DIR}/port"
 
 # ---------------------------------------------------------------------------
 # Checkout identity
@@ -75,22 +81,39 @@ test_database() {
 # Ports
 # ---------------------------------------------------------------------------
 
-# The port a .mcp.json names, or nothing if it has no tidewave entry.
-port_from() {
-  jq -r '.mcpServers.tidewave.url // empty' "$1" 2>/dev/null |
-    sed -n 's#.*localhost:\([0-9][0-9]*\)/.*#\1#p'
+# The port a checkout has claimed. The legacy fallback reads a pre-router .mcp.json,
+# which encoded the port in its URL; it covers checkouts not yet re-provisioned since
+# the router landed, and can go once none remain.
+port_of_checkout() {
+  local checkout="$1" port
+
+  if [[ -f "$checkout/$PORT_FILE" ]]; then
+    port=$(tr -dc '0-9' <"$checkout/$PORT_FILE")
+    if [[ -n "$port" ]]; then
+      echo "$port"
+      return
+    fi
+  fi
+
+  if [[ -f "$checkout/.mcp.json" ]]; then
+    jq -r '.mcpServers.tidewave.url // empty' "$checkout/.mcp.json" 2>/dev/null |
+      sed -n 's#.*localhost:\([0-9][0-9]*\)/.*#\1#p'
+  fi
 }
 
-# Ports already written into some checkout's .mcp.json. Stale entries self-clean:
-# a deleted worktree stops appearing in `git worktree list`.
+# Ports already claimed by some OTHER checkout. Stale entries self-clean: a deleted
+# worktree stops appearing in `git worktree list`.
 claimed_ports() {
   local worktree
   while read -r worktree; do
     [[ "$worktree" == "$(repo_root)" ]] && continue
-    if [[ -f "$worktree/.mcp.json" ]]; then
-      port_from "$worktree/.mcp.json"
-    fi
+    port_of_checkout "$worktree"
   done < <(git worktree list --porcelain | awk '/^worktree /{print $2}')
+}
+
+# This checkout's own port, or nothing if it has not been allocated one yet.
+my_port() {
+  port_of_checkout "$(repo_root)"
 }
 
 bound_ports() {

--- a/bin/setup-mcp
+++ b/bin/setup-mcp
@@ -1,28 +1,31 @@
 #!/usr/bin/env bash
 #
-# Give this checkout its own dev-server port and Tidewave MCP endpoint by writing
-# .mcp.json.
+# Give this checkout its own dev-server port, and make sure .mcp.json points Claude
+# Code at the router.
 #
 # The main checkout takes 4000; each worktree takes the lowest free port in
-# PORT_MIN..PORT_MAX, so several dev servers can run at once and each Claude Code
-# session talks to the server for the code it is actually looking at.
+# PORT_MIN..PORT_MAX, so several dev servers can run at once.
 #
-# Convergent, not write-once: an existing .mcp.json is re-validated, not trusted.
-# A port can stop being ours between runs — another checkout claims it, or an
-# orphaned server from a deleted worktree keeps answering on it. That orphan case
-# is the dangerous one, because it answers /tidewave/mcp *correctly* for the wrong
-# code. Re-validation is what turns that from a silent wrong answer into a fix.
+# What changed when bin/tidewave-router landed: the port no longer lives in .mcp.json.
+# It lives in .claude/run/port, and .mcp.json became byte-identical in every checkout
+# — it names the router, which asks the session where it is and resolves the port at
+# request time. That is what makes a mid-session EnterWorktree work: there is no
+# per-checkout value baked into a file that is only read at session start.
 #
-# .mcp.json is *project* scope, which outranks user scope and replaces the entry
-# wholesale (scopes match by name; fields are never merged). Keeping the name
-# `tidewave` is deliberate: MCP tool permissions are keyed on the server name, so a
-# per-worktree name would need its own mcp__<name>__* grants in settings.
+# Because it is identical everywhere, .mcp.json is committed rather than generated.
+# This script still rewrites it when it has drifted (a legacy URL-shaped entry from
+# before the router, or a deleted file), so an old checkout self-heals on first run.
 #
-# .mcp.json is gitignored, so every checkout needs this run once. bin/worktree-up
-# calls it for you.
+# Convergent, not write-once: an existing port claim is re-validated, not trusted. A
+# port can stop being ours between runs — another checkout claims it, or an orphaned
+# server from a deleted worktree keeps answering on it. That orphan case is the
+# dangerous one, because it answers /tidewave/mcp *correctly* for the wrong code.
+#
+# Keeping the MCP server name `tidewave` is deliberate: tool permissions are keyed on
+# the server name, so a per-worktree name would need its own mcp__<name>__* grants.
 #
 # Usage:
-#   bin/setup-mcp            write or repair .mcp.json
+#   bin/setup-mcp            allocate/repair this checkout's port and .mcp.json
 #   bin/setup-mcp --quiet    same, but only speak up on a change or a problem
 
 set -euo pipefail
@@ -39,9 +42,40 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 1
 fi
 
+if ! command -v node >/dev/null 2>&1; then
+  echo "setup-mcp: node is required — bin/tidewave-router is a node stdio MCP server" >&2
+  exit 1
+fi
+
 say() { $QUIET || echo "$@"; }
 
-root=$(repo_root)
+# The canonical .mcp.json, identical in every checkout — which is what lets it be
+# committed instead of generated.
+#
+# The command is relative on purpose. ${CLAUDE_PROJECT_DIR} is NOT expanded here:
+# Claude Code parses .mcp.json before that variable exists in its own environment and
+# reports "Missing environment variables: CLAUDE_PROJECT_DIR", so an absolute form
+# would fail to spawn. A relative command resolves against the session's directory,
+# which is the checkout root.
+MCP_COMMAND="bin/tidewave-router"
+
+write_mcp_json() {
+  cat >.mcp.json <<EOF
+{
+  "mcpServers": {
+    "tidewave": {
+      "type": "stdio",
+      "command": "${MCP_COMMAND}"
+    }
+  }
+}
+EOF
+}
+
+mcp_json_current() {
+  [[ -f .mcp.json ]] || return 1
+  [[ "$(jq -r '.mcpServers.tidewave.command // empty' .mcp.json 2>/dev/null)" == "$MCP_COMMAND" ]]
+}
 
 # Is $1 a port this checkout may still call its own?
 port_still_ours() {
@@ -54,7 +88,7 @@ port_still_ours() {
     ((port == MAIN_PORT)) || return 1
   fi
 
-  # Written into another live checkout's .mcp.json since we last looked?
+  # Claimed by another live checkout since we last looked?
   grep -qx "$port" <<<"$(claimed_ports)" && return 1
 
   # An orphan holding it is reapable, so try that before judging.
@@ -66,10 +100,21 @@ port_still_ours() {
   esac
 }
 
-existing=""
-[[ -f .mcp.json ]] && existing=$(port_from .mcp.json)
+record_port() {
+  mkdir -p "$RUN_DIR"
+  echo "$1" >"$PORT_FILE"
+}
+
+if ! mcp_json_current; then
+  write_mcp_json
+  say "Wrote .mcp.json -> bin/tidewave-router (stdio)."
+fi
+
+existing=$(my_port)
 
 if [[ -n "$existing" ]] && port_still_ours "$existing"; then
+  # Migrates a legacy checkout whose port was only ever in .mcp.json.
+  record_port "$existing"
   say "Port ${existing} is still this checkout's. Nothing to do."
   exit 0
 fi
@@ -77,7 +122,7 @@ fi
 if [[ -n "$existing" ]]; then
   pid=$(listener_pid "$existing")
   owner=$(port_owner "$existing")
-  echo "Port ${existing} in .mcp.json is no longer usable here (${owner}${pid:+, held by pid ${pid} at $(listener_cwd "$pid")})." >&2
+  echo "Port ${existing} is no longer usable here (${owner}${pid:+, held by pid ${pid} at $(listener_cwd "$pid")})." >&2
   echo "Reallocating." >&2
 fi
 
@@ -99,20 +144,9 @@ else
   fi
 fi
 
-cat >.mcp.json <<EOF
-{
-  "mcpServers": {
-    "tidewave": {
-      "type": "http",
-      "url": "http://localhost:${port}/tidewave/mcp"
-    }
-  }
-}
-EOF
+record_port "$port"
 
 say "Configured port ${port} for ${where}."
 say ""
-say "  wrote .mcp.json  -> tidewave at $(tidewave_url "$port")"
-say "  bin/worktree-up  -> provisions and starts the server on ${port} (live_debugger on $((port + 100)))"
-say ""
-say "Restart Claude Code here — .mcp.json is read at session start."
+say "  wrote ${PORT_FILE}  -> the router resolves this at request time"
+say "  bin/worktree-up     -> provisions and starts the server on ${port} (live_debugger on $((port + 100)))"

--- a/bin/tidewave-router
+++ b/bin/tidewave-router
@@ -1,0 +1,275 @@
+#!/usr/bin/env node
+// A stdio MCP server that forwards to whichever checkout the session is CURRENTLY in.
+//
+// The problem it solves: `.mcp.json` is read once, at session start. A session that
+// moves into a worktree mid-flight (EnterWorktree) therefore keeps talking to the
+// Tidewave of the checkout it booted in — silently answering questions about the
+// wrong tree. No hook can repoint it: no hook event carries an MCP field.
+//
+// The way out is to stop encoding the target in config at all. Claude Code answers
+// the MCP `roots/list` request with the session's current directory, and — verified
+// empirically, since the docs only describe roots in terms of --add-dir — that answer
+// FOLLOWS EnterWorktree. So we ask, per request, where the session is now, and forward
+// there. The target is late-bound; there is nothing left to go stale.
+//
+// One caveat that shapes the code: Claude Code does NOT send
+// notifications/roots/list_changed when EnterWorktree moves the session, even though
+// it advertises `roots.listChanged: true`. Waiting to be told would never fire. We
+// re-query instead, on every request that needs a target.
+//
+// Forwarding is a plain POST because Tidewave's HTTP transport is stateless JSON:
+// no session header, no SSE framing, and `tools/call` works with no prior handshake.
+// So this is a forwarder, not a session-bridging proxy.
+//
+// Failure is always loud. A checkout with no dev server produces a JSON-RPC error
+// naming the checkout and the command that fixes it — never a fallback to some other
+// checkout's server, which is the exact bug this file exists to end.
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { createInterface } from "node:readline";
+import { fileURLToPath } from "node:url";
+
+const MAIN_PORT = 4000;
+const ROOTS_TIMEOUT_MS = 2000;
+
+const send = (msg) => process.stdout.write(JSON.stringify(msg) + "\n");
+const note = (line) => process.stderr.write(`tidewave-router: ${line}\n`);
+
+// ---------------------------------------------------------------------------
+// Asking the client where it is
+// ---------------------------------------------------------------------------
+
+let nextId = 1;
+const pendingRoots = new Map(); // our request id -> resolve fn
+
+function currentRoots() {
+  return new Promise((resolve) => {
+    const id = `router-${nextId++}`;
+    const done = (value) => {
+      if (pendingRoots.delete(id)) resolve(value);
+    };
+    pendingRoots.set(id, done);
+    send({ jsonrpc: "2.0", id, method: "roots/list" });
+    // A client that never answers must not wedge the tool call.
+    setTimeout(() => done(null), ROOTS_TIMEOUT_MS);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Root -> checkout -> port
+// ---------------------------------------------------------------------------
+
+// The reported root is normally the checkout root already, but a session started in
+// a subdirectory would report that instead. Walk up to the nearest .git — a file in
+// a linked worktree, a directory in the main checkout.
+function checkoutRootOf(dir) {
+  let current = dir;
+  for (;;) {
+    if (existsSync(join(current, ".git"))) return current;
+    const parent = dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+// bin/setup-mcp writes .claude/run/port. The two fallbacks cover the window before a
+// checkout has been re-provisioned since this router landed: a legacy .mcp.json that
+// still names a port in its URL, and the main checkout's fixed port.
+function portOf(checkout) {
+  const portFile = join(checkout, ".claude", "run", "port");
+  if (existsSync(portFile)) {
+    const port = parseInt(readFileSync(portFile, "utf8").trim(), 10);
+    if (Number.isInteger(port)) return port;
+  }
+
+  const mcpJson = join(checkout, ".mcp.json");
+  if (existsSync(mcpJson)) {
+    try {
+      const url = JSON.parse(readFileSync(mcpJson, "utf8"))?.mcpServers?.tidewave?.url;
+      const match = /localhost:(\d+)\//.exec(url ?? "");
+      if (match) return parseInt(match[1], 10);
+    } catch {
+      // A malformed .mcp.json is not worth crashing the router over.
+    }
+  }
+
+  // A directory .git means the main checkout, which always binds MAIN_PORT.
+  try {
+    if (!readFileSync(join(checkout, ".git"), "utf8")) return MAIN_PORT;
+  } catch {
+    return MAIN_PORT; // reading a directory throws EISDIR
+  }
+  return null;
+}
+
+async function resolveTarget() {
+  const roots = await currentRoots();
+  const uri = roots?.roots?.[0]?.uri;
+  const dir = uri ? fileURLToPath(uri) : process.env.CLAUDE_PROJECT_DIR || process.cwd();
+
+  const checkout = checkoutRootOf(dir);
+  if (!checkout) return { error: `${dir} is not inside a git checkout` };
+
+  const port = portOf(checkout);
+  if (!port) {
+    return {
+      error:
+        `${checkout} has no dev server port on record. ` +
+        `Run bin/worktree-up in that checkout.`,
+    };
+  }
+  return { checkout, port };
+}
+
+// ---------------------------------------------------------------------------
+// Forwarding
+// ---------------------------------------------------------------------------
+
+async function forward(message) {
+  const target = await resolveTarget();
+  if (target.error) return { error: { code: -32001, message: target.error } };
+
+  const url = `http://localhost:${target.port}/tidewave/mcp`;
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify(message),
+    });
+
+    if (!response.ok) {
+      return {
+        error: {
+          code: -32002,
+          message: `Tidewave at ${url} (checkout ${target.checkout}) returned HTTP ${response.status}.`,
+        },
+      };
+    }
+    return { result: await response.json() };
+  } catch (cause) {
+    return {
+      error: {
+        code: -32003,
+        message:
+          `No Tidewave answering on port ${target.port} for checkout ${target.checkout} ` +
+          `(${cause.message}). Run bin/worktree-up there, then retry — this session is ` +
+          `pointed at the right tree, its server is just not up.`,
+      },
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Client-facing loop
+// ---------------------------------------------------------------------------
+
+// Answered locally rather than forwarded: initialize arrives before the client is
+// ready to answer roots/list, so there is no target to forward it to yet. Tools are
+// declared listChanged so a later target switch can announce a different tool set.
+function handleInitialize(msg) {
+  send({
+    jsonrpc: "2.0",
+    id: msg.id,
+    result: {
+      protocolVersion: msg.params?.protocolVersion || "2025-06-18",
+      capabilities: { tools: { listChanged: true } },
+      serverInfo: { name: "tidewave-router", version: "1.0.0" },
+    },
+  });
+}
+
+// tools/list is the one method where failing loudly is the WRONG answer. It runs once,
+// at session start; if the target's server is not up yet, an error there registers no
+// tidewave tools at all and the whole session silently has none — the failure is
+// invisible and total. Serving a cached list keeps the tools registered so the loud,
+// actionable error lands on the call instead, where someone can act on it.
+//
+// Safe to cache because Tidewave reports tools.listChanged: false and every checkout
+// runs the same version. The cache refreshes on every successful list.
+const TOOLS_CACHE = join(
+  process.env.CLAUDE_PROJECT_DIR || process.cwd(),
+  ".claude",
+  "run",
+  "tidewave-tools.json",
+);
+
+function cacheTools(result) {
+  try {
+    mkdirSync(dirname(TOOLS_CACHE), { recursive: true });
+    writeFileSync(TOOLS_CACHE, JSON.stringify(result));
+  } catch {
+    // A cache we cannot write is not worth failing a working call over.
+  }
+}
+
+function cachedTools() {
+  try {
+    return JSON.parse(readFileSync(TOOLS_CACHE, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+async function handleForwarded(msg) {
+  const outcome = await forward(msg);
+
+  if (outcome.error) {
+    if (msg.method === "tools/list") {
+      const cached = cachedTools();
+      if (cached) {
+        note(`serving cached tools/list — ${outcome.error.message}`);
+        send({ jsonrpc: "2.0", id: msg.id, result: cached });
+        return;
+      }
+    }
+    send({ jsonrpc: "2.0", id: msg.id, error: outcome.error });
+    return;
+  }
+
+  if (msg.method === "tools/list" && outcome.result?.result) {
+    cacheTools(outcome.result.result);
+  }
+
+  // Tidewave echoes our id; pass its envelope through untouched so any field we
+  // do not know about survives the hop.
+  send({ ...outcome.result, jsonrpc: "2.0", id: msg.id });
+}
+
+createInterface({ input: process.stdin }).on("line", async (line) => {
+  if (!line.trim()) return;
+
+  let msg;
+  try {
+    msg = JSON.parse(line);
+  } catch {
+    note(`ignoring unparseable line: ${line.slice(0, 120)}`);
+    return;
+  }
+
+  // A response to the roots/list we asked for.
+  if (msg.id !== undefined && msg.method === undefined) {
+    const resolve = pendingRoots.get(msg.id);
+    if (resolve) resolve(msg.error ? null : msg.result);
+    return;
+  }
+
+  switch (msg.method) {
+    case "initialize":
+      handleInitialize(msg);
+      return;
+    case "notifications/initialized":
+    case "notifications/cancelled":
+      return;
+    case "ping":
+      send({ jsonrpc: "2.0", id: msg.id, result: {} });
+      return;
+    default:
+      if (msg.id === undefined) return; // any other notification: nothing to reply to
+      await handleForwarded(msg);
+  }
+});
+
+process.stdin.on("end", () => process.exit(0));

--- a/bin/worktree-down
+++ b/bin/worktree-down
@@ -85,6 +85,8 @@ if $DROP_DB; then
   MIX_ENV=test mix ecto.drop >/dev/null 2>&1 || echo "  (already gone)" >&2
 fi
 
-rm -f .mcp.json
+# .mcp.json is NOT removed: it is committed and identical in every checkout, naming
+# bin/tidewave-router rather than a port. The port claim lived in $RUN_DIR and went
+# with it above, which is what actually releases the port for another checkout.
 
 echo "DOWN  ${root}" >&2

--- a/bin/worktree-gc
+++ b/bin/worktree-gc
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# Report — and optionally remove — worktrees that have outlived their task.
+#
+# Why this exists: a checkout's port claim lives in .claude/run/port, and
+# allocate_port() excludes every port claimed by a checkout still listed in
+# `git worktree list`. An abandoned worktree therefore holds its port forever. With
+# PORT_MIN..PORT_MAX slots available, enough abandoned worktrees exhaust the range,
+# and the failure — "No free port" at provisioning time — reads as a bug in the
+# allocator rather than as accumulated litter.
+#
+# Safety: dry-run by default, and a worktree with uncommitted changes is NEVER a
+# removal candidate, whatever its branch state. Losing uncommitted work is the one
+# failure this repo has already paid for once (see the recovery section of
+# .claude/rules/worktrees.md); a reclaimed port is not worth risking it again.
+#
+# Usage:
+#   bin/worktree-gc            list every worktree with its state; remove nothing
+#   bin/worktree-gc --prune    remove the clean, fully-merged ones
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+# shellcheck source=bin/lib/worktree-common.sh
+source bin/lib/worktree-common.sh
+
+PRUNE=false
+[[ "${1:-}" == "--prune" ]] && PRUNE=true
+
+main_root=$(repo_root)
+git fetch origin --quiet 2>/dev/null || true
+
+candidates=()
+
+printf '%-52s %-10s %-9s %-8s %s\n' CHECKOUT BRANCH PORT SERVER STATE
+
+while read -r worktree; do
+  [[ "$worktree" == "$main_root" ]] && continue
+
+  branch=$(git -C "$worktree" branch --show-current 2>/dev/null || echo "detached")
+  port=$(port_of_checkout "$worktree")
+
+  if [[ -n "$port" ]] && [[ "$(cd "$worktree" && port_owner "$port")" == "mine" ]]; then
+    server="up"
+  else
+    server="-"
+  fi
+
+  # Untracked files count: a worktree holding scratch work is still work.
+  if [[ -n "$(git -C "$worktree" status --porcelain 2>/dev/null)" ]]; then
+    state="DIRTY — keep"
+  elif [[ "$branch" == "detached" ]]; then
+    state="detached — keep"
+  else
+    # `git cherry` compares patch-ids, not commit ids: it marks a commit "-" when an
+    # equivalent change is already upstream. That is the test this repo needs, because
+    # every PR is squash-merged — the branch's commit never appears in origin/main by
+    # id, so `git log origin/main..branch` calls a fully merged branch unmerged.
+    #
+    # It is conservative by construction: a branch whose several commits were squashed
+    # into one upstream will not match by patch-id and stays "keep". Better to leave
+    # litter than to remove work that is only *probably* merged.
+    cherry=$(git -C "$worktree" cherry origin/main "$branch" 2>/dev/null || echo "?")
+
+    if [[ "$cherry" == "?" ]]; then
+      state="cannot compare — keep"
+    elif ! grep -q '^+' <<<"$cherry"; then
+      state="merged — removable"
+      candidates+=("$worktree")
+    else
+      state="$(grep -c '^+' <<<"$cherry") unmerged commit(s) — keep"
+    fi
+  fi
+
+  printf '%-52s %-10s %-9s %-8s %s\n' \
+    "${worktree#"$main_root"/}" "${branch:0:10}" "${port:-none}" "$server" "$state"
+done < <(git worktree list --porcelain | awk '/^worktree /{print $2}')
+
+echo
+echo "${#candidates[@]} removable, out of $(($(git worktree list | wc -l) - 1)) worktrees."
+echo "ports in use: $(claimed_ports | grep -c . || true) of $((PORT_MAX - PORT_MIN + 1)) (${PORT_MIN}-${PORT_MAX})"
+
+if ! $PRUNE; then
+  ((${#candidates[@]} > 0)) && echo "Run bin/worktree-gc --prune to remove them."
+  exit 0
+fi
+
+for worktree in "${candidates[@]}"; do
+  echo
+  echo "Removing ${worktree}"
+  # worktree-down first: it stops the server and drops the databases, which
+  # `git worktree remove` knows nothing about.
+  (cd "$worktree" && bin/worktree-down >&2) || echo "  (worktree-down failed; removing anyway)" >&2
+  git worktree remove "$worktree" || git worktree remove --force "$worktree"
+done
+
+git worktree prune
+echo
+echo "Done. ports now claimed: $(claimed_ports | grep -c . || true)"

--- a/bin/worktree-gc
+++ b/bin/worktree-gc
@@ -85,12 +85,48 @@ if ! $PRUNE; then
   exit 0
 fi
 
+# Drop a removed checkout's databases without its cooperation.
+#
+# bin/worktree-down is the normal path, but it only exists on branches cut after it
+# landed — and a worktree old enough to be garbage is exactly the kind whose branch
+# predates it. That case used to print "worktree-down failed; removing anyway" and
+# silently leak two databases per worktree, which is how a Postgres accumulates a
+# hundred of them. The names are derived from the checkout's basename, so we can drop
+# them ourselves; we just cannot ask the worktree to do it.
+drop_databases_of() {
+  local slug dev_db test_db db
+  slug=$(basename "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/_/g')
+  dev_db="klass_hero_dev_${slug}"
+  test_db="klass_hero_test_${slug}"
+
+  # psql rather than dropdb: database_exists already relies on psql, so this adds no
+  # new tool requirement.
+  for db in "${dev_db:0:63}" "${test_db:0:63}"; do
+    if database_exists "$db"; then
+      echo "  dropping ${db}" >&2
+      PGPASSWORD=postgres psql -h localhost -U postgres -q \
+        -c "DROP DATABASE IF EXISTS \"${db}\"" >/dev/null 2>&1 ||
+        echo "  (could not drop ${db} — still in use?)" >&2
+    fi
+  done
+}
+
 for worktree in "${candidates[@]}"; do
   echo
   echo "Removing ${worktree}"
-  # worktree-down first: it stops the server and drops the databases, which
-  # `git worktree remove` knows nothing about.
-  (cd "$worktree" && bin/worktree-down >&2) || echo "  (worktree-down failed; removing anyway)" >&2
+
+  # worktree-down first when it exists: it also stops the dev server, which nothing
+  # else here does. Fall back to dropping the databases directly.
+  if [[ -x "$worktree/bin/worktree-down" ]]; then
+    (cd "$worktree" && bin/worktree-down >&2) || {
+      echo "  (worktree-down failed; dropping databases directly)" >&2
+      drop_databases_of "$worktree"
+    }
+  else
+    echo "  (no bin/worktree-down on this branch; dropping databases directly)" >&2
+    drop_databases_of "$worktree"
+  fi
+
   git worktree remove "$worktree" || git worktree remove --force "$worktree"
 done
 

--- a/bin/worktree-status
+++ b/bin/worktree-status
@@ -26,8 +26,8 @@ echo "kind       $(linked_worktree && echo "worktree ($(git branch --show-curren
 echo "dev db     $(dev_database) $(database_exists "$(dev_database)" && echo "(exists)" || echo "(MISSING)")"
 echo "test db    $(test_database) $(database_exists "$(test_database)" && echo "(exists)" || echo "(MISSING)")"
 
-if [[ ! -f .mcp.json ]]; then
-  echo "tidewave   NOT CONFIGURED — no .mcp.json. Run bin/worktree-up."
+if [[ -z "$(my_port)" ]]; then
+  echo "tidewave   NOT CONFIGURED — no port claimed in ${PORT_FILE}. Run bin/worktree-up."
   exit 1
 fi
 

--- a/bin/worktree-up
+++ b/bin/worktree-up
@@ -13,7 +13,7 @@
 #
 # Usage:
 #   bin/worktree-up              full converge (default)
-#   bin/worktree-up --fast       databases and .mcp.json only; no seeds, no server
+#   bin/worktree-up --fast       databases and the port claim only; no seeds, no server
 #   bin/worktree-up --no-seed    converge, but never seed
 #   bin/worktree-up --reseed     seed even if the database already existed
 #   bin/worktree-up --no-server  converge, but do not start the dev server


### PR DESCRIPTION
## Summary

Sessions kept reporting some variant of *"Tidewave verification was not run: this session entered the worktree mid-session, and `.mcp.json` is read at session start, so Tidewave here still points at the previous checkout."*

The cause is structural. `.mcp.json` is read **once, at session start**, so the port baked into its URL is frozen at launch, and nothing can repoint it: no hook event carries an MCP field, `/mcp reconnect` only reconnects a server it already knows, `/reload-plugins` is plugin-scoped, and a subagent with `isolation: "worktree"` *inherits* the parent's MCP connections rather than resolving its own.

So this stops encoding the target in config. `.mcp.json` now names a stdio server, `bin/tidewave-router`, byte-identical in every checkout and therefore **committed** rather than generated. On each request the router asks Claude Code `roots/list` — which reports the session's *current* directory, and which **does follow `EnterWorktree`** — resolves that to a checkout and its port, and forwards the call there.

## Review focus

- **`bin/tidewave-router`** is the whole idea. Two behaviours are load-bearing and worth a look:
  - It **re-queries, never subscribes.** Claude Code advertises `roots.listChanged: true` but sends no notification on `EnterWorktree`, so a router that waited to be told would never fire.
  - It **never falls back to another checkout.** A target with no server produces a JSON-RPC error naming the checkout and the fix. The one exception is `tools/list`, which serves a cached list when the target is down — that call happens once at session start, and failing it would register *no* Tidewave tools for the whole session, converting a loud per-call error into a silent session-wide outage.
- **The port moved** from `.mcp.json` to `.claude/run/port`. That relocation is what lets `.mcp.json` be identical everywhere; it is also what `bin/worktree-down` clears to release a port.
- **`bin/worktree-gc`** uses `git cherry` (patch-ids) rather than `git log origin/main..branch`, because every PR here is squash-merged and the latter calls a fully merged branch unmerged. It is dry-run by default and never proposes a worktree with uncommitted changes.

Forwarding is a plain POST rather than a session-bridging proxy because Tidewave's HTTP transport turned out to be stateless: plain `application/json`, no `Mcp-Session-Id`, and `tools/call` works with no prior handshake.

## Two traps found the hard way

- **`.mcp.json` does not expand `${CLAUDE_PROJECT_DIR}`.** Claude Code parses the file before that variable exists in its own environment, reports `Missing environment variables: CLAUDE_PROJECT_DIR`, and fails to spawn with `ENOENT`. The router is declared with the relative command `bin/tidewave-router`. Making that path absolute breaks it *and* makes the file per-checkout again.
- **The `CwdChanged` hook deliberately exports no database env vars.** Exporting `LOCAL_DEV_DATABASE` via `CLAUDE_ENV_FILE` would survive the move back to main and point main's `mix` at a worktree database — #1257 recreated by hand. It is also unnecessary: `config/dev.exs` derives the name from `Path.dirname(__DIR__)`, the config file's own location.

## Test plan

- `mix precommit` — green, 4411 passed, 2 skipped.
- **End-to-end, the acceptance test:** with dev servers on 4000 (main, pid A) and 4010 (a fresh worktree, pid B), one session called `project_eval` with `File.cwd!()`, ran `EnterWorktree`, and called again. It returned the main path, then the worktree path — two distinct BEAMs, correct tree both times, no session restart.
- **Migration path:** the new worktree in that test branched from `origin/main` and so ran the *old* `bin/setup-mcp`, producing a legacy URL-style `.mcp.json` and no port file. The router resolved it correctly through its legacy fallback, which is the pre-existing-checkout case.
- Loud-failure path: routing to a checkout with no server returns `-32003` naming the checkout and `bin/worktree-up`, rather than answering from elsewhere.
- `bin/worktree-gc` dry-run across the 24 existing worktrees: 15 removable, dirty and unmerged ones held back.

## One-time migration note

`.mcp.json` used to be gitignored, so every checkout predating this holds an untracked copy, and git refuses to check a tracked file out over one. Rebasing such a worktree needs `rm .mcp.json` first, or retire it with `bin/worktree-gc --prune`. Documented in `.claude/rules/worktrees.md`.