### PR TITLE
fix: clear enrollment capacity, and guard removing a cap retroactively

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -32,6 +32,10 @@ _Avoid_: Class, Meeting, Occurrence, Program Session; and never reuse "Session" 
 A child's signup to a **Program** — the program-level commitment, made once. Feeds the **Roster** of every Session in that Program. Parents "book" a Program; the record that results is an Enrollment.
 _Avoid_: Registration, Signup; and "Booking" as a domain *noun* ("Book" is fine as a front-of-house verb only — see flagged ambiguities)
 
+**Enrollment Policy**:
+A **Program**'s optional minimum and maximum **Enrollment** counts. The maximum is the *cap* — the bound the Enrollment context enforces when a place is booked; a Program with no maximum is *uncapped*, and anyone may book. The minimum is a viability threshold only, enforced nowhere at booking time. Removing a cap from a Program that already has active Enrollments is a deliberate act the provider must acknowledge — it cannot happen as a side effect of an edit.
+_Avoid_: Capacity as a noun for the row itself ("the capacity" is the number), Limit, Quota
+
 **Roster**:
 The set of children expected at a given **Session**, seeded from the Program's active **Enrollments**. A roster belongs to one Session.
 _Avoid_: Attendance list, Class list, Sign-in sheet

--- a/lib/klass_hero/enrollment.ex
+++ b/lib/klass_hero/enrollment.ex
@@ -243,16 +243,89 @@ defmodule KlassHero.Enrollment do
 
   @doc """
   Creates or updates the enrollment capacity policy for a program (upsert).
+
+  Passing an explicit `nil` clears the corresponding limit — the write carries the nils
+  into `on_conflict`, so a stored value is replaced rather than left standing (#1370).
+
+  Removing the cap entirely (`max_enrollment` from a number to `nil`) on a program that
+  already has active enrollments is refused with `{:error, {:cap_removal_blocked, count}}`
+  unless `attrs` carries `acknowledge_cap_removal: true`. The check runs under a
+  `FOR UPDATE` lock on the same policy row `create_enrollment_with_capacity_check/3`
+  locks, so a booking landing mid-edit serialises against the removal instead of
+  slipping past the count.
   """
   def set_enrollment_policy(attrs) when is_map(attrs) do
     context_span entity: "enrollment_policy" do
-      %EnrollmentPolicy{}
-      |> EnrollmentPolicy.changeset(attrs)
-      |> Repo.insert(
-        on_conflict: {:replace, [:min_enrollment, :max_enrollment, :updated_at]},
-        conflict_target: :program_id,
-        returning: true
-      )
+      Ecto.Multi.new()
+      |> Ecto.Multi.run(:guard, fn repo, _changes ->
+        guard_cap_removal(
+          repo,
+          fetch_attr(attrs, :program_id),
+          fetch_attr(attrs, :max_enrollment),
+          fetch_attr(attrs, :acknowledge_cap_removal) == true
+        )
+      end)
+      |> Ecto.Multi.run(:upsert, fn repo, _changes -> upsert_enrollment_policy(repo, attrs) end)
+      |> Repo.transaction()
+      |> case do
+        {:ok, %{upsert: policy}} -> {:ok, policy}
+        {:error, :guard, reason, _changes} -> {:error, reason}
+        {:error, :upsert, reason, _changes} -> {:error, reason}
+      end
+    end
+  end
+
+  @doc """
+  Reports whether a pending capacity change would remove the cap consequentially.
+
+  The read the provider's form asks before saving, so the warning it shows and the rule
+  `set_enrollment_policy/1` enforces come from one predicate and cannot drift.
+  """
+  @spec assess_capacity_change(String.t(), integer() | nil) :: :ok | {:cap_removal, pos_integer()}
+  def assess_capacity_change(program_id, new_max) when is_binary(program_id) do
+    with %EnrollmentPolicy{} = policy <- Repo.get_by(EnrollmentPolicy, program_id: program_id),
+         true <- EnrollmentPolicy.cap_removal?(policy, new_max),
+         active when active > 0 <- count_active_enrollments(program_id) do
+      {:cap_removal, active}
+    else
+      _no_consequence -> :ok
+    end
+  end
+
+  # No program_id is a changeset error, not a cap removal — let the changeset report it.
+  defp guard_cap_removal(_repo, nil, _new_max, _acknowledged?), do: {:ok, :no_program}
+  defp guard_cap_removal(_repo, _program_id, _new_max, true), do: {:ok, :acknowledged}
+
+  defp guard_cap_removal(repo, program_id, new_max, false) do
+    existing =
+      repo.one(from(p in EnrollmentPolicy, where: p.program_id == ^program_id, lock: "FOR UPDATE"))
+
+    if EnrollmentPolicy.cap_removal?(existing, new_max) do
+      case count_active_enrollments_in_tx(repo, program_id) do
+        0 -> {:ok, :uncontested}
+        active -> {:error, {:cap_removal_blocked, active}}
+      end
+    else
+      {:ok, :permitted}
+    end
+  end
+
+  defp upsert_enrollment_policy(repo, attrs) do
+    %EnrollmentPolicy{}
+    |> EnrollmentPolicy.changeset(attrs)
+    |> repo.insert(
+      on_conflict: {:replace, [:min_enrollment, :max_enrollment, :updated_at]},
+      conflict_target: :program_id,
+      returning: true
+    )
+  end
+
+  # Callers pass atom-keyed attrs, but a string-keyed map must not read as an absent
+  # max_enrollment — that would look like a cap removal and block a save that isn't one.
+  defp fetch_attr(attrs, key) do
+    case Map.fetch(attrs, key) do
+      {:ok, value} -> value
+      :error -> Map.get(attrs, Atom.to_string(key))
     end
   end
 

--- a/lib/klass_hero/enrollment/enrollment_policy.ex
+++ b/lib/klass_hero/enrollment/enrollment_policy.ex
@@ -63,6 +63,17 @@ defmodule KlassHero.Enrollment.EnrollmentPolicy do
   end
 
   @doc """
+  Returns true when a change would blank an existing maximum — i.e. uncap the program.
+
+  The single statement of the rule: both the warning the provider sees while editing
+  and the guard that enforces the write call this, so the two cannot drift. A `nil`
+  policy is the create path, where there is no cap to remove.
+  """
+  @spec cap_removal?(t() | nil, integer() | nil) :: boolean()
+  def cap_removal?(%__MODULE__{max_enrollment: previous}, nil) when is_integer(previous), do: true
+  def cap_removal?(_policy, _new_max), do: false
+
+  @doc """
   Returns true if the current enrollment count is below the maximum capacity.
 
   Always true when no `max_enrollment` is set (uncapped program).

--- a/lib/klass_hero_web/components/provider_components.ex
+++ b/lib/klass_hero_web/components/provider_components.ex
@@ -905,6 +905,24 @@ defmodule KlassHeroWeb.ProviderComponents do
   defp rate_type_is?(field, value), do: to_string(field.value) == value
 
   @doc """
+  The sentence naming why removing a capacity cap is consequential.
+
+  Lives here, not in the LiveView, because both the inline warning and the flash that
+  reports a refused removal must say the same thing — and the wording is rendered in
+  the reader's locale either way.
+  """
+  @spec cap_removal_message({:cap_removal, pos_integer()} | pos_integer()) :: String.t()
+  def cap_removal_message({:cap_removal, active}), do: cap_removal_message(active)
+
+  def cap_removal_message(active) when is_integer(active) do
+    ngettext(
+      "%{count} child is already enrolled. Confirm you want this program to have no capacity limit.",
+      "%{count} children are already enrolled. Confirm you want this program to have no capacity limit.",
+      active
+    )
+  end
+
+  @doc """
   Renders the program create/edit form.
 
   ## Examples
@@ -918,6 +936,10 @@ defmodule KlassHeroWeb.ProviderComponents do
   attr :uploads, :map, required: true
   attr :instructor_options, :list, default: []
   attr :categories, :list, required: true, doc: "List of valid program categories"
+
+  attr :cap_removal_assessment, :any,
+    default: :ok,
+    doc: "`:ok`, or `{:cap_removal, active_count}` from Enrollment.assess_capacity_change/2"
 
   def program_form(assigns) do
     ~H"""
@@ -1080,6 +1102,30 @@ defmodule KlassHeroWeb.ProviderComponents do
               label={gettext("Maximum Enrollment")}
               min="1"
             />
+          </div>
+
+          <div
+            :if={@cap_removal_assessment != :ok}
+            id="cap-removal-warning"
+            class={[
+              "flex items-start gap-3 p-4 border border-amber-200 bg-amber-50 text-amber-800",
+              Theme.rounded(:lg),
+              Theme.typography(:body_small)
+            ]}
+          >
+            <.icon name="hero-exclamation-triangle-mini" class="w-5 h-5 shrink-0 mt-0.5" />
+            <div class="flex-1">
+              <p class="font-medium">{cap_removal_message(@cap_removal_assessment)}</p>
+              <p class="mt-1">
+                {gettext("Anyone will be able to book a place until you set a new maximum.")}
+              </p>
+              <.input
+                field={@enrollment_form[:acknowledge_cap_removal]}
+                type="checkbox"
+                label={gettext("I understand this program will have no capacity limit.")}
+                required
+              />
+            </div>
           </div>
         </div>
 

--- a/lib/klass_hero_web/live/provider/programs_live.ex
+++ b/lib/klass_hero_web/live/provider/programs_live.ex
@@ -78,6 +78,7 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
       |> assign(
         participant_policy_form: to_form(Enrollment.new_participant_policy_changeset(), as: "participant_policy")
       )
+      |> assign(cap_removal_assessment: :ok)
       |> assign(instructor_options: build_instructor_options(staff_members))
       |> assign(categories: ProgramCatalog.program_categories())
       |> allow_upload(:program_cover,
@@ -119,6 +120,7 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
      |> assign(
        participant_policy_form: to_form(Enrollment.new_participant_policy_changeset(), as: "participant_policy")
      )
+     |> assign(cap_removal_assessment: :ok)
      |> assign(instructor_options: build_instructor_options(socket.assigns.current_scope.provider.id))}
   end
 
@@ -140,6 +142,7 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
            program_form: to_form(changeset, as: :program_schema),
            enrollment_form: load_enrollment_policy_form(program_id),
            participant_policy_form: load_participant_policy_form(program_id),
+           cap_removal_assessment: :ok,
            instructor_options: build_instructor_options(provider_id)
          )}
 
@@ -556,7 +559,8 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
        show_program_form: false,
        editing_program_id: nil,
        enrollment_form: to_form(Enrollment.new_policy_changeset(), as: "enrollment_policy"),
-       participant_policy_form: to_form(Enrollment.new_participant_policy_changeset(), as: "participant_policy")
+       participant_policy_form: to_form(Enrollment.new_participant_policy_changeset(), as: "participant_policy"),
+       cap_removal_assessment: :ok
      )}
   end
 
@@ -584,7 +588,8 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
      socket
      |> assign(program_form: to_form(changeset, as: :program_schema))
      |> assign(enrollment_form: to_form(enrollment_changeset, as: "enrollment_policy"))
-     |> assign(participant_policy_form: to_form(participant_policy_changeset, as: "participant_policy"))}
+     |> assign(participant_policy_form: to_form(participant_policy_changeset, as: "participant_policy"))
+     |> assign(cap_removal_assessment: assess_cap_removal(socket, enrollment_params))}
   end
 
   @impl true
@@ -644,7 +649,7 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
     with {:ok, instructor_id} <- resolve_instructor(program_params["instructor_id"], socket),
          {:ok, program} <- ProgramCatalog.create_program(attrs) do
       :ok = apply_lead_instructor(program.id, instructor_id, socket.assigns.current_scope.provider.id)
-      policy_result = maybe_set_enrollment_policy(program.id, enrollment_params)
+      policy_result = set_enrollment_policy_on_create(program.id, enrollment_params)
       participant_result = set_participant_policy_on_create(program.id, participant_policy_params)
       capacity = resolve_capacity(policy_result, enrollment_params)
 
@@ -695,28 +700,35 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
     with {:ok, instructor_id} <- resolve_instructor(program_params["instructor_id"], socket),
          {:ok, updated} <- ProgramCatalog.update_program(provider_id, program_id, attrs) do
       :ok = apply_lead_instructor(program_id, instructor_id, provider_id)
-      policy_result = maybe_set_enrollment_policy(program_id, enrollment_params)
-      participant_result = set_participant_policy_on_update(program_id, participant_policy_params)
 
-      capacity = resolve_capacity(policy_result, enrollment_params)
-      active_counts = Enrollment.count_active_enrollments_batch([program_id])
-      enrolled = Map.get(active_counts, program_id, 0)
-      enrollment_data = %{program_id => %{enrolled: enrolled, capacity: capacity}}
+      case set_enrollment_policy_on_update(program_id, enrollment_params) do
+        {:error, {:cap_removal_blocked, active}} ->
+          halt_for_cap_acknowledgement(socket, active)
 
-      {:noreply,
-       socket
-       |> flash_for_save(:updated,
-         enrollment_policy: policy_result,
-         participant_policy: participant_result
-       )
-       |> maybe_flash_cover_warning(cover_result)
-       |> sync_program_row(updated, enrollment_data)
-       |> assign(
-         show_program_form: false,
-         editing_program_id: nil,
-         enrollment_form: to_form(Enrollment.new_policy_changeset(), as: "enrollment_policy"),
-         participant_policy_form: to_form(Enrollment.new_participant_policy_changeset(), as: "participant_policy")
-       )}
+        policy_result ->
+          participant_result = set_participant_policy_on_update(program_id, participant_policy_params)
+
+          capacity = resolve_capacity(policy_result, enrollment_params)
+          active_counts = Enrollment.count_active_enrollments_batch([program_id])
+          enrolled = Map.get(active_counts, program_id, 0)
+          enrollment_data = %{program_id => %{enrolled: enrolled, capacity: capacity}}
+
+          {:noreply,
+           socket
+           |> flash_for_save(:updated,
+             enrollment_policy: policy_result,
+             participant_policy: participant_result
+           )
+           |> maybe_flash_cover_warning(cover_result)
+           |> sync_program_row(updated, enrollment_data)
+           |> assign(
+             show_program_form: false,
+             editing_program_id: nil,
+             cap_removal_assessment: :ok,
+             enrollment_form: to_form(Enrollment.new_policy_changeset(), as: "enrollment_policy"),
+             participant_policy_form: to_form(Enrollment.new_participant_policy_changeset(), as: "participant_policy")
+           )}
+      end
     else
       {:error, :not_found} ->
         {:noreply, put_flash(socket, :error, gettext("Program not found."))}
@@ -1024,30 +1036,57 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
     Enum.map(members, fn m -> {Provider.staff_member_full_name(m), m.id} end)
   end
 
-  defp maybe_set_enrollment_policy(program_id, params) do
+  # Skip the upsert on create when both limits are empty — avoid storing an all-nil row
+  # for a program that never specified any.
+  defp set_enrollment_policy_on_create(program_id, params) do
     min = parse_integer(params["min_enrollment"])
     max = parse_integer(params["max_enrollment"])
 
     if is_nil(min) and is_nil(max) do
       :ok
     else
-      case Enrollment.set_enrollment_policy(%{
-             program_id: program_id,
-             min_enrollment: min,
-             max_enrollment: max
-           }) do
-        {:ok, _policy} ->
-          :ok
+      save_enrollment_policy(
+        %{program_id: program_id, min_enrollment: min, max_enrollment: max},
+        program_id
+      )
+    end
+  end
 
-        # Program already created — don't roll back, propagate error to show a warning flash.
-        {:error, reason} ->
-          Logger.warning("[Provider.ProgramsLive] Failed to save enrollment policy",
-            program_id: program_id,
-            reason: inspect(reason)
-          )
+  # Trigger: existing program edit — must allow clearing previously stored limits
+  # Why: the form is prefilled from the stored policy, so short-circuiting on all-empty
+  #   would read a deliberate clear as an absence and leave stale values (issue #1370,
+  #   the same shape #795 fixed for the participant policy)
+  # Outcome: always upsert, carrying explicit nils so on_conflict replaces stored values
+  defp set_enrollment_policy_on_update(program_id, params) do
+    save_enrollment_policy(
+      %{
+        program_id: program_id,
+        min_enrollment: parse_integer(params["min_enrollment"]),
+        max_enrollment: parse_integer(params["max_enrollment"]),
+        acknowledge_cap_removal: params["acknowledge_cap_removal"] == "true"
+      },
+      program_id
+    )
+  end
 
-          {:error, :enrollment_policy_failed}
-      end
+  defp save_enrollment_policy(attrs, program_id) do
+    case Enrollment.set_enrollment_policy(attrs) do
+      {:ok, _policy} ->
+        :ok
+
+      # Not a failure to report and move on from — the provider is being asked a
+      # question, so the reason travels intact and the caller reopens the form.
+      {:error, {:cap_removal_blocked, _active} = reason} ->
+        {:error, reason}
+
+      # Program already created — don't roll back, propagate error to show a warning flash.
+      {:error, reason} ->
+        Logger.warning("[Provider.ProgramsLive] Failed to save enrollment policy",
+          program_id: program_id,
+          reason: inspect(reason)
+        )
+
+        {:error, :enrollment_policy_failed}
     end
   end
 
@@ -1146,6 +1185,24 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
       _ ->
         put_flash(socket, :warning, save_failure_message(action, failed_sources))
     end
+  end
+
+  # Asked of Enrollment rather than decided here, so the warning the provider sees and
+  # the rule the write enforces come from one predicate (see assess_capacity_change/2).
+  defp assess_cap_removal(%{assigns: %{editing_program_id: nil}}, _params), do: :ok
+
+  defp assess_cap_removal(%{assigns: %{editing_program_id: program_id}}, params) do
+    Enrollment.assess_capacity_change(program_id, parse_integer(params["max_enrollment"]))
+  end
+
+  # The backstop, not the everyday path: the acknowledgement checkbox is `required`, so
+  # this is reached when a booking lands while the form sits open (or a crafted submit).
+  # The form stays open carrying the warning, so the answer is one tick away.
+  defp halt_for_cap_acknowledgement(socket, active) do
+    {:noreply,
+     socket
+     |> assign(cap_removal_assessment: {:cap_removal, active})
+     |> put_flash(:warning, cap_removal_message(active))}
   end
 
   defp save_success_message(:created), do: gettext("Program created successfully.")
@@ -1249,6 +1306,7 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
             instructor_options={@instructor_options}
             categories={@categories}
             editing={@editing_program_id != nil}
+            cap_removal_assessment={@cap_removal_assessment}
           />
         <% end %>
 

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -137,7 +137,7 @@ msgid "Your Data"
 msgstr "Ihre Daten"
 
 #: lib/klass_hero_web/components/core_components.ex:67
-#: lib/klass_hero_web/components/provider_components.ex:1687
+#: lib/klass_hero_web/components/provider_components.ex:1733
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr "schließen"
@@ -232,7 +232,7 @@ msgstr "Einfache Terminplanung"
 msgid "Enroll Now - %{price}"
 msgstr "Jetzt anmelden - %{price}"
 
-#: lib/klass_hero_web/components/provider_components.ex:1438
+#: lib/klass_hero_web/components/provider_components.ex:1484
 #: lib/klass_hero_web/live/booking_live.ex:285
 #, elixir-autogen, elixir-format
 msgid "Enrollment"
@@ -578,8 +578,8 @@ msgid "Dispute Resolution"
 msgstr "Streitbeilegung"
 
 #: lib/klass_hero_web/components/provider_components.ex:719
-#: lib/klass_hero_web/components/provider_components.ex:2360
-#: lib/klass_hero_web/components/provider_components.ex:2378
+#: lib/klass_hero_web/components/provider_components.ex:2406
+#: lib/klass_hero_web/components/provider_components.ex:2424
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
@@ -878,9 +878,9 @@ msgstr "Speichern..."
 msgid "Select one or both options"
 msgstr "Wählen Sie eine oder beide Optionen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2056
-#: lib/klass_hero_web/components/provider_components.ex:2057
-#: lib/klass_hero_web/components/provider_components.ex:2094
+#: lib/klass_hero_web/components/provider_components.ex:2102
+#: lib/klass_hero_web/components/provider_components.ex:2103
+#: lib/klass_hero_web/components/provider_components.ex:2140
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:448
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:484
@@ -1577,14 +1577,14 @@ msgstr "Profil"
 msgid "Quick Navigation"
 msgstr "Schnellnavigation"
 
-#: lib/klass_hero_web/components/provider_components.ex:1441
-#: lib/klass_hero_web/components/provider_components.ex:2032
-#: lib/klass_hero_web/components/provider_components.ex:2258
+#: lib/klass_hero_web/components/provider_components.ex:1487
+#: lib/klass_hero_web/components/provider_components.ex:2078
+#: lib/klass_hero_web/components/provider_components.ex:2304
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr "Aktionen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1580
+#: lib/klass_hero_web/components/provider_components.ex:1626
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr "Aktiv"
@@ -1600,7 +1600,7 @@ msgstr "Teammitglied hinzufügen"
 msgid "All Staff"
 msgstr "Alle Mitarbeiter"
 
-#: lib/klass_hero_web/components/provider_components.ex:1432
+#: lib/klass_hero_web/components/provider_components.ex:1478
 #, elixir-autogen, elixir-format
 msgid "Assigned Staff"
 msgstr "Zugewiesenes Personal"
@@ -1628,7 +1628,7 @@ msgid "Create profiles for your staff. These will be visible to parents when ass
 msgstr "Erstellen Sie Profile für Ihr Personal. Diese werden für Eltern sichtbar sein, wenn sie Programmen zugewiesen werden."
 
 #: lib/klass_hero_web/components/provider_components.ex:539
-#: lib/klass_hero_web/components/provider_components.ex:1543
+#: lib/klass_hero_web/components/provider_components.ex:1589
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:54
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:81
 #: lib/klass_hero_web/live/settings/children_live.ex:413
@@ -1645,7 +1645,7 @@ msgstr "Bearbeiten"
 msgid "Edit Profile"
 msgstr "Profil bearbeiten"
 
-#: lib/klass_hero_web/components/provider_components.ex:1582
+#: lib/klass_hero_web/components/provider_components.ex:1628
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr "Inaktiv"
@@ -1657,7 +1657,7 @@ msgid "My Programs"
 msgstr "Meine Programme"
 
 #: lib/klass_hero_web/components/provider_components.ex:416
-#: lib/klass_hero_web/components/provider_components.ex:930
+#: lib/klass_hero_web/components/provider_components.ex:952
 #, elixir-autogen, elixir-format
 msgid "New Program"
 msgstr "Neues Programm"
@@ -1669,26 +1669,26 @@ msgstr "Übersicht"
 
 #: lib/klass_hero_web/components/provider_components.ex:47
 #: lib/klass_hero_web/components/provider_components.ex:73
-#: lib/klass_hero_web/components/provider_components.ex:1581
-#: lib/klass_hero_web/components/provider_components.ex:2454
-#: lib/klass_hero_web/components/provider_components.ex:2472
+#: lib/klass_hero_web/components/provider_components.ex:1627
+#: lib/klass_hero_web/components/provider_components.ex:2500
+#: lib/klass_hero_web/components/provider_components.ex:2518
 #: lib/klass_hero_web/live/admin/sessions_live.ex:298
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr "Ausstehend"
 
-#: lib/klass_hero_web/components/provider_components.ex:1519
+#: lib/klass_hero_web/components/provider_components.ex:1565
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr "Vorschau"
 
-#: lib/klass_hero_web/components/provider_components.ex:1372
+#: lib/klass_hero_web/components/provider_components.ex:1418
 #, elixir-autogen, elixir-format
 msgid "Program Inventory"
 msgstr "Programmübersicht"
 
-#: lib/klass_hero_web/components/provider_components.ex:1429
+#: lib/klass_hero_web/components/provider_components.ex:1475
 #, elixir-autogen, elixir-format
 msgid "Program Name"
 msgstr "Programmname"
@@ -1703,15 +1703,15 @@ msgstr "Anbieter-Dashboard"
 msgid "Save for Later"
 msgstr "Für später speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:1389
+#: lib/klass_hero_web/components/provider_components.ex:1435
 #, elixir-autogen, elixir-format
 msgid "Search by name..."
 msgstr "Nach Namen suchen..."
 
-#: lib/klass_hero_web/components/provider_components.ex:1435
-#: lib/klass_hero_web/components/provider_components.ex:1804
-#: lib/klass_hero_web/components/provider_components.ex:2026
-#: lib/klass_hero_web/components/provider_components.ex:2255
+#: lib/klass_hero_web/components/provider_components.ex:1481
+#: lib/klass_hero_web/components/provider_components.ex:1850
+#: lib/klass_hero_web/components/provider_components.ex:2072
+#: lib/klass_hero_web/components/provider_components.ex:2301
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1735,15 +1735,15 @@ msgstr "Team- & Anbieterprofile"
 msgid "This is your main business identity. Verification is required to list programs."
 msgstr "Dies ist Ihre Hauptgeschäftsidentität. Eine Verifizierung ist erforderlich, um Programme anzubieten."
 
-#: lib/klass_hero_web/components/provider_components.ex:1492
-#: lib/klass_hero_web/components/provider_components.ex:1819
+#: lib/klass_hero_web/components/provider_components.ex:1538
+#: lib/klass_hero_web/components/provider_components.ex:1865
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr "Nicht zugewiesen"
 
 #: lib/klass_hero_web/components/messaging_components.ex:722
 #: lib/klass_hero_web/components/provider_components.ex:50
-#: lib/klass_hero_web/components/provider_components.ex:1583
+#: lib/klass_hero_web/components/provider_components.ex:1629
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:434
 #: lib/klass_hero_web/presenters/provider_presenter.ex:103
 #, elixir-autogen, elixir-format
@@ -1755,7 +1755,7 @@ msgstr "Unbekannt"
 msgid "Verified Business"
 msgstr "Verifiziertes Unternehmen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1530
+#: lib/klass_hero_web/components/provider_components.ex:1576
 #, elixir-autogen, elixir-format
 msgid "View Roster"
 msgstr "Teilnehmerliste"
@@ -1816,8 +1816,8 @@ msgstr "Rundnachricht an %{count} Eltern gesendet"
 #: lib/klass_hero_web/components/participation_components.ex:631
 #: lib/klass_hero_web/components/participation_components.ex:717
 #: lib/klass_hero_web/components/provider_components.ex:889
-#: lib/klass_hero_web/components/provider_components.ex:1288
-#: lib/klass_hero_web/components/provider_components.ex:2197
+#: lib/klass_hero_web/components/provider_components.ex:1334
+#: lib/klass_hero_web/components/provider_components.ex:2243
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:478
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
@@ -1873,7 +1873,7 @@ msgstr "Kind konnte nicht entfernt werden. Bitte versuchen Sie es erneut."
 msgid "Data sharing consent"
 msgstr "Einwilligung zur Datenweitergabe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2341
+#: lib/klass_hero_web/components/provider_components.ex:2387
 #: lib/klass_hero_web/live/settings/children_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1921,17 +1921,17 @@ msgstr "Rundnachricht konnte nicht gesendet werden"
 msgid "Failed to submit note"
 msgstr "Notiz konnte nicht eingereicht werden"
 
-#: lib/klass_hero_web/components/provider_components.ex:2335
-#: lib/klass_hero_web/components/provider_components.ex:2364
-#: lib/klass_hero_web/components/provider_components.ex:2380
+#: lib/klass_hero_web/components/provider_components.ex:2381
+#: lib/klass_hero_web/components/provider_components.ex:2410
+#: lib/klass_hero_web/components/provider_components.ex:2426
 #: lib/klass_hero_web/live/settings/children_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr "Vorname"
 
-#: lib/klass_hero_web/components/provider_components.ex:2336
-#: lib/klass_hero_web/components/provider_components.ex:2365
-#: lib/klass_hero_web/components/provider_components.ex:2381
+#: lib/klass_hero_web/components/provider_components.ex:2382
+#: lib/klass_hero_web/components/provider_components.ex:2411
+#: lib/klass_hero_web/components/provider_components.ex:2427
 #: lib/klass_hero_web/live/settings/children_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -2069,8 +2069,8 @@ msgstr "Einwilligung zur Datenweitergabe an Anbieter"
 msgid "Save Changes"
 msgstr "Änderungen speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:1665
-#: lib/klass_hero_web/components/provider_components.ex:1666
+#: lib/klass_hero_web/components/provider_components.ex:1711
+#: lib/klass_hero_web/components/provider_components.ex:1712
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:43
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:151
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:252
@@ -2088,7 +2088,7 @@ msgstr "Rundnachricht senden"
 msgid "Send a message to start the conversation"
 msgstr "Senden Sie eine Nachricht, um die Unterhaltung zu beginnen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2435
+#: lib/klass_hero_web/components/provider_components.ex:2481
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:249
 #, elixir-autogen, elixir-format
@@ -2219,12 +2219,12 @@ msgstr "Alter %{min} bis %{max}"
 msgid "Ages %{min}+"
 msgstr "Alter %{min}+"
 
-#: lib/klass_hero_web/components/provider_components.ex:1149
+#: lib/klass_hero_web/components/provider_components.ex:1195
 #, elixir-autogen, elixir-format
 msgid "Allowed Genders"
 msgstr "Zulässige Geschlechter"
 
-#: lib/klass_hero_web/components/provider_components.ex:2494
+#: lib/klass_hero_web/components/provider_components.ex:2540
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred during import."
 msgstr "Beim Import ist ein unerwarteter Fehler aufgetreten."
@@ -2308,19 +2308,19 @@ msgstr "Geschäftsinformationen"
 msgid "Business Logo"
 msgstr "Firmenlogo"
 
-#: lib/klass_hero_web/components/provider_components.ex:960
+#: lib/klass_hero_web/components/provider_components.ex:982
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "Category"
 msgstr "Kategorie"
 
-#: lib/klass_hero_web/components/provider_components.ex:1098
+#: lib/klass_hero_web/components/provider_components.ex:1144
 #, elixir-autogen, elixir-format
 msgid "Check eligibility at"
 msgstr "Berechtigung prüfen unter"
 
-#: lib/klass_hero_web/components/provider_components.ex:2023
-#: lib/klass_hero_web/components/provider_components.ex:2249
+#: lib/klass_hero_web/components/provider_components.ex:2069
+#: lib/klass_hero_web/components/provider_components.ex:2295
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr "Name des Kindes"
@@ -2335,7 +2335,7 @@ msgstr "Kind erfüllt die Programmanforderungen nicht"
 msgid "Child meets all program requirements"
 msgstr "Kind erfüllt alle Programmanforderungen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1259
+#: lib/klass_hero_web/components/provider_components.ex:1305
 #, elixir-autogen, elixir-format
 msgid "Choose Image"
 msgstr "Bild auswählen"
@@ -2350,7 +2350,7 @@ msgstr "Logo auswählen"
 msgid "Choose Photo"
 msgstr "Foto auswählen"
 
-#: lib/klass_hero_web/components/provider_components.ex:962
+#: lib/klass_hero_web/components/provider_components.ex:984
 #, elixir-autogen, elixir-format
 msgid "Choose a category"
 msgstr "Kategorie auswählen"
@@ -2365,7 +2365,7 @@ msgstr "Schließen Sie die Geschäftsverifizierung ab, um Programme zu erstellen
 msgid "Confirm rejection"
 msgstr "Ablehnung bestätigen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2455
+#: lib/klass_hero_web/components/provider_components.ex:2501
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr "Bestätigt"
@@ -2375,32 +2375,32 @@ msgstr "Bestätigt"
 msgid "Contact Provider"
 msgstr "Anbieter kontaktieren"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:448
+#: lib/klass_hero_web/live/provider/programs_live.ex:451
 #, elixir-autogen, elixir-format
 msgid "Could not read the uploaded file."
 msgstr "Die hochgeladene Datei konnte nicht gelesen werden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:416
+#: lib/klass_hero_web/live/provider/programs_live.ex:419
 #, elixir-autogen, elixir-format
 msgid "Could not remove invite."
 msgstr "Einladung konnte nicht entfernt werden."
 
-#: lib/klass_hero_web/components/provider_components.ex:1215
+#: lib/klass_hero_web/components/provider_components.ex:1261
 #, elixir-autogen, elixir-format
 msgid "Cover Image"
 msgstr "Titelbild"
 
-#: lib/klass_hero_web/components/provider_components.ex:1092
+#: lib/klass_hero_web/components/provider_components.ex:1138
 #, elixir-autogen, elixir-format
 msgid "Define age, gender, or grade restrictions for eligible participants."
 msgstr "Legen Sie Alters-, Geschlechts- oder Klassenstufenbeschränkungen für teilnahmeberechtigte Teilnehmer fest."
 
-#: lib/klass_hero_web/components/provider_components.ex:1208
+#: lib/klass_hero_web/components/provider_components.ex:1254
 #, elixir-autogen, elixir-format
 msgid "Describe your program..."
 msgstr "Beschreiben Sie Ihr Programm..."
 
-#: lib/klass_hero_web/components/provider_components.ex:1207
+#: lib/klass_hero_web/components/provider_components.ex:1253
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:323
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:285
 #, elixir-autogen, elixir-format
@@ -2408,13 +2408,13 @@ msgid "Description"
 msgstr "Beschreibung"
 
 #: lib/klass_hero_web/components/program_components.ex:684
-#: lib/klass_hero_web/components/provider_components.ex:1160
+#: lib/klass_hero_web/components/provider_components.ex:1206
 #: lib/klass_hero_web/live/settings/children_live.ex:635
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr "Divers"
 
-#: lib/klass_hero_web/components/provider_components.ex:2670
+#: lib/klass_hero_web/components/provider_components.ex:2716
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr "Dokumenttyp"
@@ -2448,7 +2448,7 @@ msgstr "Dokument abgelehnt."
 msgid "Document uploaded successfully."
 msgstr "Dokument erfolgreich hochgeladen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2216
+#: lib/klass_hero_web/components/provider_components.ex:2262
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr "Vorlage herunterladen"
@@ -2458,7 +2458,7 @@ msgstr "Vorlage herunterladen"
 msgid "Download document"
 msgstr "Dokument herunterladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:928
+#: lib/klass_hero_web/components/provider_components.ex:950
 #, elixir-autogen, elixir-format
 msgid "Edit Program"
 msgstr "Programm bearbeiten"
@@ -2468,30 +2468,30 @@ msgstr "Programm bearbeiten"
 msgid "Edit Team Member"
 msgstr "Teammitglied bearbeiten"
 
-#: lib/klass_hero_web/components/provider_components.ex:1037
+#: lib/klass_hero_web/components/provider_components.ex:1059
 #, elixir-autogen, elixir-format
 msgid "End Date"
 msgstr "Enddatum"
 
-#: lib/klass_hero_web/components/provider_components.ex:1024
+#: lib/klass_hero_web/components/provider_components.ex:1046
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:166
 #, elixir-autogen, elixir-format
 msgid "End Time"
 msgstr "Endzeit"
 
-#: lib/klass_hero_web/components/provider_components.ex:2029
-#: lib/klass_hero_web/components/provider_components.ex:2475
+#: lib/klass_hero_web/components/provider_components.ex:2075
+#: lib/klass_hero_web/components/provider_components.ex:2521
 #: lib/klass_hero_web/components/provider_layout_components.ex:644
 #, elixir-autogen, elixir-format
 msgid "Enrolled"
 msgstr "Angemeldet"
 
-#: lib/klass_hero_web/components/provider_components.ex:1711
+#: lib/klass_hero_web/components/provider_components.ex:1757
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr "Angemeldet (%{count})"
 
-#: lib/klass_hero_web/components/provider_components.ex:1065
+#: lib/klass_hero_web/components/provider_components.ex:1087
 #, elixir-autogen, elixir-format
 msgid "Enrollment Capacity (optional)"
 msgstr "Anmeldekapazität (optional)"
@@ -2502,7 +2502,7 @@ msgid "Explain why this document is being rejected..."
 msgstr "Erklären Sie, warum dieses Dokument abgelehnt wird..."
 
 #: lib/klass_hero_web/components/provider_components.ex:71
-#: lib/klass_hero_web/components/provider_components.ex:2476
+#: lib/klass_hero_web/components/provider_components.ex:2522
 #: lib/klass_hero_web/live/admin/emails_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2518,7 +2518,7 @@ msgstr "Dokument konnte nicht genehmigt werden."
 msgid "Failed to reject document."
 msgstr "Dokument konnte nicht abgelehnt werden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:398
+#: lib/klass_hero_web/live/provider/programs_live.ex:401
 #, elixir-autogen, elixir-format
 msgid "Failed to resend invite."
 msgstr "Einladung konnte nicht erneut gesendet werden."
@@ -2535,7 +2535,7 @@ msgid "Family Programs"
 msgstr "Familienprogramme"
 
 #: lib/klass_hero_web/components/program_components.ex:682
-#: lib/klass_hero_web/components/provider_components.ex:1159
+#: lib/klass_hero_web/components/provider_components.ex:1205
 #: lib/klass_hero_web/live/settings/children_live.ex:634
 #, elixir-autogen, elixir-format
 msgid "Female"
@@ -2546,12 +2546,12 @@ msgstr "Weiblich"
 msgid "File"
 msgstr "Datei"
 
-#: lib/klass_hero_web/components/provider_components.ex:2604
+#: lib/klass_hero_web/components/provider_components.ex:2650
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr "Die Datei ist zu groß."
 
-#: lib/klass_hero_web/components/provider_components.ex:2606
+#: lib/klass_hero_web/components/provider_components.ex:2652
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr "Dateityp wird nicht akzeptiert."
@@ -2586,7 +2586,7 @@ msgstr "Klassenstufe %{min}+"
 msgid "Grades %{min} – %{max}"
 msgstr "Klassenstufen %{min} – %{max}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2252
+#: lib/klass_hero_web/components/provider_components.ex:2298
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr "E-Mail des Erziehungsberechtigten"
@@ -2601,7 +2601,7 @@ msgstr "Porträtfoto"
 msgid "ID Document"
 msgstr "Ausweisdokument"
 
-#: lib/klass_hero_web/components/provider_components.ex:2189
+#: lib/klass_hero_web/components/provider_components.ex:2235
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Importieren"
@@ -2611,22 +2611,22 @@ msgstr "Importieren"
 msgid "Insurance Certificate"
 msgstr "Versicherungsnachweis"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:413
+#: lib/klass_hero_web/live/provider/programs_live.ex:416
 #, elixir-autogen, elixir-format
 msgid "Invite not found."
 msgstr "Einladung nicht gefunden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:410
+#: lib/klass_hero_web/live/provider/programs_live.ex:413
 #, elixir-autogen, elixir-format
 msgid "Invite removed."
 msgstr "Einladung entfernt."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:387
+#: lib/klass_hero_web/live/provider/programs_live.ex:390
 #, elixir-autogen, elixir-format
 msgid "Invite resent successfully."
 msgstr "Einladung erfolgreich erneut gesendet."
 
-#: lib/klass_hero_web/components/provider_components.ex:1728
+#: lib/klass_hero_web/components/provider_components.ex:1774
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr "Einladungen (%{count})"
@@ -2636,7 +2636,7 @@ msgstr "Einladungen (%{count})"
 msgid "JPG, PNG or WebP. Max 1MB."
 msgstr "JPG, PNG oder WebP. Max. 1 MB."
 
-#: lib/klass_hero_web/components/provider_components.ex:1262
+#: lib/klass_hero_web/components/provider_components.ex:1308
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:277
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:361
 #, elixir-autogen, elixir-format
@@ -2658,17 +2658,17 @@ msgstr "Klasse %{n}"
 msgid "Last Name"
 msgstr "Nachname"
 
-#: lib/klass_hero_web/components/provider_components.ex:1047
+#: lib/klass_hero_web/components/provider_components.ex:1069
 #, elixir-autogen, elixir-format
 msgid "Leave blank for open registration at any time."
 msgstr "Leer lassen für eine jederzeit offene Anmeldung."
 
-#: lib/klass_hero_web/components/provider_components.ex:1152
+#: lib/klass_hero_web/components/provider_components.ex:1198
 #, elixir-autogen, elixir-format
 msgid "Leave unchecked to allow all genders."
 msgstr "Nicht markiert lassen, um alle Geschlechter zuzulassen."
 
-#: lib/klass_hero_web/components/provider_components.ex:980
+#: lib/klass_hero_web/components/provider_components.ex:1002
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Location"
@@ -2681,43 +2681,43 @@ msgid "Logo upload failed. Please try again."
 msgstr "Logo-Upload fehlgeschlagen. Bitte versuchen Sie es erneut."
 
 #: lib/klass_hero_web/components/program_components.ex:683
-#: lib/klass_hero_web/components/provider_components.ex:1158
+#: lib/klass_hero_web/components/provider_components.ex:1204
 #: lib/klass_hero_web/live/settings/children_live.ex:633
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr "Männlich"
 
-#: lib/klass_hero_web/components/provider_components.ex:1142
+#: lib/klass_hero_web/components/provider_components.ex:1188
 #, elixir-autogen, elixir-format
 msgid "Maximum Age (months)"
 msgstr "Höchstalter (Monate)"
 
-#: lib/klass_hero_web/components/provider_components.ex:1080
+#: lib/klass_hero_web/components/provider_components.ex:1102
 #, elixir-autogen, elixir-format
 msgid "Maximum Enrollment"
 msgstr "Maximale Anmeldekapazität"
 
-#: lib/klass_hero_web/components/provider_components.ex:1197
+#: lib/klass_hero_web/components/provider_components.ex:1243
 #, elixir-autogen, elixir-format
 msgid "Maximum Grade"
 msgstr "Höchste Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:989
+#: lib/klass_hero_web/components/provider_components.ex:1011
 #, elixir-autogen, elixir-format
 msgid "Meeting Days"
 msgstr "Wochentage"
 
-#: lib/klass_hero_web/components/provider_components.ex:1136
+#: lib/klass_hero_web/components/provider_components.ex:1182
 #, elixir-autogen, elixir-format
 msgid "Minimum Age (months)"
 msgstr "Mindestalter (Monate)"
 
-#: lib/klass_hero_web/components/provider_components.ex:1074
+#: lib/klass_hero_web/components/provider_components.ex:1096
 #, elixir-autogen, elixir-format
 msgid "Minimum Enrollment"
 msgstr "Minimale Anmeldekapazität"
 
-#: lib/klass_hero_web/components/provider_components.ex:1190
+#: lib/klass_hero_web/components/provider_components.ex:1236
 #, elixir-autogen, elixir-format
 msgid "Minimum Grade"
 msgstr "Niedrigste Klassenstufe"
@@ -2727,18 +2727,18 @@ msgstr "Niedrigste Klassenstufe"
 msgid "No approved documents."
 msgstr "Keine genehmigten Dokumente."
 
-#: lib/klass_hero_web/components/provider_components.ex:2632
+#: lib/klass_hero_web/components/provider_components.ex:2678
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr "Noch keine Dokumente hochgeladen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2016
+#: lib/klass_hero_web/components/provider_components.ex:2062
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
 msgstr "Noch keine Anmeldungen."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:444
+#: lib/klass_hero_web/live/provider/programs_live.ex:447
 #, elixir-autogen, elixir-format
 msgid "No file selected."
 msgstr "Keine Datei ausgewählt."
@@ -2748,17 +2748,17 @@ msgstr "Keine Datei ausgewählt."
 msgid "No grade"
 msgstr "Keine Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2240
+#: lib/klass_hero_web/components/provider_components.ex:2286
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr "Noch keine Einladungen. Laden Sie eine CSV-Datei hoch, um Familien einzuladen."
 
-#: lib/klass_hero_web/components/provider_components.ex:1199
+#: lib/klass_hero_web/components/provider_components.ex:1245
 #, elixir-autogen, elixir-format
 msgid "No maximum"
 msgstr "Kein Maximum"
 
-#: lib/klass_hero_web/components/provider_components.ex:1192
+#: lib/klass_hero_web/components/provider_components.ex:1238
 #, elixir-autogen, elixir-format
 msgid "No minimum"
 msgstr "Kein Minimum"
@@ -2789,7 +2789,7 @@ msgstr "Noch keine Teammitglieder"
 msgid "No verification documents found."
 msgstr "Keine Verifizierungsdokumente gefunden."
 
-#: lib/klass_hero_web/components/provider_components.ex:1274
+#: lib/klass_hero_web/components/provider_components.ex:1320
 #, elixir-autogen, elixir-format
 msgid "None (optional)"
 msgstr "Keine (optional)"
@@ -2800,7 +2800,7 @@ msgid "Not Verified"
 msgstr "Nicht verifiziert"
 
 #: lib/klass_hero_web/components/program_components.ex:685
-#: lib/klass_hero_web/components/provider_components.ex:1161
+#: lib/klass_hero_web/components/provider_components.ex:1207
 #: lib/klass_hero_web/live/settings/children_live.ex:632
 #, elixir-autogen, elixir-format
 msgid "Not specified"
@@ -2811,7 +2811,7 @@ msgstr "Nicht angegeben"
 msgid "Our Story"
 msgstr "Unsere Geschichte"
 
-#: lib/klass_hero_web/components/provider_components.ex:2707
+#: lib/klass_hero_web/components/provider_components.ex:2753
 #: lib/klass_hero_web/live/provider/verification_live.ex:698
 #: lib/klass_hero_web/live/provider/verification_live.ex:770
 #, elixir-autogen, elixir-format
@@ -2823,7 +2823,7 @@ msgstr "PDF, JPG oder PNG. Max. 10 MB."
 msgid "Participant Requirements"
 msgstr "Teilnahmevoraussetzungen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1089
+#: lib/klass_hero_web/components/provider_components.ex:1135
 #, elixir-autogen, elixir-format
 msgid "Participant Restrictions (optional)"
 msgstr "Teilnahmebeschränkungen (optional)"
@@ -2838,8 +2838,8 @@ msgstr "Ausstehende Überprüfung"
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:106
-#: lib/klass_hero_web/live/provider/programs_live.ex:685
-#: lib/klass_hero_web/live/provider/programs_live.ex:747
+#: lib/klass_hero_web/live/provider/programs_live.ex:690
+#: lib/klass_hero_web/live/provider/programs_live.ex:759
 #: lib/klass_hero_web/live/provider/team_live.ex:305
 #: lib/klass_hero_web/live/provider/team_live.ex:348
 #: lib/klass_hero_web/live/provider/team_live.ex:467
@@ -2857,7 +2857,7 @@ msgstr "Bitte geben Sie einen Ablehnungsgrund an."
 msgid "Preview not available for this file type."
 msgstr "Vorschau für diesen Dateityp nicht verfügbar."
 
-#: lib/klass_hero_web/components/provider_components.ex:971
+#: lib/klass_hero_web/components/provider_components.ex:993
 #, elixir-autogen, elixir-format
 msgid "Price (EUR)"
 msgstr "Preis (EUR)"
@@ -2867,31 +2867,31 @@ msgstr "Preis (EUR)"
 msgid "Profile updated successfully."
 msgstr "Profil erfolgreich aktualisiert."
 
-#: lib/klass_hero_web/components/provider_components.ex:1127
+#: lib/klass_hero_web/components/provider_components.ex:1173
 #, elixir-autogen, elixir-format
 msgid "Program Start"
 msgstr "Programmbeginn"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1151
+#: lib/klass_hero_web/live/provider/programs_live.ex:1208
 #, elixir-autogen, elixir-format
 msgid "Program created successfully."
 msgstr "Programm erfolgreich erstellt."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1155
+#: lib/klass_hero_web/live/provider/programs_live.ex:1212
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr "Programm erstellt, aber die Anmeldekapazität konnte nicht gespeichert werden. Bearbeiten Sie das Programm, um es erneut zu versuchen."
 
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:54
-#: lib/klass_hero_web/live/provider/programs_live.ex:152
-#: lib/klass_hero_web/live/provider/programs_live.ex:189
-#: lib/klass_hero_web/live/provider/programs_live.ex:253
-#: lib/klass_hero_web/live/provider/programs_live.ex:722
+#: lib/klass_hero_web/live/provider/programs_live.ex:155
+#: lib/klass_hero_web/live/provider/programs_live.ex:192
+#: lib/klass_hero_web/live/provider/programs_live.ex:256
+#: lib/klass_hero_web/live/provider/programs_live.ex:734
 #, elixir-autogen, elixir-format
 msgid "Program not found."
 msgstr "Programm nicht gefunden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1152
+#: lib/klass_hero_web/live/provider/programs_live.ex:1209
 #, elixir-autogen, elixir-format
 msgid "Program updated successfully."
 msgstr "Programm erfolgreich aktualisiert."
@@ -2909,13 +2909,13 @@ msgid "Read our founding story →"
 msgstr "Lesen Sie unsere Gründungsgeschichte →"
 
 #: lib/klass_hero_web/components/participation_components.ex:805
-#: lib/klass_hero_web/components/provider_components.ex:2474
+#: lib/klass_hero_web/components/provider_components.ex:2520
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Registered"
 msgstr "Registriert"
 
-#: lib/klass_hero_web/components/provider_components.ex:1114
+#: lib/klass_hero_web/components/provider_components.ex:1160
 #, elixir-autogen, elixir-format
 msgid "Registration"
 msgstr "Anmeldung"
@@ -2925,7 +2925,7 @@ msgstr "Anmeldung"
 msgid "Registration Closed"
 msgstr "Anmeldung geschlossen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1058
+#: lib/klass_hero_web/components/provider_components.ex:1080
 #, elixir-autogen, elixir-format
 msgid "Registration Closes"
 msgstr "Anmeldeschluss"
@@ -2935,12 +2935,12 @@ msgstr "Anmeldeschluss"
 msgid "Registration Not Open Yet"
 msgstr "Anmeldung noch nicht geöffnet"
 
-#: lib/klass_hero_web/components/provider_components.ex:1053
+#: lib/klass_hero_web/components/provider_components.ex:1075
 #, elixir-autogen, elixir-format
 msgid "Registration Opens"
 msgstr "Anmeldebeginn"
 
-#: lib/klass_hero_web/components/provider_components.ex:1044
+#: lib/klass_hero_web/components/provider_components.ex:1066
 #, elixir-autogen, elixir-format
 msgid "Registration Period (optional)"
 msgstr "Anmeldezeitraum (optional)"
@@ -2990,17 +2990,17 @@ msgid "Rejection reason"
 msgstr "Ablehnungsgrund"
 
 #: lib/klass_hero_web/components/provider_components.ex:839
-#: lib/klass_hero_web/components/provider_components.ex:1238
-#: lib/klass_hero_web/components/provider_components.ex:2296
-#: lib/klass_hero_web/components/provider_components.ex:2726
-#: lib/klass_hero_web/components/provider_components.ex:2805
+#: lib/klass_hero_web/components/provider_components.ex:1284
+#: lib/klass_hero_web/components/provider_components.ex:2342
+#: lib/klass_hero_web/components/provider_components.ex:2772
+#: lib/klass_hero_web/components/provider_components.ex:2851
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:253
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr "Entfernen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2289
+#: lib/klass_hero_web/components/provider_components.ex:2335
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr "Einladung erneut senden"
@@ -3015,18 +3015,18 @@ msgstr "Überprüft"
 msgid "Role"
 msgstr "Rolle"
 
-#: lib/klass_hero_web/components/provider_components.ex:1657
+#: lib/klass_hero_web/components/provider_components.ex:1703
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:386
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
 msgstr "Teilnehmerliste: %{name}"
 
-#: lib/klass_hero_web/components/provider_components.ex:1301
+#: lib/klass_hero_web/components/provider_components.ex:1347
 #, elixir-autogen, elixir-format
 msgid "Save Program"
 msgstr "Programm speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:986
+#: lib/klass_hero_web/components/provider_components.ex:1008
 #, elixir-autogen, elixir-format
 msgid "Schedule (optional)"
 msgstr "Zeitplan (optional)"
@@ -3041,7 +3041,7 @@ msgstr "Zeitplan noch offen"
 msgid "School Grade (optional)"
 msgstr "Klassenstufe (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2704
+#: lib/klass_hero_web/components/provider_components.ex:2750
 #, elixir-autogen, elixir-format
 msgid "Select File"
 msgstr "Datei auswählen"
@@ -3052,13 +3052,13 @@ msgstr "Datei auswählen"
 msgid "Selected child does not meet the program requirements."
 msgstr "Das ausgewählte Kind erfüllt die Programmanforderungen nicht."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:675
-#: lib/klass_hero_web/live/provider/programs_live.ex:737
+#: lib/klass_hero_web/live/provider/programs_live.ex:680
+#: lib/klass_hero_web/live/provider/programs_live.ex:749
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr "Der ausgewählte Kursleiter konnte nicht gefunden werden. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2473
+#: lib/klass_hero_web/components/provider_components.ex:2519
 #: lib/klass_hero_web/live/admin/emails_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Sent"
@@ -3069,7 +3069,7 @@ msgstr "Gesendet"
 msgid "Separate multiple qualifications with commas"
 msgstr "Trennen Sie mehrere Qualifikationen durch Kommas"
 
-#: lib/klass_hero_web/components/provider_components.ex:1068
+#: lib/klass_hero_web/components/provider_components.ex:1090
 #, elixir-autogen, elixir-format
 msgid "Set minimum and maximum enrollment for this program."
 msgstr "Legen Sie die minimale und maximale Anmeldekapazität für dieses Programm fest."
@@ -3092,12 +3092,12 @@ msgstr "Der Mitarbeiter existiert nicht mehr."
 msgid "Staff member not found."
 msgstr "Mitarbeiter nicht gefunden."
 
-#: lib/klass_hero_web/components/provider_components.ex:1032
+#: lib/klass_hero_web/components/provider_components.ex:1054
 #, elixir-autogen, elixir-format
 msgid "Start Date"
 msgstr "Startdatum"
 
-#: lib/klass_hero_web/components/provider_components.ex:1019
+#: lib/klass_hero_web/components/provider_components.ex:1041
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Start Time"
@@ -3153,22 +3153,22 @@ msgstr "Erzählen Sie Eltern von Ihrer Organisation..."
 msgid "The Klass Hero Story"
 msgstr "Die Geschichte von Klass Hero"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:390
+#: lib/klass_hero_web/live/provider/programs_live.ex:393
 #, elixir-autogen, elixir-format
 msgid "This invite cannot be resent."
 msgstr "Diese Einladung kann nicht erneut gesendet werden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:729
+#: lib/klass_hero_web/live/provider/programs_live.ex:741
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr "Dieses Programm wurde von jemand anderem geändert. Bitte schließen Sie es und versuchen Sie es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:953
+#: lib/klass_hero_web/components/provider_components.ex:975
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr "Titel"
 
-#: lib/klass_hero_web/components/provider_components.ex:2605
+#: lib/klass_hero_web/components/provider_components.ex:2651
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr "Zu viele Dateien."
@@ -3188,32 +3188,32 @@ msgstr "Bis zu %{max}"
 msgid "Up to Grade %{max}"
 msgstr "Bis Klassenstufe %{max}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2175
+#: lib/klass_hero_web/components/provider_components.ex:2221
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr "CSV hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2750
+#: lib/klass_hero_web/components/provider_components.ex:2796
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr "Dokument hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2659
+#: lib/klass_hero_web/components/provider_components.ex:2705
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr "Neues Dokument hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2627
+#: lib/klass_hero_web/components/provider_components.ex:2673
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr "Laden Sie Dokumente hoch, um Ihr Unternehmen zu verifizieren. Die Dokumente werden von unserem Team überprüft."
 
-#: lib/klass_hero_web/components/provider_components.ex:2607
+#: lib/klass_hero_web/components/provider_components.ex:2653
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr "Upload-Fehler."
 
-#: lib/klass_hero_web/components/provider_components.ex:2624
+#: lib/klass_hero_web/components/provider_components.ex:2670
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr "Verifizierungsdokumente"
@@ -3272,12 +3272,12 @@ msgstr "z. B. Mike"
 msgid "e.g. mike@example.com"
 msgstr "z. B. mike@example.com"
 
-#: lib/klass_hero_web/components/provider_components.ex:954
+#: lib/klass_hero_web/components/provider_components.ex:976
 #, elixir-autogen, elixir-format
 msgid "e.g., Art Adventures"
 msgstr "z. B. Art Adventures"
 
-#: lib/klass_hero_web/components/provider_components.ex:981
+#: lib/klass_hero_web/components/provider_components.ex:1003
 #, elixir-autogen, elixir-format
 msgid "e.g., Community Center, Main St"
 msgstr "z. B. Gemeindezentrum, Hauptstraße"
@@ -3303,7 +3303,7 @@ msgid "Child Safeguarding Training"
 msgstr "Kinderschutzschulung"
 
 #: lib/klass_hero_web/components/marketing_components.ex:1498
-#: lib/klass_hero_web/components/provider_components.ex:2972
+#: lib/klass_hero_web/components/provider_components.ex:3018
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr "Vereinbarung zu Community-Standards"
@@ -3373,7 +3373,7 @@ msgstr "Zahlung per Bargeld oder Banküberweisung"
 msgid "Program fee:"
 msgstr "Programmgebühr:"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:973
+#: lib/klass_hero_web/live/provider/programs_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr "Programm gespeichert, aber der Upload des Titelbilds ist fehlgeschlagen. Sie können es erneut hochladen, indem Sie das Programm bearbeiten."
@@ -3453,7 +3453,7 @@ msgid "Vetted with Care"
 msgstr "Mit Sorgfalt geprüft"
 
 #: lib/klass_hero_web/components/marketing_components.ex:1482
-#: lib/klass_hero_web/components/provider_components.ex:2757
+#: lib/klass_hero_web/components/provider_components.ex:2803
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr "Video-Überprüfung"
@@ -3589,7 +3589,7 @@ msgstr "Kann ich meine Programme auf Klass Hero listen und was kostet das?"
 msgid "Cannot check out without a check-in"
 msgstr "Auschecken ohne Einchecken nicht möglich"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:362
+#: lib/klass_hero_web/live/provider/programs_live.ex:365
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
@@ -3627,7 +3627,7 @@ msgstr "Eingecheckt"
 msgid "Checked Out"
 msgstr "Ausgecheckt"
 
-#: lib/klass_hero_web/components/provider_components.ex:2332
+#: lib/klass_hero_web/components/provider_components.ex:2378
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Child"
@@ -3654,7 +3654,7 @@ msgid "Correct"
 msgstr "Korrigieren"
 
 #: lib/klass_hero_web/live/dashboard_live.ex:288
-#: lib/klass_hero_web/live/provider/programs_live.ex:359
+#: lib/klass_hero_web/live/provider/programs_live.ex:362
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Could not start conversation. Please try again."
@@ -3680,7 +3680,7 @@ msgstr "Benötige ich ein Konto, um zu buchen?"
 msgid "Download monthly statements for taxes"
 msgstr "Monatliche Abrechnungen für die Steuer herunterladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2093
+#: lib/klass_hero_web/components/provider_components.ex:2139
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "Enrollment not confirmed"
@@ -3758,7 +3758,7 @@ msgstr "Keine Änderungen erkannt"
 msgid "No chasing payments or sending invoices"
 msgstr "Kein Nachfassen bei Zahlungen oder Versenden von Rechnungen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1680
+#: lib/klass_hero_web/components/provider_components.ex:1726
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:407
 #, elixir-autogen, elixir-format
 msgid "No enrolled parents"
@@ -3781,7 +3781,7 @@ msgstr "Notizen"
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr "Oder: Jederzeit eine Sofortauszahlung anfordern (mindestens 50 €)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2092
+#: lib/klass_hero_web/components/provider_components.ex:2138
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -4411,7 +4411,7 @@ msgstr "Absenden"
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:24
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
-#: lib/klass_hero_web/live/provider/programs_live.ex:221
+#: lib/klass_hero_web/live/provider/programs_live.ex:224
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:156
 #, elixir-autogen, elixir-format
 msgid "Program"
@@ -4620,7 +4620,7 @@ msgid "Update your observation..."
 msgstr "Aktualisieren Sie Ihre Beobachtung..."
 
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:138
-#: lib/klass_hero_web/live/provider/programs_live.ex:441
+#: lib/klass_hero_web/live/provider/programs_live.ex:444
 #: lib/klass_hero_web/live/provider/verification_live.ex:240
 #: lib/klass_hero_web/live/provider/verification_live.ex:556
 #: lib/klass_hero_web/live/provider/verification_live.ex:594
@@ -4891,48 +4891,48 @@ msgstr "Ihr Profil ist bereits vollständig."
 msgid "for"
 msgstr "für"
 
-#: lib/klass_hero_web/components/provider_components.ex:1801
+#: lib/klass_hero_web/components/provider_components.ex:1847
 #, elixir-autogen, elixir-format
 msgid "Assigned staff"
 msgstr "Zugewiesenes Personal"
 
-#: lib/klass_hero_web/components/provider_components.ex:1803
+#: lib/klass_hero_web/components/provider_components.ex:1849
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr "Anwesenheit"
 
-#: lib/klass_hero_web/components/provider_components.ex:1785
-#: lib/klass_hero_web/components/provider_components.ex:1874
+#: lib/klass_hero_web/components/provider_components.ex:1831
+#: lib/klass_hero_web/components/provider_components.ex:1920
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr "Schließen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1802
+#: lib/klass_hero_web/components/provider_components.ex:1848
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr "Vertretung"
 
-#: lib/klass_hero_web/components/provider_components.ex:1800
+#: lib/klass_hero_web/components/provider_components.ex:1846
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr "Datum / Uhrzeit"
 
-#: lib/klass_hero_web/components/provider_components.ex:1794
+#: lib/klass_hero_web/components/provider_components.ex:1840
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled yet."
 msgstr "Noch keine Sessions geplant."
 
-#: lib/klass_hero_web/components/provider_components.ex:1783
+#: lib/klass_hero_web/components/provider_components.ex:1829
 #, elixir-autogen, elixir-format
 msgid "Sessions — %{title}"
 msgstr "Sessions — %{title}"
 
-#: lib/klass_hero_web/components/provider_components.ex:1523
+#: lib/klass_hero_web/components/provider_components.ex:1569
 #, elixir-autogen, elixir-format
 msgid "View sessions"
 msgstr "Sessions anzeigen"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:532
+#: lib/klass_hero_web/live/provider/programs_live.ex:535
 #, elixir-autogen, elixir-format
 msgid "Create a program before inviting participants."
 msgstr "Erstellen Sie zuerst ein Programm, bevor Sie Teilnehmer einladen."
@@ -4959,22 +4959,22 @@ msgstr "Abreisezeit ist kein gültiges Datum oder keine gültige Uhrzeit"
 msgid "Failed to update record"
 msgstr "Aktualisieren des Datensatzes fehlgeschlagen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2396
+#: lib/klass_hero_web/components/provider_components.ex:2442
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr "Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2115
+#: lib/klass_hero_web/components/provider_components.ex:2161
 #, elixir-autogen, elixir-format
 msgid "Invite mode"
 msgstr "Einladungsmodus"
 
-#: lib/klass_hero_web/components/provider_components.ex:2134
+#: lib/klass_hero_web/components/provider_components.ex:2180
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr "Einzelperson einladen"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:528
+#: lib/klass_hero_web/live/provider/programs_live.ex:531
 #, elixir-autogen, elixir-format
 msgid "Invite sent."
 msgstr "Einladung verschickt."
@@ -4984,12 +4984,12 @@ msgstr "Einladung verschickt."
 msgid "Leave blank to keep this child marked as present."
 msgstr "Leer lassen, um dieses Kind als anwesend markiert zu lassen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2409
+#: lib/klass_hero_web/components/provider_components.ex:2455
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr "Gesundheit & Einwilligungen (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2415
+#: lib/klass_hero_web/components/provider_components.ex:2461
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr "Gesundheitliche Besonderheiten"
@@ -5000,17 +5000,17 @@ msgstr "Gesundheitliche Besonderheiten"
 msgid "Nothing to update"
 msgstr "Nichts zu aktualisieren"
 
-#: lib/klass_hero_web/components/provider_components.ex:2417
+#: lib/klass_hero_web/components/provider_components.ex:2463
 #, elixir-autogen, elixir-format
 msgid "Nut allergy"
 msgstr "Nussallergie"
 
-#: lib/klass_hero_web/components/provider_components.ex:2421
+#: lib/klass_hero_web/components/provider_components.ex:2467
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr "Fotos dürfen in Marketingmaterialien verwendet werden"
 
-#: lib/klass_hero_web/components/provider_components.ex:2426
+#: lib/klass_hero_web/components/provider_components.ex:2472
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr "Fotos dürfen in sozialen Medien erscheinen"
@@ -5020,7 +5020,7 @@ msgstr "Fotos dürfen in sozialen Medien erscheinen"
 msgid "Present"
 msgstr "Anwesend"
 
-#: lib/klass_hero_web/components/provider_components.ex:2353
+#: lib/klass_hero_web/components/provider_components.ex:2399
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr "Hauptansprechpartner"
@@ -5047,22 +5047,22 @@ msgstr "Datensatz aktualisiert"
 msgid "Save changes"
 msgstr "Änderungen speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:2390
+#: lib/klass_hero_web/components/provider_components.ex:2436
 #, elixir-autogen, elixir-format
 msgid "School (optional)"
 msgstr "Schule (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2400
+#: lib/klass_hero_web/components/provider_components.ex:2446
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr "Schulname"
 
-#: lib/klass_hero_web/components/provider_components.ex:2374
+#: lib/klass_hero_web/components/provider_components.ex:2420
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr "Zweiter Ansprechpartner (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2443
+#: lib/klass_hero_web/components/provider_components.ex:2489
 #, elixir-autogen, elixir-format
 msgid "Send invite"
 msgstr "Einladung senden"
@@ -5072,12 +5072,12 @@ msgstr "Einladung senden"
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr "Aktualisieren Sie die Notiz für dieses Kind (z. B. um zu klären, was passiert ist)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2152
+#: lib/klass_hero_web/components/provider_components.ex:2198
 #, elixir-autogen, elixir-format
 msgid "Upload a list"
 msgstr "Liste hochladen"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:539
+#: lib/klass_hero_web/live/provider/programs_live.ex:542
 #, elixir-autogen, elixir-format
 msgid "An invite for this child and program already exists."
 msgstr "Für dieses Kind und Programm existiert bereits eine Einladung."
@@ -5172,7 +5172,7 @@ msgstr "Programm oder Session nicht gefunden."
 msgid "Property Damage"
 msgstr "Sachschaden"
 
-#: lib/klass_hero_web/components/provider_components.ex:1553
+#: lib/klass_hero_web/components/provider_components.ex:1599
 #, elixir-autogen, elixir-format
 msgid "Report Incident"
 msgstr "Vorfall melden"
@@ -5254,7 +5254,7 @@ msgstr "Ihre Woche mit den Kindern"
 msgid "Go to dashboard"
 msgstr "Zum Dashboard"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:484
+#: lib/klass_hero_web/live/provider/programs_live.ex:487
 #, elixir-autogen, elixir-format
 msgid "%{count} row could not be processed."
 msgid_plural "%{count} rows could not be processed."
@@ -5841,8 +5841,8 @@ msgstr "Wie wir Anbieter überprüfen"
 msgid "I'll be teaching"
 msgstr "Ich werde unterrichten"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:459
-#: lib/klass_hero_web/live/provider/programs_live.ex:481
+#: lib/klass_hero_web/live/provider/programs_live.ex:462
+#: lib/klass_hero_web/live/provider/programs_live.ex:484
 #, elixir-autogen, elixir-format
 msgid "Imported %{count} family."
 msgid_plural "Imported %{count} families."
@@ -5854,7 +5854,7 @@ msgstr[1] "%{count} Familien importiert."
 msgid "In 2025, Shane connected with his friend"
 msgstr "2025 tat sich Shane mit seinem Freund zusammen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1562
+#: lib/klass_hero_web/components/provider_components.ex:1608
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:43
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:74
 #, elixir-autogen, elixir-format
@@ -5924,7 +5924,7 @@ msgstr "Klass Hero ist das operative Rückgrat für Berlins Jugendpädagogen. Wi
 msgid "Last 8 weeks"
 msgstr "Letzte 8 Wochen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1272
+#: lib/klass_hero_web/components/provider_components.ex:1318
 #: lib/klass_hero_web/presenters/hero_cards_presenter.ex:27
 #, elixir-autogen, elixir-format
 msgid "Lead Instructor"
@@ -6131,7 +6131,7 @@ msgstr "Noch keine Programme — fügen Sie Ihr erstes über den Tab „Programm
 msgid "No registered children for this session."
 msgstr "Keine Kinder in dieser Sitzung angemeldet."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:468
+#: lib/klass_hero_web/live/provider/programs_live.ex:471
 #, elixir-autogen, elixir-format
 msgid "No rows imported. %{count} row could not be processed."
 msgid_plural "No rows imported. %{count} rows could not be processed."
@@ -6374,17 +6374,17 @@ msgstr "Umsatz (diese Woche)"
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr "Strenge Überprüfung, damit Familien immer wissen, wer die Gruppe leitet."
 
-#: lib/klass_hero_web/components/provider_components.ex:2482
+#: lib/klass_hero_web/components/provider_components.ex:2528
 #, elixir-autogen, elixir-format
 msgid "Row %{row}"
 msgstr "Zeile %{row}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2482
+#: lib/klass_hero_web/components/provider_components.ex:2528
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr "Zeile —"
 
-#: lib/klass_hero_web/components/provider_components.ex:2228
+#: lib/klass_hero_web/components/provider_components.ex:2274
 #, elixir-autogen, elixir-format
 msgid "Rows with errors"
 msgstr "Zeilen mit Fehlern"
@@ -7143,12 +7143,12 @@ msgstr "Deine Identität ist verifiziert."
 msgid "Experience validation"
 msgstr "Erfahrungsnachweis"
 
-#: lib/klass_hero_web/components/provider_components.ex:2786
+#: lib/klass_hero_web/components/provider_components.ex:2832
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr "MP4, MOV oder WEBM. Max. 100 MB."
 
-#: lib/klass_hero_web/components/provider_components.ex:2760
+#: lib/klass_hero_web/components/provider_components.ex:2806
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr "Nimm ein kurzes Video auf, in dem du dich vorstellst. Unser Team prüft es, um Kommunikationsfähigkeit und Übereinstimmung mit unseren Werten einzuschätzen."
@@ -7158,12 +7158,12 @@ msgstr "Nimm ein kurzes Video auf, in dem du dich vorstellst. Unser Team prüft 
 msgid "Safeguarding certificate"
 msgstr "Kinderschutz-Zertifikat"
 
-#: lib/klass_hero_web/components/provider_components.ex:2783
+#: lib/klass_hero_web/components/provider_components.ex:2829
 #, elixir-autogen, elixir-format
 msgid "Select Video"
 msgstr "Video auswählen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2829
+#: lib/klass_hero_web/components/provider_components.ex:2875
 #, elixir-autogen, elixir-format
 msgid "Upload Video"
 msgstr "Video hochladen"
@@ -7173,7 +7173,7 @@ msgstr "Video hochladen"
 msgid "Your browser does not support video playback."
 msgstr "Dein Browser unterstützt keine Videowiedergabe."
 
-#: lib/klass_hero_web/components/provider_components.ex:2976
+#: lib/klass_hero_web/components/provider_components.ex:3022
 #, elixir-autogen, elixir-format
 msgid "Confirm agreement"
 msgstr "Zustimmung bestätigen"
@@ -7183,12 +7183,12 @@ msgstr "Zustimmung bestätigen"
 msgid "Couldn't record your agreement. Please try again."
 msgstr "Deine Zustimmung konnte nicht gespeichert werden. Bitte versuche es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2999
+#: lib/klass_hero_web/components/provider_components.ex:3045
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr "Vereinbarung herunterladen (PDF)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2975
+#: lib/klass_hero_web/components/provider_components.ex:3021
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr "Ich habe die Klass Hero Community-Richtlinien gelesen und stimme ihnen zu."
@@ -7198,7 +7198,7 @@ msgstr "Ich habe die Klass Hero Community-Richtlinien gelesen und stimme ihnen z
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr "Bitte bestätige, dass du die Community-Richtlinien gelesen hast und ihnen zustimmst."
 
-#: lib/klass_hero_web/components/provider_components.ex:2884
+#: lib/klass_hero_web/components/provider_components.ex:2930
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr "Unterzeichnet von %{name} am %{date} (v%{version})."
@@ -7208,17 +7208,17 @@ msgstr "Unterzeichnet von %{name} am %{date} (v%{version})."
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr "Danke – deine Zustimmung zu den Community-Richtlinien wurde gespeichert."
 
-#: lib/klass_hero_web/components/provider_components.ex:2984
+#: lib/klass_hero_web/components/provider_components.ex:3030
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr "Die Community-Richtlinien wurden seit deiner letzten Zustimmung aktualisiert (v%{old}). Bitte lies sie erneut und stimme erneut zu."
 
-#: lib/klass_hero_web/components/provider_components.ex:2973
+#: lib/klass_hero_web/components/provider_components.ex:3019
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr "Der letzte Schritt: Lies die Klass Hero Community-Richtlinien und stimme ihnen zu."
 
-#: lib/klass_hero_web/components/provider_components.ex:2974
+#: lib/klass_hero_web/components/provider_components.ex:3020
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr "Du hast den Community-Richtlinien zugestimmt."
@@ -7487,12 +7487,12 @@ msgstr "Ihre Versicherungsbescheinigung wird geprüft."
 msgid "Your insurance is verified."
 msgstr "Ihre Versicherung ist verifiziert."
 
-#: lib/klass_hero_web/components/provider_components.ex:2928
+#: lib/klass_hero_web/components/provider_components.ex:2974
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr "Unterzeichnung durch %{name} im Namen des Unternehmens."
 
-#: lib/klass_hero_web/components/provider_components.ex:3031
+#: lib/klass_hero_web/components/provider_components.ex:3077
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr "Bestätige im Namen deines Unternehmens, dass alle Mitarbeitenden gemäß dem deutschen Kinderschutzrecht überprüft sind."
@@ -7502,7 +7502,7 @@ msgstr "Bestätige im Namen deines Unternehmens, dass alle Mitarbeitenden gemä�
 msgid "Couldn't record your declaration. Please try again."
 msgstr "Deine Erklärung konnte nicht gespeichert werden. Bitte versuche es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:3037
+#: lib/klass_hero_web/components/provider_components.ex:3083
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr "Ich bestätige im Namen des Unternehmens, dass die obige Erklärung zutrifft und ich zu ihrer Unterzeichnung berechtigt bin."
@@ -7512,17 +7512,17 @@ msgstr "Ich bestätige im Namen des Unternehmens, dass die obige Erklärung zutr
 msgid "Please confirm the declaration before signing."
 msgstr "Bitte bestätige die Erklärung vor der Unterzeichnung."
 
-#: lib/klass_hero_web/components/provider_components.ex:3062
+#: lib/klass_hero_web/components/provider_components.ex:3108
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr "Vorläufiger Text — vor der Freischaltung noch von einer in Deutschland zugelassenen Anwältin bzw. einem Anwalt zu prüfen."
 
-#: lib/klass_hero_web/components/provider_components.ex:3041
+#: lib/klass_hero_web/components/provider_components.ex:3087
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr "Erklärung unterzeichnen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3029
+#: lib/klass_hero_web/components/provider_components.ex:3075
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr "Erklärung zur Mitarbeiter-Compliance"
@@ -7532,12 +7532,12 @@ msgstr "Erklärung zur Mitarbeiter-Compliance"
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr "Danke — deine Erklärung zur Mitarbeiter-Compliance wurde erfasst."
 
-#: lib/klass_hero_web/components/provider_components.ex:3049
+#: lib/klass_hero_web/components/provider_components.ex:3095
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr "Die Erklärung zur Mitarbeiter-Compliance wurde seit deiner letzten Unterzeichnung aktualisiert (v%{old}). Bitte prüfe sie und unterzeichne erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:3035
+#: lib/klass_hero_web/components/provider_components.ex:3081
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr "Du hast die Erklärung zur Mitarbeiter-Compliance unterzeichnet."
@@ -7604,96 +7604,96 @@ msgstr "In Prüfung"
 msgid "Undelivered Events"
 msgstr "Nicht zugestellte Ereignisse"
 
-#: lib/klass_hero_web/components/provider_components.ex:1971
+#: lib/klass_hero_web/components/provider_components.ex:2017
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1896
+#: lib/klass_hero_web/components/provider_components.ex:1942
 #, elixir-autogen, elixir-format
 msgid "Lead"
 msgstr "Leitung"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:334
+#: lib/klass_hero_web/live/provider/programs_live.ex:337
 #, elixir-autogen, elixir-format
 msgid "Lead instructor updated."
 msgstr "Leitender Kursleiter aktualisiert."
 
-#: lib/klass_hero_web/components/provider_components.ex:1907
+#: lib/klass_hero_web/components/provider_components.ex:1953
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor"
 msgstr "Als leitenden Kursleiter festlegen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1537
+#: lib/klass_hero_web/components/provider_components.ex:1583
 #, elixir-autogen, elixir-format
 msgid "Manage Staffing"
 msgstr "Programmteam verwalten"
 
-#: lib/klass_hero_web/components/provider_components.ex:1935
+#: lib/klass_hero_web/components/provider_components.ex:1981
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this program yet."
 msgstr "Diesem Programm ist noch niemand zugewiesen."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:264
+#: lib/klass_hero_web/live/provider/programs_live.ex:267
 #, elixir-autogen, elixir-format
 msgid "Pick a staff member to add."
 msgstr "Bitte ein Teammitglied zum Hinzufügen auswählen."
 
-#: lib/klass_hero_web/components/provider_components.ex:1918
+#: lib/klass_hero_web/components/provider_components.ex:1964
 #, elixir-autogen, elixir-format
 msgid "Reassign the lead before removing them"
 msgstr "Vor dem Entfernen einen anderen leitenden Kursleiter festlegen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1919
+#: lib/klass_hero_web/components/provider_components.ex:1965
 #, elixir-autogen, elixir-format
 msgid "Remove from program"
 msgstr "Aus dem Programm entfernen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1953
+#: lib/klass_hero_web/components/provider_components.ex:1999
 #, elixir-autogen, elixir-format
 msgid "Select a staff member…"
 msgstr "Teammitglied auswählen …"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:279
+#: lib/klass_hero_web/live/provider/programs_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "Staff member added to the program."
 msgstr "Teammitglied zum Programm hinzugefügt."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:305
+#: lib/klass_hero_web/live/provider/programs_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "Staff member removed from the program."
 msgstr "Teammitglied aus dem Programm entfernt."
 
-#: lib/klass_hero_web/components/provider_components.ex:1976
+#: lib/klass_hero_web/components/provider_components.ex:2022
 #, elixir-autogen, elixir-format
 msgid "Staff you add can read and reply to this program's parent conversations."
 msgstr ""
 "Hinzugefügte Teammitglieder können die Elterngespräche dieses Programms lesen "
 "und beantworten."
 
-#: lib/klass_hero_web/components/provider_components.ex:1872
+#: lib/klass_hero_web/components/provider_components.ex:1918
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{title}"
 msgstr "Programmteam — %{title}"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:932
+#: lib/klass_hero_web/live/provider/programs_live.ex:944
 #, elixir-autogen, elixir-format
 msgid "That staff member could not be found."
 msgstr "Dieses Teammitglied wurde nicht gefunden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:287
+#: lib/klass_hero_web/live/provider/programs_live.ex:290
 #, elixir-autogen, elixir-format
 msgid "They are already on this program."
 msgstr "Diese Person ist bereits in diesem Programm."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:313
+#: lib/klass_hero_web/live/provider/programs_live.ex:316
 #, elixir-autogen, elixir-format
 msgid "This person is the lead instructor. Make someone else lead before removing them."
 msgstr ""
 "Diese Person ist der leitende Kursleiter. Bitte zuerst eine andere Person als "
 "Leitung festlegen."
 
-#: lib/klass_hero_web/components/provider_components.ex:1481
+#: lib/klass_hero_web/components/provider_components.ex:1527
 #, elixir-autogen, elixir-format
 msgid "%{count} staff member · no lead"
 msgid_plural "%{count} staff · no lead"
@@ -7750,23 +7750,45 @@ msgstr "Damit wird %{name} endgültig gelöscht – das lässt sich nicht rückg
 msgid "This person has a history here now — use 'Remove from team' instead."
 msgstr "Diese Person hat inzwischen eine Historie – nutze stattdessen „Aus dem Team entfernen“."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1165
+#: lib/klass_hero_web/live/provider/programs_live.ex:1222
 #, elixir-autogen, elixir-format
 msgid "Program created, but some settings could not be saved. Please review the program's limits."
 msgstr ""
 "Programm erstellt, aber einige Einstellungen konnten nicht gespeichert werden. "
 "Bitte überprüfen Sie die Grenzwerte des Programms."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1169
+#: lib/klass_hero_web/live/provider/programs_live.ex:1226
 #, elixir-autogen, elixir-format
 msgid "Program updated, but some settings could not be saved. Please review the program's limits."
 msgstr ""
 "Programm aktualisiert, aber einige Einstellungen konnten nicht gespeichert "
 "werden. Bitte überprüfen Sie die Grenzwerte des Programms."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1159
+#: lib/klass_hero_web/live/provider/programs_live.ex:1216
 #, elixir-autogen, elixir-format
 msgid "Program updated, but the enrollment capacity was rejected. The previous limits still apply."
 msgstr ""
 "Programm aktualisiert, aber die Anmeldekapazität wurde abgelehnt. Es gelten "
 "weiterhin die bisherigen Grenzwerte."
+
+#: lib/klass_hero_web/components/provider_components.ex:918
+#, elixir-autogen, elixir-format
+msgid "%{count} child is already enrolled. Confirm you want this program to have no capacity limit."
+msgid_plural "%{count} children are already enrolled. Confirm you want this program to have no capacity limit."
+msgstr[0] ""
+"%{count} Kind ist bereits angemeldet. Bestätigen Sie, dass dieses Programm "
+"keine Teilnehmerbegrenzung haben soll."
+msgstr[1] ""
+"%{count} Kinder sind bereits angemeldet. Bestätigen Sie, dass dieses "
+"Programm keine Teilnehmerbegrenzung haben soll."
+
+#: lib/klass_hero_web/components/provider_components.ex:1120
+#, elixir-autogen, elixir-format
+msgid "Anyone will be able to book a place until you set a new maximum."
+msgstr ""
+"Bis Sie ein neues Maximum festlegen, kann jede Person einen Platz buchen."
+
+#: lib/klass_hero_web/components/provider_components.ex:1125
+#, elixir-autogen, elixir-format
+msgid "I understand this program will have no capacity limit."
+msgstr "Ich verstehe, dass dieses Programm keine Teilnehmerbegrenzung haben wird."

--- a/priv/gettext/de/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/de/LC_MESSAGES/enrollment.po
@@ -11,105 +11,105 @@ msgstr ""
 "Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:2576
-#: lib/klass_hero_web/components/provider_components.ex:2593
+#: lib/klass_hero_web/components/provider_components.ex:2622
+#: lib/klass_hero_web/components/provider_components.ex:2639
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr "Vorname des Kindes"
 
-#: lib/klass_hero_web/components/provider_components.ex:2577
-#: lib/klass_hero_web/components/provider_components.ex:2594
+#: lib/klass_hero_web/components/provider_components.ex:2623
+#: lib/klass_hero_web/components/provider_components.ex:2640
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr "Nachname des Kindes"
 
-#: lib/klass_hero_web/components/provider_components.ex:2578
-#: lib/klass_hero_web/components/provider_components.ex:2595
+#: lib/klass_hero_web/components/provider_components.ex:2624
+#: lib/klass_hero_web/components/provider_components.ex:2641
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr "Geburtsdatum"
 
-#: lib/klass_hero_web/components/provider_components.ex:2589
+#: lib/klass_hero_web/components/provider_components.ex:2635
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr "Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2579
+#: lib/klass_hero_web/components/provider_components.ex:2625
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr "E-Mail des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2580
+#: lib/klass_hero_web/components/provider_components.ex:2626
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr "Vorname des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2581
+#: lib/klass_hero_web/components/provider_components.ex:2627
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr "Nachname des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2588
+#: lib/klass_hero_web/components/provider_components.ex:2634
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr "Programm"
 
-#: lib/klass_hero_web/components/provider_components.ex:2590
+#: lib/klass_hero_web/components/provider_components.ex:2636
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr "Schule"
 
-#: lib/klass_hero_web/components/provider_components.ex:2582
+#: lib/klass_hero_web/components/provider_components.ex:2628
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr "E-Mail des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2584
+#: lib/klass_hero_web/components/provider_components.ex:2630
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr "Vorname des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2586
+#: lib/klass_hero_web/components/provider_components.ex:2632
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr "Nachname des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2516
+#: lib/klass_hero_web/components/provider_components.ex:2562
 #, elixir-autogen, elixir-format
 msgid "Date of birth \"%{value}\" is not a valid date. Please correct it and resend."
 msgstr ""
 "Das Geburtsdatum „%{value}“ ist kein gültiges Datum. Bitte korrigieren Sie es "
 "und senden Sie die Einladung erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2510
+#: lib/klass_hero_web/components/provider_components.ex:2556
 #, elixir-autogen, elixir-format
 msgid "Invite link could not be generated (no token). Please resend."
 msgstr ""
 "Der Einladungslink konnte nicht erzeugt werden (kein Token). Bitte erneut "
 "senden."
 
-#: lib/klass_hero_web/components/provider_components.ex:2524
+#: lib/klass_hero_web/components/provider_components.ex:2570
 #, elixir-autogen, elixir-format
 msgid "The invitation email could not be delivered. Please check the address and resend."
 msgstr ""
 "Die Einladungs-E-Mail konnte nicht zugestellt werden. Bitte prüfen Sie die "
 "Adresse und senden Sie die Einladung erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2513
+#: lib/klass_hero_web/components/provider_components.ex:2559
 #, elixir-autogen, elixir-format
 msgid "The program is full, so this child could not be enrolled."
 msgstr ""
 "Das Programm ist ausgebucht, daher konnte dieses Kind nicht angemeldet "
 "werden."
 
-#: lib/klass_hero_web/components/provider_components.ex:2527
+#: lib/klass_hero_web/components/provider_components.ex:2573
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed and no retries remain. Please resend."
 msgstr ""
 "Diese Einladung konnte nicht abgeschlossen werden und es sind keine weiteren "
 "Versuche möglich. Bitte erneut senden."
 
-#: lib/klass_hero_web/components/provider_components.ex:2536
+#: lib/klass_hero_web/components/provider_components.ex:2582
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed. Please resend."
 msgstr "Diese Einladung konnte nicht abgeschlossen werden. Bitte erneut senden."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -137,7 +137,7 @@ msgid "Your Data"
 msgstr ""
 
 #: lib/klass_hero_web/components/core_components.ex:67
-#: lib/klass_hero_web/components/provider_components.ex:1687
+#: lib/klass_hero_web/components/provider_components.ex:1733
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr ""
@@ -232,7 +232,7 @@ msgstr ""
 msgid "Enroll Now - %{price}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1438
+#: lib/klass_hero_web/components/provider_components.ex:1484
 #: lib/klass_hero_web/live/booking_live.ex:285
 #, elixir-autogen, elixir-format
 msgid "Enrollment"
@@ -578,8 +578,8 @@ msgid "Dispute Resolution"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:719
-#: lib/klass_hero_web/components/provider_components.ex:2360
-#: lib/klass_hero_web/components/provider_components.ex:2378
+#: lib/klass_hero_web/components/provider_components.ex:2406
+#: lib/klass_hero_web/components/provider_components.ex:2424
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
@@ -878,9 +878,9 @@ msgstr ""
 msgid "Select one or both options"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2056
-#: lib/klass_hero_web/components/provider_components.ex:2057
-#: lib/klass_hero_web/components/provider_components.ex:2094
+#: lib/klass_hero_web/components/provider_components.ex:2102
+#: lib/klass_hero_web/components/provider_components.ex:2103
+#: lib/klass_hero_web/components/provider_components.ex:2140
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:448
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:484
@@ -1577,14 +1577,14 @@ msgstr ""
 msgid "Quick Navigation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1441
-#: lib/klass_hero_web/components/provider_components.ex:2032
-#: lib/klass_hero_web/components/provider_components.ex:2258
+#: lib/klass_hero_web/components/provider_components.ex:1487
+#: lib/klass_hero_web/components/provider_components.ex:2078
+#: lib/klass_hero_web/components/provider_components.ex:2304
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1580
+#: lib/klass_hero_web/components/provider_components.ex:1626
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr ""
@@ -1600,7 +1600,7 @@ msgstr ""
 msgid "All Staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1432
+#: lib/klass_hero_web/components/provider_components.ex:1478
 #, elixir-autogen, elixir-format
 msgid "Assigned Staff"
 msgstr ""
@@ -1628,7 +1628,7 @@ msgid "Create profiles for your staff. These will be visible to parents when ass
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:539
-#: lib/klass_hero_web/components/provider_components.ex:1543
+#: lib/klass_hero_web/components/provider_components.ex:1589
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:54
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:81
 #: lib/klass_hero_web/live/settings/children_live.ex:413
@@ -1645,7 +1645,7 @@ msgstr ""
 msgid "Edit Profile"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1582
+#: lib/klass_hero_web/components/provider_components.ex:1628
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr ""
@@ -1657,7 +1657,7 @@ msgid "My Programs"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:416
-#: lib/klass_hero_web/components/provider_components.ex:930
+#: lib/klass_hero_web/components/provider_components.ex:952
 #, elixir-autogen, elixir-format
 msgid "New Program"
 msgstr ""
@@ -1669,26 +1669,26 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:47
 #: lib/klass_hero_web/components/provider_components.ex:73
-#: lib/klass_hero_web/components/provider_components.ex:1581
-#: lib/klass_hero_web/components/provider_components.ex:2454
-#: lib/klass_hero_web/components/provider_components.ex:2472
+#: lib/klass_hero_web/components/provider_components.ex:1627
+#: lib/klass_hero_web/components/provider_components.ex:2500
+#: lib/klass_hero_web/components/provider_components.ex:2518
 #: lib/klass_hero_web/live/admin/sessions_live.ex:298
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1519
+#: lib/klass_hero_web/components/provider_components.ex:1565
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1372
+#: lib/klass_hero_web/components/provider_components.ex:1418
 #, elixir-autogen, elixir-format
 msgid "Program Inventory"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1429
+#: lib/klass_hero_web/components/provider_components.ex:1475
 #, elixir-autogen, elixir-format
 msgid "Program Name"
 msgstr ""
@@ -1703,15 +1703,15 @@ msgstr ""
 msgid "Save for Later"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1389
+#: lib/klass_hero_web/components/provider_components.ex:1435
 #, elixir-autogen, elixir-format
 msgid "Search by name..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1435
-#: lib/klass_hero_web/components/provider_components.ex:1804
-#: lib/klass_hero_web/components/provider_components.ex:2026
-#: lib/klass_hero_web/components/provider_components.ex:2255
+#: lib/klass_hero_web/components/provider_components.ex:1481
+#: lib/klass_hero_web/components/provider_components.ex:1850
+#: lib/klass_hero_web/components/provider_components.ex:2072
+#: lib/klass_hero_web/components/provider_components.ex:2301
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1735,15 +1735,15 @@ msgstr ""
 msgid "This is your main business identity. Verification is required to list programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1492
-#: lib/klass_hero_web/components/provider_components.ex:1819
+#: lib/klass_hero_web/components/provider_components.ex:1538
+#: lib/klass_hero_web/components/provider_components.ex:1865
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr ""
 
 #: lib/klass_hero_web/components/messaging_components.ex:722
 #: lib/klass_hero_web/components/provider_components.ex:50
-#: lib/klass_hero_web/components/provider_components.ex:1583
+#: lib/klass_hero_web/components/provider_components.ex:1629
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:434
 #: lib/klass_hero_web/presenters/provider_presenter.ex:103
 #, elixir-autogen, elixir-format
@@ -1755,7 +1755,7 @@ msgstr ""
 msgid "Verified Business"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1530
+#: lib/klass_hero_web/components/provider_components.ex:1576
 #, elixir-autogen, elixir-format
 msgid "View Roster"
 msgstr ""
@@ -1816,8 +1816,8 @@ msgstr ""
 #: lib/klass_hero_web/components/participation_components.ex:631
 #: lib/klass_hero_web/components/participation_components.ex:717
 #: lib/klass_hero_web/components/provider_components.ex:889
-#: lib/klass_hero_web/components/provider_components.ex:1288
-#: lib/klass_hero_web/components/provider_components.ex:2197
+#: lib/klass_hero_web/components/provider_components.ex:1334
+#: lib/klass_hero_web/components/provider_components.ex:2243
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:478
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
@@ -1873,7 +1873,7 @@ msgstr ""
 msgid "Data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2341
+#: lib/klass_hero_web/components/provider_components.ex:2387
 #: lib/klass_hero_web/live/settings/children_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1921,17 +1921,17 @@ msgstr ""
 msgid "Failed to submit note"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2335
-#: lib/klass_hero_web/components/provider_components.ex:2364
-#: lib/klass_hero_web/components/provider_components.ex:2380
+#: lib/klass_hero_web/components/provider_components.ex:2381
+#: lib/klass_hero_web/components/provider_components.ex:2410
+#: lib/klass_hero_web/components/provider_components.ex:2426
 #: lib/klass_hero_web/live/settings/children_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2336
-#: lib/klass_hero_web/components/provider_components.ex:2365
-#: lib/klass_hero_web/components/provider_components.ex:2381
+#: lib/klass_hero_web/components/provider_components.ex:2382
+#: lib/klass_hero_web/components/provider_components.ex:2411
+#: lib/klass_hero_web/components/provider_components.ex:2427
 #: lib/klass_hero_web/live/settings/children_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -2069,8 +2069,8 @@ msgstr ""
 msgid "Save Changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1665
-#: lib/klass_hero_web/components/provider_components.ex:1666
+#: lib/klass_hero_web/components/provider_components.ex:1711
+#: lib/klass_hero_web/components/provider_components.ex:1712
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:43
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:151
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:252
@@ -2088,7 +2088,7 @@ msgstr ""
 msgid "Send a message to start the conversation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2435
+#: lib/klass_hero_web/components/provider_components.ex:2481
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:249
 #, elixir-autogen, elixir-format
@@ -2219,12 +2219,12 @@ msgstr ""
 msgid "Ages %{min}+"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1149
+#: lib/klass_hero_web/components/provider_components.ex:1195
 #, elixir-autogen, elixir-format
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2494
+#: lib/klass_hero_web/components/provider_components.ex:2540
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred during import."
 msgstr ""
@@ -2308,19 +2308,19 @@ msgstr ""
 msgid "Business Logo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:960
+#: lib/klass_hero_web/components/provider_components.ex:982
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "Category"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1098
+#: lib/klass_hero_web/components/provider_components.ex:1144
 #, elixir-autogen, elixir-format
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2023
-#: lib/klass_hero_web/components/provider_components.ex:2249
+#: lib/klass_hero_web/components/provider_components.ex:2069
+#: lib/klass_hero_web/components/provider_components.ex:2295
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2335,7 +2335,7 @@ msgstr ""
 msgid "Child meets all program requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1259
+#: lib/klass_hero_web/components/provider_components.ex:1305
 #, elixir-autogen, elixir-format
 msgid "Choose Image"
 msgstr ""
@@ -2350,7 +2350,7 @@ msgstr ""
 msgid "Choose Photo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:962
+#: lib/klass_hero_web/components/provider_components.ex:984
 #, elixir-autogen, elixir-format
 msgid "Choose a category"
 msgstr ""
@@ -2365,7 +2365,7 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2455
+#: lib/klass_hero_web/components/provider_components.ex:2501
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
@@ -2375,32 +2375,32 @@ msgstr ""
 msgid "Contact Provider"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:448
+#: lib/klass_hero_web/live/provider/programs_live.ex:451
 #, elixir-autogen, elixir-format
 msgid "Could not read the uploaded file."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:416
+#: lib/klass_hero_web/live/provider/programs_live.ex:419
 #, elixir-autogen, elixir-format
 msgid "Could not remove invite."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1215
+#: lib/klass_hero_web/components/provider_components.ex:1261
 #, elixir-autogen, elixir-format
 msgid "Cover Image"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1092
+#: lib/klass_hero_web/components/provider_components.ex:1138
 #, elixir-autogen, elixir-format
 msgid "Define age, gender, or grade restrictions for eligible participants."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1208
+#: lib/klass_hero_web/components/provider_components.ex:1254
 #, elixir-autogen, elixir-format
 msgid "Describe your program..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1207
+#: lib/klass_hero_web/components/provider_components.ex:1253
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:323
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:285
 #, elixir-autogen, elixir-format
@@ -2408,13 +2408,13 @@ msgid "Description"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:684
-#: lib/klass_hero_web/components/provider_components.ex:1160
+#: lib/klass_hero_web/components/provider_components.ex:1206
 #: lib/klass_hero_web/live/settings/children_live.ex:635
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2670
+#: lib/klass_hero_web/components/provider_components.ex:2716
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2448,7 +2448,7 @@ msgstr ""
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2216
+#: lib/klass_hero_web/components/provider_components.ex:2262
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
@@ -2458,7 +2458,7 @@ msgstr ""
 msgid "Download document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:928
+#: lib/klass_hero_web/components/provider_components.ex:950
 #, elixir-autogen, elixir-format
 msgid "Edit Program"
 msgstr ""
@@ -2468,30 +2468,30 @@ msgstr ""
 msgid "Edit Team Member"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1037
+#: lib/klass_hero_web/components/provider_components.ex:1059
 #, elixir-autogen, elixir-format
 msgid "End Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1024
+#: lib/klass_hero_web/components/provider_components.ex:1046
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:166
 #, elixir-autogen, elixir-format
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2029
-#: lib/klass_hero_web/components/provider_components.ex:2475
+#: lib/klass_hero_web/components/provider_components.ex:2075
+#: lib/klass_hero_web/components/provider_components.ex:2521
 #: lib/klass_hero_web/components/provider_layout_components.ex:644
 #, elixir-autogen, elixir-format
 msgid "Enrolled"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1711
+#: lib/klass_hero_web/components/provider_components.ex:1757
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1065
+#: lib/klass_hero_web/components/provider_components.ex:1087
 #, elixir-autogen, elixir-format
 msgid "Enrollment Capacity (optional)"
 msgstr ""
@@ -2502,7 +2502,7 @@ msgid "Explain why this document is being rejected..."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:71
-#: lib/klass_hero_web/components/provider_components.ex:2476
+#: lib/klass_hero_web/components/provider_components.ex:2522
 #: lib/klass_hero_web/live/admin/emails_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2518,7 +2518,7 @@ msgstr ""
 msgid "Failed to reject document."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:398
+#: lib/klass_hero_web/live/provider/programs_live.ex:401
 #, elixir-autogen, elixir-format
 msgid "Failed to resend invite."
 msgstr ""
@@ -2535,7 +2535,7 @@ msgid "Family Programs"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:682
-#: lib/klass_hero_web/components/provider_components.ex:1159
+#: lib/klass_hero_web/components/provider_components.ex:1205
 #: lib/klass_hero_web/live/settings/children_live.ex:634
 #, elixir-autogen, elixir-format
 msgid "Female"
@@ -2546,12 +2546,12 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2604
+#: lib/klass_hero_web/components/provider_components.ex:2650
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2606
+#: lib/klass_hero_web/components/provider_components.ex:2652
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
@@ -2586,7 +2586,7 @@ msgstr ""
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2252
+#: lib/klass_hero_web/components/provider_components.ex:2298
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
@@ -2601,7 +2601,7 @@ msgstr ""
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2189
+#: lib/klass_hero_web/components/provider_components.ex:2235
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -2611,22 +2611,22 @@ msgstr ""
 msgid "Insurance Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:413
+#: lib/klass_hero_web/live/provider/programs_live.ex:416
 #, elixir-autogen, elixir-format
 msgid "Invite not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:410
+#: lib/klass_hero_web/live/provider/programs_live.ex:413
 #, elixir-autogen, elixir-format
 msgid "Invite removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:387
+#: lib/klass_hero_web/live/provider/programs_live.ex:390
 #, elixir-autogen, elixir-format
 msgid "Invite resent successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1728
+#: lib/klass_hero_web/components/provider_components.ex:1774
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr ""
@@ -2636,7 +2636,7 @@ msgstr ""
 msgid "JPG, PNG or WebP. Max 1MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1262
+#: lib/klass_hero_web/components/provider_components.ex:1308
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:277
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:361
 #, elixir-autogen, elixir-format
@@ -2658,17 +2658,17 @@ msgstr ""
 msgid "Last Name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1047
+#: lib/klass_hero_web/components/provider_components.ex:1069
 #, elixir-autogen, elixir-format
 msgid "Leave blank for open registration at any time."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1152
+#: lib/klass_hero_web/components/provider_components.ex:1198
 #, elixir-autogen, elixir-format
 msgid "Leave unchecked to allow all genders."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:980
+#: lib/klass_hero_web/components/provider_components.ex:1002
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Location"
@@ -2681,43 +2681,43 @@ msgid "Logo upload failed. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:683
-#: lib/klass_hero_web/components/provider_components.ex:1158
+#: lib/klass_hero_web/components/provider_components.ex:1204
 #: lib/klass_hero_web/live/settings/children_live.ex:633
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1142
+#: lib/klass_hero_web/components/provider_components.ex:1188
 #, elixir-autogen, elixir-format
 msgid "Maximum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1080
+#: lib/klass_hero_web/components/provider_components.ex:1102
 #, elixir-autogen, elixir-format
 msgid "Maximum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1197
+#: lib/klass_hero_web/components/provider_components.ex:1243
 #, elixir-autogen, elixir-format
 msgid "Maximum Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:989
+#: lib/klass_hero_web/components/provider_components.ex:1011
 #, elixir-autogen, elixir-format
 msgid "Meeting Days"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1136
+#: lib/klass_hero_web/components/provider_components.ex:1182
 #, elixir-autogen, elixir-format
 msgid "Minimum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1074
+#: lib/klass_hero_web/components/provider_components.ex:1096
 #, elixir-autogen, elixir-format
 msgid "Minimum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1190
+#: lib/klass_hero_web/components/provider_components.ex:1236
 #, elixir-autogen, elixir-format
 msgid "Minimum Grade"
 msgstr ""
@@ -2727,18 +2727,18 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2632
+#: lib/klass_hero_web/components/provider_components.ex:2678
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2016
+#: lib/klass_hero_web/components/provider_components.ex:2062
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:444
+#: lib/klass_hero_web/live/provider/programs_live.ex:447
 #, elixir-autogen, elixir-format
 msgid "No file selected."
 msgstr ""
@@ -2748,17 +2748,17 @@ msgstr ""
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2240
+#: lib/klass_hero_web/components/provider_components.ex:2286
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1199
+#: lib/klass_hero_web/components/provider_components.ex:1245
 #, elixir-autogen, elixir-format
 msgid "No maximum"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1192
+#: lib/klass_hero_web/components/provider_components.ex:1238
 #, elixir-autogen, elixir-format
 msgid "No minimum"
 msgstr ""
@@ -2789,7 +2789,7 @@ msgstr ""
 msgid "No verification documents found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1274
+#: lib/klass_hero_web/components/provider_components.ex:1320
 #, elixir-autogen, elixir-format
 msgid "None (optional)"
 msgstr ""
@@ -2800,7 +2800,7 @@ msgid "Not Verified"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:685
-#: lib/klass_hero_web/components/provider_components.ex:1161
+#: lib/klass_hero_web/components/provider_components.ex:1207
 #: lib/klass_hero_web/live/settings/children_live.ex:632
 #, elixir-autogen, elixir-format
 msgid "Not specified"
@@ -2811,7 +2811,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2707
+#: lib/klass_hero_web/components/provider_components.ex:2753
 #: lib/klass_hero_web/live/provider/verification_live.ex:698
 #: lib/klass_hero_web/live/provider/verification_live.ex:770
 #, elixir-autogen, elixir-format
@@ -2823,7 +2823,7 @@ msgstr ""
 msgid "Participant Requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1089
+#: lib/klass_hero_web/components/provider_components.ex:1135
 #, elixir-autogen, elixir-format
 msgid "Participant Restrictions (optional)"
 msgstr ""
@@ -2838,8 +2838,8 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:106
-#: lib/klass_hero_web/live/provider/programs_live.ex:685
-#: lib/klass_hero_web/live/provider/programs_live.ex:747
+#: lib/klass_hero_web/live/provider/programs_live.ex:690
+#: lib/klass_hero_web/live/provider/programs_live.ex:759
 #: lib/klass_hero_web/live/provider/team_live.ex:305
 #: lib/klass_hero_web/live/provider/team_live.ex:348
 #: lib/klass_hero_web/live/provider/team_live.ex:467
@@ -2857,7 +2857,7 @@ msgstr ""
 msgid "Preview not available for this file type."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:971
+#: lib/klass_hero_web/components/provider_components.ex:993
 #, elixir-autogen, elixir-format
 msgid "Price (EUR)"
 msgstr ""
@@ -2867,31 +2867,31 @@ msgstr ""
 msgid "Profile updated successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1127
+#: lib/klass_hero_web/components/provider_components.ex:1173
 #, elixir-autogen, elixir-format
 msgid "Program Start"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1151
+#: lib/klass_hero_web/live/provider/programs_live.ex:1208
 #, elixir-autogen, elixir-format
 msgid "Program created successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1155
+#: lib/klass_hero_web/live/provider/programs_live.ex:1212
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:54
-#: lib/klass_hero_web/live/provider/programs_live.ex:152
-#: lib/klass_hero_web/live/provider/programs_live.ex:189
-#: lib/klass_hero_web/live/provider/programs_live.ex:253
-#: lib/klass_hero_web/live/provider/programs_live.ex:722
+#: lib/klass_hero_web/live/provider/programs_live.ex:155
+#: lib/klass_hero_web/live/provider/programs_live.ex:192
+#: lib/klass_hero_web/live/provider/programs_live.ex:256
+#: lib/klass_hero_web/live/provider/programs_live.ex:734
 #, elixir-autogen, elixir-format
 msgid "Program not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1152
+#: lib/klass_hero_web/live/provider/programs_live.ex:1209
 #, elixir-autogen, elixir-format
 msgid "Program updated successfully."
 msgstr ""
@@ -2909,13 +2909,13 @@ msgid "Read our founding story →"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:805
-#: lib/klass_hero_web/components/provider_components.ex:2474
+#: lib/klass_hero_web/components/provider_components.ex:2520
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Registered"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1114
+#: lib/klass_hero_web/components/provider_components.ex:1160
 #, elixir-autogen, elixir-format
 msgid "Registration"
 msgstr ""
@@ -2925,7 +2925,7 @@ msgstr ""
 msgid "Registration Closed"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1058
+#: lib/klass_hero_web/components/provider_components.ex:1080
 #, elixir-autogen, elixir-format
 msgid "Registration Closes"
 msgstr ""
@@ -2935,12 +2935,12 @@ msgstr ""
 msgid "Registration Not Open Yet"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1053
+#: lib/klass_hero_web/components/provider_components.ex:1075
 #, elixir-autogen, elixir-format
 msgid "Registration Opens"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1044
+#: lib/klass_hero_web/components/provider_components.ex:1066
 #, elixir-autogen, elixir-format
 msgid "Registration Period (optional)"
 msgstr ""
@@ -2990,17 +2990,17 @@ msgid "Rejection reason"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:839
-#: lib/klass_hero_web/components/provider_components.ex:1238
-#: lib/klass_hero_web/components/provider_components.ex:2296
-#: lib/klass_hero_web/components/provider_components.ex:2726
-#: lib/klass_hero_web/components/provider_components.ex:2805
+#: lib/klass_hero_web/components/provider_components.ex:1284
+#: lib/klass_hero_web/components/provider_components.ex:2342
+#: lib/klass_hero_web/components/provider_components.ex:2772
+#: lib/klass_hero_web/components/provider_components.ex:2851
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:253
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2289
+#: lib/klass_hero_web/components/provider_components.ex:2335
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -3015,18 +3015,18 @@ msgstr ""
 msgid "Role"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1657
+#: lib/klass_hero_web/components/provider_components.ex:1703
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:386
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1301
+#: lib/klass_hero_web/components/provider_components.ex:1347
 #, elixir-autogen, elixir-format
 msgid "Save Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:986
+#: lib/klass_hero_web/components/provider_components.ex:1008
 #, elixir-autogen, elixir-format
 msgid "Schedule (optional)"
 msgstr ""
@@ -3041,7 +3041,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2704
+#: lib/klass_hero_web/components/provider_components.ex:2750
 #, elixir-autogen, elixir-format
 msgid "Select File"
 msgstr ""
@@ -3052,13 +3052,13 @@ msgstr ""
 msgid "Selected child does not meet the program requirements."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:675
-#: lib/klass_hero_web/live/provider/programs_live.ex:737
+#: lib/klass_hero_web/live/provider/programs_live.ex:680
+#: lib/klass_hero_web/live/provider/programs_live.ex:749
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2473
+#: lib/klass_hero_web/components/provider_components.ex:2519
 #: lib/klass_hero_web/live/admin/emails_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Sent"
@@ -3069,7 +3069,7 @@ msgstr ""
 msgid "Separate multiple qualifications with commas"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1068
+#: lib/klass_hero_web/components/provider_components.ex:1090
 #, elixir-autogen, elixir-format
 msgid "Set minimum and maximum enrollment for this program."
 msgstr ""
@@ -3092,12 +3092,12 @@ msgstr ""
 msgid "Staff member not found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1032
+#: lib/klass_hero_web/components/provider_components.ex:1054
 #, elixir-autogen, elixir-format
 msgid "Start Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1019
+#: lib/klass_hero_web/components/provider_components.ex:1041
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:165
 #, elixir-autogen, elixir-format
 msgid "Start Time"
@@ -3153,22 +3153,22 @@ msgstr ""
 msgid "The Klass Hero Story"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:390
+#: lib/klass_hero_web/live/provider/programs_live.ex:393
 #, elixir-autogen, elixir-format
 msgid "This invite cannot be resent."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:729
+#: lib/klass_hero_web/live/provider/programs_live.ex:741
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:953
+#: lib/klass_hero_web/components/provider_components.ex:975
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2605
+#: lib/klass_hero_web/components/provider_components.ex:2651
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -3188,32 +3188,32 @@ msgstr ""
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2175
+#: lib/klass_hero_web/components/provider_components.ex:2221
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2750
+#: lib/klass_hero_web/components/provider_components.ex:2796
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2659
+#: lib/klass_hero_web/components/provider_components.ex:2705
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2627
+#: lib/klass_hero_web/components/provider_components.ex:2673
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2607
+#: lib/klass_hero_web/components/provider_components.ex:2653
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2624
+#: lib/klass_hero_web/components/provider_components.ex:2670
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -3272,12 +3272,12 @@ msgstr ""
 msgid "e.g. mike@example.com"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:954
+#: lib/klass_hero_web/components/provider_components.ex:976
 #, elixir-autogen, elixir-format
 msgid "e.g., Art Adventures"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:981
+#: lib/klass_hero_web/components/provider_components.ex:1003
 #, elixir-autogen, elixir-format
 msgid "e.g., Community Center, Main St"
 msgstr ""
@@ -3303,7 +3303,7 @@ msgid "Child Safeguarding Training"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1498
-#: lib/klass_hero_web/components/provider_components.ex:2972
+#: lib/klass_hero_web/components/provider_components.ex:3018
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr ""
@@ -3373,7 +3373,7 @@ msgstr ""
 msgid "Program fee:"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:973
+#: lib/klass_hero_web/live/provider/programs_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr ""
@@ -3453,7 +3453,7 @@ msgid "Vetted with Care"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1482
-#: lib/klass_hero_web/components/provider_components.ex:2757
+#: lib/klass_hero_web/components/provider_components.ex:2803
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr ""
@@ -3589,7 +3589,7 @@ msgstr ""
 msgid "Cannot check out without a check-in"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:362
+#: lib/klass_hero_web/live/provider/programs_live.ex:365
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
@@ -3627,7 +3627,7 @@ msgstr ""
 msgid "Checked Out"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2332
+#: lib/klass_hero_web/components/provider_components.ex:2378
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Child"
@@ -3654,7 +3654,7 @@ msgid "Correct"
 msgstr ""
 
 #: lib/klass_hero_web/live/dashboard_live.ex:288
-#: lib/klass_hero_web/live/provider/programs_live.ex:359
+#: lib/klass_hero_web/live/provider/programs_live.ex:362
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Could not start conversation. Please try again."
@@ -3680,7 +3680,7 @@ msgstr ""
 msgid "Download monthly statements for taxes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2093
+#: lib/klass_hero_web/components/provider_components.ex:2139
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "Enrollment not confirmed"
@@ -3758,7 +3758,7 @@ msgstr ""
 msgid "No chasing payments or sending invoices"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1680
+#: lib/klass_hero_web/components/provider_components.ex:1726
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:407
 #, elixir-autogen, elixir-format
 msgid "No enrolled parents"
@@ -3781,7 +3781,7 @@ msgstr ""
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2092
+#: lib/klass_hero_web/components/provider_components.ex:2138
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -4411,7 +4411,7 @@ msgstr ""
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:24
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
-#: lib/klass_hero_web/live/provider/programs_live.ex:221
+#: lib/klass_hero_web/live/provider/programs_live.ex:224
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:156
 #, elixir-autogen, elixir-format
 msgid "Program"
@@ -4620,7 +4620,7 @@ msgid "Update your observation..."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:138
-#: lib/klass_hero_web/live/provider/programs_live.ex:441
+#: lib/klass_hero_web/live/provider/programs_live.ex:444
 #: lib/klass_hero_web/live/provider/verification_live.ex:240
 #: lib/klass_hero_web/live/provider/verification_live.ex:556
 #: lib/klass_hero_web/live/provider/verification_live.ex:594
@@ -4891,48 +4891,48 @@ msgstr ""
 msgid "for"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1801
+#: lib/klass_hero_web/components/provider_components.ex:1847
 #, elixir-autogen, elixir-format
 msgid "Assigned staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1803
+#: lib/klass_hero_web/components/provider_components.ex:1849
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1785
-#: lib/klass_hero_web/components/provider_components.ex:1874
+#: lib/klass_hero_web/components/provider_components.ex:1831
+#: lib/klass_hero_web/components/provider_components.ex:1920
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1802
+#: lib/klass_hero_web/components/provider_components.ex:1848
 #, elixir-autogen, elixir-format
 msgid "Cover"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1800
+#: lib/klass_hero_web/components/provider_components.ex:1846
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1794
+#: lib/klass_hero_web/components/provider_components.ex:1840
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1783
+#: lib/klass_hero_web/components/provider_components.ex:1829
 #, elixir-autogen, elixir-format
 msgid "Sessions — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1523
+#: lib/klass_hero_web/components/provider_components.ex:1569
 #, elixir-autogen, elixir-format
 msgid "View sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:532
+#: lib/klass_hero_web/live/provider/programs_live.ex:535
 #, elixir-autogen, elixir-format
 msgid "Create a program before inviting participants."
 msgstr ""
@@ -4959,22 +4959,22 @@ msgstr ""
 msgid "Failed to update record"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2396
+#: lib/klass_hero_web/components/provider_components.ex:2442
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2115
+#: lib/klass_hero_web/components/provider_components.ex:2161
 #, elixir-autogen, elixir-format
 msgid "Invite mode"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2134
+#: lib/klass_hero_web/components/provider_components.ex:2180
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:528
+#: lib/klass_hero_web/live/provider/programs_live.ex:531
 #, elixir-autogen, elixir-format
 msgid "Invite sent."
 msgstr ""
@@ -4984,12 +4984,12 @@ msgstr ""
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2409
+#: lib/klass_hero_web/components/provider_components.ex:2455
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2415
+#: lib/klass_hero_web/components/provider_components.ex:2461
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr ""
@@ -5000,17 +5000,17 @@ msgstr ""
 msgid "Nothing to update"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2417
+#: lib/klass_hero_web/components/provider_components.ex:2463
 #, elixir-autogen, elixir-format
 msgid "Nut allergy"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2421
+#: lib/klass_hero_web/components/provider_components.ex:2467
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2426
+#: lib/klass_hero_web/components/provider_components.ex:2472
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr ""
@@ -5020,7 +5020,7 @@ msgstr ""
 msgid "Present"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2353
+#: lib/klass_hero_web/components/provider_components.ex:2399
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr ""
@@ -5047,22 +5047,22 @@ msgstr ""
 msgid "Save changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2390
+#: lib/klass_hero_web/components/provider_components.ex:2436
 #, elixir-autogen, elixir-format
 msgid "School (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2400
+#: lib/klass_hero_web/components/provider_components.ex:2446
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2374
+#: lib/klass_hero_web/components/provider_components.ex:2420
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2443
+#: lib/klass_hero_web/components/provider_components.ex:2489
 #, elixir-autogen, elixir-format
 msgid "Send invite"
 msgstr ""
@@ -5072,12 +5072,12 @@ msgstr ""
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2152
+#: lib/klass_hero_web/components/provider_components.ex:2198
 #, elixir-autogen, elixir-format
 msgid "Upload a list"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:539
+#: lib/klass_hero_web/live/provider/programs_live.ex:542
 #, elixir-autogen, elixir-format
 msgid "An invite for this child and program already exists."
 msgstr ""
@@ -5172,7 +5172,7 @@ msgstr ""
 msgid "Property Damage"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1553
+#: lib/klass_hero_web/components/provider_components.ex:1599
 #, elixir-autogen, elixir-format
 msgid "Report Incident"
 msgstr ""
@@ -5254,7 +5254,7 @@ msgstr ""
 msgid "Go to dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:484
+#: lib/klass_hero_web/live/provider/programs_live.ex:487
 #, elixir-autogen, elixir-format
 msgid "%{count} row could not be processed."
 msgid_plural "%{count} rows could not be processed."
@@ -5841,8 +5841,8 @@ msgstr ""
 msgid "I'll be teaching"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:459
-#: lib/klass_hero_web/live/provider/programs_live.ex:481
+#: lib/klass_hero_web/live/provider/programs_live.ex:462
+#: lib/klass_hero_web/live/provider/programs_live.ex:484
 #, elixir-autogen, elixir-format
 msgid "Imported %{count} family."
 msgid_plural "Imported %{count} families."
@@ -5854,7 +5854,7 @@ msgstr[1] ""
 msgid "In 2025, Shane connected with his friend"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1562
+#: lib/klass_hero_web/components/provider_components.ex:1608
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:43
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:74
 #, elixir-autogen, elixir-format
@@ -5924,7 +5924,7 @@ msgstr ""
 msgid "Last 8 weeks"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1272
+#: lib/klass_hero_web/components/provider_components.ex:1318
 #: lib/klass_hero_web/presenters/hero_cards_presenter.ex:27
 #, elixir-autogen, elixir-format
 msgid "Lead Instructor"
@@ -6131,7 +6131,7 @@ msgstr ""
 msgid "No registered children for this session."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:468
+#: lib/klass_hero_web/live/provider/programs_live.ex:471
 #, elixir-autogen, elixir-format
 msgid "No rows imported. %{count} row could not be processed."
 msgid_plural "No rows imported. %{count} rows could not be processed."
@@ -6374,17 +6374,17 @@ msgstr ""
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2482
+#: lib/klass_hero_web/components/provider_components.ex:2528
 #, elixir-autogen, elixir-format
 msgid "Row %{row}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2482
+#: lib/klass_hero_web/components/provider_components.ex:2528
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2228
+#: lib/klass_hero_web/components/provider_components.ex:2274
 #, elixir-autogen, elixir-format
 msgid "Rows with errors"
 msgstr ""
@@ -7143,12 +7143,12 @@ msgstr ""
 msgid "Experience validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2786
+#: lib/klass_hero_web/components/provider_components.ex:2832
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2760
+#: lib/klass_hero_web/components/provider_components.ex:2806
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
@@ -7158,12 +7158,12 @@ msgstr ""
 msgid "Safeguarding certificate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2783
+#: lib/klass_hero_web/components/provider_components.ex:2829
 #, elixir-autogen, elixir-format
 msgid "Select Video"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2829
+#: lib/klass_hero_web/components/provider_components.ex:2875
 #, elixir-autogen, elixir-format
 msgid "Upload Video"
 msgstr ""
@@ -7173,7 +7173,7 @@ msgstr ""
 msgid "Your browser does not support video playback."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2976
+#: lib/klass_hero_web/components/provider_components.ex:3022
 #, elixir-autogen, elixir-format
 msgid "Confirm agreement"
 msgstr ""
@@ -7183,12 +7183,12 @@ msgstr ""
 msgid "Couldn't record your agreement. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2999
+#: lib/klass_hero_web/components/provider_components.ex:3045
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2975
+#: lib/klass_hero_web/components/provider_components.ex:3021
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr ""
@@ -7198,7 +7198,7 @@ msgstr ""
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2884
+#: lib/klass_hero_web/components/provider_components.ex:2930
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr ""
@@ -7208,17 +7208,17 @@ msgstr ""
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2984
+#: lib/klass_hero_web/components/provider_components.ex:3030
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2973
+#: lib/klass_hero_web/components/provider_components.ex:3019
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2974
+#: lib/klass_hero_web/components/provider_components.ex:3020
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
@@ -7487,12 +7487,12 @@ msgstr ""
 msgid "Your insurance is verified."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2928
+#: lib/klass_hero_web/components/provider_components.ex:2974
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3031
+#: lib/klass_hero_web/components/provider_components.ex:3077
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr ""
@@ -7502,7 +7502,7 @@ msgstr ""
 msgid "Couldn't record your declaration. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3037
+#: lib/klass_hero_web/components/provider_components.ex:3083
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr ""
@@ -7512,17 +7512,17 @@ msgstr ""
 msgid "Please confirm the declaration before signing."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3062
+#: lib/klass_hero_web/components/provider_components.ex:3108
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3041
+#: lib/klass_hero_web/components/provider_components.ex:3087
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3029
+#: lib/klass_hero_web/components/provider_components.ex:3075
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr ""
@@ -7532,12 +7532,12 @@ msgstr ""
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3049
+#: lib/klass_hero_web/components/provider_components.ex:3095
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3035
+#: lib/klass_hero_web/components/provider_components.ex:3081
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
@@ -7604,92 +7604,92 @@ msgstr ""
 msgid "Undelivered Events"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1971
+#: lib/klass_hero_web/components/provider_components.ex:2017
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1896
+#: lib/klass_hero_web/components/provider_components.ex:1942
 #, elixir-autogen, elixir-format
 msgid "Lead"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:334
+#: lib/klass_hero_web/live/provider/programs_live.ex:337
 #, elixir-autogen, elixir-format
 msgid "Lead instructor updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1907
+#: lib/klass_hero_web/components/provider_components.ex:1953
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1537
+#: lib/klass_hero_web/components/provider_components.ex:1583
 #, elixir-autogen, elixir-format
 msgid "Manage Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1935
+#: lib/klass_hero_web/components/provider_components.ex:1981
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this program yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:264
+#: lib/klass_hero_web/live/provider/programs_live.ex:267
 #, elixir-autogen, elixir-format
 msgid "Pick a staff member to add."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1918
+#: lib/klass_hero_web/components/provider_components.ex:1964
 #, elixir-autogen, elixir-format
 msgid "Reassign the lead before removing them"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1919
+#: lib/klass_hero_web/components/provider_components.ex:1965
 #, elixir-autogen, elixir-format
 msgid "Remove from program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1953
+#: lib/klass_hero_web/components/provider_components.ex:1999
 #, elixir-autogen, elixir-format
 msgid "Select a staff member…"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:279
+#: lib/klass_hero_web/live/provider/programs_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "Staff member added to the program."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:305
+#: lib/klass_hero_web/live/provider/programs_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "Staff member removed from the program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1976
+#: lib/klass_hero_web/components/provider_components.ex:2022
 #, elixir-autogen, elixir-format
 msgid "Staff you add can read and reply to this program's parent conversations."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1872
+#: lib/klass_hero_web/components/provider_components.ex:1918
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:932
+#: lib/klass_hero_web/live/provider/programs_live.ex:944
 #, elixir-autogen, elixir-format
 msgid "That staff member could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:287
+#: lib/klass_hero_web/live/provider/programs_live.ex:290
 #, elixir-autogen, elixir-format
 msgid "They are already on this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:313
+#: lib/klass_hero_web/live/provider/programs_live.ex:316
 #, elixir-autogen, elixir-format
 msgid "This person is the lead instructor. Make someone else lead before removing them."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1481
+#: lib/klass_hero_web/components/provider_components.ex:1527
 #, elixir-autogen, elixir-format
 msgid "%{count} staff member · no lead"
 msgid_plural "%{count} staff · no lead"
@@ -7746,17 +7746,34 @@ msgstr ""
 msgid "This person has a history here now — use 'Remove from team' instead."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1165
+#: lib/klass_hero_web/live/provider/programs_live.ex:1222
 #, elixir-autogen, elixir-format
 msgid "Program created, but some settings could not be saved. Please review the program's limits."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1169
+#: lib/klass_hero_web/live/provider/programs_live.ex:1226
 #, elixir-autogen, elixir-format
 msgid "Program updated, but some settings could not be saved. Please review the program's limits."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1159
+#: lib/klass_hero_web/live/provider/programs_live.ex:1216
 #, elixir-autogen, elixir-format
 msgid "Program updated, but the enrollment capacity was rejected. The previous limits still apply."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:918
+#, elixir-autogen, elixir-format
+msgid "%{count} child is already enrolled. Confirm you want this program to have no capacity limit."
+msgid_plural "%{count} children are already enrolled. Confirm you want this program to have no capacity limit."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1120
+#, elixir-autogen, elixir-format
+msgid "Anyone will be able to book a place until you set a new maximum."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1125
+#, elixir-autogen, elixir-format
+msgid "I understand this program will have no capacity limit."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -137,7 +137,7 @@ msgid "Your Data"
 msgstr ""
 
 #: lib/klass_hero_web/components/core_components.ex:67
-#: lib/klass_hero_web/components/provider_components.ex:1687
+#: lib/klass_hero_web/components/provider_components.ex:1733
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr ""
@@ -232,7 +232,7 @@ msgstr ""
 msgid "Enroll Now - %{price}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1438
+#: lib/klass_hero_web/components/provider_components.ex:1484
 #: lib/klass_hero_web/live/booking_live.ex:285
 #, elixir-autogen, elixir-format
 msgid "Enrollment"
@@ -578,8 +578,8 @@ msgid "Dispute Resolution"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:719
-#: lib/klass_hero_web/components/provider_components.ex:2360
-#: lib/klass_hero_web/components/provider_components.ex:2378
+#: lib/klass_hero_web/components/provider_components.ex:2406
+#: lib/klass_hero_web/components/provider_components.ex:2424
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
@@ -878,9 +878,9 @@ msgstr ""
 msgid "Select one or both options"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2056
-#: lib/klass_hero_web/components/provider_components.ex:2057
-#: lib/klass_hero_web/components/provider_components.ex:2094
+#: lib/klass_hero_web/components/provider_components.ex:2102
+#: lib/klass_hero_web/components/provider_components.ex:2103
+#: lib/klass_hero_web/components/provider_components.ex:2140
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:448
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:484
@@ -1577,14 +1577,14 @@ msgstr ""
 msgid "Quick Navigation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1441
-#: lib/klass_hero_web/components/provider_components.ex:2032
-#: lib/klass_hero_web/components/provider_components.ex:2258
+#: lib/klass_hero_web/components/provider_components.ex:1487
+#: lib/klass_hero_web/components/provider_components.ex:2078
+#: lib/klass_hero_web/components/provider_components.ex:2304
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1580
+#: lib/klass_hero_web/components/provider_components.ex:1626
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Active"
 msgstr ""
@@ -1600,7 +1600,7 @@ msgstr ""
 msgid "All Staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1432
+#: lib/klass_hero_web/components/provider_components.ex:1478
 #, elixir-autogen, elixir-format
 msgid "Assigned Staff"
 msgstr ""
@@ -1628,7 +1628,7 @@ msgid "Create profiles for your staff. These will be visible to parents when ass
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:539
-#: lib/klass_hero_web/components/provider_components.ex:1543
+#: lib/klass_hero_web/components/provider_components.ex:1589
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:54
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:81
 #: lib/klass_hero_web/live/settings/children_live.ex:413
@@ -1645,7 +1645,7 @@ msgstr ""
 msgid "Edit Profile"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1582
+#: lib/klass_hero_web/components/provider_components.ex:1628
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr ""
@@ -1657,7 +1657,7 @@ msgid "My Programs"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:416
-#: lib/klass_hero_web/components/provider_components.ex:930
+#: lib/klass_hero_web/components/provider_components.ex:952
 #, elixir-autogen, elixir-format, fuzzy
 msgid "New Program"
 msgstr ""
@@ -1669,26 +1669,26 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:47
 #: lib/klass_hero_web/components/provider_components.ex:73
-#: lib/klass_hero_web/components/provider_components.ex:1581
-#: lib/klass_hero_web/components/provider_components.ex:2454
-#: lib/klass_hero_web/components/provider_components.ex:2472
+#: lib/klass_hero_web/components/provider_components.ex:1627
+#: lib/klass_hero_web/components/provider_components.ex:2500
+#: lib/klass_hero_web/components/provider_components.ex:2518
 #: lib/klass_hero_web/live/admin/sessions_live.ex:298
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1519
+#: lib/klass_hero_web/components/provider_components.ex:1565
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1372
+#: lib/klass_hero_web/components/provider_components.ex:1418
 #, elixir-autogen, elixir-format
 msgid "Program Inventory"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1429
+#: lib/klass_hero_web/components/provider_components.ex:1475
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program Name"
 msgstr ""
@@ -1703,15 +1703,15 @@ msgstr ""
 msgid "Save for Later"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1389
+#: lib/klass_hero_web/components/provider_components.ex:1435
 #, elixir-autogen, elixir-format
 msgid "Search by name..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1435
-#: lib/klass_hero_web/components/provider_components.ex:1804
-#: lib/klass_hero_web/components/provider_components.ex:2026
-#: lib/klass_hero_web/components/provider_components.ex:2255
+#: lib/klass_hero_web/components/provider_components.ex:1481
+#: lib/klass_hero_web/components/provider_components.ex:1850
+#: lib/klass_hero_web/components/provider_components.ex:2072
+#: lib/klass_hero_web/components/provider_components.ex:2301
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1735,15 +1735,15 @@ msgstr ""
 msgid "This is your main business identity. Verification is required to list programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1492
-#: lib/klass_hero_web/components/provider_components.ex:1819
+#: lib/klass_hero_web/components/provider_components.ex:1538
+#: lib/klass_hero_web/components/provider_components.ex:1865
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr ""
 
 #: lib/klass_hero_web/components/messaging_components.ex:722
 #: lib/klass_hero_web/components/provider_components.ex:50
-#: lib/klass_hero_web/components/provider_components.ex:1583
+#: lib/klass_hero_web/components/provider_components.ex:1629
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:434
 #: lib/klass_hero_web/presenters/provider_presenter.ex:103
 #, elixir-autogen, elixir-format
@@ -1755,7 +1755,7 @@ msgstr ""
 msgid "Verified Business"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1530
+#: lib/klass_hero_web/components/provider_components.ex:1576
 #, elixir-autogen, elixir-format
 msgid "View Roster"
 msgstr ""
@@ -1816,8 +1816,8 @@ msgstr ""
 #: lib/klass_hero_web/components/participation_components.ex:631
 #: lib/klass_hero_web/components/participation_components.ex:717
 #: lib/klass_hero_web/components/provider_components.ex:889
-#: lib/klass_hero_web/components/provider_components.ex:1288
-#: lib/klass_hero_web/components/provider_components.ex:2197
+#: lib/klass_hero_web/components/provider_components.ex:1334
+#: lib/klass_hero_web/components/provider_components.ex:2243
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:478
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
@@ -1873,7 +1873,7 @@ msgstr ""
 msgid "Data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2341
+#: lib/klass_hero_web/components/provider_components.ex:2387
 #: lib/klass_hero_web/live/settings/children_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1921,17 +1921,17 @@ msgstr ""
 msgid "Failed to submit note"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2335
-#: lib/klass_hero_web/components/provider_components.ex:2364
-#: lib/klass_hero_web/components/provider_components.ex:2380
+#: lib/klass_hero_web/components/provider_components.ex:2381
+#: lib/klass_hero_web/components/provider_components.ex:2410
+#: lib/klass_hero_web/components/provider_components.ex:2426
 #: lib/klass_hero_web/live/settings/children_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2336
-#: lib/klass_hero_web/components/provider_components.ex:2365
-#: lib/klass_hero_web/components/provider_components.ex:2381
+#: lib/klass_hero_web/components/provider_components.ex:2382
+#: lib/klass_hero_web/components/provider_components.ex:2411
+#: lib/klass_hero_web/components/provider_components.ex:2427
 #: lib/klass_hero_web/live/settings/children_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -2069,8 +2069,8 @@ msgstr ""
 msgid "Save Changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1665
-#: lib/klass_hero_web/components/provider_components.ex:1666
+#: lib/klass_hero_web/components/provider_components.ex:1711
+#: lib/klass_hero_web/components/provider_components.ex:1712
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:43
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:151
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:252
@@ -2088,7 +2088,7 @@ msgstr ""
 msgid "Send a message to start the conversation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2435
+#: lib/klass_hero_web/components/provider_components.ex:2481
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:249
 #, elixir-autogen, elixir-format, fuzzy
@@ -2219,12 +2219,12 @@ msgstr ""
 msgid "Ages %{min}+"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1149
+#: lib/klass_hero_web/components/provider_components.ex:1195
 #, elixir-autogen, elixir-format
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2494
+#: lib/klass_hero_web/components/provider_components.ex:2540
 #, elixir-autogen, elixir-format, fuzzy
 msgid "An unexpected error occurred during import."
 msgstr ""
@@ -2308,19 +2308,19 @@ msgstr ""
 msgid "Business Logo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:960
+#: lib/klass_hero_web/components/provider_components.ex:982
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "Category"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1098
+#: lib/klass_hero_web/components/provider_components.ex:1144
 #, elixir-autogen, elixir-format
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2023
-#: lib/klass_hero_web/components/provider_components.ex:2249
+#: lib/klass_hero_web/components/provider_components.ex:2069
+#: lib/klass_hero_web/components/provider_components.ex:2295
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2335,7 +2335,7 @@ msgstr ""
 msgid "Child meets all program requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1259
+#: lib/klass_hero_web/components/provider_components.ex:1305
 #, elixir-autogen, elixir-format
 msgid "Choose Image"
 msgstr ""
@@ -2350,7 +2350,7 @@ msgstr ""
 msgid "Choose Photo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:962
+#: lib/klass_hero_web/components/provider_components.ex:984
 #, elixir-autogen, elixir-format
 msgid "Choose a category"
 msgstr ""
@@ -2365,7 +2365,7 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2455
+#: lib/klass_hero_web/components/provider_components.ex:2501
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
@@ -2375,32 +2375,32 @@ msgstr ""
 msgid "Contact Provider"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:448
+#: lib/klass_hero_web/live/provider/programs_live.ex:451
 #, elixir-autogen, elixir-format
 msgid "Could not read the uploaded file."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:416
+#: lib/klass_hero_web/live/provider/programs_live.ex:419
 #, elixir-autogen, elixir-format
 msgid "Could not remove invite."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1215
+#: lib/klass_hero_web/components/provider_components.ex:1261
 #, elixir-autogen, elixir-format
 msgid "Cover Image"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1092
+#: lib/klass_hero_web/components/provider_components.ex:1138
 #, elixir-autogen, elixir-format
 msgid "Define age, gender, or grade restrictions for eligible participants."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1208
+#: lib/klass_hero_web/components/provider_components.ex:1254
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Describe your program..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1207
+#: lib/klass_hero_web/components/provider_components.ex:1253
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:323
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:285
 #, elixir-autogen, elixir-format
@@ -2408,13 +2408,13 @@ msgid "Description"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:684
-#: lib/klass_hero_web/components/provider_components.ex:1160
+#: lib/klass_hero_web/components/provider_components.ex:1206
 #: lib/klass_hero_web/live/settings/children_live.ex:635
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2670
+#: lib/klass_hero_web/components/provider_components.ex:2716
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2448,7 +2448,7 @@ msgstr ""
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2216
+#: lib/klass_hero_web/components/provider_components.ex:2262
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
@@ -2458,7 +2458,7 @@ msgstr ""
 msgid "Download document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:928
+#: lib/klass_hero_web/components/provider_components.ex:950
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit Program"
 msgstr ""
@@ -2468,30 +2468,30 @@ msgstr ""
 msgid "Edit Team Member"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1037
+#: lib/klass_hero_web/components/provider_components.ex:1059
 #, elixir-autogen, elixir-format
 msgid "End Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1024
+#: lib/klass_hero_web/components/provider_components.ex:1046
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:166
 #, elixir-autogen, elixir-format
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2029
-#: lib/klass_hero_web/components/provider_components.ex:2475
+#: lib/klass_hero_web/components/provider_components.ex:2075
+#: lib/klass_hero_web/components/provider_components.ex:2521
 #: lib/klass_hero_web/components/provider_layout_components.ex:644
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrolled"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1711
+#: lib/klass_hero_web/components/provider_components.ex:1757
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1065
+#: lib/klass_hero_web/components/provider_components.ex:1087
 #, elixir-autogen, elixir-format
 msgid "Enrollment Capacity (optional)"
 msgstr ""
@@ -2502,7 +2502,7 @@ msgid "Explain why this document is being rejected..."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:71
-#: lib/klass_hero_web/components/provider_components.ex:2476
+#: lib/klass_hero_web/components/provider_components.ex:2522
 #: lib/klass_hero_web/live/admin/emails_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2518,7 +2518,7 @@ msgstr ""
 msgid "Failed to reject document."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:398
+#: lib/klass_hero_web/live/provider/programs_live.ex:401
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to resend invite."
 msgstr ""
@@ -2535,7 +2535,7 @@ msgid "Family Programs"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:682
-#: lib/klass_hero_web/components/provider_components.ex:1159
+#: lib/klass_hero_web/components/provider_components.ex:1205
 #: lib/klass_hero_web/live/settings/children_live.ex:634
 #, elixir-autogen, elixir-format
 msgid "Female"
@@ -2546,12 +2546,12 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2604
+#: lib/klass_hero_web/components/provider_components.ex:2650
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2606
+#: lib/klass_hero_web/components/provider_components.ex:2652
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
@@ -2586,7 +2586,7 @@ msgstr ""
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2252
+#: lib/klass_hero_web/components/provider_components.ex:2298
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
@@ -2601,7 +2601,7 @@ msgstr ""
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2189
+#: lib/klass_hero_web/components/provider_components.ex:2235
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import"
 msgstr ""
@@ -2611,22 +2611,22 @@ msgstr ""
 msgid "Insurance Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:413
+#: lib/klass_hero_web/live/provider/programs_live.ex:416
 #, elixir-autogen, elixir-format
 msgid "Invite not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:410
+#: lib/klass_hero_web/live/provider/programs_live.ex:413
 #, elixir-autogen, elixir-format
 msgid "Invite removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:387
+#: lib/klass_hero_web/live/provider/programs_live.ex:390
 #, elixir-autogen, elixir-format
 msgid "Invite resent successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1728
+#: lib/klass_hero_web/components/provider_components.ex:1774
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr ""
@@ -2636,7 +2636,7 @@ msgstr ""
 msgid "JPG, PNG or WebP. Max 1MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1262
+#: lib/klass_hero_web/components/provider_components.ex:1308
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:277
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:361
 #, elixir-autogen, elixir-format
@@ -2658,17 +2658,17 @@ msgstr ""
 msgid "Last Name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1047
+#: lib/klass_hero_web/components/provider_components.ex:1069
 #, elixir-autogen, elixir-format
 msgid "Leave blank for open registration at any time."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1152
+#: lib/klass_hero_web/components/provider_components.ex:1198
 #, elixir-autogen, elixir-format
 msgid "Leave unchecked to allow all genders."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:980
+#: lib/klass_hero_web/components/provider_components.ex:1002
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:172
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Location"
@@ -2681,43 +2681,43 @@ msgid "Logo upload failed. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:683
-#: lib/klass_hero_web/components/provider_components.ex:1158
+#: lib/klass_hero_web/components/provider_components.ex:1204
 #: lib/klass_hero_web/live/settings/children_live.ex:633
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1142
+#: lib/klass_hero_web/components/provider_components.ex:1188
 #, elixir-autogen, elixir-format
 msgid "Maximum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1080
+#: lib/klass_hero_web/components/provider_components.ex:1102
 #, elixir-autogen, elixir-format
 msgid "Maximum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1197
+#: lib/klass_hero_web/components/provider_components.ex:1243
 #, elixir-autogen, elixir-format
 msgid "Maximum Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:989
+#: lib/klass_hero_web/components/provider_components.ex:1011
 #, elixir-autogen, elixir-format
 msgid "Meeting Days"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1136
+#: lib/klass_hero_web/components/provider_components.ex:1182
 #, elixir-autogen, elixir-format
 msgid "Minimum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1074
+#: lib/klass_hero_web/components/provider_components.ex:1096
 #, elixir-autogen, elixir-format
 msgid "Minimum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1190
+#: lib/klass_hero_web/components/provider_components.ex:1236
 #, elixir-autogen, elixir-format
 msgid "Minimum Grade"
 msgstr ""
@@ -2727,18 +2727,18 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2632
+#: lib/klass_hero_web/components/provider_components.ex:2678
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2016
+#: lib/klass_hero_web/components/provider_components.ex:2062
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:444
+#: lib/klass_hero_web/live/provider/programs_live.ex:447
 #, elixir-autogen, elixir-format
 msgid "No file selected."
 msgstr ""
@@ -2748,17 +2748,17 @@ msgstr ""
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2240
+#: lib/klass_hero_web/components/provider_components.ex:2286
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1199
+#: lib/klass_hero_web/components/provider_components.ex:1245
 #, elixir-autogen, elixir-format
 msgid "No maximum"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1192
+#: lib/klass_hero_web/components/provider_components.ex:1238
 #, elixir-autogen, elixir-format
 msgid "No minimum"
 msgstr ""
@@ -2789,7 +2789,7 @@ msgstr ""
 msgid "No verification documents found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1274
+#: lib/klass_hero_web/components/provider_components.ex:1320
 #, elixir-autogen, elixir-format
 msgid "None (optional)"
 msgstr ""
@@ -2800,7 +2800,7 @@ msgid "Not Verified"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:685
-#: lib/klass_hero_web/components/provider_components.ex:1161
+#: lib/klass_hero_web/components/provider_components.ex:1207
 #: lib/klass_hero_web/live/settings/children_live.ex:632
 #, elixir-autogen, elixir-format
 msgid "Not specified"
@@ -2811,7 +2811,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2707
+#: lib/klass_hero_web/components/provider_components.ex:2753
 #: lib/klass_hero_web/live/provider/verification_live.ex:698
 #: lib/klass_hero_web/live/provider/verification_live.ex:770
 #, elixir-autogen, elixir-format
@@ -2823,7 +2823,7 @@ msgstr ""
 msgid "Participant Requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1089
+#: lib/klass_hero_web/components/provider_components.ex:1135
 #, elixir-autogen, elixir-format
 msgid "Participant Restrictions (optional)"
 msgstr ""
@@ -2838,8 +2838,8 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:106
-#: lib/klass_hero_web/live/provider/programs_live.ex:685
-#: lib/klass_hero_web/live/provider/programs_live.ex:747
+#: lib/klass_hero_web/live/provider/programs_live.ex:690
+#: lib/klass_hero_web/live/provider/programs_live.ex:759
 #: lib/klass_hero_web/live/provider/team_live.ex:305
 #: lib/klass_hero_web/live/provider/team_live.ex:348
 #: lib/klass_hero_web/live/provider/team_live.ex:467
@@ -2857,7 +2857,7 @@ msgstr ""
 msgid "Preview not available for this file type."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:971
+#: lib/klass_hero_web/components/provider_components.ex:993
 #, elixir-autogen, elixir-format
 msgid "Price (EUR)"
 msgstr ""
@@ -2867,31 +2867,31 @@ msgstr ""
 msgid "Profile updated successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1127
+#: lib/klass_hero_web/components/provider_components.ex:1173
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program Start"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1151
+#: lib/klass_hero_web/live/provider/programs_live.ex:1208
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program created successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1155
+#: lib/klass_hero_web/live/provider/programs_live.ex:1212
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:54
-#: lib/klass_hero_web/live/provider/programs_live.ex:152
-#: lib/klass_hero_web/live/provider/programs_live.ex:189
-#: lib/klass_hero_web/live/provider/programs_live.ex:253
-#: lib/klass_hero_web/live/provider/programs_live.ex:722
+#: lib/klass_hero_web/live/provider/programs_live.ex:155
+#: lib/klass_hero_web/live/provider/programs_live.ex:192
+#: lib/klass_hero_web/live/provider/programs_live.ex:256
+#: lib/klass_hero_web/live/provider/programs_live.ex:734
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1152
+#: lib/klass_hero_web/live/provider/programs_live.ex:1209
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program updated successfully."
 msgstr ""
@@ -2909,13 +2909,13 @@ msgid "Read our founding story →"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:805
-#: lib/klass_hero_web/components/provider_components.ex:2474
+#: lib/klass_hero_web/components/provider_components.ex:2520
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registered"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1114
+#: lib/klass_hero_web/components/provider_components.ex:1160
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration"
 msgstr ""
@@ -2925,7 +2925,7 @@ msgstr ""
 msgid "Registration Closed"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1058
+#: lib/klass_hero_web/components/provider_components.ex:1080
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration Closes"
 msgstr ""
@@ -2935,12 +2935,12 @@ msgstr ""
 msgid "Registration Not Open Yet"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1053
+#: lib/klass_hero_web/components/provider_components.ex:1075
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration Opens"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1044
+#: lib/klass_hero_web/components/provider_components.ex:1066
 #, elixir-autogen, elixir-format
 msgid "Registration Period (optional)"
 msgstr ""
@@ -2990,17 +2990,17 @@ msgid "Rejection reason"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:839
-#: lib/klass_hero_web/components/provider_components.ex:1238
-#: lib/klass_hero_web/components/provider_components.ex:2296
-#: lib/klass_hero_web/components/provider_components.ex:2726
-#: lib/klass_hero_web/components/provider_components.ex:2805
+#: lib/klass_hero_web/components/provider_components.ex:1284
+#: lib/klass_hero_web/components/provider_components.ex:2342
+#: lib/klass_hero_web/components/provider_components.ex:2772
+#: lib/klass_hero_web/components/provider_components.ex:2851
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:253
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2289
+#: lib/klass_hero_web/components/provider_components.ex:2335
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -3015,18 +3015,18 @@ msgstr ""
 msgid "Role"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1657
+#: lib/klass_hero_web/components/provider_components.ex:1703
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:386
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1301
+#: lib/klass_hero_web/components/provider_components.ex:1347
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Save Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:986
+#: lib/klass_hero_web/components/provider_components.ex:1008
 #, elixir-autogen, elixir-format
 msgid "Schedule (optional)"
 msgstr ""
@@ -3041,7 +3041,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2704
+#: lib/klass_hero_web/components/provider_components.ex:2750
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select File"
 msgstr ""
@@ -3052,13 +3052,13 @@ msgstr ""
 msgid "Selected child does not meet the program requirements."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:675
-#: lib/klass_hero_web/live/provider/programs_live.ex:737
+#: lib/klass_hero_web/live/provider/programs_live.ex:680
+#: lib/klass_hero_web/live/provider/programs_live.ex:749
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2473
+#: lib/klass_hero_web/components/provider_components.ex:2519
 #: lib/klass_hero_web/live/admin/emails_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Sent"
@@ -3069,7 +3069,7 @@ msgstr ""
 msgid "Separate multiple qualifications with commas"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1068
+#: lib/klass_hero_web/components/provider_components.ex:1090
 #, elixir-autogen, elixir-format
 msgid "Set minimum and maximum enrollment for this program."
 msgstr ""
@@ -3092,12 +3092,12 @@ msgstr ""
 msgid "Staff member not found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1032
+#: lib/klass_hero_web/components/provider_components.ex:1054
 #, elixir-autogen, elixir-format
 msgid "Start Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1019
+#: lib/klass_hero_web/components/provider_components.ex:1041
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:165
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Start Time"
@@ -3153,22 +3153,22 @@ msgstr ""
 msgid "The Klass Hero Story"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:390
+#: lib/klass_hero_web/live/provider/programs_live.ex:393
 #, elixir-autogen, elixir-format
 msgid "This invite cannot be resent."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:729
+#: lib/klass_hero_web/live/provider/programs_live.ex:741
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:953
+#: lib/klass_hero_web/components/provider_components.ex:975
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2605
+#: lib/klass_hero_web/components/provider_components.ex:2651
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -3188,32 +3188,32 @@ msgstr ""
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2175
+#: lib/klass_hero_web/components/provider_components.ex:2221
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2750
+#: lib/klass_hero_web/components/provider_components.ex:2796
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2659
+#: lib/klass_hero_web/components/provider_components.ex:2705
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2627
+#: lib/klass_hero_web/components/provider_components.ex:2673
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2607
+#: lib/klass_hero_web/components/provider_components.ex:2653
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2624
+#: lib/klass_hero_web/components/provider_components.ex:2670
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -3272,12 +3272,12 @@ msgstr ""
 msgid "e.g. mike@example.com"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:954
+#: lib/klass_hero_web/components/provider_components.ex:976
 #, elixir-autogen, elixir-format
 msgid "e.g., Art Adventures"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:981
+#: lib/klass_hero_web/components/provider_components.ex:1003
 #, elixir-autogen, elixir-format
 msgid "e.g., Community Center, Main St"
 msgstr ""
@@ -3303,7 +3303,7 @@ msgid "Child Safeguarding Training"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1498
-#: lib/klass_hero_web/components/provider_components.ex:2972
+#: lib/klass_hero_web/components/provider_components.ex:3018
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr ""
@@ -3373,7 +3373,7 @@ msgstr ""
 msgid "Program fee:"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:973
+#: lib/klass_hero_web/live/provider/programs_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr ""
@@ -3453,7 +3453,7 @@ msgid "Vetted with Care"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1482
-#: lib/klass_hero_web/components/provider_components.ex:2757
+#: lib/klass_hero_web/components/provider_components.ex:2803
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr ""
@@ -3589,7 +3589,7 @@ msgstr ""
 msgid "Cannot check out without a check-in"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:362
+#: lib/klass_hero_web/live/provider/programs_live.ex:365
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
@@ -3627,7 +3627,7 @@ msgstr ""
 msgid "Checked Out"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2332
+#: lib/klass_hero_web/components/provider_components.ex:2378
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Child"
@@ -3654,7 +3654,7 @@ msgid "Correct"
 msgstr ""
 
 #: lib/klass_hero_web/live/dashboard_live.ex:288
-#: lib/klass_hero_web/live/provider/programs_live.ex:359
+#: lib/klass_hero_web/live/provider/programs_live.ex:362
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Could not start conversation. Please try again."
@@ -3680,7 +3680,7 @@ msgstr ""
 msgid "Download monthly statements for taxes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2093
+#: lib/klass_hero_web/components/provider_components.ex:2139
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:483
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrollment not confirmed"
@@ -3758,7 +3758,7 @@ msgstr ""
 msgid "No chasing payments or sending invoices"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1680
+#: lib/klass_hero_web/components/provider_components.ex:1726
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:407
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No enrolled parents"
@@ -3781,7 +3781,7 @@ msgstr ""
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2092
+#: lib/klass_hero_web/components/provider_components.ex:2138
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -4411,7 +4411,7 @@ msgstr ""
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:24
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
-#: lib/klass_hero_web/live/provider/programs_live.ex:221
+#: lib/klass_hero_web/live/provider/programs_live.ex:224
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:156
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program"
@@ -4620,7 +4620,7 @@ msgid "Update your observation..."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:138
-#: lib/klass_hero_web/live/provider/programs_live.ex:441
+#: lib/klass_hero_web/live/provider/programs_live.ex:444
 #: lib/klass_hero_web/live/provider/verification_live.ex:240
 #: lib/klass_hero_web/live/provider/verification_live.ex:556
 #: lib/klass_hero_web/live/provider/verification_live.ex:594
@@ -4891,48 +4891,48 @@ msgstr ""
 msgid "for"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1801
+#: lib/klass_hero_web/components/provider_components.ex:1847
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assigned staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1803
+#: lib/klass_hero_web/components/provider_components.ex:1849
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1785
-#: lib/klass_hero_web/components/provider_components.ex:1874
+#: lib/klass_hero_web/components/provider_components.ex:1831
+#: lib/klass_hero_web/components/provider_components.ex:1920
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Close"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1802
+#: lib/klass_hero_web/components/provider_components.ex:1848
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cover"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1800
+#: lib/klass_hero_web/components/provider_components.ex:1846
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1794
+#: lib/klass_hero_web/components/provider_components.ex:1840
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No sessions scheduled yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1783
+#: lib/klass_hero_web/components/provider_components.ex:1829
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sessions — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1523
+#: lib/klass_hero_web/components/provider_components.ex:1569
 #, elixir-autogen, elixir-format
 msgid "View sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:532
+#: lib/klass_hero_web/live/provider/programs_live.ex:535
 #, elixir-autogen, elixir-format
 msgid "Create a program before inviting participants."
 msgstr ""
@@ -4959,22 +4959,22 @@ msgstr ""
 msgid "Failed to update record"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2396
+#: lib/klass_hero_web/components/provider_components.ex:2442
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2115
+#: lib/klass_hero_web/components/provider_components.ex:2161
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invite mode"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2134
+#: lib/klass_hero_web/components/provider_components.ex:2180
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:528
+#: lib/klass_hero_web/live/provider/programs_live.ex:531
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invite sent."
 msgstr ""
@@ -4984,12 +4984,12 @@ msgstr ""
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2409
+#: lib/klass_hero_web/components/provider_components.ex:2455
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2415
+#: lib/klass_hero_web/components/provider_components.ex:2461
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr ""
@@ -5000,17 +5000,17 @@ msgstr ""
 msgid "Nothing to update"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2417
+#: lib/klass_hero_web/components/provider_components.ex:2463
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nut allergy"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2421
+#: lib/klass_hero_web/components/provider_components.ex:2467
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2426
+#: lib/klass_hero_web/components/provider_components.ex:2472
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr ""
@@ -5020,7 +5020,7 @@ msgstr ""
 msgid "Present"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2353
+#: lib/klass_hero_web/components/provider_components.ex:2399
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr ""
@@ -5047,22 +5047,22 @@ msgstr ""
 msgid "Save changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2390
+#: lib/klass_hero_web/components/provider_components.ex:2436
 #, elixir-autogen, elixir-format, fuzzy
 msgid "School (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2400
+#: lib/klass_hero_web/components/provider_components.ex:2446
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2374
+#: lib/klass_hero_web/components/provider_components.ex:2420
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2443
+#: lib/klass_hero_web/components/provider_components.ex:2489
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Send invite"
 msgstr ""
@@ -5072,12 +5072,12 @@ msgstr ""
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2152
+#: lib/klass_hero_web/components/provider_components.ex:2198
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload a list"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:539
+#: lib/klass_hero_web/live/provider/programs_live.ex:542
 #, elixir-autogen, elixir-format
 msgid "An invite for this child and program already exists."
 msgstr ""
@@ -5172,7 +5172,7 @@ msgstr ""
 msgid "Property Damage"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1553
+#: lib/klass_hero_web/components/provider_components.ex:1599
 #, elixir-autogen, elixir-format
 msgid "Report Incident"
 msgstr ""
@@ -5254,7 +5254,7 @@ msgstr ""
 msgid "Go to dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:484
+#: lib/klass_hero_web/live/provider/programs_live.ex:487
 #, elixir-autogen, elixir-format
 msgid "%{count} row could not be processed."
 msgid_plural "%{count} rows could not be processed."
@@ -5841,8 +5841,8 @@ msgstr ""
 msgid "I'll be teaching"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:459
-#: lib/klass_hero_web/live/provider/programs_live.ex:481
+#: lib/klass_hero_web/live/provider/programs_live.ex:462
+#: lib/klass_hero_web/live/provider/programs_live.ex:484
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Imported %{count} family."
 msgid_plural "Imported %{count} families."
@@ -5854,7 +5854,7 @@ msgstr[1] ""
 msgid "In 2025, Shane connected with his friend"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1562
+#: lib/klass_hero_web/components/provider_components.ex:1608
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:43
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:74
 #, elixir-autogen, elixir-format
@@ -5924,7 +5924,7 @@ msgstr ""
 msgid "Last 8 weeks"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1272
+#: lib/klass_hero_web/components/provider_components.ex:1318
 #: lib/klass_hero_web/presenters/hero_cards_presenter.ex:27
 #, elixir-autogen, elixir-format
 msgid "Lead Instructor"
@@ -6131,7 +6131,7 @@ msgstr ""
 msgid "No registered children for this session."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:468
+#: lib/klass_hero_web/live/provider/programs_live.ex:471
 #, elixir-autogen, elixir-format
 msgid "No rows imported. %{count} row could not be processed."
 msgid_plural "No rows imported. %{count} rows could not be processed."
@@ -6374,17 +6374,17 @@ msgstr ""
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2482
+#: lib/klass_hero_web/components/provider_components.ex:2528
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Row %{row}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2482
+#: lib/klass_hero_web/components/provider_components.ex:2528
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2228
+#: lib/klass_hero_web/components/provider_components.ex:2274
 #, elixir-autogen, elixir-format
 msgid "Rows with errors"
 msgstr ""
@@ -7143,12 +7143,12 @@ msgstr ""
 msgid "Experience validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2786
+#: lib/klass_hero_web/components/provider_components.ex:2832
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2760
+#: lib/klass_hero_web/components/provider_components.ex:2806
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
@@ -7158,12 +7158,12 @@ msgstr ""
 msgid "Safeguarding certificate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2783
+#: lib/klass_hero_web/components/provider_components.ex:2829
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select Video"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2829
+#: lib/klass_hero_web/components/provider_components.ex:2875
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload Video"
 msgstr ""
@@ -7173,7 +7173,7 @@ msgstr ""
 msgid "Your browser does not support video playback."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2976
+#: lib/klass_hero_web/components/provider_components.ex:3022
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Confirm agreement"
 msgstr ""
@@ -7183,12 +7183,12 @@ msgstr ""
 msgid "Couldn't record your agreement. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2999
+#: lib/klass_hero_web/components/provider_components.ex:3045
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2975
+#: lib/klass_hero_web/components/provider_components.ex:3021
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr ""
@@ -7198,7 +7198,7 @@ msgstr ""
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2884
+#: lib/klass_hero_web/components/provider_components.ex:2930
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr ""
@@ -7208,17 +7208,17 @@ msgstr ""
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2984
+#: lib/klass_hero_web/components/provider_components.ex:3030
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2973
+#: lib/klass_hero_web/components/provider_components.ex:3019
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2974
+#: lib/klass_hero_web/components/provider_components.ex:3020
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
@@ -7487,12 +7487,12 @@ msgstr ""
 msgid "Your insurance is verified."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2928
+#: lib/klass_hero_web/components/provider_components.ex:2974
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3031
+#: lib/klass_hero_web/components/provider_components.ex:3077
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr ""
@@ -7502,7 +7502,7 @@ msgstr ""
 msgid "Couldn't record your declaration. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3037
+#: lib/klass_hero_web/components/provider_components.ex:3083
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr ""
@@ -7512,17 +7512,17 @@ msgstr ""
 msgid "Please confirm the declaration before signing."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3062
+#: lib/klass_hero_web/components/provider_components.ex:3108
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3041
+#: lib/klass_hero_web/components/provider_components.ex:3087
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3029
+#: lib/klass_hero_web/components/provider_components.ex:3075
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr ""
@@ -7532,12 +7532,12 @@ msgstr ""
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3049
+#: lib/klass_hero_web/components/provider_components.ex:3095
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3035
+#: lib/klass_hero_web/components/provider_components.ex:3081
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
@@ -7604,92 +7604,92 @@ msgstr ""
 msgid "Undelivered Events"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1971
+#: lib/klass_hero_web/components/provider_components.ex:2017
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1896
+#: lib/klass_hero_web/components/provider_components.ex:1942
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Lead"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:334
+#: lib/klass_hero_web/live/provider/programs_live.ex:337
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Lead instructor updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1907
+#: lib/klass_hero_web/components/provider_components.ex:1953
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1537
+#: lib/klass_hero_web/components/provider_components.ex:1583
 #, elixir-autogen, elixir-format
 msgid "Manage Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1935
+#: lib/klass_hero_web/components/provider_components.ex:1981
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this program yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:264
+#: lib/klass_hero_web/live/provider/programs_live.ex:267
 #, elixir-autogen, elixir-format
 msgid "Pick a staff member to add."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1918
+#: lib/klass_hero_web/components/provider_components.ex:1964
 #, elixir-autogen, elixir-format
 msgid "Reassign the lead before removing them"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1919
+#: lib/klass_hero_web/components/provider_components.ex:1965
 #, elixir-autogen, elixir-format
 msgid "Remove from program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1953
+#: lib/klass_hero_web/components/provider_components.ex:1999
 #, elixir-autogen, elixir-format
 msgid "Select a staff member…"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:279
+#: lib/klass_hero_web/live/provider/programs_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "Staff member added to the program."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:305
+#: lib/klass_hero_web/live/provider/programs_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "Staff member removed from the program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1976
+#: lib/klass_hero_web/components/provider_components.ex:2022
 #, elixir-autogen, elixir-format
 msgid "Staff you add can read and reply to this program's parent conversations."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1872
+#: lib/klass_hero_web/components/provider_components.ex:1918
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Staffing — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:932
+#: lib/klass_hero_web/live/provider/programs_live.ex:944
 #, elixir-autogen, elixir-format
 msgid "That staff member could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:287
+#: lib/klass_hero_web/live/provider/programs_live.ex:290
 #, elixir-autogen, elixir-format
 msgid "They are already on this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:313
+#: lib/klass_hero_web/live/provider/programs_live.ex:316
 #, elixir-autogen, elixir-format
 msgid "This person is the lead instructor. Make someone else lead before removing them."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1481
+#: lib/klass_hero_web/components/provider_components.ex:1527
 #, elixir-autogen, elixir-format
 msgid "%{count} staff member · no lead"
 msgid_plural "%{count} staff · no lead"
@@ -7746,17 +7746,34 @@ msgstr ""
 msgid "This person has a history here now — use 'Remove from team' instead."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1165
+#: lib/klass_hero_web/live/provider/programs_live.ex:1222
 #, elixir-autogen, elixir-format
 msgid "Program created, but some settings could not be saved. Please review the program's limits."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1169
+#: lib/klass_hero_web/live/provider/programs_live.ex:1226
 #, elixir-autogen, elixir-format
 msgid "Program updated, but some settings could not be saved. Please review the program's limits."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1159
+#: lib/klass_hero_web/live/provider/programs_live.ex:1216
 #, elixir-autogen, elixir-format
 msgid "Program updated, but the enrollment capacity was rejected. The previous limits still apply."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:918
+#, elixir-autogen, elixir-format
+msgid "%{count} child is already enrolled. Confirm you want this program to have no capacity limit."
+msgid_plural "%{count} children are already enrolled. Confirm you want this program to have no capacity limit."
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1120
+#, elixir-autogen, elixir-format
+msgid "Anyone will be able to book a place until you set a new maximum."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1125
+#, elixir-autogen, elixir-format
+msgid "I understand this program will have no capacity limit."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/en/LC_MESSAGES/enrollment.po
@@ -11,95 +11,95 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:2576
-#: lib/klass_hero_web/components/provider_components.ex:2593
+#: lib/klass_hero_web/components/provider_components.ex:2622
+#: lib/klass_hero_web/components/provider_components.ex:2639
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2577
-#: lib/klass_hero_web/components/provider_components.ex:2594
+#: lib/klass_hero_web/components/provider_components.ex:2623
+#: lib/klass_hero_web/components/provider_components.ex:2640
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2578
-#: lib/klass_hero_web/components/provider_components.ex:2595
+#: lib/klass_hero_web/components/provider_components.ex:2624
+#: lib/klass_hero_web/components/provider_components.ex:2641
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2589
+#: lib/klass_hero_web/components/provider_components.ex:2635
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2579
+#: lib/klass_hero_web/components/provider_components.ex:2625
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2580
+#: lib/klass_hero_web/components/provider_components.ex:2626
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2581
+#: lib/klass_hero_web/components/provider_components.ex:2627
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2588
+#: lib/klass_hero_web/components/provider_components.ex:2634
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2590
+#: lib/klass_hero_web/components/provider_components.ex:2636
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2582
+#: lib/klass_hero_web/components/provider_components.ex:2628
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2584
+#: lib/klass_hero_web/components/provider_components.ex:2630
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2586
+#: lib/klass_hero_web/components/provider_components.ex:2632
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2516
+#: lib/klass_hero_web/components/provider_components.ex:2562
 #, elixir-autogen, elixir-format
 msgid "Date of birth \"%{value}\" is not a valid date. Please correct it and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2510
+#: lib/klass_hero_web/components/provider_components.ex:2556
 #, elixir-autogen, elixir-format
 msgid "Invite link could not be generated (no token). Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2524
+#: lib/klass_hero_web/components/provider_components.ex:2570
 #, elixir-autogen, elixir-format
 msgid "The invitation email could not be delivered. Please check the address and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2513
+#: lib/klass_hero_web/components/provider_components.ex:2559
 #, elixir-autogen, elixir-format
 msgid "The program is full, so this child could not be enrolled."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2527
+#: lib/klass_hero_web/components/provider_components.ex:2573
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed and no retries remain. Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2536
+#: lib/klass_hero_web/components/provider_components.ex:2582
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed. Please resend."
 msgstr ""

--- a/priv/gettext/enrollment.pot
+++ b/priv/gettext/enrollment.pot
@@ -11,95 +11,95 @@
 msgid ""
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2576
-#: lib/klass_hero_web/components/provider_components.ex:2593
+#: lib/klass_hero_web/components/provider_components.ex:2622
+#: lib/klass_hero_web/components/provider_components.ex:2639
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2577
-#: lib/klass_hero_web/components/provider_components.ex:2594
+#: lib/klass_hero_web/components/provider_components.ex:2623
+#: lib/klass_hero_web/components/provider_components.ex:2640
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2578
-#: lib/klass_hero_web/components/provider_components.ex:2595
+#: lib/klass_hero_web/components/provider_components.ex:2624
+#: lib/klass_hero_web/components/provider_components.ex:2641
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2589
+#: lib/klass_hero_web/components/provider_components.ex:2635
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2579
+#: lib/klass_hero_web/components/provider_components.ex:2625
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2580
+#: lib/klass_hero_web/components/provider_components.ex:2626
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2581
+#: lib/klass_hero_web/components/provider_components.ex:2627
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2588
+#: lib/klass_hero_web/components/provider_components.ex:2634
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2590
+#: lib/klass_hero_web/components/provider_components.ex:2636
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2582
+#: lib/klass_hero_web/components/provider_components.ex:2628
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2584
+#: lib/klass_hero_web/components/provider_components.ex:2630
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2586
+#: lib/klass_hero_web/components/provider_components.ex:2632
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2516
+#: lib/klass_hero_web/components/provider_components.ex:2562
 #, elixir-autogen, elixir-format
 msgid "Date of birth \"%{value}\" is not a valid date. Please correct it and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2510
+#: lib/klass_hero_web/components/provider_components.ex:2556
 #, elixir-autogen, elixir-format
 msgid "Invite link could not be generated (no token). Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2524
+#: lib/klass_hero_web/components/provider_components.ex:2570
 #, elixir-autogen, elixir-format
 msgid "The invitation email could not be delivered. Please check the address and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2513
+#: lib/klass_hero_web/components/provider_components.ex:2559
 #, elixir-autogen, elixir-format
 msgid "The program is full, so this child could not be enrolled."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2527
+#: lib/klass_hero_web/components/provider_components.ex:2573
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed and no retries remain. Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2536
+#: lib/klass_hero_web/components/provider_components.ex:2582
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed. Please resend."
 msgstr ""

--- a/test/klass_hero/enrollment/cap_removal_test.exs
+++ b/test/klass_hero/enrollment/cap_removal_test.exs
@@ -1,0 +1,219 @@
+defmodule KlassHero.Enrollment.CapRemovalTest do
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+
+  alias KlassHero.Enrollment
+  alias KlassHero.Enrollment.EnrollmentPolicy
+
+  defp capped_program(max_enrollment) do
+    program = insert(:program_schema)
+
+    {:ok, _policy} =
+      Enrollment.set_enrollment_policy(%{program_id: program.id, max_enrollment: max_enrollment})
+
+    program
+  end
+
+  defp stored_policy(program_id), do: Repo.get_by(EnrollmentPolicy, program_id: program_id)
+
+  describe "EnrollmentPolicy.cap_removal?/2" do
+    @truth_table [
+      {12, nil, true, "blanking a stored maximum"},
+      {12, 30, false, "raising it"},
+      {12, 5, false, "lowering it"},
+      {nil, nil, false, "leaving an already-uncapped program uncapped"},
+      {nil, 12, false, "adding a maximum where there was none"}
+    ]
+
+    test "is true only when a stored maximum is being blanked" do
+      for {previous, new_max, expected, label} <- @truth_table do
+        policy = %EnrollmentPolicy{max_enrollment: previous}
+
+        assert EnrollmentPolicy.cap_removal?(policy, new_max) == expected,
+               "#{label}: expected cap_removal?(#{inspect(previous)}, #{inspect(new_max)}) " <>
+                 "to be #{expected}"
+      end
+    end
+
+    test "is false with no policy at all, which is the create path" do
+      refute EnrollmentPolicy.cap_removal?(nil, nil)
+    end
+  end
+
+  describe "set_enrollment_policy/1 — clearing capacity (#1370)" do
+    test "clears both limits on a program with no active enrollments" do
+      program = capped_program(12)
+
+      assert {:ok, _policy} =
+               Enrollment.set_enrollment_policy(%{
+                 program_id: program.id,
+                 min_enrollment: nil,
+                 max_enrollment: nil
+               })
+
+      assert %EnrollmentPolicy{min_enrollment: nil, max_enrollment: nil} = stored_policy(program.id)
+    end
+
+    test "keeps exactly one policy row rather than deleting it" do
+      program = capped_program(12)
+
+      {:ok, _} =
+        Enrollment.set_enrollment_policy(%{
+          program_id: program.id,
+          min_enrollment: nil,
+          max_enrollment: nil
+        })
+
+      assert Repo.aggregate(
+               from(p in EnrollmentPolicy, where: p.program_id == ^program.id),
+               :count
+             ) == 1
+    end
+
+    test "clearing only the minimum is never guarded" do
+      program = insert(:program_schema)
+
+      {:ok, _} =
+        Enrollment.set_enrollment_policy(%{
+          program_id: program.id,
+          min_enrollment: 3,
+          max_enrollment: 12
+        })
+
+      insert(:enrollment_schema, program_id: program.id, status: "confirmed")
+
+      assert {:ok, _} =
+               Enrollment.set_enrollment_policy(%{
+                 program_id: program.id,
+                 min_enrollment: nil,
+                 max_enrollment: 12
+               })
+
+      assert %EnrollmentPolicy{min_enrollment: nil, max_enrollment: 12} = stored_policy(program.id)
+    end
+  end
+
+  describe "set_enrollment_policy/1 — removing the cap with active enrollments" do
+    test "refuses an unacknowledged removal and leaves the stored cap intact" do
+      program = capped_program(12)
+      insert(:enrollment_schema, program_id: program.id, status: "confirmed")
+      insert(:enrollment_schema, program_id: program.id, status: "pending")
+
+      assert {:error, {:cap_removal_blocked, 2}} =
+               Enrollment.set_enrollment_policy(%{program_id: program.id, max_enrollment: nil})
+
+      assert %EnrollmentPolicy{max_enrollment: 12} = stored_policy(program.id)
+    end
+
+    test "permits the removal when explicitly acknowledged" do
+      program = capped_program(12)
+      insert(:enrollment_schema, program_id: program.id, status: "confirmed")
+
+      assert {:ok, _} =
+               Enrollment.set_enrollment_policy(%{
+                 program_id: program.id,
+                 max_enrollment: nil,
+                 acknowledge_cap_removal: true
+               })
+
+      assert %EnrollmentPolicy{max_enrollment: nil} = stored_policy(program.id)
+    end
+
+    test "ignores cancelled enrollments when counting" do
+      program = capped_program(12)
+      insert(:enrollment_schema, program_id: program.id, status: "cancelled")
+
+      assert {:ok, _} =
+               Enrollment.set_enrollment_policy(%{program_id: program.id, max_enrollment: nil})
+
+      assert %EnrollmentPolicy{max_enrollment: nil} = stored_policy(program.id)
+    end
+
+    test "leaves raising the cap unguarded" do
+      program = capped_program(12)
+      insert(:enrollment_schema, program_id: program.id, status: "confirmed")
+
+      assert {:ok, _} =
+               Enrollment.set_enrollment_policy(%{program_id: program.id, max_enrollment: 30})
+
+      assert %EnrollmentPolicy{max_enrollment: 30} = stored_policy(program.id)
+    end
+
+    test "leaves lowering the cap below the enrolled count unguarded" do
+      program = capped_program(12)
+
+      for _ <- 1..3, do: insert(:enrollment_schema, program_id: program.id, status: "confirmed")
+
+      assert {:ok, _} =
+               Enrollment.set_enrollment_policy(%{program_id: program.id, max_enrollment: 2})
+
+      assert %EnrollmentPolicy{max_enrollment: 2} = stored_policy(program.id)
+    end
+
+    test "is inert on create, where there is no cap to remove" do
+      program = insert(:program_schema)
+      insert(:enrollment_schema, program_id: program.id, status: "confirmed")
+
+      assert {:ok, _} =
+               Enrollment.set_enrollment_policy(%{
+                 program_id: program.id,
+                 min_enrollment: 3,
+                 max_enrollment: nil
+               })
+
+      assert %EnrollmentPolicy{min_enrollment: 3, max_enrollment: nil} = stored_policy(program.id)
+    end
+  end
+
+  describe "assess_capacity_change/2" do
+    test "reports the removal and the count that makes it consequential" do
+      program = capped_program(12)
+      insert(:enrollment_schema, program_id: program.id, status: "confirmed")
+      insert(:enrollment_schema, program_id: program.id, status: "pending")
+
+      assert {:cap_removal, 2} = Enrollment.assess_capacity_change(program.id, nil)
+    end
+
+    test "reports :ok when the cap is being kept" do
+      program = capped_program(12)
+      insert(:enrollment_schema, program_id: program.id, status: "confirmed")
+
+      assert :ok = Enrollment.assess_capacity_change(program.id, 30)
+    end
+
+    test "reports :ok when no one is enrolled" do
+      program = capped_program(12)
+
+      assert :ok = Enrollment.assess_capacity_change(program.id, nil)
+    end
+
+    test "reports :ok when no policy exists yet" do
+      program = insert(:program_schema)
+
+      assert :ok = Enrollment.assess_capacity_change(program.id, nil)
+    end
+
+    # The whole point of the shared predicate: the hint the provider sees and the
+    # rule the write enforces must never disagree, or the form warns about a save
+    # that succeeds (or stays silent before one that fails).
+    test "agrees with what the write actually does" do
+      for {max, enrolled} <- [{nil, 0}, {nil, 2}, {30, 2}, {5, 2}] do
+        program = capped_program(12)
+
+        for _ <- 1..enrolled//1,
+            do: insert(:enrollment_schema, program_id: program.id, status: "confirmed")
+
+        assessment = Enrollment.assess_capacity_change(program.id, max)
+        write = Enrollment.set_enrollment_policy(%{program_id: program.id, max_enrollment: max})
+
+        assert match?({:cap_removal, _}, assessment) == match?({:error, {:cap_removal_blocked, _}}, write),
+               """
+               assessment and write disagreed for max=#{inspect(max)}, enrolled=#{enrolled}
+                 assessment: #{inspect(assessment)}
+                 write:      #{inspect(write)}
+               """
+      end
+    end
+  end
+end

--- a/test/klass_hero_web/live/provider/dashboard_program_creation_test.exs
+++ b/test/klass_hero_web/live/provider/dashboard_program_creation_test.exs
@@ -1,6 +1,7 @@
 defmodule KlassHeroWeb.Provider.DashboardProgramCreationTest do
   use KlassHeroWeb.ConnCase, async: true
 
+  import KlassHero.Factory
   import Phoenix.LiveViewTest
 
   alias KlassHero.Enrollment.EnrollmentPolicy
@@ -692,6 +693,190 @@ defmodule KlassHeroWeb.Provider.DashboardProgramCreationTest do
       html = render(view)
       assert html =~ "Program created successfully."
       refute html =~ "program limit"
+    end
+  end
+
+  # The edit form is prefilled from the stored policy, so blanking a field is a
+  # deliberate clear — not the "no limits given" the create path reads it as (#1370).
+  describe "clearing the enrollment capacity" do
+    defp edit_with_capacity(view, program, title, policy_params) do
+      open_edit_form(view, program)
+      submit_program_form(view, title, %{"enrollment_policy" => policy_params})
+    end
+
+    test "clears the stored limits when nobody is enrolled", %{conn: conn, provider: provider} do
+      program = seed_program_with_listing(provider.id, "Uncap Me")
+
+      {:ok, _} =
+        KlassHero.Enrollment.set_enrollment_policy(%{
+          program_id: program.id,
+          min_enrollment: 3,
+          max_enrollment: 12
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+
+      assert view |> element("#programs-#{program.id}") |> render() =~ "0/12"
+
+      edit_with_capacity(view, program, "Uncap Me", %{
+        "min_enrollment" => "",
+        "max_enrollment" => ""
+      })
+
+      assert_flash(view, :info, "Program updated successfully.")
+
+      assert %EnrollmentPolicy{min_enrollment: nil, max_enrollment: nil} =
+               Repo.get_by!(EnrollmentPolicy, program_id: program.id)
+
+      assert view |> element("#programs-#{program.id}") |> render() =~ "0/—"
+    end
+
+    test "keeps clearing the minimum alone unguarded", %{conn: conn, provider: provider} do
+      program = seed_program_with_listing(provider.id, "Drop The Minimum")
+
+      {:ok, _} =
+        KlassHero.Enrollment.set_enrollment_policy(%{
+          program_id: program.id,
+          min_enrollment: 3,
+          max_enrollment: 12
+        })
+
+      insert(:enrollment_schema, program_id: program.id, status: "confirmed")
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+
+      edit_with_capacity(view, program, "Drop The Minimum", %{
+        "min_enrollment" => "",
+        "max_enrollment" => "12"
+      })
+
+      assert_flash(view, :info, "Program updated successfully.")
+
+      assert %EnrollmentPolicy{min_enrollment: nil, max_enrollment: 12} =
+               Repo.get_by!(EnrollmentPolicy, program_id: program.id)
+    end
+  end
+
+  describe "removing a capacity cap with children already enrolled" do
+    defp enrolled_capped_program(provider_id, title, enrolled) do
+      program = seed_program_with_listing(provider_id, title)
+
+      {:ok, _} =
+        KlassHero.Enrollment.set_enrollment_policy(%{program_id: program.id, max_enrollment: 12})
+
+      for _ <- 1..enrolled//1,
+          do: insert(:enrollment_schema, program_id: program.id, status: "confirmed")
+
+      program
+    end
+
+    defp blank_the_maximum(view, title) do
+      view
+      |> form("#program-form", %{
+        "program_schema" => %{
+          "title" => title,
+          "description" => "Exercising a program save outcome",
+          "category" => "arts",
+          "price" => "50.00"
+        },
+        "enrollment_policy" => %{"min_enrollment" => "", "max_enrollment" => ""}
+      })
+      |> render_change()
+    end
+
+    test "warns as soon as the field is blanked, before any save", %{
+      conn: conn,
+      provider: provider
+    } do
+      program = enrolled_capped_program(provider.id, "Warn Me First", 2)
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+
+      open_edit_form(view, program)
+
+      refute has_element?(view, "#cap-removal-warning")
+
+      blank_the_maximum(view, "Warn Me First")
+
+      assert has_element?(view, "#cap-removal-warning")
+      assert has_element?(view, "#enrollment_policy_acknowledge_cap_removal")
+    end
+
+    test "stays silent while the cap is merely lowered", %{conn: conn, provider: provider} do
+      program = enrolled_capped_program(provider.id, "Lower Me", 2)
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+
+      open_edit_form(view, program)
+
+      view
+      |> form("#program-form", %{
+        "program_schema" => %{
+          "title" => "Lower Me",
+          "description" => "Exercising a program save outcome",
+          "category" => "arts",
+          "price" => "50.00"
+        },
+        "enrollment_policy" => %{"max_enrollment" => "5"}
+      })
+      |> render_change()
+
+      refute has_element?(view, "#cap-removal-warning")
+    end
+
+    # The backstop, not the everyday path: the checkbox is `required`, so reaching
+    # this needs a booking to land while the form sits open (or a crafted submit).
+    test "refuses an unacknowledged removal and keeps the form open", %{
+      conn: conn,
+      provider: provider
+    } do
+      program = enrolled_capped_program(provider.id, "Refuse Me", 2)
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+
+      open_edit_form(view, program)
+      submit_program_form(view, "Refuse Me", %{"enrollment_policy" => %{"max_enrollment" => ""}})
+
+      assert_flash(
+        view,
+        :warning,
+        "2 children are already enrolled. Confirm you want this program to have no capacity limit."
+      )
+
+      refute_flash(view, :info)
+
+      assert %EnrollmentPolicy{max_enrollment: 12} =
+               Repo.get_by!(EnrollmentPolicy, program_id: program.id)
+
+      assert has_element?(view, "#program-form")
+      assert has_element?(view, "#cap-removal-warning")
+    end
+
+    test "removes the cap once acknowledged", %{conn: conn, provider: provider} do
+      program = enrolled_capped_program(provider.id, "Acknowledged Uncap", 2)
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+
+      open_edit_form(view, program)
+
+      # The checkbox only exists once the field is blanked, so the tick can only follow
+      # the warning — which is the whole point of showing it on change rather than on save.
+      blank_the_maximum(view, "Acknowledged Uncap")
+
+      submit_program_form(view, "Acknowledged Uncap", %{
+        "enrollment_policy" => %{
+          "min_enrollment" => "",
+          "max_enrollment" => "",
+          "acknowledge_cap_removal" => "true"
+        }
+      })
+
+      assert_flash(view, :info, "Program updated successfully.")
+
+      assert %EnrollmentPolicy{max_enrollment: nil} =
+               Repo.get_by!(EnrollmentPolicy, program_id: program.id)
+
+      assert view |> element("#programs-#{program.id}") |> render() =~ "2/—"
     end
   end
 


### PR DESCRIPTION
Closes #1370

## Summary

Blanking both enrollment capacity fields on the program edit form silently did nothing — the provider got "Program updated successfully." while the old limits stayed in force. `maybe_set_enrollment_policy/2` short-circuited when both parsed values were `nil`: correct on **create** (don't store an all-nil row), wrong on **update**, where the form is prefilled from the stored policy, so empty fields are a deliberate *clear*. Split into create/update siblings, mirroring the fix #795 already applied to the sibling participant policy in the same file.

`Enrollment.set_enrollment_policy/1` already cleared correctly when handed explicit nils (verified against the dev DB before writing any code), so this needed **no delete path, no changeset change, and no migration** — the issue's two candidate designs turned out to be behaviourally identical at every read site.

On top of the fix, removing a cap entirely from a program that **already has active enrollments** is now refused unless explicitly acknowledged.

## Design

The rule is stated once, as a pure predicate `EnrollmentPolicy.cap_removal?/2`, and called twice so the warning and the enforcement cannot drift:

- `Enrollment.assess_capacity_change/2` — the read the form makes on `phx-change`, so the warning appears as soon as the field is blanked, before any save.
- `set_enrollment_policy/1` — now an `Ecto.Multi` whose guard step takes a `FOR UPDATE` lock on the same `enrollment_policies` row that `create_enrollment_with_capacity_check/3` locks. A booking landing mid-edit therefore serialises against the removal instead of slipping past the count.

Placement follows the existing convention: every changeset in this codebase is a pure `(schema, attrs)` function, and DB-state validation lives in the context function with a row lock. The acknowledgement rides through `attrs` and is never cast, so no schema field is added.

Scope decisions, all deliberate: only *removing* the cap is guarded (raising or lowering stays silent), and `min_enrollment` is unguarded — it is a viability threshold, not a safety bound.

## Review Focus

- `lib/klass_hero/enrollment.ex` — the Multi's guard step and error unwrapping
- `lib/klass_hero_web/live/provider/programs_live.ex` — the create/update split (the actual #1370 fix) and the refusal path that keeps the form open
- `CONTEXT.md` — adds an **Enrollment Policy** term; the capacity cap had no entry in the ubiquitous language despite now carrying a domain rule

## Test Plan

- `mix precommit` green: **4431 tests**, credo clean, typography / translations / read-table / ACL lints all pass
- 16 new context tests (`test/klass_hero/enrollment/cap_removal_test.exs`), including one that asserts `assess_capacity_change/2` and the write agree across the same inputs — the anti-drift guard
- 5 new LiveView tests, including the reported bug and the first tests in that file to seed *active enrollments*
- Verified against the dev DB via Tidewave: assessment `{:cap_removal, 1}`, write refused with the cap intact at 12, acknowledged write cleared it, `:ok` when merely lowering
- Driven in a browser on the issue's own repro ("Piano for Beginners", `1/12`): warning + required checkbox appear on change, submit blocked untickd, saved once ticked, row shows `1/—` and the DB row holds `nil` — UI and database now agree

## Out of scope

- `enrollment_percentage/1` renders a 0%-wide bar for `nil` capacity, so an uncapped program looks identical to an empty one — more visible now that uncapping is deliberate; worth its own issue
- Guarding a cap *lowered below* the current enrolled count (over-subscription)