### PR TITLE
feat: rename provider-facing "Business" copy to "Provider"

### DIFF
--- a/lib/klass_hero_web/components/provider_components.ex
+++ b/lib/klass_hero_web/components/provider_components.ex
@@ -204,11 +204,11 @@ defmodule KlassHeroWeb.ProviderComponents do
       <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-4">
         <div>
           <h2 class="text-xl font-semibold text-hero-charcoal mb-1">
-            {gettext("Business Profile")}
+            {gettext("Provider Profile")}
           </h2>
           <p class="text-sm text-hero-grey-500">
             {gettext(
-              "This is your main business identity. Verification is required to list programs."
+              "This is your main provider identity. Verification is required to list programs."
             )}
           </p>
         </div>
@@ -399,7 +399,7 @@ defmodule KlassHeroWeb.ProviderComponents do
             ]}
           >
             <.icon name="hero-check-badge-mini" class="w-4 h-4" />
-            {gettext("Verified Business")}
+            {gettext("Verified Provider")}
           </span>
         </div>
       </div>
@@ -426,7 +426,7 @@ defmodule KlassHeroWeb.ProviderComponents do
               Theme.transition(:normal)
             ]}
           >
-            {gettext("Complete business verification to create programs.")}
+            {gettext("Complete verification to create programs.")}
           </div>
         </div>
       </div>
@@ -3080,7 +3080,7 @@ defmodule KlassHeroWeb.ProviderComponents do
         {gettext("Verification Documents")}
       </h2>
       <p class="text-sm text-hero-grey-500 mb-6">
-        {gettext("Upload documents to verify your business. Documents are reviewed by our team.")}
+        {gettext("Upload documents to be verified. Documents are reviewed by our team.")}
       </p>
 
       <div id="verification-docs" phx-update="stream" class="space-y-3 mb-6">

--- a/lib/klass_hero_web/live/provider/edit_profile_live.ex
+++ b/lib/klass_hero_web/live/provider/edit_profile_live.ex
@@ -195,7 +195,7 @@ defmodule KlassHeroWeb.Provider.EditProfileLive do
 
           <div class={["bg-white p-6 shadow-sm border border-hero-grey-200", Theme.rounded(:xl)]}>
             <h2 class="text-lg font-semibold text-hero-charcoal mb-4">
-              {gettext("Business Information")}
+              {gettext("Provider Information")}
             </h2>
 
             <.form
@@ -208,14 +208,14 @@ defmodule KlassHeroWeb.Provider.EditProfileLive do
               <.input
                 field={@form[:description]}
                 type="textarea"
-                label={gettext("Business Description")}
+                label={gettext("Provider Description")}
                 placeholder={gettext("Tell parents about your organization...")}
                 rows="4"
               />
 
               <div>
                 <label class="block text-sm font-semibold text-hero-charcoal mb-2">
-                  {gettext("Business Logo")}
+                  {gettext("Provider Logo")}
                 </label>
 
                 <div

--- a/lib/klass_hero_web/live/provider/profile_completion_live.ex
+++ b/lib/klass_hero_web/live/provider/profile_completion_live.ex
@@ -275,8 +275,8 @@ defmodule KlassHeroWeb.Provider.ProfileCompletionLive do
             <.input
               field={@form[:business_name]}
               type="text"
-              label={gettext("Business Name")}
-              placeholder={gettext("Your business or organization name")}
+              label={gettext("Provider Name")}
+              placeholder={gettext("Your provider or organization name")}
             />
 
             <.input
@@ -309,7 +309,7 @@ defmodule KlassHeroWeb.Provider.ProfileCompletionLive do
               field={@form[:address]}
               type="text"
               label={gettext("Address")}
-              placeholder={gettext("Your business address")}
+              placeholder={gettext("Your address")}
             />
 
             <div>
@@ -341,7 +341,7 @@ defmodule KlassHeroWeb.Provider.ProfileCompletionLive do
             <%!-- Logo Upload --%>
             <div>
               <label class="block text-sm font-semibold text-gray-700 mb-2">
-                {gettext("Business Logo")}
+                {gettext("Provider Logo")}
               </label>
               <div
                 id="logo-upload"

--- a/lib/klass_hero_web/live/staff/staff_dashboard_live.ex
+++ b/lib/klass_hero_web/live/staff/staff_dashboard_live.ex
@@ -52,7 +52,7 @@ defmodule KlassHeroWeb.Staff.StaffDashboardLive do
          socket
          |> put_flash(
            :error,
-           gettext("The business associated with your account could not be found.")
+           gettext("The provider associated with your account could not be found.")
          )
          |> push_navigate(to: ~p"/")}
     end
@@ -69,7 +69,7 @@ defmodule KlassHeroWeb.Staff.StaffDashboardLive do
       {:ok, _user} ->
         {:noreply,
          socket
-         |> put_flash(:info, gettext("Welcome aboard! Let's set up your business profile."))
+         |> put_flash(:info, gettext("Welcome aboard! Let's set up your provider profile."))
          |> push_navigate(to: ~p"/provider/complete-profile")}
 
       {:error, :already_provider} ->
@@ -226,7 +226,7 @@ defmodule KlassHeroWeb.Staff.StaffDashboardLive do
             "text-sm font-medium text-brand hover:text-brand/80"
           ]}>
             <.icon name="hero-building-storefront-mini" class="w-4 h-4" />
-            {gettext("Switch business")}
+            {gettext("Switch provider")}
             <.icon name="hero-chevron-down-mini" class="w-4 h-4" />
           </summary>
           <ul class={[
@@ -260,19 +260,19 @@ defmodule KlassHeroWeb.Staff.StaffDashboardLive do
           navigate={~p"/provider/dashboard"}
           class="inline-flex items-center gap-1 text-sm text-brand hover:text-brand/80 mt-2"
         >
-          {gettext("Manage your business")} →
+          {gettext("Manage your provider profile")} →
         </.link>
       </div>
 
       <.kh_card :if={not @provider?} id="become-provider-cta" class="p-5 mt-6">
         <h2 class={Theme.typography(:card_title)}>
-          {gettext("Start your own business")}
+          {gettext("Become a provider")}
         </h2>
         <%= if @upgrade_confirm? do %>
           <div id="become-provider-confirm" class="mt-1">
             <p class="text-sm text-hero-grey-600">
               {gettext(
-                "You'll get your own provider profile to fill in, and your account will open on your business dashboard from now on. You stay on %{business}'s team.",
+                "You'll get your own provider profile to fill in, and your account will open on your provider dashboard from now on. You stay on %{business}'s team.",
                 business: @provider.business_name
               )}
             </p>

--- a/lib/klass_hero_web/live/user_live/staff_invitation.ex
+++ b/lib/klass_hero_web/live/user_live/staff_invitation.ex
@@ -26,7 +26,7 @@ defmodule KlassHeroWeb.UserLive.StaffInvitation do
         <.mk_page_hero pill={gettext("Invitation")}>
           <:title>{gettext("Invitation Expired")}</:title>
           <:lede>
-            {gettext("This invitation has expired. Please ask your business to resend it.")}
+            {gettext("This invitation has expired. Please ask your provider to resend it.")}
           </:lede>
         </.mk_page_hero>
         <section class="relative pb-20 -mt-8 lg:-mt-12 px-6 text-center">

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -1611,11 +1611,6 @@ msgstr "Zugewiesenes Personal"
 msgid "Book Now"
 msgstr "Jetzt buchen"
 
-#: lib/klass_hero_web/components/provider_components.ex:207
-#, elixir-autogen, elixir-format
-msgid "Business Profile"
-msgstr "Geschäftsprofil"
-
 #: lib/klass_hero_web/presenters/provider_presenter.ex:83
 #: lib/klass_hero_web/presenters/provider_presenter.ex:93
 #, elixir-autogen, elixir-format
@@ -1730,11 +1725,6 @@ msgstr "Team & Profile"
 msgid "Team & Provider Profiles"
 msgstr "Team- & Anbieterprofile"
 
-#: lib/klass_hero_web/components/provider_components.ex:210
-#, elixir-autogen, elixir-format
-msgid "This is your main business identity. Verification is required to list programs."
-msgstr "Dies ist Ihre Hauptgeschäftsidentität. Eine Verifizierung ist erforderlich, um Programme anzubieten."
-
 #: lib/klass_hero_web/components/provider_components.ex:1539
 #: lib/klass_hero_web/components/provider_components.ex:1900
 #, elixir-autogen, elixir-format
@@ -1749,11 +1739,6 @@ msgstr "Nicht zugewiesen"
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr "Unbekannt"
-
-#: lib/klass_hero_web/components/provider_components.ex:402
-#, elixir-autogen, elixir-format
-msgid "Verified Business"
-msgstr "Verifiziertes Unternehmen"
 
 #: lib/klass_hero_web/components/provider_components.ex:1577
 #, elixir-autogen, elixir-format
@@ -2293,22 +2278,6 @@ msgstr "Von Eltern entwickelt, um Pädagogen zu stärken."
 msgid "Business"
 msgstr "Business"
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:211
-#, elixir-autogen, elixir-format
-msgid "Business Description"
-msgstr "Geschäftsbeschreibung"
-
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:198
-#, elixir-autogen, elixir-format
-msgid "Business Information"
-msgstr "Geschäftsinformationen"
-
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:218
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:344
-#, elixir-autogen, elixir-format
-msgid "Business Logo"
-msgstr "Firmenlogo"
-
 #: lib/klass_hero_web/components/provider_components.ex:983
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:306
 #, elixir-autogen, elixir-format
@@ -2355,11 +2324,6 @@ msgstr "Foto auswählen"
 #, elixir-autogen, elixir-format
 msgid "Choose a category"
 msgstr "Kategorie auswählen"
-
-#: lib/klass_hero_web/components/provider_components.ex:429
-#, elixir-autogen, elixir-format
-msgid "Complete business verification to create programs."
-msgstr "Schließen Sie die Geschäftsverifizierung ab, um Programme zu erstellen."
 
 #: lib/klass_hero_web/live/admin/verifications_live.ex:467
 #, elixir-autogen, elixir-format
@@ -3206,11 +3170,6 @@ msgstr "Dokument hochladen"
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr "Neues Dokument hochladen"
-
-#: lib/klass_hero_web/components/provider_components.ex:3083
-#, elixir-autogen, elixir-format
-msgid "Upload documents to verify your business. Documents are reviewed by our team."
-msgstr "Laden Sie Dokumente hoch, um Ihr Unternehmen zu verifizieren. Die Dokumente werden von unserem Team überprüft."
 
 #: lib/klass_hero_web/components/provider_components.ex:3063
 #, elixir-autogen, elixir-format
@@ -4556,20 +4515,10 @@ msgstr "Teilnahme bestätigen"
 msgid "Support: %{details}"
 msgstr "Unterstützung: %{details}"
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:55
-#, elixir-autogen, elixir-format
-msgid "The business associated with your account could not be found."
-msgstr "Das mit Ihrem Konto verknüpfte Unternehmen konnte nicht gefunden werden."
-
 #: lib/klass_hero_web/live/provider/team_live.ex:253
 #, elixir-autogen, elixir-format
 msgid "This invitation cannot be resent in its current state."
 msgstr "Diese Einladung kann in ihrem aktuellen Status nicht erneut gesendet werden."
-
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:29
-#, elixir-autogen, elixir-format
-msgid "This invitation has expired. Please ask your business to resend it."
-msgstr "Diese Einladung ist abgelaufen. Bitten Sie Ihr Unternehmen, sie erneut zu senden."
 
 #: lib/klass_hero_web/live/user_live/staff_invitation.ex:18
 #, elixir-autogen, elixir-format
@@ -4721,11 +4670,6 @@ msgstr "Über den Anbieter"
 msgid "Built for the Berlin international community. Integrated secure encrypted messaging to connect with local families and trusted educators nearby."
 msgstr "Entwickelt für die internationale Berliner Gemeinschaft. Integriertes sicheres verschlüsseltes Messaging, um sich mit lokalen Familien und vertrauenswürdigen Pädagogen in Ihrer Nähe zu verbinden."
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:278
-#, elixir-autogen, elixir-format
-msgid "Business Name"
-msgstr "Unternehmensname"
-
 #: lib/klass_hero_web/components/participation_components.ex:813
 #, elixir-autogen, elixir-format
 msgid "Cancelled"
@@ -4791,11 +4735,6 @@ msgstr "Geben Sie Ihre Unternehmensdaten ein, damit Eltern Sie finden können. I
 #, elixir-autogen, elixir-format
 msgid "Fill in your business details. Your profile will be reviewed by Klass Hero before going live."
 msgstr "Geben Sie Ihre Unternehmensdaten ein. Ihr Profil wird von Klass Hero geprüft, bevor es veröffentlicht wird."
-
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:263
-#, elixir-autogen, elixir-format
-msgid "Manage your business"
-msgstr "Ihr Unternehmen verwalten"
 
 #: lib/klass_hero_web/live/messaging_live_helper.ex:444
 #, elixir-autogen, elixir-format
@@ -4871,16 +4810,6 @@ msgstr "Ihre Zuweisungen anzeigen"
 #, elixir-autogen, elixir-format
 msgid "Website"
 msgstr "Website"
-
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:312
-#, elixir-autogen, elixir-format
-msgid "Your business address"
-msgstr "Ihre Geschäftsadresse"
-
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:279
-#, elixir-autogen, elixir-format
-msgid "Your business or organization name"
-msgstr "Name Ihres Unternehmens oder Ihrer Organisation"
 
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:30
 #, elixir-autogen, elixir-format
@@ -5378,6 +5307,7 @@ msgstr "Werden Sie ein Hero"
 msgid "Become a Hero →"
 msgstr "Werden Sie ein Hero →"
 
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:269
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:314
 #, elixir-autogen, elixir-format
 msgid "Become a provider"
@@ -6519,11 +6449,6 @@ msgstr "Kostenlos starten"
 msgid "Start teaching today"
 msgstr "Heute mit dem Unterrichten beginnen"
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:269
-#, elixir-autogen, elixir-format
-msgid "Start your own business"
-msgstr "Starten Sie Ihr eigenes Unternehmen"
-
 #: lib/klass_hero_web/live/for_providers_live.ex:229
 #, elixir-autogen, elixir-format
 msgid "Still curious?"
@@ -6543,11 +6468,6 @@ msgstr "Eingereicht von"
 #, elixir-autogen, elixir-format
 msgid "Supporting local programs and eco-conscious practices."
 msgstr "Unterstützung lokaler Programme und umweltbewusster Praktiken."
-
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:229
-#, elixir-autogen, elixir-format
-msgid "Switch business"
-msgstr "Unternehmen wechseln"
 
 #: lib/klass_hero_web/live/for_providers_live.ex:240
 #, elixir-autogen, elixir-format
@@ -6749,11 +6669,6 @@ msgstr "Wöchentliches Abenteuerziel"
 msgid "Welcome"
 msgstr "Willkommen"
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:72
-#, elixir-autogen, elixir-format
-msgid "Welcome aboard! Let's set up your business profile."
-msgstr "Willkommen an Bord! Lassen Sie uns Ihr Geschäftsprofil einrichten."
-
 #: lib/klass_hero_web/live/contact_live.ex:177
 #, elixir-autogen, elixir-format
 msgid "What's on your mind?"
@@ -6799,11 +6714,6 @@ msgstr "Sie haben bereits ein Anbieterprofil."
 #, elixir-autogen, elixir-format
 msgid "You already have an account for %{email}."
 msgstr "Sie haben bereits ein Konto für %{email}."
-
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:274
-#, elixir-autogen, elixir-format
-msgid "You'll get your own provider profile to fill in, and your account will open on your business dashboard from now on. You stay on %{business}'s team."
-msgstr "Sie erhalten Ihr eigenes Anbieterprofil zum Ausfüllen, und Ihr Konto öffnet sich ab sofort auf Ihrem Geschäfts-Dashboard. Sie bleiben im Team von %{business}."
 
 #: lib/klass_hero_web/live/provider/team_live.ex:336
 #, elixir-autogen, elixir-format
@@ -8072,3 +7982,89 @@ msgstr "Einverständniserklärung zurückgezogen. Bereits erteilte Unterschrifte
 #, elixir-autogen, elixir-format
 msgid "You are not assigned to this session"
 msgstr "Sie sind diesem Termin nicht zugewiesen"
+
+#: lib/klass_hero_web/components/provider_components.ex:429
+#, elixir-autogen, elixir-format
+msgid "Complete verification to create programs."
+msgstr "Schließen Sie die Verifizierung ab, um Programme zu erstellen."
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:263
+#, elixir-autogen, elixir-format
+msgid "Manage your provider profile"
+msgstr "Ihr Anbieterprofil verwalten"
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:211
+#, elixir-autogen, elixir-format
+msgid "Provider Description"
+msgstr "Anbieterbeschreibung"
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:198
+#, elixir-autogen, elixir-format
+msgid "Provider Information"
+msgstr "Anbieterinformationen"
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:218
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:344
+#, elixir-autogen, elixir-format
+msgid "Provider Logo"
+msgstr "Anbieterlogo"
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:278
+#, elixir-autogen, elixir-format
+msgid "Provider Name"
+msgstr "Anbietername"
+
+#: lib/klass_hero_web/components/provider_components.ex:207
+#, elixir-autogen, elixir-format
+msgid "Provider Profile"
+msgstr "Anbieterprofil"
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:229
+#, elixir-autogen, elixir-format
+msgid "Switch provider"
+msgstr "Anbieter wechseln"
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:55
+#, elixir-autogen, elixir-format
+msgid "The provider associated with your account could not be found."
+msgstr "Der mit Ihrem Konto verknüpfte Anbieter konnte nicht gefunden werden."
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:29
+#, elixir-autogen, elixir-format
+msgid "This invitation has expired. Please ask your provider to resend it."
+msgstr "Diese Einladung ist abgelaufen. Bitte bitten Sie Ihren Anbieter, sie erneut zu senden."
+
+#: lib/klass_hero_web/components/provider_components.ex:210
+#, elixir-autogen, elixir-format
+msgid "This is your main provider identity. Verification is required to list programs."
+msgstr "Dies ist Ihr Hauptprofil als Anbieter. Eine Verifizierung ist erforderlich, um Programme anzubieten."
+
+#: lib/klass_hero_web/components/provider_components.ex:3083
+#, elixir-autogen, elixir-format
+msgid "Upload documents to be verified. Documents are reviewed by our team."
+msgstr "Laden Sie Dokumente hoch, um verifiziert zu werden. Die Dokumente werden von unserem Team überprüft."
+
+#: lib/klass_hero_web/components/provider_components.ex:402
+#, elixir-autogen, elixir-format
+msgid "Verified Provider"
+msgstr "Verifizierter Anbieter"
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:72
+#, elixir-autogen, elixir-format
+msgid "Welcome aboard! Let's set up your provider profile."
+msgstr "Willkommen an Bord! Lassen Sie uns Ihr Anbieterprofil einrichten."
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:274
+#, elixir-autogen, elixir-format
+msgid "You'll get your own provider profile to fill in, and your account will open on your provider dashboard from now on. You stay on %{business}'s team."
+msgstr "Sie erhalten Ihr eigenes Anbieterprofil zum Ausfüllen, und Ihr Konto öffnet sich ab sofort auf Ihrem Anbieter-Dashboard. Sie bleiben im Team von %{business}."
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:312
+#, elixir-autogen, elixir-format
+msgid "Your address"
+msgstr "Ihre Adresse"
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:279
+#, elixir-autogen, elixir-format
+msgid "Your provider or organization name"
+msgstr "Name Ihres Anbieters oder Ihrer Organisation"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -1611,11 +1611,6 @@ msgstr ""
 msgid "Book Now"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:207
-#, elixir-autogen, elixir-format
-msgid "Business Profile"
-msgstr ""
-
 #: lib/klass_hero_web/presenters/provider_presenter.ex:83
 #: lib/klass_hero_web/presenters/provider_presenter.ex:93
 #, elixir-autogen, elixir-format
@@ -1730,11 +1725,6 @@ msgstr ""
 msgid "Team & Provider Profiles"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:210
-#, elixir-autogen, elixir-format
-msgid "This is your main business identity. Verification is required to list programs."
-msgstr ""
-
 #: lib/klass_hero_web/components/provider_components.ex:1539
 #: lib/klass_hero_web/components/provider_components.ex:1900
 #, elixir-autogen, elixir-format
@@ -1748,11 +1738,6 @@ msgstr ""
 #: lib/klass_hero_web/presenters/provider_presenter.ex:103
 #, elixir-autogen, elixir-format
 msgid "Unknown"
-msgstr ""
-
-#: lib/klass_hero_web/components/provider_components.ex:402
-#, elixir-autogen, elixir-format
-msgid "Verified Business"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1577
@@ -2293,22 +2278,6 @@ msgstr ""
 msgid "Business"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:211
-#, elixir-autogen, elixir-format
-msgid "Business Description"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:198
-#, elixir-autogen, elixir-format
-msgid "Business Information"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:218
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:344
-#, elixir-autogen, elixir-format
-msgid "Business Logo"
-msgstr ""
-
 #: lib/klass_hero_web/components/provider_components.ex:983
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:306
 #, elixir-autogen, elixir-format
@@ -2354,11 +2323,6 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:985
 #, elixir-autogen, elixir-format
 msgid "Choose a category"
-msgstr ""
-
-#: lib/klass_hero_web/components/provider_components.ex:429
-#, elixir-autogen, elixir-format
-msgid "Complete business verification to create programs."
 msgstr ""
 
 #: lib/klass_hero_web/live/admin/verifications_live.ex:467
@@ -3205,11 +3169,6 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:3115
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
-msgstr ""
-
-#: lib/klass_hero_web/components/provider_components.ex:3083
-#, elixir-autogen, elixir-format
-msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:3063
@@ -4556,19 +4515,9 @@ msgstr ""
 msgid "Support: %{details}"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:55
-#, elixir-autogen, elixir-format
-msgid "The business associated with your account could not be found."
-msgstr ""
-
 #: lib/klass_hero_web/live/provider/team_live.ex:253
 #, elixir-autogen, elixir-format
 msgid "This invitation cannot be resent in its current state."
-msgstr ""
-
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:29
-#, elixir-autogen, elixir-format
-msgid "This invitation has expired. Please ask your business to resend it."
 msgstr ""
 
 #: lib/klass_hero_web/live/user_live/staff_invitation.ex:18
@@ -4721,11 +4670,6 @@ msgstr ""
 msgid "Built for the Berlin international community. Integrated secure encrypted messaging to connect with local families and trusted educators nearby."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:278
-#, elixir-autogen, elixir-format
-msgid "Business Name"
-msgstr ""
-
 #: lib/klass_hero_web/components/participation_components.ex:813
 #, elixir-autogen, elixir-format
 msgid "Cancelled"
@@ -4790,11 +4734,6 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:228
 #, elixir-autogen, elixir-format
 msgid "Fill in your business details. Your profile will be reviewed by Klass Hero before going live."
-msgstr ""
-
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:263
-#, elixir-autogen, elixir-format
-msgid "Manage your business"
 msgstr ""
 
 #: lib/klass_hero_web/live/messaging_live_helper.ex:444
@@ -4870,16 +4809,6 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:303
 #, elixir-autogen, elixir-format
 msgid "Website"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:312
-#, elixir-autogen, elixir-format
-msgid "Your business address"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:279
-#, elixir-autogen, elixir-format
-msgid "Your business or organization name"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:30
@@ -5378,6 +5307,7 @@ msgstr ""
 msgid "Become a Hero →"
 msgstr ""
 
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:269
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:314
 #, elixir-autogen, elixir-format
 msgid "Become a provider"
@@ -6519,11 +6449,6 @@ msgstr ""
 msgid "Start teaching today"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:269
-#, elixir-autogen, elixir-format
-msgid "Start your own business"
-msgstr ""
-
 #: lib/klass_hero_web/live/for_providers_live.ex:229
 #, elixir-autogen, elixir-format
 msgid "Still curious?"
@@ -6542,11 +6467,6 @@ msgstr ""
 #: lib/klass_hero_web/live/about_live.ex:25
 #, elixir-autogen, elixir-format
 msgid "Supporting local programs and eco-conscious practices."
-msgstr ""
-
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:229
-#, elixir-autogen, elixir-format
-msgid "Switch business"
 msgstr ""
 
 #: lib/klass_hero_web/live/for_providers_live.ex:240
@@ -6749,11 +6669,6 @@ msgstr ""
 msgid "Welcome"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:72
-#, elixir-autogen, elixir-format
-msgid "Welcome aboard! Let's set up your business profile."
-msgstr ""
-
 #: lib/klass_hero_web/live/contact_live.ex:177
 #, elixir-autogen, elixir-format
 msgid "What's on your mind?"
@@ -6798,11 +6713,6 @@ msgstr ""
 #: lib/klass_hero_web/live/user_live/staff_invitation.ex:89
 #, elixir-autogen, elixir-format
 msgid "You already have an account for %{email}."
-msgstr ""
-
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:274
-#, elixir-autogen, elixir-format
-msgid "You'll get your own provider profile to fill in, and your account will open on your business dashboard from now on. You stay on %{business}'s team."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/team_live.ex:336
@@ -8056,4 +7966,90 @@ msgstr ""
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:220
 #, elixir-autogen, elixir-format
 msgid "You are not assigned to this session"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:429
+#, elixir-autogen, elixir-format
+msgid "Complete verification to create programs."
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:263
+#, elixir-autogen, elixir-format
+msgid "Manage your provider profile"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:211
+#, elixir-autogen, elixir-format
+msgid "Provider Description"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:198
+#, elixir-autogen, elixir-format
+msgid "Provider Information"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:218
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:344
+#, elixir-autogen, elixir-format
+msgid "Provider Logo"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:278
+#, elixir-autogen, elixir-format
+msgid "Provider Name"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:207
+#, elixir-autogen, elixir-format
+msgid "Provider Profile"
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:229
+#, elixir-autogen, elixir-format
+msgid "Switch provider"
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:55
+#, elixir-autogen, elixir-format
+msgid "The provider associated with your account could not be found."
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:29
+#, elixir-autogen, elixir-format
+msgid "This invitation has expired. Please ask your provider to resend it."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:210
+#, elixir-autogen, elixir-format
+msgid "This is your main provider identity. Verification is required to list programs."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:3083
+#, elixir-autogen, elixir-format
+msgid "Upload documents to be verified. Documents are reviewed by our team."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:402
+#, elixir-autogen, elixir-format
+msgid "Verified Provider"
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:72
+#, elixir-autogen, elixir-format
+msgid "Welcome aboard! Let's set up your provider profile."
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:274
+#, elixir-autogen, elixir-format
+msgid "You'll get your own provider profile to fill in, and your account will open on your provider dashboard from now on. You stay on %{business}'s team."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:312
+#, elixir-autogen, elixir-format
+msgid "Your address"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:279
+#, elixir-autogen, elixir-format
+msgid "Your provider or organization name"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -1611,11 +1611,6 @@ msgstr ""
 msgid "Book Now"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:207
-#, elixir-autogen, elixir-format
-msgid "Business Profile"
-msgstr ""
-
 #: lib/klass_hero_web/presenters/provider_presenter.ex:83
 #: lib/klass_hero_web/presenters/provider_presenter.ex:93
 #, elixir-autogen, elixir-format
@@ -1730,11 +1725,6 @@ msgstr ""
 msgid "Team & Provider Profiles"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:210
-#, elixir-autogen, elixir-format
-msgid "This is your main business identity. Verification is required to list programs."
-msgstr ""
-
 #: lib/klass_hero_web/components/provider_components.ex:1539
 #: lib/klass_hero_web/components/provider_components.ex:1900
 #, elixir-autogen, elixir-format
@@ -1748,11 +1738,6 @@ msgstr ""
 #: lib/klass_hero_web/presenters/provider_presenter.ex:103
 #, elixir-autogen, elixir-format
 msgid "Unknown"
-msgstr ""
-
-#: lib/klass_hero_web/components/provider_components.ex:402
-#, elixir-autogen, elixir-format
-msgid "Verified Business"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1577
@@ -2293,22 +2278,6 @@ msgstr ""
 msgid "Business"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:211
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Business Description"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:198
-#, elixir-autogen, elixir-format
-msgid "Business Information"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:218
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:344
-#, elixir-autogen, elixir-format
-msgid "Business Logo"
-msgstr ""
-
 #: lib/klass_hero_web/components/provider_components.ex:983
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:306
 #, elixir-autogen, elixir-format
@@ -2354,11 +2323,6 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:985
 #, elixir-autogen, elixir-format
 msgid "Choose a category"
-msgstr ""
-
-#: lib/klass_hero_web/components/provider_components.ex:429
-#, elixir-autogen, elixir-format
-msgid "Complete business verification to create programs."
 msgstr ""
 
 #: lib/klass_hero_web/live/admin/verifications_live.ex:467
@@ -3205,11 +3169,6 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:3115
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
-msgstr ""
-
-#: lib/klass_hero_web/components/provider_components.ex:3083
-#, elixir-autogen, elixir-format
-msgid "Upload documents to verify your business. Documents are reviewed by our team."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:3063
@@ -4556,19 +4515,9 @@ msgstr ""
 msgid "Support: %{details}"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:55
-#, elixir-autogen, elixir-format
-msgid "The business associated with your account could not be found."
-msgstr ""
-
 #: lib/klass_hero_web/live/provider/team_live.ex:253
 #, elixir-autogen, elixir-format
 msgid "This invitation cannot be resent in its current state."
-msgstr ""
-
-#: lib/klass_hero_web/live/user_live/staff_invitation.ex:29
-#, elixir-autogen, elixir-format
-msgid "This invitation has expired. Please ask your business to resend it."
 msgstr ""
 
 #: lib/klass_hero_web/live/user_live/staff_invitation.ex:18
@@ -4721,11 +4670,6 @@ msgstr ""
 msgid "Built for the Berlin international community. Integrated secure encrypted messaging to connect with local families and trusted educators nearby."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:278
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Business Name"
-msgstr ""
-
 #: lib/klass_hero_web/components/participation_components.ex:813
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cancelled"
@@ -4790,11 +4734,6 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:228
 #, elixir-autogen, elixir-format
 msgid "Fill in your business details. Your profile will be reviewed by Klass Hero before going live."
-msgstr ""
-
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:263
-#, elixir-autogen, elixir-format
-msgid "Manage your business"
 msgstr ""
 
 #: lib/klass_hero_web/live/messaging_live_helper.ex:444
@@ -4870,16 +4809,6 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:303
 #, elixir-autogen, elixir-format
 msgid "Website"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:312
-#, elixir-autogen, elixir-format
-msgid "Your business address"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:279
-#, elixir-autogen, elixir-format
-msgid "Your business or organization name"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:30
@@ -5378,6 +5307,7 @@ msgstr ""
 msgid "Become a Hero →"
 msgstr ""
 
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:269
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:314
 #, elixir-autogen, elixir-format
 msgid "Become a provider"
@@ -6519,11 +6449,6 @@ msgstr ""
 msgid "Start teaching today"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:269
-#, elixir-autogen, elixir-format
-msgid "Start your own business"
-msgstr ""
-
 #: lib/klass_hero_web/live/for_providers_live.ex:229
 #, elixir-autogen, elixir-format
 msgid "Still curious?"
@@ -6542,11 +6467,6 @@ msgstr ""
 #: lib/klass_hero_web/live/about_live.ex:25
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Supporting local programs and eco-conscious practices."
-msgstr ""
-
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:229
-#, elixir-autogen, elixir-format
-msgid "Switch business"
 msgstr ""
 
 #: lib/klass_hero_web/live/for_providers_live.ex:240
@@ -6749,11 +6669,6 @@ msgstr ""
 msgid "Welcome"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:72
-#, elixir-autogen, elixir-format
-msgid "Welcome aboard! Let's set up your business profile."
-msgstr ""
-
 #: lib/klass_hero_web/live/contact_live.ex:177
 #, elixir-autogen, elixir-format
 msgid "What's on your mind?"
@@ -6798,11 +6713,6 @@ msgstr ""
 #: lib/klass_hero_web/live/user_live/staff_invitation.ex:89
 #, elixir-autogen, elixir-format
 msgid "You already have an account for %{email}."
-msgstr ""
-
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:274
-#, elixir-autogen, elixir-format
-msgid "You'll get your own provider profile to fill in, and your account will open on your business dashboard from now on. You stay on %{business}'s team."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/team_live.ex:336
@@ -8056,4 +7966,90 @@ msgstr ""
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:220
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You are not assigned to this session"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:429
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Complete verification to create programs."
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:263
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Manage your provider profile"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:211
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Provider Description"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:198
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Provider Information"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:218
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:344
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Provider Logo"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:278
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Provider Name"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:207
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Provider Profile"
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:229
+#, elixir-autogen, elixir-format
+msgid "Switch provider"
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:55
+#, elixir-autogen, elixir-format
+msgid "The provider associated with your account could not be found."
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/staff_invitation.ex:29
+#, elixir-autogen, elixir-format, fuzzy
+msgid "This invitation has expired. Please ask your provider to resend it."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:210
+#, elixir-autogen, elixir-format, fuzzy
+msgid "This is your main provider identity. Verification is required to list programs."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:3083
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Upload documents to be verified. Documents are reviewed by our team."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:402
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Verified Provider"
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:72
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Welcome aboard! Let's set up your provider profile."
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:274
+#, elixir-autogen, elixir-format, fuzzy
+msgid "You'll get your own provider profile to fill in, and your account will open on your provider dashboard from now on. You stay on %{business}'s team."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:312
+#, elixir-autogen, elixir-format
+msgid "Your address"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:279
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Your provider or organization name"
 msgstr ""

--- a/test/klass_hero_web/live/provider/provider_dashboard_test.exs
+++ b/test/klass_hero_web/live/provider/provider_dashboard_test.exs
@@ -210,8 +210,8 @@ defmodule KlassHeroWeb.Provider.ProviderDashboardTest do
     test "shows tooltip explaining verification requirement", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/provider/dashboard")
 
-      html = render(view)
-      assert html =~ "Complete business verification to create programs."
+      assert view |> element("#new-program-tooltip") |> render() =~
+               "Complete verification to create programs."
     end
   end
 


### PR DESCRIPTION
Closes #1083

## Summary

Renames 18 user-facing msgids so a provider's own profile is called a **Provider Profile**, not a *Business Profile*. "Business" read as intimidating for solo instructors, and the site no longer distinguishes provider account types by tier. `ProviderProfile` was already the domain term and `Anbieterprofil` already the established German (`"Team & Provider Profiles"` → `"Team- & Anbieterprofile"`), so this lands on existing vocabulary rather than introducing a concept.

Copy-only. No context code, no schema, no migration.

Scope is the issue's 7 strings plus 11 gaps found while assessing — the subtitle sitting directly under the renamed card title, the onboarding form (which inherits a renamed `"Business Logo"` through a shared msgid and would otherwise read half-renamed), and the staff surfaces.

## Review focus

**1. The German needed rewriting by hand, and this is why.** `mix gettext.merge` fuzzy-matched the renamed keys against unrelated existing strings and produced German that was not merely stale but wrong:

| msgid | What merge assigned | Which actually means |
|---|---|---|
| `Manage your provider profile` | `Verwalten Sie die Profile Ihrer Kinder` | "Manage your **children's** profiles" |
| `Provider Description` | `Beobachtung des Anbieters` | "**Observation** of the provider" |
| `Provider Profile` / `Provider Name` / `Provider Logo` | `Anbieter` | just "Provider" |

`lint_translations` treats a `fuzzy` flag as a hard failure, so all 14 fuzzy + 3 empty entries were corrected and their flags cleared. Worth a skim of the `de` catalog diff.

**2. What is deliberately *not* renamed.** `"Business Registration"`, `"Legal business name"`, and the `"An individual"` / `"A business"` selector stay — they encode the real `individual` vs `business` entity type the vetting flow branches on (B4/B5 responsible-person path), not tier language. Internal identifiers (`business_profile_card/1`, the `@business` assign, the `business_name` column, the `%{business}` interpolation variable) also stay.

**3. Two wordings are not literal swaps.** `"Manage your business"` → *Manage your provider profile* (the link navigates to the provider dashboard) and `"Start your own business"` → *Become a provider*. The latter turned out to collapse onto a msgid that already existed and was already translated `Anbieter werden` — and it is what the same card's own confirm button already says.

**4. Test assertion narrowed.** `provider_dashboard_test.exs` matched the tooltip copy against the whole page, so it would pass on a stray match anywhere. Retargeted to `element("#new-program-tooltip")`, keeping the copy coverage.

## Test plan

- `mix precommit` — 4699 passed; `lint_translations`, credo `--strict`, typography, read-table and ACL lints all clean.
- Runtime check that all 17 renamed msgids resolve to German rather than falling back to the msgid: **17/17, zero fallbacks**. Confirmed separately that the preserved vocabulary is untouched (`Business Registration` → `Gewerbeanmeldung`, `A business` → `Ein Unternehmen`).
- Browser-walked in **both locales**, asserting the new copy present and old copy absent on each surface:
  - `/provider/dashboard` — *Provider Profile* / *Anbieterprofil*, *Verified Provider* / *Verifizierter Anbieter*
  - `/provider/dashboard/edit` — *Provider Information / Description / Logo* and the German trio
  - `/provider/verification` — renamed upload copy present **and** `Business Registration` still intact on the same page
  - `/staff/dashboard` → upgrade flow → `/provider/complete-profile` — *Become a provider*, the confirm copy with `%{business}` interpolating correctly, the renamed welcome flash, and the onboarding form's labels and placeholders
- The unverified-provider tooltip path has no seed data; it is covered by the updated LiveView test.
