### PR TITLE
feat: per-session staff assignment overrides

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -268,6 +268,16 @@ config :klass_hero, :event_consumers, %{
     {StaffAssignmentHandler, :handle_event},
     {ProviderSessionDetails, :project}
   ],
+  # Session-grain overrides. Deliberately NOT routed to StaffAssignmentHandler:
+  # conversation membership is program-scoped, so a one-session substitution does
+  # not change who is in the program's conversation. Extending messaging to
+  # session-level staff is #784.
+  "integration:provider:staff_assigned_to_session" => [
+    {ProviderSessionDetails, :project}
+  ],
+  "integration:provider:staff_unassigned_from_session" => [
+    {ProviderSessionDetails, :project}
+  ],
   # Deliberately NOT routed to StaffAssignmentHandler: deactivation ends the
   # employment link but leaves assignments standing, so conversation membership
   # survives — reactivating cannot give it back (#1237).

--- a/lib/klass_hero/participation.ex
+++ b/lib/klass_hero/participation.ex
@@ -369,6 +369,34 @@ defmodule KlassHero.Participation do
   end
 
   @doc """
+  Retrieves one session, without its roster.
+
+  The cheap read for callers that only need the session's own facts — chiefly
+  Provider, resolving a session's `program_id` to check ownership before a
+  session-staffing write. `get_session_with_roster/1` answers the same question but
+  loads every participation record and resolves child info across two contexts to
+  do it, which is far more than a tenancy check needs.
+
+  Returns `{:ok, %ProgramSession{}}` or `{:error, :not_found}`.
+  """
+  @spec get_session(String.t()) :: {:ok, ProgramSession.t()} | {:error, :not_found}
+  def get_session(session_id) when is_binary(session_id), do: fetch_session(session_id)
+
+  @doc """
+  Batch sibling of `get_session/1` — the sessions matching `session_ids`.
+
+  Unknown ids are omitted rather than reported: the callers are list views
+  resolving many sessions at once, for which a missing row is a row to skip, not
+  an error to propagate. Exists so those callers don't N+1 `get_session/1`.
+  """
+  @spec get_sessions([String.t()]) :: [ProgramSession.t()]
+  def get_sessions([]), do: []
+
+  def get_sessions(session_ids) when is_list(session_ids) do
+    Repo.all(from s in ProgramSession, where: s.id in ^session_ids)
+  end
+
+  @doc """
   Retrieves a session with its complete roster.
 
   Returns `{:ok, %{session: session, roster: roster}}` or `{:error, :not_found}`.

--- a/lib/klass_hero/provider.ex
+++ b/lib/klass_hero/provider.ex
@@ -350,18 +350,19 @@ defmodule KlassHero.Provider do
   # --- Session ↔ staff overrides -------------------------------------------
 
   @doc """
-  Adds a staff member to one session, overriding the program's default roster.
+  Adds a staff member to one session, giving that session a roster of its own.
 
-  Sparse by design: a session with no overrides inherits the program roster, so
-  this is the act that flips one session onto its own staffing.
+  Additive: a session with no overrides inherits the program roster, and the first
+  add copies that roster across before appending, so nobody is displaced.
   """
   defdelegate assign_staff_to_session(attrs), to: Assignments
 
   @doc """
-  Removes one staff member's override from a session.
+  Removes one staff member from a session.
 
-  Returns `{:error, :cannot_unassign_lead}` when the target leads the session.
-  Retiring the last override returns the session to the program roster.
+  Returns `{:error, :cannot_unassign_lead}` when the target leads the session, and
+  `{:error, :cannot_empty_session}` when they are its only member — use
+  `revert_session_to_program_roster/2` to drop the session's own roster entirely.
   """
   defdelegate unassign_staff_from_session(session_id, staff_member_id, provider_id), to: Assignments
 

--- a/lib/klass_hero/provider.ex
+++ b/lib/klass_hero/provider.ex
@@ -347,6 +347,51 @@ defmodule KlassHero.Provider do
   """
   defdelegate list_program_staffing(program_ids), to: Assignments
 
+  # --- Session ↔ staff overrides -------------------------------------------
+
+  @doc """
+  Adds a staff member to one session, overriding the program's default roster.
+
+  Sparse by design: a session with no overrides inherits the program roster, so
+  this is the act that flips one session onto its own staffing.
+  """
+  defdelegate assign_staff_to_session(attrs), to: Assignments
+
+  @doc """
+  Removes one staff member's override from a session.
+
+  Returns `{:error, :cannot_unassign_lead}` when the target leads the session.
+  Retiring the last override returns the session to the program roster.
+  """
+  defdelegate unassign_staff_from_session(session_id, staff_member_id, provider_id), to: Assignments
+
+  @doc "Retires every override on a session, returning it to the program roster."
+  defdelegate revert_session_to_program_roster(session_id, provider_id), to: Assignments
+
+  @doc "Flags one of a session's existing overrides as its lead instructor."
+  defdelegate set_session_lead_instructor(session_id, staff_member_id, provider_id), to: Assignments
+
+  @doc "Clears the session's lead instructor, leaving the override active."
+  defdelegate clear_session_lead_instructor(session_id, provider_id), to: Assignments
+
+  @doc """
+  Who is on one session: its overrides when it has any, otherwise the program
+  roster. The single answer to that question — nothing re-derives the fallback.
+  """
+  defdelegate get_session_staffing(session_id), to: Assignments
+
+  @doc "Batch `get_session_staffing/1` keyed by session_id (avoids N+1 in list views)."
+  defdelegate list_session_staffing(session_ids), to: Assignments
+
+  @doc "IDOR-guarded `get_session_staffing/1` for callers taking a session_id from the client."
+  defdelegate get_session_staffing_for_provider(provider_id, session_id), to: Assignments
+
+  @doc "The staff members effectively on a session, oldest assignment first."
+  defdelegate list_session_staff(session_id), to: Assignments
+
+  @doc "The provider's active staff who do not already override the session."
+  defdelegate list_assignable_staff_for_session(provider_id, session_id), to: Assignments
+
   # --- Programs & sessions -------------------------------------------------
 
   @doc "Returns the total completed session count across all programs for a provider."

--- a/lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex
+++ b/lib/klass_hero/provider/adapters/driven/projections/provider_session_details.ex
@@ -22,11 +22,23 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
   - `:child_checked_out` — intentional no-op (counter is monotonic).
   - `:child_marked_absent` — intentional no-op (no effect on checked_in_count).
   - `:staff_assigned_to_program` / `:staff_unassigned_from_program` — re-resolve
-    current_assigned_staff_* on all `:scheduled` rows for the program, from the
-    assignment table rather than from the event. `current_assigned_staff_*` holds
-    one staff member and a program may carry several, so both directions apply
-    bootstrap's rule (earliest active assignment, active staff only) instead of
-    naming whoever the event happened to mention.
+    current_assigned_staff_* on the program's `:scheduled` rows that are **not**
+    overridden, from the assignment table rather than from the event.
+    `current_assigned_staff_*` holds one staff member and a program may carry
+    several, so both directions apply bootstrap's rule (earliest active
+    assignment, active staff only) instead of naming whoever the event happened
+    to mention.
+  - `:staff_assigned_to_session` / `:staff_unassigned_from_session` — re-resolve
+    the one named session through `Assignments.get_session_attribution/1`.
+
+  ## Attribution has two grains
+
+  `current_assigned_staff_*` names whoever is **effectively** on the session: its
+  own override roster when it has one, the program roster otherwise (#782). The
+  two grains meet in exactly two places — `Assignments.get_session_attribution/1`
+  for live events and the override LATERAL in `bootstrap_session_details/0` — and
+  those two must agree, or the same session reads differently before and after a
+  restart (#1299).
   """
 
   use KlassHero.Shared.Projection,
@@ -42,6 +54,8 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
       "integration:participation:child_marked_absent",
       "integration:provider:staff_assigned_to_program",
       "integration:provider:staff_unassigned_from_program",
+      "integration:provider:staff_assigned_to_session",
+      "integration:provider:staff_unassigned_from_session",
       "integration:provider:staff_member_deactivated"
     ]
 
@@ -49,7 +63,9 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
 
   import Ecto.Query
 
+  alias KlassHero.Provider.Assignments
   alias KlassHero.Provider.SessionDetail
+  alias KlassHero.Provider.SessionStaffAssignment
   alias KlassHero.Repo
   alias KlassHero.Shared.Domain.Events.Event
   alias KlassHero.Shared.Projection
@@ -133,6 +149,14 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
     reattribute_scheduled_sessions(program_id)
   end
 
+  # Session-grain overrides (#782). Scoped to the one session named by the event,
+  # not to its program: an override is the provider saying *this day* is staffed
+  # differently, so it must not move its siblings.
+  def handle_event(event, %Event{payload: %{session_id: session_id}})
+      when event in [:staff_assigned_to_session, :staff_unassigned_from_session] do
+    reattribute_session(session_id)
+  end
+
   # Scoped by staff member, not by program: deactivation ends the employment link
   # itself, so it reaches every program they were on. Historical rows keep their
   # attribution, matching :staff_unassigned_from_program.
@@ -145,10 +169,17 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
   # Re-resolves rather than blanks: with several staff on a program the departing
   # member's colleague should inherit the attribution, which is what a bootstrap
   # would produce. Blanking only happens to be right when they were the last one.
+  #
+  # Scoped to the sessions that actually name them, rather than to every scheduled
+  # session of the programs they were on: with session-grain overrides, "the
+  # programs they were attributed on" no longer covers the case — a substitute
+  # holds an override on one session and may be on no program at all. Sessions the
+  # departing member does not name would re-resolve to the value they already hold,
+  # so nothing is lost by narrowing.
   def handle_event(:staff_member_deactivated, %Event{payload: %{staff_member_id: staff_member_id}}) do
     staff_member_id
-    |> programs_attributed_to()
-    |> Enum.each(&reattribute_scheduled_sessions/1)
+    |> sessions_attributed_to()
+    |> Enum.each(&reattribute_session/1)
   end
 
   # The single writer for current_assigned_staff_* on live events. Reads the
@@ -160,8 +191,14 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
     now = DateTime.utc_now() |> DateTime.truncate(:second)
 
     # :scheduled only — historical rows keep their attribution as an audit trail.
+    #
+    # Overridden sessions are excluded: they are staffed by their own rows, so a
+    # program-roster edit must not reach them. Without this the program event would
+    # re-attribute every scheduled session and silently undo a substitution the
+    # provider set deliberately.
     from(d in SessionDetail,
-      where: d.program_id == ^program_id and d.status == :scheduled
+      where: d.program_id == ^program_id and d.status == :scheduled,
+      where: d.session_id not in subquery(overridden_session_ids())
     )
     |> Repo.update_all(
       set: [
@@ -172,13 +209,37 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
     )
   end
 
-  # Which programs still name the departing staff member on an upcoming session —
-  # the only ones whose attribution can change.
-  defp programs_attributed_to(staff_member_id) do
+  # The single writer for one session's attribution. Delegates the override-vs-program
+  # rule to `Assignments.get_session_attribution/1` rather than restating it, so the
+  # live path and the bootstrap SQL below stay two expressions of one rule (#1299).
+  defp reattribute_session(session_id) do
+    %{staff_id: staff_id, staff_name: staff_name} = Assignments.get_session_attribution(session_id)
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    from(d in SessionDetail,
+      where: d.session_id == ^session_id and d.status == :scheduled
+    )
+    |> Repo.update_all(
+      set: [
+        current_assigned_staff_id: staff_id,
+        current_assigned_staff_name: staff_name,
+        updated_at: now
+      ]
+    )
+  end
+
+  defp overridden_session_ids do
+    from a in SessionStaffAssignment,
+      where: is_nil(a.unassigned_at),
+      select: a.session_id
+  end
+
+  # Which upcoming sessions still name the departing staff member — the only ones
+  # whose attribution can change.
+  defp sessions_attributed_to(staff_member_id) do
     from(d in SessionDetail,
       where: d.current_assigned_staff_id == ^staff_member_id and d.status == :scheduled,
-      distinct: true,
-      select: d.program_id
+      select: d.session_id
     )
     |> Repo.all()
   end
@@ -187,7 +248,7 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
   # Design notes:
   # * UUIDs cast to ::text so Postgrex returns strings (Ecto :binary_id accepts them on insert).
   # * Status arrives as text; String.to_existing_atom/1 converts (safe: fixed four enum values).
-  # * Upsert preserves session_id, inserted_at, and cover_staff_* (not derivable from write tables).
+  # * Upsert preserves session_id and inserted_at; everything else is derivable from write tables.
   # * Raises on DB failure so WithBootstrapRetry can schedule a retry.
   defp bootstrap_session_details do
     # LATERAL subquery picks exactly one active staff assignment (earliest-assigned wins, matching
@@ -208,9 +269,12 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
       ps.start_time,
       ps.end_time,
       ps.status::text                        AS status,
-      staff.staff_member_id::text            AS current_assigned_staff_id,
-      staff.first_name                       AS staff_first_name,
-      staff.last_name                        AS staff_last_name,
+      CASE WHEN ov.present IS NULL
+           THEN staff.staff_member_id::text
+           ELSE override.staff_member_id::text
+      END                                    AS current_assigned_staff_id,
+      CASE WHEN ov.present IS NULL THEN staff.first_name ELSE override.first_name END AS staff_first_name,
+      CASE WHEN ov.present IS NULL THEN staff.last_name  ELSE override.last_name  END AS staff_last_name,
       COALESCE(counts.checked_in, 0)         AS checked_in_count,
       COALESCE(counts.total, 0)              AS total_count
     FROM program_sessions ps
@@ -224,6 +288,29 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
       ORDER BY psa.assigned_at ASC
       LIMIT 1
     ) staff ON TRUE
+    -- Session-grain override (#782), outranking the program LATERAL above. Same
+    -- earliest-active-wins shape, so `Assignments.get_session_attribution/1` (the
+    -- live path) and this rebuild cannot disagree.
+    LEFT JOIN LATERAL (
+      SELECT ssa.staff_member_id, sm.first_name, sm.last_name
+      FROM session_staff_assignments ssa
+      JOIN staff_members sm ON sm.id = ssa.staff_member_id AND sm.active
+      WHERE ssa.session_id = ps.id
+        AND ssa.unassigned_at IS NULL
+      ORDER BY ssa.assigned_at ASC
+      LIMIT 1
+    ) override ON TRUE
+    -- Whether the session is overridden *at all*, which is a different question
+    -- from who the override names: a session whose only substitute was later
+    -- deactivated is overridden to nobody, and must read blank rather than fall
+    -- back to the program roster it was deliberately taken off.
+    LEFT JOIN LATERAL (
+      SELECT 1 AS present
+      FROM session_staff_assignments ssa
+      WHERE ssa.session_id = ps.id
+        AND ssa.unassigned_at IS NULL
+      LIMIT 1
+    ) ov ON TRUE
     LEFT JOIN (
       SELECT session_id,
              COUNT(*) FILTER (WHERE status IN ('checked_in','checked_out')) AS checked_in,
@@ -278,7 +365,7 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
           Repo.insert_all(
             SessionDetail,
             attrs_list,
-            on_conflict: {:replace_all_except, [:session_id, :inserted_at, :cover_staff_id, :cover_staff_name]},
+            on_conflict: {:replace_all_except, [:session_id, :inserted_at]},
             conflict_target: [:session_id]
           )
 
@@ -345,9 +432,7 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails 
            :inserted_at,
            :status,
            :checked_in_count,
-           :total_count,
-           :cover_staff_id,
-           :cover_staff_name
+           :total_count
          ]},
       conflict_target: [:session_id]
     )

--- a/lib/klass_hero/provider/assignments.ex
+++ b/lib/klass_hero/provider/assignments.ex
@@ -137,11 +137,12 @@ defmodule KlassHero.Provider.Assignments do
   end
 
   @doc """
-  Adds a staff member to one session, overriding the program's default roster.
+  Adds a staff member to one session, giving that session a roster of its own.
 
-  The first override on a session flips it from inheriting the program roster to
-  naming its own — see `KlassHero.Provider.SessionStaffAssignment` for why the
-  table is sparse rather than seeded.
+  Additive. The first add to a session that still inherits copies the program's
+  visible roster across first, so the result is "the usual team plus this person",
+  not "this person instead of the usual team" — see `materialize_program_roster/2`
+  for why that copy is still compatible with a sparse table.
 
   `attrs.provider_id` is the tenancy authority and must come from the
   authenticated scope. `attrs.assigned_by_user_id` is optional and records who
@@ -173,23 +174,29 @@ defmodule KlassHero.Provider.Assignments do
   end
 
   @doc """
-  Removes one staff member's override from a session owned by `provider_id`.
+  Removes one staff member from a session owned by `provider_id`.
+
+  Works on a session that still inherits: the program roster is materialized first,
+  so removing one person leaves the rest rather than emptying the session.
 
   Refuses when the target leads the session, for the same reason the program-level
   sibling does: detaching them would leave the session lead-less off a single
   click. Promote a replacement or step them down first.
 
-  Retiring the *last* override on a session returns it to inheriting the program
-  roster — which is why `revert_session_to_program_roster/2` exists as the bulk
-  form rather than making callers loop.
+  Refuses to remove the *last* member. Zero override rows means "inherits the
+  program roster", so emptying a session this way would snap it back to showing the
+  whole team — `revert_session_to_program_roster/2` is the honest way to say that,
+  and the only one.
 
   Returns:
   - `{:ok, SessionStaffAssignment.t()}` on success
   - `{:error, :cannot_unassign_lead}` if the staff member currently leads the session
-  - `{:error, :not_found}` if no active override exists or it is foreign
+  - `{:error, :cannot_empty_session}` if they are the session's only member
+  - `{:error, :not_found}` if they are not on the session, or it is foreign
   """
   @spec unassign_staff_from_session(String.t(), String.t(), String.t()) ::
-          {:ok, SessionStaffAssignment.t()} | {:error, :not_found | :cannot_unassign_lead | term()}
+          {:ok, SessionStaffAssignment.t()}
+          | {:error, :not_found | :cannot_unassign_lead | :cannot_empty_session | term()}
   def unassign_staff_from_session(session_id, staff_member_id, provider_id)
       when is_binary(session_id) and is_binary(staff_member_id) and is_binary(provider_id) do
     context_span entity: "session_staff_assignment" do
@@ -229,20 +236,21 @@ defmodule KlassHero.Provider.Assignments do
   end
 
   @doc """
-  Flags one of a session's existing overrides as its lead instructor.
+  Flags one of a session's members as its lead instructor.
 
-  Unlike `set_lead_instructor/3`, this does **not** create the assignment when none
-  exists. At program grain that upsert is a convenience; at session grain it would
-  be a hidden write that silently flips a session from inheriting the program roster
-  to overriding it — a much larger change than "promote this person". Assign first,
-  then promote.
+  Promoting on a session that still inherits materializes the program roster first
+  (see `materialize_program_roster/2`), so the session keeps everyone it was showing
+  and gains its own lead. This used to refuse with `{:error, :not_found}` precisely
+  because creating a lone override row would have silently discarded the rest of the
+  roster; materialization removes that hazard, so the refusal protected nothing.
 
-  Idempotent and transactional: any previous session lead is cleared and the target
-  flagged in one transaction, so the `session_staff_assignments_single_lead` partial
-  unique index is never violated mid-flight.
+  Idempotent and transactional: the roster copy, clearing any previous session lead,
+  and flagging the target all commit together, so the
+  `session_staff_assignments_single_lead` partial unique index is never violated
+  mid-flight.
 
-  Returns `{:error, :not_found}` when the staff member, the session, or an active
-  override for the pair is missing or foreign, or the staff member is deactivated.
+  Returns `{:error, :not_found}` when the staff member or session is missing or
+  foreign, the staff member is deactivated, or they are not on this session at all.
   """
   @spec set_session_lead_instructor(String.t(), String.t(), String.t()) ::
           {:ok, SessionStaffAssignment.t()} | {:error, :not_found | term()}
@@ -250,8 +258,14 @@ defmodule KlassHero.Provider.Assignments do
       when is_binary(session_id) and is_binary(staff_member_id) and is_binary(provider_id) do
     context_span entity: "session_staff_assignment" do
       with {:ok, staff_member} <- Provider.get_active_staff_member(staff_member_id, provider_id),
-           {:ok, _session} <- ensure_session_owned(session_id, provider_id) do
+           {:ok, session} <- ensure_session_owned(session_id, provider_id) do
         Multi.new()
+        # Ahead of :clear_other_leads on purpose — a materialized program lead has to
+        # exist before the query that steps them down can see them.
+        |> Multi.run(:materialize, fn _repo, _changes ->
+          :ok = materialize_program_roster(session, provider_id)
+          {:ok, :materialized}
+        end)
         |> Multi.update_all(
           :clear_other_leads,
           other_active_session_leads_query(session_id, staff_member.id, provider_id),
@@ -411,15 +425,19 @@ defmodule KlassHero.Provider.Assignments do
   @spec list_assignable_staff_for_session(String.t(), String.t()) :: [StaffMember.t()]
   def list_assignable_staff_for_session(provider_id, session_id)
       when is_binary(provider_id) and is_binary(session_id) do
+    # Subtracts the *effective* roster, not just the override rows: a session that
+    # still inherits is showing the program's team, and offering to "add" someone
+    # already on screen is how the picker used to hand out a no-op that read as a
+    # roster wipe.
     already_on_session =
-      from(a in SessionStaffAssignment,
-        where: a.session_id == ^session_id and is_nil(a.unassigned_at),
-        select: a.staff_member_id
-      )
+      case get_session_staffing(session_id) do
+        %SessionStaffing{member_ids: member_ids} -> member_ids
+        nil -> []
+      end
 
     from(s in StaffMember,
       where: s.provider_id == ^provider_id and s.active == true,
-      where: s.id not in subquery(already_on_session),
+      where: s.id not in ^already_on_session,
       order_by: [asc: s.first_name, asc: s.last_name]
     )
     |> Repo.all()
@@ -758,7 +776,8 @@ defmodule KlassHero.Provider.Assignments do
 
   defp assign_to_session_with_event(assignment_attrs, staff_member, session) do
     Outbox.transact(@context, fn ->
-      with {:ok, assignment} <- insert_session_staff_assignment(assignment_attrs) do
+      with :ok <- materialize_program_roster(session, assignment_attrs.provider_id),
+           {:ok, assignment} <- insert_session_staff_assignment(assignment_attrs) do
         {:ok, assignment, [ProviderEvents.staff_assigned_to_session(assignment, staff_member, session.program_id)]}
       end
     end)
@@ -766,10 +785,87 @@ defmodule KlassHero.Provider.Assignments do
 
   defp unassign_from_session_with_event(session_id, staff_member_id, provider_id, staff_member, session) do
     Outbox.transact(@context, fn ->
-      with {:ok, assignment} <- retire_session_staff_assignment(session_id, staff_member_id, provider_id) do
+      with :ok <- ensure_not_last_member(session_id, staff_member_id),
+           :ok <- materialize_program_roster(session, provider_id),
+           {:ok, assignment} <- retire_session_staff_assignment(session_id, staff_member_id, provider_id) do
         {:ok, assignment, [ProviderEvents.staff_unassigned_from_session(assignment, staff_member, session.program_id)]}
       end
     end)
+  end
+
+  # The first write to a session that still inherits copies the program's visible
+  # roster in *before* the caller's change lands, so "add" adds instead of
+  # replacing and "remove" removes one person instead of all but none.
+  #
+  # This is not the copy-on-create seeding #1321 deleted: rows appear only for a
+  # session a human deliberately made different — one session per explicit action,
+  # not 500 per program — so the other sessions keep inheriting and there is
+  # nothing to reconcile. The cost is stated in the panel: once materialized, later
+  # program roster edits no longer reach this session.
+  #
+  # No events are staged for the copied rows. Consumers re-resolve the whole
+  # session through `get_session_attribution/1`, which reads these rows whether or
+  # not anything announced them; the one event for the caller's own action is what
+  # triggers that re-resolve.
+  defp materialize_program_roster(session, provider_id) do
+    if session_overridden?(session.id) do
+      :ok
+    else
+      now = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+
+      rows =
+        for row <- active_program_roster_rows(session.program_id) do
+          %{
+            id: Ecto.UUID.generate(),
+            provider_id: provider_id,
+            session_id: session.id,
+            staff_member_id: row.staff_member_id,
+            # The *program* assignment's timestamp, not `now`. `assigned_at` is the
+            # resolver's sort key and the projection names a session's earliest active
+            # member, so stamping the copies with one shared `now` would both make
+            # their order arbitrary and place them after the add that triggered the
+            # copy — silently renaming the session card. Carrying the program's own
+            # timestamps keeps the roster in its original order and correctly ranks
+            # everyone who was already there ahead of the person being added.
+            assigned_at: row.assigned_at,
+            is_lead_instructor: row.is_lead_instructor,
+            inserted_at: now,
+            updated_at: now
+          }
+        end
+
+      Repo.insert_all(SessionStaffAssignment, rows)
+      :ok
+    end
+  end
+
+  # Zero override rows means "inherits the program roster", so a session cannot
+  # express "deliberately staffed by nobody" — removing the last member would snap
+  # the roster back to the full program team. Refuse instead and point at
+  # `revert_session_to_program_roster/2`, which is the honest way to say that.
+  defp ensure_not_last_member(session_id, staff_member_id) do
+    case get_session_staffing(session_id) do
+      %SessionStaffing{member_ids: [^staff_member_id]} -> {:error, :cannot_empty_session}
+      _ -> :ok
+    end
+  end
+
+  # The program roster as the panel shows it — active staff only, in assignment
+  # order — because materializing must reproduce what the provider was looking at
+  # when they clicked.
+  defp active_program_roster_rows(program_id) do
+    from(a in ProgramStaffAssignment,
+      join: s in StaffMember,
+      on: s.id == a.staff_member_id and s.active == true,
+      where: a.program_id == ^program_id and is_nil(a.unassigned_at),
+      order_by: [asc: a.assigned_at, asc: a.id],
+      select: %{
+        staff_member_id: a.staff_member_id,
+        is_lead_instructor: a.is_lead_instructor,
+        assigned_at: a.assigned_at
+      }
+    )
+    |> Repo.all()
   end
 
   defp insert_session_staff_assignment(attrs) do
@@ -841,9 +937,10 @@ defmodule KlassHero.Provider.Assignments do
     end)
   end
 
-  # Deliberately narrower than the program-level `upsert_lead/4`: no insert branch.
-  # Promoting someone who holds no override would create one, which flips the whole
-  # session off the program roster — a far bigger change than the caller asked for.
+  # Still no insert branch, unlike the program-level `upsert_lead/4` — but for a
+  # different reason now. Materialization has already put every roster member on the
+  # session, so a miss here means the target genuinely is not on it, and inserting
+  # would be promoting a stranger rather than repairing a gap.
   defp promote_session_lead(repo, session_id, staff_member_id, provider_id) do
     case repo.one(active_session_assignment_scope(session_id, staff_member_id, provider_id)) do
       nil ->
@@ -885,7 +982,7 @@ defmodule KlassHero.Provider.Assignments do
       left_join: s in StaffMember,
       on: s.id == a.staff_member_id and s.active == true,
       where: a.session_id in ^session_ids and is_nil(a.unassigned_at),
-      order_by: [asc: a.assigned_at],
+      order_by: [asc: a.assigned_at, asc: a.id],
       select: {a.session_id, a.is_lead_instructor, s}
     )
     |> Repo.all()

--- a/lib/klass_hero/provider/assignments.ex
+++ b/lib/klass_hero/provider/assignments.ex
@@ -46,12 +46,15 @@ defmodule KlassHero.Provider.Assignments do
   import Ecto.Query, warn: false
 
   alias Ecto.Multi
+  alias KlassHero.Participation
   alias KlassHero.ProgramCatalog
   alias KlassHero.Provider
   alias KlassHero.Provider.Domain.Events.ProviderEvents
   alias KlassHero.Provider.Domain.ReadModels.ProgramStaffing
+  alias KlassHero.Provider.Domain.ReadModels.SessionStaffing
   alias KlassHero.Provider.Domain.ReadModels.StaffProgramAccess
   alias KlassHero.Provider.ProgramStaffAssignment
+  alias KlassHero.Provider.SessionStaffAssignment
   alias KlassHero.Provider.StaffMember
   alias KlassHero.Repo
   alias KlassHero.Shared.Adapters.Driven.Persistence.EctoErrorHelpers
@@ -131,6 +134,296 @@ defmodule KlassHero.Provider.Assignments do
         {:ok, assignment}
       end
     end
+  end
+
+  @doc """
+  Adds a staff member to one session, overriding the program's default roster.
+
+  The first override on a session flips it from inheriting the program roster to
+  naming its own — see `KlassHero.Provider.SessionStaffAssignment` for why the
+  table is sparse rather than seeded.
+
+  `attrs.provider_id` is the tenancy authority and must come from the
+  authenticated scope. `attrs.assigned_by_user_id` is optional and records who
+  made the override.
+
+  Returns:
+  - `{:ok, SessionStaffAssignment.t()}` on success
+  - `{:error, :already_assigned}` if the staff member already overrides this session
+  - `{:error, :not_found}` if the staff member or session is missing or foreign, or
+    the staff member is deactivated (#1306 — deactivated ≡ foreign ≡ missing)
+  """
+  @spec assign_staff_to_session(map()) ::
+          {:ok, SessionStaffAssignment.t()}
+          | {:error, :already_assigned | :not_found | term()}
+  def assign_staff_to_session(%{provider_id: provider_id} = attrs) do
+    context_span entity: "session_staff_assignment" do
+      with {:ok, staff_member} <- Provider.get_active_staff_member(attrs.staff_member_id, provider_id),
+           {:ok, session} <- ensure_session_owned(attrs.session_id, provider_id),
+           assignment_attrs = build_assignment_attrs(attrs, staff_member),
+           {:ok, assignment} <- assign_to_session_with_event(assignment_attrs, staff_member, session) do
+        Logger.info("Staff member assigned to session",
+          staff_member_id: assignment.staff_member_id,
+          session_id: assignment.session_id
+        )
+
+        {:ok, assignment}
+      end
+    end
+  end
+
+  @doc """
+  Removes one staff member's override from a session owned by `provider_id`.
+
+  Refuses when the target leads the session, for the same reason the program-level
+  sibling does: detaching them would leave the session lead-less off a single
+  click. Promote a replacement or step them down first.
+
+  Retiring the *last* override on a session returns it to inheriting the program
+  roster — which is why `revert_session_to_program_roster/2` exists as the bulk
+  form rather than making callers loop.
+
+  Returns:
+  - `{:ok, SessionStaffAssignment.t()}` on success
+  - `{:error, :cannot_unassign_lead}` if the staff member currently leads the session
+  - `{:error, :not_found}` if no active override exists or it is foreign
+  """
+  @spec unassign_staff_from_session(String.t(), String.t(), String.t()) ::
+          {:ok, SessionStaffAssignment.t()} | {:error, :not_found | :cannot_unassign_lead | term()}
+  def unassign_staff_from_session(session_id, staff_member_id, provider_id)
+      when is_binary(session_id) and is_binary(staff_member_id) and is_binary(provider_id) do
+    context_span entity: "session_staff_assignment" do
+      with {:ok, staff_member} <- Provider.get_staff_member(staff_member_id, provider_id),
+           {:ok, session} <- ensure_session_owned(session_id, provider_id),
+           {:ok, assignment} <-
+             unassign_from_session_with_event(session_id, staff_member_id, provider_id, staff_member, session) do
+        Logger.info("Staff member unassigned from session",
+          staff_member_id: staff_member_id,
+          session_id: session_id
+        )
+
+        {:ok, assignment}
+      end
+    end
+  end
+
+  @doc """
+  Retires every override on a session, returning it to the program roster.
+
+  The bulk counterpart of `unassign_staff_from_session/3`, and not expressible as a
+  loop over it: that command refuses to detach the session lead, which is right for
+  an interactive one-row detach and wrong here. Reverting is a deliberate "this
+  session has no staffing of its own", so the lead goes with the rest.
+
+  Returns `{:ok, retired_count}` — zero when the session already inherits — or
+  `{:error, :not_found}` when the session is missing or foreign.
+  """
+  @spec revert_session_to_program_roster(String.t(), String.t()) ::
+          {:ok, non_neg_integer()} | {:error, :not_found | term()}
+  def revert_session_to_program_roster(session_id, provider_id) when is_binary(session_id) and is_binary(provider_id) do
+    context_span entity: "session_staff_assignment" do
+      with {:ok, session} <- ensure_session_owned(session_id, provider_id) do
+        revert_session_with_events(session_id, provider_id, session)
+      end
+    end
+  end
+
+  @doc """
+  Flags one of a session's existing overrides as its lead instructor.
+
+  Unlike `set_lead_instructor/3`, this does **not** create the assignment when none
+  exists. At program grain that upsert is a convenience; at session grain it would
+  be a hidden write that silently flips a session from inheriting the program roster
+  to overriding it — a much larger change than "promote this person". Assign first,
+  then promote.
+
+  Idempotent and transactional: any previous session lead is cleared and the target
+  flagged in one transaction, so the `session_staff_assignments_single_lead` partial
+  unique index is never violated mid-flight.
+
+  Returns `{:error, :not_found}` when the staff member, the session, or an active
+  override for the pair is missing or foreign, or the staff member is deactivated.
+  """
+  @spec set_session_lead_instructor(String.t(), String.t(), String.t()) ::
+          {:ok, SessionStaffAssignment.t()} | {:error, :not_found | term()}
+  def set_session_lead_instructor(session_id, staff_member_id, provider_id)
+      when is_binary(session_id) and is_binary(staff_member_id) and is_binary(provider_id) do
+    context_span entity: "session_staff_assignment" do
+      with {:ok, staff_member} <- Provider.get_active_staff_member(staff_member_id, provider_id),
+           {:ok, _session} <- ensure_session_owned(session_id, provider_id) do
+        Multi.new()
+        |> Multi.update_all(
+          :clear_other_leads,
+          other_active_session_leads_query(session_id, staff_member.id, provider_id),
+          set: [is_lead_instructor: false]
+        )
+        |> Multi.run(:lead, fn repo, _ -> promote_session_lead(repo, session_id, staff_member.id, provider_id) end)
+        |> Repo.transaction()
+        |> case do
+          {:ok, %{lead: lead}} -> {:ok, lead}
+          {:error, _step, reason, _changes} -> {:error, reason}
+        end
+      end
+    end
+  end
+
+  @doc """
+  Clears the session's lead instructor, leaving the override otherwise active.
+
+  No-op when the session has no lead or is foreign.
+  """
+  @spec clear_session_lead_instructor(String.t(), String.t()) :: :ok
+  def clear_session_lead_instructor(session_id, provider_id) when is_binary(session_id) and is_binary(provider_id) do
+    from(a in SessionStaffAssignment.owned_by(provider_id),
+      where: a.session_id == ^session_id and a.is_lead_instructor and is_nil(a.unassigned_at)
+    )
+    |> Repo.update_all(set: [is_lead_instructor: false])
+
+    :ok
+  end
+
+  @doc """
+  Who is on one session: its overrides when it has any, otherwise the program roster.
+
+  The single answer to that question — see
+  `KlassHero.Provider.Domain.ReadModels.SessionStaffing` for the `:source` fact and
+  the lead rule. The projection, the provider UI, and (later) session-level
+  authorization all call this rather than re-deriving the fallback.
+
+  Returns `SessionStaffing.empty/2` shaped values for an unknown session, so callers
+  rendering a stale row get an empty roster rather than a crash.
+  """
+  @spec get_session_staffing(String.t()) :: SessionStaffing.t() | nil
+  def get_session_staffing(session_id) when is_binary(session_id) do
+    [session_id]
+    |> list_session_staffing()
+    |> Map.get(session_id)
+  end
+
+  @doc """
+  Batch sibling of `get_session_staffing/1`, keyed by `session_id`.
+
+  Four queries regardless of how many sessions are asked for — sessions, overrides,
+  program staffing, and the leads behind them — because the sessions list renders one
+  row per session and a per-row call would N+1 exactly where it hurts most.
+
+  Unknown sessions are omitted; `SessionStaffing.staffed_by?/2` and `led_by?/2` both
+  accept the resulting `nil` so callers need no defaulting step.
+  """
+  @spec list_session_staffing([String.t()]) :: %{optional(String.t()) => SessionStaffing.t()}
+  def list_session_staffing([]), do: %{}
+
+  def list_session_staffing(session_ids) when is_list(session_ids) do
+    sessions = fetch_sessions(session_ids)
+    overrides = session_overrides_by_session(Enum.map(sessions, & &1.id))
+    program_staffing = sessions |> Enum.map(& &1.program_id) |> Enum.uniq() |> Provider.list_program_staffing()
+
+    Map.new(sessions, fn session ->
+      {session.id, resolve_staffing(session, Map.get(overrides, session.id), program_staffing)}
+    end)
+  end
+
+  @doc """
+  Who a session's read-table row should name: the effective roster's earliest
+  active member, with their display name.
+
+  `provider_session_details.current_assigned_staff_*` holds exactly one person
+  while a roster holds several, so *some* rule has to pick. This is that rule, in
+  one place, for the projection's live path — its bootstrap SQL applies the same
+  one in `LATERAL … ORDER BY assigned_at ASC LIMIT 1` form. The two must agree or
+  a restart silently rewrites what the events wrote (#1299).
+
+  "Earliest active" rather than "the lead" on purpose: it is what the program-grain
+  path already meant, so promoting a lead never moves the name and the two grains
+  stay comparable.
+
+  Returns `%{staff_id: nil, staff_name: nil}` when nobody staffs the session —
+  including the case where it is overridden to a set of deactivated people, which
+  is *not* the same as inheriting the program roster.
+  """
+  @spec get_session_attribution(String.t()) :: %{staff_id: String.t() | nil, staff_name: String.t() | nil}
+  def get_session_attribution(session_id) when is_binary(session_id) do
+    with %SessionStaffing{member_ids: [winner | _]} <- get_session_staffing(session_id),
+         %StaffMember{} = staff <- Repo.get(StaffMember, winner) do
+      %{staff_id: staff.id, staff_name: StaffMember.full_name(staff)}
+    else
+      _ -> %{staff_id: nil, staff_name: nil}
+    end
+  end
+
+  @doc """
+  Whether `session_id` carries any active override — i.e. whether its staffing is
+  its own rather than the program's.
+
+  The projection asks this before applying a *program*-level change: a deliberate
+  substitution outranks a roster edit, so re-attributing every scheduled session
+  would silently undo it.
+  """
+  @spec session_overridden?(String.t()) :: boolean()
+  def session_overridden?(session_id) when is_binary(session_id) do
+    Repo.exists?(
+      from a in SessionStaffAssignment,
+        where: a.session_id == ^session_id and is_nil(a.unassigned_at)
+    )
+  end
+
+  @doc """
+  The staff members effectively on a session, oldest assignment first.
+
+  The struct-returning companion to `get_session_staffing/1`, for the panel that
+  has to render names and headshots rather than reason about ids. Falls through to
+  `list_active_staff_for_program/1` when the session inherits, so the two grains
+  render from the same shape.
+  """
+  @spec list_session_staff(String.t()) :: [StaffMember.t()]
+  def list_session_staff(session_id) when is_binary(session_id) do
+    case get_session_staffing(session_id) do
+      nil -> []
+      %SessionStaffing{source: :program, program_id: program_id} -> list_active_staff_for_program(program_id)
+      %SessionStaffing{member_ids: member_ids} -> staff_in_order(member_ids)
+    end
+  end
+
+  @doc """
+  IDOR-guarded `get_session_staffing/1` for interactive callers.
+
+  The UI opens the staffing panel with this: `session_id` arrives from the client,
+  so ownership has to be proven before anything about the session is rendered.
+  The unscoped sibling stays for the projection, which has no scope to check.
+  """
+  @spec get_session_staffing_for_provider(String.t(), String.t()) ::
+          {:ok, SessionStaffing.t()} | {:error, :not_found}
+  def get_session_staffing_for_provider(provider_id, session_id)
+      when is_binary(provider_id) and is_binary(session_id) do
+    with {:ok, _session} <- ensure_session_owned(session_id, provider_id) do
+      {:ok, get_session_staffing(session_id)}
+    end
+  end
+
+  @doc """
+  The provider's active staff who do not already override `session_id` — the
+  addable pool behind the session staffing panel's picker.
+
+  Being on the *program* does not exclude someone: an override names its own
+  people, so adding a program member to a session is the ordinary way to say
+  "of the three of you, these two work Tuesday".
+  """
+  @spec list_assignable_staff_for_session(String.t(), String.t()) :: [StaffMember.t()]
+  def list_assignable_staff_for_session(provider_id, session_id)
+      when is_binary(provider_id) and is_binary(session_id) do
+    already_on_session =
+      from(a in SessionStaffAssignment,
+        where: a.session_id == ^session_id and is_nil(a.unassigned_at),
+        select: a.staff_member_id
+      )
+
+    from(s in StaffMember,
+      where: s.provider_id == ^provider_id and s.active == true,
+      where: s.id not in subquery(already_on_session),
+      order_by: [asc: s.first_name, asc: s.last_name]
+    )
+    |> Repo.all()
+    |> Enum.map(&StaffMember.load_pay_rate/1)
   end
 
   @doc "Lists all active staff assignments for a program."
@@ -443,6 +736,235 @@ defmodule KlassHero.Provider.Assignments do
         {:error, :not_found} -> {:error, :not_found}
       end
     end
+  end
+
+  # Sessions are owned by Participation, so the session is read through its public
+  # facade and its program checked against `ensure_program_owned/2` — a session is
+  # this provider's exactly when its program is. Strongly consistent on purpose: the
+  # `provider_session_details` projection lags, so reading ownership from it would
+  # reject an override on a session created moments ago.
+  #
+  # Returns the session itself, not `:ok` — the caller needs its `program_id` for the
+  # event payload, and re-reading it would be a second round-trip for a fact already
+  # in hand.
+  defp ensure_session_owned(session_id, provider_id) do
+    acl_span source: "provider", target: "participation" do
+      with {:ok, session} <- Participation.get_session(session_id),
+           :ok <- ensure_program_owned(session.program_id, provider_id) do
+        {:ok, session}
+      end
+    end
+  end
+
+  defp assign_to_session_with_event(assignment_attrs, staff_member, session) do
+    Outbox.transact(@context, fn ->
+      with {:ok, assignment} <- insert_session_staff_assignment(assignment_attrs) do
+        {:ok, assignment, [ProviderEvents.staff_assigned_to_session(assignment, staff_member, session.program_id)]}
+      end
+    end)
+  end
+
+  defp unassign_from_session_with_event(session_id, staff_member_id, provider_id, staff_member, session) do
+    Outbox.transact(@context, fn ->
+      with {:ok, assignment} <- retire_session_staff_assignment(session_id, staff_member_id, provider_id) do
+        {:ok, assignment, [ProviderEvents.staff_unassigned_from_session(assignment, staff_member, session.program_id)]}
+      end
+    end)
+  end
+
+  defp insert_session_staff_assignment(attrs) do
+    %SessionStaffAssignment{}
+    |> SessionStaffAssignment.create_changeset(attrs)
+    |> Repo.insert()
+    |> case do
+      {:ok, assignment} ->
+        {:ok, assignment}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        if EctoErrorHelpers.any_unique_constraint_violation?(changeset.errors) do
+          {:error, :already_assigned}
+        else
+          {:error, changeset}
+        end
+    end
+  end
+
+  defp retire_session_staff_assignment(session_id, staff_member_id, provider_id) do
+    session_id
+    |> active_session_assignment_scope(staff_member_id, provider_id)
+    |> Repo.one()
+    |> case do
+      nil ->
+        {:error, :not_found}
+
+      %SessionStaffAssignment{is_lead_instructor: true} ->
+        {:error, :cannot_unassign_lead}
+
+      assignment ->
+        assignment
+        |> SessionStaffAssignment.unassign_changeset()
+        |> Repo.update()
+    end
+  end
+
+  defp revert_session_with_events(session_id, provider_id, session) do
+    Outbox.transact(@context, fn ->
+      doomed =
+        from(a in SessionStaffAssignment.owned_by(provider_id),
+          join: s in StaffMember,
+          on: s.id == a.staff_member_id,
+          where: a.session_id == ^session_id and is_nil(a.unassigned_at),
+          select: {a, s}
+        )
+        |> Repo.all()
+
+      {count, _} =
+        from(a in SessionStaffAssignment.owned_by(provider_id),
+          where: a.session_id == ^session_id and is_nil(a.unassigned_at)
+        )
+        |> Repo.update_all(
+          set: [
+            unassigned_at: DateTime.utc_now() |> DateTime.truncate(:microsecond),
+            is_lead_instructor: false
+          ]
+        )
+
+      # One event per retired row rather than a single "reverted" event: consumers
+      # already key on (session, staff member), and #784 will want that granularity
+      # to decide whose messaging membership changed.
+      events =
+        Enum.map(doomed, fn {assignment, staff_member} ->
+          ProviderEvents.staff_unassigned_from_session(assignment, staff_member, session.program_id)
+        end)
+
+      {:ok, count, events}
+    end)
+  end
+
+  # Deliberately narrower than the program-level `upsert_lead/4`: no insert branch.
+  # Promoting someone who holds no override would create one, which flips the whole
+  # session off the program roster — a far bigger change than the caller asked for.
+  defp promote_session_lead(repo, session_id, staff_member_id, provider_id) do
+    case repo.one(active_session_assignment_scope(session_id, staff_member_id, provider_id)) do
+      nil ->
+        {:error, :not_found}
+
+      assignment ->
+        assignment
+        |> SessionStaffAssignment.lead_changeset(true)
+        |> repo.update()
+    end
+  end
+
+  defp other_active_session_leads_query(session_id, staff_member_id, provider_id) do
+    from a in SessionStaffAssignment.owned_by(provider_id),
+      where:
+        a.session_id == ^session_id and a.staff_member_id != ^staff_member_id and
+          a.is_lead_instructor and is_nil(a.unassigned_at)
+  end
+
+  # Sessions belong to Participation, so they are read through its facade (ADR-0015)
+  # rather than joined to from here — which is also why the resolver cannot be one
+  # SQL statement.
+  defp fetch_sessions(session_ids) do
+    acl_span source: "provider", target: "participation" do
+      Participation.get_sessions(session_ids)
+    end
+  end
+
+  # Every active override for these sessions, with the staff member LEFT-joined on
+  # `active`. Left, not inner, because the two facts differ: the *row* existing is
+  # what makes a session overridden, while the staff member being active is what
+  # makes them a member. An inner join would collapse them, and a session whose only
+  # substitute was later deactivated would silently fall back to the program roster —
+  # resurrecting exactly the people the provider took off that day.
+  defp session_overrides_by_session([]), do: %{}
+
+  defp session_overrides_by_session(session_ids) do
+    from(a in SessionStaffAssignment,
+      left_join: s in StaffMember,
+      on: s.id == a.staff_member_id and s.active == true,
+      where: a.session_id in ^session_ids and is_nil(a.unassigned_at),
+      order_by: [asc: a.assigned_at],
+      select: {a.session_id, a.is_lead_instructor, s}
+    )
+    |> Repo.all()
+    |> Enum.group_by(fn {session_id, _lead?, _staff} -> session_id end)
+  end
+
+  # Ordered by the caller's ids, not by the query: `member_ids` already carries the
+  # earliest-assigned-first order the attribution rule depends on, and an `IN` gives
+  # no order at all.
+  defp staff_in_order(member_ids) do
+    by_id =
+      from(s in StaffMember, where: s.id in ^member_ids)
+      |> Repo.all()
+      |> Map.new(&{&1.id, StaffMember.load_pay_rate(&1)})
+
+    for id <- member_ids, staff = by_id[id], do: staff
+  end
+
+  defp resolve_staffing(session, nil, program_staffing) do
+    inherited_staffing(session, program_staffing)
+  end
+
+  defp resolve_staffing(session, override_rows, program_staffing) do
+    members = for {_id, _lead?, staff} <- override_rows, staff != nil, do: staff
+
+    %SessionStaffing{
+      session_id: session.id,
+      program_id: session.program_id,
+      lead: resolve_session_lead(override_rows, members, session.program_id, program_staffing),
+      member_ids: Enum.map(members, & &1.id),
+      member_count: length(members),
+      source: :override
+    }
+  end
+
+  defp inherited_staffing(session, program_staffing) do
+    case Map.get(program_staffing, session.program_id) do
+      nil ->
+        SessionStaffing.empty(session.id, session.program_id)
+
+      %ProgramStaffing{} = staffing ->
+        %SessionStaffing{
+          session_id: session.id,
+          program_id: session.program_id,
+          lead: staffing.lead,
+          member_ids: staffing.member_ids,
+          member_count: staffing.member_count,
+          source: :program
+        }
+    end
+  end
+
+  # Session lead first; failing that, the program lead — but only when they are
+  # actually working this session. Naming an absent lead is the worse failure: the
+  # roster would claim supervision nobody is providing.
+  defp resolve_session_lead(override_rows, members, program_id, program_staffing) do
+    flagged = Enum.find(override_rows, fn {_id, lead?, staff} -> lead? and staff != nil end)
+
+    case flagged do
+      {_id, _lead?, staff} -> to_lead_map(staff)
+      nil -> inherited_lead(members, program_id, program_staffing)
+    end
+  end
+
+  defp inherited_lead(members, program_id, program_staffing) do
+    with %ProgramStaffing{lead: %{id: lead_id} = lead} <- Map.get(program_staffing, program_id),
+         true <- Enum.any?(members, &(&1.id == lead_id)) do
+      lead
+    else
+      _ -> nil
+    end
+  end
+
+  # The single active (session, staff) override for the provider, if one exists.
+  defp active_session_assignment_scope(session_id, staff_member_id, provider_id) do
+    from a in SessionStaffAssignment.owned_by(provider_id),
+      where:
+        a.session_id == ^session_id and a.staff_member_id == ^staff_member_id and
+          is_nil(a.unassigned_at)
   end
 
   # The assignment and the event announcing it commit together; the outbox job then

--- a/lib/klass_hero/provider/domain/events/provider_events.ex
+++ b/lib/klass_hero/provider/domain/events/provider_events.ex
@@ -28,6 +28,7 @@ defmodule KlassHero.Provider.Domain.Events.ProviderEvents do
 
   alias KlassHero.Provider.ProgramStaffAssignment
   alias KlassHero.Provider.ProviderProfile
+  alias KlassHero.Provider.SessionStaffAssignment
   alias KlassHero.Provider.StaffMember
   alias KlassHero.Shared.Domain.Events.Event
 
@@ -94,6 +95,18 @@ defmodule KlassHero.Provider.Domain.Events.ProviderEvents do
     assignment_event(:staff_unassigned_from_program, assignment, staff_member, opts)
   end
 
+  @doc "Creates a staff_assigned_to_session event."
+  @spec staff_assigned_to_session(SessionStaffAssignment.t(), StaffMember.t(), String.t()) :: Event.t()
+  def staff_assigned_to_session(%SessionStaffAssignment{} = assignment, %StaffMember{} = staff_member, program_id) do
+    session_assignment_event(:staff_assigned_to_session, assignment, staff_member, program_id)
+  end
+
+  @doc "Creates a staff_unassigned_from_session event."
+  @spec staff_unassigned_from_session(SessionStaffAssignment.t(), StaffMember.t(), String.t()) :: Event.t()
+  def staff_unassigned_from_session(%SessionStaffAssignment{} = assignment, %StaffMember{} = staff_member, program_id) do
+    session_assignment_event(:staff_unassigned_from_session, assignment, staff_member, program_id)
+  end
+
   @doc """
   Creates a `staff_member_deactivated` event.
 
@@ -117,6 +130,26 @@ defmodule KlassHero.Provider.Domain.Events.ProviderEvents do
       staff_member.id,
       payload
     )
+  end
+
+  # `program_id` is passed in rather than read off the assignment: a session
+  # override carries no program_id of its own, and the producer already holds the
+  # session it verified ownership against. Consumers need it to scope the program
+  # roster they fall back to.
+  #
+  # `entity_id` is the *session*, not the staff member — unlike the program-level
+  # sibling. A consumer of this event re-resolves one session's staffing, and the
+  # session is the thing it addresses.
+  defp session_assignment_event(event_type, assignment, staff_member, program_id) do
+    payload = %{
+      provider_id: assignment.provider_id,
+      session_id: assignment.session_id,
+      program_id: program_id,
+      staff_member_id: assignment.staff_member_id,
+      staff_user_id: staff_member.user_id
+    }
+
+    Event.new(event_type, @source_context, :session, assignment.session_id, payload)
   end
 
   # assigned_at/unassigned_at are deliberately absent: no consumer reads them.

--- a/lib/klass_hero/provider/domain/read_models/session_staffing.ex
+++ b/lib/klass_hero/provider/domain/read_models/session_staffing.ex
@@ -1,0 +1,102 @@
+defmodule KlassHero.Provider.Domain.ReadModels.SessionStaffing do
+  @moduledoc """
+  Read-model of who is on one session: the lead (if any), every active member, and
+  **where the answer came from**.
+
+  The session-grain counterpart of
+  `KlassHero.Provider.Domain.ReadModels.ProgramStaffing`. Staffing has two grains —
+  a program's default roster and a per-session override — and this struct is the
+  single answer to "who is actually working this session".
+
+  `source` is the fact that makes the two grains legible:
+
+  * `:program` — the session carries no overrides and inherits the program roster.
+  * `:override` — a provider deliberately staffed this session, and these rows
+    *replace* the program roster rather than adding to it. That is what makes
+    "two staff splitting a weekly schedule" expressible: each session names
+    exactly who works it.
+
+  `member_ids` carries **everyone active on the session, the lead included**, so
+  `member_count == length(member_ids)` holds unconditionally and no caller needs a
+  "lead or member?" branch — the same guarantee `ProgramStaffing` gives.
+
+  Built only by `KlassHero.Provider.Assignments.get_session_staffing/1` and its
+  batch sibling. Nothing else re-derives the override-vs-program rule; that
+  duplication is what made the program-grain reads drift in #1310.
+  """
+
+  @typedoc "The lead instructor shaped for display, or nil when the session has none."
+  @type lead :: %{id: String.t(), name: String.t(), headshot_url: String.t() | nil} | nil
+
+  @typedoc "Whether this roster is the program's default or an override for this session."
+  @type source :: :program | :override
+
+  @typedoc "Active staffing of one session."
+  @type t :: %__MODULE__{
+          session_id: String.t(),
+          program_id: String.t(),
+          lead: lead(),
+          member_ids: [String.t()],
+          member_count: non_neg_integer(),
+          source: source()
+        }
+
+  @enforce_keys [:session_id, :program_id, :member_ids, :member_count, :source]
+
+  defstruct [
+    :session_id,
+    :program_id,
+    :lead,
+    member_ids: [],
+    member_count: 0,
+    source: :program
+  ]
+
+  @doc """
+  The zero-staff value.
+
+  `source` is `:program`, not `:override`: a session nobody staffs is inheriting an
+  empty program roster. An override is a row a provider deliberately created, so
+  "no rows anywhere" can never be one.
+  """
+  @spec empty(String.t(), String.t()) :: t()
+  def empty(session_id, program_id) when is_binary(session_id) and is_binary(program_id) do
+    %__MODULE__{
+      session_id: session_id,
+      program_id: program_id,
+      lead: nil,
+      member_ids: [],
+      member_count: 0,
+      source: :program
+    }
+  end
+
+  @doc """
+  Whether `staff_member_id` is on this session, leading it or not.
+
+  Accepts `nil` so a caller can pass a batch-read lookup straight through without
+  first defaulting an absent session.
+  """
+  @spec staffed_by?(t() | nil, String.t()) :: boolean()
+  def staffed_by?(nil, _staff_member_id), do: false
+
+  def staffed_by?(%__MODULE__{member_ids: member_ids}, staff_member_id) do
+    staff_member_id in member_ids
+  end
+
+  @doc "Whether `staff_member_id` leads this session."
+  @spec led_by?(t() | nil, String.t()) :: boolean()
+  def led_by?(nil, _staff_member_id), do: false
+  def led_by?(%__MODULE__{lead: nil}, _staff_member_id), do: false
+  def led_by?(%__MODULE__{lead: %{id: lead_id}}, staff_member_id), do: lead_id == staff_member_id
+
+  @doc """
+  Whether this roster was deliberately overridden for the session.
+
+  The UI needs the distinction to say so, and to decide whether "revert to the
+  program roster" is a meaningful action.
+  """
+  @spec overridden?(t()) :: boolean()
+  def overridden?(%__MODULE__{source: :override}), do: true
+  def overridden?(%__MODULE__{}), do: false
+end

--- a/lib/klass_hero/provider/session_detail.ex
+++ b/lib/klass_hero/provider/session_detail.ex
@@ -10,6 +10,15 @@ defmodule KlassHero.Provider.SessionDetail do
 
   Staff names and counts are denormalized here at projection time so the
   dashboard renders a session without joining across contexts.
+  `current_assigned_staff_*` names whoever is **effectively** on the session —
+  its own override roster where it has one, the program roster otherwise (#782).
+
+  The columns `cover_staff_id` / `cover_staff_name` were dropped here in #782.
+  Nothing had ever written them since they were added in April, and per-session
+  overrides express what they were reserved for. The database columns go one
+  release later: Fly runs migrations while the previous release is still serving
+  (#1347), so a destructive migration cannot ship with the code that stopped
+  reading them.
   """
 
   use Ecto.Schema
@@ -31,8 +40,6 @@ defmodule KlassHero.Provider.SessionDetail do
 
     field :current_assigned_staff_id, :binary_id
     field :current_assigned_staff_name, :string
-    field :cover_staff_id, :binary_id
-    field :cover_staff_name, :string
 
     field :checked_in_count, :integer, default: 0
     field :total_count, :integer, default: 0
@@ -53,8 +60,6 @@ defmodule KlassHero.Provider.SessionDetail do
           status: status() | nil,
           current_assigned_staff_id: Ecto.UUID.t() | nil,
           current_assigned_staff_name: String.t() | nil,
-          cover_staff_id: Ecto.UUID.t() | nil,
-          cover_staff_name: String.t() | nil,
           checked_in_count: non_neg_integer(),
           total_count: non_neg_integer(),
           inserted_at: DateTime.t() | nil,

--- a/lib/klass_hero/provider/session_staff_assignment.ex
+++ b/lib/klass_hero/provider/session_staff_assignment.ex
@@ -1,0 +1,134 @@
+defmodule KlassHero.Provider.SessionStaffAssignment do
+  @moduledoc """
+  Schema-as-struct for the `session_staff_assignments` table — a **sparse override**
+  of a program's staffing for one session.
+
+  Rows exist only where a provider deliberately overrode the session: a substitute
+  covering one day, or two staff splitting a weekly schedule. A session with no
+  active rows here inherits the program roster, so the common case costs nothing
+  and there is no snapshot to drift.
+
+  That sparseness is the whole design. The alternative — copying
+  `program_staff_assignments` into every session at creation — was rejected because
+  it rebuilds the denormalised staffing mirror #1321 deleted, at up to 500 sessions
+  × N staff per program, with no way to correct the copy when program staffing
+  later changes.
+
+  `KlassHero.Provider.Assignments.get_session_staffing/1` is the only thing that
+  resolves override-vs-program; nothing else re-derives the rule.
+
+  ## Constraints
+
+  A staff member can hold one active override per session (partial unique index on
+  `session_id + staff_member_id` where `unassigned_at IS NULL`), and a session can
+  have one active lead (`session_staff_assignments_single_lead`). Soft-deleting via
+  `unassigned_at` lifts both and allows re-assignment.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+  import Ecto.Query, only: [from: 2]
+
+  alias KlassHero.Provider.ProviderProfile
+  alias KlassHero.Provider.StaffMember
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  @timestamps_opts [type: :utc_datetime_usec]
+
+  schema "session_staff_assignments" do
+    belongs_to :provider, ProviderProfile
+    belongs_to :staff_member, StaffMember
+    field :session_id, :binary_id
+    field :assigned_by_user_id, :binary_id
+    field :assigned_at, :utc_datetime_usec
+    field :unassigned_at, :utc_datetime_usec
+    field :is_lead_instructor, :boolean, default: false
+
+    timestamps()
+  end
+
+  @type t :: %__MODULE__{}
+
+  @castable_fields ~w(session_id assigned_at)a
+  @optional_fields ~w(unassigned_at is_lead_instructor assigned_by_user_id)a
+
+  @doc """
+  Changeset for creating a session staff override.
+
+  `provider_id` and `staff_member_id` are set programmatically, not cast from user
+  input — the command takes them from the ownership-proven `StaffMember`, which is
+  the only tenancy authority an INSERT can carry (a query scope cannot reach it).
+  """
+  def create_changeset(schema \\ %__MODULE__{}, attrs) do
+    schema
+    |> cast(attrs, @castable_fields ++ @optional_fields)
+    |> put_change(:provider_id, attrs[:provider_id] || attrs["provider_id"])
+    |> put_change(:staff_member_id, attrs[:staff_member_id] || attrs["staff_member_id"])
+    |> validate_required([:provider_id, :session_id, :staff_member_id, :assigned_at])
+    |> foreign_key_constraint(:provider_id)
+    |> foreign_key_constraint(:session_id)
+    |> foreign_key_constraint(:staff_member_id)
+    |> unique_constraint([:session_id, :staff_member_id],
+      name: :session_staff_assignments_active_unique,
+      message: "staff member is already assigned to this session"
+    )
+    |> unique_constraint(:session_id,
+      name: :session_staff_assignments_single_lead,
+      message: "session already has a lead instructor"
+    )
+  end
+
+  @doc """
+  Changeset retiring an override, which lifts both partial unique indexes.
+
+  Clears `is_lead_instructor` for the same reason the program-level sibling does:
+  a retired row that still reads as leading is exactly the state a later query
+  forgetting `is_nil(unassigned_at)` would silently believe.
+  """
+  def unassign_changeset(schema) do
+    change(schema, %{
+      unassigned_at: DateTime.utc_now() |> DateTime.truncate(:microsecond),
+      is_lead_instructor: false
+    })
+  end
+
+  @doc """
+  Changeset toggling the lead flag on an existing override.
+
+  Carries the single-lead partial unique constraint so promoting a second lead
+  before the previous one is cleared surfaces as a changeset error rather than a
+  raw DB exception.
+  """
+  def lead_changeset(schema, is_lead?) when is_boolean(is_lead?) do
+    schema
+    |> change(%{is_lead_instructor: is_lead?})
+    |> unique_constraint(:session_id,
+      name: :session_staff_assignments_single_lead,
+      message: "session already has a lead instructor"
+    )
+  end
+
+  @doc """
+  Narrows a query to overrides owned by `provider_id`.
+
+  Composed into every mutation query so a crafted `session_id`/`staff_member_id`
+  pair cannot reach another provider's row, even where a caller's pre-check is
+  missing.
+  """
+  @spec owned_by(Ecto.Queryable.t(), String.t()) :: Ecto.Query.t()
+  def owned_by(query \\ __MODULE__, provider_id) when is_binary(provider_id) do
+    from a in query, where: a.provider_id == ^provider_id
+  end
+
+  @doc "Returns true when the override is still active (never retired)."
+  @spec active?(t()) :: boolean()
+  def active?(%__MODULE__{unassigned_at: nil}), do: true
+  def active?(%__MODULE__{}), do: false
+
+  @doc "Returns true when the override is the session's active lead instructor."
+  @spec lead?(t()) :: boolean()
+  def lead?(%__MODULE__{is_lead_instructor: true, unassigned_at: nil}), do: true
+  def lead?(%__MODULE__{}), do: false
+end

--- a/lib/klass_hero_web/components/core_components.ex
+++ b/lib/klass_hero_web/components/core_components.ex
@@ -31,12 +31,16 @@ defmodule KlassHeroWeb.CoreComponents do
     assigns = assign_new(assigns, :id, fn -> "flash-#{assigns.kind}" end)
 
     ~H"""
+    <%!-- z-[60] sits above modal chrome (z-50) rather than level with it. A flash
+          rendered earlier in the DOM at the same z-index loses to the modal painted
+          over it, which silently swallowed every error raised from inside one — and
+          a refusal the user never sees reads as a frozen panel. --%>
     <div
       :if={msg = render_slot(@inner_block) || Phoenix.Flash.get(@flash, @kind)}
       id={@id}
       phx-click={JS.push("lv:clear-flash", value: %{key: @kind}) |> hide("##{@id}")}
       role="alert"
-      class="fixed top-4 right-4 z-50 max-w-md"
+      class="fixed top-4 right-4 z-[60] max-w-md"
       {@rest}
     >
       <div class={[

--- a/lib/klass_hero_web/components/provider_components.ex
+++ b/lib/klass_hero_web/components/provider_components.ex
@@ -1640,6 +1640,7 @@ defmodule KlassHeroWeb.ProviderComponents do
   attr :icon, :string, required: true
   attr :title, :string, required: true
   attr :disabled, :boolean, default: false
+  attr :intent, :atom, default: :neutral, values: [:neutral, :promote, :destructive]
   attr :rest, :global, include: ~w(id phx-click phx-value-id phx-value-program-id)
 
   defp action_button(assigns) do
@@ -1649,21 +1650,45 @@ defmodule KlassHeroWeb.ProviderComponents do
       title={@title}
       aria-label={@title}
       disabled={@disabled}
-      class={[
-        "p-2",
-        Theme.rounded(:lg),
-        Theme.transition(:normal),
-        if(@disabled,
-          do: "text-hero-grey-300 cursor-not-allowed",
-          else: "text-hero-grey-400 hover:text-hero-charcoal hover:bg-hero-grey-100"
-        )
-      ]}
+      class={
+        [
+          # 44px, not the 36px a bare `p-2` glyph gives: on a phone these are the
+          # panel's primary controls and there is no hover to discover them by.
+          "inline-flex min-h-11 min-w-11 items-center justify-center border",
+          Theme.rounded(:md),
+          Theme.transition(:fast),
+          if(@disabled,
+            do: "border-hero-grey-100 bg-hero-grey-50 text-hero-grey-300 cursor-not-allowed",
+            else: action_button_intent(@intent)
+          )
+        ]
+      }
       {@rest}
     >
       <.icon name={@icon} class="w-5 h-5" />
     </button>
     """
   end
+
+  # A resting surface — border plus fill — so the control reads as pressable before
+  # anyone touches it, then a press state and a focus ring. The hover tint splits by
+  # intent because two adjacent icon-only buttons that highlight identically give no
+  # clue which one is the one you cannot undo.
+  @action_button_base "bg-white text-hero-grey-700 border-hero-grey-200 active:scale-95 " <>
+                        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1"
+
+  defp action_button_intent(:destructive),
+    do: @action_button_base <> " hover:border-red-200 hover:bg-red-50 hover:text-red-600 focus-visible:ring-red-400"
+
+  defp action_button_intent(:promote),
+    do:
+      @action_button_base <>
+        " hover:border-hero-yellow-700 hover:bg-hero-yellow-100 hover:text-hero-grey-900 focus-visible:ring-hero-yellow-700"
+
+  defp action_button_intent(:neutral),
+    do:
+      @action_button_base <>
+        " hover:border-hero-grey-300 hover:bg-hero-grey-50 hover:text-hero-grey-900 focus-visible:ring-hero-grey-400"
 
   @doc """
   Renders a tabbed modal displaying the enrollment roster and invites for a program.
@@ -1936,7 +1961,7 @@ defmodule KlassHeroWeb.ProviderComponents do
                   <span
                     :if={member.lead?}
                     id={"staffing-lead-badge-#{member.id}"}
-                    class="ml-1 inline-block px-2 py-0.5 text-xs font-semibold bg-hero-yellow text-hero-charcoal rounded-full align-middle"
+                    class="ml-1 inline-block px-2 py-0.5 text-xs font-semibold bg-hero-yellow-500 text-hero-grey-900 rounded-full align-middle"
                   >
                     {gettext("Lead")}
                   </span>
@@ -1949,6 +1974,7 @@ defmodule KlassHeroWeb.ProviderComponents do
                   :if={!member.lead?}
                   id={"promote-staff-#{member.id}"}
                   icon="hero-star-mini"
+                  intent={:promote}
                   title={gettext("Make lead instructor")}
                   phx-click="promote_to_lead"
                   phx-value-staff-id={member.id}
@@ -1958,6 +1984,7 @@ defmodule KlassHeroWeb.ProviderComponents do
                 <.action_button
                   id={"remove-staff-#{member.id}"}
                   icon="hero-user-minus-mini"
+                  intent={:destructive}
                   title={
                     if(member.lead?,
                       do: gettext("Reassign the lead before removing them"),
@@ -2065,9 +2092,12 @@ defmodule KlassHeroWeb.ProviderComponents do
             </h2>
             <p class="mt-1 truncate text-sm text-hero-grey-500">{@modal.program_title}</p>
           </div>
-          <button type="button" phx-click="close_session_staffing" aria-label={gettext("Close")}>
-            <.icon name="hero-x-mark" class="w-5 h-5" />
-          </button>
+          <.action_button
+            id="session-staffing-close"
+            icon="hero-x-mark"
+            title={gettext("Close")}
+            phx-click="close_session_staffing"
+          />
         </div>
 
         <div class="flex-1 overflow-y-auto px-4 py-4 sm:px-6">
@@ -2079,7 +2109,7 @@ defmodule KlassHeroWeb.ProviderComponents do
               "mb-4 flex items-start gap-2 px-3 py-2 text-sm",
               Theme.rounded(:lg),
               if(@modal.overridden?,
-                do: "bg-hero-yellow/20 text-hero-charcoal",
+                do: "bg-hero-yellow-100 text-hero-grey-900",
                 else: "bg-hero-grey-50 text-hero-grey-600"
               )
             ]}
@@ -2090,11 +2120,11 @@ defmodule KlassHeroWeb.ProviderComponents do
             />
             <span>
               <%= if @modal.overridden? do %>
-                {gettext(
-                  "Staffed just for this session. The program's usual team does not apply here."
-                )}
+                {gettext("Staffed just for this session. Changes here do not touch the program.")}
               <% else %>
-                {gettext("Using the program's usual team. Adding someone staffs this session only.")}
+                {gettext(
+                  "Using the program's usual team. The first change here copies them onto this session, so later program changes stop reaching it."
+                )}
               <% end %>
             </span>
           </div>
@@ -2112,12 +2142,12 @@ defmodule KlassHeroWeb.ProviderComponents do
               <.staff_avatar member={member} />
 
               <div class="min-w-0 flex-1">
-                <p class="truncate font-medium text-hero-charcoal">
+                <p class="truncate font-medium text-hero-grey-900">
                   {member.full_name}
                   <span
                     :if={member.lead?}
                     id={"session-staffing-lead-badge-#{member.id}"}
-                    class="ml-1 inline-block px-2 py-0.5 text-xs font-semibold bg-hero-yellow text-hero-charcoal rounded-full align-middle"
+                    class="ml-1 inline-block px-2 py-0.5 text-xs font-semibold bg-hero-yellow-500 text-hero-grey-900 rounded-full align-middle"
                   >
                     {gettext("Lead")}
                   </span>
@@ -2125,14 +2155,15 @@ defmodule KlassHeroWeb.ProviderComponents do
                 <p :if={member.role} class="truncate text-sm text-hero-grey-500">{member.role}</p>
               </div>
 
-              <%!-- Promote and remove act on override rows, so they are only offered
-                    once this session has its own roster. On an inherited roster they
-                    would silently create one. --%>
-              <div :if={@modal.overridden?} class="flex shrink-0 items-center gap-1">
+              <%!-- Offered whether or not the session already has its own roster: the
+                    first change materializes the program's team onto this session
+                    rather than replacing it, so acting here no longer discards anyone. --%>
+              <div class="flex shrink-0 items-center gap-1">
                 <.action_button
                   :if={!member.lead?}
                   id={"promote-session-staff-#{member.id}"}
                   icon="hero-star-mini"
+                  intent={:promote}
                   title={gettext("Make lead instructor for this session")}
                   phx-click="promote_session_lead"
                   phx-value-staff-id={member.id}
@@ -2140,13 +2171,9 @@ defmodule KlassHeroWeb.ProviderComponents do
                 <.action_button
                   id={"remove-session-staff-#{member.id}"}
                   icon="hero-user-minus-mini"
-                  title={
-                    if(member.lead?,
-                      do: gettext("Reassign the lead before removing them"),
-                      else: gettext("Remove from this session")
-                    )
-                  }
-                  disabled={member.lead?}
+                  intent={:destructive}
+                  title={session_removal_title(member, @modal.members)}
+                  disabled={member.lead? or length(@modal.members) == 1}
                   phx-click="remove_session_staff"
                   phx-value-staff-id={member.id}
                 />
@@ -2163,49 +2190,66 @@ defmodule KlassHeroWeb.ProviderComponents do
           </p>
 
           <div class="mt-4 border-t border-hero-grey-200 pt-4">
-            <form
+            <.form
+              for={@modal.add_form}
               phx-submit="assign_session_staff"
               id="session-staffing-add-form"
-              class="flex flex-col gap-2 sm:flex-row"
+              class="flex flex-col items-end gap-2 sm:flex-row"
             >
-              <select
-                id="session-staffing-add-select"
-                name="staff-id"
-                disabled={@modal.assignable_options == []}
-                class={[
-                  "flex-1 border border-hero-grey-300 px-3 py-2 text-hero-charcoal disabled:bg-hero-grey-50",
-                  Theme.rounded(:lg)
-                ]}
-              >
-                <option value="">{gettext("Select a staff member…")}</option>
-                <option :for={{label, value} <- @modal.assignable_options} value={value}>
-                  {label}
-                </option>
-              </select>
+              <%!-- A tracked form input rather than a bare <select>: the option list
+                    changes whenever the roster does, and an untracked select loses the
+                    provider's pick the moment a re-render rebuilds its options. --%>
+              <div class="w-full flex-1">
+                <.input
+                  field={@modal.add_form[:staff_id]}
+                  type="select"
+                  id="session-staffing-add-select"
+                  prompt={gettext("Select a staff member…")}
+                  options={@modal.assignable_options}
+                  disabled={@modal.assignable_options == []}
+                />
+              </div>
               <button
                 type="submit"
                 id="session-staffing-add-btn"
                 disabled={@modal.assignable_options == []}
                 class={[
-                  "flex items-center justify-center gap-2 px-4 py-2 font-semibold",
-                  "bg-hero-yellow hover:bg-hero-yellow-dark text-hero-charcoal",
-                  "disabled:bg-hero-grey-100 disabled:text-hero-grey-400",
-                  Theme.rounded(:lg),
-                  Theme.transition(:normal)
+                  "flex min-h-11 w-full items-center justify-center gap-2 px-4 py-2 font-semibold sm:w-auto",
+                  "bg-hero-yellow-500 hover:bg-hero-yellow-600 text-hero-grey-900",
+                  "active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hero-yellow-700",
+                  "disabled:bg-hero-grey-100 disabled:text-hero-grey-400 disabled:active:scale-100",
+                  Theme.rounded(:md),
+                  Theme.transition(:fast)
                 ]}
               >
                 <.icon name="hero-plus-mini" class="w-5 h-5" />
                 {gettext("Add")}
               </button>
-            </form>
+            </.form>
+
+            <p
+              :if={@modal.assignable_options == []}
+              id="session-staffing-nobody-addable"
+              class="mt-2 text-sm text-hero-grey-500"
+            >
+              {gettext("Everyone on your team is already working this session.")}
+            </p>
 
             <button
               :if={@modal.overridden?}
               type="button"
               id="session-staffing-revert-btn"
               phx-click="revert_session_staffing"
-              class="mt-3 text-sm font-medium text-hero-grey-600 underline hover:text-hero-charcoal"
+              class={[
+                "mt-3 flex min-h-11 w-full items-center justify-center gap-2 px-4 py-2",
+                "border border-hero-grey-300 bg-white text-sm font-medium text-hero-grey-700",
+                "hover:border-hero-grey-400 hover:bg-hero-grey-50 hover:text-hero-grey-900",
+                "active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hero-grey-400",
+                Theme.rounded(:md),
+                Theme.transition(:fast)
+              ]}
             >
+              <.icon name="hero-arrow-uturn-left-mini" class="w-5 h-5" />
               {gettext("Go back to the program's usual team")}
             </button>
           </div>
@@ -2214,6 +2258,16 @@ defmodule KlassHeroWeb.ProviderComponents do
     </div>
     """
   end
+
+  # Disabled rather than hidden, so the tooltip can say *why* — both refusals come
+  # from the context (`:cannot_unassign_lead`, `:cannot_empty_session`), and a
+  # control that silently vanishes teaches the provider nothing about the rule.
+  defp session_removal_title(%{lead?: true}, _members), do: gettext("Reassign the lead before removing them")
+
+  defp session_removal_title(_member, [_only]),
+    do: gettext("A session needs someone — use “Go back to the program's usual team” instead")
+
+  defp session_removal_title(_member, _members), do: gettext("Remove from this session")
 
   attr :member, :map, required: true
 

--- a/lib/klass_hero_web/components/provider_components.ex
+++ b/lib/klass_hero_web/components/provider_components.ex
@@ -1801,7 +1801,10 @@ defmodule KlassHeroWeb.ProviderComponents do
 
   @doc """
   Renders a modal listing every session of a program with date/time, assigned
-  staff, cover staff (reserved), attendance count, and status.
+  staff, attendance count, and status.
+
+  "Assigned staff" is the session's *effective* staffing: its own override roster
+  where the provider set one, the program roster otherwise (#782).
 
   ## Example
 
@@ -1845,7 +1848,6 @@ defmodule KlassHeroWeb.ProviderComponents do
                 <tr>
                   <th class="px-4 py-3">{gettext("Date / time")}</th>
                   <th class="px-4 py-3">{gettext("Assigned staff")}</th>
-                  <th class="px-4 py-3">{gettext("Cover")}</th>
                   <th class="px-4 py-3">{gettext("Attendance")}</th>
                   <th class="px-4 py-3">{gettext("Status")}</th>
                 </tr>
@@ -1863,9 +1865,6 @@ defmodule KlassHeroWeb.ProviderComponents do
                   </td>
                   <td class="px-4 py-3">
                     {s.current_assigned_staff_name || gettext("Unassigned")}
-                  </td>
-                  <td class="px-4 py-3 text-hero-grey-500">
-                    {s.cover_staff_name || "—"}
                   </td>
                   <td class="px-4 py-3">
                     <span :if={s.status != :cancelled}>
@@ -2021,6 +2020,194 @@ defmodule KlassHeroWeb.ProviderComponents do
             <p class="mt-2 text-xs text-hero-grey-400">
               {gettext("Staff you add can read and reply to this program's parent conversations.")}
             </p>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  @doc """
+  Renders the staffing panel for one *session*: who is working it, who leads it,
+  and the controls to add, promote, remove and revert (#782).
+
+  The session sibling of `staffing_modal/1`, and deliberately a separate component
+  rather than a mode on it: this one has to say **where its roster came from**. A
+  session with no overrides shows the program's roster and offers to override it; a
+  session that has been overridden shows its own people and offers to revert. That
+  distinction is the whole feature, and folding it into a flag would bury it.
+
+  ## Example
+
+      <.session_staffing_modal :if={@session_staffing_modal} modal={@session_staffing_modal} />
+  """
+  attr :modal, :map, required: true
+
+  def session_staffing_modal(assigns) do
+    ~H"""
+    <div
+      id="session-staffing-modal"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="session-staffing-modal-title"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      phx-window-keydown="close_session_staffing"
+      phx-key="escape"
+    >
+      <div
+        class="bg-white rounded-lg shadow-xl w-full max-w-lg max-h-[85vh] overflow-hidden flex flex-col"
+        phx-click-away="close_session_staffing"
+      >
+        <div class="flex items-start justify-between gap-3 px-4 py-4 sm:px-6 border-b border-hero-grey-200">
+          <div class="min-w-0">
+            <h2 id="session-staffing-modal-title" class={Theme.typography(:section_title)}>
+              {gettext("Staffing — %{date}", date: @modal.session_label)}
+            </h2>
+            <p class="mt-1 truncate text-sm text-hero-grey-500">{@modal.program_title}</p>
+          </div>
+          <button type="button" phx-click="close_session_staffing" aria-label={gettext("Close")}>
+            <.icon name="hero-x-mark" class="w-5 h-5" />
+          </button>
+        </div>
+
+        <div class="flex-1 overflow-y-auto px-4 py-4 sm:px-6">
+          <%!-- Where this roster came from is the panel's headline fact, not a footnote:
+                everything below reads differently depending on it. --%>
+          <div
+            id="session-staffing-source"
+            class={[
+              "mb-4 flex items-start gap-2 px-3 py-2 text-sm",
+              Theme.rounded(:lg),
+              if(@modal.overridden?,
+                do: "bg-hero-yellow/20 text-hero-charcoal",
+                else: "bg-hero-grey-50 text-hero-grey-600"
+              )
+            ]}
+          >
+            <.icon
+              name={if(@modal.overridden?, do: "hero-user-plus-mini", else: "hero-users-mini")}
+              class="w-5 h-5 shrink-0"
+            />
+            <span>
+              <%= if @modal.overridden? do %>
+                {gettext(
+                  "Staffed just for this session. The program's usual team does not apply here."
+                )}
+              <% else %>
+                {gettext("Using the program's usual team. Adding someone staffs this session only.")}
+              <% end %>
+            </span>
+          </div>
+
+          <ul
+            :if={@modal.members != []}
+            id="session-staffing-members"
+            class="divide-y divide-hero-grey-100"
+          >
+            <li
+              :for={member <- @modal.members}
+              id={"session-staffing-member-#{member.id}"}
+              class="flex items-center gap-3 py-3"
+            >
+              <.staff_avatar member={member} />
+
+              <div class="min-w-0 flex-1">
+                <p class="truncate font-medium text-hero-charcoal">
+                  {member.full_name}
+                  <span
+                    :if={member.lead?}
+                    id={"session-staffing-lead-badge-#{member.id}"}
+                    class="ml-1 inline-block px-2 py-0.5 text-xs font-semibold bg-hero-yellow text-hero-charcoal rounded-full align-middle"
+                  >
+                    {gettext("Lead")}
+                  </span>
+                </p>
+                <p :if={member.role} class="truncate text-sm text-hero-grey-500">{member.role}</p>
+              </div>
+
+              <%!-- Promote and remove act on override rows, so they are only offered
+                    once this session has its own roster. On an inherited roster they
+                    would silently create one. --%>
+              <div :if={@modal.overridden?} class="flex shrink-0 items-center gap-1">
+                <.action_button
+                  :if={!member.lead?}
+                  id={"promote-session-staff-#{member.id}"}
+                  icon="hero-star-mini"
+                  title={gettext("Make lead instructor for this session")}
+                  phx-click="promote_session_lead"
+                  phx-value-staff-id={member.id}
+                />
+                <.action_button
+                  id={"remove-session-staff-#{member.id}"}
+                  icon="hero-user-minus-mini"
+                  title={
+                    if(member.lead?,
+                      do: gettext("Reassign the lead before removing them"),
+                      else: gettext("Remove from this session")
+                    )
+                  }
+                  disabled={member.lead?}
+                  phx-click="remove_session_staff"
+                  phx-value-staff-id={member.id}
+                />
+              </div>
+            </li>
+          </ul>
+
+          <p
+            :if={@modal.members == []}
+            id="session-staffing-empty"
+            class="py-6 text-center text-hero-grey-500"
+          >
+            {gettext("Nobody is working this session yet.")}
+          </p>
+
+          <div class="mt-4 border-t border-hero-grey-200 pt-4">
+            <form
+              phx-submit="assign_session_staff"
+              id="session-staffing-add-form"
+              class="flex flex-col gap-2 sm:flex-row"
+            >
+              <select
+                id="session-staffing-add-select"
+                name="staff-id"
+                disabled={@modal.assignable_options == []}
+                class={[
+                  "flex-1 border border-hero-grey-300 px-3 py-2 text-hero-charcoal disabled:bg-hero-grey-50",
+                  Theme.rounded(:lg)
+                ]}
+              >
+                <option value="">{gettext("Select a staff member…")}</option>
+                <option :for={{label, value} <- @modal.assignable_options} value={value}>
+                  {label}
+                </option>
+              </select>
+              <button
+                type="submit"
+                id="session-staffing-add-btn"
+                disabled={@modal.assignable_options == []}
+                class={[
+                  "flex items-center justify-center gap-2 px-4 py-2 font-semibold",
+                  "bg-hero-yellow hover:bg-hero-yellow-dark text-hero-charcoal",
+                  "disabled:bg-hero-grey-100 disabled:text-hero-grey-400",
+                  Theme.rounded(:lg),
+                  Theme.transition(:normal)
+                ]}
+              >
+                <.icon name="hero-plus-mini" class="w-5 h-5" />
+                {gettext("Add")}
+              </button>
+            </form>
+
+            <button
+              :if={@modal.overridden?}
+              type="button"
+              id="session-staffing-revert-btn"
+              phx-click="revert_session_staffing"
+              class="mt-3 text-sm font-medium text-hero-grey-600 underline hover:text-hero-charcoal"
+            >
+              {gettext("Go back to the program's usual team")}
+            </button>
           </div>
         </div>
       </div>

--- a/lib/klass_hero_web/live/provider/sessions_live.ex
+++ b/lib/klass_hero_web/live/provider/sessions_live.ex
@@ -209,11 +209,11 @@ defmodule KlassHeroWeb.Provider.SessionsLive do
   end
 
   @impl true
-  def handle_event("assign_session_staff", %{"staff-id" => ""}, socket) do
+  def handle_event("assign_session_staff", %{"add_staff" => %{"staff_id" => ""}}, socket) do
     {:noreply, put_flash(socket, :error, gettext("Pick a staff member to add."))}
   end
 
-  def handle_event("assign_session_staff", %{"staff-id" => staff_member_id}, socket) do
+  def handle_event("assign_session_staff", %{"add_staff" => %{"staff_id" => staff_member_id}}, socket) do
     %{session_id: session_id} = socket.assigns.session_staffing_modal
 
     %{
@@ -261,6 +261,19 @@ defmodule KlassHeroWeb.Provider.SessionsLive do
          |> put_flash(
            :error,
            gettext("This person leads the session. Make someone else lead before removing them.")
+         )}
+
+      # The button is disabled for this case, so reaching it means a stale panel —
+      # re-read so the disabled state catches up with what the context enforced.
+      {:error, :cannot_empty_session} ->
+        {:noreply,
+         socket
+         |> refresh_session_staffing()
+         |> put_flash(
+           :error,
+           gettext(
+             "A session needs at least one person. Use “Go back to the program's usual team” to drop this session's own roster."
+           )
          )}
 
       # Already gone — a benign double-click or a second tab, not an error worth a
@@ -368,7 +381,10 @@ defmodule KlassHeroWeb.Provider.SessionsLive do
          program_title: Map.get(socket.assigns.program_names, staffing.program_id, gettext("Program")),
          overridden?: SessionStaffing.overridden?(staffing),
          members: members,
-         assignable_options: assignable
+         assignable_options: assignable,
+         # Rebuilt on every re-read, so the picker resets to its prompt after a
+         # successful add instead of still naming the person now on the roster.
+         add_form: to_form(%{"staff_id" => ""}, as: :add_staff)
        }}
     end
   end

--- a/lib/klass_hero_web/live/provider/sessions_live.ex
+++ b/lib/klass_hero_web/live/provider/sessions_live.ex
@@ -1,10 +1,14 @@
 defmodule KlassHeroWeb.Provider.SessionsLive do
   use KlassHeroWeb, :live_view
 
+  import KlassHeroWeb.ProviderComponents
+
   alias KlassHero.Participation
   alias KlassHero.ProgramCatalog
   alias KlassHero.Provider
+  alias KlassHero.Provider.Domain.ReadModels.SessionStaffing
   alias KlassHeroWeb.Helpers.TaskHelpers
+  alias KlassHeroWeb.Presenters.ProgramStaffingPresenter
   alias KlassHeroWeb.Presenters.ProviderPresenter
   alias KlassHeroWeb.Theme
 
@@ -52,6 +56,7 @@ defmodule KlassHeroWeb.Provider.SessionsLive do
       |> assign(:program_names, program_names(provider_programs))
       |> assign(:business, business)
       |> assign(:form, nil)
+      |> assign(:session_staffing_modal, nil)
       |> stream(:sessions, [])
 
     if connected?(socket) do
@@ -182,6 +187,121 @@ defmodule KlassHeroWeb.Provider.SessionsLive do
     end
   end
 
+  # --- Session staffing panel (#782) ---------------------------------------
+  #
+  # `session_id` arrives from the client, so every entry point goes through the
+  # scoped read; foreign and unknown are indistinguishable, leaking no oracle.
+
+  @impl true
+  def handle_event("manage_session_staffing", %{"id" => session_id}, socket) do
+    case build_session_staffing_modal(session_id, socket) do
+      {:ok, modal} ->
+        {:noreply, assign(socket, :session_staffing_modal, modal)}
+
+      {:error, :not_found} ->
+        {:noreply, session_staffing_not_found(socket, "open", session_id)}
+    end
+  end
+
+  @impl true
+  def handle_event("close_session_staffing", _params, socket) do
+    {:noreply, assign(socket, :session_staffing_modal, nil)}
+  end
+
+  @impl true
+  def handle_event("assign_session_staff", %{"staff-id" => ""}, socket) do
+    {:noreply, put_flash(socket, :error, gettext("Pick a staff member to add."))}
+  end
+
+  def handle_event("assign_session_staff", %{"staff-id" => staff_member_id}, socket) do
+    %{session_id: session_id} = socket.assigns.session_staffing_modal
+
+    %{
+      provider_id: socket.assigns.provider_id,
+      session_id: session_id,
+      staff_member_id: staff_member_id,
+      assigned_by_user_id: socket.assigns.current_scope.user.id
+    }
+    |> Provider.assign_staff_to_session()
+    |> case do
+      {:ok, _assignment} ->
+        {:noreply,
+         socket
+         |> refresh_session_staffing()
+         |> put_flash(:info, gettext("Staff member added to this session."))}
+
+      # The picker excludes them, so this is a stale panel (two tabs, back button)
+      # rather than user error — re-read so the list stops offering them.
+      {:error, :already_assigned} ->
+        {:noreply,
+         socket
+         |> refresh_session_staffing()
+         |> put_flash(:error, gettext("They are already working this session."))}
+
+      {:error, :not_found} ->
+        {:noreply, session_staffing_not_found(socket, "assign", staff_member_id)}
+    end
+  end
+
+  @impl true
+  def handle_event("remove_session_staff", %{"staff-id" => staff_member_id}, socket) do
+    %{session_id: session_id} = socket.assigns.session_staffing_modal
+
+    case Provider.unassign_staff_from_session(session_id, staff_member_id, socket.assigns.provider_id) do
+      {:ok, _assignment} ->
+        {:noreply,
+         socket
+         |> refresh_session_staffing()
+         |> put_flash(:info, gettext("Staff member removed from this session."))}
+
+      {:error, :cannot_unassign_lead} ->
+        {:noreply,
+         socket
+         |> refresh_session_staffing()
+         |> put_flash(
+           :error,
+           gettext("This person leads the session. Make someone else lead before removing them.")
+         )}
+
+      # Already gone — a benign double-click or a second tab, not an error worth a
+      # red flash. Re-read so the row disappears.
+      {:error, :not_found} ->
+        {:noreply, refresh_session_staffing(socket)}
+    end
+  end
+
+  @impl true
+  def handle_event("promote_session_lead", %{"staff-id" => staff_member_id}, socket) do
+    %{session_id: session_id} = socket.assigns.session_staffing_modal
+
+    case Provider.set_session_lead_instructor(session_id, staff_member_id, socket.assigns.provider_id) do
+      {:ok, _assignment} ->
+        {:noreply,
+         socket
+         |> refresh_session_staffing()
+         |> put_flash(:info, gettext("Lead instructor for this session updated."))}
+
+      {:error, :not_found} ->
+        {:noreply, session_staffing_not_found(socket, "promote", staff_member_id)}
+    end
+  end
+
+  @impl true
+  def handle_event("revert_session_staffing", _params, socket) do
+    %{session_id: session_id} = socket.assigns.session_staffing_modal
+
+    case Provider.revert_session_to_program_roster(session_id, socket.assigns.provider_id) do
+      {:ok, _count} ->
+        {:noreply,
+         socket
+         |> refresh_session_staffing()
+         |> put_flash(:info, gettext("This session is back on the program's usual team."))}
+
+      {:error, :not_found} ->
+        {:noreply, session_staffing_not_found(socket, "revert", session_id)}
+    end
+  end
+
   @impl true
   def handle_info({:session_changed, session_id}, socket) do
     {:noreply, update_session_in_stream(socket, session_id)}
@@ -220,6 +340,73 @@ defmodule KlassHeroWeb.Provider.SessionsLive do
   def handle_info(_message, socket), do: {:noreply, socket}
 
   defp program_names(programs), do: Map.new(programs, &{&1.id, &1.title})
+
+  # Two scoped facade reads joined by a presenter. `get_session_staffing_for_provider/2`
+  # is the IDOR guard *and* the source of the override-vs-program fact the panel
+  # renders — one call answers "may they see this?" and "where did this roster come
+  # from?".
+  defp build_session_staffing_modal(session_id, socket) do
+    provider_id = socket.assigns.provider_id
+
+    with {:ok, staffing} <- Provider.get_session_staffing_for_provider(provider_id, session_id) do
+      lead_id = staffing.lead && staffing.lead.id
+
+      members =
+        session_id
+        |> Provider.list_session_staff()
+        |> ProgramStaffingPresenter.for_panel(lead_id)
+
+      assignable =
+        provider_id
+        |> Provider.list_assignable_staff_for_session(session_id)
+        |> staff_to_options()
+
+      {:ok,
+       %{
+         session_id: session_id,
+         session_label: session_label(session_id),
+         program_title: Map.get(socket.assigns.program_names, staffing.program_id, gettext("Program")),
+         overridden?: SessionStaffing.overridden?(staffing),
+         members: members,
+         assignable_options: assignable
+       }}
+    end
+  end
+
+  # Every mutation re-reads rather than patching the assign in place: the context
+  # owns who works the session and whether that roster is its own.
+  defp refresh_session_staffing(socket) do
+    %{session_id: session_id} = socket.assigns.session_staffing_modal
+
+    case build_session_staffing_modal(session_id, socket) do
+      {:ok, modal} -> assign(socket, :session_staffing_modal, modal)
+      {:error, :not_found} -> assign(socket, :session_staffing_modal, nil)
+    end
+  end
+
+  # Read rather than pulled off the stream: a stream is not enumerable state to
+  # search, and the panel can be reopened after a reset has cleared the entry.
+  defp session_label(session_id) do
+    case Participation.get_session(session_id) do
+      {:ok, session} -> Calendar.strftime(session.session_date, "%a, %d %b")
+      {:error, :not_found} -> gettext("Session")
+    end
+  end
+
+  defp staff_to_options(members) do
+    Enum.map(members, fn m -> {Provider.staff_member_full_name(m), m.id} end)
+  end
+
+  defp session_staffing_not_found(socket, action, subject_id) do
+    Logger.warning("[SessionsLive] Session staffing #{action} for unknown or foreign target",
+      session_id: subject_id,
+      provider_id: socket.assigns.provider_id
+    )
+
+    socket
+    |> assign(:session_staffing_modal, nil)
+    |> put_flash(:error, gettext("That session could not be found."))
+  end
 
   defp build_initial_form_data(selected_date) do
     %{

--- a/lib/klass_hero_web/live/provider/sessions_live.html.heex
+++ b/lib/klass_hero_web/live/provider/sessions_live.html.heex
@@ -89,6 +89,23 @@
             <% true -> %>
               <span class="text-sm text-gray-500">{gettext("No actions available")}</span>
           <% end %>
+
+          <%!-- Staffing is editable on any session, including a completed one:
+                correcting who actually worked a past date is a real need. --%>
+          <button
+            id={"manage-session-staffing-#{session.id}"}
+            phx-click="manage_session_staffing"
+            phx-value-id={session.id}
+            class={[
+              "px-4 py-2 bg-white text-hero-charcoal font-medium border border-hero-grey-300",
+              "hover:bg-hero-grey-50 focus:outline-none focus:ring-2 focus:ring-hero-blue-500 focus:ring-offset-2",
+              Theme.rounded(:lg),
+              Theme.transition(:normal)
+            ]}
+          >
+            <.icon name="hero-users" class="w-4 h-4 mr-1 inline" />
+            {gettext("Staffing")}
+          </button>
         </:actions>
       </.participation_card>
     </div>
@@ -112,6 +129,8 @@
       </div>
     </div>
   </div>
+
+  <.session_staffing_modal :if={@session_staffing_modal} modal={@session_staffing_modal} />
 
   <%= if @live_action == :new do %>
     <div

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -578,8 +578,8 @@ msgid "Dispute Resolution"
 msgstr "Streitbeilegung"
 
 #: lib/klass_hero_web/components/provider_components.ex:719
-#: lib/klass_hero_web/components/provider_components.ex:2406
-#: lib/klass_hero_web/components/provider_components.ex:2424
+#: lib/klass_hero_web/components/provider_components.ex:2593
+#: lib/klass_hero_web/components/provider_components.ex:2611
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
@@ -621,7 +621,7 @@ msgstr "Einchecken fehlgeschlagen: %{reason}"
 msgid "Failed to check out: %{reason}"
 msgstr "Auschecken fehlgeschlagen: %{reason}"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:155
+#: lib/klass_hero_web/live/provider/sessions_live.ex:160
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:116
 #, elixir-autogen, elixir-format
 msgid "Failed to complete session: %{reason}"
@@ -632,7 +632,7 @@ msgstr "Sitzung konnte nicht abgeschlossen werden: %{reason}"
 msgid "Failed to delete account. Please try again."
 msgstr "Konto konnte nicht gelöscht werden. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:132
+#: lib/klass_hero_web/live/provider/sessions_live.ex:137
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:87
 #, elixir-autogen, elixir-format
 msgid "Failed to start session: %{reason}"
@@ -683,8 +683,8 @@ msgstr "Geistiges Eigentum"
 msgid "Introduction"
 msgstr "Einleitung"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:110
-#: lib/klass_hero_web/live/provider/sessions_live.ex:362
+#: lib/klass_hero_web/live/provider/sessions_live.ex:115
+#: lib/klass_hero_web/live/provider/sessions_live.ex:549
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:63
 #, elixir-autogen, elixir-format
 msgid "Invalid date format"
@@ -756,7 +756,7 @@ msgstr "Nachricht"
 msgid "Message sent successfully!"
 msgstr "Nachricht erfolgreich gesendet!"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:46
+#: lib/klass_hero_web/live/provider/sessions_live.ex:50
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:4
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:21
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:228
@@ -878,9 +878,9 @@ msgstr "Speichern..."
 msgid "Select one or both options"
 msgstr "Wählen Sie eine oder beide Optionen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2102
-#: lib/klass_hero_web/components/provider_components.ex:2103
-#: lib/klass_hero_web/components/provider_components.ex:2140
+#: lib/klass_hero_web/components/provider_components.ex:2289
+#: lib/klass_hero_web/components/provider_components.ex:2290
+#: lib/klass_hero_web/components/provider_components.ex:2327
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:448
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:484
@@ -888,7 +888,7 @@ msgstr "Wählen Sie eine oder beide Optionen"
 msgid "Send Message"
 msgstr "Nachricht senden"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:141
+#: lib/klass_hero_web/live/provider/sessions_live.ex:146
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:102
 #, elixir-autogen, elixir-format
 msgid "Session completed successfully"
@@ -902,7 +902,7 @@ msgstr "Sitzung erfolgreich abgeschlossen"
 msgid "Session not found"
 msgstr "Sitzung nicht gefunden"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:118
+#: lib/klass_hero_web/live/provider/sessions_live.ex:123
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:73
 #, elixir-autogen, elixir-format
 msgid "Session started successfully"
@@ -1578,8 +1578,8 @@ msgid "Quick Navigation"
 msgstr "Schnellnavigation"
 
 #: lib/klass_hero_web/components/provider_components.ex:1487
-#: lib/klass_hero_web/components/provider_components.ex:2078
-#: lib/klass_hero_web/components/provider_components.ex:2304
+#: lib/klass_hero_web/components/provider_components.ex:2265
+#: lib/klass_hero_web/components/provider_components.ex:2491
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr "Aktionen"
@@ -1670,8 +1670,8 @@ msgstr "Übersicht"
 #: lib/klass_hero_web/components/provider_components.ex:47
 #: lib/klass_hero_web/components/provider_components.ex:73
 #: lib/klass_hero_web/components/provider_components.ex:1627
-#: lib/klass_hero_web/components/provider_components.ex:2500
-#: lib/klass_hero_web/components/provider_components.ex:2518
+#: lib/klass_hero_web/components/provider_components.ex:2687
+#: lib/klass_hero_web/components/provider_components.ex:2705
 #: lib/klass_hero_web/live/admin/sessions_live.ex:298
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
@@ -1709,9 +1709,9 @@ msgid "Search by name..."
 msgstr "Nach Namen suchen..."
 
 #: lib/klass_hero_web/components/provider_components.ex:1481
-#: lib/klass_hero_web/components/provider_components.ex:1850
-#: lib/klass_hero_web/components/provider_components.ex:2072
-#: lib/klass_hero_web/components/provider_components.ex:2301
+#: lib/klass_hero_web/components/provider_components.ex:1852
+#: lib/klass_hero_web/components/provider_components.ex:2259
+#: lib/klass_hero_web/components/provider_components.ex:2488
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1736,7 +1736,7 @@ msgid "This is your main business identity. Verification is required to list pro
 msgstr "Dies ist Ihre Hauptgeschäftsidentität. Eine Verifizierung ist erforderlich, um Programme anzubieten."
 
 #: lib/klass_hero_web/components/provider_components.ex:1538
-#: lib/klass_hero_web/components/provider_components.ex:1865
+#: lib/klass_hero_web/components/provider_components.ex:1867
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr "Nicht zugewiesen"
@@ -1817,13 +1817,13 @@ msgstr "Rundnachricht an %{count} Eltern gesendet"
 #: lib/klass_hero_web/components/participation_components.ex:717
 #: lib/klass_hero_web/components/provider_components.ex:889
 #: lib/klass_hero_web/components/provider_components.ex:1334
-#: lib/klass_hero_web/components/provider_components.ex:2243
+#: lib/klass_hero_web/components/provider_components.ex:2430
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:478
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:222
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:356
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:191
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:210
 #: lib/klass_hero_web/live/settings/children_live.ex:544
 #: lib/klass_hero_web/live/settings/children_live.ex:703
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:237
@@ -1873,7 +1873,7 @@ msgstr "Kind konnte nicht entfernt werden. Bitte versuchen Sie es erneut."
 msgid "Data sharing consent"
 msgstr "Einwilligung zur Datenweitergabe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2387
+#: lib/klass_hero_web/components/provider_components.ex:2574
 #: lib/klass_hero_web/live/settings/children_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1921,17 +1921,17 @@ msgstr "Rundnachricht konnte nicht gesendet werden"
 msgid "Failed to submit note"
 msgstr "Notiz konnte nicht eingereicht werden"
 
-#: lib/klass_hero_web/components/provider_components.ex:2381
-#: lib/klass_hero_web/components/provider_components.ex:2410
-#: lib/klass_hero_web/components/provider_components.ex:2426
+#: lib/klass_hero_web/components/provider_components.ex:2568
+#: lib/klass_hero_web/components/provider_components.ex:2597
+#: lib/klass_hero_web/components/provider_components.ex:2613
 #: lib/klass_hero_web/live/settings/children_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr "Vorname"
 
-#: lib/klass_hero_web/components/provider_components.ex:2382
-#: lib/klass_hero_web/components/provider_components.ex:2411
-#: lib/klass_hero_web/components/provider_components.ex:2427
+#: lib/klass_hero_web/components/provider_components.ex:2569
+#: lib/klass_hero_web/components/provider_components.ex:2598
+#: lib/klass_hero_web/components/provider_components.ex:2614
 #: lib/klass_hero_web/live/settings/children_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -2088,7 +2088,7 @@ msgstr "Rundnachricht senden"
 msgid "Send a message to start the conversation"
 msgstr "Senden Sie eine Nachricht, um die Unterhaltung zu beginnen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2481
+#: lib/klass_hero_web/components/provider_components.ex:2668
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:249
 #, elixir-autogen, elixir-format
@@ -2224,7 +2224,7 @@ msgstr "Alter %{min}+"
 msgid "Allowed Genders"
 msgstr "Zulässige Geschlechter"
 
-#: lib/klass_hero_web/components/provider_components.ex:2540
+#: lib/klass_hero_web/components/provider_components.ex:2727
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred during import."
 msgstr "Beim Import ist ein unerwarteter Fehler aufgetreten."
@@ -2319,8 +2319,8 @@ msgstr "Kategorie"
 msgid "Check eligibility at"
 msgstr "Berechtigung prüfen unter"
 
-#: lib/klass_hero_web/components/provider_components.ex:2069
-#: lib/klass_hero_web/components/provider_components.ex:2295
+#: lib/klass_hero_web/components/provider_components.ex:2256
+#: lib/klass_hero_web/components/provider_components.ex:2482
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr "Name des Kindes"
@@ -2365,7 +2365,7 @@ msgstr "Schließen Sie die Geschäftsverifizierung ab, um Programme zu erstellen
 msgid "Confirm rejection"
 msgstr "Ablehnung bestätigen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2501
+#: lib/klass_hero_web/components/provider_components.ex:2688
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr "Bestätigt"
@@ -2414,7 +2414,7 @@ msgstr "Beschreibung"
 msgid "Diverse"
 msgstr "Divers"
 
-#: lib/klass_hero_web/components/provider_components.ex:2716
+#: lib/klass_hero_web/components/provider_components.ex:2903
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr "Dokumenttyp"
@@ -2448,7 +2448,7 @@ msgstr "Dokument abgelehnt."
 msgid "Document uploaded successfully."
 msgstr "Dokument erfolgreich hochgeladen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2262
+#: lib/klass_hero_web/components/provider_components.ex:2449
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr "Vorlage herunterladen"
@@ -2474,13 +2474,13 @@ msgid "End Date"
 msgstr "Enddatum"
 
 #: lib/klass_hero_web/components/provider_components.ex:1046
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:166
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "End Time"
 msgstr "Endzeit"
 
-#: lib/klass_hero_web/components/provider_components.ex:2075
-#: lib/klass_hero_web/components/provider_components.ex:2521
+#: lib/klass_hero_web/components/provider_components.ex:2262
+#: lib/klass_hero_web/components/provider_components.ex:2708
 #: lib/klass_hero_web/components/provider_layout_components.ex:644
 #, elixir-autogen, elixir-format
 msgid "Enrolled"
@@ -2502,7 +2502,7 @@ msgid "Explain why this document is being rejected..."
 msgstr "Erklären Sie, warum dieses Dokument abgelehnt wird..."
 
 #: lib/klass_hero_web/components/provider_components.ex:71
-#: lib/klass_hero_web/components/provider_components.ex:2522
+#: lib/klass_hero_web/components/provider_components.ex:2709
 #: lib/klass_hero_web/live/admin/emails_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2546,12 +2546,12 @@ msgstr "Weiblich"
 msgid "File"
 msgstr "Datei"
 
-#: lib/klass_hero_web/components/provider_components.ex:2650
+#: lib/klass_hero_web/components/provider_components.ex:2837
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr "Die Datei ist zu groß."
 
-#: lib/klass_hero_web/components/provider_components.ex:2652
+#: lib/klass_hero_web/components/provider_components.ex:2839
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr "Dateityp wird nicht akzeptiert."
@@ -2586,7 +2586,7 @@ msgstr "Klassenstufe %{min}+"
 msgid "Grades %{min} – %{max}"
 msgstr "Klassenstufen %{min} – %{max}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2298
+#: lib/klass_hero_web/components/provider_components.ex:2485
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr "E-Mail des Erziehungsberechtigten"
@@ -2601,7 +2601,7 @@ msgstr "Porträtfoto"
 msgid "ID Document"
 msgstr "Ausweisdokument"
 
-#: lib/klass_hero_web/components/provider_components.ex:2235
+#: lib/klass_hero_web/components/provider_components.ex:2422
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Importieren"
@@ -2669,7 +2669,7 @@ msgid "Leave unchecked to allow all genders."
 msgstr "Nicht markiert lassen, um alle Geschlechter zuzulassen."
 
 #: lib/klass_hero_web/components/provider_components.ex:1002
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:172
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:191
 #, elixir-autogen, elixir-format
 msgid "Location"
 msgstr "Ort"
@@ -2727,12 +2727,12 @@ msgstr "Niedrigste Klassenstufe"
 msgid "No approved documents."
 msgstr "Keine genehmigten Dokumente."
 
-#: lib/klass_hero_web/components/provider_components.ex:2678
+#: lib/klass_hero_web/components/provider_components.ex:2865
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr "Noch keine Dokumente hochgeladen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2062
+#: lib/klass_hero_web/components/provider_components.ex:2249
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
@@ -2748,7 +2748,7 @@ msgstr "Keine Datei ausgewählt."
 msgid "No grade"
 msgstr "Keine Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2286
+#: lib/klass_hero_web/components/provider_components.ex:2473
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr "Noch keine Einladungen. Laden Sie eine CSV-Datei hoch, um Familien einzuladen."
@@ -2811,7 +2811,7 @@ msgstr "Nicht angegeben"
 msgid "Our Story"
 msgstr "Unsere Geschichte"
 
-#: lib/klass_hero_web/components/provider_components.ex:2753
+#: lib/klass_hero_web/components/provider_components.ex:2940
 #: lib/klass_hero_web/live/provider/verification_live.ex:698
 #: lib/klass_hero_web/live/provider/verification_live.ex:770
 #, elixir-autogen, elixir-format
@@ -2909,7 +2909,7 @@ msgid "Read our founding story →"
 msgstr "Lesen Sie unsere Gründungsgeschichte →"
 
 #: lib/klass_hero_web/components/participation_components.ex:805
-#: lib/klass_hero_web/components/provider_components.ex:2520
+#: lib/klass_hero_web/components/provider_components.ex:2707
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Registered"
@@ -2991,16 +2991,16 @@ msgstr "Ablehnungsgrund"
 
 #: lib/klass_hero_web/components/provider_components.ex:839
 #: lib/klass_hero_web/components/provider_components.ex:1284
-#: lib/klass_hero_web/components/provider_components.ex:2342
-#: lib/klass_hero_web/components/provider_components.ex:2772
-#: lib/klass_hero_web/components/provider_components.ex:2851
+#: lib/klass_hero_web/components/provider_components.ex:2529
+#: lib/klass_hero_web/components/provider_components.ex:2959
+#: lib/klass_hero_web/components/provider_components.ex:3038
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:253
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr "Entfernen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2335
+#: lib/klass_hero_web/components/provider_components.ex:2522
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr "Einladung erneut senden"
@@ -3041,7 +3041,7 @@ msgstr "Zeitplan noch offen"
 msgid "School Grade (optional)"
 msgstr "Klassenstufe (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2750
+#: lib/klass_hero_web/components/provider_components.ex:2937
 #, elixir-autogen, elixir-format
 msgid "Select File"
 msgstr "Datei auswählen"
@@ -3058,7 +3058,7 @@ msgstr "Das ausgewählte Kind erfüllt die Programmanforderungen nicht."
 msgid "Selected instructor could not be found. Please try again."
 msgstr "Der ausgewählte Kursleiter konnte nicht gefunden werden. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2519
+#: lib/klass_hero_web/components/provider_components.ex:2706
 #: lib/klass_hero_web/live/admin/emails_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Sent"
@@ -3098,7 +3098,7 @@ msgid "Start Date"
 msgstr "Startdatum"
 
 #: lib/klass_hero_web/components/provider_components.ex:1041
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:165
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:184
 #, elixir-autogen, elixir-format
 msgid "Start Time"
 msgstr "Startzeit"
@@ -3168,7 +3168,7 @@ msgstr "Dieses Programm wurde von jemand anderem geändert. Bitte schließen Sie
 msgid "Title"
 msgstr "Titel"
 
-#: lib/klass_hero_web/components/provider_components.ex:2651
+#: lib/klass_hero_web/components/provider_components.ex:2838
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr "Zu viele Dateien."
@@ -3188,32 +3188,32 @@ msgstr "Bis zu %{max}"
 msgid "Up to Grade %{max}"
 msgstr "Bis Klassenstufe %{max}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2221
+#: lib/klass_hero_web/components/provider_components.ex:2408
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr "CSV hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2796
+#: lib/klass_hero_web/components/provider_components.ex:2983
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr "Dokument hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2705
+#: lib/klass_hero_web/components/provider_components.ex:2892
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr "Neues Dokument hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2673
+#: lib/klass_hero_web/components/provider_components.ex:2860
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr "Laden Sie Dokumente hoch, um Ihr Unternehmen zu verifizieren. Die Dokumente werden von unserem Team überprüft."
 
-#: lib/klass_hero_web/components/provider_components.ex:2653
+#: lib/klass_hero_web/components/provider_components.ex:2840
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr "Upload-Fehler."
 
-#: lib/klass_hero_web/components/provider_components.ex:2670
+#: lib/klass_hero_web/components/provider_components.ex:2857
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr "Verifizierungsdokumente"
@@ -3303,7 +3303,7 @@ msgid "Child Safeguarding Training"
 msgstr "Kinderschutzschulung"
 
 #: lib/klass_hero_web/components/marketing_components.ex:1498
-#: lib/klass_hero_web/components/provider_components.ex:3018
+#: lib/klass_hero_web/components/provider_components.ex:3205
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr "Vereinbarung zu Community-Standards"
@@ -3453,7 +3453,7 @@ msgid "Vetted with Care"
 msgstr "Mit Sorgfalt geprüft"
 
 #: lib/klass_hero_web/components/marketing_components.ex:1482
-#: lib/klass_hero_web/components/provider_components.ex:2803
+#: lib/klass_hero_web/components/provider_components.ex:2990
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr "Video-Überprüfung"
@@ -3627,7 +3627,7 @@ msgstr "Eingecheckt"
 msgid "Checked Out"
 msgstr "Ausgecheckt"
 
-#: lib/klass_hero_web/components/provider_components.ex:2378
+#: lib/klass_hero_web/components/provider_components.ex:2565
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Child"
@@ -3680,7 +3680,7 @@ msgstr "Benötige ich ein Konto, um zu buchen?"
 msgid "Download monthly statements for taxes"
 msgstr "Monatliche Abrechnungen für die Steuer herunterladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2139
+#: lib/klass_hero_web/components/provider_components.ex:2326
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "Enrollment not confirmed"
@@ -3766,7 +3766,7 @@ msgstr "Kein Risiko von Zahlungsausfällen"
 
 #: lib/klass_hero_web/components/participation_components.ex:830
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:155
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:178
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:197
 #, elixir-autogen, elixir-format
 msgid "Notes"
 msgstr "Notizen"
@@ -3776,7 +3776,7 @@ msgstr "Notizen"
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr "Oder: Jederzeit eine Sofortauszahlung anfordern (mindestens 50 €)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2138
+#: lib/klass_hero_web/components/provider_components.ex:2325
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -3959,7 +3959,7 @@ msgstr "%{checked_in} / %{total} eingecheckt"
 msgid "%{count} unread"
 msgstr "%{count} ungelesen"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:380
+#: lib/klass_hero_web/live/provider/sessions_live.ex:567
 #, elixir-autogen, elixir-format
 msgid "A session already exists at this time"
 msgstr "Zu dieser Zeit existiert bereits eine Sitzung"
@@ -4128,19 +4128,19 @@ msgid "Could not start private conversation"
 msgstr "Private Unterhaltung konnte nicht gestartet werden"
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:18
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:135
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:200
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:154
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:219
 #, elixir-autogen, elixir-format
 msgid "Create Session"
 msgstr "Sitzung erstellen"
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:162
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:181
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr "Datum"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:356
-#: lib/klass_hero_web/live/provider/sessions_live.ex:357
+#: lib/klass_hero_web/live/provider/sessions_live.ex:543
+#: lib/klass_hero_web/live/provider/sessions_live.ex:544
 #, elixir-autogen, elixir-format
 msgid "Date is required"
 msgstr "Datum ist erforderlich"
@@ -4183,7 +4183,7 @@ msgstr "E-Mails"
 msgid "Emergency: %{details}"
 msgstr "Notfall: %{details}"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:379
+#: lib/klass_hero_web/live/provider/sessions_live.ex:566
 #, elixir-autogen, elixir-format
 msgid "End time must be after start time"
 msgstr "Die Endzeit muss nach der Startzeit liegen"
@@ -4198,7 +4198,7 @@ msgstr "Erwartet"
 msgid "Failed to archive email"
 msgstr "E-Mail konnte nicht archiviert werden"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:316
+#: lib/klass_hero_web/live/provider/sessions_live.ex:503
 #, elixir-autogen, elixir-format
 msgid "Failed to create session: %{reason}"
 msgstr "Sitzung konnte nicht erstellt werden: %{reason}"
@@ -4255,7 +4255,7 @@ msgid "Invalid Invitation"
 msgstr "Ungültige Einladung"
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:260
-#: lib/klass_hero_web/live/provider/sessions_live.ex:375
+#: lib/klass_hero_web/live/provider/sessions_live.ex:562
 #, elixir-autogen, elixir-format
 msgid "Invalid time format"
 msgstr "Ungültiges Zeitformat"
@@ -4311,7 +4311,7 @@ msgstr "Verwalten Sie Ihre geplanten Sitzungen und die Anwesenheit"
 msgid "Mark Unread"
 msgstr "Als ungelesen markieren"
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:181
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:200
 #, elixir-autogen, elixir-format
 msgid "Max Capacity"
 msgstr "Maximale Kapazität"
@@ -4352,7 +4352,7 @@ msgstr "Keine Ergebnisse"
 msgid "No sessions found for the selected filters."
 msgstr "Keine Sitzungen für die ausgewählten Filter gefunden."
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:105
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:122
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:316
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled"
@@ -4394,7 +4394,7 @@ msgstr "Ausstehende Überprüfungen"
 msgid "Please explain why you're rejecting this note..."
 msgstr "Bitte erklären Sie, warum Sie diese Notiz ablehnen..."
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:382
+#: lib/klass_hero_web/live/provider/sessions_live.ex:569
 #, elixir-autogen, elixir-format
 msgid "Please fill in all required fields"
 msgstr "Bitte füllen Sie alle erforderlichen Felder aus"
@@ -4408,12 +4408,13 @@ msgstr "Absenden"
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
 #: lib/klass_hero_web/live/provider/programs_live.ex:224
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:156
+#: lib/klass_hero_web/live/provider/sessions_live.ex:368
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:175
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr "Programm"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:174
+#: lib/klass_hero_web/live/provider/sessions_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "Program is required"
 msgstr "Programm ist erforderlich"
@@ -4485,7 +4486,7 @@ msgstr "Erneut versuchen"
 msgid "Revised Note"
 msgstr "Überarbeitete Notiz"
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:157
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:176
 #, elixir-autogen, elixir-format
 msgid "Select a program..."
 msgstr "Programm auswählen..."
@@ -4502,6 +4503,7 @@ msgstr "Wird gesendet"
 
 #: lib/klass_hero_web/components/participation_components.ex:70
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:16
+#: lib/klass_hero_web/live/provider/sessions_live.ex:392
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:16
 #, elixir-autogen, elixir-format
 msgid "Session"
@@ -4518,7 +4520,7 @@ msgstr "Sitzungsnotizen (optional)"
 msgid "Session Roster"
 msgstr "Teilnehmerliste"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:298
+#: lib/klass_hero_web/live/provider/sessions_live.ex:485
 #, elixir-autogen, elixir-format
 msgid "Session created successfully"
 msgstr "Sitzung erfolgreich erstellt"
@@ -4579,8 +4581,8 @@ msgstr "Diese Einladung wurde bereits verwendet."
 msgid "This invite link is invalid or has expired."
 msgstr "Dieser Einladungslink ist ungültig oder abgelaufen."
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:366
-#: lib/klass_hero_web/live/provider/sessions_live.ex:367
+#: lib/klass_hero_web/live/provider/sessions_live.ex:553
+#: lib/klass_hero_web/live/provider/sessions_live.ex:554
 #, elixir-autogen, elixir-format
 msgid "Time is required"
 msgstr "Uhrzeit ist erforderlich"
@@ -4595,7 +4597,7 @@ msgstr "An"
 msgid "Type your reply..."
 msgstr "Ihre Antwort eingeben..."
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:178
+#: lib/klass_hero_web/live/provider/sessions_live.ex:183
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:123
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:92
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:121
@@ -4650,7 +4652,7 @@ msgstr "Kommentar schreiben..."
 msgid "You already have an account. Log in to see your new enrollment."
 msgstr "Sie haben bereits ein Konto. Melden Sie sich an, um Ihre neue Anmeldung zu sehen."
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:108
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:125
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:319
 #, elixir-autogen, elixir-format
 msgid "You have no sessions scheduled for %{date}"
@@ -4887,38 +4889,34 @@ msgstr "Ihr Profil ist bereits vollständig."
 msgid "for"
 msgstr "für"
 
-#: lib/klass_hero_web/components/provider_components.ex:1847
+#: lib/klass_hero_web/components/provider_components.ex:1850
 #, elixir-autogen, elixir-format
 msgid "Assigned staff"
 msgstr "Zugewiesenes Personal"
 
-#: lib/klass_hero_web/components/provider_components.ex:1849
+#: lib/klass_hero_web/components/provider_components.ex:1851
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr "Anwesenheit"
 
-#: lib/klass_hero_web/components/provider_components.ex:1831
-#: lib/klass_hero_web/components/provider_components.ex:1920
+#: lib/klass_hero_web/components/provider_components.ex:1834
+#: lib/klass_hero_web/components/provider_components.ex:1919
+#: lib/klass_hero_web/components/provider_components.ex:2068
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr "Schließen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1848
-#, elixir-autogen, elixir-format
-msgid "Cover"
-msgstr "Vertretung"
-
-#: lib/klass_hero_web/components/provider_components.ex:1846
+#: lib/klass_hero_web/components/provider_components.ex:1849
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr "Datum / Uhrzeit"
 
-#: lib/klass_hero_web/components/provider_components.ex:1840
+#: lib/klass_hero_web/components/provider_components.ex:1843
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled yet."
 msgstr "Noch keine Sessions geplant."
 
-#: lib/klass_hero_web/components/provider_components.ex:1829
+#: lib/klass_hero_web/components/provider_components.ex:1832
 #, elixir-autogen, elixir-format
 msgid "Sessions — %{title}"
 msgstr "Sessions — %{title}"
@@ -4955,17 +4953,17 @@ msgstr "Abreisezeit ist kein gültiges Datum oder keine gültige Uhrzeit"
 msgid "Failed to update record"
 msgstr "Aktualisieren des Datensatzes fehlgeschlagen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2442
+#: lib/klass_hero_web/components/provider_components.ex:2629
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr "Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2161
+#: lib/klass_hero_web/components/provider_components.ex:2348
 #, elixir-autogen, elixir-format
 msgid "Invite mode"
 msgstr "Einladungsmodus"
 
-#: lib/klass_hero_web/components/provider_components.ex:2180
+#: lib/klass_hero_web/components/provider_components.ex:2367
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr "Einzelperson einladen"
@@ -4980,12 +4978,12 @@ msgstr "Einladung verschickt."
 msgid "Leave blank to keep this child marked as present."
 msgstr "Leer lassen, um dieses Kind als anwesend markiert zu lassen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2455
+#: lib/klass_hero_web/components/provider_components.ex:2642
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr "Gesundheit & Einwilligungen (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2461
+#: lib/klass_hero_web/components/provider_components.ex:2648
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr "Gesundheitliche Besonderheiten"
@@ -4996,17 +4994,17 @@ msgstr "Gesundheitliche Besonderheiten"
 msgid "Nothing to update"
 msgstr "Nichts zu aktualisieren"
 
-#: lib/klass_hero_web/components/provider_components.ex:2463
+#: lib/klass_hero_web/components/provider_components.ex:2650
 #, elixir-autogen, elixir-format
 msgid "Nut allergy"
 msgstr "Nussallergie"
 
-#: lib/klass_hero_web/components/provider_components.ex:2467
+#: lib/klass_hero_web/components/provider_components.ex:2654
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr "Fotos dürfen in Marketingmaterialien verwendet werden"
 
-#: lib/klass_hero_web/components/provider_components.ex:2472
+#: lib/klass_hero_web/components/provider_components.ex:2659
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr "Fotos dürfen in sozialen Medien erscheinen"
@@ -5016,7 +5014,7 @@ msgstr "Fotos dürfen in sozialen Medien erscheinen"
 msgid "Present"
 msgstr "Anwesend"
 
-#: lib/klass_hero_web/components/provider_components.ex:2399
+#: lib/klass_hero_web/components/provider_components.ex:2586
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr "Hauptansprechpartner"
@@ -5043,22 +5041,22 @@ msgstr "Datensatz aktualisiert"
 msgid "Save changes"
 msgstr "Änderungen speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:2436
+#: lib/klass_hero_web/components/provider_components.ex:2623
 #, elixir-autogen, elixir-format
 msgid "School (optional)"
 msgstr "Schule (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2446
+#: lib/klass_hero_web/components/provider_components.ex:2633
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr "Schulname"
 
-#: lib/klass_hero_web/components/provider_components.ex:2420
+#: lib/klass_hero_web/components/provider_components.ex:2607
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr "Zweiter Ansprechpartner (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2489
+#: lib/klass_hero_web/components/provider_components.ex:2676
 #, elixir-autogen, elixir-format
 msgid "Send invite"
 msgstr "Einladung senden"
@@ -5068,7 +5066,7 @@ msgstr "Einladung senden"
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr "Aktualisieren Sie die Notiz für dieses Kind (z. B. um zu klären, was passiert ist)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2198
+#: lib/klass_hero_web/components/provider_components.ex:2385
 #, elixir-autogen, elixir-format
 msgid "Upload a list"
 msgstr "Liste hochladen"
@@ -6370,17 +6368,17 @@ msgstr "Umsatz (diese Woche)"
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr "Strenge Überprüfung, damit Familien immer wissen, wer die Gruppe leitet."
 
-#: lib/klass_hero_web/components/provider_components.ex:2528
+#: lib/klass_hero_web/components/provider_components.ex:2715
 #, elixir-autogen, elixir-format
 msgid "Row %{row}"
 msgstr "Zeile %{row}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2528
+#: lib/klass_hero_web/components/provider_components.ex:2715
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr "Zeile —"
 
-#: lib/klass_hero_web/components/provider_components.ex:2274
+#: lib/klass_hero_web/components/provider_components.ex:2461
 #, elixir-autogen, elixir-format
 msgid "Rows with errors"
 msgstr "Zeilen mit Fehlern"
@@ -7139,12 +7137,12 @@ msgstr "Deine Identität ist verifiziert."
 msgid "Experience validation"
 msgstr "Erfahrungsnachweis"
 
-#: lib/klass_hero_web/components/provider_components.ex:2832
+#: lib/klass_hero_web/components/provider_components.ex:3019
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr "MP4, MOV oder WEBM. Max. 100 MB."
 
-#: lib/klass_hero_web/components/provider_components.ex:2806
+#: lib/klass_hero_web/components/provider_components.ex:2993
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr "Nimm ein kurzes Video auf, in dem du dich vorstellst. Unser Team prüft es, um Kommunikationsfähigkeit und Übereinstimmung mit unseren Werten einzuschätzen."
@@ -7154,12 +7152,12 @@ msgstr "Nimm ein kurzes Video auf, in dem du dich vorstellst. Unser Team prüft 
 msgid "Safeguarding certificate"
 msgstr "Kinderschutz-Zertifikat"
 
-#: lib/klass_hero_web/components/provider_components.ex:2829
+#: lib/klass_hero_web/components/provider_components.ex:3016
 #, elixir-autogen, elixir-format
 msgid "Select Video"
 msgstr "Video auswählen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2875
+#: lib/klass_hero_web/components/provider_components.ex:3062
 #, elixir-autogen, elixir-format
 msgid "Upload Video"
 msgstr "Video hochladen"
@@ -7169,7 +7167,7 @@ msgstr "Video hochladen"
 msgid "Your browser does not support video playback."
 msgstr "Dein Browser unterstützt keine Videowiedergabe."
 
-#: lib/klass_hero_web/components/provider_components.ex:3022
+#: lib/klass_hero_web/components/provider_components.ex:3209
 #, elixir-autogen, elixir-format
 msgid "Confirm agreement"
 msgstr "Zustimmung bestätigen"
@@ -7179,12 +7177,12 @@ msgstr "Zustimmung bestätigen"
 msgid "Couldn't record your agreement. Please try again."
 msgstr "Deine Zustimmung konnte nicht gespeichert werden. Bitte versuche es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:3045
+#: lib/klass_hero_web/components/provider_components.ex:3232
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr "Vereinbarung herunterladen (PDF)"
 
-#: lib/klass_hero_web/components/provider_components.ex:3021
+#: lib/klass_hero_web/components/provider_components.ex:3208
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr "Ich habe die Klass Hero Community-Richtlinien gelesen und stimme ihnen zu."
@@ -7194,7 +7192,7 @@ msgstr "Ich habe die Klass Hero Community-Richtlinien gelesen und stimme ihnen z
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr "Bitte bestätige, dass du die Community-Richtlinien gelesen hast und ihnen zustimmst."
 
-#: lib/klass_hero_web/components/provider_components.ex:2930
+#: lib/klass_hero_web/components/provider_components.ex:3117
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr "Unterzeichnet von %{name} am %{date} (v%{version})."
@@ -7204,17 +7202,17 @@ msgstr "Unterzeichnet von %{name} am %{date} (v%{version})."
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr "Danke – deine Zustimmung zu den Community-Richtlinien wurde gespeichert."
 
-#: lib/klass_hero_web/components/provider_components.ex:3030
+#: lib/klass_hero_web/components/provider_components.ex:3217
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr "Die Community-Richtlinien wurden seit deiner letzten Zustimmung aktualisiert (v%{old}). Bitte lies sie erneut und stimme erneut zu."
 
-#: lib/klass_hero_web/components/provider_components.ex:3019
+#: lib/klass_hero_web/components/provider_components.ex:3206
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr "Der letzte Schritt: Lies die Klass Hero Community-Richtlinien und stimme ihnen zu."
 
-#: lib/klass_hero_web/components/provider_components.ex:3020
+#: lib/klass_hero_web/components/provider_components.ex:3207
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr "Du hast den Community-Richtlinien zugestimmt."
@@ -7483,12 +7481,12 @@ msgstr "Ihre Versicherungsbescheinigung wird geprüft."
 msgid "Your insurance is verified."
 msgstr "Ihre Versicherung ist verifiziert."
 
-#: lib/klass_hero_web/components/provider_components.ex:2974
+#: lib/klass_hero_web/components/provider_components.ex:3161
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr "Unterzeichnung durch %{name} im Namen des Unternehmens."
 
-#: lib/klass_hero_web/components/provider_components.ex:3077
+#: lib/klass_hero_web/components/provider_components.ex:3264
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr "Bestätige im Namen deines Unternehmens, dass alle Mitarbeitenden gemäß dem deutschen Kinderschutzrecht überprüft sind."
@@ -7498,7 +7496,7 @@ msgstr "Bestätige im Namen deines Unternehmens, dass alle Mitarbeitenden gemä�
 msgid "Couldn't record your declaration. Please try again."
 msgstr "Deine Erklärung konnte nicht gespeichert werden. Bitte versuche es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:3083
+#: lib/klass_hero_web/components/provider_components.ex:3270
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr "Ich bestätige im Namen des Unternehmens, dass die obige Erklärung zutrifft und ich zu ihrer Unterzeichnung berechtigt bin."
@@ -7508,17 +7506,17 @@ msgstr "Ich bestätige im Namen des Unternehmens, dass die obige Erklärung zutr
 msgid "Please confirm the declaration before signing."
 msgstr "Bitte bestätige die Erklärung vor der Unterzeichnung."
 
-#: lib/klass_hero_web/components/provider_components.ex:3108
+#: lib/klass_hero_web/components/provider_components.ex:3295
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr "Vorläufiger Text — vor der Freischaltung noch von einer in Deutschland zugelassenen Anwältin bzw. einem Anwalt zu prüfen."
 
-#: lib/klass_hero_web/components/provider_components.ex:3087
+#: lib/klass_hero_web/components/provider_components.ex:3274
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr "Erklärung unterzeichnen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3075
+#: lib/klass_hero_web/components/provider_components.ex:3262
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr "Erklärung zur Mitarbeiter-Compliance"
@@ -7528,12 +7526,12 @@ msgstr "Erklärung zur Mitarbeiter-Compliance"
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr "Danke — deine Erklärung zur Mitarbeiter-Compliance wurde erfasst."
 
-#: lib/klass_hero_web/components/provider_components.ex:3095
+#: lib/klass_hero_web/components/provider_components.ex:3282
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr "Die Erklärung zur Mitarbeiter-Compliance wurde seit deiner letzten Unterzeichnung aktualisiert (v%{old}). Bitte prüfe sie und unterzeichne erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:3081
+#: lib/klass_hero_web/components/provider_components.ex:3268
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr "Du hast die Erklärung zur Mitarbeiter-Compliance unterzeichnet."
@@ -7600,12 +7598,14 @@ msgstr "In Prüfung"
 msgid "Undelivered Events"
 msgstr "Nicht zugestellte Ereignisse"
 
-#: lib/klass_hero_web/components/provider_components.ex:2017
+#: lib/klass_hero_web/components/provider_components.ex:2016
+#: lib/klass_hero_web/components/provider_components.ex:2198
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1942
+#: lib/klass_hero_web/components/provider_components.ex:1941
+#: lib/klass_hero_web/components/provider_components.ex:2122
 #, elixir-autogen, elixir-format
 msgid "Lead"
 msgstr "Leitung"
@@ -7615,7 +7615,7 @@ msgstr "Leitung"
 msgid "Lead instructor updated."
 msgstr "Leitender Kursleiter aktualisiert."
 
-#: lib/klass_hero_web/components/provider_components.ex:1953
+#: lib/klass_hero_web/components/provider_components.ex:1952
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor"
 msgstr "Als leitenden Kursleiter festlegen"
@@ -7625,27 +7625,30 @@ msgstr "Als leitenden Kursleiter festlegen"
 msgid "Manage Staffing"
 msgstr "Programmteam verwalten"
 
-#: lib/klass_hero_web/components/provider_components.ex:1981
+#: lib/klass_hero_web/components/provider_components.ex:1980
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this program yet."
 msgstr "Diesem Programm ist noch niemand zugewiesen."
 
 #: lib/klass_hero_web/live/provider/programs_live.ex:267
+#: lib/klass_hero_web/live/provider/sessions_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "Pick a staff member to add."
 msgstr "Bitte ein Teammitglied zum Hinzufügen auswählen."
 
-#: lib/klass_hero_web/components/provider_components.ex:1964
+#: lib/klass_hero_web/components/provider_components.ex:1963
+#: lib/klass_hero_web/components/provider_components.ex:2145
 #, elixir-autogen, elixir-format
 msgid "Reassign the lead before removing them"
 msgstr "Vor dem Entfernen einen anderen leitenden Kursleiter festlegen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1965
+#: lib/klass_hero_web/components/provider_components.ex:1964
 #, elixir-autogen, elixir-format
 msgid "Remove from program"
 msgstr "Aus dem Programm entfernen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1999
+#: lib/klass_hero_web/components/provider_components.ex:1998
+#: lib/klass_hero_web/components/provider_components.ex:2180
 #, elixir-autogen, elixir-format
 msgid "Select a staff member…"
 msgstr "Teammitglied auswählen …"
@@ -7660,14 +7663,14 @@ msgstr "Teammitglied zum Programm hinzugefügt."
 msgid "Staff member removed from the program."
 msgstr "Teammitglied aus dem Programm entfernt."
 
-#: lib/klass_hero_web/components/provider_components.ex:2022
+#: lib/klass_hero_web/components/provider_components.ex:2021
 #, elixir-autogen, elixir-format
 msgid "Staff you add can read and reply to this program's parent conversations."
 msgstr ""
 "Hinzugefügte Teammitglieder können die Elterngespräche dieses Programms lesen "
 "und beantworten."
 
-#: lib/klass_hero_web/components/provider_components.ex:1918
+#: lib/klass_hero_web/components/provider_components.ex:1917
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{title}"
 msgstr "Programmteam — %{title}"
@@ -7788,3 +7791,78 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "I understand this program will have no capacity limit."
 msgstr "Ich verstehe, dass dieses Programm keine Teilnehmerbegrenzung haben wird."
+
+#: lib/klass_hero_web/components/provider_components.ex:2209
+#, elixir-autogen, elixir-format
+msgid "Go back to the program's usual team"
+msgstr "Zurück zum üblichen Programmteam"
+
+#: lib/klass_hero_web/live/provider/sessions_live.ex:282
+#, elixir-autogen, elixir-format
+msgid "Lead instructor for this session updated."
+msgstr "Leitung für diesen Termin aktualisiert."
+
+#: lib/klass_hero_web/components/provider_components.ex:2136
+#, elixir-autogen, elixir-format
+msgid "Make lead instructor for this session"
+msgstr "Als Leitung für diesen Termin festlegen"
+
+#: lib/klass_hero_web/components/provider_components.ex:2162
+#, elixir-autogen, elixir-format
+msgid "Nobody is working this session yet."
+msgstr "Für diesen Termin ist noch niemand eingeteilt."
+
+#: lib/klass_hero_web/components/provider_components.ex:2146
+#, elixir-autogen, elixir-format
+msgid "Remove from this session"
+msgstr "Von diesem Termin entfernen"
+
+#: lib/klass_hero_web/live/provider/sessions_live.ex:231
+#, elixir-autogen, elixir-format
+msgid "Staff member added to this session."
+msgstr "Teammitglied zu diesem Termin hinzugefügt."
+
+#: lib/klass_hero_web/live/provider/sessions_live.ex:255
+#, elixir-autogen, elixir-format
+msgid "Staff member removed from this session."
+msgstr "Teammitglied von diesem Termin entfernt."
+
+#: lib/klass_hero_web/components/provider_components.ex:2093
+#, elixir-autogen, elixir-format
+msgid "Staffed just for this session. The program's usual team does not apply here."
+msgstr "Nur für diesen Termin eingeteilt. Das übliche Programmteam gilt hier nicht."
+
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:107
+#, elixir-autogen, elixir-format
+msgid "Staffing"
+msgstr "Team"
+
+#: lib/klass_hero_web/components/provider_components.ex:2064
+#, elixir-autogen, elixir-format
+msgid "Staffing — %{date}"
+msgstr "Team — %{date}"
+
+#: lib/klass_hero_web/live/provider/sessions_live.ex:408
+#, elixir-autogen, elixir-format
+msgid "That session could not be found."
+msgstr "Dieser Termin konnte nicht gefunden werden."
+
+#: lib/klass_hero_web/live/provider/sessions_live.ex:239
+#, elixir-autogen, elixir-format
+msgid "They are already working this session."
+msgstr "Diese Person ist bereits für diesen Termin eingeteilt."
+
+#: lib/klass_hero_web/live/provider/sessions_live.ex:263
+#, elixir-autogen, elixir-format
+msgid "This person leads the session. Make someone else lead before removing them."
+msgstr "Diese Person leitet den Termin. Bitte zuerst eine andere Person als Leitung festlegen."
+
+#: lib/klass_hero_web/live/provider/sessions_live.ex:298
+#, elixir-autogen, elixir-format
+msgid "This session is back on the program's usual team."
+msgstr "Dieser Termin nutzt wieder das übliche Programmteam."
+
+#: lib/klass_hero_web/components/provider_components.ex:2097
+#, elixir-autogen, elixir-format
+msgid "Using the program's usual team. Adding someone staffs this session only."
+msgstr "Es gilt das übliche Programmteam. Wer hier hinzugefügt wird, ist nur für diesen Termin eingeteilt."

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -136,8 +136,8 @@ msgstr "Keine Internetverbindung gefunden"
 msgid "Your Data"
 msgstr "Ihre Daten"
 
-#: lib/klass_hero_web/components/core_components.ex:67
-#: lib/klass_hero_web/components/provider_components.ex:1733
+#: lib/klass_hero_web/components/core_components.ex:71
+#: lib/klass_hero_web/components/provider_components.ex:1758
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr "schließen"
@@ -578,8 +578,8 @@ msgid "Dispute Resolution"
 msgstr "Streitbeilegung"
 
 #: lib/klass_hero_web/components/provider_components.ex:719
-#: lib/klass_hero_web/components/provider_components.ex:2593
-#: lib/klass_hero_web/components/provider_components.ex:2611
+#: lib/klass_hero_web/components/provider_components.ex:2647
+#: lib/klass_hero_web/components/provider_components.ex:2665
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
@@ -684,7 +684,7 @@ msgid "Introduction"
 msgstr "Einleitung"
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:115
-#: lib/klass_hero_web/live/provider/sessions_live.ex:549
+#: lib/klass_hero_web/live/provider/sessions_live.ex:565
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:63
 #, elixir-autogen, elixir-format
 msgid "Invalid date format"
@@ -878,9 +878,9 @@ msgstr "Speichern..."
 msgid "Select one or both options"
 msgstr "Wählen Sie eine oder beide Optionen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2289
-#: lib/klass_hero_web/components/provider_components.ex:2290
-#: lib/klass_hero_web/components/provider_components.ex:2327
+#: lib/klass_hero_web/components/provider_components.ex:2343
+#: lib/klass_hero_web/components/provider_components.ex:2344
+#: lib/klass_hero_web/components/provider_components.ex:2381
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:448
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:484
@@ -1578,8 +1578,8 @@ msgid "Quick Navigation"
 msgstr "Schnellnavigation"
 
 #: lib/klass_hero_web/components/provider_components.ex:1487
-#: lib/klass_hero_web/components/provider_components.ex:2265
-#: lib/klass_hero_web/components/provider_components.ex:2491
+#: lib/klass_hero_web/components/provider_components.ex:2319
+#: lib/klass_hero_web/components/provider_components.ex:2545
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr "Aktionen"
@@ -1670,8 +1670,8 @@ msgstr "Übersicht"
 #: lib/klass_hero_web/components/provider_components.ex:47
 #: lib/klass_hero_web/components/provider_components.ex:73
 #: lib/klass_hero_web/components/provider_components.ex:1627
-#: lib/klass_hero_web/components/provider_components.ex:2687
-#: lib/klass_hero_web/components/provider_components.ex:2705
+#: lib/klass_hero_web/components/provider_components.ex:2741
+#: lib/klass_hero_web/components/provider_components.ex:2759
 #: lib/klass_hero_web/live/admin/sessions_live.ex:298
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
@@ -1709,9 +1709,9 @@ msgid "Search by name..."
 msgstr "Nach Namen suchen..."
 
 #: lib/klass_hero_web/components/provider_components.ex:1481
-#: lib/klass_hero_web/components/provider_components.ex:1852
-#: lib/klass_hero_web/components/provider_components.ex:2259
-#: lib/klass_hero_web/components/provider_components.ex:2488
+#: lib/klass_hero_web/components/provider_components.ex:1877
+#: lib/klass_hero_web/components/provider_components.ex:2313
+#: lib/klass_hero_web/components/provider_components.ex:2542
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1736,7 +1736,7 @@ msgid "This is your main business identity. Verification is required to list pro
 msgstr "Dies ist Ihre Hauptgeschäftsidentität. Eine Verifizierung ist erforderlich, um Programme anzubieten."
 
 #: lib/klass_hero_web/components/provider_components.ex:1538
-#: lib/klass_hero_web/components/provider_components.ex:1867
+#: lib/klass_hero_web/components/provider_components.ex:1892
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr "Nicht zugewiesen"
@@ -1817,7 +1817,7 @@ msgstr "Rundnachricht an %{count} Eltern gesendet"
 #: lib/klass_hero_web/components/participation_components.ex:717
 #: lib/klass_hero_web/components/provider_components.ex:889
 #: lib/klass_hero_web/components/provider_components.ex:1334
-#: lib/klass_hero_web/components/provider_components.ex:2430
+#: lib/klass_hero_web/components/provider_components.ex:2484
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:478
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
@@ -1873,7 +1873,7 @@ msgstr "Kind konnte nicht entfernt werden. Bitte versuchen Sie es erneut."
 msgid "Data sharing consent"
 msgstr "Einwilligung zur Datenweitergabe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2574
+#: lib/klass_hero_web/components/provider_components.ex:2628
 #: lib/klass_hero_web/live/settings/children_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1921,17 +1921,17 @@ msgstr "Rundnachricht konnte nicht gesendet werden"
 msgid "Failed to submit note"
 msgstr "Notiz konnte nicht eingereicht werden"
 
-#: lib/klass_hero_web/components/provider_components.ex:2568
-#: lib/klass_hero_web/components/provider_components.ex:2597
-#: lib/klass_hero_web/components/provider_components.ex:2613
+#: lib/klass_hero_web/components/provider_components.ex:2622
+#: lib/klass_hero_web/components/provider_components.ex:2651
+#: lib/klass_hero_web/components/provider_components.ex:2667
 #: lib/klass_hero_web/live/settings/children_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr "Vorname"
 
-#: lib/klass_hero_web/components/provider_components.ex:2569
-#: lib/klass_hero_web/components/provider_components.ex:2598
-#: lib/klass_hero_web/components/provider_components.ex:2614
+#: lib/klass_hero_web/components/provider_components.ex:2623
+#: lib/klass_hero_web/components/provider_components.ex:2652
+#: lib/klass_hero_web/components/provider_components.ex:2668
 #: lib/klass_hero_web/live/settings/children_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -2069,8 +2069,8 @@ msgstr "Einwilligung zur Datenweitergabe an Anbieter"
 msgid "Save Changes"
 msgstr "Änderungen speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:1711
-#: lib/klass_hero_web/components/provider_components.ex:1712
+#: lib/klass_hero_web/components/provider_components.ex:1736
+#: lib/klass_hero_web/components/provider_components.ex:1737
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:43
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:151
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:252
@@ -2088,7 +2088,7 @@ msgstr "Rundnachricht senden"
 msgid "Send a message to start the conversation"
 msgstr "Senden Sie eine Nachricht, um die Unterhaltung zu beginnen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2668
+#: lib/klass_hero_web/components/provider_components.ex:2722
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:249
 #, elixir-autogen, elixir-format
@@ -2224,7 +2224,7 @@ msgstr "Alter %{min}+"
 msgid "Allowed Genders"
 msgstr "Zulässige Geschlechter"
 
-#: lib/klass_hero_web/components/provider_components.ex:2727
+#: lib/klass_hero_web/components/provider_components.ex:2781
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred during import."
 msgstr "Beim Import ist ein unerwarteter Fehler aufgetreten."
@@ -2319,8 +2319,8 @@ msgstr "Kategorie"
 msgid "Check eligibility at"
 msgstr "Berechtigung prüfen unter"
 
-#: lib/klass_hero_web/components/provider_components.ex:2256
-#: lib/klass_hero_web/components/provider_components.ex:2482
+#: lib/klass_hero_web/components/provider_components.ex:2310
+#: lib/klass_hero_web/components/provider_components.ex:2536
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr "Name des Kindes"
@@ -2365,7 +2365,7 @@ msgstr "Schließen Sie die Geschäftsverifizierung ab, um Programme zu erstellen
 msgid "Confirm rejection"
 msgstr "Ablehnung bestätigen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2688
+#: lib/klass_hero_web/components/provider_components.ex:2742
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr "Bestätigt"
@@ -2414,7 +2414,7 @@ msgstr "Beschreibung"
 msgid "Diverse"
 msgstr "Divers"
 
-#: lib/klass_hero_web/components/provider_components.ex:2903
+#: lib/klass_hero_web/components/provider_components.ex:2957
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr "Dokumenttyp"
@@ -2448,7 +2448,7 @@ msgstr "Dokument abgelehnt."
 msgid "Document uploaded successfully."
 msgstr "Dokument erfolgreich hochgeladen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2449
+#: lib/klass_hero_web/components/provider_components.ex:2503
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr "Vorlage herunterladen"
@@ -2479,14 +2479,14 @@ msgstr "Enddatum"
 msgid "End Time"
 msgstr "Endzeit"
 
-#: lib/klass_hero_web/components/provider_components.ex:2262
-#: lib/klass_hero_web/components/provider_components.ex:2708
+#: lib/klass_hero_web/components/provider_components.ex:2316
+#: lib/klass_hero_web/components/provider_components.ex:2762
 #: lib/klass_hero_web/components/provider_layout_components.ex:644
 #, elixir-autogen, elixir-format
 msgid "Enrolled"
 msgstr "Angemeldet"
 
-#: lib/klass_hero_web/components/provider_components.ex:1757
+#: lib/klass_hero_web/components/provider_components.ex:1782
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr "Angemeldet (%{count})"
@@ -2502,7 +2502,7 @@ msgid "Explain why this document is being rejected..."
 msgstr "Erklären Sie, warum dieses Dokument abgelehnt wird..."
 
 #: lib/klass_hero_web/components/provider_components.ex:71
-#: lib/klass_hero_web/components/provider_components.ex:2709
+#: lib/klass_hero_web/components/provider_components.ex:2763
 #: lib/klass_hero_web/live/admin/emails_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2546,12 +2546,12 @@ msgstr "Weiblich"
 msgid "File"
 msgstr "Datei"
 
-#: lib/klass_hero_web/components/provider_components.ex:2837
+#: lib/klass_hero_web/components/provider_components.ex:2891
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr "Die Datei ist zu groß."
 
-#: lib/klass_hero_web/components/provider_components.ex:2839
+#: lib/klass_hero_web/components/provider_components.ex:2893
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr "Dateityp wird nicht akzeptiert."
@@ -2586,7 +2586,7 @@ msgstr "Klassenstufe %{min}+"
 msgid "Grades %{min} – %{max}"
 msgstr "Klassenstufen %{min} – %{max}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2485
+#: lib/klass_hero_web/components/provider_components.ex:2539
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr "E-Mail des Erziehungsberechtigten"
@@ -2601,7 +2601,7 @@ msgstr "Porträtfoto"
 msgid "ID Document"
 msgstr "Ausweisdokument"
 
-#: lib/klass_hero_web/components/provider_components.ex:2422
+#: lib/klass_hero_web/components/provider_components.ex:2476
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Importieren"
@@ -2626,7 +2626,7 @@ msgstr "Einladung entfernt."
 msgid "Invite resent successfully."
 msgstr "Einladung erfolgreich erneut gesendet."
 
-#: lib/klass_hero_web/components/provider_components.ex:1774
+#: lib/klass_hero_web/components/provider_components.ex:1799
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr "Einladungen (%{count})"
@@ -2727,12 +2727,12 @@ msgstr "Niedrigste Klassenstufe"
 msgid "No approved documents."
 msgstr "Keine genehmigten Dokumente."
 
-#: lib/klass_hero_web/components/provider_components.ex:2865
+#: lib/klass_hero_web/components/provider_components.ex:2919
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr "Noch keine Dokumente hochgeladen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2249
+#: lib/klass_hero_web/components/provider_components.ex:2303
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
@@ -2748,7 +2748,7 @@ msgstr "Keine Datei ausgewählt."
 msgid "No grade"
 msgstr "Keine Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2473
+#: lib/klass_hero_web/components/provider_components.ex:2527
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr "Noch keine Einladungen. Laden Sie eine CSV-Datei hoch, um Familien einzuladen."
@@ -2811,7 +2811,7 @@ msgstr "Nicht angegeben"
 msgid "Our Story"
 msgstr "Unsere Geschichte"
 
-#: lib/klass_hero_web/components/provider_components.ex:2940
+#: lib/klass_hero_web/components/provider_components.ex:2994
 #: lib/klass_hero_web/live/provider/verification_live.ex:698
 #: lib/klass_hero_web/live/provider/verification_live.ex:770
 #, elixir-autogen, elixir-format
@@ -2909,7 +2909,7 @@ msgid "Read our founding story →"
 msgstr "Lesen Sie unsere Gründungsgeschichte →"
 
 #: lib/klass_hero_web/components/participation_components.ex:805
-#: lib/klass_hero_web/components/provider_components.ex:2707
+#: lib/klass_hero_web/components/provider_components.ex:2761
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Registered"
@@ -2991,16 +2991,16 @@ msgstr "Ablehnungsgrund"
 
 #: lib/klass_hero_web/components/provider_components.ex:839
 #: lib/klass_hero_web/components/provider_components.ex:1284
-#: lib/klass_hero_web/components/provider_components.ex:2529
-#: lib/klass_hero_web/components/provider_components.ex:2959
-#: lib/klass_hero_web/components/provider_components.ex:3038
+#: lib/klass_hero_web/components/provider_components.ex:2583
+#: lib/klass_hero_web/components/provider_components.ex:3013
+#: lib/klass_hero_web/components/provider_components.ex:3092
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:253
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr "Entfernen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2522
+#: lib/klass_hero_web/components/provider_components.ex:2576
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr "Einladung erneut senden"
@@ -3015,7 +3015,7 @@ msgstr "Überprüft"
 msgid "Role"
 msgstr "Rolle"
 
-#: lib/klass_hero_web/components/provider_components.ex:1703
+#: lib/klass_hero_web/components/provider_components.ex:1728
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:386
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
@@ -3041,7 +3041,7 @@ msgstr "Zeitplan noch offen"
 msgid "School Grade (optional)"
 msgstr "Klassenstufe (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2937
+#: lib/klass_hero_web/components/provider_components.ex:2991
 #, elixir-autogen, elixir-format
 msgid "Select File"
 msgstr "Datei auswählen"
@@ -3058,7 +3058,7 @@ msgstr "Das ausgewählte Kind erfüllt die Programmanforderungen nicht."
 msgid "Selected instructor could not be found. Please try again."
 msgstr "Der ausgewählte Kursleiter konnte nicht gefunden werden. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2706
+#: lib/klass_hero_web/components/provider_components.ex:2760
 #: lib/klass_hero_web/live/admin/emails_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Sent"
@@ -3168,7 +3168,7 @@ msgstr "Dieses Programm wurde von jemand anderem geändert. Bitte schließen Sie
 msgid "Title"
 msgstr "Titel"
 
-#: lib/klass_hero_web/components/provider_components.ex:2838
+#: lib/klass_hero_web/components/provider_components.ex:2892
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr "Zu viele Dateien."
@@ -3188,32 +3188,32 @@ msgstr "Bis zu %{max}"
 msgid "Up to Grade %{max}"
 msgstr "Bis Klassenstufe %{max}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2408
+#: lib/klass_hero_web/components/provider_components.ex:2462
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr "CSV hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2983
+#: lib/klass_hero_web/components/provider_components.ex:3037
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr "Dokument hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2892
+#: lib/klass_hero_web/components/provider_components.ex:2946
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr "Neues Dokument hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2860
+#: lib/klass_hero_web/components/provider_components.ex:2914
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr "Laden Sie Dokumente hoch, um Ihr Unternehmen zu verifizieren. Die Dokumente werden von unserem Team überprüft."
 
-#: lib/klass_hero_web/components/provider_components.ex:2840
+#: lib/klass_hero_web/components/provider_components.ex:2894
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr "Upload-Fehler."
 
-#: lib/klass_hero_web/components/provider_components.ex:2857
+#: lib/klass_hero_web/components/provider_components.ex:2911
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr "Verifizierungsdokumente"
@@ -3303,7 +3303,7 @@ msgid "Child Safeguarding Training"
 msgstr "Kinderschutzschulung"
 
 #: lib/klass_hero_web/components/marketing_components.ex:1498
-#: lib/klass_hero_web/components/provider_components.ex:3205
+#: lib/klass_hero_web/components/provider_components.ex:3259
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr "Vereinbarung zu Community-Standards"
@@ -3453,7 +3453,7 @@ msgid "Vetted with Care"
 msgstr "Mit Sorgfalt geprüft"
 
 #: lib/klass_hero_web/components/marketing_components.ex:1482
-#: lib/klass_hero_web/components/provider_components.ex:2990
+#: lib/klass_hero_web/components/provider_components.ex:3044
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr "Video-Überprüfung"
@@ -3627,7 +3627,7 @@ msgstr "Eingecheckt"
 msgid "Checked Out"
 msgstr "Ausgecheckt"
 
-#: lib/klass_hero_web/components/provider_components.ex:2565
+#: lib/klass_hero_web/components/provider_components.ex:2619
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Child"
@@ -3680,7 +3680,7 @@ msgstr "Benötige ich ein Konto, um zu buchen?"
 msgid "Download monthly statements for taxes"
 msgstr "Monatliche Abrechnungen für die Steuer herunterladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2326
+#: lib/klass_hero_web/components/provider_components.ex:2380
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "Enrollment not confirmed"
@@ -3753,7 +3753,7 @@ msgstr "Keine Änderungen erkannt"
 msgid "No chasing payments or sending invoices"
 msgstr "Kein Nachfassen bei Zahlungen oder Versenden von Rechnungen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1726
+#: lib/klass_hero_web/components/provider_components.ex:1751
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:407
 #, elixir-autogen, elixir-format
 msgid "No enrolled parents"
@@ -3776,7 +3776,7 @@ msgstr "Notizen"
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr "Oder: Jederzeit eine Sofortauszahlung anfordern (mindestens 50 €)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2325
+#: lib/klass_hero_web/components/provider_components.ex:2379
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -3959,7 +3959,7 @@ msgstr "%{checked_in} / %{total} eingecheckt"
 msgid "%{count} unread"
 msgstr "%{count} ungelesen"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:567
+#: lib/klass_hero_web/live/provider/sessions_live.ex:583
 #, elixir-autogen, elixir-format
 msgid "A session already exists at this time"
 msgstr "Zu dieser Zeit existiert bereits eine Sitzung"
@@ -4139,8 +4139,8 @@ msgstr "Sitzung erstellen"
 msgid "Date"
 msgstr "Datum"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:543
-#: lib/klass_hero_web/live/provider/sessions_live.ex:544
+#: lib/klass_hero_web/live/provider/sessions_live.ex:559
+#: lib/klass_hero_web/live/provider/sessions_live.ex:560
 #, elixir-autogen, elixir-format
 msgid "Date is required"
 msgstr "Datum ist erforderlich"
@@ -4183,7 +4183,7 @@ msgstr "E-Mails"
 msgid "Emergency: %{details}"
 msgstr "Notfall: %{details}"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:566
+#: lib/klass_hero_web/live/provider/sessions_live.ex:582
 #, elixir-autogen, elixir-format
 msgid "End time must be after start time"
 msgstr "Die Endzeit muss nach der Startzeit liegen"
@@ -4198,7 +4198,7 @@ msgstr "Erwartet"
 msgid "Failed to archive email"
 msgstr "E-Mail konnte nicht archiviert werden"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:503
+#: lib/klass_hero_web/live/provider/sessions_live.ex:519
 #, elixir-autogen, elixir-format
 msgid "Failed to create session: %{reason}"
 msgstr "Sitzung konnte nicht erstellt werden: %{reason}"
@@ -4255,7 +4255,7 @@ msgid "Invalid Invitation"
 msgstr "Ungültige Einladung"
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:260
-#: lib/klass_hero_web/live/provider/sessions_live.ex:562
+#: lib/klass_hero_web/live/provider/sessions_live.ex:578
 #, elixir-autogen, elixir-format
 msgid "Invalid time format"
 msgstr "Ungültiges Zeitformat"
@@ -4394,7 +4394,7 @@ msgstr "Ausstehende Überprüfungen"
 msgid "Please explain why you're rejecting this note..."
 msgstr "Bitte erklären Sie, warum Sie diese Notiz ablehnen..."
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:569
+#: lib/klass_hero_web/live/provider/sessions_live.ex:585
 #, elixir-autogen, elixir-format
 msgid "Please fill in all required fields"
 msgstr "Bitte füllen Sie alle erforderlichen Felder aus"
@@ -4408,7 +4408,7 @@ msgstr "Absenden"
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
 #: lib/klass_hero_web/live/provider/programs_live.ex:224
-#: lib/klass_hero_web/live/provider/sessions_live.ex:368
+#: lib/klass_hero_web/live/provider/sessions_live.ex:381
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:175
 #, elixir-autogen, elixir-format
 msgid "Program"
@@ -4503,7 +4503,7 @@ msgstr "Wird gesendet"
 
 #: lib/klass_hero_web/components/participation_components.ex:70
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:16
-#: lib/klass_hero_web/live/provider/sessions_live.ex:392
+#: lib/klass_hero_web/live/provider/sessions_live.ex:408
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:16
 #, elixir-autogen, elixir-format
 msgid "Session"
@@ -4520,7 +4520,7 @@ msgstr "Sitzungsnotizen (optional)"
 msgid "Session Roster"
 msgstr "Teilnehmerliste"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:485
+#: lib/klass_hero_web/live/provider/sessions_live.ex:501
 #, elixir-autogen, elixir-format
 msgid "Session created successfully"
 msgstr "Sitzung erfolgreich erstellt"
@@ -4581,8 +4581,8 @@ msgstr "Diese Einladung wurde bereits verwendet."
 msgid "This invite link is invalid or has expired."
 msgstr "Dieser Einladungslink ist ungültig oder abgelaufen."
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:553
-#: lib/klass_hero_web/live/provider/sessions_live.ex:554
+#: lib/klass_hero_web/live/provider/sessions_live.ex:569
+#: lib/klass_hero_web/live/provider/sessions_live.ex:570
 #, elixir-autogen, elixir-format
 msgid "Time is required"
 msgstr "Uhrzeit ist erforderlich"
@@ -4889,34 +4889,34 @@ msgstr "Ihr Profil ist bereits vollständig."
 msgid "for"
 msgstr "für"
 
-#: lib/klass_hero_web/components/provider_components.ex:1850
+#: lib/klass_hero_web/components/provider_components.ex:1875
 #, elixir-autogen, elixir-format
 msgid "Assigned staff"
 msgstr "Zugewiesenes Personal"
 
-#: lib/klass_hero_web/components/provider_components.ex:1851
+#: lib/klass_hero_web/components/provider_components.ex:1876
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr "Anwesenheit"
 
-#: lib/klass_hero_web/components/provider_components.ex:1834
-#: lib/klass_hero_web/components/provider_components.ex:1919
-#: lib/klass_hero_web/components/provider_components.ex:2068
+#: lib/klass_hero_web/components/provider_components.ex:1859
+#: lib/klass_hero_web/components/provider_components.ex:1944
+#: lib/klass_hero_web/components/provider_components.ex:2098
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr "Schließen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1849
+#: lib/klass_hero_web/components/provider_components.ex:1874
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr "Datum / Uhrzeit"
 
-#: lib/klass_hero_web/components/provider_components.ex:1843
+#: lib/klass_hero_web/components/provider_components.ex:1868
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled yet."
 msgstr "Noch keine Sessions geplant."
 
-#: lib/klass_hero_web/components/provider_components.ex:1832
+#: lib/klass_hero_web/components/provider_components.ex:1857
 #, elixir-autogen, elixir-format
 msgid "Sessions — %{title}"
 msgstr "Sessions — %{title}"
@@ -4953,17 +4953,17 @@ msgstr "Abreisezeit ist kein gültiges Datum oder keine gültige Uhrzeit"
 msgid "Failed to update record"
 msgstr "Aktualisieren des Datensatzes fehlgeschlagen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2629
+#: lib/klass_hero_web/components/provider_components.ex:2683
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr "Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2348
+#: lib/klass_hero_web/components/provider_components.ex:2402
 #, elixir-autogen, elixir-format
 msgid "Invite mode"
 msgstr "Einladungsmodus"
 
-#: lib/klass_hero_web/components/provider_components.ex:2367
+#: lib/klass_hero_web/components/provider_components.ex:2421
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr "Einzelperson einladen"
@@ -4978,12 +4978,12 @@ msgstr "Einladung verschickt."
 msgid "Leave blank to keep this child marked as present."
 msgstr "Leer lassen, um dieses Kind als anwesend markiert zu lassen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2642
+#: lib/klass_hero_web/components/provider_components.ex:2696
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr "Gesundheit & Einwilligungen (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2648
+#: lib/klass_hero_web/components/provider_components.ex:2702
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr "Gesundheitliche Besonderheiten"
@@ -4994,17 +4994,17 @@ msgstr "Gesundheitliche Besonderheiten"
 msgid "Nothing to update"
 msgstr "Nichts zu aktualisieren"
 
-#: lib/klass_hero_web/components/provider_components.ex:2650
+#: lib/klass_hero_web/components/provider_components.ex:2704
 #, elixir-autogen, elixir-format
 msgid "Nut allergy"
 msgstr "Nussallergie"
 
-#: lib/klass_hero_web/components/provider_components.ex:2654
+#: lib/klass_hero_web/components/provider_components.ex:2708
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr "Fotos dürfen in Marketingmaterialien verwendet werden"
 
-#: lib/klass_hero_web/components/provider_components.ex:2659
+#: lib/klass_hero_web/components/provider_components.ex:2713
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr "Fotos dürfen in sozialen Medien erscheinen"
@@ -5014,7 +5014,7 @@ msgstr "Fotos dürfen in sozialen Medien erscheinen"
 msgid "Present"
 msgstr "Anwesend"
 
-#: lib/klass_hero_web/components/provider_components.ex:2586
+#: lib/klass_hero_web/components/provider_components.ex:2640
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr "Hauptansprechpartner"
@@ -5041,22 +5041,22 @@ msgstr "Datensatz aktualisiert"
 msgid "Save changes"
 msgstr "Änderungen speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:2623
+#: lib/klass_hero_web/components/provider_components.ex:2677
 #, elixir-autogen, elixir-format
 msgid "School (optional)"
 msgstr "Schule (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2633
+#: lib/klass_hero_web/components/provider_components.ex:2687
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr "Schulname"
 
-#: lib/klass_hero_web/components/provider_components.ex:2607
+#: lib/klass_hero_web/components/provider_components.ex:2661
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr "Zweiter Ansprechpartner (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2676
+#: lib/klass_hero_web/components/provider_components.ex:2730
 #, elixir-autogen, elixir-format
 msgid "Send invite"
 msgstr "Einladung senden"
@@ -5066,7 +5066,7 @@ msgstr "Einladung senden"
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr "Aktualisieren Sie die Notiz für dieses Kind (z. B. um zu klären, was passiert ist)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2385
+#: lib/klass_hero_web/components/provider_components.ex:2439
 #, elixir-autogen, elixir-format
 msgid "Upload a list"
 msgstr "Liste hochladen"
@@ -6368,17 +6368,17 @@ msgstr "Umsatz (diese Woche)"
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr "Strenge Überprüfung, damit Familien immer wissen, wer die Gruppe leitet."
 
-#: lib/klass_hero_web/components/provider_components.ex:2715
+#: lib/klass_hero_web/components/provider_components.ex:2769
 #, elixir-autogen, elixir-format
 msgid "Row %{row}"
 msgstr "Zeile %{row}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2715
+#: lib/klass_hero_web/components/provider_components.ex:2769
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr "Zeile —"
 
-#: lib/klass_hero_web/components/provider_components.ex:2461
+#: lib/klass_hero_web/components/provider_components.ex:2515
 #, elixir-autogen, elixir-format
 msgid "Rows with errors"
 msgstr "Zeilen mit Fehlern"
@@ -7137,12 +7137,12 @@ msgstr "Deine Identität ist verifiziert."
 msgid "Experience validation"
 msgstr "Erfahrungsnachweis"
 
-#: lib/klass_hero_web/components/provider_components.ex:3019
+#: lib/klass_hero_web/components/provider_components.ex:3073
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr "MP4, MOV oder WEBM. Max. 100 MB."
 
-#: lib/klass_hero_web/components/provider_components.ex:2993
+#: lib/klass_hero_web/components/provider_components.ex:3047
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr "Nimm ein kurzes Video auf, in dem du dich vorstellst. Unser Team prüft es, um Kommunikationsfähigkeit und Übereinstimmung mit unseren Werten einzuschätzen."
@@ -7152,12 +7152,12 @@ msgstr "Nimm ein kurzes Video auf, in dem du dich vorstellst. Unser Team prüft 
 msgid "Safeguarding certificate"
 msgstr "Kinderschutz-Zertifikat"
 
-#: lib/klass_hero_web/components/provider_components.ex:3016
+#: lib/klass_hero_web/components/provider_components.ex:3070
 #, elixir-autogen, elixir-format
 msgid "Select Video"
 msgstr "Video auswählen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3062
+#: lib/klass_hero_web/components/provider_components.ex:3116
 #, elixir-autogen, elixir-format
 msgid "Upload Video"
 msgstr "Video hochladen"
@@ -7167,7 +7167,7 @@ msgstr "Video hochladen"
 msgid "Your browser does not support video playback."
 msgstr "Dein Browser unterstützt keine Videowiedergabe."
 
-#: lib/klass_hero_web/components/provider_components.ex:3209
+#: lib/klass_hero_web/components/provider_components.ex:3263
 #, elixir-autogen, elixir-format
 msgid "Confirm agreement"
 msgstr "Zustimmung bestätigen"
@@ -7177,12 +7177,12 @@ msgstr "Zustimmung bestätigen"
 msgid "Couldn't record your agreement. Please try again."
 msgstr "Deine Zustimmung konnte nicht gespeichert werden. Bitte versuche es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:3232
+#: lib/klass_hero_web/components/provider_components.ex:3286
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr "Vereinbarung herunterladen (PDF)"
 
-#: lib/klass_hero_web/components/provider_components.ex:3208
+#: lib/klass_hero_web/components/provider_components.ex:3262
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr "Ich habe die Klass Hero Community-Richtlinien gelesen und stimme ihnen zu."
@@ -7192,7 +7192,7 @@ msgstr "Ich habe die Klass Hero Community-Richtlinien gelesen und stimme ihnen z
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr "Bitte bestätige, dass du die Community-Richtlinien gelesen hast und ihnen zustimmst."
 
-#: lib/klass_hero_web/components/provider_components.ex:3117
+#: lib/klass_hero_web/components/provider_components.ex:3171
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr "Unterzeichnet von %{name} am %{date} (v%{version})."
@@ -7202,17 +7202,17 @@ msgstr "Unterzeichnet von %{name} am %{date} (v%{version})."
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr "Danke – deine Zustimmung zu den Community-Richtlinien wurde gespeichert."
 
-#: lib/klass_hero_web/components/provider_components.ex:3217
+#: lib/klass_hero_web/components/provider_components.ex:3271
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr "Die Community-Richtlinien wurden seit deiner letzten Zustimmung aktualisiert (v%{old}). Bitte lies sie erneut und stimme erneut zu."
 
-#: lib/klass_hero_web/components/provider_components.ex:3206
+#: lib/klass_hero_web/components/provider_components.ex:3260
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr "Der letzte Schritt: Lies die Klass Hero Community-Richtlinien und stimme ihnen zu."
 
-#: lib/klass_hero_web/components/provider_components.ex:3207
+#: lib/klass_hero_web/components/provider_components.ex:3261
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr "Du hast den Community-Richtlinien zugestimmt."
@@ -7481,12 +7481,12 @@ msgstr "Ihre Versicherungsbescheinigung wird geprüft."
 msgid "Your insurance is verified."
 msgstr "Ihre Versicherung ist verifiziert."
 
-#: lib/klass_hero_web/components/provider_components.ex:3161
+#: lib/klass_hero_web/components/provider_components.ex:3215
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr "Unterzeichnung durch %{name} im Namen des Unternehmens."
 
-#: lib/klass_hero_web/components/provider_components.ex:3264
+#: lib/klass_hero_web/components/provider_components.ex:3318
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr "Bestätige im Namen deines Unternehmens, dass alle Mitarbeitenden gemäß dem deutschen Kinderschutzrecht überprüft sind."
@@ -7496,7 +7496,7 @@ msgstr "Bestätige im Namen deines Unternehmens, dass alle Mitarbeitenden gemä�
 msgid "Couldn't record your declaration. Please try again."
 msgstr "Deine Erklärung konnte nicht gespeichert werden. Bitte versuche es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:3270
+#: lib/klass_hero_web/components/provider_components.ex:3324
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr "Ich bestätige im Namen des Unternehmens, dass die obige Erklärung zutrifft und ich zu ihrer Unterzeichnung berechtigt bin."
@@ -7506,17 +7506,17 @@ msgstr "Ich bestätige im Namen des Unternehmens, dass die obige Erklärung zutr
 msgid "Please confirm the declaration before signing."
 msgstr "Bitte bestätige die Erklärung vor der Unterzeichnung."
 
-#: lib/klass_hero_web/components/provider_components.ex:3295
+#: lib/klass_hero_web/components/provider_components.ex:3349
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr "Vorläufiger Text — vor der Freischaltung noch von einer in Deutschland zugelassenen Anwältin bzw. einem Anwalt zu prüfen."
 
-#: lib/klass_hero_web/components/provider_components.ex:3274
+#: lib/klass_hero_web/components/provider_components.ex:3328
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr "Erklärung unterzeichnen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3262
+#: lib/klass_hero_web/components/provider_components.ex:3316
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr "Erklärung zur Mitarbeiter-Compliance"
@@ -7526,12 +7526,12 @@ msgstr "Erklärung zur Mitarbeiter-Compliance"
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr "Danke — deine Erklärung zur Mitarbeiter-Compliance wurde erfasst."
 
-#: lib/klass_hero_web/components/provider_components.ex:3282
+#: lib/klass_hero_web/components/provider_components.ex:3336
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr "Die Erklärung zur Mitarbeiter-Compliance wurde seit deiner letzten Unterzeichnung aktualisiert (v%{old}). Bitte prüfe sie und unterzeichne erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:3268
+#: lib/klass_hero_web/components/provider_components.ex:3322
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr "Du hast die Erklärung zur Mitarbeiter-Compliance unterzeichnet."
@@ -7598,14 +7598,14 @@ msgstr "In Prüfung"
 msgid "Undelivered Events"
 msgstr "Nicht zugestellte Ereignisse"
 
-#: lib/klass_hero_web/components/provider_components.ex:2016
-#: lib/klass_hero_web/components/provider_components.ex:2198
+#: lib/klass_hero_web/components/provider_components.ex:2043
+#: lib/klass_hero_web/components/provider_components.ex:2226
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1941
-#: lib/klass_hero_web/components/provider_components.ex:2122
+#: lib/klass_hero_web/components/provider_components.ex:1966
+#: lib/klass_hero_web/components/provider_components.ex:2152
 #, elixir-autogen, elixir-format
 msgid "Lead"
 msgstr "Leitung"
@@ -7615,7 +7615,7 @@ msgstr "Leitung"
 msgid "Lead instructor updated."
 msgstr "Leitender Kursleiter aktualisiert."
 
-#: lib/klass_hero_web/components/provider_components.ex:1952
+#: lib/klass_hero_web/components/provider_components.ex:1978
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor"
 msgstr "Als leitenden Kursleiter festlegen"
@@ -7625,7 +7625,7 @@ msgstr "Als leitenden Kursleiter festlegen"
 msgid "Manage Staffing"
 msgstr "Programmteam verwalten"
 
-#: lib/klass_hero_web/components/provider_components.ex:1980
+#: lib/klass_hero_web/components/provider_components.ex:2007
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this program yet."
 msgstr "Diesem Programm ist noch niemand zugewiesen."
@@ -7636,19 +7636,19 @@ msgstr "Diesem Programm ist noch niemand zugewiesen."
 msgid "Pick a staff member to add."
 msgstr "Bitte ein Teammitglied zum Hinzufügen auswählen."
 
-#: lib/klass_hero_web/components/provider_components.ex:1963
-#: lib/klass_hero_web/components/provider_components.ex:2145
+#: lib/klass_hero_web/components/provider_components.ex:1990
+#: lib/klass_hero_web/components/provider_components.ex:2265
 #, elixir-autogen, elixir-format
 msgid "Reassign the lead before removing them"
 msgstr "Vor dem Entfernen einen anderen leitenden Kursleiter festlegen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1964
+#: lib/klass_hero_web/components/provider_components.ex:1991
 #, elixir-autogen, elixir-format
 msgid "Remove from program"
 msgstr "Aus dem Programm entfernen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1998
-#: lib/klass_hero_web/components/provider_components.ex:2180
+#: lib/klass_hero_web/components/provider_components.ex:2025
+#: lib/klass_hero_web/components/provider_components.ex:2207
 #, elixir-autogen, elixir-format
 msgid "Select a staff member…"
 msgstr "Teammitglied auswählen …"
@@ -7663,14 +7663,14 @@ msgstr "Teammitglied zum Programm hinzugefügt."
 msgid "Staff member removed from the program."
 msgstr "Teammitglied aus dem Programm entfernt."
 
-#: lib/klass_hero_web/components/provider_components.ex:2021
+#: lib/klass_hero_web/components/provider_components.ex:2048
 #, elixir-autogen, elixir-format
 msgid "Staff you add can read and reply to this program's parent conversations."
 msgstr ""
 "Hinzugefügte Teammitglieder können die Elterngespräche dieses Programms lesen "
 "und beantworten."
 
-#: lib/klass_hero_web/components/provider_components.ex:1917
+#: lib/klass_hero_web/components/provider_components.ex:1942
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{title}"
 msgstr "Programmteam — %{title}"
@@ -7792,27 +7792,27 @@ msgstr ""
 msgid "I understand this program will have no capacity limit."
 msgstr "Ich verstehe, dass dieses Programm keine Teilnehmerbegrenzung haben wird."
 
-#: lib/klass_hero_web/components/provider_components.ex:2209
+#: lib/klass_hero_web/components/provider_components.ex:2253
 #, elixir-autogen, elixir-format
 msgid "Go back to the program's usual team"
 msgstr "Zurück zum üblichen Programmteam"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:282
+#: lib/klass_hero_web/live/provider/sessions_live.ex:295
 #, elixir-autogen, elixir-format
 msgid "Lead instructor for this session updated."
 msgstr "Leitung für diesen Termin aktualisiert."
 
-#: lib/klass_hero_web/components/provider_components.ex:2136
+#: lib/klass_hero_web/components/provider_components.ex:2167
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor for this session"
 msgstr "Als Leitung für diesen Termin festlegen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2162
+#: lib/klass_hero_web/components/provider_components.ex:2189
 #, elixir-autogen, elixir-format
 msgid "Nobody is working this session yet."
 msgstr "Für diesen Termin ist noch niemand eingeteilt."
 
-#: lib/klass_hero_web/components/provider_components.ex:2146
+#: lib/klass_hero_web/components/provider_components.ex:2270
 #, elixir-autogen, elixir-format
 msgid "Remove from this session"
 msgstr "Von diesem Termin entfernen"
@@ -7827,22 +7827,17 @@ msgstr "Teammitglied zu diesem Termin hinzugefügt."
 msgid "Staff member removed from this session."
 msgstr "Teammitglied von diesem Termin entfernt."
 
-#: lib/klass_hero_web/components/provider_components.ex:2093
-#, elixir-autogen, elixir-format
-msgid "Staffed just for this session. The program's usual team does not apply here."
-msgstr "Nur für diesen Termin eingeteilt. Das übliche Programmteam gilt hier nicht."
-
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Staffing"
 msgstr "Team"
 
-#: lib/klass_hero_web/components/provider_components.ex:2064
+#: lib/klass_hero_web/components/provider_components.ex:2091
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{date}"
 msgstr "Team — %{date}"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:408
+#: lib/klass_hero_web/live/provider/sessions_live.ex:424
 #, elixir-autogen, elixir-format
 msgid "That session could not be found."
 msgstr "Dieser Termin konnte nicht gefunden werden."
@@ -7857,12 +7852,32 @@ msgstr "Diese Person ist bereits für diesen Termin eingeteilt."
 msgid "This person leads the session. Make someone else lead before removing them."
 msgstr "Diese Person leitet den Termin. Bitte zuerst eine andere Person als Leitung festlegen."
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:298
+#: lib/klass_hero_web/live/provider/sessions_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "This session is back on the program's usual team."
 msgstr "Dieser Termin nutzt wieder das übliche Programmteam."
 
-#: lib/klass_hero_web/components/provider_components.ex:2097
+#: lib/klass_hero_web/live/provider/sessions_live.ex:274
 #, elixir-autogen, elixir-format
-msgid "Using the program's usual team. Adding someone staffs this session only."
-msgstr "Es gilt das übliche Programmteam. Wer hier hinzugefügt wird, ist nur für diesen Termin eingeteilt."
+msgid "A session needs at least one person. Use “Go back to the program's usual team” to drop this session's own roster."
+msgstr "Ein Termin braucht mindestens eine Person. Nutze „Zurück zum üblichen Programmteam“, um die eigene Besetzung dieses Termins aufzuheben."
+
+#: lib/klass_hero_web/components/provider_components.ex:2268
+#, elixir-autogen, elixir-format
+msgid "A session needs someone — use “Go back to the program's usual team” instead"
+msgstr "Ein Termin braucht jemanden — nutze stattdessen „Zurück zum üblichen Programmteam“"
+
+#: lib/klass_hero_web/components/provider_components.ex:2235
+#, elixir-autogen, elixir-format
+msgid "Everyone on your team is already working this session."
+msgstr "Alle aus deinem Team arbeiten bereits bei diesem Termin."
+
+#: lib/klass_hero_web/components/provider_components.ex:2123
+#, elixir-autogen, elixir-format
+msgid "Staffed just for this session. Changes here do not touch the program."
+msgstr "Nur für diesen Termin eingeteilt. Änderungen hier wirken sich nicht auf das Programm aus."
+
+#: lib/klass_hero_web/components/provider_components.ex:2125
+#, elixir-autogen, elixir-format
+msgid "Using the program's usual team. The first change here copies them onto this session, so later program changes stop reaching it."
+msgstr "Es gilt das übliche Programmteam. Die erste Änderung hier übernimmt das Team in diesen Termin — spätere Änderungen am Programm greifen dann nicht mehr."

--- a/priv/gettext/de/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/de/LC_MESSAGES/enrollment.po
@@ -11,105 +11,105 @@ msgstr ""
 "Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:2622
-#: lib/klass_hero_web/components/provider_components.ex:2639
+#: lib/klass_hero_web/components/provider_components.ex:2809
+#: lib/klass_hero_web/components/provider_components.ex:2826
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr "Vorname des Kindes"
 
-#: lib/klass_hero_web/components/provider_components.ex:2623
-#: lib/klass_hero_web/components/provider_components.ex:2640
+#: lib/klass_hero_web/components/provider_components.ex:2810
+#: lib/klass_hero_web/components/provider_components.ex:2827
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr "Nachname des Kindes"
 
-#: lib/klass_hero_web/components/provider_components.ex:2624
-#: lib/klass_hero_web/components/provider_components.ex:2641
+#: lib/klass_hero_web/components/provider_components.ex:2811
+#: lib/klass_hero_web/components/provider_components.ex:2828
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr "Geburtsdatum"
 
-#: lib/klass_hero_web/components/provider_components.ex:2635
+#: lib/klass_hero_web/components/provider_components.ex:2822
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr "Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2625
+#: lib/klass_hero_web/components/provider_components.ex:2812
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr "E-Mail des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2626
+#: lib/klass_hero_web/components/provider_components.ex:2813
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr "Vorname des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2627
+#: lib/klass_hero_web/components/provider_components.ex:2814
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr "Nachname des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2634
+#: lib/klass_hero_web/components/provider_components.ex:2821
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr "Programm"
 
-#: lib/klass_hero_web/components/provider_components.ex:2636
+#: lib/klass_hero_web/components/provider_components.ex:2823
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr "Schule"
 
-#: lib/klass_hero_web/components/provider_components.ex:2628
+#: lib/klass_hero_web/components/provider_components.ex:2815
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr "E-Mail des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2630
+#: lib/klass_hero_web/components/provider_components.ex:2817
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr "Vorname des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2632
+#: lib/klass_hero_web/components/provider_components.ex:2819
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr "Nachname des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2562
+#: lib/klass_hero_web/components/provider_components.ex:2749
 #, elixir-autogen, elixir-format
 msgid "Date of birth \"%{value}\" is not a valid date. Please correct it and resend."
 msgstr ""
 "Das Geburtsdatum „%{value}“ ist kein gültiges Datum. Bitte korrigieren Sie es "
 "und senden Sie die Einladung erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2556
+#: lib/klass_hero_web/components/provider_components.ex:2743
 #, elixir-autogen, elixir-format
 msgid "Invite link could not be generated (no token). Please resend."
 msgstr ""
 "Der Einladungslink konnte nicht erzeugt werden (kein Token). Bitte erneut "
 "senden."
 
-#: lib/klass_hero_web/components/provider_components.ex:2570
+#: lib/klass_hero_web/components/provider_components.ex:2757
 #, elixir-autogen, elixir-format
 msgid "The invitation email could not be delivered. Please check the address and resend."
 msgstr ""
 "Die Einladungs-E-Mail konnte nicht zugestellt werden. Bitte prüfen Sie die "
 "Adresse und senden Sie die Einladung erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2559
+#: lib/klass_hero_web/components/provider_components.ex:2746
 #, elixir-autogen, elixir-format
 msgid "The program is full, so this child could not be enrolled."
 msgstr ""
 "Das Programm ist ausgebucht, daher konnte dieses Kind nicht angemeldet "
 "werden."
 
-#: lib/klass_hero_web/components/provider_components.ex:2573
+#: lib/klass_hero_web/components/provider_components.ex:2760
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed and no retries remain. Please resend."
 msgstr ""
 "Diese Einladung konnte nicht abgeschlossen werden und es sind keine weiteren "
 "Versuche möglich. Bitte erneut senden."
 
-#: lib/klass_hero_web/components/provider_components.ex:2582
+#: lib/klass_hero_web/components/provider_components.ex:2769
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed. Please resend."
 msgstr "Diese Einladung konnte nicht abgeschlossen werden. Bitte erneut senden."

--- a/priv/gettext/de/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/de/LC_MESSAGES/enrollment.po
@@ -11,105 +11,105 @@ msgstr ""
 "Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:2809
-#: lib/klass_hero_web/components/provider_components.ex:2826
+#: lib/klass_hero_web/components/provider_components.ex:2863
+#: lib/klass_hero_web/components/provider_components.ex:2880
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr "Vorname des Kindes"
 
-#: lib/klass_hero_web/components/provider_components.ex:2810
-#: lib/klass_hero_web/components/provider_components.ex:2827
+#: lib/klass_hero_web/components/provider_components.ex:2864
+#: lib/klass_hero_web/components/provider_components.ex:2881
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr "Nachname des Kindes"
 
-#: lib/klass_hero_web/components/provider_components.ex:2811
-#: lib/klass_hero_web/components/provider_components.ex:2828
+#: lib/klass_hero_web/components/provider_components.ex:2865
+#: lib/klass_hero_web/components/provider_components.ex:2882
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr "Geburtsdatum"
 
-#: lib/klass_hero_web/components/provider_components.ex:2822
+#: lib/klass_hero_web/components/provider_components.ex:2876
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr "Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2812
+#: lib/klass_hero_web/components/provider_components.ex:2866
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr "E-Mail des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2813
+#: lib/klass_hero_web/components/provider_components.ex:2867
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr "Vorname des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2814
+#: lib/klass_hero_web/components/provider_components.ex:2868
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr "Nachname des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2821
+#: lib/klass_hero_web/components/provider_components.ex:2875
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr "Programm"
 
-#: lib/klass_hero_web/components/provider_components.ex:2823
+#: lib/klass_hero_web/components/provider_components.ex:2877
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr "Schule"
 
-#: lib/klass_hero_web/components/provider_components.ex:2815
+#: lib/klass_hero_web/components/provider_components.ex:2869
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr "E-Mail des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2817
+#: lib/klass_hero_web/components/provider_components.ex:2871
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr "Vorname des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2819
+#: lib/klass_hero_web/components/provider_components.ex:2873
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr "Nachname des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2749
+#: lib/klass_hero_web/components/provider_components.ex:2803
 #, elixir-autogen, elixir-format
 msgid "Date of birth \"%{value}\" is not a valid date. Please correct it and resend."
 msgstr ""
 "Das Geburtsdatum „%{value}“ ist kein gültiges Datum. Bitte korrigieren Sie es "
 "und senden Sie die Einladung erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2743
+#: lib/klass_hero_web/components/provider_components.ex:2797
 #, elixir-autogen, elixir-format
 msgid "Invite link could not be generated (no token). Please resend."
 msgstr ""
 "Der Einladungslink konnte nicht erzeugt werden (kein Token). Bitte erneut "
 "senden."
 
-#: lib/klass_hero_web/components/provider_components.ex:2757
+#: lib/klass_hero_web/components/provider_components.ex:2811
 #, elixir-autogen, elixir-format
 msgid "The invitation email could not be delivered. Please check the address and resend."
 msgstr ""
 "Die Einladungs-E-Mail konnte nicht zugestellt werden. Bitte prüfen Sie die "
 "Adresse und senden Sie die Einladung erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2746
+#: lib/klass_hero_web/components/provider_components.ex:2800
 #, elixir-autogen, elixir-format
 msgid "The program is full, so this child could not be enrolled."
 msgstr ""
 "Das Programm ist ausgebucht, daher konnte dieses Kind nicht angemeldet "
 "werden."
 
-#: lib/klass_hero_web/components/provider_components.ex:2760
+#: lib/klass_hero_web/components/provider_components.ex:2814
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed and no retries remain. Please resend."
 msgstr ""
 "Diese Einladung konnte nicht abgeschlossen werden und es sind keine weiteren "
 "Versuche möglich. Bitte erneut senden."
 
-#: lib/klass_hero_web/components/provider_components.ex:2769
+#: lib/klass_hero_web/components/provider_components.ex:2823
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed. Please resend."
 msgstr "Diese Einladung konnte nicht abgeschlossen werden. Bitte erneut senden."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -578,8 +578,8 @@ msgid "Dispute Resolution"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:719
-#: lib/klass_hero_web/components/provider_components.ex:2406
-#: lib/klass_hero_web/components/provider_components.ex:2424
+#: lib/klass_hero_web/components/provider_components.ex:2593
+#: lib/klass_hero_web/components/provider_components.ex:2611
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
@@ -621,7 +621,7 @@ msgstr ""
 msgid "Failed to check out: %{reason}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:155
+#: lib/klass_hero_web/live/provider/sessions_live.ex:160
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:116
 #, elixir-autogen, elixir-format
 msgid "Failed to complete session: %{reason}"
@@ -632,7 +632,7 @@ msgstr ""
 msgid "Failed to delete account. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:132
+#: lib/klass_hero_web/live/provider/sessions_live.ex:137
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:87
 #, elixir-autogen, elixir-format
 msgid "Failed to start session: %{reason}"
@@ -683,8 +683,8 @@ msgstr ""
 msgid "Introduction"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:110
-#: lib/klass_hero_web/live/provider/sessions_live.ex:362
+#: lib/klass_hero_web/live/provider/sessions_live.ex:115
+#: lib/klass_hero_web/live/provider/sessions_live.ex:549
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:63
 #, elixir-autogen, elixir-format
 msgid "Invalid date format"
@@ -756,7 +756,7 @@ msgstr ""
 msgid "Message sent successfully!"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:46
+#: lib/klass_hero_web/live/provider/sessions_live.ex:50
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:4
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:21
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:228
@@ -878,9 +878,9 @@ msgstr ""
 msgid "Select one or both options"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2102
-#: lib/klass_hero_web/components/provider_components.ex:2103
-#: lib/klass_hero_web/components/provider_components.ex:2140
+#: lib/klass_hero_web/components/provider_components.ex:2289
+#: lib/klass_hero_web/components/provider_components.ex:2290
+#: lib/klass_hero_web/components/provider_components.ex:2327
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:448
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:484
@@ -888,7 +888,7 @@ msgstr ""
 msgid "Send Message"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:141
+#: lib/klass_hero_web/live/provider/sessions_live.ex:146
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:102
 #, elixir-autogen, elixir-format
 msgid "Session completed successfully"
@@ -902,7 +902,7 @@ msgstr ""
 msgid "Session not found"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:118
+#: lib/klass_hero_web/live/provider/sessions_live.ex:123
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:73
 #, elixir-autogen, elixir-format
 msgid "Session started successfully"
@@ -1578,8 +1578,8 @@ msgid "Quick Navigation"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1487
-#: lib/klass_hero_web/components/provider_components.ex:2078
-#: lib/klass_hero_web/components/provider_components.ex:2304
+#: lib/klass_hero_web/components/provider_components.ex:2265
+#: lib/klass_hero_web/components/provider_components.ex:2491
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
@@ -1670,8 +1670,8 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:47
 #: lib/klass_hero_web/components/provider_components.ex:73
 #: lib/klass_hero_web/components/provider_components.ex:1627
-#: lib/klass_hero_web/components/provider_components.ex:2500
-#: lib/klass_hero_web/components/provider_components.ex:2518
+#: lib/klass_hero_web/components/provider_components.ex:2687
+#: lib/klass_hero_web/components/provider_components.ex:2705
 #: lib/klass_hero_web/live/admin/sessions_live.ex:298
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
@@ -1709,9 +1709,9 @@ msgid "Search by name..."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1481
-#: lib/klass_hero_web/components/provider_components.ex:1850
-#: lib/klass_hero_web/components/provider_components.ex:2072
-#: lib/klass_hero_web/components/provider_components.ex:2301
+#: lib/klass_hero_web/components/provider_components.ex:1852
+#: lib/klass_hero_web/components/provider_components.ex:2259
+#: lib/klass_hero_web/components/provider_components.ex:2488
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1736,7 +1736,7 @@ msgid "This is your main business identity. Verification is required to list pro
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1538
-#: lib/klass_hero_web/components/provider_components.ex:1865
+#: lib/klass_hero_web/components/provider_components.ex:1867
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr ""
@@ -1817,13 +1817,13 @@ msgstr ""
 #: lib/klass_hero_web/components/participation_components.ex:717
 #: lib/klass_hero_web/components/provider_components.ex:889
 #: lib/klass_hero_web/components/provider_components.ex:1334
-#: lib/klass_hero_web/components/provider_components.ex:2243
+#: lib/klass_hero_web/components/provider_components.ex:2430
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:478
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:222
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:356
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:191
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:210
 #: lib/klass_hero_web/live/settings/children_live.ex:544
 #: lib/klass_hero_web/live/settings/children_live.ex:703
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:237
@@ -1873,7 +1873,7 @@ msgstr ""
 msgid "Data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2387
+#: lib/klass_hero_web/components/provider_components.ex:2574
 #: lib/klass_hero_web/live/settings/children_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1921,17 +1921,17 @@ msgstr ""
 msgid "Failed to submit note"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2381
-#: lib/klass_hero_web/components/provider_components.ex:2410
-#: lib/klass_hero_web/components/provider_components.ex:2426
+#: lib/klass_hero_web/components/provider_components.ex:2568
+#: lib/klass_hero_web/components/provider_components.ex:2597
+#: lib/klass_hero_web/components/provider_components.ex:2613
 #: lib/klass_hero_web/live/settings/children_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2382
-#: lib/klass_hero_web/components/provider_components.ex:2411
-#: lib/klass_hero_web/components/provider_components.ex:2427
+#: lib/klass_hero_web/components/provider_components.ex:2569
+#: lib/klass_hero_web/components/provider_components.ex:2598
+#: lib/klass_hero_web/components/provider_components.ex:2614
 #: lib/klass_hero_web/live/settings/children_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -2088,7 +2088,7 @@ msgstr ""
 msgid "Send a message to start the conversation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2481
+#: lib/klass_hero_web/components/provider_components.ex:2668
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:249
 #, elixir-autogen, elixir-format
@@ -2224,7 +2224,7 @@ msgstr ""
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2540
+#: lib/klass_hero_web/components/provider_components.ex:2727
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred during import."
 msgstr ""
@@ -2319,8 +2319,8 @@ msgstr ""
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2069
-#: lib/klass_hero_web/components/provider_components.ex:2295
+#: lib/klass_hero_web/components/provider_components.ex:2256
+#: lib/klass_hero_web/components/provider_components.ex:2482
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2365,7 +2365,7 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2501
+#: lib/klass_hero_web/components/provider_components.ex:2688
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
@@ -2414,7 +2414,7 @@ msgstr ""
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2716
+#: lib/klass_hero_web/components/provider_components.ex:2903
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2448,7 +2448,7 @@ msgstr ""
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2262
+#: lib/klass_hero_web/components/provider_components.ex:2449
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
@@ -2474,13 +2474,13 @@ msgid "End Date"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1046
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:166
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2075
-#: lib/klass_hero_web/components/provider_components.ex:2521
+#: lib/klass_hero_web/components/provider_components.ex:2262
+#: lib/klass_hero_web/components/provider_components.ex:2708
 #: lib/klass_hero_web/components/provider_layout_components.ex:644
 #, elixir-autogen, elixir-format
 msgid "Enrolled"
@@ -2502,7 +2502,7 @@ msgid "Explain why this document is being rejected..."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:71
-#: lib/klass_hero_web/components/provider_components.ex:2522
+#: lib/klass_hero_web/components/provider_components.ex:2709
 #: lib/klass_hero_web/live/admin/emails_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2546,12 +2546,12 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2650
+#: lib/klass_hero_web/components/provider_components.ex:2837
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2652
+#: lib/klass_hero_web/components/provider_components.ex:2839
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
@@ -2586,7 +2586,7 @@ msgstr ""
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2298
+#: lib/klass_hero_web/components/provider_components.ex:2485
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
@@ -2601,7 +2601,7 @@ msgstr ""
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2235
+#: lib/klass_hero_web/components/provider_components.ex:2422
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -2669,7 +2669,7 @@ msgid "Leave unchecked to allow all genders."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1002
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:172
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:191
 #, elixir-autogen, elixir-format
 msgid "Location"
 msgstr ""
@@ -2727,12 +2727,12 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2678
+#: lib/klass_hero_web/components/provider_components.ex:2865
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2062
+#: lib/klass_hero_web/components/provider_components.ex:2249
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
@@ -2748,7 +2748,7 @@ msgstr ""
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2286
+#: lib/klass_hero_web/components/provider_components.ex:2473
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
@@ -2811,7 +2811,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2753
+#: lib/klass_hero_web/components/provider_components.ex:2940
 #: lib/klass_hero_web/live/provider/verification_live.ex:698
 #: lib/klass_hero_web/live/provider/verification_live.ex:770
 #, elixir-autogen, elixir-format
@@ -2909,7 +2909,7 @@ msgid "Read our founding story →"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:805
-#: lib/klass_hero_web/components/provider_components.ex:2520
+#: lib/klass_hero_web/components/provider_components.ex:2707
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Registered"
@@ -2991,16 +2991,16 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:839
 #: lib/klass_hero_web/components/provider_components.ex:1284
-#: lib/klass_hero_web/components/provider_components.ex:2342
-#: lib/klass_hero_web/components/provider_components.ex:2772
-#: lib/klass_hero_web/components/provider_components.ex:2851
+#: lib/klass_hero_web/components/provider_components.ex:2529
+#: lib/klass_hero_web/components/provider_components.ex:2959
+#: lib/klass_hero_web/components/provider_components.ex:3038
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:253
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2335
+#: lib/klass_hero_web/components/provider_components.ex:2522
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -3041,7 +3041,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2750
+#: lib/klass_hero_web/components/provider_components.ex:2937
 #, elixir-autogen, elixir-format
 msgid "Select File"
 msgstr ""
@@ -3058,7 +3058,7 @@ msgstr ""
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2519
+#: lib/klass_hero_web/components/provider_components.ex:2706
 #: lib/klass_hero_web/live/admin/emails_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Sent"
@@ -3098,7 +3098,7 @@ msgid "Start Date"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1041
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:165
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:184
 #, elixir-autogen, elixir-format
 msgid "Start Time"
 msgstr ""
@@ -3168,7 +3168,7 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2651
+#: lib/klass_hero_web/components/provider_components.ex:2838
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -3188,32 +3188,32 @@ msgstr ""
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2221
+#: lib/klass_hero_web/components/provider_components.ex:2408
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2796
+#: lib/klass_hero_web/components/provider_components.ex:2983
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2705
+#: lib/klass_hero_web/components/provider_components.ex:2892
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2673
+#: lib/klass_hero_web/components/provider_components.ex:2860
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2653
+#: lib/klass_hero_web/components/provider_components.ex:2840
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2670
+#: lib/klass_hero_web/components/provider_components.ex:2857
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -3303,7 +3303,7 @@ msgid "Child Safeguarding Training"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1498
-#: lib/klass_hero_web/components/provider_components.ex:3018
+#: lib/klass_hero_web/components/provider_components.ex:3205
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr ""
@@ -3453,7 +3453,7 @@ msgid "Vetted with Care"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1482
-#: lib/klass_hero_web/components/provider_components.ex:2803
+#: lib/klass_hero_web/components/provider_components.ex:2990
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr ""
@@ -3627,7 +3627,7 @@ msgstr ""
 msgid "Checked Out"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2378
+#: lib/klass_hero_web/components/provider_components.ex:2565
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Child"
@@ -3680,7 +3680,7 @@ msgstr ""
 msgid "Download monthly statements for taxes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2139
+#: lib/klass_hero_web/components/provider_components.ex:2326
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "Enrollment not confirmed"
@@ -3766,7 +3766,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:830
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:155
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:178
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:197
 #, elixir-autogen, elixir-format
 msgid "Notes"
 msgstr ""
@@ -3776,7 +3776,7 @@ msgstr ""
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2138
+#: lib/klass_hero_web/components/provider_components.ex:2325
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -3959,7 +3959,7 @@ msgstr ""
 msgid "%{count} unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:380
+#: lib/klass_hero_web/live/provider/sessions_live.ex:567
 #, elixir-autogen, elixir-format
 msgid "A session already exists at this time"
 msgstr ""
@@ -4128,19 +4128,19 @@ msgid "Could not start private conversation"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:18
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:135
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:200
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:154
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:219
 #, elixir-autogen, elixir-format
 msgid "Create Session"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:162
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:181
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:356
-#: lib/klass_hero_web/live/provider/sessions_live.ex:357
+#: lib/klass_hero_web/live/provider/sessions_live.ex:543
+#: lib/klass_hero_web/live/provider/sessions_live.ex:544
 #, elixir-autogen, elixir-format
 msgid "Date is required"
 msgstr ""
@@ -4183,7 +4183,7 @@ msgstr ""
 msgid "Emergency: %{details}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:379
+#: lib/klass_hero_web/live/provider/sessions_live.ex:566
 #, elixir-autogen, elixir-format
 msgid "End time must be after start time"
 msgstr ""
@@ -4198,7 +4198,7 @@ msgstr ""
 msgid "Failed to archive email"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:316
+#: lib/klass_hero_web/live/provider/sessions_live.ex:503
 #, elixir-autogen, elixir-format
 msgid "Failed to create session: %{reason}"
 msgstr ""
@@ -4255,7 +4255,7 @@ msgid "Invalid Invitation"
 msgstr ""
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:260
-#: lib/klass_hero_web/live/provider/sessions_live.ex:375
+#: lib/klass_hero_web/live/provider/sessions_live.ex:562
 #, elixir-autogen, elixir-format
 msgid "Invalid time format"
 msgstr ""
@@ -4311,7 +4311,7 @@ msgstr ""
 msgid "Mark Unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:181
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:200
 #, elixir-autogen, elixir-format
 msgid "Max Capacity"
 msgstr ""
@@ -4352,7 +4352,7 @@ msgstr ""
 msgid "No sessions found for the selected filters."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:105
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:122
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:316
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled"
@@ -4394,7 +4394,7 @@ msgstr ""
 msgid "Please explain why you're rejecting this note..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:382
+#: lib/klass_hero_web/live/provider/sessions_live.ex:569
 #, elixir-autogen, elixir-format
 msgid "Please fill in all required fields"
 msgstr ""
@@ -4408,12 +4408,13 @@ msgstr ""
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
 #: lib/klass_hero_web/live/provider/programs_live.ex:224
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:156
+#: lib/klass_hero_web/live/provider/sessions_live.ex:368
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:175
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:174
+#: lib/klass_hero_web/live/provider/sessions_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "Program is required"
 msgstr ""
@@ -4485,7 +4486,7 @@ msgstr ""
 msgid "Revised Note"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:157
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:176
 #, elixir-autogen, elixir-format
 msgid "Select a program..."
 msgstr ""
@@ -4502,6 +4503,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:70
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:16
+#: lib/klass_hero_web/live/provider/sessions_live.ex:392
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:16
 #, elixir-autogen, elixir-format
 msgid "Session"
@@ -4518,7 +4520,7 @@ msgstr ""
 msgid "Session Roster"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:298
+#: lib/klass_hero_web/live/provider/sessions_live.ex:485
 #, elixir-autogen, elixir-format
 msgid "Session created successfully"
 msgstr ""
@@ -4579,8 +4581,8 @@ msgstr ""
 msgid "This invite link is invalid or has expired."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:366
-#: lib/klass_hero_web/live/provider/sessions_live.ex:367
+#: lib/klass_hero_web/live/provider/sessions_live.ex:553
+#: lib/klass_hero_web/live/provider/sessions_live.ex:554
 #, elixir-autogen, elixir-format
 msgid "Time is required"
 msgstr ""
@@ -4595,7 +4597,7 @@ msgstr ""
 msgid "Type your reply..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:178
+#: lib/klass_hero_web/live/provider/sessions_live.ex:183
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:123
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:92
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:121
@@ -4650,7 +4652,7 @@ msgstr ""
 msgid "You already have an account. Log in to see your new enrollment."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:108
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:125
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:319
 #, elixir-autogen, elixir-format
 msgid "You have no sessions scheduled for %{date}"
@@ -4887,38 +4889,34 @@ msgstr ""
 msgid "for"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1847
+#: lib/klass_hero_web/components/provider_components.ex:1850
 #, elixir-autogen, elixir-format
 msgid "Assigned staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1849
+#: lib/klass_hero_web/components/provider_components.ex:1851
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1831
-#: lib/klass_hero_web/components/provider_components.ex:1920
+#: lib/klass_hero_web/components/provider_components.ex:1834
+#: lib/klass_hero_web/components/provider_components.ex:1919
+#: lib/klass_hero_web/components/provider_components.ex:2068
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1848
-#, elixir-autogen, elixir-format
-msgid "Cover"
-msgstr ""
-
-#: lib/klass_hero_web/components/provider_components.ex:1846
+#: lib/klass_hero_web/components/provider_components.ex:1849
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1840
+#: lib/klass_hero_web/components/provider_components.ex:1843
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1829
+#: lib/klass_hero_web/components/provider_components.ex:1832
 #, elixir-autogen, elixir-format
 msgid "Sessions — %{title}"
 msgstr ""
@@ -4955,17 +4953,17 @@ msgstr ""
 msgid "Failed to update record"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2442
+#: lib/klass_hero_web/components/provider_components.ex:2629
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2161
+#: lib/klass_hero_web/components/provider_components.ex:2348
 #, elixir-autogen, elixir-format
 msgid "Invite mode"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2180
+#: lib/klass_hero_web/components/provider_components.ex:2367
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr ""
@@ -4980,12 +4978,12 @@ msgstr ""
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2455
+#: lib/klass_hero_web/components/provider_components.ex:2642
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2461
+#: lib/klass_hero_web/components/provider_components.ex:2648
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr ""
@@ -4996,17 +4994,17 @@ msgstr ""
 msgid "Nothing to update"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2463
+#: lib/klass_hero_web/components/provider_components.ex:2650
 #, elixir-autogen, elixir-format
 msgid "Nut allergy"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2467
+#: lib/klass_hero_web/components/provider_components.ex:2654
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2472
+#: lib/klass_hero_web/components/provider_components.ex:2659
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr ""
@@ -5016,7 +5014,7 @@ msgstr ""
 msgid "Present"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2399
+#: lib/klass_hero_web/components/provider_components.ex:2586
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr ""
@@ -5043,22 +5041,22 @@ msgstr ""
 msgid "Save changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2436
+#: lib/klass_hero_web/components/provider_components.ex:2623
 #, elixir-autogen, elixir-format
 msgid "School (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2446
+#: lib/klass_hero_web/components/provider_components.ex:2633
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2420
+#: lib/klass_hero_web/components/provider_components.ex:2607
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2489
+#: lib/klass_hero_web/components/provider_components.ex:2676
 #, elixir-autogen, elixir-format
 msgid "Send invite"
 msgstr ""
@@ -5068,7 +5066,7 @@ msgstr ""
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2198
+#: lib/klass_hero_web/components/provider_components.ex:2385
 #, elixir-autogen, elixir-format
 msgid "Upload a list"
 msgstr ""
@@ -6370,17 +6368,17 @@ msgstr ""
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2528
+#: lib/klass_hero_web/components/provider_components.ex:2715
 #, elixir-autogen, elixir-format
 msgid "Row %{row}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2528
+#: lib/klass_hero_web/components/provider_components.ex:2715
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2274
+#: lib/klass_hero_web/components/provider_components.ex:2461
 #, elixir-autogen, elixir-format
 msgid "Rows with errors"
 msgstr ""
@@ -7139,12 +7137,12 @@ msgstr ""
 msgid "Experience validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2832
+#: lib/klass_hero_web/components/provider_components.ex:3019
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2806
+#: lib/klass_hero_web/components/provider_components.ex:2993
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
@@ -7154,12 +7152,12 @@ msgstr ""
 msgid "Safeguarding certificate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2829
+#: lib/klass_hero_web/components/provider_components.ex:3016
 #, elixir-autogen, elixir-format
 msgid "Select Video"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2875
+#: lib/klass_hero_web/components/provider_components.ex:3062
 #, elixir-autogen, elixir-format
 msgid "Upload Video"
 msgstr ""
@@ -7169,7 +7167,7 @@ msgstr ""
 msgid "Your browser does not support video playback."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3022
+#: lib/klass_hero_web/components/provider_components.ex:3209
 #, elixir-autogen, elixir-format
 msgid "Confirm agreement"
 msgstr ""
@@ -7179,12 +7177,12 @@ msgstr ""
 msgid "Couldn't record your agreement. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3045
+#: lib/klass_hero_web/components/provider_components.ex:3232
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3021
+#: lib/klass_hero_web/components/provider_components.ex:3208
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr ""
@@ -7194,7 +7192,7 @@ msgstr ""
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2930
+#: lib/klass_hero_web/components/provider_components.ex:3117
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr ""
@@ -7204,17 +7202,17 @@ msgstr ""
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3030
+#: lib/klass_hero_web/components/provider_components.ex:3217
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3019
+#: lib/klass_hero_web/components/provider_components.ex:3206
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3020
+#: lib/klass_hero_web/components/provider_components.ex:3207
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
@@ -7483,12 +7481,12 @@ msgstr ""
 msgid "Your insurance is verified."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2974
+#: lib/klass_hero_web/components/provider_components.ex:3161
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3077
+#: lib/klass_hero_web/components/provider_components.ex:3264
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr ""
@@ -7498,7 +7496,7 @@ msgstr ""
 msgid "Couldn't record your declaration. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3083
+#: lib/klass_hero_web/components/provider_components.ex:3270
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr ""
@@ -7508,17 +7506,17 @@ msgstr ""
 msgid "Please confirm the declaration before signing."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3108
+#: lib/klass_hero_web/components/provider_components.ex:3295
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3087
+#: lib/klass_hero_web/components/provider_components.ex:3274
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3075
+#: lib/klass_hero_web/components/provider_components.ex:3262
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr ""
@@ -7528,12 +7526,12 @@ msgstr ""
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3095
+#: lib/klass_hero_web/components/provider_components.ex:3282
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3081
+#: lib/klass_hero_web/components/provider_components.ex:3268
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
@@ -7600,12 +7598,14 @@ msgstr ""
 msgid "Undelivered Events"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2017
+#: lib/klass_hero_web/components/provider_components.ex:2016
+#: lib/klass_hero_web/components/provider_components.ex:2198
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1942
+#: lib/klass_hero_web/components/provider_components.ex:1941
+#: lib/klass_hero_web/components/provider_components.ex:2122
 #, elixir-autogen, elixir-format
 msgid "Lead"
 msgstr ""
@@ -7615,7 +7615,7 @@ msgstr ""
 msgid "Lead instructor updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1953
+#: lib/klass_hero_web/components/provider_components.ex:1952
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor"
 msgstr ""
@@ -7625,27 +7625,30 @@ msgstr ""
 msgid "Manage Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1981
+#: lib/klass_hero_web/components/provider_components.ex:1980
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this program yet."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/programs_live.ex:267
+#: lib/klass_hero_web/live/provider/sessions_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "Pick a staff member to add."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1964
+#: lib/klass_hero_web/components/provider_components.ex:1963
+#: lib/klass_hero_web/components/provider_components.ex:2145
 #, elixir-autogen, elixir-format
 msgid "Reassign the lead before removing them"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1965
+#: lib/klass_hero_web/components/provider_components.ex:1964
 #, elixir-autogen, elixir-format
 msgid "Remove from program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1999
+#: lib/klass_hero_web/components/provider_components.ex:1998
+#: lib/klass_hero_web/components/provider_components.ex:2180
 #, elixir-autogen, elixir-format
 msgid "Select a staff member…"
 msgstr ""
@@ -7660,12 +7663,12 @@ msgstr ""
 msgid "Staff member removed from the program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2022
+#: lib/klass_hero_web/components/provider_components.ex:2021
 #, elixir-autogen, elixir-format
 msgid "Staff you add can read and reply to this program's parent conversations."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1918
+#: lib/klass_hero_web/components/provider_components.ex:1917
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{title}"
 msgstr ""
@@ -7772,4 +7775,79 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:1125
 #, elixir-autogen, elixir-format
 msgid "I understand this program will have no capacity limit."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2209
+#, elixir-autogen, elixir-format
+msgid "Go back to the program's usual team"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/sessions_live.ex:282
+#, elixir-autogen, elixir-format
+msgid "Lead instructor for this session updated."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2136
+#, elixir-autogen, elixir-format
+msgid "Make lead instructor for this session"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2162
+#, elixir-autogen, elixir-format
+msgid "Nobody is working this session yet."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2146
+#, elixir-autogen, elixir-format
+msgid "Remove from this session"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/sessions_live.ex:231
+#, elixir-autogen, elixir-format
+msgid "Staff member added to this session."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/sessions_live.ex:255
+#, elixir-autogen, elixir-format
+msgid "Staff member removed from this session."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2093
+#, elixir-autogen, elixir-format
+msgid "Staffed just for this session. The program's usual team does not apply here."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:107
+#, elixir-autogen, elixir-format
+msgid "Staffing"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2064
+#, elixir-autogen, elixir-format
+msgid "Staffing — %{date}"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/sessions_live.ex:408
+#, elixir-autogen, elixir-format
+msgid "That session could not be found."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/sessions_live.ex:239
+#, elixir-autogen, elixir-format
+msgid "They are already working this session."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/sessions_live.ex:263
+#, elixir-autogen, elixir-format
+msgid "This person leads the session. Make someone else lead before removing them."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/sessions_live.ex:298
+#, elixir-autogen, elixir-format
+msgid "This session is back on the program's usual team."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2097
+#, elixir-autogen, elixir-format
+msgid "Using the program's usual team. Adding someone staffs this session only."
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -136,8 +136,8 @@ msgstr ""
 msgid "Your Data"
 msgstr ""
 
-#: lib/klass_hero_web/components/core_components.ex:67
-#: lib/klass_hero_web/components/provider_components.ex:1733
+#: lib/klass_hero_web/components/core_components.ex:71
+#: lib/klass_hero_web/components/provider_components.ex:1758
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr ""
@@ -578,8 +578,8 @@ msgid "Dispute Resolution"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:719
-#: lib/klass_hero_web/components/provider_components.ex:2593
-#: lib/klass_hero_web/components/provider_components.ex:2611
+#: lib/klass_hero_web/components/provider_components.ex:2647
+#: lib/klass_hero_web/components/provider_components.ex:2665
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
@@ -684,7 +684,7 @@ msgid "Introduction"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:115
-#: lib/klass_hero_web/live/provider/sessions_live.ex:549
+#: lib/klass_hero_web/live/provider/sessions_live.ex:565
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:63
 #, elixir-autogen, elixir-format
 msgid "Invalid date format"
@@ -878,9 +878,9 @@ msgstr ""
 msgid "Select one or both options"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2289
-#: lib/klass_hero_web/components/provider_components.ex:2290
-#: lib/klass_hero_web/components/provider_components.ex:2327
+#: lib/klass_hero_web/components/provider_components.ex:2343
+#: lib/klass_hero_web/components/provider_components.ex:2344
+#: lib/klass_hero_web/components/provider_components.ex:2381
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:448
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:484
@@ -1578,8 +1578,8 @@ msgid "Quick Navigation"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1487
-#: lib/klass_hero_web/components/provider_components.ex:2265
-#: lib/klass_hero_web/components/provider_components.ex:2491
+#: lib/klass_hero_web/components/provider_components.ex:2319
+#: lib/klass_hero_web/components/provider_components.ex:2545
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
@@ -1670,8 +1670,8 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:47
 #: lib/klass_hero_web/components/provider_components.ex:73
 #: lib/klass_hero_web/components/provider_components.ex:1627
-#: lib/klass_hero_web/components/provider_components.ex:2687
-#: lib/klass_hero_web/components/provider_components.ex:2705
+#: lib/klass_hero_web/components/provider_components.ex:2741
+#: lib/klass_hero_web/components/provider_components.ex:2759
 #: lib/klass_hero_web/live/admin/sessions_live.ex:298
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
@@ -1709,9 +1709,9 @@ msgid "Search by name..."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1481
-#: lib/klass_hero_web/components/provider_components.ex:1852
-#: lib/klass_hero_web/components/provider_components.ex:2259
-#: lib/klass_hero_web/components/provider_components.ex:2488
+#: lib/klass_hero_web/components/provider_components.ex:1877
+#: lib/klass_hero_web/components/provider_components.ex:2313
+#: lib/klass_hero_web/components/provider_components.ex:2542
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1736,7 +1736,7 @@ msgid "This is your main business identity. Verification is required to list pro
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1538
-#: lib/klass_hero_web/components/provider_components.ex:1867
+#: lib/klass_hero_web/components/provider_components.ex:1892
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr ""
@@ -1817,7 +1817,7 @@ msgstr ""
 #: lib/klass_hero_web/components/participation_components.ex:717
 #: lib/klass_hero_web/components/provider_components.ex:889
 #: lib/klass_hero_web/components/provider_components.ex:1334
-#: lib/klass_hero_web/components/provider_components.ex:2430
+#: lib/klass_hero_web/components/provider_components.ex:2484
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:478
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
@@ -1873,7 +1873,7 @@ msgstr ""
 msgid "Data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2574
+#: lib/klass_hero_web/components/provider_components.ex:2628
 #: lib/klass_hero_web/live/settings/children_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1921,17 +1921,17 @@ msgstr ""
 msgid "Failed to submit note"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2568
-#: lib/klass_hero_web/components/provider_components.ex:2597
-#: lib/klass_hero_web/components/provider_components.ex:2613
+#: lib/klass_hero_web/components/provider_components.ex:2622
+#: lib/klass_hero_web/components/provider_components.ex:2651
+#: lib/klass_hero_web/components/provider_components.ex:2667
 #: lib/klass_hero_web/live/settings/children_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2569
-#: lib/klass_hero_web/components/provider_components.ex:2598
-#: lib/klass_hero_web/components/provider_components.ex:2614
+#: lib/klass_hero_web/components/provider_components.ex:2623
+#: lib/klass_hero_web/components/provider_components.ex:2652
+#: lib/klass_hero_web/components/provider_components.ex:2668
 #: lib/klass_hero_web/live/settings/children_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -2069,8 +2069,8 @@ msgstr ""
 msgid "Save Changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1711
-#: lib/klass_hero_web/components/provider_components.ex:1712
+#: lib/klass_hero_web/components/provider_components.ex:1736
+#: lib/klass_hero_web/components/provider_components.ex:1737
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:43
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:151
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:252
@@ -2088,7 +2088,7 @@ msgstr ""
 msgid "Send a message to start the conversation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2668
+#: lib/klass_hero_web/components/provider_components.ex:2722
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:249
 #, elixir-autogen, elixir-format
@@ -2224,7 +2224,7 @@ msgstr ""
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2727
+#: lib/klass_hero_web/components/provider_components.ex:2781
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred during import."
 msgstr ""
@@ -2319,8 +2319,8 @@ msgstr ""
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2256
-#: lib/klass_hero_web/components/provider_components.ex:2482
+#: lib/klass_hero_web/components/provider_components.ex:2310
+#: lib/klass_hero_web/components/provider_components.ex:2536
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2365,7 +2365,7 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2688
+#: lib/klass_hero_web/components/provider_components.ex:2742
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
@@ -2414,7 +2414,7 @@ msgstr ""
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2903
+#: lib/klass_hero_web/components/provider_components.ex:2957
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2448,7 +2448,7 @@ msgstr ""
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2449
+#: lib/klass_hero_web/components/provider_components.ex:2503
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
@@ -2479,14 +2479,14 @@ msgstr ""
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2262
-#: lib/klass_hero_web/components/provider_components.ex:2708
+#: lib/klass_hero_web/components/provider_components.ex:2316
+#: lib/klass_hero_web/components/provider_components.ex:2762
 #: lib/klass_hero_web/components/provider_layout_components.ex:644
 #, elixir-autogen, elixir-format
 msgid "Enrolled"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1757
+#: lib/klass_hero_web/components/provider_components.ex:1782
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr ""
@@ -2502,7 +2502,7 @@ msgid "Explain why this document is being rejected..."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:71
-#: lib/klass_hero_web/components/provider_components.ex:2709
+#: lib/klass_hero_web/components/provider_components.ex:2763
 #: lib/klass_hero_web/live/admin/emails_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2546,12 +2546,12 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2837
+#: lib/klass_hero_web/components/provider_components.ex:2891
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2839
+#: lib/klass_hero_web/components/provider_components.ex:2893
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
@@ -2586,7 +2586,7 @@ msgstr ""
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2485
+#: lib/klass_hero_web/components/provider_components.ex:2539
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
@@ -2601,7 +2601,7 @@ msgstr ""
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2422
+#: lib/klass_hero_web/components/provider_components.ex:2476
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -2626,7 +2626,7 @@ msgstr ""
 msgid "Invite resent successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1774
+#: lib/klass_hero_web/components/provider_components.ex:1799
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr ""
@@ -2727,12 +2727,12 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2865
+#: lib/klass_hero_web/components/provider_components.ex:2919
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2249
+#: lib/klass_hero_web/components/provider_components.ex:2303
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
@@ -2748,7 +2748,7 @@ msgstr ""
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2473
+#: lib/klass_hero_web/components/provider_components.ex:2527
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
@@ -2811,7 +2811,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2940
+#: lib/klass_hero_web/components/provider_components.ex:2994
 #: lib/klass_hero_web/live/provider/verification_live.ex:698
 #: lib/klass_hero_web/live/provider/verification_live.ex:770
 #, elixir-autogen, elixir-format
@@ -2909,7 +2909,7 @@ msgid "Read our founding story →"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:805
-#: lib/klass_hero_web/components/provider_components.ex:2707
+#: lib/klass_hero_web/components/provider_components.ex:2761
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Registered"
@@ -2991,16 +2991,16 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:839
 #: lib/klass_hero_web/components/provider_components.ex:1284
-#: lib/klass_hero_web/components/provider_components.ex:2529
-#: lib/klass_hero_web/components/provider_components.ex:2959
-#: lib/klass_hero_web/components/provider_components.ex:3038
+#: lib/klass_hero_web/components/provider_components.ex:2583
+#: lib/klass_hero_web/components/provider_components.ex:3013
+#: lib/klass_hero_web/components/provider_components.ex:3092
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:253
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2522
+#: lib/klass_hero_web/components/provider_components.ex:2576
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -3015,7 +3015,7 @@ msgstr ""
 msgid "Role"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1703
+#: lib/klass_hero_web/components/provider_components.ex:1728
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:386
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
@@ -3041,7 +3041,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2937
+#: lib/klass_hero_web/components/provider_components.ex:2991
 #, elixir-autogen, elixir-format
 msgid "Select File"
 msgstr ""
@@ -3058,7 +3058,7 @@ msgstr ""
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2706
+#: lib/klass_hero_web/components/provider_components.ex:2760
 #: lib/klass_hero_web/live/admin/emails_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Sent"
@@ -3168,7 +3168,7 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2838
+#: lib/klass_hero_web/components/provider_components.ex:2892
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -3188,32 +3188,32 @@ msgstr ""
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2408
+#: lib/klass_hero_web/components/provider_components.ex:2462
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2983
+#: lib/klass_hero_web/components/provider_components.ex:3037
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2892
+#: lib/klass_hero_web/components/provider_components.ex:2946
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2860
+#: lib/klass_hero_web/components/provider_components.ex:2914
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2840
+#: lib/klass_hero_web/components/provider_components.ex:2894
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2857
+#: lib/klass_hero_web/components/provider_components.ex:2911
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -3303,7 +3303,7 @@ msgid "Child Safeguarding Training"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1498
-#: lib/klass_hero_web/components/provider_components.ex:3205
+#: lib/klass_hero_web/components/provider_components.ex:3259
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr ""
@@ -3453,7 +3453,7 @@ msgid "Vetted with Care"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1482
-#: lib/klass_hero_web/components/provider_components.ex:2990
+#: lib/klass_hero_web/components/provider_components.ex:3044
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr ""
@@ -3627,7 +3627,7 @@ msgstr ""
 msgid "Checked Out"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2565
+#: lib/klass_hero_web/components/provider_components.ex:2619
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Child"
@@ -3680,7 +3680,7 @@ msgstr ""
 msgid "Download monthly statements for taxes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2326
+#: lib/klass_hero_web/components/provider_components.ex:2380
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "Enrollment not confirmed"
@@ -3753,7 +3753,7 @@ msgstr ""
 msgid "No chasing payments or sending invoices"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1726
+#: lib/klass_hero_web/components/provider_components.ex:1751
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:407
 #, elixir-autogen, elixir-format
 msgid "No enrolled parents"
@@ -3776,7 +3776,7 @@ msgstr ""
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2325
+#: lib/klass_hero_web/components/provider_components.ex:2379
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -3959,7 +3959,7 @@ msgstr ""
 msgid "%{count} unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:567
+#: lib/klass_hero_web/live/provider/sessions_live.ex:583
 #, elixir-autogen, elixir-format
 msgid "A session already exists at this time"
 msgstr ""
@@ -4139,8 +4139,8 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:543
-#: lib/klass_hero_web/live/provider/sessions_live.ex:544
+#: lib/klass_hero_web/live/provider/sessions_live.ex:559
+#: lib/klass_hero_web/live/provider/sessions_live.ex:560
 #, elixir-autogen, elixir-format
 msgid "Date is required"
 msgstr ""
@@ -4183,7 +4183,7 @@ msgstr ""
 msgid "Emergency: %{details}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:566
+#: lib/klass_hero_web/live/provider/sessions_live.ex:582
 #, elixir-autogen, elixir-format
 msgid "End time must be after start time"
 msgstr ""
@@ -4198,7 +4198,7 @@ msgstr ""
 msgid "Failed to archive email"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:503
+#: lib/klass_hero_web/live/provider/sessions_live.ex:519
 #, elixir-autogen, elixir-format
 msgid "Failed to create session: %{reason}"
 msgstr ""
@@ -4255,7 +4255,7 @@ msgid "Invalid Invitation"
 msgstr ""
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:260
-#: lib/klass_hero_web/live/provider/sessions_live.ex:562
+#: lib/klass_hero_web/live/provider/sessions_live.ex:578
 #, elixir-autogen, elixir-format
 msgid "Invalid time format"
 msgstr ""
@@ -4394,7 +4394,7 @@ msgstr ""
 msgid "Please explain why you're rejecting this note..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:569
+#: lib/klass_hero_web/live/provider/sessions_live.ex:585
 #, elixir-autogen, elixir-format
 msgid "Please fill in all required fields"
 msgstr ""
@@ -4408,7 +4408,7 @@ msgstr ""
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
 #: lib/klass_hero_web/live/provider/programs_live.ex:224
-#: lib/klass_hero_web/live/provider/sessions_live.ex:368
+#: lib/klass_hero_web/live/provider/sessions_live.ex:381
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:175
 #, elixir-autogen, elixir-format
 msgid "Program"
@@ -4503,7 +4503,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:70
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:16
-#: lib/klass_hero_web/live/provider/sessions_live.ex:392
+#: lib/klass_hero_web/live/provider/sessions_live.ex:408
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:16
 #, elixir-autogen, elixir-format
 msgid "Session"
@@ -4520,7 +4520,7 @@ msgstr ""
 msgid "Session Roster"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:485
+#: lib/klass_hero_web/live/provider/sessions_live.ex:501
 #, elixir-autogen, elixir-format
 msgid "Session created successfully"
 msgstr ""
@@ -4581,8 +4581,8 @@ msgstr ""
 msgid "This invite link is invalid or has expired."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:553
-#: lib/klass_hero_web/live/provider/sessions_live.ex:554
+#: lib/klass_hero_web/live/provider/sessions_live.ex:569
+#: lib/klass_hero_web/live/provider/sessions_live.ex:570
 #, elixir-autogen, elixir-format
 msgid "Time is required"
 msgstr ""
@@ -4889,34 +4889,34 @@ msgstr ""
 msgid "for"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1850
+#: lib/klass_hero_web/components/provider_components.ex:1875
 #, elixir-autogen, elixir-format
 msgid "Assigned staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1851
+#: lib/klass_hero_web/components/provider_components.ex:1876
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1834
-#: lib/klass_hero_web/components/provider_components.ex:1919
-#: lib/klass_hero_web/components/provider_components.ex:2068
+#: lib/klass_hero_web/components/provider_components.ex:1859
+#: lib/klass_hero_web/components/provider_components.ex:1944
+#: lib/klass_hero_web/components/provider_components.ex:2098
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1849
+#: lib/klass_hero_web/components/provider_components.ex:1874
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1843
+#: lib/klass_hero_web/components/provider_components.ex:1868
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1832
+#: lib/klass_hero_web/components/provider_components.ex:1857
 #, elixir-autogen, elixir-format
 msgid "Sessions — %{title}"
 msgstr ""
@@ -4953,17 +4953,17 @@ msgstr ""
 msgid "Failed to update record"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2629
+#: lib/klass_hero_web/components/provider_components.ex:2683
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2348
+#: lib/klass_hero_web/components/provider_components.ex:2402
 #, elixir-autogen, elixir-format
 msgid "Invite mode"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2367
+#: lib/klass_hero_web/components/provider_components.ex:2421
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr ""
@@ -4978,12 +4978,12 @@ msgstr ""
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2642
+#: lib/klass_hero_web/components/provider_components.ex:2696
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2648
+#: lib/klass_hero_web/components/provider_components.ex:2702
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr ""
@@ -4994,17 +4994,17 @@ msgstr ""
 msgid "Nothing to update"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2650
+#: lib/klass_hero_web/components/provider_components.ex:2704
 #, elixir-autogen, elixir-format
 msgid "Nut allergy"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2654
+#: lib/klass_hero_web/components/provider_components.ex:2708
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2659
+#: lib/klass_hero_web/components/provider_components.ex:2713
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr ""
@@ -5014,7 +5014,7 @@ msgstr ""
 msgid "Present"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2586
+#: lib/klass_hero_web/components/provider_components.ex:2640
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr ""
@@ -5041,22 +5041,22 @@ msgstr ""
 msgid "Save changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2623
+#: lib/klass_hero_web/components/provider_components.ex:2677
 #, elixir-autogen, elixir-format
 msgid "School (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2633
+#: lib/klass_hero_web/components/provider_components.ex:2687
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2607
+#: lib/klass_hero_web/components/provider_components.ex:2661
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2676
+#: lib/klass_hero_web/components/provider_components.ex:2730
 #, elixir-autogen, elixir-format
 msgid "Send invite"
 msgstr ""
@@ -5066,7 +5066,7 @@ msgstr ""
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2385
+#: lib/klass_hero_web/components/provider_components.ex:2439
 #, elixir-autogen, elixir-format
 msgid "Upload a list"
 msgstr ""
@@ -6368,17 +6368,17 @@ msgstr ""
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2715
+#: lib/klass_hero_web/components/provider_components.ex:2769
 #, elixir-autogen, elixir-format
 msgid "Row %{row}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2715
+#: lib/klass_hero_web/components/provider_components.ex:2769
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2461
+#: lib/klass_hero_web/components/provider_components.ex:2515
 #, elixir-autogen, elixir-format
 msgid "Rows with errors"
 msgstr ""
@@ -7137,12 +7137,12 @@ msgstr ""
 msgid "Experience validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3019
+#: lib/klass_hero_web/components/provider_components.ex:3073
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2993
+#: lib/klass_hero_web/components/provider_components.ex:3047
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
@@ -7152,12 +7152,12 @@ msgstr ""
 msgid "Safeguarding certificate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3016
+#: lib/klass_hero_web/components/provider_components.ex:3070
 #, elixir-autogen, elixir-format
 msgid "Select Video"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3062
+#: lib/klass_hero_web/components/provider_components.ex:3116
 #, elixir-autogen, elixir-format
 msgid "Upload Video"
 msgstr ""
@@ -7167,7 +7167,7 @@ msgstr ""
 msgid "Your browser does not support video playback."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3209
+#: lib/klass_hero_web/components/provider_components.ex:3263
 #, elixir-autogen, elixir-format
 msgid "Confirm agreement"
 msgstr ""
@@ -7177,12 +7177,12 @@ msgstr ""
 msgid "Couldn't record your agreement. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3232
+#: lib/klass_hero_web/components/provider_components.ex:3286
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3208
+#: lib/klass_hero_web/components/provider_components.ex:3262
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr ""
@@ -7192,7 +7192,7 @@ msgstr ""
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3117
+#: lib/klass_hero_web/components/provider_components.ex:3171
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr ""
@@ -7202,17 +7202,17 @@ msgstr ""
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3217
+#: lib/klass_hero_web/components/provider_components.ex:3271
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3206
+#: lib/klass_hero_web/components/provider_components.ex:3260
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3207
+#: lib/klass_hero_web/components/provider_components.ex:3261
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
@@ -7481,12 +7481,12 @@ msgstr ""
 msgid "Your insurance is verified."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3161
+#: lib/klass_hero_web/components/provider_components.ex:3215
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3264
+#: lib/klass_hero_web/components/provider_components.ex:3318
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr ""
@@ -7496,7 +7496,7 @@ msgstr ""
 msgid "Couldn't record your declaration. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3270
+#: lib/klass_hero_web/components/provider_components.ex:3324
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr ""
@@ -7506,17 +7506,17 @@ msgstr ""
 msgid "Please confirm the declaration before signing."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3295
+#: lib/klass_hero_web/components/provider_components.ex:3349
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3274
+#: lib/klass_hero_web/components/provider_components.ex:3328
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3262
+#: lib/klass_hero_web/components/provider_components.ex:3316
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr ""
@@ -7526,12 +7526,12 @@ msgstr ""
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3282
+#: lib/klass_hero_web/components/provider_components.ex:3336
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3268
+#: lib/klass_hero_web/components/provider_components.ex:3322
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
@@ -7598,14 +7598,14 @@ msgstr ""
 msgid "Undelivered Events"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2016
-#: lib/klass_hero_web/components/provider_components.ex:2198
+#: lib/klass_hero_web/components/provider_components.ex:2043
+#: lib/klass_hero_web/components/provider_components.ex:2226
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1941
-#: lib/klass_hero_web/components/provider_components.ex:2122
+#: lib/klass_hero_web/components/provider_components.ex:1966
+#: lib/klass_hero_web/components/provider_components.ex:2152
 #, elixir-autogen, elixir-format
 msgid "Lead"
 msgstr ""
@@ -7615,7 +7615,7 @@ msgstr ""
 msgid "Lead instructor updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1952
+#: lib/klass_hero_web/components/provider_components.ex:1978
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor"
 msgstr ""
@@ -7625,7 +7625,7 @@ msgstr ""
 msgid "Manage Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1980
+#: lib/klass_hero_web/components/provider_components.ex:2007
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this program yet."
 msgstr ""
@@ -7636,19 +7636,19 @@ msgstr ""
 msgid "Pick a staff member to add."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1963
-#: lib/klass_hero_web/components/provider_components.ex:2145
+#: lib/klass_hero_web/components/provider_components.ex:1990
+#: lib/klass_hero_web/components/provider_components.ex:2265
 #, elixir-autogen, elixir-format
 msgid "Reassign the lead before removing them"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1964
+#: lib/klass_hero_web/components/provider_components.ex:1991
 #, elixir-autogen, elixir-format
 msgid "Remove from program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1998
-#: lib/klass_hero_web/components/provider_components.ex:2180
+#: lib/klass_hero_web/components/provider_components.ex:2025
+#: lib/klass_hero_web/components/provider_components.ex:2207
 #, elixir-autogen, elixir-format
 msgid "Select a staff member…"
 msgstr ""
@@ -7663,12 +7663,12 @@ msgstr ""
 msgid "Staff member removed from the program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2021
+#: lib/klass_hero_web/components/provider_components.ex:2048
 #, elixir-autogen, elixir-format
 msgid "Staff you add can read and reply to this program's parent conversations."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1917
+#: lib/klass_hero_web/components/provider_components.ex:1942
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{title}"
 msgstr ""
@@ -7777,27 +7777,27 @@ msgstr ""
 msgid "I understand this program will have no capacity limit."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2209
+#: lib/klass_hero_web/components/provider_components.ex:2253
 #, elixir-autogen, elixir-format
 msgid "Go back to the program's usual team"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:282
+#: lib/klass_hero_web/live/provider/sessions_live.ex:295
 #, elixir-autogen, elixir-format
 msgid "Lead instructor for this session updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2136
+#: lib/klass_hero_web/components/provider_components.ex:2167
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor for this session"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2162
+#: lib/klass_hero_web/components/provider_components.ex:2189
 #, elixir-autogen, elixir-format
 msgid "Nobody is working this session yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2146
+#: lib/klass_hero_web/components/provider_components.ex:2270
 #, elixir-autogen, elixir-format
 msgid "Remove from this session"
 msgstr ""
@@ -7812,22 +7812,17 @@ msgstr ""
 msgid "Staff member removed from this session."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2093
-#, elixir-autogen, elixir-format
-msgid "Staffed just for this session. The program's usual team does not apply here."
-msgstr ""
-
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2064
+#: lib/klass_hero_web/components/provider_components.ex:2091
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{date}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:408
+#: lib/klass_hero_web/live/provider/sessions_live.ex:424
 #, elixir-autogen, elixir-format
 msgid "That session could not be found."
 msgstr ""
@@ -7842,12 +7837,32 @@ msgstr ""
 msgid "This person leads the session. Make someone else lead before removing them."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:298
+#: lib/klass_hero_web/live/provider/sessions_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "This session is back on the program's usual team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2097
+#: lib/klass_hero_web/live/provider/sessions_live.ex:274
 #, elixir-autogen, elixir-format
-msgid "Using the program's usual team. Adding someone staffs this session only."
+msgid "A session needs at least one person. Use “Go back to the program's usual team” to drop this session's own roster."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2268
+#, elixir-autogen, elixir-format
+msgid "A session needs someone — use “Go back to the program's usual team” instead"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2235
+#, elixir-autogen, elixir-format
+msgid "Everyone on your team is already working this session."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2123
+#, elixir-autogen, elixir-format
+msgid "Staffed just for this session. Changes here do not touch the program."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2125
+#, elixir-autogen, elixir-format
+msgid "Using the program's usual team. The first change here copies them onto this session, so later program changes stop reaching it."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -136,8 +136,8 @@ msgstr ""
 msgid "Your Data"
 msgstr ""
 
-#: lib/klass_hero_web/components/core_components.ex:67
-#: lib/klass_hero_web/components/provider_components.ex:1733
+#: lib/klass_hero_web/components/core_components.ex:71
+#: lib/klass_hero_web/components/provider_components.ex:1758
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr ""
@@ -578,8 +578,8 @@ msgid "Dispute Resolution"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:719
-#: lib/klass_hero_web/components/provider_components.ex:2593
-#: lib/klass_hero_web/components/provider_components.ex:2611
+#: lib/klass_hero_web/components/provider_components.ex:2647
+#: lib/klass_hero_web/components/provider_components.ex:2665
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
@@ -684,7 +684,7 @@ msgid "Introduction"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:115
-#: lib/klass_hero_web/live/provider/sessions_live.ex:549
+#: lib/klass_hero_web/live/provider/sessions_live.ex:565
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:63
 #, elixir-autogen, elixir-format
 msgid "Invalid date format"
@@ -878,9 +878,9 @@ msgstr ""
 msgid "Select one or both options"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2289
-#: lib/klass_hero_web/components/provider_components.ex:2290
-#: lib/klass_hero_web/components/provider_components.ex:2327
+#: lib/klass_hero_web/components/provider_components.ex:2343
+#: lib/klass_hero_web/components/provider_components.ex:2344
+#: lib/klass_hero_web/components/provider_components.ex:2381
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:448
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:484
@@ -1578,8 +1578,8 @@ msgid "Quick Navigation"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1487
-#: lib/klass_hero_web/components/provider_components.ex:2265
-#: lib/klass_hero_web/components/provider_components.ex:2491
+#: lib/klass_hero_web/components/provider_components.ex:2319
+#: lib/klass_hero_web/components/provider_components.ex:2545
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
@@ -1670,8 +1670,8 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:47
 #: lib/klass_hero_web/components/provider_components.ex:73
 #: lib/klass_hero_web/components/provider_components.ex:1627
-#: lib/klass_hero_web/components/provider_components.ex:2687
-#: lib/klass_hero_web/components/provider_components.ex:2705
+#: lib/klass_hero_web/components/provider_components.ex:2741
+#: lib/klass_hero_web/components/provider_components.ex:2759
 #: lib/klass_hero_web/live/admin/sessions_live.ex:298
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
@@ -1709,9 +1709,9 @@ msgid "Search by name..."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1481
-#: lib/klass_hero_web/components/provider_components.ex:1852
-#: lib/klass_hero_web/components/provider_components.ex:2259
-#: lib/klass_hero_web/components/provider_components.ex:2488
+#: lib/klass_hero_web/components/provider_components.ex:1877
+#: lib/klass_hero_web/components/provider_components.ex:2313
+#: lib/klass_hero_web/components/provider_components.ex:2542
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1736,7 +1736,7 @@ msgid "This is your main business identity. Verification is required to list pro
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1538
-#: lib/klass_hero_web/components/provider_components.ex:1867
+#: lib/klass_hero_web/components/provider_components.ex:1892
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr ""
@@ -1817,7 +1817,7 @@ msgstr ""
 #: lib/klass_hero_web/components/participation_components.ex:717
 #: lib/klass_hero_web/components/provider_components.ex:889
 #: lib/klass_hero_web/components/provider_components.ex:1334
-#: lib/klass_hero_web/components/provider_components.ex:2430
+#: lib/klass_hero_web/components/provider_components.ex:2484
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:478
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
@@ -1873,7 +1873,7 @@ msgstr ""
 msgid "Data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2574
+#: lib/klass_hero_web/components/provider_components.ex:2628
 #: lib/klass_hero_web/live/settings/children_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1921,17 +1921,17 @@ msgstr ""
 msgid "Failed to submit note"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2568
-#: lib/klass_hero_web/components/provider_components.ex:2597
-#: lib/klass_hero_web/components/provider_components.ex:2613
+#: lib/klass_hero_web/components/provider_components.ex:2622
+#: lib/klass_hero_web/components/provider_components.ex:2651
+#: lib/klass_hero_web/components/provider_components.ex:2667
 #: lib/klass_hero_web/live/settings/children_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2569
-#: lib/klass_hero_web/components/provider_components.ex:2598
-#: lib/klass_hero_web/components/provider_components.ex:2614
+#: lib/klass_hero_web/components/provider_components.ex:2623
+#: lib/klass_hero_web/components/provider_components.ex:2652
+#: lib/klass_hero_web/components/provider_components.ex:2668
 #: lib/klass_hero_web/live/settings/children_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -2069,8 +2069,8 @@ msgstr ""
 msgid "Save Changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1711
-#: lib/klass_hero_web/components/provider_components.ex:1712
+#: lib/klass_hero_web/components/provider_components.ex:1736
+#: lib/klass_hero_web/components/provider_components.ex:1737
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:43
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:151
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:252
@@ -2088,7 +2088,7 @@ msgstr ""
 msgid "Send a message to start the conversation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2668
+#: lib/klass_hero_web/components/provider_components.ex:2722
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:249
 #, elixir-autogen, elixir-format, fuzzy
@@ -2224,7 +2224,7 @@ msgstr ""
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2727
+#: lib/klass_hero_web/components/provider_components.ex:2781
 #, elixir-autogen, elixir-format, fuzzy
 msgid "An unexpected error occurred during import."
 msgstr ""
@@ -2319,8 +2319,8 @@ msgstr ""
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2256
-#: lib/klass_hero_web/components/provider_components.ex:2482
+#: lib/klass_hero_web/components/provider_components.ex:2310
+#: lib/klass_hero_web/components/provider_components.ex:2536
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2365,7 +2365,7 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2688
+#: lib/klass_hero_web/components/provider_components.ex:2742
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
@@ -2414,7 +2414,7 @@ msgstr ""
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2903
+#: lib/klass_hero_web/components/provider_components.ex:2957
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2448,7 +2448,7 @@ msgstr ""
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2449
+#: lib/klass_hero_web/components/provider_components.ex:2503
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
@@ -2479,14 +2479,14 @@ msgstr ""
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2262
-#: lib/klass_hero_web/components/provider_components.ex:2708
+#: lib/klass_hero_web/components/provider_components.ex:2316
+#: lib/klass_hero_web/components/provider_components.ex:2762
 #: lib/klass_hero_web/components/provider_layout_components.ex:644
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrolled"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1757
+#: lib/klass_hero_web/components/provider_components.ex:1782
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr ""
@@ -2502,7 +2502,7 @@ msgid "Explain why this document is being rejected..."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:71
-#: lib/klass_hero_web/components/provider_components.ex:2709
+#: lib/klass_hero_web/components/provider_components.ex:2763
 #: lib/klass_hero_web/live/admin/emails_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2546,12 +2546,12 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2837
+#: lib/klass_hero_web/components/provider_components.ex:2891
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2839
+#: lib/klass_hero_web/components/provider_components.ex:2893
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
@@ -2586,7 +2586,7 @@ msgstr ""
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2485
+#: lib/klass_hero_web/components/provider_components.ex:2539
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
@@ -2601,7 +2601,7 @@ msgstr ""
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2422
+#: lib/klass_hero_web/components/provider_components.ex:2476
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import"
 msgstr ""
@@ -2626,7 +2626,7 @@ msgstr ""
 msgid "Invite resent successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1774
+#: lib/klass_hero_web/components/provider_components.ex:1799
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr ""
@@ -2727,12 +2727,12 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2865
+#: lib/klass_hero_web/components/provider_components.ex:2919
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2249
+#: lib/klass_hero_web/components/provider_components.ex:2303
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
@@ -2748,7 +2748,7 @@ msgstr ""
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2473
+#: lib/klass_hero_web/components/provider_components.ex:2527
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
@@ -2811,7 +2811,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2940
+#: lib/klass_hero_web/components/provider_components.ex:2994
 #: lib/klass_hero_web/live/provider/verification_live.ex:698
 #: lib/klass_hero_web/live/provider/verification_live.ex:770
 #, elixir-autogen, elixir-format
@@ -2909,7 +2909,7 @@ msgid "Read our founding story →"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:805
-#: lib/klass_hero_web/components/provider_components.ex:2707
+#: lib/klass_hero_web/components/provider_components.ex:2761
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registered"
@@ -2991,16 +2991,16 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:839
 #: lib/klass_hero_web/components/provider_components.ex:1284
-#: lib/klass_hero_web/components/provider_components.ex:2529
-#: lib/klass_hero_web/components/provider_components.ex:2959
-#: lib/klass_hero_web/components/provider_components.ex:3038
+#: lib/klass_hero_web/components/provider_components.ex:2583
+#: lib/klass_hero_web/components/provider_components.ex:3013
+#: lib/klass_hero_web/components/provider_components.ex:3092
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:253
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2522
+#: lib/klass_hero_web/components/provider_components.ex:2576
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -3015,7 +3015,7 @@ msgstr ""
 msgid "Role"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1703
+#: lib/klass_hero_web/components/provider_components.ex:1728
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:386
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
@@ -3041,7 +3041,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2937
+#: lib/klass_hero_web/components/provider_components.ex:2991
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select File"
 msgstr ""
@@ -3058,7 +3058,7 @@ msgstr ""
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2706
+#: lib/klass_hero_web/components/provider_components.ex:2760
 #: lib/klass_hero_web/live/admin/emails_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Sent"
@@ -3168,7 +3168,7 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2838
+#: lib/klass_hero_web/components/provider_components.ex:2892
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -3188,32 +3188,32 @@ msgstr ""
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2408
+#: lib/klass_hero_web/components/provider_components.ex:2462
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2983
+#: lib/klass_hero_web/components/provider_components.ex:3037
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2892
+#: lib/klass_hero_web/components/provider_components.ex:2946
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2860
+#: lib/klass_hero_web/components/provider_components.ex:2914
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2840
+#: lib/klass_hero_web/components/provider_components.ex:2894
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2857
+#: lib/klass_hero_web/components/provider_components.ex:2911
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -3303,7 +3303,7 @@ msgid "Child Safeguarding Training"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1498
-#: lib/klass_hero_web/components/provider_components.ex:3205
+#: lib/klass_hero_web/components/provider_components.ex:3259
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr ""
@@ -3453,7 +3453,7 @@ msgid "Vetted with Care"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1482
-#: lib/klass_hero_web/components/provider_components.ex:2990
+#: lib/klass_hero_web/components/provider_components.ex:3044
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr ""
@@ -3627,7 +3627,7 @@ msgstr ""
 msgid "Checked Out"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2565
+#: lib/klass_hero_web/components/provider_components.ex:2619
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Child"
@@ -3680,7 +3680,7 @@ msgstr ""
 msgid "Download monthly statements for taxes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2326
+#: lib/klass_hero_web/components/provider_components.ex:2380
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:483
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrollment not confirmed"
@@ -3753,7 +3753,7 @@ msgstr ""
 msgid "No chasing payments or sending invoices"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1726
+#: lib/klass_hero_web/components/provider_components.ex:1751
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:407
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No enrolled parents"
@@ -3776,7 +3776,7 @@ msgstr ""
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2325
+#: lib/klass_hero_web/components/provider_components.ex:2379
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -3959,7 +3959,7 @@ msgstr ""
 msgid "%{count} unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:567
+#: lib/klass_hero_web/live/provider/sessions_live.ex:583
 #, elixir-autogen, elixir-format
 msgid "A session already exists at this time"
 msgstr ""
@@ -4139,8 +4139,8 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:543
-#: lib/klass_hero_web/live/provider/sessions_live.ex:544
+#: lib/klass_hero_web/live/provider/sessions_live.ex:559
+#: lib/klass_hero_web/live/provider/sessions_live.ex:560
 #, elixir-autogen, elixir-format
 msgid "Date is required"
 msgstr ""
@@ -4183,7 +4183,7 @@ msgstr ""
 msgid "Emergency: %{details}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:566
+#: lib/klass_hero_web/live/provider/sessions_live.ex:582
 #, elixir-autogen, elixir-format
 msgid "End time must be after start time"
 msgstr ""
@@ -4198,7 +4198,7 @@ msgstr ""
 msgid "Failed to archive email"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:503
+#: lib/klass_hero_web/live/provider/sessions_live.ex:519
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to create session: %{reason}"
 msgstr ""
@@ -4255,7 +4255,7 @@ msgid "Invalid Invitation"
 msgstr ""
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:260
-#: lib/klass_hero_web/live/provider/sessions_live.ex:562
+#: lib/klass_hero_web/live/provider/sessions_live.ex:578
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invalid time format"
 msgstr ""
@@ -4394,7 +4394,7 @@ msgstr ""
 msgid "Please explain why you're rejecting this note..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:569
+#: lib/klass_hero_web/live/provider/sessions_live.ex:585
 #, elixir-autogen, elixir-format
 msgid "Please fill in all required fields"
 msgstr ""
@@ -4408,7 +4408,7 @@ msgstr ""
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
 #: lib/klass_hero_web/live/provider/programs_live.ex:224
-#: lib/klass_hero_web/live/provider/sessions_live.ex:368
+#: lib/klass_hero_web/live/provider/sessions_live.ex:381
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:175
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program"
@@ -4503,7 +4503,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:70
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:16
-#: lib/klass_hero_web/live/provider/sessions_live.ex:392
+#: lib/klass_hero_web/live/provider/sessions_live.ex:408
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:16
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Session"
@@ -4520,7 +4520,7 @@ msgstr ""
 msgid "Session Roster"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:485
+#: lib/klass_hero_web/live/provider/sessions_live.ex:501
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Session created successfully"
 msgstr ""
@@ -4581,8 +4581,8 @@ msgstr ""
 msgid "This invite link is invalid or has expired."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:553
-#: lib/klass_hero_web/live/provider/sessions_live.ex:554
+#: lib/klass_hero_web/live/provider/sessions_live.ex:569
+#: lib/klass_hero_web/live/provider/sessions_live.ex:570
 #, elixir-autogen, elixir-format
 msgid "Time is required"
 msgstr ""
@@ -4889,34 +4889,34 @@ msgstr ""
 msgid "for"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1850
+#: lib/klass_hero_web/components/provider_components.ex:1875
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assigned staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1851
+#: lib/klass_hero_web/components/provider_components.ex:1876
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1834
-#: lib/klass_hero_web/components/provider_components.ex:1919
-#: lib/klass_hero_web/components/provider_components.ex:2068
+#: lib/klass_hero_web/components/provider_components.ex:1859
+#: lib/klass_hero_web/components/provider_components.ex:1944
+#: lib/klass_hero_web/components/provider_components.ex:2098
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Close"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1849
+#: lib/klass_hero_web/components/provider_components.ex:1874
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1843
+#: lib/klass_hero_web/components/provider_components.ex:1868
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No sessions scheduled yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1832
+#: lib/klass_hero_web/components/provider_components.ex:1857
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sessions — %{title}"
 msgstr ""
@@ -4953,17 +4953,17 @@ msgstr ""
 msgid "Failed to update record"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2629
+#: lib/klass_hero_web/components/provider_components.ex:2683
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2348
+#: lib/klass_hero_web/components/provider_components.ex:2402
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invite mode"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2367
+#: lib/klass_hero_web/components/provider_components.ex:2421
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr ""
@@ -4978,12 +4978,12 @@ msgstr ""
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2642
+#: lib/klass_hero_web/components/provider_components.ex:2696
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2648
+#: lib/klass_hero_web/components/provider_components.ex:2702
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr ""
@@ -4994,17 +4994,17 @@ msgstr ""
 msgid "Nothing to update"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2650
+#: lib/klass_hero_web/components/provider_components.ex:2704
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nut allergy"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2654
+#: lib/klass_hero_web/components/provider_components.ex:2708
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2659
+#: lib/klass_hero_web/components/provider_components.ex:2713
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr ""
@@ -5014,7 +5014,7 @@ msgstr ""
 msgid "Present"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2586
+#: lib/klass_hero_web/components/provider_components.ex:2640
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr ""
@@ -5041,22 +5041,22 @@ msgstr ""
 msgid "Save changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2623
+#: lib/klass_hero_web/components/provider_components.ex:2677
 #, elixir-autogen, elixir-format, fuzzy
 msgid "School (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2633
+#: lib/klass_hero_web/components/provider_components.ex:2687
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2607
+#: lib/klass_hero_web/components/provider_components.ex:2661
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2676
+#: lib/klass_hero_web/components/provider_components.ex:2730
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Send invite"
 msgstr ""
@@ -5066,7 +5066,7 @@ msgstr ""
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2385
+#: lib/klass_hero_web/components/provider_components.ex:2439
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload a list"
 msgstr ""
@@ -6368,17 +6368,17 @@ msgstr ""
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2715
+#: lib/klass_hero_web/components/provider_components.ex:2769
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Row %{row}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2715
+#: lib/klass_hero_web/components/provider_components.ex:2769
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2461
+#: lib/klass_hero_web/components/provider_components.ex:2515
 #, elixir-autogen, elixir-format
 msgid "Rows with errors"
 msgstr ""
@@ -7137,12 +7137,12 @@ msgstr ""
 msgid "Experience validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3019
+#: lib/klass_hero_web/components/provider_components.ex:3073
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2993
+#: lib/klass_hero_web/components/provider_components.ex:3047
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
@@ -7152,12 +7152,12 @@ msgstr ""
 msgid "Safeguarding certificate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3016
+#: lib/klass_hero_web/components/provider_components.ex:3070
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select Video"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3062
+#: lib/klass_hero_web/components/provider_components.ex:3116
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload Video"
 msgstr ""
@@ -7167,7 +7167,7 @@ msgstr ""
 msgid "Your browser does not support video playback."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3209
+#: lib/klass_hero_web/components/provider_components.ex:3263
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Confirm agreement"
 msgstr ""
@@ -7177,12 +7177,12 @@ msgstr ""
 msgid "Couldn't record your agreement. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3232
+#: lib/klass_hero_web/components/provider_components.ex:3286
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3208
+#: lib/klass_hero_web/components/provider_components.ex:3262
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr ""
@@ -7192,7 +7192,7 @@ msgstr ""
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3117
+#: lib/klass_hero_web/components/provider_components.ex:3171
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr ""
@@ -7202,17 +7202,17 @@ msgstr ""
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3217
+#: lib/klass_hero_web/components/provider_components.ex:3271
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3206
+#: lib/klass_hero_web/components/provider_components.ex:3260
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3207
+#: lib/klass_hero_web/components/provider_components.ex:3261
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
@@ -7481,12 +7481,12 @@ msgstr ""
 msgid "Your insurance is verified."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3161
+#: lib/klass_hero_web/components/provider_components.ex:3215
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3264
+#: lib/klass_hero_web/components/provider_components.ex:3318
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr ""
@@ -7496,7 +7496,7 @@ msgstr ""
 msgid "Couldn't record your declaration. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3270
+#: lib/klass_hero_web/components/provider_components.ex:3324
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr ""
@@ -7506,17 +7506,17 @@ msgstr ""
 msgid "Please confirm the declaration before signing."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3295
+#: lib/klass_hero_web/components/provider_components.ex:3349
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3274
+#: lib/klass_hero_web/components/provider_components.ex:3328
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3262
+#: lib/klass_hero_web/components/provider_components.ex:3316
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr ""
@@ -7526,12 +7526,12 @@ msgstr ""
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3282
+#: lib/klass_hero_web/components/provider_components.ex:3336
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3268
+#: lib/klass_hero_web/components/provider_components.ex:3322
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
@@ -7598,14 +7598,14 @@ msgstr ""
 msgid "Undelivered Events"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2016
-#: lib/klass_hero_web/components/provider_components.ex:2198
+#: lib/klass_hero_web/components/provider_components.ex:2043
+#: lib/klass_hero_web/components/provider_components.ex:2226
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1941
-#: lib/klass_hero_web/components/provider_components.ex:2122
+#: lib/klass_hero_web/components/provider_components.ex:1966
+#: lib/klass_hero_web/components/provider_components.ex:2152
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Lead"
 msgstr ""
@@ -7615,7 +7615,7 @@ msgstr ""
 msgid "Lead instructor updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1952
+#: lib/klass_hero_web/components/provider_components.ex:1978
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor"
 msgstr ""
@@ -7625,7 +7625,7 @@ msgstr ""
 msgid "Manage Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1980
+#: lib/klass_hero_web/components/provider_components.ex:2007
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this program yet."
 msgstr ""
@@ -7636,19 +7636,19 @@ msgstr ""
 msgid "Pick a staff member to add."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1963
-#: lib/klass_hero_web/components/provider_components.ex:2145
+#: lib/klass_hero_web/components/provider_components.ex:1990
+#: lib/klass_hero_web/components/provider_components.ex:2265
 #, elixir-autogen, elixir-format
 msgid "Reassign the lead before removing them"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1964
+#: lib/klass_hero_web/components/provider_components.ex:1991
 #, elixir-autogen, elixir-format
 msgid "Remove from program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1998
-#: lib/klass_hero_web/components/provider_components.ex:2180
+#: lib/klass_hero_web/components/provider_components.ex:2025
+#: lib/klass_hero_web/components/provider_components.ex:2207
 #, elixir-autogen, elixir-format
 msgid "Select a staff member…"
 msgstr ""
@@ -7663,12 +7663,12 @@ msgstr ""
 msgid "Staff member removed from the program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2021
+#: lib/klass_hero_web/components/provider_components.ex:2048
 #, elixir-autogen, elixir-format
 msgid "Staff you add can read and reply to this program's parent conversations."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1917
+#: lib/klass_hero_web/components/provider_components.ex:1942
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Staffing — %{title}"
 msgstr ""
@@ -7777,27 +7777,27 @@ msgstr ""
 msgid "I understand this program will have no capacity limit."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2209
+#: lib/klass_hero_web/components/provider_components.ex:2253
 #, elixir-autogen, elixir-format
 msgid "Go back to the program's usual team"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:282
+#: lib/klass_hero_web/live/provider/sessions_live.ex:295
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Lead instructor for this session updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2136
+#: lib/klass_hero_web/components/provider_components.ex:2167
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Make lead instructor for this session"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2162
+#: lib/klass_hero_web/components/provider_components.ex:2189
 #, elixir-autogen, elixir-format
 msgid "Nobody is working this session yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2146
+#: lib/klass_hero_web/components/provider_components.ex:2270
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove from this session"
 msgstr ""
@@ -7812,22 +7812,17 @@ msgstr ""
 msgid "Staff member removed from this session."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2093
-#, elixir-autogen, elixir-format
-msgid "Staffed just for this session. The program's usual team does not apply here."
-msgstr ""
-
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:107
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2064
+#: lib/klass_hero_web/components/provider_components.ex:2091
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Staffing — %{date}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:408
+#: lib/klass_hero_web/live/provider/sessions_live.ex:424
 #, elixir-autogen, elixir-format
 msgid "That session could not be found."
 msgstr ""
@@ -7842,12 +7837,32 @@ msgstr ""
 msgid "This person leads the session. Make someone else lead before removing them."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:298
+#: lib/klass_hero_web/live/provider/sessions_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "This session is back on the program's usual team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2097
+#: lib/klass_hero_web/live/provider/sessions_live.ex:274
 #, elixir-autogen, elixir-format
-msgid "Using the program's usual team. Adding someone staffs this session only."
+msgid "A session needs at least one person. Use “Go back to the program's usual team” to drop this session's own roster."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2268
+#, elixir-autogen, elixir-format
+msgid "A session needs someone — use “Go back to the program's usual team” instead"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2235
+#, elixir-autogen, elixir-format
+msgid "Everyone on your team is already working this session."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2123
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Staffed just for this session. Changes here do not touch the program."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2125
+#, elixir-autogen, elixir-format
+msgid "Using the program's usual team. The first change here copies them onto this session, so later program changes stop reaching it."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -578,8 +578,8 @@ msgid "Dispute Resolution"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:719
-#: lib/klass_hero_web/components/provider_components.ex:2406
-#: lib/klass_hero_web/components/provider_components.ex:2424
+#: lib/klass_hero_web/components/provider_components.ex:2593
+#: lib/klass_hero_web/components/provider_components.ex:2611
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
@@ -621,7 +621,7 @@ msgstr ""
 msgid "Failed to check out: %{reason}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:155
+#: lib/klass_hero_web/live/provider/sessions_live.ex:160
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:116
 #, elixir-autogen, elixir-format
 msgid "Failed to complete session: %{reason}"
@@ -632,7 +632,7 @@ msgstr ""
 msgid "Failed to delete account. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:132
+#: lib/klass_hero_web/live/provider/sessions_live.ex:137
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:87
 #, elixir-autogen, elixir-format
 msgid "Failed to start session: %{reason}"
@@ -683,8 +683,8 @@ msgstr ""
 msgid "Introduction"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:110
-#: lib/klass_hero_web/live/provider/sessions_live.ex:362
+#: lib/klass_hero_web/live/provider/sessions_live.ex:115
+#: lib/klass_hero_web/live/provider/sessions_live.ex:549
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:63
 #, elixir-autogen, elixir-format
 msgid "Invalid date format"
@@ -756,7 +756,7 @@ msgstr ""
 msgid "Message sent successfully!"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:46
+#: lib/klass_hero_web/live/provider/sessions_live.ex:50
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:4
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:21
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:228
@@ -878,9 +878,9 @@ msgstr ""
 msgid "Select one or both options"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2102
-#: lib/klass_hero_web/components/provider_components.ex:2103
-#: lib/klass_hero_web/components/provider_components.ex:2140
+#: lib/klass_hero_web/components/provider_components.ex:2289
+#: lib/klass_hero_web/components/provider_components.ex:2290
+#: lib/klass_hero_web/components/provider_components.ex:2327
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:448
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:484
@@ -888,7 +888,7 @@ msgstr ""
 msgid "Send Message"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:141
+#: lib/klass_hero_web/live/provider/sessions_live.ex:146
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:102
 #, elixir-autogen, elixir-format
 msgid "Session completed successfully"
@@ -902,7 +902,7 @@ msgstr ""
 msgid "Session not found"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:118
+#: lib/klass_hero_web/live/provider/sessions_live.ex:123
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:73
 #, elixir-autogen, elixir-format
 msgid "Session started successfully"
@@ -1578,8 +1578,8 @@ msgid "Quick Navigation"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1487
-#: lib/klass_hero_web/components/provider_components.ex:2078
-#: lib/klass_hero_web/components/provider_components.ex:2304
+#: lib/klass_hero_web/components/provider_components.ex:2265
+#: lib/klass_hero_web/components/provider_components.ex:2491
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
@@ -1670,8 +1670,8 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:47
 #: lib/klass_hero_web/components/provider_components.ex:73
 #: lib/klass_hero_web/components/provider_components.ex:1627
-#: lib/klass_hero_web/components/provider_components.ex:2500
-#: lib/klass_hero_web/components/provider_components.ex:2518
+#: lib/klass_hero_web/components/provider_components.ex:2687
+#: lib/klass_hero_web/components/provider_components.ex:2705
 #: lib/klass_hero_web/live/admin/sessions_live.ex:298
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
@@ -1709,9 +1709,9 @@ msgid "Search by name..."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1481
-#: lib/klass_hero_web/components/provider_components.ex:1850
-#: lib/klass_hero_web/components/provider_components.ex:2072
-#: lib/klass_hero_web/components/provider_components.ex:2301
+#: lib/klass_hero_web/components/provider_components.ex:1852
+#: lib/klass_hero_web/components/provider_components.ex:2259
+#: lib/klass_hero_web/components/provider_components.ex:2488
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1736,7 +1736,7 @@ msgid "This is your main business identity. Verification is required to list pro
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1538
-#: lib/klass_hero_web/components/provider_components.ex:1865
+#: lib/klass_hero_web/components/provider_components.ex:1867
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr ""
@@ -1817,13 +1817,13 @@ msgstr ""
 #: lib/klass_hero_web/components/participation_components.ex:717
 #: lib/klass_hero_web/components/provider_components.ex:889
 #: lib/klass_hero_web/components/provider_components.ex:1334
-#: lib/klass_hero_web/components/provider_components.ex:2243
+#: lib/klass_hero_web/components/provider_components.ex:2430
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:478
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:222
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:356
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:191
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:210
 #: lib/klass_hero_web/live/settings/children_live.ex:544
 #: lib/klass_hero_web/live/settings/children_live.ex:703
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:237
@@ -1873,7 +1873,7 @@ msgstr ""
 msgid "Data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2387
+#: lib/klass_hero_web/components/provider_components.ex:2574
 #: lib/klass_hero_web/live/settings/children_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1921,17 +1921,17 @@ msgstr ""
 msgid "Failed to submit note"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2381
-#: lib/klass_hero_web/components/provider_components.ex:2410
-#: lib/klass_hero_web/components/provider_components.ex:2426
+#: lib/klass_hero_web/components/provider_components.ex:2568
+#: lib/klass_hero_web/components/provider_components.ex:2597
+#: lib/klass_hero_web/components/provider_components.ex:2613
 #: lib/klass_hero_web/live/settings/children_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2382
-#: lib/klass_hero_web/components/provider_components.ex:2411
-#: lib/klass_hero_web/components/provider_components.ex:2427
+#: lib/klass_hero_web/components/provider_components.ex:2569
+#: lib/klass_hero_web/components/provider_components.ex:2598
+#: lib/klass_hero_web/components/provider_components.ex:2614
 #: lib/klass_hero_web/live/settings/children_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -2088,7 +2088,7 @@ msgstr ""
 msgid "Send a message to start the conversation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2481
+#: lib/klass_hero_web/components/provider_components.ex:2668
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:249
 #, elixir-autogen, elixir-format, fuzzy
@@ -2224,7 +2224,7 @@ msgstr ""
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2540
+#: lib/klass_hero_web/components/provider_components.ex:2727
 #, elixir-autogen, elixir-format, fuzzy
 msgid "An unexpected error occurred during import."
 msgstr ""
@@ -2319,8 +2319,8 @@ msgstr ""
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2069
-#: lib/klass_hero_web/components/provider_components.ex:2295
+#: lib/klass_hero_web/components/provider_components.ex:2256
+#: lib/klass_hero_web/components/provider_components.ex:2482
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2365,7 +2365,7 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2501
+#: lib/klass_hero_web/components/provider_components.ex:2688
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
@@ -2414,7 +2414,7 @@ msgstr ""
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2716
+#: lib/klass_hero_web/components/provider_components.ex:2903
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2448,7 +2448,7 @@ msgstr ""
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2262
+#: lib/klass_hero_web/components/provider_components.ex:2449
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
@@ -2474,13 +2474,13 @@ msgid "End Date"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1046
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:166
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2075
-#: lib/klass_hero_web/components/provider_components.ex:2521
+#: lib/klass_hero_web/components/provider_components.ex:2262
+#: lib/klass_hero_web/components/provider_components.ex:2708
 #: lib/klass_hero_web/components/provider_layout_components.ex:644
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrolled"
@@ -2502,7 +2502,7 @@ msgid "Explain why this document is being rejected..."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:71
-#: lib/klass_hero_web/components/provider_components.ex:2522
+#: lib/klass_hero_web/components/provider_components.ex:2709
 #: lib/klass_hero_web/live/admin/emails_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2546,12 +2546,12 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2650
+#: lib/klass_hero_web/components/provider_components.ex:2837
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2652
+#: lib/klass_hero_web/components/provider_components.ex:2839
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
@@ -2586,7 +2586,7 @@ msgstr ""
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2298
+#: lib/klass_hero_web/components/provider_components.ex:2485
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
@@ -2601,7 +2601,7 @@ msgstr ""
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2235
+#: lib/klass_hero_web/components/provider_components.ex:2422
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import"
 msgstr ""
@@ -2669,7 +2669,7 @@ msgid "Leave unchecked to allow all genders."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1002
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:172
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:191
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Location"
 msgstr ""
@@ -2727,12 +2727,12 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2678
+#: lib/klass_hero_web/components/provider_components.ex:2865
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2062
+#: lib/klass_hero_web/components/provider_components.ex:2249
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
@@ -2748,7 +2748,7 @@ msgstr ""
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2286
+#: lib/klass_hero_web/components/provider_components.ex:2473
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
@@ -2811,7 +2811,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2753
+#: lib/klass_hero_web/components/provider_components.ex:2940
 #: lib/klass_hero_web/live/provider/verification_live.ex:698
 #: lib/klass_hero_web/live/provider/verification_live.ex:770
 #, elixir-autogen, elixir-format
@@ -2909,7 +2909,7 @@ msgid "Read our founding story →"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:805
-#: lib/klass_hero_web/components/provider_components.ex:2520
+#: lib/klass_hero_web/components/provider_components.ex:2707
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registered"
@@ -2991,16 +2991,16 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:839
 #: lib/klass_hero_web/components/provider_components.ex:1284
-#: lib/klass_hero_web/components/provider_components.ex:2342
-#: lib/klass_hero_web/components/provider_components.ex:2772
-#: lib/klass_hero_web/components/provider_components.ex:2851
+#: lib/klass_hero_web/components/provider_components.ex:2529
+#: lib/klass_hero_web/components/provider_components.ex:2959
+#: lib/klass_hero_web/components/provider_components.ex:3038
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:253
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2335
+#: lib/klass_hero_web/components/provider_components.ex:2522
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -3041,7 +3041,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2750
+#: lib/klass_hero_web/components/provider_components.ex:2937
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select File"
 msgstr ""
@@ -3058,7 +3058,7 @@ msgstr ""
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2519
+#: lib/klass_hero_web/components/provider_components.ex:2706
 #: lib/klass_hero_web/live/admin/emails_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Sent"
@@ -3098,7 +3098,7 @@ msgid "Start Date"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1041
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:165
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:184
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Start Time"
 msgstr ""
@@ -3168,7 +3168,7 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2651
+#: lib/klass_hero_web/components/provider_components.ex:2838
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -3188,32 +3188,32 @@ msgstr ""
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2221
+#: lib/klass_hero_web/components/provider_components.ex:2408
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2796
+#: lib/klass_hero_web/components/provider_components.ex:2983
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2705
+#: lib/klass_hero_web/components/provider_components.ex:2892
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2673
+#: lib/klass_hero_web/components/provider_components.ex:2860
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2653
+#: lib/klass_hero_web/components/provider_components.ex:2840
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2670
+#: lib/klass_hero_web/components/provider_components.ex:2857
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -3303,7 +3303,7 @@ msgid "Child Safeguarding Training"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1498
-#: lib/klass_hero_web/components/provider_components.ex:3018
+#: lib/klass_hero_web/components/provider_components.ex:3205
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr ""
@@ -3453,7 +3453,7 @@ msgid "Vetted with Care"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1482
-#: lib/klass_hero_web/components/provider_components.ex:2803
+#: lib/klass_hero_web/components/provider_components.ex:2990
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr ""
@@ -3627,7 +3627,7 @@ msgstr ""
 msgid "Checked Out"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2378
+#: lib/klass_hero_web/components/provider_components.ex:2565
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Child"
@@ -3680,7 +3680,7 @@ msgstr ""
 msgid "Download monthly statements for taxes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2139
+#: lib/klass_hero_web/components/provider_components.ex:2326
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:483
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrollment not confirmed"
@@ -3766,7 +3766,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:830
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:155
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:178
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:197
 #, elixir-autogen, elixir-format
 msgid "Notes"
 msgstr ""
@@ -3776,7 +3776,7 @@ msgstr ""
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2138
+#: lib/klass_hero_web/components/provider_components.ex:2325
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -3959,7 +3959,7 @@ msgstr ""
 msgid "%{count} unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:380
+#: lib/klass_hero_web/live/provider/sessions_live.ex:567
 #, elixir-autogen, elixir-format
 msgid "A session already exists at this time"
 msgstr ""
@@ -4128,19 +4128,19 @@ msgid "Could not start private conversation"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:18
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:135
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:200
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:154
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:219
 #, elixir-autogen, elixir-format
 msgid "Create Session"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:162
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:181
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:356
-#: lib/klass_hero_web/live/provider/sessions_live.ex:357
+#: lib/klass_hero_web/live/provider/sessions_live.ex:543
+#: lib/klass_hero_web/live/provider/sessions_live.ex:544
 #, elixir-autogen, elixir-format
 msgid "Date is required"
 msgstr ""
@@ -4183,7 +4183,7 @@ msgstr ""
 msgid "Emergency: %{details}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:379
+#: lib/klass_hero_web/live/provider/sessions_live.ex:566
 #, elixir-autogen, elixir-format
 msgid "End time must be after start time"
 msgstr ""
@@ -4198,7 +4198,7 @@ msgstr ""
 msgid "Failed to archive email"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:316
+#: lib/klass_hero_web/live/provider/sessions_live.ex:503
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to create session: %{reason}"
 msgstr ""
@@ -4255,7 +4255,7 @@ msgid "Invalid Invitation"
 msgstr ""
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:260
-#: lib/klass_hero_web/live/provider/sessions_live.ex:375
+#: lib/klass_hero_web/live/provider/sessions_live.ex:562
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invalid time format"
 msgstr ""
@@ -4311,7 +4311,7 @@ msgstr ""
 msgid "Mark Unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:181
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:200
 #, elixir-autogen, elixir-format
 msgid "Max Capacity"
 msgstr ""
@@ -4352,7 +4352,7 @@ msgstr ""
 msgid "No sessions found for the selected filters."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:105
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:122
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:316
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled"
@@ -4394,7 +4394,7 @@ msgstr ""
 msgid "Please explain why you're rejecting this note..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:382
+#: lib/klass_hero_web/live/provider/sessions_live.ex:569
 #, elixir-autogen, elixir-format
 msgid "Please fill in all required fields"
 msgstr ""
@@ -4408,12 +4408,13 @@ msgstr ""
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
 #: lib/klass_hero_web/live/provider/programs_live.ex:224
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:156
+#: lib/klass_hero_web/live/provider/sessions_live.ex:368
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:175
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:174
+#: lib/klass_hero_web/live/provider/sessions_live.ex:179
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program is required"
 msgstr ""
@@ -4485,7 +4486,7 @@ msgstr ""
 msgid "Revised Note"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:157
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:176
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select a program..."
 msgstr ""
@@ -4502,6 +4503,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:70
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:16
+#: lib/klass_hero_web/live/provider/sessions_live.ex:392
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:16
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Session"
@@ -4518,7 +4520,7 @@ msgstr ""
 msgid "Session Roster"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:298
+#: lib/klass_hero_web/live/provider/sessions_live.ex:485
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Session created successfully"
 msgstr ""
@@ -4579,8 +4581,8 @@ msgstr ""
 msgid "This invite link is invalid or has expired."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:366
-#: lib/klass_hero_web/live/provider/sessions_live.ex:367
+#: lib/klass_hero_web/live/provider/sessions_live.ex:553
+#: lib/klass_hero_web/live/provider/sessions_live.ex:554
 #, elixir-autogen, elixir-format
 msgid "Time is required"
 msgstr ""
@@ -4595,7 +4597,7 @@ msgstr ""
 msgid "Type your reply..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:178
+#: lib/klass_hero_web/live/provider/sessions_live.ex:183
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:123
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:92
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:121
@@ -4650,7 +4652,7 @@ msgstr ""
 msgid "You already have an account. Log in to see your new enrollment."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:108
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:125
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:319
 #, elixir-autogen, elixir-format
 msgid "You have no sessions scheduled for %{date}"
@@ -4887,38 +4889,34 @@ msgstr ""
 msgid "for"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1847
+#: lib/klass_hero_web/components/provider_components.ex:1850
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assigned staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1849
+#: lib/klass_hero_web/components/provider_components.ex:1851
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1831
-#: lib/klass_hero_web/components/provider_components.ex:1920
+#: lib/klass_hero_web/components/provider_components.ex:1834
+#: lib/klass_hero_web/components/provider_components.ex:1919
+#: lib/klass_hero_web/components/provider_components.ex:2068
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Close"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1848
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Cover"
-msgstr ""
-
-#: lib/klass_hero_web/components/provider_components.ex:1846
+#: lib/klass_hero_web/components/provider_components.ex:1849
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1840
+#: lib/klass_hero_web/components/provider_components.ex:1843
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No sessions scheduled yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1829
+#: lib/klass_hero_web/components/provider_components.ex:1832
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sessions — %{title}"
 msgstr ""
@@ -4955,17 +4953,17 @@ msgstr ""
 msgid "Failed to update record"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2442
+#: lib/klass_hero_web/components/provider_components.ex:2629
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2161
+#: lib/klass_hero_web/components/provider_components.ex:2348
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invite mode"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2180
+#: lib/klass_hero_web/components/provider_components.ex:2367
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr ""
@@ -4980,12 +4978,12 @@ msgstr ""
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2455
+#: lib/klass_hero_web/components/provider_components.ex:2642
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2461
+#: lib/klass_hero_web/components/provider_components.ex:2648
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr ""
@@ -4996,17 +4994,17 @@ msgstr ""
 msgid "Nothing to update"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2463
+#: lib/klass_hero_web/components/provider_components.ex:2650
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nut allergy"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2467
+#: lib/klass_hero_web/components/provider_components.ex:2654
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2472
+#: lib/klass_hero_web/components/provider_components.ex:2659
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr ""
@@ -5016,7 +5014,7 @@ msgstr ""
 msgid "Present"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2399
+#: lib/klass_hero_web/components/provider_components.ex:2586
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr ""
@@ -5043,22 +5041,22 @@ msgstr ""
 msgid "Save changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2436
+#: lib/klass_hero_web/components/provider_components.ex:2623
 #, elixir-autogen, elixir-format, fuzzy
 msgid "School (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2446
+#: lib/klass_hero_web/components/provider_components.ex:2633
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2420
+#: lib/klass_hero_web/components/provider_components.ex:2607
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2489
+#: lib/klass_hero_web/components/provider_components.ex:2676
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Send invite"
 msgstr ""
@@ -5068,7 +5066,7 @@ msgstr ""
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2198
+#: lib/klass_hero_web/components/provider_components.ex:2385
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload a list"
 msgstr ""
@@ -6370,17 +6368,17 @@ msgstr ""
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2528
+#: lib/klass_hero_web/components/provider_components.ex:2715
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Row %{row}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2528
+#: lib/klass_hero_web/components/provider_components.ex:2715
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2274
+#: lib/klass_hero_web/components/provider_components.ex:2461
 #, elixir-autogen, elixir-format
 msgid "Rows with errors"
 msgstr ""
@@ -7139,12 +7137,12 @@ msgstr ""
 msgid "Experience validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2832
+#: lib/klass_hero_web/components/provider_components.ex:3019
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2806
+#: lib/klass_hero_web/components/provider_components.ex:2993
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
@@ -7154,12 +7152,12 @@ msgstr ""
 msgid "Safeguarding certificate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2829
+#: lib/klass_hero_web/components/provider_components.ex:3016
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select Video"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2875
+#: lib/klass_hero_web/components/provider_components.ex:3062
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload Video"
 msgstr ""
@@ -7169,7 +7167,7 @@ msgstr ""
 msgid "Your browser does not support video playback."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3022
+#: lib/klass_hero_web/components/provider_components.ex:3209
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Confirm agreement"
 msgstr ""
@@ -7179,12 +7177,12 @@ msgstr ""
 msgid "Couldn't record your agreement. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3045
+#: lib/klass_hero_web/components/provider_components.ex:3232
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3021
+#: lib/klass_hero_web/components/provider_components.ex:3208
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr ""
@@ -7194,7 +7192,7 @@ msgstr ""
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2930
+#: lib/klass_hero_web/components/provider_components.ex:3117
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr ""
@@ -7204,17 +7202,17 @@ msgstr ""
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3030
+#: lib/klass_hero_web/components/provider_components.ex:3217
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3019
+#: lib/klass_hero_web/components/provider_components.ex:3206
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3020
+#: lib/klass_hero_web/components/provider_components.ex:3207
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
@@ -7483,12 +7481,12 @@ msgstr ""
 msgid "Your insurance is verified."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2974
+#: lib/klass_hero_web/components/provider_components.ex:3161
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3077
+#: lib/klass_hero_web/components/provider_components.ex:3264
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr ""
@@ -7498,7 +7496,7 @@ msgstr ""
 msgid "Couldn't record your declaration. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3083
+#: lib/klass_hero_web/components/provider_components.ex:3270
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr ""
@@ -7508,17 +7506,17 @@ msgstr ""
 msgid "Please confirm the declaration before signing."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3108
+#: lib/klass_hero_web/components/provider_components.ex:3295
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3087
+#: lib/klass_hero_web/components/provider_components.ex:3274
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3075
+#: lib/klass_hero_web/components/provider_components.ex:3262
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr ""
@@ -7528,12 +7526,12 @@ msgstr ""
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3095
+#: lib/klass_hero_web/components/provider_components.ex:3282
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3081
+#: lib/klass_hero_web/components/provider_components.ex:3268
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
@@ -7600,12 +7598,14 @@ msgstr ""
 msgid "Undelivered Events"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2017
+#: lib/klass_hero_web/components/provider_components.ex:2016
+#: lib/klass_hero_web/components/provider_components.ex:2198
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1942
+#: lib/klass_hero_web/components/provider_components.ex:1941
+#: lib/klass_hero_web/components/provider_components.ex:2122
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Lead"
 msgstr ""
@@ -7615,7 +7615,7 @@ msgstr ""
 msgid "Lead instructor updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1953
+#: lib/klass_hero_web/components/provider_components.ex:1952
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor"
 msgstr ""
@@ -7625,27 +7625,30 @@ msgstr ""
 msgid "Manage Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1981
+#: lib/klass_hero_web/components/provider_components.ex:1980
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this program yet."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/programs_live.ex:267
+#: lib/klass_hero_web/live/provider/sessions_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "Pick a staff member to add."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1964
+#: lib/klass_hero_web/components/provider_components.ex:1963
+#: lib/klass_hero_web/components/provider_components.ex:2145
 #, elixir-autogen, elixir-format
 msgid "Reassign the lead before removing them"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1965
+#: lib/klass_hero_web/components/provider_components.ex:1964
 #, elixir-autogen, elixir-format
 msgid "Remove from program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1999
+#: lib/klass_hero_web/components/provider_components.ex:1998
+#: lib/klass_hero_web/components/provider_components.ex:2180
 #, elixir-autogen, elixir-format
 msgid "Select a staff member…"
 msgstr ""
@@ -7660,12 +7663,12 @@ msgstr ""
 msgid "Staff member removed from the program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2022
+#: lib/klass_hero_web/components/provider_components.ex:2021
 #, elixir-autogen, elixir-format
 msgid "Staff you add can read and reply to this program's parent conversations."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1918
+#: lib/klass_hero_web/components/provider_components.ex:1917
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Staffing — %{title}"
 msgstr ""
@@ -7772,4 +7775,79 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:1125
 #, elixir-autogen, elixir-format
 msgid "I understand this program will have no capacity limit."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2209
+#, elixir-autogen, elixir-format
+msgid "Go back to the program's usual team"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/sessions_live.ex:282
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Lead instructor for this session updated."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2136
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Make lead instructor for this session"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2162
+#, elixir-autogen, elixir-format
+msgid "Nobody is working this session yet."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2146
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Remove from this session"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/sessions_live.ex:231
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Staff member added to this session."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/sessions_live.ex:255
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Staff member removed from this session."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2093
+#, elixir-autogen, elixir-format
+msgid "Staffed just for this session. The program's usual team does not apply here."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:107
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Staffing"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2064
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Staffing — %{date}"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/sessions_live.ex:408
+#, elixir-autogen, elixir-format
+msgid "That session could not be found."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/sessions_live.ex:239
+#, elixir-autogen, elixir-format, fuzzy
+msgid "They are already working this session."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/sessions_live.ex:263
+#, elixir-autogen, elixir-format, fuzzy
+msgid "This person leads the session. Make someone else lead before removing them."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/sessions_live.ex:298
+#, elixir-autogen, elixir-format
+msgid "This session is back on the program's usual team."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2097
+#, elixir-autogen, elixir-format
+msgid "Using the program's usual team. Adding someone staffs this session only."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/en/LC_MESSAGES/enrollment.po
@@ -11,95 +11,95 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:2622
-#: lib/klass_hero_web/components/provider_components.ex:2639
+#: lib/klass_hero_web/components/provider_components.ex:2809
+#: lib/klass_hero_web/components/provider_components.ex:2826
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2623
-#: lib/klass_hero_web/components/provider_components.ex:2640
+#: lib/klass_hero_web/components/provider_components.ex:2810
+#: lib/klass_hero_web/components/provider_components.ex:2827
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2624
-#: lib/klass_hero_web/components/provider_components.ex:2641
+#: lib/klass_hero_web/components/provider_components.ex:2811
+#: lib/klass_hero_web/components/provider_components.ex:2828
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2635
+#: lib/klass_hero_web/components/provider_components.ex:2822
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2625
+#: lib/klass_hero_web/components/provider_components.ex:2812
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2626
+#: lib/klass_hero_web/components/provider_components.ex:2813
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2627
+#: lib/klass_hero_web/components/provider_components.ex:2814
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2634
+#: lib/klass_hero_web/components/provider_components.ex:2821
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2636
+#: lib/klass_hero_web/components/provider_components.ex:2823
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2628
+#: lib/klass_hero_web/components/provider_components.ex:2815
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2630
+#: lib/klass_hero_web/components/provider_components.ex:2817
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2632
+#: lib/klass_hero_web/components/provider_components.ex:2819
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2562
+#: lib/klass_hero_web/components/provider_components.ex:2749
 #, elixir-autogen, elixir-format
 msgid "Date of birth \"%{value}\" is not a valid date. Please correct it and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2556
+#: lib/klass_hero_web/components/provider_components.ex:2743
 #, elixir-autogen, elixir-format
 msgid "Invite link could not be generated (no token). Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2570
+#: lib/klass_hero_web/components/provider_components.ex:2757
 #, elixir-autogen, elixir-format
 msgid "The invitation email could not be delivered. Please check the address and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2559
+#: lib/klass_hero_web/components/provider_components.ex:2746
 #, elixir-autogen, elixir-format
 msgid "The program is full, so this child could not be enrolled."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2573
+#: lib/klass_hero_web/components/provider_components.ex:2760
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed and no retries remain. Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2582
+#: lib/klass_hero_web/components/provider_components.ex:2769
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed. Please resend."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/en/LC_MESSAGES/enrollment.po
@@ -11,95 +11,95 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:2809
-#: lib/klass_hero_web/components/provider_components.ex:2826
+#: lib/klass_hero_web/components/provider_components.ex:2863
+#: lib/klass_hero_web/components/provider_components.ex:2880
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2810
-#: lib/klass_hero_web/components/provider_components.ex:2827
+#: lib/klass_hero_web/components/provider_components.ex:2864
+#: lib/klass_hero_web/components/provider_components.ex:2881
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2811
-#: lib/klass_hero_web/components/provider_components.ex:2828
+#: lib/klass_hero_web/components/provider_components.ex:2865
+#: lib/klass_hero_web/components/provider_components.ex:2882
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2822
+#: lib/klass_hero_web/components/provider_components.ex:2876
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2812
+#: lib/klass_hero_web/components/provider_components.ex:2866
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2813
+#: lib/klass_hero_web/components/provider_components.ex:2867
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2814
+#: lib/klass_hero_web/components/provider_components.ex:2868
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2821
+#: lib/klass_hero_web/components/provider_components.ex:2875
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2823
+#: lib/klass_hero_web/components/provider_components.ex:2877
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2815
+#: lib/klass_hero_web/components/provider_components.ex:2869
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2817
+#: lib/klass_hero_web/components/provider_components.ex:2871
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2819
+#: lib/klass_hero_web/components/provider_components.ex:2873
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2749
+#: lib/klass_hero_web/components/provider_components.ex:2803
 #, elixir-autogen, elixir-format
 msgid "Date of birth \"%{value}\" is not a valid date. Please correct it and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2743
+#: lib/klass_hero_web/components/provider_components.ex:2797
 #, elixir-autogen, elixir-format
 msgid "Invite link could not be generated (no token). Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2757
+#: lib/klass_hero_web/components/provider_components.ex:2811
 #, elixir-autogen, elixir-format
 msgid "The invitation email could not be delivered. Please check the address and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2746
+#: lib/klass_hero_web/components/provider_components.ex:2800
 #, elixir-autogen, elixir-format
 msgid "The program is full, so this child could not be enrolled."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2760
+#: lib/klass_hero_web/components/provider_components.ex:2814
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed and no retries remain. Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2769
+#: lib/klass_hero_web/components/provider_components.ex:2823
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed. Please resend."
 msgstr ""

--- a/priv/gettext/enrollment.pot
+++ b/priv/gettext/enrollment.pot
@@ -11,95 +11,95 @@
 msgid ""
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2809
-#: lib/klass_hero_web/components/provider_components.ex:2826
+#: lib/klass_hero_web/components/provider_components.ex:2863
+#: lib/klass_hero_web/components/provider_components.ex:2880
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2810
-#: lib/klass_hero_web/components/provider_components.ex:2827
+#: lib/klass_hero_web/components/provider_components.ex:2864
+#: lib/klass_hero_web/components/provider_components.ex:2881
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2811
-#: lib/klass_hero_web/components/provider_components.ex:2828
+#: lib/klass_hero_web/components/provider_components.ex:2865
+#: lib/klass_hero_web/components/provider_components.ex:2882
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2822
+#: lib/klass_hero_web/components/provider_components.ex:2876
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2812
+#: lib/klass_hero_web/components/provider_components.ex:2866
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2813
+#: lib/klass_hero_web/components/provider_components.ex:2867
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2814
+#: lib/klass_hero_web/components/provider_components.ex:2868
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2821
+#: lib/klass_hero_web/components/provider_components.ex:2875
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2823
+#: lib/klass_hero_web/components/provider_components.ex:2877
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2815
+#: lib/klass_hero_web/components/provider_components.ex:2869
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2817
+#: lib/klass_hero_web/components/provider_components.ex:2871
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2819
+#: lib/klass_hero_web/components/provider_components.ex:2873
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2749
+#: lib/klass_hero_web/components/provider_components.ex:2803
 #, elixir-autogen, elixir-format
 msgid "Date of birth \"%{value}\" is not a valid date. Please correct it and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2743
+#: lib/klass_hero_web/components/provider_components.ex:2797
 #, elixir-autogen, elixir-format
 msgid "Invite link could not be generated (no token). Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2757
+#: lib/klass_hero_web/components/provider_components.ex:2811
 #, elixir-autogen, elixir-format
 msgid "The invitation email could not be delivered. Please check the address and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2746
+#: lib/klass_hero_web/components/provider_components.ex:2800
 #, elixir-autogen, elixir-format
 msgid "The program is full, so this child could not be enrolled."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2760
+#: lib/klass_hero_web/components/provider_components.ex:2814
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed and no retries remain. Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2769
+#: lib/klass_hero_web/components/provider_components.ex:2823
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed. Please resend."
 msgstr ""

--- a/priv/gettext/enrollment.pot
+++ b/priv/gettext/enrollment.pot
@@ -11,95 +11,95 @@
 msgid ""
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2622
-#: lib/klass_hero_web/components/provider_components.ex:2639
+#: lib/klass_hero_web/components/provider_components.ex:2809
+#: lib/klass_hero_web/components/provider_components.ex:2826
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2623
-#: lib/klass_hero_web/components/provider_components.ex:2640
+#: lib/klass_hero_web/components/provider_components.ex:2810
+#: lib/klass_hero_web/components/provider_components.ex:2827
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2624
-#: lib/klass_hero_web/components/provider_components.ex:2641
+#: lib/klass_hero_web/components/provider_components.ex:2811
+#: lib/klass_hero_web/components/provider_components.ex:2828
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2635
+#: lib/klass_hero_web/components/provider_components.ex:2822
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2625
+#: lib/klass_hero_web/components/provider_components.ex:2812
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2626
+#: lib/klass_hero_web/components/provider_components.ex:2813
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2627
+#: lib/klass_hero_web/components/provider_components.ex:2814
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2634
+#: lib/klass_hero_web/components/provider_components.ex:2821
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2636
+#: lib/klass_hero_web/components/provider_components.ex:2823
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2628
+#: lib/klass_hero_web/components/provider_components.ex:2815
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2630
+#: lib/klass_hero_web/components/provider_components.ex:2817
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2632
+#: lib/klass_hero_web/components/provider_components.ex:2819
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2562
+#: lib/klass_hero_web/components/provider_components.ex:2749
 #, elixir-autogen, elixir-format
 msgid "Date of birth \"%{value}\" is not a valid date. Please correct it and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2556
+#: lib/klass_hero_web/components/provider_components.ex:2743
 #, elixir-autogen, elixir-format
 msgid "Invite link could not be generated (no token). Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2570
+#: lib/klass_hero_web/components/provider_components.ex:2757
 #, elixir-autogen, elixir-format
 msgid "The invitation email could not be delivered. Please check the address and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2559
+#: lib/klass_hero_web/components/provider_components.ex:2746
 #, elixir-autogen, elixir-format
 msgid "The program is full, so this child could not be enrolled."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2573
+#: lib/klass_hero_web/components/provider_components.ex:2760
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed and no retries remain. Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2582
+#: lib/klass_hero_web/components/provider_components.ex:2769
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed. Please resend."
 msgstr ""

--- a/priv/repo/migrations/20260819072932_create_session_staff_assignments.exs
+++ b/priv/repo/migrations/20260819072932_create_session_staff_assignments.exs
@@ -1,0 +1,42 @@
+defmodule KlassHero.Repo.Migrations.CreateSessionStaffAssignments do
+  use Ecto.Migration
+
+  def change do
+    create table(:session_staff_assignments, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+
+      add :provider_id, references(:providers, type: :binary_id, on_delete: :delete_all),
+        null: false
+
+      add :session_id, references(:program_sessions, type: :binary_id, on_delete: :delete_all),
+        null: false
+
+      add :staff_member_id, references(:staff_members, type: :binary_id, on_delete: :delete_all),
+        null: false
+
+      # Who made the override, for the audit trail. Nilified rather than cascading:
+      # the assignment outlives the account that created it.
+      add :assigned_by_user_id, references(:users, type: :binary_id, on_delete: :nilify_all)
+
+      add :assigned_at, :utc_datetime_usec, null: false
+      add :unassigned_at, :utc_datetime_usec
+      add :is_lead_instructor, :boolean, null: false, default: false
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create index(:session_staff_assignments, [:provider_id])
+    create index(:session_staff_assignments, [:session_id])
+    create index(:session_staff_assignments, [:staff_member_id])
+
+    create unique_index(:session_staff_assignments, [:session_id, :staff_member_id],
+             where: "unassigned_at IS NULL",
+             name: :session_staff_assignments_active_unique
+           )
+
+    create unique_index(:session_staff_assignments, [:session_id],
+             where: "is_lead_instructor AND unassigned_at IS NULL",
+             name: :session_staff_assignments_single_lead
+           )
+  end
+end

--- a/test/klass_hero/provider/adapters/driven/projections/provider_session_details_session_staff_test.exs
+++ b/test/klass_hero/provider/adapters/driven/projections/provider_session_details_session_staff_test.exs
@@ -72,6 +72,21 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetailsS
     staff_member
   end
 
+  # The real substitution flow. Adding someone materializes the program roster, so
+  # taking the regular off is a second, separate act — and it takes both for a
+  # session to be genuinely staffed by the substitute alone.
+  defp substitute!(ctx, substitute, regular) do
+    override!(ctx, substitute)
+
+    {:ok, retired} = Provider.unassign_staff_from_session(ctx.session.id, regular.id, ctx.provider.id)
+
+    retired
+    |> ProviderEvents.staff_unassigned_from_session(regular, ctx.program.id)
+    |> ProviderSessionDetails.project()
+
+    substitute
+  end
+
   defp seed_session_row!(ctx) do
     ProviderSessionDetails.project(
       Event.new(:session_created, :participation, :session, ctx.session.id, %{
@@ -90,21 +105,34 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetailsS
   end
 
   describe "staff_assigned_to_session" do
-    test "attributes the session to the override, not the program roster", ctx do
+    test "keeps naming the program's earliest active member when someone is added", ctx do
       regular = ctx |> staff("Ana") |> then(&on_program!(ctx, &1))
       seed_session_row!(ctx)
       assert attribution(ctx.session.id) == {regular.id, "Ana Stone"}
 
-      substitute = ctx |> staff("Bea") |> then(&override!(ctx, &1))
+      _extra = ctx |> staff("Bea") |> then(&override!(ctx, &1))
+
+      # Adding is additive: the program roster is copied across and Bea appended,
+      # so Ana still wins on earliest-assigned. Materializing with fresh
+      # timestamps would reorder the roster and rename the card for no reason the
+      # provider can see.
+      assert attribution(ctx.session.id) == {regular.id, "Ana Stone"}
+    end
+
+    test "attributes the session to the substitute once the regular is taken off", ctx do
+      regular = ctx |> staff("Ana") |> then(&on_program!(ctx, &1))
+      seed_session_row!(ctx)
+
+      substitute = ctx |> staff("Bea") |> then(&substitute!(ctx, &1, regular))
 
       assert attribution(ctx.session.id) == {substitute.id, "Bea Stone"}
     end
 
     test "blanks the attribution when the only override holder is deactivated", ctx do
-      _regular = ctx |> staff("Ana") |> then(&on_program!(ctx, &1))
+      regular = ctx |> staff("Ana") |> then(&on_program!(ctx, &1))
       seed_session_row!(ctx)
 
-      substitute = ctx |> staff("Bea") |> then(&override!(ctx, &1))
+      substitute = ctx |> staff("Bea") |> then(&substitute!(ctx, &1, regular))
       {:ok, _} = Provider.deactivate_staff_member(substitute)
 
       substitute
@@ -118,26 +146,28 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetailsS
   end
 
   describe "staff_unassigned_from_session" do
-    test "returns the session to the program roster when the last override goes", ctx do
+    test "re-attributes to whoever is left when someone is taken off", ctx do
       regular = ctx |> staff("Ana") |> then(&on_program!(ctx, &1))
       seed_session_row!(ctx)
-      substitute = ctx |> staff("Bea") |> then(&override!(ctx, &1))
+      extra = ctx |> staff("Bea") |> then(&override!(ctx, &1))
 
-      {:ok, retired} = Provider.unassign_staff_from_session(ctx.session.id, substitute.id, ctx.provider.id)
+      {:ok, retired} = Provider.unassign_staff_from_session(ctx.session.id, extra.id, ctx.provider.id)
 
       retired
-      |> ProviderEvents.staff_unassigned_from_session(substitute, ctx.program.id)
+      |> ProviderEvents.staff_unassigned_from_session(extra, ctx.program.id)
       |> ProviderSessionDetails.project()
 
+      # The session stays overridden — Ana's materialized row survives the removal —
+      # and she is who it names either way.
       assert attribution(ctx.session.id) == {regular.id, "Ana Stone"}
     end
   end
 
   describe "program-level changes do not clobber an overridden session" do
     test "assigning someone to the program leaves the override standing", ctx do
-      _regular = ctx |> staff("Ana") |> then(&on_program!(ctx, &1))
+      regular = ctx |> staff("Ana") |> then(&on_program!(ctx, &1))
       seed_session_row!(ctx)
-      substitute = ctx |> staff("Bea") |> then(&override!(ctx, &1))
+      substitute = ctx |> staff("Bea") |> then(&substitute!(ctx, &1, regular))
 
       newcomer = ctx |> staff("Cal") |> then(&on_program!(ctx, &1))
 
@@ -172,9 +202,9 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetailsS
 
   describe "bootstrap agrees with the incremental path (#1299)" do
     test "rebuild reproduces the override attribution", ctx do
-      _regular = ctx |> staff("Ana") |> then(&on_program!(ctx, &1))
+      regular = ctx |> staff("Ana") |> then(&on_program!(ctx, &1))
       seed_session_row!(ctx)
-      substitute = ctx |> staff("Bea") |> then(&override!(ctx, &1))
+      substitute = ctx |> staff("Bea") |> then(&substitute!(ctx, &1, regular))
 
       live = attribution(ctx.session.id)
 
@@ -186,6 +216,29 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetailsS
 
       assert attribution(ctx.session.id) == live
       assert attribution(ctx.session.id) == {substitute.id, "Bea Stone"}
+    end
+
+    test "rebuild reproduces the attribution of a materialized roster", ctx do
+      # The pairing that matters most for materialization: the live path picks the
+      # earliest active member in Elixir, bootstrap does it in SQL with
+      # ORDER BY assigned_at ASC LIMIT 1. Copies carry the program assignment's own
+      # timestamp precisely so both land on the same person.
+      regular = ctx |> staff("Ana") |> then(&on_program!(ctx, &1))
+      seed_session_row!(ctx)
+      _extra = ctx |> staff("Bea") |> then(&override!(ctx, &1))
+
+      live = attribution(ctx.session.id)
+
+      start_supervised!(
+        Supervisor.child_spec({ProviderSessionDetails, name: :session_staff_bootstrap_materialized},
+          id: :session_staff_bootstrap_materialized
+        )
+      )
+
+      :ok = ProviderSessionDetails.rebuild(:session_staff_bootstrap_materialized)
+
+      assert attribution(ctx.session.id) == live
+      assert attribution(ctx.session.id) == {regular.id, "Ana Stone"}
     end
 
     test "rebuild reproduces the program fallback for an un-overridden session", ctx do
@@ -204,9 +257,9 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetailsS
     end
 
     test "rebuild blanks an override whose only holder is deactivated", ctx do
-      _regular = ctx |> staff("Ana") |> then(&on_program!(ctx, &1))
+      regular = ctx |> staff("Ana") |> then(&on_program!(ctx, &1))
       seed_session_row!(ctx)
-      substitute = ctx |> staff("Bea") |> then(&override!(ctx, &1))
+      substitute = ctx |> staff("Bea") |> then(&substitute!(ctx, &1, regular))
       {:ok, _} = Provider.deactivate_staff_member(substitute)
 
       start_supervised!(
@@ -223,8 +276,8 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetailsS
     test "rebuild keeps a retired override out of the attribution", ctx do
       regular = ctx |> staff("Ana") |> then(&on_program!(ctx, &1))
       seed_session_row!(ctx)
-      substitute = ctx |> staff("Bea") |> then(&override!(ctx, &1))
-      {:ok, _} = Provider.unassign_staff_from_session(ctx.session.id, substitute.id, ctx.provider.id)
+      extra = ctx |> staff("Bea") |> then(&override!(ctx, &1))
+      {:ok, _} = Provider.unassign_staff_from_session(ctx.session.id, extra.id, ctx.provider.id)
 
       start_supervised!(
         Supervisor.child_spec({ProviderSessionDetails, name: :session_staff_bootstrap_retired},

--- a/test/klass_hero/provider/adapters/driven/projections/provider_session_details_session_staff_test.exs
+++ b/test/klass_hero/provider/adapters/driven/projections/provider_session_details_session_staff_test.exs
@@ -1,0 +1,240 @@
+defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetailsSessionStaffTest do
+  @moduledoc """
+  Session-level staffing in `provider_session_details` (#782).
+
+  Its own file rather than another describe block in
+  `provider_session_details_test.exs`: every test here needs real
+  `program_sessions` rows (the resolver reads sessions through Participation's
+  facade), whereas that file's helpers fabricate read-table rows with invented
+  `session_id`s.
+
+  The pairing that matters is with the bootstrap tests below the live ones — the
+  #1299 guard. A rule that the incremental path applies and a rebuild does not
+  makes the same session read differently before and after a restart.
+  """
+
+  use KlassHero.DataCase, async: false
+
+  import KlassHero.Factory
+
+  alias KlassHero.Provider
+  alias KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetails
+  alias KlassHero.Provider.Domain.Events.ProviderEvents
+  alias KlassHero.Provider.ProgramStaffAssignment
+  alias KlassHero.Provider.SessionDetail
+  alias KlassHero.Provider.StaffMember
+  alias KlassHero.Repo
+  alias KlassHero.Shared.Domain.Events.Event
+
+  @test_server_name :test_provider_session_details_session_staff
+
+  setup do
+    start_supervised!({ProviderSessionDetails, name: @test_server_name})
+    :sys.get_state(@test_server_name)
+
+    provider = insert(:provider_profile_schema)
+    program = insert(:program_schema, provider_id: provider.id, title: "Judo")
+    session = insert(:program_session_schema, program_id: program.id)
+
+    {:ok, provider: provider, program: program, session: session}
+  end
+
+  defp staff(ctx, first_name) do
+    insert(:staff_member_schema, provider_id: ctx.provider.id, first_name: first_name, last_name: "Stone")
+  end
+
+  defp on_program!(ctx, staff_member) do
+    {:ok, _} =
+      Provider.assign_staff_to_program(%{
+        provider_id: ctx.provider.id,
+        program_id: ctx.program.id,
+        staff_member_id: staff_member.id
+      })
+
+    staff_member
+  end
+
+  # Built through the real command + the real ProviderEvents constructor: this is
+  # the only place a producer is paired with this consumer, and a hand-rolled
+  # payload would hide drift between them (#1216).
+  defp override!(ctx, staff_member) do
+    {:ok, assignment} =
+      Provider.assign_staff_to_session(%{
+        provider_id: ctx.provider.id,
+        session_id: ctx.session.id,
+        staff_member_id: staff_member.id
+      })
+
+    assignment
+    |> ProviderEvents.staff_assigned_to_session(staff_member, ctx.program.id)
+    |> ProviderSessionDetails.project()
+
+    staff_member
+  end
+
+  defp seed_session_row!(ctx) do
+    ProviderSessionDetails.project(
+      Event.new(:session_created, :participation, :session, ctx.session.id, %{
+        session_id: ctx.session.id,
+        program_id: ctx.program.id,
+        session_date: ctx.session.session_date,
+        start_time: ctx.session.start_time,
+        end_time: ctx.session.end_time
+      })
+    )
+  end
+
+  defp attribution(session_id) do
+    row = Repo.get(SessionDetail, session_id)
+    {row.current_assigned_staff_id, row.current_assigned_staff_name}
+  end
+
+  describe "staff_assigned_to_session" do
+    test "attributes the session to the override, not the program roster", ctx do
+      regular = ctx |> staff("Ana") |> then(&on_program!(ctx, &1))
+      seed_session_row!(ctx)
+      assert attribution(ctx.session.id) == {regular.id, "Ana Stone"}
+
+      substitute = ctx |> staff("Bea") |> then(&override!(ctx, &1))
+
+      assert attribution(ctx.session.id) == {substitute.id, "Bea Stone"}
+    end
+
+    test "blanks the attribution when the only override holder is deactivated", ctx do
+      _regular = ctx |> staff("Ana") |> then(&on_program!(ctx, &1))
+      seed_session_row!(ctx)
+
+      substitute = ctx |> staff("Bea") |> then(&override!(ctx, &1))
+      {:ok, _} = Provider.deactivate_staff_member(substitute)
+
+      substitute
+      |> ProviderEvents.staff_member_deactivated()
+      |> ProviderSessionDetails.project()
+
+      # Not "Ana": the session is still overridden, just overridden to nobody.
+      # Falling back would resurrect staff the provider took off this day.
+      assert attribution(ctx.session.id) == {nil, nil}
+    end
+  end
+
+  describe "staff_unassigned_from_session" do
+    test "returns the session to the program roster when the last override goes", ctx do
+      regular = ctx |> staff("Ana") |> then(&on_program!(ctx, &1))
+      seed_session_row!(ctx)
+      substitute = ctx |> staff("Bea") |> then(&override!(ctx, &1))
+
+      {:ok, retired} = Provider.unassign_staff_from_session(ctx.session.id, substitute.id, ctx.provider.id)
+
+      retired
+      |> ProviderEvents.staff_unassigned_from_session(substitute, ctx.program.id)
+      |> ProviderSessionDetails.project()
+
+      assert attribution(ctx.session.id) == {regular.id, "Ana Stone"}
+    end
+  end
+
+  describe "program-level changes do not clobber an overridden session" do
+    test "assigning someone to the program leaves the override standing", ctx do
+      _regular = ctx |> staff("Ana") |> then(&on_program!(ctx, &1))
+      seed_session_row!(ctx)
+      substitute = ctx |> staff("Bea") |> then(&override!(ctx, &1))
+
+      newcomer = ctx |> staff("Cal") |> then(&on_program!(ctx, &1))
+
+      %ProgramStaffAssignment{
+        provider_id: ctx.provider.id,
+        program_id: ctx.program.id,
+        staff_member_id: newcomer.id
+      }
+      |> ProviderEvents.staff_assigned_to_program(newcomer)
+      |> ProviderSessionDetails.project()
+
+      # A deliberate substitution outranks a program-roster change. Without this
+      # guard the program event would re-attribute every :scheduled session,
+      # silently undoing the override.
+      assert attribution(ctx.session.id) == {substitute.id, "Bea Stone"}
+    end
+
+    test "an un-overridden sibling session still follows the program", ctx do
+      regular = ctx |> staff("Ana") |> then(&on_program!(ctx, &1))
+
+      sibling =
+        insert(:program_session_schema, program_id: ctx.program.id, session_date: Date.add(Date.utc_today(), 7))
+
+      seed_session_row!(ctx)
+      seed_session_row!(%{ctx | session: sibling})
+
+      _substitute = ctx |> staff("Bea") |> then(&override!(ctx, &1))
+
+      assert attribution(sibling.id) == {regular.id, "Ana Stone"}
+    end
+  end
+
+  describe "bootstrap agrees with the incremental path (#1299)" do
+    test "rebuild reproduces the override attribution", ctx do
+      _regular = ctx |> staff("Ana") |> then(&on_program!(ctx, &1))
+      seed_session_row!(ctx)
+      substitute = ctx |> staff("Bea") |> then(&override!(ctx, &1))
+
+      live = attribution(ctx.session.id)
+
+      start_supervised!(
+        Supervisor.child_spec({ProviderSessionDetails, name: :session_staff_bootstrap}, id: :session_staff_bootstrap)
+      )
+
+      :ok = ProviderSessionDetails.rebuild(:session_staff_bootstrap)
+
+      assert attribution(ctx.session.id) == live
+      assert attribution(ctx.session.id) == {substitute.id, "Bea Stone"}
+    end
+
+    test "rebuild reproduces the program fallback for an un-overridden session", ctx do
+      regular = ctx |> staff("Ana") |> then(&on_program!(ctx, &1))
+      seed_session_row!(ctx)
+
+      start_supervised!(
+        Supervisor.child_spec({ProviderSessionDetails, name: :session_staff_bootstrap_program},
+          id: :session_staff_bootstrap_program
+        )
+      )
+
+      :ok = ProviderSessionDetails.rebuild(:session_staff_bootstrap_program)
+
+      assert attribution(ctx.session.id) == {regular.id, StaffMember.full_name(regular)}
+    end
+
+    test "rebuild blanks an override whose only holder is deactivated", ctx do
+      _regular = ctx |> staff("Ana") |> then(&on_program!(ctx, &1))
+      seed_session_row!(ctx)
+      substitute = ctx |> staff("Bea") |> then(&override!(ctx, &1))
+      {:ok, _} = Provider.deactivate_staff_member(substitute)
+
+      start_supervised!(
+        Supervisor.child_spec({ProviderSessionDetails, name: :session_staff_bootstrap_deactivated},
+          id: :session_staff_bootstrap_deactivated
+        )
+      )
+
+      :ok = ProviderSessionDetails.rebuild(:session_staff_bootstrap_deactivated)
+
+      assert attribution(ctx.session.id) == {nil, nil}
+    end
+
+    test "rebuild keeps a retired override out of the attribution", ctx do
+      regular = ctx |> staff("Ana") |> then(&on_program!(ctx, &1))
+      seed_session_row!(ctx)
+      substitute = ctx |> staff("Bea") |> then(&override!(ctx, &1))
+      {:ok, _} = Provider.unassign_staff_from_session(ctx.session.id, substitute.id, ctx.provider.id)
+
+      start_supervised!(
+        Supervisor.child_spec({ProviderSessionDetails, name: :session_staff_bootstrap_retired},
+          id: :session_staff_bootstrap_retired
+        )
+      )
+
+      :ok = ProviderSessionDetails.rebuild(:session_staff_bootstrap_retired)
+
+      assert attribution(ctx.session.id) == {regular.id, "Ana Stone"}
+    end
+  end
+end

--- a/test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs
+++ b/test/klass_hero/provider/adapters/driven/projections/provider_session_details_test.exs
@@ -141,8 +141,8 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetailsT
 
     test "duplicate delivery preserves evolved state written by other handlers" do
       # session_created must be a no-op on duplicate (at-least-once) delivery — it
-      # must NOT stomp status/counts/cover_staff_* that other handlers evolved
-      # between deliveries.
+      # must NOT stomp the status/counts that other handlers evolved between
+      # deliveries.
       provider = insert(:provider_profile_schema)
       program = insert(:program_schema, provider_id: provider.id, title: "Aikido")
       session_id = Ecto.UUID.generate()
@@ -158,17 +158,9 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetailsT
       broadcast(:session_created, session_id, payload)
 
       # Simulate evolved state written by other handlers between deliveries.
-      cover_staff_id = Ecto.UUID.generate()
-
       Repo.update_all(
         from(d in SessionDetail, where: d.session_id == ^session_id),
-        set: [
-          status: :in_progress,
-          checked_in_count: 5,
-          total_count: 10,
-          cover_staff_id: cover_staff_id,
-          cover_staff_name: "Cover Person"
-        ]
+        set: [status: :in_progress, checked_in_count: 5, total_count: 10]
       )
 
       # Replay the same event.
@@ -180,8 +172,6 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetailsT
       assert row.status == :in_progress
       assert row.checked_in_count == 5
       assert row.total_count == 10
-      assert row.cover_staff_id == cover_staff_id
-      assert row.cover_staff_name == "Cover Person"
     end
 
     test "skips the insert and warns when the program does not exist" do
@@ -460,8 +450,13 @@ defmodule KlassHero.Provider.Adapters.Driven.Projections.ProviderSessionDetailsT
     provider = insert(:provider_profile_schema)
     program = insert(:program_schema, provider_id: provider.id)
 
-    scheduled_session_id = Ecto.UUID.generate()
-    completed_session_id = Ecto.UUID.generate()
+    # Real `program_sessions` rows, not invented ids: attribution is now resolved
+    # per session (#782), and the resolver reads the session through Participation's
+    # facade to find its program. A fabricated id resolves to nothing.
+    scheduled_session_id = insert(:program_session_schema, program_id: program.id).id
+
+    completed_session_id =
+      insert(:program_session_schema, program_id: program.id, session_date: Date.add(Date.utc_today(), 30)).id
 
     for {id, status} <- [{scheduled_session_id, :scheduled}, {completed_session_id, :completed}] do
       insert_program_session(

--- a/test/klass_hero/provider/assignments/assign_staff_to_session_test.exs
+++ b/test/klass_hero/provider/assignments/assign_staff_to_session_test.exs
@@ -4,6 +4,7 @@ defmodule KlassHero.Provider.Assignments.AssignStaffToSessionTest do
   import KlassHero.Factory
 
   alias KlassHero.Provider
+  alias KlassHero.Provider.Assignments
   alias KlassHero.Provider.SessionStaffAssignment
 
   defp setup_session do
@@ -61,7 +62,10 @@ defmodule KlassHero.Provider.Assignments.AssignStaffToSessionTest do
 
     test "allows re-assignment after the first override was retired" do
       ctx = setup_session()
+      other = insert(:staff_member_schema, provider_id: ctx.provider.id)
       {:ok, _first} = assign(ctx)
+      # Someone has to stay: removing the session's only member is refused.
+      {:ok, _} = assign(ctx, other.id)
       {:ok, _retired} = Provider.unassign_staff_from_session(ctx.session.id, ctx.staff.id, ctx.provider.id)
 
       assert {:ok, _second} = assign(ctx)
@@ -92,6 +96,83 @@ defmodule KlassHero.Provider.Assignments.AssignStaffToSessionTest do
                  session_id: Ecto.UUID.generate(),
                  staff_member_id: ctx.staff.id
                })
+    end
+  end
+
+  describe "assign_staff_to_session/1 on a session that still inherits" do
+    defp on_program!(ctx, staff_member) do
+      {:ok, _} =
+        Provider.assign_staff_to_program(%{
+          provider_id: ctx.provider.id,
+          program_id: ctx.program.id,
+          staff_member_id: staff_member.id
+        })
+
+      staff_member
+    end
+
+    defp regular_staff(ctx, count) do
+      for _ <- 1..count do
+        ctx |> then(&insert(:staff_member_schema, provider_id: &1.provider.id)) |> then(&on_program!(ctx, &1))
+      end
+    end
+
+    test "copies the program roster across and appends, rather than replacing it" do
+      ctx = setup_session()
+      regulars = regular_staff(ctx, 3)
+
+      assert {:ok, _} = assign(ctx)
+
+      staffing = Provider.get_session_staffing(ctx.session.id)
+
+      assert staffing.source == :override
+      assert staffing.member_count == 4
+      assert Enum.sort(staffing.member_ids) == Enum.sort([ctx.staff.id | Enum.map(regulars, & &1.id)])
+    end
+
+    test "keeps naming the same person on the session card" do
+      ctx = setup_session()
+      [first | _] = regular_staff(ctx, 3)
+
+      before = Assignments.get_session_attribution(ctx.session.id)
+      assert before.staff_id == first.id
+
+      assert {:ok, _} = assign(ctx)
+
+      # Materialized rows share a wall-clock instant, so without the per-row
+      # stagger the earliest-active winner would be arbitrary and the card would
+      # rename itself for no reason the provider can see.
+      assert Assignments.get_session_attribution(ctx.session.id) == before
+    end
+
+    test "carries the program lead across, so the session is not left lead-less" do
+      ctx = setup_session()
+      [lead | _] = regular_staff(ctx, 2)
+      {:ok, _} = Provider.set_lead_instructor(ctx.program.id, lead.id, ctx.provider.id)
+
+      assert {:ok, _} = assign(ctx)
+
+      assert %{lead: %{id: lead_id}} = Provider.get_session_staffing(ctx.session.id)
+      assert lead_id == lead.id
+    end
+
+    test "leaves the program's other sessions inheriting" do
+      ctx = setup_session()
+      regular_staff(ctx, 2)
+
+      sibling =
+        insert(:program_session_schema, program_id: ctx.program.id, session_date: Date.add(Date.utc_today(), 7))
+
+      assert {:ok, _} = assign(ctx)
+
+      assert Provider.get_session_staffing(sibling.id).source == :program
+    end
+
+    test "is already_assigned for someone the session already shows via the program" do
+      ctx = setup_session()
+      [regular | _] = regular_staff(ctx, 2)
+
+      assert {:error, :already_assigned} = assign(ctx, regular.id)
     end
   end
 end

--- a/test/klass_hero/provider/assignments/assign_staff_to_session_test.exs
+++ b/test/klass_hero/provider/assignments/assign_staff_to_session_test.exs
@@ -1,0 +1,97 @@
+defmodule KlassHero.Provider.Assignments.AssignStaffToSessionTest do
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+
+  alias KlassHero.Provider
+  alias KlassHero.Provider.SessionStaffAssignment
+
+  defp setup_session do
+    provider = insert(:provider_profile_schema)
+    program = insert(:program_schema, provider_id: provider.id)
+    session = insert(:program_session_schema, program_id: program.id)
+    staff = insert(:staff_member_schema, provider_id: provider.id)
+
+    %{provider: provider, program: program, session: session, staff: staff}
+  end
+
+  defp assign(ctx, staff_member_id \\ nil) do
+    Provider.assign_staff_to_session(%{
+      provider_id: ctx.provider.id,
+      session_id: ctx.session.id,
+      staff_member_id: staff_member_id || ctx.staff.id
+    })
+  end
+
+  describe "assign_staff_to_session/1" do
+    test "creates an override carrying the session, staff member and provider" do
+      ctx = setup_session()
+
+      assert {:ok, %SessionStaffAssignment{} = assignment} = assign(ctx)
+
+      assert assignment.provider_id == ctx.provider.id
+      assert assignment.session_id == ctx.session.id
+      assert assignment.staff_member_id == ctx.staff.id
+      assert %DateTime{} = assignment.assigned_at
+      assert is_nil(assignment.unassigned_at)
+      refute assignment.is_lead_instructor
+    end
+
+    test "records who made the override when a user is supplied" do
+      ctx = setup_session()
+      user = KlassHero.AccountsFixtures.user_fixture()
+
+      assert {:ok, assignment} =
+               Provider.assign_staff_to_session(%{
+                 provider_id: ctx.provider.id,
+                 session_id: ctx.session.id,
+                 staff_member_id: ctx.staff.id,
+                 assigned_by_user_id: user.id
+               })
+
+      assert assignment.assigned_by_user_id == user.id
+    end
+
+    test "refuses a second active assignment of the same staff member" do
+      ctx = setup_session()
+      {:ok, _first} = assign(ctx)
+
+      assert {:error, :already_assigned} = assign(ctx)
+    end
+
+    test "allows re-assignment after the first override was retired" do
+      ctx = setup_session()
+      {:ok, _first} = assign(ctx)
+      {:ok, _retired} = Provider.unassign_staff_from_session(ctx.session.id, ctx.staff.id, ctx.provider.id)
+
+      assert {:ok, _second} = assign(ctx)
+    end
+
+    test "a session may carry several overrides — that is what splitting a schedule means" do
+      ctx = setup_session()
+      other = insert(:staff_member_schema, provider_id: ctx.provider.id)
+
+      assert {:ok, _} = assign(ctx)
+      assert {:ok, _} = assign(ctx, other.id)
+    end
+
+    # Cross-tenant rejection is asserted module-wide in ownership_guard_test.exs.
+    test "a deactivated staff member cannot be newly attached" do
+      ctx = setup_session()
+      {:ok, _} = Provider.deactivate_staff_member(ctx.staff)
+
+      assert {:error, :not_found} = assign(ctx)
+    end
+
+    test "an unknown session is not_found" do
+      ctx = setup_session()
+
+      assert {:error, :not_found} =
+               Provider.assign_staff_to_session(%{
+                 provider_id: ctx.provider.id,
+                 session_id: Ecto.UUID.generate(),
+                 staff_member_id: ctx.staff.id
+               })
+    end
+  end
+end

--- a/test/klass_hero/provider/assignments/get_session_staffing_test.exs
+++ b/test/klass_hero/provider/assignments/get_session_staffing_test.exs
@@ -1,0 +1,231 @@
+defmodule KlassHero.Provider.Assignments.GetSessionStaffingTest do
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+
+  alias KlassHero.Provider
+  alias KlassHero.Provider.Domain.ReadModels.SessionStaffing
+
+  setup do
+    provider = insert(:provider_profile_schema)
+    program = insert(:program_schema, provider_id: provider.id)
+    session = insert(:program_session_schema, program_id: program.id)
+
+    {:ok, provider: provider, program: program, session: session}
+  end
+
+  defp staff(ctx, opts \\ []) do
+    insert(:staff_member_schema, [provider_id: ctx.provider.id] ++ opts)
+  end
+
+  defp on_program!(ctx, staff_member) do
+    {:ok, _} =
+      Provider.assign_staff_to_program(%{
+        provider_id: ctx.provider.id,
+        program_id: ctx.program.id,
+        staff_member_id: staff_member.id
+      })
+
+    staff_member
+  end
+
+  defp on_session!(ctx, staff_member) do
+    {:ok, _} =
+      Provider.assign_staff_to_session(%{
+        provider_id: ctx.provider.id,
+        session_id: ctx.session.id,
+        staff_member_id: staff_member.id
+      })
+
+    staff_member
+  end
+
+  describe "get_session_staffing/1 with no overrides" do
+    test "inherits the program roster", ctx do
+      a = ctx |> staff() |> then(&on_program!(ctx, &1))
+      b = ctx |> staff() |> then(&on_program!(ctx, &1))
+
+      staffing = Provider.get_session_staffing(ctx.session.id)
+
+      assert staffing.source == :program
+      assert staffing.session_id == ctx.session.id
+      assert staffing.program_id == ctx.program.id
+      assert Enum.sort(staffing.member_ids) == Enum.sort([a.id, b.id])
+      assert staffing.member_count == 2
+    end
+
+    test "inherits the program lead", ctx do
+      lead = ctx |> staff() |> then(&on_program!(ctx, &1))
+      {:ok, _} = Provider.set_lead_instructor(ctx.program.id, lead.id, ctx.provider.id)
+
+      assert %SessionStaffing{lead: %{id: lead_id}} = Provider.get_session_staffing(ctx.session.id)
+      assert lead_id == lead.id
+    end
+
+    test "is the empty value when nobody staffs the program either", ctx do
+      staffing = Provider.get_session_staffing(ctx.session.id)
+
+      assert staffing.source == :program
+      assert staffing.member_ids == []
+      assert staffing.member_count == 0
+      assert staffing.lead == nil
+    end
+
+    test "skips deactivated staff, matching every other staffing read", ctx do
+      active = ctx |> staff() |> then(&on_program!(ctx, &1))
+      departed = ctx |> staff() |> then(&on_program!(ctx, &1))
+      {:ok, _} = Provider.deactivate_staff_member(departed)
+
+      assert %SessionStaffing{member_ids: [only]} = Provider.get_session_staffing(ctx.session.id)
+      assert only == active.id
+    end
+  end
+
+  describe "get_session_staffing/1 with overrides" do
+    test "replaces the program roster rather than adding to it", ctx do
+      _on_program_only = ctx |> staff() |> then(&on_program!(ctx, &1))
+      substitute = ctx |> staff() |> then(&on_session!(ctx, &1))
+
+      staffing = Provider.get_session_staffing(ctx.session.id)
+
+      assert staffing.source == :override
+      assert staffing.member_ids == [substitute.id]
+      assert staffing.member_count == 1
+    end
+
+    test "a retired override stops counting and the session falls back to the program", ctx do
+      regular = ctx |> staff() |> then(&on_program!(ctx, &1))
+      substitute = ctx |> staff() |> then(&on_session!(ctx, &1))
+
+      {:ok, _} = Provider.unassign_staff_from_session(ctx.session.id, substitute.id, ctx.provider.id)
+
+      staffing = Provider.get_session_staffing(ctx.session.id)
+
+      assert staffing.source == :program
+      assert staffing.member_ids == [regular.id]
+    end
+
+    test "a deactivated override holder does not staff the session", ctx do
+      _regular = ctx |> staff() |> then(&on_program!(ctx, &1))
+      substitute = ctx |> staff() |> then(&on_session!(ctx, &1))
+      {:ok, _} = Provider.deactivate_staff_member(substitute)
+
+      staffing = Provider.get_session_staffing(ctx.session.id)
+
+      # The override row is still there, so the session is still overridden —
+      # it is simply overridden to nobody. Falling back to the program here
+      # would resurrect staff the provider deliberately removed for this day.
+      assert staffing.source == :override
+      assert staffing.member_ids == []
+    end
+  end
+
+  describe "get_session_staffing/1 lead resolution under overrides" do
+    test "uses the session's own lead when one is flagged", ctx do
+      program_lead = ctx |> staff() |> then(&on_program!(ctx, &1))
+      {:ok, _} = Provider.set_lead_instructor(ctx.program.id, program_lead.id, ctx.provider.id)
+
+      substitute = ctx |> staff() |> then(&on_session!(ctx, &1))
+      {:ok, _} = Provider.set_session_lead_instructor(ctx.session.id, substitute.id, ctx.provider.id)
+
+      assert %SessionStaffing{lead: %{id: lead_id}} = Provider.get_session_staffing(ctx.session.id)
+      assert lead_id == substitute.id
+    end
+
+    test "inherits the program lead when they are among the override members", ctx do
+      program_lead = ctx |> staff() |> then(&on_program!(ctx, &1))
+      {:ok, _} = Provider.set_lead_instructor(ctx.program.id, program_lead.id, ctx.provider.id)
+
+      # The program lead works this session too, alongside a substitute.
+      on_session!(ctx, program_lead)
+      _substitute = ctx |> staff() |> then(&on_session!(ctx, &1))
+
+      assert %SessionStaffing{lead: %{id: lead_id}} = Provider.get_session_staffing(ctx.session.id)
+      assert lead_id == program_lead.id
+    end
+
+    test "has no lead when the program lead is not working the session", ctx do
+      program_lead = ctx |> staff() |> then(&on_program!(ctx, &1))
+      {:ok, _} = Provider.set_lead_instructor(ctx.program.id, program_lead.id, ctx.provider.id)
+
+      _substitute = ctx |> staff() |> then(&on_session!(ctx, &1))
+
+      # Naming a lead who is not there is the worse failure — the roster would
+      # claim supervision that nobody is providing.
+      assert %SessionStaffing{lead: nil} = Provider.get_session_staffing(ctx.session.id)
+    end
+  end
+
+  describe "list_session_staffing/1" do
+    test "agrees with the per-session call for every session", ctx do
+      # A different date: program_sessions is unique on (program, date, start time).
+      other_session =
+        insert(:program_session_schema, program_id: ctx.program.id, session_date: Date.add(Date.utc_today(), 7))
+
+      regular = ctx |> staff() |> then(&on_program!(ctx, &1))
+      substitute = ctx |> staff() |> then(&on_session!(ctx, &1))
+
+      batch = Provider.list_session_staffing([ctx.session.id, other_session.id])
+
+      assert batch[ctx.session.id] == Provider.get_session_staffing(ctx.session.id)
+      assert batch[other_session.id] == Provider.get_session_staffing(other_session.id)
+
+      assert batch[ctx.session.id].member_ids == [substitute.id]
+      assert batch[other_session.id].member_ids == [regular.id]
+    end
+
+    test "returns an empty map for an empty list", _ctx do
+      assert Provider.list_session_staffing([]) == %{}
+    end
+
+    test "omits unknown sessions rather than inventing them", ctx do
+      assert Provider.list_session_staffing([Ecto.UUID.generate()]) == %{}
+      assert map_size(Provider.list_session_staffing([ctx.session.id])) == 1
+    end
+  end
+
+  describe "get_session_staffing_for_provider/2" do
+    test "returns the staffing for an owned session", ctx do
+      assert {:ok, %SessionStaffing{}} =
+               Provider.get_session_staffing_for_provider(ctx.provider.id, ctx.session.id)
+    end
+
+    test "is not_found for another provider's session", ctx do
+      other_provider = insert(:provider_profile_schema)
+
+      assert {:error, :not_found} =
+               Provider.get_session_staffing_for_provider(other_provider.id, ctx.session.id)
+    end
+
+    test "is not_found for an unknown session", ctx do
+      assert {:error, :not_found} =
+               Provider.get_session_staffing_for_provider(ctx.provider.id, Ecto.UUID.generate())
+    end
+  end
+
+  describe "list_assignable_staff_for_session/2" do
+    test "offers the provider's active staff who do not already override the session", ctx do
+      already = ctx |> staff() |> then(&on_session!(ctx, &1))
+      addable = staff(ctx)
+      departed = staff(ctx)
+      {:ok, _} = Provider.deactivate_staff_member(departed)
+
+      ids = ctx.provider.id |> Provider.list_assignable_staff_for_session(ctx.session.id) |> Enum.map(& &1.id)
+
+      assert addable.id in ids
+      refute already.id in ids
+      refute departed.id in ids
+    end
+
+    test "offers staff who are on the program but not yet on this session", ctx do
+      # Being on the program is not being on the session — an override names
+      # its own people, so a program member is still addable here.
+      on_program = ctx |> staff() |> then(&on_program!(ctx, &1))
+      _substitute = ctx |> staff() |> then(&on_session!(ctx, &1))
+
+      ids = ctx.provider.id |> Provider.list_assignable_staff_for_session(ctx.session.id) |> Enum.map(& &1.id)
+
+      assert on_program.id in ids
+    end
+  end
+end

--- a/test/klass_hero/provider/assignments/get_session_staffing_test.exs
+++ b/test/klass_hero/provider/assignments/get_session_staffing_test.exs
@@ -29,13 +29,15 @@ defmodule KlassHero.Provider.Assignments.GetSessionStaffingTest do
     staff_member
   end
 
-  defp on_session!(ctx, staff_member) do
-    {:ok, _} =
-      Provider.assign_staff_to_session(%{
-        provider_id: ctx.provider.id,
-        session_id: ctx.session.id,
-        staff_member_id: staff_member.id
-      })
+  # Rows are seeded directly rather than through `assign_staff_to_session/1`,
+  # which materializes the program roster on a session's first override. That is
+  # the *command's* policy; these tests are about how the resolver reads whatever
+  # rows exist, so they place the rows themselves and keep the two separable.
+  defp on_session!(ctx, staff_member, opts \\ []) do
+    insert(
+      :session_staff_assignment_schema,
+      [provider_id: ctx.provider.id, session_id: ctx.session.id, staff_member_id: staff_member.id] ++ opts
+    )
 
     staff_member
   end
@@ -95,9 +97,8 @@ defmodule KlassHero.Provider.Assignments.GetSessionStaffingTest do
 
     test "a retired override stops counting and the session falls back to the program", ctx do
       regular = ctx |> staff() |> then(&on_program!(ctx, &1))
-      substitute = ctx |> staff() |> then(&on_session!(ctx, &1))
-
-      {:ok, _} = Provider.unassign_staff_from_session(ctx.session.id, substitute.id, ctx.provider.id)
+      substitute = staff(ctx)
+      on_session!(ctx, substitute, unassigned_at: DateTime.utc_now())
 
       staffing = Provider.get_session_staffing(ctx.session.id)
 
@@ -217,15 +218,28 @@ defmodule KlassHero.Provider.Assignments.GetSessionStaffingTest do
       refute departed.id in ids
     end
 
-    test "offers staff who are on the program but not yet on this session", ctx do
-      # Being on the program is not being on the session — an override names
-      # its own people, so a program member is still addable here.
+    test "offers a program member the session's own roster left out", ctx do
+      # Once a session names its own people, being on the program is not being on
+      # the session — so a program member the override omits is addable again.
       on_program = ctx |> staff() |> then(&on_program!(ctx, &1))
       _substitute = ctx |> staff() |> then(&on_session!(ctx, &1))
 
       ids = ctx.provider.id |> Provider.list_assignable_staff_for_session(ctx.session.id) |> Enum.map(& &1.id)
 
       assert on_program.id in ids
+    end
+
+    test "withholds the program roster from a session that still inherits it", ctx do
+      # The picker subtracts the *effective* roster. On an inherited session the
+      # program's team is already on screen, and offering to "add" them was how
+      # the panel handed out a no-op that read as a roster wipe.
+      inherited = ctx |> staff() |> then(&on_program!(ctx, &1))
+      addable = staff(ctx)
+
+      ids = ctx.provider.id |> Provider.list_assignable_staff_for_session(ctx.session.id) |> Enum.map(& &1.id)
+
+      refute inherited.id in ids
+      assert addable.id in ids
     end
   end
 end

--- a/test/klass_hero/provider/assignments/lead_instructor_test.exs
+++ b/test/klass_hero/provider/assignments/lead_instructor_test.exs
@@ -145,4 +145,61 @@ defmodule KlassHero.Provider.Assignments.LeadInstructorTest do
     |> Ecto.Changeset.change(active: false)
     |> Repo.update!()
   end
+
+  describe "set_session_lead_instructor/3 on a session that still inherits" do
+    setup do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+      session = insert(:program_session_schema, program_id: program.id)
+
+      regulars =
+        for _ <- 1..3 do
+          staff = insert(:staff_member_schema, provider_id: provider.id)
+
+          {:ok, _} =
+            Provider.assign_staff_to_program(%{
+              provider_id: provider.id,
+              program_id: program.id,
+              staff_member_id: staff.id
+            })
+
+          staff
+        end
+
+      {:ok, provider: provider, program: program, session: session, regulars: regulars}
+    end
+
+    test "materializes the roster and flags the target, keeping everyone", ctx do
+      [_, promoted, _] = ctx.regulars
+
+      assert {:ok, _} = Provider.set_session_lead_instructor(ctx.session.id, promoted.id, ctx.provider.id)
+
+      staffing = Provider.get_session_staffing(ctx.session.id)
+
+      # Used to be {:error, :not_found}: creating a lone override row would have
+      # discarded the other two. Materializing first removes that hazard, so the
+      # promotion no longer has to be refused.
+      assert staffing.source == :override
+      assert Enum.sort(staffing.member_ids) == Enum.sort(Enum.map(ctx.regulars, & &1.id))
+      assert staffing.lead.id == promoted.id
+    end
+
+    test "steps the copied program lead down rather than leaving two", ctx do
+      [old_lead, new_lead, _] = ctx.regulars
+      {:ok, _} = Provider.set_lead_instructor(ctx.program.id, old_lead.id, ctx.provider.id)
+
+      assert {:ok, _} = Provider.set_session_lead_instructor(ctx.session.id, new_lead.id, ctx.provider.id)
+
+      assert Provider.get_session_staffing(ctx.session.id).lead.id == new_lead.id
+      # The program itself is untouched — only this session moved.
+      assert Provider.get_lead_instructor(ctx.program.id).id == old_lead.id
+    end
+
+    test "is not_found for someone who is on neither the session nor the program", ctx do
+      stranger = insert(:staff_member_schema, provider_id: ctx.provider.id)
+
+      assert {:error, :not_found} =
+               Provider.set_session_lead_instructor(ctx.session.id, stranger.id, ctx.provider.id)
+    end
+  end
 end

--- a/test/klass_hero/provider/assignments/unassign_staff_from_session_test.exs
+++ b/test/klass_hero/provider/assignments/unassign_staff_from_session_test.exs
@@ -1,0 +1,115 @@
+defmodule KlassHero.Provider.Assignments.UnassignStaffFromSessionTest do
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+
+  alias KlassHero.Provider
+  alias KlassHero.Provider.SessionStaffAssignment
+
+  setup do
+    provider = insert(:provider_profile_schema)
+    program = insert(:program_schema, provider_id: provider.id)
+    session = insert(:program_session_schema, program_id: program.id)
+    staff = insert(:staff_member_schema, provider_id: provider.id)
+
+    {:ok, provider: provider, program: program, session: session, staff: staff}
+  end
+
+  defp assign!(ctx, staff_member_id \\ nil) do
+    {:ok, assignment} =
+      Provider.assign_staff_to_session(%{
+        provider_id: ctx.provider.id,
+        session_id: ctx.session.id,
+        staff_member_id: staff_member_id || ctx.staff.id
+      })
+
+    assignment
+  end
+
+  describe "unassign_staff_from_session/3" do
+    test "retires the override and stamps unassigned_at", ctx do
+      assign!(ctx)
+
+      assert {:ok, %SessionStaffAssignment{} = retired} =
+               Provider.unassign_staff_from_session(ctx.session.id, ctx.staff.id, ctx.provider.id)
+
+      assert %DateTime{} = retired.unassigned_at
+      refute SessionStaffAssignment.active?(retired)
+    end
+
+    test "is not_found when no active override exists", ctx do
+      assert {:error, :not_found} =
+               Provider.unassign_staff_from_session(ctx.session.id, ctx.staff.id, ctx.provider.id)
+    end
+
+    test "is not_found on a second retire of the same override", ctx do
+      assign!(ctx)
+      {:ok, _} = Provider.unassign_staff_from_session(ctx.session.id, ctx.staff.id, ctx.provider.id)
+
+      assert {:error, :not_found} =
+               Provider.unassign_staff_from_session(ctx.session.id, ctx.staff.id, ctx.provider.id)
+    end
+
+    test "a deactivated staff member can still be detached", ctx do
+      assign!(ctx)
+      {:ok, _} = Provider.deactivate_staff_member(ctx.staff)
+
+      assert {:ok, _} = Provider.unassign_staff_from_session(ctx.session.id, ctx.staff.id, ctx.provider.id)
+    end
+  end
+
+  describe "unassign_staff_from_session/3 lead guard" do
+    setup ctx do
+      assign!(ctx)
+      {:ok, _lead} = Provider.set_session_lead_instructor(ctx.session.id, ctx.staff.id, ctx.provider.id)
+      :ok
+    end
+
+    test "refuses to retire the session's lead instructor", ctx do
+      assert {:error, :cannot_unassign_lead} =
+               Provider.unassign_staff_from_session(ctx.session.id, ctx.staff.id, ctx.provider.id)
+    end
+
+    test "allows the retire once the lead has been stepped down", ctx do
+      :ok = Provider.clear_session_lead_instructor(ctx.session.id, ctx.provider.id)
+
+      assert {:ok, _} = Provider.unassign_staff_from_session(ctx.session.id, ctx.staff.id, ctx.provider.id)
+    end
+
+    test "allows the retire once someone else leads", ctx do
+      other = insert(:staff_member_schema, provider_id: ctx.provider.id)
+      assign!(ctx, other.id)
+      {:ok, _} = Provider.set_session_lead_instructor(ctx.session.id, other.id, ctx.provider.id)
+
+      assert {:ok, _} = Provider.unassign_staff_from_session(ctx.session.id, ctx.staff.id, ctx.provider.id)
+    end
+  end
+
+  describe "revert_session_to_program_roster/2" do
+    test "retires every override so the session inherits the program roster again", ctx do
+      other = insert(:staff_member_schema, provider_id: ctx.provider.id)
+      assign!(ctx)
+      assign!(ctx, other.id)
+      {:ok, _} = Provider.set_session_lead_instructor(ctx.session.id, ctx.staff.id, ctx.provider.id)
+
+      # Unlike the per-row retire, this clears the lead too — reverting is a
+      # deliberate "this session has no staffing of its own", not a detach.
+      assert {:ok, 2} = Provider.revert_session_to_program_roster(ctx.session.id, ctx.provider.id)
+
+      staffing = Provider.get_session_staffing(ctx.session.id)
+      assert staffing.source == :program
+    end
+
+    test "is a no-op returning zero on a session that carries no overrides", ctx do
+      assert {:ok, 0} = Provider.revert_session_to_program_roster(ctx.session.id, ctx.provider.id)
+    end
+
+    test "cannot reach another provider's session", ctx do
+      other_provider = insert(:provider_profile_schema)
+      assign!(ctx)
+
+      assert {:error, :not_found} =
+               Provider.revert_session_to_program_roster(ctx.session.id, other_provider.id)
+    end
+  end
+end

--- a/test/klass_hero/provider/assignments/unassign_staff_from_session_test.exs
+++ b/test/klass_hero/provider/assignments/unassign_staff_from_session_test.exs
@@ -15,6 +15,22 @@ defmodule KlassHero.Provider.Assignments.UnassignStaffFromSessionTest do
     {:ok, provider: provider, program: program, session: session, staff: staff}
   end
 
+  # Puts a second person on the session, so "remove this one" never doubles as
+  # "empty the session" — which is refused, and has its own describe block. Scoped
+  # to the removal tests rather than the top-level setup, because the revert tests
+  # need a session that carries no overrides at all.
+  defp bystander_on_session(ctx) do
+    bystander = insert(:staff_member_schema, provider_id: ctx.provider.id)
+
+    insert(:session_staff_assignment_schema,
+      provider_id: ctx.provider.id,
+      session_id: ctx.session.id,
+      staff_member_id: bystander.id
+    )
+
+    {:ok, bystander: bystander}
+  end
+
   defp assign!(ctx, staff_member_id \\ nil) do
     {:ok, assignment} =
       Provider.assign_staff_to_session(%{
@@ -27,6 +43,8 @@ defmodule KlassHero.Provider.Assignments.UnassignStaffFromSessionTest do
   end
 
   describe "unassign_staff_from_session/3" do
+    setup :bystander_on_session
+
     test "retires the override and stamps unassigned_at", ctx do
       assign!(ctx)
 
@@ -37,7 +55,7 @@ defmodule KlassHero.Provider.Assignments.UnassignStaffFromSessionTest do
       refute SessionStaffAssignment.active?(retired)
     end
 
-    test "is not_found when no active override exists", ctx do
+    test "is not_found when this staff member holds no active override", ctx do
       assert {:error, :not_found} =
                Provider.unassign_staff_from_session(ctx.session.id, ctx.staff.id, ctx.provider.id)
     end
@@ -59,6 +77,8 @@ defmodule KlassHero.Provider.Assignments.UnassignStaffFromSessionTest do
   end
 
   describe "unassign_staff_from_session/3 lead guard" do
+    setup :bystander_on_session
+
     setup ctx do
       assign!(ctx)
       {:ok, _lead} = Provider.set_session_lead_instructor(ctx.session.id, ctx.staff.id, ctx.provider.id)
@@ -110,6 +130,61 @@ defmodule KlassHero.Provider.Assignments.UnassignStaffFromSessionTest do
 
       assert {:error, :not_found} =
                Provider.revert_session_to_program_roster(ctx.session.id, other_provider.id)
+    end
+  end
+
+  describe "unassign_staff_from_session/3 on a session that still inherits" do
+    defp on_program!(ctx, staff_member) do
+      {:ok, _} =
+        Provider.assign_staff_to_program(%{
+          provider_id: ctx.provider.id,
+          program_id: ctx.program.id,
+          staff_member_id: staff_member.id
+        })
+
+      staff_member
+    end
+
+    test "materializes the program roster and removes one, leaving the rest", ctx do
+      regulars =
+        for _ <- 1..3 do
+          ctx.provider.id |> then(&insert(:staff_member_schema, provider_id: &1)) |> then(&on_program!(ctx, &1))
+        end
+
+      [departing | staying] = regulars
+
+      assert {:ok, _} = Provider.unassign_staff_from_session(ctx.session.id, departing.id, ctx.provider.id)
+
+      staffing = Provider.get_session_staffing(ctx.session.id)
+
+      assert staffing.source == :override
+      assert Enum.sort(staffing.member_ids) == Enum.sort(Enum.map(staying, & &1.id))
+    end
+
+    test "refuses to remove the only member, leaving the roster untouched", ctx do
+      only = ctx.provider.id |> then(&insert(:staff_member_schema, provider_id: &1)) |> then(&on_program!(ctx, &1))
+
+      assert {:error, :cannot_empty_session} =
+               Provider.unassign_staff_from_session(ctx.session.id, only.id, ctx.provider.id)
+
+      # Refused *before* materializing, so the session is still inheriting rather
+      # than left holding a roster the caller never asked to create.
+      staffing = Provider.get_session_staffing(ctx.session.id)
+      assert staffing.source == :program
+      assert staffing.member_ids == [only.id]
+    end
+
+    test "refuses to remove the last remaining member of an overridden session", ctx do
+      solo = insert(:staff_member_schema, provider_id: ctx.provider.id)
+
+      insert(:session_staff_assignment_schema,
+        provider_id: ctx.provider.id,
+        session_id: ctx.session.id,
+        staff_member_id: solo.id
+      )
+
+      assert {:error, :cannot_empty_session} =
+               Provider.unassign_staff_from_session(ctx.session.id, solo.id, ctx.provider.id)
     end
   end
 end

--- a/test/klass_hero/provider/domain/read_models/session_staffing_test.exs
+++ b/test/klass_hero/provider/domain/read_models/session_staffing_test.exs
@@ -1,0 +1,75 @@
+defmodule KlassHero.Provider.Domain.ReadModels.SessionStaffingTest do
+  use ExUnit.Case, async: true
+
+  alias KlassHero.Provider.Domain.ReadModels.SessionStaffing
+
+  defp staffing(overrides \\ %{}) do
+    struct!(
+      %SessionStaffing{
+        session_id: "sess-1",
+        program_id: "prog-1",
+        lead: nil,
+        member_ids: [],
+        member_count: 0,
+        source: :program
+      },
+      overrides
+    )
+  end
+
+  describe "empty/2" do
+    test "is the zero-staff value and reads as inherited from the program" do
+      empty = SessionStaffing.empty("sess-1", "prog-1")
+
+      assert empty.session_id == "sess-1"
+      assert empty.program_id == "prog-1"
+      assert empty.member_ids == []
+      assert empty.member_count == 0
+      assert empty.lead == nil
+      # A session nobody staffs is inheriting an empty program roster, not
+      # overriding it — an override is a row a provider deliberately created.
+      assert empty.source == :program
+    end
+  end
+
+  describe "staffed_by?/2" do
+    test "is true for a member, lead or not" do
+      s = staffing(%{member_ids: ["staff-1", "staff-2"], member_count: 2, lead: %{id: "staff-1"}})
+
+      assert SessionStaffing.staffed_by?(s, "staff-1")
+      assert SessionStaffing.staffed_by?(s, "staff-2")
+    end
+
+    test "is false for a non-member" do
+      refute SessionStaffing.staffed_by?(staffing(), "staff-9")
+    end
+
+    test "accepts nil so a batch-read miss passes straight through" do
+      refute SessionStaffing.staffed_by?(nil, "staff-1")
+    end
+  end
+
+  describe "led_by?/2" do
+    test "is true only for the lead" do
+      s = staffing(%{member_ids: ["staff-1", "staff-2"], member_count: 2, lead: %{id: "staff-1"}})
+
+      assert SessionStaffing.led_by?(s, "staff-1")
+      refute SessionStaffing.led_by?(s, "staff-2")
+    end
+
+    test "is false when the session has no lead" do
+      refute SessionStaffing.led_by?(staffing(%{member_ids: ["staff-1"], member_count: 1}), "staff-1")
+    end
+
+    test "accepts nil" do
+      refute SessionStaffing.led_by?(nil, "staff-1")
+    end
+  end
+
+  describe "overridden?/1" do
+    test "distinguishes a deliberate override from an inherited roster" do
+      assert SessionStaffing.overridden?(staffing(%{source: :override}))
+      refute SessionStaffing.overridden?(staffing(%{source: :program}))
+    end
+  end
+end

--- a/test/klass_hero/provider/session_staff_assignment_test.exs
+++ b/test/klass_hero/provider/session_staff_assignment_test.exs
@@ -1,0 +1,165 @@
+defmodule KlassHero.Provider.SessionStaffAssignmentTest do
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+
+  alias KlassHero.Provider.SessionStaffAssignment
+  alias KlassHero.Repo
+
+  defp session_context do
+    provider = insert(:provider_profile_schema)
+    program = insert(:program_schema, provider_id: provider.id)
+    session = insert(:program_session_schema, program_id: program.id)
+    staff = insert(:staff_member_schema, provider_id: provider.id)
+
+    %{provider: provider, session: session, staff: staff}
+  end
+
+  defp create_attrs(%{provider: provider, session: session, staff: staff}, overrides \\ %{}) do
+    Map.merge(
+      %{
+        provider_id: provider.id,
+        session_id: session.id,
+        staff_member_id: staff.id,
+        assigned_at: DateTime.utc_now() |> DateTime.truncate(:microsecond)
+      },
+      overrides
+    )
+  end
+
+  describe "create_changeset/2" do
+    test "requires provider_id, session_id, staff_member_id and assigned_at" do
+      changeset = SessionStaffAssignment.create_changeset(%SessionStaffAssignment{}, %{})
+
+      refute changeset.valid?
+
+      assert %{
+               provider_id: ["can't be blank"],
+               session_id: ["can't be blank"],
+               staff_member_id: ["can't be blank"],
+               assigned_at: ["can't be blank"]
+             } = errors_on(changeset)
+    end
+
+    test "sets provider_id and staff_member_id via put_change, not cast" do
+      # Trigger: these are programmatic keys — the command takes them from the
+      #          ownership-proven StaffMember, never from caller-supplied attrs.
+      changeset =
+        SessionStaffAssignment.create_changeset(%SessionStaffAssignment{}, %{
+          provider_id: "p-1",
+          staff_member_id: "s-1",
+          session_id: "sess-1",
+          assigned_at: DateTime.utc_now()
+        })
+
+      assert changeset.valid?
+      assert Ecto.Changeset.get_field(changeset, :provider_id) == "p-1"
+      assert Ecto.Changeset.get_field(changeset, :staff_member_id) == "s-1"
+    end
+
+    test "rejects a second active assignment of the same staff member to the same session" do
+      ctx = session_context()
+
+      assert {:ok, _first} =
+               %SessionStaffAssignment{}
+               |> SessionStaffAssignment.create_changeset(create_attrs(ctx))
+               |> Repo.insert()
+
+      assert {:error, changeset} =
+               %SessionStaffAssignment{}
+               |> SessionStaffAssignment.create_changeset(create_attrs(ctx))
+               |> Repo.insert()
+
+      assert %{session_id: ["staff member is already assigned to this session"]} = errors_on(changeset)
+    end
+  end
+
+  describe "active?/1" do
+    test "is true when never unassigned" do
+      assert SessionStaffAssignment.active?(%SessionStaffAssignment{unassigned_at: nil})
+    end
+
+    test "is false once unassigned" do
+      refute SessionStaffAssignment.active?(%SessionStaffAssignment{unassigned_at: DateTime.utc_now()})
+    end
+  end
+
+  describe "lead?/1" do
+    test "is true only for an active, flagged assignment" do
+      assert SessionStaffAssignment.lead?(%SessionStaffAssignment{is_lead_instructor: true, unassigned_at: nil})
+    end
+
+    test "is false for a retired assignment even when the flag survived" do
+      refute SessionStaffAssignment.lead?(%SessionStaffAssignment{
+               is_lead_instructor: true,
+               unassigned_at: DateTime.utc_now()
+             })
+    end
+
+    test "is false for an active assignment that does not lead" do
+      refute SessionStaffAssignment.lead?(%SessionStaffAssignment{is_lead_instructor: false, unassigned_at: nil})
+    end
+  end
+
+  describe "unassign_changeset/1" do
+    test "clears the lead flag so a retired row can never read as both dead and leading" do
+      changeset = SessionStaffAssignment.unassign_changeset(%SessionStaffAssignment{is_lead_instructor: true})
+
+      assert %DateTime{} = Ecto.Changeset.get_field(changeset, :unassigned_at)
+      refute Ecto.Changeset.get_field(changeset, :is_lead_instructor)
+    end
+
+    test "lifts the partial unique index so the same staff member can be re-assigned" do
+      ctx = session_context()
+
+      {:ok, first} =
+        %SessionStaffAssignment{}
+        |> SessionStaffAssignment.create_changeset(create_attrs(ctx))
+        |> Repo.insert()
+
+      {:ok, _retired} = first |> SessionStaffAssignment.unassign_changeset() |> Repo.update()
+
+      assert {:ok, _second} =
+               %SessionStaffAssignment{}
+               |> SessionStaffAssignment.create_changeset(create_attrs(ctx))
+               |> Repo.insert()
+    end
+  end
+
+  describe "lead_changeset/2" do
+    test "surfaces a second lead on the same session as a changeset error, not a raw DB exception" do
+      ctx = session_context()
+      other_staff = insert(:staff_member_schema, provider_id: ctx.provider.id)
+
+      {:ok, _lead} =
+        %SessionStaffAssignment{}
+        |> SessionStaffAssignment.create_changeset(create_attrs(ctx, %{is_lead_instructor: true}))
+        |> Repo.insert()
+
+      {:ok, second} =
+        %SessionStaffAssignment{}
+        |> SessionStaffAssignment.create_changeset(create_attrs(ctx, %{staff_member_id: other_staff.id}))
+        |> Repo.insert()
+
+      assert {:error, changeset} = second |> SessionStaffAssignment.lead_changeset(true) |> Repo.update()
+      assert %{session_id: ["session already has a lead instructor"]} = errors_on(changeset)
+    end
+  end
+
+  describe "owned_by/2" do
+    test "narrows to the given provider's rows" do
+      ctx = session_context()
+      other_provider = insert(:provider_profile_schema)
+
+      {:ok, mine} =
+        %SessionStaffAssignment{}
+        |> SessionStaffAssignment.create_changeset(create_attrs(ctx))
+        |> Repo.insert()
+
+      assert [found] = SessionStaffAssignment.owned_by(ctx.provider.id) |> Repo.all()
+      assert found.id == mine.id
+
+      assert [] = SessionStaffAssignment.owned_by(other_provider.id) |> Repo.all()
+    end
+  end
+end

--- a/test/klass_hero/shared/error_store_repo_test.exs
+++ b/test/klass_hero/shared/error_store_repo_test.exs
@@ -94,6 +94,12 @@ defmodule KlassHero.Shared.ErrorStoreRepoTest do
 
       assert dispatched != []
 
+      # `function_exported?/3` answers for *loaded* modules only, so without this it
+      # reports false for every function whenever this test happens to run before the
+      # siblings that call the shim — a seed-dependent failure claiming an upgrade
+      # broke error reporting (reproduces on --seed 178683).
+      Code.ensure_loaded!(ErrorStoreRepo)
+
       for {name, arity} <- dispatched do
         assert function_exported?(ErrorStoreRepo, name, arity),
                "ErrorTracker.Repo dispatches #{name}/#{arity}, which the shim does not export"

--- a/test/klass_hero_web/live/provider/sessions_live_test.exs
+++ b/test/klass_hero_web/live/provider/sessions_live_test.exs
@@ -678,7 +678,7 @@ defmodule KlassHeroWeb.Provider.SessionsLiveTest do
       refute has_element?(view, "#session-staffing-revert-btn")
     end
 
-    test "adding a substitute overrides the session and replaces the roster", ctx do
+    test "adding someone keeps the program's roster and appends to it", ctx do
       substitute = insert(:staff_member_schema, provider_id: ctx.provider.id, first_name: "Bea", last_name: "Stone")
 
       {:ok, view, _html} = live(ctx.conn, ~p"/provider/sessions")
@@ -686,12 +686,66 @@ defmodule KlassHeroWeb.Provider.SessionsLiveTest do
 
       view
       |> element("#session-staffing-add-form")
-      |> render_submit(%{"staff-id" => substitute.id})
+      |> render_submit(%{"add_staff" => %{"staff_id" => substitute.id}})
 
+      # Both, not one: "Add" adds. The session takes its own roster, but it takes
+      # the program's team with it rather than discarding them.
       assert has_element?(view, "#session-staffing-member-#{substitute.id}")
-      refute has_element?(view, "#session-staffing-member-#{ctx.regular.id}")
+      assert has_element?(view, "#session-staffing-member-#{ctx.regular.id}")
       assert has_element?(view, "#session-staffing-revert-btn")
       assert render(view) =~ "Staffed just for this session"
+    end
+
+    test "the picker does not offer people the session already shows", ctx do
+      {:ok, view, _html} = live(ctx.conn, ~p"/provider/sessions")
+      open_panel(view, ctx.session)
+
+      refute has_element?(view, "#session-staffing-add-select option[value='#{ctx.regular.id}']")
+      assert has_element?(view, "#session-staffing-nobody-addable")
+    end
+
+    test "removing works on an inherited roster and leaves the rest", ctx do
+      other = insert(:staff_member_schema, provider_id: ctx.provider.id, first_name: "Cal", last_name: "Stone")
+
+      {:ok, _} =
+        KlassHero.Provider.assign_staff_to_program(%{
+          provider_id: ctx.provider.id,
+          program_id: ctx.program.id,
+          staff_member_id: other.id
+        })
+
+      {:ok, view, _html} = live(ctx.conn, ~p"/provider/sessions")
+      open_panel(view, ctx.session)
+
+      view |> element("#remove-session-staff-#{ctx.regular.id}") |> render_click()
+
+      refute has_element?(view, "#session-staffing-member-#{ctx.regular.id}")
+      assert has_element?(view, "#session-staffing-member-#{other.id}")
+    end
+
+    test "the last member's removal is disabled rather than hidden", ctx do
+      {:ok, view, _html} = live(ctx.conn, ~p"/provider/sessions")
+      open_panel(view, ctx.session)
+
+      assert has_element?(view, "#remove-session-staff-#{ctx.regular.id}[disabled]")
+    end
+
+    test "promote and remove are offered on a roster that is still inherited", ctx do
+      other = insert(:staff_member_schema, provider_id: ctx.provider.id)
+
+      {:ok, _} =
+        KlassHero.Provider.assign_staff_to_program(%{
+          provider_id: ctx.provider.id,
+          program_id: ctx.program.id,
+          staff_member_id: other.id
+        })
+
+      {:ok, view, _html} = live(ctx.conn, ~p"/provider/sessions")
+      open_panel(view, ctx.session)
+
+      refute render(view) =~ "Staffed just for this session"
+      assert has_element?(view, "#promote-session-staff-#{ctx.regular.id}")
+      assert has_element?(view, "#remove-session-staff-#{ctx.regular.id}:not([disabled])")
     end
 
     test "reverting returns the session to the program roster", ctx do

--- a/test/klass_hero_web/live/provider/sessions_live_test.exs
+++ b/test/klass_hero_web/live/provider/sessions_live_test.exs
@@ -635,4 +635,118 @@ defmodule KlassHeroWeb.Provider.SessionsLiveTest do
       assert_flash(view, :info, "Session completed successfully")
     end
   end
+
+  describe "session staffing panel (#782)" do
+    setup :register_and_log_in_provider
+
+    setup %{provider: provider} do
+      program = insert(:program_schema, provider_id: provider.id, title: "Judo")
+
+      session =
+        insert(:program_session_schema,
+          program_id: program.id,
+          session_date: Date.utc_today(),
+          status: :scheduled
+        )
+
+      regular = insert(:staff_member_schema, provider_id: provider.id, first_name: "Ana", last_name: "Stone")
+
+      {:ok, _} =
+        KlassHero.Provider.assign_staff_to_program(%{
+          provider_id: provider.id,
+          program_id: program.id,
+          staff_member_id: regular.id
+        })
+
+      {:ok, program: program, session: session, regular: regular}
+    end
+
+    defp open_panel(view, session) do
+      view |> element("#manage-session-staffing-#{session.id}") |> render_click()
+      view
+    end
+
+    test "opens showing the program's roster and says it is inherited", ctx do
+      {:ok, view, _html} = live(ctx.conn, ~p"/provider/sessions")
+
+      open_panel(view, ctx.session)
+
+      assert has_element?(view, "#session-staffing-modal")
+      assert has_element?(view, "#session-staffing-member-#{ctx.regular.id}")
+      assert render(view) =~ "Using the program"
+      # Nothing to revert to while the roster is still the program's.
+      refute has_element?(view, "#session-staffing-revert-btn")
+    end
+
+    test "adding a substitute overrides the session and replaces the roster", ctx do
+      substitute = insert(:staff_member_schema, provider_id: ctx.provider.id, first_name: "Bea", last_name: "Stone")
+
+      {:ok, view, _html} = live(ctx.conn, ~p"/provider/sessions")
+      open_panel(view, ctx.session)
+
+      view
+      |> element("#session-staffing-add-form")
+      |> render_submit(%{"staff-id" => substitute.id})
+
+      assert has_element?(view, "#session-staffing-member-#{substitute.id}")
+      refute has_element?(view, "#session-staffing-member-#{ctx.regular.id}")
+      assert has_element?(view, "#session-staffing-revert-btn")
+      assert render(view) =~ "Staffed just for this session"
+    end
+
+    test "reverting returns the session to the program roster", ctx do
+      substitute = insert(:staff_member_schema, provider_id: ctx.provider.id)
+
+      {:ok, _} =
+        KlassHero.Provider.assign_staff_to_session(%{
+          provider_id: ctx.provider.id,
+          session_id: ctx.session.id,
+          staff_member_id: substitute.id
+        })
+
+      {:ok, view, _html} = live(ctx.conn, ~p"/provider/sessions")
+      open_panel(view, ctx.session)
+
+      view |> element("#session-staffing-revert-btn") |> render_click()
+
+      assert has_element?(view, "#session-staffing-member-#{ctx.regular.id}")
+      refute has_element?(view, "#session-staffing-revert-btn")
+    end
+
+    test "promoting a session lead badges them and blocks their removal", ctx do
+      substitute = insert(:staff_member_schema, provider_id: ctx.provider.id)
+
+      {:ok, _} =
+        KlassHero.Provider.assign_staff_to_session(%{
+          provider_id: ctx.provider.id,
+          session_id: ctx.session.id,
+          staff_member_id: substitute.id
+        })
+
+      {:ok, view, _html} = live(ctx.conn, ~p"/provider/sessions")
+      open_panel(view, ctx.session)
+
+      view |> element("#promote-session-staff-#{substitute.id}") |> render_click()
+
+      assert has_element?(view, "#session-staffing-lead-badge-#{substitute.id}")
+      assert has_element?(view, "#remove-session-staff-#{substitute.id}[disabled]")
+    end
+
+    test "a foreign session cannot be opened", ctx do
+      other_provider = insert(:provider_profile_schema)
+      other_program = insert(:program_schema, provider_id: other_provider.id)
+
+      foreign =
+        insert(:program_session_schema, program_id: other_program.id, session_date: Date.utc_today())
+
+      {:ok, view, _html} = live(ctx.conn, ~p"/provider/sessions")
+
+      # The button is not rendered for a session they cannot see, so drive the
+      # event directly — that is the shape a tampered client takes.
+      render_click(view, "manage_session_staffing", %{"id" => foreign.id})
+
+      refute has_element?(view, "#session-staffing-modal")
+      assert_flash(view, :error, "That session could not be found.")
+    end
+  end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -44,6 +44,7 @@ defmodule KlassHero.Factory do
   alias KlassHero.ProgramCatalog.ProgramListing
   alias KlassHero.Provider.ProgramStaffAssignment
   alias KlassHero.Provider.ProviderProfile
+  alias KlassHero.Provider.SessionStaffAssignment
   alias KlassHero.Provider.SessionStats
   alias KlassHero.Provider.StaffMember
   alias KlassHero.Provider.VerificationDocument
@@ -511,6 +512,40 @@ defmodule KlassHero.Factory do
       assignment,
       %{unassigned_at: DateTime.add(assignment.assigned_at, 3600, :second)}
     )
+  end
+
+  @doc """
+  Factory for `KlassHero.Provider.SessionStaffAssignment` — a per-session staffing
+  override.
+
+  Mints its own provider/program/session/staff, like its program-level sibling.
+  Pass `session_id:` and `staff_member_id:` explicitly when the test needs the
+  override to sit on a session it already built — which is most of them, since an
+  override is only meaningful next to the program roster it replaces.
+
+  ## Examples
+
+      override = insert(:session_staff_assignment_schema)
+
+      insert(:session_staff_assignment_schema,
+        provider_id: provider.id,
+        session_id: session.id,
+        staff_member_id: substitute.id
+      )
+  """
+  def session_staff_assignment_schema_factory do
+    provider = insert(:provider_profile_schema)
+    program = insert(:program_schema, provider_id: provider.id)
+    session = insert(:program_session_schema, program_id: program.id)
+    staff = insert(:staff_member_schema, provider_id: provider.id)
+
+    %SessionStaffAssignment{
+      id: Ecto.UUID.generate(),
+      provider_id: provider.id,
+      session_id: session.id,
+      staff_member_id: staff.id,
+      assigned_at: DateTime.utc_now() |> DateTime.truncate(:microsecond)
+    }
   end
 
   # =============================================================================


### PR DESCRIPTION
## Summary

Staffing had one grain: every staff member on a program covered all its sessions. A substitute covering one day, or two staff splitting a weekly schedule, had no way to be expressed — a gap `CONTEXT.md:297` already flagged.

This adds a **sparse** `session_staff_assignments` table. A session with no override rows inherits the program roster; a session with rows uses exactly those.

**Adding is additive.** The first add / remove / promote on a session that still inherits copies the program's visible roster into override rows, then applies the change — so "Add" gives you the usual team *plus* the substitute, and remove takes one person off rather than all but one. Rows still appear only for a session someone deliberately made different, so this is not the copy-on-create seeding rejected below.

**The issue's original AC2 — copy program assignments into every session at creation — was deliberately dropped.** It would have rebuilt the denormalised staffing mirror removed in #1321 (after three drift bugs: #1309, #1312, #1320), at up to 500 sessions × N staff per program, with no path to reconcile the copy when program staffing later changed. Sparse overrides need no seeding, so there is nothing to drift.

Its AC4 ("staff only see sessions where they have a session-level assignment") was also struck: it contradicts #783, which specifies session assignment as *additive*, and as literally worded would have blanked every existing staff member's session list without a backfill. Authorization is unchanged here.

The issue body has been updated to match, and #923 is closed as a duplicate (its per-session **lead instructor** ask is folded in).

## Review Focus

**1. The resolver is the whole design** — `Provider.get_session_staffing/1` returns a `SessionStaffing` read model carrying members, lead, and `source: :override | :program`. The projection, the new UI, and the follow-ups in #783/#784 all call it; nothing re-derives the fallback. It mirrors the existing `ProgramStaffing` / `StaffProgramAccess` pair.

**2. The #1299 guard is the riskiest surface.** `provider_session_details.current_assigned_staff_*` now means *effective* staff. That rule is expressed twice — `Assignments.get_session_attribution/1` for live events, and a new override LATERAL in `bootstrap_session_details/0` — and the two must agree or a restart rewrites what the events wrote. Both apply earliest-active-wins. `provider_session_details_session_staff_test.exs` pairs every live scenario with its `rebuild/1` twin.

**3. Two deliberate asymmetries worth checking:**

- A session overridden to a set of *deactivated* staff reads **blank**, not "fall back to the program". The override query uses a LEFT join to `staff_members` on `active` precisely so the row existing (⇒ overridden) stays a different fact from the person being active (⇒ a member). Falling back would resurrect the people the provider took off that day.
- A session's lead is its own flagged override; failing that the program lead, **but only if they are among the override members**. Naming a lead who is not working the session is the worse failure.

**4. `set_session_lead_instructor/3` still has no insert branch, but for a different reason than `upsert_lead/4`.** Materialization has already put every roster member on the session, so a miss there means the target genuinely is not on it. Promote and remove are now offered on an inherited roster, since acting on one no longer discards anyone.

**5. Removing the last member is refused (`:cannot_empty_session`).** Zero rows means "inherits", so a session cannot express "staffed by nobody" — emptying one would snap it back to the whole program team. `revert_session_to_program_roster/2` is the honest way to say that, and the button is disabled with the reason in its tooltip. An explicitly-unstaffed session would need a real marker, not a reinterpretation of zero rows.

**6. Materialized rows carry the program assignment's own `assigned_at`, not `now`.** The caller's row is stamped in `build_assignment_attrs/2` before the transaction opens, so `now`-stamped copies sorted *after* it — and since the projection names a session's earliest-active member, adding a substitute silently renamed the session card. Pinned by `keeps naming the same person on the session card`.

**7. Behaviour changes to existing code:**

- Program-level assignment events now skip sessions carrying an override (otherwise a roster edit silently undoes a substitution).
- `:staff_member_deactivated` narrowed from program-scoped to session-scoped re-attribution — a substitute may be on no program at all. Sessions not naming the departing member re-resolve to the value they already hold, so nothing is lost.
- Dead `cover_staff_id` / `cover_staff_name` removed from the schema, both `:replace_all_except` lists, and the sessions modal. **The DB columns stay for now** — Fly migrates while the previous release still serves (#1347), so the `DROP COLUMN` ships in a follow-up PR.

## UI fixes (second commit)

Four defects found walking the panel locally, three of them the one cause above.

- **The flash was invisible.** `flash/1` and both staffing modals were `z-50`, and the modal renders later in the DOM, so every flash raised from inside one was painted over. Clicks landed and the server answered — the answer had nowhere to appear, which reads as a frozen panel. Raised to `z-[60]`; this also un-silences the program staffing modal. **No LiveView test can catch this class of bug** — `assert_flash` reads the assign, not the stacking context.
- **Icon controls did not read as clickable**: no resting surface, no press or focus state, 36px target. `action_button/1` now has a bordered surface, `active:`/`focus-visible:` states, a 44px minimum, and an intent-tinted hover so promote and remove no longer highlight identically.
- **The add form dropped its selection.** A bare `<select>` loses its value whenever a re-render rebuilds the options, which is exactly what a promote or remove does. Now `to_form/2` + `<.input type="select">`, per `.claude/rules/liveview.md`.
- **Some of the flat look was classes that compile to nothing.** `text-hero-charcoal`, bare `bg-hero-yellow` and `hover:bg-hero-yellow-dark` have no `@theme` token, so the Lead badge and the source banner had no brand colour at all. Repaired in the two staffing modals; **~100 further uses remain app-wide** and are worth their own issue.

Also fixes a seed-dependent flake in `error_store_repo_test.exs`: `function_exported?/3` answers for *loaded* modules only, so the dispatch-table check failed whenever it ran before the siblings that call the shim (reproduces on `--seed 178683`).

## Test Plan

- `mix precommit` green: 4563 tests, `credo --strict` clean, all five lints pass.
- New coverage: entity changesets (12), `SessionStaffing` predicates (8), commands + resolver (25), projection live↔bootstrap pairing (9, including the materialized roster), LiveView panel (9).
- Verified against the running dev app via Tidewave, end-to-end through the real outbox and Oban:
  - overriding one session left its sibling on the program roster (`:override` / 1 member vs `:program` / 3);
  - `provider_session_details` showed the substitute on the overridden session and the program's earliest-active on the sibling;
  - **restarted the dev server to force a projection bootstrap — both rows were byte-identical afterwards** (the #1299 guard, which no unit test substitutes for).
- Walked the panel in Chrome at 390×844 mobile, including the reported repro (click an icon, then add): flash now visible above the modal; adding took the roster 1 → 2 with nobody displaced; promote badged the lead and locked their removal; the last remaining member's remove is disabled with the reason in its tooltip.
- Dev DB left with zero active overrides.

## Follow-ups

- #783 — widen staff session authorization (additive).
- #784 — messaging staff resolution; its code references are stale (`program_staff_participant_schema.ex` was dropped in `20260816071028`).
- A follow-up PR drops the `cover_staff_*` columns.
- #1417 — the ~110 remaining dead `hero-*` utility classes app-wide.
- #1416 — `StubStorageAdapter`'s global Agent races across async tests (hit this PR's first CI run; passed unchanged on re-run).

Closes #782. Closes #923.

