### PR TITLE
fix: narrow captured params before the error store keeps them

### DIFF
--- a/lib/klass_hero/shared/error_context_filter.ex
+++ b/lib/klass_hero/shared/error_context_filter.ex
@@ -2,16 +2,32 @@ defmodule KlassHero.Shared.ErrorContextFilter do
   @moduledoc """
   Narrows the context ErrorTracker persists, before it is written.
 
-  `ErrorTracker.Integrations.Oban` sets the whole of `job.args` as context on every
-  job start, and ErrorTracker stores context alongside each error occurrence in the
-  production database. `ProcessInviteClaimWorker`'s args carry a child's name, date of
-  birth and medical conditions, so the unfiltered default would put children's health
-  data in an error log.
+  ErrorTracker stores context alongside each error occurrence in the production
+  database, and two of the things it captures carry user-submitted data verbatim:
+  Oban job args, and the params of the request or LiveView event that crashed.
+  `ProcessInviteClaimWorker`'s args and the children form both carry a child's name,
+  date of birth and medical conditions, so the unfiltered default would put children's
+  health data in an error log.
 
-  Job args are therefore allowlisted rather than denylisted: a new worker, or a new
-  field on an existing one, is excluded until someone adds it here. Everything else in
-  the context passes through — `KlassHeroWeb.Router.set_error_tracker_context/2`'s
+  Both are therefore closed by default — a new worker, a new form, or a new field on an
+  existing one is minimised until someone allowlists it. The two halves narrow
+  differently because they fail differently:
+
+    * **Job args** are *removed*, and the dropped names recorded in a sibling
+      `job.args.redacted` key. Without that sibling an operator would read the surviving
+      args as the whole story.
+
+    * **Params** keep their keys and lose their values — a nested form map becomes a
+      marker naming its fields, an unlisted scalar becomes `"[redacted]"`. The key
+      staying in place is what announces the redaction, so no sibling key is needed.
+      Which fields were submitted is the debugging signal; what was in them is the PII.
+
+  Everything else in the context passes through — `KlassHeroWeb.Router.set_error_tracker_context/2`'s
   user_id/email predate this filter and are deliberate.
+
+  `sanitize/1` is called once, on the fully merged context at report time, so a single
+  LiveView crash can arrive carrying mount, `handle_params` and `handle_event` params at
+  once. Each key is narrowed independently.
 
   Wired via `config :error_tracker, filter: KlassHero.Shared.ErrorContextFilter`.
   """
@@ -20,6 +36,12 @@ defmodule KlassHero.Shared.ErrorContextFilter do
 
   @args_key "job.args"
   @redacted_key "job.args.redacted"
+
+  # Every key under which ErrorTracker records user-submitted params.
+  # `request.params` is the controller/plug side; there is no "phoenix.params".
+  @param_keys ~w(live_view.event_params live_view.params request.params)
+
+  @scalar_marker "[redacted]"
 
   # Correlation ids only — enough to find the row this job was about, never its contents.
   # "trace_context" carries OTel propagation (`Shared.Tracing.Context.inject_into_args/1`);
@@ -30,8 +52,24 @@ defmodule KlassHero.Shared.ErrorContextFilter do
     trace_context
   )
 
+  # Correlation ids, the flags and navigation state that explain what the user was doing,
+  # and "_target" — LiveView's name of the field that triggered the change, which is a
+  # field name, not a field value. "consent" earns its place by precedent: in #1322 the
+  # captured flag was the only surviving proof that a guardian had ticked the box.
+  @allowed_params ~w(
+    invite_id user_id program_id parent_id child_id provider_id
+    enrollment_id staff_member_id conversation_id message_id email_id
+    id consent page per_page sort filter tab _target
+  )
+
   @impl true
   def sanitize(context) when is_map(context) do
+    context
+    |> filter_args()
+    |> filter_params()
+  end
+
+  defp filter_args(context) do
     case context do
       %{@args_key => args} when is_map(args) -> put_filtered_args(context, args)
       _ -> context
@@ -46,5 +84,31 @@ defmodule KlassHero.Shared.ErrorContextFilter do
       [] -> context
       dropped -> Map.put(context, @redacted_key, Enum.sort(dropped))
     end
+  end
+
+  defp filter_params(context) do
+    Enum.reduce(@param_keys, context, fn key, acc ->
+      case acc do
+        %{^key => params} when is_map(params) and map_size(params) > 0 ->
+          Map.put(acc, key, Map.new(params, &narrow_param/1))
+
+        _ ->
+          acc
+      end
+    end)
+  end
+
+  defp narrow_param({key, value}) do
+    cond do
+      to_string(key) in @allowed_params -> {key, value}
+      is_map(value) -> {key, nested_marker(value)}
+      true -> {key, @scalar_marker}
+    end
+  end
+
+  defp nested_marker(map) do
+    names = map |> Map.keys() |> Enum.map(&to_string/1) |> Enum.sort()
+
+    "[#{length(names)} keys redacted: #{Enum.join(names, ", ")}]"
   end
 end

--- a/test/klass_hero/shared/error_context_filter_test.exs
+++ b/test/klass_hero/shared/error_context_filter_test.exs
@@ -61,6 +61,95 @@ defmodule KlassHero.Shared.ErrorContextFilterTest do
     end
   end
 
+  describe "sanitize/1 on captured params" do
+    # The exact shape recorded in production when the #1322 crash hit
+    # ChildrenLive's "save_child": the guardian's whole form, health fields included.
+    test "replaces a nested form map with its key names" do
+      context = %{
+        "live_view.event" => "save_child",
+        "live_view.event_params" => %{
+          "child" => %{
+            "first_name" => "Louis",
+            "last_name" => "Davids",
+            "date_of_birth" => "2017-03-15",
+            "allergies" => "none",
+            "support_needs" => "none",
+            "emergency_contact" => "0163-194 5369",
+            "gender" => "male",
+            "school_grade" => "4"
+          },
+          "consent" => "true"
+        }
+      }
+
+      assert %{"live_view.event_params" => params} = ErrorContextFilter.sanitize(context)
+
+      assert params["child"] ==
+               "[8 keys redacted: allergies, date_of_birth, emergency_contact, first_name, " <>
+                 "gender, last_name, school_grade, support_needs]"
+    end
+
+    # Which fields were submitted is the debugging signal; what was in them is the PII.
+    # Losing the consent flag would have cost us the only proof the box was ticked.
+    test "keeps allowlisted scalars so a crash is still diagnosable" do
+      context = %{
+        "live_view.event_params" => %{
+          "consent" => "true",
+          "child_id" => "616fd5e9",
+          "_target" => ["child", "allergies"]
+        }
+      }
+
+      assert %{"live_view.event_params" => params} = ErrorContextFilter.sanitize(context)
+
+      assert params == %{
+               "consent" => "true",
+               "child_id" => "616fd5e9",
+               "_target" => ["child", "allergies"]
+             }
+    end
+
+    test "redacts a top-level scalar that is not allowlisted, keeping its key" do
+      context = %{"live_view.event_params" => %{"email" => "parent@example.com"}}
+
+      assert %{"live_view.event_params" => params} = ErrorContextFilter.sanitize(context)
+      assert params == %{"email" => "[redacted]"}
+    end
+
+    # sanitize/1 runs once on the merged context at report time, so a LiveView crash can
+    # carry mount, handle_params and handle_event params at once — plus request.params
+    # when the dead render went through the router first.
+    test "narrows every params key present in one context" do
+      sensitive = %{"child" => %{"allergies" => "none"}}
+
+      context = %{
+        "live_view.params" => sensitive,
+        "live_view.event_params" => sensitive,
+        "request.params" => sensitive
+      }
+
+      sanitized = ErrorContextFilter.sanitize(context)
+
+      for key <- ["live_view.params", "live_view.event_params", "request.params"] do
+        assert sanitized[key]["child"] == "[1 keys redacted: allergies]"
+      end
+    end
+
+    test "leaves an empty params map alone" do
+      context = %{"live_view.event_params" => %{}}
+
+      assert ErrorContextFilter.sanitize(context) == context
+    end
+
+    # request.params is nil until Plug fetches it; live_view.event_params is absent
+    # entirely on a mount crash. Neither may raise.
+    test "leaves a non-map params value alone" do
+      context = %{"request.params" => nil, "live_view.event_params" => "unfetched"}
+
+      assert ErrorContextFilter.sanitize(context) == context
+    end
+  end
+
   describe "sanitize/1 on everything else" do
     # The router sets user_id/email via ErrorTracker.set_context/1. Those are deliberate
     # and pre-date this filter; narrowing to job args must leave them alone.
@@ -74,6 +163,21 @@ defmodule KlassHero.Shared.ErrorContextFilterTest do
       context = %{"job.args" => "not-a-map"}
 
       assert ErrorContextFilter.sanitize(context) == context
+    end
+
+    # The two halves are independent: an Oban failure has no params, a LiveView crash has
+    # no job args, and a filter that only handled one of them is what produced #1391.
+    test "narrows job args and params in the same context" do
+      context = %{
+        "job.args" => %{"invite_id" => "inv-1", "medical_conditions" => "Asthma"},
+        "live_view.event_params" => %{"child" => %{"allergies" => "none"}}
+      }
+
+      sanitized = ErrorContextFilter.sanitize(context)
+
+      assert sanitized["job.args"] == %{"invite_id" => "inv-1"}
+      assert sanitized["job.args.redacted"] == ["medical_conditions"]
+      assert sanitized["live_view.event_params"]["child"] == "[1 keys redacted: allergies]"
     end
   end
 end


### PR DESCRIPTION
## Summary

`ErrorContextFilter` narrowed only `job.args`. Its moduledoc reasons carefully about a child's name, date of birth and medical conditions reaching the production error store through `ProcessInviteClaimWorker` — then every other context key fell through the `_ -> context` clause untouched.

`ErrorTracker` also records the params of whatever crashed. So a crash inside any `handle_event` stored the entire submitted form. The occurrence behind #1322 holds a real child's name, date of birth, `allergies` and `support_needs`, captured when `ChildrenLive` crashed mid-save. It is also — awkwardly — the only reason the affected guardian could be identified when remediating #1335. That identification was luck built on this bug, not a design.

Params now **keep their keys and lose their values**:

```elixir
"live_view.event_params" => %{
  "child" => "[8 keys redacted: allergies, date_of_birth, emergency_contact,
                first_name, gender, last_name, school_grade, support_needs]",
  "consent" => "true"
}
```

Which fields were submitted is the debugging signal; what was in them is the PII.

## Review focus

**Why not register fields per form.** The `job.args` half allowlists by key, and mirroring that for forms was the obvious move. It was rejected because it needs maintenance no one will do: a new field on the children form would leak until someone remembered to list it. Keys-not-values minimises anything new by default — the same closed-by-default principle the existing moduledoc already claims, now actually enforceable for data the filter had never looked at.

**The two halves redact differently, on purpose.** `job.args` *removes* dropped keys, so it needs the sibling `job.args.redacted` list or an operator reads the survivors as the whole story. Params replace values in place, so the surviving key announces its own redaction and no sibling is needed. Both are documented in the moduledoc.

**`consent` is allowlisted deliberately.** In #1322 the captured `"consent" => "true"` flag was the only surviving proof a guardian had ticked the box. It is a boolean, not personal data, and it is exactly the kind of signal worth keeping. `_target` is allowlisted for the same reason — it names the field that triggered a change, it does not carry the field's contents.

**One correction to the issue:** there is no `phoenix.params` key in `error_tracker` v0.9.0. The controller-side equivalent is `request.params` (`deps/error_tracker/lib/error_tracker/integrations/plug.ex:116-130`), which is what this covers.

**Sequencing worth knowing:** `sanitize/1` runs once, on the fully merged context at `report/3` time — not per `set_context` call. So one LiveView crash can arrive carrying `live_view.params`, `live_view.event_params` and `request.params` together. Each is narrowed independently; there's a test for all three present at once.

## Test plan

`mix precommit` — 4416 passed, credo clean, all lints pass.

`test/klass_hero/shared/error_context_filter_test.exs` gains a `describe` block covering:
- the exact production payload shape from the #1322 occurrence
- allowlisted scalars surviving (`consent`, `child_id`, `_target`)
- an unlisted scalar redacted with its key intact
- all three param keys narrowed in one context
- empty map, `nil`, and a non-map value left alone (`request.params` is `nil` until Plug fetches it)
- job args and params narrowed in the same context — the independence that was missing

## Follow-up, not in this PR

At least one stored occurrence in production still holds the child data described above and should be scrubbed once this ships. `bin/prod-db` is SELECT-only by design, so that needs a separate write path.

Closes #1391
