### PR TITLE
refactor: reach replay through a Shared root module

### DIFF
--- a/lib/klass_hero/shared/adapters/driven/workers/event_delivery_worker.ex
+++ b/lib/klass_hero/shared/adapters/driven/workers/event_delivery_worker.ex
@@ -193,6 +193,9 @@ defmodule KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorker do
   The inverse of `compensate/2`, and deliberately in the same module: the job-args
   shape is this worker's, and building it anywhere else would give it a third knower.
 
+  Callers outside Shared go through `KlassHero.Shared.EventReplay`, which is the
+  root-level door to this; `adapters/` is Shared's internals.
+
   The stored `payload` is already `EventSerializer.serialize/1` output, so it goes
   straight back into `args` with no `deserialize/1` round-trip — which matters
   because deserializing calls `String.to_existing_atom/1`, and an event whose type

--- a/lib/klass_hero/shared/event_replay.ex
+++ b/lib/klass_hero/shared/event_replay.ex
@@ -1,0 +1,30 @@
+defmodule KlassHero.Shared.EventReplay do
+  @moduledoc """
+  Re-delivers an integration event that permanently failed delivery.
+
+  Shared's public surface is its root modules; everything under `adapters/` is
+  internal to it. This module exists so a caller outside Shared — today the admin's
+  `ReplayEventAction` — has a root-level entry point to reach for, rather than
+  naming `Adapters.Driven.Workers.EventDeliveryWorker` and making a deep path the
+  next caller copies.
+
+  It forwards and does nothing else, deliberately. The registry check, the
+  transaction and the job-args shape stay in `EventDeliveryWorker`, next to the
+  `compensate/2` that writes the row this replays: that shape is the worker's, and
+  a second module building it would give it a second owner.
+
+  See `EventDeliveryWorker.replay/1` for what replay guarantees — chiefly that
+  consumers already recorded in `processed_events` do not run again, and that a row
+  naming a consumer no longer in `:event_consumers` is refused rather than
+  delivered to nobody.
+  """
+
+  alias KlassHero.Shared.Adapters.Driven.Persistence.Schemas.UndeliveredEvent
+  alias KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorker
+
+  @doc """
+  Re-enqueues delivery of a dead-lettered event to the consumers that missed it.
+  """
+  @spec replay(UndeliveredEvent.t()) :: :ok | {:error, {:retired_consumers, [String.t()]}}
+  defdelegate replay(undelivered_event), to: EventDeliveryWorker
+end

--- a/lib/klass_hero_web/live/admin/actions/replay_event_action.ex
+++ b/lib/klass_hero_web/live/admin/actions/replay_event_action.ex
@@ -15,7 +15,7 @@ defmodule KlassHeroWeb.Admin.Actions.ReplayEventAction do
 
   ## Refusal is a failure, not a quiet success
 
-  `EventDeliveryWorker.replay/1` refuses a row naming a consumer that has since left
+  `EventReplay.replay/1` refuses a row naming a consumer that has since left
   `:event_consumers`, because delivering to an unrouted topic reports `:ok` having
   done nothing. The flash reports that class rather than the refs — the row already
   lists them, and a bulk refusal would otherwise put a paragraph of fully-qualified
@@ -24,7 +24,7 @@ defmodule KlassHeroWeb.Admin.Actions.ReplayEventAction do
 
   use BackpexWeb, :item_action
 
-  alias KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorker
+  alias KlassHero.Shared.EventReplay
 
   require KlassHeroWeb.BackpexCompat
   require Logger
@@ -54,7 +54,7 @@ defmodule KlassHeroWeb.Admin.Actions.ReplayEventAction do
   @impl Backpex.ItemAction
   def handle(socket, items, _data) do
     admin_id = socket.assigns.current_scope.user.id
-    results = Enum.map(items, fn item -> {item, EventDeliveryWorker.replay(item)} end)
+    results = Enum.map(items, fn item -> {item, EventReplay.replay(item)} end)
     failures = Enum.reject(results, fn {_item, result} -> result == :ok end)
 
     Enum.each(failures, &log_refusal(&1, admin_id))


### PR DESCRIPTION
Follow-up to #1400, which squash-merged while this commit was still in flight — so it carries the review fix that missed the merge, nothing else.

## Why

The boundary review on #1400 flagged that `ReplayEventAction` aliases `KlassHero.Shared.Adapters.Driven.Workers.EventDeliveryWorker` directly. Checking the claim against the codebase:

- The web layer references `KlassHero.Shared.*` **20 times**.
- **18** go through a root module — `Storage`, `Tracing`, `NameUtils`, `Money`, `FeatureFlags`, `Locales`, `ErrorIds`, `ChangesetErrors`, `Interaction`.
- Of the two that reach into `Adapters.*`, one is `UndeliveredEventLive`'s Backpex `adapter_config` (the documented admin-only exception), and the other is the line this PR removes.

So it was the first web→Shared *function call* down an adapter path — not a defect, but the kind of line the next admin action copies.

## What this is not

`Shared.EventReplay` forwards and nothing else. The registry check, the transaction, and the job-args shape all stay on `EventDeliveryWorker`, beside the `compensate/2` that writes the row being replayed. That placement was deliberate — the args shape is the worker's, and a second module building it would give it a second owner. This adds a door, not an owner.

Note the convention it follows is *not* "root module = swappable seam". `Storage` earns its root spot by hiding which adapter is configured, but `NameUtils`, `Money` and `ErrorIds` are root modules and are not seams. The rule Shared actually keeps is simpler: **root = public surface, `adapters/` = internal.**

## Test plan

- `mix precommit` green — 4478 tests.
- No new test file. `storage_test.exs` earns its place by pinning adapter selection; a `defdelegate` has no behaviour to pin, and asserting it forwards would test the compiler. Covered transitively by `replay_event_action_test.exs`, which drives the action through the new entry point, and directly by the `replay/1` block in `event_delivery_worker_test.exs`.
- Verified afterwards that the only remaining `KlassHero.Shared.Adapters.*` reference in `lib/klass_hero_web/` is the pre-existing Backpex `adapter_config`.