### PR TITLE
fix: drop length caps from projection read tables

### DIFF
--- a/.claude/rules/domain-architecture.md
+++ b/.claude/rules/domain-architecture.md
@@ -86,9 +86,18 @@ Directionality still classifies the surviving event code:
 
   | Kind | Home | Shape | Example |
   |---|---|---|---|
-  | Projection read **table** | context root | Ecto schema **is** the DTO; **no changeset** — the projection owns every write | `provider/provider_program.ex`, `messaging/enrolled_child.ex` |
+  | Projection read **table** | context root | Ecto schema **is** the DTO; **no changeset** — the projection owns every write; string columns are **`text`**, never a capped `varchar` | `provider/provider_program.ex`, `messaging/enrolled_child.ex` |
   | Query-shaped struct over **write** tables | `domain/read_models/` | plain struct, no schema twin, no table; built by a `select:` or a `from_*/1` narrowing | `provider/domain/read_models/staff_membership.ex` |
   | Event-maintained table with **no** projection | context root + an ops submodule | schema **keeps** its changeset, because a handler writes it directly | *none — see below* |
+
+- **A length cap on a read table is unenforceable, so it is a liability.** The
+  no-changeset rule is what makes it one: a `varchar(n)` there cannot reject an
+  over-long value, only raise 22001 inside `EventDeliveryWorker`, exhaust Oban's ten
+  attempts and discard the event — losing every field of that update, not just the
+  long one (#1376). Read-table string columns are `text`; caps belong on the write
+  side, where a changeset turns them into a user-visible error. Enforced by
+  `test/klass_hero/shared/read_table_column_types_test.exs`, which reads
+  `information_schema` — `mix lint_read_tables` is text-based and cannot see it.
 
 - **The third kind currently has no instance, and that is a warning, not an
   omission.** Its only example was `messaging/program_staff_participant.ex` +

--- a/lib/klass_hero/shared/read_table.ex
+++ b/lib/klass_hero/shared/read_table.ex
@@ -12,8 +12,8 @@ defmodule KlassHero.Shared.ReadTable do
       end
 
   A read table is the denormalized output of a projection GenServer under
-  `adapters/driven/projections/`. Three rules follow from that, and
-  `mix lint_read_tables` enforces all three:
+  `adapters/driven/projections/`. Four rules follow from that; `mix lint_read_tables`
+  enforces the first three, and a guard test enforces the fourth:
 
   1. **No changeset.** The projection is the only writer, so there is no user input
      to validate at this boundary. A changeset here means something other than the
@@ -23,6 +23,14 @@ defmodule KlassHero.Shared.ReadTable do
      should be one.
   3. **It lives at the context root** (`lib/klass_hero/<context>/<name>.ex`), beside
      the entities, not inside `adapters/`.
+  4. **No length caps.** Its string columns are `text`. Rule 1 is why: with no
+     changeset, a `varchar(n)` cannot *reject* an over-long value — it can only crash
+     the projection mid-delivery, exhaust Oban's attempts and discard the event,
+     losing every field of that update (#1376). Caps belong on the write side, where a
+     changeset turns them into a user-visible error. This one is enforced by
+     `test/klass_hero/shared/read_table_column_types_test.exs`, not by the lint: the
+     property lives in the database, and `field :url, :string` reads identically
+     whether the column is `varchar(255)` or `text`.
 
   This `use` is the declaration the lint keys off. It is deliberately a code token
   rather than a phrase in the moduledoc: a moduledoc can be reworded by a docs pass

--- a/lib/mix/tasks/lint_read_tables.ex
+++ b/lib/mix/tasks/lint_read_tables.ex
@@ -20,6 +20,11 @@ defmodule Mix.Tasks.LintReadTables do
   Text-based on purpose: this runs in the `quality` CI job, which must keep its
   `mix compile --warnings-as-errors` step first (see `.github/workflows/ci.yml`).
 
+  That is also this task's limit. The fourth read-table rule — **no length caps**,
+  see `KlassHero.Shared.ReadTable` — is invisible here, because `field :url, :string`
+  reads identically whether the column is `varchar(255)` or `text`. It is enforced
+  against the database by `test/klass_hero/shared/read_table_column_types_test.exs`.
+
   ## Escape hatch
 
   A file-wide `# read-table-lint-ignore: <reason>` comment exempts a file. These

--- a/priv/repo/migrations/20260817191500_read_table_text_columns.exs
+++ b/priv/repo/migrations/20260817191500_read_table_text_columns.exs
@@ -1,0 +1,115 @@
+defmodule KlassHero.Repo.Migrations.ReadTableTextColumns do
+  @moduledoc """
+  Drops every length cap from the projection read tables, and the two dead
+  `icon_path` columns with them.
+
+  A read table has no changeset — the projection is its only writer — so a
+  `varchar(n)` there can never reject an over-long value. It can only raise
+  Postgres 22001 inside `EventDeliveryWorker`, burn all ten Oban attempts and
+  discard the event, losing every field of that update: #1376, where a 295- and a
+  318-character `cover_image_url` froze two public listings three edits behind
+  their programs.
+
+  `varchar(n) -> text` is binary-coercible in Postgres, so no table is rewritten;
+  indexes on the converted columns rebuild under a brief lock.
+
+  `icon_path` is dead on both sides — no schema field on `Program` or
+  `ProgramListing`, and the projection discards it from stale payloads — so
+  dropping it cannot break the release still serving during the migration.
+
+  `down` restores the caps but is irreversible for data: a value longer than the
+  restored limit fails the reverse.
+  """
+
+  use Ecto.Migration
+
+  def up do
+    alter table(:program_listings) do
+      modify :title, :text
+      modify :category, :text
+      modify :age_range, :text
+      modify :pricing_period, :text
+      modify :location, :text
+      modify :cover_image_url, :text
+      modify :season, :text
+      modify :meeting_days, {:array, :text}
+      remove :icon_path
+    end
+
+    alter table(:conversation_summaries) do
+      modify :subject, :text
+      modify :other_participant_name, :text
+      modify :program_name, :text
+      modify :conversation_type, :text
+      modify :enrolled_child_names, {:array, :text}
+    end
+
+    alter table(:messaging_enrolled_children) do
+      modify :child_first_name, :text
+    end
+
+    alter table(:provider_programs) do
+      modify :name, :text
+    end
+
+    alter table(:provider_session_details) do
+      modify :program_title, :text
+      modify :status, :text
+      modify :current_assigned_staff_name, :text
+      modify :cover_staff_name, :text
+    end
+
+    alter table(:provider_session_stats) do
+      modify :program_title, :text
+    end
+
+    alter table(:programs) do
+      remove :icon_path
+    end
+  end
+
+  def down do
+    alter table(:program_listings) do
+      modify :title, :string
+      modify :category, :string
+      modify :age_range, :string
+      modify :pricing_period, :string
+      modify :location, :string
+      modify :cover_image_url, :string
+      modify :season, :string
+      modify :meeting_days, {:array, :string}
+      add :icon_path, :string
+    end
+
+    alter table(:conversation_summaries) do
+      modify :subject, :string
+      modify :other_participant_name, :string
+      modify :program_name, :string
+      modify :conversation_type, :string
+      modify :enrolled_child_names, {:array, :string}
+    end
+
+    alter table(:messaging_enrolled_children) do
+      modify :child_first_name, :string
+    end
+
+    alter table(:provider_programs) do
+      modify :name, :string
+    end
+
+    alter table(:provider_session_details) do
+      modify :program_title, :string
+      modify :status, :string
+      modify :current_assigned_staff_name, :string
+      modify :cover_staff_name, :string
+    end
+
+    alter table(:provider_session_stats) do
+      modify :program_title, :string
+    end
+
+    alter table(:programs) do
+      add :icon_path, :text
+    end
+  end
+end

--- a/test/klass_hero/program_catalog/adapters/driven/projections/program_listings_test.exs
+++ b/test/klass_hero/program_catalog/adapters/driven/projections/program_listings_test.exs
@@ -320,6 +320,32 @@ defmodule KlassHero.ProgramCatalog.Adapters.Driven.Projections.ProgramListingsTe
       assert listing.registration_start_date == ~D[2026-07-01]
       assert listing.registration_end_date == ~D[2026-07-31]
     end
+
+    # #1376: the read column was varchar(255) while the write side allows 500, so a
+    # storage URL over the limit raised 22001 here, exhausted all ten Oban attempts
+    # and discarded the update *whole* — location stayed stale too, not just the image.
+    test "projects a cover_image_url longer than 255 characters" do
+      program_id = Ecto.UUID.generate()
+
+      url =
+        "https://storage.example.com/program_covers/providers/#{Ecto.UUID.generate()}/" <>
+          String.duplicate("a", 240) <> ".jpg"
+
+      assert String.length(url) > 255
+
+      ProgramEvents.program_updated(program_id, %{
+        provider_id: Ecto.UUID.generate(),
+        title: "Soccer Camp",
+        location: "Online",
+        cover_image_url: url
+      })
+      |> through_outbox()
+      |> dispatch()
+
+      listing = Repo.get!(ProgramListing, program_id)
+      assert listing.cover_image_url == url
+      assert listing.location == "Online"
+    end
   end
 
   describe "macro invariants after happy-path startup" do

--- a/test/klass_hero/shared/read_table_column_types_test.exs
+++ b/test/klass_hero/shared/read_table_column_types_test.exs
@@ -1,0 +1,87 @@
+defmodule KlassHero.Shared.ReadTableColumnTypesTest do
+  @moduledoc """
+  Guards the fourth read-table rule: **no length caps** (see
+  `KlassHero.Shared.ReadTable`).
+
+  A read table has no changeset — the projection is its only writer — so a
+  `varchar(n)` on it can never *reject* an over-long value. It can only raise
+  Postgres 22001 inside `EventDeliveryWorker`, burn all ten Oban attempts and
+  discard the event, losing every field of that update (#1376).
+
+  This runs against the database rather than the source, because that is where
+  the property is true: `field :cover_image_url, :string` reads identically
+  whether the column is `varchar(255)` or `text`, which is exactly why
+  `mix lint_read_tables` (text-based, runs before compile in the `quality` job)
+  cannot see this class.
+  """
+
+  use KlassHero.DataCase, async: true
+
+  @text_udts ["text", "_text"]
+
+  test "every read-table string column is text, never a capped varchar" do
+    columns = read_table_string_columns()
+
+    # Without this the test passes vacuously when the enumeration breaks — a
+    # renamed marker or an empty module list would report green (#1142).
+    refute columns == [], "no read-table string columns found — the enumeration is broken"
+
+    capped =
+      for {module, field, table, column, udt} <- columns, udt not in @text_udts do
+        "#{inspect(module)}.#{field} -> #{table}.#{column} is #{inspect(udt)}"
+      end
+
+    assert capped == [], """
+    Read-table columns carrying a length cap:
+
+    #{Enum.join(capped, "\n")}
+
+    A read table has no changeset, so a width cap cannot reject anything — it
+    can only crash the projection mid-delivery and discard the event (#1376).
+    Migrate these columns to :text.
+    """
+  end
+
+  defp read_table_string_columns do
+    modules = read_table_modules()
+    udts = column_udts(Enum.map(modules, & &1.__schema__(:source)))
+
+    for module <- modules,
+        field <- module.__schema__(:fields),
+        string_field?(module, field) do
+      table = module.__schema__(:source)
+      column = to_string(module.__schema__(:field_source, field))
+
+      {module, field, table, column, Map.get(udts, {table, column})}
+    end
+  end
+
+  defp read_table_modules do
+    {:ok, modules} = :application.get_key(:klass_hero, :modules)
+
+    Enum.filter(modules, fn module ->
+      Code.ensure_loaded?(module) and function_exported?(module, :__read_table__, 0)
+    end)
+  end
+
+  # Ecto.Enum is parameterized; Ecto.Type.type/1 unwraps it to its underlying
+  # :string, so enum-backed columns are covered without a special case.
+  defp string_field?(module, field) do
+    type = Ecto.Type.type(module.__schema__(:type, field))
+    type in [:string, {:array, :string}]
+  end
+
+  defp column_udts(tables) do
+    {:ok, %{rows: rows}} =
+      Repo.query(
+        """
+        SELECT table_name, column_name, udt_name
+        FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = ANY($1)
+        """,
+        [tables]
+      )
+
+    Map.new(rows, fn [table, column, udt] -> {{table, column}, udt} end)
+  end
+end


### PR DESCRIPTION
## Summary

`program_listings.cover_image_url` was `varchar(255)` while `programs.cover_image_url` is `varchar(500)` (write side validated at `max: 500`). A storage URL over 255 chars raised Postgres `22001` inside `EventDeliveryWorker`, exhausted all ten Oban attempts and **discarded** the event. Two public listings sat three edits behind their programs — `location` was stale along with the image, because the whole update was lost, not just the long field.

The cause is a class, not a column: a projection read table has **no changeset** by design, so a width cap there can never reject a value — it can only crash the projection. This PR removes the caps and adds a guard so the next one can't ship.

- **Migration** — every read-table string column → `text` (18 scalars + 2 arrays across the six read tables), plus the dead `icon_path` columns dropped from `programs` and `program_listings`.
- **Guard test** — enumerates modules exporting `__read_table__/0`, resolves each string field's real column via `__schema__(:field_source, …)`, and asserts `information_schema` reports `text`/`_text`. `Ecto.Type.type/1` unwraps `Ecto.Enum`, so enum-backed columns are covered with no special case.
- **Regression test** — a `program_updated` event carrying a 320-char `cover_image_url` crossing the real outbox boundary, asserting both the URL and `location` land.
- **Docs** — the fourth read-table rule in `KlassHero.Shared.ReadTable`, `.claude/rules/domain-architecture.md`, and a note in `mix lint_read_tables` saying why that task can't enforce it.

`programs.cover_image_url` deliberately keeps its `varchar(500)`: on the write side a changeset backs it, so the cap produces a user-visible error rather than a crashed worker.

## Review focus

- **Why a test, not a lint rule.** `mix lint_read_tables` is text-based on purpose (it runs before compile in the `quality` job) and `field :url, :string` reads identically whether the column is `varchar(255)` or `text`. The property only exists in the database, so the guard reads `information_schema`. A migration-text lint was considered and rejected — raw `execute("ALTER TABLE …")` and later `modify`s slip past it.
- **`Ecto.Enum` columns included** (`conversation_summaries.conversation_type`, `provider_session_details.status`). Their values are bounded so a cap can't be hit, but one rule with zero exceptions beats one with two, and `Ecto.Enum` over `text` behaves identically.
- **Migration safety.** `varchar(n) → text` is binary-coercible in Postgres — no table rewrite; indexes on converted columns rebuild under a brief lock (trivial at 9 programs). `down` restores the caps and is irreversible for data, documented in the moduledoc.
- **The `icon_path` drops are safe in this release.** Both columns are dead: no schema field on `Program` or `ProgramListing`, the projection explicitly discards `icon_path` from stale payloads, and there are zero references repo-wide outside the original migrations. So the old release still serving during `release_command` cannot break.
- **No backfill needed.** `ProjectionSupervisor` starts `ProgramListings`, whose bootstrap re-`insert_all`s from `programs` with `on_conflict: {:replace_all_except, [:id, :inserted_at]}` — the two drifted rows re-sync on boot after deploy.

## Test plan

- `mix precommit` — green: 4411 tests, 0 failures; format, credo --strict, typography, translations, read-table and ACL lints all pass.
- Guard test verified **red before the migration**, listing all 20 capped columns in one failure, then green after.
- Regression test verified red by temporarily narrowing the test DB column back to `varchar(255)` — reproduced the exact production error, `ERROR 22001 (string_data_right_truncation)`.
- Post-migration `information_schema` check on the dev DB: zero `character varying` across all six read tables, `_text` for both arrays, `icon_path` gone.

Post-deploy check: confirm `77f4f6a1-8d4b-4bbf-b1b8-7bfbc8eebddc` and `d91153df-005d-46dd-9e43-aa2c6070bbeb` have matching `cover_image_url` / `location` and that `program_listings.updated_at` has caught up.

## Follow-up (not this PR)

Any projection write failure — not just this one — ends in an Oban `discard` and an `undelivered_events` row with no replay path. This PR removes one cause of that outcome; it does not make the outcome recoverable. Worth its own issue.

Closes #1376
