### PR TITLE
refactor: flatten the accounts context layout

### DIFF
--- a/.claude/agents/architecture-reviewer.md
+++ b/.claude/agents/architecture-reviewer.md
@@ -21,12 +21,25 @@ convention and does NOT reintroduce the removed layering.
 
 ---
 
+> **Migration window (read before running checks 5–8).** A repo-wide flatten is
+> in progress: `accounts` has been converted to the new one-level layout below;
+> the other six contexts (provider, family, messaging, participation,
+> enrollment, program_catalog) and `shared` still carry the old
+> `adapters/{driven,driving}/` + `domain/` tree. **Both shapes are legal at
+> once** until the migration finishes — never flag an unconverted context for
+> keeping the old tree, and never flag `accounts` (or any newly-converted
+> context) for lacking `adapters/`/`domain/`. Checks below identify a kind by
+> what it **is** (a `use`/behaviour/naming signature) first, then accept
+> either shape's legal location — a check written as "for each file in
+> `adapters/driven/projections/`" would pass vacuously on a flattened context
+> and must not be trusted on its own.
+
 ## Context
 
 Bounded contexts under `lib/klass_hero/`:
 Accounts, Family, Provider, ProgramCatalog, Enrollment, Messaging, Participation, Shared, Admin.
 
-Current per-context layout:
+**Flattened shape** (`accounts` today; others convert one PR at a time):
 ```
 context.ex                  # Public API — the ONLY module other contexts call
 context/
@@ -34,10 +47,31 @@ context/
 │                           #   (validators, state machines). e.g. provider/staff_member.ex
 ├── <read_table>.ex         # Projection read-table schema: IS the DTO, no changeset —
 │                           #   the projection owns every write. e.g. program_catalog/program_listing.ex
-├── <use_case>.ex           # Flat command/query modules at root (e.g. enrollment/claim_invite.ex)
-│                           #   some contexts also use application/commands|queries/
+├── <use_case>.ex           # Command/query modules at the root
+├── events.ex               # Factory for this context's integration events
+├── <handler>.ex            # Consumes another context's events — named for what it
+│                           #   consumes, NOT filed under an events/ dir
+├── <worker>.ex             # Oban worker
+├── projections/            # CQRS projection GenServers          (3+ files)
+├── workers/                # Oban workers                         (3+ files)
+├── acl/                    # Cross-context read adapters          (3+ files)
+├── notifications/          # Email/notification senders           (3+ files)
+├── queries/                # Composable write-side query builders (3+ files)
+└── read_models/            # Query-shaped structs over WRITE tables (3+ files)
+```
+A kind gets its own directory only at 3+ files; below that its modules sit at the
+context root. There is no `adapters/` or `domain/` layer in this shape.
+
+**Old DDD-derived shape** (still: provider, family, messaging, participation,
+enrollment, program_catalog, shared):
+```
+context.ex
+context/
+├── <entity>.ex
+├── <read_table>.ex
+├── <use_case>.ex           #   some contexts also use application/commands|queries/
 ├── domain/
-│   ├── events/             # Domain & integration event structs (pure)
+│   ├── events/             # Domain & integration event structs (pure), one per file
 │   └── read_models/        # Query-shaped plain structs over WRITE tables (no logic,
 │                           #   no Ecto schema, no read table of their own)
 └── adapters/
@@ -45,19 +79,17 @@ context/
     └── driving/{events,workers}/
 ```
 
-**Survivors** (legitimate subdirs): `adapters/driven/projections/` + `domain/read_models/`
-(CQRS), `adapters/driven/persistence/queries/` (composable query builders over the context's
-own **write-side** tables), `adapters/driven/acl/` (cross-context reads),
-`adapters/driven/notifications/`, `adapters/driving/events/`, `adapters/driving/workers/`,
-`domain/events/`.
+**Survivors** (legitimate in either shape): projection GenServers, read models (CQRS),
+composable write-side query builders, ACL adapters (cross-context reads), notification
+senders, event handlers, Oban workers, and the event-struct factory/files.
 
-Projection read **tables** do NOT live under `persistence/` — their schema sits at the
-context root and is the DTO (see the tree above). `persistence/{repositories,schemas}/`
-survives in **Shared only**, for the event and job infrastructure tables
-(`processed_events`, `job_compensations`, `undelivered_events`); no bounded context has a
-repository left.
+Projection read **tables** do NOT live under `persistence/`/`queries/` — their schema sits at
+the context root and is the DTO (see the trees above), in both shapes.
+`adapters/driven/persistence/{repositories,schemas}/` survives in **Shared only**, for the
+event and job infrastructure tables (`processed_events`, `job_compensations`,
+`undelivered_events`); no bounded context has a repository left.
 
-**Removed** (flag if reintroduced): `domain/models/`, `domain/ports/`,
+**Removed** (flag if reintroduced, regardless of shape): `domain/models/`, `domain/ports/`,
 `application/use_cases/`, persistence mappers for aggregates, `use Boundary`,
 per-context `for_*` DI wiring in `config/config.exs`.
 
@@ -104,8 +136,8 @@ violation. e.g. `program_catalog/program_listing.ex`, `provider/provider_program
 
 **Rule:** Code in context A reaches context B only through B's root module
 `KlassHero.B` — called **directly**, at every layer (ADR 0015); an ACL adapter under
-A's `adapters/driven/acl/` is a valid wrapper but not the expected one. Never alias
-B's internal schemas, entity modules, or Repo.
+A's `acl/` (flat shape) or `adapters/driven/acl/` (old shape) is a valid wrapper but
+not the expected one. Never alias B's internal schemas, entity modules, or Repo.
 
 **How to verify:**
 1. For each changed module, list `alias`/references that resolve to another context
@@ -114,27 +146,36 @@ B's internal schemas, entity modules, or Repo.
 
 ## Check 5: Survivor placement
 
-**Rule:** The subdirectories that survived the flatten hold only their intended kinds:
-- projections → `adapters/driven/projections/`
-- ACL adapters → `adapters/driven/acl/`
-- notifications → `adapters/driven/notifications/`
-- event handlers → `adapters/driving/events/` (specific handlers in `events/event_handlers/`)
-- Oban workers → `adapters/driving/workers/`
+**Rule:** Each surviving kind is identified by what it **is**, not by which tree its
+context happens to use, and must sit in a location legal for that context's current
+shape:
 
-A projection's **read table** goes the other way: it lives at the **context root**
-(`lib/klass_hero/<context>/<name>.ex`), beside the entities, never under `adapters/`.
-It declares itself with `use KlassHero.Shared.ReadTable` and carries **no changeset** —
-the projection is its only writer.
+| Kind | Identify by | Legal locations |
+|---|---|---|
+| Projection GenServer | `use KlassHero.Shared.Projection` (or `.WithBootstrapRetry`) | `<context>/projections/` (3+ files), `<context>/<name>.ex` at root, or old `adapters/driven/projections/` |
+| Oban worker | `use Oban.Worker` | `<context>/workers/` (3+ files), `<context>/<name>.ex` at root, or old `adapters/driving/workers/` |
+| Event handler | consumes another context's events — registered as `{Module, :function}` under `:event_consumers` in `config/config.exs` | `<context>/<handler>.ex` at root, named for what it consumes (flat shape has no `events/` dir for these), or old `adapters/driving/events/` |
+| ACL adapter | moduledoc/name signals anti-corruption-layer purpose (e.g. name ends `ACL`, or moduledoc states cross-context translation) | `<context>/acl/` (3+ files), `<context>/<name>.ex` at root, or old `adapters/driven/acl/` |
+| Notification sender | sends email/notifications via a Shared adapter | `<context>/notifications/` (3+ files), `<context>/<name>.ex` at root, or old `adapters/driven/notifications/` |
+
+A projection's **read table** goes the other way in *both* shapes: it lives at the
+**context root** (`lib/klass_hero/<context>/<name>.ex`), beside the entities, never
+under `adapters/`, `projections/`, or `persistence/`. It declares itself with
+`use KlassHero.Shared.ReadTable` and carries **no changeset** — the projection is its
+only writer.
 
 **How to verify:**
-1. Grep new `use Oban.Worker` — must be in `adapters/driving/workers/`
-2. New event handlers must be in `adapters/driving/events/**`
-3. New projection GenServers must be in `adapters/driven/projections/`
-4. Grep new `use KlassHero.Shared.ReadTable` — must be at a context root, and the module
+1. Grep new `use Oban.Worker`, `use KlassHero.Shared.Projection`, and moduledocs naming
+   an ACL — do this by signature across the whole diff, not by walking a fixed directory,
+   so a flattened context's root-level modules aren't missed
+2. For each match, confirm it sits in one of that kind's legal locations from the table above
+3. Grep new `use KlassHero.Shared.ReadTable` — must be at a context root, and the module
    must define no `*changeset*` clause
-5. Flag anything placed outside its directory
+4. Flag anything placed somewhere illegal under **both** shapes (e.g. filed under a
+   nonstandard directory like `services/`, or a projection dropped loose at the root of a
+   context whose projections already number 3+ elsewhere)
 
-`mix lint_read_tables` gates rule 4 in CI, keyed off the same `use` line. If you find a
+`mix lint_read_tables` gates rule 3 in CI, keyed off the same `use` line. If you find a
 placement violation this check would catch, the gate should have caught it first — say so,
 because that means the two have drifted.
 
@@ -145,29 +186,37 @@ because that means the two have drifted.
 `bootstrap_impl/0` and `handle_event/2`.
 
 **How to verify:**
-1. For each file in `adapters/driven/projections/`
+1. Locate every projection GenServer by its `use KlassHero.Shared.Projection[, ...]`
+   signature — this finds them under the flat `<context>/projections/` layout and the old
+   `adapters/driven/projections/` tree alike
 2. Confirm `use KlassHero.Shared.Projection, ...` with a `:topics` list
 3. Confirm `bootstrap_impl/0` and `handle_event/2` are implemented
 4. Reference: `lib/klass_hero/provider/adapters/driven/projections/provider_programs.ex`
+   (old shape — `accounts` has no projection yet, since none of its kinds have reached 3 files)
 5. Flag hand-rolled projection GenServers that bypass the macro
 
 ## Check 7: Read-model DTO purity
 
-**Rule:** Read models in `domain/read_models/` are display-optimized structs with no
-business logic and no Ecto/Phoenix/Repo dependencies.
+**Rule:** Read models are display-optimized structs over WRITE tables with no business
+logic and no Ecto/Phoenix/Repo dependencies, wherever they're declared.
 
 **How to verify:**
-1. For each file in `domain/read_models/`
+1. Locate candidates in `domain/read_models/` (old shape) and `read_models/` (flat shape,
+   3+ files); below that threshold a flattened context's read models sit as ordinary
+   `<name>.ex` files at the context root, so also check any new root-level module the diff
+   introduces as a query-shaped struct over write tables
 2. Confirm `defstruct` (not `use Ecto.Schema`) and no infra imports
 3. Flag business logic or `KlassHero.Repo` usage
 
 ## Check 8: Event struct purity & placement
 
-**Rule:** Event structs live in `domain/events/` and are pure (no Ecto/Phoenix/Repo/Oban).
+**Rule:** Event structs are pure (no Ecto/Phoenix/Repo/Oban), wherever they're declared.
 Consumers are registered per topic under `:event_consumers` in `config/config.exs`.
 
 **How to verify:**
-1. For each file in `domain/events/`
+1. Locate event structs in `domain/events/` (old shape — one file per struct) or in the
+   single context-root `events.ex` factory (flat shape — one file holding all of that
+   context's integration event structs)
 2. Confirm pure struct definitions, no infra dependencies
 3. If a new event is introduced, confirm a consumer is registered in `config/config.exs`
    under `:event_consumers`. That registry is also the staging filter — an unregistered
@@ -202,6 +251,9 @@ Consumers are registered per topic under `:event_consumers` in `config/config.ex
 ## Rules
 
 - Run ALL 8 checks for every review — do not skip checks even if they seem irrelevant
+- Both the flattened and old-DDD-derived shapes are legal simultaneously during the
+  migration (see the note above `## Context`) — a context using the old tree is not itself
+  a finding, and neither is a context missing `adapters/`/`domain/` because it's flat
 - Severity: `error` for reintroduced-DDD structural violations (ports, DI, Boundary,
   domain/models split) and cross-context internal access; `warning` for placement/convention
 - Always read the actual file content before flagging — do not rely on path inference alone

--- a/.claude/agents/boundary-checker.md
+++ b/.claude/agents/boundary-checker.md
@@ -86,8 +86,21 @@ schemas, or `adapters/` modules.
    catches the old tree's `KlassHero.B.Adapters.*` / `KlassHero.B.<...>Schema` just as
    well as a flattened context's `KlassHero.B.<Entity>` or `KlassHero.B.<HandlerName>`,
    which carry no `Adapters` segment to grep for
-4. Exception: Shared infrastructure (`KlassHero.Shared.*` — `Tracing`, `Projection`,
-   `Outbox`, `FeatureFlags`, `RepositoryHelpers`) is universal
+4. Exceptions — these are `KlassHero.B.<Something>` but are NOT internals:
+   - Shared infrastructure (`KlassHero.Shared.*` — `Tracing`, `Projection`, `Outbox`,
+     `FeatureFlags`, `RepositoryHelpers`) is universal
+   - **B's event factory** (`KlassHero.B.Events`, or `KlassHero.B.Domain.Events.BEvents`
+     in the old shape). An event is the public contract *between* contexts, so its
+     constructor is public surface. Constructing one from another context's **test** to
+     build a real envelope is the documented pattern — hand-rolling the struct instead is
+     what hides payload drift.
+   - **B's handler modules named in the `:event_consumers` registry** in
+     `config/config.exs`. That registry names every context's handlers by design; it is
+     the wiring, not a boundary crossing. Test code invoking such a handler directly to
+     exercise the wiring is integration-test infrastructure, not production reach-in.
+
+   Note the asymmetry these exceptions preserve: **production** code in A must still never
+   name B's handler or entity modules. Only config wiring and test construction may.
 
 **Example violation:**
 ```elixir

--- a/.claude/agents/boundary-checker.md
+++ b/.claude/agents/boundary-checker.md
@@ -21,6 +21,19 @@ internals. This agent enforces that convention.
 
 ---
 
+> **Migration window (read before running checks 1–5).** A repo-wide flatten of the
+> `adapters/{driven,driving}/` + `domain/` tree is in progress: `accounts` has already
+> converted to a one-level layout (`adapters/driven/acl/` → `acl/`, `adapters/driving/events/`
+> → handler files named for what they consume, sitting at the context root, etc.); the
+> other six contexts (provider, family, messaging, participation, enrollment,
+> program_catalog) and `shared` still carry the old tree. **Both shapes are legal at once**
+> until the migration finishes — never flag an unconverted context for keeping the old
+> paths, and never flag `accounts` (or any newly-converted context) for lacking
+> `adapters/`/`domain/`. Checks below identify a module by what it **does** (a
+> `use`/registration/naming signature) first, then accept either shape's legal location —
+> a check written as "for each file in `adapters/driving/events/`" would pass vacuously on
+> a flattened context and must not be trusted on its own.
+
 ## Scope
 
 Two scan modes, specified by the caller:
@@ -45,8 +58,9 @@ context B's data are:
    default for a cross-context read (ADR 0015). It applies at every layer — a
    projection, event handler, worker or web helper calls the facade with no adapter
    in between.
-2. Wrap that facade call in an ACL adapter under A's `adapters/driven/acl/` **only
-   when the adapter earns its place** by doing genuine translation: remapping B's
+2. Wrap that facade call in an ACL adapter under A's `acl/` (flat shape) or
+   `adapters/driven/acl/` (old shape) **only when the adapter earns its place** by
+   doing genuine translation: remapping B's
    errors into A's vocabulary, masking fields behind a business rule, or reaching
    B's tables directly to break a dependency cycle. An ACL that only forwards a
    call is indirection without a payer.
@@ -67,9 +81,11 @@ schemas, or `adapters/` modules.
 **How to verify:**
 1. For each file, extract all `alias`/module references
 2. Determine each referenced module's owning context
-3. Flag references that resolve to another context's internals
-   (`KlassHero.B.<Entity>`, `KlassHero.B.Adapters.*`, `KlassHero.B.<...>Schema`)
-   rather than `KlassHero.B` itself
+3. Flag references that resolve to another context's internals — anything nested under
+   `KlassHero.B.*` other than `KlassHero.B` itself. This test is shape-agnostic: it
+   catches the old tree's `KlassHero.B.Adapters.*` / `KlassHero.B.<...>Schema` just as
+   well as a flattened context's `KlassHero.B.<Entity>` or `KlassHero.B.<HandlerName>`,
+   which carry no `Adapters` segment to grep for
 4. Exception: Shared infrastructure (`KlassHero.Shared.*` — `Tracing`, `Projection`,
    `Outbox`, `FeatureFlags`, `RepositoryHelpers`) is universal
 
@@ -110,15 +126,18 @@ is fine (schema-as-struct: the context module is the data-access API).
 
 ## Check 3: Event handlers must use facade APIs
 
-**Rule:** Event handlers in `adapters/driving/events/` that act on another context
-must call that context's root facade — not its internal entity, query, or adapter
-modules.
+**Rule:** Event handlers that act on another context must call that context's root
+facade — not its internal entity, query, or adapter modules.
 
 **How to verify:**
-1. For each event handler, extract calls that reach into another context
-2. Calls should be to `KlassHero.<Context>.function_name()` (facade)
-3. Flag calls to `KlassHero.<Context>.Adapters.*` or internal entity modules
-4. Within-context handlers MAY call their own context's internals directly
+1. Locate event handlers by registration, not by directory: every `{Module, :function}`
+   tuple under `:event_consumers` in `config/config.exs` names one. This finds handlers
+   filed under the old `adapters/driving/events/` tree and a flattened context's
+   root-level `<handler>.ex` (named for what it consumes) alike
+2. For each, extract calls that reach into another context
+3. Calls should be to `KlassHero.<Context>.function_name()` (facade)
+4. Flag calls to `KlassHero.<Context>.Adapters.*` or any other internal entity module
+5. Within-context handlers MAY call their own context's internals directly
 
 **Example violation:**
 ```elixir
@@ -132,12 +151,15 @@ KlassHero.Provider.assign_staff_to_program(attrs)
 
 ## Check 4: Domain event & read-model isolation
 
-**Rule:** `domain/events/` and `domain/read_models/` must be pure — ZERO
+**Rule:** A context's integration event structs and its read models must be pure — ZERO
 dependencies on Ecto (`Ecto.Changeset/Schema/Query`), Phoenix, infrastructure
-(`KlassHero.Repo`, `Oban`, `Jason`), or other contexts' internals.
+(`KlassHero.Repo`, `Oban`, `Jason`), or other contexts' internals — regardless of where
+they're declared.
 
 **How to verify:**
-1. For each file in `domain/events/`, `domain/read_models/`
+1. Locate them in `domain/events/` + `domain/read_models/` (old shape, one file per
+   struct) and in the flat shape's `events.ex` factory + `read_models/` dir (or, below
+   the 3-file threshold, ordinary root-level modules the diff introduces as read models)
 2. Extract `alias`/`import`/`use`/`require` declarations
 3. Allow: own context's domain modules, Elixir/Erlang stdlib,
    `KlassHero.Shared.Domain.*`, `Logger`
@@ -145,7 +167,10 @@ dependencies on Ecto (`Ecto.Changeset/Schema/Query`), Phoenix, infrastructure
 
 ## Check 5: ACL adapter correctness
 
-**Rule:** Anti-Corruption Layer adapters (`adapters/driven/acl/`) must:
+**Rule:** Anti-Corruption Layer adapters — identified by a moduledoc/name signaling
+cross-context translation (name ends `ACL`, or the moduledoc states the purpose), living
+in `acl/` (flat shape, 3+ files), a root-level `<name>.ex` (flat shape, below threshold),
+or the old `adapters/driven/acl/` — must:
 - Call the target context's PUBLIC facade API (not internal modules) — unless the ACL
   exists precisely to reach the tables directly and break a dependency cycle, which its
   moduledoc must say
@@ -201,6 +226,9 @@ are deliberate instances of it.
 
 - In `full` mode, scan the ENTIRE codebase — boundary violations can be pre-existing
 - In `changed-files` mode, scan only the provided files and their immediate references
+- Both the flattened and old-DDD-derived shapes are legal simultaneously during the
+  migration (see the note above `## Scope`) — a context using the old tree is not itself
+  a finding, and neither is a context missing `adapters/`/`domain/` because it's flat
 - The `Accounts.User` reference is a KNOWN exception — do not flag it
 - Shared (`KlassHero.Shared.*`) is universal infrastructure — accessible to all
 - A context using `Repo` on its OWN schemas is correct (schema-as-struct) — never flag it

--- a/.claude/rules/authentication.md
+++ b/.claude/rules/authentication.md
@@ -4,17 +4,22 @@ The project uses **Phoenix's standard `phx.gen.auth` authentication** for simpli
 
 ## Directory Structure
 
-Accounts is conventional Phoenix (flattened from DDD, #993):
+Accounts is conventional Phoenix (flattened from DDD, #993) and was the first
+context to adopt the flat layout — every module sits at the context root, with
+no `adapters/`, `domain/`, or `types/` nesting. See `domain-architecture.md`.
 
 ```
+lib/klass_hero/accounts.ex          # Public API
 lib/klass_hero/accounts/
-  user.ex              # Schema-as-struct: Ecto schema + struct + functional core
-  user_token.ex        # Token generation/verification
-  scope.ex             # Accounts.Scope (auth scope)
-  persona_grant.ex     # Role/persona grants
-  user_notifier.ex     # Email sending utility
-  types/               # user_role.ex, user_roles.ex (Ecto.Enum types)
-  domain/events/       # user_events.ex, accounts_integration_events.ex
+  user.ex                    # Schema-as-struct: Ecto schema + struct + functional core
+  user_token.ex              # Token generation/verification
+  scope.ex                   # Accounts.Scope (auth scope)
+  persona_grant.ex           # Role/persona grants
+  user_notifier.ex           # Email sending utility
+  user_role.ex               # Valid role atoms (:parent, :provider, :staff)
+  user_roles.ex              # Custom Ecto.Type mapping the text[] roles column
+  events.ex                  # Accounts.Events — factory for emitted integration events
+  staff_invitation_handler.ex # Consumes Provider's :staff_member_invited
 
 lib/klass_hero_web/
   user_auth.ex         # Authentication plug and helpers

--- a/.claude/rules/domain-architecture.md
+++ b/.claude/rules/domain-architecture.md
@@ -40,6 +40,13 @@ context/
 holds **3+ files**; below that its modules sit at the context root. Same
 extraction threshold the front end uses for components (`frontend.md`).
 
+The threshold covers **only the kinds listed above**. It does not license a
+catch-all: `services/`, `helpers/`, `support/` are not kinds — "service" is DDD
+for "module I could not otherwise place", and such a directory sorts modules by
+having no category. Pure domain-logic modules (`program_pricing.ex`,
+`csv_parser.ex`, `referral_code_generator.ex`) sit at the **context root** beside
+the use cases, however many there are.
+
 There is no `adapters/` or `domain/` layer, and no `driven`/`driving` split. The
 kind name already carries directionality — a handler or worker is inbound, a
 projection, ACL, or notification is outbound — so encoding it a second time in

--- a/.claude/rules/domain-architecture.md
+++ b/.claude/rules/domain-architecture.md
@@ -25,14 +25,37 @@ context/
 ├── <entity>.ex             # Schema-as-struct (see below)
 ├── <read_table>.ex         # Projection read-table schema — IS the DTO, no changeset
 ├── <use_case>.ex           # Command/query modules at the root
-├── domain/
-│   ├── events/             # Domain & integration event structs
-│   └── read_models/        # Query-shaped structs over WRITE tables only (no logic,
-│                           #   no schema twin) — see "CQRS Read Models"
-└── adapters/
-    ├── driven/{projections,persistence,acl,notifications}/
-    └── driving/{events,workers}/
+├── events.ex               # Factory for this context's integration events
+├── <handler>.ex            # Consumes another context's events
+├── <worker>.ex             # Oban worker
+├── projections/            # CQRS projection GenServers          (3+ files)
+├── workers/                # Oban workers                         (3+ files)
+├── acl/                    # Cross-context read adapters          (3+ files)
+├── notifications/          # Email/notification senders           (3+ files)
+├── queries/                # Composable write-side query builders (3+ files)
+└── read_models/            # Query-shaped structs over WRITE tables (3+ files)
 ```
+
+**One level, and only when it earns it.** A kind gets its own directory once it
+holds **3+ files**; below that its modules sit at the context root. Same
+extraction threshold the front end uses for components (`frontend.md`).
+
+There is no `adapters/` or `domain/` layer, and no `driven`/`driving` split. The
+kind name already carries directionality — a handler or worker is inbound, a
+projection, ACL, or notification is outbound — so encoding it a second time in
+the path bought nothing and cost two segments on every module name.
+
+`accounts/` is the reference: nothing there reaches three files, so the whole
+context is flat.
+
+See ADR 0018 for the reasoning.
+
+> **Migration in progress.** Accounts is flat. The other six contexts still carry
+> the old `adapters/{driven,driving}/…` + `domain/…` tree and are being converted
+> one PR at a time. **Both shapes are legal until that finishes** — do not flag an
+> unconverted context as a violation, and do not half-convert one as a drive-by.
+> When reading the sections below, `adapters/driven/projections/` and
+> `projections/` name the same thing.
 
 ### Schema-as-struct
 
@@ -43,51 +66,52 @@ An entity is **one module** that is simultaneously:
 
 `provider/staff_member.ex` is the canonical example — read its moduledoc. No separate `domain/models/`, no mappers, no ports.
 
-### What survives in `adapters/`
+### Which kinds exist
 
-The flatten deleted aggregate ports, mappers, and DI wiring. Subdirectories remain only where indirection earns its place:
+The flatten deleted aggregate ports, mappers, and DI wiring. These kinds remain — each at
+the context root, or in a same-named directory once it holds 3+ files:
 
-- `adapters/driven/projections/` — CQRS projection GenServers
-- `adapters/driven/persistence/queries/` — composable query builders over a context's own
-  **write-side** tables (Messaging's `conversation_queries.ex`, `message_queries.ex`). Only
-  earns its place when the bindings are genuinely composed by more than one caller
-- `adapters/driven/persistence/{repositories,schemas}/` — **Shared only**, for the event and
-  job infrastructure tables (`processed_events`, `job_compensations`, `undelivered_events`).
-  Internal to Shared's exactly-once and dead-letter machinery — each schema's moduledoc says
-  so — never domain models. No bounded context has a repository left; do not copy this into one
-- `adapters/driven/acl/` — cross-context read adapters (anti-corruption layer)
-- `adapters/driven/notifications/` — email/notification senders
-- `adapters/driving/events/` — event handlers reacting to other contexts' events
-- `adapters/driving/workers/` — Oban workers
+- `projections/` — CQRS projection GenServers
+- `queries/` — composable query builders over a context's own **write-side** tables
+  (Messaging's `conversation_queries.ex`, `message_queries.ex`). Only earns its place when
+  the bindings are genuinely composed by more than one caller
+- `acl/` — cross-context read adapters (anti-corruption layer)
+- `notifications/` — email/notification senders
+- event handlers reacting to other contexts' events — named for what they consume
+  (`staff_invitation_handler.ex`), not filed under an `events/` directory
+- `workers/` — Oban workers
+- `events.ex` — the factory for the context's own integration event structs
+
+**Shared is the exception.** `shared/adapters/driven/persistence/{repositories,schemas}/`
+holds the event and job infrastructure tables (`processed_events`, `job_compensations`,
+`undelivered_events`) — internal to Shared's exactly-once and dead-letter machinery, as each
+schema's moduledoc says, never domain models. No bounded context has a repository left; do
+not copy this into one.
 
 ## Cross-Context Access
 
 - Call other contexts **only** through their root `<context>.ex` module — never their internal schemas/Repo.
 - For cross-context **reads**: **call the owning context's root facade directly** (ADR 0015). This is the default at every layer — a projection, event handler, worker or web helper calls the facade with no adapter in between. Reach for something heavier only when it earns its place:
-  - an **ACL adapter** (`adapters/driven/acl/`) when there is genuine translation to do — remapping the other context's errors into your vocabulary, masking fields behind a business rule, cycle-breaking direct table access, or a query no facade expresses. An ACL that only forwards a call is indirection without a payer; fold it into the caller.
+  - an **ACL adapter** (`acl/`) when there is genuine translation to do — remapping the other context's errors into your vocabulary, masking fields behind a business rule, cycle-breaking direct table access, or a query no facade expresses. An ACL that only forwards a call is indirection without a payer; fold it into the caller.
   - a **projection** when a per-render facade call cannot serve the read path.
 - There is **no** per-context *aggregate* `config :klass_hero, :<context>, for_managing_*: Adapter` DI wiring anymore. Call collaborators directly. (Shared is the exception: its genuine env-swapped adapter seams — `outbox`, `feature_flags`, `storage`, `for_tracking_processed_events` — keep a slim behaviour at the Shared root + a config-selected impl. That is idiomatic Elixir DI, not ceremony; see ADR 0006.)
 
 ## Event System
 
-Directionality still classifies the surviving event code:
-
-> If Oban triggers it, it's **driving**. If the application calls it outward, it's **driven**.
-
 - **One `Event` struct**, staged inside the producer's transaction via `Shared.Outbox.transact/2` and delivered by `EventDeliveryWorker`, an Oban job. Consumers are registered per topic under `:event_consumers` in `config/config.exs`; that registry is also the staging filter, so an event nobody consumes is dropped rather than staged.
 - **Same-context reactions are not events.** A producer calls them directly, inside its own transaction, so the write and its consequence commit together.
 - **UI updates are not events either.** A LiveView receives a plain tagged tuple over `Phoenix.PubSub` naming what changed, broadcast post-commit by whoever wrote the data.
-- **Shared event infrastructure** (`shared/outbox.ex`, `shared/adapters/driven/events/`, `shared/adapters/driven/workers/event_delivery_worker.ex`): staging adapters, the consumer registry, the exactly-once gate, retry helpers, test doubles — driven, because the application calls them outward. Context consumers live under their own `adapters/driving/events/`.
+- **Shared event infrastructure** (`shared/outbox.ex`, `shared/adapters/driven/events/`, `shared/adapters/driven/workers/event_delivery_worker.ex`): staging adapters, the consumer registry, the exactly-once gate, retry helpers, test doubles. Context consumers live in the context that consumes the event.
 
 ## CQRS Read Models
 
-- Projection GenServers in `adapters/driven/projections/` subscribe to events and denormalize into dedicated read tables.
+- Projection GenServers in `projections/` subscribe to events and denormalize into dedicated read tables.
 - **Three read-side kinds, three homes.** Getting this wrong is what produced #1254/#1258, so pick deliberately:
 
   | Kind | Home | Shape | Example |
   |---|---|---|---|
   | Projection read **table** | context root | Ecto schema **is** the DTO; **no changeset** — the projection owns every write; string columns are **`text`**, never a capped `varchar` | `provider/provider_program.ex`, `messaging/enrolled_child.ex` |
-  | Query-shaped struct over **write** tables | `domain/read_models/` | plain struct, no schema twin, no table; built by a `select:` or a `from_*/1` narrowing | `provider/domain/read_models/staff_membership.ex` |
+  | Query-shaped struct over **write** tables | `read_models/` | plain struct, no schema twin, no table; built by a `select:` or a `from_*/1` narrowing | `provider/domain/read_models/staff_membership.ex` |
   | Event-maintained table with **no** projection | context root + an ops submodule | schema **keeps** its changeset, because a handler writes it directly | *none — see below* |
 
 - **A length cap on a read table is unenforceable, so it is a liability.** The

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -60,7 +60,7 @@ This command:
 
 ## Projection Tests: `async: false`
 
-Test modules covering event-driven projections (modules under `**/adapters/driven/projections/`) use `use KlassHero.DataCase, async: false`. Projection GenServers run DB queries during `init/1`'s `{:continue, :bootstrap}` before the test process can call `Ecto.Adapters.SQL.Sandbox.allow/3` on the spawned pid, so the only reliable fix is shared-sandbox mode (which `async: false` flips on automatically via `DataCase.setup_sandbox/1`). Don't add `Sandbox.allow` calls in these files — they're redundant under shared mode. This rule does NOT apply to macro-level tests like `test/klass_hero/shared/projection_test.exs`, which exercise the macro against `Agent`-backed fakes with no DB at all and stay `async: true`.
+Test modules covering event-driven projections (any module built on `KlassHero.Shared.Projection`, wherever it sits) use `use KlassHero.DataCase, async: false`. Projection GenServers run DB queries during `init/1`'s `{:continue, :bootstrap}` before the test process can call `Ecto.Adapters.SQL.Sandbox.allow/3` on the spawned pid, so the only reliable fix is shared-sandbox mode (which `async: false` flips on automatically via `DataCase.setup_sandbox/1`). Don't add `Sandbox.allow` calls in these files — they're redundant under shared mode. This rule does NOT apply to macro-level tests like `test/klass_hero/shared/projection_test.exs`, which exercise the macro against `Agent`-backed fakes with no DB at all and stay `async: true`.
 
 ## Assert the State Change, Not the Event
 

--- a/.claude/skills/triage-qa-discussion/SKILL.md
+++ b/.claude/skills/triage-qa-discussion/SKILL.md
@@ -116,7 +116,7 @@ For each confirmed finding, in order:
 2. Re-read the file to get current state (it may have changed from prior fixes)
 3. Respect the project's conventional-Phoenix layout (flattened from DDD, #986–#1002):
    - **Entity logic + persistence** → the schema-as-struct module at the context root, e.g. `lib/klass_hero/{context}/{entity}.ex` (Ecto schema + struct + functional core); the context API is `lib/klass_hero/{context}.ex`
-   - **CQRS projections / read-tables** → `lib/klass_hero/{context}/adapters/driven/projections/` and `.../persistence/` (projection tables only)
+   - **CQRS projections** → `lib/klass_hero/{context}/projections/`; read-table schemas sit at the context root. (Contexts not yet migrated to the flat layout still use `.../adapters/driven/projections/` — see `domain-architecture.md`.)
    - **Migrations** → `priv/repo/migrations/`
    - **LiveView** → `lib/klass_hero_web/live/`
    - **Tests** → mirror the source file path under `test/`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,24 +56,24 @@ context/
 ├── <read_table>.ex         # Projection read-table schema: IS the DTO, no changeset
 │                           #   e.g. provider/provider_program.ex, messaging/enrolled_child.ex
 ├── <use_case>.ex           # Command/query modules at the root (e.g. claim_invite.ex)
-├── domain/
-│   ├── events/             # Domain & integration event structs
-│   └── read_models/        # Query-shaped structs over WRITE tables only — no schema
-│                           #   twin, no read table (e.g. read_models/staff_membership.ex)
-└── adapters/
-    ├── driven/
-    │   ├── projections/     # CQRS projection GenServers (maintain read tables)
-    │   ├── persistence/queries/  # Composable query builders over WRITE-side tables
-    │   │                         #   (only when >1 caller genuinely composes them)
-    │   └── acl/             # Cross-context read adapters (anti-corruption layer)
-    └── driving/
-        ├── events/          # Event handlers (react to other contexts' events)
-        └── workers/         # Oban background job workers
+├── events.ex               # Factory for this context's integration event structs
+├── <handler>.ex            # Consumes another context's events
+│                           #   e.g. accounts/staff_invitation_handler.ex
+├── projections/            # CQRS projection GenServers (maintain read tables)
+├── workers/                # Oban background job workers
+├── acl/                    # Cross-context read adapters (anti-corruption layer)
+├── notifications/          # Email/notification senders
+├── queries/                # Composable query builders over WRITE-side tables
+│                           #   (only when >1 caller genuinely composes them)
+└── read_models/            # Query-shaped structs over WRITE tables only — no schema
+                            #   twin, no read table (e.g. staff_membership.ex)
 ```
 
 **Key rule — schema-as-struct:** an entity module is simultaneously the Ecto schema, the struct callers match on, and the functional core. Changesets are the validation gatekeeper at the DB boundary; pure business logic (invitation state machines, `full_name/1`, domain validators returning `{:error, [msg]}` lists) lives in the same file. See `provider/staff_member.ex`'s moduledoc for the canonical explanation.
 
-**What survives in subdirs:** only indirection that earns its place — CQRS projections + read-models, event handlers/workers, and cross-context ACL adapters. Aggregate ports, mappers, and DI wiring were deleted.
+**Key rule — one level, only when earned:** a kind gets its own directory at **3+ files**; below that its modules sit at the context root. There is no `adapters/` or `domain/` layer and no `driven`/`driving` split — the kind name already carries directionality. `accounts/` is the reference: nothing reaches three files there, so it is entirely flat.
+
+> **Migration in progress.** Accounts is flat; the other six contexts still carry the old `adapters/{driven,driving}/…` + `domain/…` tree and convert one PR at a time. **Both shapes are legal until that finishes** — don't flag an unconverted context, and don't half-convert one as a drive-by.
 
 **Active contexts:**
 
@@ -90,9 +90,9 @@ context/
 
 See `.claude/rules/domain-architecture.md` for patterns. For context-specific details, read the code under `lib/klass_hero/<context>/` directly — Claude Code explores on-demand.
 
-**Context boundaries:** Not tooling-enforced (`boundary` library removed). Cross-context isolation is a convention — call other contexts only through their root module's public API (e.g. `KlassHero.Family`), never reach into their internals. For cross-context *reads*, **call the owning context's root facade directly** (ADR 0015) — at every layer, adapters included. An ACL under `adapters/driven/acl/` is for genuine translation only (error remapping, business-rule masking, cycle-breaking table access); a projection is for a read path a per-render facade call can't serve. Never call another context's Repo/schemas directly.
+**Context boundaries:** Not tooling-enforced (`boundary` library removed). Cross-context isolation is a convention — call other contexts only through their root module's public API (e.g. `KlassHero.Family`), never reach into their internals. For cross-context *reads*, **call the owning context's root facade directly** (ADR 0015) — at every layer, adapters included. An ACL under `acl/` is for genuine translation only (error remapping, business-rule masking, cycle-breaking table access); a projection is for a read path a per-render facade call can't serve. Never call another context's Repo/schemas directly.
 
-**CQRS reads:** Read models are maintained by projection GenServers (`adapters/driven/projections/`) that subscribe to events and denormalize into dedicated read tables. A read table's Ecto schema lives at the context root and **is** the DTO — no separate struct, no mapper, no per-table repository; queries go in the context module or a context-root submodule (`provider/programs.ex`, `provider/assignments.ex`). Program Catalog, Messaging, and Provider have these. Build new projections on `KlassHero.Shared.Projection` (base macro) — see `provider/adapters/driven/projections/provider_programs.ex` for the canonical projection and `program_catalog/program_listing.ex` for the read-table schema. See `.claude/rules/domain-architecture.md` for the three read-side kinds and where each lives.
+**CQRS reads:** Read models are maintained by projection GenServers (`projections/`) that subscribe to events and denormalize into dedicated read tables. A read table's Ecto schema lives at the context root and **is** the DTO — no separate struct, no mapper, no per-table repository; queries go in the context module or a context-root submodule (`provider/programs.ex`, `provider/assignments.ex`). Program Catalog, Messaging, and Provider have these. Build new projections on `KlassHero.Shared.Projection` (base macro) — see `provider/adapters/driven/projections/provider_programs.ex` for the canonical projection and `program_catalog/program_listing.ex` for the read-table schema. See `.claude/rules/domain-architecture.md` for the three read-side kinds and where each lives.
 
 > **Note:** Per-context *aggregate* port DI wiring (`config :klass_hero, :<context>, for_managing_*: Adapter`) is gone — those ports were ceremony (one prod impl). What survives is Shared's genuine env-swapped adapter seams, where a behaviour + config-selected impl is idiomatic Elixir DI, not DDD ceremony: `outbox`, `feature_flags`, `storage` (each real-vs-test/stub), plus `:shared, for_tracking_processed_events`. Their slim behaviours live at the Shared root (`KlassHero.Shared.ForStoringFiles` etc.), not in a `domain/ports/` tree. Do not add new *aggregate* port-wiring — call collaborators directly — but a new genuinely swappable external adapter may follow the Shared seam pattern.
 
@@ -122,7 +122,7 @@ config :klass_hero, :event_consumers, %{
 That registry is also the filter: `Outbox.stage/2` drops an event no one consumes rather than
 staging work for nobody. So adding an event means defining the struct, staging it from the use
 case, and registering its consumer here — an event with no entry is never delivered. Consumers
-live under their own context's `adapters/driving/events/`.
+live in the context that consumes the event.
 
 **UI updates are not events.** A LiveView receives a plain tagged tuple over `Phoenix.PubSub`
 naming what changed (`{:session_changed, id}`), broadcast by whoever wrote the data.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ context/
 
 **Key rule — schema-as-struct:** an entity module is simultaneously the Ecto schema, the struct callers match on, and the functional core. Changesets are the validation gatekeeper at the DB boundary; pure business logic (invitation state machines, `full_name/1`, domain validators returning `{:error, [msg]}` lists) lives in the same file. See `provider/staff_member.ex`'s moduledoc for the canonical explanation.
 
-**Key rule — one level, only when earned:** a kind gets its own directory at **3+ files**; below that its modules sit at the context root. There is no `adapters/` or `domain/` layer and no `driven`/`driving` split — the kind name already carries directionality. `accounts/` is the reference: nothing reaches three files there, so it is entirely flat.
+**Key rule — one level, only when earned:** a kind gets its own directory at **3+ files**; below that its modules sit at the context root. There is no `adapters/` or `domain/` layer and no `driven`/`driving` split — the kind name already carries directionality. `accounts/` is the reference: nothing reaches three files there, so it is entirely flat. The threshold covers only the kinds listed above — `services/`/`helpers/` are not kinds, so pure domain-logic modules (`program_pricing.ex`, `csv_parser.ex`) go at the context root however many there are.
 
 > **Migration in progress.** Accounts is flat; the other six contexts still carry the old `adapters/{driven,driving}/…` + `domain/…` tree and convert one PR at a time. **Both shapes are legal until that finishes** — don't flag an unconverted context, and don't half-convert one as a drive-by.
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -9,8 +9,8 @@ import Config
 
 alias ExAws.Request.Req
 alias FunWithFlags.Notifications.PhoenixPubSub
-alias KlassHero.Accounts.Adapters.Driving.Events.StaffInvitationHandler
 alias KlassHero.Accounts.Scope
+alias KlassHero.Accounts.StaffInvitationHandler
 alias KlassHero.Enrollment.Adapters.Driving.Events.InviteFamilyReadyHandler
 alias KlassHero.Enrollment.Adapters.Driving.Workers.SendInviteEmailWorker
 alias KlassHero.Family.Adapters.Driving.Events.FamilyEventHandler

--- a/docs/adr/0018-context-directories-are-flat-one-level-when-earned.md
+++ b/docs/adr/0018-context-directories-are-flat-one-level-when-earned.md
@@ -1,0 +1,88 @@
+# Context directories are flat, one level deep, and only when earned
+
+A bounded context puts its modules **at the context root**. A kind of module gets its own
+directory only once it holds **three or more files**, and that directory is one level deep:
+`provider/projections/`, never `provider/adapters/driven/projections/`.
+
+There is no `adapters/` layer, no `domain/` layer, and no `driven`/`driving` split.
+
+```
+context.ex
+context/
+├── <entity>.ex        <read_table>.ex     <use_case>.ex
+├── events.ex          # factory for this context's integration events
+├── <handler>.ex       # consumes another context's events
+├── projections/  workers/  acl/  notifications/  queries/  read_models/
+└──                    # each only once it holds 3+ files
+```
+
+## Why
+
+The #986→#1002 flatten removed DDD's aggregate ports, mappers, and DI wiring, and dropped the
+`boundary` library. It kept the directory scaffolding, sanctioned as a whitelist of survivors.
+Three years of evidence say the scaffolding was the part worth deleting.
+
+**The `driven`/`driving` split states directionality twice.** A handler or worker is inbound;
+a projection, ACL, or notification is outbound. The kind name already says which. The extra
+segment is not a second fact, it is the same fact re-encoded in the path — and it is a fact
+nobody reads: the old rule of thumb ("if Oban triggers it, it's driving") was needed only to
+decide which folder to type.
+
+**The codebase already declared these segments meaningless.** `KlassHero.Shared.Tracing`
+carries `@noise_segments` — a hardcoded list of module-name segments (`Adapters`, `Driven`,
+`Driving`, `Persistence`, `Repositories`, `Schemas`, `Mappers`, `Queries`, `Events`,
+`EventHandlers`, `Workers`, `Projections`) that `gen_span_name/1` strips back out before a
+span is named, because a span called
+`KlassHero.Provider.Adapters.Driven.Projections.ProviderPrograms.handle_event/2` is unreadable.
+When the observability layer has to delete your directory structure to make traces legible,
+the structure is noise. This ADR makes the file tree agree with what tracing already assumed.
+
+**The cost is concrete and per-module.** Accounts paid four directory levels for one file,
+`adapters/driving/events/staff_invitation_handler.ex`, yielding the seven-segment module name
+`KlassHero.Accounts.Adapters.Driving.Events.StaffInvitationHandler`. Its event factory
+stuttered: `Accounts.Domain.Events.AccountsEvents`.
+
+**Nesting also hides drift.** Three test modules sat under
+`test/klass_hero/accounts/adapters/driven/persistence/schemas/` — a path with no `lib`
+counterpart since the original flatten deleted Accounts' driven side entirely. They tested
+plain `User` changesets. A flat tree makes that kind of orphan obvious; a deep one absorbs it.
+
+## The 3-file threshold
+
+A directory earns its place when it saves you from scanning; below three files it only adds a
+hop. This is the same extraction threshold the front end already applies to components
+(`.claude/rules/frontend.md`), so it is one rule for the codebase rather than two.
+
+It also means the convention scales in both directions. Accounts has nine modules and no
+subdirectories at all. Provider has enough projections and workers that both keep a directory —
+one level, holding files, rather than three levels holding one.
+
+## Consequences
+
+- Module names shorten by two to four segments. Span names do **not** change: the segments being
+  removed are already in `@noise_segments`.
+- `@noise_segments` becomes scaffolding for a tree that no longer exists — but it must survive
+  until **every** context is flat, since it is load-bearing for the unconverted ones. Pruning it
+  is the closing task of the last migration PR, not the first (#1259: a rename silently
+  relocates production spans).
+- Naming a module `<Context>.Events` puts a noise segment in the leaf position, so
+  `gen_span_name/1` reduces it to bare `<Context>`. Harmless for a pure event factory, which
+  emits no spans; do not give such a module tracing without renaming it first.
+- ADR 0015 (`adapters/driven/acl/`) and ADR 0006 (Shared's `adapters/driven/persistence/`)
+  describe paths in the pre-flat shape. Their **decisions** stand unchanged — only the spelling
+  of the paths moves. Shared keeps its `adapters/` tree for now; its env-swapped seams are a
+  separate question this ADR does not reopen.
+
+## Migration
+
+Accounts is the pilot and is flat. The remaining six contexts convert one PR at a time.
+
+**Both shapes are legal until that completes.** Reviewers and review agents must accept either,
+and must not flag an unconverted context — nor half-convert one as a drive-by, which produces a
+context whose module names disagree with its own tree.
+
+The lockstep rename sites for each remaining context are `lib/klass_hero/projection_supervisor.ex`
+(which aliases projection modules by full name) and the alias block at the top of
+`config/config.exs`. Both `mix lint_read_tables` and `mix lint_acl_boundary` are already
+layout-agnostic — they check depth and first-path-segment respectively, never the literal
+`adapters/driven` string — so neither needs changing.

--- a/docs/adr/0018-context-directories-are-flat-one-level-when-earned.md
+++ b/docs/adr/0018-context-directories-are-flat-one-level-when-earned.md
@@ -53,6 +53,18 @@ A directory earns its place when it saves you from scanning; below three files i
 hop. This is the same extraction threshold the front end already applies to components
 (`.claude/rules/frontend.md`), so it is one rule for the codebase rather than two.
 
+The threshold applies **only to the named kinds above** — `projections/`, `workers/`, `acl/`,
+`notifications/`, `queries/`, `read_models/`. Each names something a module *is*, so the
+directory answers a question.
+
+It does **not** license a catch-all. `domain/services/` — which today holds
+`program_pricing.ex`, `program_filter.ex`, `csv_parser.ex`, `referral_code_generator.ex` and
+friends — is not a kind; "service" is DDD for "module I could not otherwise place", and a
+`services/` directory sorts modules by having no category. Those are ordinary domain-logic
+modules and belong at the **context root** beside the use cases, whatever their number:
+`program_catalog/program_pricing.ex`. Same for anything that would be tempted into a
+`helpers/`, `support/`, or `lib/` bucket.
+
 It also means the convention scales in both directions. Accounts has nine modules and no
 subdirectories at all. Provider has enough projections and workers that both keep a directory —
 one level, holding files, rather than three levels holding one.

--- a/lib/klass_hero/accounts.ex
+++ b/lib/klass_hero/accounts.ex
@@ -289,9 +289,10 @@ defmodule KlassHero.Accounts do
   end
 
   defp normalize_email_change_result({:ok, %{update_email: updated_user}}), do: {:ok, updated_user}
-  defp normalize_email_change_result({:error, :verify_token, _reason, _}), do: {:error, :invalid_token}
-  defp normalize_email_change_result({:error, :fetch_token, _reason, _}), do: {:error, :invalid_token}
-  defp normalize_email_change_result({:error, :update_email, changeset, _}), do: {:error, changeset}
+
+  defp normalize_email_change_result({:error, step, _reason, _}) when step in [:verify_token, :fetch_token],
+    do: {:error, :invalid_token}
+
   defp normalize_email_change_result({:error, _step, reason, _}), do: {:error, reason}
 
   @doc """
@@ -429,19 +430,16 @@ defmodule KlassHero.Accounts do
   """
   def deliver_user_update_email_instructions(%User{} = user, current_email, update_email_url_fun)
       when is_function(update_email_url_fun, 1) do
-    {encoded_token, user_token} = UserToken.build_email_token(user, "change:#{current_email}")
-
-    Repo.insert!(user_token)
-    UserNotifier.deliver_update_email_instructions(user, update_email_url_fun.(encoded_token))
+    token = issue_email_token(user, "change:#{current_email}")
+    UserNotifier.deliver_update_email_instructions(user, update_email_url_fun.(token))
   end
 
   @doc """
   Delivers the magic link login instructions to the given user.
   """
   def deliver_login_instructions(%User{} = user, magic_link_url_fun) when is_function(magic_link_url_fun, 1) do
-    {encoded_token, user_token} = UserToken.build_email_token(user, "login")
-    Repo.insert!(user_token)
-    UserNotifier.deliver_login_instructions(user, magic_link_url_fun.(encoded_token))
+    token = issue_email_token(user, "login")
+    UserNotifier.deliver_login_instructions(user, magic_link_url_fun.(token))
   end
 
   @doc """
@@ -452,8 +450,11 @@ defmodule KlassHero.Accounts do
 
   Returns the URL-safe encoded token string.
   """
-  def generate_magic_link_token(%User{} = user) do
-    {encoded_token, user_token} = UserToken.build_email_token(user, "login")
+  def generate_magic_link_token(%User{} = user), do: issue_email_token(user, "login")
+
+  # Persists a hashed email token and hands back the URL-safe half to send out.
+  defp issue_email_token(user, context) do
+    {encoded_token, user_token} = UserToken.build_email_token(user, context)
     Repo.insert!(user_token)
     encoded_token
   end
@@ -495,7 +496,6 @@ defmodule KlassHero.Accounts do
     |> Repo.transaction()
     |> case do
       {:ok, %{anonymize_user: user}} -> {:ok, user}
-      {:error, :anonymize_user, changeset, _} -> {:error, changeset}
       {:error, _step, reason, _} -> {:error, reason}
     end
   end
@@ -541,9 +541,9 @@ defmodule KlassHero.Accounts do
   """
   @spec get_display_name(String.t()) :: {:ok, String.t()} | {:error, :not_found}
   def get_display_name(user_id) do
-    case Repo.one(from(u in User, where: u.id == ^user_id, select: u.name)) do
-      nil -> {:error, :not_found}
-      name -> {:ok, name}
+    case get_display_names([user_id]) do
+      %{^user_id => name} -> {:ok, name}
+      _ -> {:error, :not_found}
     end
   end
 
@@ -686,7 +686,6 @@ defmodule KlassHero.Accounts do
     |> Repo.transaction()
     |> case do
       {:ok, %{update_user: user, fetch_tokens: tokens}} -> {:ok, {user, tokens}}
-      {:error, :update_user, changeset, _} -> {:error, changeset}
       {:error, _step, reason, _} -> {:error, reason}
     end
   end

--- a/lib/klass_hero/accounts.ex
+++ b/lib/klass_hero/accounts.ex
@@ -7,7 +7,7 @@ defmodule KlassHero.Accounts do
 
   import Ecto.Query, warn: false
 
-  alias KlassHero.Accounts.Domain.Events.AccountsEvents
+  alias KlassHero.Accounts.Events
   alias KlassHero.Accounts.{PersonaGrant, User, UserNotifier, UserToken}
   alias KlassHero.Provider
   alias KlassHero.Provider.StaffMember
@@ -39,7 +39,7 @@ defmodule KlassHero.Accounts do
   defp register(attrs, changeset_fn) when is_map(attrs) do
     Outbox.transact(__MODULE__, fn ->
       with {:ok, user} <- %User{} |> changeset_fn.(attrs) |> Repo.insert() do
-        {:ok, user, [AccountsEvents.user_registered(user, %{registration_source: "web"})]}
+        {:ok, user, [Events.user_registered(user, %{registration_source: "web"})]}
       end
     end)
   end
@@ -237,7 +237,7 @@ defmodule KlassHero.Accounts do
   def emit_staff_user_registered(user_id, staff_member_id, provider_id)
       when is_binary(user_id) and is_binary(staff_member_id) and is_binary(provider_id) do
     user_id
-    |> AccountsEvents.staff_user_registered(%{
+    |> Events.staff_user_registered(%{
       staff_member_id: staff_member_id,
       provider_id: provider_id
     })
@@ -403,7 +403,7 @@ defmodule KlassHero.Accounts do
     Outbox.transact(__MODULE__, fn ->
       with {:ok, {confirmed_user, tokens}} <-
              user |> User.confirm_changeset() |> update_user_and_delete_all_tokens() do
-        event = AccountsEvents.user_confirmed(confirmed_user, %{confirmation_method: "magic_link"})
+        event = Events.user_confirmed(confirmed_user, %{confirmation_method: "magic_link"})
         {:ok, {confirmed_user, tokens}, [event]}
       end
     end)
@@ -476,7 +476,7 @@ defmodule KlassHero.Accounts do
 
       Outbox.transact(__MODULE__, fn ->
         with {:ok, anonymized_user} <- anonymize(user) do
-          event = AccountsEvents.user_anonymized(anonymized_user, %{previous_email: previous_email})
+          event = Events.user_anonymized(anonymized_user, %{previous_email: previous_email})
           {:ok, anonymized_user, [event]}
         end
       end)

--- a/lib/klass_hero/accounts/events.ex
+++ b/lib/klass_hero/accounts/events.ex
@@ -1,4 +1,4 @@
-defmodule KlassHero.Accounts.Domain.Events.AccountsEvents do
+defmodule KlassHero.Accounts.Events do
   @moduledoc """
   Factory for Accounts events. All factories do fail-fast validation and raise
   `ArgumentError` on invalid inputs.

--- a/lib/klass_hero/accounts/staff_invitation_handler.ex
+++ b/lib/klass_hero/accounts/staff_invitation_handler.ex
@@ -1,4 +1,4 @@
-defmodule KlassHero.Accounts.Adapters.Driving.Events.StaffInvitationHandler do
+defmodule KlassHero.Accounts.StaffInvitationHandler do
   @moduledoc """
   Integration event handler for `:staff_member_invited` events from Provider context.
 
@@ -15,7 +15,7 @@ defmodule KlassHero.Accounts.Adapters.Driving.Events.StaffInvitationHandler do
   @behaviour KlassHero.Shared.ForHandlingEvents
 
   alias KlassHero.Accounts
-  alias KlassHero.Accounts.Domain.Events.AccountsEvents
+  alias KlassHero.Accounts.Events
   alias KlassHero.Accounts.User
   alias KlassHero.Accounts.UserNotifier
   alias KlassHero.Shared.Domain.Events.Event
@@ -78,13 +78,13 @@ defmodule KlassHero.Accounts.Adapters.Driving.Events.StaffInvitationHandler do
 
   defp emit_sent(staff_member_id, provider_id) do
     staff_member_id
-    |> AccountsEvents.staff_invitation_sent(%{provider_id: provider_id})
+    |> Events.staff_invitation_sent(%{provider_id: provider_id})
     |> then(&Outbox.stage(KlassHero.Accounts, &1))
   end
 
   defp emit_failed(staff_member_id, provider_id, reason) do
     staff_member_id
-    |> AccountsEvents.staff_invitation_failed(%{
+    |> Events.staff_invitation_failed(%{
       provider_id: provider_id,
       reason: reason
     })

--- a/lib/klass_hero/accounts/user.ex
+++ b/lib/klass_hero/accounts/user.ex
@@ -11,10 +11,10 @@ defmodule KlassHero.Accounts.User do
 
   import Ecto.Changeset
 
-  alias KlassHero.Accounts.Types.{UserRole, UserRoles}
+  alias KlassHero.Accounts.User
+  alias KlassHero.Accounts.{UserRole, UserRoles}
   # Cross-context references for admin dashboard preloading (read-only).
   # Pragmatic DDD boundary crossing — see AccountLive moduledoc.
-  alias KlassHero.Accounts.User
   alias KlassHero.Family.ParentProfile
   alias KlassHero.Provider.ProviderProfile
   alias KlassHero.Shared.Locales

--- a/lib/klass_hero/accounts/user.ex
+++ b/lib/klass_hero/accounts/user.ex
@@ -118,10 +118,10 @@ defmodule KlassHero.Accounts.User do
   end
 
   defp put_default_role(changeset) do
-    case get_field(changeset, :intended_roles) do
-      nil -> put_change(changeset, :intended_roles, [:parent])
-      [] -> put_change(changeset, :intended_roles, [:parent])
-      _ -> changeset
+    if get_field(changeset, :intended_roles) in [nil, []] do
+      put_change(changeset, :intended_roles, [:parent])
+    else
+      changeset
     end
   end
 

--- a/lib/klass_hero/accounts/user_notifier.ex
+++ b/lib/klass_hero/accounts/user_notifier.ex
@@ -49,11 +49,12 @@ defmodule KlassHero.Accounts.UserNotifier do
   @doc """
   Deliver instructions to log in with a magic link.
   """
+  def deliver_login_instructions(%User{confirmed_at: nil} = user, url) do
+    deliver_confirmation_instructions(user, url)
+  end
+
   def deliver_login_instructions(user, url) do
-    case user do
-      %User{confirmed_at: nil} -> deliver_confirmation_instructions(user, url)
-      _ -> deliver_magic_link_instructions(user, url)
-    end
+    deliver_magic_link_instructions(user, url)
   end
 
   defp deliver_magic_link_instructions(user, url) do

--- a/lib/klass_hero/accounts/user_role.ex
+++ b/lib/klass_hero/accounts/user_role.ex
@@ -1,4 +1,4 @@
-defmodule KlassHero.Accounts.Types.UserRole do
+defmodule KlassHero.Accounts.UserRole do
   @moduledoc """
   Valid user roles and associated permissions. Roles: `:parent`, `:provider`, `:staff`
   (ADR-0005: staff is an independent persona, not a kind of provider).

--- a/lib/klass_hero/accounts/user_role.ex
+++ b/lib/klass_hero/accounts/user_role.ex
@@ -1,34 +1,10 @@
 defmodule KlassHero.Accounts.UserRole do
   @moduledoc """
-  Valid user roles and associated permissions. Roles: `:parent`, `:provider`, `:staff`
+  Valid user roles. Roles: `:parent`, `:provider`, `:staff`
   (ADR-0005: staff is an independent persona, not a kind of provider).
-
-  Permissions are defined structurally for future authorization — not yet enforced.
   """
 
   @valid_roles [:parent, :provider, :staff]
-
-  @role_permissions %{
-    parent: [
-      :view_programs,
-      :enroll_children,
-      :view_child_progress,
-      :manage_family_profile,
-      :submit_reviews
-    ],
-    provider: [
-      :manage_programs,
-      :view_enrollments,
-      :manage_schedule,
-      :view_analytics,
-      :respond_to_reviews
-    ],
-    staff: [
-      :view_assigned_programs,
-      :view_staff_dashboard,
-      :manage_own_profile
-    ]
-  }
 
   @type t :: :parent | :provider | :staff
 
@@ -59,12 +35,4 @@ defmodule KlassHero.Accounts.UserRole do
   end
 
   def from_string(_), do: {:error, :invalid_role}
-
-  @doc "Returns permissions for a role (structural definition only — not yet enforced)."
-  @spec permissions(term()) :: [atom()]
-  def permissions(role) when is_atom(role) do
-    Map.get(@role_permissions, role, [])
-  end
-
-  def permissions(_), do: []
 end

--- a/lib/klass_hero/accounts/user_roles.ex
+++ b/lib/klass_hero/accounts/user_roles.ex
@@ -1,4 +1,4 @@
-defmodule KlassHero.Accounts.Types.UserRoles do
+defmodule KlassHero.Accounts.UserRoles do
   @moduledoc """
   Custom Ecto type for user role arrays. Stores as `text[]` in PostgreSQL,
   loads as atoms in Elixir. Accepts both atoms and strings; deduplicates on cast.
@@ -8,7 +8,7 @@ defmodule KlassHero.Accounts.Types.UserRoles do
 
   use Ecto.Type
 
-  alias KlassHero.Accounts.Types.UserRole
+  alias KlassHero.Accounts.UserRole
 
   @impl true
   def type, do: {:array, :string}

--- a/lib/klass_hero/shared/for_handling_events.ex
+++ b/lib/klass_hero/shared/for_handling_events.ex
@@ -6,6 +6,19 @@ defmodule KlassHero.Shared.ForHandlingEvents do
   usually another context's, since an event is the public contract between
   contexts.
 
+  ## Routing is config, not this behaviour
+
+  Implementing this behaviour does **not** subscribe you to anything.
+  `EventDeliveryWorker` resolves consumers solely through
+  `EventConsumerRegistry.consumers_for/1`, which reads the `:event_consumers`
+  map in `config/config.exs`. Nothing calls `subscribed_events/0` at runtime.
+
+  A handler is wired when, and only when, it appears under its topic there:
+
+      "integration:provider:staff_member_invited" => [
+        {StaffInvitationHandler, :handle_event}
+      ]
+
   ## Example
 
       defmodule MyApp.Participation.ChildAnonymizedHandler do
@@ -31,9 +44,12 @@ defmodule KlassHero.Shared.ForHandlingEvents do
   @callback handle_event(Event.t()) :: :ok | {:error, term()} | :ignore
 
   @doc """
-  Returns the list of event types this handler subscribes to.
+  Declares the event types this handler expects to be routed.
 
-  Return `[:all]` to receive all events (use sparingly).
+  This is a declaration checked against config, not a subscription — see the
+  moduledoc. `event_consumer_wiring_test.exs` asserts it agrees with the topics
+  `:event_consumers` actually routes here, which is what catches the silent
+  failure of adding a `handle_event/1` clause and forgetting the registry entry.
   """
-  @callback subscribed_events() :: [atom()] | [:all]
+  @callback subscribed_events() :: [atom()]
 end

--- a/lib/klass_hero/shared/tracing.ex
+++ b/lib/klass_hero/shared/tracing.ex
@@ -22,6 +22,13 @@ defmodule KlassHero.Shared.Tracing do
 
   """
 
+  # Module-name segments stripped before a span is named, so a span reads
+  # `Provider.ProviderPrograms.handle_event/2` rather than repeating the tree.
+  #
+  # This list is scaffolding for the nested context layout and should shrink
+  # with it — but only once *every* context is flat. While contexts still carry
+  # `Adapters.Driven.Projections.*` and friends in their module names, pruning
+  # an entry here silently renames live production spans (#1259).
   @noise_segments ~w[
     Elixir KlassHero Adapters Driven Driving Persistence Repositories
     Schemas Mappers Queries Events EventHandlers Workers Projections

--- a/test/klass_hero/accounts/events_test.exs
+++ b/test/klass_hero/accounts/events_test.exs
@@ -1,7 +1,7 @@
-defmodule KlassHero.Accounts.Domain.Events.AccountsEventsTest do
+defmodule KlassHero.Accounts.EventsTest do
   use ExUnit.Case, async: true
 
-  alias KlassHero.Accounts.Domain.Events.AccountsEvents
+  alias KlassHero.Accounts.Events
   alias KlassHero.Shared.Domain.Events.Event
 
   # The staff factories take an id, because their producers hold one and not a
@@ -22,7 +22,7 @@ defmodule KlassHero.Accounts.Domain.Events.AccountsEventsTest do
       @entity entity
 
       test "builds an event with stable identity fields" do
-        event = apply(AccountsEvents, @fun, ["id-1"])
+        event = apply(Events, @fun, ["id-1"])
 
         assert %Event{} = event
         assert event.event_type == @fun
@@ -34,7 +34,7 @@ defmodule KlassHero.Accounts.Domain.Events.AccountsEventsTest do
 
       test "the id argument wins over a caller-supplied one and preserves extras" do
         payload = %{@id => "overridden", :extra => "data"}
-        event = apply(AccountsEvents, @fun, ["real-id", payload])
+        event = apply(Events, @fun, ["real-id", payload])
 
         assert Map.get(event.payload, @id) == "real-id"
         assert event.payload.extra == "data"
@@ -43,7 +43,7 @@ defmodule KlassHero.Accounts.Domain.Events.AccountsEventsTest do
       test "raises for a nil or blank id" do
         for bad_id <- [nil, ""] do
           assert_raise ArgumentError, ~r/requires a non-empty #{@id} string/, fn ->
-            apply(AccountsEvents, @fun, [bad_id])
+            apply(Events, @fun, [bad_id])
           end
         end
       end
@@ -63,7 +63,7 @@ defmodule KlassHero.Accounts.Domain.Events.AccountsEventsTest do
 
     test "raises for a user missing a required field" do
       for {user, message} <- @invalid do
-        assert_raise ArgumentError, message, fn -> AccountsEvents.user_registered(user) end
+        assert_raise ArgumentError, message, fn -> Events.user_registered(user) end
       end
     end
 
@@ -72,13 +72,13 @@ defmodule KlassHero.Accounts.Domain.Events.AccountsEventsTest do
 
       assert_raise ArgumentError,
                    ~r/User.intended_roles must be a list/,
-                   fn -> AccountsEvents.user_registered(user) end
+                   fn -> Events.user_registered(user) end
     end
 
     test "succeeds with valid user" do
       user = %{id: 1, email: "test@example.com", name: "Test User"}
 
-      event = AccountsEvents.user_registered(user)
+      event = Events.user_registered(user)
 
       assert %Event{} = event
       assert event.event_type == :user_registered
@@ -93,7 +93,7 @@ defmodule KlassHero.Accounts.Domain.Events.AccountsEventsTest do
     test "succeeds with valid user and custom payload" do
       user = %{id: 1, email: "test@example.com", name: "Test User"}
 
-      event = AccountsEvents.user_registered(user, %{source: "web"})
+      event = Events.user_registered(user, %{source: "web"})
 
       assert event.payload.source == "web"
     end
@@ -107,7 +107,7 @@ defmodule KlassHero.Accounts.Domain.Events.AccountsEventsTest do
           ] do
         user = %{id: 1, email: "test@example.com", name: "Test User", intended_roles: roles}
 
-        assert AccountsEvents.user_registered(user).payload.intended_roles == expected
+        assert Events.user_registered(user).payload.intended_roles == expected
       end
     end
 
@@ -115,7 +115,7 @@ defmodule KlassHero.Accounts.Domain.Events.AccountsEventsTest do
       # Provider tiers removed (ADR-0004)
       user = %{id: 1, email: "test@example.com", name: "Test User", intended_roles: [:provider]}
 
-      event = AccountsEvents.user_registered(user)
+      event = Events.user_registered(user)
 
       refute Map.has_key?(event.payload, :provider_subscription_tier)
     end
@@ -134,14 +134,14 @@ defmodule KlassHero.Accounts.Domain.Events.AccountsEventsTest do
 
     test "raises for a user missing a required field" do
       for {user, message} <- @invalid_confirmed do
-        assert_raise ArgumentError, message, fn -> AccountsEvents.user_confirmed(user) end
+        assert_raise ArgumentError, message, fn -> Events.user_confirmed(user) end
       end
     end
 
     test "succeeds with valid user" do
       user = %{id: 1, email: "test@example.com", confirmed_at: @confirmed_at}
 
-      event = AccountsEvents.user_confirmed(user)
+      event = Events.user_confirmed(user)
 
       assert %Event{} = event
       assert event.event_type == :user_confirmed
@@ -159,7 +159,7 @@ defmodule KlassHero.Accounts.Domain.Events.AccountsEventsTest do
     test "succeeds with valid user and custom payload" do
       user = %{id: 1, email: "test@example.com", confirmed_at: @confirmed_at}
 
-      event = AccountsEvents.user_confirmed(user, %{confirmation_token: "abc123"})
+      event = Events.user_confirmed(user, %{confirmation_token: "abc123"})
 
       assert event.payload.confirmation_token == "abc123"
     end
@@ -173,7 +173,7 @@ defmodule KlassHero.Accounts.Domain.Events.AccountsEventsTest do
         intended_roles: [:provider]
       }
 
-      event = AccountsEvents.user_confirmed(user)
+      event = Events.user_confirmed(user)
 
       assert event.payload.name == "Test Provider"
       assert event.payload.intended_roles == ["provider"]
@@ -187,7 +187,7 @@ defmodule KlassHero.Accounts.Domain.Events.AccountsEventsTest do
 
       for payload <- [%{}, %{previous_email: nil}, %{previous_email: ""}] do
         assert_raise ArgumentError, ~r/requires :previous_email in payload/, fn ->
-          AccountsEvents.user_anonymized(user, payload)
+          Events.user_anonymized(user, payload)
         end
       end
     end
@@ -198,14 +198,14 @@ defmodule KlassHero.Accounts.Domain.Events.AccountsEventsTest do
       assert_raise ArgumentError,
                    "User.id cannot be nil for user_anonymized event",
                    fn ->
-                     AccountsEvents.user_anonymized(user, %{previous_email: "old@example.com"})
+                     Events.user_anonymized(user, %{previous_email: "old@example.com"})
                    end
     end
 
     test "succeeds with valid user and previous_email" do
       user = %{id: 1, email: "deleted_1@anonymized.local"}
 
-      event = AccountsEvents.user_anonymized(user, %{previous_email: "old@example.com"})
+      event = Events.user_anonymized(user, %{previous_email: "old@example.com"})
 
       assert %Event{} = event
       assert event.event_type == :user_anonymized
@@ -222,7 +222,7 @@ defmodule KlassHero.Accounts.Domain.Events.AccountsEventsTest do
       user = %{id: 1, email: "deleted_1@anonymized.local"}
 
       event =
-        AccountsEvents.user_anonymized(user, %{
+        Events.user_anonymized(user, %{
           previous_email: "old@example.com",
           deletion_reason: "user_requested"
         })

--- a/test/klass_hero/accounts/staff_invitation_handler_test.exs
+++ b/test/klass_hero/accounts/staff_invitation_handler_test.exs
@@ -1,4 +1,4 @@
-defmodule KlassHero.Accounts.Adapters.Driving.Events.StaffInvitationHandlerTest do
+defmodule KlassHero.Accounts.StaffInvitationHandlerTest do
   @moduledoc """
   Tests for StaffInvitationHandler.
 
@@ -14,7 +14,7 @@ defmodule KlassHero.Accounts.Adapters.Driving.Events.StaffInvitationHandlerTest 
   import KlassHero.EventTestHelper
   import Swoosh.TestAssertions
 
-  alias KlassHero.Accounts.Adapters.Driving.Events.StaffInvitationHandler
+  alias KlassHero.Accounts.StaffInvitationHandler
   alias KlassHero.Provider.Domain.Events.ProviderEvents
   alias KlassHero.Shared.Domain.Events.Event
 

--- a/test/klass_hero/accounts/user_add_role_test.exs
+++ b/test/klass_hero/accounts/user_add_role_test.exs
@@ -1,4 +1,4 @@
-defmodule KlassHero.Accounts.Adapters.Driven.Persistence.Schemas.UserAddRoleTest do
+defmodule KlassHero.Accounts.UserAddRoleTest do
   use KlassHero.DataCase, async: true
 
   alias KlassHero.Accounts.User

--- a/test/klass_hero/accounts/user_remove_role_test.exs
+++ b/test/klass_hero/accounts/user_remove_role_test.exs
@@ -1,4 +1,4 @@
-defmodule KlassHero.Accounts.Adapters.Driven.Persistence.Schemas.UserRemoveRoleTest do
+defmodule KlassHero.Accounts.UserRemoveRoleTest do
   use KlassHero.DataCase, async: true
 
   alias KlassHero.Accounts.User

--- a/test/klass_hero/accounts/user_role_test.exs
+++ b/test/klass_hero/accounts/user_role_test.exs
@@ -88,42 +88,6 @@ defmodule KlassHero.Accounts.UserRoleTest do
     end
   end
 
-  describe "permissions/1" do
-    test "returns the five parent permissions" do
-      assert UserRole.permissions(:parent) |> Enum.sort() ==
-               Enum.sort([
-                 :view_programs,
-                 :enroll_children,
-                 :view_child_progress,
-                 :manage_family_profile,
-                 :submit_reviews
-               ])
-    end
-
-    test "returns the five provider permissions" do
-      assert UserRole.permissions(:provider) |> Enum.sort() ==
-               Enum.sort([
-                 :manage_programs,
-                 :view_enrollments,
-                 :manage_schedule,
-                 :view_analytics,
-                 :respond_to_reviews
-               ])
-    end
-
-    test "returns a non-empty list for :staff" do
-      assert UserRole.permissions(:staff) != []
-      assert is_list(UserRole.permissions(:staff))
-    end
-
-    for invalid <- [:admin, :invalid, "parent", nil, 123, %{}] do
-      @invalid invalid
-      test "returns [] for #{inspect(invalid)}" do
-        assert UserRole.permissions(@invalid) == []
-      end
-    end
-  end
-
   property "to_string then from_string round-trips every valid role" do
     check all(role <- member_of(UserRole.valid_roles())) do
       {:ok, string} = UserRole.to_string(role)

--- a/test/klass_hero/accounts/user_role_test.exs
+++ b/test/klass_hero/accounts/user_role_test.exs
@@ -1,8 +1,8 @@
-defmodule KlassHero.Accounts.Types.UserRoleTest do
+defmodule KlassHero.Accounts.UserRoleTest do
   use ExUnit.Case, async: true
   use ExUnitProperties
 
-  alias KlassHero.Accounts.Types.UserRole
+  alias KlassHero.Accounts.UserRole
 
   test "valid_roles/0 returns the known role atoms" do
     assert UserRole.valid_roles() == [:parent, :provider, :staff]

--- a/test/klass_hero/accounts/user_roles_test.exs
+++ b/test/klass_hero/accounts/user_roles_test.exs
@@ -1,8 +1,8 @@
-defmodule KlassHero.Accounts.Types.UserRolesTest do
+defmodule KlassHero.Accounts.UserRolesTest do
   use ExUnit.Case, async: true
   use ExUnitProperties
 
-  alias KlassHero.Accounts.Types.UserRoles
+  alias KlassHero.Accounts.UserRoles
 
   test "type/0 is an array of strings" do
     assert UserRoles.type() == {:array, :string}

--- a/test/klass_hero/accounts/user_staff_registration_test.exs
+++ b/test/klass_hero/accounts/user_staff_registration_test.exs
@@ -1,4 +1,4 @@
-defmodule KlassHero.Accounts.Adapters.Driven.Persistence.Schemas.UserStaffRegistrationTest do
+defmodule KlassHero.Accounts.UserStaffRegistrationTest do
   use KlassHero.DataCase, async: true
 
   alias KlassHero.Accounts.User

--- a/test/klass_hero/family/adapters/driving/events/family_event_handler_test.exs
+++ b/test/klass_hero/family/adapters/driving/events/family_event_handler_test.exs
@@ -8,7 +8,7 @@ defmodule KlassHero.Family.Adapters.Driving.Events.FamilyEventHandlerTest do
   import KlassHero.EventTestHelper
   import KlassHero.Factory
 
-  alias KlassHero.Accounts.Domain.Events.AccountsEvents
+  alias KlassHero.Accounts
   alias KlassHero.AccountsFixtures
   alias KlassHero.Family.Adapters.Driving.Events.FamilyEventHandler
   alias KlassHero.Family.Child
@@ -43,7 +43,7 @@ defmodule KlassHero.Family.Adapters.Driving.Events.FamilyEventHandlerTest do
       )
 
       event =
-        AccountsEvents.user_anonymized(
+        Accounts.Events.user_anonymized(
           %{id: user.id, email: "deleted_#{user.id}@anonymized.local"},
           %{previous_email: user.email}
         )
@@ -69,7 +69,7 @@ defmodule KlassHero.Family.Adapters.Driving.Events.FamilyEventHandlerTest do
       {child, _parent} = insert_child_with_guardian(parent: parent)
 
       event =
-        AccountsEvents.user_anonymized(
+        Accounts.Events.user_anonymized(
           %{id: user.id, email: "deleted_#{user.id}@anonymized.local"},
           %{previous_email: user.email}
         )
@@ -84,7 +84,7 @@ defmodule KlassHero.Family.Adapters.Driving.Events.FamilyEventHandlerTest do
       user = AccountsFixtures.user_fixture()
 
       event =
-        AccountsEvents.user_anonymized(
+        Accounts.Events.user_anonymized(
           %{id: user.id, email: "deleted_#{user.id}@anonymized.local"},
           %{previous_email: user.email}
         )

--- a/test/klass_hero/integration/staff_invitation_saga_test.exs
+++ b/test/klass_hero/integration/staff_invitation_saga_test.exs
@@ -26,9 +26,8 @@ defmodule KlassHero.Integration.StaffInvitationSagaTest do
   import Swoosh.TestAssertions
 
   alias KlassHero.Accounts
-  alias KlassHero.Accounts.Adapters.Driving.Events.StaffInvitationHandler
-  alias KlassHero.Accounts.Domain.Events.AccountsEvents
   alias KlassHero.Accounts.Scope
+  alias KlassHero.Accounts.StaffInvitationHandler
   alias KlassHero.Provider
   alias KlassHero.Provider.Adapters.Driving.Events.EventHandlers.StaffInvitationStatusHandler
   alias KlassHero.Provider.Domain.Events.ProviderEvents
@@ -48,21 +47,21 @@ defmodule KlassHero.Integration.StaffInvitationSagaTest do
   end
 
   defp build_sent_event(staff) do
-    AccountsEvents.staff_invitation_sent(
+    Accounts.Events.staff_invitation_sent(
       staff.id,
       %{provider_id: staff.provider_id}
     )
   end
 
   defp build_failed_event(staff, reason \\ "delivery_error") do
-    AccountsEvents.staff_invitation_failed(
+    Accounts.Events.staff_invitation_failed(
       staff.id,
       %{provider_id: staff.provider_id, reason: reason}
     )
   end
 
   defp build_registered_event(user_id, staff, opts) do
-    AccountsEvents.staff_user_registered(
+    Accounts.Events.staff_user_registered(
       user_id,
       Map.merge(%{staff_member_id: staff.id, provider_id: staff.provider_id}, opts)
     )

--- a/test/klass_hero/messaging/adapters/driving/events/messaging_event_handler_test.exs
+++ b/test/klass_hero/messaging/adapters/driving/events/messaging_event_handler_test.exs
@@ -8,7 +8,7 @@ defmodule KlassHero.Messaging.Adapters.Driving.Events.MessagingEventHandlerTest 
   import KlassHero.EventTestHelper
   import KlassHero.Factory
 
-  alias KlassHero.Accounts.Domain.Events.AccountsEvents
+  alias KlassHero.Accounts
   alias KlassHero.AccountsFixtures
   alias KlassHero.Messaging.Adapters.Driving.Events.MessagingEventHandler
   alias KlassHero.Messaging.Message
@@ -37,7 +37,7 @@ defmodule KlassHero.Messaging.Adapters.Driving.Events.MessagingEventHandlerTest 
       )
 
       event =
-        AccountsEvents.user_anonymized(
+        Accounts.Events.user_anonymized(
           %{id: user.id, email: "deleted_#{user.id}@anonymized.local"},
           %{previous_email: user.email}
         )
@@ -69,7 +69,7 @@ defmodule KlassHero.Messaging.Adapters.Driving.Events.MessagingEventHandlerTest 
       user = AccountsFixtures.user_fixture()
 
       event =
-        AccountsEvents.user_anonymized(
+        Accounts.Events.user_anonymized(
           %{id: user.id, email: "deleted_#{user.id}@anonymized.local"},
           %{previous_email: user.email}
         )
@@ -84,7 +84,7 @@ defmodule KlassHero.Messaging.Adapters.Driving.Events.MessagingEventHandlerTest 
       user = AccountsFixtures.user_fixture()
 
       event =
-        AccountsEvents.user_anonymized(
+        Accounts.Events.user_anonymized(
           %{id: user.id, email: "deleted_#{user.id}@anonymized.local"},
           %{previous_email: user.email}
         )

--- a/test/klass_hero/provider/adapters/driving/events/event_handlers/staff_invitation_status_handler_test.exs
+++ b/test/klass_hero/provider/adapters/driving/events/event_handlers/staff_invitation_status_handler_test.exs
@@ -1,7 +1,7 @@
 defmodule KlassHero.Provider.Adapters.Driving.Events.EventHandlers.StaffInvitationStatusHandlerTest do
   use KlassHero.DataCase, async: true
 
-  alias KlassHero.Accounts.Domain.Events.AccountsEvents
+  alias KlassHero.Accounts
   alias KlassHero.AccountsFixtures
   alias KlassHero.Provider
   alias KlassHero.Provider.Adapters.Driving.Events.EventHandlers.StaffInvitationStatusHandler
@@ -21,7 +21,7 @@ defmodule KlassHero.Provider.Adapters.Driving.Events.EventHandlers.StaffInvitati
     test "transitions pending staff member to :sent and sets invitation_sent_at" do
       staff = ProviderFixtures.staff_member_fixture(invitation_status: :pending)
 
-      event = AccountsEvents.staff_invitation_sent(staff.id)
+      event = Accounts.Events.staff_invitation_sent(staff.id)
 
       assert :ok = StaffInvitationStatusHandler.handle_event(event)
 
@@ -37,7 +37,7 @@ defmodule KlassHero.Provider.Adapters.Driving.Events.EventHandlers.StaffInvitati
           invitation_sent_at: ~U[2025-01-01 10:00:00Z]
         )
 
-      event = AccountsEvents.staff_invitation_sent(staff.id)
+      event = Accounts.Events.staff_invitation_sent(staff.id)
 
       assert :ok = StaffInvitationStatusHandler.handle_event(event)
 
@@ -50,7 +50,7 @@ defmodule KlassHero.Provider.Adapters.Driving.Events.EventHandlers.StaffInvitati
       # Staff already in :sent — the :pending -> :sent transition is invalid
       staff = ProviderFixtures.staff_member_fixture(invitation_status: :sent)
 
-      event = AccountsEvents.staff_invitation_sent(staff.id)
+      event = Accounts.Events.staff_invitation_sent(staff.id)
 
       # Returns :ok instead of {:error, _} — idempotent by design
       assert :ok = StaffInvitationStatusHandler.handle_event(event)
@@ -65,7 +65,7 @@ defmodule KlassHero.Provider.Adapters.Driving.Events.EventHandlers.StaffInvitati
     test "transitions pending staff member to :failed" do
       staff = ProviderFixtures.staff_member_fixture(invitation_status: :pending)
 
-      event = AccountsEvents.staff_invitation_failed(staff.id)
+      event = Accounts.Events.staff_invitation_failed(staff.id)
 
       assert :ok = StaffInvitationStatusHandler.handle_event(event)
 
@@ -76,7 +76,7 @@ defmodule KlassHero.Provider.Adapters.Driving.Events.EventHandlers.StaffInvitati
     test "is idempotent when staff already in :failed status (was re-enqueued)" do
       staff = ProviderFixtures.staff_member_fixture(invitation_status: :failed)
 
-      event = AccountsEvents.staff_invitation_failed(staff.id)
+      event = Accounts.Events.staff_invitation_failed(staff.id)
 
       assert :ok = StaffInvitationStatusHandler.handle_event(event)
 
@@ -96,7 +96,7 @@ defmodule KlassHero.Provider.Adapters.Driving.Events.EventHandlers.StaffInvitati
         )
 
       event =
-        AccountsEvents.staff_user_registered(user.id, %{
+        Accounts.Events.staff_user_registered(user.id, %{
           staff_member_id: staff.id
         })
 
@@ -114,7 +114,7 @@ defmodule KlassHero.Provider.Adapters.Driving.Events.EventHandlers.StaffInvitati
       staff = ProviderFixtures.staff_member_fixture(invitation_status: :pending)
 
       event =
-        AccountsEvents.staff_user_registered(user.id, %{
+        Accounts.Events.staff_user_registered(user.id, %{
           staff_member_id: staff.id
         })
 
@@ -135,7 +135,7 @@ defmodule KlassHero.Provider.Adapters.Driving.Events.EventHandlers.StaffInvitati
         )
 
       event =
-        AccountsEvents.staff_user_registered(user.id, %{
+        Accounts.Events.staff_user_registered(user.id, %{
           staff_member_id: staff.id
         })
 
@@ -152,12 +152,12 @@ defmodule KlassHero.Provider.Adapters.Driving.Events.EventHandlers.StaffInvitati
 
   describe "handle_event/1 with non-existent staff member" do
     test "returns error for :staff_invitation_sent with unknown staff_member_id" do
-      event = AccountsEvents.staff_invitation_sent(Ecto.UUID.generate())
+      event = Accounts.Events.staff_invitation_sent(Ecto.UUID.generate())
       assert {:error, :not_found} = StaffInvitationStatusHandler.handle_event(event)
     end
 
     test "returns error for :staff_invitation_failed with unknown staff_member_id" do
-      event = AccountsEvents.staff_invitation_failed(Ecto.UUID.generate())
+      event = Accounts.Events.staff_invitation_failed(Ecto.UUID.generate())
       assert {:error, :not_found} = StaffInvitationStatusHandler.handle_event(event)
     end
 
@@ -165,7 +165,7 @@ defmodule KlassHero.Provider.Adapters.Driving.Events.EventHandlers.StaffInvitati
       user = AccountsFixtures.unconfirmed_user_fixture()
 
       event =
-        AccountsEvents.staff_user_registered(user.id, %{
+        Accounts.Events.staff_user_registered(user.id, %{
           staff_member_id: Ecto.UUID.generate()
         })
 
@@ -190,7 +190,7 @@ defmodule KlassHero.Provider.Adapters.Driving.Events.EventHandlers.StaffInvitati
         )
 
       event =
-        AccountsEvents.staff_user_registered(
+        Accounts.Events.staff_user_registered(
           user.id,
           %{staff_member_id: staff.id, provider_id: provider.id}
         )
@@ -222,7 +222,7 @@ defmodule KlassHero.Provider.Adapters.Driving.Events.EventHandlers.StaffInvitati
   describe "handle_event/1 for malformed payloads" do
     test "returns error for missing staff_member_id" do
       event =
-        AccountsEvents.staff_invitation_sent(Ecto.UUID.generate(), %{
+        Accounts.Events.staff_invitation_sent(Ecto.UUID.generate(), %{
           provider_id: Ecto.UUID.generate()
         })
 
@@ -234,7 +234,7 @@ defmodule KlassHero.Provider.Adapters.Driving.Events.EventHandlers.StaffInvitati
 
     test "returns error for missing user_id in staff_user_registered" do
       event =
-        AccountsEvents.staff_user_registered(Ecto.UUID.generate(), %{
+        Accounts.Events.staff_user_registered(Ecto.UUID.generate(), %{
           staff_member_id: Ecto.UUID.generate(),
           provider_id: Ecto.UUID.generate()
         })


### PR DESCRIPTION
Flattens the `accounts` context's directory layout as the pilot for a repo-wide
convention change, records the convention as ADR 0018, and updates the docs and
review-agent specs that enforce it. A small simplification pass over Accounts
rides along.

## Why

The #986→#1002 flatten removed DDD's ports, mappers, and DI wiring but kept the
directory scaffolding. Accounts paid **four directory levels for one file** —
`adapters/driving/events/staff_invitation_handler.ex`, module name
`KlassHero.Accounts.Adapters.Driving.Events.StaffInvitationHandler` — and its
event factory stuttered as `Accounts.Domain.Events.AccountsEvents`.

The `driven`/`driving` split states directionality twice: a handler or worker is
inbound, a projection or ACL is outbound, and the kind name already says so.

The strongest evidence it was scaffolding is `Shared.Tracing.@noise_segments` —
a hardcoded list (`Adapters`, `Driven`, `Driving`, `Events`, `Workers`,
`Projections`, …) that `gen_span_name/1` **strips back out** of every module name
before it becomes a span, because the full name is unreadable in a trace. When
the observability layer deletes your directory structure to stay legible, the
structure is noise. This makes the file tree agree.

## The convention (ADR 0018)

Modules at the context root. A kind earns a **one-level** directory at 3+ files
— the same extraction threshold `frontend.md` already applies to components. No
`adapters/`, no `domain/`, no `driven`/`driving`. Nothing in Accounts reaches
three, so it is entirely flat.

The threshold covers only named kinds (`projections/`, `workers/`, `acl/`,
`notifications/`, `queries/`, `read_models/`). It does **not** license a
catch-all: `services/` is DDD for "module I could not otherwise place", so the
four contexts that have one move those modules to the context root.

## Review focus

**1. The migration window is the risky part.** Only Accounts is converted; the
other six keep the old tree. Both shapes must stay legal or `/review-architecture`
turns into noise. The `architecture-reviewer` checks previously read *"for each
file in `adapters/driven/projections/`"* — against a flat context that matches
nothing and **passes vacuously**, a false negative that reads as "clean". Checks
now identify artifacts by code signature (`use KlassHero.Shared.Projection`,
`use Oban.Worker`, `:event_consumers` registration) and then validate placement
against either shape.

**2. Two departures from the plan, both from verification.**
- `anonymize_user(nil)` was expected to be dead code. It has two tests asserting
  `{:error, :user_not_found}` — a public error contract, so it **stays**.
  `UserRole.permissions/1` went instead: zero production callers, and its tests
  only asserted a literal table matched itself, so they could not fail.
- The `Ecto.Multi` cleanup is not the planned shared helper. The three sites
  aren't uniform, but each carried a clause returning the value the generic
  clause below it already produced. Deleting dead clauses beat adding an
  abstraction.

**3. Naming trap, deliberately accepted.** `gen_span_name/1` strips `Events`, so
`KlassHero.Accounts.Events` reduces to bare `Accounts`. Latent only — the factory
emits no spans. `@noise_segments` is **not** pruned here; it stays load-bearing
for the six unconverted contexts, and pruning early silently relocates production
spans (#1259). A comment at `tracing.ex:25` says so.

## Test plan

- `mix precommit` — **4690 passed**, credo clean. Baseline 4699 minus the 9
  deleted `permissions/1` cases.
- `mix lint_read_tables` / `mix lint_acl_boundary` — green, confirming both are
  layout-agnostic (they key on depth and first-path-segment, never the literal
  `adapters/driven` string), so neither needed changing.
- `event_consumer_wiring_test.exs` — proves the renamed handler is still routed
  from `"integration:provider:staff_member_invited"`.
- **Tidewave against real dev data:** built the event with the real
  `ProviderEvents.staff_member_invited/2` constructor → renamed handler returned
  `:ok` → invitation email delivered with the token URL → `:staff_invitation_sent`
  staged with `source_context: "accounts"` → delivery job enqueued.
- `/review-architecture` — architecture-reviewer 8/8 clean, and confirmed it does
  **not** flag the unconverted `provider` context. boundary-checker 5/5 clean.

One review finding was fixed in-branch: broadening boundary check 1 closed a
false negative but opened a false positive against event factories and registry
wiring, now explicitly exempted (production code still may not name another
context's handler or entity modules — only config and tests may).

## Also fixed

`authentication.md`'s Accounts tree was already wrong before this branch: it
listed `user_events.ex` and `accounts_integration_events.ex`, neither of which
has ever existed; called the roles modules `Ecto.Enum` types when one is a
hand-rolled `Ecto.Type`; and omitted the invitation handler.

Three test modules sat under `test/.../accounts/adapters/driven/persistence/schemas/`,
a path with no lib counterpart since the original flatten deleted Accounts' driven
side. They test plain `User` changesets and moved to the context root.

## Follow-ups

#1425 provider · #1426 family · #1427 messaging · #1428 participation ·
#1429 enrollment · #1430 program_catalog · #1431 `{:array, Ecto.Enum}` for roles

Pre-existing, out of scope, noted by review: `accounts.ex` aliases
`KlassHero.Provider.StaffMember` (an entity, not the facade) — unchanged from
main.
