### PR TITLE
chore: drop hand-rolled current_url from admin SessionsLive and EmailsLive

### DIFF
--- a/lib/klass_hero_web/live/admin/emails_live.ex
+++ b/lib/klass_hero_web/live/admin/emails_live.ex
@@ -24,16 +24,11 @@ defmodule KlassHeroWeb.Admin.EmailsLive do
      |> assign(:allow_images, false)}
   end
 
+  # @current_url is assigned by Backpex.InitAssigns' handle_params hook, attached
+  # in the :admin_custom live_session.
   @impl true
-  def handle_params(params, uri, socket) do
-    current_url = URI.parse(uri).path
-
-    socket =
-      socket
-      |> assign(:current_url, current_url)
-      |> apply_action(socket.assigns.live_action, params)
-
-    {:noreply, socket}
+  def handle_params(params, _uri, socket) do
+    {:noreply, apply_action(socket, socket.assigns.live_action, params)}
   end
 
   defp apply_action(socket, :index, _params) do

--- a/lib/klass_hero_web/live/admin/sessions_live.ex
+++ b/lib/klass_hero_web/live/admin/sessions_live.ex
@@ -35,16 +35,11 @@ defmodule KlassHeroWeb.Admin.SessionsLive do
      |> assign(:selected_status, nil)}
   end
 
+  # @current_url is assigned by Backpex.InitAssigns' handle_params hook, attached
+  # in the :admin_custom live_session.
   @impl true
-  def handle_params(params, uri, socket) do
-    current_url = URI.parse(uri).path
-
-    socket =
-      socket
-      |> assign(:current_url, current_url)
-      |> apply_action(socket.assigns.live_action, params)
-
-    {:noreply, socket}
+  def handle_params(params, _uri, socket) do
+    {:noreply, apply_action(socket, socket.assigns.live_action, params)}
   end
 
   defp apply_action(socket, :index, _params) do

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -844,7 +844,7 @@ msgstr "Fragen zu diesen Bedingungen?"
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:37
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:69
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:101
-#: lib/klass_hero_web/live/admin/sessions_live.ex:252
+#: lib/klass_hero_web/live/admin/sessions_live.ex:247
 #: lib/klass_hero_web/live/provider/participation_live.ex:171
 #: lib/klass_hero_web/live/provider/participation_live.ex:217
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:110
@@ -891,8 +891,8 @@ msgstr "Nachricht senden"
 msgid "Session completed successfully"
 msgstr "Sitzung erfolgreich abgeschlossen"
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:67
-#: lib/klass_hero_web/live/admin/sessions_live.ex:73
+#: lib/klass_hero_web/live/admin/sessions_live.ex:62
+#: lib/klass_hero_web/live/admin/sessions_live.ex:68
 #: lib/klass_hero_web/live/provider/participation_live.ex:287
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:231
 #, elixir-autogen, elixir-format
@@ -1412,7 +1412,7 @@ msgstr "Übersicht"
 #: lib/klass_hero_web/components/provider_components.ex:1635
 #: lib/klass_hero_web/components/provider_components.ex:2952
 #: lib/klass_hero_web/components/provider_components.ex:2970
-#: lib/klass_hero_web/live/admin/sessions_live.ex:298
+#: lib/klass_hero_web/live/admin/sessions_live.ex:293
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Pending"
@@ -1969,7 +1969,7 @@ msgstr "Genehmigen"
 
 #: lib/klass_hero_web/components/participation_components.ex:826
 #: lib/klass_hero_web/components/provider_components.ex:49
-#: lib/klass_hero_web/live/admin/sessions_live.ex:295
+#: lib/klass_hero_web/live/admin/sessions_live.ex:290
 #: lib/klass_hero_web/live/admin/verifications_live.ex:202
 #: lib/klass_hero_web/presenters/vetting_checklist_presenter.ex:141
 #, elixir-autogen, elixir-format
@@ -2213,7 +2213,7 @@ msgstr "Erklären Sie, warum dieses Dokument abgelehnt wird..."
 
 #: lib/klass_hero_web/components/provider_components.ex:72
 #: lib/klass_hero_web/components/provider_components.ex:2974
-#: lib/klass_hero_web/live/admin/emails_live.ex:212
+#: lib/klass_hero_web/live/admin/emails_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Failed"
 msgstr "Fehlgeschlagen"
@@ -2771,7 +2771,7 @@ msgid "Selected instructor could not be found. Please try again."
 msgstr "Der ausgewählte Kursleiter konnte nicht gefunden werden. Bitte versuchen Sie es erneut."
 
 #: lib/klass_hero_web/components/provider_components.ex:2971
-#: lib/klass_hero_web/live/admin/emails_live.ex:211
+#: lib/klass_hero_web/live/admin/emails_live.ex:206
 #, elixir-autogen, elixir-format
 msgid "Sent"
 msgstr "Gesendet"
@@ -3212,7 +3212,7 @@ msgstr "Dieses Kind ist derzeit für folgende Programme angemeldet:"
 msgid "This deletion request has expired. Please try again."
 msgstr "Diese Löschanfrage ist abgelaufen. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:250
+#: lib/klass_hero_web/live/admin/sessions_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "A reason is required for corrections"
 msgstr "Ein Grund für die Korrektur ist erforderlich"
@@ -3238,7 +3238,7 @@ msgstr "Alle Status"
 msgid "All payments processed securely through Stripe."
 msgstr "Alle Zahlungen werden sicher über Stripe abgewickelt."
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:262
+#: lib/klass_hero_web/live/admin/sessions_live.ex:257
 #, elixir-autogen, elixir-format
 msgid "An error occurred"
 msgstr "Ein Fehler ist aufgetreten"
@@ -3248,7 +3248,7 @@ msgstr "Ein Fehler ist aufgetreten"
 msgid "Apple Pay / Google Pay"
 msgstr "Apple Pay / Google Pay"
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:178
+#: lib/klass_hero_web/live/admin/sessions_live.ex:173
 #, elixir-autogen, elixir-format
 msgid "Attendance corrected successfully"
 msgstr "Anwesenheit erfolgreich korrigiert"
@@ -3293,7 +3293,7 @@ msgstr "Kann ich mein Buchungsdatum ändern?"
 msgid "Can I list my programs on Klass Hero and what does it cost?"
 msgstr "Kann ich meine Programme auf Klass Hero listen und was kostet das?"
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:256
+#: lib/klass_hero_web/live/admin/sessions_live.ex:251
 #, elixir-autogen, elixir-format
 msgid "Cannot check out without a check-in"
 msgstr "Auschecken ohne Einchecken nicht möglich"
@@ -3324,13 +3324,13 @@ msgstr "Auschecken"
 msgid "Check-out time"
 msgstr "Auscheckzeit"
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:277
+#: lib/klass_hero_web/live/admin/sessions_live.ex:272
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "Checked In"
 msgstr "Eingecheckt"
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:278
+#: lib/klass_hero_web/live/admin/sessions_live.ex:273
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:200
 #, elixir-autogen, elixir-format
 msgid "Checked Out"
@@ -3421,7 +3421,7 @@ msgid "How does the booking system work?"
 msgstr "Wie funktioniert das Buchungssystem?"
 
 #: lib/klass_hero_web/components/participation_components.ex:807
-#: lib/klass_hero_web/live/admin/sessions_live.ex:276
+#: lib/klass_hero_web/live/admin/sessions_live.ex:271
 #, elixir-autogen, elixir-format
 msgid "In Progress"
 msgstr "In Bearbeitung"
@@ -3452,7 +3452,7 @@ msgstr "Klass Hero"
 msgid "No change"
 msgstr "Keine Änderung"
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:251
+#: lib/klass_hero_web/live/admin/sessions_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "No changes detected"
 msgstr "Keine Änderungen erkannt"
@@ -3542,7 +3542,7 @@ msgstr "Echtzeit-Dashboard zeigt alle Buchungen und das verfügbare Guthaben"
 msgid "Reason for correction"
 msgstr "Grund für die Korrektur"
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:254
+#: lib/klass_hero_web/live/admin/sessions_live.ex:249
 #, elixir-autogen, elixir-format
 msgid "Record was modified by someone else. Please refresh."
 msgstr "Datensatz wurde von jemand anderem geändert. Bitte aktualisieren."
@@ -3717,7 +3717,7 @@ msgstr "Wichtige Notizen zur heutigen Sitzung..."
 msgid "Archive"
 msgstr "Archiv"
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:207
+#: lib/klass_hero_web/live/admin/emails_live.ex:202
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:57
 #, elixir-autogen, elixir-format
 msgid "Archived"
@@ -3750,7 +3750,7 @@ msgstr "Broadcast-Nachrichten sind einseitig"
 msgid "Check In"
 msgstr "Einchecken"
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:258
+#: lib/klass_hero_web/live/admin/sessions_live.ex:253
 #, elixir-autogen, elixir-format
 msgid "Check-in time must be before check-out time"
 msgstr "Die Eincheckzeit muss vor der Auscheckzeit liegen"
@@ -3821,7 +3821,7 @@ msgstr "Einwilligungen"
 msgid "Content fetch failed"
 msgstr "Inhaltsabruf fehlgeschlagen"
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:119
+#: lib/klass_hero_web/live/admin/emails_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "Content fetch retrying..."
 msgstr "Inhalt wird erneut abgerufen..."
@@ -3864,24 +3864,24 @@ msgstr "Z.B. von Eltern abgeholt, Medikamentenerinnerung gegeben..."
 msgid "Edit & Resubmit"
 msgstr "Bearbeiten & erneut einreichen"
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:136
+#: lib/klass_hero_web/live/admin/emails_live.ex:131
 #, elixir-autogen, elixir-format
 msgid "Email archived"
 msgstr "E-Mail archiviert"
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:156
+#: lib/klass_hero_web/live/admin/emails_live.ex:151
 #, elixir-autogen, elixir-format
 msgid "Email marked as unread"
 msgstr "E-Mail als ungelesen markiert"
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:66
+#: lib/klass_hero_web/live/admin/emails_live.ex:61
 #, elixir-autogen, elixir-format
 msgid "Email not found"
 msgstr "E-Mail nicht gefunden"
 
 #: lib/klass_hero_web/components/layouts/admin.html.heex:76
 #: lib/klass_hero_web/live/admin/emails_live.ex:21
-#: lib/klass_hero_web/live/admin/emails_live.ex:41
+#: lib/klass_hero_web/live/admin/emails_live.ex:36
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "Emails"
@@ -3902,7 +3902,7 @@ msgstr "Die Endzeit muss nach der Startzeit liegen"
 msgid "Expected"
 msgstr "Erwartet"
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:139
+#: lib/klass_hero_web/live/admin/emails_live.ex:134
 #, elixir-autogen, elixir-format
 msgid "Failed to archive email"
 msgstr "E-Mail konnte nicht archiviert werden"
@@ -3917,7 +3917,7 @@ msgstr "Sitzung konnte nicht erstellt werden: %{reason}"
 msgid "Failed to fetch email content."
 msgstr "E-Mail-Inhalt konnte nicht abgerufen werden."
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:159
+#: lib/klass_hero_web/live/admin/emails_live.ex:154
 #, elixir-autogen, elixir-format
 msgid "Failed to mark email as unread"
 msgstr "E-Mail konnte nicht als ungelesen markiert werden"
@@ -3927,12 +3927,12 @@ msgstr "E-Mail konnte nicht als ungelesen markiert werden"
 msgid "Failed to resend invitation. Please try again."
 msgstr "Einladung konnte nicht erneut gesendet werden. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:122
+#: lib/klass_hero_web/live/admin/emails_live.ex:117
 #, elixir-autogen, elixir-format
 msgid "Failed to schedule retry"
 msgstr "Wiederholung konnte nicht geplant werden"
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:103
+#: lib/klass_hero_web/live/admin/emails_live.ex:98
 #, elixir-autogen, elixir-format
 msgid "Failed to send reply"
 msgstr "Antwort konnte nicht gesendet werden"
@@ -3963,7 +3963,7 @@ msgstr "Ein: %{time}"
 msgid "Invalid Invitation"
 msgstr "Ungültige Einladung"
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:260
+#: lib/klass_hero_web/live/admin/sessions_live.ex:255
 #: lib/klass_hero_web/live/provider/sessions_live.ex:578
 #, elixir-autogen, elixir-format
 msgid "Invalid time format"
@@ -4141,7 +4141,7 @@ msgstr "Anbieter"
 msgid "Provider observation"
 msgstr "Beobachtung des Anbieters"
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:206
+#: lib/klass_hero_web/live/admin/emails_live.ex:201
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "Read"
@@ -4167,7 +4167,7 @@ msgstr "Privat antworten"
 msgid "Reply privately is only available for broadcast messages"
 msgstr "Privates Antworten ist nur für Broadcast-Nachrichten verfügbar"
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:100
+#: lib/klass_hero_web/live/admin/emails_live.ex:95
 #, elixir-autogen, elixir-format
 msgid "Reply sent successfully"
 msgstr "Antwort erfolgreich gesendet"
@@ -4207,7 +4207,7 @@ msgstr "Programm auswählen..."
 msgid "Send Reply"
 msgstr "Antwort senden"
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:210
+#: lib/klass_hero_web/live/admin/emails_live.ex:205
 #, elixir-autogen, elixir-format
 msgid "Sending"
 msgstr "Wird gesendet"
@@ -4307,7 +4307,7 @@ msgid "Unauthorized"
 msgstr "Nicht autorisiert"
 
 #: lib/klass_hero_web/components/parent_components.ex:495
-#: lib/klass_hero_web/live/admin/emails_live.ex:205
+#: lib/klass_hero_web/live/admin/emails_live.ex:200
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:35
 #, elixir-autogen, elixir-format
 msgid "Unread"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -844,7 +844,7 @@ msgstr ""
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:37
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:69
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:101
-#: lib/klass_hero_web/live/admin/sessions_live.ex:252
+#: lib/klass_hero_web/live/admin/sessions_live.ex:247
 #: lib/klass_hero_web/live/provider/participation_live.ex:171
 #: lib/klass_hero_web/live/provider/participation_live.ex:217
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:110
@@ -891,8 +891,8 @@ msgstr ""
 msgid "Session completed successfully"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:67
-#: lib/klass_hero_web/live/admin/sessions_live.ex:73
+#: lib/klass_hero_web/live/admin/sessions_live.ex:62
+#: lib/klass_hero_web/live/admin/sessions_live.ex:68
 #: lib/klass_hero_web/live/provider/participation_live.ex:287
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:231
 #, elixir-autogen, elixir-format
@@ -1412,7 +1412,7 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:1635
 #: lib/klass_hero_web/components/provider_components.ex:2952
 #: lib/klass_hero_web/components/provider_components.ex:2970
-#: lib/klass_hero_web/live/admin/sessions_live.ex:298
+#: lib/klass_hero_web/live/admin/sessions_live.ex:293
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Pending"
@@ -1969,7 +1969,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:826
 #: lib/klass_hero_web/components/provider_components.ex:49
-#: lib/klass_hero_web/live/admin/sessions_live.ex:295
+#: lib/klass_hero_web/live/admin/sessions_live.ex:290
 #: lib/klass_hero_web/live/admin/verifications_live.ex:202
 #: lib/klass_hero_web/presenters/vetting_checklist_presenter.ex:141
 #, elixir-autogen, elixir-format
@@ -2213,7 +2213,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:72
 #: lib/klass_hero_web/components/provider_components.ex:2974
-#: lib/klass_hero_web/live/admin/emails_live.ex:212
+#: lib/klass_hero_web/live/admin/emails_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Failed"
 msgstr ""
@@ -2771,7 +2771,7 @@ msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:2971
-#: lib/klass_hero_web/live/admin/emails_live.ex:211
+#: lib/klass_hero_web/live/admin/emails_live.ex:206
 #, elixir-autogen, elixir-format
 msgid "Sent"
 msgstr ""
@@ -3212,7 +3212,7 @@ msgstr ""
 msgid "This deletion request has expired. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:250
+#: lib/klass_hero_web/live/admin/sessions_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "A reason is required for corrections"
 msgstr ""
@@ -3238,7 +3238,7 @@ msgstr ""
 msgid "All payments processed securely through Stripe."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:262
+#: lib/klass_hero_web/live/admin/sessions_live.ex:257
 #, elixir-autogen, elixir-format
 msgid "An error occurred"
 msgstr ""
@@ -3248,7 +3248,7 @@ msgstr ""
 msgid "Apple Pay / Google Pay"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:178
+#: lib/klass_hero_web/live/admin/sessions_live.ex:173
 #, elixir-autogen, elixir-format
 msgid "Attendance corrected successfully"
 msgstr ""
@@ -3293,7 +3293,7 @@ msgstr ""
 msgid "Can I list my programs on Klass Hero and what does it cost?"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:256
+#: lib/klass_hero_web/live/admin/sessions_live.ex:251
 #, elixir-autogen, elixir-format
 msgid "Cannot check out without a check-in"
 msgstr ""
@@ -3324,13 +3324,13 @@ msgstr ""
 msgid "Check-out time"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:277
+#: lib/klass_hero_web/live/admin/sessions_live.ex:272
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "Checked In"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:278
+#: lib/klass_hero_web/live/admin/sessions_live.ex:273
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:200
 #, elixir-autogen, elixir-format
 msgid "Checked Out"
@@ -3421,7 +3421,7 @@ msgid "How does the booking system work?"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:807
-#: lib/klass_hero_web/live/admin/sessions_live.ex:276
+#: lib/klass_hero_web/live/admin/sessions_live.ex:271
 #, elixir-autogen, elixir-format
 msgid "In Progress"
 msgstr ""
@@ -3452,7 +3452,7 @@ msgstr ""
 msgid "No change"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:251
+#: lib/klass_hero_web/live/admin/sessions_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "No changes detected"
 msgstr ""
@@ -3542,7 +3542,7 @@ msgstr ""
 msgid "Reason for correction"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:254
+#: lib/klass_hero_web/live/admin/sessions_live.ex:249
 #, elixir-autogen, elixir-format
 msgid "Record was modified by someone else. Please refresh."
 msgstr ""
@@ -3717,7 +3717,7 @@ msgstr ""
 msgid "Archive"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:207
+#: lib/klass_hero_web/live/admin/emails_live.ex:202
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:57
 #, elixir-autogen, elixir-format
 msgid "Archived"
@@ -3750,7 +3750,7 @@ msgstr ""
 msgid "Check In"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:258
+#: lib/klass_hero_web/live/admin/sessions_live.ex:253
 #, elixir-autogen, elixir-format
 msgid "Check-in time must be before check-out time"
 msgstr ""
@@ -3821,7 +3821,7 @@ msgstr ""
 msgid "Content fetch failed"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:119
+#: lib/klass_hero_web/live/admin/emails_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "Content fetch retrying..."
 msgstr ""
@@ -3864,24 +3864,24 @@ msgstr ""
 msgid "Edit & Resubmit"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:136
+#: lib/klass_hero_web/live/admin/emails_live.ex:131
 #, elixir-autogen, elixir-format
 msgid "Email archived"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:156
+#: lib/klass_hero_web/live/admin/emails_live.ex:151
 #, elixir-autogen, elixir-format
 msgid "Email marked as unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:66
+#: lib/klass_hero_web/live/admin/emails_live.ex:61
 #, elixir-autogen, elixir-format
 msgid "Email not found"
 msgstr ""
 
 #: lib/klass_hero_web/components/layouts/admin.html.heex:76
 #: lib/klass_hero_web/live/admin/emails_live.ex:21
-#: lib/klass_hero_web/live/admin/emails_live.ex:41
+#: lib/klass_hero_web/live/admin/emails_live.ex:36
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "Emails"
@@ -3902,7 +3902,7 @@ msgstr ""
 msgid "Expected"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:139
+#: lib/klass_hero_web/live/admin/emails_live.ex:134
 #, elixir-autogen, elixir-format
 msgid "Failed to archive email"
 msgstr ""
@@ -3917,7 +3917,7 @@ msgstr ""
 msgid "Failed to fetch email content."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:159
+#: lib/klass_hero_web/live/admin/emails_live.ex:154
 #, elixir-autogen, elixir-format
 msgid "Failed to mark email as unread"
 msgstr ""
@@ -3927,12 +3927,12 @@ msgstr ""
 msgid "Failed to resend invitation. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:122
+#: lib/klass_hero_web/live/admin/emails_live.ex:117
 #, elixir-autogen, elixir-format
 msgid "Failed to schedule retry"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:103
+#: lib/klass_hero_web/live/admin/emails_live.ex:98
 #, elixir-autogen, elixir-format
 msgid "Failed to send reply"
 msgstr ""
@@ -3963,7 +3963,7 @@ msgstr ""
 msgid "Invalid Invitation"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:260
+#: lib/klass_hero_web/live/admin/sessions_live.ex:255
 #: lib/klass_hero_web/live/provider/sessions_live.ex:578
 #, elixir-autogen, elixir-format
 msgid "Invalid time format"
@@ -4141,7 +4141,7 @@ msgstr ""
 msgid "Provider observation"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:206
+#: lib/klass_hero_web/live/admin/emails_live.ex:201
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "Read"
@@ -4167,7 +4167,7 @@ msgstr ""
 msgid "Reply privately is only available for broadcast messages"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:100
+#: lib/klass_hero_web/live/admin/emails_live.ex:95
 #, elixir-autogen, elixir-format
 msgid "Reply sent successfully"
 msgstr ""
@@ -4207,7 +4207,7 @@ msgstr ""
 msgid "Send Reply"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:210
+#: lib/klass_hero_web/live/admin/emails_live.ex:205
 #, elixir-autogen, elixir-format
 msgid "Sending"
 msgstr ""
@@ -4307,7 +4307,7 @@ msgid "Unauthorized"
 msgstr ""
 
 #: lib/klass_hero_web/components/parent_components.ex:495
-#: lib/klass_hero_web/live/admin/emails_live.ex:205
+#: lib/klass_hero_web/live/admin/emails_live.ex:200
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:35
 #, elixir-autogen, elixir-format
 msgid "Unread"

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -844,7 +844,7 @@ msgstr ""
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:37
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:69
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:101
-#: lib/klass_hero_web/live/admin/sessions_live.ex:252
+#: lib/klass_hero_web/live/admin/sessions_live.ex:247
 #: lib/klass_hero_web/live/provider/participation_live.ex:171
 #: lib/klass_hero_web/live/provider/participation_live.ex:217
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:110
@@ -891,8 +891,8 @@ msgstr ""
 msgid "Session completed successfully"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:67
-#: lib/klass_hero_web/live/admin/sessions_live.ex:73
+#: lib/klass_hero_web/live/admin/sessions_live.ex:62
+#: lib/klass_hero_web/live/admin/sessions_live.ex:68
 #: lib/klass_hero_web/live/provider/participation_live.ex:287
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:231
 #, elixir-autogen, elixir-format
@@ -1412,7 +1412,7 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:1635
 #: lib/klass_hero_web/components/provider_components.ex:2952
 #: lib/klass_hero_web/components/provider_components.ex:2970
-#: lib/klass_hero_web/live/admin/sessions_live.ex:298
+#: lib/klass_hero_web/live/admin/sessions_live.ex:293
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Pending"
@@ -1969,7 +1969,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:826
 #: lib/klass_hero_web/components/provider_components.ex:49
-#: lib/klass_hero_web/live/admin/sessions_live.ex:295
+#: lib/klass_hero_web/live/admin/sessions_live.ex:290
 #: lib/klass_hero_web/live/admin/verifications_live.ex:202
 #: lib/klass_hero_web/presenters/vetting_checklist_presenter.ex:141
 #, elixir-autogen, elixir-format
@@ -2213,7 +2213,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:72
 #: lib/klass_hero_web/components/provider_components.ex:2974
-#: lib/klass_hero_web/live/admin/emails_live.ex:212
+#: lib/klass_hero_web/live/admin/emails_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Failed"
 msgstr ""
@@ -2771,7 +2771,7 @@ msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:2971
-#: lib/klass_hero_web/live/admin/emails_live.ex:211
+#: lib/klass_hero_web/live/admin/emails_live.ex:206
 #, elixir-autogen, elixir-format
 msgid "Sent"
 msgstr ""
@@ -3212,7 +3212,7 @@ msgstr ""
 msgid "This deletion request has expired. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:250
+#: lib/klass_hero_web/live/admin/sessions_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "A reason is required for corrections"
 msgstr ""
@@ -3238,7 +3238,7 @@ msgstr ""
 msgid "All payments processed securely through Stripe."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:262
+#: lib/klass_hero_web/live/admin/sessions_live.ex:257
 #, elixir-autogen, elixir-format
 msgid "An error occurred"
 msgstr ""
@@ -3248,7 +3248,7 @@ msgstr ""
 msgid "Apple Pay / Google Pay"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:178
+#: lib/klass_hero_web/live/admin/sessions_live.ex:173
 #, elixir-autogen, elixir-format
 msgid "Attendance corrected successfully"
 msgstr ""
@@ -3293,7 +3293,7 @@ msgstr ""
 msgid "Can I list my programs on Klass Hero and what does it cost?"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:256
+#: lib/klass_hero_web/live/admin/sessions_live.ex:251
 #, elixir-autogen, elixir-format
 msgid "Cannot check out without a check-in"
 msgstr ""
@@ -3324,13 +3324,13 @@ msgstr ""
 msgid "Check-out time"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:277
+#: lib/klass_hero_web/live/admin/sessions_live.ex:272
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:199
 #, elixir-autogen, elixir-format
 msgid "Checked In"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:278
+#: lib/klass_hero_web/live/admin/sessions_live.ex:273
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:200
 #, elixir-autogen, elixir-format
 msgid "Checked Out"
@@ -3421,7 +3421,7 @@ msgid "How does the booking system work?"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:807
-#: lib/klass_hero_web/live/admin/sessions_live.ex:276
+#: lib/klass_hero_web/live/admin/sessions_live.ex:271
 #, elixir-autogen, elixir-format, fuzzy
 msgid "In Progress"
 msgstr ""
@@ -3452,7 +3452,7 @@ msgstr ""
 msgid "No change"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:251
+#: lib/klass_hero_web/live/admin/sessions_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "No changes detected"
 msgstr ""
@@ -3542,7 +3542,7 @@ msgstr ""
 msgid "Reason for correction"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:254
+#: lib/klass_hero_web/live/admin/sessions_live.ex:249
 #, elixir-autogen, elixir-format
 msgid "Record was modified by someone else. Please refresh."
 msgstr ""
@@ -3717,7 +3717,7 @@ msgstr ""
 msgid "Archive"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:207
+#: lib/klass_hero_web/live/admin/emails_live.ex:202
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:57
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Archived"
@@ -3750,7 +3750,7 @@ msgstr ""
 msgid "Check In"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:258
+#: lib/klass_hero_web/live/admin/sessions_live.ex:253
 #, elixir-autogen, elixir-format
 msgid "Check-in time must be before check-out time"
 msgstr ""
@@ -3821,7 +3821,7 @@ msgstr ""
 msgid "Content fetch failed"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:119
+#: lib/klass_hero_web/live/admin/emails_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "Content fetch retrying..."
 msgstr ""
@@ -3864,24 +3864,24 @@ msgstr ""
 msgid "Edit & Resubmit"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:136
+#: lib/klass_hero_web/live/admin/emails_live.ex:131
 #, elixir-autogen, elixir-format
 msgid "Email archived"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:156
+#: lib/klass_hero_web/live/admin/emails_live.ex:151
 #, elixir-autogen, elixir-format
 msgid "Email marked as unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:66
+#: lib/klass_hero_web/live/admin/emails_live.ex:61
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Email not found"
 msgstr ""
 
 #: lib/klass_hero_web/components/layouts/admin.html.heex:76
 #: lib/klass_hero_web/live/admin/emails_live.ex:21
-#: lib/klass_hero_web/live/admin/emails_live.ex:41
+#: lib/klass_hero_web/live/admin/emails_live.ex:36
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:4
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Emails"
@@ -3902,7 +3902,7 @@ msgstr ""
 msgid "Expected"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:139
+#: lib/klass_hero_web/live/admin/emails_live.ex:134
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to archive email"
 msgstr ""
@@ -3917,7 +3917,7 @@ msgstr ""
 msgid "Failed to fetch email content."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:159
+#: lib/klass_hero_web/live/admin/emails_live.ex:154
 #, elixir-autogen, elixir-format
 msgid "Failed to mark email as unread"
 msgstr ""
@@ -3927,12 +3927,12 @@ msgstr ""
 msgid "Failed to resend invitation. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:122
+#: lib/klass_hero_web/live/admin/emails_live.ex:117
 #, elixir-autogen, elixir-format
 msgid "Failed to schedule retry"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:103
+#: lib/klass_hero_web/live/admin/emails_live.ex:98
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to send reply"
 msgstr ""
@@ -3963,7 +3963,7 @@ msgstr ""
 msgid "Invalid Invitation"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/sessions_live.ex:260
+#: lib/klass_hero_web/live/admin/sessions_live.ex:255
 #: lib/klass_hero_web/live/provider/sessions_live.ex:578
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invalid time format"
@@ -4141,7 +4141,7 @@ msgstr ""
 msgid "Provider observation"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:206
+#: lib/klass_hero_web/live/admin/emails_live.ex:201
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "Read"
@@ -4167,7 +4167,7 @@ msgstr ""
 msgid "Reply privately is only available for broadcast messages"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:100
+#: lib/klass_hero_web/live/admin/emails_live.ex:95
 #, elixir-autogen, elixir-format
 msgid "Reply sent successfully"
 msgstr ""
@@ -4207,7 +4207,7 @@ msgstr ""
 msgid "Send Reply"
 msgstr ""
 
-#: lib/klass_hero_web/live/admin/emails_live.ex:210
+#: lib/klass_hero_web/live/admin/emails_live.ex:205
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sending"
 msgstr ""
@@ -4307,7 +4307,7 @@ msgid "Unauthorized"
 msgstr ""
 
 #: lib/klass_hero_web/components/parent_components.ex:495
-#: lib/klass_hero_web/live/admin/emails_live.ex:205
+#: lib/klass_hero_web/live/admin/emails_live.ex:200
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:35
 #, elixir-autogen, elixir-format
 msgid "Unread"

--- a/test/klass_hero_web/live/admin/emails_live_test.exs
+++ b/test/klass_hero_web/live/admin/emails_live_test.exs
@@ -33,6 +33,16 @@ defmodule KlassHeroWeb.Admin.EmailsLiveTest do
       {:ok, view, _html} = live(conn, ~p"/admin/emails")
       assert has_element?(view, "#emails-empty")
     end
+
+    # @current_url comes from Backpex.InitAssigns' handle_params hook, attached in
+    # the :admin_custom live_session. Nothing else asserts that hook is wired, so
+    # dropping it from the router would otherwise surface as a runtime KeyError.
+    test "highlights the Emails sidebar item", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/admin/emails")
+
+      assert has_element?(view, ~s|a[href="/admin/emails"].bg-neutral|)
+      refute has_element?(view, ~s|a[href="/admin/sessions"].bg-neutral|)
+    end
   end
 
   describe "Show" do

--- a/test/klass_hero_web/live/admin/sessions_live_test.exs
+++ b/test/klass_hero_web/live/admin/sessions_live_test.exs
@@ -11,6 +11,16 @@ defmodule KlassHeroWeb.Admin.SessionsLiveTest do
       {:ok, _view, html} = live(conn, ~p"/admin/sessions")
       assert html =~ "Sessions"
     end
+
+    # @current_url comes from Backpex.InitAssigns' handle_params hook, attached in
+    # the :admin_custom live_session. Nothing else asserts that hook is wired, so
+    # dropping it from the router would otherwise surface as a runtime KeyError.
+    test "highlights the Sessions sidebar item", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/admin/sessions")
+
+      assert has_element?(view, ~s|a[href="/admin/sessions"].bg-neutral|)
+      refute has_element?(view, ~s|a[href="/admin/emails"].bg-neutral|)
+    end
   end
 
   describe "non-admin access" do


### PR DESCRIPTION
Closes #1402

## Summary

`Backpex.InitAssigns` — attached to the `:admin_custom` `live_session` in #1401 — already assigns `current_url` through its own `handle_params` hook. `SessionsLive` and `EmailsLive` also derived it by hand. Attached hooks run *before* the module's own `handle_params/3`, so the hand-rolled value overwrote the hook's on every render: one redundant, immediately-discarded assign, plus a lifecycle-ordering puzzle for the next reader.

## Not a like-for-like swap — verified

The values differ (`InitAssigns` assigns the full URI, our code assigned path only), so the issue's first acceptance criterion needed proving rather than assuming. Both checks pass:

1. `Backpex.Router.active?/2` calls `URI.parse(current_path)` itself and compares only `.path`. Full-URI and path-only give identical results for `/admin/sessions`, `/admin/sessions?date_from=…&status=…`, `/admin/sessions/:id`, and `/admin/emails?status=unread`.
2. Rendered `sidebar_item/1` with a query-param-carrying full URI: active item gets `class=" bg-neutral text-neutral-content"`, siblings get `class=""`.

Confirmed in the browser against all four URL shapes — exactly one sidebar item active in each:

| URL | Active |
|---|---|
| `/admin/sessions` | `/admin/sessions` |
| `/admin/sessions?status=…&date_from=…&date_to=…` | `/admin/sessions` |
| `/admin/sessions/:id` (prefix match) | `/admin/sessions` |
| `/admin/emails?status=unread` | `/admin/emails` |

## Review Focus

**The new tests are the substance of this PR, not the deletion.** The deletion makes both LiveViews wholly dependent on the router's `on_mount` list, which is the only thing satisfying the admin layout's assign contract (`@sidebar_open`, `@preferences_manifest`, `@current_url`). `layouts.ex` declares `attr :current_url, :string, required: true`, but layouts are invoked by Phoenix rather than from a HEEx call site, so `required: true` gets no compile-time check — dropping `InitAssigns` later would raise a runtime `KeyError` with nothing in the suite to catch it. One assertion per LiveView closes that.

Note the tests are characterization tests, not red-green drivers: they pass both before and after the deletion, because path-only and full-URI both highlight correctly. Their teeth come from the `assert`/`refute` pair — `assert` proves the selector can match, `refute` proves it isn't matching every sidebar link.

Anchored on `.bg-neutral` deliberately: Backpex spreads `current_url` onto the `<a>` as a literal HTML attribute via `assigns_to_attributes`, so `a[current_url]` would be a misleading selector.

## Gettext churn

Reference lines only. Shortening both files by five lines shifted every `gettext` call below the change. `mix gettext.merge` reports `0 new, 0 removed, 0 fuzzy` across all six files — no German translation needed.

## Test Plan

- `mix precommit` green: 4751 passed, credo `--strict` clean, all five lints pass
- `mix test` on both admin LiveView test files: 32 passed (30 existing + 2 new)
- Browser verification of the four URL shapes above against a dev server

## Follow-up

The seven Backpex resource routes have no sidebar-highlighting coverage at all. Filing a separate low-priority issue for a shared admin-layout contract test rather than widening this chore.
