### PR TITLE
feat: authorize staff session access at session grain

### DIFF
--- a/docs/adr/0017-attendance-writes-authorize-at-the-context-boundary.md
+++ b/docs/adr/0017-attendance-writes-authorize-at-the-context-boundary.md
@@ -41,7 +41,7 @@ deterministic answer. `AttendanceAuthorization.authorize/2` takes the first that
 | Order | Rule | Cost |
 |---|---|---|
 | 1. provider | the scope's provider owns the session's program | 1 query (`ProgramProviderResolver`) |
-| 2. staff | the scope's staff member is assigned to it (`StaffProgramAccess`, #1323) | 1 query |
+| 2. staff | the scope's staff member is on the session (`SessionStaffing`, #783) | 4 queries |
 | 3. admin | `scope.user.is_admin` | none |
 | else | `{:error, :unauthorized}` | — |
 
@@ -57,6 +57,28 @@ where a reason *is* demanded. Admin-first would invert exactly this.
 
 A staff member with no assignment is authorized for nothing, per `StaffProgramAccess`'s own
 rule: assignment is a deliberate act, so "not assigned yet" and "not allowed" are the same fact.
+
+## Amended by #783: the staff rule is asked at session grain
+
+`authorize/2` takes the session, not its program id. The provider and admin branches still read
+`session.program_id` — ownership and the admin flag are program-wide facts — but the staff
+branch asks `Provider.get_session_staffing/1`, which returns a session's own overrides when it
+has any and falls back to the program roster when it does not.
+
+This is one question with the program grain as its *fallback*, not two rules OR-ed together, and
+the difference is not cosmetic. #782 lets a provider take one person off a single session:
+`unassign_staff_from_session/3` materializes the program roster onto that session and drops them
+from it, deliberately leaving their `ProgramStaffAssignment` intact. Under an OR they would keep
+authorizing on the program row — the removal silently undone at the layer meant to enforce it.
+Asking the resolver instead means the two grains cannot disagree, because only one of them is
+ever consulted.
+
+The cost is the staff row above: `get_session_staffing/1` resolves sessions, overrides, program
+staffing and leads, so the branch went from one query to four, and one of them re-reads a
+session Participation already holds (`Assignments.fetch_sessions/1` calls back through
+`Participation.get_sessions/1`). Acceptable on a write path that already fetches the record and
+its session. Not acceptable per row — which is why the staff sessions list uses the batch
+`list_session_staffing/1`, four queries regardless of how many sessions the day holds.
 
 ## Derived, not declared
 

--- a/lib/klass_hero/participation.ex
+++ b/lib/klass_hero/participation.ex
@@ -828,12 +828,12 @@ defmodule KlassHero.Participation do
     end
   end
 
-  # The record names its session and the session names its program; the program is
-  # what a role is authorized against. Kept here rather than in the authorizer so
-  # that module stays free of this context's own tables.
+  # The record names its session, and the session is what a role is authorized
+  # against. Fetched here rather than in the authorizer so that module stays free
+  # of this context's own tables.
   defp authorize_for_record(%Scope{} = scope, %ParticipationRecord{} = record) do
     with {:ok, session} <- fetch_session(record.session_id) do
-      AttendanceAuthorization.authorize(scope, session.program_id)
+      AttendanceAuthorization.authorize(scope, session)
     end
   end
 

--- a/lib/klass_hero/participation/attendance_authorization.ex
+++ b/lib/klass_hero/participation/attendance_authorization.ex
@@ -26,23 +26,44 @@ defmodule KlassHero.Participation.AttendanceAuthorization do
   A staff member with no assignment is authorized for nothing, per
   `StaffProgramAccess`'s own rule (#1323): assignment is a deliberate act, so
   "not assigned yet" and "not allowed" are the same fact.
+
+  ## The staff rule is asked at session grain (#783)
+
+  Since #782 a provider can staff one session differently from its program, so
+  "assigned to the program" stopped being the whole answer. The staff branch asks
+  `Provider.get_session_staffing/1`, which resolves a session's own overrides when
+  it has any and falls back to the program roster when it does not — one question,
+  with the program grain as its fallback rather than as a second rule beside it.
+
+  That distinction is the point, and it is *not* what #783 originally specified.
+  OR-ing a session check onto a program check reads as more permissive in the
+  right direction only. It is also more permissive in the wrong one:
+  `unassign_staff_from_session/3` takes someone off a single session by
+  materializing the program roster and dropping them from it, and their
+  `ProgramStaffAssignment` deliberately survives that. Under an OR they would
+  still authorize — the removal silently undone at the layer that enforces it.
   """
 
   alias KlassHero.Accounts.Scope
   alias KlassHero.Participation.Adapters.Driven.ACL.ProgramProviderResolver
+  alias KlassHero.Participation.ProgramSession
   alias KlassHero.Provider
-  alias KlassHero.Provider.Domain.ReadModels.StaffProgramAccess
+  alias KlassHero.Provider.Domain.ReadModels.SessionStaffing
 
   @type role :: :provider | :staff | :admin
 
   @doc """
-  Resolves the scope's role for `program_id`, or refuses.
+  Resolves the scope's role for `session`, or refuses.
+
+  Takes the session rather than its program id because the staff rule is answered
+  at session grain; ownership and the admin flag are still program-wide facts, so
+  those two branches read `session.program_id`.
   """
-  @spec authorize(Scope.t(), String.t()) :: {:ok, role()} | {:error, :unauthorized}
-  def authorize(%Scope{} = scope, program_id) when is_binary(program_id) do
+  @spec authorize(Scope.t(), ProgramSession.t()) :: {:ok, role()} | {:error, :unauthorized}
+  def authorize(%Scope{} = scope, %ProgramSession{} = session) do
     cond do
-      provider_owns?(scope, program_id) -> {:ok, :provider}
-      staff_assigned?(scope, program_id) -> {:ok, :staff}
+      provider_owns?(scope, session.program_id) -> {:ok, :provider}
+      staff_on_session?(scope, session) -> {:ok, :staff}
       admin?(scope) -> {:ok, :admin}
       true -> {:error, :unauthorized}
     end
@@ -54,12 +75,12 @@ defmodule KlassHero.Participation.AttendanceAuthorization do
     ProgramProviderResolver.resolve_provider_id(program_id) == {:ok, provider.id}
   end
 
-  defp staff_assigned?(%Scope{staff_member: nil}, _program_id), do: false
+  defp staff_on_session?(%Scope{staff_member: nil}, _session), do: false
 
-  defp staff_assigned?(%Scope{staff_member: staff_member}, program_id) do
-    staff_member.id
-    |> Provider.get_staff_program_access()
-    |> StaffProgramAccess.authorized?(program_id)
+  defp staff_on_session?(%Scope{staff_member: staff_member}, session) do
+    session.id
+    |> Provider.get_session_staffing()
+    |> SessionStaffing.staffed_by?(staff_member.id)
   end
 
   defp admin?(%Scope{user: %{is_admin: true}}), do: true

--- a/lib/klass_hero_web/helpers/staff_live_helpers.ex
+++ b/lib/klass_hero_web/helpers/staff_live_helpers.ex
@@ -38,4 +38,20 @@ defmodule KlassHeroWeb.Helpers.StaffLiveHelpers do
 
     {programs, access}
   end
+
+  @doc """
+  Every program the provider runs, as `%{program_id => title}`.
+
+  For naming rows that were let through on a session-grain gate (#783): a staff
+  member covering a single session has no assignment to the program behind it, so
+  a titles map built from assignments would come up empty for exactly the row the
+  override put on screen. Titles carry no access — the caller has already decided
+  what to render — so scoping this to the provider is the honest boundary.
+  """
+  @spec provider_program_names(String.t()) :: %{optional(String.t()) => String.t()}
+  def provider_program_names(provider_id) when is_binary(provider_id) do
+    provider_id
+    |> ProgramCatalog.list_programs_for_provider()
+    |> Map.new(&{&1.id, &1.title})
+  end
 end

--- a/lib/klass_hero_web/live/staff/staff_participation_live.ex
+++ b/lib/klass_hero_web/live/staff/staff_participation_live.ex
@@ -10,10 +10,10 @@ defmodule KlassHeroWeb.Staff.StaffParticipationLive do
     ]
 
   alias KlassHero.Participation
-  alias KlassHero.Provider.Domain.ReadModels.StaffProgramAccess
+  alias KlassHero.Provider
+  alias KlassHero.Provider.Domain.ReadModels.SessionStaffing
   alias KlassHeroWeb.Helpers.ParticipationEditHelpers
   alias KlassHeroWeb.Helpers.ParticipationLiveHandlers
-  alias KlassHeroWeb.Helpers.StaffLiveHelpers
   alias KlassHeroWeb.Theme
 
   require Logger
@@ -22,8 +22,6 @@ defmodule KlassHeroWeb.Staff.StaffParticipationLive do
   def mount(%{"session_id" => session_id}, _session, socket) do
     staff_member = socket.assigns.current_scope.staff_member
 
-    {_programs, program_access} = StaffLiveHelpers.load_assigned_programs(staff_member)
-
     socket =
       socket
       |> assign(:page_title, gettext("Manage Participation"))
@@ -31,7 +29,6 @@ defmodule KlassHeroWeb.Staff.StaffParticipationLive do
       |> assign(:session_id, session_id)
       |> assign(:provider_id, staff_member.provider_id)
       |> assign(:staff_member, staff_member)
-      |> assign(:program_access, program_access)
       |> assign(:session, nil)
       |> assign(:participation_records, [])
       |> assign(:checkout_form_expanded, nil)
@@ -189,6 +186,12 @@ defmodule KlassHeroWeb.Staff.StaffParticipationLive do
     {:noreply, socket}
   end
 
+  defp staffs_session?(staff_member, session_id) do
+    session_id
+    |> Provider.get_session_staffing()
+    |> SessionStaffing.staffed_by?(staff_member.id)
+  end
+
   defp load_session_data(socket) do
     session_id = socket.assigns.session_id
 
@@ -198,7 +201,9 @@ defmodule KlassHeroWeb.Staff.StaffParticipationLive do
         # the screen instead of rendering a page whose every button fails. The
         # authorization of record is in the context now (ADR-0017) — this gate is no
         # longer the only thing standing between staff and a child's record (#1353).
-        if StaffProgramAccess.authorized?(socket.assigns.program_access, session.program_id) do
+        # Asked at session grain, so it agrees with the context rather than
+        # shadowing it with a coarser answer (#783).
+        if staffs_session?(socket.assigns.staff_member, session_id) do
           socket
           |> assign(:session, session)
           |> assign(:participation_records, session.participation_records || [])
@@ -212,7 +217,7 @@ defmodule KlassHeroWeb.Staff.StaffParticipationLive do
           )
 
           socket
-          |> put_flash(:error, gettext("You are not assigned to this program"))
+          |> put_flash(:error, gettext("You are not assigned to this session"))
           |> push_navigate(to: ~p"/staff/sessions")
         end
 

--- a/lib/klass_hero_web/live/staff/staff_sessions_live.ex
+++ b/lib/klass_hero_web/live/staff/staff_sessions_live.ex
@@ -2,7 +2,8 @@ defmodule KlassHeroWeb.Staff.StaffSessionsLive do
   use KlassHeroWeb, :live_view
 
   alias KlassHero.Participation
-  alias KlassHero.Provider.Domain.ReadModels.StaffProgramAccess
+  alias KlassHero.Provider
+  alias KlassHero.Provider.Domain.ReadModels.SessionStaffing
   alias KlassHeroWeb.Helpers.StaffLiveHelpers
   alias KlassHeroWeb.Theme
 
@@ -14,18 +15,19 @@ defmodule KlassHeroWeb.Staff.StaffSessionsLive do
     provider_id = staff_member.provider_id
     selected_date = Date.utc_today()
 
-    {programs, program_access} = StaffLiveHelpers.load_assigned_programs(staff_member)
-
     socket =
       socket
       |> assign(:page_title, gettext("My Sessions"))
-      |> assign(:program_names, Map.new(programs, &{&1.id, &1.title}))
+      # Names every program the provider runs, not only the ones this staff member
+      # is assigned to. A session reaches the stream on its own staffing (#783), so
+      # deriving titles from program assignments would leave an overridden session
+      # rendering the generic "Session" fallback.
+      |> assign(:program_names, StaffLiveHelpers.provider_program_names(provider_id))
       |> assign(:attendance, %{})
       |> assign(:active_nav, :roster)
       |> assign(:provider_id, provider_id)
       |> assign(:staff_member, staff_member)
       |> assign(:selected_date, selected_date)
-      |> assign(:program_access, program_access)
       |> assign(:filter_program_id, nil)
       |> stream(:sessions, [])
 
@@ -149,15 +151,19 @@ defmodule KlassHeroWeb.Staff.StaffSessionsLive do
   defp load_sessions(socket) do
     provider_id = socket.assigns.provider_id
     selected_date = socket.assigns.selected_date
-    access = socket.assigns.program_access
+    staff_member_id = socket.assigns.staff_member.id
     filter_program_id = socket.assigns.filter_program_id
 
     {:ok, sessions} = Participation.list_provider_sessions(provider_id, selected_date)
 
+    # Batch, never per row: `list_session_staffing/1` costs four queries whatever
+    # the day's session count, where a per-session call would N+1 the whole list.
+    staffing = Provider.list_session_staffing(Enum.map(sessions, & &1.id))
+
     filtered =
       sessions
-      |> Enum.filter(&StaffProgramAccess.authorized?(access, &1.program_id))
-      |> maybe_filter_by_program(filter_program_id, access)
+      |> Enum.filter(&SessionStaffing.staffed_by?(staffing[&1.id], staff_member_id))
+      |> maybe_filter_by_program(filter_program_id)
 
     socket
     |> stream(:sessions, filtered, reset: true)
@@ -165,21 +171,19 @@ defmodule KlassHeroWeb.Staff.StaffSessionsLive do
     |> assign(:sessions_error, nil)
   end
 
-  defp maybe_filter_by_program(sessions, nil, _access), do: sessions
-  defp maybe_filter_by_program(sessions, "", _access), do: sessions
+  # Narrows an already-authorized list, so it carries no access check of its own.
+  # Reachable only by query param — no filter control exists in the template.
+  defp maybe_filter_by_program(sessions, nil), do: sessions
+  defp maybe_filter_by_program(sessions, ""), do: sessions
 
-  defp maybe_filter_by_program(sessions, program_id, access) do
-    if StaffProgramAccess.authorized?(access, program_id) do
-      Enum.filter(sessions, &(&1.program_id == program_id))
-    else
-      sessions
-    end
+  defp maybe_filter_by_program(sessions, program_id) do
+    Enum.filter(sessions, &(&1.program_id == program_id))
   end
 
   defp authorize_session_action(session_id, socket) do
     case Participation.get_session_with_roster(session_id) do
       {:ok, %{session: session}} ->
-        if StaffProgramAccess.authorized?(socket.assigns.program_access, session.program_id) do
+        if staffs_session?(socket, session.id) do
           :ok
         else
           {:error, :unauthorized}
@@ -190,14 +194,24 @@ defmodule KlassHeroWeb.Staff.StaffSessionsLive do
     end
   end
 
+  defp staffs_session?(socket, session_id) do
+    session_id
+    |> Provider.get_session_staffing()
+    |> SessionStaffing.staffed_by?(socket.assigns.staff_member.id)
+  end
+
   defp update_session_in_stream(socket, session_id) do
     case Participation.get_session_with_roster(session_id) do
       {:ok, %{session: session, roster: roster}} ->
         # Session events fan out across dates — a schedule edit cancels every
         # orphaned date, an enrolment seeds every upcoming roster — so check the
         # session's own date rather than trusting the event to concern this day.
-        if StaffProgramAccess.authorized?(socket.assigns.program_access, session.program_id) and
-             session.session_date == socket.assigns.selected_date do
+        # Date first, and deliberately: it is an in-memory comparison while
+        # `staffs_session?/2` costs a round trip, and this topic carries every
+        # participation message for the provider, not only the ones this view
+        # renders. `and` short-circuits, so an off-date message never queries.
+        if session.session_date == socket.assigns.selected_date and
+             staffs_session?(socket, session.id) do
           socket
           |> assign(
             :attendance,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -622,7 +622,7 @@ msgid "Failed to check out: %{reason}"
 msgstr "Auschecken fehlgeschlagen: %{reason}"
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:160
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:116
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:118
 #, elixir-autogen, elixir-format
 msgid "Failed to complete session: %{reason}"
 msgstr "Sitzung konnte nicht abgeschlossen werden: %{reason}"
@@ -633,7 +633,7 @@ msgid "Failed to delete account. Please try again."
 msgstr "Konto konnte nicht gelöscht werden. Bitte versuchen Sie es erneut."
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:137
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:87
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:89
 #, elixir-autogen, elixir-format
 msgid "Failed to start session: %{reason}"
 msgstr "Sitzung konnte nicht gestartet werden: %{reason}"
@@ -685,7 +685,7 @@ msgstr "Einleitung"
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:115
 #: lib/klass_hero_web/live/provider/sessions_live.ex:565
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:63
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:65
 #, elixir-autogen, elixir-format
 msgid "Invalid date format"
 msgstr "Ungültiges Datumsformat"
@@ -758,8 +758,8 @@ msgstr "Nachricht erfolgreich gesendet!"
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:50
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:4
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:21
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:228
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:20
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:242
 #, elixir-autogen, elixir-format
 msgid "My Sessions"
 msgstr "Meine Sitzungen"
@@ -850,8 +850,8 @@ msgstr "Fragen zu diesen Bedingungen?"
 #: lib/klass_hero_web/live/admin/sessions_live.ex:252
 #: lib/klass_hero_web/live/provider/participation_live.ex:171
 #: lib/klass_hero_web/live/provider/participation_live.ex:217
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:113
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:159
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:110
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "Record not found"
 msgstr "Eintrag nicht gefunden"
@@ -889,7 +889,7 @@ msgid "Send Message"
 msgstr "Nachricht senden"
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:146
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:102
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:104
 #, elixir-autogen, elixir-format
 msgid "Session completed successfully"
 msgstr "Sitzung erfolgreich abgeschlossen"
@@ -897,13 +897,13 @@ msgstr "Sitzung erfolgreich abgeschlossen"
 #: lib/klass_hero_web/live/admin/sessions_live.ex:67
 #: lib/klass_hero_web/live/admin/sessions_live.ex:73
 #: lib/klass_hero_web/live/provider/participation_live.ex:287
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:226
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:231
 #, elixir-autogen, elixir-format
 msgid "Session not found"
 msgstr "Sitzung nicht gefunden"
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:123
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:73
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:75
 #, elixir-autogen, elixir-format
 msgid "Session started successfully"
 msgstr "Sitzung erfolgreich gestartet"
@@ -1384,8 +1384,8 @@ msgstr "Teilnahmeverlauf konnte nicht geladen werden"
 
 #: lib/klass_hero_web/live/provider/participation_live.ex:27
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:65
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:29
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:276
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:27
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:290
 #, elixir-autogen, elixir-format
 msgid "Manage Participation"
 msgstr "Teilnahme verwalten"
@@ -2114,7 +2114,7 @@ msgid "Type a message..."
 msgstr "Nachricht eingeben..."
 
 #: lib/klass_hero_web/live/provider/participation_live.ex:307
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:246
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:251
 #, elixir-autogen, elixir-format
 msgid "Unable to refresh roster. Please reload."
 msgstr "Teilnehmerliste konnte nicht aktualisiert werden. Bitte laden Sie die Seite neu."
@@ -4092,7 +4092,7 @@ msgid "Complete Registration"
 msgstr "Registrierung abschließen"
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:76
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:287
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:301
 #, elixir-autogen, elixir-format
 msgid "Complete Session"
 msgstr "Sitzung abschließen"
@@ -4322,7 +4322,7 @@ msgid "Max Capacity"
 msgstr "Maximale Kapazität"
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:90
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:301
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:315
 #, elixir-autogen, elixir-format
 msgid "No actions available"
 msgstr "Keine Aktionen verfügbar"
@@ -4358,7 +4358,7 @@ msgid "No sessions found for the selected filters."
 msgstr "Keine Sitzungen für die ausgewählten Filter gefunden."
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:122
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:316
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:330
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled"
 msgstr "Keine Sitzungen geplant"
@@ -4536,7 +4536,7 @@ msgid "Staff Dashboard"
 msgstr "Mitarbeiter-Dashboard"
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:54
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:265
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:279
 #, elixir-autogen, elixir-format
 msgid "Start Session"
 msgstr "Sitzung starten"
@@ -4604,8 +4604,8 @@ msgstr "Ihre Antwort eingeben..."
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:183
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:123
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:92
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:121
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:94
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:123
 #, elixir-autogen, elixir-format
 msgid "Unauthorized"
 msgstr "Nicht autorisiert"
@@ -4632,7 +4632,7 @@ msgid "Upload connection lost. Please try again."
 msgstr "Upload-Verbindung unterbrochen. Bitte versuchen Sie es erneut."
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:87
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:298
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:312
 #, elixir-autogen, elixir-format
 msgid "View Participation"
 msgstr "Teilnahme anzeigen"
@@ -4658,7 +4658,7 @@ msgid "You already have an account. Log in to see your new enrollment."
 msgstr "Sie haben bereits ein Konto. Melden Sie sich an, um Ihre neue Anmeldung zu sehen."
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:125
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:319
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:333
 #, elixir-autogen, elixir-format
 msgid "You have no sessions scheduled for %{date}"
 msgstr "Sie haben keine Sitzungen geplant für %{date}"
@@ -4693,7 +4693,7 @@ msgstr "Teilnehmerliste"
 msgid "Unlimited team seats"
 msgstr "Unbegrenzte Team-Plätze"
 
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:229
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "View and manage your assigned sessions"
 msgstr "Ihre zugewiesenen Sitzungen anzeigen und verwalten"
@@ -4702,7 +4702,6 @@ msgstr "Ihre zugewiesenen Sitzungen anzeigen und verwalten"
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:82
 #: lib/klass_hero_web/live/provider/participation_live.ex:276
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:53
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:215
 #, elixir-autogen, elixir-format
 msgid "You are not assigned to this program"
 msgstr "Sie sind diesem Programm nicht zugewiesen"
@@ -4948,13 +4947,13 @@ msgid "Departure notes"
 msgstr "Notizen zur Abreise"
 
 #: lib/klass_hero_web/live/provider/participation_live.ex:220
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:162
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:159
 #, elixir-autogen, elixir-format
 msgid "Departure time is not a valid date and time"
 msgstr "Abreisezeit ist kein gültiges Datum oder keine gültige Uhrzeit"
 
 #: lib/klass_hero_web/live/provider/participation_live.ex:231
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:173
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:170
 #, elixir-autogen, elixir-format
 msgid "Failed to update record"
 msgstr "Aktualisieren des Datensatzes fehlgeschlagen"
@@ -4995,7 +4994,7 @@ msgid "Medical conditions"
 msgstr "Gesundheitliche Besonderheiten"
 
 #: lib/klass_hero_web/live/provider/participation_live.ex:223
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:165
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:162
 #, elixir-autogen, elixir-format
 msgid "Nothing to update"
 msgstr "Nichts zu aktualisieren"
@@ -5037,7 +5036,7 @@ msgid "Record departure time (optional)"
 msgstr "Abreisezeit erfassen (optional)"
 
 #: lib/klass_hero_web/live/provider/participation_live.ex:211
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:153
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:150
 #, elixir-autogen, elixir-format
 msgid "Record updated"
 msgstr "Datensatz aktualisiert"
@@ -8068,3 +8067,8 @@ msgstr "Einverständniserklärung hinzugefügt."
 #, elixir-autogen, elixir-format
 msgid "Waiver retired. Signatures already collected are kept."
 msgstr "Einverständniserklärung zurückgezogen. Bereits erteilte Unterschriften bleiben erhalten."
+
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:220
+#, elixir-autogen, elixir-format
+msgid "You are not assigned to this session"
+msgstr "Sie sind diesem Termin nicht zugewiesen"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -622,7 +622,7 @@ msgid "Failed to check out: %{reason}"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:160
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:116
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:118
 #, elixir-autogen, elixir-format
 msgid "Failed to complete session: %{reason}"
 msgstr ""
@@ -633,7 +633,7 @@ msgid "Failed to delete account. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:137
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:87
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:89
 #, elixir-autogen, elixir-format
 msgid "Failed to start session: %{reason}"
 msgstr ""
@@ -685,7 +685,7 @@ msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:115
 #: lib/klass_hero_web/live/provider/sessions_live.ex:565
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:63
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:65
 #, elixir-autogen, elixir-format
 msgid "Invalid date format"
 msgstr ""
@@ -758,8 +758,8 @@ msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:50
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:4
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:21
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:228
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:20
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:242
 #, elixir-autogen, elixir-format
 msgid "My Sessions"
 msgstr ""
@@ -850,8 +850,8 @@ msgstr ""
 #: lib/klass_hero_web/live/admin/sessions_live.ex:252
 #: lib/klass_hero_web/live/provider/participation_live.ex:171
 #: lib/klass_hero_web/live/provider/participation_live.ex:217
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:113
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:159
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:110
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "Record not found"
 msgstr ""
@@ -889,7 +889,7 @@ msgid "Send Message"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:146
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:102
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:104
 #, elixir-autogen, elixir-format
 msgid "Session completed successfully"
 msgstr ""
@@ -897,13 +897,13 @@ msgstr ""
 #: lib/klass_hero_web/live/admin/sessions_live.ex:67
 #: lib/klass_hero_web/live/admin/sessions_live.ex:73
 #: lib/klass_hero_web/live/provider/participation_live.ex:287
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:226
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:231
 #, elixir-autogen, elixir-format
 msgid "Session not found"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:123
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:73
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:75
 #, elixir-autogen, elixir-format
 msgid "Session started successfully"
 msgstr ""
@@ -1384,8 +1384,8 @@ msgstr ""
 
 #: lib/klass_hero_web/live/provider/participation_live.ex:27
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:65
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:29
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:276
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:27
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:290
 #, elixir-autogen, elixir-format
 msgid "Manage Participation"
 msgstr ""
@@ -2114,7 +2114,7 @@ msgid "Type a message..."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/participation_live.ex:307
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:246
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:251
 #, elixir-autogen, elixir-format
 msgid "Unable to refresh roster. Please reload."
 msgstr ""
@@ -4092,7 +4092,7 @@ msgid "Complete Registration"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:76
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:287
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:301
 #, elixir-autogen, elixir-format
 msgid "Complete Session"
 msgstr ""
@@ -4322,7 +4322,7 @@ msgid "Max Capacity"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:90
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:301
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:315
 #, elixir-autogen, elixir-format
 msgid "No actions available"
 msgstr ""
@@ -4358,7 +4358,7 @@ msgid "No sessions found for the selected filters."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:122
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:316
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:330
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled"
 msgstr ""
@@ -4536,7 +4536,7 @@ msgid "Staff Dashboard"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:54
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:265
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:279
 #, elixir-autogen, elixir-format
 msgid "Start Session"
 msgstr ""
@@ -4604,8 +4604,8 @@ msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:183
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:123
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:92
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:121
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:94
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:123
 #, elixir-autogen, elixir-format
 msgid "Unauthorized"
 msgstr ""
@@ -4632,7 +4632,7 @@ msgid "Upload connection lost. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:87
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:298
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:312
 #, elixir-autogen, elixir-format
 msgid "View Participation"
 msgstr ""
@@ -4658,7 +4658,7 @@ msgid "You already have an account. Log in to see your new enrollment."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:125
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:319
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:333
 #, elixir-autogen, elixir-format
 msgid "You have no sessions scheduled for %{date}"
 msgstr ""
@@ -4693,7 +4693,7 @@ msgstr ""
 msgid "Unlimited team seats"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:229
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "View and manage your assigned sessions"
 msgstr ""
@@ -4702,7 +4702,6 @@ msgstr ""
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:82
 #: lib/klass_hero_web/live/provider/participation_live.ex:276
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:53
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:215
 #, elixir-autogen, elixir-format
 msgid "You are not assigned to this program"
 msgstr ""
@@ -4948,13 +4947,13 @@ msgid "Departure notes"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/participation_live.ex:220
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:162
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:159
 #, elixir-autogen, elixir-format
 msgid "Departure time is not a valid date and time"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/participation_live.ex:231
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:173
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:170
 #, elixir-autogen, elixir-format
 msgid "Failed to update record"
 msgstr ""
@@ -4995,7 +4994,7 @@ msgid "Medical conditions"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/participation_live.ex:223
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:165
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:162
 #, elixir-autogen, elixir-format
 msgid "Nothing to update"
 msgstr ""
@@ -5037,7 +5036,7 @@ msgid "Record departure time (optional)"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/participation_live.ex:211
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:153
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:150
 #, elixir-autogen, elixir-format
 msgid "Record updated"
 msgstr ""
@@ -8052,4 +8051,9 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/programs_live.ex:343
 #, elixir-autogen, elixir-format
 msgid "Waiver retired. Signatures already collected are kept."
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:220
+#, elixir-autogen, elixir-format
+msgid "You are not assigned to this session"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -622,7 +622,7 @@ msgid "Failed to check out: %{reason}"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:160
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:116
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:118
 #, elixir-autogen, elixir-format
 msgid "Failed to complete session: %{reason}"
 msgstr ""
@@ -633,7 +633,7 @@ msgid "Failed to delete account. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:137
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:87
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:89
 #, elixir-autogen, elixir-format
 msgid "Failed to start session: %{reason}"
 msgstr ""
@@ -685,7 +685,7 @@ msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:115
 #: lib/klass_hero_web/live/provider/sessions_live.ex:565
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:63
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:65
 #, elixir-autogen, elixir-format
 msgid "Invalid date format"
 msgstr ""
@@ -758,8 +758,8 @@ msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:50
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:4
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:21
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:228
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:20
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:242
 #, elixir-autogen, elixir-format
 msgid "My Sessions"
 msgstr ""
@@ -850,8 +850,8 @@ msgstr ""
 #: lib/klass_hero_web/live/admin/sessions_live.ex:252
 #: lib/klass_hero_web/live/provider/participation_live.ex:171
 #: lib/klass_hero_web/live/provider/participation_live.ex:217
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:113
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:159
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:110
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "Record not found"
 msgstr ""
@@ -889,7 +889,7 @@ msgid "Send Message"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:146
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:102
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:104
 #, elixir-autogen, elixir-format
 msgid "Session completed successfully"
 msgstr ""
@@ -897,13 +897,13 @@ msgstr ""
 #: lib/klass_hero_web/live/admin/sessions_live.ex:67
 #: lib/klass_hero_web/live/admin/sessions_live.ex:73
 #: lib/klass_hero_web/live/provider/participation_live.ex:287
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:226
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:231
 #, elixir-autogen, elixir-format
 msgid "Session not found"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:123
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:73
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:75
 #, elixir-autogen, elixir-format
 msgid "Session started successfully"
 msgstr ""
@@ -1384,8 +1384,8 @@ msgstr ""
 
 #: lib/klass_hero_web/live/provider/participation_live.ex:27
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:65
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:29
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:276
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:27
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:290
 #, elixir-autogen, elixir-format
 msgid "Manage Participation"
 msgstr ""
@@ -2114,7 +2114,7 @@ msgid "Type a message..."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/participation_live.ex:307
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:246
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:251
 #, elixir-autogen, elixir-format
 msgid "Unable to refresh roster. Please reload."
 msgstr ""
@@ -4092,7 +4092,7 @@ msgid "Complete Registration"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:76
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:287
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:301
 #, elixir-autogen, elixir-format
 msgid "Complete Session"
 msgstr ""
@@ -4322,7 +4322,7 @@ msgid "Max Capacity"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:90
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:301
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:315
 #, elixir-autogen, elixir-format
 msgid "No actions available"
 msgstr ""
@@ -4358,7 +4358,7 @@ msgid "No sessions found for the selected filters."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:122
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:316
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:330
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled"
 msgstr ""
@@ -4536,7 +4536,7 @@ msgid "Staff Dashboard"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:54
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:265
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:279
 #, elixir-autogen, elixir-format
 msgid "Start Session"
 msgstr ""
@@ -4604,8 +4604,8 @@ msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:183
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:123
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:92
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:121
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:94
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:123
 #, elixir-autogen, elixir-format
 msgid "Unauthorized"
 msgstr ""
@@ -4632,7 +4632,7 @@ msgid "Upload connection lost. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:87
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:298
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:312
 #, elixir-autogen, elixir-format
 msgid "View Participation"
 msgstr ""
@@ -4658,7 +4658,7 @@ msgid "You already have an account. Log in to see your new enrollment."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:125
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:319
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:333
 #, elixir-autogen, elixir-format
 msgid "You have no sessions scheduled for %{date}"
 msgstr ""
@@ -4693,7 +4693,7 @@ msgstr ""
 msgid "Unlimited team seats"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:229
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "View and manage your assigned sessions"
 msgstr ""
@@ -4702,7 +4702,6 @@ msgstr ""
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:82
 #: lib/klass_hero_web/live/provider/participation_live.ex:276
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:53
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:215
 #, elixir-autogen, elixir-format
 msgid "You are not assigned to this program"
 msgstr ""
@@ -4948,13 +4947,13 @@ msgid "Departure notes"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/participation_live.ex:220
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:162
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:159
 #, elixir-autogen, elixir-format
 msgid "Departure time is not a valid date and time"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/participation_live.ex:231
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:173
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:170
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to update record"
 msgstr ""
@@ -4995,7 +4994,7 @@ msgid "Medical conditions"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/participation_live.ex:223
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:165
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:162
 #, elixir-autogen, elixir-format
 msgid "Nothing to update"
 msgstr ""
@@ -5037,7 +5036,7 @@ msgid "Record departure time (optional)"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/participation_live.ex:211
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:153
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:150
 #, elixir-autogen, elixir-format
 msgid "Record updated"
 msgstr ""
@@ -8052,4 +8051,9 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/programs_live.ex:343
 #, elixir-autogen, elixir-format
 msgid "Waiver retired. Signatures already collected are kept."
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:220
+#, elixir-autogen, elixir-format, fuzzy
+msgid "You are not assigned to this session"
 msgstr ""

--- a/test/klass_hero/participation/attendance_authorization_test.exs
+++ b/test/klass_hero/participation/attendance_authorization_test.exs
@@ -13,53 +13,54 @@ defmodule KlassHero.Participation.AttendanceAuthorizationTest do
   alias KlassHero.Accounts.Scope
   alias KlassHero.AccountsFixtures
   alias KlassHero.Participation.AttendanceAuthorization
+  alias KlassHero.Provider
   alias KlassHero.ProviderFixtures
 
   describe "authorize/2" do
     test "a provider owning the program is authorized as :provider" do
-      %{provider: provider, program: program} = provider_with_program()
+      %{provider: provider, session: session} = provider_with_session()
       scope = scope_for(provider_profile: provider)
 
-      assert {:ok, :provider} = AttendanceAuthorization.authorize(scope, program.id)
+      assert {:ok, :provider} = AttendanceAuthorization.authorize(scope, session)
     end
 
     test "a provider is refused on another provider's program" do
       %{provider: provider} = provider_with_program()
-      %{program: foreign_program} = provider_with_program()
+      %{session: foreign_session} = provider_with_session()
       scope = scope_for(provider_profile: provider)
 
-      assert {:error, :unauthorized} = AttendanceAuthorization.authorize(scope, foreign_program.id)
+      assert {:error, :unauthorized} = AttendanceAuthorization.authorize(scope, foreign_session)
     end
 
     test "a staff member assigned to the program is authorized as :staff" do
-      %{provider: provider, program: program} = provider_with_program()
+      %{provider: provider, program: program, session: session} = provider_with_session()
       staff = assigned_staff(provider, program)
       scope = scope_for(staff_member: staff)
 
-      assert {:ok, :staff} = AttendanceAuthorization.authorize(scope, program.id)
+      assert {:ok, :staff} = AttendanceAuthorization.authorize(scope, session)
     end
 
     test "a staff member with no assignment to the program is refused" do
-      %{provider: provider, program: program} = provider_with_program()
+      %{provider: provider, session: session} = provider_with_session()
       staff = ProviderFixtures.staff_member_fixture(%{provider_id: provider.id})
       scope = scope_for(staff_member: staff)
 
-      assert {:error, :unauthorized} = AttendanceAuthorization.authorize(scope, program.id)
+      assert {:error, :unauthorized} = AttendanceAuthorization.authorize(scope, session)
     end
 
     test "a platform admin holding no persona is authorized as :admin" do
-      %{program: program} = provider_with_program()
+      %{session: session} = provider_with_session()
       # `user_fixture/1`, not `unconfirmed_user_fixture/1` — `registration_changeset`
       # never casts `is_admin`, so the unconfirmed variant drops the flag silently.
       scope = scope_for(user: AccountsFixtures.user_fixture(is_admin: true))
 
-      assert {:ok, :admin} = AttendanceAuthorization.authorize(scope, program.id)
+      assert {:ok, :admin} = AttendanceAuthorization.authorize(scope, session)
     end
 
     test "a user with no persona and no admin flag is refused" do
-      %{program: program} = provider_with_program()
+      %{session: session} = provider_with_session()
 
-      assert {:error, :unauthorized} = AttendanceAuthorization.authorize(scope_for([]), program.id)
+      assert {:error, :unauthorized} = AttendanceAuthorization.authorize(scope_for([]), session)
     end
   end
 
@@ -68,7 +69,7 @@ defmodule KlassHero.Participation.AttendanceAuthorizationTest do
   # ever reshuffled — the single-persona cases above pass under all of them.
   describe "authorize/2 fall-through order" do
     test "an admin who owns the program is authorized as :provider, not :admin" do
-      %{provider: provider, program: program} = provider_with_program()
+      %{provider: provider, session: session} = provider_with_session()
 
       scope =
         scope_for(
@@ -76,12 +77,12 @@ defmodule KlassHero.Participation.AttendanceAuthorizationTest do
           provider_profile: provider
         )
 
-      assert {:ok, :provider} = AttendanceAuthorization.authorize(scope, program.id)
+      assert {:ok, :provider} = AttendanceAuthorization.authorize(scope, session)
     end
 
     test "an admin who does not own the program falls through to :admin" do
       %{provider: provider} = provider_with_program()
-      %{program: foreign_program} = provider_with_program()
+      %{session: foreign_session} = provider_with_session()
 
       scope =
         scope_for(
@@ -89,24 +90,81 @@ defmodule KlassHero.Participation.AttendanceAuthorizationTest do
           provider_profile: provider
         )
 
-      assert {:ok, :admin} = AttendanceAuthorization.authorize(scope, foreign_program.id)
+      assert {:ok, :admin} = AttendanceAuthorization.authorize(scope, foreign_session)
     end
 
     test "a provider who is also staff is authorized as :provider on their own program" do
-      %{provider: provider, program: program} = provider_with_program()
+      %{provider: provider, program: program, session: session} = provider_with_session()
       staff = assigned_staff(provider, program)
       scope = scope_for(provider_profile: provider, staff_member: staff)
 
-      assert {:ok, :provider} = AttendanceAuthorization.authorize(scope, program.id)
+      assert {:ok, :provider} = AttendanceAuthorization.authorize(scope, session)
     end
 
     test "a provider who is also staff elsewhere is authorized as :staff on that program" do
       %{provider: own_provider} = provider_with_program()
-      %{provider: other_provider, program: other_program} = provider_with_program()
+
+      %{provider: other_provider, program: other_program, session: other_session} =
+        provider_with_session()
+
       staff = assigned_staff(other_provider, other_program)
       scope = scope_for(provider_profile: own_provider, staff_member: staff)
 
-      assert {:ok, :staff} = AttendanceAuthorization.authorize(scope, other_program.id)
+      assert {:ok, :staff} = AttendanceAuthorization.authorize(scope, other_session)
+    end
+  end
+
+  # Session grain (#783). Program assignment is the *fallback* the resolver applies
+  # when a session carries no overrides — it is not a second rule OR-ed alongside
+  # one. These pin the two cases that distinction decides.
+  describe "authorize/2 at session grain" do
+    test "a staff member removed from one session is refused, though still on the program" do
+      %{provider: provider, program: program, session: session} = provider_with_session()
+      staff = assigned_staff(provider, program)
+      colleague = assigned_staff(provider, program)
+
+      # Removing one member materializes the program roster onto the session and
+      # drops that person, leaving the colleague. The program assignment survives,
+      # which is exactly why a program-grain check would keep letting them in.
+      assert {:ok, _} = Provider.unassign_staff_from_session(session.id, staff.id, provider.id)
+
+      assert {:error, :unauthorized} =
+               AttendanceAuthorization.authorize(scope_for(staff_member: staff), session)
+
+      assert {:ok, :staff} =
+               AttendanceAuthorization.authorize(scope_for(staff_member: colleague), session)
+    end
+
+    test "a staff member on the session but not the program is authorized as :staff" do
+      %{provider: provider, session: session} = provider_with_session()
+      staff = ProviderFixtures.staff_member_fixture(%{provider_id: provider.id})
+
+      assert {:ok, _} =
+               Provider.assign_staff_to_session(%{
+                 provider_id: provider.id,
+                 session_id: session.id,
+                 staff_member_id: staff.id
+               })
+
+      assert {:ok, :staff} =
+               AttendanceAuthorization.authorize(scope_for(staff_member: staff), session)
+    end
+
+    test "a deactivated staff member on the session is refused" do
+      %{provider: provider, session: session} = provider_with_session()
+      staff = ProviderFixtures.staff_member_fixture(%{provider_id: provider.id})
+
+      assert {:ok, _} =
+               Provider.assign_staff_to_session(%{
+                 provider_id: provider.id,
+                 session_id: session.id,
+                 staff_member_id: staff.id
+               })
+
+      {:ok, _} = Provider.deactivate_staff_member(staff)
+
+      assert {:error, :unauthorized} =
+               AttendanceAuthorization.authorize(scope_for(staff_member: staff), session)
     end
   end
 
@@ -115,6 +173,13 @@ defmodule KlassHero.Participation.AttendanceAuthorizationTest do
     program = insert(:program_schema, provider_id: provider.id)
 
     %{provider: provider, program: program}
+  end
+
+  defp provider_with_session do
+    %{provider: provider, program: program} = provider_with_program()
+    session = insert(:program_session_schema, program_id: program.id)
+
+    %{provider: provider, program: program, session: session}
   end
 
   defp assigned_staff(provider, program) do

--- a/test/klass_hero/participation/record_check_in_test.exs
+++ b/test/klass_hero/participation/record_check_in_test.exs
@@ -9,8 +9,11 @@ defmodule KlassHero.Participation.RecordCheckInTest do
 
   import KlassHero.Factory
 
+  alias KlassHero.Accounts.Scope
   alias KlassHero.AccountsFixtures
   alias KlassHero.Participation.ParticipationRecord
+  alias KlassHero.Provider
+  alias KlassHero.ProviderFixtures
 
   describe "execute/1" do
     test "successfully checks in a registered record" do
@@ -127,5 +130,78 @@ defmodule KlassHero.Participation.RecordCheckInTest do
       assert reloaded.check_in_at != nil
       assert reloaded.check_in_by == scope.user.id
     end
+  end
+
+  # The write path is the authorization of record (ADR-0017), so a staff member's
+  # reach has to be proven here and not only at the LiveView gate that shows them
+  # the roster. Both of these are invisible to a program-grain check: the first
+  # has no program assignment to find, the second still has one (#783).
+  describe "execute/1 staff authorization at session grain" do
+    test "a staff member on the session but not the program can check a child in" do
+      %{provider: provider, session: session, record: record} = staffed_session()
+      staff = ProviderFixtures.staff_member_fixture(%{provider_id: provider.id})
+      user = AccountsFixtures.user_fixture()
+
+      assert {:ok, _} =
+               Provider.assign_staff_to_session(%{
+                 provider_id: provider.id,
+                 session_id: session.id,
+                 staff_member_id: staff.id
+               })
+
+      assert {:ok, checked_in} =
+               KlassHero.Participation.record_check_in(
+                 %Scope{user: user, staff_member: staff},
+                 record.id,
+                 notes: nil
+               )
+
+      assert checked_in.status == :checked_in
+      assert checked_in.check_in_by == user.id
+    end
+
+    test "a staff member removed from the session is refused, though still on the program" do
+      %{provider: provider, program: program, session: session, record: record} = staffed_session()
+      staff = assigned_staff(provider, program)
+      _colleague = assigned_staff(provider, program)
+      user = AccountsFixtures.user_fixture()
+
+      assert {:ok, _} = Provider.unassign_staff_from_session(session.id, staff.id, provider.id)
+
+      assert {:error, :unauthorized} =
+               KlassHero.Participation.record_check_in(
+                 %Scope{user: user, staff_member: staff},
+                 record.id,
+                 notes: nil
+               )
+    end
+  end
+
+  defp staffed_session do
+    provider = insert(:provider_profile_schema)
+    program = insert(:program_schema, provider_id: provider.id)
+    session = insert(:program_session_schema, program_id: program.id, status: :in_progress)
+    child = insert(:child_schema)
+
+    record =
+      insert(:participation_record_schema,
+        session_id: session.id,
+        child_id: child.id,
+        status: :registered
+      )
+
+    %{provider: provider, program: program, session: session, record: record}
+  end
+
+  defp assigned_staff(provider, program) do
+    staff = ProviderFixtures.staff_member_fixture(%{provider_id: provider.id})
+
+    ProviderFixtures.program_assignment_fixture(%{
+      provider_id: provider.id,
+      staff_member_id: staff.id,
+      program_id: program.id
+    })
+
+    staff
   end
 end

--- a/test/klass_hero_web/live/staff/staff_participation_live_test.exs
+++ b/test/klass_hero_web/live/staff/staff_participation_live_test.exs
@@ -53,6 +53,59 @@ defmodule KlassHeroWeb.Staff.StaffParticipationLiveTest do
       assert {:error, {:live_redirect, %{to: "/staff/sessions"}}} =
                live(conn, ~p"/staff/participation/#{session.id}")
     end
+
+    test "opens the roster for a session the staff member covers without the program", %{conn: conn} do
+      %{conn: conn, provider: provider, staff: staff} = register_and_log_in_staff(%{conn: conn})
+      session = session_in_new_program(provider)
+
+      assert {:ok, _} =
+               KlassHero.Provider.assign_staff_to_session(%{
+                 provider_id: provider.id,
+                 session_id: session.id,
+                 staff_member_id: staff.id
+               })
+
+      {:ok, view, _html} = live(conn, ~p"/staff/participation/#{session.id}")
+
+      assert has_element?(view, "#staff-participation")
+    end
+
+    test "redirects a staff member taken off the session, though still on the program", %{conn: conn} do
+      %{conn: conn, provider: provider, staff: staff} = register_and_log_in_staff(%{conn: conn})
+      session = session_in_new_program(provider)
+
+      for member <- [staff, ProviderFixtures.staff_member_fixture(%{provider_id: provider.id})] do
+        ProviderFixtures.program_assignment_fixture(%{
+          provider_id: provider.id,
+          program_id: session.program_id,
+          staff_member_id: member.id
+        })
+      end
+
+      assert {:ok, _} =
+               KlassHero.Provider.unassign_staff_from_session(session.id, staff.id, provider.id)
+
+      assert {:error, {:live_redirect, %{to: "/staff/sessions"}}} =
+               live(conn, ~p"/staff/participation/#{session.id}")
+    end
+  end
+
+  defp session_in_new_program(provider) do
+    program = insert(:program_schema, provider_id: provider.id, category: "sports")
+
+    _listing =
+      insert(:program_listing_schema,
+        id: program.id,
+        provider_id: provider.id,
+        category: "sports",
+        title: "Soccer Training"
+      )
+
+    insert(:program_session_schema,
+      program_id: program.id,
+      session_date: Date.utc_today(),
+      status: :in_progress
+    )
   end
 
   describe "participation management" do

--- a/test/klass_hero_web/live/staff/staff_sessions_live_test.exs
+++ b/test/klass_hero_web/live/staff/staff_sessions_live_test.exs
@@ -137,6 +137,91 @@ defmodule KlassHeroWeb.Staff.StaffSessionsLiveTest do
              )
     end
 
+    # Session grain (#783). Visibility follows the effective roster, so it tracks a
+    # per-session override in both directions — someone put on one session sees it
+    # without a program assignment, someone taken off one stops seeing it despite
+    # keeping theirs.
+    test "shows a session the staff member covers without a program assignment",
+         %{conn: conn} = ctx do
+      program = unassigned_program(ctx, category: "arts", title: "Art Workshop")
+      session = session_on(program, Date.utc_today(), :scheduled)
+
+      assert {:ok, _} =
+               KlassHero.Provider.assign_staff_to_session(%{
+                 provider_id: ctx.provider.id,
+                 session_id: session.id,
+                 staff_member_id: ctx.staff.id
+               })
+
+      {:ok, view, _html} = live(conn, ~p"/staff/sessions")
+
+      assert has_element?(
+               view,
+               "button[phx-value-session_id='#{session.id}']",
+               "Start Session"
+             )
+
+      # The program title has to survive the same path: it used to come only from
+      # the staff member's assigned programs, which this session is not among.
+      assert has_element?(view, "h3", "Art Workshop")
+    end
+
+    test "hides a session the staff member was taken off, though still on the program",
+         %{conn: conn} = ctx do
+      program = assigned_program(ctx, title: "Soccer Training")
+      session = session_on(program, Date.utc_today(), :scheduled)
+
+      colleague = ProviderFixtures.staff_member_fixture(%{provider_id: ctx.provider.id})
+
+      ProviderFixtures.program_assignment_fixture(%{
+        provider_id: ctx.provider.id,
+        program_id: program.id,
+        staff_member_id: colleague.id
+      })
+
+      assert {:ok, _} =
+               KlassHero.Provider.unassign_staff_from_session(
+                 session.id,
+                 ctx.staff.id,
+                 ctx.provider.id
+               )
+
+      {:ok, view, _html} = live(conn, ~p"/staff/sessions")
+
+      refute has_element?(
+               view,
+               "button[phx-value-session_id='#{session.id}']",
+               "Start Session"
+             )
+    end
+
+    test "rejects start_session for a session the staff member was taken off",
+         %{conn: conn} = ctx do
+      program = assigned_program(ctx, title: "Soccer Training")
+      session = session_on(program, Date.utc_today(), :scheduled)
+
+      colleague = ProviderFixtures.staff_member_fixture(%{provider_id: ctx.provider.id})
+
+      ProviderFixtures.program_assignment_fixture(%{
+        provider_id: ctx.provider.id,
+        program_id: program.id,
+        staff_member_id: colleague.id
+      })
+
+      assert {:ok, _} =
+               KlassHero.Provider.unassign_staff_from_session(
+                 session.id,
+                 ctx.staff.id,
+                 ctx.provider.id
+               )
+
+      {:ok, view, _html} = live(conn, ~p"/staff/sessions")
+
+      render_click(view, "start_session", %{"session_id" => session.id})
+
+      assert render(view) =~ "Unauthorized"
+    end
+
     test "filters sessions by program_id query param", %{conn: conn} = ctx do
       program_a = assigned_program(ctx, title: "Soccer")
       session_on(program_a, Date.utc_today(), :scheduled)


### PR DESCRIPTION
Closes #783.

## Summary

Since #782 a provider can staff one session differently from its program, but every authorization answer was still asked at **program grain**. A staff member covering a single session had no program assignment, so they were filtered out of the session list, blocked from the roster, and refused on every attendance write.

`AttendanceAuthorization.authorize/2` now takes the session. Its staff branch asks `Provider.get_session_staffing/1`, which returns a session's own overrides when it has any and falls back to the program roster when it does not. Provider and admin branches still read `session.program_id` — ownership and the admin flag are program-wide facts.

## Review focus

**This deliberately does not implement #783's Definition of Done as written**, on two points.

**1. The DoD's OR is over-permissive.** It asks to "*also* allow when a session assignment exists". But `unassign_staff_from_session/3` takes someone off a single session by materializing the program roster and dropping them from it, deliberately leaving their `ProgramStaffAssignment` intact (its own test: *"materializes the program roster and removes one, leaving the rest"*). Under an OR they would keep authorizing on the program row — the removal silently undone at the layer meant to enforce it. `SessionStaffing.staffed_by?/2` already resolves overrides-else-program, so it is the complete answer, not a second one to OR in. DoD checkbox 4 passes under both shapes, so the spec could not catch this.

**2. The DoD names only the two LiveViews.** ADR-0017 (#1353) moved the authorization *of record* into `Participation.AttendanceAuthorization`. Changing only the LiveViews would let session-only staff see the roster and have every check-in fail `:unauthorized` — the failure ADR-0017 exists to prevent. Both gates now ask the same predicate.

Also worth a look:
- **Cost.** The staff branch went from 1 query to 4, and one of them re-reads a session Participation already holds (`Assignments.fetch_sessions/1` calls back through `Participation.get_sessions/1`). Accepted on a write path; the sessions list uses the batch `list_session_staffing/1` instead — 4 queries regardless of the day's session count. ADR-0017's fall-through table is amended to say so.
- **`update_session_in_stream/2`** checks the date before the staffing query. `and` short-circuits, and that topic carries every participation message for the provider, so an off-date message never queries.
- **Program titles** now come from the provider rather than the staff member's assignments. Without that, a session let through by an override renders the generic "Session" fallback instead of its name. Titles carry no access, and a title is only ever looked up for a session already in the stream.
- **`maybe_filter_by_program/2`** lost its access-check argument. It narrows an already-authorized list, so the check was redundant; a bogus `program_id` query param now yields an empty list rather than being ignored. No UI control sets this param.

## Test plan

`mix precommit` green — 4685 tests, credo clean, all lints.

New coverage, both directions of the divergence:
- `attendance_authorization_test.exs` — session-only staff authorized; staff removed from a session refused **while still program-assigned**; deactivated override member refused.
- `record_check_in_test.exs` — the end-to-end write. This file previously asserted no unauthorized path at all.
- Both staff LiveView tests — the session appears in the list with its real program title; a removed staff member is redirected; `start_session` on a session they no longer staff is rejected.

Verified against dev data: across 528 (session × staff) pairs on non-overridden sessions, session-grain and program-grain agree **exactly** — so no existing staff member's access changed. On a constructed override, the two diverge in exactly the two intended places: the substitute gains access without a program assignment, and the removed colleague loses it while keeping theirs.

Browser-checked on mobile (390×844) as a session-only staff member: session listed with its program name, roster opens, and a check-out completes.
