### PR TITLE
feat: union session-level staff into messaging entitlement

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -268,15 +268,20 @@ config :klass_hero, :event_consumers, %{
     {StaffAssignmentHandler, :handle_event},
     {ProviderSessionDetails, :project}
   ],
-  # Session-grain overrides. Deliberately NOT routed to StaffAssignmentHandler:
-  # conversation membership is program-scoped, so a one-session substitution does
-  # not change who is in the program's conversation. Extending messaging to
-  # session-level staff is #784.
+  # Session-grain overrides, routed to StaffAssignmentHandler since #784.
+  # Conversation membership is still program-scoped — what changed is that
+  # entitlement to it is the *union* of the two grains, because a session override
+  # admits someone holding no program assignment at all. So a substitute joins the
+  # program's conversations, and leaves them only once no claim of either grain
+  # remains. This registry is also `Outbox.stage/2`'s filter, so these two lines
+  # are the wiring, not a preference.
   "integration:provider:staff_assigned_to_session" => [
-    {ProviderSessionDetails, :project}
+    {ProviderSessionDetails, :project},
+    {StaffAssignmentHandler, :handle_event}
   ],
   "integration:provider:staff_unassigned_from_session" => [
-    {ProviderSessionDetails, :project}
+    {ProviderSessionDetails, :project},
+    {StaffAssignmentHandler, :handle_event}
   ],
   # Deliberately NOT routed to StaffAssignmentHandler: deactivation ends the
   # employment link but leaves assignments standing, so conversation membership

--- a/docs/adr/0017-attendance-writes-authorize-at-the-context-boundary.md
+++ b/docs/adr/0017-attendance-writes-authorize-at-the-context-boundary.md
@@ -80,6 +80,31 @@ session Participation already holds (`Assignments.fetch_sessions/1` calls back t
 its session. Not acceptable per row — which is why the staff sessions list uses the batch
 `list_session_staffing/1`, four queries regardless of how many sessions the day holds.
 
+## Amended by #784: messaging unions the two grains instead
+
+Messaging combines the same two grains with the opposite operator.
+`Provider.list_conversation_staff_user_ids_for_program/1` returns the program roster **plus**
+everyone holding an active override on one of the program's sessions, and Messaging seeds
+conversation participants from that union.
+
+The operator follows the artifact, not a house style. Attendance authorizes a write against **one
+session**, so exactly one roster can be the right answer and a fallback is the honest way to pick
+it — which is the whole argument two sections up. A conversation is **program-scoped**: there is
+no `conversations.session_id`, and there is no per-session thread to be excluded from. Its
+question is "may you talk to this program's parents", and someone running any one of its sessions
+may. Being taken off a single Tuesday is a reason to lose that Tuesday's attendance rights; it is
+not a reason to lose the thread.
+
+The union is also what closes #784 at all. `assign_staff_to_session/1` requires only active
+employment, never a `ProgramStaffAssignment`, so a substitute can hold no program-level row —
+under replacement semantics the program conversation would simply never see them.
+
+The cost is a second removal rule. One retired row no longer settles whether someone leaves, so
+`StaffAssignmentHandler` re-asks the union before evicting anyone, in both directions. Without
+that, unassigning someone from the program would evict them from conversations for a session they
+still run — #784 through the opposite door — and it is the exact mirror of the failure OR-ing
+would have caused here.
+
 ## Derived, not declared
 
 `is_admin` lives on the user and is deliberately absent from `registration_changeset`'s cast

--- a/lib/klass_hero/messaging.ex
+++ b/lib/klass_hero/messaging.ex
@@ -658,19 +658,24 @@ defmodule KlassHero.Messaging do
   defdelegate get_display_name(user_id), to: KlassHero.Accounts
 
   @doc """
-  Returns the user IDs of staff currently active on a program, read from
+  Returns the user IDs entitled to a program's conversations, read from
   Provider (#1321) rather than from a mirror Messaging maintained itself.
 
   Access-granting, and only that: `AddAssignedStaff` seeds these users as
-  participants when a conversation is created. The render path used to share it to
-  decide which senders show branded attribution, which is how deactivating a staff
-  member restyled every message they had ever sent (#1348) — attribution now comes
-  from `messages.sender_role`, so a change here can no longer reach the past.
+  participants when a conversation is created, and `StaffAssignmentHandler` asks
+  the same question again before evicting anyone. The render path used to share it
+  to decide which senders show branded attribution, which is how deactivating a
+  staff member restyled every message they had ever sent (#1348) — attribution now
+  comes from `messages.sender_role`, so a change here can no longer reach the past.
+
+  Named for entitlement rather than for the program roster because since #784 it is
+  wider than one: Provider unions the roster with anyone overriding one of the
+  program's sessions.
   """
-  @spec get_active_staff_user_ids(String.t()) :: [String.t()]
-  defdelegate get_active_staff_user_ids(program_id),
+  @spec get_conversation_staff_user_ids(String.t()) :: [String.t()]
+  defdelegate get_conversation_staff_user_ids(program_id),
     to: ProviderStaffResolver,
-    as: :list_active_staff_user_ids
+    as: :list_conversation_staff_user_ids
 
   @doc """
   User IDs of everyone who has ever been staff at the provider.

--- a/lib/klass_hero/messaging/adapters/driven/provider/provider_staff_resolver.ex
+++ b/lib/klass_hero/messaging/adapters/driven/provider/provider_staff_resolver.ex
@@ -15,16 +15,21 @@ defmodule KlassHero.Messaging.Adapters.Driven.Provider.ProviderStaffResolver do
   end
 
   @doc """
-  User IDs of the staff currently active on a program.
+  User IDs of the staff entitled to a program's conversations.
 
   Messaging mirrored this in `program_staff_participants` until #1321. The mirror
   had no projection, bootstrap or rebuild, so only an event could correct it —
   and three bugs (#1309, #1312, #1320) were drift between it and this source.
+
+  Provider unions the two staffing grains here — the program roster plus anyone
+  overriding one of its sessions (#784) — rather than resolving between them as
+  `get_session_staffing/1` does for attendance. A conversation spans every session,
+  so it takes the wider set; ADR-0017 has the full reasoning.
   """
-  @spec list_active_staff_user_ids(String.t()) :: [String.t()]
-  def list_active_staff_user_ids(program_id) do
+  @spec list_conversation_staff_user_ids(String.t()) :: [String.t()]
+  def list_conversation_staff_user_ids(program_id) do
     acl_span source: "messaging", target: "provider" do
-      KlassHero.Provider.list_active_staff_user_ids_for_program(program_id)
+      KlassHero.Provider.list_conversation_staff_user_ids_for_program(program_id)
     end
   end
 
@@ -34,7 +39,7 @@ defmodule KlassHero.Messaging.Adapters.Driven.Provider.ProviderStaffResolver do
   Only the render path wants this, and only for messages written before
   `messages.sender_role` existed (#1348). Employment *ever* is the closest available
   approximation of who was provider-side at send time; employment *now* — which is
-  what `list_active_staff_user_ids/1` answers — is the question that rewrote history.
+  what `list_conversation_staff_user_ids/1` answers — is the question that rewrote history.
   """
   @spec list_staff_user_ids(String.t()) :: [String.t()]
   def list_staff_user_ids(provider_id) do

--- a/lib/klass_hero/messaging/adapters/driving/events/staff_assignment_handler.ex
+++ b/lib/klass_hero/messaging/adapters/driving/events/staff_assignment_handler.ex
@@ -1,6 +1,7 @@
 defmodule KlassHero.Messaging.Adapters.Driving.Events.StaffAssignmentHandler do
   @moduledoc """
-  Handles Provider integration events for staff-program assignment changes.
+  Handles Provider integration events for staff assignment changes, at both the
+  program and the session grain.
 
   On assignment, adds the staff user as a participant to every active program
   conversation where they are not already an active participant. The participant
@@ -11,6 +12,21 @@ defmodule KlassHero.Messaging.Adapters.Driving.Events.StaffAssignmentHandler do
   On unassignment, delegates to `RemoveAssignedStaff` to soft-leave the staff in
   every active program conversation; the returned `:participant_removed` events
   are dispatched after the wrapping transaction commits.
+
+  ## Both grains, one pair of paths (#784)
+
+  A conversation is program-scoped, so entitlement to one is the **union** of the
+  two staffing grains: on the program's roster, or overriding any one of its
+  sessions. `Provider.list_conversation_staff_user_ids_for_program/1` is that
+  union, and it is the only rule here — this module never re-derives it.
+
+  Session events therefore need no paths of their own. Their payload is a superset
+  of the program-level one, carrying the `program_id` the producer verified
+  ownership against, so both grains land on the same add and remove functions.
+
+  What the second grain does change is that a single retired row no longer settles
+  removal, which is what the guard in `remove_staff_from_existing_conversations/2`
+  is for.
 
   ## Why this handler survived #1321
 
@@ -40,15 +56,24 @@ defmodule KlassHero.Messaging.Adapters.Driving.Events.StaffAssignmentHandler do
 
   @context Messaging
 
-  @impl true
-  def subscribed_events, do: [:staff_assigned_to_program, :staff_unassigned_from_program]
+  # Program and session grain land on the same two paths: the session payload is a
+  # superset of the program one (`ProviderEvents.session_assignment_event/4`), so
+  # nothing downstream has to know which grain produced the event. Derived lists
+  # rather than four literals, so `subscribed_events/0` and the guard below cannot
+  # drift apart — an event subscribed to but not guarded falls through to `:ignore`
+  # and is silently dropped.
+  @assignment_events [:staff_assigned_to_program, :staff_assigned_to_session]
+  @unassignment_events [:staff_unassigned_from_program, :staff_unassigned_from_session]
+  @handled_events @assignment_events ++ @unassignment_events
 
-  # One guard for both directions, deliberately: when each clause carried its own,
-  # only the assign side ever got one, and the unassign side compared a column
-  # against nil for as long as nothing could reach it (#1309).
   @impl true
-  def handle_event(%{event_type: event_type, payload: payload})
-      when event_type in [:staff_assigned_to_program, :staff_unassigned_from_program] do
+  def subscribed_events, do: @handled_events
+
+  # One guard for every direction and grain, deliberately: when each clause carried
+  # its own, only the assign side ever got one, and the unassign side compared a
+  # column against nil for as long as nothing could reach it (#1309).
+  @impl true
+  def handle_event(%{event_type: event_type, payload: payload}) when event_type in @handled_events do
     if is_nil(Map.get(payload, :staff_user_id)) do
       Logger.debug("Skipping #{event_type} — staff member has no user_id yet",
         staff_member_id: payload.staff_member_id
@@ -62,8 +87,13 @@ defmodule KlassHero.Messaging.Adapters.Driving.Events.StaffAssignmentHandler do
 
   def handle_event(_event), do: :ignore
 
-  defp with_retry(:staff_assigned_to_program, payload), do: handle_assignment_with_retry(payload)
-  defp with_retry(:staff_unassigned_from_program, payload), do: handle_unassignment_with_retry(payload)
+  defp with_retry(event_type, payload) when event_type in @assignment_events do
+    handle_assignment_with_retry(payload)
+  end
+
+  defp with_retry(event_type, payload) when event_type in @unassignment_events do
+    handle_unassignment_with_retry(payload)
+  end
 
   defp handle_assignment_with_retry(payload) do
     operation = fn ->
@@ -122,7 +152,31 @@ defmodule KlassHero.Messaging.Adapters.Driving.Events.StaffAssignmentHandler do
   end
 
   # Symmetric to add: RemoveAssignedStaff returns events as data.
+  #
+  # Guarded because entitlement is a union of two grains (#784), so retiring one
+  # row does not settle the question. Without this, unassigning someone from the
+  # *program* would evict them from conversations for a session they still run —
+  # #784 reintroduced through the opposite door — and retiring one session override
+  # would evict a member of the program roster.
+  #
+  # Safe to state as a plain re-read: delivery is post-commit, so the row this
+  # event describes is already gone when the question is asked. The policy lives
+  # here rather than in `RemoveAssignedStaff`, whose contract is the mechanical
+  # "remove this user from every active conversation of this program".
   defp remove_staff_from_existing_conversations(program_id, staff_user_id) do
+    if staff_user_id in Messaging.get_conversation_staff_user_ids(program_id) do
+      Logger.debug("Keeping conversation membership — another staffing claim remains",
+        program_id: program_id,
+        user_id: staff_user_id
+      )
+
+      :ok
+    else
+      leave_all_conversations(program_id, staff_user_id)
+    end
+  end
+
+  defp leave_all_conversations(program_id, staff_user_id) do
     Outbox.transact(@context, fn ->
       with {:ok, {_removals, events}} <- RemoveAssignedStaff.execute(program_id, staff_user_id) do
         {:ok, :ok, events}

--- a/lib/klass_hero/messaging/add_assigned_staff.ex
+++ b/lib/klass_hero/messaging/add_assigned_staff.ex
@@ -31,7 +31,7 @@ defmodule KlassHero.Messaging.AddAssignedStaff do
 
   def execute(conversation_id, program_id, excluded_user_id) do
     program_id
-    |> ProviderStaffResolver.list_active_staff_user_ids()
+    |> ProviderStaffResolver.list_conversation_staff_user_ids()
     |> Enum.reject(&(&1 == excluded_user_id))
     |> add(conversation_id)
   end

--- a/lib/klass_hero/provider.ex
+++ b/lib/klass_hero/provider.ex
@@ -320,6 +320,13 @@ defmodule KlassHero.Provider do
   @doc "Lists the user IDs of claimed, active staff assigned to a program."
   defdelegate list_active_staff_user_ids_for_program(program_id), to: Assignments
 
+  @doc """
+  Lists the user IDs entitled to a program's conversations: its roster **plus**
+  anyone overriding one of its sessions (#784). A union, not `get_session_staffing/1`'s
+  replacement — see that function's docs for which question takes which grain.
+  """
+  defdelegate list_conversation_staff_user_ids_for_program(program_id), to: Assignments
+
   @doc "Lists the provider's active staff who are not currently assigned to the program."
   defdelegate list_assignable_staff_for_program(provider_id, program_id), to: Assignments
 

--- a/lib/klass_hero/provider/assignments.ex
+++ b/lib/klass_hero/provider/assignments.ex
@@ -489,6 +489,54 @@ defmodule KlassHero.Provider.Assignments do
     |> Repo.all()
   end
 
+  @doc """
+  Lists the *user* IDs of staff who may take part in a program's conversations.
+
+  The program roster **plus** anyone holding an active override on one of the
+  program's sessions. Wider than `list_active_staff_user_ids_for_program/1` on
+  purpose: `assign_staff_to_session/1` requires only active employment, so a
+  substitute covering one Tuesday can hold no `ProgramStaffAssignment` at all and
+  was cut off from parent messaging for a session they were running (#784).
+
+  A **union**, not the replacement `get_session_staffing/1` performs, and the
+  difference is the question being asked. Attendance asks "may you write *this
+  session's* records", so the session's own roster must win — see ADR-0017. A
+  conversation is program-scoped and spans every session, so being taken off one
+  Tuesday is no reason to lose the thread.
+  """
+  @spec list_conversation_staff_user_ids_for_program(String.t()) :: [String.t()]
+  def list_conversation_staff_user_ids_for_program(program_id) when is_binary(program_id) do
+    Enum.uniq(
+      list_active_staff_user_ids_for_program(program_id) ++
+        session_override_staff_user_ids(program_id)
+    )
+  end
+
+  # One query rather than "fetch the program's sessions, then their overrides":
+  # the session ids are never wanted for themselves, and a term program holds
+  # hundreds. Sessions belong to Participation, so the table is named directly
+  # inside an `acl_span` (ADR-0015) — the same shape `ParticipationSessionStatsACL`
+  # uses, and what `mix lint_acl_boundary` requires of it.
+  #
+  # Inner join on the staff member, unlike `session_overrides_by_session/1`'s LEFT:
+  # that one keeps the override row alive when its member is deactivated so the
+  # session does not snap back to the program roster. This one only collects user
+  # ids, and a deactivated member contributes none.
+  defp session_override_staff_user_ids(program_id) do
+    acl_span source: "provider", target: "participation" do
+      from(a in SessionStaffAssignment,
+        join: sess in "program_sessions",
+        on: sess.id == a.session_id,
+        join: s in StaffMember,
+        on: s.id == a.staff_member_id,
+        where: sess.program_id == type(^program_id, :binary_id),
+        where: is_nil(a.unassigned_at) and s.active == true and not is_nil(s.user_id),
+        select: s.user_id
+      )
+      |> Repo.all()
+    end
+  end
+
   # "Currently staffing a program" — no `unassigned_at`, and the person still
   # employed — in one place, because three reads need exactly this and had each
   # spelled it out. Callers add their own program filter and `select:`; the

--- a/test/klass_hero/messaging/adapters/driving/events/staff_assignment_handler_test.exs
+++ b/test/klass_hero/messaging/adapters/driving/events/staff_assignment_handler_test.exs
@@ -7,6 +7,7 @@ defmodule KlassHero.Messaging.Adapters.Driving.Events.StaffAssignmentHandlerTest
   alias KlassHero.Messaging.Adapters.Driving.Events.StaffAssignmentHandler
   alias KlassHero.Provider.Domain.Events.ProviderEvents
   alias KlassHero.Provider.ProgramStaffAssignment
+  alias KlassHero.Provider.SessionStaffAssignment
   alias KlassHero.Provider.StaffMember
 
   setup do
@@ -165,6 +166,120 @@ defmodule KlassHero.Messaging.Adapters.Driving.Events.StaffAssignmentHandlerTest
     end
   end
 
+  # #784. The session payload is a superset of the program one, so these exercise
+  # the same add/remove paths through a wider `subscribed_events/0`.
+  describe "handle_event/1 - staff_assigned_to_session" do
+    test "skips when staff_user_id is nil" do
+      event = build_session_assignment_event(Ecto.UUID.generate(), Ecto.UUID.generate(), nil)
+      assert :ok = StaffAssignmentHandler.handle_event(event)
+    end
+
+    test "back-fills a session-only substitute into the program's active conversations" do
+      %{provider: provider, program: program} = program_with_conversation()
+      conversation = program.conversation
+      substitute = KlassHero.AccountsFixtures.user_fixture()
+
+      event = build_session_assignment_event(provider.id, program.id, substitute.id)
+      assert :ok = StaffAssignmentHandler.handle_event(event)
+
+      assert KlassHero.Messaging.participant?(conversation.id, substitute.id)
+
+      assert [participant_added] =
+               Enum.filter(get_published_integration_events(), &(&1.event_type == :participant_added))
+
+      assert participant_added.entity_id == conversation.id
+      assert participant_added.payload.participant_user_ids == [substitute.id]
+      assert participant_added.payload.source == :later_assignment
+    end
+  end
+
+  describe "handle_event/1 - the keep-guard" do
+    test "staff_unassigned_from_session evicts when no claim on the program remains" do
+      %{provider: provider, program: program} = program_with_conversation()
+      conversation = program.conversation
+      staff_user = KlassHero.AccountsFixtures.user_fixture()
+      insert(:participant_schema, conversation_id: conversation.id, user_id: staff_user.id)
+
+      event = build_session_unassignment_event(provider.id, program.id, staff_user.id)
+      assert :ok = StaffAssignmentHandler.handle_event(event)
+
+      refute KlassHero.Messaging.participant?(conversation.id, staff_user.id)
+    end
+
+    test "staff_unassigned_from_session keeps someone still on the program roster" do
+      %{provider: provider, program: program} = program_with_conversation()
+      conversation = program.conversation
+      staff = claimed_staff_on_program(provider.id, program.id)
+      insert(:participant_schema, conversation_id: conversation.id, user_id: staff.user_id)
+
+      event = build_session_unassignment_event(provider.id, program.id, staff.user_id)
+      assert :ok = StaffAssignmentHandler.handle_event(event)
+
+      assert KlassHero.Messaging.participant?(conversation.id, staff.user_id)
+    end
+
+    # The mirror of #784: without the guard, taking someone off the *program*
+    # would evict them from conversations for a session they still run.
+    test "staff_unassigned_from_program keeps someone who still overrides a session" do
+      %{provider: provider, program: program} = program_with_conversation()
+      conversation = program.conversation
+      staff = claimed_staff_overriding_session(provider.id, program.id)
+      insert(:participant_schema, conversation_id: conversation.id, user_id: staff.user_id)
+
+      event = build_unassignment_event(provider.id, program.id, staff.user_id)
+      assert :ok = StaffAssignmentHandler.handle_event(event)
+
+      assert KlassHero.Messaging.participant?(conversation.id, staff.user_id)
+    end
+  end
+
+  defp program_with_conversation do
+    provider = insert(:provider_profile_schema)
+    program = insert(:program_schema, provider_id: provider.id)
+    parent_user = KlassHero.AccountsFixtures.user_fixture()
+
+    conversation =
+      insert(:conversation_schema, provider_id: provider.id, type: "direct", program_id: program.id)
+
+    insert(:participant_schema, conversation_id: conversation.id, user_id: parent_user.id)
+
+    %{provider: provider, program: Map.put(program, :conversation, conversation)}
+  end
+
+  defp claimed_staff(provider_id) do
+    insert(:staff_member_schema,
+      provider_id: provider_id,
+      user_id: KlassHero.AccountsFixtures.user_fixture().id,
+      invitation_status: :accepted
+    )
+  end
+
+  defp claimed_staff_on_program(provider_id, program_id) do
+    staff = claimed_staff(provider_id)
+
+    {:ok, _} =
+      KlassHero.Provider.assign_staff_to_program(%{
+        provider_id: provider_id,
+        program_id: program_id,
+        staff_member_id: staff.id
+      })
+
+    staff
+  end
+
+  defp claimed_staff_overriding_session(provider_id, program_id) do
+    staff = claimed_staff(provider_id)
+    session = insert(:program_session_schema, program_id: program_id)
+
+    insert(:session_staff_assignment_schema,
+      provider_id: provider_id,
+      session_id: session.id,
+      staff_member_id: staff.id
+    )
+
+    staff
+  end
+
   # Built through the real producer constructors, not hand-rolled maps. The
   # hand-rolled ones carried `assigned_at`/`unassigned_at`, which production
   # payloads deliberately omit (provider_events.ex) — so the tests asserted
@@ -183,10 +298,37 @@ defmodule KlassHero.Messaging.Adapters.Driving.Events.StaffAssignmentHandlerTest
     )
   end
 
+  defp build_session_assignment_event(provider_id, program_id, staff_user_id) do
+    ProviderEvents.staff_assigned_to_session(
+      session_assignment(provider_id),
+      %StaffMember{user_id: staff_user_id},
+      program_id
+    )
+  end
+
+  defp build_session_unassignment_event(provider_id, program_id, staff_user_id) do
+    ProviderEvents.staff_unassigned_from_session(
+      session_assignment(provider_id),
+      %StaffMember{user_id: staff_user_id},
+      program_id
+    )
+  end
+
   defp assignment(provider_id, program_id) do
     %ProgramStaffAssignment{
       provider_id: provider_id,
       program_id: program_id,
+      staff_member_id: Ecto.UUID.generate()
+    }
+  end
+
+  # A session override carries no program_id of its own — the producer passes it
+  # separately (provider_events.ex), which is why these constructors take three
+  # arguments where the program-level pair takes two.
+  defp session_assignment(provider_id) do
+    %SessionStaffAssignment{
+      provider_id: provider_id,
+      session_id: Ecto.UUID.generate(),
       staff_member_id: Ecto.UUID.generate()
     }
   end

--- a/test/klass_hero/messaging/add_assigned_staff_test.exs
+++ b/test/klass_hero/messaging/add_assigned_staff_test.exs
@@ -134,6 +134,49 @@ defmodule KlassHero.Messaging.AddAssignedStaffTest do
       assert {:ok, {[], []}} = AddAssignedStaff.execute(conversation_id, nil, owner.id)
     end
 
+    # #784: `assign_staff_to_session/1` requires only active employment, so a
+    # substitute covering one session can hold no `ProgramStaffAssignment` at all.
+    # Seeding from the program roster alone cut them off from parent messaging for
+    # a session they were running.
+    test "seeds a staff member who only overrides one of the program's sessions" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+      session = insert(:program_session_schema, program_id: program.id)
+      owner = AccountsFixtures.user_fixture()
+      substitute = AccountsFixtures.user_fixture()
+
+      staff_member =
+        insert(:staff_member_schema,
+          provider_id: provider.id,
+          user_id: substitute.id,
+          invitation_status: :accepted
+        )
+
+      insert(:session_staff_assignment_schema,
+        provider_id: provider.id,
+        session_id: session.id,
+        staff_member_id: staff_member.id
+      )
+
+      conversation_id = Ecto.UUID.generate()
+
+      Repo.insert!(%Conversation{
+        id: conversation_id,
+        type: :direct,
+        provider_id: provider.id,
+        program_id: program.id
+      })
+
+      assert {:ok, {:ok, {added_ids, [event]}}} =
+               Repo.transaction(fn ->
+                 AddAssignedStaff.execute(conversation_id, program.id, owner.id)
+               end)
+
+      assert added_ids == [substitute.id]
+      assert KlassHero.Messaging.participant?(conversation_id, substitute.id)
+      assert event.payload.participant_user_ids == [substitute.id]
+    end
+
     test "owner is the only staff member — returns {:ok, {[], []}}" do
       provider = insert(:provider_profile_schema)
       program = insert(:program_schema, provider_id: provider.id)

--- a/test/klass_hero/messaging/staff_messaging_integration_test.exs
+++ b/test/klass_hero/messaging/staff_messaging_integration_test.exs
@@ -64,7 +64,7 @@ defmodule KlassHero.Messaging.StaffMessagingIntegrationTest do
       # 2. Messaging now sees the staff member — derived from Provider (#1321),
       #    so this is true the moment the assignment commits, with no dependence
       #    on the handler above having run.
-      staff_ids = Messaging.get_active_staff_user_ids(ctx.program.id)
+      staff_ids = Messaging.get_conversation_staff_user_ids(ctx.program.id)
       assert ctx.staff_user.id in staff_ids
 
       # 3. Create a conversation — staff should be auto-added (new conversations
@@ -105,7 +105,7 @@ defmodule KlassHero.Messaging.StaffMessagingIntegrationTest do
       refute KlassHero.Messaging.participant?(conversation.id, ctx.staff_user.id)
 
       # 7. And Messaging no longer counts them as staff on the program
-      assert [] = Messaging.get_active_staff_user_ids(ctx.program.id)
+      assert [] = Messaging.get_conversation_staff_user_ids(ctx.program.id)
     end
   end
 

--- a/test/klass_hero/provider/assignments/list_conversation_staff_user_ids_for_program_test.exs
+++ b/test/klass_hero/provider/assignments/list_conversation_staff_user_ids_for_program_test.exs
@@ -1,0 +1,140 @@
+defmodule KlassHero.Provider.Assignments.ListConversationStaffUserIdsForProgramTest do
+  @moduledoc """
+  Who may participate in a program's *conversations* (#784).
+
+  Deliberately wider than `list_active_staff_user_ids_for_program/1`: a session
+  override admits someone who holds no program assignment at all
+  (`assign_staff_to_session/1` requires only active employment), and messaging is
+  program-scoped, so running any one session earns the whole program's thread.
+
+  The union is *not* the resolution `get_session_staffing/1` performs. That one
+  replaces the program roster with a session's overrides, because attendance asks
+  about one session. This one adds to it, because a conversation spans them all.
+  """
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+
+  alias KlassHero.AccountsFixtures
+  alias KlassHero.Provider
+  alias KlassHero.Provider.SessionStaffAssignment
+  alias KlassHero.Repo
+
+  # One fixture carrying every rule at once, so a regression in any single rule
+  # shows as a diff on one id set rather than passing quietly elsewhere.
+  setup do
+    provider = insert(:provider_profile_schema)
+    program = insert(:program_schema, provider_id: provider.id)
+    session = insert(:program_session_schema, program_id: program.id)
+
+    on_program = claimed_staff(provider.id)
+    on_session = claimed_staff(provider.id)
+    on_both = claimed_staff(provider.id)
+    released_from_session = claimed_staff(provider.id)
+    deactivated = claimed_staff(provider.id)
+    unclaimed = insert(:staff_member_schema, provider_id: provider.id, user_id: nil)
+
+    other_program = insert(:program_schema, provider_id: provider.id)
+    other_session = insert(:program_session_schema, program_id: other_program.id)
+    elsewhere = claimed_staff(provider.id)
+
+    assign_to_program!(provider.id, program.id, on_program.id)
+    assign_to_program!(provider.id, program.id, on_both.id)
+
+    for staff <- [on_session, on_both, deactivated, unclaimed] do
+      override!(provider.id, session.id, staff.id)
+    end
+
+    override!(provider.id, other_session.id, elsewhere.id)
+
+    provider.id
+    |> override!(session.id, released_from_session.id)
+    |> SessionStaffAssignment.unassign_changeset()
+    |> Repo.update!()
+
+    {:ok, deactivated} = Provider.deactivate_staff_member(deactivated)
+
+    %{
+      provider: provider,
+      program: program,
+      on_program: on_program,
+      on_session: on_session,
+      on_both: on_both,
+      released_from_session: released_from_session,
+      deactivated: deactivated,
+      unclaimed: unclaimed,
+      elsewhere: elsewhere
+    }
+  end
+
+  describe "list_conversation_staff_user_ids_for_program/1" do
+    test "includes staff assigned to the program", ctx do
+      assert MapSet.member?(user_ids(ctx), ctx.on_program.user_id)
+    end
+
+    test "includes staff who only override one of the program's sessions", ctx do
+      assert MapSet.member?(user_ids(ctx), ctx.on_session.user_id)
+    end
+
+    test "returns someone holding both claims exactly once", ctx do
+      ids = Provider.list_conversation_staff_user_ids_for_program(ctx.program.id)
+
+      assert Enum.count(ids, &(&1 == ctx.on_both.user_id)) == 1
+    end
+
+    for {label, key} <- [
+          {"an override that was retired", :released_from_session},
+          {"a deactivated staff member", :deactivated},
+          {"unclaimed staff, who have no user id (#1309)", :unclaimed},
+          {"an override on another program's session", :elsewhere}
+        ] do
+      test "excludes #{label}", ctx do
+        excluded = ctx[unquote(key)]
+
+        refute MapSet.member?(user_ids(ctx), excluded.user_id),
+               "expected #{unquote(label)} (user_id #{inspect(excluded.user_id)}) to be excluded"
+      end
+    end
+
+    test "returns an empty list for a program nobody staffs at either grain", ctx do
+      unstaffed = insert(:program_schema, provider_id: ctx.provider.id)
+
+      assert Provider.list_conversation_staff_user_ids_for_program(unstaffed.id) == []
+    end
+  end
+
+  defp user_ids(ctx) do
+    ctx.program.id
+    |> Provider.list_conversation_staff_user_ids_for_program()
+    |> MapSet.new()
+  end
+
+  defp claimed_staff(provider_id) do
+    insert(:staff_member_schema,
+      provider_id: provider_id,
+      user_id: AccountsFixtures.user_fixture().id,
+      invitation_status: :accepted
+    )
+  end
+
+  defp assign_to_program!(provider_id, program_id, staff_member_id) do
+    {:ok, assignment} =
+      Provider.assign_staff_to_program(%{
+        provider_id: provider_id,
+        program_id: program_id,
+        staff_member_id: staff_member_id
+      })
+
+    assignment
+  end
+
+  # Inserted rather than driven through `assign_staff_to_session/1`: that command
+  # has its own test, and this one is about the read.
+  defp override!(provider_id, session_id, staff_member_id) do
+    insert(:session_staff_assignment_schema,
+      provider_id: provider_id,
+      session_id: session_id,
+      staff_member_id: staff_member_id
+    )
+  end
+end

--- a/test/klass_hero/provider/staff_invite_accept_messaging_test.exs
+++ b/test/klass_hero/provider/staff_invite_accept_messaging_test.exs
@@ -75,7 +75,7 @@ defmodule KlassHero.Provider.StaffInviteAcceptMessagingTest do
 
         # Derived, so already true: no event has been consumed yet — the job is
         # staged, not run — and Messaging nonetheless counts them as staff.
-        assert Messaging.get_active_staff_user_ids(program.id) == [user.id]
+        assert Messaging.get_conversation_staff_user_ids(program.id) == [user.id]
 
         # The participant row is the half that still needs the replay to land.
         refute participant?(conversation.id, user.id)

--- a/test/klass_hero/provider/staff_offboarding_cascade_test.exs
+++ b/test/klass_hero/provider/staff_offboarding_cascade_test.exs
@@ -53,7 +53,7 @@ defmodule KlassHero.Provider.StaffOffboardingCascadeTest do
         # Precondition: assignment put them in the conversation, and Messaging
         # counts them as staff on the program.
         assert Messaging.participant?(conversation.id, staff_user.id)
-        assert staff_user.id in Messaging.get_active_staff_user_ids(program.id)
+        assert staff_user.id in Messaging.get_conversation_staff_user_ids(program.id)
 
         {:ok, %{unassigned_count: 1}} = Provider.offboard_staff_member(staff)
 
@@ -61,7 +61,7 @@ defmodule KlassHero.Provider.StaffOffboardingCascadeTest do
         # "Counts as staff" is derived, so it flips with the write itself;
         # the participant row is event-maintained, so it survives until the
         # staged unassignment is consumed.
-        refute staff_user.id in Messaging.get_active_staff_user_ids(program.id)
+        refute staff_user.id in Messaging.get_conversation_staff_user_ids(program.id)
         assert Messaging.participant?(conversation.id, staff_user.id)
 
         drain()

--- a/test/klass_hero_web/live/staff/messages_live/staff_inbox_visibility_test.exs
+++ b/test/klass_hero_web/live/staff/messages_live/staff_inbox_visibility_test.exs
@@ -22,8 +22,10 @@ defmodule KlassHeroWeb.Staff.MessagesLive.StaffInboxVisibilityTest do
   alias KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries
   alias KlassHero.Messaging.Adapters.Driving.Events.StaffAssignmentHandler
   alias KlassHero.Messaging.CreateDirectConversation
+  alias KlassHero.Provider
+  alias KlassHero.Provider.Domain.Events.ProviderEvents
   alias KlassHero.Provider.ProviderProfile
-  alias KlassHero.Shared.Domain.Events.Event
+  alias KlassHero.Provider.StaffMember
 
   @projection_name :inbox_e2e_projection
 
@@ -51,6 +53,24 @@ defmodule KlassHeroWeb.Staff.MessagesLive.StaffInboxVisibilityTest do
 
     clear_integration_events()
     :ok
+  end
+
+  # Retires the real assignment row *before* delivering the event, and builds the
+  # event through the producer's own constructor.
+  #
+  # Both mattered as of #784. Entitlement to a program's conversations is now the
+  # union of the program roster and any session override, and the handler re-reads
+  # it before evicting anyone — so an event fired over a row that still stands is
+  # correctly ignored. The hand-rolled payloads this replaced also carried an
+  # `unassigned_at`/`assigned_at` that `ProviderEvents` deliberately omits, which is
+  # the payload drift #1309 was about.
+  defp unassign_and_deliver(provider, program, assignment, staff_user) do
+    {:ok, retired} =
+      Provider.unassign_staff_from_program(program.id, assignment.staff_member_id, provider.id)
+
+    StaffAssignmentHandler.handle_event(
+      ProviderEvents.staff_unassigned_from_program(retired, %StaffMember{user_id: staff_user.id})
+    )
   end
 
   describe "staff inbox visibility" do
@@ -137,23 +157,17 @@ defmodule KlassHeroWeb.Staff.MessagesLive.StaffInboxVisibilityTest do
         invitation_status: :accepted
       })
 
-      assignment_event = %Event{
-        event_id: Ecto.UUID.generate(),
-        event_type: :staff_assigned_to_program,
-        source_context: :provider,
-        entity_type: :staff_member,
-        entity_id: Ecto.UUID.generate(),
-        occurred_at: DateTime.utc_now(),
-        payload: %{
+      assignment =
+        assign_active_staff(%{
           provider_id: provider.id,
           program_id: program.id,
-          staff_member_id: Ecto.UUID.generate(),
-          staff_user_id: staff_user.id,
-          assigned_at: DateTime.utc_now()
-        }
-      }
+          staff_user_id: staff_user.id
+        })
 
-      assert :ok = StaffAssignmentHandler.handle_event(assignment_event)
+      assert :ok =
+               StaffAssignmentHandler.handle_event(
+                 ProviderEvents.staff_assigned_to_program(assignment, %StaffMember{user_id: staff_user.id})
+               )
 
       flush_to_projection()
 
@@ -180,11 +194,12 @@ defmodule KlassHeroWeb.Staff.MessagesLive.StaffInboxVisibilityTest do
         invitation_status: :accepted
       })
 
-      assign_active_staff(%{
-        provider_id: provider.id,
-        program_id: program.id,
-        staff_user_id: staff_user.id
-      })
+      assignment =
+        assign_active_staff(%{
+          provider_id: provider.id,
+          program_id: program.id,
+          staff_user_id: staff_user.id
+        })
 
       scope = %Scope{
         user: provider_owner,
@@ -202,24 +217,7 @@ defmodule KlassHeroWeb.Staff.MessagesLive.StaffInboxVisibilityTest do
 
       flush_to_projection()
 
-      # Now unassign the staff
-      unassignment_event = %Event{
-        event_id: Ecto.UUID.generate(),
-        event_type: :staff_unassigned_from_program,
-        source_context: :provider,
-        entity_type: :staff_member,
-        entity_id: Ecto.UUID.generate(),
-        occurred_at: DateTime.utc_now(),
-        payload: %{
-          provider_id: provider.id,
-          program_id: program.id,
-          staff_member_id: Ecto.UUID.generate(),
-          staff_user_id: staff_user.id,
-          unassigned_at: DateTime.utc_now()
-        }
-      }
-
-      assert :ok = StaffAssignmentHandler.handle_event(unassignment_event)
+      assert :ok = unassign_and_deliver(provider, program, assignment, staff_user)
 
       flush_to_projection()
 
@@ -246,11 +244,12 @@ defmodule KlassHeroWeb.Staff.MessagesLive.StaffInboxVisibilityTest do
         invitation_status: :accepted
       })
 
-      assign_active_staff(%{
-        provider_id: provider.id,
-        program_id: program.id,
-        staff_user_id: staff_user.id
-      })
+      assignment =
+        assign_active_staff(%{
+          provider_id: provider.id,
+          program_id: program.id,
+          staff_user_id: staff_user.id
+        })
 
       scope = %Scope{
         user: provider_owner,
@@ -276,23 +275,7 @@ defmodule KlassHeroWeb.Staff.MessagesLive.StaffInboxVisibilityTest do
              "ACT 1: staff should see the conversation after initial create"
 
       # ACT 2 — unassign staff; conversation disappears from inbox
-      unassignment_event = %Event{
-        event_id: Ecto.UUID.generate(),
-        event_type: :staff_unassigned_from_program,
-        source_context: :provider,
-        entity_type: :staff_member,
-        entity_id: Ecto.UUID.generate(),
-        occurred_at: DateTime.utc_now(),
-        payload: %{
-          provider_id: provider.id,
-          program_id: program.id,
-          staff_member_id: Ecto.UUID.generate(),
-          staff_user_id: staff_user.id,
-          unassigned_at: DateTime.utc_now()
-        }
-      }
-
-      assert :ok = StaffAssignmentHandler.handle_event(unassignment_event)
+      assert :ok = unassign_and_deliver(provider, program, assignment, staff_user)
       flush_to_projection()
 
       {:ok, view, _html} = live(log_in_user(conn, staff_user), ~p"/staff/messages")
@@ -301,23 +284,18 @@ defmodule KlassHeroWeb.Staff.MessagesLive.StaffInboxVisibilityTest do
              "ACT 2: staff should NOT see the conversation after unassignment"
 
       # ACT 3 — re-assign the SAME staff; conversation must re-appear
-      reassignment_event = %Event{
-        event_id: Ecto.UUID.generate(),
-        event_type: :staff_assigned_to_program,
-        source_context: :provider,
-        entity_type: :staff_member,
-        entity_id: Ecto.UUID.generate(),
-        occurred_at: DateTime.utc_now(),
-        payload: %{
+      reassignment =
+        assign_active_staff(%{
           provider_id: provider.id,
           program_id: program.id,
-          staff_member_id: Ecto.UUID.generate(),
-          staff_user_id: staff_user.id,
-          assigned_at: DateTime.utc_now()
-        }
-      }
+          staff_user_id: staff_user.id
+        })
 
-      assert :ok = StaffAssignmentHandler.handle_event(reassignment_event)
+      assert :ok =
+               StaffAssignmentHandler.handle_event(
+                 ProviderEvents.staff_assigned_to_program(reassignment, %StaffMember{user_id: staff_user.id})
+               )
+
       flush_to_projection()
 
       {:ok, view, _html} = live(log_in_user(conn, staff_user), ~p"/staff/messages")


### PR DESCRIPTION
## Summary

`AddAssignedStaff` seeded conversation participants from program-level assignments only. Since
#1413, `Provider.assign_staff_to_session/1` requires just active employment — never a
`ProgramStaffAssignment` — so a substitute covering one session could hold no program-level row
at all and was cut off from parent messaging for a session they were running.

Adds `Provider.list_conversation_staff_user_ids_for_program/1`: the program roster **plus**
anyone holding an active override on one of the program's sessions. Messaging reads that, and the
two session-grain topics #1413 deliberately left unrouted now reach `StaffAssignmentHandler`.

Closes #784. The issue body was rewritten first — its original DoD, code references, and
"new port method" note all predate the flatten (#986–#1002), #1321, and #1419.

## Review focus

**1. Union, not replacement — and why that is not a contradiction of ADR-0017.**
ADR-0017 rejects OR-ing a session check onto a program check for *attendance*, because
`unassign_staff_from_session/3` drops someone from a materialized roster while their
`ProgramStaffAssignment` deliberately survives. That reasoning is grain-specific: attendance
authorizes one session, so exactly one roster can be right. A conversation is program-scoped and
has no `session_id` at all, so anyone running any session of the program is entitled to its
thread. ADR-0017 gains a section stating the asymmetry, because otherwise it reads as someone
forgetting the ADR.

**2. The keep-guard is the load-bearing part.**
Entitlement now has two sources, so one retired row no longer settles removal.
`remove_staff_from_existing_conversations/2` re-asks the union before evicting. Without it,
unassigning someone from the *program* would evict them from conversations for a session they
still run — this bug through the opposite door. Safe as a plain re-read because delivery is
post-commit, so the retired row is already gone when the guard runs.

**3. Session events need no new paths.**
The session payload is a superset of the program-level one
(`ProviderEvents.session_assignment_event/4` adds `session_id` to the same four keys), so both
grains land on the same add/remove functions. `subscribed_events/0` and the `handle_event/1`
guard are derived from shared module attributes so they cannot drift — a topic subscribed but not
guarded would fall through to `:ignore` and be dropped silently.

**4. The cross-context read.**
`session_override_staff_user_ids/1` joins `in "program_sessions"` by raw table name inside an
`acl_span source: "provider", target: "participation"` — sessions belong to Participation, and
this is the shape `participation_session_stats_acl.ex` already uses and `mix lint_acl_boundary`
requires. One query rather than "fetch the program's sessions, then their overrides", because a
term program holds hundreds of sessions and their ids are never wanted for themselves.

**5. Three staff-inbox tests changed shape, not intent.**
They fired hand-rolled `%Event{}` unassignment structs while leaving the real assignment row
standing — a state production cannot reach, since `unassign_staff_from_program/3` retires the row
in the same transaction that stages the event. The guard correctly refused to evict. They now
drive the real command and build events through `ProviderEvents`, which also drops the
`assigned_at`/`unassigned_at` payload drift of #1309.

**6. Rename.** `Messaging.get_active_staff_user_ids/1` →
`get_conversation_staff_user_ids/1` (and the resolver's sibling), because the old names promised
a program roster and now return more. Access-granting only; attribution has come from
`messages.sender_role` since #1348.

## Test plan

- `mix precommit` — 4699 passed, credo `--strict` clean, `lint_acl_boundary` clean
- New `list_conversation_staff_user_ids_for_program_test.exs` — 8 cases in one tabular block:
  program-only included, session-only included, both deduped, retired override / deactivated
  staff / unclaimed staff / another program's session all excluded
- `add_assigned_staff_test.exs` — a session-only substitute is seeded into a new conversation
- `staff_assignment_handler_test.exs` — session backfill, plus all three keep-guard cases
  (evict when no claim remains; keep on a surviving roster claim; keep on a surviving override)

Verified end-to-end against dev data via Tidewave, on a real program with a real conversation:

| Check | Result |
|---|---|
| Substitute on program roster? | no — the #784 precondition |
| In union before override | no |
| In union after override | yes |
| Participant after `staff_assigned_to_session` | yes |
| Retire override, roster claim remains | kept |
| Retire both | evicted |
| Retire program only, override remains | kept |
| `:event_consumers` registry routes both session topics | yes, `staff_member_deactivated` untouched |

The registry check matters on its own: it is `Outbox.stage/2`'s staging filter, so an unrouted
topic is never delivered — and no test covers the config file itself.
