### PR TITLE
fix: narrow the exception reason before the error store keeps it

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -40,6 +40,7 @@ alias KlassHero.Shared.Adapters.Driven.Storage.S3StorageAdapter
 alias KlassHero.Shared.Adapters.Driven.Workers.CompensationSweepWorker
 alias KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorker
 alias KlassHero.Shared.ErrorContextFilter
+alias KlassHero.Shared.ErrorStoreRepo
 alias Swoosh.Adapters.Local
 
 # The supported-locale set, declared once. Config owns it because config.exs is
@@ -64,8 +65,12 @@ config :elixir, :time_zone_database, Tz.TimeZoneDatabase
 
 # `filter` narrows what gets persisted: Oban job args reach here in full, and some
 # carry child health data. See KlassHero.Shared.ErrorContextFilter.
+#
+# `repo` is deliberately NOT KlassHero.Repo. ErrorTracker's filter reaches the context only,
+# so the exception message lands in `reason` unfiltered; the shim narrows it at the write
+# boundary, which is the one point every report path passes through (#1398).
 config :error_tracker,
-  repo: KlassHero.Repo,
+  repo: ErrorStoreRepo,
   otp_app: :klass_hero,
   enabled: true,
   filter: ErrorContextFilter

--- a/docs/runbooks/prod-db-access.md
+++ b/docs/runbooks/prod-db-access.md
@@ -61,6 +61,13 @@ select context from error_tracker_occurrences
  where error_id = <ID> order by inserted_at desc limit 1;
 ```
 
+`reason` is narrowed before it is stored (#1398), so it reads as the exception's leading clause
+plus a marker — `key :program_id not found in: [redacted]`. A reason of
+`[reason redacted: unrecognised message shape]` means the message matched no known shape and was
+dropped whole; identify the error from `kind`, `source_function` and the occurrence's stacktrace,
+and if the shape is one that carries no user data, add it to
+`KlassHero.Shared.ErrorReasonFilter`'s allowlist so the next occurrence reads properly.
+
 ## Safety model
 
 - `debug-ro` is the MPG `reader` role — **SELECT-only, structurally**. Writes are

--- a/lib/klass_hero/shared/error_context_filter.ex
+++ b/lib/klass_hero/shared/error_context_filter.ex
@@ -30,6 +30,16 @@ defmodule KlassHero.Shared.ErrorContextFilter do
   once. Each key is narrowed independently.
 
   Wired via `config :error_tracker, filter: KlassHero.Shared.ErrorContextFilter`.
+
+  ## What this filter does NOT cover
+
+  `reason` — the exception message — is out of reach here, and no configuration can change
+  that: `ErrorTracker.report/3` runs this filter over the context, then passes `reason` to
+  storage separately, and `ErrorTracker.Filter` has no second callback. An exception that
+  interpolates the value that caused it (`MatchError`, `KeyError`, `Oban.PerformError`)
+  therefore leaks through a surface this module cannot see (#1398). Narrowing it happens at
+  the write boundary instead — see `KlassHero.Shared.ErrorReasonFilter` and
+  `KlassHero.Shared.ErrorStoreRepo`.
   """
 
   @behaviour ErrorTracker.Filter

--- a/lib/klass_hero/shared/error_reason_filter.ex
+++ b/lib/klass_hero/shared/error_reason_filter.ex
@@ -1,0 +1,94 @@
+defmodule KlassHero.Shared.ErrorReasonFilter do
+  @moduledoc """
+  Narrows the exception message ErrorTracker persists as `reason`.
+
+  Sibling of `KlassHero.Shared.ErrorContextFilter`, which cannot reach this surface:
+  `ErrorTracker.report/3` runs the configured filter over the *context* only, then passes
+  `reason` — `Exception.message(exception)` — straight to storage. Any exception that
+  interpolates the value that caused it therefore writes that value to
+  `error_tracker_errors.reason` and `error_tracker_occurrences.reason` (#1398).
+
+  Applied at the write boundary by `KlassHero.Shared.ErrorStoreRepo`, so every report path
+  is covered — Phoenix, Oban, a manual `ErrorTracker.report/3`, and any integration a future
+  `error_tracker` adds.
+
+  Narrowing happens in two stages, because exceptions leak in two different shapes:
+
+    * **After a line break.** Elixir renders a payload-bearing exception as a safe clause, a
+      blank line, then the interpolated term (`key :x not found in:\\n\\n    %{...}`);
+      Postgres puts the offending value in the `detail` that follows the same break. The
+      first line is kept and a `[redacted]` marker announces what went — the marker is the
+      point, exactly as the sibling filter keeps param keys in place.
+
+    * **Inline.** `Oban.PerformError` (`<worker> failed with <term>`), `ArgumentError`, and
+      any custom exception interpolating into its own `:message` put the payload on the same
+      line as the clause. Nothing structural separates the two, so the first line is judged
+      against `@safe_shapes`.
+
+  **Closed by default.** A first line matching no known shape is replaced wholesale, so a new
+  exception kind is minimised until someone adds it here. The cost is real: the first
+  occurrence of a novel exception shows the marker instead of its message, and triage falls
+  back to `kind`, `source_function`, `source_line` and the stacktrace. Every kind seen in
+  production is covered below, so this bites on novel custom exceptions only.
+  """
+
+  @redaction_marker "[redacted]"
+  @unrecognised_marker "[reason redacted: unrecognised message shape]"
+
+  # First lines proven to carry no interpolated value, each named by the exception it covers.
+  @safe_shapes [
+    # KeyError, with and without a term
+    ~r/^key .+ not found(?: in:)?$/,
+    # MatchError
+    ~r/^no match of right hand side value:$/,
+    # CaseClauseError
+    ~r/^no case clause matching:$/,
+    # FunctionClauseError
+    ~r{^no function clause matching in .+/\d+$},
+    # WithClauseError
+    ~r/^no with clause matching:$/,
+    # Protocol.UndefinedError
+    ~r/^protocol .+ not implemented for .+$/,
+    # Postgrex.Error — the value lives in `detail`, below the break
+    ~r/^ERROR \d{5} \(\w+\) /,
+    # Ecto.ConstraintError
+    ~r/^constraint error when attempting to \w+ struct:$/,
+    # Ecto.NoResultsError / Ecto.MultipleResultsError
+    ~r/^expected at (?:least|most) one result but got /,
+    # Oban.TimeoutError
+    ~r/^.+ timed out after \d+ms$/,
+    # DBConnection timeouts and checkout failures
+    ~r/^(?:client .+ timed out|connection not available)/
+  ]
+
+  # The head identifies the error, the tail is the payload — Oban.PerformError wraps whatever
+  # term a worker returned in `{:error, term}`, so the tail is arbitrary user data.
+  @inline_payload_shape ~r/^(?<head>.+? failed with ).+$/s
+
+  @spec sanitize(String.t()) :: String.t()
+  def sanitize(reason) when is_binary(reason) do
+    {head, dropped?} = split_first_line(reason)
+
+    if safe_shape?(head), do: mark(head, dropped?), else: redact(head)
+  end
+
+  defp split_first_line(reason) do
+    case String.split(reason, "\n", parts: 2) do
+      [head] -> {head, false}
+      [head, ""] -> {head, false}
+      [head, _payload] -> {head, true}
+    end
+  end
+
+  defp safe_shape?(head), do: Enum.any?(@safe_shapes, &Regex.match?(&1, head))
+
+  defp mark(head, false), do: head
+  defp mark(head, true), do: head <> " " <> @redaction_marker
+
+  defp redact(head) do
+    case Regex.run(@inline_payload_shape, head, capture: ["head"]) do
+      [prefix] -> prefix <> @redaction_marker
+      nil -> @unrecognised_marker
+    end
+  end
+end

--- a/lib/klass_hero/shared/error_store_repo.ex
+++ b/lib/klass_hero/shared/error_store_repo.ex
@@ -1,0 +1,47 @@
+defmodule KlassHero.Shared.ErrorStoreRepo do
+  @moduledoc """
+  The repo `error_tracker` writes through, so `reason` can be narrowed on its way to disk.
+
+  `ErrorTracker.Repo` is not an Ecto repo — it is a dispatcher that calls
+  `apply(Application.fetch_env!(:error_tracker, :repo), action, args ++ [opts])`. Every
+  database call the dependency makes, reporting and dashboard alike, goes through it. Pointing
+  `config :error_tracker, repo:` at this module therefore covers every report path at once —
+  Phoenix, Oban, a manual `ErrorTracker.report/3`, and any integration a future version adds.
+
+  That matters because the dependency offers no hook here: `ErrorTracker.Filter` sanitizes the
+  *context* only, and `reason` — `Exception.message(exception)` — reaches storage unfiltered
+  (#1398). This is the last point at which it can be narrowed.
+
+  Everything other than `reason` on the two error-store schemas is delegated untouched. The set
+  of functions below is not arbitrary: it is exactly what `ErrorTracker.Repo` dispatches, and
+  `KlassHero.Shared.ErrorStoreRepoTest` fails if a dependency upgrade adds to that set.
+  """
+
+  alias Ecto.Changeset
+  alias ErrorTracker.Error
+  alias ErrorTracker.Occurrence
+  alias KlassHero.Repo, as: AppRepo
+  alias KlassHero.Shared.ErrorReasonFilter
+
+  def insert!(%Error{reason: reason} = error, opts) when is_binary(reason) do
+    AppRepo.insert!(%{error | reason: ErrorReasonFilter.sanitize(reason)}, opts)
+  end
+
+  def insert!(%Changeset{data: %Occurrence{}} = changeset, opts) do
+    changeset
+    |> Changeset.update_change(:reason, &ErrorReasonFilter.sanitize/1)
+    |> AppRepo.insert!(opts)
+  end
+
+  def insert!(struct_or_changeset, opts), do: AppRepo.insert!(struct_or_changeset, opts)
+
+  defdelegate update(changeset, opts), to: AppRepo
+  defdelegate get(queryable, id, opts), to: AppRepo
+  defdelegate get!(queryable, id, opts), to: AppRepo
+  defdelegate one(queryable, opts), to: AppRepo
+  defdelegate all(queryable, opts), to: AppRepo
+  defdelegate delete_all(queryable, opts), to: AppRepo
+  defdelegate aggregate(queryable, aggregate, opts), to: AppRepo
+  defdelegate transaction(fun_or_multi, opts), to: AppRepo
+  defdelegate __adapter__(), to: AppRepo
+end

--- a/priv/repo/migrations/20260818070000_scrub_error_tracker_reasons.exs
+++ b/priv/repo/migrations/20260818070000_scrub_error_tracker_reasons.exs
@@ -1,0 +1,46 @@
+defmodule KlassHero.Repo.Migrations.ScrubErrorTrackerReasons do
+  @moduledoc """
+  Narrows `reason` on the rows written before #1398 was fixed.
+
+  Two production rows are known to embed user data — a `KeyError` rendering a message sent to
+  parents plus a staff member's name, and a `MatchError` rendering an email address. The
+  forward path is closed by `KlassHero.Shared.ErrorStore.Repo`; this closes the history.
+
+  Irreversible: the original text is the thing being destroyed, so `down/0` is a no-op.
+
+  This calls `ErrorReasonFilter.sanitize/1` rather than reimplementing it in SQL, which pins
+  the migration to that module. If the module is ever renamed or removed, replace this body
+  with `:ok` — by then every environment has already run it.
+  """
+
+  use Ecto.Migration
+
+  import Ecto.Query
+
+  alias KlassHero.Shared.ErrorReasonFilter
+
+  require Logger
+
+  @tables ~w(error_tracker_errors error_tracker_occurrences)
+
+  def up do
+    for table <- @tables, do: scrub(table)
+  end
+
+  def down, do: :ok
+
+  defp scrub(table) do
+    rows = repo().all(from(t in table, select: {t.id, t.reason}))
+
+    narrowed =
+      for {id, reason} <- rows,
+          is_binary(reason),
+          scrubbed = ErrorReasonFilter.sanitize(reason),
+          scrubbed != reason do
+        repo().update_all(from(t in table, where: t.id == ^id), set: [reason: scrubbed])
+        id
+      end
+
+    Logger.info("#{table}: narrowed #{length(narrowed)} of #{length(rows)} reasons")
+  end
+end

--- a/test/klass_hero/shared/error_reason_filter_test.exs
+++ b/test/klass_hero/shared/error_reason_filter_test.exs
@@ -1,0 +1,135 @@
+defmodule KlassHero.Shared.ErrorReasonFilterTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias KlassHero.Shared.ErrorReasonFilter
+
+  @unrecognised "[reason redacted: unrecognised message shape]"
+
+  # Every input is built with Exception.message/1 rather than hand-written, so an Elixir
+  # upgrade that reshapes exception messages fails these tests loudly instead of silently
+  # reopening the leak.
+  @payload %{"email" => "anna@example.de", "staff" => "Anna Muster"}
+
+  # Payload below the fold: a safe clause, a blank line, then the interpolated term.
+  @separated [
+    {"KeyError", Exception.message(%KeyError{key: :program_id, term: @payload}),
+     "key :program_id not found in: [redacted]"},
+    {"MatchError", Exception.message(%MatchError{term: {:error, @payload}}),
+     "no match of right hand side value: [redacted]"},
+    {"CaseClauseError", Exception.message(%CaseClauseError{term: @payload}), "no case clause matching: [redacted]"},
+    {"Protocol.UndefinedError",
+     Exception.message(%Protocol.UndefinedError{
+       protocol: Enumerable,
+       value: @payload,
+       description: ""
+     }), "protocol Enumerable not implemented for Map [redacted]"},
+    {"Postgrex.Error, whose detail names the offending value",
+     Exception.message(%Postgrex.Error{
+       postgres: %{
+         code: :unique_violation,
+         message: "duplicate key value violates unique constraint \"users_email_index\"",
+         detail: "Key (email)=(anna@example.de) already exists.",
+         severity: "ERROR",
+         pg_code: "23505"
+       }
+     }),
+     "ERROR 23505 (unique_violation) duplicate key value violates unique constraint \"users_email_index\" [redacted]"},
+    {"Ecto.ConstraintError", "constraint error when attempting to insert struct:\n\n    * \"x\" (unique_constraint)",
+     "constraint error when attempting to insert struct: [redacted]"}
+  ]
+
+  # Payload on the same line as the clause — nothing structural separates the two, so these
+  # are judged against the allowlist.
+  @inline [
+    {"Oban.PerformError keeps its worker",
+     Exception.message(Oban.PerformError.exception({KlassHero.Family, {:error, @payload}})),
+     "KlassHero.Family failed with [redacted]"},
+    {"ArgumentError interpolating into its own message",
+     Exception.message(%ArgumentError{message: "bad value #{inspect(@payload)}"}), @unrecognised},
+    {"Oban.CrashError, which banners an arbitrary exception",
+     Exception.message(
+       Oban.CrashError.exception({:error, %ArgumentError{message: "bad value #{inspect(@payload)}"}, []})
+     ), @unrecognised},
+    {"an exit term, which can be any value at all", inspect({:shutdown, @payload}), @unrecognised}
+  ]
+
+  # Recognised shapes that carry nothing, and so survive whole.
+  @intact [
+    {"FunctionClauseError",
+     Exception.message(%FunctionClauseError{
+       module: KlassHero.Family,
+       function: :create_child,
+       arity: 2
+     }), "no function clause matching in KlassHero.Family.create_child/2"},
+    {"KeyError raised without a term", Exception.message(%KeyError{key: :program_id, term: nil}),
+     "key :program_id not found"},
+    {"Oban.TimeoutError", Exception.message(Oban.TimeoutError.exception({KlassHero.Family, 5000})),
+     "KlassHero.Family timed out after 5000ms"}
+  ]
+
+  describe "sanitize/1" do
+    test "keeps the clause and drops the term rendered below it" do
+      for {name, reason, expected} <- @separated do
+        assert ErrorReasonFilter.sanitize(reason) == expected, "#{name} was not narrowed"
+      end
+    end
+
+    test "redacts a payload rendered inline, keeping only what the allowlist recognises" do
+      for {name, reason, expected} <- @inline do
+        assert ErrorReasonFilter.sanitize(reason) == expected, "#{name} was not narrowed"
+      end
+    end
+
+    test "leaves a recognised message that carries no payload untouched" do
+      for {name, reason, expected} <- @intact do
+        assert ErrorReasonFilter.sanitize(reason) == expected, "#{name} should have survived"
+      end
+    end
+  end
+
+  # The two rows found in production, kept as named tests because their value is the shape,
+  # not the rule: this is what #1398 was filed for.
+  describe "sanitize/1 on the reasons found in production" do
+    test "drops the message text and staff name a KeyError had rendered" do
+      reason =
+        Exception.message(%KeyError{
+          key: :program_id,
+          term: %{"body" => "Hallo, der Kurs faellt aus", "staff" => "Anna Muster"}
+        })
+
+      sanitized = ErrorReasonFilter.sanitize(reason)
+
+      assert sanitized == "key :program_id not found in: [redacted]"
+      refute sanitized =~ "Anna Muster"
+    end
+
+    test "drops the email address a MatchError had rendered" do
+      reason = Exception.message(%MatchError{term: {:error, %{"email" => "anna@example.de"}}})
+
+      sanitized = ErrorReasonFilter.sanitize(reason)
+
+      assert sanitized == "no match of right hand side value: [redacted]"
+      refute sanitized =~ "anna@example.de"
+    end
+  end
+
+  describe "sanitize/1 invariants" do
+    property "nothing below the first line survives, whatever a future exception renders" do
+      heads = for {_name, reason, _expected} <- @separated, do: hd(String.split(reason, "\n"))
+
+      check all(
+              head <- member_of(heads),
+              payload <- string(:alphanumeric, min_length: 20, max_length: 60)
+            ) do
+        assert ErrorReasonFilter.sanitize(head <> "\n\n    " <> payload) == head <> " [redacted]"
+      end
+    end
+
+    property "the result is always a single line" do
+      check all(reason <- string(:printable, min_length: 1, max_length: 200)) do
+        refute ErrorReasonFilter.sanitize(reason) =~ "\n"
+      end
+    end
+  end
+end

--- a/test/klass_hero/shared/error_reporting_test.exs
+++ b/test/klass_hero/shared/error_reporting_test.exs
@@ -1,0 +1,56 @@
+defmodule KlassHero.Shared.ErrorReportingTest do
+  # `config/test.exs` disables ErrorTracker so the suite's deliberate Oban failures do not
+  # write error rows. This is the one test that turns it back on: everything else here is
+  # unit-tested against the filter and the shim directly, but nothing else proves that a real
+  # `ErrorTracker.report/3` lands narrowed in both tables.
+  use KlassHero.DataCase, async: false
+
+  alias ErrorTracker.Occurrence
+
+  @stacktrace [{KlassHero.Family, :create_child, 2, [file: "lib/klass_hero/family.ex", line: 42]}]
+
+  setup do
+    previous = Application.get_env(:error_tracker, :enabled)
+    Application.put_env(:error_tracker, :enabled, true)
+    on_exit(fn -> Application.put_env(:error_tracker, :enabled, previous) end)
+
+    :ok
+  end
+
+  test "a reported exception stores no interpolated user data in either table" do
+    exception = %KeyError{
+      key: :program_id,
+      term: %{"body" => "Hallo, der Kurs faellt aus", "staff" => "Anna Muster"}
+    }
+
+    occurrence = ErrorTracker.report(exception, @stacktrace)
+
+    assert occurrence.reason == "key :program_id not found in: [redacted]"
+
+    stored_error = Repo.get!(ErrorTracker.Error, occurrence.error_id)
+    stored_occurrence = Repo.get!(Occurrence, occurrence.id)
+
+    for row <- [stored_error, stored_occurrence], leaked <- ["Anna Muster", "Kurs faellt aus"] do
+      refute row.reason =~ leaked
+    end
+
+    assert stored_error.kind == "Elixir.KeyError"
+  end
+
+  test "narrowing the reason does not move the fingerprint" do
+    # Error.new/3 hashes kind + source_line + source_function and deliberately excludes
+    # reason. prod-watch dedups on that fingerprint and stamps it into the issues it files,
+    # so a fix that shifted it would orphan every already-filed issue.
+    exception = %KeyError{key: :program_id, term: %{"email" => "anna@example.de"}}
+
+    {:ok, stacktrace} = ErrorTracker.Stacktrace.new(@stacktrace)
+
+    {:ok, unnarrowed} =
+      ErrorTracker.Error.new("Elixir.KeyError", Exception.message(exception), stacktrace)
+
+    occurrence = ErrorTracker.report(exception, @stacktrace)
+
+    assert Repo.get!(ErrorTracker.Error, occurrence.error_id).fingerprint ==
+             unnarrowed.fingerprint
+  end
+end

--- a/test/klass_hero/shared/error_store_repo_test.exs
+++ b/test/klass_hero/shared/error_store_repo_test.exs
@@ -1,0 +1,105 @@
+defmodule KlassHero.Shared.ErrorStoreRepoTest do
+  use KlassHero.DataCase, async: true
+
+  alias ErrorTracker.Occurrence
+  alias KlassHero.Accounts.User
+  alias KlassHero.Shared.ErrorStoreRepo
+
+  @leaky_reason Exception.message(%MatchError{term: {:error, %{"email" => "anna@example.de"}}})
+
+  setup do
+    {:ok, stacktrace} =
+      ErrorTracker.Stacktrace.new([
+        {KlassHero.Family, :create_child, 2, [file: "lib/klass_hero/family.ex", line: 42]}
+      ])
+
+    {:ok, error} = ErrorTracker.Error.new("Elixir.MatchError", @leaky_reason, stacktrace)
+
+    %{error: error, stacktrace: stacktrace}
+  end
+
+  describe "insert!/2" do
+    test "narrows the reason of an error on its way to the table", %{error: error} do
+      inserted = ErrorStoreRepo.insert!(error, [])
+
+      assert inserted.reason == "no match of right hand side value: [redacted]"
+      refute Repo.get!(ErrorTracker.Error, inserted.id).reason =~ "anna@example.de"
+    end
+
+    test "narrows the reason of an occurrence too", ctx do
+      # Both tables carry `reason`, and the occurrence is written from a changeset rather
+      # than a struct — two shapes, one seam.
+      error = ErrorStoreRepo.insert!(ctx.error, [])
+
+      occurrence =
+        error
+        |> Ecto.build_assoc(:occurrences)
+        |> Occurrence.changeset(%{
+          stacktrace: ctx.stacktrace,
+          context: %{},
+          breadcrumbs: [],
+          reason: @leaky_reason
+        })
+        |> ErrorStoreRepo.insert!([])
+
+      assert occurrence.reason == "no match of right hand side value: [redacted]"
+      refute Repo.get!(Occurrence, occurrence.id).reason =~ "anna@example.de"
+    end
+
+    test "leaves rows that are not the error store alone" do
+      user = KlassHero.AccountsFixtures.user_fixture()
+
+      assert ErrorStoreRepo.get!(User, user.id, []).id == user.id
+    end
+  end
+
+  describe "delegation" do
+    setup %{error: error} do
+      %{inserted: ErrorStoreRepo.insert!(error, [])}
+    end
+
+    test "reads pass through to the application repo", %{inserted: inserted} do
+      assert [%ErrorTracker.Error{}] = ErrorStoreRepo.all(ErrorTracker.Error, [])
+      assert %ErrorTracker.Error{} = ErrorStoreRepo.one(ErrorTracker.Error, [])
+      assert %ErrorTracker.Error{} = ErrorStoreRepo.get(ErrorTracker.Error, inserted.id, [])
+      assert %ErrorTracker.Error{} = ErrorStoreRepo.get!(ErrorTracker.Error, inserted.id, [])
+      assert ErrorStoreRepo.aggregate(ErrorTracker.Error, :count, []) == 1
+    end
+
+    test "writes and transactions pass through", %{inserted: inserted} do
+      {:ok, resolved} =
+        inserted |> Ecto.Changeset.change(status: :resolved) |> ErrorStoreRepo.update([])
+
+      assert resolved.status == :resolved
+      assert {:ok, :done} = ErrorStoreRepo.transaction(fn -> :done end, [])
+      assert {1, nil} = ErrorStoreRepo.delete_all(ErrorTracker.Error, [])
+    end
+
+    test "reports the adapter, which ErrorTracker asks for to pick its SQL dialect" do
+      assert ErrorStoreRepo.__adapter__() == Ecto.Adapters.Postgres
+    end
+  end
+
+  describe "coverage of the dependency's dispatch table" do
+    # ErrorTracker.Repo reaches the real repo through `apply(repo, action, args ++ [opts])`
+    # over a fixed list. An upgrade adding one function to that list would raise
+    # UndefinedFunctionError at report time — i.e. error reporting would break precisely
+    # when something is already broken. This test fails at upgrade time instead.
+    test "the shim exports every function the dependency dispatches" do
+      source = File.read!("deps/error_tracker/lib/error_tracker/repo.ex")
+
+      dispatched =
+        for [_, action, args] <- Regex.scan(~r/dispatch\(:([a-z_]+!?), \[([^\]]*)\]/, source),
+            do: {String.to_atom(action), length(String.split(args, ", ")) + 1}
+
+      assert dispatched != []
+
+      for {name, arity} <- dispatched do
+        assert function_exported?(ErrorStoreRepo, name, arity),
+               "ErrorTracker.Repo dispatches #{name}/#{arity}, which the shim does not export"
+      end
+
+      assert function_exported?(ErrorStoreRepo, :__adapter__, 0)
+    end
+  end
+end


### PR DESCRIPTION
Closes #1398.

## Summary

`ErrorContextFilter` (#1391) closed the structured surface of the error store — `job.args`, `live_view.event_params`, `request.params`. It cannot reach `reason`: `ErrorTracker.report/3` runs the configured filter over the *context*, then passes `Exception.message(exception)` to storage separately, and `ErrorTracker.Filter` has no second callback. Any exception that interpolates the value that caused it wrote that value to both `error_tracker_errors.reason` and `error_tracker_occurrences.reason`. Two production rows do: a `KeyError` rendering a message sent to parents plus a staff member's name, and a `MatchError` rendering an email address.

The fix narrows `reason` at the **write boundary**. `ErrorTracker.Repo` is a dispatcher, not an Ecto repo — it calls `apply(Application.fetch_env!(:error_tracker, :repo), action, args ++ [opts])` over a fixed list, and every database call the dependency makes goes through it. Pointing `config :error_tracker, repo:` at a shim therefore covers every report path at once (Phoenix, Oban, a manual `report/3`, and any integration a future version adds), instead of only the telemetry handlers we would otherwise have had to copy — the alternative would have meant owning ~200 lines of the dependency's integration code, including the `:start` branches that accumulate `live_view.*` context.

`ErrorReasonFilter` narrows in two stages, because exceptions leak in two shapes:

- **Below a blank line** — `KeyError`, `MatchError`, `CaseClauseError`, `Protocol.UndefinedError`, and Postgrex's `detail`. The first line is kept and a `[redacted]` marker announces what went.
- **Inline** — `Oban.PerformError` (`<worker> failed with <term>`), `ArgumentError`, `Oban.CrashError`'s banner. Nothing structural separates clause from payload, so the first line is judged against an allowlist of shapes.

**Closed by default**, matching the sibling filter: a first line matching no known shape is replaced whole, so a new exception kind is minimised until someone allowlists it. Every kind seen in production is covered.

A migration scrubs the existing rows on both tables (15 errors / ~182 occurrences in production).

## Review focus

- **The allowlist in `error_reason_filter.ex`** is the security-relevant part. Each entry is a first-line shape proven to carry no interpolated value; adding one wrongly reopens the leak.
- **The closed-by-default trade-off.** The first occurrence of a novel exception type shows `[reason redacted: unrecognised message shape]` instead of its message, and triage falls back to `kind`, `source_function` and the stacktrace. The runbook documents the recovery: identify it, then allowlist the shape. A denylist would keep triage sharper at the cost of shipping new leaky kinds unredacted — worth a second opinion.
- **The shim's coupling to the dependency's dispatch list.** A future `error_tracker` adding a dispatched function would raise `UndefinedFunctionError` at report time — i.e. reporting would break exactly when something is already broken. `RepoTest` parses `deps/error_tracker/lib/error_tracker/repo.ex` and fails at upgrade time instead.
- **The migration calls an application module** rather than reimplementing the rules in SQL, which pins it to `ErrorReasonFilter`. The moduledoc says what to do if that module is ever renamed.

## Test plan

- `ErrorReasonFilterTest` — tabular tests over the three shape classes, the two production leaks as named cases, and two properties (nothing below the first line survives whatever the payload; the result is always one line). Inputs are built with `Exception.message/1`, not hand-written, so an Elixir upgrade that reshapes messages fails loudly.
- `ErrorStore.RepoTest` — the struct and changeset paths are both narrowed, non-error-store rows pass through, all delegates work, and the dispatch-coverage guard.
- `ErrorStore.ErrorReportingTest` — flips `error_tracker, enabled: true` (the suite disables it) and drives a real `ErrorTracker.report/3` end to end, asserting both tables and that **the fingerprint does not move**. `Error.new/3` hashes `kind <> source_line <> source_function` and excludes `reason` by design, so prod-watch's dedup and the fingerprints stamped into already-filed issues stay valid.
- `mix precommit` green: 4464 tests, credo strict, all lints.
- Verified against the real dev database: seeded a pre-fix leaky row, ran the migration (`error_tracker_errors: narrowed 1 of 1`, same for occurrences), confirmed both rows scrubbed with `kind` and `fingerprint` unchanged, and confirmed the dashboard's read path (`ErrorTracker.Repo.all/aggregate/with_adapter`) resolves through the shim.