### PR TITLE
feat: custom waivers for providers to create and parents to sign at enrollment

### DIFF
--- a/lib/klass_hero/enrollment.ex
+++ b/lib/klass_hero/enrollment.ex
@@ -52,6 +52,10 @@ defmodule KlassHero.Enrollment do
   already exists for the child/program, `{:error, :waiver_intent_required}` when `:waivers`
   is missing, `{:error, :waivers_unsigned}` when a required waiver was not signed, or
   `{:error, term()}` on validation failure.
+
+  Note that a returned `%Ecto.Changeset{}` is no longer necessarily the enrollment's own —
+  since the waiver gate joined this transaction it may belong to a `WaiverAcceptance`.
+  Callers that render changeset errors should not assume the enrollment schema.
   """
   def create_enrollment(params) when is_map(params) do
     context_span entity: "enrollment" do

--- a/lib/klass_hero/enrollment.ex
+++ b/lib/klass_hero/enrollment.ex
@@ -42,22 +42,32 @@ defmodule KlassHero.Enrollment do
   @doc """
   Creates a new enrollment.
 
+  `params` must carry a `:waivers` intent — `{:accepted, [waiver_version_id]}` when a parent
+  signed at the point of enrolling, or `:deferred` when there is no signer present (the
+  invite saga). It has no default: `[]` would mean both "signed nothing" and "don't care",
+  so an omitted key would silently skip the gate. `:audit` optionally carries
+  `:ip_address` and `:user_agent` for the acceptance record.
+
   Returns `{:ok, Enrollment.t()}`, `{:error, :duplicate_resource}` if an active enrollment
-  already exists for the child/program, or `{:error, term()}` on validation failure.
+  already exists for the child/program, `{:error, :waiver_intent_required}` when `:waivers`
+  is missing, `{:error, :waivers_unsigned}` when a required waiver was not signed, or
+  `{:error, term()}` on validation failure.
   """
   def create_enrollment(params) when is_map(params) do
     context_span entity: "enrollment" do
-      do_create_enrollment(params)
+      with {:ok, intent} <- Waivers.validate_intent(params) do
+        do_create_enrollment(params, intent)
+      end
     end
   end
 
-  defp do_create_enrollment(%{identity_id: identity_id} = params) when is_binary(identity_id) do
+  defp do_create_enrollment(%{identity_id: identity_id} = params, intent) when is_binary(identity_id) do
     with {:ok, parent} <- fetch_parent(identity_id),
          :ok <- ensure_child_belongs_to_parent(params[:child_id], parent.id),
          {:ok, :eligible} <- ensure_eligible(params[:program_id], params[:child_id]) do
       params
       |> build_enrollment_attrs(parent.id)
-      |> persist_enrollment(identity_id)
+      |> persist_enrollment(identity_id, waiver_context(params, intent))
     end
   end
 
@@ -66,10 +76,14 @@ defmodule KlassHero.Enrollment do
   # parent_user_id and Messaging's enrolled-children read table requires it — passing
   # the missing key through produced an event that crashed that projection on every
   # invite-claimed enrollment.
-  defp do_create_enrollment(params) do
+  defp do_create_enrollment(params, intent) do
     params
     |> build_enrollment_attrs(params[:parent_id])
-    |> persist_enrollment(params[:identity_id] || parent_user_id(params[:parent_id]))
+    |> persist_enrollment(params[:identity_id] || parent_user_id(params[:parent_id]), waiver_context(params, intent))
+  end
+
+  defp waiver_context(params, intent) do
+    %{intent: intent, audit: params[:audit] || %{}}
   end
 
   defp parent_user_id(nil), do: nil
@@ -162,8 +176,8 @@ defmodule KlassHero.Enrollment do
     }
   end
 
-  defp persist_enrollment(attrs, identity_id) do
-    create_enrollment_with_capacity_check(attrs, attrs[:program_id], identity_id)
+  defp persist_enrollment(attrs, identity_id, waiver_ctx) do
+    create_enrollment_with_capacity_check(attrs, attrs[:program_id], identity_id, waiver_ctx)
   end
 
   defp enrollment_created_event(enrollment, identity_id) do
@@ -800,7 +814,8 @@ defmodule KlassHero.Enrollment do
   # (`SELECT FOR UPDATE`) inside a transaction to prevent TOCTOU races where concurrent
   # requests could both pass the capacity check. Falls through to a plain insert when
   # program_id is nil (no policy to lock).
-  defp create_enrollment_with_capacity_check(attrs, nil, identity_id) do
+  # No program means no waivers — they are program-scoped, so there is nothing to gate on.
+  defp create_enrollment_with_capacity_check(attrs, nil, identity_id, _waiver_ctx) do
     Outbox.transact(__MODULE__, fn ->
       with {:ok, enrollment} <- create_enrollment_record(attrs) do
         {:ok, enrollment, [enrollment_created_event(enrollment, identity_id)]}
@@ -808,7 +823,7 @@ defmodule KlassHero.Enrollment do
     end)
   end
 
-  defp create_enrollment_with_capacity_check(attrs, program_id, identity_id)
+  defp create_enrollment_with_capacity_check(attrs, program_id, identity_id, waiver_ctx)
        when is_map(attrs) and is_binary(program_id) do
     Ecto.Multi.new()
     |> Ecto.Multi.run(:lock_and_check, fn repo, _changes ->
@@ -823,7 +838,17 @@ defmodule KlassHero.Enrollment do
           check_capacity(policy, active)
       end
     end)
+    # Resolved inside the Multi for the same reason the capacity row is locked: a provider
+    # publishing a required waiver between a pre-flight check and the insert would otherwise
+    # leave an enrollment with an unsigned required waiver.
+    |> Ecto.Multi.run(:check_waivers, fn repo, _changes ->
+      Waivers.resolve_acceptances(repo, program_id, waiver_ctx.intent)
+    end)
     |> Ecto.Multi.run(:create, fn _repo, _changes -> create_enrollment_record(attrs) end)
+    |> Ecto.Multi.run(:accept_waivers, fn repo, %{create: enrollment, check_waivers: versions} ->
+      signer = %{enrollment_id: enrollment.id, parent_id: enrollment.parent_id}
+      Waivers.record_acceptances(repo, versions, signer, waiver_ctx.audit)
+    end)
     # Staged in the same Multi as the capacity lock, so an enrollment and the event
     # announcing it cannot disagree about whether it happened.
     |> Ecto.Multi.run(:stage, fn _repo, %{create: enrollment} ->
@@ -834,6 +859,8 @@ defmodule KlassHero.Enrollment do
     |> case do
       {:ok, %{create: enrollment}} -> {:ok, enrollment}
       {:error, :lock_and_check, :program_full, _} -> {:error, :program_full}
+      {:error, :check_waivers, :waivers_unsigned, _} -> {:error, :waivers_unsigned}
+      {:error, :accept_waivers, reason, _} -> {:error, reason}
       {:error, :create, reason, _} -> {:error, reason}
     end
   end

--- a/lib/klass_hero/enrollment.ex
+++ b/lib/klass_hero/enrollment.ex
@@ -29,6 +29,7 @@ defmodule KlassHero.Enrollment do
   alias KlassHero.Enrollment.ParticipantPolicy
   alias KlassHero.Enrollment.ParticipantPolicyForm
   alias KlassHero.Enrollment.SingleInviteForm
+  alias KlassHero.Enrollment.Waivers
   alias KlassHero.Family
   alias KlassHero.Repo
   alias KlassHero.Shared.Adapters.Driven.Persistence.EctoErrorHelpers
@@ -340,6 +341,26 @@ defmodule KlassHero.Enrollment do
       end
     end
   end
+
+  @doc """
+  Creates a program waiver and publishes its first version.
+
+  Returns `{:ok, %{waiver: Waiver.t(), version: WaiverVersion.t()}}` or `{:error, :not_found}`
+  when the provider does not own the program.
+  """
+  defdelegate create_waiver(provider_id, attrs), to: Waivers
+
+  @doc "Appends a new version of a waiver's text, leaving the previous version untouched."
+  defdelegate publish_waiver_version(provider_id, waiver_id, body), to: Waivers
+
+  @doc "Retires a waiver from future enrollments. Signed acceptances are unaffected."
+  defdelegate archive_waiver(provider_id, waiver_id), to: Waivers
+
+  @doc "Lists a program's active waivers, each paired with its current version."
+  defdelegate list_program_waivers(program_id), to: Waivers
+
+  @doc "The current version of every required, active waiver on a program."
+  defdelegate list_required_waiver_versions(program_id), to: Waivers
 
   defp cancel_with_event(enrollment_id, cancelled, admin_id, reason) do
     Outbox.transact(__MODULE__, fn ->

--- a/lib/klass_hero/enrollment.ex
+++ b/lib/klass_hero/enrollment.ex
@@ -610,7 +610,11 @@ defmodule KlassHero.Enrollment do
       enrollments ->
         child_map = child_map_for(enrollments)
         parent_map = parent_map_for(enrollments)
-        Enum.map(enrollments, &build_roster_entry(&1, child_map, parent_map))
+        # A third batched lookup in the shape of the two above — one aggregate query, not
+        # one per row.
+        waiver_status = Waivers.waiver_status_for_enrollments(Enum.map(enrollments, & &1.id))
+
+        Enum.map(enrollments, &build_roster_entry(&1, child_map, parent_map, waiver_status))
     end
   end
 
@@ -638,7 +642,7 @@ defmodule KlassHero.Enrollment do
     |> Map.new(fn p -> {p.id, p} end)
   end
 
-  defp build_roster_entry(enrollment, child_map, parent_map) do
+  defp build_roster_entry(enrollment, child_map, parent_map, waiver_status) do
     child_name =
       case Map.get(child_map, enrollment.child_id) do
         nil -> "Unknown"
@@ -659,7 +663,8 @@ defmodule KlassHero.Enrollment do
       parent_id: enrollment.parent_id,
       parent_user_id: parent_user_id,
       status: enrollment.status,
-      enrolled_at: enrollment.enrolled_at
+      enrolled_at: enrollment.enrolled_at,
+      waiver_status: Map.get(waiver_status, enrollment.id, :not_required)
     }
   end
 

--- a/lib/klass_hero/enrollment.ex
+++ b/lib/klass_hero/enrollment.ex
@@ -376,6 +376,19 @@ defmodule KlassHero.Enrollment do
   @doc "The current version of every required, active waiver on a program."
   defdelegate list_required_waiver_versions(program_id), to: Waivers
 
+  @doc "The waivers in force for an enrollment's program, each marked signed or not."
+  defdelegate list_enrollment_waivers(enrollment_id), to: Waivers
+
+  @doc """
+  Records signatures on an existing enrollment (the deferred path).
+
+  Only the enrolling parent may sign; anyone else gets `{:error, :not_found}`.
+  """
+  defdelegate sign_waivers(enrollment_id, parent_id, version_ids, audit), to: Waivers
+
+  @doc "Waiver status per enrollment (`:signed | :unsigned | :not_required`), for the roster."
+  defdelegate waiver_status_for_enrollments(enrollment_ids), to: Waivers
+
   defp cancel_with_event(enrollment_id, cancelled, admin_id, reason) do
     Outbox.transact(__MODULE__, fn ->
       fields = %{

--- a/lib/klass_hero/enrollment/adapters/driving/events/invite_family_ready_handler.ex
+++ b/lib/klass_hero/enrollment/adapters/driving/events/invite_family_ready_handler.ex
@@ -85,13 +85,18 @@ defmodule KlassHero.Enrollment.Adapters.Driving.Events.InviteFamilyReadyHandler 
   end
 
   # Bulk invites bypass payment/tier/eligibility checks — use "transfer" + "confirmed" directly.
+  #
+  # `waivers: :deferred` because this runs in a background job with no parent present to sign
+  # anything. Any required waiver stays outstanding on the enrollment and is surfaced to the
+  # parent afterwards; blocking here would only strand the invite.
   defp create_enrollment(child_id, parent_id, program_id) do
     Enrollment.create_enrollment(%{
       program_id: program_id,
       child_id: child_id,
       parent_id: parent_id,
       status: :confirmed,
-      payment_method: "transfer"
+      payment_method: "transfer",
+      waivers: :deferred
     })
   end
 

--- a/lib/klass_hero/enrollment/waiver.ex
+++ b/lib/klass_hero/enrollment/waiver.ex
@@ -1,0 +1,77 @@
+defmodule KlassHero.Enrollment.Waiver do
+  @moduledoc """
+  A provider-authored legal waiver attached to a program (`waivers` table).
+
+  Owned by the Enrollment context, beside `ParticipantPolicy` and `EnrollmentPolicy`:
+  providers configure it, and the context enforces it during enrollment. A `required`
+  waiver blocks self-serve enrollment until it is signed.
+
+  This module is both the Ecto schema and the struct consumers pattern-match. The changeset
+  is the validation gatekeeper; `active?/1` and `archived?/1` are the functional core.
+
+  ## Identity, not text
+
+  A waiver row carries no body. The text lives in `WaiverVersion` rows, appended one per
+  edit, so a signature can be bound to the exact wording it was given. Editing a waiver's
+  wording therefore never touches this table.
+
+  ## Retirement is archival, never deletion
+
+  `archived_at` retires a waiver from future enrollments while leaving every signature under
+  it intact and its text reproducible. Hard-deleting the row would destroy the referent of a
+  legal record, which is the one outcome this feature exists to prevent — the DB refuses it
+  too (`:restrict` on the acceptance FKs). `archived_at` is not castable: it moves only
+  through `archive_changeset/2`.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  @timestamps_opts [type: :utc_datetime_usec]
+
+  @title_max 200
+
+  schema "waivers" do
+    field :program_id, :binary_id
+    field :title, :string
+    field :required, :boolean, default: true
+    field :archived_at, :utc_datetime_usec
+
+    timestamps()
+  end
+
+  @type t :: %__MODULE__{}
+
+  @doc "Maximum title length, enforced here rather than as a column cap."
+  def title_max_length, do: @title_max
+
+  @doc """
+  Changeset for creating or renaming a waiver.
+
+  `archived_at` is deliberately absent from the cast list — see the moduledoc.
+  """
+  def changeset(%__MODULE__{} = waiver, attrs) do
+    waiver
+    |> cast(attrs, [:program_id, :title, :required])
+    |> validate_required([:program_id, :title])
+    |> validate_length(:title, max: @title_max)
+  end
+
+  @doc "Changeset that retires a waiver by stamping `archived_at`."
+  def archive_changeset(%__MODULE__{} = waiver, %DateTime{} = archived_at) do
+    change(waiver, %{archived_at: archived_at})
+  end
+
+  @doc "Whether the waiver still applies to new enrollments."
+  @spec active?(t()) :: boolean()
+  def active?(%__MODULE__{archived_at: nil}), do: true
+  def active?(%__MODULE__{}), do: false
+
+  @doc "Whether the waiver has been retired."
+  @spec archived?(t()) :: boolean()
+  def archived?(%__MODULE__{archived_at: nil}), do: false
+  def archived?(%__MODULE__{}), do: true
+end

--- a/lib/klass_hero/enrollment/waiver_acceptance.ex
+++ b/lib/klass_hero/enrollment/waiver_acceptance.ex
@@ -1,0 +1,86 @@
+defmodule KlassHero.Enrollment.WaiverAcceptance do
+  @moduledoc """
+  A parent's signature on one waiver version, bound to one enrollment
+  (`waiver_acceptances` table).
+
+  This module is both the Ecto schema and the struct consumers pattern-match. The changeset
+  is the validation gatekeeper; `accept/3` is the functional core that builds the record
+  from the version being signed.
+
+  ## What makes this evidence
+
+  The row references the exact `WaiverVersion` signed, and separately copies that version's
+  text into `body_snapshot`. The version row is the source of truth; the snapshot is
+  deliberate redundancy that survives even a catastrophic loss of the versions table. Both
+  are required — an acceptance that cannot produce the text agreed to proves nothing.
+
+  Append-only. A later version of the same waiver produces no change here: what was signed
+  stays signed, at the version it was signed against.
+
+  `ip_address` is nullable on purpose. When no trustworthy client IP is available the field
+  stays `nil` rather than recording the proxy's address, which would look like evidence
+  without being any.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias KlassHero.Enrollment.WaiverVersion
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  @timestamps_opts [type: :utc_datetime_usec]
+
+  schema "waiver_acceptances" do
+    field :waiver_version_id, :binary_id
+    field :waiver_id, :binary_id
+    field :enrollment_id, :binary_id
+    field :parent_id, :binary_id
+    field :accepted_at, :utc_datetime_usec
+    field :ip_address, :string
+    field :user_agent, :string
+    field :body_snapshot, :string
+
+    timestamps()
+  end
+
+  @type t :: %__MODULE__{}
+
+  @required ~w(waiver_version_id waiver_id enrollment_id parent_id accepted_at body_snapshot)a
+  @optional ~w(ip_address user_agent)a
+
+  @doc "Insert changeset. There is no update counterpart — a signature is never edited."
+  def changeset(%__MODULE__{} = acceptance, attrs) do
+    acceptance
+    |> cast(attrs, @required ++ @optional)
+    |> validate_required(@required)
+    |> unique_constraint([:enrollment_id, :waiver_id],
+      name: :waiver_acceptances_enrollment_id_waiver_id_index,
+      message: "already signed for this enrollment"
+    )
+    |> foreign_key_constraint(:waiver_version_id)
+    |> foreign_key_constraint(:waiver_id)
+    |> foreign_key_constraint(:enrollment_id)
+  end
+
+  @doc """
+  Builds the attributes for a signature on `version`.
+
+  `signer` carries `:enrollment_id` and `:parent_id`; `audit` optionally carries
+  `:ip_address` and `:user_agent`. Missing audit keys stay `nil` — see the moduledoc.
+  """
+  @spec accept(WaiverVersion.t(), map(), map()) :: map()
+  def accept(%WaiverVersion{} = version, signer, audit) do
+    %{
+      waiver_version_id: version.id,
+      waiver_id: version.waiver_id,
+      enrollment_id: signer.enrollment_id,
+      parent_id: signer.parent_id,
+      accepted_at: DateTime.utc_now(),
+      ip_address: Map.get(audit, :ip_address),
+      user_agent: Map.get(audit, :user_agent),
+      body_snapshot: version.body
+    }
+  end
+end

--- a/lib/klass_hero/enrollment/waiver_version.ex
+++ b/lib/klass_hero/enrollment/waiver_version.ex
@@ -1,0 +1,108 @@
+defmodule KlassHero.Enrollment.WaiverVersion do
+  @moduledoc """
+  One published wording of a `Waiver` (`waiver_versions` table).
+
+  This module is both the Ecto schema and the struct consumers pattern-match. The changeset
+  is the validation gatekeeper; `publish/3` is the functional core that allocates the next
+  version number.
+
+  ## Append-only, and why it has to be
+
+  A row here is never updated. Editing a waiver's wording publishes a *new* version; the old
+  row stays exactly as signed. That is the whole point: a recorded version number is
+  worthless as evidence unless its text is reproducible verbatim, the same rule
+  `Provider.CommunityGuidelines` states for the platform's own agreements. Storing the body
+  on the waiver and bumping a counter would lose the wording of any version nobody happened
+  to sign — leaving audit holes precisely where a provider revised a form before anyone
+  signed it.
+
+  There is deliberately no `update_changeset/2`. Do not add one.
+
+  A version already signed also cannot be deleted: `waiver_acceptances` references it with
+  `on_delete: :restrict`.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  @timestamps_opts [type: :utc_datetime_usec]
+
+  # Long-form legal text; generous, but bounded so a runaway paste cannot fill the column.
+  @body_max 50_000
+
+  schema "waiver_versions" do
+    field :waiver_id, :binary_id
+    field :body, :string
+    field :version, :integer
+    field :published_at, :utc_datetime_usec
+
+    timestamps()
+  end
+
+  @type t :: %__MODULE__{}
+
+  @doc "Maximum body length, enforced in the changeset rather than as a column cap."
+  def body_max_length, do: @body_max
+
+  @doc """
+  Insert changeset. There is no update counterpart — see the moduledoc.
+  """
+  def changeset(%__MODULE__{} = version, attrs) do
+    version
+    |> cast(attrs, [:waiver_id, :body, :version, :published_at])
+    |> validate_required([:waiver_id, :body, :version, :published_at])
+    |> validate_length(:body, max: @body_max)
+    |> validate_number(:version, greater_than_or_equal_to: 1)
+    |> validate_body_present()
+    |> unique_constraint([:waiver_id, :version],
+      name: :waiver_versions_waiver_id_version_index,
+      message: "already published"
+    )
+    |> foreign_key_constraint(:waiver_id)
+    |> check_constraint(:version, name: :waiver_version_positive)
+  end
+
+  @doc """
+  Builds the attributes for the next version of a waiver.
+
+  `previous` is the waiver's current latest version, or `nil` when nothing has been
+  published yet. Returns `{:ok, attrs}` or `{:error, [{field, message}]}`.
+
+  The body is trimmed, because trailing whitespace differences would otherwise produce a new
+  legal version that reads identically to the last one.
+  """
+  @spec publish(binary(), String.t() | nil, t() | nil) :: {:ok, map()} | {:error, keyword()}
+  def publish(waiver_id, body, previous) do
+    trimmed = body |> to_string() |> String.trim()
+
+    cond do
+      trimmed == "" ->
+        {:error, [body: "is required"]}
+
+      String.length(trimmed) > @body_max ->
+        {:error, [body: "is too long"]}
+
+      true ->
+        {:ok,
+         %{
+           waiver_id: waiver_id,
+           body: trimmed,
+           version: next_version(previous),
+           published_at: DateTime.utc_now()
+         }}
+    end
+  end
+
+  defp next_version(nil), do: 1
+  defp next_version(%__MODULE__{version: version}), do: version + 1
+
+  defp validate_body_present(changeset) do
+    case get_field(changeset, :body) do
+      nil -> changeset
+      body -> if String.trim(body) == "", do: add_error(changeset, :body, "is required"), else: changeset
+    end
+  end
+end

--- a/lib/klass_hero/enrollment/waivers.ex
+++ b/lib/klass_hero/enrollment/waivers.ex
@@ -23,6 +23,7 @@ defmodule KlassHero.Enrollment.Waivers do
 
   import Ecto.Query
 
+  alias KlassHero.Enrollment.Enrollment
   alias KlassHero.Enrollment.Waiver
   alias KlassHero.Enrollment.WaiverAcceptance
   alias KlassHero.Enrollment.WaiverVersion
@@ -94,6 +95,109 @@ defmodule KlassHero.Enrollment.Waivers do
     |> Repo.all()
     |> pair_with_versions()
     |> Enum.map(& &1.version)
+  end
+
+  @doc """
+  The waivers in force for an enrollment's program, each marked signed or not.
+
+  Drives both the booking form's checkboxes and the standalone signing page.
+  """
+  @spec list_enrollment_waivers(binary()) :: [%{waiver: Waiver.t(), version: WaiverVersion.t(), signed?: boolean()}]
+  def list_enrollment_waivers(enrollment_id) do
+    case Repo.get(Enrollment, enrollment_id) do
+      nil ->
+        []
+
+      enrollment ->
+        signed = signed_version_ids(enrollment_id)
+
+        for entry <- list_program_waivers(enrollment.program_id),
+            do: Map.put(entry, :signed?, entry.version.id in signed)
+    end
+  end
+
+  @doc """
+  Records signatures on an enrollment that already exists — the deferred path.
+
+  Only the enrolling parent may sign: `parent_id` must match `enrollment.parent_id`, else
+  `{:error, :not_found}`. The enrollment's own `program_id` decides which versions are
+  signable, so a version id from another program is ignored rather than trusted.
+  """
+  @spec sign_waivers(binary(), binary(), [binary()], map()) ::
+          {:ok, [WaiverAcceptance.t()]} | {:error, :not_found | Ecto.Changeset.t()}
+  def sign_waivers(enrollment_id, parent_id, version_ids, audit) do
+    with {:ok, enrollment} <- fetch_enrollment_for_parent(enrollment_id, parent_id) do
+      signable =
+        Repo
+        |> current_versions_for_program(enrollment.program_id)
+        |> Enum.filter(&(&1.id in version_ids))
+        |> Enum.map(& &1.version)
+
+      record_acceptances(Repo, signable, %{enrollment_id: enrollment.id, parent_id: parent_id}, audit)
+    end
+  end
+
+  @doc """
+  Waiver status per enrollment, for the provider roster.
+
+  `:not_required` when the program has no required waivers at all — distinct from `:signed`,
+  because "nothing to sign" and "signed everything" mean different things to a provider
+  looking for who still owes them a form.
+  """
+  @spec waiver_status_for_enrollments([binary()]) :: %{binary() => :signed | :unsigned | :not_required}
+  def waiver_status_for_enrollments([]), do: %{}
+
+  def waiver_status_for_enrollments(enrollment_ids) do
+    enrollments =
+      Enrollment
+      |> where([e], e.id in ^enrollment_ids)
+      |> select([e], {e.id, e.program_id})
+      |> Repo.all()
+
+    required_by_program =
+      enrollments
+      |> Enum.map(&elem(&1, 1))
+      |> Enum.uniq()
+      |> Map.new(&{&1, MapSet.new(list_required_waiver_versions(&1), fn v -> v.id end)})
+
+    signed_by_enrollment = signed_version_ids_by_enrollment(enrollment_ids)
+
+    Map.new(enrollments, fn {id, program_id} ->
+      required = Map.get(required_by_program, program_id, MapSet.new())
+      signed = Map.get(signed_by_enrollment, id, MapSet.new())
+
+      cond do
+        MapSet.size(required) == 0 -> {id, :not_required}
+        MapSet.subset?(required, signed) -> {id, :signed}
+        true -> {id, :unsigned}
+      end
+    end)
+  end
+
+  defp fetch_enrollment_for_parent(enrollment_id, parent_id) do
+    case Repo.get(Enrollment, enrollment_id) do
+      # Same shape as the create path's ownership guard: a foreign enrollment is
+      # indistinguishable from a missing one, so probing tells an attacker nothing.
+      %Enrollment{parent_id: ^parent_id} = enrollment -> {:ok, enrollment}
+      _otherwise -> {:error, :not_found}
+    end
+  end
+
+  defp signed_version_ids(enrollment_id) do
+    WaiverAcceptance
+    |> where([a], a.enrollment_id == ^enrollment_id)
+    |> select([a], a.waiver_version_id)
+    |> Repo.all()
+    |> MapSet.new()
+  end
+
+  defp signed_version_ids_by_enrollment(enrollment_ids) do
+    WaiverAcceptance
+    |> where([a], a.enrollment_id in ^enrollment_ids)
+    |> select([a], {a.enrollment_id, a.waiver_version_id})
+    |> Repo.all()
+    |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
+    |> Map.new(fn {id, versions} -> {id, MapSet.new(versions)} end)
   end
 
   @doc """

--- a/lib/klass_hero/enrollment/waivers.ex
+++ b/lib/klass_hero/enrollment/waivers.ex
@@ -109,10 +109,10 @@ defmodule KlassHero.Enrollment.Waivers do
         []
 
       enrollment ->
-        signed = signed_version_ids(enrollment_id)
+        signed = signed_waiver_ids(enrollment_id)
 
         for entry <- list_program_waivers(enrollment.program_id),
-            do: Map.put(entry, :signed?, entry.version.id in signed)
+            do: Map.put(entry, :signed?, entry.waiver.id in signed)
     end
   end
 
@@ -158,9 +158,9 @@ defmodule KlassHero.Enrollment.Waivers do
       enrollments
       |> Enum.map(&elem(&1, 1))
       |> Enum.uniq()
-      |> Map.new(&{&1, MapSet.new(list_required_waiver_versions(&1), fn v -> v.id end)})
+      |> Map.new(&{&1, MapSet.new(list_required_waiver_versions(&1), fn v -> v.waiver_id end)})
 
-    signed_by_enrollment = signed_version_ids_by_enrollment(enrollment_ids)
+    signed_by_enrollment = signed_waiver_ids_by_enrollment(enrollment_ids)
 
     Map.new(enrollments, fn {id, program_id} ->
       required = Map.get(required_by_program, program_id, MapSet.new())
@@ -183,21 +183,25 @@ defmodule KlassHero.Enrollment.Waivers do
     end
   end
 
-  defp signed_version_ids(enrollment_id) do
+  # Signatures are counted per *waiver*, never per version — the `(enrollment_id, waiver_id)`
+  # unique index says one signature per waiver is the whole obligation, and decision 8 says a
+  # later version binds future enrollments only. Counting per version would both report a
+  # signed parent as unsigned and invite a re-sign that index refuses.
+  defp signed_waiver_ids(enrollment_id) do
     WaiverAcceptance
     |> where([a], a.enrollment_id == ^enrollment_id)
-    |> select([a], a.waiver_version_id)
+    |> select([a], a.waiver_id)
     |> Repo.all()
     |> MapSet.new()
   end
 
-  defp signed_version_ids_by_enrollment(enrollment_ids) do
+  defp signed_waiver_ids_by_enrollment(enrollment_ids) do
     WaiverAcceptance
     |> where([a], a.enrollment_id in ^enrollment_ids)
-    |> select([a], {a.enrollment_id, a.waiver_version_id})
+    |> select([a], {a.enrollment_id, a.waiver_id})
     |> Repo.all()
     |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
-    |> Map.new(fn {id, versions} -> {id, MapSet.new(versions)} end)
+    |> Map.new(fn {id, waiver_ids} -> {id, MapSet.new(waiver_ids)} end)
   end
 
   @doc """

--- a/lib/klass_hero/enrollment/waivers.ex
+++ b/lib/klass_hero/enrollment/waivers.ex
@@ -1,0 +1,157 @@
+defmodule KlassHero.Enrollment.Waivers do
+  @moduledoc """
+  Authoring and lookup for program waivers, reached through the `KlassHero.Enrollment` facade.
+
+  A context-root query submodule in the shape of `Provider.Programs` — not a repository. It
+  owns the three waiver tables' read and write paths so `enrollment.ex` stays the shell.
+
+  ## Ownership
+
+  Waivers hang off a program, and programs belong to Program Catalog. Every authoring call
+  therefore proves ownership through `ProgramCatalog.get_program_for_provider/2` before
+  touching anything, because `program_id` here is a bare correlation id: the database will
+  happily accept a waiver pointing at someone else's program.
+
+  ## Latest version
+
+  "The waiver's current wording" is the highest-numbered row in `waiver_versions`, resolved
+  with a `DISTINCT ON` rather than by storing a pointer on the waiver — a pointer would be a
+  second source of truth to keep in step, and versions are append-only anyway.
+  """
+
+  use KlassHero.Shared.Tracing
+
+  import Ecto.Query
+
+  alias KlassHero.Enrollment.Waiver
+  alias KlassHero.Enrollment.WaiverVersion
+  alias KlassHero.ProgramCatalog
+  alias KlassHero.Repo
+
+  @doc """
+  Creates a waiver and publishes its first version in one transaction.
+
+  Returns `{:ok, %{waiver: Waiver.t(), version: WaiverVersion.t()}}`, `{:error, :not_found}`
+  when the provider does not own the program, or `{:error, changeset | keyword}`.
+  """
+  def create_waiver(provider_id, %{program_id: program_id} = attrs) do
+    with :ok <- ensure_program_owned(provider_id, program_id),
+         {:ok, version_attrs} <- WaiverVersion.publish(nil, attrs[:body], nil) do
+      insert_waiver_with_version(attrs, version_attrs)
+    end
+  end
+
+  @doc """
+  Appends a new version of a waiver's text. The previous version is left untouched.
+
+  Returns `{:ok, WaiverVersion.t()}`, `{:error, :not_found}` when the provider does not own
+  the waiver's program, or `{:error, changeset | keyword}`.
+  """
+  def publish_waiver_version(provider_id, waiver_id, body) do
+    with {:ok, waiver} <- fetch_owned_waiver(provider_id, waiver_id),
+         {:ok, attrs} <- WaiverVersion.publish(waiver.id, body, latest_version(waiver.id)) do
+      %WaiverVersion{}
+      |> WaiverVersion.changeset(attrs)
+      |> Repo.insert()
+    end
+  end
+
+  @doc """
+  Retires a waiver from future enrollments. Signed acceptances under it are unaffected.
+  """
+  def archive_waiver(provider_id, waiver_id) do
+    with {:ok, waiver} <- fetch_owned_waiver(provider_id, waiver_id) do
+      waiver
+      |> Waiver.archive_changeset(DateTime.utc_now())
+      |> Repo.update()
+    end
+  end
+
+  @doc """
+  Lists a program's active waivers, each paired with its current version.
+
+  Returns `[%{waiver: Waiver.t(), version: WaiverVersion.t()}]`, ordered by title.
+  """
+  def list_program_waivers(program_id) do
+    waivers =
+      Waiver
+      |> where([w], w.program_id == ^program_id and is_nil(w.archived_at))
+      |> order_by([w], asc: w.title)
+      |> Repo.all()
+
+    pair_with_versions(waivers)
+  end
+
+  @doc """
+  The current version of every *required*, active waiver on a program.
+
+  This is what the enrollment gate compares a parent's signatures against.
+  """
+  def list_required_waiver_versions(program_id) do
+    Waiver
+    |> where([w], w.program_id == ^program_id and is_nil(w.archived_at) and w.required)
+    |> Repo.all()
+    |> pair_with_versions()
+    |> Enum.map(& &1.version)
+  end
+
+  defp pair_with_versions([]), do: []
+
+  defp pair_with_versions(waivers) do
+    versions = latest_versions_by_waiver(Enum.map(waivers, & &1.id))
+
+    for waiver <- waivers, version = Map.get(versions, waiver.id), do: %{waiver: waiver, version: version}
+  end
+
+  # DISTINCT ON (waiver_id) with a descending version order = the newest row per waiver.
+  defp latest_versions_by_waiver(waiver_ids) do
+    WaiverVersion
+    |> where([v], v.waiver_id in ^waiver_ids)
+    |> distinct([v], v.waiver_id)
+    |> order_by([v], asc: v.waiver_id, desc: v.version)
+    |> Repo.all()
+    |> Map.new(&{&1.waiver_id, &1})
+  end
+
+  defp latest_version(waiver_id) do
+    WaiverVersion
+    |> where([v], v.waiver_id == ^waiver_id)
+    |> order_by([v], desc: v.version)
+    |> limit(1)
+    |> Repo.one()
+  end
+
+  defp insert_waiver_with_version(attrs, version_attrs) do
+    Ecto.Multi.new()
+    |> Ecto.Multi.insert(:waiver, Waiver.changeset(%Waiver{}, attrs))
+    |> Ecto.Multi.insert(:version, fn %{waiver: waiver} ->
+      WaiverVersion.changeset(%WaiverVersion{}, %{version_attrs | waiver_id: waiver.id})
+    end)
+    |> Repo.transaction()
+    |> case do
+      {:ok, %{waiver: waiver, version: version}} -> {:ok, %{waiver: waiver, version: version}}
+      {:error, _step, reason, _changes} -> {:error, reason}
+    end
+  end
+
+  defp fetch_owned_waiver(provider_id, waiver_id) do
+    case Repo.get(Waiver, waiver_id) do
+      nil ->
+        {:error, :not_found}
+
+      waiver ->
+        with :ok <- ensure_program_owned(provider_id, waiver.program_id), do: {:ok, waiver}
+    end
+  end
+
+  # Program Catalog owns programs; Enrollment reads ownership off its facade (ADR 0015),
+  # with the hop kept visible in traces.
+  defp ensure_program_owned(provider_id, program_id) do
+    acl_span source: "enrollment", target: "program_catalog" do
+      case ProgramCatalog.get_program_for_provider(provider_id, program_id) do
+        {:ok, _program} -> :ok
+        {:error, :not_found} -> {:error, :not_found}
+      end
+    end
+  end
+end

--- a/lib/klass_hero/enrollment/waivers.ex
+++ b/lib/klass_hero/enrollment/waivers.ex
@@ -24,6 +24,7 @@ defmodule KlassHero.Enrollment.Waivers do
   import Ecto.Query
 
   alias KlassHero.Enrollment.Waiver
+  alias KlassHero.Enrollment.WaiverAcceptance
   alias KlassHero.Enrollment.WaiverVersion
   alias KlassHero.ProgramCatalog
   alias KlassHero.Repo
@@ -93,6 +94,95 @@ defmodule KlassHero.Enrollment.Waivers do
     |> Repo.all()
     |> pair_with_versions()
     |> Enum.map(& &1.version)
+  end
+
+  @doc """
+  Validates the caller's waiver intent.
+
+  There is deliberately no default. `[]` would read as both "signed nothing" and "don't
+  care", so a caller that forgets the key would silently skip the gate — the same
+  bypass-by-omission that putting the gate in the LiveView would produce. Missing intent is
+  an error instead.
+  """
+  @spec validate_intent(map()) :: {:ok, :deferred | {:accepted, [binary()]}} | {:error, :waiver_intent_required}
+  def validate_intent(%{waivers: :deferred}), do: {:ok, :deferred}
+
+  def validate_intent(%{waivers: {:accepted, ids}}) when is_list(ids), do: {:ok, {:accepted, ids}}
+
+  def validate_intent(_params), do: {:error, :waiver_intent_required}
+
+  @doc """
+  Resolves which waiver versions a signature set actually covers, failing if a required one
+  is missing.
+
+  Runs on the caller's transaction connection, because a provider publishing a required
+  waiver between a pre-flight check and the insert would otherwise produce an enrollment
+  with an unsigned required waiver — the same TOCTOU the capacity lock exists to prevent.
+
+  Ids that do not belong to this program's active waivers are ignored rather than rejected;
+  they cannot satisfy a requirement, and treating a stale id as a hard error would turn a
+  harmless double-submit into a failed enrolment.
+  """
+  @spec resolve_acceptances(Ecto.Repo.t(), binary() | nil, :deferred | {:accepted, [binary()]}) ::
+          {:ok, [WaiverVersion.t()]} | {:error, :waivers_unsigned}
+  def resolve_acceptances(_repo, _program_id, :deferred), do: {:ok, []}
+
+  def resolve_acceptances(_repo, nil, _intent), do: {:ok, []}
+
+  def resolve_acceptances(repo, program_id, {:accepted, ids}) do
+    current = current_versions_for_program(repo, program_id)
+    accepted = Enum.filter(current, &(&1.id in ids))
+    required_ids = for %{required: true, version: v} <- current, do: v.id
+
+    if Enum.all?(required_ids, fn id -> Enum.any?(accepted, &(&1.version.id == id)) end) do
+      {:ok, Enum.map(accepted, & &1.version)}
+    else
+      {:error, :waivers_unsigned}
+    end
+  end
+
+  @doc """
+  Inserts one acceptance per signed version, on the caller's transaction connection.
+  """
+  @spec record_acceptances(Ecto.Repo.t(), [WaiverVersion.t()], map(), map()) ::
+          {:ok, [WaiverAcceptance.t()]} | {:error, Ecto.Changeset.t()}
+  def record_acceptances(repo, versions, signer, audit) do
+    Enum.reduce_while(versions, {:ok, []}, fn version, {:ok, acc} ->
+      %WaiverAcceptance{}
+      |> WaiverAcceptance.changeset(WaiverAcceptance.accept(version, signer, audit))
+      |> repo.insert()
+      |> case do
+        {:ok, acceptance} -> {:cont, {:ok, [acceptance | acc]}}
+        {:error, changeset} -> {:halt, {:error, changeset}}
+      end
+    end)
+  end
+
+  # Active waivers on the program paired with their current version, flattened so the gate
+  # can filter on `required` and match on `version.id` in one pass.
+  defp current_versions_for_program(repo, program_id) do
+    waivers =
+      Waiver
+      |> where([w], w.program_id == ^program_id and is_nil(w.archived_at))
+      |> repo.all()
+
+    case waivers do
+      [] ->
+        []
+
+      waivers ->
+        versions =
+          WaiverVersion
+          |> where([v], v.waiver_id in ^Enum.map(waivers, & &1.id))
+          |> distinct([v], v.waiver_id)
+          |> order_by([v], asc: v.waiver_id, desc: v.version)
+          |> repo.all()
+          |> Map.new(&{&1.waiver_id, &1})
+
+        for waiver <- waivers,
+            version = Map.get(versions, waiver.id),
+            do: %{id: version.id, required: waiver.required, version: version}
+    end
   end
 
   defp pair_with_versions([]), do: []

--- a/lib/klass_hero_web/audit_info.ex
+++ b/lib/klass_hero_web/audit_info.ex
@@ -1,0 +1,68 @@
+defmodule KlassHeroWeb.AuditInfo do
+  @moduledoc """
+  Extracts the audit trail recorded alongside a waiver signature.
+
+  ## Only `fly-client-ip` is trusted
+
+  The app runs behind Fly's proxy, which overwrites `fly-client-ip` at the edge. Anything a
+  client sends under that name is discarded before it reaches us, so it is the one header
+  here that a signer cannot forge. `x-forwarded-for` is deliberately ignored: a client can
+  set it to whatever it likes, and a forged IP in a legal audit trail is worse than no IP,
+  because it reads as evidence.
+
+  When no trusted header is present the address is `nil` rather than a fallback. The proxy's
+  own address (what `:peer_data` would yield) identifies nobody.
+
+  Connect info only exists on the *connected* LiveView mount; the dead render has none, so
+  `nil` is a normal input here, not an error.
+  """
+
+  alias Phoenix.LiveView.Socket
+
+  @trusted_ip_header "fly-client-ip"
+
+  @doc """
+  Captures the audit trail from a mounting LiveView.
+
+  Call this in `mount/3`. Connect info is unavailable on the dead render, so a disconnected
+  mount yields empty values and the connected mount that follows fills them in — read the
+  result from assigns at submit time rather than calling this again from an event handler,
+  where connect info is no longer reachable.
+  """
+  @spec from_socket(Socket.t()) :: %{
+          ip_address: String.t() | nil,
+          user_agent: String.t() | nil
+        }
+  def from_socket(socket) do
+    if Phoenix.LiveView.connected?(socket) do
+      from_connect_info(%{
+        user_agent: Phoenix.LiveView.get_connect_info(socket, :user_agent),
+        x_headers: Phoenix.LiveView.get_connect_info(socket, :x_headers) || []
+      })
+    else
+      from_connect_info(nil)
+    end
+  end
+
+  @doc """
+  Builds `%{ip_address: ..., user_agent: ...}` from a LiveView's connect info.
+  """
+  @spec from_connect_info(map() | nil) :: %{ip_address: String.t() | nil, user_agent: String.t() | nil}
+  def from_connect_info(nil), do: %{ip_address: nil, user_agent: nil}
+
+  def from_connect_info(info) when is_map(info) do
+    %{
+      ip_address: info |> Map.get(:x_headers, []) |> trusted_client_ip(),
+      user_agent: Map.get(info, :user_agent)
+    }
+  end
+
+  defp trusted_client_ip(headers) when is_list(headers) do
+    Enum.find_value(headers, fn
+      {name, value} -> if String.downcase(name) == @trusted_ip_header, do: value
+      _other -> nil
+    end)
+  end
+
+  defp trusted_client_ip(_headers), do: nil
+end

--- a/lib/klass_hero_web/components/booking_components.ex
+++ b/lib/klass_hero_web/components/booking_components.ex
@@ -195,4 +195,38 @@ defmodule KlassHeroWeb.BookingComponents do
     </div>
     """
   end
+
+  @doc """
+  Marks a waiver as blocking or skippable.
+
+  Every waiver carries one of the two labels. Marking only one state would leave the other
+  readable by absence, and absence is the weakest signal available for the fact that decides
+  whether a parent can enrol at all. Rendered identically on the provider's authoring modal,
+  the booking form, and the standalone signing page, so the two audiences learn one
+  vocabulary rather than opposite ones.
+  """
+  attr :required, :boolean, required: true
+  attr :class, :string, default: ""
+
+  def waiver_requirement(assigns) do
+    ~H"""
+    <span
+      :if={@required}
+      class={[
+        "shrink-0 inline-block px-2 py-0.5 text-xs font-semibold rounded-full",
+        Theme.bg(:accent),
+        Theme.text_color(:heading),
+        @class
+      ]}
+    >
+      {gettext("Required")}
+    </span>
+    <span
+      :if={!@required}
+      class={["shrink-0 text-xs font-normal", Theme.text_color(:muted), @class]}
+    >
+      {gettext("(optional)")}
+    </span>
+    """
+  end
 end

--- a/lib/klass_hero_web/components/provider_components.ex
+++ b/lib/klass_hero_web/components/provider_components.ex
@@ -1965,15 +1965,17 @@ defmodule KlassHeroWeb.ProviderComponents do
               class="flex items-start gap-3 py-3"
             >
               <div class="min-w-0 flex-1">
-                <p class="truncate font-medium text-hero-charcoal">
-                  {entry.waiver.title}
+                <%!-- The badge sits outside the truncating title, or a long title swallows it
+                      on a narrow viewport — losing the one word that says this one blocks. --%>
+                <div class="flex items-center gap-2">
+                  <p class="truncate font-medium text-hero-charcoal">{entry.waiver.title}</p>
                   <span
                     :if={entry.waiver.required}
-                    class="ml-1 inline-block px-2 py-0.5 text-xs font-semibold bg-hero-yellow text-hero-charcoal rounded-full align-middle"
+                    class="shrink-0 inline-block px-2 py-0.5 text-xs font-semibold bg-hero-yellow-500 text-hero-grey-900 rounded-full"
                   >
                     {gettext("Required")}
                   </span>
-                </p>
+                </div>
                 <p class="text-sm text-hero-grey-500">
                   {gettext("Version %{number}", number: entry.version.version)}
                 </p>
@@ -1987,12 +1989,20 @@ defmodule KlassHeroWeb.ProviderComponents do
                   phx-click="edit_waiver"
                   phx-value-id={entry.waiver.id}
                 />
+                <%!-- Retiring cannot be undone from the UI, so it gets the same confirm as
+                      the other one-click destructive actions in this file. --%>
                 <.action_button
                   id={"archive-waiver-#{entry.waiver.id}"}
                   icon="hero-archive-box-mini"
                   title={gettext("Retire this waiver")}
                   phx-click="archive_waiver"
                   phx-value-id={entry.waiver.id}
+                  data-confirm={
+                    gettext(
+                      "Retire \"%{title}\"? Parents will no longer be asked to sign it. Signatures already collected are kept.",
+                      title: entry.waiver.title
+                    )
+                  }
                 />
               </div>
             </li>

--- a/lib/klass_hero_web/components/provider_components.ex
+++ b/lib/klass_hero_web/components/provider_components.ex
@@ -2457,6 +2457,9 @@ defmodule KlassHeroWeb.ProviderComponents do
             {gettext("Status")}
           </th>
           <th class="px-3 py-2 text-left text-xs font-semibold text-hero-grey-500 uppercase">
+            {gettext("Waivers")}
+          </th>
+          <th class="px-3 py-2 text-left text-xs font-semibold text-hero-grey-500 uppercase">
             {gettext("Enrolled")}
           </th>
           <th class="px-3 py-2 text-right text-xs font-semibold text-hero-grey-500 uppercase">
@@ -2473,6 +2476,22 @@ defmodule KlassHeroWeb.ProviderComponents do
             <.status_pill color={enrollment_status_color(entry.status)}>
               {enrollment_status_label(entry.status)}
             </.status_pill>
+          </td>
+          <td class="px-3 py-3">
+            <%!-- A dash rather than "Signed" when the program requires nothing: a provider
+                  scanning for who still owes them a form should not see a green tick that
+                  means "there was never anything to sign". --%>
+            <span id={"waiver-status-#{entry.enrollment_id}"} data-status={entry.waiver_status}>
+              <span :if={entry.waiver_status == :not_required} class="text-sm text-hero-grey-400">
+                —
+              </span>
+              <.status_pill
+                :if={entry.waiver_status != :not_required}
+                color={if entry.waiver_status == :signed, do: "success", else: "warning"}
+              >
+                {if entry.waiver_status == :signed, do: gettext("Signed"), else: gettext("Unsigned")}
+              </.status_pill>
+            </span>
           </td>
           <td class="px-3 py-3 text-sm text-hero-grey-500">
             {format_enrollment_date(entry.enrolled_at)}

--- a/lib/klass_hero_web/components/provider_components.ex
+++ b/lib/klass_hero_web/components/provider_components.ex
@@ -1585,6 +1585,13 @@ defmodule KlassHeroWeb.ProviderComponents do
                     phx-value-id={program.id}
                   />
                   <.action_button
+                    id={"manage-waivers-#{program.id}"}
+                    icon="hero-shield-check-mini"
+                    title={gettext("Manage Waivers")}
+                    phx-click="manage_waivers"
+                    phx-value-id={program.id}
+                  />
+                  <.action_button
                     icon="hero-pencil-square-mini"
                     title={gettext("Edit")}
                     phx-click="edit_program"
@@ -1903,6 +1910,143 @@ defmodule KlassHeroWeb.ProviderComponents do
               </tbody>
             </table>
           <% end %>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  @doc """
+  Renders the waivers panel for one program: the legal forms parents sign at enrollment.
+
+  Editing publishes a *new* version rather than rewriting the current one, and archiving
+  retires a form without deleting it — both because a signature is only evidence while the
+  wording it was given stays reproducible.
+
+  ## Example
+
+      <.waivers_modal :if={@waivers_modal} modal={@waivers_modal} />
+  """
+  attr :modal, :map, required: true
+
+  def waivers_modal(assigns) do
+    ~H"""
+    <div
+      id="program-waivers-modal"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="program-waivers-modal-title"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      phx-window-keydown="close_waivers"
+      phx-key="escape"
+    >
+      <div
+        class="bg-white rounded-lg shadow-xl w-full max-w-2xl max-h-[85vh] overflow-hidden flex flex-col"
+        phx-click-away="close_waivers"
+      >
+        <div class="flex items-center justify-between px-4 py-4 sm:px-6 border-b border-hero-grey-200">
+          <h2 id="program-waivers-modal-title" class={Theme.typography(:section_title)}>
+            {gettext("Waivers — %{title}", title: @modal.program_name)}
+          </h2>
+          <button type="button" phx-click="close_waivers" aria-label={gettext("Close")}>
+            <.icon name="hero-x-mark" class="w-5 h-5" />
+          </button>
+        </div>
+
+        <div class="flex-1 overflow-y-auto px-4 py-4 sm:px-6 space-y-6">
+          <p :if={@modal.waivers == []} id="waivers-empty" class="text-sm text-hero-grey-500">
+            {gettext("No waivers yet. Parents enrol without signing anything.")}
+          </p>
+
+          <ul :if={@modal.waivers != []} id="waiver-list" class="divide-y divide-hero-grey-100">
+            <li
+              :for={entry <- @modal.waivers}
+              id={"waiver-#{entry.waiver.id}"}
+              class="flex items-start gap-3 py-3"
+            >
+              <div class="min-w-0 flex-1">
+                <p class="truncate font-medium text-hero-charcoal">
+                  {entry.waiver.title}
+                  <span
+                    :if={entry.waiver.required}
+                    class="ml-1 inline-block px-2 py-0.5 text-xs font-semibold bg-hero-yellow text-hero-charcoal rounded-full align-middle"
+                  >
+                    {gettext("Required")}
+                  </span>
+                </p>
+                <p class="text-sm text-hero-grey-500">
+                  {gettext("Version %{number}", number: entry.version.version)}
+                </p>
+              </div>
+
+              <div class="flex shrink-0 items-center gap-1">
+                <.action_button
+                  id={"edit-waiver-#{entry.waiver.id}"}
+                  icon="hero-pencil-square-mini"
+                  title={gettext("Revise text")}
+                  phx-click="edit_waiver"
+                  phx-value-id={entry.waiver.id}
+                />
+                <.action_button
+                  id={"archive-waiver-#{entry.waiver.id}"}
+                  icon="hero-archive-box-mini"
+                  title={gettext("Retire this waiver")}
+                  phx-click="archive_waiver"
+                  phx-value-id={entry.waiver.id}
+                />
+              </div>
+            </li>
+          </ul>
+
+          <.form for={@modal.form} id="waiver-form" phx-submit="save_waiver" class="space-y-4">
+            <h3 class={[Theme.typography(:card_title), "text-hero-charcoal"]}>
+              {if @modal.editing_id,
+                do: gettext("Publish a new version"),
+                else: gettext("Add a waiver")}
+            </h3>
+
+            <.input
+              :if={!@modal.editing_id}
+              field={@modal.form[:title]}
+              type="text"
+              label={gettext("Title")}
+            />
+
+            <.input
+              field={@modal.form[:body]}
+              type="textarea"
+              rows="8"
+              label={gettext("Legal text")}
+            />
+
+            <.input
+              :if={!@modal.editing_id}
+              field={@modal.form[:required]}
+              type="checkbox"
+              label={gettext("Parents must sign this before enrolling")}
+            />
+
+            <p :if={@modal.editing_id} class="text-xs text-hero-grey-500">
+              {gettext(
+                "Publishing keeps every earlier version on record; signatures already given stay bound to the wording they were shown."
+              )}
+            </p>
+
+            <div class="flex gap-2">
+              <.kh_button type="submit" id="save-waiver">
+                {if @modal.editing_id, do: gettext("Publish version"), else: gettext("Add waiver")}
+              </.kh_button>
+              <.kh_button
+                :if={@modal.editing_id}
+                type="button"
+                variant={:secondary}
+                id="cancel-waiver-edit"
+                phx-click="cancel_waiver_edit"
+              >
+                {gettext("Cancel")}
+              </.kh_button>
+            </div>
+          </.form>
         </div>
       </div>
     </div>

--- a/lib/klass_hero_web/components/provider_components.ex
+++ b/lib/klass_hero_web/components/provider_components.ex
@@ -10,6 +10,7 @@ defmodule KlassHeroWeb.ProviderComponents do
     router: KlassHeroWeb.Router,
     statics: KlassHeroWeb.static_paths()
 
+  import KlassHeroWeb.BookingComponents, only: [waiver_requirement: 1]
   import KlassHeroWeb.CoreComponents, only: [input: 1]
   import KlassHeroWeb.ParticipationComponents, only: [participation_status: 1]
   import KlassHeroWeb.UIComponents
@@ -1969,12 +1970,7 @@ defmodule KlassHeroWeb.ProviderComponents do
                       on a narrow viewport — losing the one word that says this one blocks. --%>
                 <div class="flex items-center gap-2">
                   <p class="truncate font-medium text-hero-charcoal">{entry.waiver.title}</p>
-                  <span
-                    :if={entry.waiver.required}
-                    class="shrink-0 inline-block px-2 py-0.5 text-xs font-semibold bg-hero-yellow-500 text-hero-grey-900 rounded-full"
-                  >
-                    {gettext("Required")}
-                  </span>
+                  <.waiver_requirement required={entry.waiver.required} />
                 </div>
                 <p class="text-sm text-hero-grey-500">
                   {gettext("Version %{number}", number: entry.version.version)}

--- a/lib/klass_hero_web/endpoint.ex
+++ b/lib/klass_hero_web/endpoint.ex
@@ -15,8 +15,8 @@ defmodule KlassHeroWeb.Endpoint do
   ]
 
   socket "/live", Socket,
-    websocket: [connect_info: [:user_agent, session: @session_options]],
-    longpoll: [connect_info: [:user_agent, session: @session_options]]
+    websocket: [connect_info: [:user_agent, :x_headers, session: @session_options]],
+    longpoll: [connect_info: [:user_agent, :x_headers, session: @session_options]]
 
   if Application.compile_env(:klass_hero, :sql_sandbox) do
     plug Sandbox

--- a/lib/klass_hero_web/live/booking_live.ex
+++ b/lib/klass_hero_web/live/booking_live.ex
@@ -161,6 +161,15 @@ defmodule KlassHeroWeb.BookingLive do
           {:error, :child_not_selected} ->
             {:noreply, put_flash(socket, :error, gettext("Please select a child for enrollment."))}
 
+          # Reachable two ways: the parent left a box unticked, or the provider published a
+          # new version while this page was open. Re-read the waivers so the second case
+          # shows the text now in force rather than the stale copy they were looking at.
+          {:error, :waivers_unsigned} ->
+            {:noreply,
+             socket
+             |> assign(waivers: Enrollment.list_program_waivers(socket.assigns.program.id))
+             |> put_flash(:error, gettext("Please read and sign every required waiver before enrolling."))}
+
           {:error, :no_parent_profile} ->
             {:noreply,
              socket
@@ -266,7 +275,7 @@ defmodule KlassHeroWeb.BookingLive do
       # A signer is present here, so the intent is always `:accepted` — never `:deferred`.
       # The context re-checks the set against the program's current required waivers, so a
       # stale or tampered list fails there rather than being trusted from the client.
-      waivers: {:accepted, socket.assigns.signed_waiver_version_ids},
+      waivers: {:accepted, List.wrap(params["waiver_version_ids"])},
       audit: socket.assigns.audit
     }
 
@@ -344,7 +353,7 @@ defmodule KlassHeroWeb.BookingLive do
           </div>
         </div>
 
-        <form phx-submit="complete_enrollment" class="space-y-6">
+        <form id="booking-form" phx-submit="complete_enrollment" class="space-y-6">
           <div class={[Theme.bg(:surface), Theme.rounded(:xl), "p-6 shadow-lg"]}>
             <label class={["block text-sm font-semibold mb-3", Theme.text_color(:body)]}>
               {gettext("Select Child")}
@@ -406,6 +415,56 @@ defmodule KlassHeroWeb.BookingLive do
                 )}
               </p>
               <p class={["text-xs", Theme.text_color(:muted)]}>0/500</p>
+            </div>
+          </div>
+
+          <div
+            :if={@waivers != []}
+            id="booking-waivers"
+            class={[Theme.bg(:surface), Theme.rounded(:xl), "p-6 shadow-lg"]}
+          >
+            <h2 class={["block text-sm font-semibold mb-3", Theme.text_color(:body)]}>
+              {gettext("Waivers")}
+            </h2>
+
+            <div :for={entry <- @waivers} id={"waiver-#{entry.waiver.id}"} class="mb-4 last:mb-0">
+              <h3 class={[Theme.typography(:card_title), Theme.text_color(:heading), "mb-2"]}>
+                {entry.waiver.title}
+                <span
+                  :if={!entry.waiver.required}
+                  class={["text-xs font-normal", Theme.text_color(:muted)]}
+                >
+                  {gettext("(optional)")}
+                </span>
+              </h3>
+
+              <%!-- Scrollable rather than truncated: a parent must be able to read the whole
+                    text before signing, and a "read more" that collapses it would weaken the
+                    claim that they saw it. --%>
+              <div
+                class={[
+                  "max-h-48 overflow-y-auto border p-3 text-sm whitespace-pre-line mb-2",
+                  Theme.rounded(:lg),
+                  Theme.border_color(:medium),
+                  Theme.text_color(:body)
+                ]}
+                tabindex="0"
+              >
+                {entry.version.body}
+              </div>
+
+              <label class="flex items-start gap-2 text-sm cursor-pointer">
+                <input
+                  type="checkbox"
+                  id={"sign-waiver-#{entry.waiver.id}"}
+                  name="waiver_version_ids[]"
+                  value={entry.version.id}
+                  class="mt-0.5"
+                />
+                <span class={Theme.text_color(:body)}>
+                  {gettext("I have read and agree to %{title}", title: entry.waiver.title)}
+                </span>
+              </label>
             </div>
           </div>
 

--- a/lib/klass_hero_web/live/booking_live.ex
+++ b/lib/klass_hero_web/live/booking_live.ex
@@ -428,14 +428,13 @@ defmodule KlassHeroWeb.BookingLive do
             </h2>
 
             <div :for={entry <- @waivers} id={"waiver-#{entry.waiver.id}"} class="mb-4 last:mb-0">
-              <h3 class={[Theme.typography(:card_title), Theme.text_color(:heading), "mb-2"]}>
+              <h3 class={[
+                Theme.typography(:card_title),
+                Theme.text_color(:heading),
+                "mb-2 flex flex-wrap items-center gap-2"
+              ]}>
                 {entry.waiver.title}
-                <span
-                  :if={!entry.waiver.required}
-                  class={["text-xs font-normal", Theme.text_color(:muted)]}
-                >
-                  {gettext("(optional)")}
-                </span>
+                <.waiver_requirement required={entry.waiver.required} />
               </h3>
 
               <%!-- Scrollable rather than truncated: a parent must be able to read the whole

--- a/lib/klass_hero_web/live/booking_live.ex
+++ b/lib/klass_hero_web/live/booking_live.ex
@@ -6,6 +6,7 @@ defmodule KlassHeroWeb.BookingLive do
   alias KlassHero.Enrollment
   alias KlassHero.Family
   alias KlassHero.ProgramCatalog
+  alias KlassHeroWeb.AuditInfo
   alias KlassHeroWeb.Presenters.ChildPresenter
   alias KlassHeroWeb.Presenters.ProgramPresenter
   alias KlassHeroWeb.Theme
@@ -43,7 +44,12 @@ defmodule KlassHeroWeb.BookingLive do
           eligibility_status: nil,
           special_requirements: "",
           payment_method: "card",
-          total_amount: total_amount
+          total_amount: total_amount,
+          waivers: Enrollment.list_program_waivers(program.id),
+          signed_waiver_version_ids: [],
+          # Connect info exists only on the connected mount, so capture it here and read it
+          # from assigns at submit — it is unreachable from a handle_event.
+          audit: AuditInfo.from_socket(socket)
         )
 
       {:ok, socket}
@@ -256,7 +262,12 @@ defmodule KlassHeroWeb.BookingLive do
       vat_amount: Decimal.new("0.00"),
       card_fee_amount: Decimal.new("0.00"),
       total_amount: socket.assigns.total_amount,
-      special_requirements: params["special_requirements"]
+      special_requirements: params["special_requirements"],
+      # A signer is present here, so the intent is always `:accepted` — never `:deferred`.
+      # The context re-checks the set against the program's current required waivers, so a
+      # stale or tampered list fails there rather than being trusted from the client.
+      waivers: {:accepted, socket.assigns.signed_waiver_version_ids},
+      audit: socket.assigns.audit
     }
 
     Enrollment.create_enrollment(enrollment_params)

--- a/lib/klass_hero_web/live/dashboard_live.ex
+++ b/lib/klass_hero_web/live/dashboard_live.ex
@@ -30,6 +30,7 @@ defmodule KlassHeroWeb.DashboardLive do
         active_nav: :home,
         user: user,
         loading?: true,
+        waivers_outstanding: [],
         children_count: 0,
         kid_picker_items: [],
         active_program_count: 0,
@@ -70,7 +71,8 @@ defmodule KlassHeroWeb.DashboardLive do
         upcoming_count: length(data.upcoming_sessions),
         upcoming_sessions: data.upcoming_sessions,
         recent_messages: data.recent_messages,
-        family_programs_empty?: active == [] and expired == []
+        family_programs_empty?: active == [] and expired == [],
+        waivers_outstanding: outstanding_waiver_items(active)
       )
       |> stream(:family_programs, build_family_program_items(active, expired), reset: true)
 
@@ -195,6 +197,22 @@ defmodule KlassHeroWeb.DashboardLive do
 
   defp relative_time(_), do: nil
 
+  # An enrollment created by a provider's bulk invite has no signer at creation, so its
+  # required waivers arrive outstanding. Only active programs are worth nagging about — a
+  # finished program's unsigned waiver is a record to keep, not an action to take.
+  defp outstanding_waiver_items([]), do: []
+
+  defp outstanding_waiver_items(active_programs) do
+    statuses =
+      active_programs
+      |> Enum.map(fn {enrollment, _program} -> enrollment.id end)
+      |> Enrollment.waiver_status_for_enrollments()
+
+    for {enrollment, program} <- active_programs,
+        Map.get(statuses, enrollment.id) == :unsigned,
+        do: %{enrollment_id: enrollment.id, program_title: program.title}
+  end
+
   defp load_family_programs(parent_id) do
     enrollments = Enrollment.list_parent_enrollments(parent_id)
 
@@ -294,6 +312,23 @@ defmodule KlassHeroWeb.DashboardLive do
   def render(assigns) do
     ~H"""
     <div class="space-y-6">
+      <%!-- Enrollments created by a provider's bulk invite have no signer at creation, so
+            their waivers arrive outstanding. This is the only place the parent learns that. --%>
+      <section :if={@waivers_outstanding != []} id="waivers-outstanding">
+        <div class="rounded-xl border border-amber-300 bg-amber-50 p-4">
+          <h2 class="font-semibold text-amber-900 mb-2">
+            {gettext("Waivers waiting for your signature")}
+          </h2>
+          <ul class="space-y-1 text-sm">
+            <li :for={item <- @waivers_outstanding} id={"waivers-outstanding-#{item.enrollment_id}"}>
+              <.link navigate={~p"/enrollments/#{item.enrollment_id}/waivers"} class="underline">
+                {gettext("Sign the waivers for %{program}", program: item.program_title)}
+              </.link>
+            </li>
+          </ul>
+        </div>
+      </section>
+
       <section :if={@kid_picker_items != []} id="kid-picker">
         <.pa_kid_picker
           kids={@kid_picker_items}

--- a/lib/klass_hero_web/live/dashboard_live.ex
+++ b/lib/klass_hero_web/live/dashboard_live.ex
@@ -315,8 +315,13 @@ defmodule KlassHeroWeb.DashboardLive do
       <%!-- Enrollments created by a provider's bulk invite have no signer at creation, so
             their waivers arrive outstanding. This is the only place the parent learns that. --%>
       <section :if={@waivers_outstanding != []} id="waivers-outstanding">
-        <div class="rounded-xl border border-amber-300 bg-amber-50 p-4">
-          <h2 class="font-semibold text-amber-900 mb-2">
+        <div class={[
+          "p-4 border",
+          Theme.rounded(:xl),
+          Theme.bg(:accent_light),
+          Theme.border_color(:accent)
+        ]}>
+          <h2 class={["font-semibold mb-2", Theme.text_color(:heading)]}>
             {gettext("Waivers waiting for your signature")}
           </h2>
           <ul class="space-y-1 text-sm">

--- a/lib/klass_hero_web/live/enrollment_waivers_live.ex
+++ b/lib/klass_hero_web/live/enrollment_waivers_live.ex
@@ -138,12 +138,8 @@ defmodule KlassHeroWeb.EnrollmentWaiversLive do
             {entry.version.body}
           </div>
 
-          <p
-            :if={entry.signed?}
-            id={"waiver-signed-#{entry.waiver.id}"}
-            class="text-sm font-semibold text-green-700"
-          >
-            {gettext("Signed")}
+          <p :if={entry.signed?} id={"waiver-signed-#{entry.waiver.id}"}>
+            <.status_pill color="success">{gettext("Signed")}</.status_pill>
           </p>
 
           <label :if={!entry.signed?} class="flex items-start gap-2 text-sm cursor-pointer">

--- a/lib/klass_hero_web/live/enrollment_waivers_live.ex
+++ b/lib/klass_hero_web/live/enrollment_waivers_live.ex
@@ -15,6 +15,8 @@ defmodule KlassHeroWeb.EnrollmentWaiversLive do
   """
   use KlassHeroWeb, :live_view
 
+  import KlassHeroWeb.BookingComponents, only: [waiver_requirement: 1]
+
   alias KlassHero.Enrollment
   alias KlassHero.Family
   alias KlassHero.ProgramCatalog
@@ -116,14 +118,13 @@ defmodule KlassHeroWeb.EnrollmentWaiversLive do
           id={"waiver-#{entry.waiver.id}"}
           class={[Theme.bg(:surface), Theme.rounded(:xl), "p-6 shadow-lg"]}
         >
-          <h2 class={[Theme.typography(:card_title), Theme.text_color(:heading), "mb-2"]}>
+          <h2 class={[
+            Theme.typography(:card_title),
+            Theme.text_color(:heading),
+            "mb-2 flex flex-wrap items-center gap-2"
+          ]}>
             {entry.waiver.title}
-            <span
-              :if={!entry.waiver.required}
-              class={["text-xs font-normal", Theme.text_color(:muted)]}
-            >
-              {gettext("(optional)")}
-            </span>
+            <.waiver_requirement required={entry.waiver.required} />
           </h2>
 
           <div

--- a/lib/klass_hero_web/live/enrollment_waivers_live.ex
+++ b/lib/klass_hero_web/live/enrollment_waivers_live.ex
@@ -1,0 +1,170 @@
+defmodule KlassHeroWeb.EnrollmentWaiversLive do
+  @moduledoc """
+  Signing the waivers outstanding on an existing enrollment.
+
+  Reached from the parent dashboard when an enrollment was created without a signer present
+  — a provider's bulk invite creates the enrollment from a background job, so the waivers
+  stay outstanding until the parent gets here.
+
+  ## Only the enrolling parent
+
+  Authorization runs on **mount and on submit**, not mount alone: a mount-only check leaves
+  the submit event reachable directly over the socket by anyone who can guess an enrollment
+  id. `Enrollment.sign_waivers/4` re-checks server-side regardless, so this is
+  defence in depth rather than the only guard.
+  """
+  use KlassHeroWeb, :live_view
+
+  alias KlassHero.Enrollment
+  alias KlassHero.Family
+  alias KlassHero.ProgramCatalog
+  alias KlassHeroWeb.AuditInfo
+  alias KlassHeroWeb.Theme
+
+  @impl true
+  def mount(%{"id" => enrollment_id}, _session, socket) do
+    case authorize(socket, enrollment_id) do
+      {:ok, enrollment, parent} ->
+        {:ok,
+         socket
+         |> assign(
+           page_title: gettext("Waivers"),
+           active_nav: :bookings,
+           enrollment: enrollment,
+           parent_id: parent.id,
+           program_title: program_title(enrollment.program_id),
+           waivers: Enrollment.list_enrollment_waivers(enrollment_id),
+           audit: AuditInfo.from_socket(socket)
+         )}
+
+      {:error, _reason} ->
+        {:ok,
+         socket
+         |> put_flash(:error, gettext("Enrollment not found."))
+         |> redirect(to: ~p"/dashboard")}
+    end
+  end
+
+  @impl true
+  def handle_event("sign_waivers", params, socket) do
+    %{enrollment: enrollment, parent_id: parent_id} = socket.assigns
+    version_ids = List.wrap(params["waiver_version_ids"])
+
+    case Enrollment.sign_waivers(enrollment.id, parent_id, version_ids, socket.assigns.audit) do
+      {:ok, []} ->
+        {:noreply, put_flash(socket, :error, gettext("Please tick a waiver to sign it."))}
+
+      {:ok, _acceptances} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, gettext("Thank you — your waivers are on record."))
+         |> push_navigate(to: ~p"/dashboard")}
+
+      {:error, :not_found} ->
+        {:noreply,
+         socket
+         |> put_flash(:error, gettext("Enrollment not found."))
+         |> redirect(to: ~p"/dashboard")}
+
+      {:error, _reason} ->
+        {:noreply,
+         socket
+         |> assign(waivers: Enrollment.list_enrollment_waivers(enrollment.id))
+         |> put_flash(:error, gettext("Something went wrong. Please try again or contact support."))}
+    end
+  end
+
+  defp authorize(socket, enrollment_id) do
+    identity_id = socket.assigns.current_scope.user.id
+
+    with {:ok, parent} <- Family.get_parent_by_identity(identity_id),
+         {:ok, enrollment} <- Enrollment.get_enrollment(enrollment_id),
+         # A foreign enrollment is reported exactly like a missing one, so probing ids
+         # reveals nothing about which exist.
+         true <- enrollment.parent_id == parent.id do
+      {:ok, enrollment, parent}
+    else
+      _otherwise -> {:error, :not_found}
+    end
+  end
+
+  defp program_title(program_id) do
+    case ProgramCatalog.get_program_by_id(program_id) do
+      {:ok, program} -> program.title
+      {:error, _reason} -> gettext("this program")
+    end
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="max-w-2xl mx-auto px-4 py-6">
+      <h1 class={[Theme.typography(:page_title), Theme.text_color(:heading), "mb-2"]}>
+        {gettext("Waivers")}
+      </h1>
+      <p class={["mb-6", Theme.text_color(:secondary)]}>
+        {gettext("Please read and sign these before %{program} begins.", program: @program_title)}
+      </p>
+
+      <p :if={@waivers == []} id="waivers-none" class={Theme.text_color(:secondary)}>
+        {gettext("There is nothing to sign for this enrollment.")}
+      </p>
+
+      <form :if={@waivers != []} id="sign-waivers-form" phx-submit="sign_waivers" class="space-y-6">
+        <div
+          :for={entry <- @waivers}
+          id={"waiver-#{entry.waiver.id}"}
+          class={[Theme.bg(:surface), Theme.rounded(:xl), "p-6 shadow-lg"]}
+        >
+          <h2 class={[Theme.typography(:card_title), Theme.text_color(:heading), "mb-2"]}>
+            {entry.waiver.title}
+            <span
+              :if={!entry.waiver.required}
+              class={["text-xs font-normal", Theme.text_color(:muted)]}
+            >
+              {gettext("(optional)")}
+            </span>
+          </h2>
+
+          <div
+            class={[
+              "max-h-64 overflow-y-auto border p-3 text-sm whitespace-pre-line mb-3",
+              Theme.rounded(:lg),
+              Theme.border_color(:medium),
+              Theme.text_color(:body)
+            ]}
+            tabindex="0"
+          >
+            {entry.version.body}
+          </div>
+
+          <p
+            :if={entry.signed?}
+            id={"waiver-signed-#{entry.waiver.id}"}
+            class="text-sm font-semibold text-green-700"
+          >
+            {gettext("Signed")}
+          </p>
+
+          <label :if={!entry.signed?} class="flex items-start gap-2 text-sm cursor-pointer">
+            <input
+              type="checkbox"
+              id={"sign-waiver-#{entry.waiver.id}"}
+              name="waiver_version_ids[]"
+              value={entry.version.id}
+              class="mt-0.5"
+            />
+            <span class={Theme.text_color(:body)}>
+              {gettext("I have read and agree to %{title}", title: entry.waiver.title)}
+            </span>
+          </label>
+        </div>
+
+        <.kh_button type="submit" id="submit-waivers" class="w-full">
+          {gettext("Sign waivers")}
+        </.kh_button>
+      </form>
+    </div>
+    """
+  end
+end

--- a/lib/klass_hero_web/live/provider/programs_live.ex
+++ b/lib/klass_hero_web/live/provider/programs_live.ex
@@ -73,6 +73,7 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
       )
       |> assign(sessions_modal: nil)
       |> assign(staffing_modal: nil)
+      |> assign(waivers_modal: nil)
       |> assign(program_form: to_form(ProgramCatalog.new_program_changeset(), as: :program_schema))
       |> assign(enrollment_form: to_form(Enrollment.new_policy_changeset(), as: "enrollment_policy"))
       |> assign(
@@ -260,6 +261,84 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
   @impl true
   def handle_event("close_staffing", _params, socket) do
     {:noreply, assign(socket, :staffing_modal, nil)}
+  end
+
+  @impl true
+  def handle_event("manage_waivers", %{"id" => program_id}, socket) do
+    provider_id = socket.assigns.current_scope.provider.id
+
+    # Same IDOR guard as manage_staffing/view_roster: program_id is client-supplied.
+    case ProgramCatalog.get_program_for_provider(provider_id, program_id) do
+      {:ok, program} ->
+        {:noreply, assign(socket, :waivers_modal, build_waivers_modal(program_id, program.title))}
+
+      {:error, :not_found} ->
+        Logger.warning("[ProgramsLive] Waiver access attempt for unknown or foreign program",
+          program_id: program_id,
+          provider_id: provider_id
+        )
+
+        {:noreply, put_flash(socket, :error, gettext("Program not found."))}
+    end
+  end
+
+  @impl true
+  def handle_event("close_waivers", _params, socket) do
+    {:noreply, assign(socket, :waivers_modal, nil)}
+  end
+
+  @impl true
+  def handle_event("edit_waiver", %{"id" => waiver_id}, socket) do
+    modal = socket.assigns.waivers_modal
+    entry = Enum.find(modal.waivers, &(&1.waiver.id == waiver_id))
+
+    {:noreply,
+     assign(socket, :waivers_modal, %{
+       modal
+       | editing_id: waiver_id,
+         form: to_form(%{"body" => entry.version.body}, as: :waiver)
+     })}
+  end
+
+  @impl true
+  def handle_event("cancel_waiver_edit", _params, socket) do
+    modal = socket.assigns.waivers_modal
+    {:noreply, assign(socket, :waivers_modal, %{modal | editing_id: nil, form: blank_waiver_form()})}
+  end
+
+  @impl true
+  def handle_event("save_waiver", %{"waiver" => params}, socket) do
+    %{program_id: program_id, program_name: program_name, editing_id: editing_id} = socket.assigns.waivers_modal
+    provider_id = socket.assigns.current_scope.provider.id
+
+    save_waiver(provider_id, program_id, editing_id, params)
+    |> case do
+      {:ok, _result} ->
+        {:noreply, assign(socket, :waivers_modal, build_waivers_modal(program_id, program_name))}
+
+      {:error, reason} ->
+        {:noreply,
+         socket
+         |> put_flash(:error, waiver_error_message(reason))
+         |> assign(:waivers_modal, %{
+           socket.assigns.waivers_modal
+           | form: to_form(params, as: :waiver, errors: waiver_form_errors(reason))
+         })}
+    end
+  end
+
+  @impl true
+  def handle_event("archive_waiver", %{"id" => waiver_id}, socket) do
+    %{program_id: program_id, program_name: program_name} = socket.assigns.waivers_modal
+    provider_id = socket.assigns.current_scope.provider.id
+
+    case Enrollment.archive_waiver(provider_id, waiver_id) do
+      {:ok, _waiver} ->
+        {:noreply, assign(socket, :waivers_modal, build_waivers_modal(program_id, program_name))}
+
+      {:error, :not_found} ->
+        {:noreply, put_flash(socket, :error, gettext("Waiver not found."))}
+    end
   end
 
   @impl true
@@ -823,6 +902,47 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
   # Two facade reads joined by a presenter, the same shape ProgramDetailLive uses
   # for the public "Meet the Heroes" section — `is_lead_instructor` on the
   # assignment is the single source of truth for who leads.
+  # Rebuilt from the context after every write rather than patched in place — the panel is
+  # small, and a stale local copy is how a "current version" display drifts from the row a
+  # signature will actually bind to.
+  defp build_waivers_modal(program_id, program_name) do
+    %{
+      program_id: program_id,
+      program_name: program_name,
+      waivers: Enrollment.list_program_waivers(program_id),
+      editing_id: nil,
+      form: blank_waiver_form()
+    }
+  end
+
+  defp blank_waiver_form do
+    to_form(%{"title" => "", "body" => "", "required" => "true"}, as: :waiver)
+  end
+
+  defp save_waiver(provider_id, _program_id, waiver_id, %{"body" => body}) when is_binary(waiver_id) do
+    Enrollment.publish_waiver_version(provider_id, waiver_id, body)
+  end
+
+  defp save_waiver(provider_id, program_id, nil, params) do
+    Enrollment.create_waiver(provider_id, %{
+      program_id: program_id,
+      title: params["title"],
+      body: params["body"],
+      required: params["required"] == "true"
+    })
+  end
+
+  defp waiver_error_message(:not_found), do: gettext("Program not found.")
+  defp waiver_error_message(_reason), do: gettext("Check the waiver details and try again.")
+
+  # Domain validators return a keyword list of {field, message}; changesets carry their own.
+  defp waiver_form_errors(errors) when is_list(errors) do
+    for {field, message} <- errors, do: {field, {message, []}}
+  end
+
+  defp waiver_form_errors(%Ecto.Changeset{} = changeset), do: changeset.errors
+  defp waiver_form_errors(_reason), do: []
+
   defp build_staffing_modal(program_id, program_name, provider_id) do
     lead_id =
       case Provider.get_lead_instructor(program_id) do
@@ -1336,6 +1456,8 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
         <.sessions_modal :if={@sessions_modal} modal={@sessions_modal} />
 
         <.staffing_modal :if={@staffing_modal} modal={@staffing_modal} />
+
+        <.waivers_modal :if={@waivers_modal} modal={@waivers_modal} />
       </div>
     </.pv_dashboard_shell>
     """

--- a/lib/klass_hero_web/live/provider/programs_live.ex
+++ b/lib/klass_hero_web/live/provider/programs_live.ex
@@ -314,7 +314,10 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
     save_waiver(provider_id, program_id, editing_id, params)
     |> case do
       {:ok, _result} ->
-        {:noreply, assign(socket, :waivers_modal, build_waivers_modal(program_id, program_name))}
+        {:noreply,
+         socket
+         |> assign(:waivers_modal, build_waivers_modal(program_id, program_name))
+         |> put_flash(:info, waiver_saved_message(editing_id))}
 
       {:error, reason} ->
         {:noreply,
@@ -334,7 +337,10 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
 
     case Enrollment.archive_waiver(provider_id, waiver_id) do
       {:ok, _waiver} ->
-        {:noreply, assign(socket, :waivers_modal, build_waivers_modal(program_id, program_name))}
+        {:noreply,
+         socket
+         |> assign(:waivers_modal, build_waivers_modal(program_id, program_name))
+         |> put_flash(:info, gettext("Waiver retired. Signatures already collected are kept."))}
 
       {:error, :not_found} ->
         {:noreply, put_flash(socket, :error, gettext("Waiver not found."))}
@@ -931,6 +937,9 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
       required: params["required"] == "true"
     })
   end
+
+  defp waiver_saved_message(nil), do: gettext("Waiver added.")
+  defp waiver_saved_message(_editing_id), do: gettext("New version published. It applies to future enrolments.")
 
   defp waiver_error_message(:not_found), do: gettext("Program not found.")
   defp waiver_error_message(_reason), do: gettext("Check the waiver details and try again.")

--- a/lib/klass_hero_web/router.ex
+++ b/lib/klass_hero_web/router.ex
@@ -108,6 +108,7 @@ defmodule KlassHeroWeb.Router do
       live "/family/settings/children/:child_id/edit", Settings.ChildrenLive, :edit
 
       live "/programs/:id/booking", BookingLive, :new
+      live "/enrollments/:id/waivers", EnrollmentWaiversLive, :show
       live "/messages", MessagesLive.Index, :index
       live "/messages/:id", MessagesLive.Show, :show
     end

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -137,12 +137,12 @@ msgid "Your Data"
 msgstr "Ihre Daten"
 
 #: lib/klass_hero_web/components/core_components.ex:71
-#: lib/klass_hero_web/components/provider_components.ex:1758
+#: lib/klass_hero_web/components/provider_components.ex:1765
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr "schließen"
 
-#: lib/klass_hero_web/live/booking_live.ex:355
+#: lib/klass_hero_web/live/booking_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "%{name} (Age %{age})"
 msgstr "%{name} (Alter %{age})"
@@ -152,17 +152,17 @@ msgstr "%{name} (Alter %{age})"
 msgid "About This Program"
 msgstr "Über dieses Programm"
 
-#: lib/klass_hero_web/live/booking_live.ex:290
+#: lib/klass_hero_web/live/booking_live.ex:310
 #, elixir-autogen, elixir-format
 msgid "Activity Summary"
 msgstr "Aktivitätsübersicht"
 
-#: lib/klass_hero_web/live/booking_live.ex:368
+#: lib/klass_hero_web/live/booking_live.ex:388
 #, elixir-autogen, elixir-format
 msgid "Add another child"
 msgstr "Weiteres Kind hinzufügen"
 
-#: lib/klass_hero_web/live/booking_live.ex:331
+#: lib/klass_hero_web/live/booking_live.ex:351
 #, elixir-autogen, elixir-format
 msgid "Add another program"
 msgstr "Weiteres Programm hinzufügen"
@@ -172,12 +172,12 @@ msgstr "Weiteres Programm hinzufügen"
 msgid "Ages %{range}"
 msgstr "Alter %{range}"
 
-#: lib/klass_hero_web/live/booking_live.ex:441
+#: lib/klass_hero_web/live/booking_live.ex:511
 #, elixir-autogen, elixir-format
 msgid "An invoice will be emailed to you after enrollment completion"
 msgstr "Nach Abschluss der Anmeldung erhalten Sie eine Rechnung per E-Mail"
 
-#: lib/klass_hero_web/live/booking_live.ex:385
+#: lib/klass_hero_web/live/booking_live.ex:405
 #, elixir-autogen, elixir-format
 msgid "Any allergies, medical conditions, or special instructions..."
 msgstr "Allergien, medizinische Bedingungen oder besondere Hinweise..."
@@ -187,12 +187,12 @@ msgstr "Allergien, medizinische Bedingungen oder besondere Hinweise..."
 msgid "Book camps, tutors, and workshops instantly. Our integrated planner helps you manage your child's busy life."
 msgstr "Buchen Sie Camps, Nachhilfe und Workshops sofort. Unser integrierter Planer hilft Ihnen, den vollen Terminkalender Ihres Kindes zu verwalten."
 
-#: lib/klass_hero_web/live/booking_live.ex:418
+#: lib/klass_hero_web/live/booking_live.ex:488
 #, elixir-autogen, elixir-format
 msgid "Cash / Bank Transfer"
 msgstr "Bar / Überweisung"
 
-#: lib/klass_hero_web/live/booking_live.ex:443
+#: lib/klass_hero_web/live/booking_live.ex:513
 #, elixir-autogen, elixir-format
 msgid "Cash/transfer payments will show as \"Pending\" until received"
 msgstr "Bar-/Überweisungszahlungen werden als \"Ausstehend\" angezeigt, bis sie eingegangen sind"
@@ -202,22 +202,22 @@ msgstr "Bar-/Überweisungszahlungen werden als \"Ausstehend\" angezeigt, bis sie
 msgid "Community Focused"
 msgstr "Gemeinschaftsorientiert"
 
-#: lib/klass_hero_web/live/booking_live.ex:460
+#: lib/klass_hero_web/live/booking_live.ex:530
 #, elixir-autogen, elixir-format
 msgid "Complete Enrollment"
 msgstr "Anmeldung abschließen"
 
-#: lib/klass_hero_web/live/booking_live.ex:409
+#: lib/klass_hero_web/live/booking_live.ex:479
 #, elixir-autogen, elixir-format
 msgid "Credit Card"
 msgstr "Kreditkarte"
 
-#: lib/klass_hero_web/live/booking_live.ex:442
+#: lib/klass_hero_web/live/booking_live.ex:512
 #, elixir-autogen, elixir-format
 msgid "Credit card payments are processed immediately"
 msgstr "Kreditkartenzahlungen werden sofort verarbeitet"
 
-#: lib/klass_hero_web/live/booking_live.ex:322
+#: lib/klass_hero_web/live/booking_live.ex:342
 #, elixir-autogen, elixir-format
 msgid "Duration:"
 msgstr "Dauer:"
@@ -233,22 +233,22 @@ msgid "Enroll Now - %{price}"
 msgstr "Jetzt anmelden - %{price}"
 
 #: lib/klass_hero_web/components/provider_components.ex:1484
-#: lib/klass_hero_web/live/booking_live.ex:285
+#: lib/klass_hero_web/live/booking_live.ex:305
 #, elixir-autogen, elixir-format
 msgid "Enrollment"
 msgstr "Anmeldung"
 
-#: lib/klass_hero_web/live/booking_live.ex:36
+#: lib/klass_hero_web/live/booking_live.ex:37
 #, elixir-autogen, elixir-format
 msgid "Enrollment - %{title}"
 msgstr "Anmeldung - %{title}"
 
-#: lib/klass_hero_web/live/booking_live.ex:189
+#: lib/klass_hero_web/live/booking_live.ex:204
 #, elixir-autogen, elixir-format
 msgid "Enrollment failed. Please try again or contact support."
 msgstr "Anmeldung fehlgeschlagen. Bitte versuchen Sie es erneut oder kontaktieren Sie den Support."
 
-#: lib/klass_hero_web/live/booking_live.ex:128
+#: lib/klass_hero_web/live/booking_live.ex:134
 #, elixir-autogen, elixir-format
 msgid "Enrollment successful! You'll receive a confirmation email shortly."
 msgstr "Anmeldung erfolgreich! Sie erhalten in Kürze eine Bestätigungs-E-Mail."
@@ -274,7 +274,7 @@ msgstr "Empfohlene Programme"
 msgid "Invalid pagination state. Please refresh the page."
 msgstr "Ungültiger Seitenstatus. Bitte laden Sie die Seite neu."
 
-#: lib/klass_hero_web/live/booking_live.ex:439
+#: lib/klass_hero_web/live/booking_live.ex:509
 #, elixir-autogen, elixir-format
 msgid "Invoice & Payment Confirmation"
 msgstr "Rechnung & Zahlungsbestätigung"
@@ -296,32 +296,32 @@ msgstr[1] "Lernen Sie die Helden kennen"
 msgid "No programs found"
 msgstr "Keine Programme gefunden"
 
-#: lib/klass_hero_web/live/booking_live.ex:393
+#: lib/klass_hero_web/live/booking_live.ex:413
 #, elixir-autogen, elixir-format
 msgid "Optional: Include any important information we should know about your child."
 msgstr "Optional: Wichtige Informationen über Ihr Kind, die wir wissen sollten."
 
-#: lib/klass_hero_web/live/booking_live.ex:410
+#: lib/klass_hero_web/live/booking_live.ex:480
 #, elixir-autogen, elixir-format
 msgid "Pay securely with Visa, Mastercard, or other cards"
 msgstr "Sicher bezahlen mit Visa, Mastercard oder anderen Karten"
 
-#: lib/klass_hero_web/live/booking_live.ex:404
+#: lib/klass_hero_web/live/booking_live.ex:474
 #, elixir-autogen, elixir-format
 msgid "Payment Method"
 msgstr "Zahlungsmethode"
 
-#: lib/klass_hero_web/live/booking_live.ex:428
+#: lib/klass_hero_web/live/booking_live.ex:498
 #, elixir-autogen, elixir-format
 msgid "Payment Summary"
 msgstr "Zahlungsübersicht"
 
-#: lib/klass_hero_web/live/booking_live.ex:152
+#: lib/klass_hero_web/live/booking_live.ex:158
 #, elixir-autogen, elixir-format
 msgid "Payment information is invalid. Please check your details."
 msgstr "Zahlungsinformationen ungültig. Bitte überprüfen Sie Ihre Angaben."
 
-#: lib/klass_hero_web/live/booking_live.ex:156
+#: lib/klass_hero_web/live/booking_live.ex:162
 #, elixir-autogen, elixir-format
 msgid "Please select a child for enrollment."
 msgstr "Bitte wählen Sie ein Kind für die Anmeldung aus."
@@ -331,7 +331,7 @@ msgstr "Bitte wählen Sie ein Kind für die Anmeldung aus."
 msgid "Klass Hero - Connecting Families with Trusted Youth Educators"
 msgstr "Klass Hero - Wir verbinden Familien mit vertrauenswürdigen Jugendpädagogen"
 
-#: lib/klass_hero_web/live/booking_live.ex:54
+#: lib/klass_hero_web/live/booking_live.ex:60
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:59
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:57
 #, elixir-autogen, elixir-format
@@ -354,37 +354,37 @@ msgstr "Sicherheit zuerst"
 msgid "Search programs..."
 msgstr "Programme suchen..."
 
-#: lib/klass_hero_web/live/booking_live.ex:339
+#: lib/klass_hero_web/live/booking_live.ex:359
 #, elixir-autogen, elixir-format
 msgid "Select Child"
 msgstr "Kind auswählen"
 
-#: lib/klass_hero_web/live/booking_live.ex:349
+#: lib/klass_hero_web/live/booking_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "Select a child"
 msgstr "Ein Kind auswählen"
 
-#: lib/klass_hero_web/live/booking_live.ex:64
+#: lib/klass_hero_web/live/booking_live.ex:70
 #, elixir-autogen, elixir-format
 msgid "Sorry, this program is currently full. Check back later for availability."
 msgstr "Dieses Programm ist derzeit ausgebucht. Bitte schauen Sie später wieder vorbei."
 
-#: lib/klass_hero_web/live/booking_live.ex:137
+#: lib/klass_hero_web/live/booking_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "Sorry, this program is now full. Please choose another program."
 msgstr "Dieses Programm ist jetzt ausgebucht. Bitte wählen Sie ein anderes Programm."
 
-#: lib/klass_hero_web/live/booking_live.ex:378
+#: lib/klass_hero_web/live/booking_live.ex:398
 #, elixir-autogen, elixir-format
 msgid "Special Requirements"
 msgstr "Besondere Anforderungen"
 
-#: lib/klass_hero_web/live/booking_live.ex:315
+#: lib/klass_hero_web/live/booking_live.ex:335
 #, elixir-autogen, elixir-format
 msgid "Total Price:"
 msgstr "Gesamtpreis:"
 
-#: lib/klass_hero_web/live/booking_live.ex:434
+#: lib/klass_hero_web/live/booking_live.ex:504
 #, elixir-autogen, elixir-format
 msgid "Total due today:"
 msgstr "Heute fällig:"
@@ -578,8 +578,8 @@ msgid "Dispute Resolution"
 msgstr "Streitbeilegung"
 
 #: lib/klass_hero_web/components/provider_components.ex:719
-#: lib/klass_hero_web/components/provider_components.ex:2647
-#: lib/klass_hero_web/components/provider_components.ex:2665
+#: lib/klass_hero_web/components/provider_components.ex:2810
+#: lib/klass_hero_web/components/provider_components.ex:2828
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
@@ -878,9 +878,9 @@ msgstr "Speichern..."
 msgid "Select one or both options"
 msgstr "Wählen Sie eine oder beide Optionen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2343
-#: lib/klass_hero_web/components/provider_components.ex:2344
-#: lib/klass_hero_web/components/provider_components.ex:2381
+#: lib/klass_hero_web/components/provider_components.ex:2506
+#: lib/klass_hero_web/components/provider_components.ex:2507
+#: lib/klass_hero_web/components/provider_components.ex:2544
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:448
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:484
@@ -1578,13 +1578,13 @@ msgid "Quick Navigation"
 msgstr "Schnellnavigation"
 
 #: lib/klass_hero_web/components/provider_components.ex:1487
-#: lib/klass_hero_web/components/provider_components.ex:2319
-#: lib/klass_hero_web/components/provider_components.ex:2545
+#: lib/klass_hero_web/components/provider_components.ex:2466
+#: lib/klass_hero_web/components/provider_components.ex:2708
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr "Aktionen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1626
+#: lib/klass_hero_web/components/provider_components.ex:1633
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr "Aktiv"
@@ -1628,7 +1628,7 @@ msgid "Create profiles for your staff. These will be visible to parents when ass
 msgstr "Erstellen Sie Profile für Ihr Personal. Diese werden für Eltern sichtbar sein, wenn sie Programmen zugewiesen werden."
 
 #: lib/klass_hero_web/components/provider_components.ex:539
-#: lib/klass_hero_web/components/provider_components.ex:1589
+#: lib/klass_hero_web/components/provider_components.ex:1596
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:54
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:81
 #: lib/klass_hero_web/live/settings/children_live.ex:413
@@ -1645,7 +1645,7 @@ msgstr "Bearbeiten"
 msgid "Edit Profile"
 msgstr "Profil bearbeiten"
 
-#: lib/klass_hero_web/components/provider_components.ex:1628
+#: lib/klass_hero_web/components/provider_components.ex:1635
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr "Inaktiv"
@@ -1669,9 +1669,9 @@ msgstr "Übersicht"
 
 #: lib/klass_hero_web/components/provider_components.ex:47
 #: lib/klass_hero_web/components/provider_components.ex:73
-#: lib/klass_hero_web/components/provider_components.ex:1627
-#: lib/klass_hero_web/components/provider_components.ex:2741
-#: lib/klass_hero_web/components/provider_components.ex:2759
+#: lib/klass_hero_web/components/provider_components.ex:1634
+#: lib/klass_hero_web/components/provider_components.ex:2904
+#: lib/klass_hero_web/components/provider_components.ex:2922
 #: lib/klass_hero_web/live/admin/sessions_live.ex:298
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
@@ -1709,9 +1709,9 @@ msgid "Search by name..."
 msgstr "Nach Namen suchen..."
 
 #: lib/klass_hero_web/components/provider_components.ex:1481
-#: lib/klass_hero_web/components/provider_components.ex:1877
-#: lib/klass_hero_web/components/provider_components.ex:2313
-#: lib/klass_hero_web/components/provider_components.ex:2542
+#: lib/klass_hero_web/components/provider_components.ex:1884
+#: lib/klass_hero_web/components/provider_components.ex:2457
+#: lib/klass_hero_web/components/provider_components.ex:2705
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1736,14 +1736,14 @@ msgid "This is your main business identity. Verification is required to list pro
 msgstr "Dies ist Ihre Hauptgeschäftsidentität. Eine Verifizierung ist erforderlich, um Programme anzubieten."
 
 #: lib/klass_hero_web/components/provider_components.ex:1538
-#: lib/klass_hero_web/components/provider_components.ex:1892
+#: lib/klass_hero_web/components/provider_components.ex:1899
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr "Nicht zugewiesen"
 
 #: lib/klass_hero_web/components/messaging_components.ex:722
 #: lib/klass_hero_web/components/provider_components.ex:50
-#: lib/klass_hero_web/components/provider_components.ex:1629
+#: lib/klass_hero_web/components/provider_components.ex:1636
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:434
 #: lib/klass_hero_web/presenters/provider_presenter.ex:103
 #, elixir-autogen, elixir-format
@@ -1817,7 +1817,8 @@ msgstr "Rundnachricht an %{count} Eltern gesendet"
 #: lib/klass_hero_web/components/participation_components.ex:717
 #: lib/klass_hero_web/components/provider_components.ex:889
 #: lib/klass_hero_web/components/provider_components.ex:1334
-#: lib/klass_hero_web/components/provider_components.ex:2484
+#: lib/klass_hero_web/components/provider_components.ex:2046
+#: lib/klass_hero_web/components/provider_components.ex:2647
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:478
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
@@ -1852,7 +1853,7 @@ msgstr "Kind erfolgreich entfernt."
 msgid "Child updated successfully."
 msgstr "Kind erfolgreich aktualisiert."
 
-#: lib/klass_hero_web/live/dashboard_live.ex:176
+#: lib/klass_hero_web/live/dashboard_live.ex:178
 #: lib/klass_hero_web/live/messaging_live_helper.ex:336
 #, elixir-autogen, elixir-format
 msgid "Conversation"
@@ -1873,7 +1874,7 @@ msgstr "Kind konnte nicht entfernt werden. Bitte versuchen Sie es erneut."
 msgid "Data sharing consent"
 msgstr "Einwilligung zur Datenweitergabe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2628
+#: lib/klass_hero_web/components/provider_components.ex:2791
 #: lib/klass_hero_web/live/settings/children_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1921,17 +1922,17 @@ msgstr "Rundnachricht konnte nicht gesendet werden"
 msgid "Failed to submit note"
 msgstr "Notiz konnte nicht eingereicht werden"
 
-#: lib/klass_hero_web/components/provider_components.ex:2622
-#: lib/klass_hero_web/components/provider_components.ex:2651
-#: lib/klass_hero_web/components/provider_components.ex:2667
+#: lib/klass_hero_web/components/provider_components.ex:2785
+#: lib/klass_hero_web/components/provider_components.ex:2814
+#: lib/klass_hero_web/components/provider_components.ex:2830
 #: lib/klass_hero_web/live/settings/children_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr "Vorname"
 
-#: lib/klass_hero_web/components/provider_components.ex:2623
-#: lib/klass_hero_web/components/provider_components.ex:2652
-#: lib/klass_hero_web/components/provider_components.ex:2668
+#: lib/klass_hero_web/components/provider_components.ex:2786
+#: lib/klass_hero_web/components/provider_components.ex:2815
+#: lib/klass_hero_web/components/provider_components.ex:2831
 #: lib/klass_hero_web/live/settings/children_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -2026,7 +2027,7 @@ msgstr "Telefonnummer oder Name"
 msgid "Please check the form for errors."
 msgstr "Bitte überprüfen Sie das Formular auf Fehler."
 
-#: lib/klass_hero_web/live/booking_live.ex:163
+#: lib/klass_hero_web/live/booking_live.ex:178
 #, elixir-autogen, elixir-format
 msgid "Please complete your profile before making a booking."
 msgstr "Bitte vervollständigen Sie Ihr Profil, bevor Sie eine Buchung vornehmen."
@@ -2069,8 +2070,8 @@ msgstr "Einwilligung zur Datenweitergabe an Anbieter"
 msgid "Save Changes"
 msgstr "Änderungen speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:1736
-#: lib/klass_hero_web/components/provider_components.ex:1737
+#: lib/klass_hero_web/components/provider_components.ex:1743
+#: lib/klass_hero_web/components/provider_components.ex:1744
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:43
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:151
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:252
@@ -2088,7 +2089,7 @@ msgstr "Rundnachricht senden"
 msgid "Send a message to start the conversation"
 msgstr "Senden Sie eine Nachricht, um die Unterhaltung zu beginnen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2722
+#: lib/klass_hero_web/components/provider_components.ex:2885
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:249
 #, elixir-autogen, elixir-format
@@ -2224,7 +2225,7 @@ msgstr "Alter %{min}+"
 msgid "Allowed Genders"
 msgstr "Zulässige Geschlechter"
 
-#: lib/klass_hero_web/components/provider_components.ex:2781
+#: lib/klass_hero_web/components/provider_components.ex:2944
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred during import."
 msgstr "Beim Import ist ein unerwarteter Fehler aufgetreten."
@@ -2272,7 +2273,7 @@ msgstr "Zurück zu den Verifizierungen"
 msgid "Bio"
 msgstr "Biografie"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:389
+#: lib/klass_hero_web/live/dashboard_live.ex:429
 #, elixir-autogen, elixir-format
 msgid "Book a Program"
 msgstr "Programm buchen"
@@ -2319,8 +2320,8 @@ msgstr "Kategorie"
 msgid "Check eligibility at"
 msgstr "Berechtigung prüfen unter"
 
-#: lib/klass_hero_web/components/provider_components.ex:2310
-#: lib/klass_hero_web/components/provider_components.ex:2536
+#: lib/klass_hero_web/components/provider_components.ex:2454
+#: lib/klass_hero_web/components/provider_components.ex:2699
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr "Name des Kindes"
@@ -2365,7 +2366,7 @@ msgstr "Schließen Sie die Geschäftsverifizierung ab, um Programme zu erstellen
 msgid "Confirm rejection"
 msgstr "Ablehnung bestätigen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2742
+#: lib/klass_hero_web/components/provider_components.ex:2905
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr "Bestätigt"
@@ -2375,12 +2376,12 @@ msgstr "Bestätigt"
 msgid "Contact Provider"
 msgstr "Anbieter kontaktieren"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:451
+#: lib/klass_hero_web/live/provider/programs_live.ex:530
 #, elixir-autogen, elixir-format
 msgid "Could not read the uploaded file."
 msgstr "Die hochgeladene Datei konnte nicht gelesen werden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:419
+#: lib/klass_hero_web/live/provider/programs_live.ex:498
 #, elixir-autogen, elixir-format
 msgid "Could not remove invite."
 msgstr "Einladung konnte nicht entfernt werden."
@@ -2414,7 +2415,7 @@ msgstr "Beschreibung"
 msgid "Diverse"
 msgstr "Divers"
 
-#: lib/klass_hero_web/components/provider_components.ex:2957
+#: lib/klass_hero_web/components/provider_components.ex:3120
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr "Dokumenttyp"
@@ -2448,7 +2449,7 @@ msgstr "Dokument abgelehnt."
 msgid "Document uploaded successfully."
 msgstr "Dokument erfolgreich hochgeladen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2503
+#: lib/klass_hero_web/components/provider_components.ex:2666
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr "Vorlage herunterladen"
@@ -2479,14 +2480,14 @@ msgstr "Enddatum"
 msgid "End Time"
 msgstr "Endzeit"
 
-#: lib/klass_hero_web/components/provider_components.ex:2316
-#: lib/klass_hero_web/components/provider_components.ex:2762
+#: lib/klass_hero_web/components/provider_components.ex:2463
+#: lib/klass_hero_web/components/provider_components.ex:2925
 #: lib/klass_hero_web/components/provider_layout_components.ex:644
 #, elixir-autogen, elixir-format
 msgid "Enrolled"
 msgstr "Angemeldet"
 
-#: lib/klass_hero_web/components/provider_components.ex:1782
+#: lib/klass_hero_web/components/provider_components.ex:1789
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr "Angemeldet (%{count})"
@@ -2502,7 +2503,7 @@ msgid "Explain why this document is being rejected..."
 msgstr "Erklären Sie, warum dieses Dokument abgelehnt wird..."
 
 #: lib/klass_hero_web/components/provider_components.ex:71
-#: lib/klass_hero_web/components/provider_components.ex:2763
+#: lib/klass_hero_web/components/provider_components.ex:2926
 #: lib/klass_hero_web/live/admin/emails_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2518,7 +2519,7 @@ msgstr "Dokument konnte nicht genehmigt werden."
 msgid "Failed to reject document."
 msgstr "Dokument konnte nicht abgelehnt werden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:401
+#: lib/klass_hero_web/live/provider/programs_live.ex:480
 #, elixir-autogen, elixir-format
 msgid "Failed to resend invite."
 msgstr "Einladung konnte nicht erneut gesendet werden."
@@ -2529,7 +2530,7 @@ msgstr "Einladung konnte nicht erneut gesendet werden."
 msgid "Failed to upload document."
 msgstr "Dokument konnte nicht hochgeladen werden."
 
-#: lib/klass_hero_web/live/dashboard_live.ex:362
+#: lib/klass_hero_web/live/dashboard_live.ex:402
 #, elixir-autogen, elixir-format
 msgid "Family Programs"
 msgstr "Familienprogramme"
@@ -2546,12 +2547,12 @@ msgstr "Weiblich"
 msgid "File"
 msgstr "Datei"
 
-#: lib/klass_hero_web/components/provider_components.ex:2891
+#: lib/klass_hero_web/components/provider_components.ex:3054
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr "Die Datei ist zu groß."
 
-#: lib/klass_hero_web/components/provider_components.ex:2893
+#: lib/klass_hero_web/components/provider_components.ex:3056
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr "Dateityp wird nicht akzeptiert."
@@ -2586,7 +2587,7 @@ msgstr "Klassenstufe %{min}+"
 msgid "Grades %{min} – %{max}"
 msgstr "Klassenstufen %{min} – %{max}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2539
+#: lib/klass_hero_web/components/provider_components.ex:2702
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr "E-Mail des Erziehungsberechtigten"
@@ -2601,7 +2602,7 @@ msgstr "Porträtfoto"
 msgid "ID Document"
 msgstr "Ausweisdokument"
 
-#: lib/klass_hero_web/components/provider_components.ex:2476
+#: lib/klass_hero_web/components/provider_components.ex:2639
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Importieren"
@@ -2611,22 +2612,22 @@ msgstr "Importieren"
 msgid "Insurance Certificate"
 msgstr "Versicherungsnachweis"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:416
+#: lib/klass_hero_web/live/provider/programs_live.ex:495
 #, elixir-autogen, elixir-format
 msgid "Invite not found."
 msgstr "Einladung nicht gefunden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:413
+#: lib/klass_hero_web/live/provider/programs_live.ex:492
 #, elixir-autogen, elixir-format
 msgid "Invite removed."
 msgstr "Einladung entfernt."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:390
+#: lib/klass_hero_web/live/provider/programs_live.ex:469
 #, elixir-autogen, elixir-format
 msgid "Invite resent successfully."
 msgstr "Einladung erfolgreich erneut gesendet."
 
-#: lib/klass_hero_web/components/provider_components.ex:1799
+#: lib/klass_hero_web/components/provider_components.ex:1806
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr "Einladungen (%{count})"
@@ -2727,18 +2728,18 @@ msgstr "Niedrigste Klassenstufe"
 msgid "No approved documents."
 msgstr "Keine genehmigten Dokumente."
 
-#: lib/klass_hero_web/components/provider_components.ex:2919
+#: lib/klass_hero_web/components/provider_components.ex:3082
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr "Noch keine Dokumente hochgeladen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2303
+#: lib/klass_hero_web/components/provider_components.ex:2447
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
 msgstr "Noch keine Anmeldungen."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:447
+#: lib/klass_hero_web/live/provider/programs_live.ex:526
 #, elixir-autogen, elixir-format
 msgid "No file selected."
 msgstr "Keine Datei ausgewählt."
@@ -2748,7 +2749,7 @@ msgstr "Keine Datei ausgewählt."
 msgid "No grade"
 msgstr "Keine Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2527
+#: lib/klass_hero_web/components/provider_components.ex:2690
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr "Noch keine Einladungen. Laden Sie eine CSV-Datei hoch, um Familien einzuladen."
@@ -2768,7 +2769,7 @@ msgstr "Kein Minimum"
 msgid "No pending documents to review."
 msgstr "Keine ausstehenden Dokumente zur Überprüfung."
 
-#: lib/klass_hero_web/live/dashboard_live.ex:378
+#: lib/klass_hero_web/live/dashboard_live.ex:418
 #, elixir-autogen, elixir-format
 msgid "No programs booked yet"
 msgstr "Noch keine Programme gebucht"
@@ -2811,7 +2812,7 @@ msgstr "Nicht angegeben"
 msgid "Our Story"
 msgstr "Unsere Geschichte"
 
-#: lib/klass_hero_web/components/provider_components.ex:2994
+#: lib/klass_hero_web/components/provider_components.ex:3157
 #: lib/klass_hero_web/live/provider/verification_live.ex:698
 #: lib/klass_hero_web/live/provider/verification_live.ex:770
 #, elixir-autogen, elixir-format
@@ -2838,8 +2839,8 @@ msgstr "Ausstehende Überprüfung"
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:106
-#: lib/klass_hero_web/live/provider/programs_live.ex:690
-#: lib/klass_hero_web/live/provider/programs_live.ex:759
+#: lib/klass_hero_web/live/provider/programs_live.ex:769
+#: lib/klass_hero_web/live/provider/programs_live.ex:838
 #: lib/klass_hero_web/live/provider/team_live.ex:305
 #: lib/klass_hero_web/live/provider/team_live.ex:348
 #: lib/klass_hero_web/live/provider/team_live.ex:467
@@ -2872,26 +2873,28 @@ msgstr "Profil erfolgreich aktualisiert."
 msgid "Program Start"
 msgstr "Programmbeginn"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1208
+#: lib/klass_hero_web/live/provider/programs_live.ex:1328
 #, elixir-autogen, elixir-format
 msgid "Program created successfully."
 msgstr "Programm erfolgreich erstellt."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1212
+#: lib/klass_hero_web/live/provider/programs_live.ex:1332
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr "Programm erstellt, aber die Anmeldekapazität konnte nicht gespeichert werden. Bearbeiten Sie das Programm, um es erneut zu versuchen."
 
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:54
-#: lib/klass_hero_web/live/provider/programs_live.ex:155
-#: lib/klass_hero_web/live/provider/programs_live.ex:192
-#: lib/klass_hero_web/live/provider/programs_live.ex:256
-#: lib/klass_hero_web/live/provider/programs_live.ex:734
+#: lib/klass_hero_web/live/provider/programs_live.ex:156
+#: lib/klass_hero_web/live/provider/programs_live.ex:193
+#: lib/klass_hero_web/live/provider/programs_live.ex:257
+#: lib/klass_hero_web/live/provider/programs_live.ex:281
+#: lib/klass_hero_web/live/provider/programs_live.ex:813
+#: lib/klass_hero_web/live/provider/programs_live.ex:935
 #, elixir-autogen, elixir-format
 msgid "Program not found."
 msgstr "Programm nicht gefunden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1209
+#: lib/klass_hero_web/live/provider/programs_live.ex:1329
 #, elixir-autogen, elixir-format
 msgid "Program updated successfully."
 msgstr "Programm erfolgreich aktualisiert."
@@ -2909,7 +2912,7 @@ msgid "Read our founding story →"
 msgstr "Lesen Sie unsere Gründungsgeschichte →"
 
 #: lib/klass_hero_web/components/participation_components.ex:805
-#: lib/klass_hero_web/components/provider_components.ex:2761
+#: lib/klass_hero_web/components/provider_components.ex:2924
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Registered"
@@ -2945,7 +2948,7 @@ msgstr "Anmeldebeginn"
 msgid "Registration Period (optional)"
 msgstr "Anmeldezeitraum (optional)"
 
-#: lib/klass_hero_web/live/booking_live.ex:144
+#: lib/klass_hero_web/live/booking_live.ex:150
 #, elixir-autogen, elixir-format
 msgid "Registration has closed for this program."
 msgstr "Die Anmeldung für dieses Programm ist geschlossen."
@@ -2955,7 +2958,7 @@ msgstr "Die Anmeldung für dieses Programm ist geschlossen."
 msgid "Registration is closed"
 msgstr "Anmeldung geschlossen"
 
-#: lib/klass_hero_web/live/booking_live.ex:73
+#: lib/klass_hero_web/live/booking_live.ex:79
 #, elixir-autogen, elixir-format
 msgid "Registration is not currently open for this program."
 msgstr "Die Anmeldung für dieses Programm ist derzeit nicht geöffnet."
@@ -2991,16 +2994,16 @@ msgstr "Ablehnungsgrund"
 
 #: lib/klass_hero_web/components/provider_components.ex:839
 #: lib/klass_hero_web/components/provider_components.ex:1284
-#: lib/klass_hero_web/components/provider_components.ex:2583
-#: lib/klass_hero_web/components/provider_components.ex:3013
-#: lib/klass_hero_web/components/provider_components.ex:3092
+#: lib/klass_hero_web/components/provider_components.ex:2746
+#: lib/klass_hero_web/components/provider_components.ex:3176
+#: lib/klass_hero_web/components/provider_components.ex:3255
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:253
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr "Entfernen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2576
+#: lib/klass_hero_web/components/provider_components.ex:2739
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr "Einladung erneut senden"
@@ -3015,7 +3018,7 @@ msgstr "Überprüft"
 msgid "Role"
 msgstr "Rolle"
 
-#: lib/klass_hero_web/components/provider_components.ex:1728
+#: lib/klass_hero_web/components/provider_components.ex:1735
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:386
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
@@ -3041,24 +3044,24 @@ msgstr "Zeitplan noch offen"
 msgid "School Grade (optional)"
 msgstr "Klassenstufe (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2991
+#: lib/klass_hero_web/components/provider_components.ex:3154
 #, elixir-autogen, elixir-format
 msgid "Select File"
 msgstr "Datei auswählen"
 
-#: lib/klass_hero_web/live/booking_live.ex:116
-#: lib/klass_hero_web/live/booking_live.ex:173
+#: lib/klass_hero_web/live/booking_live.ex:122
+#: lib/klass_hero_web/live/booking_live.ex:188
 #, elixir-autogen, elixir-format
 msgid "Selected child does not meet the program requirements."
 msgstr "Das ausgewählte Kind erfüllt die Programmanforderungen nicht."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:680
-#: lib/klass_hero_web/live/provider/programs_live.ex:749
+#: lib/klass_hero_web/live/provider/programs_live.ex:759
+#: lib/klass_hero_web/live/provider/programs_live.ex:828
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr "Der ausgewählte Kursleiter konnte nicht gefunden werden. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2760
+#: lib/klass_hero_web/components/provider_components.ex:2923
 #: lib/klass_hero_web/live/admin/emails_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Sent"
@@ -3108,7 +3111,7 @@ msgstr "Startzeit"
 msgid "Submitted"
 msgstr "Eingereicht"
 
-#: lib/klass_hero_web/live/booking_live.ex:324
+#: lib/klass_hero_web/live/booking_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "TBD"
 msgstr "Noch offen"
@@ -3153,22 +3156,23 @@ msgstr "Erzählen Sie Eltern von Ihrer Organisation..."
 msgid "The Klass Hero Story"
 msgstr "Die Geschichte von Klass Hero"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:393
+#: lib/klass_hero_web/live/provider/programs_live.ex:472
 #, elixir-autogen, elixir-format
 msgid "This invite cannot be resent."
 msgstr "Diese Einladung kann nicht erneut gesendet werden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:741
+#: lib/klass_hero_web/live/provider/programs_live.ex:820
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr "Dieses Programm wurde von jemand anderem geändert. Bitte schließen Sie es und versuchen Sie es erneut."
 
 #: lib/klass_hero_web/components/provider_components.ex:975
+#: lib/klass_hero_web/components/provider_components.ex:2012
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr "Titel"
 
-#: lib/klass_hero_web/components/provider_components.ex:2892
+#: lib/klass_hero_web/components/provider_components.ex:3055
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr "Zu viele Dateien."
@@ -3188,32 +3192,32 @@ msgstr "Bis zu %{max}"
 msgid "Up to Grade %{max}"
 msgstr "Bis Klassenstufe %{max}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2462
+#: lib/klass_hero_web/components/provider_components.ex:2625
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr "CSV hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3037
+#: lib/klass_hero_web/components/provider_components.ex:3200
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr "Dokument hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2946
+#: lib/klass_hero_web/components/provider_components.ex:3109
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr "Neues Dokument hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2914
+#: lib/klass_hero_web/components/provider_components.ex:3077
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr "Laden Sie Dokumente hoch, um Ihr Unternehmen zu verifizieren. Die Dokumente werden von unserem Team überprüft."
 
-#: lib/klass_hero_web/components/provider_components.ex:2894
+#: lib/klass_hero_web/components/provider_components.ex:3057
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr "Upload-Fehler."
 
-#: lib/klass_hero_web/components/provider_components.ex:2911
+#: lib/klass_hero_web/components/provider_components.ex:3074
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr "Verifizierungsdokumente"
@@ -3303,7 +3307,7 @@ msgid "Child Safeguarding Training"
 msgstr "Kinderschutzschulung"
 
 #: lib/klass_hero_web/components/marketing_components.ex:1498
-#: lib/klass_hero_web/components/provider_components.ex:3259
+#: lib/klass_hero_web/components/provider_components.ex:3422
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr "Vereinbarung zu Community-Standards"
@@ -3363,17 +3367,17 @@ msgstr "Wenn Sie mehr über unsere Trust-&-Safety-Standards oder den Verifizieru
 msgid "Monitoring provider activity and feedback"
 msgstr "Überwachung der Anbieteraktivität und des Feedbacks"
 
-#: lib/klass_hero_web/live/booking_live.ex:419
+#: lib/klass_hero_web/live/booking_live.ex:489
 #, elixir-autogen, elixir-format
 msgid "Pay by cash or direct bank transfer"
 msgstr "Zahlung per Bargeld oder Banküberweisung"
 
-#: lib/klass_hero_web/live/booking_live.ex:430
+#: lib/klass_hero_web/live/booking_live.ex:500
 #, elixir-autogen, elixir-format
 msgid "Program fee:"
 msgstr "Programmgebühr:"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:985
+#: lib/klass_hero_web/live/provider/programs_live.ex:1105
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr "Programm gespeichert, aber der Upload des Titelbilds ist fehlgeschlagen. Sie können es erneut hochladen, indem Sie das Programm bearbeiten."
@@ -3399,7 +3403,8 @@ msgid "Reviewing concerns or reports promptly and seriously"
 msgstr "Bedenken oder Meldungen zügig und gewissenhaft prüfen"
 
 #: lib/klass_hero_web/controllers/invite_claim_controller.ex:57
-#: lib/klass_hero_web/live/booking_live.ex:197
+#: lib/klass_hero_web/live/booking_live.ex:212
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:73
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Please try again or contact support."
 msgstr "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut oder kontaktieren Sie den Support."
@@ -3414,7 +3419,7 @@ msgstr "Schulen und Einrichtungen mit zuverlässigen Anbietern unterstützen"
 msgid "Taking action when standards are not met"
 msgstr "Bei Nichteinhaltung von Standards Maßnahmen ergreifen"
 
-#: lib/klass_hero_web/live/booking_live.ex:181
+#: lib/klass_hero_web/live/booking_live.ex:196
 #, elixir-autogen, elixir-format
 msgid "This child is already enrolled in this program."
 msgstr "Dieses Kind ist bereits für dieses Programm angemeldet."
@@ -3453,7 +3458,7 @@ msgid "Vetted with Care"
 msgstr "Mit Sorgfalt geprüft"
 
 #: lib/klass_hero_web/components/marketing_components.ex:1482
-#: lib/klass_hero_web/components/provider_components.ex:3044
+#: lib/klass_hero_web/components/provider_components.ex:3207
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr "Video-Überprüfung"
@@ -3589,7 +3594,7 @@ msgstr "Kann ich meine Programme auf Klass Hero listen und was kostet das?"
 msgid "Cannot check out without a check-in"
 msgstr "Auschecken ohne Einchecken nicht möglich"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:365
+#: lib/klass_hero_web/live/provider/programs_live.ex:444
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
@@ -3627,7 +3632,7 @@ msgstr "Eingecheckt"
 msgid "Checked Out"
 msgstr "Ausgecheckt"
 
-#: lib/klass_hero_web/components/provider_components.ex:2619
+#: lib/klass_hero_web/components/provider_components.ex:2782
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Child"
@@ -3653,8 +3658,8 @@ msgstr "Kontaktieren Sie den Anbieter direkt (Details in der Bestätigungs-E-Mai
 msgid "Correct"
 msgstr "Korrigieren"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:288
-#: lib/klass_hero_web/live/provider/programs_live.ex:362
+#: lib/klass_hero_web/live/dashboard_live.ex:306
+#: lib/klass_hero_web/live/provider/programs_live.ex:441
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Could not start conversation. Please try again."
@@ -3680,7 +3685,7 @@ msgstr "Benötige ich ein Konto, um zu buchen?"
 msgid "Download monthly statements for taxes"
 msgstr "Monatliche Abrechnungen für die Steuer herunterladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2380
+#: lib/klass_hero_web/components/provider_components.ex:2543
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "Enrollment not confirmed"
@@ -3753,7 +3758,7 @@ msgstr "Keine Änderungen erkannt"
 msgid "No chasing payments or sending invoices"
 msgstr "Kein Nachfassen bei Zahlungen oder Versenden von Rechnungen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1751
+#: lib/klass_hero_web/components/provider_components.ex:1758
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:407
 #, elixir-autogen, elixir-format
 msgid "No enrolled parents"
@@ -3776,7 +3781,7 @@ msgstr "Notizen"
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr "Oder: Jederzeit eine Sofortauszahlung anfordern (mindestens 50 €)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2379
+#: lib/klass_hero_web/components/provider_components.ex:2542
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -3878,7 +3883,7 @@ msgstr "Mitarbeiter"
 msgid "Track Everything:"
 msgstr "Alles im Überblick:"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:275
+#: lib/klass_hero_web/live/dashboard_live.ex:293
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:144
 #, elixir-autogen, elixir-format
 msgid "Upgrade your plan to send messages."
@@ -4407,7 +4412,7 @@ msgstr "Absenden"
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:24
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
-#: lib/klass_hero_web/live/provider/programs_live.ex:224
+#: lib/klass_hero_web/live/provider/programs_live.ex:225
 #: lib/klass_hero_web/live/provider/sessions_live.ex:381
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:175
 #, elixir-autogen, elixir-format
@@ -4618,7 +4623,7 @@ msgid "Update your observation..."
 msgstr "Aktualisieren Sie Ihre Beobachtung..."
 
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:138
-#: lib/klass_hero_web/live/provider/programs_live.ex:444
+#: lib/klass_hero_web/live/provider/programs_live.ex:523
 #: lib/klass_hero_web/live/provider/verification_live.ex:240
 #: lib/klass_hero_web/live/provider/verification_live.ex:556
 #: lib/klass_hero_web/live/provider/verification_live.ex:594
@@ -4889,34 +4894,35 @@ msgstr "Ihr Profil ist bereits vollständig."
 msgid "for"
 msgstr "für"
 
-#: lib/klass_hero_web/components/provider_components.ex:1875
+#: lib/klass_hero_web/components/provider_components.ex:1882
 #, elixir-autogen, elixir-format
 msgid "Assigned staff"
 msgstr "Zugewiesenes Personal"
 
-#: lib/klass_hero_web/components/provider_components.ex:1876
+#: lib/klass_hero_web/components/provider_components.ex:1883
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr "Anwesenheit"
 
-#: lib/klass_hero_web/components/provider_components.ex:1859
-#: lib/klass_hero_web/components/provider_components.ex:1944
-#: lib/klass_hero_web/components/provider_components.ex:2098
+#: lib/klass_hero_web/components/provider_components.ex:1866
+#: lib/klass_hero_web/components/provider_components.ex:1951
+#: lib/klass_hero_web/components/provider_components.ex:2088
+#: lib/klass_hero_web/components/provider_components.ex:2242
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr "Schließen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1874
+#: lib/klass_hero_web/components/provider_components.ex:1881
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr "Datum / Uhrzeit"
 
-#: lib/klass_hero_web/components/provider_components.ex:1868
+#: lib/klass_hero_web/components/provider_components.ex:1875
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled yet."
 msgstr "Noch keine Sessions geplant."
 
-#: lib/klass_hero_web/components/provider_components.ex:1857
+#: lib/klass_hero_web/components/provider_components.ex:1864
 #, elixir-autogen, elixir-format
 msgid "Sessions — %{title}"
 msgstr "Sessions — %{title}"
@@ -4926,7 +4932,7 @@ msgstr "Sessions — %{title}"
 msgid "View sessions"
 msgstr "Sessions anzeigen"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:535
+#: lib/klass_hero_web/live/provider/programs_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Create a program before inviting participants."
 msgstr "Erstellen Sie zuerst ein Programm, bevor Sie Teilnehmer einladen."
@@ -4953,22 +4959,22 @@ msgstr "Abreisezeit ist kein gültiges Datum oder keine gültige Uhrzeit"
 msgid "Failed to update record"
 msgstr "Aktualisieren des Datensatzes fehlgeschlagen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2683
+#: lib/klass_hero_web/components/provider_components.ex:2846
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr "Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2402
+#: lib/klass_hero_web/components/provider_components.ex:2565
 #, elixir-autogen, elixir-format
 msgid "Invite mode"
 msgstr "Einladungsmodus"
 
-#: lib/klass_hero_web/components/provider_components.ex:2421
+#: lib/klass_hero_web/components/provider_components.ex:2584
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr "Einzelperson einladen"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:531
+#: lib/klass_hero_web/live/provider/programs_live.ex:610
 #, elixir-autogen, elixir-format
 msgid "Invite sent."
 msgstr "Einladung verschickt."
@@ -4978,12 +4984,12 @@ msgstr "Einladung verschickt."
 msgid "Leave blank to keep this child marked as present."
 msgstr "Leer lassen, um dieses Kind als anwesend markiert zu lassen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2696
+#: lib/klass_hero_web/components/provider_components.ex:2859
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr "Gesundheit & Einwilligungen (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2702
+#: lib/klass_hero_web/components/provider_components.ex:2865
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr "Gesundheitliche Besonderheiten"
@@ -4994,17 +5000,17 @@ msgstr "Gesundheitliche Besonderheiten"
 msgid "Nothing to update"
 msgstr "Nichts zu aktualisieren"
 
-#: lib/klass_hero_web/components/provider_components.ex:2704
+#: lib/klass_hero_web/components/provider_components.ex:2867
 #, elixir-autogen, elixir-format
 msgid "Nut allergy"
 msgstr "Nussallergie"
 
-#: lib/klass_hero_web/components/provider_components.ex:2708
+#: lib/klass_hero_web/components/provider_components.ex:2871
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr "Fotos dürfen in Marketingmaterialien verwendet werden"
 
-#: lib/klass_hero_web/components/provider_components.ex:2713
+#: lib/klass_hero_web/components/provider_components.ex:2876
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr "Fotos dürfen in sozialen Medien erscheinen"
@@ -5014,7 +5020,7 @@ msgstr "Fotos dürfen in sozialen Medien erscheinen"
 msgid "Present"
 msgstr "Anwesend"
 
-#: lib/klass_hero_web/components/provider_components.ex:2640
+#: lib/klass_hero_web/components/provider_components.ex:2803
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr "Hauptansprechpartner"
@@ -5041,22 +5047,22 @@ msgstr "Datensatz aktualisiert"
 msgid "Save changes"
 msgstr "Änderungen speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:2677
+#: lib/klass_hero_web/components/provider_components.ex:2840
 #, elixir-autogen, elixir-format
 msgid "School (optional)"
 msgstr "Schule (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2687
+#: lib/klass_hero_web/components/provider_components.ex:2850
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr "Schulname"
 
-#: lib/klass_hero_web/components/provider_components.ex:2661
+#: lib/klass_hero_web/components/provider_components.ex:2824
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr "Zweiter Ansprechpartner (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2730
+#: lib/klass_hero_web/components/provider_components.ex:2893
 #, elixir-autogen, elixir-format
 msgid "Send invite"
 msgstr "Einladung senden"
@@ -5066,12 +5072,12 @@ msgstr "Einladung senden"
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr "Aktualisieren Sie die Notiz für dieses Kind (z. B. um zu klären, was passiert ist)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2439
+#: lib/klass_hero_web/components/provider_components.ex:2602
 #, elixir-autogen, elixir-format
 msgid "Upload a list"
 msgstr "Liste hochladen"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:542
+#: lib/klass_hero_web/live/provider/programs_live.ex:621
 #, elixir-autogen, elixir-format
 msgid "An invite for this child and program already exists."
 msgstr "Für dieses Kind und Programm existiert bereits eine Einladung."
@@ -5166,7 +5172,7 @@ msgstr "Programm oder Session nicht gefunden."
 msgid "Property Damage"
 msgstr "Sachschaden"
 
-#: lib/klass_hero_web/components/provider_components.ex:1599
+#: lib/klass_hero_web/components/provider_components.ex:1606
 #, elixir-autogen, elixir-format
 msgid "Report Incident"
 msgstr "Vorfall melden"
@@ -5248,7 +5254,7 @@ msgstr "Ihre Woche mit den Kindern"
 msgid "Go to dashboard"
 msgstr "Zum Dashboard"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:487
+#: lib/klass_hero_web/live/provider/programs_live.ex:566
 #, elixir-autogen, elixir-format
 msgid "%{count} row could not be processed."
 msgid_plural "%{count} rows could not be processed."
@@ -5311,7 +5317,7 @@ msgstr "Über alle Programme hinweg"
 msgid "Active policy required to teach."
 msgstr "Aktive Versicherungspolice erforderlich, um zu unterrichten."
 
-#: lib/klass_hero_web/live/dashboard_live.ex:308
+#: lib/klass_hero_web/live/dashboard_live.ex:348
 #: lib/klass_hero_web/live/provider/overview_live.ex:251
 #, elixir-autogen, elixir-format
 msgid "Active programs"
@@ -5835,8 +5841,8 @@ msgstr "Wie wir Anbieter überprüfen"
 msgid "I'll be teaching"
 msgstr "Ich werde unterrichten"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:462
-#: lib/klass_hero_web/live/provider/programs_live.ex:484
+#: lib/klass_hero_web/live/provider/programs_live.ex:541
+#: lib/klass_hero_web/live/provider/programs_live.ex:563
 #, elixir-autogen, elixir-format
 msgid "Imported %{count} family."
 msgid_plural "Imported %{count} families."
@@ -5848,7 +5854,7 @@ msgstr[1] "%{count} Familien importiert."
 msgid "In 2025, Shane connected with his friend"
 msgstr "2025 tat sich Shane mit seinem Freund zusammen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1608
+#: lib/klass_hero_web/components/provider_components.ex:1615
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:43
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:74
 #, elixir-autogen, elixir-format
@@ -6065,7 +6071,7 @@ msgstr "Monat"
 msgid "Mother and child-safety specialist with 10+ years in quality assurance. Architecting our Safety-First Verification engine."
 msgstr "Mutter und Kindersicherheitsspezialistin mit über 10 Jahren Erfahrung in der Qualitätssicherung. Verantwortlich für die Konzeption unserer Safety-First-Verifizierungs-Engine."
 
-#: lib/klass_hero_web/live/dashboard_live.ex:177
+#: lib/klass_hero_web/live/dashboard_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "New conversation"
 msgstr "Neue Unterhaltung"
@@ -6125,14 +6131,14 @@ msgstr "Noch keine Programme — fügen Sie Ihr erstes über den Tab „Programm
 msgid "No registered children for this session."
 msgstr "Keine Kinder in dieser Sitzung angemeldet."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:471
+#: lib/klass_hero_web/live/provider/programs_live.ex:550
 #, elixir-autogen, elixir-format
 msgid "No rows imported. %{count} row could not be processed."
 msgid_plural "No rows imported. %{count} rows could not be processed."
 msgstr[0] "Keine Zeilen importiert. %{count} Zeile konnte nicht verarbeitet werden."
 msgstr[1] "Keine Zeilen importiert. %{count} Zeilen konnten nicht verarbeitet werden."
 
-#: lib/klass_hero_web/live/dashboard_live.ex:348
+#: lib/klass_hero_web/live/dashboard_live.ex:388
 #, elixir-autogen, elixir-format
 msgid "No upcoming sessions in the next few weeks."
 msgstr "Keine bevorstehenden Sitzungen in den nächsten Wochen."
@@ -6368,17 +6374,17 @@ msgstr "Umsatz (diese Woche)"
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr "Strenge Überprüfung, damit Familien immer wissen, wer die Gruppe leitet."
 
-#: lib/klass_hero_web/components/provider_components.ex:2769
+#: lib/klass_hero_web/components/provider_components.ex:2932
 #, elixir-autogen, elixir-format
 msgid "Row %{row}"
 msgstr "Zeile %{row}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2769
+#: lib/klass_hero_web/components/provider_components.ex:2932
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr "Zeile —"
 
-#: lib/klass_hero_web/components/provider_components.ex:2515
+#: lib/klass_hero_web/components/provider_components.ex:2678
 #, elixir-autogen, elixir-format
 msgid "Rows with errors"
 msgstr "Zeilen mit Fehlern"
@@ -6648,17 +6654,17 @@ msgstr "Unbekannter Elternteil"
 msgid "Unlimited programs and locations"
 msgstr "Unbegrenzte Programme und Standorte"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:320
+#: lib/klass_hero_web/live/dashboard_live.ex:360
 #, elixir-autogen, elixir-format
 msgid "Unread messages"
 msgstr "Ungelesene Nachrichten"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:333
+#: lib/klass_hero_web/live/dashboard_live.ex:373
 #, elixir-autogen, elixir-format
 msgid "Upcoming sessions"
 msgstr "Anstehende Sitzungen"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:314
+#: lib/klass_hero_web/live/dashboard_live.ex:354
 #, elixir-autogen, elixir-format
 msgid "Upcoming this week"
 msgstr "Diese Woche anstehend"
@@ -6673,7 +6679,7 @@ msgstr "Geprüft"
 msgid "View"
 msgstr "Ansehen"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:338
+#: lib/klass_hero_web/live/dashboard_live.ex:378
 #, elixir-autogen, elixir-format
 msgid "View all"
 msgstr "Alle anzeigen"
@@ -7137,12 +7143,12 @@ msgstr "Deine Identität ist verifiziert."
 msgid "Experience validation"
 msgstr "Erfahrungsnachweis"
 
-#: lib/klass_hero_web/components/provider_components.ex:3073
+#: lib/klass_hero_web/components/provider_components.ex:3236
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr "MP4, MOV oder WEBM. Max. 100 MB."
 
-#: lib/klass_hero_web/components/provider_components.ex:3047
+#: lib/klass_hero_web/components/provider_components.ex:3210
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr "Nimm ein kurzes Video auf, in dem du dich vorstellst. Unser Team prüft es, um Kommunikationsfähigkeit und Übereinstimmung mit unseren Werten einzuschätzen."
@@ -7152,12 +7158,12 @@ msgstr "Nimm ein kurzes Video auf, in dem du dich vorstellst. Unser Team prüft 
 msgid "Safeguarding certificate"
 msgstr "Kinderschutz-Zertifikat"
 
-#: lib/klass_hero_web/components/provider_components.ex:3070
+#: lib/klass_hero_web/components/provider_components.ex:3233
 #, elixir-autogen, elixir-format
 msgid "Select Video"
 msgstr "Video auswählen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3116
+#: lib/klass_hero_web/components/provider_components.ex:3279
 #, elixir-autogen, elixir-format
 msgid "Upload Video"
 msgstr "Video hochladen"
@@ -7167,7 +7173,7 @@ msgstr "Video hochladen"
 msgid "Your browser does not support video playback."
 msgstr "Dein Browser unterstützt keine Videowiedergabe."
 
-#: lib/klass_hero_web/components/provider_components.ex:3263
+#: lib/klass_hero_web/components/provider_components.ex:3426
 #, elixir-autogen, elixir-format
 msgid "Confirm agreement"
 msgstr "Zustimmung bestätigen"
@@ -7177,12 +7183,12 @@ msgstr "Zustimmung bestätigen"
 msgid "Couldn't record your agreement. Please try again."
 msgstr "Deine Zustimmung konnte nicht gespeichert werden. Bitte versuche es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:3286
+#: lib/klass_hero_web/components/provider_components.ex:3449
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr "Vereinbarung herunterladen (PDF)"
 
-#: lib/klass_hero_web/components/provider_components.ex:3262
+#: lib/klass_hero_web/components/provider_components.ex:3425
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr "Ich habe die Klass Hero Community-Richtlinien gelesen und stimme ihnen zu."
@@ -7192,7 +7198,7 @@ msgstr "Ich habe die Klass Hero Community-Richtlinien gelesen und stimme ihnen z
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr "Bitte bestätige, dass du die Community-Richtlinien gelesen hast und ihnen zustimmst."
 
-#: lib/klass_hero_web/components/provider_components.ex:3171
+#: lib/klass_hero_web/components/provider_components.ex:3334
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr "Unterzeichnet von %{name} am %{date} (v%{version})."
@@ -7202,17 +7208,17 @@ msgstr "Unterzeichnet von %{name} am %{date} (v%{version})."
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr "Danke – deine Zustimmung zu den Community-Richtlinien wurde gespeichert."
 
-#: lib/klass_hero_web/components/provider_components.ex:3271
+#: lib/klass_hero_web/components/provider_components.ex:3434
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr "Die Community-Richtlinien wurden seit deiner letzten Zustimmung aktualisiert (v%{old}). Bitte lies sie erneut und stimme erneut zu."
 
-#: lib/klass_hero_web/components/provider_components.ex:3260
+#: lib/klass_hero_web/components/provider_components.ex:3423
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr "Der letzte Schritt: Lies die Klass Hero Community-Richtlinien und stimme ihnen zu."
 
-#: lib/klass_hero_web/components/provider_components.ex:3261
+#: lib/klass_hero_web/components/provider_components.ex:3424
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr "Du hast den Community-Richtlinien zugestimmt."
@@ -7481,12 +7487,12 @@ msgstr "Ihre Versicherungsbescheinigung wird geprüft."
 msgid "Your insurance is verified."
 msgstr "Ihre Versicherung ist verifiziert."
 
-#: lib/klass_hero_web/components/provider_components.ex:3215
+#: lib/klass_hero_web/components/provider_components.ex:3378
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr "Unterzeichnung durch %{name} im Namen des Unternehmens."
 
-#: lib/klass_hero_web/components/provider_components.ex:3318
+#: lib/klass_hero_web/components/provider_components.ex:3481
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr "Bestätige im Namen deines Unternehmens, dass alle Mitarbeitenden gemäß dem deutschen Kinderschutzrecht überprüft sind."
@@ -7496,7 +7502,7 @@ msgstr "Bestätige im Namen deines Unternehmens, dass alle Mitarbeitenden gemä�
 msgid "Couldn't record your declaration. Please try again."
 msgstr "Deine Erklärung konnte nicht gespeichert werden. Bitte versuche es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:3324
+#: lib/klass_hero_web/components/provider_components.ex:3487
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr "Ich bestätige im Namen des Unternehmens, dass die obige Erklärung zutrifft und ich zu ihrer Unterzeichnung berechtigt bin."
@@ -7506,17 +7512,17 @@ msgstr "Ich bestätige im Namen des Unternehmens, dass die obige Erklärung zutr
 msgid "Please confirm the declaration before signing."
 msgstr "Bitte bestätige die Erklärung vor der Unterzeichnung."
 
-#: lib/klass_hero_web/components/provider_components.ex:3349
+#: lib/klass_hero_web/components/provider_components.ex:3512
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr "Vorläufiger Text — vor der Freischaltung noch von einer in Deutschland zugelassenen Anwältin bzw. einem Anwalt zu prüfen."
 
-#: lib/klass_hero_web/components/provider_components.ex:3328
+#: lib/klass_hero_web/components/provider_components.ex:3491
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr "Erklärung unterzeichnen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3316
+#: lib/klass_hero_web/components/provider_components.ex:3479
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr "Erklärung zur Mitarbeiter-Compliance"
@@ -7526,12 +7532,12 @@ msgstr "Erklärung zur Mitarbeiter-Compliance"
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr "Danke — deine Erklärung zur Mitarbeiter-Compliance wurde erfasst."
 
-#: lib/klass_hero_web/components/provider_components.ex:3336
+#: lib/klass_hero_web/components/provider_components.ex:3499
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr "Die Erklärung zur Mitarbeiter-Compliance wurde seit deiner letzten Unterzeichnung aktualisiert (v%{old}). Bitte prüfe sie und unterzeichne erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:3322
+#: lib/klass_hero_web/components/provider_components.ex:3485
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr "Du hast die Erklärung zur Mitarbeiter-Compliance unterzeichnet."
@@ -7546,12 +7552,12 @@ msgstr "Sitzungsnotiz"
 msgid "Session note submitted for review"
 msgstr "Sitzungsnotiz zur Überprüfung eingereicht"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:372
+#: lib/klass_hero_web/live/dashboard_live.ex:412
 #, elixir-autogen, elixir-format
 msgid "Loading your programs…"
 msgstr "Deine Programme werden geladen…"
 
-#: lib/klass_hero_web/live/dashboard_live.ex:342
+#: lib/klass_hero_web/live/dashboard_live.ex:382
 #, elixir-autogen, elixir-format
 msgid "Loading…"
 msgstr "Wird geladen…"
@@ -7598,24 +7604,24 @@ msgstr "In Prüfung"
 msgid "Undelivered Events"
 msgstr "Nicht zugestellte Ereignisse"
 
-#: lib/klass_hero_web/components/provider_components.ex:2043
-#: lib/klass_hero_web/components/provider_components.ex:2226
+#: lib/klass_hero_web/components/provider_components.ex:2187
+#: lib/klass_hero_web/components/provider_components.ex:2370
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1966
-#: lib/klass_hero_web/components/provider_components.ex:2152
+#: lib/klass_hero_web/components/provider_components.ex:2110
+#: lib/klass_hero_web/components/provider_components.ex:2296
 #, elixir-autogen, elixir-format
 msgid "Lead"
 msgstr "Leitung"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:337
+#: lib/klass_hero_web/live/provider/programs_live.ex:416
 #, elixir-autogen, elixir-format
 msgid "Lead instructor updated."
 msgstr "Leitender Kursleiter aktualisiert."
 
-#: lib/klass_hero_web/components/provider_components.ex:1978
+#: lib/klass_hero_web/components/provider_components.ex:2122
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor"
 msgstr "Als leitenden Kursleiter festlegen"
@@ -7625,67 +7631,67 @@ msgstr "Als leitenden Kursleiter festlegen"
 msgid "Manage Staffing"
 msgstr "Programmteam verwalten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2007
+#: lib/klass_hero_web/components/provider_components.ex:2151
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this program yet."
 msgstr "Diesem Programm ist noch niemand zugewiesen."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:267
+#: lib/klass_hero_web/live/provider/programs_live.ex:346
 #: lib/klass_hero_web/live/provider/sessions_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "Pick a staff member to add."
 msgstr "Bitte ein Teammitglied zum Hinzufügen auswählen."
 
-#: lib/klass_hero_web/components/provider_components.ex:1990
-#: lib/klass_hero_web/components/provider_components.ex:2265
+#: lib/klass_hero_web/components/provider_components.ex:2134
+#: lib/klass_hero_web/components/provider_components.ex:2409
 #, elixir-autogen, elixir-format
 msgid "Reassign the lead before removing them"
 msgstr "Vor dem Entfernen einen anderen leitenden Kursleiter festlegen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1991
+#: lib/klass_hero_web/components/provider_components.ex:2135
 #, elixir-autogen, elixir-format
 msgid "Remove from program"
 msgstr "Aus dem Programm entfernen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2025
-#: lib/klass_hero_web/components/provider_components.ex:2207
+#: lib/klass_hero_web/components/provider_components.ex:2169
+#: lib/klass_hero_web/components/provider_components.ex:2351
 #, elixir-autogen, elixir-format
 msgid "Select a staff member…"
 msgstr "Teammitglied auswählen …"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:282
+#: lib/klass_hero_web/live/provider/programs_live.ex:361
 #, elixir-autogen, elixir-format
 msgid "Staff member added to the program."
 msgstr "Teammitglied zum Programm hinzugefügt."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:308
+#: lib/klass_hero_web/live/provider/programs_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "Staff member removed from the program."
 msgstr "Teammitglied aus dem Programm entfernt."
 
-#: lib/klass_hero_web/components/provider_components.ex:2048
+#: lib/klass_hero_web/components/provider_components.ex:2192
 #, elixir-autogen, elixir-format
 msgid "Staff you add can read and reply to this program's parent conversations."
 msgstr ""
 "Hinzugefügte Teammitglieder können die Elterngespräche dieses Programms lesen "
 "und beantworten."
 
-#: lib/klass_hero_web/components/provider_components.ex:1942
+#: lib/klass_hero_web/components/provider_components.ex:2086
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{title}"
 msgstr "Programmteam — %{title}"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:944
+#: lib/klass_hero_web/live/provider/programs_live.ex:1064
 #, elixir-autogen, elixir-format
 msgid "That staff member could not be found."
 msgstr "Dieses Teammitglied wurde nicht gefunden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:290
+#: lib/klass_hero_web/live/provider/programs_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "They are already on this program."
 msgstr "Diese Person ist bereits in diesem Programm."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:316
+#: lib/klass_hero_web/live/provider/programs_live.ex:395
 #, elixir-autogen, elixir-format
 msgid "This person is the lead instructor. Make someone else lead before removing them."
 msgstr ""
@@ -7749,21 +7755,21 @@ msgstr "Damit wird %{name} endgültig gelöscht – das lässt sich nicht rückg
 msgid "This person has a history here now — use 'Remove from team' instead."
 msgstr "Diese Person hat inzwischen eine Historie – nutze stattdessen „Aus dem Team entfernen“."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1222
+#: lib/klass_hero_web/live/provider/programs_live.ex:1342
 #, elixir-autogen, elixir-format
 msgid "Program created, but some settings could not be saved. Please review the program's limits."
 msgstr ""
 "Programm erstellt, aber einige Einstellungen konnten nicht gespeichert werden. "
 "Bitte überprüfen Sie die Grenzwerte des Programms."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1226
+#: lib/klass_hero_web/live/provider/programs_live.ex:1346
 #, elixir-autogen, elixir-format
 msgid "Program updated, but some settings could not be saved. Please review the program's limits."
 msgstr ""
 "Programm aktualisiert, aber einige Einstellungen konnten nicht gespeichert "
 "werden. Bitte überprüfen Sie die Grenzwerte des Programms."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1216
+#: lib/klass_hero_web/live/provider/programs_live.ex:1336
 #, elixir-autogen, elixir-format
 msgid "Program updated, but the enrollment capacity was rejected. The previous limits still apply."
 msgstr ""
@@ -7792,7 +7798,7 @@ msgstr ""
 msgid "I understand this program will have no capacity limit."
 msgstr "Ich verstehe, dass dieses Programm keine Teilnehmerbegrenzung haben wird."
 
-#: lib/klass_hero_web/components/provider_components.ex:2253
+#: lib/klass_hero_web/components/provider_components.ex:2397
 #, elixir-autogen, elixir-format
 msgid "Go back to the program's usual team"
 msgstr "Zurück zum üblichen Programmteam"
@@ -7802,17 +7808,17 @@ msgstr "Zurück zum üblichen Programmteam"
 msgid "Lead instructor for this session updated."
 msgstr "Leitung für diesen Termin aktualisiert."
 
-#: lib/klass_hero_web/components/provider_components.ex:2167
+#: lib/klass_hero_web/components/provider_components.ex:2311
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor for this session"
 msgstr "Als Leitung für diesen Termin festlegen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2189
+#: lib/klass_hero_web/components/provider_components.ex:2333
 #, elixir-autogen, elixir-format
 msgid "Nobody is working this session yet."
 msgstr "Für diesen Termin ist noch niemand eingeteilt."
 
-#: lib/klass_hero_web/components/provider_components.ex:2270
+#: lib/klass_hero_web/components/provider_components.ex:2414
 #, elixir-autogen, elixir-format
 msgid "Remove from this session"
 msgstr "Von diesem Termin entfernen"
@@ -7832,7 +7838,7 @@ msgstr "Teammitglied von diesem Termin entfernt."
 msgid "Staffing"
 msgstr "Team"
 
-#: lib/klass_hero_web/components/provider_components.ex:2091
+#: lib/klass_hero_web/components/provider_components.ex:2235
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{date}"
 msgstr "Team — %{date}"
@@ -7862,22 +7868,184 @@ msgstr "Dieser Termin nutzt wieder das übliche Programmteam."
 msgid "A session needs at least one person. Use “Go back to the program's usual team” to drop this session's own roster."
 msgstr "Ein Termin braucht mindestens eine Person. Nutze „Zurück zum üblichen Programmteam“, um die eigene Besetzung dieses Termins aufzuheben."
 
-#: lib/klass_hero_web/components/provider_components.ex:2268
+#: lib/klass_hero_web/components/provider_components.ex:2412
 #, elixir-autogen, elixir-format
 msgid "A session needs someone — use “Go back to the program's usual team” instead"
 msgstr "Ein Termin braucht jemanden — nutze stattdessen „Zurück zum üblichen Programmteam“"
 
-#: lib/klass_hero_web/components/provider_components.ex:2235
+#: lib/klass_hero_web/components/provider_components.ex:2379
 #, elixir-autogen, elixir-format
 msgid "Everyone on your team is already working this session."
 msgstr "Alle aus deinem Team arbeiten bereits bei diesem Termin."
 
-#: lib/klass_hero_web/components/provider_components.ex:2123
+#: lib/klass_hero_web/components/provider_components.ex:2267
 #, elixir-autogen, elixir-format
 msgid "Staffed just for this session. Changes here do not touch the program."
 msgstr "Nur für diesen Termin eingeteilt. Änderungen hier wirken sich nicht auf das Programm aus."
 
-#: lib/klass_hero_web/components/provider_components.ex:2125
+#: lib/klass_hero_web/components/provider_components.ex:2269
 #, elixir-autogen, elixir-format
 msgid "Using the program's usual team. The first change here copies them onto this session, so later program changes stop reaching it."
 msgstr "Es gilt das übliche Programmteam. Die erste Änderung hier übernimmt das Team in diesen Termin — spätere Änderungen am Programm greifen dann nicht mehr."
+
+#: lib/klass_hero_web/live/booking_live.ex:437
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:125
+#, elixir-autogen, elixir-format
+msgid "(optional)"
+msgstr "(optional)"
+
+#: lib/klass_hero_web/components/provider_components.ex:2005
+#, elixir-autogen, elixir-format
+msgid "Add a waiver"
+msgstr "Verzichtserklärung hinzufügen"
+
+#: lib/klass_hero_web/components/provider_components.ex:2037
+#, elixir-autogen, elixir-format
+msgid "Add waiver"
+msgstr "Hinzufügen"
+
+#: lib/klass_hero_web/live/provider/programs_live.ex:936
+#, elixir-autogen, elixir-format
+msgid "Check the waiver details and try again."
+msgstr "Bitte prüfe die Angaben zur Verzichtserklärung und versuche es erneut."
+
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:43
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:66
+#, elixir-autogen, elixir-format
+msgid "Enrollment not found."
+msgstr "Anmeldung nicht gefunden."
+
+#: lib/klass_hero_web/live/booking_live.ex:465
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:154
+#, elixir-autogen, elixir-format
+msgid "I have read and agree to %{title}"
+msgstr "Ich habe %{title} gelesen und stimme zu"
+
+#: lib/klass_hero_web/components/provider_components.ex:2019
+#, elixir-autogen, elixir-format
+msgid "Legal text"
+msgstr "Rechtstext"
+
+#: lib/klass_hero_web/components/provider_components.ex:1590
+#, elixir-autogen, elixir-format
+msgid "Manage Waivers"
+msgstr "Verzichtserklärungen verwalten"
+
+#: lib/klass_hero_web/components/provider_components.ex:1958
+#, elixir-autogen, elixir-format
+msgid "No waivers yet. Parents enrol without signing anything."
+msgstr "Noch keine Verzichtserklärungen. Eltern melden sich ohne Unterschrift an."
+
+#: lib/klass_hero_web/components/provider_components.ex:2026
+#, elixir-autogen, elixir-format
+msgid "Parents must sign this before enrolling"
+msgstr "Eltern müssen dies vor der Anmeldung unterschreiben"
+
+#: lib/klass_hero_web/live/booking_live.ex:171
+#, elixir-autogen, elixir-format
+msgid "Please read and sign every required waiver before enrolling."
+msgstr "Bitte lies und unterschreibe alle erforderlichen Verzichtserklärungen vor der Anmeldung."
+
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:106
+#, elixir-autogen, elixir-format
+msgid "Please read and sign these before %{program} begins."
+msgstr "Bitte lies und unterschreibe diese, bevor %{program} beginnt."
+
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:55
+#, elixir-autogen, elixir-format
+msgid "Please tick a waiver to sign it."
+msgstr "Bitte wähle eine Verzichtserklärung aus, um sie zu unterschreiben."
+
+#: lib/klass_hero_web/components/provider_components.ex:2004
+#, elixir-autogen, elixir-format
+msgid "Publish a new version"
+msgstr "Neue Version veröffentlichen"
+
+#: lib/klass_hero_web/components/provider_components.ex:2037
+#, elixir-autogen, elixir-format
+msgid "Publish version"
+msgstr "Version veröffentlichen"
+
+#: lib/klass_hero_web/components/provider_components.ex:2030
+#, elixir-autogen, elixir-format
+msgid "Publishing keeps every earlier version on record; signatures already given stay bound to the wording they were shown."
+msgstr "Beim Veröffentlichen bleibt jede frühere Version erhalten; bereits geleistete Unterschriften bleiben an den damals gezeigten Wortlaut gebunden."
+
+#: lib/klass_hero_web/components/provider_components.ex:1974
+#, elixir-autogen, elixir-format
+msgid "Required"
+msgstr "Erforderlich"
+
+#: lib/klass_hero_web/components/provider_components.ex:1993
+#, elixir-autogen, elixir-format
+msgid "Retire this waiver"
+msgstr "Diese Verzichtserklärung zurückziehen"
+
+#: lib/klass_hero_web/components/provider_components.ex:1986
+#, elixir-autogen, elixir-format
+msgid "Revise text"
+msgstr "Text überarbeiten"
+
+#: lib/klass_hero_web/live/dashboard_live.ex:330
+#, elixir-autogen, elixir-format
+msgid "Sign the waivers for %{program}"
+msgstr "Verzichtserklärungen für %{program} unterschreiben"
+
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:160
+#, elixir-autogen, elixir-format
+msgid "Sign waivers"
+msgstr "Verzichtserklärungen unterschreiben"
+
+#: lib/klass_hero_web/components/provider_components.ex:2492
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:142
+#, elixir-autogen, elixir-format
+msgid "Signed"
+msgstr "Unterschrieben"
+
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:60
+#, elixir-autogen, elixir-format
+msgid "Thank you — your waivers are on record."
+msgstr "Danke — deine Verzichtserklärungen sind erfasst."
+
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:110
+#, elixir-autogen, elixir-format
+msgid "There is nothing to sign for this enrollment."
+msgstr "Für diese Anmeldung gibt es nichts zu unterschreiben."
+
+#: lib/klass_hero_web/components/provider_components.ex:2492
+#, elixir-autogen, elixir-format
+msgid "Unsigned"
+msgstr "Nicht unterschrieben"
+
+#: lib/klass_hero_web/components/provider_components.ex:1978
+#, elixir-autogen, elixir-format
+msgid "Version %{number}"
+msgstr "Version %{number}"
+
+#: lib/klass_hero_web/live/provider/programs_live.ex:340
+#, elixir-autogen, elixir-format
+msgid "Waiver not found."
+msgstr "Verzichtserklärung nicht gefunden."
+
+#: lib/klass_hero_web/components/provider_components.ex:2460
+#: lib/klass_hero_web/live/booking_live.ex:427
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:31
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:103
+#, elixir-autogen, elixir-format
+msgid "Waivers"
+msgstr "Verzichtserklärungen"
+
+#: lib/klass_hero_web/live/dashboard_live.ex:325
+#, elixir-autogen, elixir-format
+msgid "Waivers waiting for your signature"
+msgstr "Verzichtserklärungen warten auf deine Unterschrift"
+
+#: lib/klass_hero_web/components/provider_components.ex:1949
+#, elixir-autogen, elixir-format
+msgid "Waivers — %{title}"
+msgstr "Verzichtserklärungen — %{title}"
+
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:94
+#, elixir-autogen, elixir-format
+msgid "this program"
+msgstr "dieses Programm"

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -45,7 +45,7 @@ msgstr "Kontakt"
 #: lib/klass_hero_web/components/layouts/app.html.heex:129
 #: lib/klass_hero_web/components/layouts/app.html.heex:204
 #: lib/klass_hero_web/components/layouts/app.html.heex:229
-#: lib/klass_hero_web/components/provider_components.ex:390
+#: lib/klass_hero_web/components/provider_components.ex:391
 #: lib/klass_hero_web/components/ui_components.ex:268
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
@@ -137,7 +137,7 @@ msgid "Your Data"
 msgstr "Ihre Daten"
 
 #: lib/klass_hero_web/components/core_components.ex:71
-#: lib/klass_hero_web/components/provider_components.ex:1765
+#: lib/klass_hero_web/components/provider_components.ex:1766
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr "schließen"
@@ -172,7 +172,7 @@ msgstr "Weiteres Programm hinzufügen"
 msgid "Ages %{range}"
 msgstr "Alter %{range}"
 
-#: lib/klass_hero_web/live/booking_live.ex:511
+#: lib/klass_hero_web/live/booking_live.ex:510
 #, elixir-autogen, elixir-format
 msgid "An invoice will be emailed to you after enrollment completion"
 msgstr "Nach Abschluss der Anmeldung erhalten Sie eine Rechnung per E-Mail"
@@ -187,12 +187,12 @@ msgstr "Allergien, medizinische Bedingungen oder besondere Hinweise..."
 msgid "Book camps, tutors, and workshops instantly. Our integrated planner helps you manage your child's busy life."
 msgstr "Buchen Sie Camps, Nachhilfe und Workshops sofort. Unser integrierter Planer hilft Ihnen, den vollen Terminkalender Ihres Kindes zu verwalten."
 
-#: lib/klass_hero_web/live/booking_live.ex:488
+#: lib/klass_hero_web/live/booking_live.ex:487
 #, elixir-autogen, elixir-format
 msgid "Cash / Bank Transfer"
 msgstr "Bar / Überweisung"
 
-#: lib/klass_hero_web/live/booking_live.ex:513
+#: lib/klass_hero_web/live/booking_live.ex:512
 #, elixir-autogen, elixir-format
 msgid "Cash/transfer payments will show as \"Pending\" until received"
 msgstr "Bar-/Überweisungszahlungen werden als \"Ausstehend\" angezeigt, bis sie eingegangen sind"
@@ -202,17 +202,17 @@ msgstr "Bar-/Überweisungszahlungen werden als \"Ausstehend\" angezeigt, bis sie
 msgid "Community Focused"
 msgstr "Gemeinschaftsorientiert"
 
-#: lib/klass_hero_web/live/booking_live.ex:530
+#: lib/klass_hero_web/live/booking_live.ex:529
 #, elixir-autogen, elixir-format
 msgid "Complete Enrollment"
 msgstr "Anmeldung abschließen"
 
-#: lib/klass_hero_web/live/booking_live.ex:479
+#: lib/klass_hero_web/live/booking_live.ex:478
 #, elixir-autogen, elixir-format
 msgid "Credit Card"
 msgstr "Kreditkarte"
 
-#: lib/klass_hero_web/live/booking_live.ex:512
+#: lib/klass_hero_web/live/booking_live.ex:511
 #, elixir-autogen, elixir-format
 msgid "Credit card payments are processed immediately"
 msgstr "Kreditkartenzahlungen werden sofort verarbeitet"
@@ -232,7 +232,7 @@ msgstr "Einfache Terminplanung"
 msgid "Enroll Now - %{price}"
 msgstr "Jetzt anmelden - %{price}"
 
-#: lib/klass_hero_web/components/provider_components.ex:1484
+#: lib/klass_hero_web/components/provider_components.ex:1485
 #: lib/klass_hero_web/live/booking_live.ex:305
 #, elixir-autogen, elixir-format
 msgid "Enrollment"
@@ -274,7 +274,7 @@ msgstr "Empfohlene Programme"
 msgid "Invalid pagination state. Please refresh the page."
 msgstr "Ungültiger Seitenstatus. Bitte laden Sie die Seite neu."
 
-#: lib/klass_hero_web/live/booking_live.ex:509
+#: lib/klass_hero_web/live/booking_live.ex:508
 #, elixir-autogen, elixir-format
 msgid "Invoice & Payment Confirmation"
 msgstr "Rechnung & Zahlungsbestätigung"
@@ -301,17 +301,17 @@ msgstr "Keine Programme gefunden"
 msgid "Optional: Include any important information we should know about your child."
 msgstr "Optional: Wichtige Informationen über Ihr Kind, die wir wissen sollten."
 
-#: lib/klass_hero_web/live/booking_live.ex:480
+#: lib/klass_hero_web/live/booking_live.ex:479
 #, elixir-autogen, elixir-format
 msgid "Pay securely with Visa, Mastercard, or other cards"
 msgstr "Sicher bezahlen mit Visa, Mastercard oder anderen Karten"
 
-#: lib/klass_hero_web/live/booking_live.ex:474
+#: lib/klass_hero_web/live/booking_live.ex:473
 #, elixir-autogen, elixir-format
 msgid "Payment Method"
 msgstr "Zahlungsmethode"
 
-#: lib/klass_hero_web/live/booking_live.ex:498
+#: lib/klass_hero_web/live/booking_live.ex:497
 #, elixir-autogen, elixir-format
 msgid "Payment Summary"
 msgstr "Zahlungsübersicht"
@@ -384,7 +384,7 @@ msgstr "Besondere Anforderungen"
 msgid "Total Price:"
 msgstr "Gesamtpreis:"
 
-#: lib/klass_hero_web/live/booking_live.ex:504
+#: lib/klass_hero_web/live/booking_live.ex:503
 #, elixir-autogen, elixir-format
 msgid "Total due today:"
 msgstr "Heute fällig:"
@@ -577,9 +577,9 @@ msgstr "Wird gelöscht..."
 msgid "Dispute Resolution"
 msgstr "Streitbeilegung"
 
-#: lib/klass_hero_web/components/provider_components.ex:719
-#: lib/klass_hero_web/components/provider_components.ex:2820
-#: lib/klass_hero_web/components/provider_components.ex:2838
+#: lib/klass_hero_web/components/provider_components.ex:720
+#: lib/klass_hero_web/components/provider_components.ex:2816
+#: lib/klass_hero_web/components/provider_components.ex:2834
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
@@ -878,9 +878,9 @@ msgstr "Speichern..."
 msgid "Select one or both options"
 msgstr "Wählen Sie eine oder beide Optionen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2516
-#: lib/klass_hero_web/components/provider_components.ex:2517
-#: lib/klass_hero_web/components/provider_components.ex:2554
+#: lib/klass_hero_web/components/provider_components.ex:2512
+#: lib/klass_hero_web/components/provider_components.ex:2513
+#: lib/klass_hero_web/components/provider_components.ex:2550
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:448
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:484
@@ -1324,7 +1324,7 @@ msgstr "Push-, E-Mail-, SMS-Einstellungen"
 
 #: lib/klass_hero_web/components/composite_components.ex:103
 #: lib/klass_hero_web/components/layouts/admin.html.heex:85
-#: lib/klass_hero_web/components/provider_components.ex:120
+#: lib/klass_hero_web/components/provider_components.ex:121
 #: lib/klass_hero_web/live/admin/sessions_live.ex:26
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:3
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:348
@@ -1456,7 +1456,7 @@ msgstr "Lebenskompetenzen"
 msgid "Music"
 msgstr "Musik"
 
-#: lib/klass_hero_web/components/provider_components.ex:755
+#: lib/klass_hero_web/components/provider_components.ex:756
 #: lib/klass_hero_web/live/for_providers_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "Qualifications"
@@ -1577,19 +1577,19 @@ msgstr "Profil"
 msgid "Quick Navigation"
 msgstr "Schnellnavigation"
 
-#: lib/klass_hero_web/components/provider_components.ex:1487
-#: lib/klass_hero_web/components/provider_components.ex:2476
-#: lib/klass_hero_web/components/provider_components.ex:2718
+#: lib/klass_hero_web/components/provider_components.ex:1488
+#: lib/klass_hero_web/components/provider_components.ex:2472
+#: lib/klass_hero_web/components/provider_components.ex:2714
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr "Aktionen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1633
+#: lib/klass_hero_web/components/provider_components.ex:1634
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr "Aktiv"
 
-#: lib/klass_hero_web/components/provider_components.ex:672
+#: lib/klass_hero_web/components/provider_components.ex:673
 #: lib/klass_hero_web/live/provider/team_live.ex:627
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
@@ -1600,7 +1600,7 @@ msgstr "Teammitglied hinzufügen"
 msgid "All Staff"
 msgstr "Alle Mitarbeiter"
 
-#: lib/klass_hero_web/components/provider_components.ex:1478
+#: lib/klass_hero_web/components/provider_components.ex:1479
 #, elixir-autogen, elixir-format
 msgid "Assigned Staff"
 msgstr "Zugewiesenes Personal"
@@ -1611,7 +1611,7 @@ msgstr "Zugewiesenes Personal"
 msgid "Book Now"
 msgstr "Jetzt buchen"
 
-#: lib/klass_hero_web/components/provider_components.ex:206
+#: lib/klass_hero_web/components/provider_components.ex:207
 #, elixir-autogen, elixir-format
 msgid "Business Profile"
 msgstr "Geschäftsprofil"
@@ -1627,8 +1627,8 @@ msgstr "Gewerbeanmeldung"
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr "Erstellen Sie Profile für Ihr Personal. Diese werden für Eltern sichtbar sein, wenn sie Programmen zugewiesen werden."
 
-#: lib/klass_hero_web/components/provider_components.ex:539
-#: lib/klass_hero_web/components/provider_components.ex:1596
+#: lib/klass_hero_web/components/provider_components.ex:540
+#: lib/klass_hero_web/components/provider_components.ex:1597
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:54
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:81
 #: lib/klass_hero_web/live/settings/children_live.ex:413
@@ -1638,57 +1638,57 @@ msgstr "Erstellen Sie Profile für Ihr Personal. Diese werden für Eltern sichtb
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: lib/klass_hero_web/components/provider_components.ex:224
+#: lib/klass_hero_web/components/provider_components.ex:225
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:31
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "Edit Profile"
 msgstr "Profil bearbeiten"
 
-#: lib/klass_hero_web/components/provider_components.ex:1635
+#: lib/klass_hero_web/components/provider_components.ex:1636
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr "Inaktiv"
 
-#: lib/klass_hero_web/components/provider_components.ex:113
+#: lib/klass_hero_web/components/provider_components.ex:114
 #: lib/klass_hero_web/live/provider/programs_live.ex:54
 #, elixir-autogen, elixir-format
 msgid "My Programs"
 msgstr "Meine Programme"
 
-#: lib/klass_hero_web/components/provider_components.ex:416
-#: lib/klass_hero_web/components/provider_components.ex:952
+#: lib/klass_hero_web/components/provider_components.ex:417
+#: lib/klass_hero_web/components/provider_components.ex:953
 #, elixir-autogen, elixir-format
 msgid "New Program"
 msgstr "Neues Programm"
 
-#: lib/klass_hero_web/components/provider_components.ex:99
+#: lib/klass_hero_web/components/provider_components.ex:100
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr "Übersicht"
 
-#: lib/klass_hero_web/components/provider_components.ex:47
-#: lib/klass_hero_web/components/provider_components.ex:73
-#: lib/klass_hero_web/components/provider_components.ex:1634
-#: lib/klass_hero_web/components/provider_components.ex:2914
-#: lib/klass_hero_web/components/provider_components.ex:2932
+#: lib/klass_hero_web/components/provider_components.ex:48
+#: lib/klass_hero_web/components/provider_components.ex:74
+#: lib/klass_hero_web/components/provider_components.ex:1635
+#: lib/klass_hero_web/components/provider_components.ex:2910
+#: lib/klass_hero_web/components/provider_components.ex:2928
 #: lib/klass_hero_web/live/admin/sessions_live.ex:298
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr "Ausstehend"
 
-#: lib/klass_hero_web/components/provider_components.ex:1565
+#: lib/klass_hero_web/components/provider_components.ex:1566
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr "Vorschau"
 
-#: lib/klass_hero_web/components/provider_components.ex:1418
+#: lib/klass_hero_web/components/provider_components.ex:1419
 #, elixir-autogen, elixir-format
 msgid "Program Inventory"
 msgstr "Programmübersicht"
 
-#: lib/klass_hero_web/components/provider_components.ex:1475
+#: lib/klass_hero_web/components/provider_components.ex:1476
 #, elixir-autogen, elixir-format
 msgid "Program Name"
 msgstr "Programmname"
@@ -1703,15 +1703,15 @@ msgstr "Anbieter-Dashboard"
 msgid "Save for Later"
 msgstr "Für später speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:1435
+#: lib/klass_hero_web/components/provider_components.ex:1436
 #, elixir-autogen, elixir-format
 msgid "Search by name..."
 msgstr "Nach Namen suchen..."
 
-#: lib/klass_hero_web/components/provider_components.ex:1481
-#: lib/klass_hero_web/components/provider_components.ex:1884
-#: lib/klass_hero_web/components/provider_components.ex:2467
-#: lib/klass_hero_web/components/provider_components.ex:2715
+#: lib/klass_hero_web/components/provider_components.ex:1482
+#: lib/klass_hero_web/components/provider_components.ex:1885
+#: lib/klass_hero_web/components/provider_components.ex:2463
+#: lib/klass_hero_web/components/provider_components.ex:2711
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1719,7 +1719,7 @@ msgstr "Nach Namen suchen..."
 msgid "Status"
 msgstr "Status"
 
-#: lib/klass_hero_web/components/provider_components.ex:106
+#: lib/klass_hero_web/components/provider_components.ex:107
 #: lib/klass_hero_web/live/provider/team_live.ex:36
 #, elixir-autogen, elixir-format
 msgid "Team & Profiles"
@@ -1730,32 +1730,32 @@ msgstr "Team & Profile"
 msgid "Team & Provider Profiles"
 msgstr "Team- & Anbieterprofile"
 
-#: lib/klass_hero_web/components/provider_components.ex:209
+#: lib/klass_hero_web/components/provider_components.ex:210
 #, elixir-autogen, elixir-format
 msgid "This is your main business identity. Verification is required to list programs."
 msgstr "Dies ist Ihre Hauptgeschäftsidentität. Eine Verifizierung ist erforderlich, um Programme anzubieten."
 
-#: lib/klass_hero_web/components/provider_components.ex:1538
-#: lib/klass_hero_web/components/provider_components.ex:1899
+#: lib/klass_hero_web/components/provider_components.ex:1539
+#: lib/klass_hero_web/components/provider_components.ex:1900
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr "Nicht zugewiesen"
 
 #: lib/klass_hero_web/components/messaging_components.ex:722
-#: lib/klass_hero_web/components/provider_components.ex:50
-#: lib/klass_hero_web/components/provider_components.ex:1636
+#: lib/klass_hero_web/components/provider_components.ex:51
+#: lib/klass_hero_web/components/provider_components.ex:1637
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:434
 #: lib/klass_hero_web/presenters/provider_presenter.ex:103
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr "Unbekannt"
 
-#: lib/klass_hero_web/components/provider_components.ex:401
+#: lib/klass_hero_web/components/provider_components.ex:402
 #, elixir-autogen, elixir-format
 msgid "Verified Business"
 msgstr "Verifiziertes Unternehmen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1576
+#: lib/klass_hero_web/components/provider_components.ex:1577
 #, elixir-autogen, elixir-format
 msgid "View Roster"
 msgstr "Teilnehmerliste"
@@ -1815,10 +1815,10 @@ msgstr "Rundnachricht an %{count} Eltern gesendet"
 #: lib/klass_hero_web/components/participation_components.ex:441
 #: lib/klass_hero_web/components/participation_components.ex:631
 #: lib/klass_hero_web/components/participation_components.ex:717
-#: lib/klass_hero_web/components/provider_components.ex:889
-#: lib/klass_hero_web/components/provider_components.ex:1334
-#: lib/klass_hero_web/components/provider_components.ex:2056
-#: lib/klass_hero_web/components/provider_components.ex:2657
+#: lib/klass_hero_web/components/provider_components.ex:890
+#: lib/klass_hero_web/components/provider_components.ex:1335
+#: lib/klass_hero_web/components/provider_components.ex:2052
+#: lib/klass_hero_web/components/provider_components.ex:2653
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:478
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
@@ -1874,7 +1874,7 @@ msgstr "Kind konnte nicht entfernt werden. Bitte versuchen Sie es erneut."
 msgid "Data sharing consent"
 msgstr "Einwilligung zur Datenweitergabe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2801
+#: lib/klass_hero_web/components/provider_components.ex:2797
 #: lib/klass_hero_web/live/settings/children_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1922,17 +1922,17 @@ msgstr "Rundnachricht konnte nicht gesendet werden"
 msgid "Failed to submit note"
 msgstr "Notiz konnte nicht eingereicht werden"
 
-#: lib/klass_hero_web/components/provider_components.ex:2795
-#: lib/klass_hero_web/components/provider_components.ex:2824
-#: lib/klass_hero_web/components/provider_components.ex:2840
+#: lib/klass_hero_web/components/provider_components.ex:2791
+#: lib/klass_hero_web/components/provider_components.ex:2820
+#: lib/klass_hero_web/components/provider_components.ex:2836
 #: lib/klass_hero_web/live/settings/children_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr "Vorname"
 
-#: lib/klass_hero_web/components/provider_components.ex:2796
-#: lib/klass_hero_web/components/provider_components.ex:2825
-#: lib/klass_hero_web/components/provider_components.ex:2841
+#: lib/klass_hero_web/components/provider_components.ex:2792
+#: lib/klass_hero_web/components/provider_components.ex:2821
+#: lib/klass_hero_web/components/provider_components.ex:2837
 #: lib/klass_hero_web/live/settings/children_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -2063,15 +2063,15 @@ msgstr "Programm-Rundnachricht"
 msgid "Provider data sharing consent"
 msgstr "Einwilligung zur Datenweitergabe an Anbieter"
 
-#: lib/klass_hero_web/components/provider_components.ex:874
+#: lib/klass_hero_web/components/provider_components.ex:875
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:294
 #: lib/klass_hero_web/live/settings/children_live.ex:719
 #, elixir-autogen, elixir-format
 msgid "Save Changes"
 msgstr "Änderungen speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:1743
 #: lib/klass_hero_web/components/provider_components.ex:1744
+#: lib/klass_hero_web/components/provider_components.ex:1745
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:43
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:151
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:252
@@ -2089,7 +2089,7 @@ msgstr "Rundnachricht senden"
 msgid "Send a message to start the conversation"
 msgstr "Senden Sie eine Nachricht, um die Unterhaltung zu beginnen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2895
+#: lib/klass_hero_web/components/provider_components.ex:2891
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:249
 #, elixir-autogen, elixir-format
@@ -2195,12 +2195,12 @@ msgstr[1] "%{count} Jahre"
 msgid "%{gender} only"
 msgstr "Nur %{gender}"
 
-#: lib/klass_hero_web/components/provider_components.ex:309
+#: lib/klass_hero_web/components/provider_components.ex:310
 #, elixir-autogen, elixir-format
 msgid "Action Required"
 msgstr "Aktion erforderlich"
 
-#: lib/klass_hero_web/components/provider_components.ex:876
+#: lib/klass_hero_web/components/provider_components.ex:877
 #, elixir-autogen, elixir-format
 msgid "Add Member"
 msgstr "Mitglied hinzufügen"
@@ -2220,12 +2220,12 @@ msgstr "Alter %{min} bis %{max}"
 msgid "Ages %{min}+"
 msgstr "Alter %{min}+"
 
-#: lib/klass_hero_web/components/provider_components.ex:1195
+#: lib/klass_hero_web/components/provider_components.ex:1196
 #, elixir-autogen, elixir-format
 msgid "Allowed Genders"
 msgstr "Zulässige Geschlechter"
 
-#: lib/klass_hero_web/components/provider_components.ex:2954
+#: lib/klass_hero_web/components/provider_components.ex:2950
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred during import."
 msgstr "Beim Import ist ein unerwarteter Fehler aufgetreten."
@@ -2238,7 +2238,7 @@ msgid "Approve"
 msgstr "Genehmigen"
 
 #: lib/klass_hero_web/components/participation_components.ex:826
-#: lib/klass_hero_web/components/provider_components.ex:48
+#: lib/klass_hero_web/components/provider_components.ex:49
 #: lib/klass_hero_web/live/admin/sessions_live.ex:295
 #: lib/klass_hero_web/live/admin/verifications_live.ex:202
 #: lib/klass_hero_web/presenters/vetting_checklist_presenter.ex:141
@@ -2268,7 +2268,7 @@ msgstr "Zurück zum Dashboard"
 msgid "Back to verifications"
 msgstr "Zurück zu den Verifizierungen"
 
-#: lib/klass_hero_web/components/provider_components.ex:728
+#: lib/klass_hero_web/components/provider_components.ex:729
 #, elixir-autogen, elixir-format
 msgid "Bio"
 msgstr "Biografie"
@@ -2278,7 +2278,7 @@ msgstr "Biografie"
 msgid "Book a Program"
 msgstr "Programm buchen"
 
-#: lib/klass_hero_web/components/provider_components.ex:729
+#: lib/klass_hero_web/components/provider_components.ex:730
 #, elixir-autogen, elixir-format
 msgid "Brief description of experience and specialties..."
 msgstr "Kurze Beschreibung der Erfahrung und Spezialgebiete..."
@@ -2309,19 +2309,19 @@ msgstr "Geschäftsinformationen"
 msgid "Business Logo"
 msgstr "Firmenlogo"
 
-#: lib/klass_hero_web/components/provider_components.ex:982
+#: lib/klass_hero_web/components/provider_components.ex:983
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "Category"
 msgstr "Kategorie"
 
-#: lib/klass_hero_web/components/provider_components.ex:1144
+#: lib/klass_hero_web/components/provider_components.ex:1145
 #, elixir-autogen, elixir-format
 msgid "Check eligibility at"
 msgstr "Berechtigung prüfen unter"
 
-#: lib/klass_hero_web/components/provider_components.ex:2464
-#: lib/klass_hero_web/components/provider_components.ex:2709
+#: lib/klass_hero_web/components/provider_components.ex:2460
+#: lib/klass_hero_web/components/provider_components.ex:2705
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr "Name des Kindes"
@@ -2336,7 +2336,7 @@ msgstr "Kind erfüllt die Programmanforderungen nicht"
 msgid "Child meets all program requirements"
 msgstr "Kind erfüllt alle Programmanforderungen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1305
+#: lib/klass_hero_web/components/provider_components.ex:1306
 #, elixir-autogen, elixir-format
 msgid "Choose Image"
 msgstr "Bild auswählen"
@@ -2346,17 +2346,17 @@ msgstr "Bild auswählen"
 msgid "Choose Logo"
 msgstr "Logo auswählen"
 
-#: lib/klass_hero_web/components/provider_components.ex:853
+#: lib/klass_hero_web/components/provider_components.ex:854
 #, elixir-autogen, elixir-format
 msgid "Choose Photo"
 msgstr "Foto auswählen"
 
-#: lib/klass_hero_web/components/provider_components.ex:984
+#: lib/klass_hero_web/components/provider_components.ex:985
 #, elixir-autogen, elixir-format
 msgid "Choose a category"
 msgstr "Kategorie auswählen"
 
-#: lib/klass_hero_web/components/provider_components.ex:428
+#: lib/klass_hero_web/components/provider_components.ex:429
 #, elixir-autogen, elixir-format
 msgid "Complete business verification to create programs."
 msgstr "Schließen Sie die Geschäftsverifizierung ab, um Programme zu erstellen."
@@ -2366,7 +2366,7 @@ msgstr "Schließen Sie die Geschäftsverifizierung ab, um Programme zu erstellen
 msgid "Confirm rejection"
 msgstr "Ablehnung bestätigen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2915
+#: lib/klass_hero_web/components/provider_components.ex:2911
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr "Bestätigt"
@@ -2386,22 +2386,22 @@ msgstr "Die hochgeladene Datei konnte nicht gelesen werden."
 msgid "Could not remove invite."
 msgstr "Einladung konnte nicht entfernt werden."
 
-#: lib/klass_hero_web/components/provider_components.ex:1261
+#: lib/klass_hero_web/components/provider_components.ex:1262
 #, elixir-autogen, elixir-format
 msgid "Cover Image"
 msgstr "Titelbild"
 
-#: lib/klass_hero_web/components/provider_components.ex:1138
+#: lib/klass_hero_web/components/provider_components.ex:1139
 #, elixir-autogen, elixir-format
 msgid "Define age, gender, or grade restrictions for eligible participants."
 msgstr "Legen Sie Alters-, Geschlechts- oder Klassenstufenbeschränkungen für teilnahmeberechtigte Teilnehmer fest."
 
-#: lib/klass_hero_web/components/provider_components.ex:1254
+#: lib/klass_hero_web/components/provider_components.ex:1255
 #, elixir-autogen, elixir-format
 msgid "Describe your program..."
 msgstr "Beschreiben Sie Ihr Programm..."
 
-#: lib/klass_hero_web/components/provider_components.ex:1253
+#: lib/klass_hero_web/components/provider_components.ex:1254
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:323
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:285
 #, elixir-autogen, elixir-format
@@ -2409,13 +2409,13 @@ msgid "Description"
 msgstr "Beschreibung"
 
 #: lib/klass_hero_web/components/program_components.ex:684
-#: lib/klass_hero_web/components/provider_components.ex:1206
+#: lib/klass_hero_web/components/provider_components.ex:1207
 #: lib/klass_hero_web/live/settings/children_live.ex:635
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr "Divers"
 
-#: lib/klass_hero_web/components/provider_components.ex:3130
+#: lib/klass_hero_web/components/provider_components.ex:3126
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr "Dokumenttyp"
@@ -2449,7 +2449,7 @@ msgstr "Dokument abgelehnt."
 msgid "Document uploaded successfully."
 msgstr "Dokument erfolgreich hochgeladen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2676
+#: lib/klass_hero_web/components/provider_components.ex:2672
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr "Vorlage herunterladen"
@@ -2459,40 +2459,40 @@ msgstr "Vorlage herunterladen"
 msgid "Download document"
 msgstr "Dokument herunterladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:950
+#: lib/klass_hero_web/components/provider_components.ex:951
 #, elixir-autogen, elixir-format
 msgid "Edit Program"
 msgstr "Programm bearbeiten"
 
-#: lib/klass_hero_web/components/provider_components.ex:670
+#: lib/klass_hero_web/components/provider_components.ex:671
 #, elixir-autogen, elixir-format
 msgid "Edit Team Member"
 msgstr "Teammitglied bearbeiten"
 
-#: lib/klass_hero_web/components/provider_components.ex:1059
+#: lib/klass_hero_web/components/provider_components.ex:1060
 #, elixir-autogen, elixir-format
 msgid "End Date"
 msgstr "Enddatum"
 
-#: lib/klass_hero_web/components/provider_components.ex:1046
+#: lib/klass_hero_web/components/provider_components.ex:1047
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "End Time"
 msgstr "Endzeit"
 
-#: lib/klass_hero_web/components/provider_components.ex:2473
-#: lib/klass_hero_web/components/provider_components.ex:2935
+#: lib/klass_hero_web/components/provider_components.ex:2469
+#: lib/klass_hero_web/components/provider_components.ex:2931
 #: lib/klass_hero_web/components/provider_layout_components.ex:644
 #, elixir-autogen, elixir-format
 msgid "Enrolled"
 msgstr "Angemeldet"
 
-#: lib/klass_hero_web/components/provider_components.ex:1789
+#: lib/klass_hero_web/components/provider_components.ex:1790
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr "Angemeldet (%{count})"
 
-#: lib/klass_hero_web/components/provider_components.ex:1087
+#: lib/klass_hero_web/components/provider_components.ex:1088
 #, elixir-autogen, elixir-format
 msgid "Enrollment Capacity (optional)"
 msgstr "Anmeldekapazität (optional)"
@@ -2502,8 +2502,8 @@ msgstr "Anmeldekapazität (optional)"
 msgid "Explain why this document is being rejected..."
 msgstr "Erklären Sie, warum dieses Dokument abgelehnt wird..."
 
-#: lib/klass_hero_web/components/provider_components.ex:71
-#: lib/klass_hero_web/components/provider_components.ex:2936
+#: lib/klass_hero_web/components/provider_components.ex:72
+#: lib/klass_hero_web/components/provider_components.ex:2932
 #: lib/klass_hero_web/live/admin/emails_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2536,7 +2536,7 @@ msgid "Family Programs"
 msgstr "Familienprogramme"
 
 #: lib/klass_hero_web/components/program_components.ex:682
-#: lib/klass_hero_web/components/provider_components.ex:1205
+#: lib/klass_hero_web/components/provider_components.ex:1206
 #: lib/klass_hero_web/live/settings/children_live.ex:634
 #, elixir-autogen, elixir-format
 msgid "Female"
@@ -2547,22 +2547,22 @@ msgstr "Weiblich"
 msgid "File"
 msgstr "Datei"
 
-#: lib/klass_hero_web/components/provider_components.ex:3064
+#: lib/klass_hero_web/components/provider_components.ex:3060
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr "Die Datei ist zu groß."
 
-#: lib/klass_hero_web/components/provider_components.ex:3066
+#: lib/klass_hero_web/components/provider_components.ex:3062
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr "Dateityp wird nicht akzeptiert."
 
-#: lib/klass_hero_web/components/provider_components.ex:756
+#: lib/klass_hero_web/components/provider_components.ex:757
 #, elixir-autogen, elixir-format
 msgid "First Aid, UEFA B License, Child Care Cert"
 msgstr "Erste Hilfe, UEFA-B-Lizenz, Kinderbetreuungszertifikat"
 
-#: lib/klass_hero_web/components/provider_components.ex:698
+#: lib/klass_hero_web/components/provider_components.ex:699
 #, elixir-autogen, elixir-format
 msgid "First Name"
 msgstr "Vorname"
@@ -2587,12 +2587,12 @@ msgstr "Klassenstufe %{min}+"
 msgid "Grades %{min} – %{max}"
 msgstr "Klassenstufen %{min} – %{max}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2712
+#: lib/klass_hero_web/components/provider_components.ex:2708
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr "E-Mail des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:817
+#: lib/klass_hero_web/components/provider_components.ex:818
 #, elixir-autogen, elixir-format
 msgid "Headshot Photo"
 msgstr "Porträtfoto"
@@ -2602,7 +2602,7 @@ msgstr "Porträtfoto"
 msgid "ID Document"
 msgstr "Ausweisdokument"
 
-#: lib/klass_hero_web/components/provider_components.ex:2649
+#: lib/klass_hero_web/components/provider_components.ex:2645
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Importieren"
@@ -2627,17 +2627,17 @@ msgstr "Einladung entfernt."
 msgid "Invite resent successfully."
 msgstr "Einladung erfolgreich erneut gesendet."
 
-#: lib/klass_hero_web/components/provider_components.ex:1806
+#: lib/klass_hero_web/components/provider_components.ex:1807
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr "Einladungen (%{count})"
 
-#: lib/klass_hero_web/components/provider_components.ex:856
+#: lib/klass_hero_web/components/provider_components.ex:857
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 1MB."
 msgstr "JPG, PNG oder WebP. Max. 1 MB."
 
-#: lib/klass_hero_web/components/provider_components.ex:1308
+#: lib/klass_hero_web/components/provider_components.ex:1309
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:277
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:361
 #, elixir-autogen, elixir-format
@@ -2654,22 +2654,22 @@ msgstr "Klass Hero wurde genau dafür entwickelt. Eine umfassende Betriebsplattf
 msgid "Klasse %{n}"
 msgstr "Klasse %{n}"
 
-#: lib/klass_hero_web/components/provider_components.ex:704
+#: lib/klass_hero_web/components/provider_components.ex:705
 #, elixir-autogen, elixir-format
 msgid "Last Name"
 msgstr "Nachname"
 
-#: lib/klass_hero_web/components/provider_components.ex:1069
+#: lib/klass_hero_web/components/provider_components.ex:1070
 #, elixir-autogen, elixir-format
 msgid "Leave blank for open registration at any time."
 msgstr "Leer lassen für eine jederzeit offene Anmeldung."
 
-#: lib/klass_hero_web/components/provider_components.ex:1198
+#: lib/klass_hero_web/components/provider_components.ex:1199
 #, elixir-autogen, elixir-format
 msgid "Leave unchecked to allow all genders."
 msgstr "Nicht markiert lassen, um alle Geschlechter zuzulassen."
 
-#: lib/klass_hero_web/components/provider_components.ex:1002
+#: lib/klass_hero_web/components/provider_components.ex:1003
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:191
 #, elixir-autogen, elixir-format
 msgid "Location"
@@ -2682,43 +2682,43 @@ msgid "Logo upload failed. Please try again."
 msgstr "Logo-Upload fehlgeschlagen. Bitte versuchen Sie es erneut."
 
 #: lib/klass_hero_web/components/program_components.ex:683
-#: lib/klass_hero_web/components/provider_components.ex:1204
+#: lib/klass_hero_web/components/provider_components.ex:1205
 #: lib/klass_hero_web/live/settings/children_live.ex:633
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr "Männlich"
 
-#: lib/klass_hero_web/components/provider_components.ex:1188
+#: lib/klass_hero_web/components/provider_components.ex:1189
 #, elixir-autogen, elixir-format
 msgid "Maximum Age (months)"
 msgstr "Höchstalter (Monate)"
 
-#: lib/klass_hero_web/components/provider_components.ex:1102
+#: lib/klass_hero_web/components/provider_components.ex:1103
 #, elixir-autogen, elixir-format
 msgid "Maximum Enrollment"
 msgstr "Maximale Anmeldekapazität"
 
-#: lib/klass_hero_web/components/provider_components.ex:1243
+#: lib/klass_hero_web/components/provider_components.ex:1244
 #, elixir-autogen, elixir-format
 msgid "Maximum Grade"
 msgstr "Höchste Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:1011
+#: lib/klass_hero_web/components/provider_components.ex:1012
 #, elixir-autogen, elixir-format
 msgid "Meeting Days"
 msgstr "Wochentage"
 
-#: lib/klass_hero_web/components/provider_components.ex:1182
+#: lib/klass_hero_web/components/provider_components.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Minimum Age (months)"
 msgstr "Mindestalter (Monate)"
 
-#: lib/klass_hero_web/components/provider_components.ex:1096
+#: lib/klass_hero_web/components/provider_components.ex:1097
 #, elixir-autogen, elixir-format
 msgid "Minimum Enrollment"
 msgstr "Minimale Anmeldekapazität"
 
-#: lib/klass_hero_web/components/provider_components.ex:1236
+#: lib/klass_hero_web/components/provider_components.ex:1237
 #, elixir-autogen, elixir-format
 msgid "Minimum Grade"
 msgstr "Niedrigste Klassenstufe"
@@ -2728,12 +2728,12 @@ msgstr "Niedrigste Klassenstufe"
 msgid "No approved documents."
 msgstr "Keine genehmigten Dokumente."
 
-#: lib/klass_hero_web/components/provider_components.ex:3092
+#: lib/klass_hero_web/components/provider_components.ex:3088
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr "Noch keine Dokumente hochgeladen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2457
+#: lib/klass_hero_web/components/provider_components.ex:2453
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
@@ -2749,17 +2749,17 @@ msgstr "Keine Datei ausgewählt."
 msgid "No grade"
 msgstr "Keine Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2700
+#: lib/klass_hero_web/components/provider_components.ex:2696
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr "Noch keine Einladungen. Laden Sie eine CSV-Datei hoch, um Familien einzuladen."
 
-#: lib/klass_hero_web/components/provider_components.ex:1245
+#: lib/klass_hero_web/components/provider_components.ex:1246
 #, elixir-autogen, elixir-format
 msgid "No maximum"
 msgstr "Kein Maximum"
 
-#: lib/klass_hero_web/components/provider_components.ex:1238
+#: lib/klass_hero_web/components/provider_components.ex:1239
 #, elixir-autogen, elixir-format
 msgid "No minimum"
 msgstr "Kein Minimum"
@@ -2790,18 +2790,18 @@ msgstr "Noch keine Teammitglieder"
 msgid "No verification documents found."
 msgstr "Keine Verifizierungsdokumente gefunden."
 
-#: lib/klass_hero_web/components/provider_components.ex:1320
+#: lib/klass_hero_web/components/provider_components.ex:1321
 #, elixir-autogen, elixir-format
 msgid "None (optional)"
 msgstr "Keine (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:325
+#: lib/klass_hero_web/components/provider_components.ex:326
 #, elixir-autogen, elixir-format
 msgid "Not Verified"
 msgstr "Nicht verifiziert"
 
 #: lib/klass_hero_web/components/program_components.ex:685
-#: lib/klass_hero_web/components/provider_components.ex:1207
+#: lib/klass_hero_web/components/provider_components.ex:1208
 #: lib/klass_hero_web/live/settings/children_live.ex:632
 #, elixir-autogen, elixir-format
 msgid "Not specified"
@@ -2812,7 +2812,7 @@ msgstr "Nicht angegeben"
 msgid "Our Story"
 msgstr "Unsere Geschichte"
 
-#: lib/klass_hero_web/components/provider_components.ex:3167
+#: lib/klass_hero_web/components/provider_components.ex:3163
 #: lib/klass_hero_web/live/provider/verification_live.ex:698
 #: lib/klass_hero_web/live/provider/verification_live.ex:770
 #, elixir-autogen, elixir-format
@@ -2824,13 +2824,13 @@ msgstr "PDF, JPG oder PNG. Max. 10 MB."
 msgid "Participant Requirements"
 msgstr "Teilnahmevoraussetzungen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1135
+#: lib/klass_hero_web/components/provider_components.ex:1136
 #, elixir-autogen, elixir-format
 msgid "Participant Restrictions (optional)"
 msgstr "Teilnahmebeschränkungen (optional)"
 
 #: lib/klass_hero_web/components/participation_components.ex:825
-#: lib/klass_hero_web/components/provider_components.ex:293
+#: lib/klass_hero_web/components/provider_components.ex:294
 #, elixir-autogen, elixir-format
 msgid "Pending Review"
 msgstr "Ausstehende Überprüfung"
@@ -2858,7 +2858,7 @@ msgstr "Bitte geben Sie einen Ablehnungsgrund an."
 msgid "Preview not available for this file type."
 msgstr "Vorschau für diesen Dateityp nicht verfügbar."
 
-#: lib/klass_hero_web/components/provider_components.ex:993
+#: lib/klass_hero_web/components/provider_components.ex:994
 #, elixir-autogen, elixir-format
 msgid "Price (EUR)"
 msgstr "Preis (EUR)"
@@ -2868,7 +2868,7 @@ msgstr "Preis (EUR)"
 msgid "Profile updated successfully."
 msgstr "Profil erfolgreich aktualisiert."
 
-#: lib/klass_hero_web/components/provider_components.ex:1173
+#: lib/klass_hero_web/components/provider_components.ex:1174
 #, elixir-autogen, elixir-format
 msgid "Program Start"
 msgstr "Programmbeginn"
@@ -2912,13 +2912,13 @@ msgid "Read our founding story →"
 msgstr "Lesen Sie unsere Gründungsgeschichte →"
 
 #: lib/klass_hero_web/components/participation_components.ex:805
-#: lib/klass_hero_web/components/provider_components.ex:2934
+#: lib/klass_hero_web/components/provider_components.ex:2930
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Registered"
 msgstr "Registriert"
 
-#: lib/klass_hero_web/components/provider_components.ex:1160
+#: lib/klass_hero_web/components/provider_components.ex:1161
 #, elixir-autogen, elixir-format
 msgid "Registration"
 msgstr "Anmeldung"
@@ -2928,7 +2928,7 @@ msgstr "Anmeldung"
 msgid "Registration Closed"
 msgstr "Anmeldung geschlossen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1080
+#: lib/klass_hero_web/components/provider_components.ex:1081
 #, elixir-autogen, elixir-format
 msgid "Registration Closes"
 msgstr "Anmeldeschluss"
@@ -2938,12 +2938,12 @@ msgstr "Anmeldeschluss"
 msgid "Registration Not Open Yet"
 msgstr "Anmeldung noch nicht geöffnet"
 
-#: lib/klass_hero_web/components/provider_components.ex:1075
+#: lib/klass_hero_web/components/provider_components.ex:1076
 #, elixir-autogen, elixir-format
 msgid "Registration Opens"
 msgstr "Anmeldebeginn"
 
-#: lib/klass_hero_web/components/provider_components.ex:1066
+#: lib/klass_hero_web/components/provider_components.ex:1067
 #, elixir-autogen, elixir-format
 msgid "Registration Period (optional)"
 msgstr "Anmeldezeitraum (optional)"
@@ -2980,7 +2980,7 @@ msgid "Reject"
 msgstr "Ablehnen"
 
 #: lib/klass_hero_web/components/participation_components.ex:827
-#: lib/klass_hero_web/components/provider_components.ex:49
+#: lib/klass_hero_web/components/provider_components.ex:50
 #: lib/klass_hero_web/live/admin/verifications_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Rejected"
@@ -2992,18 +2992,18 @@ msgstr "Abgelehnt"
 msgid "Rejection reason"
 msgstr "Ablehnungsgrund"
 
-#: lib/klass_hero_web/components/provider_components.ex:839
-#: lib/klass_hero_web/components/provider_components.ex:1284
-#: lib/klass_hero_web/components/provider_components.ex:2756
-#: lib/klass_hero_web/components/provider_components.ex:3186
-#: lib/klass_hero_web/components/provider_components.ex:3265
+#: lib/klass_hero_web/components/provider_components.ex:840
+#: lib/klass_hero_web/components/provider_components.ex:1285
+#: lib/klass_hero_web/components/provider_components.ex:2752
+#: lib/klass_hero_web/components/provider_components.ex:3182
+#: lib/klass_hero_web/components/provider_components.ex:3261
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:253
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr "Entfernen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2749
+#: lib/klass_hero_web/components/provider_components.ex:2745
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr "Einladung erneut senden"
@@ -3013,23 +3013,23 @@ msgstr "Einladung erneut senden"
 msgid "Reviewed"
 msgstr "Überprüft"
 
-#: lib/klass_hero_web/components/provider_components.ex:713
+#: lib/klass_hero_web/components/provider_components.ex:714
 #, elixir-autogen, elixir-format
 msgid "Role"
 msgstr "Rolle"
 
-#: lib/klass_hero_web/components/provider_components.ex:1735
+#: lib/klass_hero_web/components/provider_components.ex:1736
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:386
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
 msgstr "Teilnehmerliste: %{name}"
 
-#: lib/klass_hero_web/components/provider_components.ex:1347
+#: lib/klass_hero_web/components/provider_components.ex:1348
 #, elixir-autogen, elixir-format
 msgid "Save Program"
 msgstr "Programm speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:1008
+#: lib/klass_hero_web/components/provider_components.ex:1009
 #, elixir-autogen, elixir-format
 msgid "Schedule (optional)"
 msgstr "Zeitplan (optional)"
@@ -3044,7 +3044,7 @@ msgstr "Zeitplan noch offen"
 msgid "School Grade (optional)"
 msgstr "Klassenstufe (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:3164
+#: lib/klass_hero_web/components/provider_components.ex:3160
 #, elixir-autogen, elixir-format
 msgid "Select File"
 msgstr "Datei auswählen"
@@ -3061,23 +3061,23 @@ msgstr "Das ausgewählte Kind erfüllt die Programmanforderungen nicht."
 msgid "Selected instructor could not be found. Please try again."
 msgstr "Der ausgewählte Kursleiter konnte nicht gefunden werden. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2933
+#: lib/klass_hero_web/components/provider_components.ex:2929
 #: lib/klass_hero_web/live/admin/emails_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Sent"
 msgstr "Gesendet"
 
-#: lib/klass_hero_web/components/provider_components.ex:760
+#: lib/klass_hero_web/components/provider_components.ex:761
 #, elixir-autogen, elixir-format
 msgid "Separate multiple qualifications with commas"
 msgstr "Trennen Sie mehrere Qualifikationen durch Kommas"
 
-#: lib/klass_hero_web/components/provider_components.ex:1090
+#: lib/klass_hero_web/components/provider_components.ex:1091
 #, elixir-autogen, elixir-format
 msgid "Set minimum and maximum enrollment for this program."
 msgstr "Legen Sie die minimale und maximale Anmeldekapazität für dieses Programm fest."
 
-#: lib/klass_hero_web/components/provider_components.ex:734
+#: lib/klass_hero_web/components/provider_components.ex:735
 #, elixir-autogen, elixir-format
 msgid "Specialties"
 msgstr "Spezialisierungen"
@@ -3095,12 +3095,12 @@ msgstr "Der Mitarbeiter existiert nicht mehr."
 msgid "Staff member not found."
 msgstr "Mitarbeiter nicht gefunden."
 
-#: lib/klass_hero_web/components/provider_components.ex:1054
+#: lib/klass_hero_web/components/provider_components.ex:1055
 #, elixir-autogen, elixir-format
 msgid "Start Date"
 msgstr "Startdatum"
 
-#: lib/klass_hero_web/components/provider_components.ex:1041
+#: lib/klass_hero_web/components/provider_components.ex:1042
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:184
 #, elixir-autogen, elixir-format
 msgid "Start Time"
@@ -3166,13 +3166,13 @@ msgstr "Diese Einladung kann nicht erneut gesendet werden."
 msgid "This program was modified by someone else. Please close and try again."
 msgstr "Dieses Programm wurde von jemand anderem geändert. Bitte schließen Sie es und versuchen Sie es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:975
-#: lib/klass_hero_web/components/provider_components.ex:2022
+#: lib/klass_hero_web/components/provider_components.ex:976
+#: lib/klass_hero_web/components/provider_components.ex:2018
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr "Titel"
 
-#: lib/klass_hero_web/components/provider_components.ex:3065
+#: lib/klass_hero_web/components/provider_components.ex:3061
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr "Zu viele Dateien."
@@ -3192,32 +3192,32 @@ msgstr "Bis zu %{max}"
 msgid "Up to Grade %{max}"
 msgstr "Bis Klassenstufe %{max}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2635
+#: lib/klass_hero_web/components/provider_components.ex:2631
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr "CSV hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3210
+#: lib/klass_hero_web/components/provider_components.ex:3206
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr "Dokument hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3119
+#: lib/klass_hero_web/components/provider_components.ex:3115
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr "Neues Dokument hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3087
+#: lib/klass_hero_web/components/provider_components.ex:3083
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr "Laden Sie Dokumente hoch, um Ihr Unternehmen zu verifizieren. Die Dokumente werden von unserem Team überprüft."
 
-#: lib/klass_hero_web/components/provider_components.ex:3067
+#: lib/klass_hero_web/components/provider_components.ex:3063
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr "Upload-Fehler."
 
-#: lib/klass_hero_web/components/provider_components.ex:3084
+#: lib/klass_hero_web/components/provider_components.ex:3080
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr "Verifizierungsdokumente"
@@ -3239,7 +3239,7 @@ msgstr "Verifizierungsdokument nicht gefunden."
 msgid "Verifications"
 msgstr "Verifizierungen"
 
-#: lib/klass_hero_web/components/provider_components.ex:277
+#: lib/klass_hero_web/components/provider_components.ex:278
 #: lib/klass_hero_web/components/provider_layout_components.ex:212
 #: lib/klass_hero_web/components/ui_components.ex:1930
 #, elixir-autogen, elixir-format
@@ -3256,32 +3256,32 @@ msgstr "Wir sind Klass Hero — Eltern, Brüder und Partner von Pädagogen — u
 msgid "You don't have access to that page."
 msgstr "Sie haben keinen Zugriff auf diese Seite."
 
-#: lib/klass_hero_web/components/provider_components.ex:714
+#: lib/klass_hero_web/components/provider_components.ex:715
 #, elixir-autogen, elixir-format
 msgid "e.g. Head Coach"
 msgstr "z. B. Cheftrainer"
 
-#: lib/klass_hero_web/components/provider_components.ex:705
+#: lib/klass_hero_web/components/provider_components.ex:706
 #, elixir-autogen, elixir-format
 msgid "e.g. Johnson"
 msgstr "z. B. Johnson"
 
-#: lib/klass_hero_web/components/provider_components.ex:699
+#: lib/klass_hero_web/components/provider_components.ex:700
 #, elixir-autogen, elixir-format
 msgid "e.g. Mike"
 msgstr "z. B. Mike"
 
-#: lib/klass_hero_web/components/provider_components.ex:720
+#: lib/klass_hero_web/components/provider_components.ex:721
 #, elixir-autogen, elixir-format
 msgid "e.g. mike@example.com"
 msgstr "z. B. mike@example.com"
 
-#: lib/klass_hero_web/components/provider_components.ex:976
+#: lib/klass_hero_web/components/provider_components.ex:977
 #, elixir-autogen, elixir-format
 msgid "e.g., Art Adventures"
 msgstr "z. B. Art Adventures"
 
-#: lib/klass_hero_web/components/provider_components.ex:1003
+#: lib/klass_hero_web/components/provider_components.ex:1004
 #, elixir-autogen, elixir-format
 msgid "e.g., Community Center, Main St"
 msgstr "z. B. Gemeindezentrum, Hauptstraße"
@@ -3307,7 +3307,7 @@ msgid "Child Safeguarding Training"
 msgstr "Kinderschutzschulung"
 
 #: lib/klass_hero_web/components/marketing_components.ex:1498
-#: lib/klass_hero_web/components/provider_components.ex:3432
+#: lib/klass_hero_web/components/provider_components.ex:3428
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr "Vereinbarung zu Community-Standards"
@@ -3367,12 +3367,12 @@ msgstr "Wenn Sie mehr über unsere Trust-&-Safety-Standards oder den Verifizieru
 msgid "Monitoring provider activity and feedback"
 msgstr "Überwachung der Anbieteraktivität und des Feedbacks"
 
-#: lib/klass_hero_web/live/booking_live.ex:489
+#: lib/klass_hero_web/live/booking_live.ex:488
 #, elixir-autogen, elixir-format
 msgid "Pay by cash or direct bank transfer"
 msgstr "Zahlung per Bargeld oder Banküberweisung"
 
-#: lib/klass_hero_web/live/booking_live.ex:500
+#: lib/klass_hero_web/live/booking_live.ex:499
 #, elixir-autogen, elixir-format
 msgid "Program fee:"
 msgstr "Programmgebühr:"
@@ -3404,7 +3404,7 @@ msgstr "Bedenken oder Meldungen zügig und gewissenhaft prüfen"
 
 #: lib/klass_hero_web/controllers/invite_claim_controller.ex:57
 #: lib/klass_hero_web/live/booking_live.ex:212
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:73
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:75
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Please try again or contact support."
 msgstr "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut oder kontaktieren Sie den Support."
@@ -3458,7 +3458,7 @@ msgid "Vetted with Care"
 msgstr "Mit Sorgfalt geprüft"
 
 #: lib/klass_hero_web/components/marketing_components.ex:1482
-#: lib/klass_hero_web/components/provider_components.ex:3217
+#: lib/klass_hero_web/components/provider_components.ex:3213
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr "Video-Überprüfung"
@@ -3632,7 +3632,7 @@ msgstr "Eingecheckt"
 msgid "Checked Out"
 msgstr "Ausgecheckt"
 
-#: lib/klass_hero_web/components/provider_components.ex:2792
+#: lib/klass_hero_web/components/provider_components.ex:2788
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Child"
@@ -3685,7 +3685,7 @@ msgstr "Benötige ich ein Konto, um zu buchen?"
 msgid "Download monthly statements for taxes"
 msgstr "Monatliche Abrechnungen für die Steuer herunterladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2553
+#: lib/klass_hero_web/components/provider_components.ex:2549
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "Enrollment not confirmed"
@@ -3758,7 +3758,7 @@ msgstr "Keine Änderungen erkannt"
 msgid "No chasing payments or sending invoices"
 msgstr "Kein Nachfassen bei Zahlungen oder Versenden von Rechnungen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1758
+#: lib/klass_hero_web/components/provider_components.ex:1759
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:407
 #, elixir-autogen, elixir-format
 msgid "No enrolled parents"
@@ -3781,7 +3781,7 @@ msgstr "Notizen"
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr "Oder: Jederzeit eine Sofortauszahlung anfordern (mindestens 50 €)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2552
+#: lib/klass_hero_web/components/provider_components.ex:2548
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -4466,7 +4466,7 @@ msgstr "Privates Antworten ist nur für Broadcast-Nachrichten verfügbar"
 msgid "Reply sent successfully"
 msgstr "Antwort erfolgreich gesendet"
 
-#: lib/klass_hero_web/components/provider_components.ex:553
+#: lib/klass_hero_web/components/provider_components.ex:554
 #, elixir-autogen, elixir-format
 msgid "Resend"
 msgstr "Erneut senden"
@@ -4894,40 +4894,40 @@ msgstr "Ihr Profil ist bereits vollständig."
 msgid "for"
 msgstr "für"
 
-#: lib/klass_hero_web/components/provider_components.ex:1882
+#: lib/klass_hero_web/components/provider_components.ex:1883
 #, elixir-autogen, elixir-format
 msgid "Assigned staff"
 msgstr "Zugewiesenes Personal"
 
-#: lib/klass_hero_web/components/provider_components.ex:1883
+#: lib/klass_hero_web/components/provider_components.ex:1884
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr "Anwesenheit"
 
-#: lib/klass_hero_web/components/provider_components.ex:1866
-#: lib/klass_hero_web/components/provider_components.ex:1951
-#: lib/klass_hero_web/components/provider_components.ex:2098
-#: lib/klass_hero_web/components/provider_components.ex:2252
+#: lib/klass_hero_web/components/provider_components.ex:1867
+#: lib/klass_hero_web/components/provider_components.ex:1952
+#: lib/klass_hero_web/components/provider_components.ex:2094
+#: lib/klass_hero_web/components/provider_components.ex:2248
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr "Schließen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1881
+#: lib/klass_hero_web/components/provider_components.ex:1882
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr "Datum / Uhrzeit"
 
-#: lib/klass_hero_web/components/provider_components.ex:1875
+#: lib/klass_hero_web/components/provider_components.ex:1876
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled yet."
 msgstr "Noch keine Sessions geplant."
 
-#: lib/klass_hero_web/components/provider_components.ex:1864
+#: lib/klass_hero_web/components/provider_components.ex:1865
 #, elixir-autogen, elixir-format
 msgid "Sessions — %{title}"
 msgstr "Sessions — %{title}"
 
-#: lib/klass_hero_web/components/provider_components.ex:1569
+#: lib/klass_hero_web/components/provider_components.ex:1570
 #, elixir-autogen, elixir-format
 msgid "View sessions"
 msgstr "Sessions anzeigen"
@@ -4959,17 +4959,17 @@ msgstr "Abreisezeit ist kein gültiges Datum oder keine gültige Uhrzeit"
 msgid "Failed to update record"
 msgstr "Aktualisieren des Datensatzes fehlgeschlagen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2856
+#: lib/klass_hero_web/components/provider_components.ex:2852
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr "Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2575
+#: lib/klass_hero_web/components/provider_components.ex:2571
 #, elixir-autogen, elixir-format
 msgid "Invite mode"
 msgstr "Einladungsmodus"
 
-#: lib/klass_hero_web/components/provider_components.ex:2594
+#: lib/klass_hero_web/components/provider_components.ex:2590
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr "Einzelperson einladen"
@@ -4984,12 +4984,12 @@ msgstr "Einladung verschickt."
 msgid "Leave blank to keep this child marked as present."
 msgstr "Leer lassen, um dieses Kind als anwesend markiert zu lassen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2869
+#: lib/klass_hero_web/components/provider_components.ex:2865
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr "Gesundheit & Einwilligungen (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2875
+#: lib/klass_hero_web/components/provider_components.ex:2871
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr "Gesundheitliche Besonderheiten"
@@ -5000,17 +5000,17 @@ msgstr "Gesundheitliche Besonderheiten"
 msgid "Nothing to update"
 msgstr "Nichts zu aktualisieren"
 
-#: lib/klass_hero_web/components/provider_components.ex:2877
+#: lib/klass_hero_web/components/provider_components.ex:2873
 #, elixir-autogen, elixir-format
 msgid "Nut allergy"
 msgstr "Nussallergie"
 
-#: lib/klass_hero_web/components/provider_components.ex:2881
+#: lib/klass_hero_web/components/provider_components.ex:2877
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr "Fotos dürfen in Marketingmaterialien verwendet werden"
 
-#: lib/klass_hero_web/components/provider_components.ex:2886
+#: lib/klass_hero_web/components/provider_components.ex:2882
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr "Fotos dürfen in sozialen Medien erscheinen"
@@ -5020,7 +5020,7 @@ msgstr "Fotos dürfen in sozialen Medien erscheinen"
 msgid "Present"
 msgstr "Anwesend"
 
-#: lib/klass_hero_web/components/provider_components.ex:2813
+#: lib/klass_hero_web/components/provider_components.ex:2809
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr "Hauptansprechpartner"
@@ -5047,22 +5047,22 @@ msgstr "Datensatz aktualisiert"
 msgid "Save changes"
 msgstr "Änderungen speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:2850
+#: lib/klass_hero_web/components/provider_components.ex:2846
 #, elixir-autogen, elixir-format
 msgid "School (optional)"
 msgstr "Schule (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2860
+#: lib/klass_hero_web/components/provider_components.ex:2856
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr "Schulname"
 
-#: lib/klass_hero_web/components/provider_components.ex:2834
+#: lib/klass_hero_web/components/provider_components.ex:2830
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr "Zweiter Ansprechpartner (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2903
+#: lib/klass_hero_web/components/provider_components.ex:2899
 #, elixir-autogen, elixir-format
 msgid "Send invite"
 msgstr "Einladung senden"
@@ -5072,7 +5072,7 @@ msgstr "Einladung senden"
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr "Aktualisieren Sie die Notiz für dieses Kind (z. B. um zu klären, was passiert ist)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2612
+#: lib/klass_hero_web/components/provider_components.ex:2608
 #, elixir-autogen, elixir-format
 msgid "Upload a list"
 msgstr "Liste hochladen"
@@ -5107,7 +5107,7 @@ msgstr "Foto hierher ziehen oder klicken zum Auswählen"
 msgid "High"
 msgstr "Hoch"
 
-#: lib/klass_hero_web/components/provider_components.ex:787
+#: lib/klass_hero_web/components/provider_components.ex:788
 #, elixir-autogen, elixir-format
 msgid "Hourly"
 msgstr "Stündlich"
@@ -5132,22 +5132,22 @@ msgstr "Niedrig"
 msgid "Medium"
 msgstr "Mittel"
 
-#: lib/klass_hero_web/components/provider_components.ex:777
+#: lib/klass_hero_web/components/provider_components.ex:778
 #, elixir-autogen, elixir-format
 msgid "None"
 msgstr "Keine"
 
-#: lib/klass_hero_web/components/provider_components.ex:766
+#: lib/klass_hero_web/components/provider_components.ex:767
 #, elixir-autogen, elixir-format
 msgid "Pay Rate"
 msgstr "Vergütung"
 
-#: lib/klass_hero_web/components/provider_components.ex:524
+#: lib/klass_hero_web/components/provider_components.ex:525
 #, elixir-autogen, elixir-format
 msgid "Pay rate"
 msgstr "Vergütung"
 
-#: lib/klass_hero_web/components/provider_components.ex:797
+#: lib/klass_hero_web/components/provider_components.ex:798
 #, elixir-autogen, elixir-format
 msgid "Per Session"
 msgstr "Pro Sitzung"
@@ -5172,7 +5172,7 @@ msgstr "Programm oder Session nicht gefunden."
 msgid "Property Damage"
 msgstr "Sachschaden"
 
-#: lib/klass_hero_web/components/provider_components.ex:1606
+#: lib/klass_hero_web/components/provider_components.ex:1607
 #, elixir-autogen, elixir-format
 msgid "Report Incident"
 msgstr "Vorfall melden"
@@ -5854,7 +5854,7 @@ msgstr[1] "%{count} Familien importiert."
 msgid "In 2025, Shane connected with his friend"
 msgstr "2025 tat sich Shane mit seinem Freund zusammen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1615
+#: lib/klass_hero_web/components/provider_components.ex:1616
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:43
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:74
 #, elixir-autogen, elixir-format
@@ -5924,7 +5924,7 @@ msgstr "Klass Hero ist das operative Rückgrat für Berlins Jugendpädagogen. Wi
 msgid "Last 8 weeks"
 msgstr "Letzte 8 Wochen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1318
+#: lib/klass_hero_web/components/provider_components.ex:1319
 #: lib/klass_hero_web/presenters/hero_cards_presenter.ex:27
 #, elixir-autogen, elixir-format
 msgid "Lead Instructor"
@@ -6374,17 +6374,17 @@ msgstr "Umsatz (diese Woche)"
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr "Strenge Überprüfung, damit Familien immer wissen, wer die Gruppe leitet."
 
-#: lib/klass_hero_web/components/provider_components.ex:2942
+#: lib/klass_hero_web/components/provider_components.ex:2938
 #, elixir-autogen, elixir-format
 msgid "Row %{row}"
 msgstr "Zeile %{row}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2942
+#: lib/klass_hero_web/components/provider_components.ex:2938
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr "Zeile —"
 
-#: lib/klass_hero_web/components/provider_components.ex:2688
+#: lib/klass_hero_web/components/provider_components.ex:2684
 #, elixir-autogen, elixir-format
 msgid "Rows with errors"
 msgstr "Zeilen mit Fehlern"
@@ -6996,7 +6996,7 @@ msgstr "Identitäts- und Altersverifizierung"
 msgid "Identity verifications"
 msgstr "Identitätsprüfungen"
 
-#: lib/klass_hero_web/components/provider_components.ex:72
+#: lib/klass_hero_web/components/provider_components.ex:73
 #, elixir-autogen, elixir-format
 msgid "In progress"
 msgstr "In Bearbeitung"
@@ -7026,7 +7026,7 @@ msgstr "Noch keine Identitätsprüfungen."
 msgid "Not started"
 msgstr "Nicht begonnen"
 
-#: lib/klass_hero_web/components/provider_components.ex:70
+#: lib/klass_hero_web/components/provider_components.ex:71
 #, elixir-autogen, elixir-format
 msgid "Passed"
 msgstr "Bestanden"
@@ -7143,12 +7143,12 @@ msgstr "Deine Identität ist verifiziert."
 msgid "Experience validation"
 msgstr "Erfahrungsnachweis"
 
-#: lib/klass_hero_web/components/provider_components.ex:3246
+#: lib/klass_hero_web/components/provider_components.ex:3242
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr "MP4, MOV oder WEBM. Max. 100 MB."
 
-#: lib/klass_hero_web/components/provider_components.ex:3220
+#: lib/klass_hero_web/components/provider_components.ex:3216
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr "Nimm ein kurzes Video auf, in dem du dich vorstellst. Unser Team prüft es, um Kommunikationsfähigkeit und Übereinstimmung mit unseren Werten einzuschätzen."
@@ -7158,12 +7158,12 @@ msgstr "Nimm ein kurzes Video auf, in dem du dich vorstellst. Unser Team prüft 
 msgid "Safeguarding certificate"
 msgstr "Kinderschutz-Zertifikat"
 
-#: lib/klass_hero_web/components/provider_components.ex:3243
+#: lib/klass_hero_web/components/provider_components.ex:3239
 #, elixir-autogen, elixir-format
 msgid "Select Video"
 msgstr "Video auswählen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3289
+#: lib/klass_hero_web/components/provider_components.ex:3285
 #, elixir-autogen, elixir-format
 msgid "Upload Video"
 msgstr "Video hochladen"
@@ -7173,7 +7173,7 @@ msgstr "Video hochladen"
 msgid "Your browser does not support video playback."
 msgstr "Dein Browser unterstützt keine Videowiedergabe."
 
-#: lib/klass_hero_web/components/provider_components.ex:3436
+#: lib/klass_hero_web/components/provider_components.ex:3432
 #, elixir-autogen, elixir-format
 msgid "Confirm agreement"
 msgstr "Zustimmung bestätigen"
@@ -7183,12 +7183,12 @@ msgstr "Zustimmung bestätigen"
 msgid "Couldn't record your agreement. Please try again."
 msgstr "Deine Zustimmung konnte nicht gespeichert werden. Bitte versuche es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:3459
+#: lib/klass_hero_web/components/provider_components.ex:3455
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr "Vereinbarung herunterladen (PDF)"
 
-#: lib/klass_hero_web/components/provider_components.ex:3435
+#: lib/klass_hero_web/components/provider_components.ex:3431
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr "Ich habe die Klass Hero Community-Richtlinien gelesen und stimme ihnen zu."
@@ -7198,7 +7198,7 @@ msgstr "Ich habe die Klass Hero Community-Richtlinien gelesen und stimme ihnen z
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr "Bitte bestätige, dass du die Community-Richtlinien gelesen hast und ihnen zustimmst."
 
-#: lib/klass_hero_web/components/provider_components.ex:3344
+#: lib/klass_hero_web/components/provider_components.ex:3340
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr "Unterzeichnet von %{name} am %{date} (v%{version})."
@@ -7208,17 +7208,17 @@ msgstr "Unterzeichnet von %{name} am %{date} (v%{version})."
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr "Danke – deine Zustimmung zu den Community-Richtlinien wurde gespeichert."
 
-#: lib/klass_hero_web/components/provider_components.ex:3444
+#: lib/klass_hero_web/components/provider_components.ex:3440
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr "Die Community-Richtlinien wurden seit deiner letzten Zustimmung aktualisiert (v%{old}). Bitte lies sie erneut und stimme erneut zu."
 
-#: lib/klass_hero_web/components/provider_components.ex:3433
+#: lib/klass_hero_web/components/provider_components.ex:3429
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr "Der letzte Schritt: Lies die Klass Hero Community-Richtlinien und stimme ihnen zu."
 
-#: lib/klass_hero_web/components/provider_components.ex:3434
+#: lib/klass_hero_web/components/provider_components.ex:3430
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr "Du hast den Community-Richtlinien zugestimmt."
@@ -7487,12 +7487,12 @@ msgstr "Ihre Versicherungsbescheinigung wird geprüft."
 msgid "Your insurance is verified."
 msgstr "Ihre Versicherung ist verifiziert."
 
-#: lib/klass_hero_web/components/provider_components.ex:3388
+#: lib/klass_hero_web/components/provider_components.ex:3384
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr "Unterzeichnung durch %{name} im Namen des Unternehmens."
 
-#: lib/klass_hero_web/components/provider_components.ex:3491
+#: lib/klass_hero_web/components/provider_components.ex:3487
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr "Bestätige im Namen deines Unternehmens, dass alle Mitarbeitenden gemäß dem deutschen Kinderschutzrecht überprüft sind."
@@ -7502,7 +7502,7 @@ msgstr "Bestätige im Namen deines Unternehmens, dass alle Mitarbeitenden gemä�
 msgid "Couldn't record your declaration. Please try again."
 msgstr "Deine Erklärung konnte nicht gespeichert werden. Bitte versuche es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:3497
+#: lib/klass_hero_web/components/provider_components.ex:3493
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr "Ich bestätige im Namen des Unternehmens, dass die obige Erklärung zutrifft und ich zu ihrer Unterzeichnung berechtigt bin."
@@ -7512,17 +7512,17 @@ msgstr "Ich bestätige im Namen des Unternehmens, dass die obige Erklärung zutr
 msgid "Please confirm the declaration before signing."
 msgstr "Bitte bestätige die Erklärung vor der Unterzeichnung."
 
-#: lib/klass_hero_web/components/provider_components.ex:3522
+#: lib/klass_hero_web/components/provider_components.ex:3518
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr "Vorläufiger Text — vor der Freischaltung noch von einer in Deutschland zugelassenen Anwältin bzw. einem Anwalt zu prüfen."
 
-#: lib/klass_hero_web/components/provider_components.ex:3501
+#: lib/klass_hero_web/components/provider_components.ex:3497
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr "Erklärung unterzeichnen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3489
+#: lib/klass_hero_web/components/provider_components.ex:3485
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr "Erklärung zur Mitarbeiter-Compliance"
@@ -7532,12 +7532,12 @@ msgstr "Erklärung zur Mitarbeiter-Compliance"
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr "Danke — deine Erklärung zur Mitarbeiter-Compliance wurde erfasst."
 
-#: lib/klass_hero_web/components/provider_components.ex:3509
+#: lib/klass_hero_web/components/provider_components.ex:3505
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr "Die Erklärung zur Mitarbeiter-Compliance wurde seit deiner letzten Unterzeichnung aktualisiert (v%{old}). Bitte prüfe sie und unterzeichne erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:3495
+#: lib/klass_hero_web/components/provider_components.ex:3491
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr "Du hast die Erklärung zur Mitarbeiter-Compliance unterzeichnet."
@@ -7604,14 +7604,14 @@ msgstr "In Prüfung"
 msgid "Undelivered Events"
 msgstr "Nicht zugestellte Ereignisse"
 
-#: lib/klass_hero_web/components/provider_components.ex:2197
-#: lib/klass_hero_web/components/provider_components.ex:2380
+#: lib/klass_hero_web/components/provider_components.ex:2193
+#: lib/klass_hero_web/components/provider_components.ex:2376
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2120
-#: lib/klass_hero_web/components/provider_components.ex:2306
+#: lib/klass_hero_web/components/provider_components.ex:2116
+#: lib/klass_hero_web/components/provider_components.ex:2302
 #, elixir-autogen, elixir-format
 msgid "Lead"
 msgstr "Leitung"
@@ -7621,17 +7621,17 @@ msgstr "Leitung"
 msgid "Lead instructor updated."
 msgstr "Leitender Kursleiter aktualisiert."
 
-#: lib/klass_hero_web/components/provider_components.ex:2132
+#: lib/klass_hero_web/components/provider_components.ex:2128
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor"
 msgstr "Als leitenden Kursleiter festlegen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1583
+#: lib/klass_hero_web/components/provider_components.ex:1584
 #, elixir-autogen, elixir-format
 msgid "Manage Staffing"
 msgstr "Programmteam verwalten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2161
+#: lib/klass_hero_web/components/provider_components.ex:2157
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this program yet."
 msgstr "Diesem Programm ist noch niemand zugewiesen."
@@ -7642,19 +7642,19 @@ msgstr "Diesem Programm ist noch niemand zugewiesen."
 msgid "Pick a staff member to add."
 msgstr "Bitte ein Teammitglied zum Hinzufügen auswählen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2144
-#: lib/klass_hero_web/components/provider_components.ex:2419
+#: lib/klass_hero_web/components/provider_components.ex:2140
+#: lib/klass_hero_web/components/provider_components.ex:2415
 #, elixir-autogen, elixir-format
 msgid "Reassign the lead before removing them"
 msgstr "Vor dem Entfernen einen anderen leitenden Kursleiter festlegen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2145
+#: lib/klass_hero_web/components/provider_components.ex:2141
 #, elixir-autogen, elixir-format
 msgid "Remove from program"
 msgstr "Aus dem Programm entfernen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2179
-#: lib/klass_hero_web/components/provider_components.ex:2361
+#: lib/klass_hero_web/components/provider_components.ex:2175
+#: lib/klass_hero_web/components/provider_components.ex:2357
 #, elixir-autogen, elixir-format
 msgid "Select a staff member…"
 msgstr "Teammitglied auswählen …"
@@ -7669,14 +7669,14 @@ msgstr "Teammitglied zum Programm hinzugefügt."
 msgid "Staff member removed from the program."
 msgstr "Teammitglied aus dem Programm entfernt."
 
-#: lib/klass_hero_web/components/provider_components.ex:2202
+#: lib/klass_hero_web/components/provider_components.ex:2198
 #, elixir-autogen, elixir-format
 msgid "Staff you add can read and reply to this program's parent conversations."
 msgstr ""
 "Hinzugefügte Teammitglieder können die Elterngespräche dieses Programms lesen "
 "und beantworten."
 
-#: lib/klass_hero_web/components/provider_components.ex:2096
+#: lib/klass_hero_web/components/provider_components.ex:2092
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{title}"
 msgstr "Programmteam — %{title}"
@@ -7698,19 +7698,19 @@ msgstr ""
 "Diese Person ist der leitende Kursleiter. Bitte zuerst eine andere Person als "
 "Leitung festlegen."
 
-#: lib/klass_hero_web/components/provider_components.ex:1527
+#: lib/klass_hero_web/components/provider_components.ex:1528
 #, elixir-autogen, elixir-format
 msgid "%{count} staff member · no lead"
 msgid_plural "%{count} staff · no lead"
 msgstr[0] "%{count} Mitarbeiter*in · keine Leitung"
 msgstr[1] "%{count} Mitarbeitende · keine Leitung"
 
-#: lib/klass_hero_web/components/provider_components.ex:563
+#: lib/klass_hero_web/components/provider_components.ex:564
 #, elixir-autogen, elixir-format
 msgid "%{name} will be unassigned from every program and removed from those conversations. Their history is kept and you can add them back later."
 msgstr "%{name} wird aus allen Programmen und den zugehörigen Unterhaltungen entfernt. Der Verlauf bleibt erhalten und du kannst die Person später wieder hinzufügen."
 
-#: lib/klass_hero_web/components/provider_components.ex:639
+#: lib/klass_hero_web/components/provider_components.ex:640
 #, elixir-autogen, elixir-format
 msgid "Add back to team"
 msgstr "Wieder ins Team aufnehmen"
@@ -7720,7 +7720,7 @@ msgstr "Wieder ins Team aufnehmen"
 msgid "Could not bring this team member back. Please try again."
 msgstr "Teammitglied konnte nicht zurückgeholt werden. Bitte versuche es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:601
+#: lib/klass_hero_web/components/provider_components.ex:602
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr "Eintrag löschen"
@@ -7730,7 +7730,7 @@ msgstr "Eintrag löschen"
 msgid "Former team members"
 msgstr "Ehemalige Teammitglieder"
 
-#: lib/klass_hero_web/components/provider_components.ex:575
+#: lib/klass_hero_web/components/provider_components.ex:576
 #, elixir-autogen, elixir-format
 msgid "Remove from team"
 msgstr "Aus dem Team entfernen"
@@ -7745,7 +7745,7 @@ msgstr "Teammitglied ist zurück. Weise die Person wieder Programmen zu, wenn du
 msgid "Team member removed from the team."
 msgstr "Teammitglied aus dem Team entfernt."
 
-#: lib/klass_hero_web/components/provider_components.ex:591
+#: lib/klass_hero_web/components/provider_components.ex:592
 #, elixir-autogen, elixir-format
 msgid "This deletes %{name} permanently — there's nothing to undo. Use it only for an entry added by mistake."
 msgstr "Damit wird %{name} endgültig gelöscht – das lässt sich nicht rückgängig machen. Nutze das nur für einen versehentlich angelegten Eintrag."
@@ -7776,7 +7776,7 @@ msgstr ""
 "Programm aktualisiert, aber die Anmeldekapazität wurde abgelehnt. Es gelten "
 "weiterhin die bisherigen Grenzwerte."
 
-#: lib/klass_hero_web/components/provider_components.ex:918
+#: lib/klass_hero_web/components/provider_components.ex:919
 #, elixir-autogen, elixir-format
 msgid "%{count} child is already enrolled. Confirm you want this program to have no capacity limit."
 msgid_plural "%{count} children are already enrolled. Confirm you want this program to have no capacity limit."
@@ -7787,18 +7787,18 @@ msgstr[1] ""
 "%{count} Kinder sind bereits angemeldet. Bestätigen Sie, dass dieses "
 "Programm keine Teilnehmerbegrenzung haben soll."
 
-#: lib/klass_hero_web/components/provider_components.ex:1120
+#: lib/klass_hero_web/components/provider_components.ex:1121
 #, elixir-autogen, elixir-format
 msgid "Anyone will be able to book a place until you set a new maximum."
 msgstr ""
 "Bis Sie ein neues Maximum festlegen, kann jede Person einen Platz buchen."
 
-#: lib/klass_hero_web/components/provider_components.ex:1125
+#: lib/klass_hero_web/components/provider_components.ex:1126
 #, elixir-autogen, elixir-format
 msgid "I understand this program will have no capacity limit."
 msgstr "Ich verstehe, dass dieses Programm keine Teilnehmerbegrenzung haben wird."
 
-#: lib/klass_hero_web/components/provider_components.ex:2407
+#: lib/klass_hero_web/components/provider_components.ex:2403
 #, elixir-autogen, elixir-format
 msgid "Go back to the program's usual team"
 msgstr "Zurück zum üblichen Programmteam"
@@ -7808,17 +7808,17 @@ msgstr "Zurück zum üblichen Programmteam"
 msgid "Lead instructor for this session updated."
 msgstr "Leitung für diesen Termin aktualisiert."
 
-#: lib/klass_hero_web/components/provider_components.ex:2321
+#: lib/klass_hero_web/components/provider_components.ex:2317
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor for this session"
 msgstr "Als Leitung für diesen Termin festlegen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2343
+#: lib/klass_hero_web/components/provider_components.ex:2339
 #, elixir-autogen, elixir-format
 msgid "Nobody is working this session yet."
 msgstr "Für diesen Termin ist noch niemand eingeteilt."
 
-#: lib/klass_hero_web/components/provider_components.ex:2424
+#: lib/klass_hero_web/components/provider_components.ex:2420
 #, elixir-autogen, elixir-format
 msgid "Remove from this session"
 msgstr "Von diesem Termin entfernen"
@@ -7838,7 +7838,7 @@ msgstr "Teammitglied von diesem Termin entfernt."
 msgid "Staffing"
 msgstr "Team"
 
-#: lib/klass_hero_web/components/provider_components.ex:2245
+#: lib/klass_hero_web/components/provider_components.ex:2241
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{date}"
 msgstr "Team — %{date}"
@@ -7868,38 +7868,37 @@ msgstr "Dieser Termin nutzt wieder das übliche Programmteam."
 msgid "A session needs at least one person. Use “Go back to the program's usual team” to drop this session's own roster."
 msgstr "Ein Termin braucht mindestens eine Person. Nutze „Zurück zum üblichen Programmteam“, um die eigene Besetzung dieses Termins aufzuheben."
 
-#: lib/klass_hero_web/components/provider_components.ex:2422
+#: lib/klass_hero_web/components/provider_components.ex:2418
 #, elixir-autogen, elixir-format
 msgid "A session needs someone — use “Go back to the program's usual team” instead"
 msgstr "Ein Termin braucht jemanden — nutze stattdessen „Zurück zum üblichen Programmteam“"
 
-#: lib/klass_hero_web/components/provider_components.ex:2389
+#: lib/klass_hero_web/components/provider_components.ex:2385
 #, elixir-autogen, elixir-format
 msgid "Everyone on your team is already working this session."
 msgstr "Alle aus deinem Team arbeiten bereits bei diesem Termin."
 
-#: lib/klass_hero_web/components/provider_components.ex:2277
+#: lib/klass_hero_web/components/provider_components.ex:2273
 #, elixir-autogen, elixir-format
 msgid "Staffed just for this session. Changes here do not touch the program."
 msgstr "Nur für diesen Termin eingeteilt. Änderungen hier wirken sich nicht auf das Programm aus."
 
-#: lib/klass_hero_web/components/provider_components.ex:2279
+#: lib/klass_hero_web/components/provider_components.ex:2275
 #, elixir-autogen, elixir-format
 msgid "Using the program's usual team. The first change here copies them onto this session, so later program changes stop reaching it."
 msgstr "Es gilt das übliche Programmteam. Die erste Änderung hier übernimmt das Team in diesen Termin — spätere Änderungen am Programm greifen dann nicht mehr."
 
-#: lib/klass_hero_web/live/booking_live.ex:437
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:125
+#: lib/klass_hero_web/components/booking_components.ex:228
 #, elixir-autogen, elixir-format
 msgid "(optional)"
 msgstr "(optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2015
+#: lib/klass_hero_web/components/provider_components.ex:2011
 #, elixir-autogen, elixir-format
 msgid "Add a waiver"
 msgstr "Verzichtserklärung hinzufügen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2047
+#: lib/klass_hero_web/components/provider_components.ex:2043
 #, elixir-autogen, elixir-format
 msgid "Add waiver"
 msgstr "Hinzufügen"
@@ -7909,34 +7908,34 @@ msgstr "Hinzufügen"
 msgid "Check the waiver details and try again."
 msgstr "Bitte prüfe die Angaben zur Verzichtserklärung und versuche es erneut."
 
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:43
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:66
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:45
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:68
 #, elixir-autogen, elixir-format
 msgid "Enrollment not found."
 msgstr "Anmeldung nicht gefunden."
 
-#: lib/klass_hero_web/live/booking_live.ex:465
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:154
+#: lib/klass_hero_web/live/booking_live.ex:464
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:155
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to %{title}"
 msgstr "Ich habe %{title} gelesen und stimme zu"
 
-#: lib/klass_hero_web/components/provider_components.ex:2029
+#: lib/klass_hero_web/components/provider_components.ex:2025
 #, elixir-autogen, elixir-format
 msgid "Legal text"
 msgstr "Rechtstext"
 
-#: lib/klass_hero_web/components/provider_components.ex:1590
+#: lib/klass_hero_web/components/provider_components.ex:1591
 #, elixir-autogen, elixir-format
 msgid "Manage Waivers"
 msgstr "Verzichtserklärungen verwalten"
 
-#: lib/klass_hero_web/components/provider_components.ex:1958
+#: lib/klass_hero_web/components/provider_components.ex:1959
 #, elixir-autogen, elixir-format
 msgid "No waivers yet. Parents enrol without signing anything."
 msgstr "Noch keine Verzichtserklärungen. Eltern melden sich ohne Unterschrift an."
 
-#: lib/klass_hero_web/components/provider_components.ex:2036
+#: lib/klass_hero_web/components/provider_components.ex:2032
 #, elixir-autogen, elixir-format
 msgid "Parents must sign this before enrolling"
 msgstr "Eltern müssen dies vor der Anmeldung unterschreiben"
@@ -7946,42 +7945,42 @@ msgstr "Eltern müssen dies vor der Anmeldung unterschreiben"
 msgid "Please read and sign every required waiver before enrolling."
 msgstr "Bitte lies und unterschreibe alle erforderlichen Verzichtserklärungen vor der Anmeldung."
 
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:106
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:108
 #, elixir-autogen, elixir-format
 msgid "Please read and sign these before %{program} begins."
 msgstr "Bitte lies und unterschreibe diese, bevor %{program} beginnt."
 
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:55
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:57
 #, elixir-autogen, elixir-format
 msgid "Please tick a waiver to sign it."
 msgstr "Bitte wähle eine Verzichtserklärung aus, um sie zu unterschreiben."
 
-#: lib/klass_hero_web/components/provider_components.ex:2014
+#: lib/klass_hero_web/components/provider_components.ex:2010
 #, elixir-autogen, elixir-format
 msgid "Publish a new version"
 msgstr "Neue Version veröffentlichen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2047
+#: lib/klass_hero_web/components/provider_components.ex:2043
 #, elixir-autogen, elixir-format
 msgid "Publish version"
 msgstr "Version veröffentlichen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2040
+#: lib/klass_hero_web/components/provider_components.ex:2036
 #, elixir-autogen, elixir-format
 msgid "Publishing keeps every earlier version on record; signatures already given stay bound to the wording they were shown."
 msgstr "Beim Veröffentlichen bleibt jede frühere Version erhalten; bereits geleistete Unterschriften bleiben an den damals gezeigten Wortlaut gebunden."
 
-#: lib/klass_hero_web/components/provider_components.ex:1976
+#: lib/klass_hero_web/components/booking_components.ex:222
 #, elixir-autogen, elixir-format
 msgid "Required"
 msgstr "Erforderlich"
 
-#: lib/klass_hero_web/components/provider_components.ex:1997
+#: lib/klass_hero_web/components/provider_components.ex:1993
 #, elixir-autogen, elixir-format
 msgid "Retire this waiver"
 msgstr "Diese Verzichtserklärung zurückziehen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1988
+#: lib/klass_hero_web/components/provider_components.ex:1984
 #, elixir-autogen, elixir-format
 msgid "Revise text"
 msgstr "Text überarbeiten"
@@ -7991,33 +7990,33 @@ msgstr "Text überarbeiten"
 msgid "Sign the waivers for %{program}"
 msgstr "Verzichtserklärungen für %{program} unterschreiben"
 
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:160
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:161
 #, elixir-autogen, elixir-format
 msgid "Sign waivers"
 msgstr "Verzichtserklärungen unterschreiben"
 
-#: lib/klass_hero_web/components/provider_components.ex:2502
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:142
+#: lib/klass_hero_web/components/provider_components.ex:2498
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "Signed"
 msgstr "Unterschrieben"
 
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:60
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:62
 #, elixir-autogen, elixir-format
 msgid "Thank you — your waivers are on record."
 msgstr "Danke — deine Verzichtserklärungen sind erfasst."
 
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:110
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:112
 #, elixir-autogen, elixir-format
 msgid "There is nothing to sign for this enrollment."
 msgstr "Für diese Anmeldung gibt es nichts zu unterschreiben."
 
-#: lib/klass_hero_web/components/provider_components.ex:2502
+#: lib/klass_hero_web/components/provider_components.ex:2498
 #, elixir-autogen, elixir-format
 msgid "Unsigned"
 msgstr "Nicht unterschrieben"
 
-#: lib/klass_hero_web/components/provider_components.ex:1980
+#: lib/klass_hero_web/components/provider_components.ex:1976
 #, elixir-autogen, elixir-format
 msgid "Version %{number}"
 msgstr "Version %{number}"
@@ -8027,10 +8026,10 @@ msgstr "Version %{number}"
 msgid "Waiver not found."
 msgstr "Verzichtserklärung nicht gefunden."
 
-#: lib/klass_hero_web/components/provider_components.ex:2470
+#: lib/klass_hero_web/components/provider_components.ex:2466
 #: lib/klass_hero_web/live/booking_live.ex:427
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:31
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:103
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:33
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:105
 #, elixir-autogen, elixir-format
 msgid "Waivers"
 msgstr "Verzichtserklärungen"
@@ -8040,12 +8039,12 @@ msgstr "Verzichtserklärungen"
 msgid "Waivers waiting for your signature"
 msgstr "Verzichtserklärungen warten auf deine Unterschrift"
 
-#: lib/klass_hero_web/components/provider_components.ex:1949
+#: lib/klass_hero_web/components/provider_components.ex:1950
 #, elixir-autogen, elixir-format
 msgid "Waivers — %{title}"
 msgstr "Verzichtserklärungen — %{title}"
 
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:94
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:96
 #, elixir-autogen, elixir-format
 msgid "this program"
 msgstr "dieses Programm"
@@ -8055,7 +8054,7 @@ msgstr "dieses Programm"
 msgid "New version published. It applies to future enrolments."
 msgstr "Neue Fassung veröffentlicht. Sie gilt für künftige Anmeldungen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2001
+#: lib/klass_hero_web/components/provider_components.ex:1997
 #, elixir-autogen, elixir-format
 msgid "Retire \"%{title}\"? Parents will no longer be asked to sign it. Signatures already collected are kept."
 msgstr "\"%{title}\" zurückziehen? Eltern werden nicht mehr um eine Unterschrift gebeten. Bereits erteilte Unterschriften bleiben erhalten."

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -578,8 +578,8 @@ msgid "Dispute Resolution"
 msgstr "Streitbeilegung"
 
 #: lib/klass_hero_web/components/provider_components.ex:719
-#: lib/klass_hero_web/components/provider_components.ex:2810
-#: lib/klass_hero_web/components/provider_components.ex:2828
+#: lib/klass_hero_web/components/provider_components.ex:2820
+#: lib/klass_hero_web/components/provider_components.ex:2838
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
@@ -878,9 +878,9 @@ msgstr "Speichern..."
 msgid "Select one or both options"
 msgstr "Wählen Sie eine oder beide Optionen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2506
-#: lib/klass_hero_web/components/provider_components.ex:2507
-#: lib/klass_hero_web/components/provider_components.ex:2544
+#: lib/klass_hero_web/components/provider_components.ex:2516
+#: lib/klass_hero_web/components/provider_components.ex:2517
+#: lib/klass_hero_web/components/provider_components.ex:2554
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:448
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:484
@@ -1578,8 +1578,8 @@ msgid "Quick Navigation"
 msgstr "Schnellnavigation"
 
 #: lib/klass_hero_web/components/provider_components.ex:1487
-#: lib/klass_hero_web/components/provider_components.ex:2466
-#: lib/klass_hero_web/components/provider_components.ex:2708
+#: lib/klass_hero_web/components/provider_components.ex:2476
+#: lib/klass_hero_web/components/provider_components.ex:2718
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr "Aktionen"
@@ -1670,8 +1670,8 @@ msgstr "Übersicht"
 #: lib/klass_hero_web/components/provider_components.ex:47
 #: lib/klass_hero_web/components/provider_components.ex:73
 #: lib/klass_hero_web/components/provider_components.ex:1634
-#: lib/klass_hero_web/components/provider_components.ex:2904
-#: lib/klass_hero_web/components/provider_components.ex:2922
+#: lib/klass_hero_web/components/provider_components.ex:2914
+#: lib/klass_hero_web/components/provider_components.ex:2932
 #: lib/klass_hero_web/live/admin/sessions_live.ex:298
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
@@ -1710,8 +1710,8 @@ msgstr "Nach Namen suchen..."
 
 #: lib/klass_hero_web/components/provider_components.ex:1481
 #: lib/klass_hero_web/components/provider_components.ex:1884
-#: lib/klass_hero_web/components/provider_components.ex:2457
-#: lib/klass_hero_web/components/provider_components.ex:2705
+#: lib/klass_hero_web/components/provider_components.ex:2467
+#: lib/klass_hero_web/components/provider_components.ex:2715
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1817,8 +1817,8 @@ msgstr "Rundnachricht an %{count} Eltern gesendet"
 #: lib/klass_hero_web/components/participation_components.ex:717
 #: lib/klass_hero_web/components/provider_components.ex:889
 #: lib/klass_hero_web/components/provider_components.ex:1334
-#: lib/klass_hero_web/components/provider_components.ex:2046
-#: lib/klass_hero_web/components/provider_components.ex:2647
+#: lib/klass_hero_web/components/provider_components.ex:2056
+#: lib/klass_hero_web/components/provider_components.ex:2657
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:478
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
@@ -1874,7 +1874,7 @@ msgstr "Kind konnte nicht entfernt werden. Bitte versuchen Sie es erneut."
 msgid "Data sharing consent"
 msgstr "Einwilligung zur Datenweitergabe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2791
+#: lib/klass_hero_web/components/provider_components.ex:2801
 #: lib/klass_hero_web/live/settings/children_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1922,17 +1922,17 @@ msgstr "Rundnachricht konnte nicht gesendet werden"
 msgid "Failed to submit note"
 msgstr "Notiz konnte nicht eingereicht werden"
 
-#: lib/klass_hero_web/components/provider_components.ex:2785
-#: lib/klass_hero_web/components/provider_components.ex:2814
-#: lib/klass_hero_web/components/provider_components.ex:2830
+#: lib/klass_hero_web/components/provider_components.ex:2795
+#: lib/klass_hero_web/components/provider_components.ex:2824
+#: lib/klass_hero_web/components/provider_components.ex:2840
 #: lib/klass_hero_web/live/settings/children_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr "Vorname"
 
-#: lib/klass_hero_web/components/provider_components.ex:2786
-#: lib/klass_hero_web/components/provider_components.ex:2815
-#: lib/klass_hero_web/components/provider_components.ex:2831
+#: lib/klass_hero_web/components/provider_components.ex:2796
+#: lib/klass_hero_web/components/provider_components.ex:2825
+#: lib/klass_hero_web/components/provider_components.ex:2841
 #: lib/klass_hero_web/live/settings/children_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -2089,7 +2089,7 @@ msgstr "Rundnachricht senden"
 msgid "Send a message to start the conversation"
 msgstr "Senden Sie eine Nachricht, um die Unterhaltung zu beginnen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2885
+#: lib/klass_hero_web/components/provider_components.ex:2895
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:249
 #, elixir-autogen, elixir-format
@@ -2225,7 +2225,7 @@ msgstr "Alter %{min}+"
 msgid "Allowed Genders"
 msgstr "Zulässige Geschlechter"
 
-#: lib/klass_hero_web/components/provider_components.ex:2944
+#: lib/klass_hero_web/components/provider_components.ex:2954
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred during import."
 msgstr "Beim Import ist ein unerwarteter Fehler aufgetreten."
@@ -2320,8 +2320,8 @@ msgstr "Kategorie"
 msgid "Check eligibility at"
 msgstr "Berechtigung prüfen unter"
 
-#: lib/klass_hero_web/components/provider_components.ex:2454
-#: lib/klass_hero_web/components/provider_components.ex:2699
+#: lib/klass_hero_web/components/provider_components.ex:2464
+#: lib/klass_hero_web/components/provider_components.ex:2709
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr "Name des Kindes"
@@ -2366,7 +2366,7 @@ msgstr "Schließen Sie die Geschäftsverifizierung ab, um Programme zu erstellen
 msgid "Confirm rejection"
 msgstr "Ablehnung bestätigen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2905
+#: lib/klass_hero_web/components/provider_components.ex:2915
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr "Bestätigt"
@@ -2376,12 +2376,12 @@ msgstr "Bestätigt"
 msgid "Contact Provider"
 msgstr "Anbieter kontaktieren"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:530
+#: lib/klass_hero_web/live/provider/programs_live.ex:536
 #, elixir-autogen, elixir-format
 msgid "Could not read the uploaded file."
 msgstr "Die hochgeladene Datei konnte nicht gelesen werden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:498
+#: lib/klass_hero_web/live/provider/programs_live.ex:504
 #, elixir-autogen, elixir-format
 msgid "Could not remove invite."
 msgstr "Einladung konnte nicht entfernt werden."
@@ -2415,7 +2415,7 @@ msgstr "Beschreibung"
 msgid "Diverse"
 msgstr "Divers"
 
-#: lib/klass_hero_web/components/provider_components.ex:3120
+#: lib/klass_hero_web/components/provider_components.ex:3130
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr "Dokumenttyp"
@@ -2449,7 +2449,7 @@ msgstr "Dokument abgelehnt."
 msgid "Document uploaded successfully."
 msgstr "Dokument erfolgreich hochgeladen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2666
+#: lib/klass_hero_web/components/provider_components.ex:2676
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr "Vorlage herunterladen"
@@ -2480,8 +2480,8 @@ msgstr "Enddatum"
 msgid "End Time"
 msgstr "Endzeit"
 
-#: lib/klass_hero_web/components/provider_components.ex:2463
-#: lib/klass_hero_web/components/provider_components.ex:2925
+#: lib/klass_hero_web/components/provider_components.ex:2473
+#: lib/klass_hero_web/components/provider_components.ex:2935
 #: lib/klass_hero_web/components/provider_layout_components.ex:644
 #, elixir-autogen, elixir-format
 msgid "Enrolled"
@@ -2503,7 +2503,7 @@ msgid "Explain why this document is being rejected..."
 msgstr "Erklären Sie, warum dieses Dokument abgelehnt wird..."
 
 #: lib/klass_hero_web/components/provider_components.ex:71
-#: lib/klass_hero_web/components/provider_components.ex:2926
+#: lib/klass_hero_web/components/provider_components.ex:2936
 #: lib/klass_hero_web/live/admin/emails_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2519,7 +2519,7 @@ msgstr "Dokument konnte nicht genehmigt werden."
 msgid "Failed to reject document."
 msgstr "Dokument konnte nicht abgelehnt werden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:480
+#: lib/klass_hero_web/live/provider/programs_live.ex:486
 #, elixir-autogen, elixir-format
 msgid "Failed to resend invite."
 msgstr "Einladung konnte nicht erneut gesendet werden."
@@ -2547,12 +2547,12 @@ msgstr "Weiblich"
 msgid "File"
 msgstr "Datei"
 
-#: lib/klass_hero_web/components/provider_components.ex:3054
+#: lib/klass_hero_web/components/provider_components.ex:3064
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr "Die Datei ist zu groß."
 
-#: lib/klass_hero_web/components/provider_components.ex:3056
+#: lib/klass_hero_web/components/provider_components.ex:3066
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr "Dateityp wird nicht akzeptiert."
@@ -2587,7 +2587,7 @@ msgstr "Klassenstufe %{min}+"
 msgid "Grades %{min} – %{max}"
 msgstr "Klassenstufen %{min} – %{max}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2702
+#: lib/klass_hero_web/components/provider_components.ex:2712
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr "E-Mail des Erziehungsberechtigten"
@@ -2602,7 +2602,7 @@ msgstr "Porträtfoto"
 msgid "ID Document"
 msgstr "Ausweisdokument"
 
-#: lib/klass_hero_web/components/provider_components.ex:2639
+#: lib/klass_hero_web/components/provider_components.ex:2649
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Importieren"
@@ -2612,17 +2612,17 @@ msgstr "Importieren"
 msgid "Insurance Certificate"
 msgstr "Versicherungsnachweis"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:495
+#: lib/klass_hero_web/live/provider/programs_live.ex:501
 #, elixir-autogen, elixir-format
 msgid "Invite not found."
 msgstr "Einladung nicht gefunden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:492
+#: lib/klass_hero_web/live/provider/programs_live.ex:498
 #, elixir-autogen, elixir-format
 msgid "Invite removed."
 msgstr "Einladung entfernt."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:469
+#: lib/klass_hero_web/live/provider/programs_live.ex:475
 #, elixir-autogen, elixir-format
 msgid "Invite resent successfully."
 msgstr "Einladung erfolgreich erneut gesendet."
@@ -2728,18 +2728,18 @@ msgstr "Niedrigste Klassenstufe"
 msgid "No approved documents."
 msgstr "Keine genehmigten Dokumente."
 
-#: lib/klass_hero_web/components/provider_components.ex:3082
+#: lib/klass_hero_web/components/provider_components.ex:3092
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr "Noch keine Dokumente hochgeladen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2447
+#: lib/klass_hero_web/components/provider_components.ex:2457
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
 msgstr "Noch keine Anmeldungen."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:526
+#: lib/klass_hero_web/live/provider/programs_live.ex:532
 #, elixir-autogen, elixir-format
 msgid "No file selected."
 msgstr "Keine Datei ausgewählt."
@@ -2749,7 +2749,7 @@ msgstr "Keine Datei ausgewählt."
 msgid "No grade"
 msgstr "Keine Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2690
+#: lib/klass_hero_web/components/provider_components.ex:2700
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr "Noch keine Einladungen. Laden Sie eine CSV-Datei hoch, um Familien einzuladen."
@@ -2812,7 +2812,7 @@ msgstr "Nicht angegeben"
 msgid "Our Story"
 msgstr "Unsere Geschichte"
 
-#: lib/klass_hero_web/components/provider_components.ex:3157
+#: lib/klass_hero_web/components/provider_components.ex:3167
 #: lib/klass_hero_web/live/provider/verification_live.ex:698
 #: lib/klass_hero_web/live/provider/verification_live.ex:770
 #, elixir-autogen, elixir-format
@@ -2839,8 +2839,8 @@ msgstr "Ausstehende Überprüfung"
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:106
-#: lib/klass_hero_web/live/provider/programs_live.ex:769
-#: lib/klass_hero_web/live/provider/programs_live.ex:838
+#: lib/klass_hero_web/live/provider/programs_live.ex:775
+#: lib/klass_hero_web/live/provider/programs_live.ex:844
 #: lib/klass_hero_web/live/provider/team_live.ex:305
 #: lib/klass_hero_web/live/provider/team_live.ex:348
 #: lib/klass_hero_web/live/provider/team_live.ex:467
@@ -2873,12 +2873,12 @@ msgstr "Profil erfolgreich aktualisiert."
 msgid "Program Start"
 msgstr "Programmbeginn"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1328
+#: lib/klass_hero_web/live/provider/programs_live.ex:1337
 #, elixir-autogen, elixir-format
 msgid "Program created successfully."
 msgstr "Programm erfolgreich erstellt."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1332
+#: lib/klass_hero_web/live/provider/programs_live.ex:1341
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr "Programm erstellt, aber die Anmeldekapazität konnte nicht gespeichert werden. Bearbeiten Sie das Programm, um es erneut zu versuchen."
@@ -2888,13 +2888,13 @@ msgstr "Programm erstellt, aber die Anmeldekapazität konnte nicht gespeichert w
 #: lib/klass_hero_web/live/provider/programs_live.ex:193
 #: lib/klass_hero_web/live/provider/programs_live.ex:257
 #: lib/klass_hero_web/live/provider/programs_live.ex:281
-#: lib/klass_hero_web/live/provider/programs_live.ex:813
-#: lib/klass_hero_web/live/provider/programs_live.ex:935
+#: lib/klass_hero_web/live/provider/programs_live.ex:819
+#: lib/klass_hero_web/live/provider/programs_live.ex:944
 #, elixir-autogen, elixir-format
 msgid "Program not found."
 msgstr "Programm nicht gefunden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1329
+#: lib/klass_hero_web/live/provider/programs_live.ex:1338
 #, elixir-autogen, elixir-format
 msgid "Program updated successfully."
 msgstr "Programm erfolgreich aktualisiert."
@@ -2912,7 +2912,7 @@ msgid "Read our founding story →"
 msgstr "Lesen Sie unsere Gründungsgeschichte →"
 
 #: lib/klass_hero_web/components/participation_components.ex:805
-#: lib/klass_hero_web/components/provider_components.ex:2924
+#: lib/klass_hero_web/components/provider_components.ex:2934
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Registered"
@@ -2994,16 +2994,16 @@ msgstr "Ablehnungsgrund"
 
 #: lib/klass_hero_web/components/provider_components.ex:839
 #: lib/klass_hero_web/components/provider_components.ex:1284
-#: lib/klass_hero_web/components/provider_components.ex:2746
-#: lib/klass_hero_web/components/provider_components.ex:3176
-#: lib/klass_hero_web/components/provider_components.ex:3255
+#: lib/klass_hero_web/components/provider_components.ex:2756
+#: lib/klass_hero_web/components/provider_components.ex:3186
+#: lib/klass_hero_web/components/provider_components.ex:3265
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:253
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr "Entfernen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2739
+#: lib/klass_hero_web/components/provider_components.ex:2749
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr "Einladung erneut senden"
@@ -3044,7 +3044,7 @@ msgstr "Zeitplan noch offen"
 msgid "School Grade (optional)"
 msgstr "Klassenstufe (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:3154
+#: lib/klass_hero_web/components/provider_components.ex:3164
 #, elixir-autogen, elixir-format
 msgid "Select File"
 msgstr "Datei auswählen"
@@ -3055,13 +3055,13 @@ msgstr "Datei auswählen"
 msgid "Selected child does not meet the program requirements."
 msgstr "Das ausgewählte Kind erfüllt die Programmanforderungen nicht."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:759
-#: lib/klass_hero_web/live/provider/programs_live.ex:828
+#: lib/klass_hero_web/live/provider/programs_live.ex:765
+#: lib/klass_hero_web/live/provider/programs_live.ex:834
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr "Der ausgewählte Kursleiter konnte nicht gefunden werden. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2923
+#: lib/klass_hero_web/components/provider_components.ex:2933
 #: lib/klass_hero_web/live/admin/emails_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Sent"
@@ -3156,23 +3156,23 @@ msgstr "Erzählen Sie Eltern von Ihrer Organisation..."
 msgid "The Klass Hero Story"
 msgstr "Die Geschichte von Klass Hero"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:472
+#: lib/klass_hero_web/live/provider/programs_live.ex:478
 #, elixir-autogen, elixir-format
 msgid "This invite cannot be resent."
 msgstr "Diese Einladung kann nicht erneut gesendet werden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:820
+#: lib/klass_hero_web/live/provider/programs_live.ex:826
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr "Dieses Programm wurde von jemand anderem geändert. Bitte schließen Sie es und versuchen Sie es erneut."
 
 #: lib/klass_hero_web/components/provider_components.ex:975
-#: lib/klass_hero_web/components/provider_components.ex:2012
+#: lib/klass_hero_web/components/provider_components.ex:2022
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr "Titel"
 
-#: lib/klass_hero_web/components/provider_components.ex:3055
+#: lib/klass_hero_web/components/provider_components.ex:3065
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr "Zu viele Dateien."
@@ -3192,32 +3192,32 @@ msgstr "Bis zu %{max}"
 msgid "Up to Grade %{max}"
 msgstr "Bis Klassenstufe %{max}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2625
+#: lib/klass_hero_web/components/provider_components.ex:2635
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr "CSV hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3200
+#: lib/klass_hero_web/components/provider_components.ex:3210
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr "Dokument hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3109
+#: lib/klass_hero_web/components/provider_components.ex:3119
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr "Neues Dokument hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3077
+#: lib/klass_hero_web/components/provider_components.ex:3087
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr "Laden Sie Dokumente hoch, um Ihr Unternehmen zu verifizieren. Die Dokumente werden von unserem Team überprüft."
 
-#: lib/klass_hero_web/components/provider_components.ex:3057
+#: lib/klass_hero_web/components/provider_components.ex:3067
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr "Upload-Fehler."
 
-#: lib/klass_hero_web/components/provider_components.ex:3074
+#: lib/klass_hero_web/components/provider_components.ex:3084
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr "Verifizierungsdokumente"
@@ -3307,7 +3307,7 @@ msgid "Child Safeguarding Training"
 msgstr "Kinderschutzschulung"
 
 #: lib/klass_hero_web/components/marketing_components.ex:1498
-#: lib/klass_hero_web/components/provider_components.ex:3422
+#: lib/klass_hero_web/components/provider_components.ex:3432
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr "Vereinbarung zu Community-Standards"
@@ -3377,7 +3377,7 @@ msgstr "Zahlung per Bargeld oder Banküberweisung"
 msgid "Program fee:"
 msgstr "Programmgebühr:"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1105
+#: lib/klass_hero_web/live/provider/programs_live.ex:1114
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr "Programm gespeichert, aber der Upload des Titelbilds ist fehlgeschlagen. Sie können es erneut hochladen, indem Sie das Programm bearbeiten."
@@ -3458,7 +3458,7 @@ msgid "Vetted with Care"
 msgstr "Mit Sorgfalt geprüft"
 
 #: lib/klass_hero_web/components/marketing_components.ex:1482
-#: lib/klass_hero_web/components/provider_components.ex:3207
+#: lib/klass_hero_web/components/provider_components.ex:3217
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr "Video-Überprüfung"
@@ -3594,7 +3594,7 @@ msgstr "Kann ich meine Programme auf Klass Hero listen und was kostet das?"
 msgid "Cannot check out without a check-in"
 msgstr "Auschecken ohne Einchecken nicht möglich"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:444
+#: lib/klass_hero_web/live/provider/programs_live.ex:450
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
@@ -3632,7 +3632,7 @@ msgstr "Eingecheckt"
 msgid "Checked Out"
 msgstr "Ausgecheckt"
 
-#: lib/klass_hero_web/components/provider_components.ex:2782
+#: lib/klass_hero_web/components/provider_components.ex:2792
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Child"
@@ -3659,7 +3659,7 @@ msgid "Correct"
 msgstr "Korrigieren"
 
 #: lib/klass_hero_web/live/dashboard_live.ex:306
-#: lib/klass_hero_web/live/provider/programs_live.ex:441
+#: lib/klass_hero_web/live/provider/programs_live.ex:447
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Could not start conversation. Please try again."
@@ -3685,7 +3685,7 @@ msgstr "Benötige ich ein Konto, um zu buchen?"
 msgid "Download monthly statements for taxes"
 msgstr "Monatliche Abrechnungen für die Steuer herunterladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2543
+#: lib/klass_hero_web/components/provider_components.ex:2553
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "Enrollment not confirmed"
@@ -3781,7 +3781,7 @@ msgstr "Notizen"
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr "Oder: Jederzeit eine Sofortauszahlung anfordern (mindestens 50 €)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2542
+#: lib/klass_hero_web/components/provider_components.ex:2552
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -4623,7 +4623,7 @@ msgid "Update your observation..."
 msgstr "Aktualisieren Sie Ihre Beobachtung..."
 
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:138
-#: lib/klass_hero_web/live/provider/programs_live.ex:523
+#: lib/klass_hero_web/live/provider/programs_live.ex:529
 #: lib/klass_hero_web/live/provider/verification_live.ex:240
 #: lib/klass_hero_web/live/provider/verification_live.ex:556
 #: lib/klass_hero_web/live/provider/verification_live.ex:594
@@ -4906,8 +4906,8 @@ msgstr "Anwesenheit"
 
 #: lib/klass_hero_web/components/provider_components.ex:1866
 #: lib/klass_hero_web/components/provider_components.ex:1951
-#: lib/klass_hero_web/components/provider_components.ex:2088
-#: lib/klass_hero_web/components/provider_components.ex:2242
+#: lib/klass_hero_web/components/provider_components.ex:2098
+#: lib/klass_hero_web/components/provider_components.ex:2252
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr "Schließen"
@@ -4932,7 +4932,7 @@ msgstr "Sessions — %{title}"
 msgid "View sessions"
 msgstr "Sessions anzeigen"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:614
+#: lib/klass_hero_web/live/provider/programs_live.ex:620
 #, elixir-autogen, elixir-format
 msgid "Create a program before inviting participants."
 msgstr "Erstellen Sie zuerst ein Programm, bevor Sie Teilnehmer einladen."
@@ -4959,22 +4959,22 @@ msgstr "Abreisezeit ist kein gültiges Datum oder keine gültige Uhrzeit"
 msgid "Failed to update record"
 msgstr "Aktualisieren des Datensatzes fehlgeschlagen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2846
+#: lib/klass_hero_web/components/provider_components.ex:2856
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr "Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2565
+#: lib/klass_hero_web/components/provider_components.ex:2575
 #, elixir-autogen, elixir-format
 msgid "Invite mode"
 msgstr "Einladungsmodus"
 
-#: lib/klass_hero_web/components/provider_components.ex:2584
+#: lib/klass_hero_web/components/provider_components.ex:2594
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr "Einzelperson einladen"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:610
+#: lib/klass_hero_web/live/provider/programs_live.ex:616
 #, elixir-autogen, elixir-format
 msgid "Invite sent."
 msgstr "Einladung verschickt."
@@ -4984,12 +4984,12 @@ msgstr "Einladung verschickt."
 msgid "Leave blank to keep this child marked as present."
 msgstr "Leer lassen, um dieses Kind als anwesend markiert zu lassen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2859
+#: lib/klass_hero_web/components/provider_components.ex:2869
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr "Gesundheit & Einwilligungen (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2865
+#: lib/klass_hero_web/components/provider_components.ex:2875
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr "Gesundheitliche Besonderheiten"
@@ -5000,17 +5000,17 @@ msgstr "Gesundheitliche Besonderheiten"
 msgid "Nothing to update"
 msgstr "Nichts zu aktualisieren"
 
-#: lib/klass_hero_web/components/provider_components.ex:2867
+#: lib/klass_hero_web/components/provider_components.ex:2877
 #, elixir-autogen, elixir-format
 msgid "Nut allergy"
 msgstr "Nussallergie"
 
-#: lib/klass_hero_web/components/provider_components.ex:2871
+#: lib/klass_hero_web/components/provider_components.ex:2881
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr "Fotos dürfen in Marketingmaterialien verwendet werden"
 
-#: lib/klass_hero_web/components/provider_components.ex:2876
+#: lib/klass_hero_web/components/provider_components.ex:2886
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr "Fotos dürfen in sozialen Medien erscheinen"
@@ -5020,7 +5020,7 @@ msgstr "Fotos dürfen in sozialen Medien erscheinen"
 msgid "Present"
 msgstr "Anwesend"
 
-#: lib/klass_hero_web/components/provider_components.ex:2803
+#: lib/klass_hero_web/components/provider_components.ex:2813
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr "Hauptansprechpartner"
@@ -5047,22 +5047,22 @@ msgstr "Datensatz aktualisiert"
 msgid "Save changes"
 msgstr "Änderungen speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:2840
+#: lib/klass_hero_web/components/provider_components.ex:2850
 #, elixir-autogen, elixir-format
 msgid "School (optional)"
 msgstr "Schule (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2850
+#: lib/klass_hero_web/components/provider_components.ex:2860
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr "Schulname"
 
-#: lib/klass_hero_web/components/provider_components.ex:2824
+#: lib/klass_hero_web/components/provider_components.ex:2834
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr "Zweiter Ansprechpartner (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2893
+#: lib/klass_hero_web/components/provider_components.ex:2903
 #, elixir-autogen, elixir-format
 msgid "Send invite"
 msgstr "Einladung senden"
@@ -5072,12 +5072,12 @@ msgstr "Einladung senden"
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr "Aktualisieren Sie die Notiz für dieses Kind (z. B. um zu klären, was passiert ist)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2602
+#: lib/klass_hero_web/components/provider_components.ex:2612
 #, elixir-autogen, elixir-format
 msgid "Upload a list"
 msgstr "Liste hochladen"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:621
+#: lib/klass_hero_web/live/provider/programs_live.ex:627
 #, elixir-autogen, elixir-format
 msgid "An invite for this child and program already exists."
 msgstr "Für dieses Kind und Programm existiert bereits eine Einladung."
@@ -5254,7 +5254,7 @@ msgstr "Ihre Woche mit den Kindern"
 msgid "Go to dashboard"
 msgstr "Zum Dashboard"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:566
+#: lib/klass_hero_web/live/provider/programs_live.ex:572
 #, elixir-autogen, elixir-format
 msgid "%{count} row could not be processed."
 msgid_plural "%{count} rows could not be processed."
@@ -5841,8 +5841,8 @@ msgstr "Wie wir Anbieter überprüfen"
 msgid "I'll be teaching"
 msgstr "Ich werde unterrichten"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:541
-#: lib/klass_hero_web/live/provider/programs_live.ex:563
+#: lib/klass_hero_web/live/provider/programs_live.ex:547
+#: lib/klass_hero_web/live/provider/programs_live.ex:569
 #, elixir-autogen, elixir-format
 msgid "Imported %{count} family."
 msgid_plural "Imported %{count} families."
@@ -6131,7 +6131,7 @@ msgstr "Noch keine Programme — fügen Sie Ihr erstes über den Tab „Programm
 msgid "No registered children for this session."
 msgstr "Keine Kinder in dieser Sitzung angemeldet."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:550
+#: lib/klass_hero_web/live/provider/programs_live.ex:556
 #, elixir-autogen, elixir-format
 msgid "No rows imported. %{count} row could not be processed."
 msgid_plural "No rows imported. %{count} rows could not be processed."
@@ -6374,17 +6374,17 @@ msgstr "Umsatz (diese Woche)"
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr "Strenge Überprüfung, damit Familien immer wissen, wer die Gruppe leitet."
 
-#: lib/klass_hero_web/components/provider_components.ex:2932
+#: lib/klass_hero_web/components/provider_components.ex:2942
 #, elixir-autogen, elixir-format
 msgid "Row %{row}"
 msgstr "Zeile %{row}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2932
+#: lib/klass_hero_web/components/provider_components.ex:2942
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr "Zeile —"
 
-#: lib/klass_hero_web/components/provider_components.ex:2678
+#: lib/klass_hero_web/components/provider_components.ex:2688
 #, elixir-autogen, elixir-format
 msgid "Rows with errors"
 msgstr "Zeilen mit Fehlern"
@@ -7143,12 +7143,12 @@ msgstr "Deine Identität ist verifiziert."
 msgid "Experience validation"
 msgstr "Erfahrungsnachweis"
 
-#: lib/klass_hero_web/components/provider_components.ex:3236
+#: lib/klass_hero_web/components/provider_components.ex:3246
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr "MP4, MOV oder WEBM. Max. 100 MB."
 
-#: lib/klass_hero_web/components/provider_components.ex:3210
+#: lib/klass_hero_web/components/provider_components.ex:3220
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr "Nimm ein kurzes Video auf, in dem du dich vorstellst. Unser Team prüft es, um Kommunikationsfähigkeit und Übereinstimmung mit unseren Werten einzuschätzen."
@@ -7158,12 +7158,12 @@ msgstr "Nimm ein kurzes Video auf, in dem du dich vorstellst. Unser Team prüft 
 msgid "Safeguarding certificate"
 msgstr "Kinderschutz-Zertifikat"
 
-#: lib/klass_hero_web/components/provider_components.ex:3233
+#: lib/klass_hero_web/components/provider_components.ex:3243
 #, elixir-autogen, elixir-format
 msgid "Select Video"
 msgstr "Video auswählen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3279
+#: lib/klass_hero_web/components/provider_components.ex:3289
 #, elixir-autogen, elixir-format
 msgid "Upload Video"
 msgstr "Video hochladen"
@@ -7173,7 +7173,7 @@ msgstr "Video hochladen"
 msgid "Your browser does not support video playback."
 msgstr "Dein Browser unterstützt keine Videowiedergabe."
 
-#: lib/klass_hero_web/components/provider_components.ex:3426
+#: lib/klass_hero_web/components/provider_components.ex:3436
 #, elixir-autogen, elixir-format
 msgid "Confirm agreement"
 msgstr "Zustimmung bestätigen"
@@ -7183,12 +7183,12 @@ msgstr "Zustimmung bestätigen"
 msgid "Couldn't record your agreement. Please try again."
 msgstr "Deine Zustimmung konnte nicht gespeichert werden. Bitte versuche es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:3449
+#: lib/klass_hero_web/components/provider_components.ex:3459
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr "Vereinbarung herunterladen (PDF)"
 
-#: lib/klass_hero_web/components/provider_components.ex:3425
+#: lib/klass_hero_web/components/provider_components.ex:3435
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr "Ich habe die Klass Hero Community-Richtlinien gelesen und stimme ihnen zu."
@@ -7198,7 +7198,7 @@ msgstr "Ich habe die Klass Hero Community-Richtlinien gelesen und stimme ihnen z
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr "Bitte bestätige, dass du die Community-Richtlinien gelesen hast und ihnen zustimmst."
 
-#: lib/klass_hero_web/components/provider_components.ex:3334
+#: lib/klass_hero_web/components/provider_components.ex:3344
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr "Unterzeichnet von %{name} am %{date} (v%{version})."
@@ -7208,17 +7208,17 @@ msgstr "Unterzeichnet von %{name} am %{date} (v%{version})."
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr "Danke – deine Zustimmung zu den Community-Richtlinien wurde gespeichert."
 
-#: lib/klass_hero_web/components/provider_components.ex:3434
+#: lib/klass_hero_web/components/provider_components.ex:3444
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr "Die Community-Richtlinien wurden seit deiner letzten Zustimmung aktualisiert (v%{old}). Bitte lies sie erneut und stimme erneut zu."
 
-#: lib/klass_hero_web/components/provider_components.ex:3423
+#: lib/klass_hero_web/components/provider_components.ex:3433
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr "Der letzte Schritt: Lies die Klass Hero Community-Richtlinien und stimme ihnen zu."
 
-#: lib/klass_hero_web/components/provider_components.ex:3424
+#: lib/klass_hero_web/components/provider_components.ex:3434
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr "Du hast den Community-Richtlinien zugestimmt."
@@ -7487,12 +7487,12 @@ msgstr "Ihre Versicherungsbescheinigung wird geprüft."
 msgid "Your insurance is verified."
 msgstr "Ihre Versicherung ist verifiziert."
 
-#: lib/klass_hero_web/components/provider_components.ex:3378
+#: lib/klass_hero_web/components/provider_components.ex:3388
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr "Unterzeichnung durch %{name} im Namen des Unternehmens."
 
-#: lib/klass_hero_web/components/provider_components.ex:3481
+#: lib/klass_hero_web/components/provider_components.ex:3491
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr "Bestätige im Namen deines Unternehmens, dass alle Mitarbeitenden gemäß dem deutschen Kinderschutzrecht überprüft sind."
@@ -7502,7 +7502,7 @@ msgstr "Bestätige im Namen deines Unternehmens, dass alle Mitarbeitenden gemä�
 msgid "Couldn't record your declaration. Please try again."
 msgstr "Deine Erklärung konnte nicht gespeichert werden. Bitte versuche es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:3487
+#: lib/klass_hero_web/components/provider_components.ex:3497
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr "Ich bestätige im Namen des Unternehmens, dass die obige Erklärung zutrifft und ich zu ihrer Unterzeichnung berechtigt bin."
@@ -7512,17 +7512,17 @@ msgstr "Ich bestätige im Namen des Unternehmens, dass die obige Erklärung zutr
 msgid "Please confirm the declaration before signing."
 msgstr "Bitte bestätige die Erklärung vor der Unterzeichnung."
 
-#: lib/klass_hero_web/components/provider_components.ex:3512
+#: lib/klass_hero_web/components/provider_components.ex:3522
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr "Vorläufiger Text — vor der Freischaltung noch von einer in Deutschland zugelassenen Anwältin bzw. einem Anwalt zu prüfen."
 
-#: lib/klass_hero_web/components/provider_components.ex:3491
+#: lib/klass_hero_web/components/provider_components.ex:3501
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr "Erklärung unterzeichnen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3479
+#: lib/klass_hero_web/components/provider_components.ex:3489
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr "Erklärung zur Mitarbeiter-Compliance"
@@ -7532,12 +7532,12 @@ msgstr "Erklärung zur Mitarbeiter-Compliance"
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr "Danke — deine Erklärung zur Mitarbeiter-Compliance wurde erfasst."
 
-#: lib/klass_hero_web/components/provider_components.ex:3499
+#: lib/klass_hero_web/components/provider_components.ex:3509
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr "Die Erklärung zur Mitarbeiter-Compliance wurde seit deiner letzten Unterzeichnung aktualisiert (v%{old}). Bitte prüfe sie und unterzeichne erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:3485
+#: lib/klass_hero_web/components/provider_components.ex:3495
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr "Du hast die Erklärung zur Mitarbeiter-Compliance unterzeichnet."
@@ -7604,24 +7604,24 @@ msgstr "In Prüfung"
 msgid "Undelivered Events"
 msgstr "Nicht zugestellte Ereignisse"
 
-#: lib/klass_hero_web/components/provider_components.ex:2187
-#: lib/klass_hero_web/components/provider_components.ex:2370
+#: lib/klass_hero_web/components/provider_components.ex:2197
+#: lib/klass_hero_web/components/provider_components.ex:2380
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2110
-#: lib/klass_hero_web/components/provider_components.ex:2296
+#: lib/klass_hero_web/components/provider_components.ex:2120
+#: lib/klass_hero_web/components/provider_components.ex:2306
 #, elixir-autogen, elixir-format
 msgid "Lead"
 msgstr "Leitung"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:416
+#: lib/klass_hero_web/live/provider/programs_live.ex:422
 #, elixir-autogen, elixir-format
 msgid "Lead instructor updated."
 msgstr "Leitender Kursleiter aktualisiert."
 
-#: lib/klass_hero_web/components/provider_components.ex:2122
+#: lib/klass_hero_web/components/provider_components.ex:2132
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor"
 msgstr "Als leitenden Kursleiter festlegen"
@@ -7631,67 +7631,67 @@ msgstr "Als leitenden Kursleiter festlegen"
 msgid "Manage Staffing"
 msgstr "Programmteam verwalten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2151
+#: lib/klass_hero_web/components/provider_components.ex:2161
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this program yet."
 msgstr "Diesem Programm ist noch niemand zugewiesen."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:346
+#: lib/klass_hero_web/live/provider/programs_live.ex:352
 #: lib/klass_hero_web/live/provider/sessions_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "Pick a staff member to add."
 msgstr "Bitte ein Teammitglied zum Hinzufügen auswählen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2134
-#: lib/klass_hero_web/components/provider_components.ex:2409
+#: lib/klass_hero_web/components/provider_components.ex:2144
+#: lib/klass_hero_web/components/provider_components.ex:2419
 #, elixir-autogen, elixir-format
 msgid "Reassign the lead before removing them"
 msgstr "Vor dem Entfernen einen anderen leitenden Kursleiter festlegen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2135
+#: lib/klass_hero_web/components/provider_components.ex:2145
 #, elixir-autogen, elixir-format
 msgid "Remove from program"
 msgstr "Aus dem Programm entfernen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2169
-#: lib/klass_hero_web/components/provider_components.ex:2351
+#: lib/klass_hero_web/components/provider_components.ex:2179
+#: lib/klass_hero_web/components/provider_components.ex:2361
 #, elixir-autogen, elixir-format
 msgid "Select a staff member…"
 msgstr "Teammitglied auswählen …"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:361
+#: lib/klass_hero_web/live/provider/programs_live.ex:367
 #, elixir-autogen, elixir-format
 msgid "Staff member added to the program."
 msgstr "Teammitglied zum Programm hinzugefügt."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:387
+#: lib/klass_hero_web/live/provider/programs_live.ex:393
 #, elixir-autogen, elixir-format
 msgid "Staff member removed from the program."
 msgstr "Teammitglied aus dem Programm entfernt."
 
-#: lib/klass_hero_web/components/provider_components.ex:2192
+#: lib/klass_hero_web/components/provider_components.ex:2202
 #, elixir-autogen, elixir-format
 msgid "Staff you add can read and reply to this program's parent conversations."
 msgstr ""
 "Hinzugefügte Teammitglieder können die Elterngespräche dieses Programms lesen "
 "und beantworten."
 
-#: lib/klass_hero_web/components/provider_components.ex:2086
+#: lib/klass_hero_web/components/provider_components.ex:2096
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{title}"
 msgstr "Programmteam — %{title}"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1064
+#: lib/klass_hero_web/live/provider/programs_live.ex:1073
 #, elixir-autogen, elixir-format
 msgid "That staff member could not be found."
 msgstr "Dieses Teammitglied wurde nicht gefunden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:369
+#: lib/klass_hero_web/live/provider/programs_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "They are already on this program."
 msgstr "Diese Person ist bereits in diesem Programm."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:395
+#: lib/klass_hero_web/live/provider/programs_live.ex:401
 #, elixir-autogen, elixir-format
 msgid "This person is the lead instructor. Make someone else lead before removing them."
 msgstr ""
@@ -7755,21 +7755,21 @@ msgstr "Damit wird %{name} endgültig gelöscht – das lässt sich nicht rückg
 msgid "This person has a history here now — use 'Remove from team' instead."
 msgstr "Diese Person hat inzwischen eine Historie – nutze stattdessen „Aus dem Team entfernen“."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1342
+#: lib/klass_hero_web/live/provider/programs_live.ex:1351
 #, elixir-autogen, elixir-format
 msgid "Program created, but some settings could not be saved. Please review the program's limits."
 msgstr ""
 "Programm erstellt, aber einige Einstellungen konnten nicht gespeichert werden. "
 "Bitte überprüfen Sie die Grenzwerte des Programms."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1346
+#: lib/klass_hero_web/live/provider/programs_live.ex:1355
 #, elixir-autogen, elixir-format
 msgid "Program updated, but some settings could not be saved. Please review the program's limits."
 msgstr ""
 "Programm aktualisiert, aber einige Einstellungen konnten nicht gespeichert "
 "werden. Bitte überprüfen Sie die Grenzwerte des Programms."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1336
+#: lib/klass_hero_web/live/provider/programs_live.ex:1345
 #, elixir-autogen, elixir-format
 msgid "Program updated, but the enrollment capacity was rejected. The previous limits still apply."
 msgstr ""
@@ -7798,7 +7798,7 @@ msgstr ""
 msgid "I understand this program will have no capacity limit."
 msgstr "Ich verstehe, dass dieses Programm keine Teilnehmerbegrenzung haben wird."
 
-#: lib/klass_hero_web/components/provider_components.ex:2397
+#: lib/klass_hero_web/components/provider_components.ex:2407
 #, elixir-autogen, elixir-format
 msgid "Go back to the program's usual team"
 msgstr "Zurück zum üblichen Programmteam"
@@ -7808,17 +7808,17 @@ msgstr "Zurück zum üblichen Programmteam"
 msgid "Lead instructor for this session updated."
 msgstr "Leitung für diesen Termin aktualisiert."
 
-#: lib/klass_hero_web/components/provider_components.ex:2311
+#: lib/klass_hero_web/components/provider_components.ex:2321
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor for this session"
 msgstr "Als Leitung für diesen Termin festlegen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2333
+#: lib/klass_hero_web/components/provider_components.ex:2343
 #, elixir-autogen, elixir-format
 msgid "Nobody is working this session yet."
 msgstr "Für diesen Termin ist noch niemand eingeteilt."
 
-#: lib/klass_hero_web/components/provider_components.ex:2414
+#: lib/klass_hero_web/components/provider_components.ex:2424
 #, elixir-autogen, elixir-format
 msgid "Remove from this session"
 msgstr "Von diesem Termin entfernen"
@@ -7838,7 +7838,7 @@ msgstr "Teammitglied von diesem Termin entfernt."
 msgid "Staffing"
 msgstr "Team"
 
-#: lib/klass_hero_web/components/provider_components.ex:2235
+#: lib/klass_hero_web/components/provider_components.ex:2245
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{date}"
 msgstr "Team — %{date}"
@@ -7868,22 +7868,22 @@ msgstr "Dieser Termin nutzt wieder das übliche Programmteam."
 msgid "A session needs at least one person. Use “Go back to the program's usual team” to drop this session's own roster."
 msgstr "Ein Termin braucht mindestens eine Person. Nutze „Zurück zum üblichen Programmteam“, um die eigene Besetzung dieses Termins aufzuheben."
 
-#: lib/klass_hero_web/components/provider_components.ex:2412
+#: lib/klass_hero_web/components/provider_components.ex:2422
 #, elixir-autogen, elixir-format
 msgid "A session needs someone — use “Go back to the program's usual team” instead"
 msgstr "Ein Termin braucht jemanden — nutze stattdessen „Zurück zum üblichen Programmteam“"
 
-#: lib/klass_hero_web/components/provider_components.ex:2379
+#: lib/klass_hero_web/components/provider_components.ex:2389
 #, elixir-autogen, elixir-format
 msgid "Everyone on your team is already working this session."
 msgstr "Alle aus deinem Team arbeiten bereits bei diesem Termin."
 
-#: lib/klass_hero_web/components/provider_components.ex:2267
+#: lib/klass_hero_web/components/provider_components.ex:2277
 #, elixir-autogen, elixir-format
 msgid "Staffed just for this session. Changes here do not touch the program."
 msgstr "Nur für diesen Termin eingeteilt. Änderungen hier wirken sich nicht auf das Programm aus."
 
-#: lib/klass_hero_web/components/provider_components.ex:2269
+#: lib/klass_hero_web/components/provider_components.ex:2279
 #, elixir-autogen, elixir-format
 msgid "Using the program's usual team. The first change here copies them onto this session, so later program changes stop reaching it."
 msgstr "Es gilt das übliche Programmteam. Die erste Änderung hier übernimmt das Team in diesen Termin — spätere Änderungen am Programm greifen dann nicht mehr."
@@ -7894,17 +7894,17 @@ msgstr "Es gilt das übliche Programmteam. Die erste Änderung hier übernimmt d
 msgid "(optional)"
 msgstr "(optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2005
+#: lib/klass_hero_web/components/provider_components.ex:2015
 #, elixir-autogen, elixir-format
 msgid "Add a waiver"
 msgstr "Verzichtserklärung hinzufügen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2037
+#: lib/klass_hero_web/components/provider_components.ex:2047
 #, elixir-autogen, elixir-format
 msgid "Add waiver"
 msgstr "Hinzufügen"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:936
+#: lib/klass_hero_web/live/provider/programs_live.ex:945
 #, elixir-autogen, elixir-format
 msgid "Check the waiver details and try again."
 msgstr "Bitte prüfe die Angaben zur Verzichtserklärung und versuche es erneut."
@@ -7921,7 +7921,7 @@ msgstr "Anmeldung nicht gefunden."
 msgid "I have read and agree to %{title}"
 msgstr "Ich habe %{title} gelesen und stimme zu"
 
-#: lib/klass_hero_web/components/provider_components.ex:2019
+#: lib/klass_hero_web/components/provider_components.ex:2029
 #, elixir-autogen, elixir-format
 msgid "Legal text"
 msgstr "Rechtstext"
@@ -7936,7 +7936,7 @@ msgstr "Verzichtserklärungen verwalten"
 msgid "No waivers yet. Parents enrol without signing anything."
 msgstr "Noch keine Verzichtserklärungen. Eltern melden sich ohne Unterschrift an."
 
-#: lib/klass_hero_web/components/provider_components.ex:2026
+#: lib/klass_hero_web/components/provider_components.ex:2036
 #, elixir-autogen, elixir-format
 msgid "Parents must sign this before enrolling"
 msgstr "Eltern müssen dies vor der Anmeldung unterschreiben"
@@ -7956,32 +7956,32 @@ msgstr "Bitte lies und unterschreibe diese, bevor %{program} beginnt."
 msgid "Please tick a waiver to sign it."
 msgstr "Bitte wähle eine Verzichtserklärung aus, um sie zu unterschreiben."
 
-#: lib/klass_hero_web/components/provider_components.ex:2004
+#: lib/klass_hero_web/components/provider_components.ex:2014
 #, elixir-autogen, elixir-format
 msgid "Publish a new version"
 msgstr "Neue Version veröffentlichen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2037
+#: lib/klass_hero_web/components/provider_components.ex:2047
 #, elixir-autogen, elixir-format
 msgid "Publish version"
 msgstr "Version veröffentlichen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2030
+#: lib/klass_hero_web/components/provider_components.ex:2040
 #, elixir-autogen, elixir-format
 msgid "Publishing keeps every earlier version on record; signatures already given stay bound to the wording they were shown."
 msgstr "Beim Veröffentlichen bleibt jede frühere Version erhalten; bereits geleistete Unterschriften bleiben an den damals gezeigten Wortlaut gebunden."
 
-#: lib/klass_hero_web/components/provider_components.ex:1974
+#: lib/klass_hero_web/components/provider_components.ex:1976
 #, elixir-autogen, elixir-format
 msgid "Required"
 msgstr "Erforderlich"
 
-#: lib/klass_hero_web/components/provider_components.ex:1993
+#: lib/klass_hero_web/components/provider_components.ex:1997
 #, elixir-autogen, elixir-format
 msgid "Retire this waiver"
 msgstr "Diese Verzichtserklärung zurückziehen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1986
+#: lib/klass_hero_web/components/provider_components.ex:1988
 #, elixir-autogen, elixir-format
 msgid "Revise text"
 msgstr "Text überarbeiten"
@@ -7996,7 +7996,7 @@ msgstr "Verzichtserklärungen für %{program} unterschreiben"
 msgid "Sign waivers"
 msgstr "Verzichtserklärungen unterschreiben"
 
-#: lib/klass_hero_web/components/provider_components.ex:2492
+#: lib/klass_hero_web/components/provider_components.ex:2502
 #: lib/klass_hero_web/live/enrollment_waivers_live.ex:142
 #, elixir-autogen, elixir-format
 msgid "Signed"
@@ -8012,22 +8012,22 @@ msgstr "Danke — deine Verzichtserklärungen sind erfasst."
 msgid "There is nothing to sign for this enrollment."
 msgstr "Für diese Anmeldung gibt es nichts zu unterschreiben."
 
-#: lib/klass_hero_web/components/provider_components.ex:2492
+#: lib/klass_hero_web/components/provider_components.ex:2502
 #, elixir-autogen, elixir-format
 msgid "Unsigned"
 msgstr "Nicht unterschrieben"
 
-#: lib/klass_hero_web/components/provider_components.ex:1978
+#: lib/klass_hero_web/components/provider_components.ex:1980
 #, elixir-autogen, elixir-format
 msgid "Version %{number}"
 msgstr "Version %{number}"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:340
+#: lib/klass_hero_web/live/provider/programs_live.ex:346
 #, elixir-autogen, elixir-format
 msgid "Waiver not found."
 msgstr "Verzichtserklärung nicht gefunden."
 
-#: lib/klass_hero_web/components/provider_components.ex:2460
+#: lib/klass_hero_web/components/provider_components.ex:2470
 #: lib/klass_hero_web/live/booking_live.ex:427
 #: lib/klass_hero_web/live/enrollment_waivers_live.ex:31
 #: lib/klass_hero_web/live/enrollment_waivers_live.ex:103
@@ -8049,3 +8049,23 @@ msgstr "Verzichtserklärungen — %{title}"
 #, elixir-autogen, elixir-format
 msgid "this program"
 msgstr "dieses Programm"
+
+#: lib/klass_hero_web/live/provider/programs_live.ex:942
+#, elixir-autogen, elixir-format
+msgid "New version published. It applies to future enrolments."
+msgstr "Neue Fassung veröffentlicht. Sie gilt für künftige Anmeldungen."
+
+#: lib/klass_hero_web/components/provider_components.ex:2001
+#, elixir-autogen, elixir-format
+msgid "Retire \"%{title}\"? Parents will no longer be asked to sign it. Signatures already collected are kept."
+msgstr "\"%{title}\" zurückziehen? Eltern werden nicht mehr um eine Unterschrift gebeten. Bereits erteilte Unterschriften bleiben erhalten."
+
+#: lib/klass_hero_web/live/provider/programs_live.ex:941
+#, elixir-autogen, elixir-format
+msgid "Waiver added."
+msgstr "Einverständniserklärung hinzugefügt."
+
+#: lib/klass_hero_web/live/provider/programs_live.ex:343
+#, elixir-autogen, elixir-format
+msgid "Waiver retired. Signatures already collected are kept."
+msgstr "Einverständniserklärung zurückgezogen. Bereits erteilte Unterschriften bleiben erhalten."

--- a/priv/gettext/de/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/de/LC_MESSAGES/enrollment.po
@@ -11,105 +11,105 @@ msgstr ""
 "Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:2863
-#: lib/klass_hero_web/components/provider_components.ex:2880
+#: lib/klass_hero_web/components/provider_components.ex:3026
+#: lib/klass_hero_web/components/provider_components.ex:3043
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr "Vorname des Kindes"
 
-#: lib/klass_hero_web/components/provider_components.ex:2864
-#: lib/klass_hero_web/components/provider_components.ex:2881
+#: lib/klass_hero_web/components/provider_components.ex:3027
+#: lib/klass_hero_web/components/provider_components.ex:3044
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr "Nachname des Kindes"
 
-#: lib/klass_hero_web/components/provider_components.ex:2865
-#: lib/klass_hero_web/components/provider_components.ex:2882
+#: lib/klass_hero_web/components/provider_components.ex:3028
+#: lib/klass_hero_web/components/provider_components.ex:3045
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr "Geburtsdatum"
 
-#: lib/klass_hero_web/components/provider_components.ex:2876
+#: lib/klass_hero_web/components/provider_components.ex:3039
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr "Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2866
+#: lib/klass_hero_web/components/provider_components.ex:3029
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr "E-Mail des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2867
+#: lib/klass_hero_web/components/provider_components.ex:3030
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr "Vorname des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2868
+#: lib/klass_hero_web/components/provider_components.ex:3031
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr "Nachname des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2875
+#: lib/klass_hero_web/components/provider_components.ex:3038
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr "Programm"
 
-#: lib/klass_hero_web/components/provider_components.ex:2877
+#: lib/klass_hero_web/components/provider_components.ex:3040
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr "Schule"
 
-#: lib/klass_hero_web/components/provider_components.ex:2869
+#: lib/klass_hero_web/components/provider_components.ex:3032
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr "E-Mail des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2871
+#: lib/klass_hero_web/components/provider_components.ex:3034
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr "Vorname des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2873
+#: lib/klass_hero_web/components/provider_components.ex:3036
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr "Nachname des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2803
+#: lib/klass_hero_web/components/provider_components.ex:2966
 #, elixir-autogen, elixir-format
 msgid "Date of birth \"%{value}\" is not a valid date. Please correct it and resend."
 msgstr ""
 "Das Geburtsdatum „%{value}“ ist kein gültiges Datum. Bitte korrigieren Sie es "
 "und senden Sie die Einladung erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2797
+#: lib/klass_hero_web/components/provider_components.ex:2960
 #, elixir-autogen, elixir-format
 msgid "Invite link could not be generated (no token). Please resend."
 msgstr ""
 "Der Einladungslink konnte nicht erzeugt werden (kein Token). Bitte erneut "
 "senden."
 
-#: lib/klass_hero_web/components/provider_components.ex:2811
+#: lib/klass_hero_web/components/provider_components.ex:2974
 #, elixir-autogen, elixir-format
 msgid "The invitation email could not be delivered. Please check the address and resend."
 msgstr ""
 "Die Einladungs-E-Mail konnte nicht zugestellt werden. Bitte prüfen Sie die "
 "Adresse und senden Sie die Einladung erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2800
+#: lib/klass_hero_web/components/provider_components.ex:2963
 #, elixir-autogen, elixir-format
 msgid "The program is full, so this child could not be enrolled."
 msgstr ""
 "Das Programm ist ausgebucht, daher konnte dieses Kind nicht angemeldet "
 "werden."
 
-#: lib/klass_hero_web/components/provider_components.ex:2814
+#: lib/klass_hero_web/components/provider_components.ex:2977
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed and no retries remain. Please resend."
 msgstr ""
 "Diese Einladung konnte nicht abgeschlossen werden und es sind keine weiteren "
 "Versuche möglich. Bitte erneut senden."
 
-#: lib/klass_hero_web/components/provider_components.ex:2823
+#: lib/klass_hero_web/components/provider_components.ex:2986
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed. Please resend."
 msgstr "Diese Einladung konnte nicht abgeschlossen werden. Bitte erneut senden."

--- a/priv/gettext/de/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/de/LC_MESSAGES/enrollment.po
@@ -11,105 +11,105 @@ msgstr ""
 "Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:3036
-#: lib/klass_hero_web/components/provider_components.ex:3053
+#: lib/klass_hero_web/components/provider_components.ex:3032
+#: lib/klass_hero_web/components/provider_components.ex:3049
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr "Vorname des Kindes"
 
-#: lib/klass_hero_web/components/provider_components.ex:3037
-#: lib/klass_hero_web/components/provider_components.ex:3054
+#: lib/klass_hero_web/components/provider_components.ex:3033
+#: lib/klass_hero_web/components/provider_components.ex:3050
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr "Nachname des Kindes"
 
-#: lib/klass_hero_web/components/provider_components.ex:3038
-#: lib/klass_hero_web/components/provider_components.ex:3055
+#: lib/klass_hero_web/components/provider_components.ex:3034
+#: lib/klass_hero_web/components/provider_components.ex:3051
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr "Geburtsdatum"
 
-#: lib/klass_hero_web/components/provider_components.ex:3049
+#: lib/klass_hero_web/components/provider_components.ex:3045
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr "Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:3039
+#: lib/klass_hero_web/components/provider_components.ex:3035
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr "E-Mail des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:3040
+#: lib/klass_hero_web/components/provider_components.ex:3036
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr "Vorname des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:3041
+#: lib/klass_hero_web/components/provider_components.ex:3037
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr "Nachname des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:3048
+#: lib/klass_hero_web/components/provider_components.ex:3044
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr "Programm"
 
-#: lib/klass_hero_web/components/provider_components.ex:3050
+#: lib/klass_hero_web/components/provider_components.ex:3046
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr "Schule"
 
-#: lib/klass_hero_web/components/provider_components.ex:3042
+#: lib/klass_hero_web/components/provider_components.ex:3038
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr "E-Mail des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:3044
+#: lib/klass_hero_web/components/provider_components.ex:3040
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr "Vorname des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:3046
+#: lib/klass_hero_web/components/provider_components.ex:3042
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr "Nachname des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2976
+#: lib/klass_hero_web/components/provider_components.ex:2972
 #, elixir-autogen, elixir-format
 msgid "Date of birth \"%{value}\" is not a valid date. Please correct it and resend."
 msgstr ""
 "Das Geburtsdatum „%{value}“ ist kein gültiges Datum. Bitte korrigieren Sie es "
 "und senden Sie die Einladung erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2970
+#: lib/klass_hero_web/components/provider_components.ex:2966
 #, elixir-autogen, elixir-format
 msgid "Invite link could not be generated (no token). Please resend."
 msgstr ""
 "Der Einladungslink konnte nicht erzeugt werden (kein Token). Bitte erneut "
 "senden."
 
-#: lib/klass_hero_web/components/provider_components.ex:2984
+#: lib/klass_hero_web/components/provider_components.ex:2980
 #, elixir-autogen, elixir-format
 msgid "The invitation email could not be delivered. Please check the address and resend."
 msgstr ""
 "Die Einladungs-E-Mail konnte nicht zugestellt werden. Bitte prüfen Sie die "
 "Adresse und senden Sie die Einladung erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2973
+#: lib/klass_hero_web/components/provider_components.ex:2969
 #, elixir-autogen, elixir-format
 msgid "The program is full, so this child could not be enrolled."
 msgstr ""
 "Das Programm ist ausgebucht, daher konnte dieses Kind nicht angemeldet "
 "werden."
 
-#: lib/klass_hero_web/components/provider_components.ex:2987
+#: lib/klass_hero_web/components/provider_components.ex:2983
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed and no retries remain. Please resend."
 msgstr ""
 "Diese Einladung konnte nicht abgeschlossen werden und es sind keine weiteren "
 "Versuche möglich. Bitte erneut senden."
 
-#: lib/klass_hero_web/components/provider_components.ex:2996
+#: lib/klass_hero_web/components/provider_components.ex:2992
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed. Please resend."
 msgstr "Diese Einladung konnte nicht abgeschlossen werden. Bitte erneut senden."

--- a/priv/gettext/de/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/de/LC_MESSAGES/enrollment.po
@@ -11,105 +11,105 @@ msgstr ""
 "Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:3026
-#: lib/klass_hero_web/components/provider_components.ex:3043
+#: lib/klass_hero_web/components/provider_components.ex:3036
+#: lib/klass_hero_web/components/provider_components.ex:3053
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr "Vorname des Kindes"
 
-#: lib/klass_hero_web/components/provider_components.ex:3027
-#: lib/klass_hero_web/components/provider_components.ex:3044
+#: lib/klass_hero_web/components/provider_components.ex:3037
+#: lib/klass_hero_web/components/provider_components.ex:3054
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr "Nachname des Kindes"
 
-#: lib/klass_hero_web/components/provider_components.ex:3028
-#: lib/klass_hero_web/components/provider_components.ex:3045
+#: lib/klass_hero_web/components/provider_components.ex:3038
+#: lib/klass_hero_web/components/provider_components.ex:3055
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr "Geburtsdatum"
 
-#: lib/klass_hero_web/components/provider_components.ex:3039
+#: lib/klass_hero_web/components/provider_components.ex:3049
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr "Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:3029
+#: lib/klass_hero_web/components/provider_components.ex:3039
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr "E-Mail des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:3030
+#: lib/klass_hero_web/components/provider_components.ex:3040
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr "Vorname des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:3031
+#: lib/klass_hero_web/components/provider_components.ex:3041
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr "Nachname des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:3038
+#: lib/klass_hero_web/components/provider_components.ex:3048
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr "Programm"
 
-#: lib/klass_hero_web/components/provider_components.ex:3040
+#: lib/klass_hero_web/components/provider_components.ex:3050
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr "Schule"
 
-#: lib/klass_hero_web/components/provider_components.ex:3032
+#: lib/klass_hero_web/components/provider_components.ex:3042
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr "E-Mail des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:3034
+#: lib/klass_hero_web/components/provider_components.ex:3044
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr "Vorname des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:3036
+#: lib/klass_hero_web/components/provider_components.ex:3046
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr "Nachname des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2966
+#: lib/klass_hero_web/components/provider_components.ex:2976
 #, elixir-autogen, elixir-format
 msgid "Date of birth \"%{value}\" is not a valid date. Please correct it and resend."
 msgstr ""
 "Das Geburtsdatum „%{value}“ ist kein gültiges Datum. Bitte korrigieren Sie es "
 "und senden Sie die Einladung erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2960
+#: lib/klass_hero_web/components/provider_components.ex:2970
 #, elixir-autogen, elixir-format
 msgid "Invite link could not be generated (no token). Please resend."
 msgstr ""
 "Der Einladungslink konnte nicht erzeugt werden (kein Token). Bitte erneut "
 "senden."
 
-#: lib/klass_hero_web/components/provider_components.ex:2974
+#: lib/klass_hero_web/components/provider_components.ex:2984
 #, elixir-autogen, elixir-format
 msgid "The invitation email could not be delivered. Please check the address and resend."
 msgstr ""
 "Die Einladungs-E-Mail konnte nicht zugestellt werden. Bitte prüfen Sie die "
 "Adresse und senden Sie die Einladung erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2963
+#: lib/klass_hero_web/components/provider_components.ex:2973
 #, elixir-autogen, elixir-format
 msgid "The program is full, so this child could not be enrolled."
 msgstr ""
 "Das Programm ist ausgebucht, daher konnte dieses Kind nicht angemeldet "
 "werden."
 
-#: lib/klass_hero_web/components/provider_components.ex:2977
+#: lib/klass_hero_web/components/provider_components.ex:2987
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed and no retries remain. Please resend."
 msgstr ""
 "Diese Einladung konnte nicht abgeschlossen werden und es sind keine weiteren "
 "Versuche möglich. Bitte erneut senden."
 
-#: lib/klass_hero_web/components/provider_components.ex:2986
+#: lib/klass_hero_web/components/provider_components.ex:2996
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed. Please resend."
 msgstr "Diese Einladung konnte nicht abgeschlossen werden. Bitte erneut senden."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -45,7 +45,7 @@ msgstr ""
 #: lib/klass_hero_web/components/layouts/app.html.heex:129
 #: lib/klass_hero_web/components/layouts/app.html.heex:204
 #: lib/klass_hero_web/components/layouts/app.html.heex:229
-#: lib/klass_hero_web/components/provider_components.ex:390
+#: lib/klass_hero_web/components/provider_components.ex:391
 #: lib/klass_hero_web/components/ui_components.ex:268
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
@@ -137,7 +137,7 @@ msgid "Your Data"
 msgstr ""
 
 #: lib/klass_hero_web/components/core_components.ex:71
-#: lib/klass_hero_web/components/provider_components.ex:1765
+#: lib/klass_hero_web/components/provider_components.ex:1766
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr ""
@@ -172,7 +172,7 @@ msgstr ""
 msgid "Ages %{range}"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:511
+#: lib/klass_hero_web/live/booking_live.ex:510
 #, elixir-autogen, elixir-format
 msgid "An invoice will be emailed to you after enrollment completion"
 msgstr ""
@@ -187,12 +187,12 @@ msgstr ""
 msgid "Book camps, tutors, and workshops instantly. Our integrated planner helps you manage your child's busy life."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:488
+#: lib/klass_hero_web/live/booking_live.ex:487
 #, elixir-autogen, elixir-format
 msgid "Cash / Bank Transfer"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:513
+#: lib/klass_hero_web/live/booking_live.ex:512
 #, elixir-autogen, elixir-format
 msgid "Cash/transfer payments will show as \"Pending\" until received"
 msgstr ""
@@ -202,17 +202,17 @@ msgstr ""
 msgid "Community Focused"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:530
+#: lib/klass_hero_web/live/booking_live.ex:529
 #, elixir-autogen, elixir-format
 msgid "Complete Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:479
+#: lib/klass_hero_web/live/booking_live.ex:478
 #, elixir-autogen, elixir-format
 msgid "Credit Card"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:512
+#: lib/klass_hero_web/live/booking_live.ex:511
 #, elixir-autogen, elixir-format
 msgid "Credit card payments are processed immediately"
 msgstr ""
@@ -232,7 +232,7 @@ msgstr ""
 msgid "Enroll Now - %{price}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1484
+#: lib/klass_hero_web/components/provider_components.ex:1485
 #: lib/klass_hero_web/live/booking_live.ex:305
 #, elixir-autogen, elixir-format
 msgid "Enrollment"
@@ -274,7 +274,7 @@ msgstr ""
 msgid "Invalid pagination state. Please refresh the page."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:509
+#: lib/klass_hero_web/live/booking_live.ex:508
 #, elixir-autogen, elixir-format
 msgid "Invoice & Payment Confirmation"
 msgstr ""
@@ -301,17 +301,17 @@ msgstr ""
 msgid "Optional: Include any important information we should know about your child."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:480
+#: lib/klass_hero_web/live/booking_live.ex:479
 #, elixir-autogen, elixir-format
 msgid "Pay securely with Visa, Mastercard, or other cards"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:474
+#: lib/klass_hero_web/live/booking_live.ex:473
 #, elixir-autogen, elixir-format
 msgid "Payment Method"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:498
+#: lib/klass_hero_web/live/booking_live.ex:497
 #, elixir-autogen, elixir-format
 msgid "Payment Summary"
 msgstr ""
@@ -384,7 +384,7 @@ msgstr ""
 msgid "Total Price:"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:504
+#: lib/klass_hero_web/live/booking_live.ex:503
 #, elixir-autogen, elixir-format
 msgid "Total due today:"
 msgstr ""
@@ -577,9 +577,9 @@ msgstr ""
 msgid "Dispute Resolution"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:719
-#: lib/klass_hero_web/components/provider_components.ex:2820
-#: lib/klass_hero_web/components/provider_components.ex:2838
+#: lib/klass_hero_web/components/provider_components.ex:720
+#: lib/klass_hero_web/components/provider_components.ex:2816
+#: lib/klass_hero_web/components/provider_components.ex:2834
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
@@ -878,9 +878,9 @@ msgstr ""
 msgid "Select one or both options"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2516
-#: lib/klass_hero_web/components/provider_components.ex:2517
-#: lib/klass_hero_web/components/provider_components.ex:2554
+#: lib/klass_hero_web/components/provider_components.ex:2512
+#: lib/klass_hero_web/components/provider_components.ex:2513
+#: lib/klass_hero_web/components/provider_components.ex:2550
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:448
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:484
@@ -1324,7 +1324,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/composite_components.ex:103
 #: lib/klass_hero_web/components/layouts/admin.html.heex:85
-#: lib/klass_hero_web/components/provider_components.ex:120
+#: lib/klass_hero_web/components/provider_components.ex:121
 #: lib/klass_hero_web/live/admin/sessions_live.ex:26
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:3
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:348
@@ -1456,7 +1456,7 @@ msgstr ""
 msgid "Music"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:755
+#: lib/klass_hero_web/components/provider_components.ex:756
 #: lib/klass_hero_web/live/for_providers_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "Qualifications"
@@ -1577,19 +1577,19 @@ msgstr ""
 msgid "Quick Navigation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1487
-#: lib/klass_hero_web/components/provider_components.ex:2476
-#: lib/klass_hero_web/components/provider_components.ex:2718
+#: lib/klass_hero_web/components/provider_components.ex:1488
+#: lib/klass_hero_web/components/provider_components.ex:2472
+#: lib/klass_hero_web/components/provider_components.ex:2714
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1633
+#: lib/klass_hero_web/components/provider_components.ex:1634
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:672
+#: lib/klass_hero_web/components/provider_components.ex:673
 #: lib/klass_hero_web/live/provider/team_live.ex:627
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
@@ -1600,7 +1600,7 @@ msgstr ""
 msgid "All Staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1478
+#: lib/klass_hero_web/components/provider_components.ex:1479
 #, elixir-autogen, elixir-format
 msgid "Assigned Staff"
 msgstr ""
@@ -1611,7 +1611,7 @@ msgstr ""
 msgid "Book Now"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:206
+#: lib/klass_hero_web/components/provider_components.ex:207
 #, elixir-autogen, elixir-format
 msgid "Business Profile"
 msgstr ""
@@ -1627,8 +1627,8 @@ msgstr ""
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:539
-#: lib/klass_hero_web/components/provider_components.ex:1596
+#: lib/klass_hero_web/components/provider_components.ex:540
+#: lib/klass_hero_web/components/provider_components.ex:1597
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:54
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:81
 #: lib/klass_hero_web/live/settings/children_live.ex:413
@@ -1638,57 +1638,57 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:224
+#: lib/klass_hero_web/components/provider_components.ex:225
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:31
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "Edit Profile"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1635
+#: lib/klass_hero_web/components/provider_components.ex:1636
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:113
+#: lib/klass_hero_web/components/provider_components.ex:114
 #: lib/klass_hero_web/live/provider/programs_live.ex:54
 #, elixir-autogen, elixir-format
 msgid "My Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:416
-#: lib/klass_hero_web/components/provider_components.ex:952
+#: lib/klass_hero_web/components/provider_components.ex:417
+#: lib/klass_hero_web/components/provider_components.ex:953
 #, elixir-autogen, elixir-format
 msgid "New Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:99
+#: lib/klass_hero_web/components/provider_components.ex:100
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:47
-#: lib/klass_hero_web/components/provider_components.ex:73
-#: lib/klass_hero_web/components/provider_components.ex:1634
-#: lib/klass_hero_web/components/provider_components.ex:2914
-#: lib/klass_hero_web/components/provider_components.ex:2932
+#: lib/klass_hero_web/components/provider_components.ex:48
+#: lib/klass_hero_web/components/provider_components.ex:74
+#: lib/klass_hero_web/components/provider_components.ex:1635
+#: lib/klass_hero_web/components/provider_components.ex:2910
+#: lib/klass_hero_web/components/provider_components.ex:2928
 #: lib/klass_hero_web/live/admin/sessions_live.ex:298
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1565
+#: lib/klass_hero_web/components/provider_components.ex:1566
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1418
+#: lib/klass_hero_web/components/provider_components.ex:1419
 #, elixir-autogen, elixir-format
 msgid "Program Inventory"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1475
+#: lib/klass_hero_web/components/provider_components.ex:1476
 #, elixir-autogen, elixir-format
 msgid "Program Name"
 msgstr ""
@@ -1703,15 +1703,15 @@ msgstr ""
 msgid "Save for Later"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1435
+#: lib/klass_hero_web/components/provider_components.ex:1436
 #, elixir-autogen, elixir-format
 msgid "Search by name..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1481
-#: lib/klass_hero_web/components/provider_components.ex:1884
-#: lib/klass_hero_web/components/provider_components.ex:2467
-#: lib/klass_hero_web/components/provider_components.ex:2715
+#: lib/klass_hero_web/components/provider_components.ex:1482
+#: lib/klass_hero_web/components/provider_components.ex:1885
+#: lib/klass_hero_web/components/provider_components.ex:2463
+#: lib/klass_hero_web/components/provider_components.ex:2711
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1719,7 +1719,7 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:106
+#: lib/klass_hero_web/components/provider_components.ex:107
 #: lib/klass_hero_web/live/provider/team_live.ex:36
 #, elixir-autogen, elixir-format
 msgid "Team & Profiles"
@@ -1730,32 +1730,32 @@ msgstr ""
 msgid "Team & Provider Profiles"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:209
+#: lib/klass_hero_web/components/provider_components.ex:210
 #, elixir-autogen, elixir-format
 msgid "This is your main business identity. Verification is required to list programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1538
-#: lib/klass_hero_web/components/provider_components.ex:1899
+#: lib/klass_hero_web/components/provider_components.ex:1539
+#: lib/klass_hero_web/components/provider_components.ex:1900
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr ""
 
 #: lib/klass_hero_web/components/messaging_components.ex:722
-#: lib/klass_hero_web/components/provider_components.ex:50
-#: lib/klass_hero_web/components/provider_components.ex:1636
+#: lib/klass_hero_web/components/provider_components.ex:51
+#: lib/klass_hero_web/components/provider_components.ex:1637
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:434
 #: lib/klass_hero_web/presenters/provider_presenter.ex:103
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:401
+#: lib/klass_hero_web/components/provider_components.ex:402
 #, elixir-autogen, elixir-format
 msgid "Verified Business"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1576
+#: lib/klass_hero_web/components/provider_components.ex:1577
 #, elixir-autogen, elixir-format
 msgid "View Roster"
 msgstr ""
@@ -1815,10 +1815,10 @@ msgstr ""
 #: lib/klass_hero_web/components/participation_components.ex:441
 #: lib/klass_hero_web/components/participation_components.ex:631
 #: lib/klass_hero_web/components/participation_components.ex:717
-#: lib/klass_hero_web/components/provider_components.ex:889
-#: lib/klass_hero_web/components/provider_components.ex:1334
-#: lib/klass_hero_web/components/provider_components.ex:2056
-#: lib/klass_hero_web/components/provider_components.ex:2657
+#: lib/klass_hero_web/components/provider_components.ex:890
+#: lib/klass_hero_web/components/provider_components.ex:1335
+#: lib/klass_hero_web/components/provider_components.ex:2052
+#: lib/klass_hero_web/components/provider_components.ex:2653
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:478
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
@@ -1874,7 +1874,7 @@ msgstr ""
 msgid "Data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2801
+#: lib/klass_hero_web/components/provider_components.ex:2797
 #: lib/klass_hero_web/live/settings/children_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1922,17 +1922,17 @@ msgstr ""
 msgid "Failed to submit note"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2795
-#: lib/klass_hero_web/components/provider_components.ex:2824
-#: lib/klass_hero_web/components/provider_components.ex:2840
+#: lib/klass_hero_web/components/provider_components.ex:2791
+#: lib/klass_hero_web/components/provider_components.ex:2820
+#: lib/klass_hero_web/components/provider_components.ex:2836
 #: lib/klass_hero_web/live/settings/children_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2796
-#: lib/klass_hero_web/components/provider_components.ex:2825
-#: lib/klass_hero_web/components/provider_components.ex:2841
+#: lib/klass_hero_web/components/provider_components.ex:2792
+#: lib/klass_hero_web/components/provider_components.ex:2821
+#: lib/klass_hero_web/components/provider_components.ex:2837
 #: lib/klass_hero_web/live/settings/children_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -2063,15 +2063,15 @@ msgstr ""
 msgid "Provider data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:874
+#: lib/klass_hero_web/components/provider_components.ex:875
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:294
 #: lib/klass_hero_web/live/settings/children_live.ex:719
 #, elixir-autogen, elixir-format
 msgid "Save Changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1743
 #: lib/klass_hero_web/components/provider_components.ex:1744
+#: lib/klass_hero_web/components/provider_components.ex:1745
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:43
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:151
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:252
@@ -2089,7 +2089,7 @@ msgstr ""
 msgid "Send a message to start the conversation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2895
+#: lib/klass_hero_web/components/provider_components.ex:2891
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:249
 #, elixir-autogen, elixir-format
@@ -2195,12 +2195,12 @@ msgstr[1] ""
 msgid "%{gender} only"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:309
+#: lib/klass_hero_web/components/provider_components.ex:310
 #, elixir-autogen, elixir-format
 msgid "Action Required"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:876
+#: lib/klass_hero_web/components/provider_components.ex:877
 #, elixir-autogen, elixir-format
 msgid "Add Member"
 msgstr ""
@@ -2220,12 +2220,12 @@ msgstr ""
 msgid "Ages %{min}+"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1195
+#: lib/klass_hero_web/components/provider_components.ex:1196
 #, elixir-autogen, elixir-format
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2954
+#: lib/klass_hero_web/components/provider_components.ex:2950
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred during import."
 msgstr ""
@@ -2238,7 +2238,7 @@ msgid "Approve"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:826
-#: lib/klass_hero_web/components/provider_components.ex:48
+#: lib/klass_hero_web/components/provider_components.ex:49
 #: lib/klass_hero_web/live/admin/sessions_live.ex:295
 #: lib/klass_hero_web/live/admin/verifications_live.ex:202
 #: lib/klass_hero_web/presenters/vetting_checklist_presenter.ex:141
@@ -2268,7 +2268,7 @@ msgstr ""
 msgid "Back to verifications"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:728
+#: lib/klass_hero_web/components/provider_components.ex:729
 #, elixir-autogen, elixir-format
 msgid "Bio"
 msgstr ""
@@ -2278,7 +2278,7 @@ msgstr ""
 msgid "Book a Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:729
+#: lib/klass_hero_web/components/provider_components.ex:730
 #, elixir-autogen, elixir-format
 msgid "Brief description of experience and specialties..."
 msgstr ""
@@ -2309,19 +2309,19 @@ msgstr ""
 msgid "Business Logo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:982
+#: lib/klass_hero_web/components/provider_components.ex:983
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "Category"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1144
+#: lib/klass_hero_web/components/provider_components.ex:1145
 #, elixir-autogen, elixir-format
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2464
-#: lib/klass_hero_web/components/provider_components.ex:2709
+#: lib/klass_hero_web/components/provider_components.ex:2460
+#: lib/klass_hero_web/components/provider_components.ex:2705
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2336,7 +2336,7 @@ msgstr ""
 msgid "Child meets all program requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1305
+#: lib/klass_hero_web/components/provider_components.ex:1306
 #, elixir-autogen, elixir-format
 msgid "Choose Image"
 msgstr ""
@@ -2346,17 +2346,17 @@ msgstr ""
 msgid "Choose Logo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:853
+#: lib/klass_hero_web/components/provider_components.ex:854
 #, elixir-autogen, elixir-format
 msgid "Choose Photo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:984
+#: lib/klass_hero_web/components/provider_components.ex:985
 #, elixir-autogen, elixir-format
 msgid "Choose a category"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:428
+#: lib/klass_hero_web/components/provider_components.ex:429
 #, elixir-autogen, elixir-format
 msgid "Complete business verification to create programs."
 msgstr ""
@@ -2366,7 +2366,7 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2915
+#: lib/klass_hero_web/components/provider_components.ex:2911
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
@@ -2386,22 +2386,22 @@ msgstr ""
 msgid "Could not remove invite."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1261
+#: lib/klass_hero_web/components/provider_components.ex:1262
 #, elixir-autogen, elixir-format
 msgid "Cover Image"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1138
+#: lib/klass_hero_web/components/provider_components.ex:1139
 #, elixir-autogen, elixir-format
 msgid "Define age, gender, or grade restrictions for eligible participants."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1254
+#: lib/klass_hero_web/components/provider_components.ex:1255
 #, elixir-autogen, elixir-format
 msgid "Describe your program..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1253
+#: lib/klass_hero_web/components/provider_components.ex:1254
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:323
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:285
 #, elixir-autogen, elixir-format
@@ -2409,13 +2409,13 @@ msgid "Description"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:684
-#: lib/klass_hero_web/components/provider_components.ex:1206
+#: lib/klass_hero_web/components/provider_components.ex:1207
 #: lib/klass_hero_web/live/settings/children_live.ex:635
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3130
+#: lib/klass_hero_web/components/provider_components.ex:3126
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2449,7 +2449,7 @@ msgstr ""
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2676
+#: lib/klass_hero_web/components/provider_components.ex:2672
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
@@ -2459,40 +2459,40 @@ msgstr ""
 msgid "Download document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:950
+#: lib/klass_hero_web/components/provider_components.ex:951
 #, elixir-autogen, elixir-format
 msgid "Edit Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:670
+#: lib/klass_hero_web/components/provider_components.ex:671
 #, elixir-autogen, elixir-format
 msgid "Edit Team Member"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1059
+#: lib/klass_hero_web/components/provider_components.ex:1060
 #, elixir-autogen, elixir-format
 msgid "End Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1046
+#: lib/klass_hero_web/components/provider_components.ex:1047
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2473
-#: lib/klass_hero_web/components/provider_components.ex:2935
+#: lib/klass_hero_web/components/provider_components.ex:2469
+#: lib/klass_hero_web/components/provider_components.ex:2931
 #: lib/klass_hero_web/components/provider_layout_components.ex:644
 #, elixir-autogen, elixir-format
 msgid "Enrolled"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1789
+#: lib/klass_hero_web/components/provider_components.ex:1790
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1087
+#: lib/klass_hero_web/components/provider_components.ex:1088
 #, elixir-autogen, elixir-format
 msgid "Enrollment Capacity (optional)"
 msgstr ""
@@ -2502,8 +2502,8 @@ msgstr ""
 msgid "Explain why this document is being rejected..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:71
-#: lib/klass_hero_web/components/provider_components.ex:2936
+#: lib/klass_hero_web/components/provider_components.ex:72
+#: lib/klass_hero_web/components/provider_components.ex:2932
 #: lib/klass_hero_web/live/admin/emails_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2536,7 +2536,7 @@ msgid "Family Programs"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:682
-#: lib/klass_hero_web/components/provider_components.ex:1205
+#: lib/klass_hero_web/components/provider_components.ex:1206
 #: lib/klass_hero_web/live/settings/children_live.ex:634
 #, elixir-autogen, elixir-format
 msgid "Female"
@@ -2547,22 +2547,22 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3064
+#: lib/klass_hero_web/components/provider_components.ex:3060
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3066
+#: lib/klass_hero_web/components/provider_components.ex:3062
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:756
+#: lib/klass_hero_web/components/provider_components.ex:757
 #, elixir-autogen, elixir-format
 msgid "First Aid, UEFA B License, Child Care Cert"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:698
+#: lib/klass_hero_web/components/provider_components.ex:699
 #, elixir-autogen, elixir-format
 msgid "First Name"
 msgstr ""
@@ -2587,12 +2587,12 @@ msgstr ""
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2712
+#: lib/klass_hero_web/components/provider_components.ex:2708
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:817
+#: lib/klass_hero_web/components/provider_components.ex:818
 #, elixir-autogen, elixir-format
 msgid "Headshot Photo"
 msgstr ""
@@ -2602,7 +2602,7 @@ msgstr ""
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2649
+#: lib/klass_hero_web/components/provider_components.ex:2645
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -2627,17 +2627,17 @@ msgstr ""
 msgid "Invite resent successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1806
+#: lib/klass_hero_web/components/provider_components.ex:1807
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:856
+#: lib/klass_hero_web/components/provider_components.ex:857
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 1MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1308
+#: lib/klass_hero_web/components/provider_components.ex:1309
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:277
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:361
 #, elixir-autogen, elixir-format
@@ -2654,22 +2654,22 @@ msgstr ""
 msgid "Klasse %{n}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:704
+#: lib/klass_hero_web/components/provider_components.ex:705
 #, elixir-autogen, elixir-format
 msgid "Last Name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1069
+#: lib/klass_hero_web/components/provider_components.ex:1070
 #, elixir-autogen, elixir-format
 msgid "Leave blank for open registration at any time."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1198
+#: lib/klass_hero_web/components/provider_components.ex:1199
 #, elixir-autogen, elixir-format
 msgid "Leave unchecked to allow all genders."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1002
+#: lib/klass_hero_web/components/provider_components.ex:1003
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:191
 #, elixir-autogen, elixir-format
 msgid "Location"
@@ -2682,43 +2682,43 @@ msgid "Logo upload failed. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:683
-#: lib/klass_hero_web/components/provider_components.ex:1204
+#: lib/klass_hero_web/components/provider_components.ex:1205
 #: lib/klass_hero_web/live/settings/children_live.ex:633
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1188
+#: lib/klass_hero_web/components/provider_components.ex:1189
 #, elixir-autogen, elixir-format
 msgid "Maximum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1102
+#: lib/klass_hero_web/components/provider_components.ex:1103
 #, elixir-autogen, elixir-format
 msgid "Maximum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1243
+#: lib/klass_hero_web/components/provider_components.ex:1244
 #, elixir-autogen, elixir-format
 msgid "Maximum Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1011
+#: lib/klass_hero_web/components/provider_components.ex:1012
 #, elixir-autogen, elixir-format
 msgid "Meeting Days"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1182
+#: lib/klass_hero_web/components/provider_components.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Minimum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1096
+#: lib/klass_hero_web/components/provider_components.ex:1097
 #, elixir-autogen, elixir-format
 msgid "Minimum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1236
+#: lib/klass_hero_web/components/provider_components.ex:1237
 #, elixir-autogen, elixir-format
 msgid "Minimum Grade"
 msgstr ""
@@ -2728,12 +2728,12 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3092
+#: lib/klass_hero_web/components/provider_components.ex:3088
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2457
+#: lib/klass_hero_web/components/provider_components.ex:2453
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
@@ -2749,17 +2749,17 @@ msgstr ""
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2700
+#: lib/klass_hero_web/components/provider_components.ex:2696
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1245
+#: lib/klass_hero_web/components/provider_components.ex:1246
 #, elixir-autogen, elixir-format
 msgid "No maximum"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1238
+#: lib/klass_hero_web/components/provider_components.ex:1239
 #, elixir-autogen, elixir-format
 msgid "No minimum"
 msgstr ""
@@ -2790,18 +2790,18 @@ msgstr ""
 msgid "No verification documents found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1320
+#: lib/klass_hero_web/components/provider_components.ex:1321
 #, elixir-autogen, elixir-format
 msgid "None (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:325
+#: lib/klass_hero_web/components/provider_components.ex:326
 #, elixir-autogen, elixir-format
 msgid "Not Verified"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:685
-#: lib/klass_hero_web/components/provider_components.ex:1207
+#: lib/klass_hero_web/components/provider_components.ex:1208
 #: lib/klass_hero_web/live/settings/children_live.ex:632
 #, elixir-autogen, elixir-format
 msgid "Not specified"
@@ -2812,7 +2812,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3167
+#: lib/klass_hero_web/components/provider_components.ex:3163
 #: lib/klass_hero_web/live/provider/verification_live.ex:698
 #: lib/klass_hero_web/live/provider/verification_live.ex:770
 #, elixir-autogen, elixir-format
@@ -2824,13 +2824,13 @@ msgstr ""
 msgid "Participant Requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1135
+#: lib/klass_hero_web/components/provider_components.ex:1136
 #, elixir-autogen, elixir-format
 msgid "Participant Restrictions (optional)"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:825
-#: lib/klass_hero_web/components/provider_components.ex:293
+#: lib/klass_hero_web/components/provider_components.ex:294
 #, elixir-autogen, elixir-format
 msgid "Pending Review"
 msgstr ""
@@ -2858,7 +2858,7 @@ msgstr ""
 msgid "Preview not available for this file type."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:993
+#: lib/klass_hero_web/components/provider_components.ex:994
 #, elixir-autogen, elixir-format
 msgid "Price (EUR)"
 msgstr ""
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Profile updated successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1173
+#: lib/klass_hero_web/components/provider_components.ex:1174
 #, elixir-autogen, elixir-format
 msgid "Program Start"
 msgstr ""
@@ -2912,13 +2912,13 @@ msgid "Read our founding story →"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:805
-#: lib/klass_hero_web/components/provider_components.ex:2934
+#: lib/klass_hero_web/components/provider_components.ex:2930
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Registered"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1160
+#: lib/klass_hero_web/components/provider_components.ex:1161
 #, elixir-autogen, elixir-format
 msgid "Registration"
 msgstr ""
@@ -2928,7 +2928,7 @@ msgstr ""
 msgid "Registration Closed"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1080
+#: lib/klass_hero_web/components/provider_components.ex:1081
 #, elixir-autogen, elixir-format
 msgid "Registration Closes"
 msgstr ""
@@ -2938,12 +2938,12 @@ msgstr ""
 msgid "Registration Not Open Yet"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1075
+#: lib/klass_hero_web/components/provider_components.ex:1076
 #, elixir-autogen, elixir-format
 msgid "Registration Opens"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1066
+#: lib/klass_hero_web/components/provider_components.ex:1067
 #, elixir-autogen, elixir-format
 msgid "Registration Period (optional)"
 msgstr ""
@@ -2980,7 +2980,7 @@ msgid "Reject"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:827
-#: lib/klass_hero_web/components/provider_components.ex:49
+#: lib/klass_hero_web/components/provider_components.ex:50
 #: lib/klass_hero_web/live/admin/verifications_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Rejected"
@@ -2992,18 +2992,18 @@ msgstr ""
 msgid "Rejection reason"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:839
-#: lib/klass_hero_web/components/provider_components.ex:1284
-#: lib/klass_hero_web/components/provider_components.ex:2756
-#: lib/klass_hero_web/components/provider_components.ex:3186
-#: lib/klass_hero_web/components/provider_components.ex:3265
+#: lib/klass_hero_web/components/provider_components.ex:840
+#: lib/klass_hero_web/components/provider_components.ex:1285
+#: lib/klass_hero_web/components/provider_components.ex:2752
+#: lib/klass_hero_web/components/provider_components.ex:3182
+#: lib/klass_hero_web/components/provider_components.ex:3261
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:253
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2749
+#: lib/klass_hero_web/components/provider_components.ex:2745
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -3013,23 +3013,23 @@ msgstr ""
 msgid "Reviewed"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:713
+#: lib/klass_hero_web/components/provider_components.ex:714
 #, elixir-autogen, elixir-format
 msgid "Role"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1735
+#: lib/klass_hero_web/components/provider_components.ex:1736
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:386
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1347
+#: lib/klass_hero_web/components/provider_components.ex:1348
 #, elixir-autogen, elixir-format
 msgid "Save Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1008
+#: lib/klass_hero_web/components/provider_components.ex:1009
 #, elixir-autogen, elixir-format
 msgid "Schedule (optional)"
 msgstr ""
@@ -3044,7 +3044,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3164
+#: lib/klass_hero_web/components/provider_components.ex:3160
 #, elixir-autogen, elixir-format
 msgid "Select File"
 msgstr ""
@@ -3061,23 +3061,23 @@ msgstr ""
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2933
+#: lib/klass_hero_web/components/provider_components.ex:2929
 #: lib/klass_hero_web/live/admin/emails_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Sent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:760
+#: lib/klass_hero_web/components/provider_components.ex:761
 #, elixir-autogen, elixir-format
 msgid "Separate multiple qualifications with commas"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1090
+#: lib/klass_hero_web/components/provider_components.ex:1091
 #, elixir-autogen, elixir-format
 msgid "Set minimum and maximum enrollment for this program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:734
+#: lib/klass_hero_web/components/provider_components.ex:735
 #, elixir-autogen, elixir-format
 msgid "Specialties"
 msgstr ""
@@ -3095,12 +3095,12 @@ msgstr ""
 msgid "Staff member not found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1054
+#: lib/klass_hero_web/components/provider_components.ex:1055
 #, elixir-autogen, elixir-format
 msgid "Start Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1041
+#: lib/klass_hero_web/components/provider_components.ex:1042
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:184
 #, elixir-autogen, elixir-format
 msgid "Start Time"
@@ -3166,13 +3166,13 @@ msgstr ""
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:975
-#: lib/klass_hero_web/components/provider_components.ex:2022
+#: lib/klass_hero_web/components/provider_components.ex:976
+#: lib/klass_hero_web/components/provider_components.ex:2018
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3065
+#: lib/klass_hero_web/components/provider_components.ex:3061
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -3192,32 +3192,32 @@ msgstr ""
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2635
+#: lib/klass_hero_web/components/provider_components.ex:2631
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3210
+#: lib/klass_hero_web/components/provider_components.ex:3206
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3119
+#: lib/klass_hero_web/components/provider_components.ex:3115
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3087
+#: lib/klass_hero_web/components/provider_components.ex:3083
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3067
+#: lib/klass_hero_web/components/provider_components.ex:3063
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3084
+#: lib/klass_hero_web/components/provider_components.ex:3080
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -3239,7 +3239,7 @@ msgstr ""
 msgid "Verifications"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:277
+#: lib/klass_hero_web/components/provider_components.ex:278
 #: lib/klass_hero_web/components/provider_layout_components.ex:212
 #: lib/klass_hero_web/components/ui_components.ex:1930
 #, elixir-autogen, elixir-format
@@ -3256,32 +3256,32 @@ msgstr ""
 msgid "You don't have access to that page."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:714
+#: lib/klass_hero_web/components/provider_components.ex:715
 #, elixir-autogen, elixir-format
 msgid "e.g. Head Coach"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:705
+#: lib/klass_hero_web/components/provider_components.ex:706
 #, elixir-autogen, elixir-format
 msgid "e.g. Johnson"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:699
+#: lib/klass_hero_web/components/provider_components.ex:700
 #, elixir-autogen, elixir-format
 msgid "e.g. Mike"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:720
+#: lib/klass_hero_web/components/provider_components.ex:721
 #, elixir-autogen, elixir-format
 msgid "e.g. mike@example.com"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:976
+#: lib/klass_hero_web/components/provider_components.ex:977
 #, elixir-autogen, elixir-format
 msgid "e.g., Art Adventures"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1003
+#: lib/klass_hero_web/components/provider_components.ex:1004
 #, elixir-autogen, elixir-format
 msgid "e.g., Community Center, Main St"
 msgstr ""
@@ -3307,7 +3307,7 @@ msgid "Child Safeguarding Training"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1498
-#: lib/klass_hero_web/components/provider_components.ex:3432
+#: lib/klass_hero_web/components/provider_components.ex:3428
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr ""
@@ -3367,12 +3367,12 @@ msgstr ""
 msgid "Monitoring provider activity and feedback"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:489
+#: lib/klass_hero_web/live/booking_live.ex:488
 #, elixir-autogen, elixir-format
 msgid "Pay by cash or direct bank transfer"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:500
+#: lib/klass_hero_web/live/booking_live.ex:499
 #, elixir-autogen, elixir-format
 msgid "Program fee:"
 msgstr ""
@@ -3404,7 +3404,7 @@ msgstr ""
 
 #: lib/klass_hero_web/controllers/invite_claim_controller.ex:57
 #: lib/klass_hero_web/live/booking_live.ex:212
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:73
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:75
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Please try again or contact support."
 msgstr ""
@@ -3458,7 +3458,7 @@ msgid "Vetted with Care"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1482
-#: lib/klass_hero_web/components/provider_components.ex:3217
+#: lib/klass_hero_web/components/provider_components.ex:3213
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr ""
@@ -3632,7 +3632,7 @@ msgstr ""
 msgid "Checked Out"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2792
+#: lib/klass_hero_web/components/provider_components.ex:2788
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Child"
@@ -3685,7 +3685,7 @@ msgstr ""
 msgid "Download monthly statements for taxes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2553
+#: lib/klass_hero_web/components/provider_components.ex:2549
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "Enrollment not confirmed"
@@ -3758,7 +3758,7 @@ msgstr ""
 msgid "No chasing payments or sending invoices"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1758
+#: lib/klass_hero_web/components/provider_components.ex:1759
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:407
 #, elixir-autogen, elixir-format
 msgid "No enrolled parents"
@@ -3781,7 +3781,7 @@ msgstr ""
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2552
+#: lib/klass_hero_web/components/provider_components.ex:2548
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -4466,7 +4466,7 @@ msgstr ""
 msgid "Reply sent successfully"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:553
+#: lib/klass_hero_web/components/provider_components.ex:554
 #, elixir-autogen, elixir-format
 msgid "Resend"
 msgstr ""
@@ -4894,40 +4894,40 @@ msgstr ""
 msgid "for"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1882
+#: lib/klass_hero_web/components/provider_components.ex:1883
 #, elixir-autogen, elixir-format
 msgid "Assigned staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1883
+#: lib/klass_hero_web/components/provider_components.ex:1884
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1866
-#: lib/klass_hero_web/components/provider_components.ex:1951
-#: lib/klass_hero_web/components/provider_components.ex:2098
-#: lib/klass_hero_web/components/provider_components.ex:2252
+#: lib/klass_hero_web/components/provider_components.ex:1867
+#: lib/klass_hero_web/components/provider_components.ex:1952
+#: lib/klass_hero_web/components/provider_components.ex:2094
+#: lib/klass_hero_web/components/provider_components.ex:2248
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1881
+#: lib/klass_hero_web/components/provider_components.ex:1882
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1875
+#: lib/klass_hero_web/components/provider_components.ex:1876
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1864
+#: lib/klass_hero_web/components/provider_components.ex:1865
 #, elixir-autogen, elixir-format
 msgid "Sessions — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1569
+#: lib/klass_hero_web/components/provider_components.ex:1570
 #, elixir-autogen, elixir-format
 msgid "View sessions"
 msgstr ""
@@ -4959,17 +4959,17 @@ msgstr ""
 msgid "Failed to update record"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2856
+#: lib/klass_hero_web/components/provider_components.ex:2852
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2575
+#: lib/klass_hero_web/components/provider_components.ex:2571
 #, elixir-autogen, elixir-format
 msgid "Invite mode"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2594
+#: lib/klass_hero_web/components/provider_components.ex:2590
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr ""
@@ -4984,12 +4984,12 @@ msgstr ""
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2869
+#: lib/klass_hero_web/components/provider_components.ex:2865
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2875
+#: lib/klass_hero_web/components/provider_components.ex:2871
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr ""
@@ -5000,17 +5000,17 @@ msgstr ""
 msgid "Nothing to update"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2877
+#: lib/klass_hero_web/components/provider_components.ex:2873
 #, elixir-autogen, elixir-format
 msgid "Nut allergy"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2881
+#: lib/klass_hero_web/components/provider_components.ex:2877
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2886
+#: lib/klass_hero_web/components/provider_components.ex:2882
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr ""
@@ -5020,7 +5020,7 @@ msgstr ""
 msgid "Present"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2813
+#: lib/klass_hero_web/components/provider_components.ex:2809
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr ""
@@ -5047,22 +5047,22 @@ msgstr ""
 msgid "Save changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2850
+#: lib/klass_hero_web/components/provider_components.ex:2846
 #, elixir-autogen, elixir-format
 msgid "School (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2860
+#: lib/klass_hero_web/components/provider_components.ex:2856
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2834
+#: lib/klass_hero_web/components/provider_components.ex:2830
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2903
+#: lib/klass_hero_web/components/provider_components.ex:2899
 #, elixir-autogen, elixir-format
 msgid "Send invite"
 msgstr ""
@@ -5072,7 +5072,7 @@ msgstr ""
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2612
+#: lib/klass_hero_web/components/provider_components.ex:2608
 #, elixir-autogen, elixir-format
 msgid "Upload a list"
 msgstr ""
@@ -5107,7 +5107,7 @@ msgstr ""
 msgid "High"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:787
+#: lib/klass_hero_web/components/provider_components.ex:788
 #, elixir-autogen, elixir-format
 msgid "Hourly"
 msgstr ""
@@ -5132,22 +5132,22 @@ msgstr ""
 msgid "Medium"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:777
+#: lib/klass_hero_web/components/provider_components.ex:778
 #, elixir-autogen, elixir-format
 msgid "None"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:766
+#: lib/klass_hero_web/components/provider_components.ex:767
 #, elixir-autogen, elixir-format
 msgid "Pay Rate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:524
+#: lib/klass_hero_web/components/provider_components.ex:525
 #, elixir-autogen, elixir-format
 msgid "Pay rate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:797
+#: lib/klass_hero_web/components/provider_components.ex:798
 #, elixir-autogen, elixir-format
 msgid "Per Session"
 msgstr ""
@@ -5172,7 +5172,7 @@ msgstr ""
 msgid "Property Damage"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1606
+#: lib/klass_hero_web/components/provider_components.ex:1607
 #, elixir-autogen, elixir-format
 msgid "Report Incident"
 msgstr ""
@@ -5854,7 +5854,7 @@ msgstr[1] ""
 msgid "In 2025, Shane connected with his friend"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1615
+#: lib/klass_hero_web/components/provider_components.ex:1616
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:43
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:74
 #, elixir-autogen, elixir-format
@@ -5924,7 +5924,7 @@ msgstr ""
 msgid "Last 8 weeks"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1318
+#: lib/klass_hero_web/components/provider_components.ex:1319
 #: lib/klass_hero_web/presenters/hero_cards_presenter.ex:27
 #, elixir-autogen, elixir-format
 msgid "Lead Instructor"
@@ -6374,17 +6374,17 @@ msgstr ""
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2942
+#: lib/klass_hero_web/components/provider_components.ex:2938
 #, elixir-autogen, elixir-format
 msgid "Row %{row}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2942
+#: lib/klass_hero_web/components/provider_components.ex:2938
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2688
+#: lib/klass_hero_web/components/provider_components.ex:2684
 #, elixir-autogen, elixir-format
 msgid "Rows with errors"
 msgstr ""
@@ -6996,7 +6996,7 @@ msgstr ""
 msgid "Identity verifications"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:72
+#: lib/klass_hero_web/components/provider_components.ex:73
 #, elixir-autogen, elixir-format
 msgid "In progress"
 msgstr ""
@@ -7026,7 +7026,7 @@ msgstr ""
 msgid "Not started"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:70
+#: lib/klass_hero_web/components/provider_components.ex:71
 #, elixir-autogen, elixir-format
 msgid "Passed"
 msgstr ""
@@ -7143,12 +7143,12 @@ msgstr ""
 msgid "Experience validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3246
+#: lib/klass_hero_web/components/provider_components.ex:3242
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3220
+#: lib/klass_hero_web/components/provider_components.ex:3216
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
@@ -7158,12 +7158,12 @@ msgstr ""
 msgid "Safeguarding certificate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3243
+#: lib/klass_hero_web/components/provider_components.ex:3239
 #, elixir-autogen, elixir-format
 msgid "Select Video"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3289
+#: lib/klass_hero_web/components/provider_components.ex:3285
 #, elixir-autogen, elixir-format
 msgid "Upload Video"
 msgstr ""
@@ -7173,7 +7173,7 @@ msgstr ""
 msgid "Your browser does not support video playback."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3436
+#: lib/klass_hero_web/components/provider_components.ex:3432
 #, elixir-autogen, elixir-format
 msgid "Confirm agreement"
 msgstr ""
@@ -7183,12 +7183,12 @@ msgstr ""
 msgid "Couldn't record your agreement. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3459
+#: lib/klass_hero_web/components/provider_components.ex:3455
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3435
+#: lib/klass_hero_web/components/provider_components.ex:3431
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr ""
@@ -7198,7 +7198,7 @@ msgstr ""
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3344
+#: lib/klass_hero_web/components/provider_components.ex:3340
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr ""
@@ -7208,17 +7208,17 @@ msgstr ""
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3444
+#: lib/klass_hero_web/components/provider_components.ex:3440
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3433
+#: lib/klass_hero_web/components/provider_components.ex:3429
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3434
+#: lib/klass_hero_web/components/provider_components.ex:3430
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
@@ -7487,12 +7487,12 @@ msgstr ""
 msgid "Your insurance is verified."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3388
+#: lib/klass_hero_web/components/provider_components.ex:3384
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3491
+#: lib/klass_hero_web/components/provider_components.ex:3487
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr ""
@@ -7502,7 +7502,7 @@ msgstr ""
 msgid "Couldn't record your declaration. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3497
+#: lib/klass_hero_web/components/provider_components.ex:3493
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr ""
@@ -7512,17 +7512,17 @@ msgstr ""
 msgid "Please confirm the declaration before signing."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3522
+#: lib/klass_hero_web/components/provider_components.ex:3518
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3501
+#: lib/klass_hero_web/components/provider_components.ex:3497
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3489
+#: lib/klass_hero_web/components/provider_components.ex:3485
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr ""
@@ -7532,12 +7532,12 @@ msgstr ""
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3509
+#: lib/klass_hero_web/components/provider_components.ex:3505
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3495
+#: lib/klass_hero_web/components/provider_components.ex:3491
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
@@ -7604,14 +7604,14 @@ msgstr ""
 msgid "Undelivered Events"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2197
-#: lib/klass_hero_web/components/provider_components.ex:2380
+#: lib/klass_hero_web/components/provider_components.ex:2193
+#: lib/klass_hero_web/components/provider_components.ex:2376
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2120
-#: lib/klass_hero_web/components/provider_components.ex:2306
+#: lib/klass_hero_web/components/provider_components.ex:2116
+#: lib/klass_hero_web/components/provider_components.ex:2302
 #, elixir-autogen, elixir-format
 msgid "Lead"
 msgstr ""
@@ -7621,17 +7621,17 @@ msgstr ""
 msgid "Lead instructor updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2132
+#: lib/klass_hero_web/components/provider_components.ex:2128
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1583
+#: lib/klass_hero_web/components/provider_components.ex:1584
 #, elixir-autogen, elixir-format
 msgid "Manage Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2161
+#: lib/klass_hero_web/components/provider_components.ex:2157
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this program yet."
 msgstr ""
@@ -7642,19 +7642,19 @@ msgstr ""
 msgid "Pick a staff member to add."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2144
-#: lib/klass_hero_web/components/provider_components.ex:2419
+#: lib/klass_hero_web/components/provider_components.ex:2140
+#: lib/klass_hero_web/components/provider_components.ex:2415
 #, elixir-autogen, elixir-format
 msgid "Reassign the lead before removing them"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2145
+#: lib/klass_hero_web/components/provider_components.ex:2141
 #, elixir-autogen, elixir-format
 msgid "Remove from program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2179
-#: lib/klass_hero_web/components/provider_components.ex:2361
+#: lib/klass_hero_web/components/provider_components.ex:2175
+#: lib/klass_hero_web/components/provider_components.ex:2357
 #, elixir-autogen, elixir-format
 msgid "Select a staff member…"
 msgstr ""
@@ -7669,12 +7669,12 @@ msgstr ""
 msgid "Staff member removed from the program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2202
+#: lib/klass_hero_web/components/provider_components.ex:2198
 #, elixir-autogen, elixir-format
 msgid "Staff you add can read and reply to this program's parent conversations."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2096
+#: lib/klass_hero_web/components/provider_components.ex:2092
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{title}"
 msgstr ""
@@ -7694,19 +7694,19 @@ msgstr ""
 msgid "This person is the lead instructor. Make someone else lead before removing them."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1527
+#: lib/klass_hero_web/components/provider_components.ex:1528
 #, elixir-autogen, elixir-format
 msgid "%{count} staff member · no lead"
 msgid_plural "%{count} staff · no lead"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/components/provider_components.ex:563
+#: lib/klass_hero_web/components/provider_components.ex:564
 #, elixir-autogen, elixir-format
 msgid "%{name} will be unassigned from every program and removed from those conversations. Their history is kept and you can add them back later."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:639
+#: lib/klass_hero_web/components/provider_components.ex:640
 #, elixir-autogen, elixir-format
 msgid "Add back to team"
 msgstr ""
@@ -7716,7 +7716,7 @@ msgstr ""
 msgid "Could not bring this team member back. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:601
+#: lib/klass_hero_web/components/provider_components.ex:602
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr ""
@@ -7726,7 +7726,7 @@ msgstr ""
 msgid "Former team members"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:575
+#: lib/klass_hero_web/components/provider_components.ex:576
 #, elixir-autogen, elixir-format
 msgid "Remove from team"
 msgstr ""
@@ -7741,7 +7741,7 @@ msgstr ""
 msgid "Team member removed from the team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:591
+#: lib/klass_hero_web/components/provider_components.ex:592
 #, elixir-autogen, elixir-format
 msgid "This deletes %{name} permanently — there's nothing to undo. Use it only for an entry added by mistake."
 msgstr ""
@@ -7766,24 +7766,24 @@ msgstr ""
 msgid "Program updated, but the enrollment capacity was rejected. The previous limits still apply."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:918
+#: lib/klass_hero_web/components/provider_components.ex:919
 #, elixir-autogen, elixir-format
 msgid "%{count} child is already enrolled. Confirm you want this program to have no capacity limit."
 msgid_plural "%{count} children are already enrolled. Confirm you want this program to have no capacity limit."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1120
+#: lib/klass_hero_web/components/provider_components.ex:1121
 #, elixir-autogen, elixir-format
 msgid "Anyone will be able to book a place until you set a new maximum."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1125
+#: lib/klass_hero_web/components/provider_components.ex:1126
 #, elixir-autogen, elixir-format
 msgid "I understand this program will have no capacity limit."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2407
+#: lib/klass_hero_web/components/provider_components.ex:2403
 #, elixir-autogen, elixir-format
 msgid "Go back to the program's usual team"
 msgstr ""
@@ -7793,17 +7793,17 @@ msgstr ""
 msgid "Lead instructor for this session updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2321
+#: lib/klass_hero_web/components/provider_components.ex:2317
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor for this session"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2343
+#: lib/klass_hero_web/components/provider_components.ex:2339
 #, elixir-autogen, elixir-format
 msgid "Nobody is working this session yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2424
+#: lib/klass_hero_web/components/provider_components.ex:2420
 #, elixir-autogen, elixir-format
 msgid "Remove from this session"
 msgstr ""
@@ -7823,7 +7823,7 @@ msgstr ""
 msgid "Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2245
+#: lib/klass_hero_web/components/provider_components.ex:2241
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{date}"
 msgstr ""
@@ -7853,38 +7853,37 @@ msgstr ""
 msgid "A session needs at least one person. Use “Go back to the program's usual team” to drop this session's own roster."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2422
+#: lib/klass_hero_web/components/provider_components.ex:2418
 #, elixir-autogen, elixir-format
 msgid "A session needs someone — use “Go back to the program's usual team” instead"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2389
+#: lib/klass_hero_web/components/provider_components.ex:2385
 #, elixir-autogen, elixir-format
 msgid "Everyone on your team is already working this session."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2277
+#: lib/klass_hero_web/components/provider_components.ex:2273
 #, elixir-autogen, elixir-format
 msgid "Staffed just for this session. Changes here do not touch the program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2279
+#: lib/klass_hero_web/components/provider_components.ex:2275
 #, elixir-autogen, elixir-format
 msgid "Using the program's usual team. The first change here copies them onto this session, so later program changes stop reaching it."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:437
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:125
+#: lib/klass_hero_web/components/booking_components.ex:228
 #, elixir-autogen, elixir-format
 msgid "(optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2015
+#: lib/klass_hero_web/components/provider_components.ex:2011
 #, elixir-autogen, elixir-format
 msgid "Add a waiver"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2047
+#: lib/klass_hero_web/components/provider_components.ex:2043
 #, elixir-autogen, elixir-format
 msgid "Add waiver"
 msgstr ""
@@ -7894,34 +7893,34 @@ msgstr ""
 msgid "Check the waiver details and try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:43
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:66
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:45
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:68
 #, elixir-autogen, elixir-format
 msgid "Enrollment not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:465
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:154
+#: lib/klass_hero_web/live/booking_live.ex:464
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:155
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2029
+#: lib/klass_hero_web/components/provider_components.ex:2025
 #, elixir-autogen, elixir-format
 msgid "Legal text"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1590
+#: lib/klass_hero_web/components/provider_components.ex:1591
 #, elixir-autogen, elixir-format
 msgid "Manage Waivers"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1958
+#: lib/klass_hero_web/components/provider_components.ex:1959
 #, elixir-autogen, elixir-format
 msgid "No waivers yet. Parents enrol without signing anything."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2036
+#: lib/klass_hero_web/components/provider_components.ex:2032
 #, elixir-autogen, elixir-format
 msgid "Parents must sign this before enrolling"
 msgstr ""
@@ -7931,42 +7930,42 @@ msgstr ""
 msgid "Please read and sign every required waiver before enrolling."
 msgstr ""
 
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:106
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:108
 #, elixir-autogen, elixir-format
 msgid "Please read and sign these before %{program} begins."
 msgstr ""
 
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:55
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:57
 #, elixir-autogen, elixir-format
 msgid "Please tick a waiver to sign it."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2014
+#: lib/klass_hero_web/components/provider_components.ex:2010
 #, elixir-autogen, elixir-format
 msgid "Publish a new version"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2047
+#: lib/klass_hero_web/components/provider_components.ex:2043
 #, elixir-autogen, elixir-format
 msgid "Publish version"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2040
+#: lib/klass_hero_web/components/provider_components.ex:2036
 #, elixir-autogen, elixir-format
 msgid "Publishing keeps every earlier version on record; signatures already given stay bound to the wording they were shown."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1976
+#: lib/klass_hero_web/components/booking_components.ex:222
 #, elixir-autogen, elixir-format
 msgid "Required"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1997
+#: lib/klass_hero_web/components/provider_components.ex:1993
 #, elixir-autogen, elixir-format
 msgid "Retire this waiver"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1988
+#: lib/klass_hero_web/components/provider_components.ex:1984
 #, elixir-autogen, elixir-format
 msgid "Revise text"
 msgstr ""
@@ -7976,33 +7975,33 @@ msgstr ""
 msgid "Sign the waivers for %{program}"
 msgstr ""
 
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:160
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:161
 #, elixir-autogen, elixir-format
 msgid "Sign waivers"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2502
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:142
+#: lib/klass_hero_web/components/provider_components.ex:2498
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "Signed"
 msgstr ""
 
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:60
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:62
 #, elixir-autogen, elixir-format
 msgid "Thank you — your waivers are on record."
 msgstr ""
 
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:110
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:112
 #, elixir-autogen, elixir-format
 msgid "There is nothing to sign for this enrollment."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2502
+#: lib/klass_hero_web/components/provider_components.ex:2498
 #, elixir-autogen, elixir-format
 msgid "Unsigned"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1980
+#: lib/klass_hero_web/components/provider_components.ex:1976
 #, elixir-autogen, elixir-format
 msgid "Version %{number}"
 msgstr ""
@@ -8012,10 +8011,10 @@ msgstr ""
 msgid "Waiver not found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2470
+#: lib/klass_hero_web/components/provider_components.ex:2466
 #: lib/klass_hero_web/live/booking_live.ex:427
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:31
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:103
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:33
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:105
 #, elixir-autogen, elixir-format
 msgid "Waivers"
 msgstr ""
@@ -8025,12 +8024,12 @@ msgstr ""
 msgid "Waivers waiting for your signature"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1949
+#: lib/klass_hero_web/components/provider_components.ex:1950
 #, elixir-autogen, elixir-format
 msgid "Waivers — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:94
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:96
 #, elixir-autogen, elixir-format
 msgid "this program"
 msgstr ""
@@ -8040,7 +8039,7 @@ msgstr ""
 msgid "New version published. It applies to future enrolments."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2001
+#: lib/klass_hero_web/components/provider_components.ex:1997
 #, elixir-autogen, elixir-format
 msgid "Retire \"%{title}\"? Parents will no longer be asked to sign it. Signatures already collected are kept."
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -137,12 +137,12 @@ msgid "Your Data"
 msgstr ""
 
 #: lib/klass_hero_web/components/core_components.ex:71
-#: lib/klass_hero_web/components/provider_components.ex:1758
+#: lib/klass_hero_web/components/provider_components.ex:1765
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:355
+#: lib/klass_hero_web/live/booking_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "%{name} (Age %{age})"
 msgstr ""
@@ -152,17 +152,17 @@ msgstr ""
 msgid "About This Program"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:290
+#: lib/klass_hero_web/live/booking_live.ex:310
 #, elixir-autogen, elixir-format
 msgid "Activity Summary"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:368
+#: lib/klass_hero_web/live/booking_live.ex:388
 #, elixir-autogen, elixir-format
 msgid "Add another child"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:331
+#: lib/klass_hero_web/live/booking_live.ex:351
 #, elixir-autogen, elixir-format
 msgid "Add another program"
 msgstr ""
@@ -172,12 +172,12 @@ msgstr ""
 msgid "Ages %{range}"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:441
+#: lib/klass_hero_web/live/booking_live.ex:511
 #, elixir-autogen, elixir-format
 msgid "An invoice will be emailed to you after enrollment completion"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:385
+#: lib/klass_hero_web/live/booking_live.ex:405
 #, elixir-autogen, elixir-format
 msgid "Any allergies, medical conditions, or special instructions..."
 msgstr ""
@@ -187,12 +187,12 @@ msgstr ""
 msgid "Book camps, tutors, and workshops instantly. Our integrated planner helps you manage your child's busy life."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:418
+#: lib/klass_hero_web/live/booking_live.ex:488
 #, elixir-autogen, elixir-format
 msgid "Cash / Bank Transfer"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:443
+#: lib/klass_hero_web/live/booking_live.ex:513
 #, elixir-autogen, elixir-format
 msgid "Cash/transfer payments will show as \"Pending\" until received"
 msgstr ""
@@ -202,22 +202,22 @@ msgstr ""
 msgid "Community Focused"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:460
+#: lib/klass_hero_web/live/booking_live.ex:530
 #, elixir-autogen, elixir-format
 msgid "Complete Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:409
+#: lib/klass_hero_web/live/booking_live.ex:479
 #, elixir-autogen, elixir-format
 msgid "Credit Card"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:442
+#: lib/klass_hero_web/live/booking_live.ex:512
 #, elixir-autogen, elixir-format
 msgid "Credit card payments are processed immediately"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:322
+#: lib/klass_hero_web/live/booking_live.ex:342
 #, elixir-autogen, elixir-format
 msgid "Duration:"
 msgstr ""
@@ -233,22 +233,22 @@ msgid "Enroll Now - %{price}"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1484
-#: lib/klass_hero_web/live/booking_live.ex:285
+#: lib/klass_hero_web/live/booking_live.ex:305
 #, elixir-autogen, elixir-format
 msgid "Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:36
+#: lib/klass_hero_web/live/booking_live.ex:37
 #, elixir-autogen, elixir-format
 msgid "Enrollment - %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:189
+#: lib/klass_hero_web/live/booking_live.ex:204
 #, elixir-autogen, elixir-format
 msgid "Enrollment failed. Please try again or contact support."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:128
+#: lib/klass_hero_web/live/booking_live.ex:134
 #, elixir-autogen, elixir-format
 msgid "Enrollment successful! You'll receive a confirmation email shortly."
 msgstr ""
@@ -274,7 +274,7 @@ msgstr ""
 msgid "Invalid pagination state. Please refresh the page."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:439
+#: lib/klass_hero_web/live/booking_live.ex:509
 #, elixir-autogen, elixir-format
 msgid "Invoice & Payment Confirmation"
 msgstr ""
@@ -296,32 +296,32 @@ msgstr[1] ""
 msgid "No programs found"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:393
+#: lib/klass_hero_web/live/booking_live.ex:413
 #, elixir-autogen, elixir-format
 msgid "Optional: Include any important information we should know about your child."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:410
+#: lib/klass_hero_web/live/booking_live.ex:480
 #, elixir-autogen, elixir-format
 msgid "Pay securely with Visa, Mastercard, or other cards"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:404
+#: lib/klass_hero_web/live/booking_live.ex:474
 #, elixir-autogen, elixir-format
 msgid "Payment Method"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:428
+#: lib/klass_hero_web/live/booking_live.ex:498
 #, elixir-autogen, elixir-format
 msgid "Payment Summary"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:152
+#: lib/klass_hero_web/live/booking_live.ex:158
 #, elixir-autogen, elixir-format
 msgid "Payment information is invalid. Please check your details."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:156
+#: lib/klass_hero_web/live/booking_live.ex:162
 #, elixir-autogen, elixir-format
 msgid "Please select a child for enrollment."
 msgstr ""
@@ -331,7 +331,7 @@ msgstr ""
 msgid "Klass Hero - Connecting Families with Trusted Youth Educators"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:54
+#: lib/klass_hero_web/live/booking_live.ex:60
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:59
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:57
 #, elixir-autogen, elixir-format
@@ -354,37 +354,37 @@ msgstr ""
 msgid "Search programs..."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:339
+#: lib/klass_hero_web/live/booking_live.ex:359
 #, elixir-autogen, elixir-format
 msgid "Select Child"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:349
+#: lib/klass_hero_web/live/booking_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "Select a child"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:64
+#: lib/klass_hero_web/live/booking_live.ex:70
 #, elixir-autogen, elixir-format
 msgid "Sorry, this program is currently full. Check back later for availability."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:137
+#: lib/klass_hero_web/live/booking_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "Sorry, this program is now full. Please choose another program."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:378
+#: lib/klass_hero_web/live/booking_live.ex:398
 #, elixir-autogen, elixir-format
 msgid "Special Requirements"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:315
+#: lib/klass_hero_web/live/booking_live.ex:335
 #, elixir-autogen, elixir-format
 msgid "Total Price:"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:434
+#: lib/klass_hero_web/live/booking_live.ex:504
 #, elixir-autogen, elixir-format
 msgid "Total due today:"
 msgstr ""
@@ -578,8 +578,8 @@ msgid "Dispute Resolution"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:719
-#: lib/klass_hero_web/components/provider_components.ex:2647
-#: lib/klass_hero_web/components/provider_components.ex:2665
+#: lib/klass_hero_web/components/provider_components.ex:2810
+#: lib/klass_hero_web/components/provider_components.ex:2828
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
@@ -878,9 +878,9 @@ msgstr ""
 msgid "Select one or both options"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2343
-#: lib/klass_hero_web/components/provider_components.ex:2344
-#: lib/klass_hero_web/components/provider_components.ex:2381
+#: lib/klass_hero_web/components/provider_components.ex:2506
+#: lib/klass_hero_web/components/provider_components.ex:2507
+#: lib/klass_hero_web/components/provider_components.ex:2544
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:448
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:484
@@ -1578,13 +1578,13 @@ msgid "Quick Navigation"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1487
-#: lib/klass_hero_web/components/provider_components.ex:2319
-#: lib/klass_hero_web/components/provider_components.ex:2545
+#: lib/klass_hero_web/components/provider_components.ex:2466
+#: lib/klass_hero_web/components/provider_components.ex:2708
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1626
+#: lib/klass_hero_web/components/provider_components.ex:1633
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr ""
@@ -1628,7 +1628,7 @@ msgid "Create profiles for your staff. These will be visible to parents when ass
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:539
-#: lib/klass_hero_web/components/provider_components.ex:1589
+#: lib/klass_hero_web/components/provider_components.ex:1596
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:54
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:81
 #: lib/klass_hero_web/live/settings/children_live.ex:413
@@ -1645,7 +1645,7 @@ msgstr ""
 msgid "Edit Profile"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1628
+#: lib/klass_hero_web/components/provider_components.ex:1635
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr ""
@@ -1669,9 +1669,9 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:47
 #: lib/klass_hero_web/components/provider_components.ex:73
-#: lib/klass_hero_web/components/provider_components.ex:1627
-#: lib/klass_hero_web/components/provider_components.ex:2741
-#: lib/klass_hero_web/components/provider_components.ex:2759
+#: lib/klass_hero_web/components/provider_components.ex:1634
+#: lib/klass_hero_web/components/provider_components.ex:2904
+#: lib/klass_hero_web/components/provider_components.ex:2922
 #: lib/klass_hero_web/live/admin/sessions_live.ex:298
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
@@ -1709,9 +1709,9 @@ msgid "Search by name..."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1481
-#: lib/klass_hero_web/components/provider_components.ex:1877
-#: lib/klass_hero_web/components/provider_components.ex:2313
-#: lib/klass_hero_web/components/provider_components.ex:2542
+#: lib/klass_hero_web/components/provider_components.ex:1884
+#: lib/klass_hero_web/components/provider_components.ex:2457
+#: lib/klass_hero_web/components/provider_components.ex:2705
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1736,14 +1736,14 @@ msgid "This is your main business identity. Verification is required to list pro
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1538
-#: lib/klass_hero_web/components/provider_components.ex:1892
+#: lib/klass_hero_web/components/provider_components.ex:1899
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr ""
 
 #: lib/klass_hero_web/components/messaging_components.ex:722
 #: lib/klass_hero_web/components/provider_components.ex:50
-#: lib/klass_hero_web/components/provider_components.ex:1629
+#: lib/klass_hero_web/components/provider_components.ex:1636
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:434
 #: lib/klass_hero_web/presenters/provider_presenter.ex:103
 #, elixir-autogen, elixir-format
@@ -1817,7 +1817,8 @@ msgstr ""
 #: lib/klass_hero_web/components/participation_components.ex:717
 #: lib/klass_hero_web/components/provider_components.ex:889
 #: lib/klass_hero_web/components/provider_components.ex:1334
-#: lib/klass_hero_web/components/provider_components.ex:2484
+#: lib/klass_hero_web/components/provider_components.ex:2046
+#: lib/klass_hero_web/components/provider_components.ex:2647
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:478
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
@@ -1852,7 +1853,7 @@ msgstr ""
 msgid "Child updated successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:176
+#: lib/klass_hero_web/live/dashboard_live.ex:178
 #: lib/klass_hero_web/live/messaging_live_helper.ex:336
 #, elixir-autogen, elixir-format
 msgid "Conversation"
@@ -1873,7 +1874,7 @@ msgstr ""
 msgid "Data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2628
+#: lib/klass_hero_web/components/provider_components.ex:2791
 #: lib/klass_hero_web/live/settings/children_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1921,17 +1922,17 @@ msgstr ""
 msgid "Failed to submit note"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2622
-#: lib/klass_hero_web/components/provider_components.ex:2651
-#: lib/klass_hero_web/components/provider_components.ex:2667
+#: lib/klass_hero_web/components/provider_components.ex:2785
+#: lib/klass_hero_web/components/provider_components.ex:2814
+#: lib/klass_hero_web/components/provider_components.ex:2830
 #: lib/klass_hero_web/live/settings/children_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2623
-#: lib/klass_hero_web/components/provider_components.ex:2652
-#: lib/klass_hero_web/components/provider_components.ex:2668
+#: lib/klass_hero_web/components/provider_components.ex:2786
+#: lib/klass_hero_web/components/provider_components.ex:2815
+#: lib/klass_hero_web/components/provider_components.ex:2831
 #: lib/klass_hero_web/live/settings/children_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -2026,7 +2027,7 @@ msgstr ""
 msgid "Please check the form for errors."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:163
+#: lib/klass_hero_web/live/booking_live.ex:178
 #, elixir-autogen, elixir-format
 msgid "Please complete your profile before making a booking."
 msgstr ""
@@ -2069,8 +2070,8 @@ msgstr ""
 msgid "Save Changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1736
-#: lib/klass_hero_web/components/provider_components.ex:1737
+#: lib/klass_hero_web/components/provider_components.ex:1743
+#: lib/klass_hero_web/components/provider_components.ex:1744
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:43
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:151
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:252
@@ -2088,7 +2089,7 @@ msgstr ""
 msgid "Send a message to start the conversation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2722
+#: lib/klass_hero_web/components/provider_components.ex:2885
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:249
 #, elixir-autogen, elixir-format
@@ -2224,7 +2225,7 @@ msgstr ""
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2781
+#: lib/klass_hero_web/components/provider_components.ex:2944
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred during import."
 msgstr ""
@@ -2272,7 +2273,7 @@ msgstr ""
 msgid "Bio"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:389
+#: lib/klass_hero_web/live/dashboard_live.ex:429
 #, elixir-autogen, elixir-format
 msgid "Book a Program"
 msgstr ""
@@ -2319,8 +2320,8 @@ msgstr ""
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2310
-#: lib/klass_hero_web/components/provider_components.ex:2536
+#: lib/klass_hero_web/components/provider_components.ex:2454
+#: lib/klass_hero_web/components/provider_components.ex:2699
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2365,7 +2366,7 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2742
+#: lib/klass_hero_web/components/provider_components.ex:2905
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
@@ -2375,12 +2376,12 @@ msgstr ""
 msgid "Contact Provider"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:451
+#: lib/klass_hero_web/live/provider/programs_live.ex:530
 #, elixir-autogen, elixir-format
 msgid "Could not read the uploaded file."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:419
+#: lib/klass_hero_web/live/provider/programs_live.ex:498
 #, elixir-autogen, elixir-format
 msgid "Could not remove invite."
 msgstr ""
@@ -2414,7 +2415,7 @@ msgstr ""
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2957
+#: lib/klass_hero_web/components/provider_components.ex:3120
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2448,7 +2449,7 @@ msgstr ""
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2503
+#: lib/klass_hero_web/components/provider_components.ex:2666
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
@@ -2479,14 +2480,14 @@ msgstr ""
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2316
-#: lib/klass_hero_web/components/provider_components.ex:2762
+#: lib/klass_hero_web/components/provider_components.ex:2463
+#: lib/klass_hero_web/components/provider_components.ex:2925
 #: lib/klass_hero_web/components/provider_layout_components.ex:644
 #, elixir-autogen, elixir-format
 msgid "Enrolled"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1782
+#: lib/klass_hero_web/components/provider_components.ex:1789
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr ""
@@ -2502,7 +2503,7 @@ msgid "Explain why this document is being rejected..."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:71
-#: lib/klass_hero_web/components/provider_components.ex:2763
+#: lib/klass_hero_web/components/provider_components.ex:2926
 #: lib/klass_hero_web/live/admin/emails_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2518,7 +2519,7 @@ msgstr ""
 msgid "Failed to reject document."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:401
+#: lib/klass_hero_web/live/provider/programs_live.ex:480
 #, elixir-autogen, elixir-format
 msgid "Failed to resend invite."
 msgstr ""
@@ -2529,7 +2530,7 @@ msgstr ""
 msgid "Failed to upload document."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:362
+#: lib/klass_hero_web/live/dashboard_live.ex:402
 #, elixir-autogen, elixir-format
 msgid "Family Programs"
 msgstr ""
@@ -2546,12 +2547,12 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2891
+#: lib/klass_hero_web/components/provider_components.ex:3054
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2893
+#: lib/klass_hero_web/components/provider_components.ex:3056
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
@@ -2586,7 +2587,7 @@ msgstr ""
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2539
+#: lib/klass_hero_web/components/provider_components.ex:2702
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
@@ -2601,7 +2602,7 @@ msgstr ""
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2476
+#: lib/klass_hero_web/components/provider_components.ex:2639
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -2611,22 +2612,22 @@ msgstr ""
 msgid "Insurance Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:416
+#: lib/klass_hero_web/live/provider/programs_live.ex:495
 #, elixir-autogen, elixir-format
 msgid "Invite not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:413
+#: lib/klass_hero_web/live/provider/programs_live.ex:492
 #, elixir-autogen, elixir-format
 msgid "Invite removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:390
+#: lib/klass_hero_web/live/provider/programs_live.ex:469
 #, elixir-autogen, elixir-format
 msgid "Invite resent successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1799
+#: lib/klass_hero_web/components/provider_components.ex:1806
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr ""
@@ -2727,18 +2728,18 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2919
+#: lib/klass_hero_web/components/provider_components.ex:3082
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2303
+#: lib/klass_hero_web/components/provider_components.ex:2447
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:447
+#: lib/klass_hero_web/live/provider/programs_live.ex:526
 #, elixir-autogen, elixir-format
 msgid "No file selected."
 msgstr ""
@@ -2748,7 +2749,7 @@ msgstr ""
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2527
+#: lib/klass_hero_web/components/provider_components.ex:2690
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
@@ -2768,7 +2769,7 @@ msgstr ""
 msgid "No pending documents to review."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:378
+#: lib/klass_hero_web/live/dashboard_live.ex:418
 #, elixir-autogen, elixir-format
 msgid "No programs booked yet"
 msgstr ""
@@ -2811,7 +2812,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2994
+#: lib/klass_hero_web/components/provider_components.ex:3157
 #: lib/klass_hero_web/live/provider/verification_live.ex:698
 #: lib/klass_hero_web/live/provider/verification_live.ex:770
 #, elixir-autogen, elixir-format
@@ -2838,8 +2839,8 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:106
-#: lib/klass_hero_web/live/provider/programs_live.ex:690
-#: lib/klass_hero_web/live/provider/programs_live.ex:759
+#: lib/klass_hero_web/live/provider/programs_live.ex:769
+#: lib/klass_hero_web/live/provider/programs_live.ex:838
 #: lib/klass_hero_web/live/provider/team_live.ex:305
 #: lib/klass_hero_web/live/provider/team_live.ex:348
 #: lib/klass_hero_web/live/provider/team_live.ex:467
@@ -2872,26 +2873,28 @@ msgstr ""
 msgid "Program Start"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1208
+#: lib/klass_hero_web/live/provider/programs_live.ex:1328
 #, elixir-autogen, elixir-format
 msgid "Program created successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1212
+#: lib/klass_hero_web/live/provider/programs_live.ex:1332
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:54
-#: lib/klass_hero_web/live/provider/programs_live.ex:155
-#: lib/klass_hero_web/live/provider/programs_live.ex:192
-#: lib/klass_hero_web/live/provider/programs_live.ex:256
-#: lib/klass_hero_web/live/provider/programs_live.ex:734
+#: lib/klass_hero_web/live/provider/programs_live.ex:156
+#: lib/klass_hero_web/live/provider/programs_live.ex:193
+#: lib/klass_hero_web/live/provider/programs_live.ex:257
+#: lib/klass_hero_web/live/provider/programs_live.ex:281
+#: lib/klass_hero_web/live/provider/programs_live.ex:813
+#: lib/klass_hero_web/live/provider/programs_live.ex:935
 #, elixir-autogen, elixir-format
 msgid "Program not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1209
+#: lib/klass_hero_web/live/provider/programs_live.ex:1329
 #, elixir-autogen, elixir-format
 msgid "Program updated successfully."
 msgstr ""
@@ -2909,7 +2912,7 @@ msgid "Read our founding story →"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:805
-#: lib/klass_hero_web/components/provider_components.ex:2761
+#: lib/klass_hero_web/components/provider_components.ex:2924
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Registered"
@@ -2945,7 +2948,7 @@ msgstr ""
 msgid "Registration Period (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:144
+#: lib/klass_hero_web/live/booking_live.ex:150
 #, elixir-autogen, elixir-format
 msgid "Registration has closed for this program."
 msgstr ""
@@ -2955,7 +2958,7 @@ msgstr ""
 msgid "Registration is closed"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:73
+#: lib/klass_hero_web/live/booking_live.ex:79
 #, elixir-autogen, elixir-format
 msgid "Registration is not currently open for this program."
 msgstr ""
@@ -2991,16 +2994,16 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:839
 #: lib/klass_hero_web/components/provider_components.ex:1284
-#: lib/klass_hero_web/components/provider_components.ex:2583
-#: lib/klass_hero_web/components/provider_components.ex:3013
-#: lib/klass_hero_web/components/provider_components.ex:3092
+#: lib/klass_hero_web/components/provider_components.ex:2746
+#: lib/klass_hero_web/components/provider_components.ex:3176
+#: lib/klass_hero_web/components/provider_components.ex:3255
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:253
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2576
+#: lib/klass_hero_web/components/provider_components.ex:2739
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -3015,7 +3018,7 @@ msgstr ""
 msgid "Role"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1728
+#: lib/klass_hero_web/components/provider_components.ex:1735
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:386
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
@@ -3041,24 +3044,24 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2991
+#: lib/klass_hero_web/components/provider_components.ex:3154
 #, elixir-autogen, elixir-format
 msgid "Select File"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:116
-#: lib/klass_hero_web/live/booking_live.ex:173
+#: lib/klass_hero_web/live/booking_live.ex:122
+#: lib/klass_hero_web/live/booking_live.ex:188
 #, elixir-autogen, elixir-format
 msgid "Selected child does not meet the program requirements."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:680
-#: lib/klass_hero_web/live/provider/programs_live.ex:749
+#: lib/klass_hero_web/live/provider/programs_live.ex:759
+#: lib/klass_hero_web/live/provider/programs_live.ex:828
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2760
+#: lib/klass_hero_web/components/provider_components.ex:2923
 #: lib/klass_hero_web/live/admin/emails_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Sent"
@@ -3108,7 +3111,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:324
+#: lib/klass_hero_web/live/booking_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "TBD"
 msgstr ""
@@ -3153,22 +3156,23 @@ msgstr ""
 msgid "The Klass Hero Story"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:393
+#: lib/klass_hero_web/live/provider/programs_live.ex:472
 #, elixir-autogen, elixir-format
 msgid "This invite cannot be resent."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:741
+#: lib/klass_hero_web/live/provider/programs_live.ex:820
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:975
+#: lib/klass_hero_web/components/provider_components.ex:2012
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2892
+#: lib/klass_hero_web/components/provider_components.ex:3055
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -3188,32 +3192,32 @@ msgstr ""
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2462
+#: lib/klass_hero_web/components/provider_components.ex:2625
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3037
+#: lib/klass_hero_web/components/provider_components.ex:3200
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2946
+#: lib/klass_hero_web/components/provider_components.ex:3109
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2914
+#: lib/klass_hero_web/components/provider_components.ex:3077
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2894
+#: lib/klass_hero_web/components/provider_components.ex:3057
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2911
+#: lib/klass_hero_web/components/provider_components.ex:3074
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -3303,7 +3307,7 @@ msgid "Child Safeguarding Training"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1498
-#: lib/klass_hero_web/components/provider_components.ex:3259
+#: lib/klass_hero_web/components/provider_components.ex:3422
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr ""
@@ -3363,17 +3367,17 @@ msgstr ""
 msgid "Monitoring provider activity and feedback"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:419
+#: lib/klass_hero_web/live/booking_live.ex:489
 #, elixir-autogen, elixir-format
 msgid "Pay by cash or direct bank transfer"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:430
+#: lib/klass_hero_web/live/booking_live.ex:500
 #, elixir-autogen, elixir-format
 msgid "Program fee:"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:985
+#: lib/klass_hero_web/live/provider/programs_live.ex:1105
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr ""
@@ -3399,7 +3403,8 @@ msgid "Reviewing concerns or reports promptly and seriously"
 msgstr ""
 
 #: lib/klass_hero_web/controllers/invite_claim_controller.ex:57
-#: lib/klass_hero_web/live/booking_live.ex:197
+#: lib/klass_hero_web/live/booking_live.ex:212
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:73
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Please try again or contact support."
 msgstr ""
@@ -3414,7 +3419,7 @@ msgstr ""
 msgid "Taking action when standards are not met"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:181
+#: lib/klass_hero_web/live/booking_live.ex:196
 #, elixir-autogen, elixir-format
 msgid "This child is already enrolled in this program."
 msgstr ""
@@ -3453,7 +3458,7 @@ msgid "Vetted with Care"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1482
-#: lib/klass_hero_web/components/provider_components.ex:3044
+#: lib/klass_hero_web/components/provider_components.ex:3207
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr ""
@@ -3589,7 +3594,7 @@ msgstr ""
 msgid "Cannot check out without a check-in"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:365
+#: lib/klass_hero_web/live/provider/programs_live.ex:444
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
@@ -3627,7 +3632,7 @@ msgstr ""
 msgid "Checked Out"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2619
+#: lib/klass_hero_web/components/provider_components.ex:2782
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Child"
@@ -3653,8 +3658,8 @@ msgstr ""
 msgid "Correct"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:288
-#: lib/klass_hero_web/live/provider/programs_live.ex:362
+#: lib/klass_hero_web/live/dashboard_live.ex:306
+#: lib/klass_hero_web/live/provider/programs_live.ex:441
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Could not start conversation. Please try again."
@@ -3680,7 +3685,7 @@ msgstr ""
 msgid "Download monthly statements for taxes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2380
+#: lib/klass_hero_web/components/provider_components.ex:2543
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "Enrollment not confirmed"
@@ -3753,7 +3758,7 @@ msgstr ""
 msgid "No chasing payments or sending invoices"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1751
+#: lib/klass_hero_web/components/provider_components.ex:1758
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:407
 #, elixir-autogen, elixir-format
 msgid "No enrolled parents"
@@ -3776,7 +3781,7 @@ msgstr ""
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2379
+#: lib/klass_hero_web/components/provider_components.ex:2542
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -3878,7 +3883,7 @@ msgstr ""
 msgid "Track Everything:"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:275
+#: lib/klass_hero_web/live/dashboard_live.ex:293
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:144
 #, elixir-autogen, elixir-format
 msgid "Upgrade your plan to send messages."
@@ -4407,7 +4412,7 @@ msgstr ""
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:24
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
-#: lib/klass_hero_web/live/provider/programs_live.ex:224
+#: lib/klass_hero_web/live/provider/programs_live.ex:225
 #: lib/klass_hero_web/live/provider/sessions_live.ex:381
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:175
 #, elixir-autogen, elixir-format
@@ -4618,7 +4623,7 @@ msgid "Update your observation..."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:138
-#: lib/klass_hero_web/live/provider/programs_live.ex:444
+#: lib/klass_hero_web/live/provider/programs_live.ex:523
 #: lib/klass_hero_web/live/provider/verification_live.ex:240
 #: lib/klass_hero_web/live/provider/verification_live.ex:556
 #: lib/klass_hero_web/live/provider/verification_live.ex:594
@@ -4889,34 +4894,35 @@ msgstr ""
 msgid "for"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1875
+#: lib/klass_hero_web/components/provider_components.ex:1882
 #, elixir-autogen, elixir-format
 msgid "Assigned staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1876
+#: lib/klass_hero_web/components/provider_components.ex:1883
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1859
-#: lib/klass_hero_web/components/provider_components.ex:1944
-#: lib/klass_hero_web/components/provider_components.ex:2098
+#: lib/klass_hero_web/components/provider_components.ex:1866
+#: lib/klass_hero_web/components/provider_components.ex:1951
+#: lib/klass_hero_web/components/provider_components.ex:2088
+#: lib/klass_hero_web/components/provider_components.ex:2242
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1874
+#: lib/klass_hero_web/components/provider_components.ex:1881
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1868
+#: lib/klass_hero_web/components/provider_components.ex:1875
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1857
+#: lib/klass_hero_web/components/provider_components.ex:1864
 #, elixir-autogen, elixir-format
 msgid "Sessions — %{title}"
 msgstr ""
@@ -4926,7 +4932,7 @@ msgstr ""
 msgid "View sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:535
+#: lib/klass_hero_web/live/provider/programs_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Create a program before inviting participants."
 msgstr ""
@@ -4953,22 +4959,22 @@ msgstr ""
 msgid "Failed to update record"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2683
+#: lib/klass_hero_web/components/provider_components.ex:2846
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2402
+#: lib/klass_hero_web/components/provider_components.ex:2565
 #, elixir-autogen, elixir-format
 msgid "Invite mode"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2421
+#: lib/klass_hero_web/components/provider_components.ex:2584
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:531
+#: lib/klass_hero_web/live/provider/programs_live.ex:610
 #, elixir-autogen, elixir-format
 msgid "Invite sent."
 msgstr ""
@@ -4978,12 +4984,12 @@ msgstr ""
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2696
+#: lib/klass_hero_web/components/provider_components.ex:2859
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2702
+#: lib/klass_hero_web/components/provider_components.ex:2865
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr ""
@@ -4994,17 +5000,17 @@ msgstr ""
 msgid "Nothing to update"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2704
+#: lib/klass_hero_web/components/provider_components.ex:2867
 #, elixir-autogen, elixir-format
 msgid "Nut allergy"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2708
+#: lib/klass_hero_web/components/provider_components.ex:2871
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2713
+#: lib/klass_hero_web/components/provider_components.ex:2876
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr ""
@@ -5014,7 +5020,7 @@ msgstr ""
 msgid "Present"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2640
+#: lib/klass_hero_web/components/provider_components.ex:2803
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr ""
@@ -5041,22 +5047,22 @@ msgstr ""
 msgid "Save changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2677
+#: lib/klass_hero_web/components/provider_components.ex:2840
 #, elixir-autogen, elixir-format
 msgid "School (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2687
+#: lib/klass_hero_web/components/provider_components.ex:2850
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2661
+#: lib/klass_hero_web/components/provider_components.ex:2824
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2730
+#: lib/klass_hero_web/components/provider_components.ex:2893
 #, elixir-autogen, elixir-format
 msgid "Send invite"
 msgstr ""
@@ -5066,12 +5072,12 @@ msgstr ""
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2439
+#: lib/klass_hero_web/components/provider_components.ex:2602
 #, elixir-autogen, elixir-format
 msgid "Upload a list"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:542
+#: lib/klass_hero_web/live/provider/programs_live.ex:621
 #, elixir-autogen, elixir-format
 msgid "An invite for this child and program already exists."
 msgstr ""
@@ -5166,7 +5172,7 @@ msgstr ""
 msgid "Property Damage"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1599
+#: lib/klass_hero_web/components/provider_components.ex:1606
 #, elixir-autogen, elixir-format
 msgid "Report Incident"
 msgstr ""
@@ -5248,7 +5254,7 @@ msgstr ""
 msgid "Go to dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:487
+#: lib/klass_hero_web/live/provider/programs_live.ex:566
 #, elixir-autogen, elixir-format
 msgid "%{count} row could not be processed."
 msgid_plural "%{count} rows could not be processed."
@@ -5311,7 +5317,7 @@ msgstr ""
 msgid "Active policy required to teach."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:308
+#: lib/klass_hero_web/live/dashboard_live.ex:348
 #: lib/klass_hero_web/live/provider/overview_live.ex:251
 #, elixir-autogen, elixir-format
 msgid "Active programs"
@@ -5835,8 +5841,8 @@ msgstr ""
 msgid "I'll be teaching"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:462
-#: lib/klass_hero_web/live/provider/programs_live.ex:484
+#: lib/klass_hero_web/live/provider/programs_live.ex:541
+#: lib/klass_hero_web/live/provider/programs_live.ex:563
 #, elixir-autogen, elixir-format
 msgid "Imported %{count} family."
 msgid_plural "Imported %{count} families."
@@ -5848,7 +5854,7 @@ msgstr[1] ""
 msgid "In 2025, Shane connected with his friend"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1608
+#: lib/klass_hero_web/components/provider_components.ex:1615
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:43
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:74
 #, elixir-autogen, elixir-format
@@ -6065,7 +6071,7 @@ msgstr ""
 msgid "Mother and child-safety specialist with 10+ years in quality assurance. Architecting our Safety-First Verification engine."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:177
+#: lib/klass_hero_web/live/dashboard_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "New conversation"
 msgstr ""
@@ -6125,14 +6131,14 @@ msgstr ""
 msgid "No registered children for this session."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:471
+#: lib/klass_hero_web/live/provider/programs_live.ex:550
 #, elixir-autogen, elixir-format
 msgid "No rows imported. %{count} row could not be processed."
 msgid_plural "No rows imported. %{count} rows could not be processed."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:348
+#: lib/klass_hero_web/live/dashboard_live.ex:388
 #, elixir-autogen, elixir-format
 msgid "No upcoming sessions in the next few weeks."
 msgstr ""
@@ -6368,17 +6374,17 @@ msgstr ""
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2769
+#: lib/klass_hero_web/components/provider_components.ex:2932
 #, elixir-autogen, elixir-format
 msgid "Row %{row}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2769
+#: lib/klass_hero_web/components/provider_components.ex:2932
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2515
+#: lib/klass_hero_web/components/provider_components.ex:2678
 #, elixir-autogen, elixir-format
 msgid "Rows with errors"
 msgstr ""
@@ -6648,17 +6654,17 @@ msgstr ""
 msgid "Unlimited programs and locations"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:320
+#: lib/klass_hero_web/live/dashboard_live.ex:360
 #, elixir-autogen, elixir-format
 msgid "Unread messages"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:333
+#: lib/klass_hero_web/live/dashboard_live.ex:373
 #, elixir-autogen, elixir-format
 msgid "Upcoming sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:314
+#: lib/klass_hero_web/live/dashboard_live.ex:354
 #, elixir-autogen, elixir-format
 msgid "Upcoming this week"
 msgstr ""
@@ -6673,7 +6679,7 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:338
+#: lib/klass_hero_web/live/dashboard_live.ex:378
 #, elixir-autogen, elixir-format
 msgid "View all"
 msgstr ""
@@ -7137,12 +7143,12 @@ msgstr ""
 msgid "Experience validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3073
+#: lib/klass_hero_web/components/provider_components.ex:3236
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3047
+#: lib/klass_hero_web/components/provider_components.ex:3210
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
@@ -7152,12 +7158,12 @@ msgstr ""
 msgid "Safeguarding certificate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3070
+#: lib/klass_hero_web/components/provider_components.ex:3233
 #, elixir-autogen, elixir-format
 msgid "Select Video"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3116
+#: lib/klass_hero_web/components/provider_components.ex:3279
 #, elixir-autogen, elixir-format
 msgid "Upload Video"
 msgstr ""
@@ -7167,7 +7173,7 @@ msgstr ""
 msgid "Your browser does not support video playback."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3263
+#: lib/klass_hero_web/components/provider_components.ex:3426
 #, elixir-autogen, elixir-format
 msgid "Confirm agreement"
 msgstr ""
@@ -7177,12 +7183,12 @@ msgstr ""
 msgid "Couldn't record your agreement. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3286
+#: lib/klass_hero_web/components/provider_components.ex:3449
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3262
+#: lib/klass_hero_web/components/provider_components.ex:3425
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr ""
@@ -7192,7 +7198,7 @@ msgstr ""
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3171
+#: lib/klass_hero_web/components/provider_components.ex:3334
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr ""
@@ -7202,17 +7208,17 @@ msgstr ""
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3271
+#: lib/klass_hero_web/components/provider_components.ex:3434
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3260
+#: lib/klass_hero_web/components/provider_components.ex:3423
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3261
+#: lib/klass_hero_web/components/provider_components.ex:3424
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
@@ -7481,12 +7487,12 @@ msgstr ""
 msgid "Your insurance is verified."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3215
+#: lib/klass_hero_web/components/provider_components.ex:3378
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3318
+#: lib/klass_hero_web/components/provider_components.ex:3481
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr ""
@@ -7496,7 +7502,7 @@ msgstr ""
 msgid "Couldn't record your declaration. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3324
+#: lib/klass_hero_web/components/provider_components.ex:3487
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr ""
@@ -7506,17 +7512,17 @@ msgstr ""
 msgid "Please confirm the declaration before signing."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3349
+#: lib/klass_hero_web/components/provider_components.ex:3512
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3328
+#: lib/klass_hero_web/components/provider_components.ex:3491
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3316
+#: lib/klass_hero_web/components/provider_components.ex:3479
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr ""
@@ -7526,12 +7532,12 @@ msgstr ""
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3336
+#: lib/klass_hero_web/components/provider_components.ex:3499
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3322
+#: lib/klass_hero_web/components/provider_components.ex:3485
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
@@ -7546,12 +7552,12 @@ msgstr ""
 msgid "Session note submitted for review"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:372
+#: lib/klass_hero_web/live/dashboard_live.ex:412
 #, elixir-autogen, elixir-format
 msgid "Loading your programs…"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:342
+#: lib/klass_hero_web/live/dashboard_live.ex:382
 #, elixir-autogen, elixir-format
 msgid "Loading…"
 msgstr ""
@@ -7598,24 +7604,24 @@ msgstr ""
 msgid "Undelivered Events"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2043
-#: lib/klass_hero_web/components/provider_components.ex:2226
+#: lib/klass_hero_web/components/provider_components.ex:2187
+#: lib/klass_hero_web/components/provider_components.ex:2370
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1966
-#: lib/klass_hero_web/components/provider_components.ex:2152
+#: lib/klass_hero_web/components/provider_components.ex:2110
+#: lib/klass_hero_web/components/provider_components.ex:2296
 #, elixir-autogen, elixir-format
 msgid "Lead"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:337
+#: lib/klass_hero_web/live/provider/programs_live.ex:416
 #, elixir-autogen, elixir-format
 msgid "Lead instructor updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1978
+#: lib/klass_hero_web/components/provider_components.ex:2122
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor"
 msgstr ""
@@ -7625,65 +7631,65 @@ msgstr ""
 msgid "Manage Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2007
+#: lib/klass_hero_web/components/provider_components.ex:2151
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this program yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:267
+#: lib/klass_hero_web/live/provider/programs_live.ex:346
 #: lib/klass_hero_web/live/provider/sessions_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "Pick a staff member to add."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1990
-#: lib/klass_hero_web/components/provider_components.ex:2265
+#: lib/klass_hero_web/components/provider_components.ex:2134
+#: lib/klass_hero_web/components/provider_components.ex:2409
 #, elixir-autogen, elixir-format
 msgid "Reassign the lead before removing them"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1991
+#: lib/klass_hero_web/components/provider_components.ex:2135
 #, elixir-autogen, elixir-format
 msgid "Remove from program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2025
-#: lib/klass_hero_web/components/provider_components.ex:2207
+#: lib/klass_hero_web/components/provider_components.ex:2169
+#: lib/klass_hero_web/components/provider_components.ex:2351
 #, elixir-autogen, elixir-format
 msgid "Select a staff member…"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:282
+#: lib/klass_hero_web/live/provider/programs_live.ex:361
 #, elixir-autogen, elixir-format
 msgid "Staff member added to the program."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:308
+#: lib/klass_hero_web/live/provider/programs_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "Staff member removed from the program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2048
+#: lib/klass_hero_web/components/provider_components.ex:2192
 #, elixir-autogen, elixir-format
 msgid "Staff you add can read and reply to this program's parent conversations."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1942
+#: lib/klass_hero_web/components/provider_components.ex:2086
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:944
+#: lib/klass_hero_web/live/provider/programs_live.ex:1064
 #, elixir-autogen, elixir-format
 msgid "That staff member could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:290
+#: lib/klass_hero_web/live/provider/programs_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "They are already on this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:316
+#: lib/klass_hero_web/live/provider/programs_live.ex:395
 #, elixir-autogen, elixir-format
 msgid "This person is the lead instructor. Make someone else lead before removing them."
 msgstr ""
@@ -7745,17 +7751,17 @@ msgstr ""
 msgid "This person has a history here now — use 'Remove from team' instead."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1222
+#: lib/klass_hero_web/live/provider/programs_live.ex:1342
 #, elixir-autogen, elixir-format
 msgid "Program created, but some settings could not be saved. Please review the program's limits."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1226
+#: lib/klass_hero_web/live/provider/programs_live.ex:1346
 #, elixir-autogen, elixir-format
 msgid "Program updated, but some settings could not be saved. Please review the program's limits."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1216
+#: lib/klass_hero_web/live/provider/programs_live.ex:1336
 #, elixir-autogen, elixir-format
 msgid "Program updated, but the enrollment capacity was rejected. The previous limits still apply."
 msgstr ""
@@ -7777,7 +7783,7 @@ msgstr ""
 msgid "I understand this program will have no capacity limit."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2253
+#: lib/klass_hero_web/components/provider_components.ex:2397
 #, elixir-autogen, elixir-format
 msgid "Go back to the program's usual team"
 msgstr ""
@@ -7787,17 +7793,17 @@ msgstr ""
 msgid "Lead instructor for this session updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2167
+#: lib/klass_hero_web/components/provider_components.ex:2311
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor for this session"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2189
+#: lib/klass_hero_web/components/provider_components.ex:2333
 #, elixir-autogen, elixir-format
 msgid "Nobody is working this session yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2270
+#: lib/klass_hero_web/components/provider_components.ex:2414
 #, elixir-autogen, elixir-format
 msgid "Remove from this session"
 msgstr ""
@@ -7817,7 +7823,7 @@ msgstr ""
 msgid "Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2091
+#: lib/klass_hero_web/components/provider_components.ex:2235
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{date}"
 msgstr ""
@@ -7847,22 +7853,184 @@ msgstr ""
 msgid "A session needs at least one person. Use “Go back to the program's usual team” to drop this session's own roster."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2268
+#: lib/klass_hero_web/components/provider_components.ex:2412
 #, elixir-autogen, elixir-format
 msgid "A session needs someone — use “Go back to the program's usual team” instead"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2235
+#: lib/klass_hero_web/components/provider_components.ex:2379
 #, elixir-autogen, elixir-format
 msgid "Everyone on your team is already working this session."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2123
+#: lib/klass_hero_web/components/provider_components.ex:2267
 #, elixir-autogen, elixir-format
 msgid "Staffed just for this session. Changes here do not touch the program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2125
+#: lib/klass_hero_web/components/provider_components.ex:2269
 #, elixir-autogen, elixir-format
 msgid "Using the program's usual team. The first change here copies them onto this session, so later program changes stop reaching it."
+msgstr ""
+
+#: lib/klass_hero_web/live/booking_live.ex:437
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:125
+#, elixir-autogen, elixir-format
+msgid "(optional)"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2005
+#, elixir-autogen, elixir-format
+msgid "Add a waiver"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2037
+#, elixir-autogen, elixir-format
+msgid "Add waiver"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/programs_live.ex:936
+#, elixir-autogen, elixir-format
+msgid "Check the waiver details and try again."
+msgstr ""
+
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:43
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:66
+#, elixir-autogen, elixir-format
+msgid "Enrollment not found."
+msgstr ""
+
+#: lib/klass_hero_web/live/booking_live.ex:465
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:154
+#, elixir-autogen, elixir-format
+msgid "I have read and agree to %{title}"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2019
+#, elixir-autogen, elixir-format
+msgid "Legal text"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1590
+#, elixir-autogen, elixir-format
+msgid "Manage Waivers"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1958
+#, elixir-autogen, elixir-format
+msgid "No waivers yet. Parents enrol without signing anything."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2026
+#, elixir-autogen, elixir-format
+msgid "Parents must sign this before enrolling"
+msgstr ""
+
+#: lib/klass_hero_web/live/booking_live.ex:171
+#, elixir-autogen, elixir-format
+msgid "Please read and sign every required waiver before enrolling."
+msgstr ""
+
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:106
+#, elixir-autogen, elixir-format
+msgid "Please read and sign these before %{program} begins."
+msgstr ""
+
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:55
+#, elixir-autogen, elixir-format
+msgid "Please tick a waiver to sign it."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2004
+#, elixir-autogen, elixir-format
+msgid "Publish a new version"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2037
+#, elixir-autogen, elixir-format
+msgid "Publish version"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2030
+#, elixir-autogen, elixir-format
+msgid "Publishing keeps every earlier version on record; signatures already given stay bound to the wording they were shown."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1974
+#, elixir-autogen, elixir-format
+msgid "Required"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1993
+#, elixir-autogen, elixir-format
+msgid "Retire this waiver"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1986
+#, elixir-autogen, elixir-format
+msgid "Revise text"
+msgstr ""
+
+#: lib/klass_hero_web/live/dashboard_live.ex:330
+#, elixir-autogen, elixir-format
+msgid "Sign the waivers for %{program}"
+msgstr ""
+
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:160
+#, elixir-autogen, elixir-format
+msgid "Sign waivers"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2492
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:142
+#, elixir-autogen, elixir-format
+msgid "Signed"
+msgstr ""
+
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:60
+#, elixir-autogen, elixir-format
+msgid "Thank you — your waivers are on record."
+msgstr ""
+
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:110
+#, elixir-autogen, elixir-format
+msgid "There is nothing to sign for this enrollment."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2492
+#, elixir-autogen, elixir-format
+msgid "Unsigned"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1978
+#, elixir-autogen, elixir-format
+msgid "Version %{number}"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/programs_live.ex:340
+#, elixir-autogen, elixir-format
+msgid "Waiver not found."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2460
+#: lib/klass_hero_web/live/booking_live.ex:427
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:31
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:103
+#, elixir-autogen, elixir-format
+msgid "Waivers"
+msgstr ""
+
+#: lib/klass_hero_web/live/dashboard_live.ex:325
+#, elixir-autogen, elixir-format
+msgid "Waivers waiting for your signature"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1949
+#, elixir-autogen, elixir-format
+msgid "Waivers — %{title}"
+msgstr ""
+
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:94
+#, elixir-autogen, elixir-format
+msgid "this program"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -578,8 +578,8 @@ msgid "Dispute Resolution"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:719
-#: lib/klass_hero_web/components/provider_components.ex:2810
-#: lib/klass_hero_web/components/provider_components.ex:2828
+#: lib/klass_hero_web/components/provider_components.ex:2820
+#: lib/klass_hero_web/components/provider_components.ex:2838
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
@@ -878,9 +878,9 @@ msgstr ""
 msgid "Select one or both options"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2506
-#: lib/klass_hero_web/components/provider_components.ex:2507
-#: lib/klass_hero_web/components/provider_components.ex:2544
+#: lib/klass_hero_web/components/provider_components.ex:2516
+#: lib/klass_hero_web/components/provider_components.ex:2517
+#: lib/klass_hero_web/components/provider_components.ex:2554
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:448
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:484
@@ -1578,8 +1578,8 @@ msgid "Quick Navigation"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1487
-#: lib/klass_hero_web/components/provider_components.ex:2466
-#: lib/klass_hero_web/components/provider_components.ex:2708
+#: lib/klass_hero_web/components/provider_components.ex:2476
+#: lib/klass_hero_web/components/provider_components.ex:2718
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
@@ -1670,8 +1670,8 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:47
 #: lib/klass_hero_web/components/provider_components.ex:73
 #: lib/klass_hero_web/components/provider_components.ex:1634
-#: lib/klass_hero_web/components/provider_components.ex:2904
-#: lib/klass_hero_web/components/provider_components.ex:2922
+#: lib/klass_hero_web/components/provider_components.ex:2914
+#: lib/klass_hero_web/components/provider_components.ex:2932
 #: lib/klass_hero_web/live/admin/sessions_live.ex:298
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
@@ -1710,8 +1710,8 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1481
 #: lib/klass_hero_web/components/provider_components.ex:1884
-#: lib/klass_hero_web/components/provider_components.ex:2457
-#: lib/klass_hero_web/components/provider_components.ex:2705
+#: lib/klass_hero_web/components/provider_components.ex:2467
+#: lib/klass_hero_web/components/provider_components.ex:2715
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1817,8 +1817,8 @@ msgstr ""
 #: lib/klass_hero_web/components/participation_components.ex:717
 #: lib/klass_hero_web/components/provider_components.ex:889
 #: lib/klass_hero_web/components/provider_components.ex:1334
-#: lib/klass_hero_web/components/provider_components.ex:2046
-#: lib/klass_hero_web/components/provider_components.ex:2647
+#: lib/klass_hero_web/components/provider_components.ex:2056
+#: lib/klass_hero_web/components/provider_components.ex:2657
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:478
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
@@ -1874,7 +1874,7 @@ msgstr ""
 msgid "Data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2791
+#: lib/klass_hero_web/components/provider_components.ex:2801
 #: lib/klass_hero_web/live/settings/children_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1922,17 +1922,17 @@ msgstr ""
 msgid "Failed to submit note"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2785
-#: lib/klass_hero_web/components/provider_components.ex:2814
-#: lib/klass_hero_web/components/provider_components.ex:2830
+#: lib/klass_hero_web/components/provider_components.ex:2795
+#: lib/klass_hero_web/components/provider_components.ex:2824
+#: lib/klass_hero_web/components/provider_components.ex:2840
 #: lib/klass_hero_web/live/settings/children_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2786
-#: lib/klass_hero_web/components/provider_components.ex:2815
-#: lib/klass_hero_web/components/provider_components.ex:2831
+#: lib/klass_hero_web/components/provider_components.ex:2796
+#: lib/klass_hero_web/components/provider_components.ex:2825
+#: lib/klass_hero_web/components/provider_components.ex:2841
 #: lib/klass_hero_web/live/settings/children_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -2089,7 +2089,7 @@ msgstr ""
 msgid "Send a message to start the conversation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2885
+#: lib/klass_hero_web/components/provider_components.ex:2895
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:249
 #, elixir-autogen, elixir-format
@@ -2225,7 +2225,7 @@ msgstr ""
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2944
+#: lib/klass_hero_web/components/provider_components.ex:2954
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred during import."
 msgstr ""
@@ -2320,8 +2320,8 @@ msgstr ""
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2454
-#: lib/klass_hero_web/components/provider_components.ex:2699
+#: lib/klass_hero_web/components/provider_components.ex:2464
+#: lib/klass_hero_web/components/provider_components.ex:2709
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2366,7 +2366,7 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2905
+#: lib/klass_hero_web/components/provider_components.ex:2915
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
@@ -2376,12 +2376,12 @@ msgstr ""
 msgid "Contact Provider"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:530
+#: lib/klass_hero_web/live/provider/programs_live.ex:536
 #, elixir-autogen, elixir-format
 msgid "Could not read the uploaded file."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:498
+#: lib/klass_hero_web/live/provider/programs_live.ex:504
 #, elixir-autogen, elixir-format
 msgid "Could not remove invite."
 msgstr ""
@@ -2415,7 +2415,7 @@ msgstr ""
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3120
+#: lib/klass_hero_web/components/provider_components.ex:3130
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2449,7 +2449,7 @@ msgstr ""
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2666
+#: lib/klass_hero_web/components/provider_components.ex:2676
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
@@ -2480,8 +2480,8 @@ msgstr ""
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2463
-#: lib/klass_hero_web/components/provider_components.ex:2925
+#: lib/klass_hero_web/components/provider_components.ex:2473
+#: lib/klass_hero_web/components/provider_components.ex:2935
 #: lib/klass_hero_web/components/provider_layout_components.ex:644
 #, elixir-autogen, elixir-format
 msgid "Enrolled"
@@ -2503,7 +2503,7 @@ msgid "Explain why this document is being rejected..."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:71
-#: lib/klass_hero_web/components/provider_components.ex:2926
+#: lib/klass_hero_web/components/provider_components.ex:2936
 #: lib/klass_hero_web/live/admin/emails_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2519,7 +2519,7 @@ msgstr ""
 msgid "Failed to reject document."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:480
+#: lib/klass_hero_web/live/provider/programs_live.ex:486
 #, elixir-autogen, elixir-format
 msgid "Failed to resend invite."
 msgstr ""
@@ -2547,12 +2547,12 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3054
+#: lib/klass_hero_web/components/provider_components.ex:3064
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3056
+#: lib/klass_hero_web/components/provider_components.ex:3066
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
@@ -2587,7 +2587,7 @@ msgstr ""
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2702
+#: lib/klass_hero_web/components/provider_components.ex:2712
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
@@ -2602,7 +2602,7 @@ msgstr ""
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2639
+#: lib/klass_hero_web/components/provider_components.ex:2649
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -2612,17 +2612,17 @@ msgstr ""
 msgid "Insurance Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:495
+#: lib/klass_hero_web/live/provider/programs_live.ex:501
 #, elixir-autogen, elixir-format
 msgid "Invite not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:492
+#: lib/klass_hero_web/live/provider/programs_live.ex:498
 #, elixir-autogen, elixir-format
 msgid "Invite removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:469
+#: lib/klass_hero_web/live/provider/programs_live.ex:475
 #, elixir-autogen, elixir-format
 msgid "Invite resent successfully."
 msgstr ""
@@ -2728,18 +2728,18 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3082
+#: lib/klass_hero_web/components/provider_components.ex:3092
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2447
+#: lib/klass_hero_web/components/provider_components.ex:2457
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:526
+#: lib/klass_hero_web/live/provider/programs_live.ex:532
 #, elixir-autogen, elixir-format
 msgid "No file selected."
 msgstr ""
@@ -2749,7 +2749,7 @@ msgstr ""
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2690
+#: lib/klass_hero_web/components/provider_components.ex:2700
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
@@ -2812,7 +2812,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3157
+#: lib/klass_hero_web/components/provider_components.ex:3167
 #: lib/klass_hero_web/live/provider/verification_live.ex:698
 #: lib/klass_hero_web/live/provider/verification_live.ex:770
 #, elixir-autogen, elixir-format
@@ -2839,8 +2839,8 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:106
-#: lib/klass_hero_web/live/provider/programs_live.ex:769
-#: lib/klass_hero_web/live/provider/programs_live.ex:838
+#: lib/klass_hero_web/live/provider/programs_live.ex:775
+#: lib/klass_hero_web/live/provider/programs_live.ex:844
 #: lib/klass_hero_web/live/provider/team_live.ex:305
 #: lib/klass_hero_web/live/provider/team_live.ex:348
 #: lib/klass_hero_web/live/provider/team_live.ex:467
@@ -2873,12 +2873,12 @@ msgstr ""
 msgid "Program Start"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1328
+#: lib/klass_hero_web/live/provider/programs_live.ex:1337
 #, elixir-autogen, elixir-format
 msgid "Program created successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1332
+#: lib/klass_hero_web/live/provider/programs_live.ex:1341
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr ""
@@ -2888,13 +2888,13 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/programs_live.ex:193
 #: lib/klass_hero_web/live/provider/programs_live.ex:257
 #: lib/klass_hero_web/live/provider/programs_live.ex:281
-#: lib/klass_hero_web/live/provider/programs_live.ex:813
-#: lib/klass_hero_web/live/provider/programs_live.ex:935
+#: lib/klass_hero_web/live/provider/programs_live.ex:819
+#: lib/klass_hero_web/live/provider/programs_live.ex:944
 #, elixir-autogen, elixir-format
 msgid "Program not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1329
+#: lib/klass_hero_web/live/provider/programs_live.ex:1338
 #, elixir-autogen, elixir-format
 msgid "Program updated successfully."
 msgstr ""
@@ -2912,7 +2912,7 @@ msgid "Read our founding story →"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:805
-#: lib/klass_hero_web/components/provider_components.ex:2924
+#: lib/klass_hero_web/components/provider_components.ex:2934
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Registered"
@@ -2994,16 +2994,16 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:839
 #: lib/klass_hero_web/components/provider_components.ex:1284
-#: lib/klass_hero_web/components/provider_components.ex:2746
-#: lib/klass_hero_web/components/provider_components.ex:3176
-#: lib/klass_hero_web/components/provider_components.ex:3255
+#: lib/klass_hero_web/components/provider_components.ex:2756
+#: lib/klass_hero_web/components/provider_components.ex:3186
+#: lib/klass_hero_web/components/provider_components.ex:3265
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:253
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2739
+#: lib/klass_hero_web/components/provider_components.ex:2749
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -3044,7 +3044,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3154
+#: lib/klass_hero_web/components/provider_components.ex:3164
 #, elixir-autogen, elixir-format
 msgid "Select File"
 msgstr ""
@@ -3055,13 +3055,13 @@ msgstr ""
 msgid "Selected child does not meet the program requirements."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:759
-#: lib/klass_hero_web/live/provider/programs_live.ex:828
+#: lib/klass_hero_web/live/provider/programs_live.ex:765
+#: lib/klass_hero_web/live/provider/programs_live.ex:834
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2923
+#: lib/klass_hero_web/components/provider_components.ex:2933
 #: lib/klass_hero_web/live/admin/emails_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Sent"
@@ -3156,23 +3156,23 @@ msgstr ""
 msgid "The Klass Hero Story"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:472
+#: lib/klass_hero_web/live/provider/programs_live.ex:478
 #, elixir-autogen, elixir-format
 msgid "This invite cannot be resent."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:820
+#: lib/klass_hero_web/live/provider/programs_live.ex:826
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:975
-#: lib/klass_hero_web/components/provider_components.ex:2012
+#: lib/klass_hero_web/components/provider_components.ex:2022
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3055
+#: lib/klass_hero_web/components/provider_components.ex:3065
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -3192,32 +3192,32 @@ msgstr ""
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2625
+#: lib/klass_hero_web/components/provider_components.ex:2635
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3200
+#: lib/klass_hero_web/components/provider_components.ex:3210
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3109
+#: lib/klass_hero_web/components/provider_components.ex:3119
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3077
+#: lib/klass_hero_web/components/provider_components.ex:3087
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3057
+#: lib/klass_hero_web/components/provider_components.ex:3067
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3074
+#: lib/klass_hero_web/components/provider_components.ex:3084
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -3307,7 +3307,7 @@ msgid "Child Safeguarding Training"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1498
-#: lib/klass_hero_web/components/provider_components.ex:3422
+#: lib/klass_hero_web/components/provider_components.ex:3432
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr ""
@@ -3377,7 +3377,7 @@ msgstr ""
 msgid "Program fee:"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1105
+#: lib/klass_hero_web/live/provider/programs_live.ex:1114
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr ""
@@ -3458,7 +3458,7 @@ msgid "Vetted with Care"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1482
-#: lib/klass_hero_web/components/provider_components.ex:3207
+#: lib/klass_hero_web/components/provider_components.ex:3217
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr ""
@@ -3594,7 +3594,7 @@ msgstr ""
 msgid "Cannot check out without a check-in"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:444
+#: lib/klass_hero_web/live/provider/programs_live.ex:450
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
@@ -3632,7 +3632,7 @@ msgstr ""
 msgid "Checked Out"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2782
+#: lib/klass_hero_web/components/provider_components.ex:2792
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Child"
@@ -3659,7 +3659,7 @@ msgid "Correct"
 msgstr ""
 
 #: lib/klass_hero_web/live/dashboard_live.ex:306
-#: lib/klass_hero_web/live/provider/programs_live.ex:441
+#: lib/klass_hero_web/live/provider/programs_live.ex:447
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Could not start conversation. Please try again."
@@ -3685,7 +3685,7 @@ msgstr ""
 msgid "Download monthly statements for taxes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2543
+#: lib/klass_hero_web/components/provider_components.ex:2553
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "Enrollment not confirmed"
@@ -3781,7 +3781,7 @@ msgstr ""
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2542
+#: lib/klass_hero_web/components/provider_components.ex:2552
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -4623,7 +4623,7 @@ msgid "Update your observation..."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:138
-#: lib/klass_hero_web/live/provider/programs_live.ex:523
+#: lib/klass_hero_web/live/provider/programs_live.ex:529
 #: lib/klass_hero_web/live/provider/verification_live.ex:240
 #: lib/klass_hero_web/live/provider/verification_live.ex:556
 #: lib/klass_hero_web/live/provider/verification_live.ex:594
@@ -4906,8 +4906,8 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1866
 #: lib/klass_hero_web/components/provider_components.ex:1951
-#: lib/klass_hero_web/components/provider_components.ex:2088
-#: lib/klass_hero_web/components/provider_components.ex:2242
+#: lib/klass_hero_web/components/provider_components.ex:2098
+#: lib/klass_hero_web/components/provider_components.ex:2252
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr ""
@@ -4932,7 +4932,7 @@ msgstr ""
 msgid "View sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:614
+#: lib/klass_hero_web/live/provider/programs_live.ex:620
 #, elixir-autogen, elixir-format
 msgid "Create a program before inviting participants."
 msgstr ""
@@ -4959,22 +4959,22 @@ msgstr ""
 msgid "Failed to update record"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2846
+#: lib/klass_hero_web/components/provider_components.ex:2856
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2565
+#: lib/klass_hero_web/components/provider_components.ex:2575
 #, elixir-autogen, elixir-format
 msgid "Invite mode"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2584
+#: lib/klass_hero_web/components/provider_components.ex:2594
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:610
+#: lib/klass_hero_web/live/provider/programs_live.ex:616
 #, elixir-autogen, elixir-format
 msgid "Invite sent."
 msgstr ""
@@ -4984,12 +4984,12 @@ msgstr ""
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2859
+#: lib/klass_hero_web/components/provider_components.ex:2869
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2865
+#: lib/klass_hero_web/components/provider_components.ex:2875
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr ""
@@ -5000,17 +5000,17 @@ msgstr ""
 msgid "Nothing to update"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2867
+#: lib/klass_hero_web/components/provider_components.ex:2877
 #, elixir-autogen, elixir-format
 msgid "Nut allergy"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2871
+#: lib/klass_hero_web/components/provider_components.ex:2881
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2876
+#: lib/klass_hero_web/components/provider_components.ex:2886
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr ""
@@ -5020,7 +5020,7 @@ msgstr ""
 msgid "Present"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2803
+#: lib/klass_hero_web/components/provider_components.ex:2813
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr ""
@@ -5047,22 +5047,22 @@ msgstr ""
 msgid "Save changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2840
+#: lib/klass_hero_web/components/provider_components.ex:2850
 #, elixir-autogen, elixir-format
 msgid "School (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2850
+#: lib/klass_hero_web/components/provider_components.ex:2860
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2824
+#: lib/klass_hero_web/components/provider_components.ex:2834
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2893
+#: lib/klass_hero_web/components/provider_components.ex:2903
 #, elixir-autogen, elixir-format
 msgid "Send invite"
 msgstr ""
@@ -5072,12 +5072,12 @@ msgstr ""
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2602
+#: lib/klass_hero_web/components/provider_components.ex:2612
 #, elixir-autogen, elixir-format
 msgid "Upload a list"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:621
+#: lib/klass_hero_web/live/provider/programs_live.ex:627
 #, elixir-autogen, elixir-format
 msgid "An invite for this child and program already exists."
 msgstr ""
@@ -5254,7 +5254,7 @@ msgstr ""
 msgid "Go to dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:566
+#: lib/klass_hero_web/live/provider/programs_live.ex:572
 #, elixir-autogen, elixir-format
 msgid "%{count} row could not be processed."
 msgid_plural "%{count} rows could not be processed."
@@ -5841,8 +5841,8 @@ msgstr ""
 msgid "I'll be teaching"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:541
-#: lib/klass_hero_web/live/provider/programs_live.ex:563
+#: lib/klass_hero_web/live/provider/programs_live.ex:547
+#: lib/klass_hero_web/live/provider/programs_live.ex:569
 #, elixir-autogen, elixir-format
 msgid "Imported %{count} family."
 msgid_plural "Imported %{count} families."
@@ -6131,7 +6131,7 @@ msgstr ""
 msgid "No registered children for this session."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:550
+#: lib/klass_hero_web/live/provider/programs_live.ex:556
 #, elixir-autogen, elixir-format
 msgid "No rows imported. %{count} row could not be processed."
 msgid_plural "No rows imported. %{count} rows could not be processed."
@@ -6374,17 +6374,17 @@ msgstr ""
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2932
+#: lib/klass_hero_web/components/provider_components.ex:2942
 #, elixir-autogen, elixir-format
 msgid "Row %{row}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2932
+#: lib/klass_hero_web/components/provider_components.ex:2942
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2678
+#: lib/klass_hero_web/components/provider_components.ex:2688
 #, elixir-autogen, elixir-format
 msgid "Rows with errors"
 msgstr ""
@@ -7143,12 +7143,12 @@ msgstr ""
 msgid "Experience validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3236
+#: lib/klass_hero_web/components/provider_components.ex:3246
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3210
+#: lib/klass_hero_web/components/provider_components.ex:3220
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
@@ -7158,12 +7158,12 @@ msgstr ""
 msgid "Safeguarding certificate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3233
+#: lib/klass_hero_web/components/provider_components.ex:3243
 #, elixir-autogen, elixir-format
 msgid "Select Video"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3279
+#: lib/klass_hero_web/components/provider_components.ex:3289
 #, elixir-autogen, elixir-format
 msgid "Upload Video"
 msgstr ""
@@ -7173,7 +7173,7 @@ msgstr ""
 msgid "Your browser does not support video playback."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3426
+#: lib/klass_hero_web/components/provider_components.ex:3436
 #, elixir-autogen, elixir-format
 msgid "Confirm agreement"
 msgstr ""
@@ -7183,12 +7183,12 @@ msgstr ""
 msgid "Couldn't record your agreement. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3449
+#: lib/klass_hero_web/components/provider_components.ex:3459
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3425
+#: lib/klass_hero_web/components/provider_components.ex:3435
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr ""
@@ -7198,7 +7198,7 @@ msgstr ""
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3334
+#: lib/klass_hero_web/components/provider_components.ex:3344
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr ""
@@ -7208,17 +7208,17 @@ msgstr ""
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3434
+#: lib/klass_hero_web/components/provider_components.ex:3444
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3423
+#: lib/klass_hero_web/components/provider_components.ex:3433
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3424
+#: lib/klass_hero_web/components/provider_components.ex:3434
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
@@ -7487,12 +7487,12 @@ msgstr ""
 msgid "Your insurance is verified."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3378
+#: lib/klass_hero_web/components/provider_components.ex:3388
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3481
+#: lib/klass_hero_web/components/provider_components.ex:3491
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr ""
@@ -7502,7 +7502,7 @@ msgstr ""
 msgid "Couldn't record your declaration. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3487
+#: lib/klass_hero_web/components/provider_components.ex:3497
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr ""
@@ -7512,17 +7512,17 @@ msgstr ""
 msgid "Please confirm the declaration before signing."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3512
+#: lib/klass_hero_web/components/provider_components.ex:3522
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3491
+#: lib/klass_hero_web/components/provider_components.ex:3501
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3479
+#: lib/klass_hero_web/components/provider_components.ex:3489
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr ""
@@ -7532,12 +7532,12 @@ msgstr ""
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3499
+#: lib/klass_hero_web/components/provider_components.ex:3509
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3485
+#: lib/klass_hero_web/components/provider_components.ex:3495
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
@@ -7604,24 +7604,24 @@ msgstr ""
 msgid "Undelivered Events"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2187
-#: lib/klass_hero_web/components/provider_components.ex:2370
+#: lib/klass_hero_web/components/provider_components.ex:2197
+#: lib/klass_hero_web/components/provider_components.ex:2380
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2110
-#: lib/klass_hero_web/components/provider_components.ex:2296
+#: lib/klass_hero_web/components/provider_components.ex:2120
+#: lib/klass_hero_web/components/provider_components.ex:2306
 #, elixir-autogen, elixir-format
 msgid "Lead"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:416
+#: lib/klass_hero_web/live/provider/programs_live.ex:422
 #, elixir-autogen, elixir-format
 msgid "Lead instructor updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2122
+#: lib/klass_hero_web/components/provider_components.ex:2132
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor"
 msgstr ""
@@ -7631,65 +7631,65 @@ msgstr ""
 msgid "Manage Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2151
+#: lib/klass_hero_web/components/provider_components.ex:2161
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this program yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:346
+#: lib/klass_hero_web/live/provider/programs_live.ex:352
 #: lib/klass_hero_web/live/provider/sessions_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "Pick a staff member to add."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2134
-#: lib/klass_hero_web/components/provider_components.ex:2409
+#: lib/klass_hero_web/components/provider_components.ex:2144
+#: lib/klass_hero_web/components/provider_components.ex:2419
 #, elixir-autogen, elixir-format
 msgid "Reassign the lead before removing them"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2135
+#: lib/klass_hero_web/components/provider_components.ex:2145
 #, elixir-autogen, elixir-format
 msgid "Remove from program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2169
-#: lib/klass_hero_web/components/provider_components.ex:2351
+#: lib/klass_hero_web/components/provider_components.ex:2179
+#: lib/klass_hero_web/components/provider_components.ex:2361
 #, elixir-autogen, elixir-format
 msgid "Select a staff member…"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:361
+#: lib/klass_hero_web/live/provider/programs_live.ex:367
 #, elixir-autogen, elixir-format
 msgid "Staff member added to the program."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:387
+#: lib/klass_hero_web/live/provider/programs_live.ex:393
 #, elixir-autogen, elixir-format
 msgid "Staff member removed from the program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2192
+#: lib/klass_hero_web/components/provider_components.ex:2202
 #, elixir-autogen, elixir-format
 msgid "Staff you add can read and reply to this program's parent conversations."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2086
+#: lib/klass_hero_web/components/provider_components.ex:2096
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1064
+#: lib/klass_hero_web/live/provider/programs_live.ex:1073
 #, elixir-autogen, elixir-format
 msgid "That staff member could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:369
+#: lib/klass_hero_web/live/provider/programs_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "They are already on this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:395
+#: lib/klass_hero_web/live/provider/programs_live.ex:401
 #, elixir-autogen, elixir-format
 msgid "This person is the lead instructor. Make someone else lead before removing them."
 msgstr ""
@@ -7751,17 +7751,17 @@ msgstr ""
 msgid "This person has a history here now — use 'Remove from team' instead."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1342
+#: lib/klass_hero_web/live/provider/programs_live.ex:1351
 #, elixir-autogen, elixir-format
 msgid "Program created, but some settings could not be saved. Please review the program's limits."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1346
+#: lib/klass_hero_web/live/provider/programs_live.ex:1355
 #, elixir-autogen, elixir-format
 msgid "Program updated, but some settings could not be saved. Please review the program's limits."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1336
+#: lib/klass_hero_web/live/provider/programs_live.ex:1345
 #, elixir-autogen, elixir-format
 msgid "Program updated, but the enrollment capacity was rejected. The previous limits still apply."
 msgstr ""
@@ -7783,7 +7783,7 @@ msgstr ""
 msgid "I understand this program will have no capacity limit."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2397
+#: lib/klass_hero_web/components/provider_components.ex:2407
 #, elixir-autogen, elixir-format
 msgid "Go back to the program's usual team"
 msgstr ""
@@ -7793,17 +7793,17 @@ msgstr ""
 msgid "Lead instructor for this session updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2311
+#: lib/klass_hero_web/components/provider_components.ex:2321
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor for this session"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2333
+#: lib/klass_hero_web/components/provider_components.ex:2343
 #, elixir-autogen, elixir-format
 msgid "Nobody is working this session yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2414
+#: lib/klass_hero_web/components/provider_components.ex:2424
 #, elixir-autogen, elixir-format
 msgid "Remove from this session"
 msgstr ""
@@ -7823,7 +7823,7 @@ msgstr ""
 msgid "Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2235
+#: lib/klass_hero_web/components/provider_components.ex:2245
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{date}"
 msgstr ""
@@ -7853,22 +7853,22 @@ msgstr ""
 msgid "A session needs at least one person. Use “Go back to the program's usual team” to drop this session's own roster."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2412
+#: lib/klass_hero_web/components/provider_components.ex:2422
 #, elixir-autogen, elixir-format
 msgid "A session needs someone — use “Go back to the program's usual team” instead"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2379
+#: lib/klass_hero_web/components/provider_components.ex:2389
 #, elixir-autogen, elixir-format
 msgid "Everyone on your team is already working this session."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2267
+#: lib/klass_hero_web/components/provider_components.ex:2277
 #, elixir-autogen, elixir-format
 msgid "Staffed just for this session. Changes here do not touch the program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2269
+#: lib/klass_hero_web/components/provider_components.ex:2279
 #, elixir-autogen, elixir-format
 msgid "Using the program's usual team. The first change here copies them onto this session, so later program changes stop reaching it."
 msgstr ""
@@ -7879,17 +7879,17 @@ msgstr ""
 msgid "(optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2005
+#: lib/klass_hero_web/components/provider_components.ex:2015
 #, elixir-autogen, elixir-format
 msgid "Add a waiver"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2037
+#: lib/klass_hero_web/components/provider_components.ex:2047
 #, elixir-autogen, elixir-format
 msgid "Add waiver"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:936
+#: lib/klass_hero_web/live/provider/programs_live.ex:945
 #, elixir-autogen, elixir-format
 msgid "Check the waiver details and try again."
 msgstr ""
@@ -7906,7 +7906,7 @@ msgstr ""
 msgid "I have read and agree to %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2019
+#: lib/klass_hero_web/components/provider_components.ex:2029
 #, elixir-autogen, elixir-format
 msgid "Legal text"
 msgstr ""
@@ -7921,7 +7921,7 @@ msgstr ""
 msgid "No waivers yet. Parents enrol without signing anything."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2026
+#: lib/klass_hero_web/components/provider_components.ex:2036
 #, elixir-autogen, elixir-format
 msgid "Parents must sign this before enrolling"
 msgstr ""
@@ -7941,32 +7941,32 @@ msgstr ""
 msgid "Please tick a waiver to sign it."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2004
+#: lib/klass_hero_web/components/provider_components.ex:2014
 #, elixir-autogen, elixir-format
 msgid "Publish a new version"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2037
+#: lib/klass_hero_web/components/provider_components.ex:2047
 #, elixir-autogen, elixir-format
 msgid "Publish version"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2030
+#: lib/klass_hero_web/components/provider_components.ex:2040
 #, elixir-autogen, elixir-format
 msgid "Publishing keeps every earlier version on record; signatures already given stay bound to the wording they were shown."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1974
+#: lib/klass_hero_web/components/provider_components.ex:1976
 #, elixir-autogen, elixir-format
 msgid "Required"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1993
+#: lib/klass_hero_web/components/provider_components.ex:1997
 #, elixir-autogen, elixir-format
 msgid "Retire this waiver"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1986
+#: lib/klass_hero_web/components/provider_components.ex:1988
 #, elixir-autogen, elixir-format
 msgid "Revise text"
 msgstr ""
@@ -7981,7 +7981,7 @@ msgstr ""
 msgid "Sign waivers"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2492
+#: lib/klass_hero_web/components/provider_components.ex:2502
 #: lib/klass_hero_web/live/enrollment_waivers_live.ex:142
 #, elixir-autogen, elixir-format
 msgid "Signed"
@@ -7997,22 +7997,22 @@ msgstr ""
 msgid "There is nothing to sign for this enrollment."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2492
+#: lib/klass_hero_web/components/provider_components.ex:2502
 #, elixir-autogen, elixir-format
 msgid "Unsigned"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1978
+#: lib/klass_hero_web/components/provider_components.ex:1980
 #, elixir-autogen, elixir-format
 msgid "Version %{number}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:340
+#: lib/klass_hero_web/live/provider/programs_live.ex:346
 #, elixir-autogen, elixir-format
 msgid "Waiver not found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2460
+#: lib/klass_hero_web/components/provider_components.ex:2470
 #: lib/klass_hero_web/live/booking_live.ex:427
 #: lib/klass_hero_web/live/enrollment_waivers_live.ex:31
 #: lib/klass_hero_web/live/enrollment_waivers_live.ex:103
@@ -8033,4 +8033,24 @@ msgstr ""
 #: lib/klass_hero_web/live/enrollment_waivers_live.ex:94
 #, elixir-autogen, elixir-format
 msgid "this program"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/programs_live.ex:942
+#, elixir-autogen, elixir-format
+msgid "New version published. It applies to future enrolments."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2001
+#, elixir-autogen, elixir-format
+msgid "Retire \"%{title}\"? Parents will no longer be asked to sign it. Signatures already collected are kept."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/programs_live.ex:941
+#, elixir-autogen, elixir-format
+msgid "Waiver added."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/programs_live.ex:343
+#, elixir-autogen, elixir-format
+msgid "Waiver retired. Signatures already collected are kept."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -578,8 +578,8 @@ msgid "Dispute Resolution"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:719
-#: lib/klass_hero_web/components/provider_components.ex:2810
-#: lib/klass_hero_web/components/provider_components.ex:2828
+#: lib/klass_hero_web/components/provider_components.ex:2820
+#: lib/klass_hero_web/components/provider_components.ex:2838
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
@@ -878,9 +878,9 @@ msgstr ""
 msgid "Select one or both options"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2506
-#: lib/klass_hero_web/components/provider_components.ex:2507
-#: lib/klass_hero_web/components/provider_components.ex:2544
+#: lib/klass_hero_web/components/provider_components.ex:2516
+#: lib/klass_hero_web/components/provider_components.ex:2517
+#: lib/klass_hero_web/components/provider_components.ex:2554
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:448
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:484
@@ -1578,8 +1578,8 @@ msgid "Quick Navigation"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1487
-#: lib/klass_hero_web/components/provider_components.ex:2466
-#: lib/klass_hero_web/components/provider_components.ex:2708
+#: lib/klass_hero_web/components/provider_components.ex:2476
+#: lib/klass_hero_web/components/provider_components.ex:2718
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
@@ -1670,8 +1670,8 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:47
 #: lib/klass_hero_web/components/provider_components.ex:73
 #: lib/klass_hero_web/components/provider_components.ex:1634
-#: lib/klass_hero_web/components/provider_components.ex:2904
-#: lib/klass_hero_web/components/provider_components.ex:2922
+#: lib/klass_hero_web/components/provider_components.ex:2914
+#: lib/klass_hero_web/components/provider_components.ex:2932
 #: lib/klass_hero_web/live/admin/sessions_live.ex:298
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
@@ -1710,8 +1710,8 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1481
 #: lib/klass_hero_web/components/provider_components.ex:1884
-#: lib/klass_hero_web/components/provider_components.ex:2457
-#: lib/klass_hero_web/components/provider_components.ex:2705
+#: lib/klass_hero_web/components/provider_components.ex:2467
+#: lib/klass_hero_web/components/provider_components.ex:2715
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1817,8 +1817,8 @@ msgstr ""
 #: lib/klass_hero_web/components/participation_components.ex:717
 #: lib/klass_hero_web/components/provider_components.ex:889
 #: lib/klass_hero_web/components/provider_components.ex:1334
-#: lib/klass_hero_web/components/provider_components.ex:2046
-#: lib/klass_hero_web/components/provider_components.ex:2647
+#: lib/klass_hero_web/components/provider_components.ex:2056
+#: lib/klass_hero_web/components/provider_components.ex:2657
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:478
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
@@ -1874,7 +1874,7 @@ msgstr ""
 msgid "Data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2791
+#: lib/klass_hero_web/components/provider_components.ex:2801
 #: lib/klass_hero_web/live/settings/children_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1922,17 +1922,17 @@ msgstr ""
 msgid "Failed to submit note"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2785
-#: lib/klass_hero_web/components/provider_components.ex:2814
-#: lib/klass_hero_web/components/provider_components.ex:2830
+#: lib/klass_hero_web/components/provider_components.ex:2795
+#: lib/klass_hero_web/components/provider_components.ex:2824
+#: lib/klass_hero_web/components/provider_components.ex:2840
 #: lib/klass_hero_web/live/settings/children_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2786
-#: lib/klass_hero_web/components/provider_components.ex:2815
-#: lib/klass_hero_web/components/provider_components.ex:2831
+#: lib/klass_hero_web/components/provider_components.ex:2796
+#: lib/klass_hero_web/components/provider_components.ex:2825
+#: lib/klass_hero_web/components/provider_components.ex:2841
 #: lib/klass_hero_web/live/settings/children_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -2089,7 +2089,7 @@ msgstr ""
 msgid "Send a message to start the conversation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2885
+#: lib/klass_hero_web/components/provider_components.ex:2895
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:249
 #, elixir-autogen, elixir-format, fuzzy
@@ -2225,7 +2225,7 @@ msgstr ""
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2944
+#: lib/klass_hero_web/components/provider_components.ex:2954
 #, elixir-autogen, elixir-format, fuzzy
 msgid "An unexpected error occurred during import."
 msgstr ""
@@ -2320,8 +2320,8 @@ msgstr ""
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2454
-#: lib/klass_hero_web/components/provider_components.ex:2699
+#: lib/klass_hero_web/components/provider_components.ex:2464
+#: lib/klass_hero_web/components/provider_components.ex:2709
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2366,7 +2366,7 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2905
+#: lib/klass_hero_web/components/provider_components.ex:2915
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
@@ -2376,12 +2376,12 @@ msgstr ""
 msgid "Contact Provider"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:530
+#: lib/klass_hero_web/live/provider/programs_live.ex:536
 #, elixir-autogen, elixir-format
 msgid "Could not read the uploaded file."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:498
+#: lib/klass_hero_web/live/provider/programs_live.ex:504
 #, elixir-autogen, elixir-format
 msgid "Could not remove invite."
 msgstr ""
@@ -2415,7 +2415,7 @@ msgstr ""
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3120
+#: lib/klass_hero_web/components/provider_components.ex:3130
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2449,7 +2449,7 @@ msgstr ""
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2666
+#: lib/klass_hero_web/components/provider_components.ex:2676
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
@@ -2480,8 +2480,8 @@ msgstr ""
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2463
-#: lib/klass_hero_web/components/provider_components.ex:2925
+#: lib/klass_hero_web/components/provider_components.ex:2473
+#: lib/klass_hero_web/components/provider_components.ex:2935
 #: lib/klass_hero_web/components/provider_layout_components.ex:644
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrolled"
@@ -2503,7 +2503,7 @@ msgid "Explain why this document is being rejected..."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:71
-#: lib/klass_hero_web/components/provider_components.ex:2926
+#: lib/klass_hero_web/components/provider_components.ex:2936
 #: lib/klass_hero_web/live/admin/emails_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2519,7 +2519,7 @@ msgstr ""
 msgid "Failed to reject document."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:480
+#: lib/klass_hero_web/live/provider/programs_live.ex:486
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to resend invite."
 msgstr ""
@@ -2547,12 +2547,12 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3054
+#: lib/klass_hero_web/components/provider_components.ex:3064
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3056
+#: lib/klass_hero_web/components/provider_components.ex:3066
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
@@ -2587,7 +2587,7 @@ msgstr ""
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2702
+#: lib/klass_hero_web/components/provider_components.ex:2712
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
@@ -2602,7 +2602,7 @@ msgstr ""
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2639
+#: lib/klass_hero_web/components/provider_components.ex:2649
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import"
 msgstr ""
@@ -2612,17 +2612,17 @@ msgstr ""
 msgid "Insurance Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:495
+#: lib/klass_hero_web/live/provider/programs_live.ex:501
 #, elixir-autogen, elixir-format
 msgid "Invite not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:492
+#: lib/klass_hero_web/live/provider/programs_live.ex:498
 #, elixir-autogen, elixir-format
 msgid "Invite removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:469
+#: lib/klass_hero_web/live/provider/programs_live.ex:475
 #, elixir-autogen, elixir-format
 msgid "Invite resent successfully."
 msgstr ""
@@ -2728,18 +2728,18 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3082
+#: lib/klass_hero_web/components/provider_components.ex:3092
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2447
+#: lib/klass_hero_web/components/provider_components.ex:2457
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:526
+#: lib/klass_hero_web/live/provider/programs_live.ex:532
 #, elixir-autogen, elixir-format
 msgid "No file selected."
 msgstr ""
@@ -2749,7 +2749,7 @@ msgstr ""
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2690
+#: lib/klass_hero_web/components/provider_components.ex:2700
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
@@ -2812,7 +2812,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3157
+#: lib/klass_hero_web/components/provider_components.ex:3167
 #: lib/klass_hero_web/live/provider/verification_live.ex:698
 #: lib/klass_hero_web/live/provider/verification_live.ex:770
 #, elixir-autogen, elixir-format
@@ -2839,8 +2839,8 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:106
-#: lib/klass_hero_web/live/provider/programs_live.ex:769
-#: lib/klass_hero_web/live/provider/programs_live.ex:838
+#: lib/klass_hero_web/live/provider/programs_live.ex:775
+#: lib/klass_hero_web/live/provider/programs_live.ex:844
 #: lib/klass_hero_web/live/provider/team_live.ex:305
 #: lib/klass_hero_web/live/provider/team_live.ex:348
 #: lib/klass_hero_web/live/provider/team_live.ex:467
@@ -2873,12 +2873,12 @@ msgstr ""
 msgid "Program Start"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1328
+#: lib/klass_hero_web/live/provider/programs_live.ex:1337
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program created successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1332
+#: lib/klass_hero_web/live/provider/programs_live.ex:1341
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr ""
@@ -2888,13 +2888,13 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/programs_live.ex:193
 #: lib/klass_hero_web/live/provider/programs_live.ex:257
 #: lib/klass_hero_web/live/provider/programs_live.ex:281
-#: lib/klass_hero_web/live/provider/programs_live.ex:813
-#: lib/klass_hero_web/live/provider/programs_live.ex:935
+#: lib/klass_hero_web/live/provider/programs_live.ex:819
+#: lib/klass_hero_web/live/provider/programs_live.ex:944
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1329
+#: lib/klass_hero_web/live/provider/programs_live.ex:1338
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program updated successfully."
 msgstr ""
@@ -2912,7 +2912,7 @@ msgid "Read our founding story →"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:805
-#: lib/klass_hero_web/components/provider_components.ex:2924
+#: lib/klass_hero_web/components/provider_components.ex:2934
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registered"
@@ -2994,16 +2994,16 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:839
 #: lib/klass_hero_web/components/provider_components.ex:1284
-#: lib/klass_hero_web/components/provider_components.ex:2746
-#: lib/klass_hero_web/components/provider_components.ex:3176
-#: lib/klass_hero_web/components/provider_components.ex:3255
+#: lib/klass_hero_web/components/provider_components.ex:2756
+#: lib/klass_hero_web/components/provider_components.ex:3186
+#: lib/klass_hero_web/components/provider_components.ex:3265
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:253
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2739
+#: lib/klass_hero_web/components/provider_components.ex:2749
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -3044,7 +3044,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3154
+#: lib/klass_hero_web/components/provider_components.ex:3164
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select File"
 msgstr ""
@@ -3055,13 +3055,13 @@ msgstr ""
 msgid "Selected child does not meet the program requirements."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:759
-#: lib/klass_hero_web/live/provider/programs_live.ex:828
+#: lib/klass_hero_web/live/provider/programs_live.ex:765
+#: lib/klass_hero_web/live/provider/programs_live.ex:834
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2923
+#: lib/klass_hero_web/components/provider_components.ex:2933
 #: lib/klass_hero_web/live/admin/emails_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Sent"
@@ -3156,23 +3156,23 @@ msgstr ""
 msgid "The Klass Hero Story"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:472
+#: lib/klass_hero_web/live/provider/programs_live.ex:478
 #, elixir-autogen, elixir-format
 msgid "This invite cannot be resent."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:820
+#: lib/klass_hero_web/live/provider/programs_live.ex:826
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:975
-#: lib/klass_hero_web/components/provider_components.ex:2012
+#: lib/klass_hero_web/components/provider_components.ex:2022
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3055
+#: lib/klass_hero_web/components/provider_components.ex:3065
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -3192,32 +3192,32 @@ msgstr ""
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2625
+#: lib/klass_hero_web/components/provider_components.ex:2635
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3200
+#: lib/klass_hero_web/components/provider_components.ex:3210
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3109
+#: lib/klass_hero_web/components/provider_components.ex:3119
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3077
+#: lib/klass_hero_web/components/provider_components.ex:3087
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3057
+#: lib/klass_hero_web/components/provider_components.ex:3067
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3074
+#: lib/klass_hero_web/components/provider_components.ex:3084
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -3307,7 +3307,7 @@ msgid "Child Safeguarding Training"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1498
-#: lib/klass_hero_web/components/provider_components.ex:3422
+#: lib/klass_hero_web/components/provider_components.ex:3432
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr ""
@@ -3377,7 +3377,7 @@ msgstr ""
 msgid "Program fee:"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1105
+#: lib/klass_hero_web/live/provider/programs_live.ex:1114
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr ""
@@ -3458,7 +3458,7 @@ msgid "Vetted with Care"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1482
-#: lib/klass_hero_web/components/provider_components.ex:3207
+#: lib/klass_hero_web/components/provider_components.ex:3217
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr ""
@@ -3594,7 +3594,7 @@ msgstr ""
 msgid "Cannot check out without a check-in"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:444
+#: lib/klass_hero_web/live/provider/programs_live.ex:450
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
@@ -3632,7 +3632,7 @@ msgstr ""
 msgid "Checked Out"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2782
+#: lib/klass_hero_web/components/provider_components.ex:2792
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Child"
@@ -3659,7 +3659,7 @@ msgid "Correct"
 msgstr ""
 
 #: lib/klass_hero_web/live/dashboard_live.ex:306
-#: lib/klass_hero_web/live/provider/programs_live.ex:441
+#: lib/klass_hero_web/live/provider/programs_live.ex:447
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Could not start conversation. Please try again."
@@ -3685,7 +3685,7 @@ msgstr ""
 msgid "Download monthly statements for taxes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2543
+#: lib/klass_hero_web/components/provider_components.ex:2553
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:483
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrollment not confirmed"
@@ -3781,7 +3781,7 @@ msgstr ""
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2542
+#: lib/klass_hero_web/components/provider_components.ex:2552
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -4623,7 +4623,7 @@ msgid "Update your observation..."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:138
-#: lib/klass_hero_web/live/provider/programs_live.ex:523
+#: lib/klass_hero_web/live/provider/programs_live.ex:529
 #: lib/klass_hero_web/live/provider/verification_live.ex:240
 #: lib/klass_hero_web/live/provider/verification_live.ex:556
 #: lib/klass_hero_web/live/provider/verification_live.ex:594
@@ -4906,8 +4906,8 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1866
 #: lib/klass_hero_web/components/provider_components.ex:1951
-#: lib/klass_hero_web/components/provider_components.ex:2088
-#: lib/klass_hero_web/components/provider_components.ex:2242
+#: lib/klass_hero_web/components/provider_components.ex:2098
+#: lib/klass_hero_web/components/provider_components.ex:2252
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Close"
 msgstr ""
@@ -4932,7 +4932,7 @@ msgstr ""
 msgid "View sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:614
+#: lib/klass_hero_web/live/provider/programs_live.ex:620
 #, elixir-autogen, elixir-format
 msgid "Create a program before inviting participants."
 msgstr ""
@@ -4959,22 +4959,22 @@ msgstr ""
 msgid "Failed to update record"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2846
+#: lib/klass_hero_web/components/provider_components.ex:2856
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2565
+#: lib/klass_hero_web/components/provider_components.ex:2575
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invite mode"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2584
+#: lib/klass_hero_web/components/provider_components.ex:2594
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:610
+#: lib/klass_hero_web/live/provider/programs_live.ex:616
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invite sent."
 msgstr ""
@@ -4984,12 +4984,12 @@ msgstr ""
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2859
+#: lib/klass_hero_web/components/provider_components.ex:2869
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2865
+#: lib/klass_hero_web/components/provider_components.ex:2875
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr ""
@@ -5000,17 +5000,17 @@ msgstr ""
 msgid "Nothing to update"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2867
+#: lib/klass_hero_web/components/provider_components.ex:2877
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nut allergy"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2871
+#: lib/klass_hero_web/components/provider_components.ex:2881
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2876
+#: lib/klass_hero_web/components/provider_components.ex:2886
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr ""
@@ -5020,7 +5020,7 @@ msgstr ""
 msgid "Present"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2803
+#: lib/klass_hero_web/components/provider_components.ex:2813
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr ""
@@ -5047,22 +5047,22 @@ msgstr ""
 msgid "Save changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2840
+#: lib/klass_hero_web/components/provider_components.ex:2850
 #, elixir-autogen, elixir-format, fuzzy
 msgid "School (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2850
+#: lib/klass_hero_web/components/provider_components.ex:2860
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2824
+#: lib/klass_hero_web/components/provider_components.ex:2834
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2893
+#: lib/klass_hero_web/components/provider_components.ex:2903
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Send invite"
 msgstr ""
@@ -5072,12 +5072,12 @@ msgstr ""
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2602
+#: lib/klass_hero_web/components/provider_components.ex:2612
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload a list"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:621
+#: lib/klass_hero_web/live/provider/programs_live.ex:627
 #, elixir-autogen, elixir-format
 msgid "An invite for this child and program already exists."
 msgstr ""
@@ -5254,7 +5254,7 @@ msgstr ""
 msgid "Go to dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:566
+#: lib/klass_hero_web/live/provider/programs_live.ex:572
 #, elixir-autogen, elixir-format
 msgid "%{count} row could not be processed."
 msgid_plural "%{count} rows could not be processed."
@@ -5841,8 +5841,8 @@ msgstr ""
 msgid "I'll be teaching"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:541
-#: lib/klass_hero_web/live/provider/programs_live.ex:563
+#: lib/klass_hero_web/live/provider/programs_live.ex:547
+#: lib/klass_hero_web/live/provider/programs_live.ex:569
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Imported %{count} family."
 msgid_plural "Imported %{count} families."
@@ -6131,7 +6131,7 @@ msgstr ""
 msgid "No registered children for this session."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:550
+#: lib/klass_hero_web/live/provider/programs_live.ex:556
 #, elixir-autogen, elixir-format
 msgid "No rows imported. %{count} row could not be processed."
 msgid_plural "No rows imported. %{count} rows could not be processed."
@@ -6374,17 +6374,17 @@ msgstr ""
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2932
+#: lib/klass_hero_web/components/provider_components.ex:2942
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Row %{row}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2932
+#: lib/klass_hero_web/components/provider_components.ex:2942
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2678
+#: lib/klass_hero_web/components/provider_components.ex:2688
 #, elixir-autogen, elixir-format
 msgid "Rows with errors"
 msgstr ""
@@ -7143,12 +7143,12 @@ msgstr ""
 msgid "Experience validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3236
+#: lib/klass_hero_web/components/provider_components.ex:3246
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3210
+#: lib/klass_hero_web/components/provider_components.ex:3220
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
@@ -7158,12 +7158,12 @@ msgstr ""
 msgid "Safeguarding certificate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3233
+#: lib/klass_hero_web/components/provider_components.ex:3243
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select Video"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3279
+#: lib/klass_hero_web/components/provider_components.ex:3289
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload Video"
 msgstr ""
@@ -7173,7 +7173,7 @@ msgstr ""
 msgid "Your browser does not support video playback."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3426
+#: lib/klass_hero_web/components/provider_components.ex:3436
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Confirm agreement"
 msgstr ""
@@ -7183,12 +7183,12 @@ msgstr ""
 msgid "Couldn't record your agreement. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3449
+#: lib/klass_hero_web/components/provider_components.ex:3459
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3425
+#: lib/klass_hero_web/components/provider_components.ex:3435
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr ""
@@ -7198,7 +7198,7 @@ msgstr ""
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3334
+#: lib/klass_hero_web/components/provider_components.ex:3344
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr ""
@@ -7208,17 +7208,17 @@ msgstr ""
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3434
+#: lib/klass_hero_web/components/provider_components.ex:3444
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3423
+#: lib/klass_hero_web/components/provider_components.ex:3433
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3424
+#: lib/klass_hero_web/components/provider_components.ex:3434
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
@@ -7487,12 +7487,12 @@ msgstr ""
 msgid "Your insurance is verified."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3378
+#: lib/klass_hero_web/components/provider_components.ex:3388
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3481
+#: lib/klass_hero_web/components/provider_components.ex:3491
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr ""
@@ -7502,7 +7502,7 @@ msgstr ""
 msgid "Couldn't record your declaration. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3487
+#: lib/klass_hero_web/components/provider_components.ex:3497
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr ""
@@ -7512,17 +7512,17 @@ msgstr ""
 msgid "Please confirm the declaration before signing."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3512
+#: lib/klass_hero_web/components/provider_components.ex:3522
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3491
+#: lib/klass_hero_web/components/provider_components.ex:3501
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3479
+#: lib/klass_hero_web/components/provider_components.ex:3489
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr ""
@@ -7532,12 +7532,12 @@ msgstr ""
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3499
+#: lib/klass_hero_web/components/provider_components.ex:3509
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3485
+#: lib/klass_hero_web/components/provider_components.ex:3495
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
@@ -7604,24 +7604,24 @@ msgstr ""
 msgid "Undelivered Events"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2187
-#: lib/klass_hero_web/components/provider_components.ex:2370
+#: lib/klass_hero_web/components/provider_components.ex:2197
+#: lib/klass_hero_web/components/provider_components.ex:2380
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2110
-#: lib/klass_hero_web/components/provider_components.ex:2296
+#: lib/klass_hero_web/components/provider_components.ex:2120
+#: lib/klass_hero_web/components/provider_components.ex:2306
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Lead"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:416
+#: lib/klass_hero_web/live/provider/programs_live.ex:422
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Lead instructor updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2122
+#: lib/klass_hero_web/components/provider_components.ex:2132
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor"
 msgstr ""
@@ -7631,65 +7631,65 @@ msgstr ""
 msgid "Manage Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2151
+#: lib/klass_hero_web/components/provider_components.ex:2161
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this program yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:346
+#: lib/klass_hero_web/live/provider/programs_live.ex:352
 #: lib/klass_hero_web/live/provider/sessions_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "Pick a staff member to add."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2134
-#: lib/klass_hero_web/components/provider_components.ex:2409
+#: lib/klass_hero_web/components/provider_components.ex:2144
+#: lib/klass_hero_web/components/provider_components.ex:2419
 #, elixir-autogen, elixir-format
 msgid "Reassign the lead before removing them"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2135
+#: lib/klass_hero_web/components/provider_components.ex:2145
 #, elixir-autogen, elixir-format
 msgid "Remove from program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2169
-#: lib/klass_hero_web/components/provider_components.ex:2351
+#: lib/klass_hero_web/components/provider_components.ex:2179
+#: lib/klass_hero_web/components/provider_components.ex:2361
 #, elixir-autogen, elixir-format
 msgid "Select a staff member…"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:361
+#: lib/klass_hero_web/live/provider/programs_live.ex:367
 #, elixir-autogen, elixir-format
 msgid "Staff member added to the program."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:387
+#: lib/klass_hero_web/live/provider/programs_live.ex:393
 #, elixir-autogen, elixir-format
 msgid "Staff member removed from the program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2192
+#: lib/klass_hero_web/components/provider_components.ex:2202
 #, elixir-autogen, elixir-format
 msgid "Staff you add can read and reply to this program's parent conversations."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2086
+#: lib/klass_hero_web/components/provider_components.ex:2096
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Staffing — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1064
+#: lib/klass_hero_web/live/provider/programs_live.ex:1073
 #, elixir-autogen, elixir-format
 msgid "That staff member could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:369
+#: lib/klass_hero_web/live/provider/programs_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "They are already on this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:395
+#: lib/klass_hero_web/live/provider/programs_live.ex:401
 #, elixir-autogen, elixir-format
 msgid "This person is the lead instructor. Make someone else lead before removing them."
 msgstr ""
@@ -7751,17 +7751,17 @@ msgstr ""
 msgid "This person has a history here now — use 'Remove from team' instead."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1342
+#: lib/klass_hero_web/live/provider/programs_live.ex:1351
 #, elixir-autogen, elixir-format
 msgid "Program created, but some settings could not be saved. Please review the program's limits."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1346
+#: lib/klass_hero_web/live/provider/programs_live.ex:1355
 #, elixir-autogen, elixir-format
 msgid "Program updated, but some settings could not be saved. Please review the program's limits."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1336
+#: lib/klass_hero_web/live/provider/programs_live.ex:1345
 #, elixir-autogen, elixir-format
 msgid "Program updated, but the enrollment capacity was rejected. The previous limits still apply."
 msgstr ""
@@ -7783,7 +7783,7 @@ msgstr ""
 msgid "I understand this program will have no capacity limit."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2397
+#: lib/klass_hero_web/components/provider_components.ex:2407
 #, elixir-autogen, elixir-format
 msgid "Go back to the program's usual team"
 msgstr ""
@@ -7793,17 +7793,17 @@ msgstr ""
 msgid "Lead instructor for this session updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2311
+#: lib/klass_hero_web/components/provider_components.ex:2321
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Make lead instructor for this session"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2333
+#: lib/klass_hero_web/components/provider_components.ex:2343
 #, elixir-autogen, elixir-format
 msgid "Nobody is working this session yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2414
+#: lib/klass_hero_web/components/provider_components.ex:2424
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove from this session"
 msgstr ""
@@ -7823,7 +7823,7 @@ msgstr ""
 msgid "Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2235
+#: lib/klass_hero_web/components/provider_components.ex:2245
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Staffing — %{date}"
 msgstr ""
@@ -7853,22 +7853,22 @@ msgstr ""
 msgid "A session needs at least one person. Use “Go back to the program's usual team” to drop this session's own roster."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2412
+#: lib/klass_hero_web/components/provider_components.ex:2422
 #, elixir-autogen, elixir-format
 msgid "A session needs someone — use “Go back to the program's usual team” instead"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2379
+#: lib/klass_hero_web/components/provider_components.ex:2389
 #, elixir-autogen, elixir-format
 msgid "Everyone on your team is already working this session."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2267
+#: lib/klass_hero_web/components/provider_components.ex:2277
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Staffed just for this session. Changes here do not touch the program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2269
+#: lib/klass_hero_web/components/provider_components.ex:2279
 #, elixir-autogen, elixir-format
 msgid "Using the program's usual team. The first change here copies them onto this session, so later program changes stop reaching it."
 msgstr ""
@@ -7879,17 +7879,17 @@ msgstr ""
 msgid "(optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2005
+#: lib/klass_hero_web/components/provider_components.ex:2015
 #, elixir-autogen, elixir-format
 msgid "Add a waiver"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2037
+#: lib/klass_hero_web/components/provider_components.ex:2047
 #, elixir-autogen, elixir-format
 msgid "Add waiver"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:936
+#: lib/klass_hero_web/live/provider/programs_live.ex:945
 #, elixir-autogen, elixir-format
 msgid "Check the waiver details and try again."
 msgstr ""
@@ -7906,7 +7906,7 @@ msgstr ""
 msgid "I have read and agree to %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2019
+#: lib/klass_hero_web/components/provider_components.ex:2029
 #, elixir-autogen, elixir-format
 msgid "Legal text"
 msgstr ""
@@ -7921,7 +7921,7 @@ msgstr ""
 msgid "No waivers yet. Parents enrol without signing anything."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2026
+#: lib/klass_hero_web/components/provider_components.ex:2036
 #, elixir-autogen, elixir-format
 msgid "Parents must sign this before enrolling"
 msgstr ""
@@ -7941,32 +7941,32 @@ msgstr ""
 msgid "Please tick a waiver to sign it."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2004
+#: lib/klass_hero_web/components/provider_components.ex:2014
 #, elixir-autogen, elixir-format
 msgid "Publish a new version"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2037
+#: lib/klass_hero_web/components/provider_components.ex:2047
 #, elixir-autogen, elixir-format
 msgid "Publish version"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2030
+#: lib/klass_hero_web/components/provider_components.ex:2040
 #, elixir-autogen, elixir-format
 msgid "Publishing keeps every earlier version on record; signatures already given stay bound to the wording they were shown."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1974
+#: lib/klass_hero_web/components/provider_components.ex:1976
 #, elixir-autogen, elixir-format
 msgid "Required"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1993
+#: lib/klass_hero_web/components/provider_components.ex:1997
 #, elixir-autogen, elixir-format
 msgid "Retire this waiver"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1986
+#: lib/klass_hero_web/components/provider_components.ex:1988
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Revise text"
 msgstr ""
@@ -7981,7 +7981,7 @@ msgstr ""
 msgid "Sign waivers"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2492
+#: lib/klass_hero_web/components/provider_components.ex:2502
 #: lib/klass_hero_web/live/enrollment_waivers_live.ex:142
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Signed"
@@ -7997,22 +7997,22 @@ msgstr ""
 msgid "There is nothing to sign for this enrollment."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2492
+#: lib/klass_hero_web/components/provider_components.ex:2502
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Unsigned"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1978
+#: lib/klass_hero_web/components/provider_components.ex:1980
 #, elixir-autogen, elixir-format
 msgid "Version %{number}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:340
+#: lib/klass_hero_web/live/provider/programs_live.ex:346
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Waiver not found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2460
+#: lib/klass_hero_web/components/provider_components.ex:2470
 #: lib/klass_hero_web/live/booking_live.ex:427
 #: lib/klass_hero_web/live/enrollment_waivers_live.ex:31
 #: lib/klass_hero_web/live/enrollment_waivers_live.ex:103
@@ -8033,4 +8033,24 @@ msgstr ""
 #: lib/klass_hero_web/live/enrollment_waivers_live.ex:94
 #, elixir-autogen, elixir-format, fuzzy
 msgid "this program"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/programs_live.ex:942
+#, elixir-autogen, elixir-format
+msgid "New version published. It applies to future enrolments."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2001
+#, elixir-autogen, elixir-format
+msgid "Retire \"%{title}\"? Parents will no longer be asked to sign it. Signatures already collected are kept."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/programs_live.ex:941
+#, elixir-autogen, elixir-format
+msgid "Waiver added."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/programs_live.ex:343
+#, elixir-autogen, elixir-format
+msgid "Waiver retired. Signatures already collected are kept."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -137,12 +137,12 @@ msgid "Your Data"
 msgstr ""
 
 #: lib/klass_hero_web/components/core_components.ex:71
-#: lib/klass_hero_web/components/provider_components.ex:1758
+#: lib/klass_hero_web/components/provider_components.ex:1765
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:355
+#: lib/klass_hero_web/live/booking_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "%{name} (Age %{age})"
 msgstr ""
@@ -152,17 +152,17 @@ msgstr ""
 msgid "About This Program"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:290
+#: lib/klass_hero_web/live/booking_live.ex:310
 #, elixir-autogen, elixir-format
 msgid "Activity Summary"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:368
+#: lib/klass_hero_web/live/booking_live.ex:388
 #, elixir-autogen, elixir-format
 msgid "Add another child"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:331
+#: lib/klass_hero_web/live/booking_live.ex:351
 #, elixir-autogen, elixir-format
 msgid "Add another program"
 msgstr ""
@@ -172,12 +172,12 @@ msgstr ""
 msgid "Ages %{range}"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:441
+#: lib/klass_hero_web/live/booking_live.ex:511
 #, elixir-autogen, elixir-format
 msgid "An invoice will be emailed to you after enrollment completion"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:385
+#: lib/klass_hero_web/live/booking_live.ex:405
 #, elixir-autogen, elixir-format
 msgid "Any allergies, medical conditions, or special instructions..."
 msgstr ""
@@ -187,12 +187,12 @@ msgstr ""
 msgid "Book camps, tutors, and workshops instantly. Our integrated planner helps you manage your child's busy life."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:418
+#: lib/klass_hero_web/live/booking_live.ex:488
 #, elixir-autogen, elixir-format
 msgid "Cash / Bank Transfer"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:443
+#: lib/klass_hero_web/live/booking_live.ex:513
 #, elixir-autogen, elixir-format
 msgid "Cash/transfer payments will show as \"Pending\" until received"
 msgstr ""
@@ -202,22 +202,22 @@ msgstr ""
 msgid "Community Focused"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:460
+#: lib/klass_hero_web/live/booking_live.ex:530
 #, elixir-autogen, elixir-format
 msgid "Complete Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:409
+#: lib/klass_hero_web/live/booking_live.ex:479
 #, elixir-autogen, elixir-format
 msgid "Credit Card"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:442
+#: lib/klass_hero_web/live/booking_live.ex:512
 #, elixir-autogen, elixir-format
 msgid "Credit card payments are processed immediately"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:322
+#: lib/klass_hero_web/live/booking_live.ex:342
 #, elixir-autogen, elixir-format
 msgid "Duration:"
 msgstr ""
@@ -233,22 +233,22 @@ msgid "Enroll Now - %{price}"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1484
-#: lib/klass_hero_web/live/booking_live.ex:285
+#: lib/klass_hero_web/live/booking_live.ex:305
 #, elixir-autogen, elixir-format
 msgid "Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:36
+#: lib/klass_hero_web/live/booking_live.ex:37
 #, elixir-autogen, elixir-format
 msgid "Enrollment - %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:189
+#: lib/klass_hero_web/live/booking_live.ex:204
 #, elixir-autogen, elixir-format
 msgid "Enrollment failed. Please try again or contact support."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:128
+#: lib/klass_hero_web/live/booking_live.ex:134
 #, elixir-autogen, elixir-format
 msgid "Enrollment successful! You'll receive a confirmation email shortly."
 msgstr ""
@@ -274,7 +274,7 @@ msgstr ""
 msgid "Invalid pagination state. Please refresh the page."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:439
+#: lib/klass_hero_web/live/booking_live.ex:509
 #, elixir-autogen, elixir-format
 msgid "Invoice & Payment Confirmation"
 msgstr ""
@@ -296,32 +296,32 @@ msgstr[1] ""
 msgid "No programs found"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:393
+#: lib/klass_hero_web/live/booking_live.ex:413
 #, elixir-autogen, elixir-format
 msgid "Optional: Include any important information we should know about your child."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:410
+#: lib/klass_hero_web/live/booking_live.ex:480
 #, elixir-autogen, elixir-format
 msgid "Pay securely with Visa, Mastercard, or other cards"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:404
+#: lib/klass_hero_web/live/booking_live.ex:474
 #, elixir-autogen, elixir-format
 msgid "Payment Method"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:428
+#: lib/klass_hero_web/live/booking_live.ex:498
 #, elixir-autogen, elixir-format
 msgid "Payment Summary"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:152
+#: lib/klass_hero_web/live/booking_live.ex:158
 #, elixir-autogen, elixir-format
 msgid "Payment information is invalid. Please check your details."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:156
+#: lib/klass_hero_web/live/booking_live.ex:162
 #, elixir-autogen, elixir-format
 msgid "Please select a child for enrollment."
 msgstr ""
@@ -331,7 +331,7 @@ msgstr ""
 msgid "Klass Hero - Connecting Families with Trusted Youth Educators"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:54
+#: lib/klass_hero_web/live/booking_live.ex:60
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:59
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:57
 #, elixir-autogen, elixir-format
@@ -354,37 +354,37 @@ msgstr ""
 msgid "Search programs..."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:339
+#: lib/klass_hero_web/live/booking_live.ex:359
 #, elixir-autogen, elixir-format
 msgid "Select Child"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:349
+#: lib/klass_hero_web/live/booking_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "Select a child"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:64
+#: lib/klass_hero_web/live/booking_live.ex:70
 #, elixir-autogen, elixir-format
 msgid "Sorry, this program is currently full. Check back later for availability."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:137
+#: lib/klass_hero_web/live/booking_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "Sorry, this program is now full. Please choose another program."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:378
+#: lib/klass_hero_web/live/booking_live.ex:398
 #, elixir-autogen, elixir-format
 msgid "Special Requirements"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:315
+#: lib/klass_hero_web/live/booking_live.ex:335
 #, elixir-autogen, elixir-format
 msgid "Total Price:"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:434
+#: lib/klass_hero_web/live/booking_live.ex:504
 #, elixir-autogen, elixir-format
 msgid "Total due today:"
 msgstr ""
@@ -578,8 +578,8 @@ msgid "Dispute Resolution"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:719
-#: lib/klass_hero_web/components/provider_components.ex:2647
-#: lib/klass_hero_web/components/provider_components.ex:2665
+#: lib/klass_hero_web/components/provider_components.ex:2810
+#: lib/klass_hero_web/components/provider_components.ex:2828
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
@@ -878,9 +878,9 @@ msgstr ""
 msgid "Select one or both options"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2343
-#: lib/klass_hero_web/components/provider_components.ex:2344
-#: lib/klass_hero_web/components/provider_components.ex:2381
+#: lib/klass_hero_web/components/provider_components.ex:2506
+#: lib/klass_hero_web/components/provider_components.ex:2507
+#: lib/klass_hero_web/components/provider_components.ex:2544
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:448
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:484
@@ -1578,13 +1578,13 @@ msgid "Quick Navigation"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1487
-#: lib/klass_hero_web/components/provider_components.ex:2319
-#: lib/klass_hero_web/components/provider_components.ex:2545
+#: lib/klass_hero_web/components/provider_components.ex:2466
+#: lib/klass_hero_web/components/provider_components.ex:2708
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1626
+#: lib/klass_hero_web/components/provider_components.ex:1633
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Active"
 msgstr ""
@@ -1628,7 +1628,7 @@ msgid "Create profiles for your staff. These will be visible to parents when ass
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:539
-#: lib/klass_hero_web/components/provider_components.ex:1589
+#: lib/klass_hero_web/components/provider_components.ex:1596
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:54
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:81
 #: lib/klass_hero_web/live/settings/children_live.ex:413
@@ -1645,7 +1645,7 @@ msgstr ""
 msgid "Edit Profile"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1628
+#: lib/klass_hero_web/components/provider_components.ex:1635
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr ""
@@ -1669,9 +1669,9 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:47
 #: lib/klass_hero_web/components/provider_components.ex:73
-#: lib/klass_hero_web/components/provider_components.ex:1627
-#: lib/klass_hero_web/components/provider_components.ex:2741
-#: lib/klass_hero_web/components/provider_components.ex:2759
+#: lib/klass_hero_web/components/provider_components.ex:1634
+#: lib/klass_hero_web/components/provider_components.ex:2904
+#: lib/klass_hero_web/components/provider_components.ex:2922
 #: lib/klass_hero_web/live/admin/sessions_live.ex:298
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
@@ -1709,9 +1709,9 @@ msgid "Search by name..."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1481
-#: lib/klass_hero_web/components/provider_components.ex:1877
-#: lib/klass_hero_web/components/provider_components.ex:2313
-#: lib/klass_hero_web/components/provider_components.ex:2542
+#: lib/klass_hero_web/components/provider_components.ex:1884
+#: lib/klass_hero_web/components/provider_components.ex:2457
+#: lib/klass_hero_web/components/provider_components.ex:2705
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1736,14 +1736,14 @@ msgid "This is your main business identity. Verification is required to list pro
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1538
-#: lib/klass_hero_web/components/provider_components.ex:1892
+#: lib/klass_hero_web/components/provider_components.ex:1899
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr ""
 
 #: lib/klass_hero_web/components/messaging_components.ex:722
 #: lib/klass_hero_web/components/provider_components.ex:50
-#: lib/klass_hero_web/components/provider_components.ex:1629
+#: lib/klass_hero_web/components/provider_components.ex:1636
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:434
 #: lib/klass_hero_web/presenters/provider_presenter.ex:103
 #, elixir-autogen, elixir-format
@@ -1817,7 +1817,8 @@ msgstr ""
 #: lib/klass_hero_web/components/participation_components.ex:717
 #: lib/klass_hero_web/components/provider_components.ex:889
 #: lib/klass_hero_web/components/provider_components.ex:1334
-#: lib/klass_hero_web/components/provider_components.ex:2484
+#: lib/klass_hero_web/components/provider_components.ex:2046
+#: lib/klass_hero_web/components/provider_components.ex:2647
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:478
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
@@ -1852,7 +1853,7 @@ msgstr ""
 msgid "Child updated successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:176
+#: lib/klass_hero_web/live/dashboard_live.ex:178
 #: lib/klass_hero_web/live/messaging_live_helper.ex:336
 #, elixir-autogen, elixir-format
 msgid "Conversation"
@@ -1873,7 +1874,7 @@ msgstr ""
 msgid "Data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2628
+#: lib/klass_hero_web/components/provider_components.ex:2791
 #: lib/klass_hero_web/live/settings/children_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1921,17 +1922,17 @@ msgstr ""
 msgid "Failed to submit note"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2622
-#: lib/klass_hero_web/components/provider_components.ex:2651
-#: lib/klass_hero_web/components/provider_components.ex:2667
+#: lib/klass_hero_web/components/provider_components.ex:2785
+#: lib/klass_hero_web/components/provider_components.ex:2814
+#: lib/klass_hero_web/components/provider_components.ex:2830
 #: lib/klass_hero_web/live/settings/children_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2623
-#: lib/klass_hero_web/components/provider_components.ex:2652
-#: lib/klass_hero_web/components/provider_components.ex:2668
+#: lib/klass_hero_web/components/provider_components.ex:2786
+#: lib/klass_hero_web/components/provider_components.ex:2815
+#: lib/klass_hero_web/components/provider_components.ex:2831
 #: lib/klass_hero_web/live/settings/children_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -2026,7 +2027,7 @@ msgstr ""
 msgid "Please check the form for errors."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:163
+#: lib/klass_hero_web/live/booking_live.ex:178
 #, elixir-autogen, elixir-format
 msgid "Please complete your profile before making a booking."
 msgstr ""
@@ -2069,8 +2070,8 @@ msgstr ""
 msgid "Save Changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1736
-#: lib/klass_hero_web/components/provider_components.ex:1737
+#: lib/klass_hero_web/components/provider_components.ex:1743
+#: lib/klass_hero_web/components/provider_components.ex:1744
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:43
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:151
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:252
@@ -2088,7 +2089,7 @@ msgstr ""
 msgid "Send a message to start the conversation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2722
+#: lib/klass_hero_web/components/provider_components.ex:2885
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:249
 #, elixir-autogen, elixir-format, fuzzy
@@ -2224,7 +2225,7 @@ msgstr ""
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2781
+#: lib/klass_hero_web/components/provider_components.ex:2944
 #, elixir-autogen, elixir-format, fuzzy
 msgid "An unexpected error occurred during import."
 msgstr ""
@@ -2272,7 +2273,7 @@ msgstr ""
 msgid "Bio"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:389
+#: lib/klass_hero_web/live/dashboard_live.ex:429
 #, elixir-autogen, elixir-format
 msgid "Book a Program"
 msgstr ""
@@ -2319,8 +2320,8 @@ msgstr ""
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2310
-#: lib/klass_hero_web/components/provider_components.ex:2536
+#: lib/klass_hero_web/components/provider_components.ex:2454
+#: lib/klass_hero_web/components/provider_components.ex:2699
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2365,7 +2366,7 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2742
+#: lib/klass_hero_web/components/provider_components.ex:2905
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
@@ -2375,12 +2376,12 @@ msgstr ""
 msgid "Contact Provider"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:451
+#: lib/klass_hero_web/live/provider/programs_live.ex:530
 #, elixir-autogen, elixir-format
 msgid "Could not read the uploaded file."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:419
+#: lib/klass_hero_web/live/provider/programs_live.ex:498
 #, elixir-autogen, elixir-format
 msgid "Could not remove invite."
 msgstr ""
@@ -2414,7 +2415,7 @@ msgstr ""
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2957
+#: lib/klass_hero_web/components/provider_components.ex:3120
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2448,7 +2449,7 @@ msgstr ""
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2503
+#: lib/klass_hero_web/components/provider_components.ex:2666
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
@@ -2479,14 +2480,14 @@ msgstr ""
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2316
-#: lib/klass_hero_web/components/provider_components.ex:2762
+#: lib/klass_hero_web/components/provider_components.ex:2463
+#: lib/klass_hero_web/components/provider_components.ex:2925
 #: lib/klass_hero_web/components/provider_layout_components.ex:644
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrolled"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1782
+#: lib/klass_hero_web/components/provider_components.ex:1789
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr ""
@@ -2502,7 +2503,7 @@ msgid "Explain why this document is being rejected..."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:71
-#: lib/klass_hero_web/components/provider_components.ex:2763
+#: lib/klass_hero_web/components/provider_components.ex:2926
 #: lib/klass_hero_web/live/admin/emails_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2518,7 +2519,7 @@ msgstr ""
 msgid "Failed to reject document."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:401
+#: lib/klass_hero_web/live/provider/programs_live.ex:480
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to resend invite."
 msgstr ""
@@ -2529,7 +2530,7 @@ msgstr ""
 msgid "Failed to upload document."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:362
+#: lib/klass_hero_web/live/dashboard_live.ex:402
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Family Programs"
 msgstr ""
@@ -2546,12 +2547,12 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2891
+#: lib/klass_hero_web/components/provider_components.ex:3054
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2893
+#: lib/klass_hero_web/components/provider_components.ex:3056
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
@@ -2586,7 +2587,7 @@ msgstr ""
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2539
+#: lib/klass_hero_web/components/provider_components.ex:2702
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
@@ -2601,7 +2602,7 @@ msgstr ""
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2476
+#: lib/klass_hero_web/components/provider_components.ex:2639
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import"
 msgstr ""
@@ -2611,22 +2612,22 @@ msgstr ""
 msgid "Insurance Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:416
+#: lib/klass_hero_web/live/provider/programs_live.ex:495
 #, elixir-autogen, elixir-format
 msgid "Invite not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:413
+#: lib/klass_hero_web/live/provider/programs_live.ex:492
 #, elixir-autogen, elixir-format
 msgid "Invite removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:390
+#: lib/klass_hero_web/live/provider/programs_live.ex:469
 #, elixir-autogen, elixir-format
 msgid "Invite resent successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1799
+#: lib/klass_hero_web/components/provider_components.ex:1806
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr ""
@@ -2727,18 +2728,18 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2919
+#: lib/klass_hero_web/components/provider_components.ex:3082
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2303
+#: lib/klass_hero_web/components/provider_components.ex:2447
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:447
+#: lib/klass_hero_web/live/provider/programs_live.ex:526
 #, elixir-autogen, elixir-format
 msgid "No file selected."
 msgstr ""
@@ -2748,7 +2749,7 @@ msgstr ""
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2527
+#: lib/klass_hero_web/components/provider_components.ex:2690
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
@@ -2768,7 +2769,7 @@ msgstr ""
 msgid "No pending documents to review."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:378
+#: lib/klass_hero_web/live/dashboard_live.ex:418
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No programs booked yet"
 msgstr ""
@@ -2811,7 +2812,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2994
+#: lib/klass_hero_web/components/provider_components.ex:3157
 #: lib/klass_hero_web/live/provider/verification_live.ex:698
 #: lib/klass_hero_web/live/provider/verification_live.ex:770
 #, elixir-autogen, elixir-format
@@ -2838,8 +2839,8 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:106
-#: lib/klass_hero_web/live/provider/programs_live.ex:690
-#: lib/klass_hero_web/live/provider/programs_live.ex:759
+#: lib/klass_hero_web/live/provider/programs_live.ex:769
+#: lib/klass_hero_web/live/provider/programs_live.ex:838
 #: lib/klass_hero_web/live/provider/team_live.ex:305
 #: lib/klass_hero_web/live/provider/team_live.ex:348
 #: lib/klass_hero_web/live/provider/team_live.ex:467
@@ -2872,26 +2873,28 @@ msgstr ""
 msgid "Program Start"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1208
+#: lib/klass_hero_web/live/provider/programs_live.ex:1328
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program created successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1212
+#: lib/klass_hero_web/live/provider/programs_live.ex:1332
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:54
-#: lib/klass_hero_web/live/provider/programs_live.ex:155
-#: lib/klass_hero_web/live/provider/programs_live.ex:192
-#: lib/klass_hero_web/live/provider/programs_live.ex:256
-#: lib/klass_hero_web/live/provider/programs_live.ex:734
+#: lib/klass_hero_web/live/provider/programs_live.ex:156
+#: lib/klass_hero_web/live/provider/programs_live.ex:193
+#: lib/klass_hero_web/live/provider/programs_live.ex:257
+#: lib/klass_hero_web/live/provider/programs_live.ex:281
+#: lib/klass_hero_web/live/provider/programs_live.ex:813
+#: lib/klass_hero_web/live/provider/programs_live.ex:935
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1209
+#: lib/klass_hero_web/live/provider/programs_live.ex:1329
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program updated successfully."
 msgstr ""
@@ -2909,7 +2912,7 @@ msgid "Read our founding story →"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:805
-#: lib/klass_hero_web/components/provider_components.ex:2761
+#: lib/klass_hero_web/components/provider_components.ex:2924
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registered"
@@ -2945,7 +2948,7 @@ msgstr ""
 msgid "Registration Period (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:144
+#: lib/klass_hero_web/live/booking_live.ex:150
 #, elixir-autogen, elixir-format
 msgid "Registration has closed for this program."
 msgstr ""
@@ -2955,7 +2958,7 @@ msgstr ""
 msgid "Registration is closed"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:73
+#: lib/klass_hero_web/live/booking_live.ex:79
 #, elixir-autogen, elixir-format
 msgid "Registration is not currently open for this program."
 msgstr ""
@@ -2991,16 +2994,16 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:839
 #: lib/klass_hero_web/components/provider_components.ex:1284
-#: lib/klass_hero_web/components/provider_components.ex:2583
-#: lib/klass_hero_web/components/provider_components.ex:3013
-#: lib/klass_hero_web/components/provider_components.ex:3092
+#: lib/klass_hero_web/components/provider_components.ex:2746
+#: lib/klass_hero_web/components/provider_components.ex:3176
+#: lib/klass_hero_web/components/provider_components.ex:3255
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:253
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2576
+#: lib/klass_hero_web/components/provider_components.ex:2739
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -3015,7 +3018,7 @@ msgstr ""
 msgid "Role"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1728
+#: lib/klass_hero_web/components/provider_components.ex:1735
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:386
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
@@ -3041,24 +3044,24 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2991
+#: lib/klass_hero_web/components/provider_components.ex:3154
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select File"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:116
-#: lib/klass_hero_web/live/booking_live.ex:173
+#: lib/klass_hero_web/live/booking_live.ex:122
+#: lib/klass_hero_web/live/booking_live.ex:188
 #, elixir-autogen, elixir-format
 msgid "Selected child does not meet the program requirements."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:680
-#: lib/klass_hero_web/live/provider/programs_live.ex:749
+#: lib/klass_hero_web/live/provider/programs_live.ex:759
+#: lib/klass_hero_web/live/provider/programs_live.ex:828
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2760
+#: lib/klass_hero_web/components/provider_components.ex:2923
 #: lib/klass_hero_web/live/admin/emails_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Sent"
@@ -3108,7 +3111,7 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:324
+#: lib/klass_hero_web/live/booking_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "TBD"
 msgstr ""
@@ -3153,22 +3156,23 @@ msgstr ""
 msgid "The Klass Hero Story"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:393
+#: lib/klass_hero_web/live/provider/programs_live.ex:472
 #, elixir-autogen, elixir-format
 msgid "This invite cannot be resent."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:741
+#: lib/klass_hero_web/live/provider/programs_live.ex:820
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:975
+#: lib/klass_hero_web/components/provider_components.ex:2012
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2892
+#: lib/klass_hero_web/components/provider_components.ex:3055
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -3188,32 +3192,32 @@ msgstr ""
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2462
+#: lib/klass_hero_web/components/provider_components.ex:2625
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3037
+#: lib/klass_hero_web/components/provider_components.ex:3200
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2946
+#: lib/klass_hero_web/components/provider_components.ex:3109
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2914
+#: lib/klass_hero_web/components/provider_components.ex:3077
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2894
+#: lib/klass_hero_web/components/provider_components.ex:3057
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2911
+#: lib/klass_hero_web/components/provider_components.ex:3074
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -3303,7 +3307,7 @@ msgid "Child Safeguarding Training"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1498
-#: lib/klass_hero_web/components/provider_components.ex:3259
+#: lib/klass_hero_web/components/provider_components.ex:3422
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr ""
@@ -3363,17 +3367,17 @@ msgstr ""
 msgid "Monitoring provider activity and feedback"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:419
+#: lib/klass_hero_web/live/booking_live.ex:489
 #, elixir-autogen, elixir-format
 msgid "Pay by cash or direct bank transfer"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:430
+#: lib/klass_hero_web/live/booking_live.ex:500
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program fee:"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:985
+#: lib/klass_hero_web/live/provider/programs_live.ex:1105
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr ""
@@ -3399,7 +3403,8 @@ msgid "Reviewing concerns or reports promptly and seriously"
 msgstr ""
 
 #: lib/klass_hero_web/controllers/invite_claim_controller.ex:57
-#: lib/klass_hero_web/live/booking_live.ex:197
+#: lib/klass_hero_web/live/booking_live.ex:212
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:73
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Please try again or contact support."
 msgstr ""
@@ -3414,7 +3419,7 @@ msgstr ""
 msgid "Taking action when standards are not met"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:181
+#: lib/klass_hero_web/live/booking_live.ex:196
 #, elixir-autogen, elixir-format
 msgid "This child is already enrolled in this program."
 msgstr ""
@@ -3453,7 +3458,7 @@ msgid "Vetted with Care"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1482
-#: lib/klass_hero_web/components/provider_components.ex:3044
+#: lib/klass_hero_web/components/provider_components.ex:3207
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr ""
@@ -3589,7 +3594,7 @@ msgstr ""
 msgid "Cannot check out without a check-in"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:365
+#: lib/klass_hero_web/live/provider/programs_live.ex:444
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
@@ -3627,7 +3632,7 @@ msgstr ""
 msgid "Checked Out"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2619
+#: lib/klass_hero_web/components/provider_components.ex:2782
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Child"
@@ -3653,8 +3658,8 @@ msgstr ""
 msgid "Correct"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:288
-#: lib/klass_hero_web/live/provider/programs_live.ex:362
+#: lib/klass_hero_web/live/dashboard_live.ex:306
+#: lib/klass_hero_web/live/provider/programs_live.ex:441
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Could not start conversation. Please try again."
@@ -3680,7 +3685,7 @@ msgstr ""
 msgid "Download monthly statements for taxes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2380
+#: lib/klass_hero_web/components/provider_components.ex:2543
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:483
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrollment not confirmed"
@@ -3753,7 +3758,7 @@ msgstr ""
 msgid "No chasing payments or sending invoices"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1751
+#: lib/klass_hero_web/components/provider_components.ex:1758
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:407
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No enrolled parents"
@@ -3776,7 +3781,7 @@ msgstr ""
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2379
+#: lib/klass_hero_web/components/provider_components.ex:2542
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -3878,7 +3883,7 @@ msgstr ""
 msgid "Track Everything:"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:275
+#: lib/klass_hero_web/live/dashboard_live.ex:293
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:144
 #, elixir-autogen, elixir-format
 msgid "Upgrade your plan to send messages."
@@ -4407,7 +4412,7 @@ msgstr ""
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:24
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
-#: lib/klass_hero_web/live/provider/programs_live.ex:224
+#: lib/klass_hero_web/live/provider/programs_live.ex:225
 #: lib/klass_hero_web/live/provider/sessions_live.ex:381
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:175
 #, elixir-autogen, elixir-format, fuzzy
@@ -4618,7 +4623,7 @@ msgid "Update your observation..."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:138
-#: lib/klass_hero_web/live/provider/programs_live.ex:444
+#: lib/klass_hero_web/live/provider/programs_live.ex:523
 #: lib/klass_hero_web/live/provider/verification_live.ex:240
 #: lib/klass_hero_web/live/provider/verification_live.ex:556
 #: lib/klass_hero_web/live/provider/verification_live.ex:594
@@ -4889,34 +4894,35 @@ msgstr ""
 msgid "for"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1875
+#: lib/klass_hero_web/components/provider_components.ex:1882
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assigned staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1876
+#: lib/klass_hero_web/components/provider_components.ex:1883
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1859
-#: lib/klass_hero_web/components/provider_components.ex:1944
-#: lib/klass_hero_web/components/provider_components.ex:2098
+#: lib/klass_hero_web/components/provider_components.ex:1866
+#: lib/klass_hero_web/components/provider_components.ex:1951
+#: lib/klass_hero_web/components/provider_components.ex:2088
+#: lib/klass_hero_web/components/provider_components.ex:2242
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Close"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1874
+#: lib/klass_hero_web/components/provider_components.ex:1881
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1868
+#: lib/klass_hero_web/components/provider_components.ex:1875
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No sessions scheduled yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1857
+#: lib/klass_hero_web/components/provider_components.ex:1864
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sessions — %{title}"
 msgstr ""
@@ -4926,7 +4932,7 @@ msgstr ""
 msgid "View sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:535
+#: lib/klass_hero_web/live/provider/programs_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Create a program before inviting participants."
 msgstr ""
@@ -4953,22 +4959,22 @@ msgstr ""
 msgid "Failed to update record"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2683
+#: lib/klass_hero_web/components/provider_components.ex:2846
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2402
+#: lib/klass_hero_web/components/provider_components.ex:2565
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invite mode"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2421
+#: lib/klass_hero_web/components/provider_components.ex:2584
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:531
+#: lib/klass_hero_web/live/provider/programs_live.ex:610
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invite sent."
 msgstr ""
@@ -4978,12 +4984,12 @@ msgstr ""
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2696
+#: lib/klass_hero_web/components/provider_components.ex:2859
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2702
+#: lib/klass_hero_web/components/provider_components.ex:2865
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr ""
@@ -4994,17 +5000,17 @@ msgstr ""
 msgid "Nothing to update"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2704
+#: lib/klass_hero_web/components/provider_components.ex:2867
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nut allergy"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2708
+#: lib/klass_hero_web/components/provider_components.ex:2871
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2713
+#: lib/klass_hero_web/components/provider_components.ex:2876
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr ""
@@ -5014,7 +5020,7 @@ msgstr ""
 msgid "Present"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2640
+#: lib/klass_hero_web/components/provider_components.ex:2803
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr ""
@@ -5041,22 +5047,22 @@ msgstr ""
 msgid "Save changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2677
+#: lib/klass_hero_web/components/provider_components.ex:2840
 #, elixir-autogen, elixir-format, fuzzy
 msgid "School (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2687
+#: lib/klass_hero_web/components/provider_components.ex:2850
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2661
+#: lib/klass_hero_web/components/provider_components.ex:2824
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2730
+#: lib/klass_hero_web/components/provider_components.ex:2893
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Send invite"
 msgstr ""
@@ -5066,12 +5072,12 @@ msgstr ""
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2439
+#: lib/klass_hero_web/components/provider_components.ex:2602
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload a list"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:542
+#: lib/klass_hero_web/live/provider/programs_live.ex:621
 #, elixir-autogen, elixir-format
 msgid "An invite for this child and program already exists."
 msgstr ""
@@ -5166,7 +5172,7 @@ msgstr ""
 msgid "Property Damage"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1599
+#: lib/klass_hero_web/components/provider_components.ex:1606
 #, elixir-autogen, elixir-format
 msgid "Report Incident"
 msgstr ""
@@ -5248,7 +5254,7 @@ msgstr ""
 msgid "Go to dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:487
+#: lib/klass_hero_web/live/provider/programs_live.ex:566
 #, elixir-autogen, elixir-format
 msgid "%{count} row could not be processed."
 msgid_plural "%{count} rows could not be processed."
@@ -5311,7 +5317,7 @@ msgstr ""
 msgid "Active policy required to teach."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:308
+#: lib/klass_hero_web/live/dashboard_live.ex:348
 #: lib/klass_hero_web/live/provider/overview_live.ex:251
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Active programs"
@@ -5835,8 +5841,8 @@ msgstr ""
 msgid "I'll be teaching"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:462
-#: lib/klass_hero_web/live/provider/programs_live.ex:484
+#: lib/klass_hero_web/live/provider/programs_live.ex:541
+#: lib/klass_hero_web/live/provider/programs_live.ex:563
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Imported %{count} family."
 msgid_plural "Imported %{count} families."
@@ -5848,7 +5854,7 @@ msgstr[1] ""
 msgid "In 2025, Shane connected with his friend"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1608
+#: lib/klass_hero_web/components/provider_components.ex:1615
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:43
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:74
 #, elixir-autogen, elixir-format
@@ -6065,7 +6071,7 @@ msgstr ""
 msgid "Mother and child-safety specialist with 10+ years in quality assurance. Architecting our Safety-First Verification engine."
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:177
+#: lib/klass_hero_web/live/dashboard_live.ex:179
 #, elixir-autogen, elixir-format, fuzzy
 msgid "New conversation"
 msgstr ""
@@ -6125,14 +6131,14 @@ msgstr ""
 msgid "No registered children for this session."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:471
+#: lib/klass_hero_web/live/provider/programs_live.ex:550
 #, elixir-autogen, elixir-format
 msgid "No rows imported. %{count} row could not be processed."
 msgid_plural "No rows imported. %{count} rows could not be processed."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:348
+#: lib/klass_hero_web/live/dashboard_live.ex:388
 #, elixir-autogen, elixir-format
 msgid "No upcoming sessions in the next few weeks."
 msgstr ""
@@ -6368,17 +6374,17 @@ msgstr ""
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2769
+#: lib/klass_hero_web/components/provider_components.ex:2932
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Row %{row}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2769
+#: lib/klass_hero_web/components/provider_components.ex:2932
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2515
+#: lib/klass_hero_web/components/provider_components.ex:2678
 #, elixir-autogen, elixir-format
 msgid "Rows with errors"
 msgstr ""
@@ -6648,17 +6654,17 @@ msgstr ""
 msgid "Unlimited programs and locations"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:320
+#: lib/klass_hero_web/live/dashboard_live.ex:360
 #, elixir-autogen, elixir-format
 msgid "Unread messages"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:333
+#: lib/klass_hero_web/live/dashboard_live.ex:373
 #, elixir-autogen, elixir-format
 msgid "Upcoming sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:314
+#: lib/klass_hero_web/live/dashboard_live.ex:354
 #, elixir-autogen, elixir-format
 msgid "Upcoming this week"
 msgstr ""
@@ -6673,7 +6679,7 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:338
+#: lib/klass_hero_web/live/dashboard_live.ex:378
 #, elixir-autogen, elixir-format, fuzzy
 msgid "View all"
 msgstr ""
@@ -7137,12 +7143,12 @@ msgstr ""
 msgid "Experience validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3073
+#: lib/klass_hero_web/components/provider_components.ex:3236
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3047
+#: lib/klass_hero_web/components/provider_components.ex:3210
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
@@ -7152,12 +7158,12 @@ msgstr ""
 msgid "Safeguarding certificate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3070
+#: lib/klass_hero_web/components/provider_components.ex:3233
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select Video"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3116
+#: lib/klass_hero_web/components/provider_components.ex:3279
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload Video"
 msgstr ""
@@ -7167,7 +7173,7 @@ msgstr ""
 msgid "Your browser does not support video playback."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3263
+#: lib/klass_hero_web/components/provider_components.ex:3426
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Confirm agreement"
 msgstr ""
@@ -7177,12 +7183,12 @@ msgstr ""
 msgid "Couldn't record your agreement. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3286
+#: lib/klass_hero_web/components/provider_components.ex:3449
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3262
+#: lib/klass_hero_web/components/provider_components.ex:3425
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr ""
@@ -7192,7 +7198,7 @@ msgstr ""
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3171
+#: lib/klass_hero_web/components/provider_components.ex:3334
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr ""
@@ -7202,17 +7208,17 @@ msgstr ""
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3271
+#: lib/klass_hero_web/components/provider_components.ex:3434
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3260
+#: lib/klass_hero_web/components/provider_components.ex:3423
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3261
+#: lib/klass_hero_web/components/provider_components.ex:3424
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
@@ -7481,12 +7487,12 @@ msgstr ""
 msgid "Your insurance is verified."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3215
+#: lib/klass_hero_web/components/provider_components.ex:3378
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3318
+#: lib/klass_hero_web/components/provider_components.ex:3481
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr ""
@@ -7496,7 +7502,7 @@ msgstr ""
 msgid "Couldn't record your declaration. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3324
+#: lib/klass_hero_web/components/provider_components.ex:3487
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr ""
@@ -7506,17 +7512,17 @@ msgstr ""
 msgid "Please confirm the declaration before signing."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3349
+#: lib/klass_hero_web/components/provider_components.ex:3512
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3328
+#: lib/klass_hero_web/components/provider_components.ex:3491
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3316
+#: lib/klass_hero_web/components/provider_components.ex:3479
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr ""
@@ -7526,12 +7532,12 @@ msgstr ""
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3336
+#: lib/klass_hero_web/components/provider_components.ex:3499
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3322
+#: lib/klass_hero_web/components/provider_components.ex:3485
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
@@ -7546,12 +7552,12 @@ msgstr ""
 msgid "Session note submitted for review"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:372
+#: lib/klass_hero_web/live/dashboard_live.ex:412
 #, elixir-autogen, elixir-format
 msgid "Loading your programs…"
 msgstr ""
 
-#: lib/klass_hero_web/live/dashboard_live.ex:342
+#: lib/klass_hero_web/live/dashboard_live.ex:382
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Loading…"
 msgstr ""
@@ -7598,24 +7604,24 @@ msgstr ""
 msgid "Undelivered Events"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2043
-#: lib/klass_hero_web/components/provider_components.ex:2226
+#: lib/klass_hero_web/components/provider_components.ex:2187
+#: lib/klass_hero_web/components/provider_components.ex:2370
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1966
-#: lib/klass_hero_web/components/provider_components.ex:2152
+#: lib/klass_hero_web/components/provider_components.ex:2110
+#: lib/klass_hero_web/components/provider_components.ex:2296
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Lead"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:337
+#: lib/klass_hero_web/live/provider/programs_live.ex:416
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Lead instructor updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1978
+#: lib/klass_hero_web/components/provider_components.ex:2122
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor"
 msgstr ""
@@ -7625,65 +7631,65 @@ msgstr ""
 msgid "Manage Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2007
+#: lib/klass_hero_web/components/provider_components.ex:2151
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this program yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:267
+#: lib/klass_hero_web/live/provider/programs_live.ex:346
 #: lib/klass_hero_web/live/provider/sessions_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "Pick a staff member to add."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1990
-#: lib/klass_hero_web/components/provider_components.ex:2265
+#: lib/klass_hero_web/components/provider_components.ex:2134
+#: lib/klass_hero_web/components/provider_components.ex:2409
 #, elixir-autogen, elixir-format
 msgid "Reassign the lead before removing them"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1991
+#: lib/klass_hero_web/components/provider_components.ex:2135
 #, elixir-autogen, elixir-format
 msgid "Remove from program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2025
-#: lib/klass_hero_web/components/provider_components.ex:2207
+#: lib/klass_hero_web/components/provider_components.ex:2169
+#: lib/klass_hero_web/components/provider_components.ex:2351
 #, elixir-autogen, elixir-format
 msgid "Select a staff member…"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:282
+#: lib/klass_hero_web/live/provider/programs_live.ex:361
 #, elixir-autogen, elixir-format
 msgid "Staff member added to the program."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:308
+#: lib/klass_hero_web/live/provider/programs_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "Staff member removed from the program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2048
+#: lib/klass_hero_web/components/provider_components.ex:2192
 #, elixir-autogen, elixir-format
 msgid "Staff you add can read and reply to this program's parent conversations."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1942
+#: lib/klass_hero_web/components/provider_components.ex:2086
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Staffing — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:944
+#: lib/klass_hero_web/live/provider/programs_live.ex:1064
 #, elixir-autogen, elixir-format
 msgid "That staff member could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:290
+#: lib/klass_hero_web/live/provider/programs_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "They are already on this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:316
+#: lib/klass_hero_web/live/provider/programs_live.ex:395
 #, elixir-autogen, elixir-format
 msgid "This person is the lead instructor. Make someone else lead before removing them."
 msgstr ""
@@ -7745,17 +7751,17 @@ msgstr ""
 msgid "This person has a history here now — use 'Remove from team' instead."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1222
+#: lib/klass_hero_web/live/provider/programs_live.ex:1342
 #, elixir-autogen, elixir-format
 msgid "Program created, but some settings could not be saved. Please review the program's limits."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1226
+#: lib/klass_hero_web/live/provider/programs_live.ex:1346
 #, elixir-autogen, elixir-format
 msgid "Program updated, but some settings could not be saved. Please review the program's limits."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1216
+#: lib/klass_hero_web/live/provider/programs_live.ex:1336
 #, elixir-autogen, elixir-format
 msgid "Program updated, but the enrollment capacity was rejected. The previous limits still apply."
 msgstr ""
@@ -7777,7 +7783,7 @@ msgstr ""
 msgid "I understand this program will have no capacity limit."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2253
+#: lib/klass_hero_web/components/provider_components.ex:2397
 #, elixir-autogen, elixir-format
 msgid "Go back to the program's usual team"
 msgstr ""
@@ -7787,17 +7793,17 @@ msgstr ""
 msgid "Lead instructor for this session updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2167
+#: lib/klass_hero_web/components/provider_components.ex:2311
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Make lead instructor for this session"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2189
+#: lib/klass_hero_web/components/provider_components.ex:2333
 #, elixir-autogen, elixir-format
 msgid "Nobody is working this session yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2270
+#: lib/klass_hero_web/components/provider_components.ex:2414
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove from this session"
 msgstr ""
@@ -7817,7 +7823,7 @@ msgstr ""
 msgid "Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2091
+#: lib/klass_hero_web/components/provider_components.ex:2235
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Staffing — %{date}"
 msgstr ""
@@ -7847,22 +7853,184 @@ msgstr ""
 msgid "A session needs at least one person. Use “Go back to the program's usual team” to drop this session's own roster."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2268
+#: lib/klass_hero_web/components/provider_components.ex:2412
 #, elixir-autogen, elixir-format
 msgid "A session needs someone — use “Go back to the program's usual team” instead"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2235
+#: lib/klass_hero_web/components/provider_components.ex:2379
 #, elixir-autogen, elixir-format
 msgid "Everyone on your team is already working this session."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2123
+#: lib/klass_hero_web/components/provider_components.ex:2267
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Staffed just for this session. Changes here do not touch the program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2125
+#: lib/klass_hero_web/components/provider_components.ex:2269
 #, elixir-autogen, elixir-format
 msgid "Using the program's usual team. The first change here copies them onto this session, so later program changes stop reaching it."
+msgstr ""
+
+#: lib/klass_hero_web/live/booking_live.ex:437
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:125
+#, elixir-autogen, elixir-format, fuzzy
+msgid "(optional)"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2005
+#, elixir-autogen, elixir-format
+msgid "Add a waiver"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2037
+#, elixir-autogen, elixir-format
+msgid "Add waiver"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/programs_live.ex:936
+#, elixir-autogen, elixir-format
+msgid "Check the waiver details and try again."
+msgstr ""
+
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:43
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:66
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Enrollment not found."
+msgstr ""
+
+#: lib/klass_hero_web/live/booking_live.ex:465
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:154
+#, elixir-autogen, elixir-format
+msgid "I have read and agree to %{title}"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2019
+#, elixir-autogen, elixir-format
+msgid "Legal text"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1590
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Manage Waivers"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1958
+#, elixir-autogen, elixir-format
+msgid "No waivers yet. Parents enrol without signing anything."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2026
+#, elixir-autogen, elixir-format
+msgid "Parents must sign this before enrolling"
+msgstr ""
+
+#: lib/klass_hero_web/live/booking_live.ex:171
+#, elixir-autogen, elixir-format
+msgid "Please read and sign every required waiver before enrolling."
+msgstr ""
+
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:106
+#, elixir-autogen, elixir-format
+msgid "Please read and sign these before %{program} begins."
+msgstr ""
+
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:55
+#, elixir-autogen, elixir-format
+msgid "Please tick a waiver to sign it."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2004
+#, elixir-autogen, elixir-format
+msgid "Publish a new version"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2037
+#, elixir-autogen, elixir-format
+msgid "Publish version"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2030
+#, elixir-autogen, elixir-format
+msgid "Publishing keeps every earlier version on record; signatures already given stay bound to the wording they were shown."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1974
+#, elixir-autogen, elixir-format
+msgid "Required"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1993
+#, elixir-autogen, elixir-format
+msgid "Retire this waiver"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1986
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Revise text"
+msgstr ""
+
+#: lib/klass_hero_web/live/dashboard_live.ex:330
+#, elixir-autogen, elixir-format
+msgid "Sign the waivers for %{program}"
+msgstr ""
+
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:160
+#, elixir-autogen, elixir-format
+msgid "Sign waivers"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2492
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:142
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Signed"
+msgstr ""
+
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:60
+#, elixir-autogen, elixir-format
+msgid "Thank you — your waivers are on record."
+msgstr ""
+
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:110
+#, elixir-autogen, elixir-format
+msgid "There is nothing to sign for this enrollment."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2492
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Unsigned"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1978
+#, elixir-autogen, elixir-format
+msgid "Version %{number}"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/programs_live.ex:340
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Waiver not found."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2460
+#: lib/klass_hero_web/live/booking_live.ex:427
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:31
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:103
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Waivers"
+msgstr ""
+
+#: lib/klass_hero_web/live/dashboard_live.ex:325
+#, elixir-autogen, elixir-format
+msgid "Waivers waiting for your signature"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1949
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Waivers — %{title}"
+msgstr ""
+
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:94
+#, elixir-autogen, elixir-format, fuzzy
+msgid "this program"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -45,7 +45,7 @@ msgstr ""
 #: lib/klass_hero_web/components/layouts/app.html.heex:129
 #: lib/klass_hero_web/components/layouts/app.html.heex:204
 #: lib/klass_hero_web/components/layouts/app.html.heex:229
-#: lib/klass_hero_web/components/provider_components.ex:390
+#: lib/klass_hero_web/components/provider_components.ex:391
 #: lib/klass_hero_web/components/ui_components.ex:268
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
@@ -137,7 +137,7 @@ msgid "Your Data"
 msgstr ""
 
 #: lib/klass_hero_web/components/core_components.ex:71
-#: lib/klass_hero_web/components/provider_components.ex:1765
+#: lib/klass_hero_web/components/provider_components.ex:1766
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr ""
@@ -172,7 +172,7 @@ msgstr ""
 msgid "Ages %{range}"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:511
+#: lib/klass_hero_web/live/booking_live.ex:510
 #, elixir-autogen, elixir-format
 msgid "An invoice will be emailed to you after enrollment completion"
 msgstr ""
@@ -187,12 +187,12 @@ msgstr ""
 msgid "Book camps, tutors, and workshops instantly. Our integrated planner helps you manage your child's busy life."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:488
+#: lib/klass_hero_web/live/booking_live.ex:487
 #, elixir-autogen, elixir-format
 msgid "Cash / Bank Transfer"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:513
+#: lib/klass_hero_web/live/booking_live.ex:512
 #, elixir-autogen, elixir-format
 msgid "Cash/transfer payments will show as \"Pending\" until received"
 msgstr ""
@@ -202,17 +202,17 @@ msgstr ""
 msgid "Community Focused"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:530
+#: lib/klass_hero_web/live/booking_live.ex:529
 #, elixir-autogen, elixir-format
 msgid "Complete Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:479
+#: lib/klass_hero_web/live/booking_live.ex:478
 #, elixir-autogen, elixir-format
 msgid "Credit Card"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:512
+#: lib/klass_hero_web/live/booking_live.ex:511
 #, elixir-autogen, elixir-format
 msgid "Credit card payments are processed immediately"
 msgstr ""
@@ -232,7 +232,7 @@ msgstr ""
 msgid "Enroll Now - %{price}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1484
+#: lib/klass_hero_web/components/provider_components.ex:1485
 #: lib/klass_hero_web/live/booking_live.ex:305
 #, elixir-autogen, elixir-format
 msgid "Enrollment"
@@ -274,7 +274,7 @@ msgstr ""
 msgid "Invalid pagination state. Please refresh the page."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:509
+#: lib/klass_hero_web/live/booking_live.ex:508
 #, elixir-autogen, elixir-format
 msgid "Invoice & Payment Confirmation"
 msgstr ""
@@ -301,17 +301,17 @@ msgstr ""
 msgid "Optional: Include any important information we should know about your child."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:480
+#: lib/klass_hero_web/live/booking_live.ex:479
 #, elixir-autogen, elixir-format
 msgid "Pay securely with Visa, Mastercard, or other cards"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:474
+#: lib/klass_hero_web/live/booking_live.ex:473
 #, elixir-autogen, elixir-format
 msgid "Payment Method"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:498
+#: lib/klass_hero_web/live/booking_live.ex:497
 #, elixir-autogen, elixir-format
 msgid "Payment Summary"
 msgstr ""
@@ -384,7 +384,7 @@ msgstr ""
 msgid "Total Price:"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:504
+#: lib/klass_hero_web/live/booking_live.ex:503
 #, elixir-autogen, elixir-format
 msgid "Total due today:"
 msgstr ""
@@ -577,9 +577,9 @@ msgstr ""
 msgid "Dispute Resolution"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:719
-#: lib/klass_hero_web/components/provider_components.ex:2820
-#: lib/klass_hero_web/components/provider_components.ex:2838
+#: lib/klass_hero_web/components/provider_components.ex:720
+#: lib/klass_hero_web/components/provider_components.ex:2816
+#: lib/klass_hero_web/components/provider_components.ex:2834
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
@@ -878,9 +878,9 @@ msgstr ""
 msgid "Select one or both options"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2516
-#: lib/klass_hero_web/components/provider_components.ex:2517
-#: lib/klass_hero_web/components/provider_components.ex:2554
+#: lib/klass_hero_web/components/provider_components.ex:2512
+#: lib/klass_hero_web/components/provider_components.ex:2513
+#: lib/klass_hero_web/components/provider_components.ex:2550
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:448
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:484
@@ -1324,7 +1324,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/composite_components.ex:103
 #: lib/klass_hero_web/components/layouts/admin.html.heex:85
-#: lib/klass_hero_web/components/provider_components.ex:120
+#: lib/klass_hero_web/components/provider_components.ex:121
 #: lib/klass_hero_web/live/admin/sessions_live.ex:26
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:3
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:348
@@ -1456,7 +1456,7 @@ msgstr ""
 msgid "Music"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:755
+#: lib/klass_hero_web/components/provider_components.ex:756
 #: lib/klass_hero_web/live/for_providers_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "Qualifications"
@@ -1577,19 +1577,19 @@ msgstr ""
 msgid "Quick Navigation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1487
-#: lib/klass_hero_web/components/provider_components.ex:2476
-#: lib/klass_hero_web/components/provider_components.ex:2718
+#: lib/klass_hero_web/components/provider_components.ex:1488
+#: lib/klass_hero_web/components/provider_components.ex:2472
+#: lib/klass_hero_web/components/provider_components.ex:2714
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1633
+#: lib/klass_hero_web/components/provider_components.ex:1634
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Active"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:672
+#: lib/klass_hero_web/components/provider_components.ex:673
 #: lib/klass_hero_web/live/provider/team_live.ex:627
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
@@ -1600,7 +1600,7 @@ msgstr ""
 msgid "All Staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1478
+#: lib/klass_hero_web/components/provider_components.ex:1479
 #, elixir-autogen, elixir-format
 msgid "Assigned Staff"
 msgstr ""
@@ -1611,7 +1611,7 @@ msgstr ""
 msgid "Book Now"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:206
+#: lib/klass_hero_web/components/provider_components.ex:207
 #, elixir-autogen, elixir-format
 msgid "Business Profile"
 msgstr ""
@@ -1627,8 +1627,8 @@ msgstr ""
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:539
-#: lib/klass_hero_web/components/provider_components.ex:1596
+#: lib/klass_hero_web/components/provider_components.ex:540
+#: lib/klass_hero_web/components/provider_components.ex:1597
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:54
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:81
 #: lib/klass_hero_web/live/settings/children_live.ex:413
@@ -1638,57 +1638,57 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:224
+#: lib/klass_hero_web/components/provider_components.ex:225
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:31
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "Edit Profile"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1635
+#: lib/klass_hero_web/components/provider_components.ex:1636
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:113
+#: lib/klass_hero_web/components/provider_components.ex:114
 #: lib/klass_hero_web/live/provider/programs_live.ex:54
 #, elixir-autogen, elixir-format, fuzzy
 msgid "My Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:416
-#: lib/klass_hero_web/components/provider_components.ex:952
+#: lib/klass_hero_web/components/provider_components.ex:417
+#: lib/klass_hero_web/components/provider_components.ex:953
 #, elixir-autogen, elixir-format, fuzzy
 msgid "New Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:99
+#: lib/klass_hero_web/components/provider_components.ex:100
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:47
-#: lib/klass_hero_web/components/provider_components.ex:73
-#: lib/klass_hero_web/components/provider_components.ex:1634
-#: lib/klass_hero_web/components/provider_components.ex:2914
-#: lib/klass_hero_web/components/provider_components.ex:2932
+#: lib/klass_hero_web/components/provider_components.ex:48
+#: lib/klass_hero_web/components/provider_components.ex:74
+#: lib/klass_hero_web/components/provider_components.ex:1635
+#: lib/klass_hero_web/components/provider_components.ex:2910
+#: lib/klass_hero_web/components/provider_components.ex:2928
 #: lib/klass_hero_web/live/admin/sessions_live.ex:298
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1565
+#: lib/klass_hero_web/components/provider_components.ex:1566
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1418
+#: lib/klass_hero_web/components/provider_components.ex:1419
 #, elixir-autogen, elixir-format
 msgid "Program Inventory"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1475
+#: lib/klass_hero_web/components/provider_components.ex:1476
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program Name"
 msgstr ""
@@ -1703,15 +1703,15 @@ msgstr ""
 msgid "Save for Later"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1435
+#: lib/klass_hero_web/components/provider_components.ex:1436
 #, elixir-autogen, elixir-format
 msgid "Search by name..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1481
-#: lib/klass_hero_web/components/provider_components.ex:1884
-#: lib/klass_hero_web/components/provider_components.ex:2467
-#: lib/klass_hero_web/components/provider_components.ex:2715
+#: lib/klass_hero_web/components/provider_components.ex:1482
+#: lib/klass_hero_web/components/provider_components.ex:1885
+#: lib/klass_hero_web/components/provider_components.ex:2463
+#: lib/klass_hero_web/components/provider_components.ex:2711
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1719,7 +1719,7 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:106
+#: lib/klass_hero_web/components/provider_components.ex:107
 #: lib/klass_hero_web/live/provider/team_live.ex:36
 #, elixir-autogen, elixir-format
 msgid "Team & Profiles"
@@ -1730,32 +1730,32 @@ msgstr ""
 msgid "Team & Provider Profiles"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:209
+#: lib/klass_hero_web/components/provider_components.ex:210
 #, elixir-autogen, elixir-format
 msgid "This is your main business identity. Verification is required to list programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1538
-#: lib/klass_hero_web/components/provider_components.ex:1899
+#: lib/klass_hero_web/components/provider_components.ex:1539
+#: lib/klass_hero_web/components/provider_components.ex:1900
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr ""
 
 #: lib/klass_hero_web/components/messaging_components.ex:722
-#: lib/klass_hero_web/components/provider_components.ex:50
-#: lib/klass_hero_web/components/provider_components.ex:1636
+#: lib/klass_hero_web/components/provider_components.ex:51
+#: lib/klass_hero_web/components/provider_components.ex:1637
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:434
 #: lib/klass_hero_web/presenters/provider_presenter.ex:103
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:401
+#: lib/klass_hero_web/components/provider_components.ex:402
 #, elixir-autogen, elixir-format
 msgid "Verified Business"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1576
+#: lib/klass_hero_web/components/provider_components.ex:1577
 #, elixir-autogen, elixir-format
 msgid "View Roster"
 msgstr ""
@@ -1815,10 +1815,10 @@ msgstr ""
 #: lib/klass_hero_web/components/participation_components.ex:441
 #: lib/klass_hero_web/components/participation_components.ex:631
 #: lib/klass_hero_web/components/participation_components.ex:717
-#: lib/klass_hero_web/components/provider_components.ex:889
-#: lib/klass_hero_web/components/provider_components.ex:1334
-#: lib/klass_hero_web/components/provider_components.ex:2056
-#: lib/klass_hero_web/components/provider_components.ex:2657
+#: lib/klass_hero_web/components/provider_components.ex:890
+#: lib/klass_hero_web/components/provider_components.ex:1335
+#: lib/klass_hero_web/components/provider_components.ex:2052
+#: lib/klass_hero_web/components/provider_components.ex:2653
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:478
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
@@ -1874,7 +1874,7 @@ msgstr ""
 msgid "Data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2801
+#: lib/klass_hero_web/components/provider_components.ex:2797
 #: lib/klass_hero_web/live/settings/children_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1922,17 +1922,17 @@ msgstr ""
 msgid "Failed to submit note"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2795
-#: lib/klass_hero_web/components/provider_components.ex:2824
-#: lib/klass_hero_web/components/provider_components.ex:2840
+#: lib/klass_hero_web/components/provider_components.ex:2791
+#: lib/klass_hero_web/components/provider_components.ex:2820
+#: lib/klass_hero_web/components/provider_components.ex:2836
 #: lib/klass_hero_web/live/settings/children_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2796
-#: lib/klass_hero_web/components/provider_components.ex:2825
-#: lib/klass_hero_web/components/provider_components.ex:2841
+#: lib/klass_hero_web/components/provider_components.ex:2792
+#: lib/klass_hero_web/components/provider_components.ex:2821
+#: lib/klass_hero_web/components/provider_components.ex:2837
 #: lib/klass_hero_web/live/settings/children_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -2063,15 +2063,15 @@ msgstr ""
 msgid "Provider data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:874
+#: lib/klass_hero_web/components/provider_components.ex:875
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:294
 #: lib/klass_hero_web/live/settings/children_live.ex:719
 #, elixir-autogen, elixir-format
 msgid "Save Changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1743
 #: lib/klass_hero_web/components/provider_components.ex:1744
+#: lib/klass_hero_web/components/provider_components.ex:1745
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:43
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:151
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:252
@@ -2089,7 +2089,7 @@ msgstr ""
 msgid "Send a message to start the conversation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2895
+#: lib/klass_hero_web/components/provider_components.ex:2891
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:249
 #, elixir-autogen, elixir-format, fuzzy
@@ -2195,12 +2195,12 @@ msgstr[1] ""
 msgid "%{gender} only"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:309
+#: lib/klass_hero_web/components/provider_components.ex:310
 #, elixir-autogen, elixir-format
 msgid "Action Required"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:876
+#: lib/klass_hero_web/components/provider_components.ex:877
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add Member"
 msgstr ""
@@ -2220,12 +2220,12 @@ msgstr ""
 msgid "Ages %{min}+"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1195
+#: lib/klass_hero_web/components/provider_components.ex:1196
 #, elixir-autogen, elixir-format
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2954
+#: lib/klass_hero_web/components/provider_components.ex:2950
 #, elixir-autogen, elixir-format, fuzzy
 msgid "An unexpected error occurred during import."
 msgstr ""
@@ -2238,7 +2238,7 @@ msgid "Approve"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:826
-#: lib/klass_hero_web/components/provider_components.ex:48
+#: lib/klass_hero_web/components/provider_components.ex:49
 #: lib/klass_hero_web/live/admin/sessions_live.ex:295
 #: lib/klass_hero_web/live/admin/verifications_live.ex:202
 #: lib/klass_hero_web/presenters/vetting_checklist_presenter.ex:141
@@ -2268,7 +2268,7 @@ msgstr ""
 msgid "Back to verifications"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:728
+#: lib/klass_hero_web/components/provider_components.ex:729
 #, elixir-autogen, elixir-format
 msgid "Bio"
 msgstr ""
@@ -2278,7 +2278,7 @@ msgstr ""
 msgid "Book a Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:729
+#: lib/klass_hero_web/components/provider_components.ex:730
 #, elixir-autogen, elixir-format
 msgid "Brief description of experience and specialties..."
 msgstr ""
@@ -2309,19 +2309,19 @@ msgstr ""
 msgid "Business Logo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:982
+#: lib/klass_hero_web/components/provider_components.ex:983
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "Category"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1144
+#: lib/klass_hero_web/components/provider_components.ex:1145
 #, elixir-autogen, elixir-format
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2464
-#: lib/klass_hero_web/components/provider_components.ex:2709
+#: lib/klass_hero_web/components/provider_components.ex:2460
+#: lib/klass_hero_web/components/provider_components.ex:2705
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2336,7 +2336,7 @@ msgstr ""
 msgid "Child meets all program requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1305
+#: lib/klass_hero_web/components/provider_components.ex:1306
 #, elixir-autogen, elixir-format
 msgid "Choose Image"
 msgstr ""
@@ -2346,17 +2346,17 @@ msgstr ""
 msgid "Choose Logo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:853
+#: lib/klass_hero_web/components/provider_components.ex:854
 #, elixir-autogen, elixir-format
 msgid "Choose Photo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:984
+#: lib/klass_hero_web/components/provider_components.ex:985
 #, elixir-autogen, elixir-format
 msgid "Choose a category"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:428
+#: lib/klass_hero_web/components/provider_components.ex:429
 #, elixir-autogen, elixir-format
 msgid "Complete business verification to create programs."
 msgstr ""
@@ -2366,7 +2366,7 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2915
+#: lib/klass_hero_web/components/provider_components.ex:2911
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
@@ -2386,22 +2386,22 @@ msgstr ""
 msgid "Could not remove invite."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1261
+#: lib/klass_hero_web/components/provider_components.ex:1262
 #, elixir-autogen, elixir-format
 msgid "Cover Image"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1138
+#: lib/klass_hero_web/components/provider_components.ex:1139
 #, elixir-autogen, elixir-format
 msgid "Define age, gender, or grade restrictions for eligible participants."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1254
+#: lib/klass_hero_web/components/provider_components.ex:1255
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Describe your program..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1253
+#: lib/klass_hero_web/components/provider_components.ex:1254
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:323
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:285
 #, elixir-autogen, elixir-format
@@ -2409,13 +2409,13 @@ msgid "Description"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:684
-#: lib/klass_hero_web/components/provider_components.ex:1206
+#: lib/klass_hero_web/components/provider_components.ex:1207
 #: lib/klass_hero_web/live/settings/children_live.ex:635
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3130
+#: lib/klass_hero_web/components/provider_components.ex:3126
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2449,7 +2449,7 @@ msgstr ""
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2676
+#: lib/klass_hero_web/components/provider_components.ex:2672
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
@@ -2459,40 +2459,40 @@ msgstr ""
 msgid "Download document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:950
+#: lib/klass_hero_web/components/provider_components.ex:951
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:670
+#: lib/klass_hero_web/components/provider_components.ex:671
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit Team Member"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1059
+#: lib/klass_hero_web/components/provider_components.ex:1060
 #, elixir-autogen, elixir-format
 msgid "End Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1046
+#: lib/klass_hero_web/components/provider_components.ex:1047
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2473
-#: lib/klass_hero_web/components/provider_components.ex:2935
+#: lib/klass_hero_web/components/provider_components.ex:2469
+#: lib/klass_hero_web/components/provider_components.ex:2931
 #: lib/klass_hero_web/components/provider_layout_components.ex:644
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrolled"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1789
+#: lib/klass_hero_web/components/provider_components.ex:1790
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1087
+#: lib/klass_hero_web/components/provider_components.ex:1088
 #, elixir-autogen, elixir-format
 msgid "Enrollment Capacity (optional)"
 msgstr ""
@@ -2502,8 +2502,8 @@ msgstr ""
 msgid "Explain why this document is being rejected..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:71
-#: lib/klass_hero_web/components/provider_components.ex:2936
+#: lib/klass_hero_web/components/provider_components.ex:72
+#: lib/klass_hero_web/components/provider_components.ex:2932
 #: lib/klass_hero_web/live/admin/emails_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2536,7 +2536,7 @@ msgid "Family Programs"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:682
-#: lib/klass_hero_web/components/provider_components.ex:1205
+#: lib/klass_hero_web/components/provider_components.ex:1206
 #: lib/klass_hero_web/live/settings/children_live.ex:634
 #, elixir-autogen, elixir-format
 msgid "Female"
@@ -2547,22 +2547,22 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3064
+#: lib/klass_hero_web/components/provider_components.ex:3060
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3066
+#: lib/klass_hero_web/components/provider_components.ex:3062
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:756
+#: lib/klass_hero_web/components/provider_components.ex:757
 #, elixir-autogen, elixir-format
 msgid "First Aid, UEFA B License, Child Care Cert"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:698
+#: lib/klass_hero_web/components/provider_components.ex:699
 #, elixir-autogen, elixir-format, fuzzy
 msgid "First Name"
 msgstr ""
@@ -2587,12 +2587,12 @@ msgstr ""
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2712
+#: lib/klass_hero_web/components/provider_components.ex:2708
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:817
+#: lib/klass_hero_web/components/provider_components.ex:818
 #, elixir-autogen, elixir-format
 msgid "Headshot Photo"
 msgstr ""
@@ -2602,7 +2602,7 @@ msgstr ""
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2649
+#: lib/klass_hero_web/components/provider_components.ex:2645
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import"
 msgstr ""
@@ -2627,17 +2627,17 @@ msgstr ""
 msgid "Invite resent successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1806
+#: lib/klass_hero_web/components/provider_components.ex:1807
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:856
+#: lib/klass_hero_web/components/provider_components.ex:857
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 1MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1308
+#: lib/klass_hero_web/components/provider_components.ex:1309
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:277
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:361
 #, elixir-autogen, elixir-format
@@ -2654,22 +2654,22 @@ msgstr ""
 msgid "Klasse %{n}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:704
+#: lib/klass_hero_web/components/provider_components.ex:705
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Last Name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1069
+#: lib/klass_hero_web/components/provider_components.ex:1070
 #, elixir-autogen, elixir-format
 msgid "Leave blank for open registration at any time."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1198
+#: lib/klass_hero_web/components/provider_components.ex:1199
 #, elixir-autogen, elixir-format
 msgid "Leave unchecked to allow all genders."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1002
+#: lib/klass_hero_web/components/provider_components.ex:1003
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:191
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Location"
@@ -2682,43 +2682,43 @@ msgid "Logo upload failed. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:683
-#: lib/klass_hero_web/components/provider_components.ex:1204
+#: lib/klass_hero_web/components/provider_components.ex:1205
 #: lib/klass_hero_web/live/settings/children_live.ex:633
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1188
+#: lib/klass_hero_web/components/provider_components.ex:1189
 #, elixir-autogen, elixir-format
 msgid "Maximum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1102
+#: lib/klass_hero_web/components/provider_components.ex:1103
 #, elixir-autogen, elixir-format
 msgid "Maximum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1243
+#: lib/klass_hero_web/components/provider_components.ex:1244
 #, elixir-autogen, elixir-format
 msgid "Maximum Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1011
+#: lib/klass_hero_web/components/provider_components.ex:1012
 #, elixir-autogen, elixir-format
 msgid "Meeting Days"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1182
+#: lib/klass_hero_web/components/provider_components.ex:1183
 #, elixir-autogen, elixir-format
 msgid "Minimum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1096
+#: lib/klass_hero_web/components/provider_components.ex:1097
 #, elixir-autogen, elixir-format
 msgid "Minimum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1236
+#: lib/klass_hero_web/components/provider_components.ex:1237
 #, elixir-autogen, elixir-format
 msgid "Minimum Grade"
 msgstr ""
@@ -2728,12 +2728,12 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3092
+#: lib/klass_hero_web/components/provider_components.ex:3088
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2457
+#: lib/klass_hero_web/components/provider_components.ex:2453
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
@@ -2749,17 +2749,17 @@ msgstr ""
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2700
+#: lib/klass_hero_web/components/provider_components.ex:2696
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1245
+#: lib/klass_hero_web/components/provider_components.ex:1246
 #, elixir-autogen, elixir-format
 msgid "No maximum"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1238
+#: lib/klass_hero_web/components/provider_components.ex:1239
 #, elixir-autogen, elixir-format
 msgid "No minimum"
 msgstr ""
@@ -2790,18 +2790,18 @@ msgstr ""
 msgid "No verification documents found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1320
+#: lib/klass_hero_web/components/provider_components.ex:1321
 #, elixir-autogen, elixir-format
 msgid "None (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:325
+#: lib/klass_hero_web/components/provider_components.ex:326
 #, elixir-autogen, elixir-format
 msgid "Not Verified"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:685
-#: lib/klass_hero_web/components/provider_components.ex:1207
+#: lib/klass_hero_web/components/provider_components.ex:1208
 #: lib/klass_hero_web/live/settings/children_live.ex:632
 #, elixir-autogen, elixir-format
 msgid "Not specified"
@@ -2812,7 +2812,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3167
+#: lib/klass_hero_web/components/provider_components.ex:3163
 #: lib/klass_hero_web/live/provider/verification_live.ex:698
 #: lib/klass_hero_web/live/provider/verification_live.ex:770
 #, elixir-autogen, elixir-format
@@ -2824,13 +2824,13 @@ msgstr ""
 msgid "Participant Requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1135
+#: lib/klass_hero_web/components/provider_components.ex:1136
 #, elixir-autogen, elixir-format
 msgid "Participant Restrictions (optional)"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:825
-#: lib/klass_hero_web/components/provider_components.ex:293
+#: lib/klass_hero_web/components/provider_components.ex:294
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Pending Review"
 msgstr ""
@@ -2858,7 +2858,7 @@ msgstr ""
 msgid "Preview not available for this file type."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:993
+#: lib/klass_hero_web/components/provider_components.ex:994
 #, elixir-autogen, elixir-format
 msgid "Price (EUR)"
 msgstr ""
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Profile updated successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1173
+#: lib/klass_hero_web/components/provider_components.ex:1174
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program Start"
 msgstr ""
@@ -2912,13 +2912,13 @@ msgid "Read our founding story →"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:805
-#: lib/klass_hero_web/components/provider_components.ex:2934
+#: lib/klass_hero_web/components/provider_components.ex:2930
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registered"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1160
+#: lib/klass_hero_web/components/provider_components.ex:1161
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration"
 msgstr ""
@@ -2928,7 +2928,7 @@ msgstr ""
 msgid "Registration Closed"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1080
+#: lib/klass_hero_web/components/provider_components.ex:1081
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration Closes"
 msgstr ""
@@ -2938,12 +2938,12 @@ msgstr ""
 msgid "Registration Not Open Yet"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1075
+#: lib/klass_hero_web/components/provider_components.ex:1076
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration Opens"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1066
+#: lib/klass_hero_web/components/provider_components.ex:1067
 #, elixir-autogen, elixir-format
 msgid "Registration Period (optional)"
 msgstr ""
@@ -2980,7 +2980,7 @@ msgid "Reject"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:827
-#: lib/klass_hero_web/components/provider_components.ex:49
+#: lib/klass_hero_web/components/provider_components.ex:50
 #: lib/klass_hero_web/live/admin/verifications_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Rejected"
@@ -2992,18 +2992,18 @@ msgstr ""
 msgid "Rejection reason"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:839
-#: lib/klass_hero_web/components/provider_components.ex:1284
-#: lib/klass_hero_web/components/provider_components.ex:2756
-#: lib/klass_hero_web/components/provider_components.ex:3186
-#: lib/klass_hero_web/components/provider_components.ex:3265
+#: lib/klass_hero_web/components/provider_components.ex:840
+#: lib/klass_hero_web/components/provider_components.ex:1285
+#: lib/klass_hero_web/components/provider_components.ex:2752
+#: lib/klass_hero_web/components/provider_components.ex:3182
+#: lib/klass_hero_web/components/provider_components.ex:3261
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:253
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2749
+#: lib/klass_hero_web/components/provider_components.ex:2745
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -3013,23 +3013,23 @@ msgstr ""
 msgid "Reviewed"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:713
+#: lib/klass_hero_web/components/provider_components.ex:714
 #, elixir-autogen, elixir-format
 msgid "Role"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1735
+#: lib/klass_hero_web/components/provider_components.ex:1736
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:386
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1347
+#: lib/klass_hero_web/components/provider_components.ex:1348
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Save Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1008
+#: lib/klass_hero_web/components/provider_components.ex:1009
 #, elixir-autogen, elixir-format
 msgid "Schedule (optional)"
 msgstr ""
@@ -3044,7 +3044,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3164
+#: lib/klass_hero_web/components/provider_components.ex:3160
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select File"
 msgstr ""
@@ -3061,23 +3061,23 @@ msgstr ""
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2933
+#: lib/klass_hero_web/components/provider_components.ex:2929
 #: lib/klass_hero_web/live/admin/emails_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Sent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:760
+#: lib/klass_hero_web/components/provider_components.ex:761
 #, elixir-autogen, elixir-format
 msgid "Separate multiple qualifications with commas"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1090
+#: lib/klass_hero_web/components/provider_components.ex:1091
 #, elixir-autogen, elixir-format
 msgid "Set minimum and maximum enrollment for this program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:734
+#: lib/klass_hero_web/components/provider_components.ex:735
 #, elixir-autogen, elixir-format
 msgid "Specialties"
 msgstr ""
@@ -3095,12 +3095,12 @@ msgstr ""
 msgid "Staff member not found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1054
+#: lib/klass_hero_web/components/provider_components.ex:1055
 #, elixir-autogen, elixir-format
 msgid "Start Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1041
+#: lib/klass_hero_web/components/provider_components.ex:1042
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:184
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Start Time"
@@ -3166,13 +3166,13 @@ msgstr ""
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:975
-#: lib/klass_hero_web/components/provider_components.ex:2022
+#: lib/klass_hero_web/components/provider_components.ex:976
+#: lib/klass_hero_web/components/provider_components.ex:2018
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3065
+#: lib/klass_hero_web/components/provider_components.ex:3061
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -3192,32 +3192,32 @@ msgstr ""
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2635
+#: lib/klass_hero_web/components/provider_components.ex:2631
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3210
+#: lib/klass_hero_web/components/provider_components.ex:3206
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3119
+#: lib/klass_hero_web/components/provider_components.ex:3115
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3087
+#: lib/klass_hero_web/components/provider_components.ex:3083
 #, elixir-autogen, elixir-format
 msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3067
+#: lib/klass_hero_web/components/provider_components.ex:3063
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3084
+#: lib/klass_hero_web/components/provider_components.ex:3080
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -3239,7 +3239,7 @@ msgstr ""
 msgid "Verifications"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:277
+#: lib/klass_hero_web/components/provider_components.ex:278
 #: lib/klass_hero_web/components/provider_layout_components.ex:212
 #: lib/klass_hero_web/components/ui_components.ex:1930
 #, elixir-autogen, elixir-format, fuzzy
@@ -3256,32 +3256,32 @@ msgstr ""
 msgid "You don't have access to that page."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:714
+#: lib/klass_hero_web/components/provider_components.ex:715
 #, elixir-autogen, elixir-format, fuzzy
 msgid "e.g. Head Coach"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:705
+#: lib/klass_hero_web/components/provider_components.ex:706
 #, elixir-autogen, elixir-format
 msgid "e.g. Johnson"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:699
+#: lib/klass_hero_web/components/provider_components.ex:700
 #, elixir-autogen, elixir-format
 msgid "e.g. Mike"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:720
+#: lib/klass_hero_web/components/provider_components.ex:721
 #, elixir-autogen, elixir-format
 msgid "e.g. mike@example.com"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:976
+#: lib/klass_hero_web/components/provider_components.ex:977
 #, elixir-autogen, elixir-format
 msgid "e.g., Art Adventures"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1003
+#: lib/klass_hero_web/components/provider_components.ex:1004
 #, elixir-autogen, elixir-format
 msgid "e.g., Community Center, Main St"
 msgstr ""
@@ -3307,7 +3307,7 @@ msgid "Child Safeguarding Training"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1498
-#: lib/klass_hero_web/components/provider_components.ex:3432
+#: lib/klass_hero_web/components/provider_components.ex:3428
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr ""
@@ -3367,12 +3367,12 @@ msgstr ""
 msgid "Monitoring provider activity and feedback"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:489
+#: lib/klass_hero_web/live/booking_live.ex:488
 #, elixir-autogen, elixir-format
 msgid "Pay by cash or direct bank transfer"
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:500
+#: lib/klass_hero_web/live/booking_live.ex:499
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program fee:"
 msgstr ""
@@ -3404,7 +3404,7 @@ msgstr ""
 
 #: lib/klass_hero_web/controllers/invite_claim_controller.ex:57
 #: lib/klass_hero_web/live/booking_live.ex:212
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:73
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:75
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Please try again or contact support."
 msgstr ""
@@ -3458,7 +3458,7 @@ msgid "Vetted with Care"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1482
-#: lib/klass_hero_web/components/provider_components.ex:3217
+#: lib/klass_hero_web/components/provider_components.ex:3213
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr ""
@@ -3632,7 +3632,7 @@ msgstr ""
 msgid "Checked Out"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2792
+#: lib/klass_hero_web/components/provider_components.ex:2788
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Child"
@@ -3685,7 +3685,7 @@ msgstr ""
 msgid "Download monthly statements for taxes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2553
+#: lib/klass_hero_web/components/provider_components.ex:2549
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:483
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrollment not confirmed"
@@ -3758,7 +3758,7 @@ msgstr ""
 msgid "No chasing payments or sending invoices"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1758
+#: lib/klass_hero_web/components/provider_components.ex:1759
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:407
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No enrolled parents"
@@ -3781,7 +3781,7 @@ msgstr ""
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2552
+#: lib/klass_hero_web/components/provider_components.ex:2548
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -4466,7 +4466,7 @@ msgstr ""
 msgid "Reply sent successfully"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:553
+#: lib/klass_hero_web/components/provider_components.ex:554
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Resend"
 msgstr ""
@@ -4894,40 +4894,40 @@ msgstr ""
 msgid "for"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1882
+#: lib/klass_hero_web/components/provider_components.ex:1883
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assigned staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1883
+#: lib/klass_hero_web/components/provider_components.ex:1884
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1866
-#: lib/klass_hero_web/components/provider_components.ex:1951
-#: lib/klass_hero_web/components/provider_components.ex:2098
-#: lib/klass_hero_web/components/provider_components.ex:2252
+#: lib/klass_hero_web/components/provider_components.ex:1867
+#: lib/klass_hero_web/components/provider_components.ex:1952
+#: lib/klass_hero_web/components/provider_components.ex:2094
+#: lib/klass_hero_web/components/provider_components.ex:2248
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Close"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1881
+#: lib/klass_hero_web/components/provider_components.ex:1882
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1875
+#: lib/klass_hero_web/components/provider_components.ex:1876
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No sessions scheduled yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1864
+#: lib/klass_hero_web/components/provider_components.ex:1865
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sessions — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1569
+#: lib/klass_hero_web/components/provider_components.ex:1570
 #, elixir-autogen, elixir-format
 msgid "View sessions"
 msgstr ""
@@ -4959,17 +4959,17 @@ msgstr ""
 msgid "Failed to update record"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2856
+#: lib/klass_hero_web/components/provider_components.ex:2852
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2575
+#: lib/klass_hero_web/components/provider_components.ex:2571
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invite mode"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2594
+#: lib/klass_hero_web/components/provider_components.ex:2590
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr ""
@@ -4984,12 +4984,12 @@ msgstr ""
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2869
+#: lib/klass_hero_web/components/provider_components.ex:2865
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2875
+#: lib/klass_hero_web/components/provider_components.ex:2871
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr ""
@@ -5000,17 +5000,17 @@ msgstr ""
 msgid "Nothing to update"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2877
+#: lib/klass_hero_web/components/provider_components.ex:2873
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nut allergy"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2881
+#: lib/klass_hero_web/components/provider_components.ex:2877
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2886
+#: lib/klass_hero_web/components/provider_components.ex:2882
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr ""
@@ -5020,7 +5020,7 @@ msgstr ""
 msgid "Present"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2813
+#: lib/klass_hero_web/components/provider_components.ex:2809
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr ""
@@ -5047,22 +5047,22 @@ msgstr ""
 msgid "Save changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2850
+#: lib/klass_hero_web/components/provider_components.ex:2846
 #, elixir-autogen, elixir-format, fuzzy
 msgid "School (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2860
+#: lib/klass_hero_web/components/provider_components.ex:2856
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2834
+#: lib/klass_hero_web/components/provider_components.ex:2830
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2903
+#: lib/klass_hero_web/components/provider_components.ex:2899
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Send invite"
 msgstr ""
@@ -5072,7 +5072,7 @@ msgstr ""
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2612
+#: lib/klass_hero_web/components/provider_components.ex:2608
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload a list"
 msgstr ""
@@ -5107,7 +5107,7 @@ msgstr ""
 msgid "High"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:787
+#: lib/klass_hero_web/components/provider_components.ex:788
 #, elixir-autogen, elixir-format
 msgid "Hourly"
 msgstr ""
@@ -5132,22 +5132,22 @@ msgstr ""
 msgid "Medium"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:777
+#: lib/klass_hero_web/components/provider_components.ex:778
 #, elixir-autogen, elixir-format
 msgid "None"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:766
+#: lib/klass_hero_web/components/provider_components.ex:767
 #, elixir-autogen, elixir-format
 msgid "Pay Rate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:524
+#: lib/klass_hero_web/components/provider_components.ex:525
 #, elixir-autogen, elixir-format
 msgid "Pay rate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:797
+#: lib/klass_hero_web/components/provider_components.ex:798
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Per Session"
 msgstr ""
@@ -5172,7 +5172,7 @@ msgstr ""
 msgid "Property Damage"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1606
+#: lib/klass_hero_web/components/provider_components.ex:1607
 #, elixir-autogen, elixir-format
 msgid "Report Incident"
 msgstr ""
@@ -5854,7 +5854,7 @@ msgstr[1] ""
 msgid "In 2025, Shane connected with his friend"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1615
+#: lib/klass_hero_web/components/provider_components.ex:1616
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:43
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:74
 #, elixir-autogen, elixir-format
@@ -5924,7 +5924,7 @@ msgstr ""
 msgid "Last 8 weeks"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1318
+#: lib/klass_hero_web/components/provider_components.ex:1319
 #: lib/klass_hero_web/presenters/hero_cards_presenter.ex:27
 #, elixir-autogen, elixir-format
 msgid "Lead Instructor"
@@ -6374,17 +6374,17 @@ msgstr ""
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2942
+#: lib/klass_hero_web/components/provider_components.ex:2938
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Row %{row}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2942
+#: lib/klass_hero_web/components/provider_components.ex:2938
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2688
+#: lib/klass_hero_web/components/provider_components.ex:2684
 #, elixir-autogen, elixir-format
 msgid "Rows with errors"
 msgstr ""
@@ -6996,7 +6996,7 @@ msgstr ""
 msgid "Identity verifications"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:72
+#: lib/klass_hero_web/components/provider_components.ex:73
 #, elixir-autogen, elixir-format, fuzzy
 msgid "In progress"
 msgstr ""
@@ -7026,7 +7026,7 @@ msgstr ""
 msgid "Not started"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:70
+#: lib/klass_hero_web/components/provider_components.ex:71
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Passed"
 msgstr ""
@@ -7143,12 +7143,12 @@ msgstr ""
 msgid "Experience validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3246
+#: lib/klass_hero_web/components/provider_components.ex:3242
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3220
+#: lib/klass_hero_web/components/provider_components.ex:3216
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
@@ -7158,12 +7158,12 @@ msgstr ""
 msgid "Safeguarding certificate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3243
+#: lib/klass_hero_web/components/provider_components.ex:3239
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select Video"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3289
+#: lib/klass_hero_web/components/provider_components.ex:3285
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload Video"
 msgstr ""
@@ -7173,7 +7173,7 @@ msgstr ""
 msgid "Your browser does not support video playback."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3436
+#: lib/klass_hero_web/components/provider_components.ex:3432
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Confirm agreement"
 msgstr ""
@@ -7183,12 +7183,12 @@ msgstr ""
 msgid "Couldn't record your agreement. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3459
+#: lib/klass_hero_web/components/provider_components.ex:3455
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3435
+#: lib/klass_hero_web/components/provider_components.ex:3431
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr ""
@@ -7198,7 +7198,7 @@ msgstr ""
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3344
+#: lib/klass_hero_web/components/provider_components.ex:3340
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr ""
@@ -7208,17 +7208,17 @@ msgstr ""
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3444
+#: lib/klass_hero_web/components/provider_components.ex:3440
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3433
+#: lib/klass_hero_web/components/provider_components.ex:3429
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3434
+#: lib/klass_hero_web/components/provider_components.ex:3430
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
@@ -7487,12 +7487,12 @@ msgstr ""
 msgid "Your insurance is verified."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3388
+#: lib/klass_hero_web/components/provider_components.ex:3384
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3491
+#: lib/klass_hero_web/components/provider_components.ex:3487
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr ""
@@ -7502,7 +7502,7 @@ msgstr ""
 msgid "Couldn't record your declaration. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3497
+#: lib/klass_hero_web/components/provider_components.ex:3493
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr ""
@@ -7512,17 +7512,17 @@ msgstr ""
 msgid "Please confirm the declaration before signing."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3522
+#: lib/klass_hero_web/components/provider_components.ex:3518
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3501
+#: lib/klass_hero_web/components/provider_components.ex:3497
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3489
+#: lib/klass_hero_web/components/provider_components.ex:3485
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr ""
@@ -7532,12 +7532,12 @@ msgstr ""
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3509
+#: lib/klass_hero_web/components/provider_components.ex:3505
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3495
+#: lib/klass_hero_web/components/provider_components.ex:3491
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
@@ -7604,14 +7604,14 @@ msgstr ""
 msgid "Undelivered Events"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2197
-#: lib/klass_hero_web/components/provider_components.ex:2380
+#: lib/klass_hero_web/components/provider_components.ex:2193
+#: lib/klass_hero_web/components/provider_components.ex:2376
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2120
-#: lib/klass_hero_web/components/provider_components.ex:2306
+#: lib/klass_hero_web/components/provider_components.ex:2116
+#: lib/klass_hero_web/components/provider_components.ex:2302
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Lead"
 msgstr ""
@@ -7621,17 +7621,17 @@ msgstr ""
 msgid "Lead instructor updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2132
+#: lib/klass_hero_web/components/provider_components.ex:2128
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1583
+#: lib/klass_hero_web/components/provider_components.ex:1584
 #, elixir-autogen, elixir-format
 msgid "Manage Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2161
+#: lib/klass_hero_web/components/provider_components.ex:2157
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this program yet."
 msgstr ""
@@ -7642,19 +7642,19 @@ msgstr ""
 msgid "Pick a staff member to add."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2144
-#: lib/klass_hero_web/components/provider_components.ex:2419
+#: lib/klass_hero_web/components/provider_components.ex:2140
+#: lib/klass_hero_web/components/provider_components.ex:2415
 #, elixir-autogen, elixir-format
 msgid "Reassign the lead before removing them"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2145
+#: lib/klass_hero_web/components/provider_components.ex:2141
 #, elixir-autogen, elixir-format
 msgid "Remove from program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2179
-#: lib/klass_hero_web/components/provider_components.ex:2361
+#: lib/klass_hero_web/components/provider_components.ex:2175
+#: lib/klass_hero_web/components/provider_components.ex:2357
 #, elixir-autogen, elixir-format
 msgid "Select a staff member…"
 msgstr ""
@@ -7669,12 +7669,12 @@ msgstr ""
 msgid "Staff member removed from the program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2202
+#: lib/klass_hero_web/components/provider_components.ex:2198
 #, elixir-autogen, elixir-format
 msgid "Staff you add can read and reply to this program's parent conversations."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2096
+#: lib/klass_hero_web/components/provider_components.ex:2092
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Staffing — %{title}"
 msgstr ""
@@ -7694,19 +7694,19 @@ msgstr ""
 msgid "This person is the lead instructor. Make someone else lead before removing them."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1527
+#: lib/klass_hero_web/components/provider_components.ex:1528
 #, elixir-autogen, elixir-format
 msgid "%{count} staff member · no lead"
 msgid_plural "%{count} staff · no lead"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/components/provider_components.ex:563
+#: lib/klass_hero_web/components/provider_components.ex:564
 #, elixir-autogen, elixir-format
 msgid "%{name} will be unassigned from every program and removed from those conversations. Their history is kept and you can add them back later."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:639
+#: lib/klass_hero_web/components/provider_components.ex:640
 #, elixir-autogen, elixir-format
 msgid "Add back to team"
 msgstr ""
@@ -7716,7 +7716,7 @@ msgstr ""
 msgid "Could not bring this team member back. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:601
+#: lib/klass_hero_web/components/provider_components.ex:602
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Delete entry"
 msgstr ""
@@ -7726,7 +7726,7 @@ msgstr ""
 msgid "Former team members"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:575
+#: lib/klass_hero_web/components/provider_components.ex:576
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove from team"
 msgstr ""
@@ -7741,7 +7741,7 @@ msgstr ""
 msgid "Team member removed from the team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:591
+#: lib/klass_hero_web/components/provider_components.ex:592
 #, elixir-autogen, elixir-format
 msgid "This deletes %{name} permanently — there's nothing to undo. Use it only for an entry added by mistake."
 msgstr ""
@@ -7766,24 +7766,24 @@ msgstr ""
 msgid "Program updated, but the enrollment capacity was rejected. The previous limits still apply."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:918
+#: lib/klass_hero_web/components/provider_components.ex:919
 #, elixir-autogen, elixir-format
 msgid "%{count} child is already enrolled. Confirm you want this program to have no capacity limit."
 msgid_plural "%{count} children are already enrolled. Confirm you want this program to have no capacity limit."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1120
+#: lib/klass_hero_web/components/provider_components.ex:1121
 #, elixir-autogen, elixir-format
 msgid "Anyone will be able to book a place until you set a new maximum."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1125
+#: lib/klass_hero_web/components/provider_components.ex:1126
 #, elixir-autogen, elixir-format
 msgid "I understand this program will have no capacity limit."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2407
+#: lib/klass_hero_web/components/provider_components.ex:2403
 #, elixir-autogen, elixir-format
 msgid "Go back to the program's usual team"
 msgstr ""
@@ -7793,17 +7793,17 @@ msgstr ""
 msgid "Lead instructor for this session updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2321
+#: lib/klass_hero_web/components/provider_components.ex:2317
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Make lead instructor for this session"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2343
+#: lib/klass_hero_web/components/provider_components.ex:2339
 #, elixir-autogen, elixir-format
 msgid "Nobody is working this session yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2424
+#: lib/klass_hero_web/components/provider_components.ex:2420
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove from this session"
 msgstr ""
@@ -7823,7 +7823,7 @@ msgstr ""
 msgid "Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2245
+#: lib/klass_hero_web/components/provider_components.ex:2241
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Staffing — %{date}"
 msgstr ""
@@ -7853,38 +7853,37 @@ msgstr ""
 msgid "A session needs at least one person. Use “Go back to the program's usual team” to drop this session's own roster."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2422
+#: lib/klass_hero_web/components/provider_components.ex:2418
 #, elixir-autogen, elixir-format
 msgid "A session needs someone — use “Go back to the program's usual team” instead"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2389
+#: lib/klass_hero_web/components/provider_components.ex:2385
 #, elixir-autogen, elixir-format
 msgid "Everyone on your team is already working this session."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2277
+#: lib/klass_hero_web/components/provider_components.ex:2273
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Staffed just for this session. Changes here do not touch the program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2279
+#: lib/klass_hero_web/components/provider_components.ex:2275
 #, elixir-autogen, elixir-format
 msgid "Using the program's usual team. The first change here copies them onto this session, so later program changes stop reaching it."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:437
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:125
+#: lib/klass_hero_web/components/booking_components.ex:228
 #, elixir-autogen, elixir-format, fuzzy
 msgid "(optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2015
+#: lib/klass_hero_web/components/provider_components.ex:2011
 #, elixir-autogen, elixir-format
 msgid "Add a waiver"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2047
+#: lib/klass_hero_web/components/provider_components.ex:2043
 #, elixir-autogen, elixir-format
 msgid "Add waiver"
 msgstr ""
@@ -7894,34 +7893,34 @@ msgstr ""
 msgid "Check the waiver details and try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:43
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:66
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:45
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:68
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrollment not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/booking_live.ex:465
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:154
+#: lib/klass_hero_web/live/booking_live.ex:464
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:155
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2029
+#: lib/klass_hero_web/components/provider_components.ex:2025
 #, elixir-autogen, elixir-format
 msgid "Legal text"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1590
+#: lib/klass_hero_web/components/provider_components.ex:1591
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Manage Waivers"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1958
+#: lib/klass_hero_web/components/provider_components.ex:1959
 #, elixir-autogen, elixir-format
 msgid "No waivers yet. Parents enrol without signing anything."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2036
+#: lib/klass_hero_web/components/provider_components.ex:2032
 #, elixir-autogen, elixir-format
 msgid "Parents must sign this before enrolling"
 msgstr ""
@@ -7931,42 +7930,42 @@ msgstr ""
 msgid "Please read and sign every required waiver before enrolling."
 msgstr ""
 
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:106
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:108
 #, elixir-autogen, elixir-format
 msgid "Please read and sign these before %{program} begins."
 msgstr ""
 
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:55
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:57
 #, elixir-autogen, elixir-format
 msgid "Please tick a waiver to sign it."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2014
+#: lib/klass_hero_web/components/provider_components.ex:2010
 #, elixir-autogen, elixir-format
 msgid "Publish a new version"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2047
+#: lib/klass_hero_web/components/provider_components.ex:2043
 #, elixir-autogen, elixir-format
 msgid "Publish version"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2040
+#: lib/klass_hero_web/components/provider_components.ex:2036
 #, elixir-autogen, elixir-format
 msgid "Publishing keeps every earlier version on record; signatures already given stay bound to the wording they were shown."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1976
+#: lib/klass_hero_web/components/booking_components.ex:222
 #, elixir-autogen, elixir-format
 msgid "Required"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1997
+#: lib/klass_hero_web/components/provider_components.ex:1993
 #, elixir-autogen, elixir-format
 msgid "Retire this waiver"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1988
+#: lib/klass_hero_web/components/provider_components.ex:1984
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Revise text"
 msgstr ""
@@ -7976,33 +7975,33 @@ msgstr ""
 msgid "Sign the waivers for %{program}"
 msgstr ""
 
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:160
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:161
 #, elixir-autogen, elixir-format
 msgid "Sign waivers"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2502
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:142
+#: lib/klass_hero_web/components/provider_components.ex:2498
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:143
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Signed"
 msgstr ""
 
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:60
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:62
 #, elixir-autogen, elixir-format
 msgid "Thank you — your waivers are on record."
 msgstr ""
 
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:110
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:112
 #, elixir-autogen, elixir-format
 msgid "There is nothing to sign for this enrollment."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2502
+#: lib/klass_hero_web/components/provider_components.ex:2498
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Unsigned"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1980
+#: lib/klass_hero_web/components/provider_components.ex:1976
 #, elixir-autogen, elixir-format
 msgid "Version %{number}"
 msgstr ""
@@ -8012,10 +8011,10 @@ msgstr ""
 msgid "Waiver not found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2470
+#: lib/klass_hero_web/components/provider_components.ex:2466
 #: lib/klass_hero_web/live/booking_live.ex:427
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:31
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:103
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:33
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:105
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Waivers"
 msgstr ""
@@ -8025,12 +8024,12 @@ msgstr ""
 msgid "Waivers waiting for your signature"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1949
+#: lib/klass_hero_web/components/provider_components.ex:1950
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Waivers — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/live/enrollment_waivers_live.ex:94
+#: lib/klass_hero_web/live/enrollment_waivers_live.ex:96
 #, elixir-autogen, elixir-format, fuzzy
 msgid "this program"
 msgstr ""
@@ -8040,7 +8039,7 @@ msgstr ""
 msgid "New version published. It applies to future enrolments."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2001
+#: lib/klass_hero_web/components/provider_components.ex:1997
 #, elixir-autogen, elixir-format
 msgid "Retire \"%{title}\"? Parents will no longer be asked to sign it. Signatures already collected are kept."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/en/LC_MESSAGES/enrollment.po
@@ -11,95 +11,95 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:3026
-#: lib/klass_hero_web/components/provider_components.ex:3043
+#: lib/klass_hero_web/components/provider_components.ex:3036
+#: lib/klass_hero_web/components/provider_components.ex:3053
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3027
-#: lib/klass_hero_web/components/provider_components.ex:3044
+#: lib/klass_hero_web/components/provider_components.ex:3037
+#: lib/klass_hero_web/components/provider_components.ex:3054
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3028
-#: lib/klass_hero_web/components/provider_components.ex:3045
+#: lib/klass_hero_web/components/provider_components.ex:3038
+#: lib/klass_hero_web/components/provider_components.ex:3055
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3039
+#: lib/klass_hero_web/components/provider_components.ex:3049
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3029
+#: lib/klass_hero_web/components/provider_components.ex:3039
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3030
+#: lib/klass_hero_web/components/provider_components.ex:3040
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3031
+#: lib/klass_hero_web/components/provider_components.ex:3041
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3038
+#: lib/klass_hero_web/components/provider_components.ex:3048
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3040
+#: lib/klass_hero_web/components/provider_components.ex:3050
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3032
+#: lib/klass_hero_web/components/provider_components.ex:3042
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3034
+#: lib/klass_hero_web/components/provider_components.ex:3044
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3036
+#: lib/klass_hero_web/components/provider_components.ex:3046
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2966
+#: lib/klass_hero_web/components/provider_components.ex:2976
 #, elixir-autogen, elixir-format
 msgid "Date of birth \"%{value}\" is not a valid date. Please correct it and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2960
+#: lib/klass_hero_web/components/provider_components.ex:2970
 #, elixir-autogen, elixir-format
 msgid "Invite link could not be generated (no token). Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2974
+#: lib/klass_hero_web/components/provider_components.ex:2984
 #, elixir-autogen, elixir-format
 msgid "The invitation email could not be delivered. Please check the address and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2963
+#: lib/klass_hero_web/components/provider_components.ex:2973
 #, elixir-autogen, elixir-format
 msgid "The program is full, so this child could not be enrolled."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2977
+#: lib/klass_hero_web/components/provider_components.ex:2987
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed and no retries remain. Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2986
+#: lib/klass_hero_web/components/provider_components.ex:2996
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed. Please resend."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/en/LC_MESSAGES/enrollment.po
@@ -11,95 +11,95 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:2863
-#: lib/klass_hero_web/components/provider_components.ex:2880
+#: lib/klass_hero_web/components/provider_components.ex:3026
+#: lib/klass_hero_web/components/provider_components.ex:3043
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2864
-#: lib/klass_hero_web/components/provider_components.ex:2881
+#: lib/klass_hero_web/components/provider_components.ex:3027
+#: lib/klass_hero_web/components/provider_components.ex:3044
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2865
-#: lib/klass_hero_web/components/provider_components.ex:2882
+#: lib/klass_hero_web/components/provider_components.ex:3028
+#: lib/klass_hero_web/components/provider_components.ex:3045
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2876
+#: lib/klass_hero_web/components/provider_components.ex:3039
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2866
+#: lib/klass_hero_web/components/provider_components.ex:3029
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2867
+#: lib/klass_hero_web/components/provider_components.ex:3030
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2868
+#: lib/klass_hero_web/components/provider_components.ex:3031
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2875
+#: lib/klass_hero_web/components/provider_components.ex:3038
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2877
+#: lib/klass_hero_web/components/provider_components.ex:3040
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2869
+#: lib/klass_hero_web/components/provider_components.ex:3032
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2871
+#: lib/klass_hero_web/components/provider_components.ex:3034
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2873
+#: lib/klass_hero_web/components/provider_components.ex:3036
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2803
+#: lib/klass_hero_web/components/provider_components.ex:2966
 #, elixir-autogen, elixir-format
 msgid "Date of birth \"%{value}\" is not a valid date. Please correct it and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2797
+#: lib/klass_hero_web/components/provider_components.ex:2960
 #, elixir-autogen, elixir-format
 msgid "Invite link could not be generated (no token). Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2811
+#: lib/klass_hero_web/components/provider_components.ex:2974
 #, elixir-autogen, elixir-format
 msgid "The invitation email could not be delivered. Please check the address and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2800
+#: lib/klass_hero_web/components/provider_components.ex:2963
 #, elixir-autogen, elixir-format
 msgid "The program is full, so this child could not be enrolled."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2814
+#: lib/klass_hero_web/components/provider_components.ex:2977
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed and no retries remain. Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2823
+#: lib/klass_hero_web/components/provider_components.ex:2986
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed. Please resend."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/en/LC_MESSAGES/enrollment.po
@@ -11,95 +11,95 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:3036
-#: lib/klass_hero_web/components/provider_components.ex:3053
+#: lib/klass_hero_web/components/provider_components.ex:3032
+#: lib/klass_hero_web/components/provider_components.ex:3049
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3037
-#: lib/klass_hero_web/components/provider_components.ex:3054
+#: lib/klass_hero_web/components/provider_components.ex:3033
+#: lib/klass_hero_web/components/provider_components.ex:3050
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3038
-#: lib/klass_hero_web/components/provider_components.ex:3055
+#: lib/klass_hero_web/components/provider_components.ex:3034
+#: lib/klass_hero_web/components/provider_components.ex:3051
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3049
+#: lib/klass_hero_web/components/provider_components.ex:3045
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3039
+#: lib/klass_hero_web/components/provider_components.ex:3035
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3040
+#: lib/klass_hero_web/components/provider_components.ex:3036
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3041
+#: lib/klass_hero_web/components/provider_components.ex:3037
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3048
+#: lib/klass_hero_web/components/provider_components.ex:3044
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3050
+#: lib/klass_hero_web/components/provider_components.ex:3046
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3042
+#: lib/klass_hero_web/components/provider_components.ex:3038
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3044
+#: lib/klass_hero_web/components/provider_components.ex:3040
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3046
+#: lib/klass_hero_web/components/provider_components.ex:3042
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2976
+#: lib/klass_hero_web/components/provider_components.ex:2972
 #, elixir-autogen, elixir-format
 msgid "Date of birth \"%{value}\" is not a valid date. Please correct it and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2970
+#: lib/klass_hero_web/components/provider_components.ex:2966
 #, elixir-autogen, elixir-format
 msgid "Invite link could not be generated (no token). Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2984
+#: lib/klass_hero_web/components/provider_components.ex:2980
 #, elixir-autogen, elixir-format
 msgid "The invitation email could not be delivered. Please check the address and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2973
+#: lib/klass_hero_web/components/provider_components.ex:2969
 #, elixir-autogen, elixir-format
 msgid "The program is full, so this child could not be enrolled."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2987
+#: lib/klass_hero_web/components/provider_components.ex:2983
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed and no retries remain. Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2996
+#: lib/klass_hero_web/components/provider_components.ex:2992
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed. Please resend."
 msgstr ""

--- a/priv/gettext/enrollment.pot
+++ b/priv/gettext/enrollment.pot
@@ -11,95 +11,95 @@
 msgid ""
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2863
-#: lib/klass_hero_web/components/provider_components.ex:2880
+#: lib/klass_hero_web/components/provider_components.ex:3026
+#: lib/klass_hero_web/components/provider_components.ex:3043
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2864
-#: lib/klass_hero_web/components/provider_components.ex:2881
+#: lib/klass_hero_web/components/provider_components.ex:3027
+#: lib/klass_hero_web/components/provider_components.ex:3044
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2865
-#: lib/klass_hero_web/components/provider_components.ex:2882
+#: lib/klass_hero_web/components/provider_components.ex:3028
+#: lib/klass_hero_web/components/provider_components.ex:3045
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2876
+#: lib/klass_hero_web/components/provider_components.ex:3039
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2866
+#: lib/klass_hero_web/components/provider_components.ex:3029
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2867
+#: lib/klass_hero_web/components/provider_components.ex:3030
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2868
+#: lib/klass_hero_web/components/provider_components.ex:3031
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2875
+#: lib/klass_hero_web/components/provider_components.ex:3038
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2877
+#: lib/klass_hero_web/components/provider_components.ex:3040
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2869
+#: lib/klass_hero_web/components/provider_components.ex:3032
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2871
+#: lib/klass_hero_web/components/provider_components.ex:3034
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2873
+#: lib/klass_hero_web/components/provider_components.ex:3036
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2803
+#: lib/klass_hero_web/components/provider_components.ex:2966
 #, elixir-autogen, elixir-format
 msgid "Date of birth \"%{value}\" is not a valid date. Please correct it and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2797
+#: lib/klass_hero_web/components/provider_components.ex:2960
 #, elixir-autogen, elixir-format
 msgid "Invite link could not be generated (no token). Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2811
+#: lib/klass_hero_web/components/provider_components.ex:2974
 #, elixir-autogen, elixir-format
 msgid "The invitation email could not be delivered. Please check the address and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2800
+#: lib/klass_hero_web/components/provider_components.ex:2963
 #, elixir-autogen, elixir-format
 msgid "The program is full, so this child could not be enrolled."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2814
+#: lib/klass_hero_web/components/provider_components.ex:2977
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed and no retries remain. Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2823
+#: lib/klass_hero_web/components/provider_components.ex:2986
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed. Please resend."
 msgstr ""

--- a/priv/gettext/enrollment.pot
+++ b/priv/gettext/enrollment.pot
@@ -11,95 +11,95 @@
 msgid ""
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3026
-#: lib/klass_hero_web/components/provider_components.ex:3043
+#: lib/klass_hero_web/components/provider_components.ex:3036
+#: lib/klass_hero_web/components/provider_components.ex:3053
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3027
-#: lib/klass_hero_web/components/provider_components.ex:3044
+#: lib/klass_hero_web/components/provider_components.ex:3037
+#: lib/klass_hero_web/components/provider_components.ex:3054
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3028
-#: lib/klass_hero_web/components/provider_components.ex:3045
+#: lib/klass_hero_web/components/provider_components.ex:3038
+#: lib/klass_hero_web/components/provider_components.ex:3055
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3039
+#: lib/klass_hero_web/components/provider_components.ex:3049
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3029
+#: lib/klass_hero_web/components/provider_components.ex:3039
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3030
+#: lib/klass_hero_web/components/provider_components.ex:3040
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3031
+#: lib/klass_hero_web/components/provider_components.ex:3041
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3038
+#: lib/klass_hero_web/components/provider_components.ex:3048
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3040
+#: lib/klass_hero_web/components/provider_components.ex:3050
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3032
+#: lib/klass_hero_web/components/provider_components.ex:3042
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3034
+#: lib/klass_hero_web/components/provider_components.ex:3044
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3036
+#: lib/klass_hero_web/components/provider_components.ex:3046
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2966
+#: lib/klass_hero_web/components/provider_components.ex:2976
 #, elixir-autogen, elixir-format
 msgid "Date of birth \"%{value}\" is not a valid date. Please correct it and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2960
+#: lib/klass_hero_web/components/provider_components.ex:2970
 #, elixir-autogen, elixir-format
 msgid "Invite link could not be generated (no token). Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2974
+#: lib/klass_hero_web/components/provider_components.ex:2984
 #, elixir-autogen, elixir-format
 msgid "The invitation email could not be delivered. Please check the address and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2963
+#: lib/klass_hero_web/components/provider_components.ex:2973
 #, elixir-autogen, elixir-format
 msgid "The program is full, so this child could not be enrolled."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2977
+#: lib/klass_hero_web/components/provider_components.ex:2987
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed and no retries remain. Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2986
+#: lib/klass_hero_web/components/provider_components.ex:2996
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed. Please resend."
 msgstr ""

--- a/priv/gettext/enrollment.pot
+++ b/priv/gettext/enrollment.pot
@@ -11,95 +11,95 @@
 msgid ""
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3036
-#: lib/klass_hero_web/components/provider_components.ex:3053
+#: lib/klass_hero_web/components/provider_components.ex:3032
+#: lib/klass_hero_web/components/provider_components.ex:3049
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3037
-#: lib/klass_hero_web/components/provider_components.ex:3054
+#: lib/klass_hero_web/components/provider_components.ex:3033
+#: lib/klass_hero_web/components/provider_components.ex:3050
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3038
-#: lib/klass_hero_web/components/provider_components.ex:3055
+#: lib/klass_hero_web/components/provider_components.ex:3034
+#: lib/klass_hero_web/components/provider_components.ex:3051
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3049
+#: lib/klass_hero_web/components/provider_components.ex:3045
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3039
+#: lib/klass_hero_web/components/provider_components.ex:3035
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3040
+#: lib/klass_hero_web/components/provider_components.ex:3036
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3041
+#: lib/klass_hero_web/components/provider_components.ex:3037
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3048
+#: lib/klass_hero_web/components/provider_components.ex:3044
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3050
+#: lib/klass_hero_web/components/provider_components.ex:3046
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3042
+#: lib/klass_hero_web/components/provider_components.ex:3038
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3044
+#: lib/klass_hero_web/components/provider_components.ex:3040
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3046
+#: lib/klass_hero_web/components/provider_components.ex:3042
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2976
+#: lib/klass_hero_web/components/provider_components.ex:2972
 #, elixir-autogen, elixir-format
 msgid "Date of birth \"%{value}\" is not a valid date. Please correct it and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2970
+#: lib/klass_hero_web/components/provider_components.ex:2966
 #, elixir-autogen, elixir-format
 msgid "Invite link could not be generated (no token). Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2984
+#: lib/klass_hero_web/components/provider_components.ex:2980
 #, elixir-autogen, elixir-format
 msgid "The invitation email could not be delivered. Please check the address and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2973
+#: lib/klass_hero_web/components/provider_components.ex:2969
 #, elixir-autogen, elixir-format
 msgid "The program is full, so this child could not be enrolled."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2987
+#: lib/klass_hero_web/components/provider_components.ex:2983
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed and no retries remain. Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2996
+#: lib/klass_hero_web/components/provider_components.ex:2992
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed. Please resend."
 msgstr ""

--- a/priv/repo/migrations/20260819085208_create_waiver_tables.exs
+++ b/priv/repo/migrations/20260819085208_create_waiver_tables.exs
@@ -1,0 +1,99 @@
+defmodule KlassHero.Repo.Migrations.CreateWaiverTables do
+  @moduledoc """
+  Provider-authored waivers parents sign at enrollment (#828), owned by Enrollment.
+
+  Three tables rather than one, because a waiver's *text* must stay reproducible verbatim
+  after later edits: `waivers` is the durable identity, `waiver_versions` is append-only
+  text history, and `waiver_acceptances` is the legal record binding a signature to the
+  exact version signed.
+
+  Deletion rules are deliberately conservative. Every FK here is `:restrict`, and
+  `program_id` carries no FK at all:
+
+    * `program_id` is a cross-context reference into Program Catalog, so it is a bare
+      correlation id per ADR-0001. The sibling `participant_policies`/`enrollment_policies`
+      use `on_delete: :delete_all` instead — copying that would let a program deletion
+      cascade away signed legal records, running no changeset and staging no event.
+    * `:restrict` on the in-context FKs means a waiver or version that has been signed
+      cannot be deleted out from under its acceptance. Waivers are retired with
+      `archived_at`, never removed.
+  """
+
+  use Ecto.Migration
+
+  def up do
+    create table(:waivers, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      # Cross-context correlation id (ADR-0001) — no FK, so a program deletion can never
+      # cascade into signed waiver records.
+      add :program_id, :binary_id, null: false
+      add :title, :string, null: false
+      add :required, :boolean, null: false, default: true
+      add :archived_at, :utc_datetime_usec
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create index(:waivers, [:program_id])
+    create index(:waivers, [:program_id], where: "archived_at IS NULL", name: :waivers_active_idx)
+
+    create table(:waiver_versions, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+
+      add :waiver_id,
+          references(:waivers, type: :binary_id, on_delete: :restrict),
+          null: false
+
+      add :body, :text, null: false
+      add :version, :integer, null: false
+      add :published_at, :utc_datetime_usec, null: false
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create index(:waiver_versions, [:waiver_id])
+    create unique_index(:waiver_versions, [:waiver_id, :version])
+
+    create constraint(:waiver_versions, :waiver_version_positive, check: "version >= 1")
+
+    create table(:waiver_acceptances, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+
+      add :waiver_version_id,
+          references(:waiver_versions, type: :binary_id, on_delete: :restrict),
+          null: false
+
+      add :waiver_id,
+          references(:waivers, type: :binary_id, on_delete: :restrict),
+          null: false
+
+      add :enrollment_id,
+          references(:enrollments, type: :binary_id, on_delete: :restrict),
+          null: false
+
+      # Family's parent profile — cross-context correlation id, no FK (ADR-0001).
+      add :parent_id, :binary_id, null: false
+      add :accepted_at, :utc_datetime_usec, null: false
+      # Nullable on purpose: absent or untrusted forwarded headers store nothing rather
+      # than a proxy IP, which would look like evidence without being any.
+      add :ip_address, :string
+      add :user_agent, :text
+      # Redundant copy of the version's body at signing time. The version row is the
+      # source of truth; this survives even a catastrophic loss of that table.
+      add :body_snapshot, :text, null: false
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create index(:waiver_acceptances, [:enrollment_id])
+    create index(:waiver_acceptances, [:waiver_version_id])
+    create index(:waiver_acceptances, [:parent_id])
+    create unique_index(:waiver_acceptances, [:enrollment_id, :waiver_id])
+  end
+
+  def down do
+    drop table(:waiver_acceptances)
+    drop table(:waiver_versions)
+    drop table(:waivers)
+  end
+end

--- a/test/klass_hero/enrollment/create_enrollment_test.exs
+++ b/test/klass_hero/enrollment/create_enrollment_test.exs
@@ -16,7 +16,7 @@ defmodule KlassHero.Enrollment.CreateEnrollmentTest do
         parent_id: parent.id
       }
 
-      assert {:ok, enrollment} = KlassHero.Enrollment.create_enrollment(params)
+      assert {:ok, enrollment} = KlassHero.Enrollment.create_enrollment(Map.put(params, :waivers, :deferred))
       assert %Enrollment{} = enrollment
       assert enrollment.program_id == program.id
       assert enrollment.child_id == child.id
@@ -34,7 +34,7 @@ defmodule KlassHero.Enrollment.CreateEnrollmentTest do
         parent_id: parent.id
       }
 
-      {:ok, enrollment} = KlassHero.Enrollment.create_enrollment(params)
+      {:ok, enrollment} = KlassHero.Enrollment.create_enrollment(Map.put(params, :waivers, :deferred))
 
       assert enrollment.status == :pending
     end
@@ -50,7 +50,7 @@ defmodule KlassHero.Enrollment.CreateEnrollmentTest do
       }
 
       before = DateTime.utc_now() |> DateTime.truncate(:second)
-      {:ok, enrollment} = KlassHero.Enrollment.create_enrollment(params)
+      {:ok, enrollment} = KlassHero.Enrollment.create_enrollment(Map.put(params, :waivers, :deferred))
       after_time = DateTime.utc_now() |> DateTime.add(1, :second)
 
       assert DateTime.compare(enrollment.enrolled_at, before) in [:gt, :eq]
@@ -71,7 +71,7 @@ defmodule KlassHero.Enrollment.CreateEnrollmentTest do
         total_amount: Decimal.new("121.00")
       }
 
-      {:ok, enrollment} = KlassHero.Enrollment.create_enrollment(params)
+      {:ok, enrollment} = KlassHero.Enrollment.create_enrollment(Map.put(params, :waivers, :deferred))
 
       assert enrollment.subtotal == Decimal.new("100.00")
       assert enrollment.vat_amount == Decimal.new("19.00")
@@ -90,7 +90,7 @@ defmodule KlassHero.Enrollment.CreateEnrollmentTest do
         payment_method: "transfer"
       }
 
-      {:ok, enrollment} = KlassHero.Enrollment.create_enrollment(params)
+      {:ok, enrollment} = KlassHero.Enrollment.create_enrollment(Map.put(params, :waivers, :deferred))
 
       assert enrollment.payment_method == "transfer"
     end
@@ -106,7 +106,7 @@ defmodule KlassHero.Enrollment.CreateEnrollmentTest do
         special_requirements: "Allergic to peanuts"
       }
 
-      {:ok, enrollment} = KlassHero.Enrollment.create_enrollment(params)
+      {:ok, enrollment} = KlassHero.Enrollment.create_enrollment(Map.put(params, :waivers, :deferred))
 
       assert enrollment.special_requirements == "Allergic to peanuts"
     end
@@ -120,7 +120,8 @@ defmodule KlassHero.Enrollment.CreateEnrollmentTest do
         parent_id: existing.parent_id
       }
 
-      assert {:error, :duplicate_resource} = KlassHero.Enrollment.create_enrollment(params)
+      assert {:error, :duplicate_resource} =
+               KlassHero.Enrollment.create_enrollment(Map.put(params, :waivers, :deferred))
     end
 
     test "allows new enrollment after previous one cancelled" do
@@ -132,14 +133,14 @@ defmodule KlassHero.Enrollment.CreateEnrollmentTest do
         parent_id: cancelled.parent_id
       }
 
-      assert {:ok, enrollment} = KlassHero.Enrollment.create_enrollment(params)
+      assert {:ok, enrollment} = KlassHero.Enrollment.create_enrollment(Map.put(params, :waivers, :deferred))
       assert enrollment.status == :pending
     end
 
     test "returns changeset error for missing required fields" do
       params = %{}
 
-      assert {:error, %Ecto.Changeset{}} = KlassHero.Enrollment.create_enrollment(params)
+      assert {:error, %Ecto.Changeset{}} = KlassHero.Enrollment.create_enrollment(Map.put(params, :waivers, :deferred))
     end
 
     test "accepts custom enrolled_at" do
@@ -154,7 +155,7 @@ defmodule KlassHero.Enrollment.CreateEnrollmentTest do
         enrolled_at: enrolled_at
       }
 
-      {:ok, enrollment} = KlassHero.Enrollment.create_enrollment(params)
+      {:ok, enrollment} = KlassHero.Enrollment.create_enrollment(Map.put(params, :waivers, :deferred))
 
       assert enrollment.enrolled_at == enrolled_at
     end
@@ -170,7 +171,7 @@ defmodule KlassHero.Enrollment.CreateEnrollmentTest do
         status: "confirmed"
       }
 
-      {:ok, enrollment} = KlassHero.Enrollment.create_enrollment(params)
+      {:ok, enrollment} = KlassHero.Enrollment.create_enrollment(Map.put(params, :waivers, :deferred))
 
       assert enrollment.status == :confirmed
     end
@@ -198,6 +199,7 @@ defmodule KlassHero.Enrollment.CreateEnrollmentTest do
 
       result =
         KlassHero.Enrollment.create_enrollment(%{
+          waivers: :deferred,
           identity_id: parent.identity_id,
           program_id: program.id,
           child_id: child.id,
@@ -231,6 +233,7 @@ defmodule KlassHero.Enrollment.CreateEnrollmentTest do
 
       assert {:ok, enrollment} =
                KlassHero.Enrollment.create_enrollment(%{
+                 waivers: :deferred,
                  identity_id: parent.identity_id,
                  program_id: program.id,
                  child_id: child.id,
@@ -248,6 +251,7 @@ defmodule KlassHero.Enrollment.CreateEnrollmentTest do
 
       assert {:ok, _enrollment} =
                KlassHero.Enrollment.create_enrollment(%{
+                 waivers: :deferred,
                  identity_id: parent.identity_id,
                  program_id: program.id,
                  child_id: child.id,
@@ -270,6 +274,7 @@ defmodule KlassHero.Enrollment.CreateEnrollmentTest do
       # as a foreign child, avoiding an existence oracle.
       result =
         KlassHero.Enrollment.create_enrollment(%{
+          waivers: :deferred,
           identity_id: parent.identity_id,
           program_id: program.id,
           child_id: Ecto.UUID.generate(),
@@ -288,6 +293,7 @@ defmodule KlassHero.Enrollment.CreateEnrollmentTest do
 
       result =
         KlassHero.Enrollment.create_enrollment(%{
+          waivers: :deferred,
           identity_id: parent.identity_id,
           program_id: program.id,
           child_id: other_child.id,
@@ -310,6 +316,7 @@ defmodule KlassHero.Enrollment.CreateEnrollmentTest do
 
       {:ok, _} =
         KlassHero.Enrollment.create_enrollment(%{
+          waivers: :deferred,
           program_id: program.id,
           child_id: child1.id,
           parent_id: parent1.id
@@ -317,6 +324,7 @@ defmodule KlassHero.Enrollment.CreateEnrollmentTest do
 
       assert {:error, :program_full} =
                KlassHero.Enrollment.create_enrollment(%{
+                 waivers: :deferred,
                  program_id: program.id,
                  child_id: child2.id,
                  parent_id: parent2.id
@@ -329,6 +337,7 @@ defmodule KlassHero.Enrollment.CreateEnrollmentTest do
 
       assert {:ok, _} =
                KlassHero.Enrollment.create_enrollment(%{
+                 waivers: :deferred,
                  program_id: program.id,
                  child_id: child.id,
                  parent_id: parent.id
@@ -343,6 +352,7 @@ defmodule KlassHero.Enrollment.CreateEnrollmentTest do
 
       assert {:ok, _} =
                KlassHero.Enrollment.create_enrollment(%{
+                 waivers: :deferred,
                  program_id: program.id,
                  child_id: child.id,
                  parent_id: parent.id

--- a/test/klass_hero/enrollment/create_enrollment_waivers_test.exs
+++ b/test/klass_hero/enrollment/create_enrollment_waivers_test.exs
@@ -1,0 +1,191 @@
+defmodule KlassHero.Enrollment.CreateEnrollmentWaiversTest do
+  @moduledoc """
+  The waiver gate on `Enrollment.create_enrollment/1`.
+
+  These assert the gate lives *inside* the creating transaction: a blocked enrollment leaves
+  no row behind, and an acceptance never exists without its enrollment.
+  """
+
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+
+  alias KlassHero.Enrollment
+  alias KlassHero.Enrollment.Enrollment, as: EnrollmentSchema
+  alias KlassHero.Enrollment.WaiverAcceptance
+
+  defp setup_program(_context \\ %{}) do
+    provider = insert(:provider_profile_schema)
+    program = insert(:program_schema, provider_id: provider.id)
+    {child, parent} = insert_child_with_guardian()
+    %{provider: provider, program: program, child: child, parent: parent}
+  end
+
+  defp base_params(%{program: program, child: child, parent: parent}) do
+    %{program_id: program.id, child_id: child.id, parent_id: parent.id}
+  end
+
+  defp add_required_waiver(provider, program, body \\ "I agree to hold the provider harmless.") do
+    {:ok, %{waiver: waiver, version: version}} =
+      Enrollment.create_waiver(provider.id, %{
+        program_id: program.id,
+        title: "Liability Waiver",
+        required: true,
+        body: body
+      })
+
+    {waiver, version}
+  end
+
+  describe "waiver intent is mandatory" do
+    test "omitting :waivers is refused rather than silently defaulting" do
+      ctx = setup_program()
+
+      assert {:error, :waiver_intent_required} = Enrollment.create_enrollment(base_params(ctx))
+    end
+
+    test "no enrollment row is written when intent is missing" do
+      ctx = setup_program()
+
+      Enrollment.create_enrollment(base_params(ctx))
+
+      assert Repo.aggregate(EnrollmentSchema, :count) == 0
+    end
+  end
+
+  describe ":deferred" do
+    test "creates the enrollment without any acceptance" do
+      ctx = setup_program()
+      {_waiver, _version} = add_required_waiver(ctx.provider, ctx.program)
+
+      params = Map.put(base_params(ctx), :waivers, :deferred)
+
+      assert {:ok, enrollment} = Enrollment.create_enrollment(params)
+      assert enrollment.program_id == ctx.program.id
+      assert Repo.aggregate(WaiverAcceptance, :count) == 0
+    end
+  end
+
+  describe "{:accepted, ids}" do
+    test "creates the enrollment when the program has no waivers" do
+      ctx = setup_program()
+      params = Map.put(base_params(ctx), :waivers, {:accepted, []})
+
+      assert {:ok, _enrollment} = Enrollment.create_enrollment(params)
+    end
+
+    test "blocks the enrollment when a required waiver is unsigned" do
+      ctx = setup_program()
+      {_waiver, _version} = add_required_waiver(ctx.provider, ctx.program)
+
+      params = Map.put(base_params(ctx), :waivers, {:accepted, []})
+
+      assert {:error, :waivers_unsigned} = Enrollment.create_enrollment(params)
+    end
+
+    test "a blocked enrollment leaves no row behind — the gate is inside the transaction" do
+      ctx = setup_program()
+      {_waiver, _version} = add_required_waiver(ctx.provider, ctx.program)
+
+      Enrollment.create_enrollment(Map.put(base_params(ctx), :waivers, {:accepted, []}))
+
+      assert Repo.aggregate(EnrollmentSchema, :count) == 0
+      assert Repo.aggregate(WaiverAcceptance, :count) == 0
+    end
+
+    test "records an acceptance snapshotting the exact text signed" do
+      ctx = setup_program()
+      {waiver, version} = add_required_waiver(ctx.provider, ctx.program)
+
+      params = Map.put(base_params(ctx), :waivers, {:accepted, [version.id]})
+
+      assert {:ok, enrollment} = Enrollment.create_enrollment(params)
+
+      assert [acceptance] = Repo.all(WaiverAcceptance)
+      assert acceptance.enrollment_id == enrollment.id
+      assert acceptance.waiver_id == waiver.id
+      assert acceptance.waiver_version_id == version.id
+      assert acceptance.parent_id == ctx.parent.id
+      assert acceptance.body_snapshot == version.body
+    end
+
+    test "carries the audit trail onto the acceptance" do
+      ctx = setup_program()
+      {_waiver, version} = add_required_waiver(ctx.provider, ctx.program)
+
+      params =
+        base_params(ctx)
+        |> Map.put(:waivers, {:accepted, [version.id]})
+        |> Map.put(:audit, %{ip_address: "203.0.113.7", user_agent: "Mozilla/5.0"})
+
+      assert {:ok, _enrollment} = Enrollment.create_enrollment(params)
+
+      assert [acceptance] = Repo.all(WaiverAcceptance)
+      assert acceptance.ip_address == "203.0.113.7"
+      assert acceptance.user_agent == "Mozilla/5.0"
+    end
+
+    test "leaves ip_address nil when no trustworthy client IP was captured" do
+      ctx = setup_program()
+      {_waiver, version} = add_required_waiver(ctx.provider, ctx.program)
+
+      params =
+        base_params(ctx)
+        |> Map.put(:waivers, {:accepted, [version.id]})
+        |> Map.put(:audit, %{user_agent: "Mozilla/5.0"})
+
+      assert {:ok, _enrollment} = Enrollment.create_enrollment(params)
+
+      assert [acceptance] = Repo.all(WaiverAcceptance)
+      assert acceptance.ip_address == nil
+    end
+
+    test "signing a superseded version does not satisfy the gate" do
+      ctx = setup_program()
+      {waiver, v1} = add_required_waiver(ctx.provider, ctx.program, "Original text")
+      {:ok, _v2} = Enrollment.publish_waiver_version(ctx.provider.id, waiver.id, "Revised text")
+
+      params = Map.put(base_params(ctx), :waivers, {:accepted, [v1.id]})
+
+      assert {:error, :waivers_unsigned} = Enrollment.create_enrollment(params)
+    end
+
+    test "an optional waiver is recorded when signed but never blocks" do
+      ctx = setup_program()
+
+      {:ok, %{version: optional_version}} =
+        Enrollment.create_waiver(ctx.provider.id, %{
+          program_id: ctx.program.id,
+          title: "Photo release",
+          required: false,
+          body: "You may photograph my child."
+        })
+
+      # Not signing it still enrolls.
+      assert {:ok, _} = Enrollment.create_enrollment(Map.put(base_params(ctx), :waivers, {:accepted, []}))
+      assert Repo.aggregate(WaiverAcceptance, :count) == 0
+
+      # Signing it records the acceptance.
+      {other_child, other_parent} = insert_child_with_guardian()
+
+      params = %{
+        program_id: ctx.program.id,
+        child_id: other_child.id,
+        parent_id: other_parent.id,
+        waivers: {:accepted, [optional_version.id]}
+      }
+
+      assert {:ok, _} = Enrollment.create_enrollment(params)
+      assert [acceptance] = Repo.all(WaiverAcceptance)
+      assert acceptance.waiver_version_id == optional_version.id
+    end
+
+    test "an archived required waiver no longer blocks" do
+      ctx = setup_program()
+      {waiver, _version} = add_required_waiver(ctx.provider, ctx.program)
+      {:ok, _} = Enrollment.archive_waiver(ctx.provider.id, waiver.id)
+
+      assert {:ok, _} = Enrollment.create_enrollment(Map.put(base_params(ctx), :waivers, {:accepted, []}))
+    end
+  end
+end

--- a/test/klass_hero/enrollment/list_program_enrollments_test.exs
+++ b/test/klass_hero/enrollment/list_program_enrollments_test.exs
@@ -127,4 +127,58 @@ defmodule KlassHero.Enrollment.ListProgramEnrollmentsTest do
       assert entry.parent_user_id == nil
     end
   end
+
+  describe "waiver status" do
+    setup do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+      {child, parent} = insert_child_with_guardian()
+
+      %{provider: provider, program: program, child: child, parent: parent}
+    end
+
+    test "is :not_required when the program has no required waivers", ctx do
+      {:ok, _} = enroll(ctx, :deferred)
+
+      assert [%{waiver_status: :not_required}] =
+               KlassHero.Enrollment.list_program_enrollments(ctx.program.id)
+    end
+
+    test "is :unsigned while a required waiver is outstanding", ctx do
+      {_waiver, _version} = require_waiver(ctx)
+      {:ok, _} = enroll(ctx, :deferred)
+
+      assert [%{waiver_status: :unsigned}] =
+               KlassHero.Enrollment.list_program_enrollments(ctx.program.id)
+    end
+
+    test "is :signed once the parent has signed", ctx do
+      {_waiver, version} = require_waiver(ctx)
+      {:ok, _} = enroll(ctx, {:accepted, [version.id]})
+
+      assert [%{waiver_status: :signed}] =
+               KlassHero.Enrollment.list_program_enrollments(ctx.program.id)
+    end
+
+    defp require_waiver(%{provider: provider, program: program}) do
+      {:ok, %{waiver: waiver, version: version}} =
+        KlassHero.Enrollment.create_waiver(provider.id, %{
+          program_id: program.id,
+          title: "Liability Waiver",
+          required: true,
+          body: "I agree."
+        })
+
+      {waiver, version}
+    end
+
+    defp enroll(%{program: program, child: child, parent: parent}, intent) do
+      KlassHero.Enrollment.create_enrollment(%{
+        program_id: program.id,
+        child_id: child.id,
+        parent_id: parent.id,
+        waivers: intent
+      })
+    end
+  end
 end

--- a/test/klass_hero/enrollment/sign_waivers_test.exs
+++ b/test/klass_hero/enrollment/sign_waivers_test.exs
@@ -1,0 +1,157 @@
+defmodule KlassHero.Enrollment.SignWaiversTest do
+  @moduledoc """
+  Signing waivers *after* enrollment — the deferred path, where an invite-claimed enrollment
+  was created by a background job with no parent present.
+  """
+
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+
+  alias KlassHero.Enrollment
+  alias KlassHero.Enrollment.WaiverAcceptance
+
+  defp deferred_enrollment(_context \\ %{}) do
+    provider = insert(:provider_profile_schema)
+    program = insert(:program_schema, provider_id: provider.id)
+    {child, parent} = insert_child_with_guardian()
+
+    {:ok, %{waiver: waiver, version: version}} =
+      Enrollment.create_waiver(provider.id, %{
+        program_id: program.id,
+        title: "Liability Waiver",
+        required: true,
+        body: "I agree to hold the provider harmless."
+      })
+
+    {:ok, enrollment} =
+      Enrollment.create_enrollment(%{
+        program_id: program.id,
+        child_id: child.id,
+        parent_id: parent.id,
+        waivers: :deferred
+      })
+
+    %{
+      provider: provider,
+      program: program,
+      parent: parent,
+      enrollment: enrollment,
+      waiver: waiver,
+      version: version
+    }
+  end
+
+  describe "list_enrollment_waivers/1" do
+    test "reports a required waiver as outstanding after a deferred enrollment" do
+      ctx = deferred_enrollment()
+
+      assert [entry] = Enrollment.list_enrollment_waivers(ctx.enrollment.id)
+      assert entry.waiver.id == ctx.waiver.id
+      assert entry.version.id == ctx.version.id
+      refute entry.signed?
+    end
+
+    test "reports it as signed once the parent signs" do
+      ctx = deferred_enrollment()
+
+      {:ok, _} = Enrollment.sign_waivers(ctx.enrollment.id, ctx.parent.id, [ctx.version.id], %{})
+
+      assert [entry] = Enrollment.list_enrollment_waivers(ctx.enrollment.id)
+      assert entry.signed?
+    end
+  end
+
+  describe "sign_waivers/4" do
+    test "records an acceptance with the version's text" do
+      ctx = deferred_enrollment()
+
+      assert {:ok, [acceptance]} =
+               Enrollment.sign_waivers(ctx.enrollment.id, ctx.parent.id, [ctx.version.id], %{
+                 ip_address: "203.0.113.7",
+                 user_agent: "Mozilla/5.0"
+               })
+
+      assert acceptance.enrollment_id == ctx.enrollment.id
+      assert acceptance.parent_id == ctx.parent.id
+      assert acceptance.body_snapshot == ctx.version.body
+      assert acceptance.ip_address == "203.0.113.7"
+    end
+
+    test "refuses a parent who is not the enrolling parent" do
+      ctx = deferred_enrollment()
+      {_other_child, other_parent} = insert_child_with_guardian()
+
+      assert {:error, :not_found} =
+               Enrollment.sign_waivers(ctx.enrollment.id, other_parent.id, [ctx.version.id], %{})
+
+      assert Repo.aggregate(WaiverAcceptance, :count) == 0
+    end
+
+    test "refuses an unknown enrollment" do
+      ctx = deferred_enrollment()
+
+      assert {:error, :not_found} =
+               Enrollment.sign_waivers(Ecto.UUID.generate(), ctx.parent.id, [ctx.version.id], %{})
+    end
+
+    test "signing twice does not duplicate the acceptance" do
+      ctx = deferred_enrollment()
+
+      {:ok, _} = Enrollment.sign_waivers(ctx.enrollment.id, ctx.parent.id, [ctx.version.id], %{})
+
+      assert {:error, _} = Enrollment.sign_waivers(ctx.enrollment.id, ctx.parent.id, [ctx.version.id], %{})
+      assert Repo.aggregate(WaiverAcceptance, :count) == 1
+    end
+
+    test "ignores a version that does not belong to the enrollment's program" do
+      ctx = deferred_enrollment()
+      stranger = insert(:provider_profile_schema)
+      stranger_program = insert(:program_schema, provider_id: stranger.id)
+
+      {:ok, %{version: foreign_version}} =
+        Enrollment.create_waiver(stranger.id, %{
+          program_id: stranger_program.id,
+          title: "Elsewhere",
+          body: "Not this program"
+        })
+
+      assert {:ok, []} = Enrollment.sign_waivers(ctx.enrollment.id, ctx.parent.id, [foreign_version.id], %{})
+      assert Repo.aggregate(WaiverAcceptance, :count) == 0
+    end
+  end
+
+  describe "waiver_status_for_enrollments/1" do
+    test "an enrollment with an unsigned required waiver is :unsigned" do
+      ctx = deferred_enrollment()
+      id = ctx.enrollment.id
+
+      assert Enrollment.waiver_status_for_enrollments([id]) == %{id => :unsigned}
+    end
+
+    test "becomes :signed once every required waiver is signed" do
+      ctx = deferred_enrollment()
+      {:ok, _} = Enrollment.sign_waivers(ctx.enrollment.id, ctx.parent.id, [ctx.version.id], %{})
+
+      id = ctx.enrollment.id
+      assert Enrollment.waiver_status_for_enrollments([id]) == %{id => :signed}
+    end
+
+    test "is :not_required for a program with no required waivers" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+      {child, parent} = insert_child_with_guardian()
+
+      {:ok, enrollment} =
+        Enrollment.create_enrollment(%{
+          program_id: program.id,
+          child_id: child.id,
+          parent_id: parent.id,
+          waivers: {:accepted, []}
+        })
+
+      id = enrollment.id
+      assert Enrollment.waiver_status_for_enrollments([id]) == %{id => :not_required}
+    end
+  end
+end

--- a/test/klass_hero/enrollment/waiver_acceptance_test.exs
+++ b/test/klass_hero/enrollment/waiver_acceptance_test.exs
@@ -1,0 +1,111 @@
+defmodule KlassHero.Enrollment.WaiverAcceptanceTest do
+  use KlassHero.DataCase, async: true
+
+  alias KlassHero.Enrollment.WaiverAcceptance
+  alias KlassHero.Enrollment.WaiverVersion
+
+  defp a_version(overrides \\ %{}) do
+    struct!(
+      %WaiverVersion{
+        id: Ecto.UUID.generate(),
+        waiver_id: Ecto.UUID.generate(),
+        body: "I agree to hold the provider harmless.",
+        version: 2,
+        published_at: DateTime.utc_now()
+      },
+      overrides
+    )
+  end
+
+  defp valid_attrs(overrides \\ %{}) do
+    Map.merge(
+      %{
+        waiver_version_id: Ecto.UUID.generate(),
+        waiver_id: Ecto.UUID.generate(),
+        enrollment_id: Ecto.UUID.generate(),
+        parent_id: Ecto.UUID.generate(),
+        accepted_at: DateTime.utc_now(),
+        body_snapshot: "I agree to hold the provider harmless."
+      },
+      overrides
+    )
+  end
+
+  describe "changeset/2" do
+    test "is valid with every required field" do
+      assert WaiverAcceptance.changeset(%WaiverAcceptance{}, valid_attrs()).valid?
+    end
+
+    test "requires the version it was signed against" do
+      changeset =
+        WaiverAcceptance.changeset(%WaiverAcceptance{}, Map.delete(valid_attrs(), :waiver_version_id))
+
+      refute changeset.valid?
+      assert %{waiver_version_id: ["can't be blank"]} = errors_on(changeset)
+    end
+
+    test "requires a body snapshot — an acceptance without the text proves nothing" do
+      changeset = WaiverAcceptance.changeset(%WaiverAcceptance{}, valid_attrs(%{body_snapshot: nil}))
+      refute changeset.valid?
+      assert %{body_snapshot: ["can't be blank"]} = errors_on(changeset)
+    end
+
+    test "requires enrollment_id and parent_id" do
+      changeset =
+        WaiverAcceptance.changeset(
+          %WaiverAcceptance{},
+          valid_attrs(%{enrollment_id: nil, parent_id: nil})
+        )
+
+      refute changeset.valid?
+      errors = errors_on(changeset)
+      assert %{enrollment_id: [_]} = errors
+      assert %{parent_id: [_]} = errors
+    end
+
+    test "ip_address and user_agent are optional" do
+      assert WaiverAcceptance.changeset(%WaiverAcceptance{}, valid_attrs()).valid?
+    end
+  end
+
+  describe "accept/3" do
+    test "snapshots the version's body verbatim" do
+      version = a_version()
+      enrollment_id = Ecto.UUID.generate()
+      parent_id = Ecto.UUID.generate()
+
+      attrs = WaiverAcceptance.accept(version, %{enrollment_id: enrollment_id, parent_id: parent_id}, %{})
+
+      assert attrs.body_snapshot == version.body
+      assert attrs.waiver_version_id == version.id
+      assert attrs.waiver_id == version.waiver_id
+      assert attrs.enrollment_id == enrollment_id
+      assert attrs.parent_id == parent_id
+      assert %DateTime{} = attrs.accepted_at
+    end
+
+    test "carries the audit trail through" do
+      attrs =
+        WaiverAcceptance.accept(
+          a_version(),
+          %{enrollment_id: Ecto.UUID.generate(), parent_id: Ecto.UUID.generate()},
+          %{ip_address: "203.0.113.7", user_agent: "Mozilla/5.0"}
+        )
+
+      assert attrs.ip_address == "203.0.113.7"
+      assert attrs.user_agent == "Mozilla/5.0"
+    end
+
+    test "stores nil rather than a placeholder when the client IP is unknown" do
+      attrs =
+        WaiverAcceptance.accept(
+          a_version(),
+          %{enrollment_id: Ecto.UUID.generate(), parent_id: Ecto.UUID.generate()},
+          %{user_agent: "Mozilla/5.0"}
+        )
+
+      assert attrs.ip_address == nil
+      assert attrs.user_agent == "Mozilla/5.0"
+    end
+  end
+end

--- a/test/klass_hero/enrollment/waiver_test.exs
+++ b/test/klass_hero/enrollment/waiver_test.exs
@@ -1,0 +1,74 @@
+defmodule KlassHero.Enrollment.WaiverTest do
+  use KlassHero.DataCase, async: true
+
+  alias KlassHero.Enrollment.Waiver
+
+  defp valid_attrs(overrides \\ %{}) do
+    Map.merge(
+      %{program_id: Ecto.UUID.generate(), title: "Liability Waiver", required: true},
+      overrides
+    )
+  end
+
+  describe "changeset/2" do
+    test "is valid with program_id, title and required" do
+      assert Waiver.changeset(%Waiver{}, valid_attrs()).valid?
+    end
+
+    test "requires program_id" do
+      changeset = Waiver.changeset(%Waiver{}, Map.delete(valid_attrs(), :program_id))
+      refute changeset.valid?
+      assert %{program_id: ["can't be blank"]} = errors_on(changeset)
+    end
+
+    test "requires title" do
+      changeset = Waiver.changeset(%Waiver{}, valid_attrs(%{title: nil}))
+      refute changeset.valid?
+      assert %{title: ["can't be blank"]} = errors_on(changeset)
+    end
+
+    test "rejects a title longer than 200 characters" do
+      changeset = Waiver.changeset(%Waiver{}, valid_attrs(%{title: String.duplicate("a", 201)}))
+      refute changeset.valid?
+      assert %{title: [_]} = errors_on(changeset)
+    end
+
+    test "defaults required to true when omitted" do
+      changeset = Waiver.changeset(%Waiver{}, Map.delete(valid_attrs(), :required))
+      assert changeset.valid?
+      assert Ecto.Changeset.get_field(changeset, :required) == true
+    end
+
+    test "accepts an optional waiver" do
+      changeset = Waiver.changeset(%Waiver{}, valid_attrs(%{required: false}))
+      assert changeset.valid?
+      assert Ecto.Changeset.get_field(changeset, :required) == false
+    end
+
+    test "does not cast archived_at — archiving goes through archive_changeset/2" do
+      changeset = Waiver.changeset(%Waiver{}, valid_attrs(%{archived_at: DateTime.utc_now()}))
+      assert Ecto.Changeset.get_field(changeset, :archived_at) == nil
+    end
+  end
+
+  describe "archive_changeset/2" do
+    test "stamps archived_at" do
+      at = DateTime.utc_now()
+      changeset = Waiver.archive_changeset(%Waiver{}, at)
+      assert Ecto.Changeset.get_field(changeset, :archived_at) == at
+    end
+  end
+
+  describe "active?/1 and archived?/1" do
+    test "a waiver with no archived_at is active" do
+      assert Waiver.active?(%Waiver{archived_at: nil})
+      refute Waiver.archived?(%Waiver{archived_at: nil})
+    end
+
+    test "a waiver with archived_at is archived" do
+      waiver = %Waiver{archived_at: DateTime.utc_now()}
+      refute Waiver.active?(waiver)
+      assert Waiver.archived?(waiver)
+    end
+  end
+end

--- a/test/klass_hero/enrollment/waiver_version_test.exs
+++ b/test/klass_hero/enrollment/waiver_version_test.exs
@@ -1,0 +1,80 @@
+defmodule KlassHero.Enrollment.WaiverVersionTest do
+  use KlassHero.DataCase, async: true
+
+  alias KlassHero.Enrollment.WaiverVersion
+
+  defp valid_attrs(overrides \\ %{}) do
+    Map.merge(
+      %{
+        waiver_id: Ecto.UUID.generate(),
+        body: "I agree to hold the provider harmless.",
+        version: 1,
+        published_at: DateTime.utc_now()
+      },
+      overrides
+    )
+  end
+
+  describe "changeset/2" do
+    test "is valid with waiver_id, body, version and published_at" do
+      assert WaiverVersion.changeset(%WaiverVersion{}, valid_attrs()).valid?
+    end
+
+    test "requires body" do
+      changeset = WaiverVersion.changeset(%WaiverVersion{}, valid_attrs(%{body: nil}))
+      refute changeset.valid?
+      assert %{body: ["can't be blank"]} = errors_on(changeset)
+    end
+
+    test "rejects a blank body" do
+      changeset = WaiverVersion.changeset(%WaiverVersion{}, valid_attrs(%{body: "   "}))
+      refute changeset.valid?
+      assert %{body: [_]} = errors_on(changeset)
+    end
+
+    test "requires waiver_id" do
+      changeset = WaiverVersion.changeset(%WaiverVersion{}, Map.delete(valid_attrs(), :waiver_id))
+      refute changeset.valid?
+      assert %{waiver_id: ["can't be blank"]} = errors_on(changeset)
+    end
+
+    test "rejects a body longer than the maximum" do
+      long = String.duplicate("a", WaiverVersion.body_max_length() + 1)
+      changeset = WaiverVersion.changeset(%WaiverVersion{}, valid_attrs(%{body: long}))
+      refute changeset.valid?
+      assert %{body: [_]} = errors_on(changeset)
+    end
+
+    test "rejects version below 1" do
+      changeset = WaiverVersion.changeset(%WaiverVersion{}, valid_attrs(%{version: 0}))
+      refute changeset.valid?
+      assert %{version: [_]} = errors_on(changeset)
+    end
+  end
+
+  describe "publish/2" do
+    test "the first version of a waiver is version 1" do
+      waiver_id = Ecto.UUID.generate()
+      assert {:ok, attrs} = WaiverVersion.publish(waiver_id, "First text", nil)
+      assert attrs.waiver_id == waiver_id
+      assert attrs.version == 1
+      assert attrs.body == "First text"
+      assert %DateTime{} = attrs.published_at
+    end
+
+    test "publishing over an existing version increments it" do
+      previous = %WaiverVersion{version: 3}
+      assert {:ok, attrs} = WaiverVersion.publish(Ecto.UUID.generate(), "Revised text", previous)
+      assert attrs.version == 4
+    end
+
+    test "rejects a blank body without allocating a version" do
+      assert {:error, [body: _]} = WaiverVersion.publish(Ecto.UUID.generate(), "   ", nil)
+    end
+
+    test "trims surrounding whitespace from the published body" do
+      assert {:ok, attrs} = WaiverVersion.publish(Ecto.UUID.generate(), "  Text  ", nil)
+      assert attrs.body == "Text"
+    end
+  end
+end

--- a/test/klass_hero/enrollment/waivers_test.exs
+++ b/test/klass_hero/enrollment/waivers_test.exs
@@ -178,4 +178,48 @@ defmodule KlassHero.Enrollment.WaiversTest do
       assert version.version == 2
     end
   end
+
+  describe "a signature survives a later version of the same waiver" do
+    # Decision 8: publishing v2 gates *future* enrollments only. Existing acceptances stand.
+    # Reading signatures per version instead of per waiver broke that twice over — the roster
+    # called a signed parent unsigned, and the re-sign it invited hit the
+    # (enrollment_id, waiver_id) unique index, leaving the parent no way to clear the banner.
+    setup do
+      %{provider: provider, program: program} = provider_with_program()
+      {child, parent} = insert_child_with_guardian()
+
+      {:ok, %{waiver: waiver, version: v1}} =
+        Enrollment.create_waiver(provider.id, %{
+          program_id: program.id,
+          title: "Liability",
+          required: true,
+          body: "v1 text"
+        })
+
+      {:ok, enrollment} =
+        Enrollment.create_enrollment(%{
+          program_id: program.id,
+          child_id: child.id,
+          parent_id: parent.id,
+          waivers: {:accepted, [v1.id]}
+        })
+
+      {:ok, v2} = Enrollment.publish_waiver_version(provider.id, waiver.id, "v2 text")
+
+      %{provider: provider, program: program, waiver: waiver, v1: v1, v2: v2, enrollment: enrollment}
+    end
+
+    test "the roster still reports the enrollment as signed", %{enrollment: enrollment} do
+      id = enrollment.id
+      assert %{^id => :signed} = Enrollment.waiver_status_for_enrollments([id])
+    end
+
+    test "the signing page offers nothing further to sign", %{enrollment: enrollment} do
+      assert [%{signed?: true}] = Enrollment.list_enrollment_waivers(enrollment.id)
+    end
+
+    test "the provider roster entry reads signed", %{program: program, enrollment: _enrollment} do
+      assert [%{waiver_status: :signed}] = Enrollment.list_program_enrollments(program.id)
+    end
+  end
 end

--- a/test/klass_hero/enrollment/waivers_test.exs
+++ b/test/klass_hero/enrollment/waivers_test.exs
@@ -1,0 +1,181 @@
+defmodule KlassHero.Enrollment.WaiversTest do
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+
+  alias KlassHero.Enrollment
+  alias KlassHero.Enrollment.Waiver
+
+  defp provider_with_program(_context \\ %{}) do
+    provider = insert(:provider_profile_schema)
+    program = insert(:program_schema, provider_id: provider.id)
+    %{provider: provider, program: program}
+  end
+
+  describe "create_waiver/2" do
+    test "creates the waiver and its first version together" do
+      %{provider: provider, program: program} = provider_with_program()
+
+      assert {:ok, %{waiver: waiver, version: version}} =
+               Enrollment.create_waiver(provider.id, %{
+                 program_id: program.id,
+                 title: "Liability Waiver",
+                 required: true,
+                 body: "I agree to hold the provider harmless."
+               })
+
+      assert waiver.program_id == program.id
+      assert waiver.title == "Liability Waiver"
+      assert waiver.required
+      assert version.waiver_id == waiver.id
+      assert version.version == 1
+      assert version.body == "I agree to hold the provider harmless."
+    end
+
+    test "refuses a program the provider does not own" do
+      %{provider: provider} = provider_with_program()
+      %{program: someone_elses} = provider_with_program()
+
+      assert {:error, :not_found} =
+               Enrollment.create_waiver(provider.id, %{
+                 program_id: someone_elses.id,
+                 title: "Liability Waiver",
+                 body: "Text"
+               })
+    end
+
+    test "rejects a blank body without creating the waiver" do
+      %{provider: provider, program: program} = provider_with_program()
+
+      assert {:error, _} =
+               Enrollment.create_waiver(provider.id, %{
+                 program_id: program.id,
+                 title: "Liability Waiver",
+                 body: "   "
+               })
+
+      assert Enrollment.list_program_waivers(program.id) == []
+    end
+  end
+
+  describe "publish_waiver_version/3" do
+    test "appends a new version and leaves the old one intact" do
+      %{provider: provider, program: program} = provider_with_program()
+
+      {:ok, %{waiver: waiver, version: v1}} =
+        Enrollment.create_waiver(provider.id, %{
+          program_id: program.id,
+          title: "Liability Waiver",
+          body: "Original text"
+        })
+
+      assert {:ok, v2} = Enrollment.publish_waiver_version(provider.id, waiver.id, "Revised text")
+      assert v2.version == 2
+      assert v2.body == "Revised text"
+
+      # The v1 row is untouched — this is the whole point of append-only versioning.
+      assert reloaded_v1 = Repo.get(Enrollment.WaiverVersion, v1.id)
+      assert reloaded_v1.body == "Original text"
+      assert reloaded_v1.version == 1
+    end
+
+    test "refuses a waiver belonging to another provider's program" do
+      %{provider: provider, program: program} = provider_with_program()
+      %{provider: other} = provider_with_program()
+
+      {:ok, %{waiver: waiver}} =
+        Enrollment.create_waiver(provider.id, %{
+          program_id: program.id,
+          title: "Liability Waiver",
+          body: "Original text"
+        })
+
+      assert {:error, :not_found} = Enrollment.publish_waiver_version(other.id, waiver.id, "Hijacked")
+    end
+  end
+
+  describe "archive_waiver/2" do
+    test "retires the waiver without deleting it" do
+      %{provider: provider, program: program} = provider_with_program()
+
+      {:ok, %{waiver: waiver}} =
+        Enrollment.create_waiver(provider.id, %{
+          program_id: program.id,
+          title: "Liability Waiver",
+          body: "Text"
+        })
+
+      assert {:ok, archived} = Enrollment.archive_waiver(provider.id, waiver.id)
+      assert Waiver.archived?(archived)
+
+      # Still on disk, just not offered any more.
+      assert Repo.get(Waiver, waiver.id)
+      assert Enrollment.list_program_waivers(program.id) == []
+    end
+  end
+
+  describe "list_program_waivers/1" do
+    test "returns active waivers with their latest version" do
+      %{provider: provider, program: program} = provider_with_program()
+
+      {:ok, %{waiver: waiver}} =
+        Enrollment.create_waiver(provider.id, %{
+          program_id: program.id,
+          title: "Liability Waiver",
+          body: "Original text"
+        })
+
+      {:ok, _v2} = Enrollment.publish_waiver_version(provider.id, waiver.id, "Revised text")
+
+      assert [entry] = Enrollment.list_program_waivers(program.id)
+      assert entry.waiver.id == waiver.id
+      assert entry.version.version == 2
+      assert entry.version.body == "Revised text"
+    end
+
+    test "is empty for a program with no waivers" do
+      %{program: program} = provider_with_program()
+      assert Enrollment.list_program_waivers(program.id) == []
+    end
+  end
+
+  describe "list_required_waiver_versions/1" do
+    test "returns only the latest version of each required, active waiver" do
+      %{provider: provider, program: program} = provider_with_program()
+
+      {:ok, %{waiver: required}} =
+        Enrollment.create_waiver(provider.id, %{
+          program_id: program.id,
+          title: "Liability",
+          required: true,
+          body: "v1"
+        })
+
+      {:ok, _} = Enrollment.publish_waiver_version(provider.id, required.id, "v2")
+
+      {:ok, %{waiver: _optional}} =
+        Enrollment.create_waiver(provider.id, %{
+          program_id: program.id,
+          title: "Photo release",
+          required: false,
+          body: "optional text"
+        })
+
+      {:ok, %{waiver: retired}} =
+        Enrollment.create_waiver(provider.id, %{
+          program_id: program.id,
+          title: "Old form",
+          required: true,
+          body: "retired text"
+        })
+
+      {:ok, _} = Enrollment.archive_waiver(provider.id, retired.id)
+
+      versions = Enrollment.list_required_waiver_versions(program.id)
+
+      assert [version] = versions
+      assert version.waiver_id == required.id
+      assert version.version == 2
+    end
+  end
+end

--- a/test/klass_hero_web/audit_info_test.exs
+++ b/test/klass_hero_web/audit_info_test.exs
@@ -1,0 +1,51 @@
+defmodule KlassHeroWeb.AuditInfoTest do
+  use ExUnit.Case, async: true
+
+  alias KlassHeroWeb.AuditInfo
+
+  describe "from_connect_info/1" do
+    test "takes the client IP from fly-client-ip" do
+      info = %{user_agent: "Mozilla/5.0", x_headers: [{"fly-client-ip", "203.0.113.7"}]}
+
+      assert AuditInfo.from_connect_info(info) == %{
+               ip_address: "203.0.113.7",
+               user_agent: "Mozilla/5.0"
+             }
+    end
+
+    test "ignores x-forwarded-for — it is client-spoofable" do
+      info = %{user_agent: "Mozilla/5.0", x_headers: [{"x-forwarded-for", "198.51.100.1"}]}
+
+      assert %{ip_address: nil} = AuditInfo.from_connect_info(info)
+    end
+
+    test "prefers fly-client-ip even when x-forwarded-for is also present" do
+      info = %{
+        user_agent: "Mozilla/5.0",
+        x_headers: [{"x-forwarded-for", "198.51.100.1"}, {"fly-client-ip", "203.0.113.7"}]
+      }
+
+      assert %{ip_address: "203.0.113.7"} = AuditInfo.from_connect_info(info)
+    end
+
+    test "records nil rather than a placeholder when no trusted header is present" do
+      assert AuditInfo.from_connect_info(%{user_agent: "Mozilla/5.0", x_headers: []}) == %{
+               ip_address: nil,
+               user_agent: "Mozilla/5.0"
+             }
+    end
+
+    test "tolerates a nil connect_info — the dead render has none" do
+      assert AuditInfo.from_connect_info(nil) == %{ip_address: nil, user_agent: nil}
+    end
+
+    test "tolerates missing keys" do
+      assert AuditInfo.from_connect_info(%{}) == %{ip_address: nil, user_agent: nil}
+    end
+
+    test "matches the header name case-insensitively" do
+      info = %{user_agent: nil, x_headers: [{"Fly-Client-IP", "203.0.113.7"}]}
+      assert %{ip_address: "203.0.113.7"} = AuditInfo.from_connect_info(info)
+    end
+  end
+end

--- a/test/klass_hero_web/live/booking_live_waivers_test.exs
+++ b/test/klass_hero_web/live/booking_live_waivers_test.exs
@@ -47,6 +47,16 @@ defmodule KlassHeroWeb.BookingLiveWaiversTest do
     assert render(view) =~ "I agree to hold the provider harmless."
   end
 
+  test "labels both required and optional waivers", %{conn: conn, provider: provider, program: program} do
+    {blocking, _} = add_waiver(provider, program, title: "Liability", required: true)
+    {skippable, _} = add_waiver(provider, program, title: "Photo release", required: false)
+
+    {:ok, view, _html} = live(conn, ~p"/programs/#{program.id}/booking")
+
+    assert has_element?(view, "#waiver-#{blocking.id}", "Required")
+    assert has_element?(view, "#waiver-#{skippable.id}", "(optional)")
+  end
+
   test "renders no waiver section when the program has none", %{conn: conn, program: program} do
     {:ok, view, _html} = live(conn, ~p"/programs/#{program.id}/booking")
 

--- a/test/klass_hero_web/live/booking_live_waivers_test.exs
+++ b/test/klass_hero_web/live/booking_live_waivers_test.exs
@@ -1,0 +1,124 @@
+defmodule KlassHeroWeb.BookingLiveWaiversTest do
+  @moduledoc """
+  Waiver signing inside the self-serve booking form.
+
+  The gate itself is covered in `create_enrollment_waivers_test.exs`; this file covers what
+  the parent sees and what the form sends.
+  """
+  use KlassHeroWeb.ConnCase, async: true
+
+  import KlassHero.Factory
+  import Phoenix.LiveViewTest
+
+  alias KlassHero.Enrollment
+  alias KlassHero.Enrollment.WaiverAcceptance
+  alias KlassHero.Repo
+
+  setup :register_and_log_in_user
+
+  setup %{user: user} do
+    provider = insert(:provider_profile_schema)
+    program = insert(:program_schema, provider_id: provider.id)
+    parent = insert(:parent_profile_schema, identity_id: user.id)
+    {child, _} = insert_child_with_guardian(parent: parent)
+
+    %{provider: provider, program: program, parent: parent, child: child}
+  end
+
+  defp add_waiver(provider, program, opts) do
+    {:ok, %{waiver: waiver, version: version}} =
+      Enrollment.create_waiver(provider.id, %{
+        program_id: program.id,
+        title: Keyword.get(opts, :title, "Liability Waiver"),
+        required: Keyword.get(opts, :required, true),
+        body: Keyword.get(opts, :body, "I agree to hold the provider harmless.")
+      })
+
+    {waiver, version}
+  end
+
+  test "shows the waiver text and a sign checkbox", %{conn: conn, provider: provider, program: program} do
+    {waiver, _version} = add_waiver(provider, program, [])
+
+    {:ok, view, _html} = live(conn, ~p"/programs/#{program.id}/booking")
+
+    assert has_element?(view, "#waiver-#{waiver.id}")
+    assert has_element?(view, "#sign-waiver-#{waiver.id}")
+    assert render(view) =~ "I agree to hold the provider harmless."
+  end
+
+  test "renders no waiver section when the program has none", %{conn: conn, program: program} do
+    {:ok, view, _html} = live(conn, ~p"/programs/#{program.id}/booking")
+
+    refute has_element?(view, "#booking-waivers")
+  end
+
+  test "submitting without signing a required waiver is refused and creates nothing", %{
+    conn: conn,
+    provider: provider,
+    program: program,
+    child: child
+  } do
+    add_waiver(provider, program, [])
+
+    {:ok, view, _html} = live(conn, ~p"/programs/#{program.id}/booking")
+
+    html =
+      view
+      |> form("#booking-form", %{"child_id" => child.id, "special_requirements" => ""})
+      |> render_submit()
+
+    assert html =~ "waiver"
+    assert Repo.aggregate(WaiverAcceptance, :count) == 0
+  end
+
+  test "signing the required waiver enrolls and records the acceptance", %{
+    conn: conn,
+    provider: provider,
+    program: program,
+    child: child,
+    parent: parent
+  } do
+    {waiver, version} = add_waiver(provider, program, [])
+
+    # The test client sends no User-Agent of its own, so set one — otherwise the audit
+    # assertion below would pass vacuously against a nil the harness produced.
+    conn = Plug.Conn.put_req_header(conn, "user-agent", "TestBrowser/1.0")
+
+    {:ok, view, _html} = live(conn, ~p"/programs/#{program.id}/booking")
+
+    view
+    |> form("#booking-form", %{
+      "child_id" => child.id,
+      "special_requirements" => "",
+      "waiver_version_ids" => [version.id]
+    })
+    |> render_submit()
+
+    assert_redirect(view, ~p"/dashboard")
+
+    assert [acceptance] = Repo.all(WaiverAcceptance)
+    assert acceptance.waiver_id == waiver.id
+    assert acceptance.parent_id == parent.id
+    assert acceptance.body_snapshot == version.body
+    assert acceptance.user_agent == "TestBrowser/1.0"
+  end
+
+  test "an optional waiver does not block submission", %{
+    conn: conn,
+    provider: provider,
+    program: program,
+    child: child
+  } do
+    add_waiver(provider, program, required: false, title: "Photo release")
+
+    {:ok, view, _html} = live(conn, ~p"/programs/#{program.id}/booking")
+
+    view
+    |> form("#booking-form", %{"child_id" => child.id, "special_requirements" => ""})
+    |> render_submit()
+
+    assert_redirect(view, ~p"/dashboard")
+    assert Repo.aggregate(WaiverAcceptance, :count) == 0
+  end
+end

--- a/test/klass_hero_web/live/enrollment_waivers_live_test.exs
+++ b/test/klass_hero_web/live/enrollment_waivers_live_test.exs
@@ -58,6 +58,27 @@ defmodule KlassHeroWeb.EnrollmentWaiversLiveTest do
       assert render(view) =~ "I agree to hold the provider harmless."
     end
 
+    test "labels both required and optional waivers", %{
+      conn: conn,
+      enrollment: enrollment,
+      provider: provider,
+      program: program,
+      waiver: blocking
+    } do
+      {:ok, %{waiver: skippable}} =
+        Enrollment.create_waiver(provider.id, %{
+          program_id: program.id,
+          title: "Photo release",
+          required: false,
+          body: "Optional text."
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/enrollments/#{enrollment.id}/waivers")
+
+      assert has_element?(view, "#waiver-#{blocking.id}", "Required")
+      assert has_element?(view, "#waiver-#{skippable.id}", "(optional)")
+    end
+
     test "redirects when the enrollment belongs to another parent", %{conn: conn} do
       other_provider = insert(:provider_profile_schema)
       other_program = insert(:program_schema, provider_id: other_provider.id)

--- a/test/klass_hero_web/live/enrollment_waivers_live_test.exs
+++ b/test/klass_hero_web/live/enrollment_waivers_live_test.exs
@@ -1,0 +1,131 @@
+defmodule KlassHeroWeb.EnrollmentWaiversLiveTest do
+  @moduledoc """
+  The standalone signing page for enrollments created without a signer present.
+  """
+  use KlassHeroWeb.ConnCase, async: true
+
+  import KlassHero.Factory
+  import Phoenix.LiveViewTest
+
+  alias KlassHero.Enrollment
+  alias KlassHero.Enrollment.WaiverAcceptance
+  alias KlassHero.Repo
+
+  setup :register_and_log_in_user
+
+  setup %{user: user} do
+    provider = insert(:provider_profile_schema)
+    program = insert(:program_schema, provider_id: provider.id)
+    parent = insert(:parent_profile_schema, identity_id: user.id)
+    {child, _} = insert_child_with_guardian(parent: parent)
+
+    {:ok, %{waiver: waiver, version: version}} =
+      Enrollment.create_waiver(provider.id, %{
+        program_id: program.id,
+        title: "Liability Waiver",
+        required: true,
+        body: "I agree to hold the provider harmless."
+      })
+
+    {:ok, enrollment} =
+      Enrollment.create_enrollment(%{
+        program_id: program.id,
+        child_id: child.id,
+        parent_id: parent.id,
+        waivers: :deferred
+      })
+
+    %{
+      provider: provider,
+      program: program,
+      parent: parent,
+      enrollment: enrollment,
+      waiver: waiver,
+      version: version
+    }
+  end
+
+  describe "mount" do
+    test "shows the outstanding waiver text and a checkbox", %{
+      conn: conn,
+      enrollment: enrollment,
+      waiver: waiver
+    } do
+      {:ok, view, _html} = live(conn, ~p"/enrollments/#{enrollment.id}/waivers")
+
+      assert has_element?(view, "#waiver-#{waiver.id}")
+      assert has_element?(view, "#sign-waiver-#{waiver.id}")
+      assert render(view) =~ "I agree to hold the provider harmless."
+    end
+
+    test "redirects when the enrollment belongs to another parent", %{conn: conn} do
+      other_provider = insert(:provider_profile_schema)
+      other_program = insert(:program_schema, provider_id: other_provider.id)
+      {other_child, other_parent} = insert_child_with_guardian()
+
+      {:ok, foreign} =
+        Enrollment.create_enrollment(%{
+          program_id: other_program.id,
+          child_id: other_child.id,
+          parent_id: other_parent.id,
+          waivers: :deferred
+        })
+
+      assert {:error, {:redirect, %{to: "/dashboard"}}} =
+               live(conn, ~p"/enrollments/#{foreign.id}/waivers")
+    end
+
+    test "redirects for an unknown enrollment", %{conn: conn} do
+      assert {:error, {:redirect, %{to: "/dashboard"}}} =
+               live(conn, ~p"/enrollments/#{Ecto.UUID.generate()}/waivers")
+    end
+  end
+
+  describe "signing" do
+    test "records the acceptance and returns to the dashboard", %{
+      conn: conn,
+      enrollment: enrollment,
+      parent: parent,
+      version: version
+    } do
+      conn = Plug.Conn.put_req_header(conn, "user-agent", "TestBrowser/1.0")
+      {:ok, view, _html} = live(conn, ~p"/enrollments/#{enrollment.id}/waivers")
+
+      view
+      |> form("#sign-waivers-form", %{"waiver_version_ids" => [version.id]})
+      |> render_submit()
+
+      assert_redirect(view, ~p"/dashboard")
+
+      assert [acceptance] = Repo.all(WaiverAcceptance)
+      assert acceptance.enrollment_id == enrollment.id
+      assert acceptance.parent_id == parent.id
+      assert acceptance.body_snapshot == version.body
+      assert acceptance.user_agent == "TestBrowser/1.0"
+    end
+
+    test "submitting nothing ticked is refused", %{conn: conn, enrollment: enrollment} do
+      {:ok, view, _html} = live(conn, ~p"/enrollments/#{enrollment.id}/waivers")
+
+      html = view |> form("#sign-waivers-form", %{}) |> render_submit()
+
+      assert html =~ "tick"
+      assert Repo.aggregate(WaiverAcceptance, :count) == 0
+    end
+
+    test "an already-signed waiver shows as signed with no checkbox", %{
+      conn: conn,
+      enrollment: enrollment,
+      parent: parent,
+      version: version,
+      waiver: waiver
+    } do
+      {:ok, _} = Enrollment.sign_waivers(enrollment.id, parent.id, [version.id], %{})
+
+      {:ok, view, _html} = live(conn, ~p"/enrollments/#{enrollment.id}/waivers")
+
+      assert has_element?(view, "#waiver-signed-#{waiver.id}")
+      refute has_element?(view, "#sign-waiver-#{waiver.id}")
+    end
+  end
+end

--- a/test/klass_hero_web/live/provider/dashboard_program_waivers_test.exs
+++ b/test/klass_hero_web/live/provider/dashboard_program_waivers_test.exs
@@ -1,0 +1,178 @@
+defmodule KlassHeroWeb.Provider.DashboardProgramWaiversTest do
+  @moduledoc """
+  The per-program waivers panel on the Programs tab: authoring the legal text parents sign
+  at enrollment, publishing revisions, and retiring a form.
+
+  Sibling of `dashboard_program_staffing_test.exs` — same modal shape, different concern.
+  """
+  use KlassHeroWeb.ConnCase, async: true
+
+  import KlassHero.Factory
+  import Phoenix.LiveViewTest
+
+  alias KlassHero.Enrollment
+  alias KlassHero.Repo
+
+  setup :register_and_log_in_provider
+
+  setup %{provider: provider} do
+    %{program: insert_listed_program(provider, "Summer Camp")}
+  end
+
+  describe "opening and closing the panel" do
+    test "opens from the program row and closes again", %{conn: conn, program: program} do
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+
+      refute has_element?(view, "#program-waivers-modal")
+
+      view |> element("#manage-waivers-#{program.id}") |> render_click()
+      assert has_element?(view, "#program-waivers-modal")
+
+      view |> element("#program-waivers-modal button[phx-click=close_waivers]") |> render_click()
+      refute has_element?(view, "#program-waivers-modal")
+    end
+
+    test "shows an empty state when the program has no waivers", %{conn: conn, program: program} do
+      view = open_panel(conn, program)
+
+      assert has_element?(view, "#waivers-empty")
+    end
+  end
+
+  describe "creating a waiver" do
+    test "publishes the first version and lists it", %{conn: conn, program: program} do
+      view = open_panel(conn, program)
+
+      view
+      |> form("#waiver-form", %{
+        waiver: %{title: "Liability Waiver", body: "I agree to hold the provider harmless.", required: "true"}
+      })
+      |> render_submit()
+
+      assert has_element?(view, "#waiver-list")
+      refute has_element?(view, "#waivers-empty")
+
+      assert [%{waiver: waiver, version: version}] = Enrollment.list_program_waivers(program.id)
+      assert waiver.title == "Liability Waiver"
+      assert waiver.required
+      assert version.version == 1
+    end
+
+    test "reports a blank body instead of creating an empty waiver", %{conn: conn, program: program} do
+      view = open_panel(conn, program)
+
+      html =
+        view
+        |> form("#waiver-form", %{waiver: %{title: "Liability Waiver", body: "   ", required: "true"}})
+        |> render_submit()
+
+      assert html =~ "body"
+      assert Enrollment.list_program_waivers(program.id) == []
+    end
+  end
+
+  describe "revising a waiver" do
+    test "publishing new text bumps the version and keeps the old one readable", %{
+      conn: conn,
+      provider: provider,
+      program: program
+    } do
+      {:ok, %{waiver: waiver, version: v1}} =
+        Enrollment.create_waiver(provider.id, %{
+          program_id: program.id,
+          title: "Liability Waiver",
+          body: "Original text"
+        })
+
+      view = open_panel(conn, program)
+
+      view |> element("#edit-waiver-#{waiver.id}") |> render_click()
+
+      view
+      |> form("#waiver-form", %{waiver: %{body: "Revised text"}})
+      |> render_submit()
+
+      assert [%{version: current}] = Enrollment.list_program_waivers(program.id)
+      assert current.version == 2
+      assert current.body == "Revised text"
+
+      # The signed wording of v1 is still on disk, unchanged.
+      assert Repo.get(Enrollment.WaiverVersion, v1.id).body == "Original text"
+    end
+  end
+
+  describe "archiving a waiver" do
+    test "retires it from the list without deleting the record", %{
+      conn: conn,
+      provider: provider,
+      program: program
+    } do
+      {:ok, %{waiver: waiver}} =
+        Enrollment.create_waiver(provider.id, %{
+          program_id: program.id,
+          title: "Old form",
+          body: "Text"
+        })
+
+      view = open_panel(conn, program)
+
+      view |> element("#archive-waiver-#{waiver.id}") |> render_click()
+
+      assert has_element?(view, "#waivers-empty")
+      assert Enrollment.list_program_waivers(program.id) == []
+      assert Repo.get(Enrollment.Waiver, waiver.id)
+    end
+  end
+
+  describe "IDOR ownership guards" do
+    test "refuses to open the panel for another provider's program", %{conn: conn} do
+      other_provider = insert(:provider_profile_schema)
+      victim_program = insert(:program_schema, provider_id: other_provider.id)
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+
+      view = assert_idor_guarded(view, "manage_waivers", victim_program.id, "Program not found.")
+      refute has_element?(view, "#program-waivers-modal")
+    end
+
+    test "refuses to archive another provider's waiver", %{conn: conn, program: program} do
+      other_provider = insert(:provider_profile_schema)
+      victim_program = insert(:program_schema, provider_id: other_provider.id)
+
+      {:ok, %{waiver: victim_waiver}} =
+        Enrollment.create_waiver(other_provider.id, %{
+          program_id: victim_program.id,
+          title: "Their form",
+          body: "Their text"
+        })
+
+      view = open_panel(conn, program)
+
+      render_click(view, "archive_waiver", %{"id" => victim_waiver.id})
+
+      # Untouched.
+      assert [%{waiver: still_active}] = Enrollment.list_program_waivers(victim_program.id)
+      assert still_active.id == victim_waiver.id
+    end
+  end
+
+  defp open_panel(conn, program) do
+    {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+    view |> element("#manage-waivers-#{program.id}") |> render_click()
+    view
+  end
+
+  defp insert_listed_program(provider, title) do
+    program = insert(:program_schema, provider_id: provider.id, title: title)
+
+    insert(:program_listing_schema,
+      id: program.id,
+      provider_id: provider.id,
+      title: program.title,
+      category: program.category,
+      price: program.price
+    )
+
+    program
+  end
+end

--- a/test/klass_hero_web/live/provider/dashboard_program_waivers_test.exs
+++ b/test/klass_hero_web/live/provider/dashboard_program_waivers_test.exs
@@ -71,6 +71,34 @@ defmodule KlassHeroWeb.Provider.DashboardProgramWaiversTest do
     end
   end
 
+  describe "requirement labelling" do
+    # One vocabulary across all three waiver surfaces (provider panel, booking form, signing
+    # page). Labelling only one state would leave the other readable by absence — the weakest
+    # signal for the fact that decides whether a parent can enrol at all.
+    test "labels both required and optional waivers", %{conn: conn, program: program, provider: provider} do
+      {:ok, %{waiver: blocking}} =
+        Enrollment.create_waiver(provider.id, %{
+          program_id: program.id,
+          title: "Liability",
+          required: true,
+          body: "text"
+        })
+
+      {:ok, %{waiver: skippable}} =
+        Enrollment.create_waiver(provider.id, %{
+          program_id: program.id,
+          title: "Photo release",
+          required: false,
+          body: "text"
+        })
+
+      view = open_panel(conn, program)
+
+      assert has_element?(view, "#waiver-#{blocking.id}", "Required")
+      assert has_element?(view, "#waiver-#{skippable.id}", "(optional)")
+    end
+  end
+
   describe "revising a waiver" do
     test "publishing new text bumps the version and keeps the old one readable", %{
       conn: conn,


### PR DESCRIPTION
Closes #828.

## Summary

Providers can author versioned legal waivers per program; parents must read and sign every required one before self-serve enrollment completes. Each signature is stored with a reproducible copy of the exact text agreed, plus timestamp, client IP and user agent.

The issue predated the DDD→conventional-Phoenix flatten and its original spec prescribed `domain/ports/`, `application/commands/`, mappers, repositories and per-context DI. That spec was rewritten against current architecture before any code was written, and eleven design decisions were settled up front (recorded in the issue body).

## Design decisions worth reviewing

**Enrollment owns waivers *and* acceptances** — not a new context, not Provider. `Enrollment.ParticipantPolicy` is already the same shape: provider-authored, program-scoped, enforced by Enrollment at create time. Provider was the tempting home (it owns `SignedAgreement`), but Provider doesn't own programs — ProgramCatalog does, and `Provider.ProviderProgram` says of itself that it is "not an authorization source".

**Three tables, not one.** A waiver row carries no text; each edit appends a `waiver_versions` row, and an acceptance binds to the exact version signed. Storing the body on the waiver and bumping a counter would lose the wording of any version nobody happened to sign — audit holes precisely where a provider revised a form before anyone signed it.

**`create_enrollment/1` requires a `:waivers` intent, with no default.** `{:accepted, version_ids}` when a parent signed, `:deferred` when no signer is present. `[]` would mean both "signed nothing" and "don't care", so an omitted key would silently skip the gate — the same bypass-by-omission as putting the gate in the LiveView.

**The gate is an `Ecto.Multi` step, not a pre-flight check.** Same reasoning the capacity row is locked `FOR UPDATE`: a provider publishing a required waiver between check and insert would otherwise leave an enrollment with an unsigned required waiver.

**Deletion is deliberately hard.** `program_id` is a bare correlation id (ADR-0001) so a program deletion cannot cascade into signed records; every in-context FK is `:restrict`; waivers retire via `archived_at`.

**Only `fly-client-ip` is trusted for the audit IP.** Fly overwrites it at the edge. `x-forwarded-for` is client-forgeable, and a forged IP in a legal audit trail is worse than none because it reads as evidence. Absent header stores `nil`, never the proxy address.

## Review focus

- `lib/klass_hero/enrollment.ex` — the two new `Multi` steps between `:create` and `:stage`.
- `lib/klass_hero/enrollment/waivers.ex` — `resolve_acceptances/3` runs on the transaction's `repo`, not the module-level `Repo`.
- `lib/klass_hero_web/audit_info.ex` — the trusted-header decision.
- Signing authorization runs on **mount and on submit**; mount-only would leave the submit event reachable over the socket.

## Test plan

- 4580 tests pass; `mix precommit` clean (credo strict, all four lints, formatting).
- Verified against a real dev database via Tidewave, not only in tests:
  - `:waivers` omitted → `{:error, :waiver_intent_required}`
  - required waiver unsigned → `{:error, :waivers_unsigned}`
  - superseded version id → `{:error, :waivers_unsigned}`
  - enrollment count unchanged across all three refusals, proving the gate is inside the transaction
  - published v2 over v1; v1's text re-read from disk is byte-identical, and the acceptance binds to v2 with `body_snapshot == version.body`
- `architecture-reviewer`: 8/8, zero violations. `regression-analyzer`: 8/8, zero regressions.

## Deliberately out of scope

- Provider-wide waivers spanning all a provider's programs.
- Forcing re-signature after a material version change — publishing v2 never invalidates existing acceptances.
- Waiver status on the **staff** roster (the provider roster has it). Filed separately.