### PR TITLE
feat: revoke staff access to closed programs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -16,6 +16,10 @@ _Avoid_: Type, Kind, Tag
 The window during which parents may enrol in a Program. When unbounded, registration is "always open".
 _Avoid_: Enrolment window, Signup period, Booking window
 
+**Closed Program**:
+A **Program** whose end date passed longer ago than the access grace window (14 days). Its assigned **Staff Members** lose it: no sessions, no roster, no check-in or correction, no broadcast — it appears on their dashboard as a read-only "Completed" entry and nothing more. The **Provider** who owns it and an **Admin** are unaffected, because they still have to correct what happened. Derived from the end date, never stored, so a Program is never "closed" by anyone's action; it simply has been over for long enough. See [ADR-0019](adr/0019-closed-programs-revoke-staff-access.md).
+_Avoid_: Archived (that is a **Conversation**), Completed (that is a **Session**'s lifecycle), Expired, Ended (the date fact, not its consequence)
+
 **Price**:
 What a **Program** costs a parent, always **gross** — the final amount payable, VAT included whatever the rate turns out to be. A Provider entering "100" means the parent pays €100. Net and VAT are *derived* from it, never the other way round.
 _Avoid_: Net price, Fee (reserved for the platform's success-based fee), Cost
@@ -125,7 +129,7 @@ _Avoid_: using this word for an employee leaving — that is **offboarding**
 
 **Program Staff Assignment**:
 The link recording that a **Staff Member** works on a **Program**. Many Staff Members may be assigned to one Program because a class can need several people. Survives the Staff Member's **deactivation**, but not their **offboarding**.
-This is the **only** thing that decides which Programs a Staff Member sees and may act on — their dashboard, their sessions, participation, and broadcast compose all read it. A **Specialty** never grants access (#1323).
+This is the **only** thing that *grants* a Staff Member access to a Program — their dashboard, their sessions, participation, and broadcast compose all read it. A **Specialty** never grants access (#1323). Access additionally *lapses* once the Program becomes a **Closed Program** (#1082): the assignment says who, closure says whether it still counts.
 _Avoid_: Membership, Posting
 
 **Specialty**:

--- a/config/config.exs
+++ b/config/config.exs
@@ -115,12 +115,13 @@ config :klass_hero, KlassHeroWeb.Endpoint,
     formats: [html: KlassHeroWeb.ErrorHTML, json: KlassHeroWeb.ErrorJSON],
     layout: false
   ],
+
+  # `:locales` is not a Gettext option — the backend derives its own set from the
+  # .po files on disk. It lives under this key because `mix lint_translations`
+  # reads it here to decide which locales require translations.
   pubsub_server: KlassHero.PubSub,
   live_view: [signing_salt: "JU2osypv"]
 
-# `:locales` is not a Gettext option — the backend derives its own set from the
-# .po files on disk. It lives under this key because `mix lint_translations`
-# reads it here to decide which locales require translations.
 config :klass_hero, KlassHeroWeb.Gettext,
   default_locale: default_locale,
   locales: supported_locales
@@ -373,6 +374,13 @@ config :klass_hero, :messaging,
 
 # Durable delivery for staged events. See Shared.Outbox.
 config :klass_hero, :outbox, module: ObanOutbox
+
+# How long after a program's end_date its staff keep access to its sessions and
+# rosters (#1082). Its own key, not `:messaging, :retention` below: that window
+# governs when a conversation is archived for data retention, this one governs
+# when a person stops being allowed to see a child's record. Same shape today,
+# different reasons to change.
+config :klass_hero, :program_access, closed_after_days: 14
 config :klass_hero, :resend_req_options, []
 
 config :klass_hero, :scopes,

--- a/docs/adr/0019-closed-programs-revoke-staff-access.md
+++ b/docs/adr/0019-closed-programs-revoke-staff-access.md
@@ -1,0 +1,102 @@
+# Closed Programs revoke staff access, at the read model
+
+A **Staff Member** loses access to a Program once it has been over for longer than a grace
+window. The rule is applied where the Provider read models are *built*, not at the surfaces
+that ask them, so no caller has to know it exists.
+
+```elixir
+# Program grain — Assignments.get_staff_program_access/1
+%StaffProgramAccess{
+  program_ids: assigned ∩ open,          # authorized?/2 answers from this
+  closed_program_ids: assigned \ open    # closed?/2 answers from this
+}
+
+# Session grain — Assignments.list_session_staffing/1
+%SessionStaffing{program_closed?: true}  # staffed_by?/2 and led_by?/2 return false
+```
+
+Closed is **derived**, not stored: `end_date < today - closed_after_days`, with a `nil`
+`end_date` meaning a program never closes. The window is
+`config :klass_hero, :program_access, closed_after_days: 14`.
+
+## Why
+
+Before #1082 nothing consulted `end_date` for authorization. A staff member assigned to a
+program that finished a year ago could still open a child's roster, check a child in or out,
+correct an attendance record, and broadcast to the enrolled parents. The people this most
+concerns are ex-collaborators who were deactivated rather than offboarded, whose Program
+Staff Assignments deliberately survive so a reversible pause does not destroy conversation
+access.
+
+The issue asked for the four staff LiveViews to filter closed programs out. That would have
+put one authorization rule in four places and left the fifth — `Participation`'s write path,
+the guard of record since ADR-0017 — accepting the writes the UI had stopped offering. It
+would also have missed `StaffBroadcastLive` entirely.
+
+That shape is the one #1323 removed. There, whether you could check a child in and out
+depended on a `staff_members.tags` string matched against `program.category`, re-derived at
+each of four surfaces, with an empty tag list silently meaning *every* program. The fix was
+one struct, built in one place. Adding a second rule that each surface must remember to
+apply would have re-created the failure with a different input.
+
+So closure is folded into the same two structs. Four of the five call sites did not change
+at all and became correct:
+
+| Surface | Change |
+|---|---|
+| `Participation.AttendanceAuthorization` | none |
+| `StaffBroadcastLive` | none |
+| `StaffDashboardLive` roster handler | none |
+| `StaffSessionsLive` list + action gate | none for the gate; message copy only |
+| `StaffParticipationLive` | message copy only |
+
+## The costs, taken deliberately
+
+**`StaffProgramAccess` no longer means one thing.** Its moduledoc said it was derived from
+assignment rows and nothing else. It is now assignment rows narrowed by closure. Both are
+write-model facts a provider controls, and closure is read from `programs` through
+`ProgramCatalog.list_open_program_ids/1`, never from the `program_listings` projection —
+projection lag must not revoke access.
+
+**Every `SessionStaffing` consumer pays a query.** `list_session_staffing/1` asks
+ProgramCatalog once per batch, over the distinct program ids, so a full day of sessions costs
+one extra query rather than one per row. But provider-side callers that read only
+`member_ids` or `lead` pay it too and can never use the answer. The alternative — closure as
+an extra argument only authorization call sites pass — makes the query conditional and
+re-opens the hole: a future call site that omits the argument authorizes on a closed program,
+with nothing to catch it. We would rather waste the query.
+
+**It fails closed.** `list_open_program_ids/1` returns the ids that exist *and* are open, and
+callers derive closed by set difference, so an assignment naming a program that no longer
+resolves grants nothing.
+
+## What is not gated
+
+Providers and Admins. The provider owns the roster and must still correct it after a season
+ends; an admin correction still demands its written reason. ADR-0017's fall-through order —
+provider, then staff, then admin — is untouched, and only the staff branch's answer narrowed.
+
+The `SessionStaffing` display fields (`member_ids`, `member_count`, `lead`, `overridden?/1`)
+are also untouched, so the provider's own staffing panel keeps working on a closed program.
+Only the two predicates that answer authorization questions are gated.
+
+## Why 14 days and its own config key
+
+The window has to outlast the honest tail of a season: a late check-out, a correction the
+morning after the last session, a closing message to parents. It should not outlast a
+departed collaborator's interest in a child's record.
+
+Messaging already carries `days_after_program_end: 30`, and closure deliberately does **not**
+reuse it. That window decides when a conversation is archived for data retention; this one
+decides when a person stops being allowed to see a child's record. They coincide in shape
+today and would be changed for different reasons tomorrow.
+
+## Consequences
+
+- Adding a staff surface requires no new closure check, provided it asks
+  `StaffProgramAccess.authorized?/2` or `SessionStaffing.staffed_by?/2`. A surface that
+  re-derives access from `end_date` itself, or from `program_listings`, is a bug.
+- `CONTEXT.md`'s **Program Staff Assignment** entry no longer says an assignment is the only
+  thing deciding what a staff member sees; it is now the assignment, while the program is open.
+- A refusal can say *which* rule refused, because `program_closed?` rides on the struct the
+  surface already fetched. No extra query buys the better message.

--- a/lib/klass_hero/participation/attendance_authorization.ex
+++ b/lib/klass_hero/participation/attendance_authorization.ex
@@ -35,6 +35,20 @@ defmodule KlassHero.Participation.AttendanceAuthorization do
   it has any and falls back to the program roster when it does not — one question,
   with the program grain as its fallback rather than as a second rule beside it.
 
+  ## A Closed Program refuses staff, and this module does not mention it (#1082)
+
+  Once a program has been over for longer than the access grace window, its staff
+  lose it. That rule is enforced here, but no line below states it: it arrives
+  inside `SessionStaffing.staffed_by?/2`, which answers `false` for a closed
+  program's session however genuinely staffed it is.
+
+  Deliberate. The staff branch is one of five places that ask the same question,
+  and a rule spelled out at each of them is a rule one of them eventually omits —
+  the failure #1323 was. So closure is folded into the read model every asker
+  already uses, and the *provider* and *admin* branches are untouched: the
+  provider owns the roster and still corrects it after the season, and an admin
+  correction still demands its reason.
+
   That distinction is the point, and it is *not* what #783 originally specified.
   OR-ing a session check onto a program check reads as more permissive in the
   right direction only. It is also more permissive in the wrong one:

--- a/lib/klass_hero/program_catalog.ex
+++ b/lib/klass_hero/program_catalog.ex
@@ -169,6 +169,50 @@ defmodule KlassHero.ProgramCatalog do
     |> Enum.map(&Program.load_value_objects/1)
   end
 
+  @doc """
+  Whether `program` has closed to its staff (#1082).
+
+  Reads the grace window from `config :klass_hero, :program_access,
+  closed_after_days:` at runtime, so a test can vary it and a deploy is not
+  needed to change it. `Program.closed?/2` does the comparison.
+  """
+  @spec closed?(Program.t()) :: boolean()
+  def closed?(%Program{} = program), do: Program.closed?(program, closed_cutoff())
+
+  @doc """
+  Of `program_ids`, those that exist **and** have not closed to their staff.
+
+  Returns the **open** side on purpose: callers derive closed by set difference,
+  so an id matching no program lands on the closed side rather than being read as
+  open. Fail-closed by construction — see `KlassHero.Provider.Assignments`.
+
+  Not to be confused with `list_ended_program_ids/1`, which is Messaging's
+  unscoped retention sweep over every program and takes its own cutoff. This one
+  is scoped to ids the caller already holds and owns the access grace window.
+  """
+  @spec list_open_program_ids([String.t()]) :: MapSet.t(String.t())
+  def list_open_program_ids([]), do: MapSet.new()
+
+  def list_open_program_ids(program_ids) when is_list(program_ids) do
+    cutoff = closed_cutoff()
+
+    Program
+    |> where([p], p.id in ^program_ids)
+    |> where([p], is_nil(p.end_date) or p.end_date >= ^cutoff)
+    |> select([p], p.id)
+    |> Repo.all()
+    |> MapSet.new()
+  end
+
+  defp closed_cutoff do
+    days =
+      :klass_hero
+      |> Application.get_env(:program_access, [])
+      |> Keyword.get(:closed_after_days, 14)
+
+    Date.add(Date.utc_today(), -days)
+  end
+
   @doc "Returns IDs of programs with end_date before cutoff. Used by Messaging retention policy."
   @spec list_ended_program_ids(Date.t()) :: [String.t()]
   def list_ended_program_ids(cutoff_date) do

--- a/lib/klass_hero/program_catalog.ex
+++ b/lib/klass_hero/program_catalog.ex
@@ -172,8 +172,8 @@ defmodule KlassHero.ProgramCatalog do
 
   A caller that *does* hold a `provider_id` should not filter this result by hand —
   that is a check to forget. Use `get_program_for_provider/2` for a single program,
-  or `list_open_program_ids_for_provider/2` where the question is which ids a
-  provider's staff may act on.
+  or `split_programs_by_closure/2` where the question is which ids a provider's
+  staff may act on.
   """
   @spec get_programs_by_ids([String.t()]) :: [Program.t()]
   def get_programs_by_ids(ids) when is_list(ids) do
@@ -196,9 +196,14 @@ defmodule KlassHero.ProgramCatalog do
   @doc """
   Of `program_ids`, those that exist **and** have not closed to their staff.
 
-  Returns the **open** side on purpose: callers derive closed by set difference,
-  so an id matching no program lands on the closed side rather than being read as
-  open. Fail-closed by construction — see `KlassHero.Provider.Assignments`.
+  Returns the **open** side on purpose: an id matching no program is absent, so a
+  caller gating on membership fails closed rather than reading it as open.
+
+  Only for the session path, which has no provider to narrow by. Where one is in
+  scope, `split_programs_by_closure/2` answers the same question tenancy-safely
+  and distinguishes "closed" from "not yours" — a distinction this function cannot
+  make, and one that matters as soon as the closed set is rendered rather than
+  merely gated on.
 
   Not to be confused with `list_ended_program_ids/1`, which is Messaging's
   unscoped retention sweep over every program and takes its own cutoff. This one
@@ -212,26 +217,44 @@ defmodule KlassHero.ProgramCatalog do
   end
 
   @doc """
-  `list_open_program_ids/1` narrowed to one provider: of `program_ids`, those that
-  belong to `provider_id`, exist, and have not closed.
+  Of `program_ids`, those belonging to `provider_id`, split into `{open, closed}`.
 
-  A foreign id is *unreachable* rather than fetched-then-rejected — `Program.owned_by/2`
-  narrows the query, the same way `get_program_for_provider/2` does — so it lands
-  outside the open set and, by the caller's set difference, grants nothing.
+  Returns **both** sets rather than the open ones alone, because the caller must not
+  derive one from the other: "everything I asked about that did not come back open"
+  conflates three different things — closed, owned by someone else, and deleted —
+  and only the first of those may be listed back to a staff member. An id that is
+  foreign or missing appears in neither set.
 
-  Use this wherever a provider is in scope. The unscoped sibling exists for the
-  session path, which resolves sessions that may belong to any provider and so has
-  no provider to narrow by.
+  `Program.owned_by/2` narrows the query, so a foreign program is *unreachable*
+  rather than fetched-then-rejected, the same way `get_program_for_provider/2`
+  works. Closure is decided by `Program.closed?/2` — the pure predicate, not a
+  second SQL encoding of the grace window.
+
+  Use this wherever a provider is in scope. `list_open_program_ids/1` exists for
+  the session path, which resolves sessions that may belong to any provider and so
+  has none to narrow by.
   """
-  @spec list_open_program_ids_for_provider(String.t(), [String.t()]) :: MapSet.t(String.t())
-  def list_open_program_ids_for_provider(provider_id, []) when is_binary(provider_id), do: MapSet.new()
+  @spec split_programs_by_closure(String.t(), [String.t()]) ::
+          {open :: MapSet.t(String.t()), closed :: MapSet.t(String.t())}
+  def split_programs_by_closure(provider_id, []) when is_binary(provider_id) do
+    {MapSet.new(), MapSet.new()}
+  end
 
-  def list_open_program_ids_for_provider(provider_id, program_ids)
-      when is_binary(provider_id) and is_list(program_ids) do
+  def split_programs_by_closure(provider_id, program_ids) when is_binary(provider_id) and is_list(program_ids) do
+    cutoff = closed_cutoff()
+
     Program
     |> Program.owned_by(provider_id)
-    |> open_ids(program_ids)
+    |> where([p], p.id in ^program_ids)
+    |> select([p], {p.id, p.end_date})
+    |> Repo.all()
+    |> Enum.split_with(fn {_id, end_date} ->
+      not Program.closed?(%Program{end_date: end_date}, cutoff)
+    end)
+    |> then(fn {open, closed} -> {ids_of(open), ids_of(closed)} end)
   end
+
+  defp ids_of(rows), do: MapSet.new(rows, fn {id, _end_date} -> id end)
 
   # One definition of "open", so the scoped and unscoped answers cannot drift.
   defp open_ids(query, program_ids) do

--- a/lib/klass_hero/program_catalog.ex
+++ b/lib/klass_hero/program_catalog.ex
@@ -160,7 +160,21 @@ defmodule KlassHero.ProgramCatalog do
     end
   end
 
-  @doc "Fetches multiple programs by ID in one query. Missing IDs are silently omitted."
+  @doc """
+  Fetches multiple programs by ID in one query, **unscoped**. Missing IDs are
+  silently omitted.
+
+  Unscoped deliberately, and it should stay that way: its callers resolve programs
+  they cannot name a provider for — the admin session list, which *derives* each
+  provider from the result; `ProgramProviderResolver`, whose whole job is deriving
+  one from a bare program id; and a parent's dashboard, whose enrolments legitimately
+  span providers.
+
+  A caller that *does* hold a `provider_id` should not filter this result by hand —
+  that is a check to forget. Use `get_program_for_provider/2` for a single program,
+  or `list_open_program_ids_for_provider/2` where the question is which ids a
+  provider's staff may act on.
+  """
   @spec get_programs_by_ids([String.t()]) :: [Program.t()]
   def get_programs_by_ids(ids) when is_list(ids) do
     Program
@@ -194,9 +208,36 @@ defmodule KlassHero.ProgramCatalog do
   def list_open_program_ids([]), do: MapSet.new()
 
   def list_open_program_ids(program_ids) when is_list(program_ids) do
+    open_ids(Program, program_ids)
+  end
+
+  @doc """
+  `list_open_program_ids/1` narrowed to one provider: of `program_ids`, those that
+  belong to `provider_id`, exist, and have not closed.
+
+  A foreign id is *unreachable* rather than fetched-then-rejected — `Program.owned_by/2`
+  narrows the query, the same way `get_program_for_provider/2` does — so it lands
+  outside the open set and, by the caller's set difference, grants nothing.
+
+  Use this wherever a provider is in scope. The unscoped sibling exists for the
+  session path, which resolves sessions that may belong to any provider and so has
+  no provider to narrow by.
+  """
+  @spec list_open_program_ids_for_provider(String.t(), [String.t()]) :: MapSet.t(String.t())
+  def list_open_program_ids_for_provider(provider_id, []) when is_binary(provider_id), do: MapSet.new()
+
+  def list_open_program_ids_for_provider(provider_id, program_ids)
+      when is_binary(provider_id) and is_list(program_ids) do
+    Program
+    |> Program.owned_by(provider_id)
+    |> open_ids(program_ids)
+  end
+
+  # One definition of "open", so the scoped and unscoped answers cannot drift.
+  defp open_ids(query, program_ids) do
     cutoff = closed_cutoff()
 
-    Program
+    query
     |> where([p], p.id in ^program_ids)
     |> where([p], is_nil(p.end_date) or p.end_date >= ^cutoff)
     |> select([p], p.id)

--- a/lib/klass_hero/program_catalog/program.ex
+++ b/lib/klass_hero/program_catalog/program.ex
@@ -185,6 +185,20 @@ defmodule KlassHero.ProgramCatalog.Program do
   @spec free?(t()) :: boolean()
   def free?(%__MODULE__{price: price}), do: Decimal.equal?(price, Decimal.new(0))
 
+  @doc """
+  Whether the program has closed to its staff — ended on or before `cutoff`.
+
+  `cutoff` is today minus the grace window, computed by the caller
+  (`KlassHero.ProgramCatalog.closed?/1`) so this stays pure and the window stays
+  configurable. An open-ended program (`end_date: nil`) never closes.
+
+  Gates **staff** only: the provider owns the data and corrects rosters after a
+  season ends, and an admin correction is a separate path (ADR-0017).
+  """
+  @spec closed?(t(), Date.t()) :: boolean()
+  def closed?(%__MODULE__{end_date: nil}, _cutoff), do: false
+  def closed?(%__MODULE__{end_date: end_date}, cutoff), do: Date.before?(end_date, cutoff)
+
   @doc "Whether registration is currently open. Requires `load_value_objects/1` first."
   @spec registration_open?(t()) :: boolean()
   def registration_open?(%__MODULE__{registration_period: %RegistrationPeriod{} = rp}) do

--- a/lib/klass_hero/provider.ex
+++ b/lib/klass_hero/provider.ex
@@ -336,8 +336,12 @@ defmodule KlassHero.Provider do
   @doc "Lists all active program assignments for a staff member."
   defdelegate list_active_assignments_for_staff_member(staff_member_id), to: Assignments
 
-  @doc "Which programs a staff member may see and act on, from their live assignments."
-  defdelegate get_staff_program_access(staff_member_id), to: Assignments
+  @doc """
+  Which programs a staff member may see and act on, from their live assignments,
+  scoped to their own provider. Takes the `%StaffMember{}` so the tenancy cannot
+  be omitted.
+  """
+  defdelegate get_staff_program_access(staff_member), to: Assignments
 
   @doc "Promotes a `provider_id`-owned staff member to the program's lead instructor (single source of truth)."
   defdelegate set_lead_instructor(program_id, staff_member_id, provider_id), to: Assignments

--- a/lib/klass_hero/provider/assignments.ex
+++ b/lib/klass_hero/provider/assignments.ex
@@ -335,6 +335,9 @@ defmodule KlassHero.Provider.Assignments do
 
     # Over the batch's *distinct* programs, so a full day of sessions costs one
     # closure question rather than one per row (#1082).
+    # Unscoped on purpose: the caller hands us session ids, and a session's
+    # provider is only knowable by resolving it. `AttendanceAuthorization` asks
+    # this for admins too, so there is no one provider to narrow by.
     open_ids = open_program_ids(program_ids)
 
     Map.new(sessions, fn session ->
@@ -619,12 +622,16 @@ defmodule KlassHero.Provider.Assignments do
   `list_active_assignments_for_staff_member/1`: the callers gate a render loop and
   need nothing else off the row.
 
-  Not provider-scoped, because the staff member arrives already resolved from the
-  authenticated scope and carries the tenancy with them; a second narrowing here
-  would only restate it.
+  Takes the `%StaffMember{}` rather than its id, because the tenancy has to arrive
+  with it: the programs are then resolved **scoped to that staff member's own
+  provider**, so an assignment row naming another provider's program grants
+  nothing. Only a caller bypassing `assign_staff_to_program/1` can create such a
+  row — that use case proves ownership of both the staff member and the program
+  before inserting — but nothing at the database level enforces it, and this is
+  the surface where a bad row would become a child's roster.
   """
-  @spec get_staff_program_access(String.t()) :: StaffProgramAccess.t()
-  def get_staff_program_access(staff_member_id) when is_binary(staff_member_id) do
+  @spec get_staff_program_access(StaffMember.t()) :: StaffProgramAccess.t()
+  def get_staff_program_access(%StaffMember{id: staff_member_id, provider_id: provider_id}) do
     assigned =
       from(a in ProgramStaffAssignment,
         where: a.staff_member_id == ^staff_member_id and is_nil(a.unassigned_at),
@@ -632,7 +639,7 @@ defmodule KlassHero.Provider.Assignments do
       )
       |> Repo.all()
 
-    open = open_program_ids(assigned)
+    open = open_program_ids(provider_id, assigned)
 
     %StaffProgramAccess{
       staff_member_id: staff_member_id,
@@ -642,8 +649,16 @@ defmodule KlassHero.Provider.Assignments do
   end
 
   # Subtracting the open set rather than adding a closed one is what makes this
-  # fail closed: an assignment whose program no longer resolves at all comes back
-  # from neither query and lands among the closed, where it grants nothing.
+  # fail closed: an assignment whose program is foreign, or no longer resolves at
+  # all, comes back from neither query and lands among the closed, where it grants
+  # nothing. "Closed" is the honest bucket for it — the program is not actionable,
+  # and the alternative is a third set nobody reads.
+  defp open_program_ids(provider_id, program_ids) do
+    acl_span source: "provider", target: "program_catalog" do
+      ProgramCatalog.list_open_program_ids_for_provider(provider_id, program_ids)
+    end
+  end
+
   defp open_program_ids(program_ids) do
     acl_span source: "provider", target: "program_catalog" do
       ProgramCatalog.list_open_program_ids(program_ids)

--- a/lib/klass_hero/provider/assignments.ex
+++ b/lib/klass_hero/provider/assignments.ex
@@ -639,23 +639,24 @@ defmodule KlassHero.Provider.Assignments do
       )
       |> Repo.all()
 
-    open = open_program_ids(provider_id, assigned)
+    {open, closed} = split_by_closure(provider_id, assigned)
 
     %StaffProgramAccess{
       staff_member_id: staff_member_id,
-      program_ids: MapSet.intersection(MapSet.new(assigned), open),
-      closed_program_ids: MapSet.difference(MapSet.new(assigned), open)
+      program_ids: open,
+      closed_program_ids: closed
     }
   end
 
-  # Subtracting the open set rather than adding a closed one is what makes this
-  # fail closed: an assignment whose program is foreign, or no longer resolves at
-  # all, comes back from neither query and lands among the closed, where it grants
-  # nothing. "Closed" is the honest bucket for it — the program is not actionable,
-  # and the alternative is a third set nobody reads.
-  defp open_program_ids(provider_id, program_ids) do
+  # Both sets come from what the query *returned*, never from subtracting one from
+  # the assignment list. An assignment naming a foreign or deleted program lands in
+  # neither: it grants nothing, and — since `closed_program_ids` is also what the
+  # dashboard renders as "Completed" — it is not shown either. Deriving closed as
+  # "assigned minus open" would have listed another provider's program back to the
+  # staff member.
+  defp split_by_closure(provider_id, program_ids) do
     acl_span source: "provider", target: "program_catalog" do
-      ProgramCatalog.list_open_program_ids_for_provider(provider_id, program_ids)
+      ProgramCatalog.split_programs_by_closure(provider_id, program_ids)
     end
   end
 

--- a/lib/klass_hero/provider/assignments.ex
+++ b/lib/klass_hero/provider/assignments.ex
@@ -330,10 +330,17 @@ defmodule KlassHero.Provider.Assignments do
   def list_session_staffing(session_ids) when is_list(session_ids) do
     sessions = fetch_sessions(session_ids)
     overrides = session_overrides_by_session(Enum.map(sessions, & &1.id))
-    program_staffing = sessions |> Enum.map(& &1.program_id) |> Enum.uniq() |> Provider.list_program_staffing()
+    program_ids = sessions |> Enum.map(& &1.program_id) |> Enum.uniq()
+    program_staffing = Provider.list_program_staffing(program_ids)
+
+    # Over the batch's *distinct* programs, so a full day of sessions costs one
+    # closure question rather than one per row (#1082).
+    open_ids = open_program_ids(program_ids)
 
     Map.new(sessions, fn session ->
-      {session.id, resolve_staffing(session, Map.get(overrides, session.id), program_staffing)}
+      closed? = not MapSet.member?(open_ids, session.program_id)
+
+      {session.id, resolve_staffing(session, Map.get(overrides, session.id), program_staffing, closed?)}
     end)
   end
 
@@ -618,15 +625,29 @@ defmodule KlassHero.Provider.Assignments do
   """
   @spec get_staff_program_access(String.t()) :: StaffProgramAccess.t()
   def get_staff_program_access(staff_member_id) when is_binary(staff_member_id) do
-    program_ids =
+    assigned =
       from(a in ProgramStaffAssignment,
         where: a.staff_member_id == ^staff_member_id and is_nil(a.unassigned_at),
         select: a.program_id
       )
       |> Repo.all()
-      |> MapSet.new()
 
-    %StaffProgramAccess{staff_member_id: staff_member_id, program_ids: program_ids}
+    open = open_program_ids(assigned)
+
+    %StaffProgramAccess{
+      staff_member_id: staff_member_id,
+      program_ids: MapSet.intersection(MapSet.new(assigned), open),
+      closed_program_ids: MapSet.difference(MapSet.new(assigned), open)
+    }
+  end
+
+  # Subtracting the open set rather than adding a closed one is what makes this
+  # fail closed: an assignment whose program no longer resolves at all comes back
+  # from neither query and lands among the closed, where it grants nothing.
+  defp open_program_ids(program_ids) do
+    acl_span source: "provider", target: "program_catalog" do
+      ProgramCatalog.list_open_program_ids(program_ids)
+    end
   end
 
   @doc """
@@ -1049,11 +1070,11 @@ defmodule KlassHero.Provider.Assignments do
     for id <- member_ids, staff = by_id[id], do: staff
   end
 
-  defp resolve_staffing(session, nil, program_staffing) do
-    inherited_staffing(session, program_staffing)
+  defp resolve_staffing(session, nil, program_staffing, closed?) do
+    inherited_staffing(session, program_staffing, closed?)
   end
 
-  defp resolve_staffing(session, override_rows, program_staffing) do
+  defp resolve_staffing(session, override_rows, program_staffing, closed?) do
     members = for {_id, _lead?, staff} <- override_rows, staff != nil, do: staff
 
     %SessionStaffing{
@@ -1062,14 +1083,15 @@ defmodule KlassHero.Provider.Assignments do
       lead: resolve_session_lead(override_rows, members, session.program_id, program_staffing),
       member_ids: Enum.map(members, & &1.id),
       member_count: length(members),
-      source: :override
+      source: :override,
+      program_closed?: closed?
     }
   end
 
-  defp inherited_staffing(session, program_staffing) do
+  defp inherited_staffing(session, program_staffing, closed?) do
     case Map.get(program_staffing, session.program_id) do
       nil ->
-        SessionStaffing.empty(session.id, session.program_id)
+        SessionStaffing.empty(session.id, session.program_id, closed?)
 
       %ProgramStaffing{} = staffing ->
         %SessionStaffing{
@@ -1078,7 +1100,8 @@ defmodule KlassHero.Provider.Assignments do
           lead: staffing.lead,
           member_ids: staffing.member_ids,
           member_count: staffing.member_count,
-          source: :program
+          source: :program,
+          program_closed?: closed?
         }
     end
   end

--- a/lib/klass_hero/provider/domain/read_models/session_staffing.ex
+++ b/lib/klass_hero/provider/domain/read_models/session_staffing.ex
@@ -38,10 +38,11 @@ defmodule KlassHero.Provider.Domain.ReadModels.SessionStaffing do
           lead: lead(),
           member_ids: [String.t()],
           member_count: non_neg_integer(),
-          source: source()
+          source: source(),
+          program_closed?: boolean()
         }
 
-  @enforce_keys [:session_id, :program_id, :member_ids, :member_count, :source]
+  @enforce_keys [:session_id, :program_id, :member_ids, :member_count, :source, :program_closed?]
 
   defstruct [
     :session_id,
@@ -49,7 +50,8 @@ defmodule KlassHero.Provider.Domain.ReadModels.SessionStaffing do
     :lead,
     member_ids: [],
     member_count: 0,
-    source: :program
+    source: :program,
+    program_closed?: false
   ]
 
   @doc """
@@ -58,35 +60,48 @@ defmodule KlassHero.Provider.Domain.ReadModels.SessionStaffing do
   `source` is `:program`, not `:override`: a session nobody staffs is inheriting an
   empty program roster. An override is a row a provider deliberately created, so
   "no rows anywhere" can never be one.
+
+  `program_closed?` still has to be carried: having no staff and belonging to a
+  closed program are independent facts, and the caller knows the second one.
   """
-  @spec empty(String.t(), String.t()) :: t()
-  def empty(session_id, program_id) when is_binary(session_id) and is_binary(program_id) do
+  @spec empty(String.t(), String.t(), boolean()) :: t()
+  def empty(session_id, program_id, program_closed? \\ false)
+      when is_binary(session_id) and is_binary(program_id) and is_boolean(program_closed?) do
     %__MODULE__{
       session_id: session_id,
       program_id: program_id,
       lead: nil,
       member_ids: [],
       member_count: 0,
-      source: :program
+      source: :program,
+      program_closed?: program_closed?
     }
   end
 
   @doc """
-  Whether `staff_member_id` is on this session, leading it or not.
+  Whether `staff_member_id` may act on this session: on it, and its program still
+  open.
 
   Accepts `nil` so a caller can pass a batch-read lookup straight through without
   first defaulting an absent session.
+
+  A **Closed Program** refuses everyone, member and lead alike (#1082). The check
+  lives here rather than at the five call sites because every one of them is an
+  authorization decision, and a rule they each have to remember is a rule one of
+  them eventually forgets — which is what #1323 was.
   """
   @spec staffed_by?(t() | nil, String.t()) :: boolean()
   def staffed_by?(nil, _staff_member_id), do: false
+  def staffed_by?(%__MODULE__{program_closed?: true}, _staff_member_id), do: false
 
   def staffed_by?(%__MODULE__{member_ids: member_ids}, staff_member_id) do
     staff_member_id in member_ids
   end
 
-  @doc "Whether `staff_member_id` leads this session."
+  @doc "Whether `staff_member_id` leads this session. Closed programs have no lead to act."
   @spec led_by?(t() | nil, String.t()) :: boolean()
   def led_by?(nil, _staff_member_id), do: false
+  def led_by?(%__MODULE__{program_closed?: true}, _staff_member_id), do: false
   def led_by?(%__MODULE__{lead: nil}, _staff_member_id), do: false
   def led_by?(%__MODULE__{lead: %{id: lead_id}}, staff_member_id), do: lead_id == staff_member_id
 

--- a/lib/klass_hero/provider/domain/read_models/staff_program_access.ex
+++ b/lib/klass_hero/provider/domain/read_models/staff_program_access.ex
@@ -10,15 +10,21 @@ defmodule KlassHero.Provider.Domain.ReadModels.StaffProgramAccess do
   **Specialties** and carry no access (#1323).
 
   Both inputs are write-model facts, read strongly-consistently. Closure is asked
-  of `programs` through `ProgramCatalog.list_open_program_ids_for_provider/2`,
-  never of the `program_listings` projection: projection lag revoking access is
-  the failure `KlassHeroWeb.Helpers.StaffLiveHelpers`'s moduledoc warns about, and
-  it applies to closure exactly as it does to assignment.
+  of `programs` through `ProgramCatalog.split_programs_by_closure/2`, never of the
+  `program_listings` projection: projection lag revoking access is the failure
+  `KlassHeroWeb.Helpers.StaffLiveHelpers`'s moduledoc warns about, and it applies
+  to closure exactly as it does to assignment.
 
-  That same read carries the **tenancy**, which is why it is the scoped variant: a
-  program belonging to another provider is resolved out, so it reaches neither set
-  and grants nothing. Consumers therefore do not re-check the provider — a filter
-  each caller must remember is a filter one of them eventually omits.
+  That same read carries the **tenancy**, so consumers do not re-check the
+  provider — a filter each caller must remember is a filter one of them eventually
+  omits.
+
+  The two sets are therefore **not** exhaustive over the assignment rows, and that
+  is deliberate. An assignment naming another provider's program, or one since
+  deleted, appears in neither: it grants nothing *and* is not listed back to the
+  staff member. Deriving `closed_program_ids` as "assigned minus open" would have
+  put a foreign program in the dashboard's "Completed" section — fail-closed is
+  the right instinct for a gate, but this set is also rendered.
 
   Until #1323 the four staff surfaces derived this by matching a staff member's
   tags against `program.category`, with an empty tag list silently meaning *every*

--- a/lib/klass_hero/provider/domain/read_models/staff_program_access.ex
+++ b/lib/klass_hero/provider/domain/read_models/staff_program_access.ex
@@ -10,10 +10,15 @@ defmodule KlassHero.Provider.Domain.ReadModels.StaffProgramAccess do
   **Specialties** and carry no access (#1323).
 
   Both inputs are write-model facts, read strongly-consistently. Closure is asked
-  of `programs` through `ProgramCatalog.list_open_program_ids/1`, never of the
-  `program_listings` projection: projection lag revoking access is the failure
-  `KlassHeroWeb.Helpers.StaffLiveHelpers`'s moduledoc warns about, and it applies
-  to closure exactly as it does to assignment.
+  of `programs` through `ProgramCatalog.list_open_program_ids_for_provider/2`,
+  never of the `program_listings` projection: projection lag revoking access is
+  the failure `KlassHeroWeb.Helpers.StaffLiveHelpers`'s moduledoc warns about, and
+  it applies to closure exactly as it does to assignment.
+
+  That same read carries the **tenancy**, which is why it is the scoped variant: a
+  program belonging to another provider is resolved out, so it reaches neither set
+  and grants nothing. Consumers therefore do not re-check the provider — a filter
+  each caller must remember is a filter one of them eventually omits.
 
   Until #1323 the four staff surfaces derived this by matching a staff member's
   tags against `program.category`, with an empty tag list silently meaning *every*

--- a/lib/klass_hero/provider/domain/read_models/staff_program_access.ex
+++ b/lib/klass_hero/provider/domain/read_models/staff_program_access.ex
@@ -4,8 +4,16 @@ defmodule KlassHero.Provider.Domain.ReadModels.StaffProgramAccess do
 
   Derived from live **Program Staff Assignments** — the rows a provider creates
   deliberately, which already decide conversation membership, session-detail
-  attribution and the offboarding teardown. Never from `staff_members.tags`,
-  which are descriptive **Specialties** and carry no access (#1323).
+  attribution and the offboarding teardown — narrowed by whether each of those
+  programs is still open. Assignment says *who*; closure says *whether it still
+  counts* (#1082). Never from `staff_members.tags`, which are descriptive
+  **Specialties** and carry no access (#1323).
+
+  Both inputs are write-model facts, read strongly-consistently. Closure is asked
+  of `programs` through `ProgramCatalog.list_open_program_ids/1`, never of the
+  `program_listings` projection: projection lag revoking access is the failure
+  `KlassHeroWeb.Helpers.StaffLiveHelpers`'s moduledoc warns about, and it applies
+  to closure exactly as it does to assignment.
 
   Until #1323 the four staff surfaces derived this by matching a staff member's
   tags against `program.category`, with an empty tag list silently meaning *every*
@@ -23,15 +31,20 @@ defmodule KlassHero.Provider.Domain.ReadModels.StaffProgramAccess do
   membership test.
   """
 
-  @typedoc "Every Program one Staff Member is currently assigned to."
+  @typedoc """
+  Every Program one Staff Member is currently assigned to, split by whether it is
+  still open. The two sets are disjoint and together are the whole assignment
+  roster.
+  """
   @type t :: %__MODULE__{
           staff_member_id: String.t(),
-          program_ids: MapSet.t(String.t())
+          program_ids: MapSet.t(String.t()),
+          closed_program_ids: MapSet.t(String.t())
         }
 
-  @enforce_keys [:staff_member_id, :program_ids]
+  @enforce_keys [:staff_member_id, :program_ids, :closed_program_ids]
 
-  defstruct [:staff_member_id, :program_ids]
+  defstruct [:staff_member_id, :program_ids, :closed_program_ids]
 
   @doc """
   Whether the staff member may see and act on `program_id`.
@@ -40,9 +53,25 @@ defmodule KlassHero.Provider.Domain.ReadModels.StaffProgramAccess do
   case where they have only just been hired. That is the correct answer, not a
   degenerate one: assignment is a deliberate act, so "not assigned yet" and "not
   allowed" are the same fact.
+
+  Says nothing about *why* a program is refused. A caller that needs to tell a
+  Closed Program apart from one that was never assigned asks `closed?/2`.
   """
   @spec authorized?(t(), String.t()) :: boolean()
   def authorized?(%__MODULE__{program_ids: program_ids}, program_id) do
     MapSet.member?(program_ids, program_id)
+  end
+
+  @doc """
+  Whether `program_id` is assigned to this staff member but **Closed** — so it
+  may be named and listed, but not acted on (#1082).
+
+  This is the read-only half of the roster: the dashboard's "Completed" section
+  is built from it, and it is what lets a refusal say "this program has closed"
+  rather than "you are not assigned".
+  """
+  @spec closed?(t(), String.t()) :: boolean()
+  def closed?(%__MODULE__{closed_program_ids: closed_program_ids}, program_id) do
+    MapSet.member?(closed_program_ids, program_id)
   end
 end

--- a/lib/klass_hero/provider/domain/read_models/staff_program_access.ex
+++ b/lib/klass_hero/provider/domain/read_models/staff_program_access.ex
@@ -43,9 +43,13 @@ defmodule KlassHero.Provider.Domain.ReadModels.StaffProgramAccess do
   """
 
   @typedoc """
-  Every Program one Staff Member is currently assigned to, split by whether it is
-  still open. The two sets are disjoint and together are the whole assignment
-  roster.
+  The Programs one Staff Member may see, split by whether each is still open.
+
+  Disjoint, but **not** exhaustive over their assignment rows: an assignment naming
+  a program that belongs to another provider, or one since deleted, is in neither
+  set. Do not "restore" exhaustiveness — putting the unresolvable ones in
+  `closed_program_ids` lists them back to the staff member, because that set is
+  rendered as their Completed programs.
   """
   @type t :: %__MODULE__{
           staff_member_id: String.t(),

--- a/lib/klass_hero_web/helpers/staff_live_helpers.ex
+++ b/lib/klass_hero_web/helpers/staff_live_helpers.ex
@@ -24,21 +24,21 @@ defmodule KlassHeroWeb.Helpers.StaffLiveHelpers do
   projection entirely — display may lag, authorization may not, and here the two
   are the same fetch.
 
-  Still narrowed to the staff member's own provider. `get_programs_by_ids/1` is
-  not provider-scoped, and an assignment row naming another provider's program
-  must not put it on this dashboard.
+  Tenancy is not re-checked here. `Provider.get_staff_program_access/1` resolves
+  the assigned programs scoped to the staff member's own provider, so a foreign
+  program never reaches either set — there is nothing left for this function to
+  filter out.
   """
   @spec load_assigned_programs(StaffMember.t()) ::
           {open :: [Program.t()], closed :: [Program.t()], StaffProgramAccess.t()}
-  def load_assigned_programs(%StaffMember{provider_id: provider_id, id: staff_member_id}) do
-    access = Provider.get_staff_program_access(staff_member_id)
+  def load_assigned_programs(%StaffMember{} = staff_member) do
+    access = Provider.get_staff_program_access(staff_member)
 
     programs =
       access.program_ids
       |> MapSet.union(access.closed_program_ids)
       |> MapSet.to_list()
       |> ProgramCatalog.get_programs_by_ids()
-      |> Enum.filter(&(&1.provider_id == provider_id))
       |> Enum.sort_by(& &1.title)
 
     {open, closed} = Enum.split_with(programs, &StaffProgramAccess.authorized?(access, &1.id))

--- a/lib/klass_hero_web/helpers/staff_live_helpers.ex
+++ b/lib/klass_hero_web/helpers/staff_live_helpers.ex
@@ -8,35 +8,42 @@ defmodule KlassHeroWeb.Helpers.StaffLiveHelpers do
   """
 
   alias KlassHero.ProgramCatalog
-  alias KlassHero.ProgramCatalog.ProgramListing
+  alias KlassHero.ProgramCatalog.Program
   alias KlassHero.Provider
   alias KlassHero.Provider.Domain.ReadModels.StaffProgramAccess
   alias KlassHero.Provider.StaffMember
 
   @doc """
-  Loads the programs the staff member is assigned to, alongside the
-  `StaffProgramAccess` that says which programs they may act on.
+  Loads the programs the staff member is assigned to — split into the ones they
+  may act on and the **Closed** ones they may only be shown (#1082) — alongside
+  the `StaffProgramAccess` that decided the split.
 
-  Composes `ProgramCatalog.list_programs_for_provider/1` with
-  `Provider.get_staff_program_access/1`, keeping the cross-context fetch out of
-  the Provider bounded context.
+  Fetches the write rows the assignments name rather than listing the provider's
+  whole catalogue and filtering it down: a staff member on three of two hundred
+  programs costs three rows. That also keeps this path off the `program_listings`
+  projection entirely — display may lag, authorization may not, and here the two
+  are the same fetch.
 
-  The returned access comes from the assignment rows, **not** from the filtered
-  program list. Listings are read from the `provider_programs` projection, so
-  deriving the gate from them would let projection lag revoke access to a program
-  assigned moments ago: display may lag, authorization may not.
+  Still narrowed to the staff member's own provider. `get_programs_by_ids/1` is
+  not provider-scoped, and an assignment row naming another provider's program
+  must not put it on this dashboard.
   """
   @spec load_assigned_programs(StaffMember.t()) ::
-          {[ProgramListing.t()], StaffProgramAccess.t()}
+          {open :: [Program.t()], closed :: [Program.t()], StaffProgramAccess.t()}
   def load_assigned_programs(%StaffMember{provider_id: provider_id, id: staff_member_id}) do
     access = Provider.get_staff_program_access(staff_member_id)
 
     programs =
-      provider_id
-      |> ProgramCatalog.list_programs_for_provider()
-      |> Enum.filter(&StaffProgramAccess.authorized?(access, &1.id))
+      access.program_ids
+      |> MapSet.union(access.closed_program_ids)
+      |> MapSet.to_list()
+      |> ProgramCatalog.get_programs_by_ids()
+      |> Enum.filter(&(&1.provider_id == provider_id))
+      |> Enum.sort_by(& &1.title)
 
-    {programs, access}
+    {open, closed} = Enum.split_with(programs, &StaffProgramAccess.authorized?(access, &1.id))
+
+    {open, closed, access}
   end
 
   @doc """

--- a/lib/klass_hero_web/live/staff/staff_broadcast_live.ex
+++ b/lib/klass_hero_web/live/staff/staff_broadcast_live.ex
@@ -45,7 +45,7 @@ defmodule KlassHeroWeb.Staff.StaffBroadcastLive do
         # would let you broadcast about. Only the rule is shared, not
         # `StaffLiveHelpers.load_assigned_programs/1` — that fetches every listing
         # the provider has, and this page has already resolved its one program.
-        access = Provider.get_staff_program_access(staff_member.id)
+        access = Provider.get_staff_program_access(staff_member)
 
         if StaffProgramAccess.authorized?(access, program.id) do
           mount_form(socket, provider, program)

--- a/lib/klass_hero_web/live/staff/staff_dashboard_live.ex
+++ b/lib/klass_hero_web/live/staff/staff_dashboard_live.ex
@@ -23,7 +23,8 @@ defmodule KlassHeroWeb.Staff.StaffDashboardLive do
     # memberships read model carries id + business_name — no separate profile lookup needed.
     case Enum.find(memberships, &(&1.provider_id == staff_member.provider_id)) do
       %{provider_id: provider_id, business_name: business_name} ->
-        {programs, program_access} = StaffLiveHelpers.load_assigned_programs(staff_member)
+        {programs, completed_programs, program_access} =
+          StaffLiveHelpers.load_assigned_programs(staff_member)
 
         socket =
           socket
@@ -35,6 +36,7 @@ defmodule KlassHeroWeb.Staff.StaffDashboardLive do
           |> assign(:self_view, StaffMemberPresenter.to_self_view(staff_member))
           |> assign(:program_access, program_access)
           |> assign(:programs_empty?, programs == [])
+          |> assign(:completed_empty?, completed_programs == [])
           |> assign(:provider?, Scope.provider?(socket.assigns.current_scope))
           |> assign(:upgrade_confirm?, false)
           |> assign(:show_roster, false)
@@ -44,6 +46,7 @@ defmodule KlassHeroWeb.Staff.StaffDashboardLive do
           |> assign(:can_message?, false)
           |> assign(:roster_enrolled_count, 0)
           |> stream(:programs, programs)
+          |> stream(:completed_programs, completed_programs)
 
         {:ok, socket}
 
@@ -363,6 +366,34 @@ defmodule KlassHeroWeb.Staff.StaffDashboardLive do
                 {gettext("Roster")}
               </button>
             </div>
+          </div>
+        </div>
+      </div>
+
+      <%!--
+        Closed programs: named, never actionable. No Sessions link and no Roster
+        button, because `StaffProgramAccess.authorized?/2` refuses both — the
+        markup agrees with the gate rather than being the gate (#1082).
+      --%>
+      <div :if={not @completed_empty?} class="mt-8">
+        <h2 class={Theme.typography(:section_title)}>
+          {gettext("Completed Programs")}
+        </h2>
+
+        <p class="text-sm text-zinc-500 mt-1">
+          {gettext(
+            "These programs have finished. Their sessions and rosters are no longer available."
+          )}
+        </p>
+
+        <div id="completed-programs" phx-update="stream" class="mt-4 space-y-3">
+          <div
+            :for={{dom_id, program} <- @streams.completed_programs}
+            id={dom_id}
+            class="p-4 bg-hero-grey-50 rounded-lg border border-zinc-200"
+          >
+            <h3 class={[Theme.typography(:card_title), "text-zinc-500"]}>{program.title}</h3>
+            <p :if={program.category} class="text-sm text-zinc-400 mt-1">{program.category}</p>
           </div>
         </div>
       </div>

--- a/lib/klass_hero_web/live/staff/staff_participation_live.ex
+++ b/lib/klass_hero_web/live/staff/staff_participation_live.ex
@@ -186,11 +186,16 @@ defmodule KlassHeroWeb.Staff.StaffParticipationLive do
     {:noreply, socket}
   end
 
-  defp staffs_session?(staff_member, session_id) do
-    session_id
-    |> Provider.get_session_staffing()
-    |> SessionStaffing.staffed_by?(staff_member.id)
-  end
+  # Why the refusal — for the message only. The refusal itself is
+  # `SessionStaffing.staffed_by?/2`'s, and it already refuses a Closed Program on
+  # its own; this only reads the reason off the same struct so the flash can say
+  # which of the two it was, without a second round trip (#1082).
+  defp refusal_reason(%SessionStaffing{program_closed?: true}), do: :program_closed
+  defp refusal_reason(_staffing), do: :not_assigned
+
+  defp refusal_message(:program_closed), do: gettext("This program has closed. Its sessions are no longer available.")
+
+  defp refusal_message(:not_assigned), do: gettext("You are not assigned to this session")
 
   defp load_session_data(socket) do
     session_id = socket.assigns.session_id
@@ -203,21 +208,26 @@ defmodule KlassHeroWeb.Staff.StaffParticipationLive do
         # longer the only thing standing between staff and a child's record (#1353).
         # Asked at session grain, so it agrees with the context rather than
         # shadowing it with a coarser answer (#783).
-        if staffs_session?(socket.assigns.staff_member, session_id) do
+        staffing = Provider.get_session_staffing(session_id)
+
+        if SessionStaffing.staffed_by?(staffing, socket.assigns.staff_member.id) do
           socket
           |> assign(:session, session)
           |> assign(:participation_records, session.participation_records || [])
           |> assign(:session_error, nil)
           |> load_provider_notes()
         else
+          reason = refusal_reason(staffing)
+
           Logger.warning(
             "[StaffParticipationLive] Unauthorized access to session",
             session_id: session_id,
-            staff_member_id: socket.assigns.staff_member.id
+            staff_member_id: socket.assigns.staff_member.id,
+            reason: reason
           )
 
           socket
-          |> put_flash(:error, gettext("You are not assigned to this session"))
+          |> put_flash(:error, refusal_message(reason))
           |> push_navigate(to: ~p"/staff/sessions")
         end
 

--- a/lib/klass_hero_web/live/staff/staff_sessions_live.ex
+++ b/lib/klass_hero_web/live/staff/staff_sessions_live.ex
@@ -90,6 +90,14 @@ defmodule KlassHeroWeb.Staff.StaffSessionsLive do
              )}
         end
 
+      {:error, :program_closed} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           gettext("This program has closed. Its sessions are no longer available.")
+         )}
+
       {:error, :unauthorized} ->
         {:noreply, put_flash(socket, :error, gettext("Unauthorized"))}
     end
@@ -118,6 +126,14 @@ defmodule KlassHeroWeb.Staff.StaffSessionsLive do
                gettext("Failed to complete session: %{reason}", reason: inspect(reason))
              )}
         end
+
+      {:error, :program_closed} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           gettext("This program has closed. Its sessions are no longer available.")
+         )}
 
       {:error, :unauthorized} ->
         {:noreply, put_flash(socket, :error, gettext("Unauthorized"))}
@@ -183,10 +199,12 @@ defmodule KlassHeroWeb.Staff.StaffSessionsLive do
   defp authorize_session_action(session_id, socket) do
     case Participation.get_session_with_roster(session_id) do
       {:ok, %{session: session}} ->
-        if staffs_session?(socket, session.id) do
-          :ok
-        else
-          {:error, :unauthorized}
+        staffing = Provider.get_session_staffing(session.id)
+
+        cond do
+          SessionStaffing.staffed_by?(staffing, socket.assigns.staff_member.id) -> :ok
+          match?(%SessionStaffing{program_closed?: true}, staffing) -> {:error, :program_closed}
+          true -> {:error, :unauthorized}
         end
 
       {:error, _reason} ->

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -619,7 +619,7 @@ msgid "Failed to check out: %{reason}"
 msgstr "Auschecken fehlgeschlagen: %{reason}"
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:160
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:118
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:126
 #, elixir-autogen, elixir-format
 msgid "Failed to complete session: %{reason}"
 msgstr "Sitzung konnte nicht abgeschlossen werden: %{reason}"
@@ -756,7 +756,7 @@ msgstr "Nachricht erfolgreich gesendet!"
 #: lib/klass_hero_web/live/provider/sessions_live.ex:50
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:4
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:20
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:242
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "My Sessions"
 msgstr "Meine Sitzungen"
@@ -878,15 +878,15 @@ msgstr "Wählen Sie eine oder beide Optionen"
 #: lib/klass_hero_web/components/provider_components.ex:2512
 #: lib/klass_hero_web/components/provider_components.ex:2513
 #: lib/klass_hero_web/components/provider_components.ex:2550
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:448
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:484
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:478
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:479
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:515
 #, elixir-autogen, elixir-format
 msgid "Send Message"
 msgstr "Nachricht senden"
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:146
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:104
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:112
 #, elixir-autogen, elixir-format
 msgid "Session completed successfully"
 msgstr "Sitzung erfolgreich abgeschlossen"
@@ -894,7 +894,7 @@ msgstr "Sitzung erfolgreich abgeschlossen"
 #: lib/klass_hero_web/live/admin/sessions_live.ex:62
 #: lib/klass_hero_web/live/admin/sessions_live.ex:68
 #: lib/klass_hero_web/live/provider/participation_live.ex:287
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:231
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "Session not found"
 msgstr "Sitzung nicht gefunden"
@@ -1102,7 +1102,7 @@ msgstr "Fortschritt"
 #: lib/klass_hero_web/components/provider_components.ex:121
 #: lib/klass_hero_web/live/admin/sessions_live.ex:26
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:3
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:348
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:351
 #, elixir-autogen, elixir-format
 msgid "Sessions"
 msgstr "Sitzungen"
@@ -1130,7 +1130,7 @@ msgstr "Teilnahmeverlauf konnte nicht geladen werden"
 #: lib/klass_hero_web/live/provider/participation_live.ex:27
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:65
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:27
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:290
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "Manage Participation"
 msgstr "Teilnahme verwalten"
@@ -1479,7 +1479,7 @@ msgstr "Nicht zugewiesen"
 #: lib/klass_hero_web/components/messaging_components.ex:722
 #: lib/klass_hero_web/components/provider_components.ex:51
 #: lib/klass_hero_web/components/provider_components.ex:1637
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:434
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:465
 #: lib/klass_hero_web/presenters/provider_presenter.ex:103
 #, elixir-autogen, elixir-format
 msgid "Unknown"
@@ -1808,8 +1808,8 @@ msgstr "Änderungen speichern"
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:66
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:175
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:250
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:393
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:394
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:424
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:425
 #, elixir-autogen, elixir-format
 msgid "Send Broadcast"
 msgstr "Rundnachricht senden"
@@ -1844,7 +1844,7 @@ msgid "Type a message..."
 msgstr "Nachricht eingeben..."
 
 #: lib/klass_hero_web/live/provider/participation_live.ex:307
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:251
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "Unable to refresh roster. Please reload."
 msgstr "Teilnehmerliste konnte nicht aktualisiert werden. Bitte laden Sie die Seite neu."
@@ -2443,7 +2443,7 @@ msgid "No documents uploaded yet."
 msgstr "Noch keine Dokumente hochgeladen."
 
 #: lib/klass_hero_web/components/provider_components.ex:2453
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:426
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:457
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
 msgstr "Noch keine Anmeldungen."
@@ -2728,7 +2728,7 @@ msgid "Role"
 msgstr "Rolle"
 
 #: lib/klass_hero_web/components/provider_components.ex:1736
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:386
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:417
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
 msgstr "Teilnehmerliste: %{name}"
@@ -3299,7 +3299,7 @@ msgid "Cannot check out without a check-in"
 msgstr "Auschecken ohne Einchecken nicht möglich"
 
 #: lib/klass_hero_web/live/provider/programs_live.ex:451
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:147
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:150
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
 msgstr "Diesem Elternteil kann keine Nachricht gesendet werden."
@@ -3364,7 +3364,7 @@ msgstr "Korrigieren"
 
 #: lib/klass_hero_web/live/dashboard_live.ex:306
 #: lib/klass_hero_web/live/provider/programs_live.ex:448
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:201
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:204
 #, elixir-autogen, elixir-format
 msgid "Could not start conversation. Please try again."
 msgstr "Unterhaltung konnte nicht gestartet werden. Bitte versuchen Sie es erneut."
@@ -3390,7 +3390,7 @@ msgid "Download monthly statements for taxes"
 msgstr "Monatliche Abrechnungen für die Steuer herunterladen"
 
 #: lib/klass_hero_web/components/provider_components.ex:2549
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:483
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:514
 #, elixir-autogen, elixir-format
 msgid "Enrollment not confirmed"
 msgstr "Anmeldung nicht bestätigt"
@@ -3463,7 +3463,7 @@ msgid "No chasing payments or sending invoices"
 msgstr "Kein Nachfassen bei Zahlungen oder Versenden von Rechnungen"
 
 #: lib/klass_hero_web/components/provider_components.ex:1759
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:407
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:438
 #, elixir-autogen, elixir-format
 msgid "No enrolled parents"
 msgstr "Keine angemeldeten Eltern"
@@ -3486,7 +3486,7 @@ msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr "Oder: Jederzeit eine Sofortauszahlung anfordern (mindestens 50 €)"
 
 #: lib/klass_hero_web/components/provider_components.ex:2548
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:482
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:513
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
 msgstr "Elternkonto nicht verfügbar"
@@ -3588,7 +3588,7 @@ msgid "Track Everything:"
 msgstr "Alles im Überblick:"
 
 #: lib/klass_hero_web/live/dashboard_live.ex:293
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:144
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Upgrade your plan to send messages."
 msgstr "Aktualisieren Sie Ihren Plan, um Nachrichten zu senden."
@@ -3723,7 +3723,7 @@ msgstr "Archiv"
 msgid "Archived"
 msgstr "Archiviert"
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:321
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:324
 #, elixir-autogen, elixir-format
 msgid "Assigned Programs"
 msgstr "Zugewiesene Programme"
@@ -3796,7 +3796,7 @@ msgid "Complete Registration"
 msgstr "Registrierung abschließen"
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:76
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:301
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:319
 #, elixir-autogen, elixir-format
 msgid "Complete Session"
 msgstr "Sitzung abschließen"
@@ -4026,7 +4026,7 @@ msgid "Max Capacity"
 msgstr "Maximale Kapazität"
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:90
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:315
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:333
 #, elixir-autogen, elixir-format
 msgid "No actions available"
 msgstr "Keine Aktionen verfügbar"
@@ -4046,7 +4046,7 @@ msgstr "Keine E-Mails gefunden."
 msgid "No participation records yet"
 msgstr "Noch keine Teilnahmeeinträge"
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:325
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:328
 #, elixir-autogen, elixir-format
 msgid "No programs assigned yet."
 msgstr "Noch keine Programme zugewiesen."
@@ -4062,7 +4062,7 @@ msgid "No sessions found for the selected filters."
 msgstr "Keine Sitzungen für die ausgewählten Filter gefunden."
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:122
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:330
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled"
 msgstr "Keine Sitzungen geplant"
@@ -4236,13 +4236,13 @@ msgstr "Teilnehmerliste"
 msgid "Session created successfully"
 msgstr "Sitzung erfolgreich erstellt"
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:30
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:31
 #, elixir-autogen, elixir-format
 msgid "Staff Dashboard"
 msgstr "Mitarbeiter-Dashboard"
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:54
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:279
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:297
 #, elixir-autogen, elixir-format
 msgid "Start Session"
 msgstr "Sitzung starten"
@@ -4299,9 +4299,9 @@ msgid "Type your reply..."
 msgstr "Ihre Antwort eingeben..."
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:183
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:123
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:94
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:123
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:126
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:102
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:139
 #, elixir-autogen, elixir-format
 msgid "Unauthorized"
 msgstr "Nicht autorisiert"
@@ -4328,7 +4328,7 @@ msgid "Upload connection lost. Please try again."
 msgstr "Upload-Verbindung unterbrochen. Bitte versuchen Sie es erneut."
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:87
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:312
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:330
 #, elixir-autogen, elixir-format
 msgid "View Participation"
 msgstr "Teilnahme anzeigen"
@@ -4338,7 +4338,7 @@ msgstr "Teilnahme anzeigen"
 msgid "View your children's participation records"
 msgstr "Sehen Sie die Teilnahmeeinträge Ihrer Kinder ein"
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:214
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "Welcome, %{name}"
 msgstr "Willkommen, %{name}"
@@ -4354,7 +4354,7 @@ msgid "You already have an account. Log in to see your new enrollment."
 msgstr "Sie haben bereits ein Konto. Melden Sie sich an, um Ihre neue Anmeldung zu sehen."
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:125
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:333
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:351
 #, elixir-autogen, elixir-format
 msgid "You have no sessions scheduled for %{date}"
 msgstr "Sie haben keine Sitzungen geplant für %{date}"
@@ -4379,7 +4379,7 @@ msgstr "Ihr Konto wurde erstellt! Richten Sie Ihr Passwort in den Einstellungen 
 msgid "Your children's participation will appear here"
 msgstr "Die Teilnahme Ihrer Kinder wird hier angezeigt"
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:363
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:366
 #, elixir-autogen, elixir-format
 msgid "Roster"
 msgstr "Teilnehmerliste"
@@ -4389,7 +4389,7 @@ msgstr "Teilnehmerliste"
 msgid "Unlimited team seats"
 msgstr "Unbegrenzte Team-Plätze"
 
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:243
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "View and manage your assigned sessions"
 msgstr "Ihre zugewiesenen Sitzungen anzeigen und verwalten"
@@ -4890,7 +4890,7 @@ msgstr "Melden Sie einen Vorfall während eines Programms oder einer Session. Al
 msgid "Submit report"
 msgstr "Bericht absenden"
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:221
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:224
 #, elixir-autogen, elixir-format
 msgid "Your pay rate"
 msgstr "Ihre Vergütung"
@@ -5045,8 +5045,8 @@ msgstr "Werden Sie ein Hero"
 msgid "Become a Hero →"
 msgstr "Werden Sie ein Hero →"
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:269
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:314
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:272
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:317
 #, elixir-autogen, elixir-format
 msgid "Become a provider"
 msgstr "Anbieter werden"
@@ -5234,7 +5234,7 @@ msgstr "Sie konnten nicht zum Team hinzugefügt werden. Bitte versuchen Sie es e
 msgid "Could not link your account. Please try again."
 msgstr "Ihr Konto konnte nicht verknüpft werden. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:176
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "Could not set up your provider profile. Please try again."
 msgstr "Ihr Anbieterprofil konnte nicht eingerichtet werden. Bitte versuchen Sie es erneut."
@@ -5800,13 +5800,13 @@ msgstr "Keine bevorstehenden Sitzungen in den nächsten Wochen."
 msgid "Not allowed to approve this enrollment"
 msgstr "Nicht berechtigt, diese Anmeldung zu genehmigen"
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:297
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:300
 #: lib/klass_hero_web/live/user_live/settings.ex:245
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr "Nicht jetzt"
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:303
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "Offer your own programs on Klass Hero — alongside your work for %{business}."
 msgstr "Bieten Sie Ihre eigenen Programme auf Klass Hero an — zusätzlich zu Ihrer Arbeit für %{business}."
@@ -6107,7 +6107,7 @@ msgstr "Magic-Link senden"
 msgid "Send us a message"
 msgstr "Schreiben Sie uns eine Nachricht"
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:286
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:289
 #: lib/klass_hero_web/live/user_live/settings.ex:235
 #, elixir-autogen, elixir-format
 msgid "Setting up..."
@@ -6410,7 +6410,7 @@ msgstr "Warum Klass Hero"
 msgid "Year"
 msgstr "Jahr"
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:288
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:291
 #, elixir-autogen, elixir-format
 msgid "Yes, become a provider"
 msgstr "Ja, Anbieter werden"
@@ -6420,7 +6420,7 @@ msgstr "Ja, Anbieter werden"
 msgid "Yes. You can run unlimited programs, each with its own schedule and venue, and add as many team members as you need to delegate management across instructors."
 msgstr "Ja. Sie können unbegrenzt viele Programme mit jeweils eigenem Zeitplan und Veranstaltungsort betreiben und beliebig viele Teammitglieder hinzufügen, um die Verwaltung auf Ihre Kursleitungen zu verteilen."
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:80
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:83
 #: lib/klass_hero_web/live/user_live/settings.ex:490
 #, elixir-autogen, elixir-format
 msgid "You already have a provider profile."
@@ -6441,7 +6441,7 @@ msgstr "Sie sind bereits in Ihrem Team."
 msgid "You're logged in as %{current}. Log into the matching account to accept."
 msgstr "Sie sind als %{current} angemeldet. Melden Sie sich mit dem passenden Konto an, um anzunehmen."
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:167
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:170
 #, elixir-autogen, elixir-format
 msgid "You're no longer on that team."
 msgstr "Sie sind nicht mehr in diesem Team."
@@ -7689,7 +7689,7 @@ msgstr "Einverständniserklärung hinzugefügt."
 msgid "Waiver retired. Signatures already collected are kept."
 msgstr "Einverständniserklärung zurückgezogen. Bereits erteilte Unterschriften bleiben erhalten."
 
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:220
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:198
 #, elixir-autogen, elixir-format
 msgid "You are not assigned to this session"
 msgstr "Sie sind diesem Termin nicht zugewiesen"
@@ -7699,7 +7699,7 @@ msgstr "Sie sind diesem Termin nicht zugewiesen"
 msgid "Complete verification to create programs."
 msgstr "Schließen Sie die Verifizierung ab, um Programme zu erstellen."
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:263
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:266
 #, elixir-autogen, elixir-format
 msgid "Manage your provider profile"
 msgstr "Ihr Anbieterprofil verwalten"
@@ -7730,12 +7730,12 @@ msgstr "Anbietername"
 msgid "Provider Profile"
 msgstr "Anbieterprofil"
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:229
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:232
 #, elixir-autogen, elixir-format
 msgid "Switch provider"
 msgstr "Anbieter wechseln"
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:55
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:58
 #, elixir-autogen, elixir-format
 msgid "The provider associated with your account could not be found."
 msgstr "Der mit Ihrem Konto verknüpfte Anbieter konnte nicht gefunden werden."
@@ -7760,13 +7760,13 @@ msgstr "Laden Sie Dokumente hoch, um verifiziert zu werden. Die Dokumente werden
 msgid "Verified Provider"
 msgstr "Verifizierter Anbieter"
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:72
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:75
 #: lib/klass_hero_web/live/user_live/settings.ex:485
 #, elixir-autogen, elixir-format
 msgid "Welcome aboard! Let's set up your provider profile."
 msgstr "Willkommen an Bord! Lassen Sie uns Ihr Anbieterprofil einrichten."
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:274
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:277
 #, elixir-autogen, elixir-format
 msgid "You'll get your own provider profile to fill in, and your account will open on your provider dashboard from now on. You stay on %{business}'s team."
 msgstr "Sie erhalten Ihr eigenes Anbieterprofil zum Ausfüllen, und Ihr Konto öffnet sich ab sofort auf Ihrem Anbieter-Dashboard. Sie bleiben im Team von %{business}."
@@ -7904,3 +7904,23 @@ msgstr "Unbekanntes Programm"
 #, elixir-autogen, elixir-format
 msgid "waiting"
 msgstr "ausstehend"
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:380
+#, elixir-autogen, elixir-format
+msgid "Completed Programs"
+msgstr "Abgeschlossene Programme"
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:384
+#, elixir-autogen, elixir-format
+msgid "These programs have finished. Their sessions and rosters are no longer available."
+msgstr ""
+"Diese Programme sind beendet. Ihre Termine und Teilnehmerlisten sind nicht "
+"mehr verfügbar."
+
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:196
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:98
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:135
+#, elixir-autogen, elixir-format
+msgid "This program has closed. Its sessions are no longer available."
+msgstr ""
+"Dieses Programm ist abgeschlossen. Seine Termine sind nicht mehr verfügbar."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -619,7 +619,7 @@ msgid "Failed to check out: %{reason}"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:160
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:118
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:126
 #, elixir-autogen, elixir-format
 msgid "Failed to complete session: %{reason}"
 msgstr ""
@@ -756,7 +756,7 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/sessions_live.ex:50
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:4
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:20
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:242
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "My Sessions"
 msgstr ""
@@ -878,15 +878,15 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:2512
 #: lib/klass_hero_web/components/provider_components.ex:2513
 #: lib/klass_hero_web/components/provider_components.ex:2550
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:448
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:484
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:478
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:479
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:515
 #, elixir-autogen, elixir-format
 msgid "Send Message"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:146
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:104
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:112
 #, elixir-autogen, elixir-format
 msgid "Session completed successfully"
 msgstr ""
@@ -894,7 +894,7 @@ msgstr ""
 #: lib/klass_hero_web/live/admin/sessions_live.ex:62
 #: lib/klass_hero_web/live/admin/sessions_live.ex:68
 #: lib/klass_hero_web/live/provider/participation_live.ex:287
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:231
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "Session not found"
 msgstr ""
@@ -1102,7 +1102,7 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:121
 #: lib/klass_hero_web/live/admin/sessions_live.ex:26
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:3
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:348
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:351
 #, elixir-autogen, elixir-format
 msgid "Sessions"
 msgstr ""
@@ -1130,7 +1130,7 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/participation_live.ex:27
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:65
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:27
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:290
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "Manage Participation"
 msgstr ""
@@ -1479,7 +1479,7 @@ msgstr ""
 #: lib/klass_hero_web/components/messaging_components.ex:722
 #: lib/klass_hero_web/components/provider_components.ex:51
 #: lib/klass_hero_web/components/provider_components.ex:1637
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:434
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:465
 #: lib/klass_hero_web/presenters/provider_presenter.ex:103
 #, elixir-autogen, elixir-format
 msgid "Unknown"
@@ -1808,8 +1808,8 @@ msgstr ""
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:66
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:175
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:250
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:393
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:394
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:424
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:425
 #, elixir-autogen, elixir-format
 msgid "Send Broadcast"
 msgstr ""
@@ -1844,7 +1844,7 @@ msgid "Type a message..."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/participation_live.ex:307
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:251
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "Unable to refresh roster. Please reload."
 msgstr ""
@@ -2443,7 +2443,7 @@ msgid "No documents uploaded yet."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:2453
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:426
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:457
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
 msgstr ""
@@ -2728,7 +2728,7 @@ msgid "Role"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1736
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:386
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:417
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
 msgstr ""
@@ -3299,7 +3299,7 @@ msgid "Cannot check out without a check-in"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/programs_live.ex:451
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:147
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:150
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
 msgstr ""
@@ -3364,7 +3364,7 @@ msgstr ""
 
 #: lib/klass_hero_web/live/dashboard_live.ex:306
 #: lib/klass_hero_web/live/provider/programs_live.ex:448
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:201
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:204
 #, elixir-autogen, elixir-format
 msgid "Could not start conversation. Please try again."
 msgstr ""
@@ -3390,7 +3390,7 @@ msgid "Download monthly statements for taxes"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:2549
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:483
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:514
 #, elixir-autogen, elixir-format
 msgid "Enrollment not confirmed"
 msgstr ""
@@ -3463,7 +3463,7 @@ msgid "No chasing payments or sending invoices"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1759
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:407
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:438
 #, elixir-autogen, elixir-format
 msgid "No enrolled parents"
 msgstr ""
@@ -3486,7 +3486,7 @@ msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:2548
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:482
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:513
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
 msgstr ""
@@ -3588,7 +3588,7 @@ msgid "Track Everything:"
 msgstr ""
 
 #: lib/klass_hero_web/live/dashboard_live.ex:293
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:144
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Upgrade your plan to send messages."
 msgstr ""
@@ -3723,7 +3723,7 @@ msgstr ""
 msgid "Archived"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:321
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:324
 #, elixir-autogen, elixir-format
 msgid "Assigned Programs"
 msgstr ""
@@ -3796,7 +3796,7 @@ msgid "Complete Registration"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:76
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:301
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:319
 #, elixir-autogen, elixir-format
 msgid "Complete Session"
 msgstr ""
@@ -4026,7 +4026,7 @@ msgid "Max Capacity"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:90
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:315
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:333
 #, elixir-autogen, elixir-format
 msgid "No actions available"
 msgstr ""
@@ -4046,7 +4046,7 @@ msgstr ""
 msgid "No participation records yet"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:325
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:328
 #, elixir-autogen, elixir-format
 msgid "No programs assigned yet."
 msgstr ""
@@ -4062,7 +4062,7 @@ msgid "No sessions found for the selected filters."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:122
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:330
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled"
 msgstr ""
@@ -4236,13 +4236,13 @@ msgstr ""
 msgid "Session created successfully"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:30
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:31
 #, elixir-autogen, elixir-format
 msgid "Staff Dashboard"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:54
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:279
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:297
 #, elixir-autogen, elixir-format
 msgid "Start Session"
 msgstr ""
@@ -4299,9 +4299,9 @@ msgid "Type your reply..."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:183
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:123
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:94
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:123
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:126
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:102
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:139
 #, elixir-autogen, elixir-format
 msgid "Unauthorized"
 msgstr ""
@@ -4328,7 +4328,7 @@ msgid "Upload connection lost. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:87
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:312
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:330
 #, elixir-autogen, elixir-format
 msgid "View Participation"
 msgstr ""
@@ -4338,7 +4338,7 @@ msgstr ""
 msgid "View your children's participation records"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:214
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "Welcome, %{name}"
 msgstr ""
@@ -4354,7 +4354,7 @@ msgid "You already have an account. Log in to see your new enrollment."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:125
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:333
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:351
 #, elixir-autogen, elixir-format
 msgid "You have no sessions scheduled for %{date}"
 msgstr ""
@@ -4379,7 +4379,7 @@ msgstr ""
 msgid "Your children's participation will appear here"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:363
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:366
 #, elixir-autogen, elixir-format
 msgid "Roster"
 msgstr ""
@@ -4389,7 +4389,7 @@ msgstr ""
 msgid "Unlimited team seats"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:243
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "View and manage your assigned sessions"
 msgstr ""
@@ -4890,7 +4890,7 @@ msgstr ""
 msgid "Submit report"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:221
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:224
 #, elixir-autogen, elixir-format
 msgid "Your pay rate"
 msgstr ""
@@ -5045,8 +5045,8 @@ msgstr ""
 msgid "Become a Hero →"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:269
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:314
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:272
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:317
 #, elixir-autogen, elixir-format
 msgid "Become a provider"
 msgstr ""
@@ -5234,7 +5234,7 @@ msgstr ""
 msgid "Could not link your account. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:176
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "Could not set up your provider profile. Please try again."
 msgstr ""
@@ -5800,13 +5800,13 @@ msgstr ""
 msgid "Not allowed to approve this enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:297
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:300
 #: lib/klass_hero_web/live/user_live/settings.ex:245
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:303
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "Offer your own programs on Klass Hero — alongside your work for %{business}."
 msgstr ""
@@ -6107,7 +6107,7 @@ msgstr ""
 msgid "Send us a message"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:286
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:289
 #: lib/klass_hero_web/live/user_live/settings.ex:235
 #, elixir-autogen, elixir-format
 msgid "Setting up..."
@@ -6410,7 +6410,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:288
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:291
 #, elixir-autogen, elixir-format
 msgid "Yes, become a provider"
 msgstr ""
@@ -6420,7 +6420,7 @@ msgstr ""
 msgid "Yes. You can run unlimited programs, each with its own schedule and venue, and add as many team members as you need to delegate management across instructors."
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:80
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:83
 #: lib/klass_hero_web/live/user_live/settings.ex:490
 #, elixir-autogen, elixir-format
 msgid "You already have a provider profile."
@@ -6441,7 +6441,7 @@ msgstr ""
 msgid "You're logged in as %{current}. Log into the matching account to accept."
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:167
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:170
 #, elixir-autogen, elixir-format
 msgid "You're no longer on that team."
 msgstr ""
@@ -7674,7 +7674,7 @@ msgstr ""
 msgid "Waiver retired. Signatures already collected are kept."
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:220
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:198
 #, elixir-autogen, elixir-format
 msgid "You are not assigned to this session"
 msgstr ""
@@ -7684,7 +7684,7 @@ msgstr ""
 msgid "Complete verification to create programs."
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:263
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:266
 #, elixir-autogen, elixir-format
 msgid "Manage your provider profile"
 msgstr ""
@@ -7715,12 +7715,12 @@ msgstr ""
 msgid "Provider Profile"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:229
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:232
 #, elixir-autogen, elixir-format
 msgid "Switch provider"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:55
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:58
 #, elixir-autogen, elixir-format
 msgid "The provider associated with your account could not be found."
 msgstr ""
@@ -7745,13 +7745,13 @@ msgstr ""
 msgid "Verified Provider"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:72
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:75
 #: lib/klass_hero_web/live/user_live/settings.ex:485
 #, elixir-autogen, elixir-format
 msgid "Welcome aboard! Let's set up your provider profile."
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:274
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:277
 #, elixir-autogen, elixir-format
 msgid "You'll get your own provider profile to fill in, and your account will open on your provider dashboard from now on. You stay on %{business}'s team."
 msgstr ""
@@ -7888,4 +7888,21 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/overview_live.ex:322
 #, elixir-autogen, elixir-format
 msgid "waiting"
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:380
+#, elixir-autogen, elixir-format
+msgid "Completed Programs"
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:384
+#, elixir-autogen, elixir-format
+msgid "These programs have finished. Their sessions and rosters are no longer available."
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:196
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:98
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:135
+#, elixir-autogen, elixir-format
+msgid "This program has closed. Its sessions are no longer available."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -619,7 +619,7 @@ msgid "Failed to check out: %{reason}"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:160
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:118
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:126
 #, elixir-autogen, elixir-format
 msgid "Failed to complete session: %{reason}"
 msgstr ""
@@ -756,7 +756,7 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/sessions_live.ex:50
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:4
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:20
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:242
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "My Sessions"
 msgstr ""
@@ -878,15 +878,15 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:2512
 #: lib/klass_hero_web/components/provider_components.ex:2513
 #: lib/klass_hero_web/components/provider_components.ex:2550
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:448
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:484
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:478
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:479
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:515
 #, elixir-autogen, elixir-format
 msgid "Send Message"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:146
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:104
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:112
 #, elixir-autogen, elixir-format
 msgid "Session completed successfully"
 msgstr ""
@@ -894,7 +894,7 @@ msgstr ""
 #: lib/klass_hero_web/live/admin/sessions_live.ex:62
 #: lib/klass_hero_web/live/admin/sessions_live.ex:68
 #: lib/klass_hero_web/live/provider/participation_live.ex:287
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:231
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "Session not found"
 msgstr ""
@@ -1102,7 +1102,7 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:121
 #: lib/klass_hero_web/live/admin/sessions_live.ex:26
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:3
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:348
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:351
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sessions"
 msgstr ""
@@ -1130,7 +1130,7 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/participation_live.ex:27
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:65
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:27
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:290
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "Manage Participation"
 msgstr ""
@@ -1479,7 +1479,7 @@ msgstr ""
 #: lib/klass_hero_web/components/messaging_components.ex:722
 #: lib/klass_hero_web/components/provider_components.ex:51
 #: lib/klass_hero_web/components/provider_components.ex:1637
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:434
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:465
 #: lib/klass_hero_web/presenters/provider_presenter.ex:103
 #, elixir-autogen, elixir-format
 msgid "Unknown"
@@ -1808,8 +1808,8 @@ msgstr ""
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:66
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:175
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:250
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:393
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:394
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:424
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:425
 #, elixir-autogen, elixir-format
 msgid "Send Broadcast"
 msgstr ""
@@ -1844,7 +1844,7 @@ msgid "Type a message..."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/participation_live.ex:307
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:251
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "Unable to refresh roster. Please reload."
 msgstr ""
@@ -2443,7 +2443,7 @@ msgid "No documents uploaded yet."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:2453
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:426
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:457
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
 msgstr ""
@@ -2728,7 +2728,7 @@ msgid "Role"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1736
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:386
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:417
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
 msgstr ""
@@ -3299,7 +3299,7 @@ msgid "Cannot check out without a check-in"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/programs_live.ex:451
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:147
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:150
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
 msgstr ""
@@ -3364,7 +3364,7 @@ msgstr ""
 
 #: lib/klass_hero_web/live/dashboard_live.ex:306
 #: lib/klass_hero_web/live/provider/programs_live.ex:448
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:201
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:204
 #, elixir-autogen, elixir-format
 msgid "Could not start conversation. Please try again."
 msgstr ""
@@ -3390,7 +3390,7 @@ msgid "Download monthly statements for taxes"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:2549
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:483
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:514
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrollment not confirmed"
 msgstr ""
@@ -3463,7 +3463,7 @@ msgid "No chasing payments or sending invoices"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1759
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:407
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:438
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No enrolled parents"
 msgstr ""
@@ -3486,7 +3486,7 @@ msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:2548
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:482
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:513
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
 msgstr ""
@@ -3588,7 +3588,7 @@ msgid "Track Everything:"
 msgstr ""
 
 #: lib/klass_hero_web/live/dashboard_live.ex:293
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:144
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Upgrade your plan to send messages."
 msgstr ""
@@ -3723,7 +3723,7 @@ msgstr ""
 msgid "Archived"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:321
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:324
 #, elixir-autogen, elixir-format
 msgid "Assigned Programs"
 msgstr ""
@@ -3796,7 +3796,7 @@ msgid "Complete Registration"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:76
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:301
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:319
 #, elixir-autogen, elixir-format
 msgid "Complete Session"
 msgstr ""
@@ -4026,7 +4026,7 @@ msgid "Max Capacity"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:90
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:315
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:333
 #, elixir-autogen, elixir-format
 msgid "No actions available"
 msgstr ""
@@ -4046,7 +4046,7 @@ msgstr ""
 msgid "No participation records yet"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:325
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:328
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No programs assigned yet."
 msgstr ""
@@ -4062,7 +4062,7 @@ msgid "No sessions found for the selected filters."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:122
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:330
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled"
 msgstr ""
@@ -4236,13 +4236,13 @@ msgstr ""
 msgid "Session created successfully"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:30
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:31
 #, elixir-autogen, elixir-format
 msgid "Staff Dashboard"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:54
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:279
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:297
 #, elixir-autogen, elixir-format
 msgid "Start Session"
 msgstr ""
@@ -4299,9 +4299,9 @@ msgid "Type your reply..."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.ex:183
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:123
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:94
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:123
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:126
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:102
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:139
 #, elixir-autogen, elixir-format
 msgid "Unauthorized"
 msgstr ""
@@ -4328,7 +4328,7 @@ msgid "Upload connection lost. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:87
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:312
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:330
 #, elixir-autogen, elixir-format
 msgid "View Participation"
 msgstr ""
@@ -4338,7 +4338,7 @@ msgstr ""
 msgid "View your children's participation records"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:214
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:217
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Welcome, %{name}"
 msgstr ""
@@ -4354,7 +4354,7 @@ msgid "You already have an account. Log in to see your new enrollment."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:125
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:333
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:351
 #, elixir-autogen, elixir-format
 msgid "You have no sessions scheduled for %{date}"
 msgstr ""
@@ -4379,7 +4379,7 @@ msgstr ""
 msgid "Your children's participation will appear here"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:363
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:366
 #, elixir-autogen, elixir-format
 msgid "Roster"
 msgstr ""
@@ -4389,7 +4389,7 @@ msgstr ""
 msgid "Unlimited team seats"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:243
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "View and manage your assigned sessions"
 msgstr ""
@@ -4890,7 +4890,7 @@ msgstr ""
 msgid "Submit report"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:221
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:224
 #, elixir-autogen, elixir-format
 msgid "Your pay rate"
 msgstr ""
@@ -5045,8 +5045,8 @@ msgstr ""
 msgid "Become a Hero →"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:269
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:314
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:272
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:317
 #, elixir-autogen, elixir-format
 msgid "Become a provider"
 msgstr ""
@@ -5234,7 +5234,7 @@ msgstr ""
 msgid "Could not link your account. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:176
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "Could not set up your provider profile. Please try again."
 msgstr ""
@@ -5800,13 +5800,13 @@ msgstr ""
 msgid "Not allowed to approve this enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:297
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:300
 #: lib/klass_hero_web/live/user_live/settings.ex:245
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:303
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "Offer your own programs on Klass Hero — alongside your work for %{business}."
 msgstr ""
@@ -6107,7 +6107,7 @@ msgstr ""
 msgid "Send us a message"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:286
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:289
 #: lib/klass_hero_web/live/user_live/settings.ex:235
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Setting up..."
@@ -6410,7 +6410,7 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:288
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:291
 #, elixir-autogen, elixir-format
 msgid "Yes, become a provider"
 msgstr ""
@@ -6420,7 +6420,7 @@ msgstr ""
 msgid "Yes. You can run unlimited programs, each with its own schedule and venue, and add as many team members as you need to delegate management across instructors."
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:80
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:83
 #: lib/klass_hero_web/live/user_live/settings.ex:490
 #, elixir-autogen, elixir-format
 msgid "You already have a provider profile."
@@ -6441,7 +6441,7 @@ msgstr ""
 msgid "You're logged in as %{current}. Log into the matching account to accept."
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:167
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:170
 #, elixir-autogen, elixir-format
 msgid "You're no longer on that team."
 msgstr ""
@@ -7674,7 +7674,7 @@ msgstr ""
 msgid "Waiver retired. Signatures already collected are kept."
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:220
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:198
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You are not assigned to this session"
 msgstr ""
@@ -7684,7 +7684,7 @@ msgstr ""
 msgid "Complete verification to create programs."
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:263
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:266
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Manage your provider profile"
 msgstr ""
@@ -7715,12 +7715,12 @@ msgstr ""
 msgid "Provider Profile"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:229
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:232
 #, elixir-autogen, elixir-format
 msgid "Switch provider"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:55
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:58
 #, elixir-autogen, elixir-format
 msgid "The provider associated with your account could not be found."
 msgstr ""
@@ -7745,13 +7745,13 @@ msgstr ""
 msgid "Verified Provider"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:72
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:75
 #: lib/klass_hero_web/live/user_live/settings.ex:485
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Welcome aboard! Let's set up your provider profile."
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:274
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:277
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You'll get your own provider profile to fill in, and your account will open on your provider dashboard from now on. You stay on %{business}'s team."
 msgstr ""
@@ -7888,4 +7888,21 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/overview_live.ex:322
 #, elixir-autogen, elixir-format
 msgid "waiting"
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:380
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Completed Programs"
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:384
+#, elixir-autogen, elixir-format
+msgid "These programs have finished. Their sessions and rosters are no longer available."
+msgstr ""
+
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:196
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:98
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:135
+#, elixir-autogen, elixir-format
+msgid "This program has closed. Its sessions are no longer available."
 msgstr ""

--- a/test/klass_hero/participation/attendance_authorization_test.exs
+++ b/test/klass_hero/participation/attendance_authorization_test.exs
@@ -64,6 +64,60 @@ defmodule KlassHero.Participation.AttendanceAuthorizationTest do
     end
   end
 
+  # The write path is the one the issue's acceptance criteria never mentioned: the
+  # LiveViews could all be closed and this would still have accepted the check-in.
+  # `authorize/2` itself is unchanged — the refusal arrives through the read model.
+  describe "authorize/2 and Closed Programs (#1082)" do
+    test "a staff member assigned to the program is refused once it closes" do
+      %{provider: provider, program: program, session: session} = provider_with_closed_session()
+      scope = scope_for(staff_member: assigned_staff(provider, program))
+
+      assert {:error, :unauthorized} = AttendanceAuthorization.authorize(scope, session)
+    end
+
+    test "a staff member overridden onto that one session is refused too" do
+      %{provider: provider, program: program, session: session} = provider_with_closed_session()
+      staff = ProviderFixtures.staff_member_fixture(%{provider_id: provider.id})
+
+      {:ok, _} =
+        Provider.assign_staff_to_session(%{
+          provider_id: provider.id,
+          program_id: program.id,
+          session_id: session.id,
+          staff_member_id: staff.id
+        })
+
+      assert {:error, :unauthorized} =
+               AttendanceAuthorization.authorize(scope_for(staff_member: staff), session)
+    end
+
+    test "the owning provider still corrects their own closed roster" do
+      %{provider: provider, session: session} = provider_with_closed_session()
+
+      assert {:ok, :provider} =
+               AttendanceAuthorization.authorize(scope_for(provider_profile: provider), session)
+    end
+
+    test "an admin still reaches a closed program" do
+      %{session: session} = provider_with_closed_session()
+      scope = scope_for(user: AccountsFixtures.user_fixture(is_admin: true))
+
+      assert {:ok, :admin} = AttendanceAuthorization.authorize(scope, session)
+    end
+
+    test "a staff member keeps access while the program is inside its grace window" do
+      provider = ProviderFixtures.provider_profile_fixture()
+
+      program =
+        insert(:program_schema, provider_id: provider.id, end_date: Date.add(Date.utc_today(), -1))
+
+      session = insert(:program_session_schema, program_id: program.id)
+      scope = scope_for(staff_member: assigned_staff(provider, program))
+
+      assert {:ok, :staff} = AttendanceAuthorization.authorize(scope, session)
+    end
+  end
+
   # These four pin the fall-through order itself. Each one returns a different
   # role under a different precedence, so they are what fails if the order is
   # ever reshuffled — the single-persona cases above pass under all of them.
@@ -178,6 +232,21 @@ defmodule KlassHero.Participation.AttendanceAuthorizationTest do
   defp provider_with_session do
     %{provider: provider, program: program} = provider_with_program()
     session = insert(:program_session_schema, program_id: program.id)
+
+    %{provider: provider, program: program, session: session}
+  end
+
+  defp provider_with_closed_session do
+    provider = ProviderFixtures.provider_profile_fixture()
+
+    program =
+      insert(:program_schema, provider_id: provider.id, end_date: Date.add(Date.utc_today(), -15))
+
+    session =
+      insert(:program_session_schema,
+        program_id: program.id,
+        session_date: Date.add(Date.utc_today(), -20)
+      )
 
     %{provider: provider, program: program, session: session}
   end

--- a/test/klass_hero/program_catalog/list_open_program_ids_test.exs
+++ b/test/klass_hero/program_catalog/list_open_program_ids_test.exs
@@ -68,32 +68,50 @@ defmodule KlassHero.ProgramCatalog.ListOpenProgramIdsTest do
     end
   end
 
-  describe "list_open_program_ids_for_provider/2" do
-    test "omits a program belonging to another provider", %{provider: provider} do
+  describe "split_programs_by_closure/2" do
+    test "puts a foreign program in NEITHER set", %{provider: provider} do
       own = program(provider, nil)
       foreign = insert(:program_schema, provider_id: insert(:provider_profile_schema).id)
 
-      assert ProgramCatalog.list_open_program_ids_for_provider(provider.id, [own.id, foreign.id]) ==
-               MapSet.new([own.id])
+      {open, closed} = ProgramCatalog.split_programs_by_closure(provider.id, [own.id, foreign.id])
+
+      assert open == MapSet.new([own.id])
+      # Not "closed" — that set is rendered back to the staff member as their
+      # Completed programs, so another provider's program must not land in it.
+      assert closed == MapSet.new()
     end
 
-    test "answers the closure question exactly as the unscoped sibling", %{provider: provider} do
-      open = program(provider, nil)
+    test "puts an id resolving to no program in neither set", %{provider: provider} do
+      {open, closed} = ProgramCatalog.split_programs_by_closure(provider.id, [Ecto.UUID.generate()])
+
+      assert open == MapSet.new()
+      assert closed == MapSet.new()
+    end
+
+    test "splits the provider's own programs on the grace window", %{provider: provider} do
+      never_ends = program(provider, nil)
       in_grace = program(provider, Date.add(Date.utc_today(), -14))
-      closed = program(provider, Date.add(Date.utc_today(), -15))
-      ids = [open.id, in_grace.id, closed.id]
+      closed_one = program(provider, Date.add(Date.utc_today(), -15))
 
-      assert ProgramCatalog.list_open_program_ids_for_provider(provider.id, ids) ==
-               ProgramCatalog.list_open_program_ids(ids)
+      {open, closed} =
+        ProgramCatalog.split_programs_by_closure(provider.id, [never_ends.id, in_grace.id, closed_one.id])
+
+      assert open == MapSet.new([never_ends.id, in_grace.id])
+      assert closed == MapSet.new([closed_one.id])
     end
 
-    test "omits an id that resolves to no program", %{provider: provider} do
-      assert ProgramCatalog.list_open_program_ids_for_provider(provider.id, [Ecto.UUID.generate()]) ==
-               MapSet.new()
+    test "agrees with the unscoped sibling on the open side", %{provider: provider} do
+      ids =
+        for end_date <- [nil, Date.add(Date.utc_today(), -14), Date.add(Date.utc_today(), -15)],
+            do: program(provider, end_date).id
+
+      {open, _closed} = ProgramCatalog.split_programs_by_closure(provider.id, ids)
+
+      assert open == ProgramCatalog.list_open_program_ids(ids)
     end
 
     test "short-circuits on an empty list", %{provider: provider} do
-      assert ProgramCatalog.list_open_program_ids_for_provider(provider.id, []) == MapSet.new()
+      assert ProgramCatalog.split_programs_by_closure(provider.id, []) == {MapSet.new(), MapSet.new()}
     end
   end
 

--- a/test/klass_hero/program_catalog/list_open_program_ids_test.exs
+++ b/test/klass_hero/program_catalog/list_open_program_ids_test.exs
@@ -1,0 +1,80 @@
+defmodule KlassHero.ProgramCatalog.ListOpenProgramIdsTest do
+  @moduledoc """
+  The batch closure question staff authorization asks (#1082).
+
+  Deliberately returns the **open** ids rather than the closed ones: callers
+  derive closed by set difference, so an id that does not resolve to a program at
+  all lands on the closed side. Fail-closed by construction.
+  """
+
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+
+  alias KlassHero.ProgramCatalog
+
+  setup do
+    %{provider: insert(:provider_profile_schema)}
+  end
+
+  defp program(provider, end_date) do
+    insert(:program_schema, provider_id: provider.id, end_date: end_date)
+  end
+
+  describe "list_open_program_ids/1" do
+    test "keeps a program that ended inside the grace window", %{provider: provider} do
+      program = program(provider, Date.add(Date.utc_today(), -1))
+
+      assert ProgramCatalog.list_open_program_ids([program.id]) == MapSet.new([program.id])
+    end
+
+    test "drops a program that ended before the grace window", %{provider: provider} do
+      program = program(provider, Date.add(Date.utc_today(), -15))
+
+      assert ProgramCatalog.list_open_program_ids([program.id]) == MapSet.new()
+    end
+
+    test "keeps an open-ended program", %{provider: provider} do
+      program = program(provider, nil)
+
+      assert ProgramCatalog.list_open_program_ids([program.id]) == MapSet.new([program.id])
+    end
+
+    test "omits an id that resolves to no program, so callers read it as closed" do
+      assert ProgramCatalog.list_open_program_ids([Ecto.UUID.generate()]) == MapSet.new()
+    end
+
+    test "asks one question of many ids", %{provider: provider} do
+      open = program(provider, nil)
+      closed = program(provider, Date.add(Date.utc_today(), -30))
+      in_grace = program(provider, Date.add(Date.utc_today(), -14))
+
+      assert ProgramCatalog.list_open_program_ids([open.id, closed.id, in_grace.id]) ==
+               MapSet.new([open.id, in_grace.id])
+    end
+
+    test "short-circuits on an empty list" do
+      assert ProgramCatalog.list_open_program_ids([]) == MapSet.new()
+    end
+
+    test "honours a configured grace window", %{provider: provider} do
+      program = program(provider, Date.add(Date.utc_today(), -5))
+
+      original = Application.get_env(:klass_hero, :program_access)
+      Application.put_env(:klass_hero, :program_access, closed_after_days: 3)
+      on_exit(fn -> Application.put_env(:klass_hero, :program_access, original) end)
+
+      assert ProgramCatalog.list_open_program_ids([program.id]) == MapSet.new()
+    end
+  end
+
+  describe "closed?/1" do
+    test "answers for a program already in hand, without a query", %{provider: provider} do
+      closed = program(provider, Date.add(Date.utc_today(), -15))
+      open = program(provider, Date.add(Date.utc_today(), -1))
+
+      assert ProgramCatalog.closed?(closed)
+      refute ProgramCatalog.closed?(open)
+    end
+  end
+end

--- a/test/klass_hero/program_catalog/list_open_program_ids_test.exs
+++ b/test/klass_hero/program_catalog/list_open_program_ids_test.exs
@@ -68,6 +68,35 @@ defmodule KlassHero.ProgramCatalog.ListOpenProgramIdsTest do
     end
   end
 
+  describe "list_open_program_ids_for_provider/2" do
+    test "omits a program belonging to another provider", %{provider: provider} do
+      own = program(provider, nil)
+      foreign = insert(:program_schema, provider_id: insert(:provider_profile_schema).id)
+
+      assert ProgramCatalog.list_open_program_ids_for_provider(provider.id, [own.id, foreign.id]) ==
+               MapSet.new([own.id])
+    end
+
+    test "answers the closure question exactly as the unscoped sibling", %{provider: provider} do
+      open = program(provider, nil)
+      in_grace = program(provider, Date.add(Date.utc_today(), -14))
+      closed = program(provider, Date.add(Date.utc_today(), -15))
+      ids = [open.id, in_grace.id, closed.id]
+
+      assert ProgramCatalog.list_open_program_ids_for_provider(provider.id, ids) ==
+               ProgramCatalog.list_open_program_ids(ids)
+    end
+
+    test "omits an id that resolves to no program", %{provider: provider} do
+      assert ProgramCatalog.list_open_program_ids_for_provider(provider.id, [Ecto.UUID.generate()]) ==
+               MapSet.new()
+    end
+
+    test "short-circuits on an empty list", %{provider: provider} do
+      assert ProgramCatalog.list_open_program_ids_for_provider(provider.id, []) == MapSet.new()
+    end
+  end
+
   describe "closed?/1" do
     test "answers for a program already in hand, without a query", %{provider: provider} do
       closed = program(provider, Date.add(Date.utc_today(), -15))

--- a/test/klass_hero/program_catalog/program_closed_test.exs
+++ b/test/klass_hero/program_catalog/program_closed_test.exs
@@ -1,0 +1,33 @@
+defmodule KlassHero.ProgramCatalog.ProgramClosedTest do
+  @moduledoc """
+  Whether a program has closed to its staff. Pure — no database and no config
+  read: the cutoff arrives as data, so the grace window stays the shell's
+  business (#1082).
+  """
+
+  use ExUnit.Case, async: true
+
+  alias KlassHero.ProgramCatalog.Program
+
+  @cutoff ~D[2026-08-06]
+
+  describe "closed?/2" do
+    # {end_date, closed?, description}
+    @cases [
+      {nil, false, "an open-ended program never closes"},
+      {~D[2026-08-05], true, "ended before the cutoff"},
+      {~D[2026-08-06], false, "ended on the cutoff — the grace window is inclusive"},
+      {~D[2026-08-07], false, "ended after the cutoff, still inside the grace window"},
+      {~D[2026-12-29], false, "still running"}
+    ]
+
+    for {end_date, expected, description} <- @cases do
+      test description do
+        program = %Program{end_date: unquote(Macro.escape(end_date))}
+
+        assert Program.closed?(program, @cutoff) == unquote(expected),
+               "closed?/2 disagreed for end_date #{inspect(unquote(Macro.escape(end_date)))}"
+      end
+    end
+  end
+end

--- a/test/klass_hero/provider/assignments/get_staff_program_access_test.exs
+++ b/test/klass_hero/provider/assignments/get_staff_program_access_test.exs
@@ -2,6 +2,7 @@ defmodule KlassHero.Provider.Assignments.GetStaffProgramAccessTest do
   use KlassHero.DataCase, async: true
 
   import KlassHero.Factory
+  import KlassHero.ProviderFixtures, only: [program_assignment_fixture: 1]
 
   alias KlassHero.Provider
   alias KlassHero.Provider.Domain.ReadModels.StaffProgramAccess
@@ -32,7 +33,7 @@ defmodule KlassHero.Provider.Assignments.GetStaffProgramAccessTest do
       assign(program, staff)
       assign(other_program, staff)
 
-      access = Provider.get_staff_program_access(staff.id)
+      access = Provider.get_staff_program_access(staff)
 
       assert %StaffProgramAccess{staff_member_id: staff_member_id} = access
       assert staff_member_id == staff.id
@@ -46,7 +47,7 @@ defmodule KlassHero.Provider.Assignments.GetStaffProgramAccessTest do
       assign(program, staff)
       {:ok, _} = Provider.unassign_staff_from_program(program.id, staff.id, provider.id)
 
-      refute StaffProgramAccess.authorized?(Provider.get_staff_program_access(staff.id), program.id)
+      refute StaffProgramAccess.authorized?(Provider.get_staff_program_access(staff), program.id)
     end
 
     test "does not leak a colleague's assignments" do
@@ -55,13 +56,13 @@ defmodule KlassHero.Provider.Assignments.GetStaffProgramAccessTest do
 
       assign(program, colleague)
 
-      refute StaffProgramAccess.authorized?(Provider.get_staff_program_access(staff.id), program.id)
+      refute StaffProgramAccess.authorized?(Provider.get_staff_program_access(staff), program.id)
     end
 
     test "authorizes nothing for a staff member with no assignments" do
       {_provider, program, staff} = setup_provider_program_staff()
 
-      access = Provider.get_staff_program_access(staff.id)
+      access = Provider.get_staff_program_access(staff)
 
       assert %StaffProgramAccess{program_ids: program_ids} = access
       assert MapSet.size(program_ids) == 0
@@ -76,7 +77,7 @@ defmodule KlassHero.Provider.Assignments.GetStaffProgramAccessTest do
 
       assign(closed, staff)
 
-      access = Provider.get_staff_program_access(staff.id)
+      access = Provider.get_staff_program_access(staff)
 
       refute StaffProgramAccess.authorized?(access, closed.id)
       assert StaffProgramAccess.closed?(access, closed.id)
@@ -88,7 +89,7 @@ defmodule KlassHero.Provider.Assignments.GetStaffProgramAccessTest do
 
       assign(recent, staff)
 
-      access = Provider.get_staff_program_access(staff.id)
+      access = Provider.get_staff_program_access(staff)
 
       assert StaffProgramAccess.authorized?(access, recent.id)
       refute StaffProgramAccess.closed?(access, recent.id)
@@ -101,10 +102,29 @@ defmodule KlassHero.Provider.Assignments.GetStaffProgramAccessTest do
       assign(open, staff)
       assign(closed, staff)
 
-      access = Provider.get_staff_program_access(staff.id)
+      access = Provider.get_staff_program_access(staff)
 
       assert access.program_ids == MapSet.new([open.id])
       assert access.closed_program_ids == MapSet.new([closed.id])
+    end
+
+    test "grants nothing for a program belonging to another provider" do
+      {_provider, _program, staff} = setup_provider_program_staff()
+      foreign = insert(:program_schema, provider_id: insert(:provider_profile_schema).id)
+
+      # Only a fixture can build this row: `assign_staff_to_program/1` proves both
+      # the staff member and the program belong to the caller's provider before
+      # inserting. Defence in depth against a write path that skips the facade.
+      program_assignment_fixture(%{
+        provider_id: foreign.provider_id,
+        program_id: foreign.id,
+        staff_member_id: staff.id
+      })
+
+      access = Provider.get_staff_program_access(staff)
+
+      refute StaffProgramAccess.authorized?(access, foreign.id)
+      refute MapSet.member?(access.program_ids, foreign.id)
     end
 
     test "reports a program that is not closed as not closed" do
@@ -112,7 +132,7 @@ defmodule KlassHero.Provider.Assignments.GetStaffProgramAccessTest do
 
       assign(open, staff)
 
-      refute StaffProgramAccess.closed?(Provider.get_staff_program_access(staff.id), open.id)
+      refute StaffProgramAccess.closed?(Provider.get_staff_program_access(staff), open.id)
     end
   end
 end

--- a/test/klass_hero/provider/assignments/get_staff_program_access_test.exs
+++ b/test/klass_hero/provider/assignments/get_staff_program_access_test.exs
@@ -68,4 +68,51 @@ defmodule KlassHero.Provider.Assignments.GetStaffProgramAccessTest do
       refute StaffProgramAccess.authorized?(access, program.id)
     end
   end
+
+  describe "get_staff_program_access/1 and Closed Programs (#1082)" do
+    test "refuses a program that closed, while still naming it as assigned" do
+      {provider, _program, staff} = setup_provider_program_staff()
+      closed = insert(:program_schema, provider_id: provider.id, end_date: Date.add(Date.utc_today(), -15))
+
+      assign(closed, staff)
+
+      access = Provider.get_staff_program_access(staff.id)
+
+      refute StaffProgramAccess.authorized?(access, closed.id)
+      assert StaffProgramAccess.closed?(access, closed.id)
+    end
+
+    test "keeps a program that ended inside the grace window" do
+      {provider, _program, staff} = setup_provider_program_staff()
+      recent = insert(:program_schema, provider_id: provider.id, end_date: Date.add(Date.utc_today(), -1))
+
+      assign(recent, staff)
+
+      access = Provider.get_staff_program_access(staff.id)
+
+      assert StaffProgramAccess.authorized?(access, recent.id)
+      refute StaffProgramAccess.closed?(access, recent.id)
+    end
+
+    test "partitions a mixed roster into open and closed" do
+      {provider, open, staff} = setup_provider_program_staff()
+      closed = insert(:program_schema, provider_id: provider.id, end_date: Date.add(Date.utc_today(), -30))
+
+      assign(open, staff)
+      assign(closed, staff)
+
+      access = Provider.get_staff_program_access(staff.id)
+
+      assert access.program_ids == MapSet.new([open.id])
+      assert access.closed_program_ids == MapSet.new([closed.id])
+    end
+
+    test "reports a program that is not closed as not closed" do
+      {_provider, open, staff} = setup_provider_program_staff()
+
+      assign(open, staff)
+
+      refute StaffProgramAccess.closed?(Provider.get_staff_program_access(staff.id), open.id)
+    end
+  end
 end

--- a/test/klass_hero/provider/assignments/get_staff_program_access_test.exs
+++ b/test/klass_hero/provider/assignments/get_staff_program_access_test.exs
@@ -125,6 +125,9 @@ defmodule KlassHero.Provider.Assignments.GetStaffProgramAccessTest do
 
       refute StaffProgramAccess.authorized?(access, foreign.id)
       refute MapSet.member?(access.program_ids, foreign.id)
+      # And not in the closed set either: that one is rendered as "Completed", so
+      # landing there would list another provider's program back to this person.
+      refute StaffProgramAccess.closed?(access, foreign.id)
     end
 
     test "reports a program that is not closed as not closed" do

--- a/test/klass_hero/provider/domain/read_models/session_staffing_test.exs
+++ b/test/klass_hero/provider/domain/read_models/session_staffing_test.exs
@@ -11,7 +11,8 @@ defmodule KlassHero.Provider.Domain.ReadModels.SessionStaffingTest do
         lead: nil,
         member_ids: [],
         member_count: 0,
-        source: :program
+        source: :program,
+        program_closed?: false
       },
       overrides
     )
@@ -70,6 +71,43 @@ defmodule KlassHero.Provider.Domain.ReadModels.SessionStaffingTest do
     test "distinguishes a deliberate override from an inherited roster" do
       assert SessionStaffing.overridden?(staffing(%{source: :override}))
       refute SessionStaffing.overridden?(staffing(%{source: :program}))
+    end
+  end
+
+  describe "a Closed Program (#1082)" do
+    setup do
+      %{
+        closed:
+          staffing(%{
+            member_ids: ["staff-1", "staff-2"],
+            member_count: 2,
+            lead: %{id: "staff-1"},
+            source: :override,
+            program_closed?: true
+          })
+      }
+    end
+
+    test "refuses a member who is genuinely on the session", %{closed: closed} do
+      refute SessionStaffing.staffed_by?(closed, "staff-1")
+      refute SessionStaffing.staffed_by?(closed, "staff-2")
+    end
+
+    test "refuses the lead", %{closed: closed} do
+      refute SessionStaffing.led_by?(closed, "staff-1")
+    end
+
+    test "still reports the roster and its source", %{closed: closed} do
+      # Display facts, not authorization: the provider's own staffing panel keeps
+      # working on a closed program, and only the two predicates are gated.
+      assert closed.member_ids == ["staff-1", "staff-2"]
+      assert closed.member_count == 2
+      assert closed.lead == %{id: "staff-1"}
+      assert SessionStaffing.overridden?(closed)
+    end
+
+    test "empty/2 is open — closure is a fact about a program, not about having no staff" do
+      refute SessionStaffing.empty("sess-1", "prog-1").program_closed?
     end
   end
 end

--- a/test/klass_hero_web/helpers/staff_live_helpers_test.exs
+++ b/test/klass_hero_web/helpers/staff_live_helpers_test.exs
@@ -7,13 +7,22 @@ defmodule KlassHeroWeb.Helpers.StaffLiveHelpersTest do
   alias KlassHero.Provider.Domain.ReadModels.StaffProgramAccess
   alias KlassHeroWeb.Helpers.StaffLiveHelpers
 
-  # The write row backs ownership checks; the listing row is what
-  # `ProgramCatalog.list_programs_for_provider/1` reads, and it only matches when
-  # the two share an id (the projection would normally keep them in step).
-  defp program(provider, category) do
-    program = insert(:program_schema, provider_id: provider.id, category: category)
+  # The listing row is no longer what this helper reads — it fetches the write
+  # rows its assignments name (#1082) — but it is still inserted here so these
+  # tests keep exercising the shape the rest of the staff surfaces see.
+  defp program(provider, category, attrs \\ []) do
+    attrs = Keyword.merge([provider_id: provider.id, category: category], attrs)
+    program = insert(:program_schema, attrs)
     insert(:program_listing_schema, id: program.id, provider_id: provider.id, category: category)
     program
+  end
+
+  defp assign(program, staff) do
+    program_assignment_fixture(%{
+      provider_id: program.provider_id,
+      program_id: program.id,
+      staff_member_id: staff.id
+    })
   end
 
   describe "load_assigned_programs/1" do
@@ -22,15 +31,12 @@ defmodule KlassHeroWeb.Helpers.StaffLiveHelpersTest do
       staff = staff_member_fixture(provider_id: provider.id, tags: ["sports"])
       arts_program = program(provider, "arts")
 
-      program_assignment_fixture(%{
-        provider_id: provider.id,
-        program_id: arts_program.id,
-        staff_member_id: staff.id
-      })
+      assign(arts_program, staff)
 
-      {programs, access} = StaffLiveHelpers.load_assigned_programs(staff)
+      {open, closed, access} = StaffLiveHelpers.load_assigned_programs(staff)
 
-      assert Enum.map(programs, & &1.id) == [arts_program.id]
+      assert Enum.map(open, & &1.id) == [arts_program.id]
+      assert closed == []
       assert StaffProgramAccess.authorized?(access, arts_program.id)
     end
 
@@ -39,9 +45,10 @@ defmodule KlassHeroWeb.Helpers.StaffLiveHelpersTest do
       staff = staff_member_fixture(provider_id: provider.id, tags: [])
       sports_program = program(provider, "sports")
 
-      {programs, access} = StaffLiveHelpers.load_assigned_programs(staff)
+      {open, closed, access} = StaffLiveHelpers.load_assigned_programs(staff)
 
-      assert programs == []
+      assert open == []
+      assert closed == []
       refute StaffProgramAccess.authorized?(access, sports_program.id)
     end
 
@@ -52,27 +59,77 @@ defmodule KlassHeroWeb.Helpers.StaffLiveHelpersTest do
       own = program(provider, "sports")
       foreign = program(other_provider, "sports")
 
-      for p <- [own, foreign] do
-        program_assignment_fixture(%{
-          provider_id: p.provider_id,
-          program_id: p.id,
-          staff_member_id: staff.id
-        })
-      end
+      for p <- [own, foreign], do: assign(p, staff)
 
-      {programs, _access} = StaffLiveHelpers.load_assigned_programs(staff)
+      {open, _closed, _access} = StaffLiveHelpers.load_assigned_programs(staff)
 
-      assert Enum.map(programs, & &1.id) == [own.id]
+      assert Enum.map(open, & &1.id) == [own.id]
     end
 
     test "returns no programs and an empty access when the provider has none" do
       provider = provider_profile_fixture()
       staff = staff_member_fixture(provider_id: provider.id, tags: [])
 
-      assert {[], %StaffProgramAccess{program_ids: program_ids}} =
+      assert {[], [], %StaffProgramAccess{program_ids: program_ids}} =
                StaffLiveHelpers.load_assigned_programs(staff)
 
       assert MapSet.size(program_ids) == 0
+    end
+
+    test "orders each list by title" do
+      provider = provider_profile_fixture()
+      staff = staff_member_fixture(provider_id: provider.id, tags: [])
+      zebra = program(provider, "sports", title: "Zebra")
+      alpha = program(provider, "sports", title: "Alpha")
+
+      for p <- [zebra, alpha], do: assign(p, staff)
+
+      {open, _closed, _access} = StaffLiveHelpers.load_assigned_programs(staff)
+
+      assert Enum.map(open, & &1.title) == ["Alpha", "Zebra"]
+    end
+  end
+
+  describe "load_assigned_programs/1 and Closed Programs (#1082)" do
+    setup do
+      provider = provider_profile_fixture()
+      staff = staff_member_fixture(provider_id: provider.id, tags: [])
+
+      %{provider: provider, staff: staff}
+    end
+
+    test "splits the roster into open and closed", %{provider: provider, staff: staff} do
+      open = program(provider, "sports", title: "Still Running")
+      closed = program(provider, "arts", title: "Last Spring", end_date: Date.add(Date.utc_today(), -20))
+
+      for p <- [open, closed], do: assign(p, staff)
+
+      {open_programs, closed_programs, _access} = StaffLiveHelpers.load_assigned_programs(staff)
+
+      assert Enum.map(open_programs, & &1.id) == [open.id]
+      assert Enum.map(closed_programs, & &1.id) == [closed.id]
+    end
+
+    test "keeps a program inside its grace window open", %{provider: provider, staff: staff} do
+      recent = program(provider, "sports", end_date: Date.add(Date.utc_today(), -2))
+
+      assign(recent, staff)
+
+      {open_programs, closed_programs, _access} = StaffLiveHelpers.load_assigned_programs(staff)
+
+      assert Enum.map(open_programs, & &1.id) == [recent.id]
+      assert closed_programs == []
+    end
+
+    test "still names a closed program, so it can be listed read-only", %{provider: provider, staff: staff} do
+      closed = program(provider, "arts", title: "Autumn Club", end_date: Date.add(Date.utc_today(), -60))
+
+      assign(closed, staff)
+
+      {_open, [listed], _access} = StaffLiveHelpers.load_assigned_programs(staff)
+
+      assert listed.title == "Autumn Club"
+      assert listed.category == "arts"
     end
   end
 end

--- a/test/klass_hero_web/helpers/staff_live_helpers_test.exs
+++ b/test/klass_hero_web/helpers/staff_live_helpers_test.exs
@@ -66,9 +66,12 @@ defmodule KlassHeroWeb.Helpers.StaffLiveHelpersTest do
 
       for p <- [own, foreign], do: assign(p, staff)
 
-      {open, _closed, _access} = StaffLiveHelpers.load_assigned_programs(staff)
+      {open, closed, _access} = StaffLiveHelpers.load_assigned_programs(staff)
 
       assert Enum.map(open, & &1.id) == [own.id]
+      # And not merely absent from the actionable list: a foreign program must not
+      # be rendered in the read-only "Completed" section either.
+      refute foreign.id in Enum.map(closed, & &1.id)
     end
 
     test "returns no programs and an empty access when the provider has none" do

--- a/test/klass_hero_web/helpers/staff_live_helpers_test.exs
+++ b/test/klass_hero_web/helpers/staff_live_helpers_test.exs
@@ -52,6 +52,11 @@ defmodule KlassHeroWeb.Helpers.StaffLiveHelpersTest do
       refute StaffProgramAccess.authorized?(access, sports_program.id)
     end
 
+    # Defence in depth, not a reachable state: `assign_staff_to_program/1` proves
+    # ownership of both the staff member and the program before inserting, so only
+    # a fixture (or the facade-bypassing seed script) can build this row. Nothing
+    # in the database enforces it, and this is the surface where such a row would
+    # become a child's roster — so the exclusion is asserted rather than assumed.
     test "excludes an assigned program belonging to another provider" do
       provider = provider_profile_fixture()
       other_provider = provider_profile_fixture()

--- a/test/klass_hero_web/live/staff/staff_broadcast_live_test.exs
+++ b/test/klass_hero_web/live/staff/staff_broadcast_live_test.exs
@@ -109,6 +109,30 @@ defmodule KlassHeroWeb.Staff.StaffBroadcastLiveTest do
       assert flash["info"] =~ "Broadcast sent"
     end
 
+    # The issue's acceptance criteria never mentioned this surface. It closes with
+    # no change here: composing is gated on `StaffProgramAccess.authorized?/2`,
+    # which stopped saying yes once the program closed (#1082).
+    test "rejects broadcast for a Closed Program the staff member is still assigned to",
+         %{conn: conn, provider: provider, staff: staff} do
+      closed =
+        insert(:program_schema,
+          provider_id: provider.id,
+          category: "sports",
+          end_date: Date.add(Date.utc_today(), -20)
+        )
+
+      insert(:program_listing_schema, id: closed.id, provider_id: provider.id, category: "sports")
+
+      program_assignment_fixture(%{
+        provider_id: provider.id,
+        program_id: closed.id,
+        staff_member_id: staff.id
+      })
+
+      assert {:error, {:live_redirect, %{to: "/staff/dashboard"}}} =
+               live(conn, ~p"/staff/programs/#{closed.id}/broadcast")
+    end
+
     test "rejects broadcast for non-assigned program", %{conn: conn, provider: provider} do
       # Category "sports" matches the staff member's Specialties deliberately: what
       # rejects this is the missing Program Staff Assignment (#1323). Compose and the

--- a/test/klass_hero_web/live/staff/staff_dashboard_live_test.exs
+++ b/test/klass_hero_web/live/staff/staff_dashboard_live_test.exs
@@ -14,12 +14,28 @@ defmodule KlassHeroWeb.Staff.StaffDashboardLiveTest do
   # these tests no longer derive it from `staff.tags`.
   defp assigned_listing(provider, staff, attrs \\ []) do
     category = Keyword.get(attrs, :category, "sports")
-    write = insert(:program_schema, provider_id: provider.id, category: category)
 
+    # `end_date` goes on the **write** row as well as the listing: closure is read
+    # from `programs`, never from the projection, so setting it only on the
+    # listing would leave the program open however long ago it ended (#1082).
+    write =
+      insert(:program_schema,
+        provider_id: provider.id,
+        category: category,
+        end_date: Keyword.get(attrs, :end_date)
+      )
+
+    # `title:` is copied from the write row rather than left to the factory
+    # sequence: the projection keeps the two in step in production, and since
+    # #1082 the dashboard reads the write row, so a fixture that let them drift
+    # would be testing a state that cannot occur.
     listing =
       insert(
         :program_listing_schema,
-        Keyword.merge([id: write.id, provider_id: provider.id, category: category], attrs)
+        Keyword.merge(
+          [id: write.id, provider_id: provider.id, category: category, title: write.title],
+          attrs
+        )
       )
 
     program_assignment_fixture(%{
@@ -86,6 +102,59 @@ defmodule KlassHeroWeb.Staff.StaffDashboardLiveTest do
       refute html =~ "rate-label"
       refute html =~ "/ hour"
       refute html =~ "/ session"
+    end
+
+    test "a Closed Program is listed read-only, with no way to act on it (#1082)", %{
+      conn: conn,
+      provider: provider,
+      staff: staff
+    } do
+      closed = assigned_listing(provider, staff, end_date: Date.add(Date.utc_today(), -20))
+
+      {:ok, view, _html} = live(conn, ~p"/staff/dashboard")
+
+      assert has_element?(view, "#completed-programs")
+      refute has_element?(view, "#sessions-link-#{closed.id}")
+      refute has_element?(view, "#roster-btn-#{closed.id}")
+    end
+
+    test "a Closed Program's roster refuses a forged event, not only a hidden button", %{
+      conn: conn,
+      provider: provider,
+      staff: staff
+    } do
+      closed = assigned_listing(provider, staff, end_date: Date.add(Date.utc_today(), -20))
+
+      {:ok, view, _html} = live(conn, ~p"/staff/dashboard")
+
+      render_click(view, "view_roster", %{"id" => closed.id, "title" => closed.title})
+
+      refute has_element?(view, "#staff-roster-modal")
+    end
+
+    test "a program inside its grace window stays actionable", %{
+      conn: conn,
+      provider: provider,
+      staff: staff
+    } do
+      recent = assigned_listing(provider, staff, end_date: Date.add(Date.utc_today(), -2))
+
+      {:ok, view, _html} = live(conn, ~p"/staff/dashboard")
+
+      assert has_element?(view, "#roster-btn-#{recent.id}")
+      refute has_element?(view, "#completed-programs")
+    end
+
+    test "the Completed section is absent when nothing has closed", %{
+      conn: conn,
+      provider: provider,
+      staff: staff
+    } do
+      assigned_listing(provider, staff)
+
+      {:ok, view, _html} = live(conn, ~p"/staff/dashboard")
+
+      refute has_element?(view, "#completed-programs")
     end
 
     test "non-staff user is redirected", %{} do

--- a/test/klass_hero_web/live/staff/staff_participation_live_test.exs
+++ b/test/klass_hero_web/live/staff/staff_participation_live_test.exs
@@ -54,6 +54,35 @@ defmodule KlassHeroWeb.Staff.StaffParticipationLiveTest do
                live(conn, ~p"/staff/participation/#{session.id}")
     end
 
+    test "redirects a staff member off a Closed Program's roster, saying why (#1082)", %{conn: conn} do
+      %{conn: conn, provider: provider, staff: staff} = register_and_log_in_staff(%{conn: conn})
+
+      closed =
+        insert(:program_schema,
+          provider_id: provider.id,
+          category: "sports",
+          end_date: Date.add(Date.utc_today(), -20)
+        )
+
+      ProviderFixtures.program_assignment_fixture(%{
+        provider_id: provider.id,
+        program_id: closed.id,
+        staff_member_id: staff.id
+      })
+
+      session =
+        insert(:program_session_schema,
+          program_id: closed.id,
+          session_date: Date.add(Date.utc_today(), -25),
+          status: :completed
+        )
+
+      assert {:error, {:live_redirect, %{to: "/staff/sessions", flash: flash}}} =
+               live(conn, ~p"/staff/participation/#{session.id}")
+
+      assert flash["error"] =~ "This program has closed"
+    end
+
     test "opens the roster for a session the staff member covers without the program", %{conn: conn} do
       %{conn: conn, provider: provider, staff: staff} = register_and_log_in_staff(%{conn: conn})
       session = session_in_new_program(provider)

--- a/test/klass_hero_web/live/staff/staff_sessions_live_test.exs
+++ b/test/klass_hero_web/live/staff/staff_sessions_live_test.exs
@@ -35,7 +35,15 @@ defmodule KlassHeroWeb.Staff.StaffSessionsLiveTest do
 
   defp build_program(provider, attrs) do
     category = Keyword.get(attrs, :category, "sports")
-    program = insert(:program_schema, provider_id: provider.id, category: category)
+
+    # `end_date` belongs on the write row: closure is read from `programs`, never
+    # from the projection (#1082).
+    program =
+      insert(:program_schema,
+        provider_id: provider.id,
+        category: category,
+        end_date: Keyword.get(attrs, :end_date)
+      )
 
     insert(
       :program_listing_schema,
@@ -220,6 +228,43 @@ defmodule KlassHeroWeb.Staff.StaffSessionsLiveTest do
       render_click(view, "start_session", %{"session_id" => session.id})
 
       assert render(view) =~ "Unauthorized"
+    end
+
+    test "hides a Closed Program's sessions, on the day they fell (#1082)",
+         %{conn: conn} = ctx do
+      closed = assigned_program(ctx, title: "Spring Term", end_date: Date.add(Date.utc_today(), -20))
+      session = session_on(closed, Date.add(Date.utc_today(), -25), :completed)
+
+      {:ok, view, _html} = live(conn, ~p"/staff/sessions")
+
+      render_change(view, "change_date", %{"date" => Date.to_iso8601(session.session_date)})
+
+      refute has_element?(view, "#sessions-#{session.id}")
+      refute render(view) =~ "Spring Term"
+    end
+
+    test "still shows an open program's old sessions — an old date is not a closed program",
+         %{conn: conn} = ctx do
+      open = assigned_program(ctx, title: "Year Long Club")
+      session = session_on(open, Date.add(Date.utc_today(), -25), :completed)
+
+      {:ok, view, _html} = live(conn, ~p"/staff/sessions")
+
+      render_change(view, "change_date", %{"date" => Date.to_iso8601(session.session_date)})
+
+      assert render(view) =~ "Year Long Club"
+    end
+
+    test "rejects start_session on a Closed Program, naming the reason",
+         %{conn: conn} = ctx do
+      closed = assigned_program(ctx, title: "Spring Term", end_date: Date.add(Date.utc_today(), -20))
+      session = session_on(closed, Date.utc_today(), :scheduled)
+
+      {:ok, view, _html} = live(conn, ~p"/staff/sessions")
+
+      render_click(view, "start_session", %{"session_id" => session.id})
+
+      assert render(view) =~ "This program has closed"
     end
 
     test "filters sessions by program_id query param", %{conn: conn} = ctx do


### PR DESCRIPTION
Closes #1082

## Summary

A staff member assigned to a program keeps full access to its sessions and rosters forever — nothing consults `end_date` for authorization. Someone whose season finished a year ago can still open a child's roster, check a child in or out, correct an attendance record, and broadcast to enrolled parents. This most concerns people who were *deactivated* rather than offboarded, whose Program Staff Assignments deliberately survive.

A program is now **Closed** once it has been over for longer than a grace window (`config :klass_hero, :program_access, closed_after_days: 14`). Closure is derived from `end_date` — no migration, no status column, no lifecycle transition; a program with no end date never closes.

The rule is applied where the Provider read models are **built**, not at the surfaces that ask them:

- `StaffProgramAccess` carries `program_ids` (assigned **and** open) plus `closed_program_ids`, so `authorized?/2` refuses a closed program and `closed?/2` backs the dashboard's read-only Completed list.
- `SessionStaffing` carries `program_closed?`, gating `staffed_by?/2` and `led_by?/2` while leaving `member_ids`/`lead`/`overridden?/1` alone, so the provider's staffing panel keeps working.

Four of the five call sites therefore change **no logic** and become correct:

| Surface | Change |
|---|---|
| `Participation.AttendanceAuthorization` | none |
| `StaffBroadcastLive` | none |
| `StaffDashboardLive` roster handler | none |
| `StaffSessionsLive` | none for the gate; message copy only |
| `StaffParticipationLive` | message copy only |

Provider and admin are unaffected — they still have to correct what happened after a season ends. ADR-0017's fall-through order is untouched; only the staff branch's answer narrowed.

## Why not the issue's acceptance criteria

The issue asked the four staff LiveViews to filter closed programs out. That spec predates three refactors — it cites `program_catalog/domain/models/program.ex` and `ProgramRepository`, both deleted in the flatten, and says `StaffSessionsLive` gates on `assigned_program_ids`, which stopped being true at #782/#783.

More importantly it would have put one authorization rule in four places and left the fifth — the context write path, the guard of record since ADR-0017 — accepting writes the UI had stopped offering, plus missed `StaffBroadcastLive` entirely. That is the shape #1323 removed. See `docs/adr/0019-closed-programs-revoke-staff-access.md`.

## Review Focus

- **`StaffProgramAccess` no longer means one thing.** Its moduledoc claimed derivation from assignment rows only (#1323); it is now assignment rows narrowed by closure. The moduledoc is rewritten to say so. Is that widening acceptable, or should closure have stayed a separate composed predicate?
- **Every `SessionStaffing` consumer pays a ProgramCatalog query**, including four provider-side callers (`assignments.ex:360, 394, 413, 433`) that read only `member_ids`/`lead` and cannot use the answer. Batched per distinct program, so a full day costs one query, not one per row. The alternative — closure as an argument only auth call sites pass — makes the query conditional but lets a future call site silently omit it.
- **Fail-closed by construction**: `list_open_program_ids/1` returns the *open* ids and callers derive closed by set difference, so an assignment naming a program that no longer resolves grants nothing.
- **`:program_access` is its own config key**, deliberately not reusing Messaging's `days_after_program_end: 30`. Same shape, different reasons to change: one is data retention, the other is who may see a child's record.
- **The dashboard now reads write rows** (`get_programs_by_ids/1`) instead of listing the provider's whole catalogue — fewer rows, and off the projection entirely. It re-filters by `provider_id` because that getter is not provider-scoped.
- **Grace window is 14 days.** Long enough for a late check-out and a final correction, short enough not to leave a departed collaborator on child data for a month.

## Test Plan

- `mix precommit` green: **4788 tests**, credo `--strict` clean, `lint_translations` / `lint_read_tables` / `lint_acl_boundary` all pass, zero warnings.
- New: `program_closed_test.exs` (tabular, incl. the inclusive boundary day), `list_open_program_ids_test.exs` (grace, nil end date, unknown id, configured window).
- Extended: `get_staff_program_access_test.exs` (partitioning), `session_staffing_test.exs` (predicates gated, display fields not), `attendance_authorization_test.exs` (**staff refused, provider and admin still allowed** — the write path, asserted without touching the module), and all four staff LiveView tests.
- Two test fixtures were setting `end_date` on the **listing** row only; they now set it on the write row too, which is exactly the drift this design refuses to read from.
- Verified against seeded dev data via Tidewave: 2 staff assigned to a closed program, both refused at program and session grain, both still named for the Completed list; `AttendanceAuthorization` returns `{:error, :unauthorized}` for staff and `{:ok, :provider}` / `{:ok, :admin}` on the same session; a staff member on an open program still returns `{:ok, :staff}`.
- **Not done:** the browser pass. Chrome DevTools MCP could not attach to the running browser instance and the Claude extension is not connected. The Completed section's markup is covered by LiveView tests, but its visual/mobile rendering has not been eyeballed.

## German

Both new strings translated in this PR ("Abgeschlossene Programme", "Dieses Programm ist abgeschlossen…"); a fuzzy match on the section heading was corrected rather than left.
