### PR TITLE
feat: show outstanding participant invitations on provider overview

### DIFF
--- a/lib/klass_hero/enrollment.ex
+++ b/lib/klass_hero/enrollment.ex
@@ -19,6 +19,7 @@ defmodule KlassHero.Enrollment do
   alias KlassHero.Enrollment.BulkEnrollmentInvite
   alias KlassHero.Enrollment.ClaimInvite
   alias KlassHero.Enrollment.Domain.Events.EnrollmentEvents
+  alias KlassHero.Enrollment.Domain.ReadModels.OutstandingInvite
   alias KlassHero.Enrollment.Domain.Services.EnrollmentClassifier
   alias KlassHero.Enrollment.EnqueueInviteEmails
   alias KlassHero.Enrollment.Enrollment
@@ -31,6 +32,7 @@ defmodule KlassHero.Enrollment do
   alias KlassHero.Enrollment.SingleInviteForm
   alias KlassHero.Enrollment.Waivers
   alias KlassHero.Family
+  alias KlassHero.ProgramCatalog
   alias KlassHero.Repo
   alias KlassHero.Shared.Adapters.Driven.Persistence.EctoErrorHelpers
   alias KlassHero.Shared.Outbox
@@ -1114,6 +1116,43 @@ defmodule KlassHero.Enrollment do
       |> Repo.all()
 
     {:ok, invites}
+  end
+
+  @doc """
+  Lists every invite this provider has sent that nobody has accepted yet, across
+  all of their programs, oldest first.
+
+  Oldest-first because the list exists to be followed up on: the invite that has
+  gone unanswered longest is the one that needs chasing.
+
+  Returns `[%OutstandingInvite{}]` — see that module for why it mirrors the invite
+  schema's field names.
+  """
+  @spec list_outstanding_invites_for_provider(binary()) :: [OutstandingInvite.t()]
+  def list_outstanding_invites_for_provider(provider_id) when is_binary(provider_id) do
+    # One query for every program's invites. This replaced a per-program
+    # `list_program_invites/1` in a `flat_map`, which N+1'd across the dashboard's
+    # whole program list on every Overview mount (#1073).
+    invites =
+      BulkEnrollmentInvite
+      |> where([i], i.provider_id == ^provider_id)
+      |> where([i], i.status in ^BulkEnrollmentInvite.outstanding_statuses())
+      |> order_by([i], asc: i.inserted_at)
+      |> Repo.all()
+
+    # Titles come from ProgramCatalog's facade, not a join on its table:
+    # `get_titles/1` is batched and documented for exactly this cross-context need,
+    # so ADR 0015's direct-read exception does not apply here. (`list_pending/1`
+    # above still joins `programs`; its cycle-breaking rationale predates this
+    # facade and is worth revisiting separately.)
+    titles =
+      acl_span source: "enrollment", target: "program_catalog" do
+        invites |> Enum.map(& &1.program_id) |> Enum.uniq() |> ProgramCatalog.get_titles()
+      end
+
+    for invite <- invites do
+      OutstandingInvite.from_invite(invite, Map.get(titles, invite.program_id))
+    end
   end
 
   @doc """

--- a/lib/klass_hero/enrollment/bulk_enrollment_invite.ex
+++ b/lib/klass_hero/enrollment/bulk_enrollment_invite.ex
@@ -183,6 +183,16 @@ defmodule KlassHero.Enrollment.BulkEnrollmentInvite do
   def invite_sent?(%__MODULE__{status: :invite_sent}), do: true
   def invite_sent?(%__MODULE__{}), do: false
 
+  @doc """
+  Statuses meaning the invite was sent but nobody has accepted it yet.
+
+  Identical to the resendable set, and deliberately so: an invite is worth
+  resending exactly while it is still outstanding. `:registered` and `:enrolled`
+  are answered, so they are neither.
+  """
+  @spec outstanding_statuses() :: [atom()]
+  def outstanding_statuses, do: @resendable_statuses
+
   @doc "Returns true if the invite status allows resending."
   @spec resendable?(t()) :: boolean()
   def resendable?(%__MODULE__{status: status}) when status in @resendable_statuses, do: true

--- a/lib/klass_hero/enrollment/domain/read_models/outstanding_invite.ex
+++ b/lib/klass_hero/enrollment/domain/read_models/outstanding_invite.ex
@@ -1,0 +1,80 @@
+defmodule KlassHero.Enrollment.Domain.ReadModels.OutstandingInvite do
+  @moduledoc """
+  One participant invite a provider has sent that nobody has accepted yet,
+  carrying the program it belongs to.
+
+  Query-shaped struct over the write tables — no schema twin, no read table, no
+  changeset. Built by `Enrollment.list_outstanding_invites_for_provider/1`, which
+  narrows a `BulkEnrollmentInvite` and attaches the program title the invite row
+  itself does not carry.
+
+  Field names deliberately mirror `BulkEnrollmentInvite`'s, so one invite-table
+  component renders both this struct and the raw schema without a mapper between
+  them (`#1073`). `program_title` is the only field the schema has no answer for.
+  """
+
+  alias KlassHero.Enrollment.BulkEnrollmentInvite
+
+  @typedoc "A provider-wide outstanding invite row for the Overview card."
+  @type t :: %__MODULE__{
+          id: String.t(),
+          program_id: String.t(),
+          program_title: String.t() | nil,
+          child_first_name: String.t(),
+          child_last_name: String.t(),
+          guardian_email: String.t(),
+          status: :pending | :invite_sent | :failed,
+          failure_code: atom() | nil,
+          failure_context: map() | nil,
+          error_details: String.t() | nil,
+          inserted_at: DateTime.t()
+        }
+
+  @enforce_keys [
+    :id,
+    :program_id,
+    :child_first_name,
+    :child_last_name,
+    :guardian_email,
+    :status,
+    :inserted_at
+  ]
+
+  defstruct [
+    :id,
+    :program_id,
+    :program_title,
+    :child_first_name,
+    :child_last_name,
+    :guardian_email,
+    :status,
+    :failure_code,
+    :failure_context,
+    :error_details,
+    :inserted_at
+  ]
+
+  @doc """
+  Builds a row from an invite and the title of the program it belongs to.
+
+  `program_title` may be `nil` when the program row is gone; the caller renders a
+  placeholder rather than dropping the invite, which would hide an invite the
+  provider still needs to act on.
+  """
+  @spec from_invite(BulkEnrollmentInvite.t(), String.t() | nil) :: t()
+  def from_invite(%BulkEnrollmentInvite{} = invite, program_title) do
+    %__MODULE__{
+      id: to_string(invite.id),
+      program_id: to_string(invite.program_id),
+      program_title: program_title,
+      child_first_name: invite.child_first_name,
+      child_last_name: invite.child_last_name,
+      guardian_email: invite.guardian_email,
+      status: invite.status,
+      failure_code: invite.failure_code,
+      failure_context: invite.failure_context,
+      error_details: invite.error_details,
+      inserted_at: invite.inserted_at
+    }
+  end
+end

--- a/lib/klass_hero_web/components/provider_components.ex
+++ b/lib/klass_hero_web/components/provider_components.ex
@@ -2690,75 +2690,117 @@ defmodule KlassHeroWeb.ProviderComponents do
         </div>
       <% end %>
 
-      <div :if={@invites == []} id="invites-empty" class="text-center py-8">
-        <.icon name="hero-envelope" class="w-12 h-12 mx-auto text-hero-grey-300 mb-3" />
-        <p class="text-hero-grey-500">
-          {gettext("No invites yet. Upload a CSV to invite families.")}
-        </p>
-      </div>
+      <.invite_table
+        id="invites"
+        invites={@invites}
+        empty_message={gettext("No invites yet. Upload a CSV to invite families.")}
+      />
+    </div>
+    """
+  end
 
-      <div :if={@invites != []} class="overflow-x-auto -mx-4 px-4 sm:mx-0 sm:px-0">
-        <table id="invites-table" class="w-full min-w-[500px]">
-          <thead class="bg-hero-grey-50 border-b border-hero-grey-200">
-            <tr>
-              <th class="px-3 py-2 text-left text-xs font-semibold text-hero-grey-500 uppercase">
-                {gettext("Child Name")}
-              </th>
-              <th class="px-3 py-2 text-left text-xs font-semibold text-hero-grey-500 uppercase">
-                {gettext("Guardian Email")}
-              </th>
-              <th class="px-3 py-2 text-left text-xs font-semibold text-hero-grey-500 uppercase">
-                {gettext("Status")}
-              </th>
-              <th class="px-3 py-2 text-right text-xs font-semibold text-hero-grey-500 uppercase">
-                {gettext("Actions")}
-              </th>
-            </tr>
-          </thead>
-          <tbody class="divide-y divide-hero-grey-200">
-            <tr :for={invite <- @invites} id={"invite-#{invite.id}"} class="hover:bg-hero-grey-50">
-              <td class="px-3 py-3 text-sm text-hero-charcoal font-medium">
-                {invite.child_first_name} {invite.child_last_name}
-              </td>
-              <td class="px-3 py-3 text-sm text-hero-grey-500">
-                {invite.guardian_email}
-              </td>
-              <td class="px-3 py-3">
-                <.status_pill color={invite_status_color(invite.status)}>
-                  {invite_status_label(invite.status)}
-                </.status_pill>
-                <%!-- Written by three places and shown by none until #1221: a red pill with no
-                      reason tells a provider that something is wrong but not what to do about it. --%>
-                <p
-                  :if={invite.status == :failed && failure_message(invite)}
-                  id={"invite-error-#{invite.id}"}
-                  class="mt-1 text-xs text-hero-grey-500 break-words"
-                >
-                  {failure_message(invite)}
-                </p>
-              </td>
-              <td class="px-3 py-3 text-right">
-                <div class="flex items-center justify-end gap-1">
-                  <.action_button
-                    :if={invite.status in [:pending, :invite_sent, :failed]}
-                    icon="hero-arrow-path-mini"
-                    title={gettext("Resend Invite")}
-                    phx-click="resend_invite"
-                    phx-value-id={invite.id}
-                  />
-                  <.action_button
-                    :if={invite.status in [:pending, :invite_sent, :failed]}
-                    icon="hero-trash-mini"
-                    title={gettext("Remove")}
-                    phx-click="delete_invite"
-                    phx-value-id={invite.id}
-                  />
-                </div>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
+  @doc """
+  Renders invites as a table with per-row Resend / Remove actions, or an empty state.
+
+  Serves two callers with different scopes: the per-program roster tab, and the
+  Overview card's provider-wide outstanding list (#1073). `show_program?` adds the
+  column the second one needs — the first has a single program in its heading, so
+  repeating it on every row would be noise.
+
+  Renders any struct carrying the invite field names, which is why
+  `Enrollment.Domain.ReadModels.OutstandingInvite` mirrors them rather than being
+  translated by a mapper here.
+  """
+  attr :id, :string, required: true
+  attr :invites, :list, required: true
+  attr :empty_message, :string, required: true
+  attr :show_program?, :boolean, default: false
+
+  def invite_table(assigns) do
+    ~H"""
+    <div :if={@invites == []} id={"#{@id}-empty"} class="text-center py-8">
+      <.icon name="hero-envelope" class="w-12 h-12 mx-auto text-hero-grey-300 mb-3" />
+      <p class="text-hero-grey-500">{@empty_message}</p>
+    </div>
+
+    <div :if={@invites != []} class="overflow-x-auto -mx-4 px-4 sm:mx-0 sm:px-0">
+      <table id={"#{@id}-table"} class="w-full min-w-[500px]">
+        <thead class="bg-hero-grey-50 border-b border-hero-grey-200">
+          <tr>
+            <th class="px-3 py-2 text-left text-xs font-semibold text-hero-grey-500 uppercase">
+              {gettext("Child Name")}
+            </th>
+            <%!-- Hidden below `sm`: a fifth column pushes Actions off a 375px viewport,
+                  so on mobile the program rides under the child's name instead. --%>
+            <th
+              :if={@show_program?}
+              class="hidden sm:table-cell px-3 py-2 text-left text-xs font-semibold text-hero-grey-500 uppercase"
+            >
+              {gettext("Program")}
+            </th>
+            <th class="px-3 py-2 text-left text-xs font-semibold text-hero-grey-500 uppercase">
+              {gettext("Guardian Email")}
+            </th>
+            <th class="px-3 py-2 text-left text-xs font-semibold text-hero-grey-500 uppercase">
+              {gettext("Status")}
+            </th>
+            <th class="px-3 py-2 text-right text-xs font-semibold text-hero-grey-500 uppercase">
+              {gettext("Actions")}
+            </th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-hero-grey-200">
+          <tr :for={invite <- @invites} id={"invite-#{invite.id}"} class="hover:bg-hero-grey-50">
+            <td class="px-3 py-3 text-sm text-hero-charcoal font-medium">
+              {invite.child_first_name} {invite.child_last_name}
+              <span
+                :if={@show_program?}
+                class="block sm:hidden text-xs font-normal text-hero-grey-500"
+              >
+                {invite.program_title || gettext("Unknown program")}
+              </span>
+            </td>
+            <td :if={@show_program?} class="hidden sm:table-cell px-3 py-3 text-sm text-hero-grey-500">
+              {invite.program_title || gettext("Unknown program")}
+            </td>
+            <td class="px-3 py-3 text-sm text-hero-grey-500">
+              {invite.guardian_email}
+            </td>
+            <td class="px-3 py-3">
+              <.status_pill color={invite_status_color(invite.status)}>
+                {invite_status_label(invite.status)}
+              </.status_pill>
+              <%!-- Written by three places and shown by none until #1221: a red pill with no
+                    reason tells a provider that something is wrong but not what to do about it. --%>
+              <p
+                :if={invite.status == :failed && failure_message(invite)}
+                id={"invite-error-#{invite.id}"}
+                class="mt-1 text-xs text-hero-grey-500 break-words"
+              >
+                {failure_message(invite)}
+              </p>
+            </td>
+            <td class="px-3 py-3 text-right">
+              <div class="flex items-center justify-end gap-1">
+                <.action_button
+                  :if={invite.status in [:pending, :invite_sent, :failed]}
+                  icon="hero-arrow-path-mini"
+                  title={gettext("Resend Invite")}
+                  phx-click="resend_invite"
+                  phx-value-id={invite.id}
+                />
+                <.action_button
+                  :if={invite.status in [:pending, :invite_sent, :failed]}
+                  icon="hero-trash-mini"
+                  title={gettext("Remove")}
+                  phx-click="delete_invite"
+                  phx-value-id={invite.id}
+                />
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
     </div>
     """
   end

--- a/lib/klass_hero_web/components/provider_layout_components.ex
+++ b/lib/klass_hero_web/components/provider_layout_components.ex
@@ -593,54 +593,6 @@ defmodule KlassHeroWeb.ProviderLayoutComponents do
   end
 
   @doc """
-  Pending booking-request card with Accept / Decline footer actions.
-
-  `request` keys: `:id, :parent, :program, :child, :when, :color`.
-  """
-  attr :request, :map, required: true
-  attr :on_accept, :string, default: "accept_request"
-  attr :on_decline, :string, default: "decline_request"
-
-  def pv_request_card(assigns) do
-    ~H"""
-    <.kh_list_row
-      class="border border-hero-grey-200 bg-white"
-      meta={[@request[:program], @request[:child]]}
-    >
-      <:media>
-        <div
-          class="w-9 h-9 rounded-full flex items-center justify-center font-bold text-black text-sm"
-          style={"background: #{@request[:color] || "#FFEAC9"}"}
-        >
-          {String.first(@request[:parent] || "?") |> String.upcase()}
-        </div>
-      </:media>
-      <:title>{@request[:parent] || gettext("Unknown parent")}</:title>
-      <:footer>
-        <div class="flex gap-2 justify-end">
-          <button
-            type="button"
-            phx-click={@on_decline}
-            phx-value-request-id={@request[:id]}
-            class="px-3 py-1.5 text-xs font-bold rounded-lg border border-hero-grey-300 hover:bg-hero-grey-100"
-          >
-            {gettext("Decline")}
-          </button>
-          <button
-            type="button"
-            phx-click={@on_accept}
-            phx-value-request-id={@request[:id]}
-            class="px-3 py-1.5 text-xs font-bold rounded-lg bg-[var(--brand-primary)] text-black hover:shadow-md"
-          >
-            {gettext("Accept")}
-          </button>
-        </div>
-      </:footer>
-    </.kh_list_row>
-    """
-  end
-
-  @doc """
   Pending enrollment card with an Approve button.
 
   `entry` keys: `:enrollment_id, :child_name, :program_title, :enrolled_at`.

--- a/lib/klass_hero_web/live/provider/dashboard/invite_actions.ex
+++ b/lib/klass_hero_web/live/provider/dashboard/invite_actions.ex
@@ -1,0 +1,67 @@
+defmodule KlassHeroWeb.Provider.Dashboard.InviteActions do
+  @moduledoc """
+  Shared Resend / Remove handling for the provider-dashboard sub-LiveViews.
+
+  Two tabs act on the same invite through the same facade calls but hold different
+  lists: ProgramsLive shows one program's roster, OverviewLive the provider-wide
+  outstanding set (#1073). Only the reload differs, so each caller passes its own
+  `refresh` and this module owns the shared part — the mapping from
+  `Enrollment.resend_invite/2` and `delete_invite/2` results to a user-facing flash.
+
+  `refresh` runs only on success; a failed call changed nothing worth re-reading.
+
+  Follows the `Chrome`/`Params`/`Uploads` precedent in this directory: shared
+  sub-LiveView behaviour lives beside them, not duplicated into each tab.
+  """
+
+  use Gettext, backend: KlassHeroWeb.Gettext
+
+  import Phoenix.LiveView, only: [put_flash: 3]
+
+  alias KlassHero.Enrollment
+  alias Phoenix.LiveView.Socket
+
+  require Logger
+
+  @typedoc "Reloads the caller's own invite list after a successful action."
+  @type refresh :: (Socket.t() -> Socket.t())
+
+  @doc """
+  Resends an invite, refreshing via `refresh` on success. Returns the socket.
+  """
+  @spec resend(Socket.t(), String.t(), String.t(), refresh()) :: Socket.t()
+  def resend(socket, invite_id, provider_id, refresh) when is_function(refresh, 1) do
+    case Enrollment.resend_invite(invite_id, provider_id) do
+      {:ok, _invite} ->
+        socket |> refresh.() |> put_flash(:info, gettext("Invite resent successfully."))
+
+      {:error, :not_resendable} ->
+        put_flash(socket, :error, gettext("This invite cannot be resent."))
+
+      {:error, reason} ->
+        Logger.warning("[Dashboard.InviteActions] Resend invite failed unexpectedly",
+          invite_id: invite_id,
+          reason: inspect(reason)
+        )
+
+        put_flash(socket, :error, gettext("Failed to resend invite."))
+    end
+  end
+
+  @doc """
+  Removes an invite, refreshing via `refresh` on success. Returns the socket.
+  """
+  @spec delete(Socket.t(), String.t(), String.t(), refresh()) :: Socket.t()
+  def delete(socket, invite_id, provider_id, refresh) when is_function(refresh, 1) do
+    case Enrollment.delete_invite(invite_id, provider_id) do
+      :ok ->
+        socket |> refresh.() |> put_flash(:info, gettext("Invite removed."))
+
+      {:error, :not_found} ->
+        put_flash(socket, :error, gettext("Invite not found."))
+
+      {:error, :delete_failed} ->
+        put_flash(socket, :error, gettext("Could not remove invite."))
+    end
+  end
+end

--- a/lib/klass_hero_web/live/provider/overview_live.ex
+++ b/lib/klass_hero_web/live/provider/overview_live.ex
@@ -18,6 +18,7 @@ defmodule KlassHeroWeb.Provider.OverviewLive do
   alias KlassHero.Provider
   alias KlassHeroWeb.Presenters.ProviderPresenter
   alias KlassHeroWeb.Provider.Dashboard.Chrome
+  alias KlassHeroWeb.Provider.Dashboard.InviteActions
   alias KlassHeroWeb.Theme
 
   require Logger
@@ -37,7 +38,7 @@ defmodule KlassHeroWeb.Provider.OverviewLive do
     enrollment_counts = Enrollment.count_active_enrollments_batch(program_ids)
     enrolled_total = enrollment_counts |> Map.values() |> Enum.sum()
 
-    pending_requests = load_pending_requests(program_ids)
+    outstanding_invites = Enrollment.list_outstanding_invites_for_provider(provider.id)
     pending_enrollments = Enrollment.list_pending_enrollments_for_provider(program_ids)
     top_programs = build_top_programs(program_listings, enrollment_counts)
 
@@ -62,7 +63,8 @@ defmodule KlassHeroWeb.Provider.OverviewLive do
       |> assign(programs_count: length(program_listings))
       |> assign(total_sessions_completed: total_sessions)
       |> assign(enrolled_total: enrolled_total)
-      |> assign(pending_requests: pending_requests)
+      |> assign(outstanding_invites: outstanding_invites)
+      |> assign(invites_modal_open?: false)
       |> assign(pending_enrollments: pending_enrollments)
       |> assign(top_programs: top_programs)
 
@@ -104,6 +106,26 @@ defmodule KlassHeroWeb.Provider.OverviewLive do
     end
   end
 
+  @impl true
+  def handle_event("open_invites", _params, socket) do
+    {:noreply, assign(socket, :invites_modal_open?, true)}
+  end
+
+  @impl true
+  def handle_event("close_invites", _params, socket) do
+    {:noreply, assign(socket, :invites_modal_open?, false)}
+  end
+
+  @impl true
+  def handle_event("resend_invite", %{"id" => invite_id}, socket) do
+    {:noreply, invite_action(&InviteActions.resend/4, invite_id, socket)}
+  end
+
+  @impl true
+  def handle_event("delete_invite", %{"id" => invite_id}, socket) do
+    {:noreply, invite_action(&InviteActions.delete/4, invite_id, socket)}
+  end
+
   # The shared dashboard header's "New Program" CTA lives on every tab; from
   # Overview it navigates to the Programs tab with the create form opened.
   @impl true
@@ -140,30 +162,6 @@ defmodule KlassHeroWeb.Provider.OverviewLive do
   defp fetch_verification_docs(provider_id) do
     {:ok, docs} = Provider.get_provider_verification_documents(provider_id)
     docs
-  end
-
-  defp load_pending_requests(program_ids) do
-    palette = ["#FFEAC9", "#33CFFF", "#FFFF36", "#FFD896"]
-
-    program_ids
-    |> Enum.flat_map(&safe_list_invites/1)
-    |> Enum.with_index()
-    |> Enum.map(fn {invite, idx} ->
-      %{
-        id: invite.id,
-        parent: invite.invitee_name || invite.invitee_email || "Unknown",
-        program: invite.program_id,
-        child: invite[:child_name] || "—",
-        when: invite[:created_at] && Calendar.strftime(invite.created_at, "%b %d"),
-        color: Enum.at(palette, rem(idx, length(palette)))
-      }
-    end)
-    |> Enum.take(5)
-  end
-
-  defp safe_list_invites(program_id) do
-    {:ok, invites} = Enrollment.list_program_invites(program_id)
-    Enum.filter(invites, &(&1.status == :pending))
   end
 
   # Top 5 provider programs sorted by active-enrollment count desc.
@@ -204,6 +202,20 @@ defmodule KlassHeroWeb.Provider.OverviewLive do
 
   defp past?(nil, _today), do: false
   defp past?(date, today), do: Date.after?(today, date)
+
+  # Both invite actions reload the same provider-wide list, so only the
+  # InviteActions function varies.
+  defp invite_action(action, invite_id, socket) do
+    provider_id = socket.assigns.current_scope.provider.id
+
+    action.(socket, invite_id, provider_id, &refresh_outstanding_invites/1)
+  end
+
+  defp refresh_outstanding_invites(socket) do
+    provider_id = socket.assigns.current_scope.provider.id
+
+    assign(socket, :outstanding_invites, Enrollment.list_outstanding_invites_for_provider(provider_id))
+  end
 
   defp refresh_pending_enrollments(socket) do
     provider = socket.assigns.current_scope.provider
@@ -301,19 +313,39 @@ defmodule KlassHeroWeb.Provider.OverviewLive do
             </div>
           </.kh_card>
 
-          <.kh_card class="p-5">
+          <%!-- Provider-wide, not per-program: the whole point is to see invites nobody
+                answered without opening each program's roster in turn (#1073). --%>
+          <.kh_card id="outstanding-invites-card" class="p-5">
             <div class="flex items-center justify-between mb-4">
-              <h3 class="font-bold text-lg">{gettext("Pending booking requests")}</h3>
-              <span class="text-xs text-hero-grey-600 font-semibold">
-                {length(@pending_requests)} {gettext("pending")}
+              <h3 class="font-bold text-lg">{gettext("Invitations awaiting a reply")}</h3>
+              <span id="outstanding-invites-count" class="text-xs text-hero-grey-600 font-semibold">
+                {length(@outstanding_invites)} {gettext("waiting")}
               </span>
             </div>
-            <div :if={@pending_requests == []} class="text-sm text-hero-grey-600">
-              {gettext("No pending requests right now.")}
+            <%!-- Not "outstanding-invites-empty": `invite_table id="outstanding-invites"`
+                  in the modal below derives that exact id for its own empty state. --%>
+            <div
+              :if={@outstanding_invites == []}
+              id="outstanding-invites-card-empty"
+              class="text-sm text-hero-grey-600"
+            >
+              {gettext("Every invitation you sent has been answered.")}
             </div>
-            <div class="space-y-3">
-              <.pv_request_card :for={r <- @pending_requests} request={r} />
-            </div>
+            <button
+              :if={@outstanding_invites != []}
+              id="open-outstanding-invites"
+              type="button"
+              phx-click="open_invites"
+              class={[
+                "w-full px-4 py-2 text-sm font-bold border border-hero-grey-300",
+                "hover:bg-hero-grey-50 text-left flex items-center justify-between gap-2",
+                Theme.rounded(:lg),
+                Theme.transition(:normal)
+              ]}
+            >
+              {gettext("Review invitations")}
+              <.icon name="hero-chevron-right" class="w-4 h-4 shrink-0" />
+            </button>
           </.kh_card>
 
           <.kh_card id="pending-enrollments-card" class="p-5">
@@ -336,6 +368,55 @@ defmodule KlassHeroWeb.Provider.OverviewLive do
         </section>
 
         <.business_profile_card business={@business} />
+      </div>
+
+      <%!-- Assign-driven rather than URL-param driven, matching `roster_modal/1`:
+            the modal is a detail view of state this page already holds, not a
+            separately addressable page. --%>
+      <div
+        :if={@invites_modal_open?}
+        id="outstanding-invites-modal"
+        class="fixed inset-0 z-50 overflow-y-auto"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="outstanding-invites-modal-title"
+        phx-window-keydown="close_invites"
+        phx-key="Escape"
+      >
+        <div class="flex min-h-screen items-center justify-center p-4">
+          <div class="fixed inset-0 bg-black/50" phx-click="close_invites"></div>
+          <div class={["relative bg-white w-full max-w-2xl shadow-xl", Theme.rounded(:xl)]}>
+            <div class="flex items-center justify-between p-4 border-b border-hero-grey-200">
+              <h3
+                id="outstanding-invites-modal-title"
+                class="text-lg font-semibold text-hero-charcoal"
+              >
+                {gettext("Invitations awaiting a reply")}
+              </h3>
+              <button
+                id="close-outstanding-invites"
+                type="button"
+                phx-click="close_invites"
+                aria-label={gettext("Close")}
+                class={[
+                  "p-2 text-hero-grey-400 hover:text-hero-charcoal hover:bg-hero-grey-100",
+                  Theme.rounded(:lg),
+                  Theme.transition(:normal)
+                ]}
+              >
+                <.icon name="hero-x-mark-mini" class="w-5 h-5" />
+              </button>
+            </div>
+            <div class="p-4">
+              <.invite_table
+                id="outstanding-invites"
+                invites={@outstanding_invites}
+                show_program?={true}
+                empty_message={gettext("Every invitation you sent has been answered.")}
+              />
+            </div>
+          </div>
+        </div>
       </div>
     </.pv_dashboard_shell>
     """

--- a/lib/klass_hero_web/live/provider/programs_live.ex
+++ b/lib/klass_hero_web/live/provider/programs_live.ex
@@ -28,6 +28,7 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
   alias KlassHeroWeb.Presenters.ProgramStaffingPresenter
   alias KlassHeroWeb.Presenters.StaffMemberPresenter
   alias KlassHeroWeb.Provider.Dashboard.Chrome
+  alias KlassHeroWeb.Provider.Dashboard.InviteActions
 
   require Logger
 
@@ -466,43 +467,12 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
 
   @impl true
   def handle_event("resend_invite", %{"id" => invite_id}, socket) do
-    provider_id = socket.assigns.current_scope.provider.id
-
-    case Enrollment.resend_invite(invite_id, provider_id) do
-      {:ok, _} ->
-        socket = refresh_invites_silent(socket, socket.assigns.roster_program_id)
-
-        {:noreply, put_flash(socket, :info, gettext("Invite resent successfully."))}
-
-      {:error, :not_resendable} ->
-        {:noreply, put_flash(socket, :error, gettext("This invite cannot be resent."))}
-
-      {:error, reason} ->
-        Logger.warning("[ProgramsLive] Resend invite failed unexpectedly",
-          invite_id: invite_id,
-          reason: inspect(reason)
-        )
-
-        {:noreply, put_flash(socket, :error, gettext("Failed to resend invite."))}
-    end
+    {:noreply, invite_action(&InviteActions.resend/4, invite_id, socket)}
   end
 
   @impl true
   def handle_event("delete_invite", %{"id" => invite_id}, socket) do
-    provider_id = socket.assigns.current_scope.provider.id
-
-    case Enrollment.delete_invite(invite_id, provider_id) do
-      :ok ->
-        socket = refresh_invites_silent(socket, socket.assigns.roster_program_id)
-
-        {:noreply, put_flash(socket, :info, gettext("Invite removed."))}
-
-      {:error, :not_found} ->
-        {:noreply, put_flash(socket, :error, gettext("Invite not found."))}
-
-      {:error, :delete_failed} ->
-        {:noreply, put_flash(socket, :error, gettext("Could not remove invite."))}
-    end
+    {:noreply, invite_action(&InviteActions.delete/4, invite_id, socket)}
   end
 
   @impl true
@@ -853,6 +823,15 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
     {:ok, assign(socket, roster_invites: invites, roster_invite_count: invite_count)}
   end
 
+  # Both invite actions reload the same thing — the open roster's invites — so the
+  # only part that varies is which InviteActions function runs.
+  defp invite_action(action, invite_id, socket) do
+    program_id = socket.assigns.roster_program_id
+    provider_id = socket.assigns.current_scope.provider.id
+
+    action.(socket, invite_id, provider_id, &refresh_invites_silent(&1, program_id))
+  end
+
   defp refresh_invites_silent(socket, program_id) do
     case refresh_invites(socket, program_id) do
       {:ok, socket} -> socket
@@ -864,8 +843,6 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
     to_form(Enrollment.change_single_invite(), as: "single_invite")
   end
 
-  # Aggregate pending invites across all provider programs and shape them
-  # for `pv_request_card` (parent name, program, child, when, color).
   defp fetch_staff_members(provider_id) do
     {:ok, members} = Provider.list_staff_members(provider_id)
     members

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -575,8 +575,8 @@ msgid "Dispute Resolution"
 msgstr "Streitbeilegung"
 
 #: lib/klass_hero_web/components/provider_components.ex:720
-#: lib/klass_hero_web/components/provider_components.ex:2816
-#: lib/klass_hero_web/components/provider_components.ex:2834
+#: lib/klass_hero_web/components/provider_components.ex:2858
+#: lib/klass_hero_web/components/provider_components.ex:2876
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
@@ -1324,7 +1324,7 @@ msgstr "Schnellnavigation"
 
 #: lib/klass_hero_web/components/provider_components.ex:1488
 #: lib/klass_hero_web/components/provider_components.ex:2472
-#: lib/klass_hero_web/components/provider_components.ex:2714
+#: lib/klass_hero_web/components/provider_components.ex:2748
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr "Aktionen"
@@ -1340,7 +1340,7 @@ msgstr "Aktiv"
 msgid "Add Team Member"
 msgstr "Teammitglied hinzufügen"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:48
+#: lib/klass_hero_web/live/provider/programs_live.ex:49
 #, elixir-autogen, elixir-format
 msgid "All Staff"
 msgstr "Alle Mitarbeiter"
@@ -1391,7 +1391,7 @@ msgid "Inactive"
 msgstr "Inaktiv"
 
 #: lib/klass_hero_web/components/provider_components.ex:114
-#: lib/klass_hero_web/live/provider/programs_live.ex:54
+#: lib/klass_hero_web/live/provider/programs_live.ex:55
 #, elixir-autogen, elixir-format
 msgid "My Programs"
 msgstr "Meine Programme"
@@ -1410,8 +1410,8 @@ msgstr "Übersicht"
 #: lib/klass_hero_web/components/provider_components.ex:48
 #: lib/klass_hero_web/components/provider_components.ex:74
 #: lib/klass_hero_web/components/provider_components.ex:1635
-#: lib/klass_hero_web/components/provider_components.ex:2910
-#: lib/klass_hero_web/components/provider_components.ex:2928
+#: lib/klass_hero_web/components/provider_components.ex:2952
+#: lib/klass_hero_web/components/provider_components.ex:2970
 #: lib/klass_hero_web/live/admin/sessions_live.ex:298
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
@@ -1433,7 +1433,7 @@ msgstr "Programmübersicht"
 msgid "Program Name"
 msgstr "Programmname"
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:58
+#: lib/klass_hero_web/live/provider/overview_live.ex:59
 #, elixir-autogen, elixir-format
 msgid "Provider Dashboard"
 msgstr "Anbieter-Dashboard"
@@ -1451,7 +1451,7 @@ msgstr "Nach Namen suchen..."
 #: lib/klass_hero_web/components/provider_components.ex:1482
 #: lib/klass_hero_web/components/provider_components.ex:1885
 #: lib/klass_hero_web/components/provider_components.ex:2463
-#: lib/klass_hero_web/components/provider_components.ex:2711
+#: lib/klass_hero_web/components/provider_components.ex:2745
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1604,7 +1604,7 @@ msgstr "Kind konnte nicht entfernt werden. Bitte versuchen Sie es erneut."
 msgid "Data sharing consent"
 msgstr "Einwilligung zur Datenweitergabe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2797
+#: lib/klass_hero_web/components/provider_components.ex:2839
 #: lib/klass_hero_web/live/settings/children_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1652,17 +1652,17 @@ msgstr "Rundnachricht konnte nicht gesendet werden"
 msgid "Failed to submit note"
 msgstr "Notiz konnte nicht eingereicht werden"
 
-#: lib/klass_hero_web/components/provider_components.ex:2791
-#: lib/klass_hero_web/components/provider_components.ex:2820
-#: lib/klass_hero_web/components/provider_components.ex:2836
+#: lib/klass_hero_web/components/provider_components.ex:2833
+#: lib/klass_hero_web/components/provider_components.ex:2862
+#: lib/klass_hero_web/components/provider_components.ex:2878
 #: lib/klass_hero_web/live/settings/children_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr "Vorname"
 
-#: lib/klass_hero_web/components/provider_components.ex:2792
-#: lib/klass_hero_web/components/provider_components.ex:2821
-#: lib/klass_hero_web/components/provider_components.ex:2837
+#: lib/klass_hero_web/components/provider_components.ex:2834
+#: lib/klass_hero_web/components/provider_components.ex:2863
+#: lib/klass_hero_web/components/provider_components.ex:2879
 #: lib/klass_hero_web/live/settings/children_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -1819,7 +1819,7 @@ msgstr "Rundnachricht senden"
 msgid "Send a message to start the conversation"
 msgstr "Senden Sie eine Nachricht, um die Unterhaltung zu beginnen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2891
+#: lib/klass_hero_web/components/provider_components.ex:2933
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:249
 #, elixir-autogen, elixir-format
@@ -1955,12 +1955,12 @@ msgstr "Alter %{min}+"
 msgid "Allowed Genders"
 msgstr "Zulässige Geschlechter"
 
-#: lib/klass_hero_web/components/provider_components.ex:2950
+#: lib/klass_hero_web/components/provider_components.ex:2992
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred during import."
 msgstr "Beim Import ist ein unerwarteter Fehler aufgetreten."
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:670
+#: lib/klass_hero_web/components/provider_layout_components.ex:622
 #: lib/klass_hero_web/live/admin/verifications_live.ex:438
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:53
 #, elixir-autogen, elixir-format
@@ -2035,7 +2035,7 @@ msgid "Check eligibility at"
 msgstr "Berechtigung prüfen unter"
 
 #: lib/klass_hero_web/components/provider_components.ex:2460
-#: lib/klass_hero_web/components/provider_components.ex:2705
+#: lib/klass_hero_web/components/provider_components.ex:2731
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr "Name des Kindes"
@@ -2075,7 +2075,7 @@ msgstr "Kategorie auswählen"
 msgid "Confirm rejection"
 msgstr "Ablehnung bestätigen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2911
+#: lib/klass_hero_web/components/provider_components.ex:2953
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr "Bestätigt"
@@ -2085,12 +2085,12 @@ msgstr "Bestätigt"
 msgid "Contact Provider"
 msgstr "Anbieter kontaktieren"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:536
+#: lib/klass_hero_web/live/provider/programs_live.ex:506
 #, elixir-autogen, elixir-format
 msgid "Could not read the uploaded file."
 msgstr "Die hochgeladene Datei konnte nicht gelesen werden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:504
+#: lib/klass_hero_web/live/provider/dashboard/invite_actions.ex:64
 #, elixir-autogen, elixir-format
 msgid "Could not remove invite."
 msgstr "Einladung konnte nicht entfernt werden."
@@ -2124,7 +2124,7 @@ msgstr "Beschreibung"
 msgid "Diverse"
 msgstr "Divers"
 
-#: lib/klass_hero_web/components/provider_components.ex:3126
+#: lib/klass_hero_web/components/provider_components.ex:3168
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr "Dokumenttyp"
@@ -2190,8 +2190,8 @@ msgid "End Time"
 msgstr "Endzeit"
 
 #: lib/klass_hero_web/components/provider_components.ex:2469
-#: lib/klass_hero_web/components/provider_components.ex:2931
-#: lib/klass_hero_web/components/provider_layout_components.ex:660
+#: lib/klass_hero_web/components/provider_components.ex:2973
+#: lib/klass_hero_web/components/provider_layout_components.ex:612
 #, elixir-autogen, elixir-format
 msgid "Enrolled"
 msgstr "Angemeldet"
@@ -2212,7 +2212,7 @@ msgid "Explain why this document is being rejected..."
 msgstr "Erklären Sie, warum dieses Dokument abgelehnt wird..."
 
 #: lib/klass_hero_web/components/provider_components.ex:72
-#: lib/klass_hero_web/components/provider_components.ex:2932
+#: lib/klass_hero_web/components/provider_components.ex:2974
 #: lib/klass_hero_web/live/admin/emails_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2228,7 +2228,7 @@ msgstr "Dokument konnte nicht genehmigt werden."
 msgid "Failed to reject document."
 msgstr "Dokument konnte nicht abgelehnt werden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:486
+#: lib/klass_hero_web/live/provider/dashboard/invite_actions.ex:47
 #, elixir-autogen, elixir-format
 msgid "Failed to resend invite."
 msgstr "Einladung konnte nicht erneut gesendet werden."
@@ -2256,12 +2256,12 @@ msgstr "Weiblich"
 msgid "File"
 msgstr "Datei"
 
-#: lib/klass_hero_web/components/provider_components.ex:3060
+#: lib/klass_hero_web/components/provider_components.ex:3102
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr "Die Datei ist zu groß."
 
-#: lib/klass_hero_web/components/provider_components.ex:3062
+#: lib/klass_hero_web/components/provider_components.ex:3104
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr "Dateityp wird nicht akzeptiert."
@@ -2296,7 +2296,7 @@ msgstr "Klassenstufe %{min}+"
 msgid "Grades %{min} – %{max}"
 msgstr "Klassenstufen %{min} – %{max}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2708
+#: lib/klass_hero_web/components/provider_components.ex:2742
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr "E-Mail des Erziehungsberechtigten"
@@ -2321,17 +2321,17 @@ msgstr "Importieren"
 msgid "Insurance Certificate"
 msgstr "Versicherungsnachweis"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:501
+#: lib/klass_hero_web/live/provider/dashboard/invite_actions.ex:61
 #, elixir-autogen, elixir-format
 msgid "Invite not found."
 msgstr "Einladung nicht gefunden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:498
+#: lib/klass_hero_web/live/provider/dashboard/invite_actions.ex:58
 #, elixir-autogen, elixir-format
 msgid "Invite removed."
 msgstr "Einladung entfernt."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:475
+#: lib/klass_hero_web/live/provider/dashboard/invite_actions.ex:36
 #, elixir-autogen, elixir-format
 msgid "Invite resent successfully."
 msgstr "Einladung erfolgreich erneut gesendet."
@@ -2437,7 +2437,7 @@ msgstr "Niedrigste Klassenstufe"
 msgid "No approved documents."
 msgstr "Keine genehmigten Dokumente."
 
-#: lib/klass_hero_web/components/provider_components.ex:3088
+#: lib/klass_hero_web/components/provider_components.ex:3130
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr "Noch keine Dokumente hochgeladen."
@@ -2448,7 +2448,7 @@ msgstr "Noch keine Dokumente hochgeladen."
 msgid "No enrollments yet."
 msgstr "Noch keine Anmeldungen."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:532
+#: lib/klass_hero_web/live/provider/programs_live.ex:502
 #, elixir-autogen, elixir-format
 msgid "No file selected."
 msgstr "Keine Datei ausgewählt."
@@ -2521,7 +2521,7 @@ msgstr "Nicht angegeben"
 msgid "Our Story"
 msgstr "Unsere Geschichte"
 
-#: lib/klass_hero_web/components/provider_components.ex:3163
+#: lib/klass_hero_web/components/provider_components.ex:3205
 #: lib/klass_hero_web/live/provider/verification_live.ex:698
 #: lib/klass_hero_web/live/provider/verification_live.ex:770
 #, elixir-autogen, elixir-format
@@ -2548,8 +2548,8 @@ msgstr "Ausstehende Überprüfung"
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:106
-#: lib/klass_hero_web/live/provider/programs_live.ex:775
-#: lib/klass_hero_web/live/provider/programs_live.ex:844
+#: lib/klass_hero_web/live/provider/programs_live.ex:745
+#: lib/klass_hero_web/live/provider/programs_live.ex:814
 #: lib/klass_hero_web/live/provider/team_live.ex:305
 #: lib/klass_hero_web/live/provider/team_live.ex:348
 #: lib/klass_hero_web/live/provider/team_live.ex:467
@@ -2582,28 +2582,28 @@ msgstr "Profil erfolgreich aktualisiert."
 msgid "Program Start"
 msgstr "Programmbeginn"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1337
+#: lib/klass_hero_web/live/provider/programs_live.ex:1314
 #, elixir-autogen, elixir-format
 msgid "Program created successfully."
 msgstr "Programm erfolgreich erstellt."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1341
+#: lib/klass_hero_web/live/provider/programs_live.ex:1318
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr "Programm erstellt, aber die Anmeldekapazität konnte nicht gespeichert werden. Bearbeiten Sie das Programm, um es erneut zu versuchen."
 
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:54
-#: lib/klass_hero_web/live/provider/programs_live.ex:156
-#: lib/klass_hero_web/live/provider/programs_live.ex:193
-#: lib/klass_hero_web/live/provider/programs_live.ex:257
-#: lib/klass_hero_web/live/provider/programs_live.ex:281
-#: lib/klass_hero_web/live/provider/programs_live.ex:819
-#: lib/klass_hero_web/live/provider/programs_live.ex:944
+#: lib/klass_hero_web/live/provider/programs_live.ex:157
+#: lib/klass_hero_web/live/provider/programs_live.ex:194
+#: lib/klass_hero_web/live/provider/programs_live.ex:258
+#: lib/klass_hero_web/live/provider/programs_live.ex:282
+#: lib/klass_hero_web/live/provider/programs_live.ex:789
+#: lib/klass_hero_web/live/provider/programs_live.ex:921
 #, elixir-autogen, elixir-format
 msgid "Program not found."
 msgstr "Programm nicht gefunden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1338
+#: lib/klass_hero_web/live/provider/programs_live.ex:1315
 #, elixir-autogen, elixir-format
 msgid "Program updated successfully."
 msgstr "Programm erfolgreich aktualisiert."
@@ -2621,7 +2621,7 @@ msgid "Read our founding story →"
 msgstr "Lesen Sie unsere Gründungsgeschichte →"
 
 #: lib/klass_hero_web/components/participation_components.ex:805
-#: lib/klass_hero_web/components/provider_components.ex:2930
+#: lib/klass_hero_web/components/provider_components.ex:2972
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Registered"
@@ -2703,16 +2703,16 @@ msgstr "Ablehnungsgrund"
 
 #: lib/klass_hero_web/components/provider_components.ex:840
 #: lib/klass_hero_web/components/provider_components.ex:1285
-#: lib/klass_hero_web/components/provider_components.ex:2752
-#: lib/klass_hero_web/components/provider_components.ex:3182
-#: lib/klass_hero_web/components/provider_components.ex:3261
+#: lib/klass_hero_web/components/provider_components.ex:2795
+#: lib/klass_hero_web/components/provider_components.ex:3224
+#: lib/klass_hero_web/components/provider_components.ex:3303
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:253
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr "Entfernen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2745
+#: lib/klass_hero_web/components/provider_components.ex:2788
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr "Einladung erneut senden"
@@ -2753,7 +2753,7 @@ msgstr "Zeitplan noch offen"
 msgid "School Grade (optional)"
 msgstr "Klassenstufe (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:3160
+#: lib/klass_hero_web/components/provider_components.ex:3202
 #, elixir-autogen, elixir-format
 msgid "Select File"
 msgstr "Datei auswählen"
@@ -2764,13 +2764,13 @@ msgstr "Datei auswählen"
 msgid "Selected child does not meet the program requirements."
 msgstr "Das ausgewählte Kind erfüllt die Programmanforderungen nicht."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:765
-#: lib/klass_hero_web/live/provider/programs_live.ex:834
+#: lib/klass_hero_web/live/provider/programs_live.ex:735
+#: lib/klass_hero_web/live/provider/programs_live.ex:804
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr "Der ausgewählte Kursleiter konnte nicht gefunden werden. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2929
+#: lib/klass_hero_web/components/provider_components.ex:2971
 #: lib/klass_hero_web/live/admin/emails_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Sent"
@@ -2865,12 +2865,12 @@ msgstr "Erzählen Sie Eltern von Ihrer Organisation..."
 msgid "The Klass Hero Story"
 msgstr "Die Geschichte von Klass Hero"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:478
+#: lib/klass_hero_web/live/provider/dashboard/invite_actions.ex:39
 #, elixir-autogen, elixir-format
 msgid "This invite cannot be resent."
 msgstr "Diese Einladung kann nicht erneut gesendet werden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:826
+#: lib/klass_hero_web/live/provider/programs_live.ex:796
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr "Dieses Programm wurde von jemand anderem geändert. Bitte schließen Sie es und versuchen Sie es erneut."
@@ -2881,7 +2881,7 @@ msgstr "Dieses Programm wurde von jemand anderem geändert. Bitte schließen Sie
 msgid "Title"
 msgstr "Titel"
 
-#: lib/klass_hero_web/components/provider_components.ex:3061
+#: lib/klass_hero_web/components/provider_components.ex:3103
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr "Zu viele Dateien."
@@ -2906,22 +2906,22 @@ msgstr "Bis Klassenstufe %{max}"
 msgid "Upload CSV"
 msgstr "CSV hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3206
+#: lib/klass_hero_web/components/provider_components.ex:3248
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr "Dokument hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3115
+#: lib/klass_hero_web/components/provider_components.ex:3157
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr "Neues Dokument hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3063
+#: lib/klass_hero_web/components/provider_components.ex:3105
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr "Upload-Fehler."
 
-#: lib/klass_hero_web/components/provider_components.ex:3080
+#: lib/klass_hero_web/components/provider_components.ex:3122
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr "Verifizierungsdokumente"
@@ -3011,7 +3011,7 @@ msgid "Child Safeguarding Training"
 msgstr "Kinderschutzschulung"
 
 #: lib/klass_hero_web/components/marketing_components.ex:1498
-#: lib/klass_hero_web/components/provider_components.ex:3428
+#: lib/klass_hero_web/components/provider_components.ex:3470
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr "Vereinbarung zu Community-Standards"
@@ -3081,7 +3081,7 @@ msgstr "Zahlung per Bargeld oder Banküberweisung"
 msgid "Program fee:"
 msgstr "Programmgebühr:"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1114
+#: lib/klass_hero_web/live/provider/programs_live.ex:1091
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr "Programm gespeichert, aber der Upload des Titelbilds ist fehlgeschlagen. Sie können es erneut hochladen, indem Sie das Programm bearbeiten."
@@ -3162,7 +3162,7 @@ msgid "Vetted with Care"
 msgstr "Mit Sorgfalt geprüft"
 
 #: lib/klass_hero_web/components/marketing_components.ex:1482
-#: lib/klass_hero_web/components/provider_components.ex:3213
+#: lib/klass_hero_web/components/provider_components.ex:3255
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr "Video-Überprüfung"
@@ -3298,7 +3298,7 @@ msgstr "Kann ich meine Programme auf Klass Hero listen und was kostet das?"
 msgid "Cannot check out without a check-in"
 msgstr "Auschecken ohne Einchecken nicht möglich"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:450
+#: lib/klass_hero_web/live/provider/programs_live.ex:451
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
@@ -3336,7 +3336,7 @@ msgstr "Eingecheckt"
 msgid "Checked Out"
 msgstr "Ausgecheckt"
 
-#: lib/klass_hero_web/components/provider_components.ex:2788
+#: lib/klass_hero_web/components/provider_components.ex:2830
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Child"
@@ -3363,7 +3363,7 @@ msgid "Correct"
 msgstr "Korrigieren"
 
 #: lib/klass_hero_web/live/dashboard_live.ex:306
-#: lib/klass_hero_web/live/provider/programs_live.ex:447
+#: lib/klass_hero_web/live/provider/programs_live.ex:448
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Could not start conversation. Please try again."
@@ -4113,10 +4113,11 @@ msgstr "Bitte füllen Sie alle erforderlichen Felder aus"
 msgid "Post"
 msgstr "Absenden"
 
+#: lib/klass_hero_web/components/provider_components.ex:2739
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:24
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
-#: lib/klass_hero_web/live/provider/programs_live.ex:225
+#: lib/klass_hero_web/live/provider/programs_live.ex:226
 #: lib/klass_hero_web/live/provider/sessions_live.ex:381
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:175
 #, elixir-autogen, elixir-format
@@ -4318,7 +4319,7 @@ msgid "Update your observation..."
 msgstr "Aktualisieren Sie Ihre Beobachtung..."
 
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:138
-#: lib/klass_hero_web/live/provider/programs_live.ex:529
+#: lib/klass_hero_web/live/provider/programs_live.ex:499
 #: lib/klass_hero_web/live/provider/verification_live.ex:240
 #: lib/klass_hero_web/live/provider/verification_live.ex:556
 #: lib/klass_hero_web/live/provider/verification_live.ex:594
@@ -4583,6 +4584,7 @@ msgstr "Anwesenheit"
 #: lib/klass_hero_web/components/provider_components.ex:1952
 #: lib/klass_hero_web/components/provider_components.ex:2094
 #: lib/klass_hero_web/components/provider_components.ex:2248
+#: lib/klass_hero_web/live/provider/overview_live.ex:400
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr "Schließen"
@@ -4607,7 +4609,7 @@ msgstr "Sessions — %{title}"
 msgid "View sessions"
 msgstr "Sessions anzeigen"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:620
+#: lib/klass_hero_web/live/provider/programs_live.ex:590
 #, elixir-autogen, elixir-format
 msgid "Create a program before inviting participants."
 msgstr "Erstellen Sie zuerst ein Programm, bevor Sie Teilnehmer einladen."
@@ -4634,7 +4636,7 @@ msgstr "Abreisezeit ist kein gültiges Datum oder keine gültige Uhrzeit"
 msgid "Failed to update record"
 msgstr "Aktualisieren des Datensatzes fehlgeschlagen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2852
+#: lib/klass_hero_web/components/provider_components.ex:2894
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr "Klassenstufe"
@@ -4649,7 +4651,7 @@ msgstr "Einladungsmodus"
 msgid "Invite one person"
 msgstr "Einzelperson einladen"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:616
+#: lib/klass_hero_web/live/provider/programs_live.ex:586
 #, elixir-autogen, elixir-format
 msgid "Invite sent."
 msgstr "Einladung verschickt."
@@ -4659,12 +4661,12 @@ msgstr "Einladung verschickt."
 msgid "Leave blank to keep this child marked as present."
 msgstr "Leer lassen, um dieses Kind als anwesend markiert zu lassen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2865
+#: lib/klass_hero_web/components/provider_components.ex:2907
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr "Gesundheit & Einwilligungen (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2871
+#: lib/klass_hero_web/components/provider_components.ex:2913
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr "Gesundheitliche Besonderheiten"
@@ -4675,17 +4677,17 @@ msgstr "Gesundheitliche Besonderheiten"
 msgid "Nothing to update"
 msgstr "Nichts zu aktualisieren"
 
-#: lib/klass_hero_web/components/provider_components.ex:2873
+#: lib/klass_hero_web/components/provider_components.ex:2915
 #, elixir-autogen, elixir-format
 msgid "Nut allergy"
 msgstr "Nussallergie"
 
-#: lib/klass_hero_web/components/provider_components.ex:2877
+#: lib/klass_hero_web/components/provider_components.ex:2919
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr "Fotos dürfen in Marketingmaterialien verwendet werden"
 
-#: lib/klass_hero_web/components/provider_components.ex:2882
+#: lib/klass_hero_web/components/provider_components.ex:2924
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr "Fotos dürfen in sozialen Medien erscheinen"
@@ -4695,7 +4697,7 @@ msgstr "Fotos dürfen in sozialen Medien erscheinen"
 msgid "Present"
 msgstr "Anwesend"
 
-#: lib/klass_hero_web/components/provider_components.ex:2809
+#: lib/klass_hero_web/components/provider_components.ex:2851
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr "Hauptansprechpartner"
@@ -4722,22 +4724,22 @@ msgstr "Datensatz aktualisiert"
 msgid "Save changes"
 msgstr "Änderungen speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:2846
+#: lib/klass_hero_web/components/provider_components.ex:2888
 #, elixir-autogen, elixir-format
 msgid "School (optional)"
 msgstr "Schule (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2856
+#: lib/klass_hero_web/components/provider_components.ex:2898
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr "Schulname"
 
-#: lib/klass_hero_web/components/provider_components.ex:2830
+#: lib/klass_hero_web/components/provider_components.ex:2872
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr "Zweiter Ansprechpartner (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2899
+#: lib/klass_hero_web/components/provider_components.ex:2941
 #, elixir-autogen, elixir-format
 msgid "Send invite"
 msgstr "Einladung senden"
@@ -4752,7 +4754,7 @@ msgstr "Aktualisieren Sie die Notiz für dieses Kind (z. B. um zu klären, was p
 msgid "Upload a list"
 msgstr "Liste hochladen"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:627
+#: lib/klass_hero_web/live/provider/programs_live.ex:597
 #, elixir-autogen, elixir-format
 msgid "An invite for this child and program already exists."
 msgstr "Für dieses Kind und Programm existiert bereits eine Einladung."
@@ -4929,7 +4931,7 @@ msgstr "Ihre Woche mit den Kindern"
 msgid "Go to dashboard"
 msgstr "Zum Dashboard"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:572
+#: lib/klass_hero_web/live/provider/programs_live.ex:542
 #, elixir-autogen, elixir-format
 msgid "%{count} row could not be processed."
 msgid_plural "%{count} rows could not be processed."
@@ -4966,17 +4968,12 @@ msgstr "18+, amtlicher Ausweis vor Veröffentlichung verifiziert."
 msgid "A decade-plus coaching and running youth activity programs in Berlin. Built Prime Youth before founding Klass Hero."
 msgstr "Über zehn Jahre Erfahrung im Coaching und der Leitung von Jugendförderprogrammen in Berlin. Gründete Prime Youth, bevor er Klass Hero ins Leben rief."
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:635
-#, elixir-autogen, elixir-format
-msgid "Accept"
-msgstr "Akzeptieren"
-
 #: lib/klass_hero_web/components/parent_components.ex:89
 #, elixir-autogen, elixir-format
 msgid "Account settings"
 msgstr "Kontoeinstellungen"
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:261
+#: lib/klass_hero_web/live/provider/overview_live.ex:273
 #, elixir-autogen, elixir-format
 msgid "Across all programs"
 msgstr "Über alle Programme hinweg"
@@ -4987,7 +4984,7 @@ msgid "Active policy required to teach."
 msgstr "Aktive Versicherungspolice erforderlich, um zu unterrichten."
 
 #: lib/klass_hero_web/live/dashboard_live.ex:348
-#: lib/klass_hero_web/live/provider/overview_live.ex:251
+#: lib/klass_hero_web/live/provider/overview_live.ex:263
 #, elixir-autogen, elixir-format
 msgid "Active programs"
 msgstr "Aktive Programme"
@@ -5176,8 +5173,8 @@ msgstr "Mitgründer & CTO"
 #: lib/klass_hero_web/components/parent_components.ex:143
 #: lib/klass_hero_web/components/parent_components.ex:336
 #: lib/klass_hero_web/components/provider_layout_components.ex:149
-#: lib/klass_hero_web/live/provider/overview_live.ex:269
-#: lib/klass_hero_web/live/provider/overview_live.ex:277
+#: lib/klass_hero_web/live/provider/overview_live.ex:281
+#: lib/klass_hero_web/live/provider/overview_live.ex:289
 #, elixir-autogen, elixir-format
 msgid "Coming soon"
 msgstr "Demnächst verfügbar"
@@ -5252,11 +5249,6 @@ msgstr "Erstellen Sie Ihr"
 msgid "Data & privacy"
 msgstr "Daten & Datenschutz"
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:627
-#, elixir-autogen, elixir-format
-msgid "Decline"
-msgstr "Ablehnen"
-
 #: lib/klass_hero_web/live/for_providers_live.ex:370
 #, elixir-autogen, elixir-format
 msgid "Degrees, certs, and references reviewed."
@@ -5297,22 +5289,22 @@ msgstr "Programm bearbeiten"
 msgid "Email the provider and us (support@mail.klasshero.com) as soon as you can — we'll help you and the provider work it out."
 msgstr "Schreiben Sie dem Anbieter und uns (support@mail.klasshero.com) so schnell wie möglich eine E-Mail — wir helfen Ihnen und dem Anbieter, eine Lösung zu finden."
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:257
+#: lib/klass_hero_web/live/provider/overview_live.ex:269
 #, elixir-autogen, elixir-format
 msgid "Enrolled kids"
 msgstr "Angemeldete Kinder"
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:82
+#: lib/klass_hero_web/live/provider/overview_live.ex:84
 #, elixir-autogen, elixir-format
 msgid "Enrollment approved"
 msgstr "Anmeldung genehmigt"
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:90
+#: lib/klass_hero_web/live/provider/overview_live.ex:92
 #, elixir-autogen, elixir-format
 msgid "Enrollment is not pending"
 msgstr "Anmeldung ist nicht ausstehend"
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:94
+#: lib/klass_hero_web/live/provider/overview_live.ex:96
 #, elixir-autogen, elixir-format
 msgid "Enrollment not found"
 msgstr "Anmeldung nicht gefunden"
@@ -5368,7 +5360,7 @@ msgstr "Erweitertes Führungszeugnis"
 msgid "FAQ"
 msgstr "FAQ"
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:103
+#: lib/klass_hero_web/live/provider/overview_live.ex:105
 #, elixir-autogen, elixir-format
 msgid "Failed to approve"
 msgstr "Genehmigung fehlgeschlagen"
@@ -5511,8 +5503,8 @@ msgstr "Wie wir Anbieter überprüfen"
 msgid "I'll be teaching"
 msgstr "Ich werde unterrichten"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:547
-#: lib/klass_hero_web/live/provider/programs_live.ex:569
+#: lib/klass_hero_web/live/provider/programs_live.ex:517
+#: lib/klass_hero_web/live/provider/programs_live.ex:539
 #, elixir-autogen, elixir-format
 msgid "Imported %{count} family."
 msgid_plural "Imported %{count} families."
@@ -5686,7 +5678,7 @@ msgstr "Suchen Sie Programme für Ihr Kind?"
 msgid "Looking for quick answers?"
 msgstr "Suchen Sie schnelle Antworten?"
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:293
+#: lib/klass_hero_web/live/provider/overview_live.ex:305
 #, elixir-autogen, elixir-format
 msgid "Manage"
 msgstr "Verwalten"
@@ -5776,17 +5768,12 @@ msgstr "Noch keine Vorfallberichte"
 msgid "No messages yet."
 msgstr "Noch keine Nachrichten."
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:327
+#: lib/klass_hero_web/live/provider/overview_live.ex:359
 #, elixir-autogen, elixir-format
 msgid "No pending enrollments right now."
 msgstr "Derzeit keine ausstehenden Anmeldungen."
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:312
-#, elixir-autogen, elixir-format
-msgid "No pending requests right now."
-msgstr "Derzeit keine ausstehenden Anfragen."
-
-#: lib/klass_hero_web/live/provider/overview_live.ex:297
+#: lib/klass_hero_web/live/provider/overview_live.ex:309
 #, elixir-autogen, elixir-format
 msgid "No programs yet — add your first one from the Programs tab."
 msgstr "Noch keine Programme — fügen Sie Ihr erstes über den Tab „Programme“ hinzu."
@@ -5796,7 +5783,7 @@ msgstr "Noch keine Programme — fügen Sie Ihr erstes über den Tab „Programm
 msgid "No registered children for this session."
 msgstr "Keine Kinder in dieser Sitzung angemeldet."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:556
+#: lib/klass_hero_web/live/provider/programs_live.ex:526
 #, elixir-autogen, elixir-format
 msgid "No rows imported. %{count} row could not be processed."
 msgid_plural "No rows imported. %{count} rows could not be processed."
@@ -5808,7 +5795,7 @@ msgstr[1] "Keine Zeilen importiert. %{count} Zeilen konnten nicht verarbeitet we
 msgid "No upcoming sessions in the next few weeks."
 msgstr "Keine bevorstehenden Sitzungen in den nächsten Wochen."
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:85
+#: lib/klass_hero_web/live/provider/overview_live.ex:87
 #, elixir-autogen, elixir-format
 msgid "Not allowed to approve this enrollment"
 msgstr "Nicht berechtigt, diese Anmeldung zu genehmigen"
@@ -5905,12 +5892,7 @@ msgstr "Teilnahme"
 msgid "Pedagogical Interview"
 msgstr "Pädagogisches Interview"
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:306
-#, elixir-autogen, elixir-format
-msgid "Pending booking requests"
-msgstr "Ausstehende Buchungsanfragen"
-
-#: lib/klass_hero_web/live/provider/overview_live.ex:321
+#: lib/klass_hero_web/live/provider/overview_live.ex:353
 #, elixir-autogen, elixir-format
 msgid "Pending enrollments"
 msgstr "Ausstehende Anmeldungen"
@@ -5988,7 +5970,7 @@ msgstr "Fragen zu Programmen, Buchungen oder wie Sie ein Hero werden — wir les
 msgid "Questions, answered."
 msgstr "Fragen, beantwortet."
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:272
+#: lib/klass_hero_web/live/provider/overview_live.ex:284
 #, elixir-autogen, elixir-format
 msgid "Rating"
 msgstr "Bewertung"
@@ -6030,7 +6012,7 @@ msgstr "Berichte"
 msgid "Reports filed for this program will appear here."
 msgstr "Für dieses Programm eingereichte Berichte werden hier angezeigt."
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:264
+#: lib/klass_hero_web/live/provider/overview_live.ex:276
 #, elixir-autogen, elixir-format
 msgid "Revenue (this week)"
 msgstr "Umsatz (diese Woche)"
@@ -6040,12 +6022,12 @@ msgstr "Umsatz (diese Woche)"
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr "Strenge Überprüfung, damit Familien immer wissen, wer die Gruppe leitet."
 
-#: lib/klass_hero_web/components/provider_components.ex:2938
+#: lib/klass_hero_web/components/provider_components.ex:2980
 #, elixir-autogen, elixir-format
 msgid "Row %{row}"
 msgstr "Zeile %{row}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2938
+#: lib/klass_hero_web/components/provider_components.ex:2980
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr "Zeile —"
@@ -6301,11 +6283,6 @@ msgstr "Vertrauenswürdige Heroes"
 msgid "Try adjusting your search or filter criteria — there's plenty more in Berlin."
 msgstr "Versuchen Sie, Ihre Such- oder Filterkriterien anzupassen — in Berlin gibt es noch viel mehr."
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:618
-#, elixir-autogen, elixir-format
-msgid "Unknown parent"
-msgstr "Unbekannter Elternteil"
-
 #: lib/klass_hero_web/live/for_providers_live.ex:416
 #, elixir-autogen, elixir-format
 msgid "Unlimited programs and locations"
@@ -6484,7 +6461,7 @@ msgstr "Sie sind im Team — Sie können nun Programmen zugewiesen werden."
 msgid "You're on the team, but the headshot upload failed."
 msgstr "Sie sind im Team, aber der Upload des Profilfotos ist fehlgeschlagen."
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:288
+#: lib/klass_hero_web/live/provider/overview_live.ex:300
 #, elixir-autogen, elixir-format
 msgid "Your top programs"
 msgstr "Ihre Top-Programme"
@@ -6544,8 +6521,7 @@ msgstr "in"
 msgid "matching"
 msgstr "Passend"
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:308
-#: lib/klass_hero_web/live/provider/overview_live.ex:323
+#: lib/klass_hero_web/live/provider/overview_live.ex:355
 #, elixir-autogen, elixir-format
 msgid "pending"
 msgstr "Ausstehend"
@@ -6608,7 +6584,7 @@ msgstr "Gemeinschaftsstandards"
 msgid "Complete all steps to publish programs. %{approved} of %{total} approved."
 msgstr "Schließe alle Schritte ab, um Programme zu veröffentlichen. %{approved} von %{total} genehmigt."
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:240
+#: lib/klass_hero_web/live/provider/overview_live.ex:252
 #, elixir-autogen, elixir-format
 msgid "Complete your verification checklist so parents can find and book you."
 msgstr "Vervollständige deine Verifizierungs-Checkliste, damit Eltern dich finden und buchen können."
@@ -6745,7 +6721,7 @@ msgstr "Lade dein Kinderschutz-Zertifikat hoch."
 msgid "Verify identity"
 msgstr "Identität verifizieren"
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:237
+#: lib/klass_hero_web/live/provider/overview_live.ex:249
 #, elixir-autogen, elixir-format
 msgid "Verify your identity to get approved"
 msgstr "Verifiziere deine Identität, um freigegeben zu werden"
@@ -6786,12 +6762,12 @@ msgstr "Deine Identität ist verifiziert."
 msgid "Experience validation"
 msgstr "Erfahrungsnachweis"
 
-#: lib/klass_hero_web/components/provider_components.ex:3242
+#: lib/klass_hero_web/components/provider_components.ex:3284
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr "MP4, MOV oder WEBM. Max. 100 MB."
 
-#: lib/klass_hero_web/components/provider_components.ex:3216
+#: lib/klass_hero_web/components/provider_components.ex:3258
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr "Nimm ein kurzes Video auf, in dem du dich vorstellst. Unser Team prüft es, um Kommunikationsfähigkeit und Übereinstimmung mit unseren Werten einzuschätzen."
@@ -6801,12 +6777,12 @@ msgstr "Nimm ein kurzes Video auf, in dem du dich vorstellst. Unser Team prüft 
 msgid "Safeguarding certificate"
 msgstr "Kinderschutz-Zertifikat"
 
-#: lib/klass_hero_web/components/provider_components.ex:3239
+#: lib/klass_hero_web/components/provider_components.ex:3281
 #, elixir-autogen, elixir-format
 msgid "Select Video"
 msgstr "Video auswählen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3285
+#: lib/klass_hero_web/components/provider_components.ex:3327
 #, elixir-autogen, elixir-format
 msgid "Upload Video"
 msgstr "Video hochladen"
@@ -6816,7 +6792,7 @@ msgstr "Video hochladen"
 msgid "Your browser does not support video playback."
 msgstr "Dein Browser unterstützt keine Videowiedergabe."
 
-#: lib/klass_hero_web/components/provider_components.ex:3432
+#: lib/klass_hero_web/components/provider_components.ex:3474
 #, elixir-autogen, elixir-format
 msgid "Confirm agreement"
 msgstr "Zustimmung bestätigen"
@@ -6826,12 +6802,12 @@ msgstr "Zustimmung bestätigen"
 msgid "Couldn't record your agreement. Please try again."
 msgstr "Deine Zustimmung konnte nicht gespeichert werden. Bitte versuche es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:3455
+#: lib/klass_hero_web/components/provider_components.ex:3497
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr "Vereinbarung herunterladen (PDF)"
 
-#: lib/klass_hero_web/components/provider_components.ex:3431
+#: lib/klass_hero_web/components/provider_components.ex:3473
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr "Ich habe die Klass Hero Community-Richtlinien gelesen und stimme ihnen zu."
@@ -6841,7 +6817,7 @@ msgstr "Ich habe die Klass Hero Community-Richtlinien gelesen und stimme ihnen z
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr "Bitte bestätige, dass du die Community-Richtlinien gelesen hast und ihnen zustimmst."
 
-#: lib/klass_hero_web/components/provider_components.ex:3340
+#: lib/klass_hero_web/components/provider_components.ex:3382
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr "Unterzeichnet von %{name} am %{date} (v%{version})."
@@ -6851,17 +6827,17 @@ msgstr "Unterzeichnet von %{name} am %{date} (v%{version})."
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr "Danke – deine Zustimmung zu den Community-Richtlinien wurde gespeichert."
 
-#: lib/klass_hero_web/components/provider_components.ex:3440
+#: lib/klass_hero_web/components/provider_components.ex:3482
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr "Die Community-Richtlinien wurden seit deiner letzten Zustimmung aktualisiert (v%{old}). Bitte lies sie erneut und stimme erneut zu."
 
-#: lib/klass_hero_web/components/provider_components.ex:3429
+#: lib/klass_hero_web/components/provider_components.ex:3471
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr "Der letzte Schritt: Lies die Klass Hero Community-Richtlinien und stimme ihnen zu."
 
-#: lib/klass_hero_web/components/provider_components.ex:3430
+#: lib/klass_hero_web/components/provider_components.ex:3472
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr "Du hast den Community-Richtlinien zugestimmt."
@@ -7130,12 +7106,12 @@ msgstr "Ihre Versicherungsbescheinigung wird geprüft."
 msgid "Your insurance is verified."
 msgstr "Ihre Versicherung ist verifiziert."
 
-#: lib/klass_hero_web/components/provider_components.ex:3384
+#: lib/klass_hero_web/components/provider_components.ex:3426
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr "Unterzeichnung durch %{name} im Namen des Unternehmens."
 
-#: lib/klass_hero_web/components/provider_components.ex:3487
+#: lib/klass_hero_web/components/provider_components.ex:3529
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr "Bestätige im Namen deines Unternehmens, dass alle Mitarbeitenden gemäß dem deutschen Kinderschutzrecht überprüft sind."
@@ -7145,7 +7121,7 @@ msgstr "Bestätige im Namen deines Unternehmens, dass alle Mitarbeitenden gemä�
 msgid "Couldn't record your declaration. Please try again."
 msgstr "Deine Erklärung konnte nicht gespeichert werden. Bitte versuche es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:3493
+#: lib/klass_hero_web/components/provider_components.ex:3535
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr "Ich bestätige im Namen des Unternehmens, dass die obige Erklärung zutrifft und ich zu ihrer Unterzeichnung berechtigt bin."
@@ -7155,17 +7131,17 @@ msgstr "Ich bestätige im Namen des Unternehmens, dass die obige Erklärung zutr
 msgid "Please confirm the declaration before signing."
 msgstr "Bitte bestätige die Erklärung vor der Unterzeichnung."
 
-#: lib/klass_hero_web/components/provider_components.ex:3518
+#: lib/klass_hero_web/components/provider_components.ex:3560
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr "Vorläufiger Text — vor der Freischaltung noch von einer in Deutschland zugelassenen Anwältin bzw. einem Anwalt zu prüfen."
 
-#: lib/klass_hero_web/components/provider_components.ex:3497
+#: lib/klass_hero_web/components/provider_components.ex:3539
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr "Erklärung unterzeichnen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3485
+#: lib/klass_hero_web/components/provider_components.ex:3527
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr "Erklärung zur Mitarbeiter-Compliance"
@@ -7175,12 +7151,12 @@ msgstr "Erklärung zur Mitarbeiter-Compliance"
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr "Danke — deine Erklärung zur Mitarbeiter-Compliance wurde erfasst."
 
-#: lib/klass_hero_web/components/provider_components.ex:3505
+#: lib/klass_hero_web/components/provider_components.ex:3547
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr "Die Erklärung zur Mitarbeiter-Compliance wurde seit deiner letzten Unterzeichnung aktualisiert (v%{old}). Bitte prüfe sie und unterzeichne erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:3491
+#: lib/klass_hero_web/components/provider_components.ex:3533
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr "Du hast die Erklärung zur Mitarbeiter-Compliance unterzeichnet."
@@ -7260,7 +7236,7 @@ msgstr "Hinzufügen"
 msgid "Lead"
 msgstr "Leitung"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:422
+#: lib/klass_hero_web/live/provider/programs_live.ex:423
 #, elixir-autogen, elixir-format
 msgid "Lead instructor updated."
 msgstr "Leitender Kursleiter aktualisiert."
@@ -7280,7 +7256,7 @@ msgstr "Programmteam verwalten"
 msgid "Nobody is on this program yet."
 msgstr "Diesem Programm ist noch niemand zugewiesen."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:352
+#: lib/klass_hero_web/live/provider/programs_live.ex:353
 #: lib/klass_hero_web/live/provider/sessions_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "Pick a staff member to add."
@@ -7303,12 +7279,12 @@ msgstr "Aus dem Programm entfernen"
 msgid "Select a staff member…"
 msgstr "Teammitglied auswählen …"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:367
+#: lib/klass_hero_web/live/provider/programs_live.ex:368
 #, elixir-autogen, elixir-format
 msgid "Staff member added to the program."
 msgstr "Teammitglied zum Programm hinzugefügt."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:393
+#: lib/klass_hero_web/live/provider/programs_live.ex:394
 #, elixir-autogen, elixir-format
 msgid "Staff member removed from the program."
 msgstr "Teammitglied aus dem Programm entfernt."
@@ -7325,17 +7301,17 @@ msgstr ""
 msgid "Staffing — %{title}"
 msgstr "Programmteam — %{title}"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1073
+#: lib/klass_hero_web/live/provider/programs_live.ex:1050
 #, elixir-autogen, elixir-format
 msgid "That staff member could not be found."
 msgstr "Dieses Teammitglied wurde nicht gefunden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:375
+#: lib/klass_hero_web/live/provider/programs_live.ex:376
 #, elixir-autogen, elixir-format
 msgid "They are already on this program."
 msgstr "Diese Person ist bereits in diesem Programm."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:401
+#: lib/klass_hero_web/live/provider/programs_live.ex:402
 #, elixir-autogen, elixir-format
 msgid "This person is the lead instructor. Make someone else lead before removing them."
 msgstr ""
@@ -7399,21 +7375,21 @@ msgstr "Damit wird %{name} endgültig gelöscht – das lässt sich nicht rückg
 msgid "This person has a history here now — use 'Remove from team' instead."
 msgstr "Diese Person hat inzwischen eine Historie – nutze stattdessen „Aus dem Team entfernen“."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1351
+#: lib/klass_hero_web/live/provider/programs_live.ex:1328
 #, elixir-autogen, elixir-format
 msgid "Program created, but some settings could not be saved. Please review the program's limits."
 msgstr ""
 "Programm erstellt, aber einige Einstellungen konnten nicht gespeichert werden. "
 "Bitte überprüfen Sie die Grenzwerte des Programms."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1355
+#: lib/klass_hero_web/live/provider/programs_live.ex:1332
 #, elixir-autogen, elixir-format
 msgid "Program updated, but some settings could not be saved. Please review the program's limits."
 msgstr ""
 "Programm aktualisiert, aber einige Einstellungen konnten nicht gespeichert "
 "werden. Bitte überprüfen Sie die Grenzwerte des Programms."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1345
+#: lib/klass_hero_web/live/provider/programs_live.ex:1322
 #, elixir-autogen, elixir-format
 msgid "Program updated, but the enrollment capacity was rejected. The previous limits still apply."
 msgstr ""
@@ -7547,7 +7523,7 @@ msgstr "Verzichtserklärung hinzufügen"
 msgid "Add waiver"
 msgstr "Hinzufügen"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:945
+#: lib/klass_hero_web/live/provider/programs_live.ex:922
 #, elixir-autogen, elixir-format
 msgid "Check the waiver details and try again."
 msgstr "Bitte prüfe die Angaben zur Verzichtserklärung und versuche es erneut."
@@ -7665,7 +7641,7 @@ msgstr "Nicht unterschrieben"
 msgid "Version %{number}"
 msgstr "Version %{number}"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:346
+#: lib/klass_hero_web/live/provider/programs_live.ex:347
 #, elixir-autogen, elixir-format
 msgid "Waiver not found."
 msgstr "Verzichtserklärung nicht gefunden."
@@ -7693,7 +7669,7 @@ msgstr "Verzichtserklärungen — %{title}"
 msgid "this program"
 msgstr "dieses Programm"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:942
+#: lib/klass_hero_web/live/provider/programs_live.ex:919
 #, elixir-autogen, elixir-format
 msgid "New version published. It applies to future enrolments."
 msgstr "Neue Fassung veröffentlicht. Sie gilt für künftige Anmeldungen."
@@ -7703,12 +7679,12 @@ msgstr "Neue Fassung veröffentlicht. Sie gilt für künftige Anmeldungen."
 msgid "Retire \"%{title}\"? Parents will no longer be asked to sign it. Signatures already collected are kept."
 msgstr "\"%{title}\" zurückziehen? Eltern werden nicht mehr um eine Unterschrift gebeten. Bereits erteilte Unterschriften bleiben erhalten."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:941
+#: lib/klass_hero_web/live/provider/programs_live.ex:918
 #, elixir-autogen, elixir-format
 msgid "Waiver added."
 msgstr "Einverständniserklärung hinzugefügt."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:343
+#: lib/klass_hero_web/live/provider/programs_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "Waiver retired. Signatures already collected are kept."
 msgstr "Einverständniserklärung zurückgezogen. Bereits erteilte Unterschriften bleiben erhalten."
@@ -7774,7 +7750,7 @@ msgstr "Diese Einladung ist abgelaufen. Bitte bitten Sie Ihren Anbieter, sie ern
 msgid "This is your main provider identity. Verification is required to list programs."
 msgstr "Dies ist Ihr Hauptprofil als Anbieter. Eine Verifizierung ist erforderlich, um Programme anzubieten."
 
-#: lib/klass_hero_web/components/provider_components.ex:3083
+#: lib/klass_hero_web/components/provider_components.ex:3125
 #, elixir-autogen, elixir-format
 msgid "Upload documents to be verified. Documents are reviewed by our team."
 msgstr "Laden Sie Dokumente hoch, um verifiziert zu werden. Die Dokumente werden von unserem Team überprüft."
@@ -7900,3 +7876,31 @@ msgstr "Sie können dann Ihre Kinder anlegen und Kurse buchen. Ihr Anbieterkonto
 #, elixir-autogen, elixir-format
 msgid "You'll get a provider profile to fill in, and a dashboard for your activities. Your family account stays exactly as it is."
 msgstr "Sie erhalten ein Anbieterprofil zum Ausfüllen und ein Dashboard für Ihre Kurse. Ihr Familienkonto bleibt unverändert."
+
+#: lib/klass_hero_web/live/provider/overview_live.ex:332
+#: lib/klass_hero_web/live/provider/overview_live.ex:415
+#, elixir-autogen, elixir-format
+msgid "Every invitation you sent has been answered."
+msgstr "Alle von Ihnen gesendeten Einladungen wurden beantwortet."
+
+#: lib/klass_hero_web/live/provider/overview_live.ex:320
+#: lib/klass_hero_web/live/provider/overview_live.ex:394
+#, elixir-autogen, elixir-format
+msgid "Invitations awaiting a reply"
+msgstr "Einladungen ohne Antwort"
+
+#: lib/klass_hero_web/live/provider/overview_live.ex:346
+#, elixir-autogen, elixir-format
+msgid "Review invitations"
+msgstr "Einladungen prüfen"
+
+#: lib/klass_hero_web/components/provider_components.ex:2760
+#: lib/klass_hero_web/components/provider_components.ex:2764
+#, elixir-autogen, elixir-format
+msgid "Unknown program"
+msgstr "Unbekanntes Programm"
+
+#: lib/klass_hero_web/live/provider/overview_live.ex:322
+#, elixir-autogen, elixir-format
+msgid "waiting"
+msgstr "ausstehend"

--- a/priv/gettext/de/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/de/LC_MESSAGES/enrollment.po
@@ -11,105 +11,105 @@ msgstr ""
 "Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:3032
-#: lib/klass_hero_web/components/provider_components.ex:3049
+#: lib/klass_hero_web/components/provider_components.ex:3074
+#: lib/klass_hero_web/components/provider_components.ex:3091
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr "Vorname des Kindes"
 
-#: lib/klass_hero_web/components/provider_components.ex:3033
-#: lib/klass_hero_web/components/provider_components.ex:3050
+#: lib/klass_hero_web/components/provider_components.ex:3075
+#: lib/klass_hero_web/components/provider_components.ex:3092
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr "Nachname des Kindes"
 
-#: lib/klass_hero_web/components/provider_components.ex:3034
-#: lib/klass_hero_web/components/provider_components.ex:3051
+#: lib/klass_hero_web/components/provider_components.ex:3076
+#: lib/klass_hero_web/components/provider_components.ex:3093
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr "Geburtsdatum"
 
-#: lib/klass_hero_web/components/provider_components.ex:3045
+#: lib/klass_hero_web/components/provider_components.ex:3087
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr "Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:3035
+#: lib/klass_hero_web/components/provider_components.ex:3077
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr "E-Mail des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:3036
+#: lib/klass_hero_web/components/provider_components.ex:3078
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr "Vorname des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:3037
+#: lib/klass_hero_web/components/provider_components.ex:3079
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr "Nachname des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:3044
+#: lib/klass_hero_web/components/provider_components.ex:3086
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr "Programm"
 
-#: lib/klass_hero_web/components/provider_components.ex:3046
+#: lib/klass_hero_web/components/provider_components.ex:3088
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr "Schule"
 
-#: lib/klass_hero_web/components/provider_components.ex:3038
+#: lib/klass_hero_web/components/provider_components.ex:3080
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr "E-Mail des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:3040
+#: lib/klass_hero_web/components/provider_components.ex:3082
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr "Vorname des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:3042
+#: lib/klass_hero_web/components/provider_components.ex:3084
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr "Nachname des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2972
+#: lib/klass_hero_web/components/provider_components.ex:3014
 #, elixir-autogen, elixir-format
 msgid "Date of birth \"%{value}\" is not a valid date. Please correct it and resend."
 msgstr ""
 "Das Geburtsdatum „%{value}“ ist kein gültiges Datum. Bitte korrigieren Sie es "
 "und senden Sie die Einladung erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2966
+#: lib/klass_hero_web/components/provider_components.ex:3008
 #, elixir-autogen, elixir-format
 msgid "Invite link could not be generated (no token). Please resend."
 msgstr ""
 "Der Einladungslink konnte nicht erzeugt werden (kein Token). Bitte erneut "
 "senden."
 
-#: lib/klass_hero_web/components/provider_components.ex:2980
+#: lib/klass_hero_web/components/provider_components.ex:3022
 #, elixir-autogen, elixir-format
 msgid "The invitation email could not be delivered. Please check the address and resend."
 msgstr ""
 "Die Einladungs-E-Mail konnte nicht zugestellt werden. Bitte prüfen Sie die "
 "Adresse und senden Sie die Einladung erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2969
+#: lib/klass_hero_web/components/provider_components.ex:3011
 #, elixir-autogen, elixir-format
 msgid "The program is full, so this child could not be enrolled."
 msgstr ""
 "Das Programm ist ausgebucht, daher konnte dieses Kind nicht angemeldet "
 "werden."
 
-#: lib/klass_hero_web/components/provider_components.ex:2983
+#: lib/klass_hero_web/components/provider_components.ex:3025
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed and no retries remain. Please resend."
 msgstr ""
 "Diese Einladung konnte nicht abgeschlossen werden und es sind keine weiteren "
 "Versuche möglich. Bitte erneut senden."
 
-#: lib/klass_hero_web/components/provider_components.ex:2992
+#: lib/klass_hero_web/components/provider_components.ex:3034
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed. Please resend."
 msgstr "Diese Einladung konnte nicht abgeschlossen werden. Bitte erneut senden."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -575,8 +575,8 @@ msgid "Dispute Resolution"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:720
-#: lib/klass_hero_web/components/provider_components.ex:2816
-#: lib/klass_hero_web/components/provider_components.ex:2834
+#: lib/klass_hero_web/components/provider_components.ex:2858
+#: lib/klass_hero_web/components/provider_components.ex:2876
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
@@ -1324,7 +1324,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1488
 #: lib/klass_hero_web/components/provider_components.ex:2472
-#: lib/klass_hero_web/components/provider_components.ex:2714
+#: lib/klass_hero_web/components/provider_components.ex:2748
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
@@ -1340,7 +1340,7 @@ msgstr ""
 msgid "Add Team Member"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:48
+#: lib/klass_hero_web/live/provider/programs_live.ex:49
 #, elixir-autogen, elixir-format
 msgid "All Staff"
 msgstr ""
@@ -1391,7 +1391,7 @@ msgid "Inactive"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:114
-#: lib/klass_hero_web/live/provider/programs_live.ex:54
+#: lib/klass_hero_web/live/provider/programs_live.ex:55
 #, elixir-autogen, elixir-format
 msgid "My Programs"
 msgstr ""
@@ -1410,8 +1410,8 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:48
 #: lib/klass_hero_web/components/provider_components.ex:74
 #: lib/klass_hero_web/components/provider_components.ex:1635
-#: lib/klass_hero_web/components/provider_components.ex:2910
-#: lib/klass_hero_web/components/provider_components.ex:2928
+#: lib/klass_hero_web/components/provider_components.ex:2952
+#: lib/klass_hero_web/components/provider_components.ex:2970
 #: lib/klass_hero_web/live/admin/sessions_live.ex:298
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
@@ -1433,7 +1433,7 @@ msgstr ""
 msgid "Program Name"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:58
+#: lib/klass_hero_web/live/provider/overview_live.ex:59
 #, elixir-autogen, elixir-format
 msgid "Provider Dashboard"
 msgstr ""
@@ -1451,7 +1451,7 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:1482
 #: lib/klass_hero_web/components/provider_components.ex:1885
 #: lib/klass_hero_web/components/provider_components.ex:2463
-#: lib/klass_hero_web/components/provider_components.ex:2711
+#: lib/klass_hero_web/components/provider_components.ex:2745
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1604,7 +1604,7 @@ msgstr ""
 msgid "Data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2797
+#: lib/klass_hero_web/components/provider_components.ex:2839
 #: lib/klass_hero_web/live/settings/children_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1652,17 +1652,17 @@ msgstr ""
 msgid "Failed to submit note"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2791
-#: lib/klass_hero_web/components/provider_components.ex:2820
-#: lib/klass_hero_web/components/provider_components.ex:2836
+#: lib/klass_hero_web/components/provider_components.ex:2833
+#: lib/klass_hero_web/components/provider_components.ex:2862
+#: lib/klass_hero_web/components/provider_components.ex:2878
 #: lib/klass_hero_web/live/settings/children_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2792
-#: lib/klass_hero_web/components/provider_components.ex:2821
-#: lib/klass_hero_web/components/provider_components.ex:2837
+#: lib/klass_hero_web/components/provider_components.ex:2834
+#: lib/klass_hero_web/components/provider_components.ex:2863
+#: lib/klass_hero_web/components/provider_components.ex:2879
 #: lib/klass_hero_web/live/settings/children_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -1819,7 +1819,7 @@ msgstr ""
 msgid "Send a message to start the conversation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2891
+#: lib/klass_hero_web/components/provider_components.ex:2933
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:249
 #, elixir-autogen, elixir-format
@@ -1955,12 +1955,12 @@ msgstr ""
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2950
+#: lib/klass_hero_web/components/provider_components.ex:2992
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred during import."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:670
+#: lib/klass_hero_web/components/provider_layout_components.ex:622
 #: lib/klass_hero_web/live/admin/verifications_live.ex:438
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:53
 #, elixir-autogen, elixir-format
@@ -2035,7 +2035,7 @@ msgid "Check eligibility at"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:2460
-#: lib/klass_hero_web/components/provider_components.ex:2705
+#: lib/klass_hero_web/components/provider_components.ex:2731
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2075,7 +2075,7 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2911
+#: lib/klass_hero_web/components/provider_components.ex:2953
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
@@ -2085,12 +2085,12 @@ msgstr ""
 msgid "Contact Provider"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:536
+#: lib/klass_hero_web/live/provider/programs_live.ex:506
 #, elixir-autogen, elixir-format
 msgid "Could not read the uploaded file."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:504
+#: lib/klass_hero_web/live/provider/dashboard/invite_actions.ex:64
 #, elixir-autogen, elixir-format
 msgid "Could not remove invite."
 msgstr ""
@@ -2124,7 +2124,7 @@ msgstr ""
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3126
+#: lib/klass_hero_web/components/provider_components.ex:3168
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2190,8 +2190,8 @@ msgid "End Time"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:2469
-#: lib/klass_hero_web/components/provider_components.ex:2931
-#: lib/klass_hero_web/components/provider_layout_components.ex:660
+#: lib/klass_hero_web/components/provider_components.ex:2973
+#: lib/klass_hero_web/components/provider_layout_components.ex:612
 #, elixir-autogen, elixir-format
 msgid "Enrolled"
 msgstr ""
@@ -2212,7 +2212,7 @@ msgid "Explain why this document is being rejected..."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:72
-#: lib/klass_hero_web/components/provider_components.ex:2932
+#: lib/klass_hero_web/components/provider_components.ex:2974
 #: lib/klass_hero_web/live/admin/emails_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2228,7 +2228,7 @@ msgstr ""
 msgid "Failed to reject document."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:486
+#: lib/klass_hero_web/live/provider/dashboard/invite_actions.ex:47
 #, elixir-autogen, elixir-format
 msgid "Failed to resend invite."
 msgstr ""
@@ -2256,12 +2256,12 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3060
+#: lib/klass_hero_web/components/provider_components.ex:3102
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3062
+#: lib/klass_hero_web/components/provider_components.ex:3104
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
@@ -2296,7 +2296,7 @@ msgstr ""
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2708
+#: lib/klass_hero_web/components/provider_components.ex:2742
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
@@ -2321,17 +2321,17 @@ msgstr ""
 msgid "Insurance Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:501
+#: lib/klass_hero_web/live/provider/dashboard/invite_actions.ex:61
 #, elixir-autogen, elixir-format
 msgid "Invite not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:498
+#: lib/klass_hero_web/live/provider/dashboard/invite_actions.ex:58
 #, elixir-autogen, elixir-format
 msgid "Invite removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:475
+#: lib/klass_hero_web/live/provider/dashboard/invite_actions.ex:36
 #, elixir-autogen, elixir-format
 msgid "Invite resent successfully."
 msgstr ""
@@ -2437,7 +2437,7 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3088
+#: lib/klass_hero_web/components/provider_components.ex:3130
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
@@ -2448,7 +2448,7 @@ msgstr ""
 msgid "No enrollments yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:532
+#: lib/klass_hero_web/live/provider/programs_live.ex:502
 #, elixir-autogen, elixir-format
 msgid "No file selected."
 msgstr ""
@@ -2521,7 +2521,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3163
+#: lib/klass_hero_web/components/provider_components.ex:3205
 #: lib/klass_hero_web/live/provider/verification_live.ex:698
 #: lib/klass_hero_web/live/provider/verification_live.ex:770
 #, elixir-autogen, elixir-format
@@ -2548,8 +2548,8 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:106
-#: lib/klass_hero_web/live/provider/programs_live.ex:775
-#: lib/klass_hero_web/live/provider/programs_live.ex:844
+#: lib/klass_hero_web/live/provider/programs_live.ex:745
+#: lib/klass_hero_web/live/provider/programs_live.ex:814
 #: lib/klass_hero_web/live/provider/team_live.ex:305
 #: lib/klass_hero_web/live/provider/team_live.ex:348
 #: lib/klass_hero_web/live/provider/team_live.ex:467
@@ -2582,28 +2582,28 @@ msgstr ""
 msgid "Program Start"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1337
+#: lib/klass_hero_web/live/provider/programs_live.ex:1314
 #, elixir-autogen, elixir-format
 msgid "Program created successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1341
+#: lib/klass_hero_web/live/provider/programs_live.ex:1318
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:54
-#: lib/klass_hero_web/live/provider/programs_live.ex:156
-#: lib/klass_hero_web/live/provider/programs_live.ex:193
-#: lib/klass_hero_web/live/provider/programs_live.ex:257
-#: lib/klass_hero_web/live/provider/programs_live.ex:281
-#: lib/klass_hero_web/live/provider/programs_live.ex:819
-#: lib/klass_hero_web/live/provider/programs_live.ex:944
+#: lib/klass_hero_web/live/provider/programs_live.ex:157
+#: lib/klass_hero_web/live/provider/programs_live.ex:194
+#: lib/klass_hero_web/live/provider/programs_live.ex:258
+#: lib/klass_hero_web/live/provider/programs_live.ex:282
+#: lib/klass_hero_web/live/provider/programs_live.ex:789
+#: lib/klass_hero_web/live/provider/programs_live.ex:921
 #, elixir-autogen, elixir-format
 msgid "Program not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1338
+#: lib/klass_hero_web/live/provider/programs_live.ex:1315
 #, elixir-autogen, elixir-format
 msgid "Program updated successfully."
 msgstr ""
@@ -2621,7 +2621,7 @@ msgid "Read our founding story →"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:805
-#: lib/klass_hero_web/components/provider_components.ex:2930
+#: lib/klass_hero_web/components/provider_components.ex:2972
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Registered"
@@ -2703,16 +2703,16 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:840
 #: lib/klass_hero_web/components/provider_components.ex:1285
-#: lib/klass_hero_web/components/provider_components.ex:2752
-#: lib/klass_hero_web/components/provider_components.ex:3182
-#: lib/klass_hero_web/components/provider_components.ex:3261
+#: lib/klass_hero_web/components/provider_components.ex:2795
+#: lib/klass_hero_web/components/provider_components.ex:3224
+#: lib/klass_hero_web/components/provider_components.ex:3303
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:253
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2745
+#: lib/klass_hero_web/components/provider_components.ex:2788
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -2753,7 +2753,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3160
+#: lib/klass_hero_web/components/provider_components.ex:3202
 #, elixir-autogen, elixir-format
 msgid "Select File"
 msgstr ""
@@ -2764,13 +2764,13 @@ msgstr ""
 msgid "Selected child does not meet the program requirements."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:765
-#: lib/klass_hero_web/live/provider/programs_live.ex:834
+#: lib/klass_hero_web/live/provider/programs_live.ex:735
+#: lib/klass_hero_web/live/provider/programs_live.ex:804
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2929
+#: lib/klass_hero_web/components/provider_components.ex:2971
 #: lib/klass_hero_web/live/admin/emails_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Sent"
@@ -2865,12 +2865,12 @@ msgstr ""
 msgid "The Klass Hero Story"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:478
+#: lib/klass_hero_web/live/provider/dashboard/invite_actions.ex:39
 #, elixir-autogen, elixir-format
 msgid "This invite cannot be resent."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:826
+#: lib/klass_hero_web/live/provider/programs_live.ex:796
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
@@ -2881,7 +2881,7 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3061
+#: lib/klass_hero_web/components/provider_components.ex:3103
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -2906,22 +2906,22 @@ msgstr ""
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3206
+#: lib/klass_hero_web/components/provider_components.ex:3248
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3115
+#: lib/klass_hero_web/components/provider_components.ex:3157
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3063
+#: lib/klass_hero_web/components/provider_components.ex:3105
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3080
+#: lib/klass_hero_web/components/provider_components.ex:3122
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -3011,7 +3011,7 @@ msgid "Child Safeguarding Training"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1498
-#: lib/klass_hero_web/components/provider_components.ex:3428
+#: lib/klass_hero_web/components/provider_components.ex:3470
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr ""
@@ -3081,7 +3081,7 @@ msgstr ""
 msgid "Program fee:"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1114
+#: lib/klass_hero_web/live/provider/programs_live.ex:1091
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr ""
@@ -3162,7 +3162,7 @@ msgid "Vetted with Care"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1482
-#: lib/klass_hero_web/components/provider_components.ex:3213
+#: lib/klass_hero_web/components/provider_components.ex:3255
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr ""
@@ -3298,7 +3298,7 @@ msgstr ""
 msgid "Cannot check out without a check-in"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:450
+#: lib/klass_hero_web/live/provider/programs_live.ex:451
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
@@ -3336,7 +3336,7 @@ msgstr ""
 msgid "Checked Out"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2788
+#: lib/klass_hero_web/components/provider_components.ex:2830
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Child"
@@ -3363,7 +3363,7 @@ msgid "Correct"
 msgstr ""
 
 #: lib/klass_hero_web/live/dashboard_live.ex:306
-#: lib/klass_hero_web/live/provider/programs_live.ex:447
+#: lib/klass_hero_web/live/provider/programs_live.ex:448
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Could not start conversation. Please try again."
@@ -4113,10 +4113,11 @@ msgstr ""
 msgid "Post"
 msgstr ""
 
+#: lib/klass_hero_web/components/provider_components.ex:2739
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:24
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
-#: lib/klass_hero_web/live/provider/programs_live.ex:225
+#: lib/klass_hero_web/live/provider/programs_live.ex:226
 #: lib/klass_hero_web/live/provider/sessions_live.ex:381
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:175
 #, elixir-autogen, elixir-format
@@ -4318,7 +4319,7 @@ msgid "Update your observation..."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:138
-#: lib/klass_hero_web/live/provider/programs_live.ex:529
+#: lib/klass_hero_web/live/provider/programs_live.ex:499
 #: lib/klass_hero_web/live/provider/verification_live.ex:240
 #: lib/klass_hero_web/live/provider/verification_live.ex:556
 #: lib/klass_hero_web/live/provider/verification_live.ex:594
@@ -4583,6 +4584,7 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:1952
 #: lib/klass_hero_web/components/provider_components.ex:2094
 #: lib/klass_hero_web/components/provider_components.ex:2248
+#: lib/klass_hero_web/live/provider/overview_live.ex:400
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr ""
@@ -4607,7 +4609,7 @@ msgstr ""
 msgid "View sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:620
+#: lib/klass_hero_web/live/provider/programs_live.ex:590
 #, elixir-autogen, elixir-format
 msgid "Create a program before inviting participants."
 msgstr ""
@@ -4634,7 +4636,7 @@ msgstr ""
 msgid "Failed to update record"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2852
+#: lib/klass_hero_web/components/provider_components.ex:2894
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
@@ -4649,7 +4651,7 @@ msgstr ""
 msgid "Invite one person"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:616
+#: lib/klass_hero_web/live/provider/programs_live.ex:586
 #, elixir-autogen, elixir-format
 msgid "Invite sent."
 msgstr ""
@@ -4659,12 +4661,12 @@ msgstr ""
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2865
+#: lib/klass_hero_web/components/provider_components.ex:2907
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2871
+#: lib/klass_hero_web/components/provider_components.ex:2913
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr ""
@@ -4675,17 +4677,17 @@ msgstr ""
 msgid "Nothing to update"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2873
+#: lib/klass_hero_web/components/provider_components.ex:2915
 #, elixir-autogen, elixir-format
 msgid "Nut allergy"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2877
+#: lib/klass_hero_web/components/provider_components.ex:2919
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2882
+#: lib/klass_hero_web/components/provider_components.ex:2924
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr ""
@@ -4695,7 +4697,7 @@ msgstr ""
 msgid "Present"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2809
+#: lib/klass_hero_web/components/provider_components.ex:2851
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr ""
@@ -4722,22 +4724,22 @@ msgstr ""
 msgid "Save changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2846
+#: lib/klass_hero_web/components/provider_components.ex:2888
 #, elixir-autogen, elixir-format
 msgid "School (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2856
+#: lib/klass_hero_web/components/provider_components.ex:2898
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2830
+#: lib/klass_hero_web/components/provider_components.ex:2872
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2899
+#: lib/klass_hero_web/components/provider_components.ex:2941
 #, elixir-autogen, elixir-format
 msgid "Send invite"
 msgstr ""
@@ -4752,7 +4754,7 @@ msgstr ""
 msgid "Upload a list"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:627
+#: lib/klass_hero_web/live/provider/programs_live.ex:597
 #, elixir-autogen, elixir-format
 msgid "An invite for this child and program already exists."
 msgstr ""
@@ -4929,7 +4931,7 @@ msgstr ""
 msgid "Go to dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:572
+#: lib/klass_hero_web/live/provider/programs_live.ex:542
 #, elixir-autogen, elixir-format
 msgid "%{count} row could not be processed."
 msgid_plural "%{count} rows could not be processed."
@@ -4966,17 +4968,12 @@ msgstr ""
 msgid "A decade-plus coaching and running youth activity programs in Berlin. Built Prime Youth before founding Klass Hero."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:635
-#, elixir-autogen, elixir-format
-msgid "Accept"
-msgstr ""
-
 #: lib/klass_hero_web/components/parent_components.ex:89
 #, elixir-autogen, elixir-format
 msgid "Account settings"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:261
+#: lib/klass_hero_web/live/provider/overview_live.ex:273
 #, elixir-autogen, elixir-format
 msgid "Across all programs"
 msgstr ""
@@ -4987,7 +4984,7 @@ msgid "Active policy required to teach."
 msgstr ""
 
 #: lib/klass_hero_web/live/dashboard_live.ex:348
-#: lib/klass_hero_web/live/provider/overview_live.ex:251
+#: lib/klass_hero_web/live/provider/overview_live.ex:263
 #, elixir-autogen, elixir-format
 msgid "Active programs"
 msgstr ""
@@ -5176,8 +5173,8 @@ msgstr ""
 #: lib/klass_hero_web/components/parent_components.ex:143
 #: lib/klass_hero_web/components/parent_components.ex:336
 #: lib/klass_hero_web/components/provider_layout_components.ex:149
-#: lib/klass_hero_web/live/provider/overview_live.ex:269
-#: lib/klass_hero_web/live/provider/overview_live.ex:277
+#: lib/klass_hero_web/live/provider/overview_live.ex:281
+#: lib/klass_hero_web/live/provider/overview_live.ex:289
 #, elixir-autogen, elixir-format
 msgid "Coming soon"
 msgstr ""
@@ -5252,11 +5249,6 @@ msgstr ""
 msgid "Data & privacy"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:627
-#, elixir-autogen, elixir-format
-msgid "Decline"
-msgstr ""
-
 #: lib/klass_hero_web/live/for_providers_live.ex:370
 #, elixir-autogen, elixir-format
 msgid "Degrees, certs, and references reviewed."
@@ -5297,22 +5289,22 @@ msgstr ""
 msgid "Email the provider and us (support@mail.klasshero.com) as soon as you can — we'll help you and the provider work it out."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:257
+#: lib/klass_hero_web/live/provider/overview_live.ex:269
 #, elixir-autogen, elixir-format
 msgid "Enrolled kids"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:82
+#: lib/klass_hero_web/live/provider/overview_live.ex:84
 #, elixir-autogen, elixir-format
 msgid "Enrollment approved"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:90
+#: lib/klass_hero_web/live/provider/overview_live.ex:92
 #, elixir-autogen, elixir-format
 msgid "Enrollment is not pending"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:94
+#: lib/klass_hero_web/live/provider/overview_live.ex:96
 #, elixir-autogen, elixir-format
 msgid "Enrollment not found"
 msgstr ""
@@ -5368,7 +5360,7 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:103
+#: lib/klass_hero_web/live/provider/overview_live.ex:105
 #, elixir-autogen, elixir-format
 msgid "Failed to approve"
 msgstr ""
@@ -5511,8 +5503,8 @@ msgstr ""
 msgid "I'll be teaching"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:547
-#: lib/klass_hero_web/live/provider/programs_live.ex:569
+#: lib/klass_hero_web/live/provider/programs_live.ex:517
+#: lib/klass_hero_web/live/provider/programs_live.ex:539
 #, elixir-autogen, elixir-format
 msgid "Imported %{count} family."
 msgid_plural "Imported %{count} families."
@@ -5686,7 +5678,7 @@ msgstr ""
 msgid "Looking for quick answers?"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:293
+#: lib/klass_hero_web/live/provider/overview_live.ex:305
 #, elixir-autogen, elixir-format
 msgid "Manage"
 msgstr ""
@@ -5776,17 +5768,12 @@ msgstr ""
 msgid "No messages yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:327
+#: lib/klass_hero_web/live/provider/overview_live.ex:359
 #, elixir-autogen, elixir-format
 msgid "No pending enrollments right now."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:312
-#, elixir-autogen, elixir-format
-msgid "No pending requests right now."
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/overview_live.ex:297
+#: lib/klass_hero_web/live/provider/overview_live.ex:309
 #, elixir-autogen, elixir-format
 msgid "No programs yet — add your first one from the Programs tab."
 msgstr ""
@@ -5796,7 +5783,7 @@ msgstr ""
 msgid "No registered children for this session."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:556
+#: lib/klass_hero_web/live/provider/programs_live.ex:526
 #, elixir-autogen, elixir-format
 msgid "No rows imported. %{count} row could not be processed."
 msgid_plural "No rows imported. %{count} rows could not be processed."
@@ -5808,7 +5795,7 @@ msgstr[1] ""
 msgid "No upcoming sessions in the next few weeks."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:85
+#: lib/klass_hero_web/live/provider/overview_live.ex:87
 #, elixir-autogen, elixir-format
 msgid "Not allowed to approve this enrollment"
 msgstr ""
@@ -5905,12 +5892,7 @@ msgstr ""
 msgid "Pedagogical Interview"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:306
-#, elixir-autogen, elixir-format
-msgid "Pending booking requests"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/overview_live.ex:321
+#: lib/klass_hero_web/live/provider/overview_live.ex:353
 #, elixir-autogen, elixir-format
 msgid "Pending enrollments"
 msgstr ""
@@ -5988,7 +5970,7 @@ msgstr ""
 msgid "Questions, answered."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:272
+#: lib/klass_hero_web/live/provider/overview_live.ex:284
 #, elixir-autogen, elixir-format
 msgid "Rating"
 msgstr ""
@@ -6030,7 +6012,7 @@ msgstr ""
 msgid "Reports filed for this program will appear here."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:264
+#: lib/klass_hero_web/live/provider/overview_live.ex:276
 #, elixir-autogen, elixir-format
 msgid "Revenue (this week)"
 msgstr ""
@@ -6040,12 +6022,12 @@ msgstr ""
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2938
+#: lib/klass_hero_web/components/provider_components.ex:2980
 #, elixir-autogen, elixir-format
 msgid "Row %{row}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2938
+#: lib/klass_hero_web/components/provider_components.ex:2980
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr ""
@@ -6301,11 +6283,6 @@ msgstr ""
 msgid "Try adjusting your search or filter criteria — there's plenty more in Berlin."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:618
-#, elixir-autogen, elixir-format
-msgid "Unknown parent"
-msgstr ""
-
 #: lib/klass_hero_web/live/for_providers_live.ex:416
 #, elixir-autogen, elixir-format
 msgid "Unlimited programs and locations"
@@ -6484,7 +6461,7 @@ msgstr ""
 msgid "You're on the team, but the headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:288
+#: lib/klass_hero_web/live/provider/overview_live.ex:300
 #, elixir-autogen, elixir-format
 msgid "Your top programs"
 msgstr ""
@@ -6544,8 +6521,7 @@ msgstr ""
 msgid "matching"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:308
-#: lib/klass_hero_web/live/provider/overview_live.ex:323
+#: lib/klass_hero_web/live/provider/overview_live.ex:355
 #, elixir-autogen, elixir-format
 msgid "pending"
 msgstr ""
@@ -6608,7 +6584,7 @@ msgstr ""
 msgid "Complete all steps to publish programs. %{approved} of %{total} approved."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:240
+#: lib/klass_hero_web/live/provider/overview_live.ex:252
 #, elixir-autogen, elixir-format
 msgid "Complete your verification checklist so parents can find and book you."
 msgstr ""
@@ -6745,7 +6721,7 @@ msgstr ""
 msgid "Verify identity"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:237
+#: lib/klass_hero_web/live/provider/overview_live.ex:249
 #, elixir-autogen, elixir-format
 msgid "Verify your identity to get approved"
 msgstr ""
@@ -6786,12 +6762,12 @@ msgstr ""
 msgid "Experience validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3242
+#: lib/klass_hero_web/components/provider_components.ex:3284
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3216
+#: lib/klass_hero_web/components/provider_components.ex:3258
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
@@ -6801,12 +6777,12 @@ msgstr ""
 msgid "Safeguarding certificate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3239
+#: lib/klass_hero_web/components/provider_components.ex:3281
 #, elixir-autogen, elixir-format
 msgid "Select Video"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3285
+#: lib/klass_hero_web/components/provider_components.ex:3327
 #, elixir-autogen, elixir-format
 msgid "Upload Video"
 msgstr ""
@@ -6816,7 +6792,7 @@ msgstr ""
 msgid "Your browser does not support video playback."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3432
+#: lib/klass_hero_web/components/provider_components.ex:3474
 #, elixir-autogen, elixir-format
 msgid "Confirm agreement"
 msgstr ""
@@ -6826,12 +6802,12 @@ msgstr ""
 msgid "Couldn't record your agreement. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3455
+#: lib/klass_hero_web/components/provider_components.ex:3497
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3431
+#: lib/klass_hero_web/components/provider_components.ex:3473
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr ""
@@ -6841,7 +6817,7 @@ msgstr ""
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3340
+#: lib/klass_hero_web/components/provider_components.ex:3382
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr ""
@@ -6851,17 +6827,17 @@ msgstr ""
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3440
+#: lib/klass_hero_web/components/provider_components.ex:3482
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3429
+#: lib/klass_hero_web/components/provider_components.ex:3471
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3430
+#: lib/klass_hero_web/components/provider_components.ex:3472
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
@@ -7130,12 +7106,12 @@ msgstr ""
 msgid "Your insurance is verified."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3384
+#: lib/klass_hero_web/components/provider_components.ex:3426
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3487
+#: lib/klass_hero_web/components/provider_components.ex:3529
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr ""
@@ -7145,7 +7121,7 @@ msgstr ""
 msgid "Couldn't record your declaration. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3493
+#: lib/klass_hero_web/components/provider_components.ex:3535
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr ""
@@ -7155,17 +7131,17 @@ msgstr ""
 msgid "Please confirm the declaration before signing."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3518
+#: lib/klass_hero_web/components/provider_components.ex:3560
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3497
+#: lib/klass_hero_web/components/provider_components.ex:3539
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3485
+#: lib/klass_hero_web/components/provider_components.ex:3527
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr ""
@@ -7175,12 +7151,12 @@ msgstr ""
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3505
+#: lib/klass_hero_web/components/provider_components.ex:3547
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3491
+#: lib/klass_hero_web/components/provider_components.ex:3533
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
@@ -7260,7 +7236,7 @@ msgstr ""
 msgid "Lead"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:422
+#: lib/klass_hero_web/live/provider/programs_live.ex:423
 #, elixir-autogen, elixir-format
 msgid "Lead instructor updated."
 msgstr ""
@@ -7280,7 +7256,7 @@ msgstr ""
 msgid "Nobody is on this program yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:352
+#: lib/klass_hero_web/live/provider/programs_live.ex:353
 #: lib/klass_hero_web/live/provider/sessions_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "Pick a staff member to add."
@@ -7303,12 +7279,12 @@ msgstr ""
 msgid "Select a staff member…"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:367
+#: lib/klass_hero_web/live/provider/programs_live.ex:368
 #, elixir-autogen, elixir-format
 msgid "Staff member added to the program."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:393
+#: lib/klass_hero_web/live/provider/programs_live.ex:394
 #, elixir-autogen, elixir-format
 msgid "Staff member removed from the program."
 msgstr ""
@@ -7323,17 +7299,17 @@ msgstr ""
 msgid "Staffing — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1073
+#: lib/klass_hero_web/live/provider/programs_live.ex:1050
 #, elixir-autogen, elixir-format
 msgid "That staff member could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:375
+#: lib/klass_hero_web/live/provider/programs_live.ex:376
 #, elixir-autogen, elixir-format
 msgid "They are already on this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:401
+#: lib/klass_hero_web/live/provider/programs_live.ex:402
 #, elixir-autogen, elixir-format
 msgid "This person is the lead instructor. Make someone else lead before removing them."
 msgstr ""
@@ -7395,17 +7371,17 @@ msgstr ""
 msgid "This person has a history here now — use 'Remove from team' instead."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1351
+#: lib/klass_hero_web/live/provider/programs_live.ex:1328
 #, elixir-autogen, elixir-format
 msgid "Program created, but some settings could not be saved. Please review the program's limits."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1355
+#: lib/klass_hero_web/live/provider/programs_live.ex:1332
 #, elixir-autogen, elixir-format
 msgid "Program updated, but some settings could not be saved. Please review the program's limits."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1345
+#: lib/klass_hero_web/live/provider/programs_live.ex:1322
 #, elixir-autogen, elixir-format
 msgid "Program updated, but the enrollment capacity was rejected. The previous limits still apply."
 msgstr ""
@@ -7532,7 +7508,7 @@ msgstr ""
 msgid "Add waiver"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:945
+#: lib/klass_hero_web/live/provider/programs_live.ex:922
 #, elixir-autogen, elixir-format
 msgid "Check the waiver details and try again."
 msgstr ""
@@ -7650,7 +7626,7 @@ msgstr ""
 msgid "Version %{number}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:346
+#: lib/klass_hero_web/live/provider/programs_live.ex:347
 #, elixir-autogen, elixir-format
 msgid "Waiver not found."
 msgstr ""
@@ -7678,7 +7654,7 @@ msgstr ""
 msgid "this program"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:942
+#: lib/klass_hero_web/live/provider/programs_live.ex:919
 #, elixir-autogen, elixir-format
 msgid "New version published. It applies to future enrolments."
 msgstr ""
@@ -7688,12 +7664,12 @@ msgstr ""
 msgid "Retire \"%{title}\"? Parents will no longer be asked to sign it. Signatures already collected are kept."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:941
+#: lib/klass_hero_web/live/provider/programs_live.ex:918
 #, elixir-autogen, elixir-format
 msgid "Waiver added."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:343
+#: lib/klass_hero_web/live/provider/programs_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "Waiver retired. Signatures already collected are kept."
 msgstr ""
@@ -7759,7 +7735,7 @@ msgstr ""
 msgid "This is your main provider identity. Verification is required to list programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3083
+#: lib/klass_hero_web/components/provider_components.ex:3125
 #, elixir-autogen, elixir-format
 msgid "Upload documents to be verified. Documents are reviewed by our team."
 msgstr ""
@@ -7884,4 +7860,32 @@ msgstr ""
 #: lib/klass_hero_web/live/user_live/settings.ex:531
 #, elixir-autogen, elixir-format
 msgid "You'll get a provider profile to fill in, and a dashboard for your activities. Your family account stays exactly as it is."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/overview_live.ex:332
+#: lib/klass_hero_web/live/provider/overview_live.ex:415
+#, elixir-autogen, elixir-format
+msgid "Every invitation you sent has been answered."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/overview_live.ex:320
+#: lib/klass_hero_web/live/provider/overview_live.ex:394
+#, elixir-autogen, elixir-format
+msgid "Invitations awaiting a reply"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/overview_live.ex:346
+#, elixir-autogen, elixir-format
+msgid "Review invitations"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2760
+#: lib/klass_hero_web/components/provider_components.ex:2764
+#, elixir-autogen, elixir-format
+msgid "Unknown program"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/overview_live.ex:322
+#, elixir-autogen, elixir-format
+msgid "waiting"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -575,8 +575,8 @@ msgid "Dispute Resolution"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:720
-#: lib/klass_hero_web/components/provider_components.ex:2816
-#: lib/klass_hero_web/components/provider_components.ex:2834
+#: lib/klass_hero_web/components/provider_components.ex:2858
+#: lib/klass_hero_web/components/provider_components.ex:2876
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
@@ -1324,7 +1324,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1488
 #: lib/klass_hero_web/components/provider_components.ex:2472
-#: lib/klass_hero_web/components/provider_components.ex:2714
+#: lib/klass_hero_web/components/provider_components.ex:2748
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
@@ -1340,7 +1340,7 @@ msgstr ""
 msgid "Add Team Member"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:48
+#: lib/klass_hero_web/live/provider/programs_live.ex:49
 #, elixir-autogen, elixir-format
 msgid "All Staff"
 msgstr ""
@@ -1391,7 +1391,7 @@ msgid "Inactive"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:114
-#: lib/klass_hero_web/live/provider/programs_live.ex:54
+#: lib/klass_hero_web/live/provider/programs_live.ex:55
 #, elixir-autogen, elixir-format, fuzzy
 msgid "My Programs"
 msgstr ""
@@ -1410,8 +1410,8 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:48
 #: lib/klass_hero_web/components/provider_components.ex:74
 #: lib/klass_hero_web/components/provider_components.ex:1635
-#: lib/klass_hero_web/components/provider_components.ex:2910
-#: lib/klass_hero_web/components/provider_components.ex:2928
+#: lib/klass_hero_web/components/provider_components.ex:2952
+#: lib/klass_hero_web/components/provider_components.ex:2970
 #: lib/klass_hero_web/live/admin/sessions_live.ex:298
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
@@ -1433,7 +1433,7 @@ msgstr ""
 msgid "Program Name"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:58
+#: lib/klass_hero_web/live/provider/overview_live.ex:59
 #, elixir-autogen, elixir-format
 msgid "Provider Dashboard"
 msgstr ""
@@ -1451,7 +1451,7 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:1482
 #: lib/klass_hero_web/components/provider_components.ex:1885
 #: lib/klass_hero_web/components/provider_components.ex:2463
-#: lib/klass_hero_web/components/provider_components.ex:2711
+#: lib/klass_hero_web/components/provider_components.ex:2745
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1604,7 +1604,7 @@ msgstr ""
 msgid "Data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2797
+#: lib/klass_hero_web/components/provider_components.ex:2839
 #: lib/klass_hero_web/live/settings/children_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1652,17 +1652,17 @@ msgstr ""
 msgid "Failed to submit note"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2791
-#: lib/klass_hero_web/components/provider_components.ex:2820
-#: lib/klass_hero_web/components/provider_components.ex:2836
+#: lib/klass_hero_web/components/provider_components.ex:2833
+#: lib/klass_hero_web/components/provider_components.ex:2862
+#: lib/klass_hero_web/components/provider_components.ex:2878
 #: lib/klass_hero_web/live/settings/children_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2792
-#: lib/klass_hero_web/components/provider_components.ex:2821
-#: lib/klass_hero_web/components/provider_components.ex:2837
+#: lib/klass_hero_web/components/provider_components.ex:2834
+#: lib/klass_hero_web/components/provider_components.ex:2863
+#: lib/klass_hero_web/components/provider_components.ex:2879
 #: lib/klass_hero_web/live/settings/children_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -1819,7 +1819,7 @@ msgstr ""
 msgid "Send a message to start the conversation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2891
+#: lib/klass_hero_web/components/provider_components.ex:2933
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:249
 #, elixir-autogen, elixir-format, fuzzy
@@ -1955,12 +1955,12 @@ msgstr ""
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2950
+#: lib/klass_hero_web/components/provider_components.ex:2992
 #, elixir-autogen, elixir-format, fuzzy
 msgid "An unexpected error occurred during import."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:670
+#: lib/klass_hero_web/components/provider_layout_components.ex:622
 #: lib/klass_hero_web/live/admin/verifications_live.ex:438
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:53
 #, elixir-autogen, elixir-format
@@ -2035,7 +2035,7 @@ msgid "Check eligibility at"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:2460
-#: lib/klass_hero_web/components/provider_components.ex:2705
+#: lib/klass_hero_web/components/provider_components.ex:2731
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2075,7 +2075,7 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2911
+#: lib/klass_hero_web/components/provider_components.ex:2953
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
@@ -2085,12 +2085,12 @@ msgstr ""
 msgid "Contact Provider"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:536
+#: lib/klass_hero_web/live/provider/programs_live.ex:506
 #, elixir-autogen, elixir-format
 msgid "Could not read the uploaded file."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:504
+#: lib/klass_hero_web/live/provider/dashboard/invite_actions.ex:64
 #, elixir-autogen, elixir-format
 msgid "Could not remove invite."
 msgstr ""
@@ -2124,7 +2124,7 @@ msgstr ""
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3126
+#: lib/klass_hero_web/components/provider_components.ex:3168
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2190,8 +2190,8 @@ msgid "End Time"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:2469
-#: lib/klass_hero_web/components/provider_components.ex:2931
-#: lib/klass_hero_web/components/provider_layout_components.ex:660
+#: lib/klass_hero_web/components/provider_components.ex:2973
+#: lib/klass_hero_web/components/provider_layout_components.ex:612
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrolled"
 msgstr ""
@@ -2212,7 +2212,7 @@ msgid "Explain why this document is being rejected..."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:72
-#: lib/klass_hero_web/components/provider_components.ex:2932
+#: lib/klass_hero_web/components/provider_components.ex:2974
 #: lib/klass_hero_web/live/admin/emails_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2228,7 +2228,7 @@ msgstr ""
 msgid "Failed to reject document."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:486
+#: lib/klass_hero_web/live/provider/dashboard/invite_actions.ex:47
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to resend invite."
 msgstr ""
@@ -2256,12 +2256,12 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3060
+#: lib/klass_hero_web/components/provider_components.ex:3102
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3062
+#: lib/klass_hero_web/components/provider_components.ex:3104
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
@@ -2296,7 +2296,7 @@ msgstr ""
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2708
+#: lib/klass_hero_web/components/provider_components.ex:2742
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
@@ -2321,17 +2321,17 @@ msgstr ""
 msgid "Insurance Certificate"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:501
+#: lib/klass_hero_web/live/provider/dashboard/invite_actions.ex:61
 #, elixir-autogen, elixir-format
 msgid "Invite not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:498
+#: lib/klass_hero_web/live/provider/dashboard/invite_actions.ex:58
 #, elixir-autogen, elixir-format
 msgid "Invite removed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:475
+#: lib/klass_hero_web/live/provider/dashboard/invite_actions.ex:36
 #, elixir-autogen, elixir-format
 msgid "Invite resent successfully."
 msgstr ""
@@ -2437,7 +2437,7 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3088
+#: lib/klass_hero_web/components/provider_components.ex:3130
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
@@ -2448,7 +2448,7 @@ msgstr ""
 msgid "No enrollments yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:532
+#: lib/klass_hero_web/live/provider/programs_live.ex:502
 #, elixir-autogen, elixir-format
 msgid "No file selected."
 msgstr ""
@@ -2521,7 +2521,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3163
+#: lib/klass_hero_web/components/provider_components.ex:3205
 #: lib/klass_hero_web/live/provider/verification_live.ex:698
 #: lib/klass_hero_web/live/provider/verification_live.ex:770
 #, elixir-autogen, elixir-format
@@ -2548,8 +2548,8 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:106
-#: lib/klass_hero_web/live/provider/programs_live.ex:775
-#: lib/klass_hero_web/live/provider/programs_live.ex:844
+#: lib/klass_hero_web/live/provider/programs_live.ex:745
+#: lib/klass_hero_web/live/provider/programs_live.ex:814
 #: lib/klass_hero_web/live/provider/team_live.ex:305
 #: lib/klass_hero_web/live/provider/team_live.ex:348
 #: lib/klass_hero_web/live/provider/team_live.ex:467
@@ -2582,28 +2582,28 @@ msgstr ""
 msgid "Program Start"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1337
+#: lib/klass_hero_web/live/provider/programs_live.ex:1314
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program created successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1341
+#: lib/klass_hero_web/live/provider/programs_live.ex:1318
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:54
-#: lib/klass_hero_web/live/provider/programs_live.ex:156
-#: lib/klass_hero_web/live/provider/programs_live.ex:193
-#: lib/klass_hero_web/live/provider/programs_live.ex:257
-#: lib/klass_hero_web/live/provider/programs_live.ex:281
-#: lib/klass_hero_web/live/provider/programs_live.ex:819
-#: lib/klass_hero_web/live/provider/programs_live.ex:944
+#: lib/klass_hero_web/live/provider/programs_live.ex:157
+#: lib/klass_hero_web/live/provider/programs_live.ex:194
+#: lib/klass_hero_web/live/provider/programs_live.ex:258
+#: lib/klass_hero_web/live/provider/programs_live.ex:282
+#: lib/klass_hero_web/live/provider/programs_live.ex:789
+#: lib/klass_hero_web/live/provider/programs_live.ex:921
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1338
+#: lib/klass_hero_web/live/provider/programs_live.ex:1315
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program updated successfully."
 msgstr ""
@@ -2621,7 +2621,7 @@ msgid "Read our founding story →"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:805
-#: lib/klass_hero_web/components/provider_components.ex:2930
+#: lib/klass_hero_web/components/provider_components.ex:2972
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registered"
@@ -2703,16 +2703,16 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:840
 #: lib/klass_hero_web/components/provider_components.ex:1285
-#: lib/klass_hero_web/components/provider_components.ex:2752
-#: lib/klass_hero_web/components/provider_components.ex:3182
-#: lib/klass_hero_web/components/provider_components.ex:3261
+#: lib/klass_hero_web/components/provider_components.ex:2795
+#: lib/klass_hero_web/components/provider_components.ex:3224
+#: lib/klass_hero_web/components/provider_components.ex:3303
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:253
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2745
+#: lib/klass_hero_web/components/provider_components.ex:2788
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -2753,7 +2753,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3160
+#: lib/klass_hero_web/components/provider_components.ex:3202
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select File"
 msgstr ""
@@ -2764,13 +2764,13 @@ msgstr ""
 msgid "Selected child does not meet the program requirements."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:765
-#: lib/klass_hero_web/live/provider/programs_live.ex:834
+#: lib/klass_hero_web/live/provider/programs_live.ex:735
+#: lib/klass_hero_web/live/provider/programs_live.ex:804
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2929
+#: lib/klass_hero_web/components/provider_components.ex:2971
 #: lib/klass_hero_web/live/admin/emails_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "Sent"
@@ -2865,12 +2865,12 @@ msgstr ""
 msgid "The Klass Hero Story"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:478
+#: lib/klass_hero_web/live/provider/dashboard/invite_actions.ex:39
 #, elixir-autogen, elixir-format
 msgid "This invite cannot be resent."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:826
+#: lib/klass_hero_web/live/provider/programs_live.ex:796
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
@@ -2881,7 +2881,7 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3061
+#: lib/klass_hero_web/components/provider_components.ex:3103
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -2906,22 +2906,22 @@ msgstr ""
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3206
+#: lib/klass_hero_web/components/provider_components.ex:3248
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3115
+#: lib/klass_hero_web/components/provider_components.ex:3157
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3063
+#: lib/klass_hero_web/components/provider_components.ex:3105
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3080
+#: lib/klass_hero_web/components/provider_components.ex:3122
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -3011,7 +3011,7 @@ msgid "Child Safeguarding Training"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1498
-#: lib/klass_hero_web/components/provider_components.ex:3428
+#: lib/klass_hero_web/components/provider_components.ex:3470
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr ""
@@ -3081,7 +3081,7 @@ msgstr ""
 msgid "Program fee:"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1114
+#: lib/klass_hero_web/live/provider/programs_live.ex:1091
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr ""
@@ -3162,7 +3162,7 @@ msgid "Vetted with Care"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1482
-#: lib/klass_hero_web/components/provider_components.ex:3213
+#: lib/klass_hero_web/components/provider_components.ex:3255
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr ""
@@ -3298,7 +3298,7 @@ msgstr ""
 msgid "Cannot check out without a check-in"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:450
+#: lib/klass_hero_web/live/provider/programs_live.ex:451
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
@@ -3336,7 +3336,7 @@ msgstr ""
 msgid "Checked Out"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2788
+#: lib/klass_hero_web/components/provider_components.ex:2830
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Child"
@@ -3363,7 +3363,7 @@ msgid "Correct"
 msgstr ""
 
 #: lib/klass_hero_web/live/dashboard_live.ex:306
-#: lib/klass_hero_web/live/provider/programs_live.ex:447
+#: lib/klass_hero_web/live/provider/programs_live.ex:448
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Could not start conversation. Please try again."
@@ -4113,10 +4113,11 @@ msgstr ""
 msgid "Post"
 msgstr ""
 
+#: lib/klass_hero_web/components/provider_components.ex:2739
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:24
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
-#: lib/klass_hero_web/live/provider/programs_live.ex:225
+#: lib/klass_hero_web/live/provider/programs_live.ex:226
 #: lib/klass_hero_web/live/provider/sessions_live.ex:381
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:175
 #, elixir-autogen, elixir-format, fuzzy
@@ -4318,7 +4319,7 @@ msgid "Update your observation..."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:138
-#: lib/klass_hero_web/live/provider/programs_live.ex:529
+#: lib/klass_hero_web/live/provider/programs_live.ex:499
 #: lib/klass_hero_web/live/provider/verification_live.ex:240
 #: lib/klass_hero_web/live/provider/verification_live.ex:556
 #: lib/klass_hero_web/live/provider/verification_live.ex:594
@@ -4583,6 +4584,7 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:1952
 #: lib/klass_hero_web/components/provider_components.ex:2094
 #: lib/klass_hero_web/components/provider_components.ex:2248
+#: lib/klass_hero_web/live/provider/overview_live.ex:400
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Close"
 msgstr ""
@@ -4607,7 +4609,7 @@ msgstr ""
 msgid "View sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:620
+#: lib/klass_hero_web/live/provider/programs_live.ex:590
 #, elixir-autogen, elixir-format
 msgid "Create a program before inviting participants."
 msgstr ""
@@ -4634,7 +4636,7 @@ msgstr ""
 msgid "Failed to update record"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2852
+#: lib/klass_hero_web/components/provider_components.ex:2894
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
@@ -4649,7 +4651,7 @@ msgstr ""
 msgid "Invite one person"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:616
+#: lib/klass_hero_web/live/provider/programs_live.ex:586
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invite sent."
 msgstr ""
@@ -4659,12 +4661,12 @@ msgstr ""
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2865
+#: lib/klass_hero_web/components/provider_components.ex:2907
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2871
+#: lib/klass_hero_web/components/provider_components.ex:2913
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr ""
@@ -4675,17 +4677,17 @@ msgstr ""
 msgid "Nothing to update"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2873
+#: lib/klass_hero_web/components/provider_components.ex:2915
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nut allergy"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2877
+#: lib/klass_hero_web/components/provider_components.ex:2919
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2882
+#: lib/klass_hero_web/components/provider_components.ex:2924
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr ""
@@ -4695,7 +4697,7 @@ msgstr ""
 msgid "Present"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2809
+#: lib/klass_hero_web/components/provider_components.ex:2851
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr ""
@@ -4722,22 +4724,22 @@ msgstr ""
 msgid "Save changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2846
+#: lib/klass_hero_web/components/provider_components.ex:2888
 #, elixir-autogen, elixir-format, fuzzy
 msgid "School (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2856
+#: lib/klass_hero_web/components/provider_components.ex:2898
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2830
+#: lib/klass_hero_web/components/provider_components.ex:2872
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2899
+#: lib/klass_hero_web/components/provider_components.ex:2941
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Send invite"
 msgstr ""
@@ -4752,7 +4754,7 @@ msgstr ""
 msgid "Upload a list"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:627
+#: lib/klass_hero_web/live/provider/programs_live.ex:597
 #, elixir-autogen, elixir-format
 msgid "An invite for this child and program already exists."
 msgstr ""
@@ -4929,7 +4931,7 @@ msgstr ""
 msgid "Go to dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:572
+#: lib/klass_hero_web/live/provider/programs_live.ex:542
 #, elixir-autogen, elixir-format
 msgid "%{count} row could not be processed."
 msgid_plural "%{count} rows could not be processed."
@@ -4966,17 +4968,12 @@ msgstr ""
 msgid "A decade-plus coaching and running youth activity programs in Berlin. Built Prime Youth before founding Klass Hero."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:635
-#, elixir-autogen, elixir-format
-msgid "Accept"
-msgstr ""
-
 #: lib/klass_hero_web/components/parent_components.ex:89
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Account settings"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:261
+#: lib/klass_hero_web/live/provider/overview_live.ex:273
 #, elixir-autogen, elixir-format
 msgid "Across all programs"
 msgstr ""
@@ -4987,7 +4984,7 @@ msgid "Active policy required to teach."
 msgstr ""
 
 #: lib/klass_hero_web/live/dashboard_live.ex:348
-#: lib/klass_hero_web/live/provider/overview_live.ex:251
+#: lib/klass_hero_web/live/provider/overview_live.ex:263
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Active programs"
 msgstr ""
@@ -5176,8 +5173,8 @@ msgstr ""
 #: lib/klass_hero_web/components/parent_components.ex:143
 #: lib/klass_hero_web/components/parent_components.ex:336
 #: lib/klass_hero_web/components/provider_layout_components.ex:149
-#: lib/klass_hero_web/live/provider/overview_live.ex:269
-#: lib/klass_hero_web/live/provider/overview_live.ex:277
+#: lib/klass_hero_web/live/provider/overview_live.ex:281
+#: lib/klass_hero_web/live/provider/overview_live.ex:289
 #, elixir-autogen, elixir-format
 msgid "Coming soon"
 msgstr ""
@@ -5252,11 +5249,6 @@ msgstr ""
 msgid "Data & privacy"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:627
-#, elixir-autogen, elixir-format
-msgid "Decline"
-msgstr ""
-
 #: lib/klass_hero_web/live/for_providers_live.ex:370
 #, elixir-autogen, elixir-format
 msgid "Degrees, certs, and references reviewed."
@@ -5297,22 +5289,22 @@ msgstr ""
 msgid "Email the provider and us (support@mail.klasshero.com) as soon as you can — we'll help you and the provider work it out."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:257
+#: lib/klass_hero_web/live/provider/overview_live.ex:269
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrolled kids"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:82
+#: lib/klass_hero_web/live/provider/overview_live.ex:84
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrollment approved"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:90
+#: lib/klass_hero_web/live/provider/overview_live.ex:92
 #, elixir-autogen, elixir-format
 msgid "Enrollment is not pending"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:94
+#: lib/klass_hero_web/live/provider/overview_live.ex:96
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrollment not found"
 msgstr ""
@@ -5368,7 +5360,7 @@ msgstr ""
 msgid "FAQ"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:103
+#: lib/klass_hero_web/live/provider/overview_live.ex:105
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to approve"
 msgstr ""
@@ -5511,8 +5503,8 @@ msgstr ""
 msgid "I'll be teaching"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:547
-#: lib/klass_hero_web/live/provider/programs_live.ex:569
+#: lib/klass_hero_web/live/provider/programs_live.ex:517
+#: lib/klass_hero_web/live/provider/programs_live.ex:539
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Imported %{count} family."
 msgid_plural "Imported %{count} families."
@@ -5686,7 +5678,7 @@ msgstr ""
 msgid "Looking for quick answers?"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:293
+#: lib/klass_hero_web/live/provider/overview_live.ex:305
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Manage"
 msgstr ""
@@ -5776,17 +5768,12 @@ msgstr ""
 msgid "No messages yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:327
+#: lib/klass_hero_web/live/provider/overview_live.ex:359
 #, elixir-autogen, elixir-format
 msgid "No pending enrollments right now."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:312
-#, elixir-autogen, elixir-format, fuzzy
-msgid "No pending requests right now."
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/overview_live.ex:297
+#: lib/klass_hero_web/live/provider/overview_live.ex:309
 #, elixir-autogen, elixir-format
 msgid "No programs yet — add your first one from the Programs tab."
 msgstr ""
@@ -5796,7 +5783,7 @@ msgstr ""
 msgid "No registered children for this session."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:556
+#: lib/klass_hero_web/live/provider/programs_live.ex:526
 #, elixir-autogen, elixir-format
 msgid "No rows imported. %{count} row could not be processed."
 msgid_plural "No rows imported. %{count} rows could not be processed."
@@ -5808,7 +5795,7 @@ msgstr[1] ""
 msgid "No upcoming sessions in the next few weeks."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:85
+#: lib/klass_hero_web/live/provider/overview_live.ex:87
 #, elixir-autogen, elixir-format
 msgid "Not allowed to approve this enrollment"
 msgstr ""
@@ -5905,12 +5892,7 @@ msgstr ""
 msgid "Pedagogical Interview"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:306
-#, elixir-autogen, elixir-format
-msgid "Pending booking requests"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/overview_live.ex:321
+#: lib/klass_hero_web/live/provider/overview_live.ex:353
 #, elixir-autogen, elixir-format
 msgid "Pending enrollments"
 msgstr ""
@@ -5988,7 +5970,7 @@ msgstr ""
 msgid "Questions, answered."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:272
+#: lib/klass_hero_web/live/provider/overview_live.ex:284
 #, elixir-autogen, elixir-format
 msgid "Rating"
 msgstr ""
@@ -6030,7 +6012,7 @@ msgstr ""
 msgid "Reports filed for this program will appear here."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:264
+#: lib/klass_hero_web/live/provider/overview_live.ex:276
 #, elixir-autogen, elixir-format
 msgid "Revenue (this week)"
 msgstr ""
@@ -6040,12 +6022,12 @@ msgstr ""
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2938
+#: lib/klass_hero_web/components/provider_components.ex:2980
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Row %{row}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2938
+#: lib/klass_hero_web/components/provider_components.ex:2980
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr ""
@@ -6301,11 +6283,6 @@ msgstr ""
 msgid "Try adjusting your search or filter criteria — there's plenty more in Berlin."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_layout_components.ex:618
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Unknown parent"
-msgstr ""
-
 #: lib/klass_hero_web/live/for_providers_live.ex:416
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Unlimited programs and locations"
@@ -6484,7 +6461,7 @@ msgstr ""
 msgid "You're on the team, but the headshot upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:288
+#: lib/klass_hero_web/live/provider/overview_live.ex:300
 #, elixir-autogen, elixir-format
 msgid "Your top programs"
 msgstr ""
@@ -6544,8 +6521,7 @@ msgstr ""
 msgid "matching"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:308
-#: lib/klass_hero_web/live/provider/overview_live.ex:323
+#: lib/klass_hero_web/live/provider/overview_live.ex:355
 #, elixir-autogen, elixir-format, fuzzy
 msgid "pending"
 msgstr ""
@@ -6608,7 +6584,7 @@ msgstr ""
 msgid "Complete all steps to publish programs. %{approved} of %{total} approved."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:240
+#: lib/klass_hero_web/live/provider/overview_live.ex:252
 #, elixir-autogen, elixir-format
 msgid "Complete your verification checklist so parents can find and book you."
 msgstr ""
@@ -6745,7 +6721,7 @@ msgstr ""
 msgid "Verify identity"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/overview_live.ex:237
+#: lib/klass_hero_web/live/provider/overview_live.ex:249
 #, elixir-autogen, elixir-format
 msgid "Verify your identity to get approved"
 msgstr ""
@@ -6786,12 +6762,12 @@ msgstr ""
 msgid "Experience validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3242
+#: lib/klass_hero_web/components/provider_components.ex:3284
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3216
+#: lib/klass_hero_web/components/provider_components.ex:3258
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
@@ -6801,12 +6777,12 @@ msgstr ""
 msgid "Safeguarding certificate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3239
+#: lib/klass_hero_web/components/provider_components.ex:3281
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select Video"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3285
+#: lib/klass_hero_web/components/provider_components.ex:3327
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload Video"
 msgstr ""
@@ -6816,7 +6792,7 @@ msgstr ""
 msgid "Your browser does not support video playback."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3432
+#: lib/klass_hero_web/components/provider_components.ex:3474
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Confirm agreement"
 msgstr ""
@@ -6826,12 +6802,12 @@ msgstr ""
 msgid "Couldn't record your agreement. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3455
+#: lib/klass_hero_web/components/provider_components.ex:3497
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3431
+#: lib/klass_hero_web/components/provider_components.ex:3473
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr ""
@@ -6841,7 +6817,7 @@ msgstr ""
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3340
+#: lib/klass_hero_web/components/provider_components.ex:3382
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr ""
@@ -6851,17 +6827,17 @@ msgstr ""
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3440
+#: lib/klass_hero_web/components/provider_components.ex:3482
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3429
+#: lib/klass_hero_web/components/provider_components.ex:3471
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3430
+#: lib/klass_hero_web/components/provider_components.ex:3472
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
@@ -7130,12 +7106,12 @@ msgstr ""
 msgid "Your insurance is verified."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3384
+#: lib/klass_hero_web/components/provider_components.ex:3426
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3487
+#: lib/klass_hero_web/components/provider_components.ex:3529
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr ""
@@ -7145,7 +7121,7 @@ msgstr ""
 msgid "Couldn't record your declaration. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3493
+#: lib/klass_hero_web/components/provider_components.ex:3535
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr ""
@@ -7155,17 +7131,17 @@ msgstr ""
 msgid "Please confirm the declaration before signing."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3518
+#: lib/klass_hero_web/components/provider_components.ex:3560
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3497
+#: lib/klass_hero_web/components/provider_components.ex:3539
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3485
+#: lib/klass_hero_web/components/provider_components.ex:3527
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr ""
@@ -7175,12 +7151,12 @@ msgstr ""
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3505
+#: lib/klass_hero_web/components/provider_components.ex:3547
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3491
+#: lib/klass_hero_web/components/provider_components.ex:3533
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
@@ -7260,7 +7236,7 @@ msgstr ""
 msgid "Lead"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:422
+#: lib/klass_hero_web/live/provider/programs_live.ex:423
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Lead instructor updated."
 msgstr ""
@@ -7280,7 +7256,7 @@ msgstr ""
 msgid "Nobody is on this program yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:352
+#: lib/klass_hero_web/live/provider/programs_live.ex:353
 #: lib/klass_hero_web/live/provider/sessions_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "Pick a staff member to add."
@@ -7303,12 +7279,12 @@ msgstr ""
 msgid "Select a staff member…"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:367
+#: lib/klass_hero_web/live/provider/programs_live.ex:368
 #, elixir-autogen, elixir-format
 msgid "Staff member added to the program."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:393
+#: lib/klass_hero_web/live/provider/programs_live.ex:394
 #, elixir-autogen, elixir-format
 msgid "Staff member removed from the program."
 msgstr ""
@@ -7323,17 +7299,17 @@ msgstr ""
 msgid "Staffing — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1073
+#: lib/klass_hero_web/live/provider/programs_live.ex:1050
 #, elixir-autogen, elixir-format
 msgid "That staff member could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:375
+#: lib/klass_hero_web/live/provider/programs_live.ex:376
 #, elixir-autogen, elixir-format
 msgid "They are already on this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:401
+#: lib/klass_hero_web/live/provider/programs_live.ex:402
 #, elixir-autogen, elixir-format
 msgid "This person is the lead instructor. Make someone else lead before removing them."
 msgstr ""
@@ -7395,17 +7371,17 @@ msgstr ""
 msgid "This person has a history here now — use 'Remove from team' instead."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1351
+#: lib/klass_hero_web/live/provider/programs_live.ex:1328
 #, elixir-autogen, elixir-format
 msgid "Program created, but some settings could not be saved. Please review the program's limits."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1355
+#: lib/klass_hero_web/live/provider/programs_live.ex:1332
 #, elixir-autogen, elixir-format
 msgid "Program updated, but some settings could not be saved. Please review the program's limits."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1345
+#: lib/klass_hero_web/live/provider/programs_live.ex:1322
 #, elixir-autogen, elixir-format
 msgid "Program updated, but the enrollment capacity was rejected. The previous limits still apply."
 msgstr ""
@@ -7532,7 +7508,7 @@ msgstr ""
 msgid "Add waiver"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:945
+#: lib/klass_hero_web/live/provider/programs_live.ex:922
 #, elixir-autogen, elixir-format
 msgid "Check the waiver details and try again."
 msgstr ""
@@ -7650,7 +7626,7 @@ msgstr ""
 msgid "Version %{number}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:346
+#: lib/klass_hero_web/live/provider/programs_live.ex:347
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Waiver not found."
 msgstr ""
@@ -7678,7 +7654,7 @@ msgstr ""
 msgid "this program"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:942
+#: lib/klass_hero_web/live/provider/programs_live.ex:919
 #, elixir-autogen, elixir-format
 msgid "New version published. It applies to future enrolments."
 msgstr ""
@@ -7688,12 +7664,12 @@ msgstr ""
 msgid "Retire \"%{title}\"? Parents will no longer be asked to sign it. Signatures already collected are kept."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:941
+#: lib/klass_hero_web/live/provider/programs_live.ex:918
 #, elixir-autogen, elixir-format
 msgid "Waiver added."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:343
+#: lib/klass_hero_web/live/provider/programs_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "Waiver retired. Signatures already collected are kept."
 msgstr ""
@@ -7759,7 +7735,7 @@ msgstr ""
 msgid "This is your main provider identity. Verification is required to list programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3083
+#: lib/klass_hero_web/components/provider_components.ex:3125
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload documents to be verified. Documents are reviewed by our team."
 msgstr ""
@@ -7884,4 +7860,32 @@ msgstr ""
 #: lib/klass_hero_web/live/user_live/settings.ex:531
 #, elixir-autogen, elixir-format
 msgid "You'll get a provider profile to fill in, and a dashboard for your activities. Your family account stays exactly as it is."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/overview_live.ex:332
+#: lib/klass_hero_web/live/provider/overview_live.ex:415
+#, elixir-autogen, elixir-format
+msgid "Every invitation you sent has been answered."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/overview_live.ex:320
+#: lib/klass_hero_web/live/provider/overview_live.ex:394
+#, elixir-autogen, elixir-format
+msgid "Invitations awaiting a reply"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/overview_live.ex:346
+#, elixir-autogen, elixir-format
+msgid "Review invitations"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:2760
+#: lib/klass_hero_web/components/provider_components.ex:2764
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Unknown program"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/overview_live.ex:322
+#, elixir-autogen, elixir-format
+msgid "waiting"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/en/LC_MESSAGES/enrollment.po
@@ -11,95 +11,95 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:3032
-#: lib/klass_hero_web/components/provider_components.ex:3049
+#: lib/klass_hero_web/components/provider_components.ex:3074
+#: lib/klass_hero_web/components/provider_components.ex:3091
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3033
-#: lib/klass_hero_web/components/provider_components.ex:3050
+#: lib/klass_hero_web/components/provider_components.ex:3075
+#: lib/klass_hero_web/components/provider_components.ex:3092
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3034
-#: lib/klass_hero_web/components/provider_components.ex:3051
+#: lib/klass_hero_web/components/provider_components.ex:3076
+#: lib/klass_hero_web/components/provider_components.ex:3093
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3045
+#: lib/klass_hero_web/components/provider_components.ex:3087
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3035
+#: lib/klass_hero_web/components/provider_components.ex:3077
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3036
+#: lib/klass_hero_web/components/provider_components.ex:3078
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3037
+#: lib/klass_hero_web/components/provider_components.ex:3079
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3044
+#: lib/klass_hero_web/components/provider_components.ex:3086
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3046
+#: lib/klass_hero_web/components/provider_components.ex:3088
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3038
+#: lib/klass_hero_web/components/provider_components.ex:3080
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3040
+#: lib/klass_hero_web/components/provider_components.ex:3082
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3042
+#: lib/klass_hero_web/components/provider_components.ex:3084
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2972
+#: lib/klass_hero_web/components/provider_components.ex:3014
 #, elixir-autogen, elixir-format
 msgid "Date of birth \"%{value}\" is not a valid date. Please correct it and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2966
+#: lib/klass_hero_web/components/provider_components.ex:3008
 #, elixir-autogen, elixir-format
 msgid "Invite link could not be generated (no token). Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2980
+#: lib/klass_hero_web/components/provider_components.ex:3022
 #, elixir-autogen, elixir-format
 msgid "The invitation email could not be delivered. Please check the address and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2969
+#: lib/klass_hero_web/components/provider_components.ex:3011
 #, elixir-autogen, elixir-format
 msgid "The program is full, so this child could not be enrolled."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2983
+#: lib/klass_hero_web/components/provider_components.ex:3025
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed and no retries remain. Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2992
+#: lib/klass_hero_web/components/provider_components.ex:3034
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed. Please resend."
 msgstr ""

--- a/priv/gettext/enrollment.pot
+++ b/priv/gettext/enrollment.pot
@@ -11,95 +11,95 @@
 msgid ""
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3032
-#: lib/klass_hero_web/components/provider_components.ex:3049
+#: lib/klass_hero_web/components/provider_components.ex:3074
+#: lib/klass_hero_web/components/provider_components.ex:3091
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3033
-#: lib/klass_hero_web/components/provider_components.ex:3050
+#: lib/klass_hero_web/components/provider_components.ex:3075
+#: lib/klass_hero_web/components/provider_components.ex:3092
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3034
-#: lib/klass_hero_web/components/provider_components.ex:3051
+#: lib/klass_hero_web/components/provider_components.ex:3076
+#: lib/klass_hero_web/components/provider_components.ex:3093
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3045
+#: lib/klass_hero_web/components/provider_components.ex:3087
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3035
+#: lib/klass_hero_web/components/provider_components.ex:3077
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3036
+#: lib/klass_hero_web/components/provider_components.ex:3078
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3037
+#: lib/klass_hero_web/components/provider_components.ex:3079
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3044
+#: lib/klass_hero_web/components/provider_components.ex:3086
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3046
+#: lib/klass_hero_web/components/provider_components.ex:3088
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3038
+#: lib/klass_hero_web/components/provider_components.ex:3080
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3040
+#: lib/klass_hero_web/components/provider_components.ex:3082
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3042
+#: lib/klass_hero_web/components/provider_components.ex:3084
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2972
+#: lib/klass_hero_web/components/provider_components.ex:3014
 #, elixir-autogen, elixir-format
 msgid "Date of birth \"%{value}\" is not a valid date. Please correct it and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2966
+#: lib/klass_hero_web/components/provider_components.ex:3008
 #, elixir-autogen, elixir-format
 msgid "Invite link could not be generated (no token). Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2980
+#: lib/klass_hero_web/components/provider_components.ex:3022
 #, elixir-autogen, elixir-format
 msgid "The invitation email could not be delivered. Please check the address and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2969
+#: lib/klass_hero_web/components/provider_components.ex:3011
 #, elixir-autogen, elixir-format
 msgid "The program is full, so this child could not be enrolled."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2983
+#: lib/klass_hero_web/components/provider_components.ex:3025
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed and no retries remain. Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2992
+#: lib/klass_hero_web/components/provider_components.ex:3034
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed. Please resend."
 msgstr ""

--- a/test/klass_hero/enrollment/list_outstanding_invites_for_provider_test.exs
+++ b/test/klass_hero/enrollment/list_outstanding_invites_for_provider_test.exs
@@ -1,0 +1,159 @@
+defmodule KlassHero.Enrollment.ListOutstandingInvitesForProviderTest do
+  @moduledoc """
+  Covers the provider-wide "not yet accepted" invite query behind the Overview
+  card (#1073).
+  """
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+
+  alias KlassHero.Enrollment
+  alias KlassHero.Enrollment.BulkEnrollmentInvite
+  alias KlassHero.Repo
+
+  setup do
+    provider = insert(:provider_profile_schema)
+    program = insert(:program_schema, provider_id: provider.id, title: "Chess Club")
+
+    %{provider: provider, program: program}
+  end
+
+  defp invite(program, provider, attrs \\ %{}) do
+    {status, attrs} = Map.pop(attrs, :status)
+
+    {:ok, invite} =
+      Enrollment.create_invite(
+        Map.merge(
+          %{
+            program_id: program.id,
+            provider_id: provider.id,
+            child_first_name: "Jane",
+            child_last_name: "Smith",
+            child_date_of_birth: ~D[2015-06-15],
+            guardian_email: "guardian@test.com"
+          },
+          attrs
+        )
+      )
+
+    # Status is set after insert: the import changeset owns the initial value, and
+    # every later transition is the state machine's, not a caller's.
+    case status do
+      nil -> invite
+      status -> invite |> Ecto.Changeset.change(%{status: status}) |> Repo.update!()
+    end
+  end
+
+  describe "list_outstanding_invites_for_provider/1" do
+    # "Outstanding" is exactly BulkEnrollmentInvite.outstanding_statuses/0 — an
+    # invite still awaiting an answer. :registered and :enrolled were answered.
+    @status_cases [
+      {:pending, true},
+      {:invite_sent, true},
+      {:failed, true},
+      {:registered, false},
+      {:enrolled, false}
+    ]
+
+    for {status, outstanding?} <- @status_cases do
+      verdict = if outstanding?, do: "listed", else: "excluded"
+
+      test "#{status} invite is #{verdict}", %{provider: provider, program: program} do
+        invite = invite(program, provider, %{status: unquote(status)})
+
+        ids = provider.id |> Enrollment.list_outstanding_invites_for_provider() |> Enum.map(& &1.id)
+
+        assert to_string(invite.id) in ids == unquote(outstanding?),
+               "expected #{unquote(status)} invite to be #{unquote(verdict)}, got ids: #{inspect(ids)}"
+      end
+    end
+
+    test "excludes another provider's invites", %{provider: provider, program: program} do
+      other_provider = insert(:provider_profile_schema)
+      other_program = insert(:program_schema, provider_id: other_provider.id)
+
+      mine = invite(program, provider)
+      theirs = invite(other_program, other_provider)
+
+      ids = provider.id |> Enrollment.list_outstanding_invites_for_provider() |> Enum.map(& &1.id)
+
+      assert to_string(mine.id) in ids
+      refute to_string(theirs.id) in ids
+    end
+
+    test "carries the program title the invite row does not store", %{
+      provider: provider,
+      program: program
+    } do
+      invite(program, provider)
+
+      assert [row] = Enrollment.list_outstanding_invites_for_provider(provider.id)
+      assert row.program_title == "Chess Club"
+      assert row.program_id == to_string(program.id)
+    end
+
+    test "returns the longest-unanswered invite first", %{provider: provider, program: program} do
+      older = invite(program, provider, %{guardian_email: "older@test.com"})
+      newer = invite(program, provider, %{guardian_email: "newer@test.com"})
+
+      # create_invite/1 stamps second-granularity timestamps, so two invites made in
+      # the same test tick are indistinguishable by insertion alone — age has to be
+      # forced for the ordering assertion to mean anything.
+      three_days_ago =
+        DateTime.utc_now() |> DateTime.add(-3, :day) |> DateTime.truncate(:second)
+
+      older
+      |> Ecto.Changeset.change(%{inserted_at: three_days_ago})
+      |> Repo.update!()
+
+      assert [first, second] = Enrollment.list_outstanding_invites_for_provider(provider.id)
+      assert first.id == to_string(older.id)
+      assert second.id == to_string(newer.id)
+    end
+
+    test "aggregates across every program the provider runs", %{
+      provider: provider,
+      program: program
+    } do
+      second_program = insert(:program_schema, provider_id: provider.id, title: "Art Club")
+
+      invite(program, provider)
+      invite(second_program, provider)
+
+      titles =
+        provider.id
+        |> Enrollment.list_outstanding_invites_for_provider()
+        |> Enum.map(& &1.program_title)
+        |> Enum.sort()
+
+      assert titles == ["Art Club", "Chess Club"]
+    end
+
+    test "returns [] for a provider with no invites", %{provider: provider} do
+      assert Enrollment.list_outstanding_invites_for_provider(provider.id) == []
+    end
+
+    # No test pins the nil-`program_title` branch: `bulk_enrollment_invites_program_id_fkey`
+    # is RESTRICT, so a program holding invites cannot be deleted and the branch is
+    # unreachable. It is still handled rather than asserted away — `get_titles/1` omits
+    # unknown ids, so a title that ever goes missing costs the invite its program name
+    # but never drops the row, which would hide work the provider still owes.
+
+    test "excludes registered and enrolled while listing the rest", %{
+      provider: provider,
+      program: program
+    } do
+      for status <- [:pending, :invite_sent, :failed, :registered, :enrolled] do
+        invite(program, provider, %{status: status, guardian_email: "#{status}@test.com"})
+      end
+
+      statuses =
+        provider.id
+        |> Enrollment.list_outstanding_invites_for_provider()
+        |> Enum.map(& &1.status)
+        |> Enum.sort()
+
+      assert statuses == Enum.sort(BulkEnrollmentInvite.outstanding_statuses())
+    end
+  end
+end

--- a/test/klass_hero_web/components/provider_components_test.exs
+++ b/test/klass_hero_web/components/provider_components_test.exs
@@ -155,4 +155,77 @@ defmodule KlassHeroWeb.ProviderComponentsTest do
       assert html =~ "No sessions scheduled yet"
     end
   end
+
+  describe "invite_table/1" do
+    # Serves the per-program roster (one program, no column) and the Overview card's
+    # provider-wide list (many programs, column shown) — #1073.
+    defp render_invites(opts) do
+      invites = Keyword.get(opts, :invites, [outstanding_invite()])
+
+      render_component(&KlassHeroWeb.ProviderComponents.invite_table/1,
+        id: Keyword.get(opts, :id, "invites"),
+        invites: invites,
+        show_program?: Keyword.get(opts, :show_program?, false),
+        empty_message: Keyword.get(opts, :empty_message, "Nothing here")
+      )
+    end
+
+    defp outstanding_invite(overrides \\ %{}) do
+      Map.merge(
+        %{
+          id: "inv-1",
+          program_title: "Chess Club",
+          child_first_name: "Jane",
+          child_last_name: "Smith",
+          guardian_email: "guardian@test.com",
+          status: :pending,
+          failure_code: nil,
+          failure_context: nil,
+          error_details: nil
+        },
+        overrides
+      )
+    end
+
+    test "omits the program column by default" do
+      html = render_invites([])
+
+      assert html =~ "Jane"
+      assert html =~ "guardian@test.com"
+      refute html =~ "Chess Club"
+    end
+
+    test "shows the program column when asked" do
+      html = render_invites(show_program?: true)
+
+      assert html =~ "Chess Club"
+    end
+
+    test "names a missing program rather than leaving the cell blank" do
+      html = render_invites(show_program?: true, invites: [outstanding_invite(%{program_title: nil})])
+
+      assert html =~ "Unknown program"
+    end
+
+    test "derives its DOM ids from the id attr so two instances never collide" do
+      html = render_invites(id: "outstanding-invites")
+
+      assert html =~ ~s|id="outstanding-invites-table"|
+    end
+
+    test "shows the caller's empty message when there are no invites" do
+      html = render_invites(invites: [], id: "outstanding-invites", empty_message: "All answered")
+
+      assert html =~ "All answered"
+      assert html =~ ~s|id="outstanding-invites-empty"|
+    end
+
+    # Resend/Remove are offered only while the invite can still be acted on.
+    test "hides row actions for an answered invite" do
+      html = render_invites(invites: [outstanding_invite(%{status: :enrolled})])
+
+      refute html =~ "resend_invite"
+      refute html =~ "delete_invite"
+    end
+  end
 end

--- a/test/klass_hero_web/components/provider_layout_components_test.exs
+++ b/test/klass_hero_web/components/provider_layout_components_test.exs
@@ -237,28 +237,6 @@ defmodule KlassHeroWeb.ProviderLayoutComponentsTest do
     end
   end
 
-  describe "pv_request_card/1" do
-    test "renders parent + program/child meta + accept/decline footer", %{} do
-      request = %{
-        id: "req-1",
-        parent: "Anna K.",
-        program: "Code Camp",
-        child: "Mila",
-        when: "Tomorrow 15:00",
-        color: "#FFEAC9"
-      }
-
-      html = render_component(&ProviderLayoutComponents.pv_request_card/1, %{request: request})
-
-      assert html =~ "Anna K."
-      assert html =~ "Code Camp"
-      assert html =~ "Mila"
-      assert html =~ "Decline"
-      assert html =~ "Accept"
-      assert html =~ ~s|phx-value-request-id="req-1"|
-    end
-  end
-
   ## ------------------------------------------------------------------ helpers
 
   defp render_program_row(overrides) do

--- a/test/klass_hero_web/live/provider/overview_invites_test.exs
+++ b/test/klass_hero_web/live/provider/overview_invites_test.exs
@@ -1,0 +1,199 @@
+defmodule KlassHeroWeb.Provider.OverviewInvitesTest do
+  @moduledoc """
+  Covers the Overview tab's cross-program outstanding-invitations card (#1073).
+
+  The card aggregates every invite the provider has sent that nobody has accepted
+  yet. Before #1073 this path was never exercised by a test: the LiveView built its
+  card rows from fields that do not exist on `BulkEnrollmentInvite`, so merely
+  mounting Overview with one such invite raised. The mount tests below are that
+  missing coverage.
+  """
+  use KlassHeroWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias KlassHero.Enrollment
+  alias KlassHero.Enrollment.BulkEnrollmentInvite
+  alias KlassHero.ProgramCatalog.ProgramListing
+  alias KlassHero.Repo
+
+  setup :register_and_log_in_provider
+
+  # Overview reads programs from the program_listings read table and derives its
+  # KPI counts from them — a write-side program alone leaves the tab half-empty.
+  defp insert_program_with_listing(attrs) do
+    program = KlassHero.Factory.insert(:program_schema, attrs)
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    %ProgramListing{}
+    |> Ecto.Changeset.change(%{
+      id: program.id,
+      title: program.title,
+      description: program.description,
+      category: program.category,
+      age_range: program.age_range,
+      price: program.price,
+      pricing_period: program.pricing_period,
+      location: program.location,
+      start_date: program.start_date,
+      end_date: program.end_date,
+      meeting_days: program.meeting_days || [],
+      season: program.season,
+      provider_id: program.provider_id,
+      inserted_at: program.inserted_at || now,
+      updated_at: program.updated_at || now
+    })
+    |> Repo.insert!()
+
+    program
+  end
+
+  defp invite(program, provider, attrs \\ %{}) do
+    {status, attrs} = Map.pop(attrs, :status)
+
+    {:ok, invite} =
+      Enrollment.create_invite(
+        Map.merge(
+          %{
+            program_id: program.id,
+            provider_id: provider.id,
+            child_first_name: "Jane",
+            child_last_name: "Smith",
+            child_date_of_birth: ~D[2015-06-15],
+            guardian_email: "guardian@test.com"
+          },
+          attrs
+        )
+      )
+
+    case status do
+      nil -> invite
+      status -> invite |> Ecto.Changeset.change(%{status: status}) |> Repo.update!()
+    end
+  end
+
+  defp open_modal(conn) do
+    {:ok, view, _html} = live(conn, ~p"/provider/dashboard")
+    view |> element("#open-outstanding-invites") |> render_click()
+    view
+  end
+
+  setup %{provider: provider} do
+    %{program: insert_program_with_listing(provider_id: provider.id, title: "Chess Club")}
+  end
+
+  describe "the card" do
+    # An invite sits in :pending between creation and the email worker, and every
+    # "Resend" click returns it there — an ordinary state, not an edge case. It
+    # crashed the whole Overview page (a KeyError in mount/3) before #1073.
+    for status <- [:pending, :invite_sent, :failed] do
+      test "mounts and counts a #{status} invite", %{
+        conn: conn,
+        program: program,
+        provider: provider
+      } do
+        invite(program, provider, %{status: unquote(status)})
+
+        {:ok, view, _html} = live(conn, ~p"/provider/dashboard")
+
+        assert has_element?(view, "#outstanding-invites-card")
+        assert has_element?(view, "#open-outstanding-invites")
+        assert view |> element("#outstanding-invites-count") |> render() =~ "1"
+      end
+    end
+
+    # The old card filtered on :pending alone, so it read empty in production while
+    # invites sat unanswered in :invite_sent. That mis-filter was the reported gap.
+    for status <- [:registered, :enrolled] do
+      test "ignores an answered #{status} invite", %{
+        conn: conn,
+        program: program,
+        provider: provider
+      } do
+        invite(program, provider, %{status: unquote(status)})
+
+        {:ok, view, _html} = live(conn, ~p"/provider/dashboard")
+
+        assert has_element?(view, "#outstanding-invites-card-empty")
+        refute has_element?(view, "#open-outstanding-invites")
+      end
+    end
+
+    test "shows the empty state when nothing is outstanding", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard")
+
+      assert has_element?(view, "#outstanding-invites-card-empty")
+    end
+
+    test "counts invites from every program the provider runs", %{
+      conn: conn,
+      program: program,
+      provider: provider
+    } do
+      other = insert_program_with_listing(provider_id: provider.id, title: "Art Club")
+      invite(program, provider)
+      invite(other, provider, %{guardian_email: "second@test.com"})
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard")
+
+      assert view |> element("#outstanding-invites-count") |> render() =~ "2"
+    end
+  end
+
+  describe "the modal" do
+    setup %{program: program, provider: provider} do
+      %{invite: invite(program, provider)}
+    end
+
+    test "opens, names the program each invite belongs to, and closes", %{conn: conn} do
+      view = open_modal(conn)
+
+      assert has_element?(view, "#outstanding-invites-modal")
+      assert has_element?(view, "#outstanding-invites-table")
+      assert render(view) =~ "Chess Club"
+
+      view |> element("#close-outstanding-invites") |> render_click()
+
+      refute has_element?(view, "#outstanding-invites-modal")
+    end
+
+    test "offers Resend and Remove on each row", %{conn: conn, invite: invite} do
+      view = open_modal(conn)
+
+      assert has_element?(view, "#invite-#{invite.id} [phx-click=resend_invite]")
+      assert has_element?(view, "#invite-#{invite.id} [phx-click=delete_invite]")
+    end
+
+    test "Remove drops the invite and updates the count", %{conn: conn, invite: invite} do
+      view = open_modal(conn)
+
+      view
+      |> element("#invite-#{invite.id} [phx-click=delete_invite]")
+      |> render_click()
+
+      refute has_element?(view, "#invite-#{invite.id}")
+      assert has_element?(view, "#outstanding-invites-card-empty")
+    end
+
+    # No `with_testing_mode(:manual, ...)` here, deliberately: it is process-scoped,
+    # and `render_click` runs the work in the LiveView's process, not the test's — so
+    # the override would not reach the enqueue and would only look like a guard.
+    # Under the suite's `testing: :inline` the email worker therefore runs and carries
+    # the invite :pending -> :invite_sent. Both are outstanding, so it stays listed.
+    test "Resend reopens the invite and keeps it listed", %{conn: conn, invite: invite} do
+      view = open_modal(conn)
+
+      view
+      |> element("#invite-#{invite.id} [phx-click=resend_invite]")
+      |> render_click()
+
+      assert has_element?(view, "#invite-#{invite.id}")
+
+      # `resent_at` is the durable evidence the resend path ran (#1339's watermark);
+      # the status alone cannot distinguish a resend from the original send.
+      reloaded = Repo.reload!(invite)
+      assert reloaded.resent_at
+      assert reloaded.status in BulkEnrollmentInvite.outstanding_statuses()
+    end
+  end
+end


### PR DESCRIPTION
Closes #1073.

## Summary

Providers could only see who had not accepted an invite by opening each program's roster modal one at a time. The Overview tab now aggregates every unanswered invite across all of a provider's programs behind one card and modal, with the existing Resend and Remove actions.

## The feature already half-existed, and was broken

`OverviewLive.load_pending_requests/1` already aggregated invites across programs to feed a "Pending booking requests" card. It had never worked end to end:

| # | Defect |
|---|---|
| 1 | Read `invitee_name` / `invitee_email` — **no such fields** on `BulkEnrollmentInvite`. `KeyError` in `mount/3` took down the whole Overview page. |
| 2 | Read `invite[:child_name]` — Access on a struct (`UndefinedFunctionError`), against `elixir-style.md`. |
| 3 | Read `created_at`; the field is `inserted_at`. |
| 4 | Filtered `:pending` only, so it rendered **empty in production while 7 `invite_sent` invites sat unanswered** — the reported gap itself. |
| 5 | Displayed `program_id`, a raw UUID, as the program label. |
| 6 | `pv_request_card`'s Accept/Decline emitted `accept_request`/`decline_request`, which **no handler implements anywhere in `lib/`**. |

Plus one `list_program_invites/1` query per program.

It had not fired in production only because no invite currently sits in `:pending` (prod: 7 `invite_sent`, 33 `enrolled`, 0 `pending`; no `error_tracker` row). But `:pending` is the insert default *and* `reset_invite_for_resend/1` sets it on **every Resend click** — so an ordinary provider action opened the crash window on the dashboard's landing tab. No Overview test mounted with invite data, which is why nothing caught it.

## Approach

Repurpose the broken card rather than adding a second one beside it.

- `Enrollment.list_outstanding_invites_for_provider/1` — one provider-scoped query over `BulkEnrollmentInvite.outstanding_statuses/0` (`:pending`, `:invite_sent`, `:failed`), plus one batched `ProgramCatalog.get_titles/1` facade call for program names.
- `OutstandingInvite` read model (placed under `domain/read_models/`, matching Enrollment's still-unconverted shape rather than half-converting it). Its field names mirror the invite schema so one table component renders both without a mapper.
- `invite_table/1` extracted from the private `invites_tab/1`, with an optional program column.
- Resend/Remove handling moved to `Dashboard.InviteActions`, shared with `ProgramsLive`, following the `Chrome`/`Params`/`Uploads` precedent.
- Dead `pv_request_card/1` and its test deleted.

Retitled "Invitations awaiting a reply" — `CONTEXT.md` lists "Booking" as a domain noun under `_Avoid_`, and the invitee is a **Guardian**.

## Review focus

- **`enrollment.ex`** — the query goes through `ProgramCatalog.get_titles/1` rather than joining `programs` under an `acl_span`. The sibling `list_pending/1` still does the latter; its cycle-breaking rationale predates `get_titles/1` and is flagged in a comment as worth revisiting separately (not touched here).
- **`provider_components.ex`** — the extraction preserves the roster tab's DOM ids exactly (`invites-table`, `invites-empty`) so its existing tests are untouched; the program column is `hidden sm:table-cell` with a mobile line under the child's name, because a fifth column pushed Actions off a 375px viewport.

## Test plan

- `overview_invites_test.exs` is new coverage for a path that had none. Its first test **fails on `main`** with the real `KeyError` — it pins the bug, not just the feature.
- `list_outstanding_invites_for_provider_test.exs` covers the status set (tabular), provider scoping, title attachment, oldest-first ordering, cross-program aggregation, and the empty case.
- `invite_table/1` component tests cover both `show_program?` values.
- `mix precommit` green: 4749 tests, credo `--strict` clean, `lint_acl_boundary` + `lint_translations` pass. German translations included.
- Verified live against seeded data: card counts only outstanding invites, modal lists them with programs, Remove round-trips and the count updates, no console errors, checked at 375px and 1280px.