### PR TITLE
fix: write a child and its consent in one transaction

### DIFF
--- a/lib/klass_hero/family.ex
+++ b/lib/klass_hero/family.ex
@@ -66,25 +66,35 @@ defmodule KlassHero.Family do
   end
 
   @doc """
-  Creates a new child, optionally linking it to a guardian.
+  Creates a new child, optionally linking it to a guardian and recording consents.
 
   Pass `:parent_id` in `attrs` to establish the guardian relationship; the
   child and the guardian link are then created atomically.
 
+  Pass `consents: %{consent_type => boolean}` in `opts` to record the guardian's
+  consent choices in the same transaction as the child. Consent granted on a form is
+  part of what that form submitted, so it commits with the child or not at all —
+  #1322 lost a guardian's consent precisely because the two were separate calls.
+
   Returns:
   - `{:ok, Child.t()}` on success
   - `{:error, changeset}` for validation failures
+  - `{:error, {:consent, reason}}` when a consent write failed; the child is rolled back
   """
-  def create_child(attrs) when is_map(attrs) do
+  def create_child(attrs, opts \\ []) when is_map(attrs) and is_list(opts) do
     context_span entity: "child" do
       {parent_id, child_attrs} = Map.pop(attrs, :parent_id)
+      consents = Keyword.get(opts, :consents, %{})
 
-      case insert_child_with_event(child_attrs, parent_id) do
+      case insert_child_with_event(child_attrs, parent_id, consents) do
         {:ok, child} ->
           {:ok, child}
 
         {:error, %Ecto.Changeset{} = changeset} ->
           {:error, changeset}
+
+        {:error, {:consent, _reason} = consent_error} ->
+          {:error, consent_error}
       end
     end
   end
@@ -114,17 +124,23 @@ defmodule KlassHero.Family do
   end
 
   @doc """
-  Updates an existing child.
+  Updates an existing child, optionally reconciling its consents.
+
+  Pass `consents: %{consent_type => boolean}` and `:parent_id` in `opts` to bring the
+  child's consents to the given state in the same transaction as the update. A consent
+  is granted when wanted and absent, withdrawn when unwanted and present, left alone
+  otherwise.
 
   Returns:
   - `{:ok, Child.t()}` on success
   - `{:error, :not_found}` if the child doesn't exist
   - `{:error, changeset}` for validation failures
+  - `{:error, {:consent, reason}}` when a consent write failed; the update is rolled back
   """
-  def update_child(child_id, attrs) when is_binary(child_id) and is_map(attrs) do
+  def update_child(child_id, attrs, opts \\ []) when is_binary(child_id) and is_map(attrs) and is_list(opts) do
     context_span entity: "child" do
       with {:ok, child} <- fetch_child(child_id) do
-        update_child_with_event(child, attrs)
+        update_child_with_event(child, attrs, Keyword.get(opts, :consents, %{}), Keyword.get(opts, :parent_id))
       end
     end
   end
@@ -545,21 +561,59 @@ defmodule KlassHero.Family do
     end
   end
 
-  defp insert_child_with_event(child_attrs, parent_id) do
+  defp insert_child_with_event(child_attrs, parent_id, consents) do
     Outbox.transact(@context, fn ->
-      with {:ok, child} <- insert_child(child_attrs, parent_id) do
+      with {:ok, child} <- insert_child(child_attrs, parent_id),
+           :ok <- reconcile_consents(child.id, parent_id, consents) do
         {:ok, child, [child_created_event(child, parent_id)]}
       end
     end)
   end
 
-  defp update_child_with_event(child, attrs) do
+  defp update_child_with_event(child, attrs, consents, parent_id) do
     Outbox.transact(@context, fn ->
-      with {:ok, updated} <- child |> Child.changeset(attrs) |> Repo.update() do
+      with {:ok, updated} <- child |> Child.changeset(attrs) |> Repo.update(),
+           :ok <- reconcile_consents(updated.id, parent_id, consents) do
         {:ok, updated, [child_updated_event(updated)]}
       end
     end)
   end
+
+  # Brings a child's consents to the state the guardian asked for. Runs inside the
+  # caller's transaction, so a failure here rolls the child write back with it — the
+  # consent intent is never left behind with nothing recording it (#1322, #1335).
+  defp reconcile_consents(_child_id, _parent_id, consents) when map_size(consents) == 0, do: :ok
+
+  defp reconcile_consents(child_id, parent_id, consents) do
+    Enum.reduce_while(consents, :ok, fn {consent_type, wanted?}, :ok ->
+      case apply_consent(child_id, parent_id, consent_type, wanted?) do
+        :ok -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, {:consent, reason}}}
+      end
+    end)
+  end
+
+  # The current state is read here rather than by the caller beforehand: deciding on an
+  # answer fetched outside the transaction is the race this fold-in exists to close.
+  defp apply_consent(child_id, parent_id, consent_type, wanted?) do
+    case {wanted?, child_has_active_consent?(child_id, consent_type)} do
+      {true, false} ->
+        normalize_consent(grant_consent(%{parent_id: parent_id, child_id: child_id, consent_type: consent_type}))
+
+      {false, true} ->
+        normalize_consent(withdraw_consent(child_id, consent_type))
+
+      _unchanged ->
+        :ok
+    end
+  end
+
+  # Both of these mean a concurrent writer already reached the state we wanted, so the
+  # guardian's intent holds either way. Only a genuine write failure aborts.
+  defp normalize_consent({:ok, _consent}), do: :ok
+  defp normalize_consent({:error, :already_active}), do: :ok
+  defp normalize_consent({:error, :not_found}), do: :ok
+  defp normalize_consent({:error, reason}), do: {:error, reason}
 
   # The GDPR cascade used to gate on the dispatch returning :ok — its way of asking
   # "were the downstream contexts told?". Staging inside this child's own transaction

--- a/lib/klass_hero_web/live/settings/children_live.ex
+++ b/lib/klass_hero_web/live/settings/children_live.ex
@@ -197,7 +197,7 @@ defmodule KlassHeroWeb.Settings.ChildrenLive do
     if changeset.valid? do
       attrs = build_attrs(mode, child_params, socket.assigns.parent_id)
 
-      case persist_child(mode, attrs, socket.assigns.child) do
+      case persist_child(mode, attrs, socket.assigns.child, consent_opts(socket)) do
         {:ok, child} ->
           handle_save_success(socket, mode, child)
 
@@ -226,21 +226,24 @@ defmodule KlassHeroWeb.Settings.ChildrenLive do
 
   defp build_attrs(:edit, params, _parent_id), do: atomize_keys(params)
 
-  defp persist_child(:new, attrs, _child), do: Family.create_child(attrs)
-  defp persist_child(:edit, attrs, child), do: Family.update_child(child.id, attrs)
+  defp persist_child(:new, attrs, _child, opts), do: Family.create_child(attrs, opts)
+  defp persist_child(:edit, attrs, child, opts), do: Family.update_child(child.id, attrs, opts)
+
+  # The checkbox is not part of child_params — it lives in the consent_checked assign,
+  # kept current by the separate "toggle_consent" event — so the intent has to be handed
+  # to Family explicitly. Family then writes it in the same transaction as the child.
+  defp consent_opts(socket) do
+    [
+      consents: %{@consent_type => socket.assigns.consent_checked},
+      parent_id: socket.assigns.parent_id
+    ]
+  end
 
   defp handle_save_success(socket, mode, child) do
-    consent_result =
-      handle_consent_change(
-        child.id,
-        socket.assigns.parent_id,
-        socket.assigns.consent_checked
-      )
-
     socket =
       socket
       |> stream_insert(:children, child_view_data(child))
-      |> put_flash(:info, child_saved_flash(mode, consent_result))
+      |> put_flash(:info, child_saved_flash(mode))
       |> push_patch(to: ~p"/settings/children")
 
     socket =
@@ -254,49 +257,11 @@ defmodule KlassHeroWeb.Settings.ChildrenLive do
     {:noreply, socket}
   end
 
-  defp handle_consent_change(child_id, parent_id, consent_checked) do
-    child_id
-    |> resolve_consent_action(parent_id, consent_checked)
-    |> normalize_consent_result(child_id)
-  end
-
-  defp resolve_consent_action(child_id, parent_id, consent_checked) do
-    current_consent = Family.child_has_active_consent?(child_id, @consent_type)
-
-    cond do
-      consent_checked and not current_consent ->
-        Family.grant_consent(%{
-          parent_id: parent_id,
-          child_id: child_id,
-          consent_type: @consent_type
-        })
-
-      not consent_checked and current_consent ->
-        Family.withdraw_consent(child_id, @consent_type)
-
-      true ->
-        :noop
-    end
-  end
-
-  defp normalize_consent_result({:ok, _}, _child_id), do: :ok
-  defp normalize_consent_result(:noop, _child_id), do: :ok
-
-  # Idempotent: consent already exists, treat as success.
-  defp normalize_consent_result({:error, :already_active}, _child_id), do: :ok
-
-  defp normalize_consent_result({:error, reason}, child_id) do
-    Logger.error("Consent update failed for child #{child_id}: #{inspect(reason)}")
-    {:error, :consent_failed}
-  end
-
-  defp child_saved_flash(:new, :ok), do: gettext("Child added successfully.")
-
-  defp child_saved_flash(:new, {:error, _}), do: gettext("Child added, but consent update failed. Please try again.")
-
-  defp child_saved_flash(:edit, :ok), do: gettext("Child updated successfully.")
-
-  defp child_saved_flash(:edit, {:error, _}), do: gettext("Child updated, but consent update failed. Please try again.")
+  # No "saved, but consent failed" variant any more: the consent shares the child's
+  # transaction, so reaching here means both landed. A consent failure takes the child
+  # with it and is reported by save_child/3's error branch instead.
+  defp child_saved_flash(:new), do: gettext("Child added successfully.")
+  defp child_saved_flash(:edit), do: gettext("Child updated successfully.")
 
   defp child_view_data(child) do
     simple = ChildPresenter.to_simple_view(child)

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -867,7 +867,7 @@ msgid "Save Password"
 msgstr "Passwort speichern"
 
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:381
-#: lib/klass_hero_web/live/settings/children_live.ex:743
+#: lib/klass_hero_web/live/settings/children_live.ex:708
 #: lib/klass_hero_web/live/user_live/settings.ex:151
 #, elixir-autogen, elixir-format
 msgid "Saving..."
@@ -1114,7 +1114,7 @@ msgid "Cards, bank accounts, billing info"
 msgstr "Karten, Bankkonten, Rechnungsinformationen"
 
 #: lib/klass_hero_web/live/settings/children_live.ex:23
-#: lib/klass_hero_web/live/settings/children_live.ex:348
+#: lib/klass_hero_web/live/settings/children_live.ex:313
 #: lib/klass_hero_web/live/settings_live.ex:79
 #: lib/klass_hero_web/live/user_live/settings.ex:224
 #, elixir-autogen, elixir-format
@@ -1503,10 +1503,10 @@ msgstr "Wir verstehen die einzigartigen Bedürfnisse der vielfältigen Familien 
 msgid "Workshops"
 msgstr "Workshops"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:377
-#: lib/klass_hero_web/live/settings/children_live.ex:399
-#: lib/klass_hero_web/live/settings/children_live.ex:618
-#: lib/klass_hero_web/live/settings/children_live.ex:752
+#: lib/klass_hero_web/live/settings/children_live.ex:342
+#: lib/klass_hero_web/live/settings/children_live.ex:364
+#: lib/klass_hero_web/live/settings/children_live.ex:583
+#: lib/klass_hero_web/live/settings/children_live.ex:717
 #, elixir-autogen, elixir-format
 msgid "Add Child"
 msgstr "Kind Hinzufügen"
@@ -1631,7 +1631,7 @@ msgstr "Erstellen Sie Profile für Ihr Personal. Diese werden für Eltern sichtb
 #: lib/klass_hero_web/components/provider_components.ex:1543
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:54
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:81
-#: lib/klass_hero_web/live/settings/children_live.ex:448
+#: lib/klass_hero_web/live/settings/children_live.ex:413
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:54
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:81
 #, elixir-autogen, elixir-format
@@ -1760,7 +1760,7 @@ msgstr "Verifiziertes Unternehmen"
 msgid "View Roster"
 msgstr "Teilnehmerliste"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:430
+#: lib/klass_hero_web/live/settings/children_live.ex:395
 #, elixir-autogen, elixir-format
 msgid "%{age} years old"
 msgstr "%{age} Jahre alt"
@@ -1770,18 +1770,18 @@ msgstr "%{age} Jahre alt"
 msgid "%{n}m ago"
 msgstr "vor %{n} Min."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:385
+#: lib/klass_hero_web/live/settings/children_live.ex:350
 #, elixir-autogen, elixir-format
 msgid "Add your first child to get started with activities and programs."
 msgstr "Fügen Sie Ihr erstes Kind hinzu, um mit Aktivitäten und Programmen zu beginnen."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:499
-#: lib/klass_hero_web/live/settings/children_live.ex:693
+#: lib/klass_hero_web/live/settings/children_live.ex:464
+#: lib/klass_hero_web/live/settings/children_live.ex:658
 #, elixir-autogen, elixir-format
 msgid "Allergies"
 msgstr "Allergien"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:720
+#: lib/klass_hero_web/live/settings/children_live.ex:685
 #, elixir-autogen, elixir-format
 msgid "Allow activity providers to access this child's profile information for program participation."
 msgstr "Aktivitätsanbietern Zugriff auf die Profilinformationen dieses Kindes für die Programmteilnahme erlauben."
@@ -1791,12 +1791,12 @@ msgstr "Aktivitätsanbietern Zugriff auf die Profilinformationen dieses Kindes f
 msgid "An unexpected error occurred. Please try again."
 msgstr "Ein unerwarteter Fehler ist aufgetreten. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:701
+#: lib/klass_hero_web/live/settings/children_live.ex:666
 #, elixir-autogen, elixir-format
 msgid "Any special accommodations or support needs..."
 msgstr "Besondere Bedürfnisse oder Unterstützungsbedarf..."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:363
+#: lib/klass_hero_web/live/settings/children_live.ex:328
 #, elixir-autogen, elixir-format
 msgid "Back to Settings"
 msgstr "Zurück zu Einstellungen"
@@ -1824,22 +1824,17 @@ msgstr "Rundnachricht an %{count} Eltern gesendet"
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:222
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:356
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:191
-#: lib/klass_hero_web/live/settings/children_live.ex:579
-#: lib/klass_hero_web/live/settings/children_live.ex:738
+#: lib/klass_hero_web/live/settings/children_live.ex:544
+#: lib/klass_hero_web/live/settings/children_live.ex:703
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:237
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:293
+#: lib/klass_hero_web/live/settings/children_live.ex:263
 #, elixir-autogen, elixir-format
 msgid "Child added successfully."
 msgstr "Kind erfolgreich hinzugefügt."
-
-#: lib/klass_hero_web/live/settings/children_live.ex:295
-#, elixir-autogen, elixir-format
-msgid "Child added, but consent update failed. Please try again."
-msgstr "Kind hinzugefügt, aber Einwilligungsaktualisierung fehlgeschlagen. Bitte versuchen Sie es erneut."
 
 #: lib/klass_hero_web/live/settings/children_live.ex:87
 #: lib/klass_hero_web/live/settings/children_live.ex:179
@@ -1852,15 +1847,10 @@ msgstr "Kind nicht gefunden."
 msgid "Child removed successfully."
 msgstr "Kind erfolgreich entfernt."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:297
+#: lib/klass_hero_web/live/settings/children_live.ex:264
 #, elixir-autogen, elixir-format
 msgid "Child updated successfully."
 msgstr "Kind erfolgreich aktualisiert."
-
-#: lib/klass_hero_web/live/settings/children_live.ex:299
-#, elixir-autogen, elixir-format
-msgid "Child updated, but consent update failed. Please try again."
-msgstr "Kind aktualisiert, aber Einwilligungsaktualisierung fehlgeschlagen. Bitte versuchen Sie es erneut."
 
 #: lib/klass_hero_web/live/dashboard_live.ex:176
 #: lib/klass_hero_web/live/messaging_live_helper.ex:336
@@ -1878,29 +1868,29 @@ msgstr "Unterhaltung nicht gefunden"
 msgid "Could not remove child. Please try again."
 msgstr "Kind konnte nicht entfernt werden. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:477
+#: lib/klass_hero_web/live/settings/children_live.ex:442
 #, elixir-autogen, elixir-format
 msgid "Data sharing consent"
 msgstr "Einwilligung zur Datenweitergabe"
 
 #: lib/klass_hero_web/components/provider_components.ex:2341
-#: lib/klass_hero_web/live/settings/children_live.ex:657
+#: lib/klass_hero_web/live/settings/children_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr "Geburtsdatum"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:462
+#: lib/klass_hero_web/live/settings/children_live.ex:427
 #, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr "Löschen"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:620
+#: lib/klass_hero_web/live/settings/children_live.ex:585
 #, elixir-autogen, elixir-format
 msgid "Edit Child"
 msgstr "Kind bearbeiten"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:488
-#: lib/klass_hero_web/live/settings/children_live.ex:686
+#: lib/klass_hero_web/live/settings/children_live.ex:453
+#: lib/klass_hero_web/live/settings/children_live.ex:651
 #, elixir-autogen, elixir-format
 msgid "Emergency contact"
 msgstr "Notfallkontakt"
@@ -1934,7 +1924,7 @@ msgstr "Notiz konnte nicht eingereicht werden"
 #: lib/klass_hero_web/components/provider_components.ex:2335
 #: lib/klass_hero_web/components/provider_components.ex:2364
 #: lib/klass_hero_web/components/provider_components.ex:2380
-#: lib/klass_hero_web/live/settings/children_live.ex:643
+#: lib/klass_hero_web/live/settings/children_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr "Vorname"
@@ -1942,17 +1932,17 @@ msgstr "Vorname"
 #: lib/klass_hero_web/components/provider_components.ex:2336
 #: lib/klass_hero_web/components/provider_components.ex:2365
 #: lib/klass_hero_web/components/provider_components.ex:2381
-#: lib/klass_hero_web/live/settings/children_live.ex:649
+#: lib/klass_hero_web/live/settings/children_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Last name"
 msgstr "Nachname"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:694
+#: lib/klass_hero_web/live/settings/children_live.ex:659
 #, elixir-autogen, elixir-format
 msgid "List any known allergies..."
 msgstr "Bekannte Allergien auflisten..."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:349
+#: lib/klass_hero_web/live/settings/children_live.ex:314
 #, elixir-autogen, elixir-format
 msgid "Manage your children's information and consents"
 msgstr "Informationen und Einwilligungen Ihrer Kinder verwalten"
@@ -1977,7 +1967,7 @@ msgstr "Nachrichteninhalt ist erforderlich"
 msgid "Messages"
 msgstr "Nachrichten"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:384
+#: lib/klass_hero_web/live/settings/children_live.ex:349
 #: lib/klass_hero_web/presenters/child_presenter.ex:57
 #, elixir-autogen, elixir-format
 msgid "No children yet"
@@ -2026,7 +2016,7 @@ msgstr "Notiz erneut zur Überprüfung eingereicht"
 msgid "Now"
 msgstr "Jetzt"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:687
+#: lib/klass_hero_web/live/settings/children_live.ex:652
 #, elixir-autogen, elixir-format
 msgid "Phone number or name"
 msgstr "Telefonnummer oder Name"
@@ -2067,14 +2057,14 @@ msgstr "Bitte richten Sie Ihr Elternprofil ein, um Kinder zu verwalten."
 msgid "Program Broadcast"
 msgstr "Programm-Rundnachricht"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:717
+#: lib/klass_hero_web/live/settings/children_live.ex:682
 #, elixir-autogen, elixir-format
 msgid "Provider data sharing consent"
 msgstr "Einwilligung zur Datenweitergabe an Anbieter"
 
 #: lib/klass_hero_web/components/provider_components.ex:874
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:294
-#: lib/klass_hero_web/live/settings/children_live.ex:754
+#: lib/klass_hero_web/live/settings/children_live.ex:719
 #, elixir-autogen, elixir-format
 msgid "Save Changes"
 msgstr "Änderungen speichern"
@@ -2105,8 +2095,8 @@ msgstr "Senden Sie eine Nachricht, um die Unterhaltung zu beginnen"
 msgid "Sending..."
 msgstr "Wird gesendet..."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:510
-#: lib/klass_hero_web/live/settings/children_live.ex:700
+#: lib/klass_hero_web/live/settings/children_live.ex:475
+#: lib/klass_hero_web/live/settings/children_live.ex:665
 #, elixir-autogen, elixir-format
 msgid "Support needs"
 msgstr "Unterstützungsbedarf"
@@ -2419,7 +2409,7 @@ msgstr "Beschreibung"
 
 #: lib/klass_hero_web/components/program_components.ex:684
 #: lib/klass_hero_web/components/provider_components.ex:1160
-#: lib/klass_hero_web/live/settings/children_live.ex:670
+#: lib/klass_hero_web/live/settings/children_live.ex:635
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr "Divers"
@@ -2546,7 +2536,7 @@ msgstr "Familienprogramme"
 
 #: lib/klass_hero_web/components/program_components.ex:682
 #: lib/klass_hero_web/components/provider_components.ex:1159
-#: lib/klass_hero_web/live/settings/children_live.ex:669
+#: lib/klass_hero_web/live/settings/children_live.ex:634
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr "Weiblich"
@@ -2576,7 +2566,7 @@ msgstr "Erste Hilfe, UEFA-B-Lizenz, Kinderbetreuungszertifikat"
 msgid "First Name"
 msgstr "Vorname"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:665
+#: lib/klass_hero_web/live/settings/children_live.ex:630
 #, elixir-autogen, elixir-format
 msgid "Gender"
 msgstr "Geschlecht"
@@ -2658,7 +2648,7 @@ msgstr "JPG, PNG oder WebP. Max. 2 MB."
 msgid "Klass Hero was built to solve exactly that. A comprehensive operational platform that empowers educators to spend less time on paperwork and more time inspiring children."
 msgstr "Klass Hero wurde genau dafür entwickelt. Eine umfassende Betriebsplattform, die es Pädagogen ermöglicht, weniger Zeit mit Papierkram zu verbringen und mehr Zeit damit, Kinder zu inspirieren."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:679
+#: lib/klass_hero_web/live/settings/children_live.ex:644
 #, elixir-autogen, elixir-format
 msgid "Klasse %{n}"
 msgstr "Klasse %{n}"
@@ -2692,7 +2682,7 @@ msgstr "Logo-Upload fehlgeschlagen. Bitte versuchen Sie es erneut."
 
 #: lib/klass_hero_web/components/program_components.ex:683
 #: lib/klass_hero_web/components/provider_components.ex:1158
-#: lib/klass_hero_web/live/settings/children_live.ex:668
+#: lib/klass_hero_web/live/settings/children_live.ex:633
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr "Männlich"
@@ -2753,7 +2743,7 @@ msgstr "Noch keine Anmeldungen."
 msgid "No file selected."
 msgstr "Keine Datei ausgewählt."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:678
+#: lib/klass_hero_web/live/settings/children_live.ex:643
 #, elixir-autogen, elixir-format
 msgid "No grade"
 msgstr "Keine Klassenstufe"
@@ -2811,7 +2801,7 @@ msgstr "Nicht verifiziert"
 
 #: lib/klass_hero_web/components/program_components.ex:685
 #: lib/klass_hero_web/components/provider_components.ex:1161
-#: lib/klass_hero_web/live/settings/children_live.ex:667
+#: lib/klass_hero_web/live/settings/children_live.ex:632
 #, elixir-autogen, elixir-format
 msgid "Not specified"
 msgstr "Nicht angegeben"
@@ -3046,7 +3036,7 @@ msgstr "Zeitplan (optional)"
 msgid "Schedule TBD"
 msgstr "Zeitplan noch offen"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:677
+#: lib/klass_hero_web/live/settings/children_live.ex:642
 #, elixir-autogen, elixir-format
 msgid "School Grade (optional)"
 msgstr "Klassenstufe (optional)"
@@ -3488,22 +3478,22 @@ msgstr "Unser 6-Schritte-Überprüfungsverfahren"
 msgid "Could not check enrollments. Please try again."
 msgstr "Anmeldungen konnten nicht überprüft werden. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:592
+#: lib/klass_hero_web/live/settings/children_live.ex:557
 #, elixir-autogen, elixir-format
 msgid "Remove Child"
 msgstr "Kind entfernen"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:546
+#: lib/klass_hero_web/live/settings/children_live.ex:511
 #, elixir-autogen, elixir-format
 msgid "Remove Child?"
 msgstr "Kind entfernen?"
 
-#: lib/klass_hero_web/live/settings/children_live.ex:564
+#: lib/klass_hero_web/live/settings/children_live.ex:529
 #, elixir-autogen, elixir-format
 msgid "Their enrollments will be cancelled. This action cannot be undone."
 msgstr "Die Anmeldungen des Kindes werden storniert. Diese Aktion kann nicht rückgängig gemacht werden."
 
-#: lib/klass_hero_web/live/settings/children_live.ex:551
+#: lib/klass_hero_web/live/settings/children_live.ex:516
 #, elixir-autogen, elixir-format
 msgid "This child is currently enrolled in the following programs:"
 msgstr "Dieses Kind ist derzeit für folgende Programme angemeldet:"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -867,7 +867,7 @@ msgid "Save Password"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:381
-#: lib/klass_hero_web/live/settings/children_live.ex:743
+#: lib/klass_hero_web/live/settings/children_live.ex:708
 #: lib/klass_hero_web/live/user_live/settings.ex:151
 #, elixir-autogen, elixir-format
 msgid "Saving..."
@@ -1114,7 +1114,7 @@ msgid "Cards, bank accounts, billing info"
 msgstr ""
 
 #: lib/klass_hero_web/live/settings/children_live.ex:23
-#: lib/klass_hero_web/live/settings/children_live.ex:348
+#: lib/klass_hero_web/live/settings/children_live.ex:313
 #: lib/klass_hero_web/live/settings_live.ex:79
 #: lib/klass_hero_web/live/user_live/settings.ex:224
 #, elixir-autogen, elixir-format
@@ -1503,10 +1503,10 @@ msgstr ""
 msgid "Workshops"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:377
-#: lib/klass_hero_web/live/settings/children_live.ex:399
-#: lib/klass_hero_web/live/settings/children_live.ex:618
-#: lib/klass_hero_web/live/settings/children_live.ex:752
+#: lib/klass_hero_web/live/settings/children_live.ex:342
+#: lib/klass_hero_web/live/settings/children_live.ex:364
+#: lib/klass_hero_web/live/settings/children_live.ex:583
+#: lib/klass_hero_web/live/settings/children_live.ex:717
 #, elixir-autogen, elixir-format
 msgid "Add Child"
 msgstr ""
@@ -1631,7 +1631,7 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:1543
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:54
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:81
-#: lib/klass_hero_web/live/settings/children_live.ex:448
+#: lib/klass_hero_web/live/settings/children_live.ex:413
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:54
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:81
 #, elixir-autogen, elixir-format
@@ -1760,7 +1760,7 @@ msgstr ""
 msgid "View Roster"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:430
+#: lib/klass_hero_web/live/settings/children_live.ex:395
 #, elixir-autogen, elixir-format
 msgid "%{age} years old"
 msgstr ""
@@ -1770,18 +1770,18 @@ msgstr ""
 msgid "%{n}m ago"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:385
+#: lib/klass_hero_web/live/settings/children_live.ex:350
 #, elixir-autogen, elixir-format
 msgid "Add your first child to get started with activities and programs."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:499
-#: lib/klass_hero_web/live/settings/children_live.ex:693
+#: lib/klass_hero_web/live/settings/children_live.ex:464
+#: lib/klass_hero_web/live/settings/children_live.ex:658
 #, elixir-autogen, elixir-format
 msgid "Allergies"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:720
+#: lib/klass_hero_web/live/settings/children_live.ex:685
 #, elixir-autogen, elixir-format
 msgid "Allow activity providers to access this child's profile information for program participation."
 msgstr ""
@@ -1791,12 +1791,12 @@ msgstr ""
 msgid "An unexpected error occurred. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:701
+#: lib/klass_hero_web/live/settings/children_live.ex:666
 #, elixir-autogen, elixir-format
 msgid "Any special accommodations or support needs..."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:363
+#: lib/klass_hero_web/live/settings/children_live.ex:328
 #, elixir-autogen, elixir-format
 msgid "Back to Settings"
 msgstr ""
@@ -1824,21 +1824,16 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:222
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:356
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:191
-#: lib/klass_hero_web/live/settings/children_live.ex:579
-#: lib/klass_hero_web/live/settings/children_live.ex:738
+#: lib/klass_hero_web/live/settings/children_live.ex:544
+#: lib/klass_hero_web/live/settings/children_live.ex:703
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:237
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:293
+#: lib/klass_hero_web/live/settings/children_live.ex:263
 #, elixir-autogen, elixir-format
 msgid "Child added successfully."
-msgstr ""
-
-#: lib/klass_hero_web/live/settings/children_live.ex:295
-#, elixir-autogen, elixir-format
-msgid "Child added, but consent update failed. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/live/settings/children_live.ex:87
@@ -1852,14 +1847,9 @@ msgstr ""
 msgid "Child removed successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:297
+#: lib/klass_hero_web/live/settings/children_live.ex:264
 #, elixir-autogen, elixir-format
 msgid "Child updated successfully."
-msgstr ""
-
-#: lib/klass_hero_web/live/settings/children_live.ex:299
-#, elixir-autogen, elixir-format
-msgid "Child updated, but consent update failed. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/live/dashboard_live.ex:176
@@ -1878,29 +1868,29 @@ msgstr ""
 msgid "Could not remove child. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:477
+#: lib/klass_hero_web/live/settings/children_live.ex:442
 #, elixir-autogen, elixir-format
 msgid "Data sharing consent"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:2341
-#: lib/klass_hero_web/live/settings/children_live.ex:657
+#: lib/klass_hero_web/live/settings/children_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:462
+#: lib/klass_hero_web/live/settings/children_live.ex:427
 #, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:620
+#: lib/klass_hero_web/live/settings/children_live.ex:585
 #, elixir-autogen, elixir-format
 msgid "Edit Child"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:488
-#: lib/klass_hero_web/live/settings/children_live.ex:686
+#: lib/klass_hero_web/live/settings/children_live.ex:453
+#: lib/klass_hero_web/live/settings/children_live.ex:651
 #, elixir-autogen, elixir-format
 msgid "Emergency contact"
 msgstr ""
@@ -1934,7 +1924,7 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:2335
 #: lib/klass_hero_web/components/provider_components.ex:2364
 #: lib/klass_hero_web/components/provider_components.ex:2380
-#: lib/klass_hero_web/live/settings/children_live.ex:643
+#: lib/klass_hero_web/live/settings/children_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
@@ -1942,17 +1932,17 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:2336
 #: lib/klass_hero_web/components/provider_components.ex:2365
 #: lib/klass_hero_web/components/provider_components.ex:2381
-#: lib/klass_hero_web/live/settings/children_live.ex:649
+#: lib/klass_hero_web/live/settings/children_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Last name"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:694
+#: lib/klass_hero_web/live/settings/children_live.ex:659
 #, elixir-autogen, elixir-format
 msgid "List any known allergies..."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:349
+#: lib/klass_hero_web/live/settings/children_live.ex:314
 #, elixir-autogen, elixir-format
 msgid "Manage your children's information and consents"
 msgstr ""
@@ -1977,7 +1967,7 @@ msgstr ""
 msgid "Messages"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:384
+#: lib/klass_hero_web/live/settings/children_live.ex:349
 #: lib/klass_hero_web/presenters/child_presenter.ex:57
 #, elixir-autogen, elixir-format
 msgid "No children yet"
@@ -2026,7 +2016,7 @@ msgstr ""
 msgid "Now"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:687
+#: lib/klass_hero_web/live/settings/children_live.ex:652
 #, elixir-autogen, elixir-format
 msgid "Phone number or name"
 msgstr ""
@@ -2067,14 +2057,14 @@ msgstr ""
 msgid "Program Broadcast"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:717
+#: lib/klass_hero_web/live/settings/children_live.ex:682
 #, elixir-autogen, elixir-format
 msgid "Provider data sharing consent"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:874
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:294
-#: lib/klass_hero_web/live/settings/children_live.ex:754
+#: lib/klass_hero_web/live/settings/children_live.ex:719
 #, elixir-autogen, elixir-format
 msgid "Save Changes"
 msgstr ""
@@ -2105,8 +2095,8 @@ msgstr ""
 msgid "Sending..."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:510
-#: lib/klass_hero_web/live/settings/children_live.ex:700
+#: lib/klass_hero_web/live/settings/children_live.ex:475
+#: lib/klass_hero_web/live/settings/children_live.ex:665
 #, elixir-autogen, elixir-format
 msgid "Support needs"
 msgstr ""
@@ -2419,7 +2409,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:684
 #: lib/klass_hero_web/components/provider_components.ex:1160
-#: lib/klass_hero_web/live/settings/children_live.ex:670
+#: lib/klass_hero_web/live/settings/children_live.ex:635
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
@@ -2546,7 +2536,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:682
 #: lib/klass_hero_web/components/provider_components.ex:1159
-#: lib/klass_hero_web/live/settings/children_live.ex:669
+#: lib/klass_hero_web/live/settings/children_live.ex:634
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr ""
@@ -2576,7 +2566,7 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:665
+#: lib/klass_hero_web/live/settings/children_live.ex:630
 #, elixir-autogen, elixir-format
 msgid "Gender"
 msgstr ""
@@ -2658,7 +2648,7 @@ msgstr ""
 msgid "Klass Hero was built to solve exactly that. A comprehensive operational platform that empowers educators to spend less time on paperwork and more time inspiring children."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:679
+#: lib/klass_hero_web/live/settings/children_live.ex:644
 #, elixir-autogen, elixir-format
 msgid "Klasse %{n}"
 msgstr ""
@@ -2692,7 +2682,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:683
 #: lib/klass_hero_web/components/provider_components.ex:1158
-#: lib/klass_hero_web/live/settings/children_live.ex:668
+#: lib/klass_hero_web/live/settings/children_live.ex:633
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
@@ -2753,7 +2743,7 @@ msgstr ""
 msgid "No file selected."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:678
+#: lib/klass_hero_web/live/settings/children_live.ex:643
 #, elixir-autogen, elixir-format
 msgid "No grade"
 msgstr ""
@@ -2811,7 +2801,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:685
 #: lib/klass_hero_web/components/provider_components.ex:1161
-#: lib/klass_hero_web/live/settings/children_live.ex:667
+#: lib/klass_hero_web/live/settings/children_live.ex:632
 #, elixir-autogen, elixir-format
 msgid "Not specified"
 msgstr ""
@@ -3046,7 +3036,7 @@ msgstr ""
 msgid "Schedule TBD"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:677
+#: lib/klass_hero_web/live/settings/children_live.ex:642
 #, elixir-autogen, elixir-format
 msgid "School Grade (optional)"
 msgstr ""
@@ -3488,22 +3478,22 @@ msgstr ""
 msgid "Could not check enrollments. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:592
+#: lib/klass_hero_web/live/settings/children_live.ex:557
 #, elixir-autogen, elixir-format
 msgid "Remove Child"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:546
+#: lib/klass_hero_web/live/settings/children_live.ex:511
 #, elixir-autogen, elixir-format
 msgid "Remove Child?"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:564
+#: lib/klass_hero_web/live/settings/children_live.ex:529
 #, elixir-autogen, elixir-format
 msgid "Their enrollments will be cancelled. This action cannot be undone."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:551
+#: lib/klass_hero_web/live/settings/children_live.ex:516
 #, elixir-autogen, elixir-format
 msgid "This child is currently enrolled in the following programs:"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -867,7 +867,7 @@ msgid "Save Password"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:381
-#: lib/klass_hero_web/live/settings/children_live.ex:743
+#: lib/klass_hero_web/live/settings/children_live.ex:708
 #: lib/klass_hero_web/live/user_live/settings.ex:151
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Saving..."
@@ -1114,7 +1114,7 @@ msgid "Cards, bank accounts, billing info"
 msgstr ""
 
 #: lib/klass_hero_web/live/settings/children_live.ex:23
-#: lib/klass_hero_web/live/settings/children_live.ex:348
+#: lib/klass_hero_web/live/settings/children_live.ex:313
 #: lib/klass_hero_web/live/settings_live.ex:79
 #: lib/klass_hero_web/live/user_live/settings.ex:224
 #, elixir-autogen, elixir-format
@@ -1503,10 +1503,10 @@ msgstr ""
 msgid "Workshops"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:377
-#: lib/klass_hero_web/live/settings/children_live.ex:399
-#: lib/klass_hero_web/live/settings/children_live.ex:618
-#: lib/klass_hero_web/live/settings/children_live.ex:752
+#: lib/klass_hero_web/live/settings/children_live.ex:342
+#: lib/klass_hero_web/live/settings/children_live.ex:364
+#: lib/klass_hero_web/live/settings/children_live.ex:583
+#: lib/klass_hero_web/live/settings/children_live.ex:717
 #, elixir-autogen, elixir-format
 msgid "Add Child"
 msgstr ""
@@ -1631,7 +1631,7 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:1543
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:54
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:81
-#: lib/klass_hero_web/live/settings/children_live.ex:448
+#: lib/klass_hero_web/live/settings/children_live.ex:413
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:54
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:81
 #, elixir-autogen, elixir-format
@@ -1760,7 +1760,7 @@ msgstr ""
 msgid "View Roster"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:430
+#: lib/klass_hero_web/live/settings/children_live.ex:395
 #, elixir-autogen, elixir-format
 msgid "%{age} years old"
 msgstr ""
@@ -1770,18 +1770,18 @@ msgstr ""
 msgid "%{n}m ago"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:385
+#: lib/klass_hero_web/live/settings/children_live.ex:350
 #, elixir-autogen, elixir-format
 msgid "Add your first child to get started with activities and programs."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:499
-#: lib/klass_hero_web/live/settings/children_live.ex:693
+#: lib/klass_hero_web/live/settings/children_live.ex:464
+#: lib/klass_hero_web/live/settings/children_live.ex:658
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Allergies"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:720
+#: lib/klass_hero_web/live/settings/children_live.ex:685
 #, elixir-autogen, elixir-format
 msgid "Allow activity providers to access this child's profile information for program participation."
 msgstr ""
@@ -1791,12 +1791,12 @@ msgstr ""
 msgid "An unexpected error occurred. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:701
+#: lib/klass_hero_web/live/settings/children_live.ex:666
 #, elixir-autogen, elixir-format
 msgid "Any special accommodations or support needs..."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:363
+#: lib/klass_hero_web/live/settings/children_live.ex:328
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Back to Settings"
 msgstr ""
@@ -1824,21 +1824,16 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:222
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:356
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:191
-#: lib/klass_hero_web/live/settings/children_live.ex:579
-#: lib/klass_hero_web/live/settings/children_live.ex:738
+#: lib/klass_hero_web/live/settings/children_live.ex:544
+#: lib/klass_hero_web/live/settings/children_live.ex:703
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:237
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:293
+#: lib/klass_hero_web/live/settings/children_live.ex:263
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Child added successfully."
-msgstr ""
-
-#: lib/klass_hero_web/live/settings/children_live.ex:295
-#, elixir-autogen, elixir-format
-msgid "Child added, but consent update failed. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/live/settings/children_live.ex:87
@@ -1852,14 +1847,9 @@ msgstr ""
 msgid "Child removed successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:297
+#: lib/klass_hero_web/live/settings/children_live.ex:264
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Child updated successfully."
-msgstr ""
-
-#: lib/klass_hero_web/live/settings/children_live.ex:299
-#, elixir-autogen, elixir-format
-msgid "Child updated, but consent update failed. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/live/dashboard_live.ex:176
@@ -1878,29 +1868,29 @@ msgstr ""
 msgid "Could not remove child. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:477
+#: lib/klass_hero_web/live/settings/children_live.ex:442
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Data sharing consent"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:2341
-#: lib/klass_hero_web/live/settings/children_live.ex:657
+#: lib/klass_hero_web/live/settings/children_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:462
+#: lib/klass_hero_web/live/settings/children_live.ex:427
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Delete"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:620
+#: lib/klass_hero_web/live/settings/children_live.ex:585
 #, elixir-autogen, elixir-format
 msgid "Edit Child"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:488
-#: lib/klass_hero_web/live/settings/children_live.ex:686
+#: lib/klass_hero_web/live/settings/children_live.ex:453
+#: lib/klass_hero_web/live/settings/children_live.ex:651
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Emergency contact"
 msgstr ""
@@ -1934,7 +1924,7 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:2335
 #: lib/klass_hero_web/components/provider_components.ex:2364
 #: lib/klass_hero_web/components/provider_components.ex:2380
-#: lib/klass_hero_web/live/settings/children_live.ex:643
+#: lib/klass_hero_web/live/settings/children_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
@@ -1942,17 +1932,17 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:2336
 #: lib/klass_hero_web/components/provider_components.ex:2365
 #: lib/klass_hero_web/components/provider_components.ex:2381
-#: lib/klass_hero_web/live/settings/children_live.ex:649
+#: lib/klass_hero_web/live/settings/children_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Last name"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:694
+#: lib/klass_hero_web/live/settings/children_live.ex:659
 #, elixir-autogen, elixir-format
 msgid "List any known allergies..."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:349
+#: lib/klass_hero_web/live/settings/children_live.ex:314
 #, elixir-autogen, elixir-format
 msgid "Manage your children's information and consents"
 msgstr ""
@@ -1977,7 +1967,7 @@ msgstr ""
 msgid "Messages"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:384
+#: lib/klass_hero_web/live/settings/children_live.ex:349
 #: lib/klass_hero_web/presenters/child_presenter.ex:57
 #, elixir-autogen, elixir-format
 msgid "No children yet"
@@ -2026,7 +2016,7 @@ msgstr ""
 msgid "Now"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:687
+#: lib/klass_hero_web/live/settings/children_live.ex:652
 #, elixir-autogen, elixir-format
 msgid "Phone number or name"
 msgstr ""
@@ -2067,14 +2057,14 @@ msgstr ""
 msgid "Program Broadcast"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:717
+#: lib/klass_hero_web/live/settings/children_live.ex:682
 #, elixir-autogen, elixir-format
 msgid "Provider data sharing consent"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:874
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:294
-#: lib/klass_hero_web/live/settings/children_live.ex:754
+#: lib/klass_hero_web/live/settings/children_live.ex:719
 #, elixir-autogen, elixir-format
 msgid "Save Changes"
 msgstr ""
@@ -2105,8 +2095,8 @@ msgstr ""
 msgid "Sending..."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:510
-#: lib/klass_hero_web/live/settings/children_live.ex:700
+#: lib/klass_hero_web/live/settings/children_live.ex:475
+#: lib/klass_hero_web/live/settings/children_live.ex:665
 #, elixir-autogen, elixir-format
 msgid "Support needs"
 msgstr ""
@@ -2419,7 +2409,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:684
 #: lib/klass_hero_web/components/provider_components.ex:1160
-#: lib/klass_hero_web/live/settings/children_live.ex:670
+#: lib/klass_hero_web/live/settings/children_live.ex:635
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
@@ -2546,7 +2536,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:682
 #: lib/klass_hero_web/components/provider_components.ex:1159
-#: lib/klass_hero_web/live/settings/children_live.ex:669
+#: lib/klass_hero_web/live/settings/children_live.ex:634
 #, elixir-autogen, elixir-format
 msgid "Female"
 msgstr ""
@@ -2576,7 +2566,7 @@ msgstr ""
 msgid "First Name"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:665
+#: lib/klass_hero_web/live/settings/children_live.ex:630
 #, elixir-autogen, elixir-format
 msgid "Gender"
 msgstr ""
@@ -2658,7 +2648,7 @@ msgstr ""
 msgid "Klass Hero was built to solve exactly that. A comprehensive operational platform that empowers educators to spend less time on paperwork and more time inspiring children."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:679
+#: lib/klass_hero_web/live/settings/children_live.ex:644
 #, elixir-autogen, elixir-format
 msgid "Klasse %{n}"
 msgstr ""
@@ -2692,7 +2682,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:683
 #: lib/klass_hero_web/components/provider_components.ex:1158
-#: lib/klass_hero_web/live/settings/children_live.ex:668
+#: lib/klass_hero_web/live/settings/children_live.ex:633
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
@@ -2753,7 +2743,7 @@ msgstr ""
 msgid "No file selected."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:678
+#: lib/klass_hero_web/live/settings/children_live.ex:643
 #, elixir-autogen, elixir-format
 msgid "No grade"
 msgstr ""
@@ -2811,7 +2801,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:685
 #: lib/klass_hero_web/components/provider_components.ex:1161
-#: lib/klass_hero_web/live/settings/children_live.ex:667
+#: lib/klass_hero_web/live/settings/children_live.ex:632
 #, elixir-autogen, elixir-format
 msgid "Not specified"
 msgstr ""
@@ -3046,7 +3036,7 @@ msgstr ""
 msgid "Schedule TBD"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:677
+#: lib/klass_hero_web/live/settings/children_live.ex:642
 #, elixir-autogen, elixir-format
 msgid "School Grade (optional)"
 msgstr ""
@@ -3488,22 +3478,22 @@ msgstr ""
 msgid "Could not check enrollments. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:592
+#: lib/klass_hero_web/live/settings/children_live.ex:557
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove Child"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:546
+#: lib/klass_hero_web/live/settings/children_live.ex:511
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove Child?"
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:564
+#: lib/klass_hero_web/live/settings/children_live.ex:529
 #, elixir-autogen, elixir-format
 msgid "Their enrollments will be cancelled. This action cannot be undone."
 msgstr ""
 
-#: lib/klass_hero_web/live/settings/children_live.ex:551
+#: lib/klass_hero_web/live/settings/children_live.ex:516
 #, elixir-autogen, elixir-format
 msgid "This child is currently enrolled in the following programs:"
 msgstr ""

--- a/test/klass_hero/family/children_test.exs
+++ b/test/klass_hero/family/children_test.exs
@@ -11,6 +11,7 @@ defmodule KlassHero.Family.ChildrenTest do
   alias KlassHero.Family
   alias KlassHero.Family.Child
   alias KlassHero.Family.ChildGuardian
+  alias KlassHero.Family.Consent
 
   @valid_attrs %{
     first_name: "Emma",
@@ -62,6 +63,111 @@ defmodule KlassHero.Family.ChildrenTest do
                Family.create_child(Map.put(@valid_attrs, :parent_id, Ecto.UUID.generate()))
 
       assert Repo.aggregate(Child, :count) == count_before
+    end
+  end
+
+  # #1322 lost a guardian's consent because ChildrenLive persisted the child and then
+  # granted the consent as a separate top-level call. These cover the fold-in: the two
+  # writes now share one transaction, so neither can survive the other's failure.
+  describe "create_child/2 with consents" do
+    @consent_type "provider_data_sharing"
+
+    test "writes the child and its consent in one call" do
+      parent = parent()
+      attrs = Map.put(@valid_attrs, :parent_id, parent.id)
+
+      assert {:ok, %Child{} = child} =
+               Family.create_child(attrs, consents: %{@consent_type => true})
+
+      assert Family.child_has_active_consent?(child.id, @consent_type)
+    end
+
+    # The test that would have caught #1322: a failing consent write must take the
+    # child row with it, so there is no half-saved form to remediate later.
+    test "rolls back the child when the consent write fails" do
+      parent = parent()
+      attrs = Map.put(@valid_attrs, :parent_id, parent.id)
+      count_before = Repo.aggregate(Child, :count)
+
+      assert {:error, {:consent, %Ecto.Changeset{}}} =
+               Family.create_child(attrs, consents: %{"" => true})
+
+      assert Repo.aggregate(Child, :count) == count_before
+    end
+
+    test "grants nothing when consent is not requested" do
+      parent = parent()
+      attrs = Map.put(@valid_attrs, :parent_id, parent.id)
+
+      assert {:ok, child} = Family.create_child(attrs, consents: %{@consent_type => false})
+
+      refute Family.child_has_active_consent?(child.id, @consent_type)
+    end
+
+    test "grants nothing when no consents are passed at all" do
+      parent = parent()
+      attrs = Map.put(@valid_attrs, :parent_id, parent.id)
+
+      assert {:ok, child} = Family.create_child(attrs)
+
+      refute Family.child_has_active_consent?(child.id, @consent_type)
+    end
+  end
+
+  describe "update_child/3 with consents" do
+    setup do
+      parent = parent()
+
+      {:ok, child} = Family.create_child(Map.put(@valid_attrs, :parent_id, parent.id))
+
+      %{parent: parent, child: child}
+    end
+
+    test "grants a consent that was not there before", %{parent: parent, child: child} do
+      assert {:ok, _} =
+               Family.update_child(child.id, %{first_name: "Emmy"},
+                 consents: %{@consent_type => true},
+                 parent_id: parent.id
+               )
+
+      assert Family.child_has_active_consent?(child.id, @consent_type)
+    end
+
+    test "withdraws a consent that is no longer wanted", %{parent: parent, child: child} do
+      {:ok, _} = Family.grant_consent(%{parent_id: parent.id, child_id: child.id, consent_type: @consent_type})
+
+      assert {:ok, _} =
+               Family.update_child(child.id, %{first_name: "Emmy"},
+                 consents: %{@consent_type => false},
+                 parent_id: parent.id
+               )
+
+      refute Family.child_has_active_consent?(child.id, @consent_type)
+    end
+
+    # Re-submitting an unchanged form must not stack a second consent row, and must not
+    # fail on the partial unique index either.
+    test "leaves an already-granted consent alone", %{parent: parent, child: child} do
+      {:ok, _} = Family.grant_consent(%{parent_id: parent.id, child_id: child.id, consent_type: @consent_type})
+
+      assert {:ok, _} =
+               Family.update_child(child.id, %{first_name: "Emmy"},
+                 consents: %{@consent_type => true},
+                 parent_id: parent.id
+               )
+
+      assert Family.child_has_active_consent?(child.id, @consent_type)
+      assert Repo.aggregate(from(c in Consent, where: c.child_id == ^child.id), :count) == 1
+    end
+
+    test "rolls back the update when the consent write fails", %{parent: parent, child: child} do
+      assert {:error, {:consent, %Ecto.Changeset{}}} =
+               Family.update_child(child.id, %{first_name: "Emmy"},
+                 consents: %{"" => true},
+                 parent_id: parent.id
+               )
+
+      assert Repo.get!(Child, child.id).first_name == "Emma"
     end
   end
 

--- a/test/klass_hero/family/observability_test.exs
+++ b/test/klass_hero/family/observability_test.exs
@@ -17,7 +17,10 @@ defmodule KlassHero.Family.ObservabilityTest do
     test "create_child opens a context span with a nested db child span" do
       assert {:ok, _child} = Family.create_child(@valid_attrs)
 
-      assert_span("Family.create_child/1",
+      # Arity is part of the span name, so widening create_child/1 to /2 renamed this
+      # span. Saved Honeycomb queries pinned to the old name match nothing rather than
+      # failing, which is why this assertion is worth keeping exact.
+      assert_span("Family.create_child/2",
         "context.name": "Family",
         "context.operation": "create_child"
       )


### PR DESCRIPTION
## Summary

`ChildrenLive` persisted the child, then granted the consent as a *separate top-level call*. Both writes land in the same context and the same database, and nothing bound them — so when the second failed (#1322), the child row committed and the consent intent vanished. No row, no event, no audit trail, nothing to backfill from.

PR #1331 fixed the crash. It did not fix the shape that made the crash unrecoverable: any error in `grant_consent` — constraint, connection, deploy mid-submit — reproduced the same loss.

`create_child/2` and `update_child/3` now take the desired consent state and reconcile it **inside the transaction they already open** via `Outbox.transact`:

```elixir
Family.create_child(attrs, consents: %{"provider_data_sharing" => true})
```

A consent failure fails that transaction, so the child goes back with it. One form, one outcome.

## Review focus

**This adds no transaction — it uses the one that was already there.** `create_child` has run inside `Outbox.transact`'s Multi all along, with the guardian-link Multi nested inside it. The consent write simply joins that `with` chain. That is why the diff is smaller than the issue implies.

**`insert_isolated/1` turned out to be exactly the primitive this needed.** It switches on `Repo.in_transaction?()`, so `grant_consent` called from inside the fold still gets `mode: :savepoint` — a duplicate-consent constraint violation surfaces as `{:error, :already_active}` without aborting the enclosing write. PR #1331 built this for an unrelated reason and it de-risks the fold considerably. `ProcessInviteClaim` already relies on the same nesting in production.

**The current-consent read moved inside the transaction.** `ChildrenLive` used to call `child_has_active_consent?/2` *before* the save and decide on that answer. That is the race the fold-in closes, and `CLAUDE.md`'s Ecto rules forbid it outright ("never read data outside a `Multi` and use it inside").

**Two races are treated as success, deliberately** — `:already_active` on grant and `:not_found` on withdraw both mean a concurrent writer already reached the state the guardian asked for. Only a genuine write failure aborts.

**`grant_consent/1` and `withdraw_consent/2` stay public and standalone-callable.** `consents_unboxed_test.exs` is the #1322 regression test and runs them outside any transaction via `Sandbox.unboxed_run`; it still passes unchanged.

**"Child added, but consent update failed" is deleted.** That state is unreachable now — reaching the success branch means both writes landed. A consent failure falls into `save_child/3`'s existing error branch: logs, flashes the generic retry message, leaves the form populated, does not `push_patch`. Two gettext strings removed, none added.

## ⚠️ Observability note

Span names carry arity, so `Family.create_child/1` is now **`Family.create_child/2`** in Honeycomb. Saved queries or board panels pinned to the old name will match nothing rather than error. `observability_test.exs` caught this and now asserts the new name.

## Test plan

Full suite green: **4417 passed**.

Two earlier full-suite runs each failed one *different* unrelated test (`admin/incident_live_test.exs` image-stub, then a `DashboardLive` 100ms `render_async` timeout) — both pass in isolation and neither touches Family. That matches the documented ~15% full-run flake baseline on clean main, not this diff.

New coverage in `test/klass_hero/family/children_test.exs`:
- child + consent written by one call
- **the test that would have caught #1322**: force the consent write to fail, assert *no child row exists*
- consent not requested, and no consents passed at all, both grant nothing
- update grants, withdraws, and no-ops correctly; re-submitting an unchanged form does not stack a second row
- update rollback: a failed consent leaves the child's previous `first_name` intact

The two existing `describe "consent toggle"` LiveView tests pass **unchanged** — their assertions are outcome-based, so only the timing of the write moved.

Closes #1390
