### PR TITLE
fix: replace dead hero-* colour utilities and guard against new ones

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,9 @@ jobs:
       - name: Typography lint
         run: mix lint_typography
 
+      - name: Hero colour tokens resolve
+        run: mix lint_hero_colors
+
       - name: Gettext catalog check (structure + DE completeness)
         run: mix lint_translations
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,6 +190,7 @@ These checks run automatically on every PR — don't manually recheck what CI ca
 | `mix format --check-formatted` | Formatting issues |
 | `mix credo --strict` | Style violations, code smells, long lines, TODO tags |
 | `mix lint_typography` | Font/typography usage violations |
+| `mix lint_hero_colors` | A `hero-*` colour utility with no matching `--color-*` token in `app.css`'s `@theme` — Tailwind v4 emits no rule for these, silently, so they render unstyled |
 | `mix lint_translations` | Stale `.pot` templates, empty/fuzzy German `msgstr` |
 | `mix lint_read_tables` | Projection read-table convention: a context-root schema that is neither an entity nor a declared read table, a read table carrying a changeset, or a read table outside the context root |
 | `mix lint_acl_boundary` | A function reading another context's table (`in "<table>"`) without an `acl_span` — ADR 0015 permits the direct read but requires the hop stay visible in traces |

--- a/lib/klass_hero_web/components/program_components.ex
+++ b/lib/klass_hero_web/components/program_components.ex
@@ -656,7 +656,7 @@ defmodule KlassHeroWeb.ProgramComponents do
           <span
             :for={tag <- @tags}
             class={[
-              "px-2 py-0.5 text-xs font-medium bg-hero-cyan-100 text-hero-cyan",
+              "px-2 py-0.5 text-xs font-medium bg-hero-blue-100 text-hero-blue-800",
               Theme.rounded(:full)
             ]}
           >

--- a/lib/klass_hero_web/components/provider_components.ex
+++ b/lib/klass_hero_web/components/provider_components.ex
@@ -161,14 +161,14 @@ defmodule KlassHeroWeb.ProviderComponents do
         value="12,500"
         icon="hero-currency-euro-mini"
         icon_bg="bg-hero-blue-100"
-        icon_color="text-hero-blue-800"
+        icon_color="text-hero-blue-600"
       />
   """
   attr :label, :string, required: true
   attr :value, :string, required: true
   attr :icon, :string, required: true
   attr :icon_bg, :string, default: "bg-hero-blue-100"
-  attr :icon_color, :string, default: "text-hero-blue-800"
+  attr :icon_color, :string, default: "text-hero-blue-600"
 
   def provider_stat_card(assigns) do
     ~H"""

--- a/lib/klass_hero_web/components/provider_components.ex
+++ b/lib/klass_hero_web/components/provider_components.ex
@@ -139,7 +139,7 @@ defmodule KlassHeroWeb.ProviderComponents do
       class={[
         "flex items-center gap-2 px-4 py-3 text-sm font-medium whitespace-nowrap border-b-2 transition-colors",
         if(@active,
-          do: "border-hero-cyan text-hero-cyan",
+          do: "border-hero-blue-500 text-hero-blue-600",
           else:
             "border-transparent text-hero-grey-500 hover:text-hero-grey-700 hover:border-hero-grey-300"
         )
@@ -160,15 +160,15 @@ defmodule KlassHeroWeb.ProviderComponents do
         label="Total Revenue"
         value="12,500"
         icon="hero-currency-euro-mini"
-        icon_bg="bg-hero-cyan-100"
-        icon_color="text-hero-cyan"
+        icon_bg="bg-hero-blue-100"
+        icon_color="text-hero-blue-800"
       />
   """
   attr :label, :string, required: true
   attr :value, :string, required: true
   attr :icon, :string, required: true
-  attr :icon_bg, :string, default: "bg-hero-cyan-100"
-  attr :icon_color, :string, default: "text-hero-cyan"
+  attr :icon_bg, :string, default: "bg-hero-blue-100"
+  attr :icon_color, :string, default: "text-hero-blue-800"
 
   def provider_stat_card(assigns) do
     ~H"""
@@ -182,7 +182,7 @@ defmodule KlassHeroWeb.ProviderComponents do
         </div>
         <div>
           <p class="text-sm text-hero-grey-500">{@label}</p>
-          <p class="text-2xl font-bold text-hero-charcoal">{@value}</p>
+          <p class="text-2xl font-bold text-hero-black-100">{@value}</p>
         </div>
       </div>
     </div>
@@ -203,7 +203,7 @@ defmodule KlassHeroWeb.ProviderComponents do
     <div class={["bg-white p-6 shadow-sm border border-hero-grey-200", Theme.rounded(:xl)]}>
       <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-4">
         <div>
-          <h2 class="text-xl font-semibold text-hero-charcoal mb-1">
+          <h2 class="text-xl font-semibold text-hero-black-100 mb-1">
             {gettext("Provider Profile")}
           </h2>
           <p class="text-sm text-hero-grey-500">
@@ -216,7 +216,7 @@ defmodule KlassHeroWeb.ProviderComponents do
           navigate={~p"/provider/dashboard/edit"}
           class={[
             "flex items-center gap-2 px-4 py-2 border border-hero-grey-300 bg-white",
-            "hover:bg-hero-grey-50 text-hero-charcoal text-sm font-medium",
+            "hover:bg-hero-grey-50 text-hero-black-100 text-sm font-medium",
             Theme.rounded(:lg),
             Theme.transition(:normal)
           ]}
@@ -246,7 +246,7 @@ defmodule KlassHeroWeb.ProviderComponents do
           {@business.initials}
         </div>
         <div>
-          <h3 class="text-xl font-semibold text-hero-charcoal">{@business.name}</h3>
+          <h3 class="text-xl font-semibold text-hero-black-100">{@business.name}</h3>
           <p class="text-hero-grey-500 mb-2">{@business.tagline}</p>
           <div class="flex flex-wrap gap-2">
             <.verification_status_badge status={@business.verification_status} />
@@ -387,7 +387,7 @@ defmodule KlassHeroWeb.ProviderComponents do
     ~H"""
     <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 mb-6">
       <div>
-        <h1 class="text-2xl font-bold text-hero-charcoal mb-2">
+        <h1 class="text-2xl font-bold text-hero-black-100 mb-2">
           {@business.name} {gettext("Dashboard")}
         </h1>
         <div class="flex flex-wrap items-center gap-2">
@@ -420,7 +420,7 @@ defmodule KlassHeroWeb.ProviderComponents do
             :if={@business.verification_status != :verified}
             id="new-program-tooltip"
             class={[
-              "absolute right-0 top-full mt-2 w-64 p-3 bg-hero-charcoal text-white text-xs",
+              "absolute right-0 top-full mt-2 w-64 p-3 bg-hero-black text-white text-xs",
               "opacity-0 group-hover:opacity-100 pointer-events-none z-10",
               Theme.rounded(:lg),
               Theme.transition(:normal)
@@ -457,7 +457,7 @@ defmodule KlassHeroWeb.ProviderComponents do
         <div
           :if={@member.role}
           class={[
-            "absolute top-2 right-2 px-2 py-1 bg-white/90 text-xs font-medium text-hero-charcoal",
+            "absolute top-2 right-2 px-2 py-1 bg-white/90 text-xs font-medium text-hero-black-100",
             Theme.rounded(:md)
           ]}
         >
@@ -487,7 +487,7 @@ defmodule KlassHeroWeb.ProviderComponents do
 
       <div class="pt-10 px-4 pb-4">
         <div class="flex items-start justify-between gap-2 mb-1">
-          <h3 class="font-semibold text-hero-charcoal">{@member.full_name}</h3>
+          <h3 class="font-semibold text-hero-black-100">{@member.full_name}</h3>
           <.invitation_status_badge
             :if={@member.invitation_status != nil}
             status={@member.invitation_status}
@@ -501,7 +501,7 @@ defmodule KlassHeroWeb.ProviderComponents do
           <span
             :for={tag <- @member.tags}
             class={[
-              "px-2 py-1 text-xs font-medium bg-hero-cyan-100 text-hero-cyan",
+              "px-2 py-1 text-xs font-medium bg-hero-blue-100 text-hero-blue-800",
               Theme.rounded(:full)
             ]}
           >
@@ -521,7 +521,7 @@ defmodule KlassHeroWeb.ProviderComponents do
           </span>
         </div>
 
-        <p :if={@rate_label} class="text-sm text-hero-charcoal mb-3">
+        <p :if={@rate_label} class="text-sm text-hero-black-100 mb-3">
           <span class="font-semibold">{gettext("Pay rate")}:</span> {@rate_label}
         </p>
 
@@ -532,7 +532,7 @@ defmodule KlassHeroWeb.ProviderComponents do
             phx-value-id={@member.id}
             class={[
               "flex-1 px-4 py-2 border border-hero-grey-300 bg-white",
-              "hover:bg-hero-grey-50 text-hero-charcoal text-sm font-medium",
+              "hover:bg-hero-grey-50 text-hero-black-100 text-sm font-medium",
               Theme.rounded(:lg),
               Theme.transition(:normal)
             ]}
@@ -546,7 +546,7 @@ defmodule KlassHeroWeb.ProviderComponents do
             phx-click="resend_invitation"
             phx-value-id={@member.id}
             class={[
-              "px-3 py-2 bg-hero-yellow hover:bg-hero-yellow-dark text-hero-charcoal text-xs font-medium",
+              "px-3 py-2 bg-hero-yellow-500 hover:bg-hero-yellow-600 text-hero-black-100 text-xs font-medium",
               Theme.rounded(:lg),
               Theme.transition(:normal)
             ]}
@@ -568,7 +568,7 @@ defmodule KlassHeroWeb.ProviderComponents do
             }
             class={[
               "px-3 py-2 border border-hero-grey-300 bg-white",
-              "hover:bg-hero-grey-50 text-hero-charcoal text-sm font-medium",
+              "hover:bg-hero-grey-50 text-hero-black-100 text-sm font-medium",
               Theme.rounded(:lg),
               Theme.transition(:normal)
             ]}
@@ -622,7 +622,7 @@ defmodule KlassHeroWeb.ProviderComponents do
       Theme.rounded(:xl)
     ]}>
       <div class="min-w-0">
-        <p class="font-medium text-hero-charcoal truncate">{@member.full_name}</p>
+        <p class="font-medium text-hero-black-100 truncate">{@member.full_name}</p>
         <p :if={@member.role} class="text-xs text-hero-grey-500 truncate">{@member.role}</p>
       </div>
       <button
@@ -632,7 +632,7 @@ defmodule KlassHeroWeb.ProviderComponents do
         phx-value-id={@member.id}
         class={[
           "shrink-0 px-3 py-2 border border-hero-grey-300 bg-white",
-          "hover:bg-hero-grey-50 text-hero-charcoal text-sm font-medium",
+          "hover:bg-hero-grey-50 text-hero-black-100 text-sm font-medium",
           Theme.rounded(:lg),
           Theme.transition(:normal)
         ]}
@@ -666,7 +666,7 @@ defmodule KlassHeroWeb.ProviderComponents do
       class={["bg-white p-6 shadow-sm border border-hero-grey-200", Theme.rounded(:xl)]}
     >
       <div class="flex items-center justify-between mb-4">
-        <h3 class="text-lg font-semibold text-hero-charcoal">
+        <h3 class="text-lg font-semibold text-hero-black-100">
           <%= if @editing do %>
             {gettext("Edit Team Member")}
           <% else %>
@@ -677,7 +677,7 @@ defmodule KlassHeroWeb.ProviderComponents do
           type="button"
           phx-click="close_staff_form"
           class={[
-            "p-2 text-hero-grey-400 hover:text-hero-charcoal hover:bg-hero-grey-100",
+            "p-2 text-hero-grey-400 hover:text-hero-black-100 hover:bg-hero-grey-100",
             Theme.rounded(:lg)
           ]}
         >
@@ -731,7 +731,7 @@ defmodule KlassHeroWeb.ProviderComponents do
         />
 
         <div>
-          <label class="block text-sm font-semibold text-hero-charcoal mb-2">
+          <label class="block text-sm font-semibold text-hero-black-100 mb-2">
             {gettext("Specialties")}
           </label>
           <div class="flex flex-wrap gap-3">
@@ -741,7 +741,7 @@ defmodule KlassHeroWeb.ProviderComponents do
                 name="staff_member_schema[tags][]"
                 value={cat}
                 checked={cat in ((@form[:tags] && @form[:tags].value) || [])}
-                class="rounded border-hero-grey-300 text-hero-cyan focus:ring-hero-cyan"
+                class="rounded border-hero-grey-300 text-hero-blue-600 focus:ring-hero-blue-500"
               />
               {cat}
             </label>
@@ -763,7 +763,7 @@ defmodule KlassHeroWeb.ProviderComponents do
 
         <%!-- Pay Rate (visible only to the business account; not rendered in parent-facing views) --%>
         <div>
-          <label class="block text-sm font-semibold text-hero-charcoal mb-2">
+          <label class="block text-sm font-semibold text-hero-black-100 mb-2">
             {gettext("Pay Rate")}
           </label>
           <div class="flex flex-wrap items-center gap-4">
@@ -773,7 +773,7 @@ defmodule KlassHeroWeb.ProviderComponents do
                 name="staff_member_schema[rate_type]"
                 value=""
                 checked={empty_rate_type?(@form[:rate_type])}
-                class="border-hero-grey-300 text-hero-cyan focus:ring-hero-cyan"
+                class="border-hero-grey-300 text-hero-blue-600 focus:ring-hero-blue-500"
               />
               {gettext("None")}
             </label>
@@ -783,7 +783,7 @@ defmodule KlassHeroWeb.ProviderComponents do
                 name="staff_member_schema[rate_type]"
                 value="hourly"
                 checked={rate_type_is?(@form[:rate_type], "hourly")}
-                class="border-hero-grey-300 text-hero-cyan focus:ring-hero-cyan"
+                class="border-hero-grey-300 text-hero-blue-600 focus:ring-hero-blue-500"
               />
               {gettext("Hourly")}
             </label>
@@ -793,13 +793,13 @@ defmodule KlassHeroWeb.ProviderComponents do
                 name="staff_member_schema[rate_type]"
                 value="per_session"
                 checked={rate_type_is?(@form[:rate_type], "per_session")}
-                class="border-hero-grey-300 text-hero-cyan focus:ring-hero-cyan"
+                class="border-hero-grey-300 text-hero-blue-600 focus:ring-hero-blue-500"
               />
               {gettext("Per Session")}
             </label>
           </div>
           <div class="mt-2 flex items-center gap-2">
-            <span class="text-hero-charcoal font-medium" aria-hidden="true">€</span>
+            <span class="text-hero-black-100 font-medium" aria-hidden="true">€</span>
             <.input
               field={@form[:rate_amount]}
               type="number"
@@ -814,7 +814,7 @@ defmodule KlassHeroWeb.ProviderComponents do
         </div>
 
         <div>
-          <label class="block text-sm font-semibold text-hero-charcoal mb-2">
+          <label class="block text-sm font-semibold text-hero-black-100 mb-2">
             {gettext("Headshot Photo")}
           </label>
           <div
@@ -846,7 +846,7 @@ defmodule KlassHeroWeb.ProviderComponents do
               for={@uploads.headshot.ref}
               class={[
                 "inline-flex items-center gap-2 px-4 py-2 border border-hero-grey-300",
-                "bg-white hover:bg-hero-grey-50 text-hero-charcoal text-sm font-medium cursor-pointer",
+                "bg-white hover:bg-hero-grey-50 text-hero-black-100 text-sm font-medium cursor-pointer",
                 Theme.rounded(:lg)
               ]}
             >
@@ -864,8 +864,8 @@ defmodule KlassHeroWeb.ProviderComponents do
             type="submit"
             id="save-staff-btn"
             class={[
-              "flex items-center gap-2 px-6 py-2.5 bg-hero-yellow hover:bg-hero-yellow-dark",
-              "text-hero-charcoal font-semibold active:scale-[0.98]",
+              "flex items-center gap-2 px-6 py-2.5 bg-hero-yellow-500 hover:bg-hero-yellow-600",
+              "text-hero-black-100 font-semibold active:scale-[0.98]",
               Theme.rounded(:lg),
               Theme.transition(:normal)
             ]}
@@ -882,7 +882,7 @@ defmodule KlassHeroWeb.ProviderComponents do
             phx-click="close_staff_form"
             class={[
               "px-4 py-2.5 border border-hero-grey-300 bg-white",
-              "hover:bg-hero-grey-50 text-hero-charcoal text-sm font-medium",
+              "hover:bg-hero-grey-50 text-hero-black-100 text-sm font-medium",
               Theme.rounded(:lg),
               Theme.transition(:normal)
             ]}
@@ -946,7 +946,7 @@ defmodule KlassHeroWeb.ProviderComponents do
     ~H"""
     <div class={["bg-white p-6 shadow-sm border border-hero-grey-200", Theme.rounded(:xl)]}>
       <div class="flex items-center justify-between mb-6">
-        <h3 class="text-lg font-semibold text-hero-charcoal">
+        <h3 class="text-lg font-semibold text-hero-black-100">
           <%= if @editing do %>
             {gettext("Edit Program")}
           <% else %>
@@ -1006,7 +1006,7 @@ defmodule KlassHeroWeb.ProviderComponents do
         </div>
 
         <div class="space-y-3">
-          <p class="text-sm font-semibold text-hero-charcoal">{gettext("Schedule (optional)")}</p>
+          <p class="text-sm font-semibold text-hero-black-100">{gettext("Schedule (optional)")}</p>
 
           <fieldset id="meeting-days-fieldset">
             <legend class="text-sm text-hero-grey-600 mb-2">{gettext("Meeting Days")}</legend>
@@ -1017,7 +1017,7 @@ defmodule KlassHeroWeb.ProviderComponents do
                   "inline-flex items-center gap-1.5 px-3 py-1.5 border text-sm cursor-pointer",
                   Theme.rounded(:lg),
                   Theme.transition(:normal),
-                  "has-[:checked]:bg-hero-yellow has-[:checked]:border-hero-yellow-dark has-[:checked]:font-semibold",
+                  "has-[:checked]:bg-hero-yellow-500 has-[:checked]:border-hero-yellow-600 has-[:checked]:font-semibold",
                   "border-hero-grey-300 hover:border-hero-grey-400"
                 ]}
               >
@@ -1063,7 +1063,7 @@ defmodule KlassHeroWeb.ProviderComponents do
         </div>
 
         <div class="space-y-3">
-          <p class="text-sm font-semibold text-hero-charcoal">
+          <p class="text-sm font-semibold text-hero-black-100">
             {gettext("Registration Period (optional)")}
           </p>
           <p class="text-xs text-hero-grey-500">
@@ -1084,7 +1084,7 @@ defmodule KlassHeroWeb.ProviderComponents do
         </div>
 
         <div class="space-y-3">
-          <p class="text-sm font-semibold text-hero-charcoal">
+          <p class="text-sm font-semibold text-hero-black-100">
             {gettext("Enrollment Capacity (optional)")}
           </p>
           <p class="text-xs text-hero-grey-500">
@@ -1132,7 +1132,7 @@ defmodule KlassHeroWeb.ProviderComponents do
 
         <div class="space-y-4">
           <div>
-            <p class="text-sm font-semibold text-hero-charcoal">
+            <p class="text-sm font-semibold text-hero-black-100">
               {gettext("Participant Restrictions (optional)")}
             </p>
             <p class="text-xs text-hero-grey-500">
@@ -1156,7 +1156,7 @@ defmodule KlassHeroWeb.ProviderComponents do
                       nil
                     ]
                   }
-                  class="border-hero-grey-300 text-hero-cyan focus:ring-hero-cyan"
+                  class="border-hero-grey-300 text-hero-blue-600 focus:ring-hero-blue-500"
                 />
                 {gettext("Registration")}
               </label>
@@ -1169,7 +1169,7 @@ defmodule KlassHeroWeb.ProviderComponents do
                     Phoenix.HTML.Form.input_value(@participant_policy_form, :eligibility_at) ==
                       "program_start"
                   }
-                  class="border-hero-grey-300 text-hero-cyan focus:ring-hero-cyan"
+                  class="border-hero-grey-300 text-hero-blue-600 focus:ring-hero-blue-500"
                 />
                 {gettext("Program Start")}
               </label>
@@ -1221,7 +1221,7 @@ defmodule KlassHeroWeb.ProviderComponents do
                               ) ||
                                 [])
                   }
-                  class="rounded border-hero-grey-300 text-hero-cyan focus:ring-hero-cyan"
+                  class="rounded border-hero-grey-300 text-hero-blue-600 focus:ring-hero-blue-500"
                 />
                 {label}
               </label>
@@ -1258,7 +1258,7 @@ defmodule KlassHeroWeb.ProviderComponents do
         />
 
         <div>
-          <label class="block text-sm font-semibold text-hero-charcoal mb-2">
+          <label class="block text-sm font-semibold text-hero-black-100 mb-2">
             {gettext("Cover Image")}
           </label>
           <div
@@ -1297,7 +1297,7 @@ defmodule KlassHeroWeb.ProviderComponents do
               for={@uploads.program_cover.ref}
               class={[
                 "inline-flex items-center gap-2 px-4 py-2 border border-hero-grey-300",
-                "bg-white hover:bg-hero-grey-50 text-hero-charcoal text-sm font-medium cursor-pointer",
+                "bg-white hover:bg-hero-grey-50 text-hero-black-100 text-sm font-medium cursor-pointer",
                 Theme.rounded(:lg),
                 Theme.transition(:normal)
               ]}
@@ -1326,7 +1326,7 @@ defmodule KlassHeroWeb.ProviderComponents do
             type="button"
             phx-click="close_program_form"
             class={[
-              "px-4 py-2 border border-hero-grey-300 text-hero-charcoal",
+              "px-4 py-2 border border-hero-grey-300 text-hero-black-100",
               Theme.rounded(:lg),
               Theme.transition(:normal),
               "hover:bg-hero-grey-50"
@@ -1338,8 +1338,8 @@ defmodule KlassHeroWeb.ProviderComponents do
             type="submit"
             id="save-program-btn"
             class={[
-              "flex items-center gap-2 px-6 py-2.5 bg-hero-yellow hover:bg-hero-yellow-dark",
-              "text-hero-charcoal font-semibold",
+              "flex items-center gap-2 px-6 py-2.5 bg-hero-yellow-500 hover:bg-hero-yellow-600",
+              "text-hero-black-100 font-semibold",
               Theme.rounded(:lg),
               Theme.transition(:normal)
             ]}
@@ -1380,7 +1380,7 @@ defmodule KlassHeroWeb.ProviderComponents do
       class={[
         "w-full h-full min-h-[200px] border-2 border-dashed border-hero-grey-300",
         "flex flex-col items-center justify-center gap-2",
-        "text-hero-grey-400 hover:border-hero-cyan hover:text-hero-cyan active:scale-[0.98]",
+        "text-hero-grey-400 hover:border-hero-blue-500 hover:text-hero-blue-600 active:scale-[0.98]",
         Theme.rounded(:xl),
         Theme.transition(:normal),
         @class
@@ -1415,7 +1415,7 @@ defmodule KlassHeroWeb.ProviderComponents do
     <div class={["bg-white shadow-sm border border-hero-grey-200", Theme.rounded(:xl)]}>
       <div class="p-4 border-b border-hero-grey-200">
         <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-          <h3 class="text-lg font-semibold text-hero-charcoal">
+          <h3 class="text-lg font-semibold text-hero-black-100">
             {gettext("Program Inventory")}
           </h3>
           <%!-- Each control needs its own <form>: LiveView refuses a phx-change on a
@@ -1436,7 +1436,7 @@ defmodule KlassHeroWeb.ProviderComponents do
                 placeholder={gettext("Search by name...")}
                 class={[
                   "pl-10 pr-4 py-2 w-full sm:w-64 border border-hero-grey-300 bg-white",
-                  "text-sm placeholder-hero-grey-400 focus:border-hero-cyan focus:ring-1 focus:ring-hero-cyan",
+                  "text-sm placeholder-hero-grey-400 focus:border-hero-blue-500 focus:ring-1 focus:ring-hero-blue-500",
                   Theme.rounded(:lg)
                 ]}
                 phx-debounce="300"
@@ -1451,7 +1451,7 @@ defmodule KlassHeroWeb.ProviderComponents do
                 name="staff_filter"
                 class={[
                   "pl-10 pr-8 py-2 w-full sm:w-40 border border-hero-grey-300 bg-white",
-                  "text-sm focus:border-hero-cyan focus:ring-1 focus:ring-hero-cyan appearance-none",
+                  "text-sm focus:border-hero-blue-500 focus:ring-1 focus:ring-hero-blue-500 appearance-none",
                   Theme.rounded(:lg)
                 ]}
               >
@@ -1492,7 +1492,7 @@ defmodule KlassHeroWeb.ProviderComponents do
           <tbody id="programs-table-body" phx-update="stream" class="divide-y divide-hero-grey-200">
             <tr :for={{dom_id, program} <- @programs} id={dom_id} class="hover:bg-hero-grey-50">
               <td class="px-4 py-4">
-                <div class="font-medium text-hero-charcoal">{program.name}</div>
+                <div class="font-medium text-hero-black-100">{program.name}</div>
                 <div class="text-sm text-hero-grey-500">
                   {program.category} • €{program.price}
                 </div>
@@ -1512,7 +1512,7 @@ defmodule KlassHeroWeb.ProviderComponents do
                   ]}>
                     {program.assigned_staff.lead.initials}
                   </div>
-                  <span class="text-sm text-hero-charcoal">{program.assigned_staff.lead.name}</span>
+                  <span class="text-sm text-hero-black-100">{program.assigned_staff.lead.name}</span>
                   <span
                     :if={program.assigned_staff.others_count > 0}
                     class="text-sm text-hero-grey-500 whitespace-nowrap"
@@ -1548,7 +1548,7 @@ defmodule KlassHeroWeb.ProviderComponents do
                 <div class="flex items-center gap-3">
                   <div class="w-24 h-2 bg-hero-grey-200 rounded-full overflow-hidden">
                     <div
-                      class="h-full bg-hero-cyan rounded-full"
+                      class="h-full bg-hero-blue-500 rounded-full"
                       style={"width: #{enrollment_percentage(program)}%"}
                     >
                     </div>
@@ -1732,7 +1732,7 @@ defmodule KlassHeroWeb.ProviderComponents do
           Theme.rounded(:xl)
         ]}>
           <div class="flex items-center justify-between p-4 border-b border-hero-grey-200">
-            <h3 class="text-lg font-semibold text-hero-charcoal">
+            <h3 class="text-lg font-semibold text-hero-black-100">
               {gettext("Roster: %{name}", name: @program_name)}
             </h3>
             <div class="flex items-center gap-1">
@@ -1747,7 +1747,7 @@ defmodule KlassHeroWeb.ProviderComponents do
                     "p-2",
                     Theme.rounded(:lg),
                     Theme.transition(:normal),
-                    "text-hero-grey-400 hover:text-hero-charcoal hover:bg-hero-grey-100"
+                    "text-hero-grey-400 hover:text-hero-black-100 hover:bg-hero-grey-100"
                   ]}
                 >
                   <.icon name="hero-megaphone-mini" class="w-5 h-5" />
@@ -1782,8 +1782,8 @@ defmodule KlassHeroWeb.ProviderComponents do
               class={[
                 "px-4 py-3 text-sm font-medium border-b-2 -mb-px",
                 if(@active_tab == "enrolled",
-                  do: "border-hero-primary text-hero-primary",
-                  else: "border-transparent text-hero-grey-500 hover:text-hero-charcoal"
+                  do: "border-hero-blue-500 text-hero-blue-600",
+                  else: "border-transparent text-hero-grey-500 hover:text-hero-black-100"
                 )
               ]}
             >
@@ -1799,8 +1799,8 @@ defmodule KlassHeroWeb.ProviderComponents do
               class={[
                 "px-4 py-3 text-sm font-medium border-b-2 -mb-px",
                 if(@active_tab == "invites",
-                  do: "border-hero-primary text-hero-primary",
-                  else: "border-transparent text-hero-grey-500 hover:text-hero-charcoal"
+                  do: "border-hero-blue-500 text-hero-blue-600",
+                  else: "border-transparent text-hero-grey-500 hover:text-hero-black-100"
                 )
               ]}
             >
@@ -1969,7 +1969,7 @@ defmodule KlassHeroWeb.ProviderComponents do
                 <%!-- The badge sits outside the truncating title, or a long title swallows it
                       on a narrow viewport — losing the one word that says this one blocks. --%>
                 <div class="flex items-center gap-2">
-                  <p class="truncate font-medium text-hero-charcoal">{entry.waiver.title}</p>
+                  <p class="truncate font-medium text-hero-black-100">{entry.waiver.title}</p>
                   <.waiver_requirement required={entry.waiver.required} />
                 </div>
                 <p class="text-sm text-hero-grey-500">
@@ -2005,7 +2005,7 @@ defmodule KlassHeroWeb.ProviderComponents do
           </ul>
 
           <.form for={@modal.form} id="waiver-form" phx-submit="save_waiver" class="space-y-4">
-            <h3 class={[Theme.typography(:card_title), "text-hero-charcoal"]}>
+            <h3 class={[Theme.typography(:card_title), "text-hero-black-100"]}>
               {if @modal.editing_id,
                 do: gettext("Publish a new version"),
                 else: gettext("Add a waiver")}
@@ -2106,7 +2106,7 @@ defmodule KlassHeroWeb.ProviderComponents do
               <.staff_avatar member={member} />
 
               <div class="min-w-0 flex-1">
-                <p class="truncate font-medium text-hero-charcoal">
+                <p class="truncate font-medium text-hero-black-100">
                   {member.full_name}
                   <span
                     :if={member.lead?}
@@ -2168,7 +2168,7 @@ defmodule KlassHeroWeb.ProviderComponents do
                 name="staff-id"
                 disabled={@modal.assignable_options == []}
                 class={[
-                  "flex-1 border border-hero-grey-300 px-3 py-2 text-hero-charcoal disabled:bg-hero-grey-50",
+                  "flex-1 border border-hero-grey-300 px-3 py-2 text-hero-black-100 disabled:bg-hero-grey-50",
                   Theme.rounded(:lg)
                 ]}
               >
@@ -2183,7 +2183,7 @@ defmodule KlassHeroWeb.ProviderComponents do
                 disabled={@modal.assignable_options == []}
                 class={[
                   "flex items-center justify-center gap-2 px-4 py-2 font-semibold",
-                  "bg-hero-yellow hover:bg-hero-yellow-dark text-hero-charcoal",
+                  "bg-hero-yellow-500 hover:bg-hero-yellow-600 text-hero-black-100",
                   "disabled:bg-hero-grey-100 disabled:text-hero-grey-400",
                   Theme.rounded(:lg),
                   Theme.transition(:normal)
@@ -2433,7 +2433,7 @@ defmodule KlassHeroWeb.ProviderComponents do
       :if={!@member.headshot_url}
       class={[
         "w-9 h-9 shrink-0 rounded-full flex items-center justify-center",
-        "text-xs font-semibold text-hero-charcoal",
+        "text-xs font-semibold text-hero-black-100",
         Theme.gradient(:primary)
       ]}
       aria-hidden="true"
@@ -2475,7 +2475,7 @@ defmodule KlassHeroWeb.ProviderComponents do
       </thead>
       <tbody class="divide-y divide-hero-grey-200">
         <tr :for={entry <- @entries} class="hover:bg-hero-grey-50">
-          <td class="px-3 py-3 text-sm text-hero-charcoal font-medium">
+          <td class="px-3 py-3 text-sm text-hero-black-100 font-medium">
             {entry.child_name}
           </td>
           <td class="px-3 py-3">
@@ -2515,7 +2515,7 @@ defmodule KlassHeroWeb.ProviderComponents do
                   "p-2 inline-flex",
                   Theme.rounded(:lg),
                   Theme.transition(:normal),
-                  "text-hero-grey-400 hover:text-hero-charcoal hover:bg-hero-grey-100"
+                  "text-hero-grey-400 hover:text-hero-black-100 hover:bg-hero-grey-100"
                 ]}
               >
                 <.icon name="hero-chat-bubble-left-mini" class="w-5 h-5" />
@@ -2582,7 +2582,7 @@ defmodule KlassHeroWeb.ProviderComponents do
             Theme.rounded(:lg),
             Theme.transition(:normal),
             if(@invite_mode == "single",
-              do: "border-hero-primary bg-hero-primary/5 text-hero-primary",
+              do: "border-hero-blue-500 bg-hero-blue-500/5 text-hero-blue-600",
               else: "border-hero-grey-300 text-hero-grey-600 hover:bg-hero-grey-50"
             )
           ]}
@@ -2600,7 +2600,7 @@ defmodule KlassHeroWeb.ProviderComponents do
             Theme.rounded(:lg),
             Theme.transition(:normal),
             if(@invite_mode == "csv",
-              do: "border-hero-primary bg-hero-primary/5 text-hero-primary",
+              do: "border-hero-blue-500 bg-hero-blue-500/5 text-hero-blue-600",
               else: "border-hero-grey-300 text-hero-grey-600 hover:bg-hero-grey-50"
             )
           ]}
@@ -2633,7 +2633,7 @@ defmodule KlassHeroWeb.ProviderComponents do
             <.live_file_input upload={@uploads.csv_file} class="hidden" />
 
             <div :for={entry <- @uploads.csv_file.entries} class="mt-3 flex items-center gap-3">
-              <span class="text-sm text-hero-charcoal">{entry.client_name}</span>
+              <span class="text-sm text-hero-black-100">{entry.client_name}</span>
               <button
                 type="submit"
                 class={[
@@ -2648,7 +2648,7 @@ defmodule KlassHeroWeb.ProviderComponents do
                 type="button"
                 phx-click="cancel_csv_upload"
                 phx-value-ref={entry.ref}
-                class="text-sm text-hero-grey-500 hover:text-hero-charcoal"
+                class="text-sm text-hero-grey-500 hover:text-hero-black-100"
               >
                 {gettext("Cancel")}
               </button>
@@ -2751,7 +2751,7 @@ defmodule KlassHeroWeb.ProviderComponents do
         </thead>
         <tbody class="divide-y divide-hero-grey-200">
           <tr :for={invite <- @invites} id={"invite-#{invite.id}"} class="hover:bg-hero-grey-50">
-            <td class="px-3 py-3 text-sm text-hero-charcoal font-medium">
+            <td class="px-3 py-3 text-sm text-hero-black-100 font-medium">
               {invite.child_first_name} {invite.child_last_name}
               <span
                 :if={@show_program?}
@@ -2825,7 +2825,7 @@ defmodule KlassHeroWeb.ProviderComponents do
       <section aria-labelledby="single-invite-child-heading">
         <h4
           id="single-invite-child-heading"
-          class={[Theme.typography(:card_title), "mb-3 text-hero-charcoal"]}
+          class={[Theme.typography(:card_title), "mb-3 text-hero-black-100"]}
         >
           {gettext("Child")}
         </h4>
@@ -2846,7 +2846,7 @@ defmodule KlassHeroWeb.ProviderComponents do
       <section aria-labelledby="single-invite-guardian-heading">
         <h4
           id="single-invite-guardian-heading"
-          class={[Theme.typography(:card_title), "mb-3 text-hero-charcoal"]}
+          class={[Theme.typography(:card_title), "mb-3 text-hero-black-100"]}
         >
           {gettext("Primary guardian")}
         </h4>
@@ -2867,7 +2867,7 @@ defmodule KlassHeroWeb.ProviderComponents do
       <section aria-labelledby="single-invite-guardian2-heading">
         <h4
           id="single-invite-guardian2-heading"
-          class={[Theme.typography(:card_title), "mb-3 text-hero-charcoal"]}
+          class={[Theme.typography(:card_title), "mb-3 text-hero-black-100"]}
         >
           {gettext("Second guardian (optional)")}
         </h4>
@@ -2883,7 +2883,7 @@ defmodule KlassHeroWeb.ProviderComponents do
       <section aria-labelledby="single-invite-school-heading">
         <h4
           id="single-invite-school-heading"
-          class={[Theme.typography(:card_title), "mb-3 text-hero-charcoal"]}
+          class={[Theme.typography(:card_title), "mb-3 text-hero-black-100"]}
         >
           {gettext("School (optional)")}
         </h4>
@@ -2902,7 +2902,7 @@ defmodule KlassHeroWeb.ProviderComponents do
       <section aria-labelledby="single-invite-medical-heading">
         <h4
           id="single-invite-medical-heading"
-          class={[Theme.typography(:card_title), "mb-3 text-hero-charcoal"]}
+          class={[Theme.typography(:card_title), "mb-3 text-hero-black-100"]}
         >
           {gettext("Medical & consents (optional)")}
         </h4>
@@ -3118,7 +3118,7 @@ defmodule KlassHeroWeb.ProviderComponents do
   def verification_documents_panel(assigns) do
     ~H"""
     <div class={["bg-white p-6 shadow-sm border border-hero-grey-200", Theme.rounded(:xl)]}>
-      <h2 class="text-lg font-semibold text-hero-charcoal mb-4">
+      <h2 class="text-lg font-semibold text-hero-black-100 mb-4">
         {gettext("Verification Documents")}
       </h2>
       <p class="text-sm text-hero-grey-500 mb-6">
@@ -3140,7 +3140,7 @@ defmodule KlassHeroWeb.ProviderComponents do
           <div class="flex items-center gap-3">
             <.icon name="hero-document-text-mini" class="w-5 h-5 text-hero-grey-400" />
             <div>
-              <p class="text-sm font-medium text-hero-charcoal">
+              <p class="text-sm font-medium text-hero-black-100">
                 {ProviderPresenter.document_type_label(doc.document_type)}
               </p>
               <p class="text-xs text-hero-grey-500">{doc.original_filename}</p>
@@ -3153,7 +3153,7 @@ defmodule KlassHeroWeb.ProviderComponents do
       <div class={[
         "border-t border-hero-grey-200 pt-6"
       ]}>
-        <h3 class="text-sm font-semibold text-hero-charcoal mb-3">
+        <h3 class="text-sm font-semibold text-hero-black-100 mb-3">
           {gettext("Upload New Document")}
         </h3>
 
@@ -3173,7 +3173,7 @@ defmodule KlassHeroWeb.ProviderComponents do
               phx-change="select_doc_type"
               class={[
                 "w-full sm:w-64 px-3 py-2 border border-hero-grey-300 bg-white",
-                "text-sm focus:border-hero-cyan focus:ring-1 focus:ring-hero-cyan",
+                "text-sm focus:border-hero-blue-500 focus:ring-1 focus:ring-hero-blue-500",
                 Theme.rounded(:lg)
               ]}
             >
@@ -3193,7 +3193,7 @@ defmodule KlassHeroWeb.ProviderComponents do
               for={@uploads.verification_doc.ref}
               class={[
                 "inline-flex items-center gap-2 px-4 py-2 border border-hero-grey-300",
-                "bg-white hover:bg-hero-grey-50 text-hero-charcoal text-sm font-medium cursor-pointer",
+                "bg-white hover:bg-hero-grey-50 text-hero-black-100 text-sm font-medium cursor-pointer",
                 Theme.rounded(:lg),
                 Theme.transition(:normal)
               ]}
@@ -3213,7 +3213,7 @@ defmodule KlassHeroWeb.ProviderComponents do
               ]}
             >
               <.icon name="hero-document-text-mini" class="w-5 h-5 text-hero-grey-500 shrink-0" />
-              <span class="text-sm text-hero-charcoal truncate flex-1">{entry.client_name}</span>
+              <span class="text-sm text-hero-black-100 truncate flex-1">{entry.client_name}</span>
               <button
                 type="button"
                 phx-click="cancel_upload"
@@ -3238,7 +3238,7 @@ defmodule KlassHeroWeb.ProviderComponents do
             disabled={@uploads.verification_doc.entries == []}
             class={[
               "flex items-center gap-2 px-4 py-2 border border-hero-grey-300",
-              "bg-white hover:bg-hero-grey-50 text-hero-charcoal text-sm font-medium",
+              "bg-white hover:bg-hero-grey-50 text-hero-black-100 text-sm font-medium",
               "disabled:opacity-50 disabled:cursor-not-allowed",
               Theme.rounded(:lg),
               Theme.transition(:normal)
@@ -3251,7 +3251,7 @@ defmodule KlassHeroWeb.ProviderComponents do
       </div>
 
       <div :if={@video_upload?} class="border-t border-hero-grey-200 pt-6 mt-6">
-        <h3 class="text-sm font-semibold text-hero-charcoal mb-1">
+        <h3 class="text-sm font-semibold text-hero-black-100 mb-1">
           {gettext("Video Screening")}
         </h3>
         <p class="text-sm text-hero-grey-500 mb-3">
@@ -3272,7 +3272,7 @@ defmodule KlassHeroWeb.ProviderComponents do
               for={@uploads.verification_video.ref}
               class={[
                 "inline-flex items-center gap-2 px-4 py-2 border border-hero-grey-300",
-                "bg-white hover:bg-hero-grey-50 text-hero-charcoal text-sm font-medium cursor-pointer",
+                "bg-white hover:bg-hero-grey-50 text-hero-black-100 text-sm font-medium cursor-pointer",
                 Theme.rounded(:lg),
                 Theme.transition(:normal)
               ]}
@@ -3292,7 +3292,7 @@ defmodule KlassHeroWeb.ProviderComponents do
               ]}
             >
               <.icon name="hero-film-mini" class="w-5 h-5 text-hero-grey-500 shrink-0" />
-              <span class="text-sm text-hero-charcoal truncate flex-1">{entry.client_name}</span>
+              <span class="text-sm text-hero-black-100 truncate flex-1">{entry.client_name}</span>
               <button
                 type="button"
                 phx-click="cancel_upload"
@@ -3317,7 +3317,7 @@ defmodule KlassHeroWeb.ProviderComponents do
             disabled={@uploads.verification_video.entries == []}
             class={[
               "flex items-center gap-2 px-4 py-2 border border-hero-grey-300",
-              "bg-white hover:bg-hero-grey-50 text-hero-charcoal text-sm font-medium",
+              "bg-white hover:bg-hero-grey-50 text-hero-black-100 text-sm font-medium",
               "disabled:opacity-50 disabled:cursor-not-allowed",
               Theme.rounded(:lg),
               Theme.transition(:normal)
@@ -3491,7 +3491,7 @@ defmodule KlassHeroWeb.ProviderComponents do
             href={community_guidelines_pdf_path(@version)}
             target="_blank"
             rel="noopener noreferrer"
-            class="inline-flex items-center gap-2 text-sm font-medium text-hero-cyan hover:underline"
+            class="inline-flex items-center gap-2 text-sm font-medium text-hero-blue-600 hover:underline"
           >
             <.icon name="hero-arrow-down-tray-mini" class="w-4 h-4" />
             {gettext("Download the agreement (PDF)")}

--- a/lib/klass_hero_web/live/dashboard_live.ex
+++ b/lib/klass_hero_web/live/dashboard_live.ex
@@ -397,8 +397,8 @@ defmodule KlassHeroWeb.DashboardLive do
       </section>
       <section id="family-programs" class="mb-8">
         <div class="flex items-center gap-2 mb-4">
-          <.icon name="hero-academic-cap-mini" class="w-6 h-6 text-hero-cyan" />
-          <h2 class="text-xl font-semibold text-hero-charcoal">
+          <.icon name="hero-academic-cap-mini" class="w-6 h-6 text-hero-blue-600" />
+          <h2 class="text-xl font-semibold text-hero-black-100">
             {gettext("Family Programs")}
           </h2>
         </div>

--- a/lib/klass_hero_web/live/program_detail_live.ex
+++ b/lib/klass_hero_web/live/program_detail_live.ex
@@ -240,7 +240,7 @@ defmodule KlassHeroWeb.ProgramDetailLive do
       <%= if @program.cover_image_url do %>
         <div id="program-hero" class="relative">
           <img
-            id="program-hero-image"
+            id="program-cover-image"
             src={@program.cover_image_url}
             alt={@program.title}
             class="w-full h-64 sm:h-80 object-cover"

--- a/lib/klass_hero_web/live/provider/edit_profile_live.ex
+++ b/lib/klass_hero_web/live/provider/edit_profile_live.ex
@@ -184,17 +184,17 @@ defmodule KlassHeroWeb.Provider.EditProfileLive do
           <div class="flex items-center gap-4 mb-6">
             <.link
               navigate={~p"/provider/dashboard"}
-              class="flex items-center gap-1 text-hero-grey-500 hover:text-hero-charcoal transition-colors"
+              class="flex items-center gap-1 text-hero-grey-500 hover:text-hero-black-100 transition-colors"
             >
               <.icon name="hero-arrow-left-mini" class="w-5 h-5" />
               {gettext("Back to Dashboard")}
             </.link>
           </div>
 
-          <h1 class="text-2xl font-bold text-hero-charcoal">{gettext("Edit Profile")}</h1>
+          <h1 class="text-2xl font-bold text-hero-black-100">{gettext("Edit Profile")}</h1>
 
           <div class={["bg-white p-6 shadow-sm border border-hero-grey-200", Theme.rounded(:xl)]}>
-            <h2 class="text-lg font-semibold text-hero-charcoal mb-4">
+            <h2 class="text-lg font-semibold text-hero-black-100 mb-4">
               {gettext("Provider Information")}
             </h2>
 
@@ -214,7 +214,7 @@ defmodule KlassHeroWeb.Provider.EditProfileLive do
               />
 
               <div>
-                <label class="block text-sm font-semibold text-hero-charcoal mb-2">
+                <label class="block text-sm font-semibold text-hero-black-100 mb-2">
                   {gettext("Provider Logo")}
                 </label>
 
@@ -265,7 +265,7 @@ defmodule KlassHeroWeb.Provider.EditProfileLive do
                     for={@uploads.logo.ref}
                     class={[
                       "inline-flex items-center gap-2 px-4 py-2 border border-hero-grey-300",
-                      "bg-white hover:bg-hero-grey-50 text-hero-charcoal text-sm font-medium cursor-pointer",
+                      "bg-white hover:bg-hero-grey-50 text-hero-black-100 text-sm font-medium cursor-pointer",
                       Theme.rounded(:lg),
                       Theme.transition(:normal)
                     ]}
@@ -284,8 +284,8 @@ defmodule KlassHeroWeb.Provider.EditProfileLive do
                   type="submit"
                   id="save-profile-btn"
                   class={[
-                    "flex items-center gap-2 px-6 py-2.5 bg-hero-yellow hover:bg-hero-yellow-dark",
-                    "text-hero-charcoal font-semibold",
+                    "flex items-center gap-2 px-6 py-2.5 bg-hero-yellow-500 hover:bg-hero-yellow-600",
+                    "text-hero-black-100 font-semibold",
                     Theme.rounded(:lg),
                     Theme.transition(:normal)
                   ]}

--- a/lib/klass_hero_web/live/provider/incident_report_live.ex
+++ b/lib/klass_hero_web/live/provider/incident_report_live.ex
@@ -326,14 +326,14 @@ defmodule KlassHeroWeb.Provider.IncidentReportLive do
           />
 
           <div>
-            <label class="block text-sm font-medium text-hero-charcoal mb-2">
+            <label class="block text-sm font-medium text-hero-black-100 mb-2">
               {gettext("Photo (optional)")}
             </label>
 
             <label
               for={@uploads.photo.ref}
               phx-drop-target={@uploads.photo.ref}
-              class="flex flex-col items-center justify-center border-2 border-dashed border-hero-grey-300 rounded-lg p-6 cursor-pointer hover:border-hero-cyan"
+              class="flex flex-col items-center justify-center border-2 border-dashed border-hero-grey-300 rounded-lg p-6 cursor-pointer hover:border-hero-blue-500"
             >
               <.live_file_input upload={@uploads.photo} class="hidden" />
               <span class={Theme.typography(:body_small)}>
@@ -351,7 +351,7 @@ defmodule KlassHeroWeb.Provider.IncidentReportLive do
           <div class="flex justify-end gap-3 pt-4">
             <.link
               navigate={~p"/provider/dashboard"}
-              class="text-hero-grey-600 hover:text-hero-charcoal"
+              class="text-hero-grey-600 hover:text-hero-black-100"
             >
               {gettext("Cancel")}
             </.link>

--- a/lib/klass_hero_web/live/provider/incident_reports_live.ex
+++ b/lib/klass_hero_web/live/provider/incident_reports_live.ex
@@ -100,7 +100,7 @@ defmodule KlassHeroWeb.Provider.IncidentReportsLive do
               </p>
             </div>
           </div>
-          <p class={[Theme.typography(:body_small), "mt-3 text-hero-charcoal whitespace-pre-line"]}>
+          <p class={[Theme.typography(:body_small), "mt-3 text-hero-black-100 whitespace-pre-line"]}>
             {row.description}
           </p>
         </div>
@@ -112,7 +112,7 @@ defmodule KlassHeroWeb.Provider.IncidentReportsLive do
             Theme.shadow(:sm)
           ]}>
             <.icon name="hero-document-text" class="w-12 h-12 mx-auto mb-3 text-hero-grey-400" />
-            <h3 class="text-lg font-medium text-hero-charcoal mb-1">
+            <h3 class="text-lg font-medium text-hero-black-100 mb-1">
               {gettext("No incident reports yet")}
             </h3>
             <p class="text-hero-grey-600">

--- a/lib/klass_hero_web/live/provider/overview_live.ex
+++ b/lib/klass_hero_web/live/provider/overview_live.ex
@@ -389,7 +389,7 @@ defmodule KlassHeroWeb.Provider.OverviewLive do
             <div class="flex items-center justify-between p-4 border-b border-hero-grey-200">
               <h3
                 id="outstanding-invites-modal-title"
-                class="text-lg font-semibold text-hero-charcoal"
+                class="text-lg font-semibold text-hero-black-100"
               >
                 {gettext("Invitations awaiting a reply")}
               </h3>
@@ -399,7 +399,7 @@ defmodule KlassHeroWeb.Provider.OverviewLive do
                 phx-click="close_invites"
                 aria-label={gettext("Close")}
                 class={[
-                  "p-2 text-hero-grey-400 hover:text-hero-charcoal hover:bg-hero-grey-100",
+                  "p-2 text-hero-grey-400 hover:text-hero-black-100 hover:bg-hero-grey-100",
                   Theme.rounded(:lg),
                   Theme.transition(:normal)
                 ]}

--- a/lib/klass_hero_web/live/provider/participation_live.html.heex
+++ b/lib/klass_hero_web/live/provider/participation_live.html.heex
@@ -44,7 +44,7 @@
                 phx-click="expand_edit_form"
                 phx-value-id={record.id}
                 class={[
-                  "inline-flex items-center gap-1 px-3 py-1.5 text-sm bg-white text-hero-charcoal font-medium border border-hero-grey-300",
+                  "inline-flex items-center gap-1 px-3 py-1.5 text-sm bg-white text-hero-black-100 font-medium border border-hero-grey-300",
                   "hover:bg-hero-grey-50 focus:outline-none focus:ring-2 focus:ring-hero-blue-500 focus:ring-offset-2",
                   Theme.rounded(:md),
                   Theme.transition(:normal)
@@ -71,7 +71,7 @@
                 phx-click="expand_edit_form"
                 phx-value-id={record.id}
                 class={[
-                  "inline-flex items-center gap-1 px-3 py-1.5 text-sm bg-white text-hero-charcoal font-medium border border-hero-grey-300",
+                  "inline-flex items-center gap-1 px-3 py-1.5 text-sm bg-white text-hero-black-100 font-medium border border-hero-grey-300",
                   "hover:bg-hero-grey-50 focus:outline-none focus:ring-2 focus:ring-hero-blue-500 focus:ring-offset-2",
                   Theme.rounded(:md),
                   Theme.transition(:normal)

--- a/lib/klass_hero_web/live/provider/sessions_live.html.heex
+++ b/lib/klass_hero_web/live/provider/sessions_live.html.heex
@@ -97,7 +97,7 @@
             phx-click="manage_session_staffing"
             phx-value-id={session.id}
             class={[
-              "px-4 py-2 bg-white text-hero-charcoal font-medium border border-hero-grey-300",
+              "px-4 py-2 bg-white text-hero-black-100 font-medium border border-hero-grey-300",
               "hover:bg-hero-grey-50 focus:outline-none focus:ring-2 focus:ring-hero-blue-500 focus:ring-offset-2",
               Theme.rounded(:lg),
               Theme.transition(:normal)

--- a/lib/klass_hero_web/live/provider/team_live.ex
+++ b/lib/klass_hero_web/live/provider/team_live.ex
@@ -597,7 +597,7 @@ defmodule KlassHeroWeb.Provider.TeamLive do
       <div class="space-y-6">
         <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
           <div>
-            <h2 class="text-xl font-semibold text-hero-charcoal">
+            <h2 class="text-xl font-semibold text-hero-black-100">
               {gettext("Team & Provider Profiles")}
             </h2>
             <p class="text-sm text-hero-grey-500">

--- a/lib/klass_hero_web/live/staff/staff_dashboard_live.ex
+++ b/lib/klass_hero_web/live/staff/staff_dashboard_live.ex
@@ -241,7 +241,7 @@ defmodule KlassHeroWeb.Staff.StaffDashboardLive do
                 phx-value-provider-id={membership.provider_id}
                 class={[
                   "flex w-full items-center justify-between gap-2 px-4 py-3",
-                  "text-left text-sm text-hero-charcoal hover:bg-hero-grey-50"
+                  "text-left text-sm text-hero-black-100 hover:bg-hero-grey-50"
                 ]}
               >
                 {membership.business_name}
@@ -382,7 +382,7 @@ defmodule KlassHeroWeb.Staff.StaffDashboardLive do
           ]}
         >
           <div class="flex items-center justify-between p-4 border-b border-hero-grey-200">
-            <h2 class="text-lg font-semibold text-hero-charcoal">
+            <h2 class="text-lg font-semibold text-hero-black-100">
               {gettext("Roster: %{name}", name: @roster_program_name)}
             </h2>
             <div class="flex items-center gap-1">
@@ -394,7 +394,7 @@ defmodule KlassHeroWeb.Staff.StaffDashboardLive do
                   aria-label={gettext("Send Broadcast")}
                   class={[
                     "p-2 rounded-lg transition-colors",
-                    "text-hero-grey-400 hover:text-hero-charcoal hover:bg-hero-grey-100"
+                    "text-hero-grey-400 hover:text-hero-black-100 hover:bg-hero-grey-100"
                   ]}
                 >
                   <.icon name="hero-megaphone-mini" class="w-5 h-5" />
@@ -430,7 +430,7 @@ defmodule KlassHeroWeb.Staff.StaffDashboardLive do
                 <%= for entry <- @roster_entries do %>
                   <li class="py-3 flex items-center justify-between">
                     <div>
-                      <span class="font-medium text-hero-charcoal">
+                      <span class="font-medium text-hero-black-100">
                         {Map.get(entry, :child_name, gettext("Unknown"))}
                       </span>
                     </div>
@@ -448,7 +448,7 @@ defmodule KlassHeroWeb.Staff.StaffDashboardLive do
                           aria-label={gettext("Send Message")}
                           class={[
                             "p-2 inline-flex rounded-lg transition-colors",
-                            "text-hero-grey-400 hover:text-hero-charcoal hover:bg-hero-grey-100"
+                            "text-hero-grey-400 hover:text-hero-black-100 hover:bg-hero-grey-100"
                           ]}
                         >
                           <.icon name="hero-chat-bubble-left-mini" class="w-5 h-5" />

--- a/lib/klass_hero_web/live/staff/staff_participation_live.html.heex
+++ b/lib/klass_hero_web/live/staff/staff_participation_live.html.heex
@@ -44,7 +44,7 @@
                 phx-click="expand_edit_form"
                 phx-value-id={record.id}
                 class={[
-                  "inline-flex items-center gap-1 px-3 py-1.5 text-sm bg-white text-hero-charcoal font-medium border border-hero-grey-300",
+                  "inline-flex items-center gap-1 px-3 py-1.5 text-sm bg-white text-hero-black-100 font-medium border border-hero-grey-300",
                   "hover:bg-hero-grey-50 focus:outline-none focus:ring-2 focus:ring-hero-blue-500 focus:ring-offset-2",
                   Theme.rounded(:md),
                   Theme.transition(:normal)
@@ -71,7 +71,7 @@
                 phx-click="expand_edit_form"
                 phx-value-id={record.id}
                 class={[
-                  "inline-flex items-center gap-1 px-3 py-1.5 text-sm bg-white text-hero-charcoal font-medium border border-hero-grey-300",
+                  "inline-flex items-center gap-1 px-3 py-1.5 text-sm bg-white text-hero-black-100 font-medium border border-hero-grey-300",
                   "hover:bg-hero-grey-50 focus:outline-none focus:ring-2 focus:ring-hero-blue-500 focus:ring-offset-2",
                   Theme.rounded(:md),
                   Theme.transition(:normal)

--- a/lib/mix/tasks/lint_hero_colors.ex
+++ b/lib/mix/tasks/lint_hero_colors.ex
@@ -1,0 +1,125 @@
+defmodule Mix.Tasks.LintHeroColors do
+  @shortdoc "Check that every hero-* colour utility resolves to an @theme token"
+  @moduledoc """
+  Checks `hero-*` colour utilities in LiveView and component files against the
+  `--color-*` tokens declared in `assets/css/app.css`'s `@theme` block.
+
+  Tailwind v4 is CSS-first: it emits a utility only when a matching custom
+  property exists, and emits *nothing* — silently, with no build warning — when
+  one does not. A class like `bg-hero-yellow` (v3's unnumbered base colour) or
+  `hover:bg-hero-yellow-dark` (a v3 `-dark` suffix) therefore renders as
+  inherited or transparent rather than failing loudly. This task is the missing
+  diagnostic.
+
+  ## The heroicons collision
+
+  `app.css` loads `@plugin "../vendor/heroicons"`, which generates icon
+  utilities under the *same* `hero-*` prefix — `hero-plus-mini` and friends,
+  legitimately tokenless. They are separated structurally rather than by an
+  allowlist: a colour utility always carries a prefix (`bg-`, `ring-`,
+  `hover:border-`) so the name is preceded by `-`, while a bare icon class is
+  preceded by a quote or a space.
+
+  That is why no list of utility prefixes appears here. Such a list is a closed
+  enum that goes stale, and a prefix nobody enumerated would be a class nobody
+  checks — reproducing the exact silent miss this task exists to catch.
+
+  ## Usage
+
+      mix lint_hero_colors
+
+  Lines containing `hero-color-lint-ignore` — on the same line or the preceding
+  one — are skipped, for the rare `-hero-` substring that is not a class at all
+  (a DOM id, say).
+  """
+  use Mix.Task
+
+  @search_dir "lib/klass_hero_web/"
+  @theme_file "assets/css/app.css"
+  @suppression_marker "hero-color-lint-ignore"
+
+  # A `--color-*` declaration, not a `var(--color-*)` reference: the trailing
+  # colon is what separates the two.
+  @token_pattern ~r/--color-([a-z0-9-]+)\s*:/
+
+  # One leading character before `-hero-` is the whole heroicon discriminator.
+  @usage_pattern ~r/[a-z0-9]-hero-([a-z0-9]+(?:-[a-z0-9]+)*)/
+
+  @impl true
+  def run(_args) do
+    case violations(@search_dir, @theme_file) do
+      [] ->
+        Mix.shell().info("Hero colour lint passed — every hero-* utility resolves to a token.")
+
+      violations ->
+        Mix.shell().error("hero-* classes with no matching --color-* token in @theme:\n")
+
+        Enum.each(violations, fn {file, line_num, token} ->
+          Mix.shell().error("  #{file}:#{line_num}: #{token}")
+        end)
+
+        Mix.raise("Hero colour lint failed — #{length(violations)} violation(s) found")
+    end
+  end
+
+  @doc """
+  Returns `{file, line_number, token}` for every `hero-*` utility under `dir`
+  with no matching `--color-*` declaration in the stylesheet at `theme_path`.
+  """
+  def violations(dir, theme_path) do
+    defined = theme_path |> File.read!() |> parse_theme_tokens()
+
+    dir
+    |> Path.join("**/*.{ex,heex}")
+    |> Path.wildcard()
+    |> Enum.flat_map(&file_violations(&1, defined))
+  end
+
+  @doc """
+  Extracts the colour names declared in a stylesheet's `@theme` block.
+  """
+  def parse_theme_tokens(css) do
+    @token_pattern
+    |> Regex.scan(css, capture: :all_but_first)
+    |> MapSet.new(fn [name] -> name end)
+  end
+
+  @doc """
+  Extracts the `hero-*` token names a line of source references, in order and
+  without duplicates. Variant prefixes and `/opacity` modifiers fall away; bare
+  heroicon classes never match.
+  """
+  def extract_used(line) do
+    @usage_pattern
+    |> Regex.scan(line, capture: :all_but_first)
+    |> Enum.map(fn [name] -> "hero-" <> name end)
+    |> Enum.uniq()
+  end
+
+  defp file_violations(file, defined) do
+    {_line_num, _prev_line, violations} =
+      file
+      |> File.read!()
+      |> String.split("\n")
+      |> Enum.reduce({1, "", []}, fn line, {line_num, prev_line, acc} ->
+        acc =
+          if suppressed?(line, prev_line) do
+            acc
+          else
+            line
+            |> extract_used()
+            |> Enum.reject(&(&1 in defined))
+            |> Enum.reduce(acc, &[{file, line_num, &1} | &2])
+          end
+
+        {line_num + 1, line, acc}
+      end)
+
+    Enum.reverse(violations)
+  end
+
+  defp suppressed?(line, prev_line) do
+    String.contains?(line, @suppression_marker) or
+      String.contains?(prev_line, @suppression_marker)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -152,6 +152,7 @@ defmodule KlassHero.MixProject do
         "deps.unlock --unused",
         "format",
         "lint_typography",
+        "lint_hero_colors",
         "lint_translations",
         "lint_read_tables",
         "lint_acl_boundary",

--- a/test/klass_hero_web/live/program_detail_live_test.exs
+++ b/test/klass_hero_web/live/program_detail_live_test.exs
@@ -102,7 +102,7 @@ defmodule KlassHeroWeb.ProgramDetailLiveTest do
       program = insert(:program_schema, title: "Chess Club", cover_image_url: nil)
       {:ok, view, _html} = live(conn, ~p"/programs/#{program.id}")
 
-      refute has_element?(view, "#program-hero-image")
+      refute has_element?(view, "#program-cover-image")
       assert has_element?(view, "#program-hero")
     end
   end
@@ -123,7 +123,7 @@ defmodule KlassHeroWeb.ProgramDetailLiveTest do
       {:ok, view, _html} = live(conn, ~p"/programs/#{program.id}")
 
       assert has_element?(view, "h1", "Yoga for Kids")
-      assert has_element?(view, "#program-hero-image")
+      assert has_element?(view, "#program-cover-image")
       assert has_element?(view, "[phx-click='back_to_programs']")
     end
 
@@ -142,7 +142,7 @@ defmodule KlassHeroWeb.ProgramDetailLiveTest do
       {:ok, view, _html} = live(conn, ~p"/programs/#{program.id}")
 
       assert has_element?(view, "h1", "Chess Club")
-      refute has_element?(view, "#program-hero-image")
+      refute has_element?(view, "#program-cover-image")
       assert has_element?(view, "#program-hero")
       assert has_element?(view, "[phx-click='back_to_programs']")
     end

--- a/test/mix/tasks/lint_hero_colors_test.exs
+++ b/test/mix/tasks/lint_hero_colors_test.exs
@@ -1,0 +1,164 @@
+defmodule Mix.Tasks.LintHeroColorsTest do
+  @moduledoc """
+  Drives `Mix.Tasks.LintHeroColors`'s pure halves.
+
+  The heroicons case is the load-bearing one: `assets/css/app.css` loads
+  `@plugin "../vendor/heroicons"`, which generates tokenless `hero-*` utilities
+  under the same prefix as the brand colour scales. The extractor separates them
+  structurally — a colour utility always has a prefix before `-hero-`, a bare icon
+  class never does — so a regression there floods the lint with false positives
+  rather than failing quietly.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Mix.Tasks.LintHeroColors
+
+  describe "parse_theme_tokens/1" do
+    test "collects the colour names declared in @theme" do
+      css = """
+      @theme {
+        --color-hero-blue-500: oklch(78% 0.155 210); /* Primary #0fc3ff */
+        --color-hero-black: oklch(0% 0 0);
+        --font-display: "Plus Jakarta Sans", sans-serif;
+      }
+      """
+
+      tokens = LintHeroColors.parse_theme_tokens(css)
+
+      assert "hero-blue-500" in tokens
+      assert "hero-black" in tokens
+      refute "hero-charcoal" in tokens
+    end
+
+    test "ignores the :root semantic aliases that reference the scale" do
+      css = """
+      @theme {
+        --color-hero-blue-500: oklch(78% 0.155 210);
+      }
+      :root {
+        --brand-primary: var(--color-hero-blue-500);
+      }
+      """
+
+      assert LintHeroColors.parse_theme_tokens(css) == MapSet.new(["hero-blue-500"])
+    end
+  end
+
+  describe "extract_used/1" do
+    test "pulls the token name out of a plain utility" do
+      assert LintHeroColors.extract_used(~s("bg-hero-yellow")) == ["hero-yellow"]
+    end
+
+    test "strips a variant prefix" do
+      assert LintHeroColors.extract_used(~s("focus:ring-hero-cyan")) == ["hero-cyan"]
+    end
+
+    test "strips an opacity modifier" do
+      assert LintHeroColors.extract_used(~s("bg-hero-primary/5")) == ["hero-primary"]
+    end
+
+    test "keeps a multi-segment name whole" do
+      assert LintHeroColors.extract_used(~s("hover:bg-hero-yellow-dark")) == ["hero-yellow-dark"]
+    end
+
+    test "handles an arbitrary-variant prefix" do
+      assert LintHeroColors.extract_used(~s("has-[:checked]:bg-hero-yellow")) == ["hero-yellow"]
+    end
+
+    test "ignores a bare heroicon class" do
+      assert LintHeroColors.extract_used(~s(<.icon name="hero-plus-mini" class="w-5" />)) == []
+    end
+
+    test "ignores a heroicon sitting in a class list beside a colour utility" do
+      assert LintHeroColors.extract_used(~s("hero-check-mini bg-hero-yellow-500")) ==
+               ["hero-yellow-500"]
+    end
+
+    test "returns every token on the line, in order, without duplicates" do
+      line = ~s("bg-hero-yellow hover:bg-hero-yellow-dark text-hero-charcoal bg-hero-yellow")
+
+      assert LintHeroColors.extract_used(line) ==
+               ["hero-yellow", "hero-yellow-dark", "hero-charcoal"]
+    end
+  end
+
+  describe "violations/2" do
+    @tag :tmp_dir
+    test "passes a tree whose every hero-* utility resolves to a token", %{tmp_dir: dir} do
+      theme = write_theme(dir, ~w(hero-yellow-500 hero-black-100))
+      write(dir, "components/ui.ex", ~s(class="bg-hero-yellow-500 text-hero-black-100"))
+
+      assert LintHeroColors.violations(Path.join(dir, "web"), theme) == []
+    end
+
+    @tag :tmp_dir
+    test "flags a utility with no matching token", %{tmp_dir: dir} do
+      theme = write_theme(dir, ~w(hero-yellow-500))
+      write(dir, "components/ui.ex", ~s(class="bg-hero-charcoal"))
+
+      assert [{path, line_num, token}] = LintHeroColors.violations(Path.join(dir, "web"), theme)
+      assert Path.basename(path) == "ui.ex"
+      assert line_num == 1
+      assert token == "hero-charcoal"
+    end
+
+    @tag :tmp_dir
+    test "scans .heex templates as well as .ex modules", %{tmp_dir: dir} do
+      theme = write_theme(dir, ~w(hero-blue-500))
+      write(dir, "live/page.html.heex", ~s(<div class="text-hero-cyan">hi</div>))
+
+      assert [{path, _, "hero-cyan"}] = LintHeroColors.violations(Path.join(dir, "web"), theme)
+      assert Path.basename(path) == "page.html.heex"
+    end
+
+    @tag :tmp_dir
+    test "reports the line the violation is on, not the first line", %{tmp_dir: dir} do
+      theme = write_theme(dir, ~w(hero-blue-500))
+      write(dir, "components/ui.ex", "line one\nline two\nclass=\"bg-hero-primary\"\n")
+
+      assert [{_, 3, "hero-primary"}] = LintHeroColors.violations(Path.join(dir, "web"), theme)
+    end
+
+    @tag :tmp_dir
+    test "stays silent on a tree of nothing but heroicons", %{tmp_dir: dir} do
+      theme = write_theme(dir, ~w(hero-blue-500))
+      write(dir, "components/ui.ex", ~s(<.icon name="hero-academic-cap-mini" />))
+
+      assert LintHeroColors.violations(Path.join(dir, "web"), theme) == []
+    end
+
+    @tag :tmp_dir
+    test "the ignore marker exempts its own line", %{tmp_dir: dir} do
+      theme = write_theme(dir, ~w(hero-blue-500))
+      write(dir, "live/page.ex", ~s(id="program-hero-image" <%!-- hero-color-lint-ignore --%>))
+
+      assert LintHeroColors.violations(Path.join(dir, "web"), theme) == []
+    end
+
+    @tag :tmp_dir
+    test "the ignore marker exempts the following line", %{tmp_dir: dir} do
+      theme = write_theme(dir, ~w(hero-blue-500))
+
+      write(dir, "live/page.ex", """
+      <%!-- hero-color-lint-ignore: a DOM id, not a class --%>
+      id="program-hero-image"
+      """)
+
+      assert LintHeroColors.violations(Path.join(dir, "web"), theme) == []
+    end
+  end
+
+  defp write_theme(dir, tokens) do
+    path = Path.join(dir, "app.css")
+    body = Enum.map_join(tokens, "\n", &"  --color-#{&1}: oklch(50% 0 0);")
+    File.write!(path, "@theme {\n#{body}\n}\n")
+    path
+  end
+
+  defp write(dir, relative, contents) do
+    path = Path.join([dir, "web", relative])
+    File.mkdir_p!(Path.dirname(path))
+    File.write!(path, contents)
+  end
+end


### PR DESCRIPTION
Closes #1417

## Summary

Tailwind v4's CSS-first `@theme` emits a utility only when a matching `--color-*` custom
property exists, and emits **nothing — silently, with no build warning** — when one does not.
Several Tailwind v3 habits (unnumbered base colours, `-dark` suffixes, invented scale names)
had accumulated in the web layer and were rendering as inherited or transparent.

This maps every dead class onto an existing token and adds `mix lint_hero_colors` so the class
of bug cannot recur.

### What was actually dead

Verified against the compiled stylesheet (`priv/static/assets/css/app.css`) — the source cannot
tell you whether a rule was emitted:

| Token family | Uses | Compiled rules |
|---|---|---|
| `hero-charcoal` | 89 | 0 |
| `hero-cyan` (+ `-cyan-100`) | 36 | 0 |
| `hero-primary` | 10 | 0 |
| `hero-yellow` (bare) | 6 | 0 |
| `hero-yellow-dark` | 6 | 0 |

The issue's original inventory was wrong in both directions: it missed `hero-cyan` and
`hero-primary` entirely, and listed `hero-cream-100` as dead when it is defined and compiles.
The issue body has been corrected.

### Three of these were real defects, not cosmetic drift

1. **The provider verification tooltip was unreadable.** `provider_components.ex:423` was
   `bg-hero-charcoal text-white` — a dead background with white text. It explains why
   **New Program** is disabled pending verification, so an unverified provider got a dead
   button *and* no reachable explanation.
2. **Submit buttons rendered as bare text.** `#save-staff-btn`, Resend and three others were
   `bg-hero-yellow` + `text-hero-charcoal` with no other background — *both* the surface and
   the text colour dead, so there was no button shape at all.
3. **The weekday picker had no selected state.** `has-[:checked]:bg-hero-yellow` +
   `has-[:checked]:border-hero-yellow-dark` were both inert, so a selected day differed from an
   unselected one **only by `font-semibold`**.

## Review focus

**The mapping choices.** Classes are mapped to existing tokens rather than adding new ones,
because `DESIGN.md` names exactly six scales and charcoal/cyan/primary are not among them —
defining `--color-hero-charcoal` would make the code compile while putting `app.css` in
conflict with `DESIGN.md`.

Two mappings are shade-sensitive and worth a look:

- `text-hero-cyan` on a `bg-hero-blue-100` tint → `text-hero-blue-800`, per `DESIGN.md`'s
  `status_badge` rule. Measured **4.90:1**; `-700` is 3.20 and `-600` is 2.14, both below AA.
- `icon_color` on `provider_stat_card` → `text-hero-blue-600`, *not* `-800`. That attr is
  interpolated onto an `<.icon>` SVG glyph, not text, and `Theme.icon_styles(:info)` pairs the
  same tint with `-600`. (Caught by the design-system review; second commit.)

**The lint's discriminator.** `app.css` loads `@plugin "../vendor/heroicons"`, which generates
~150 tokenless `hero-*` icon utilities under the same prefix. The task separates them
structurally — a colour utility always has a prefix before `-hero-`, a bare `hero-plus-mini`
never does — so there is **no enum of utility prefixes**. That is deliberate: such a list goes
stale, and a prefix nobody enumerated would be a class nobody checks, reproducing this exact
bug one level up. Likewise the token set is *parsed* from `@theme` rather than hardcoded.

**One rename.** `#program-hero-image` → `#program-cover-image` (matching its `cover_image_url`
source). The `-hero-` substring is the lint's only false positive, and the suppression marker
could not be placed there — HEEx forbids comments inside a tag's attribute list. Renaming
leaves the new guard with zero suppressions.

## Known limitation, tracked separately

`text-hero-cyan` on white → `text-hero-blue-600` matches `Theme.text_color(:primary)` exactly,
which is the app-wide link colour. It measures **2.66:1** and fails AA — but so do all ~46
existing usages, so this PR matches the convention rather than creating a second link shade.
Filed as **#1443** with the full measured ramp; the fix is one token value, not these call sites.

Yellow-as-primary-CTA (which `DESIGN.md` rules out) predates this branch — an untouched sibling
at `provider_components.ex:2368` already used it. Filed as **#1444** rather than redesigning six
buttons inside a dead-class fix.

## Test plan

- `mix precommit` green — 4768 tests, credo `--strict` clean, all five lints pass.
- 17 new tests for the lint task. The heroicon-exclusion case is regression-critical: a break
  there floods ~150 false positives.
- **Guard proven to bite:** injecting `bg-hero-nonsense` fails the lint with file and line;
  reverting restores green. It also caught a real mistake mid-development, when a `git checkout`
  silently reverted one file's sweep.
- **Ground truth:** after `mix assets.build`,
  `grep -cE 'hero-(charcoal|cyan|primary|yellow-dark)' priv/static/assets/css/app.css` → `0`,
  and every replacement rule is present.
- **Browser-verified** on the provider app at 375/1280, all three defects fixed:
  tooltip now `oklch(0 0 0)` behind white text (21:1); `#save-staff-btn` now
  `oklch(0.97 0.22 105)` with `oklch(0.2 0 0)` text (16.42:1); weekday picker fills yellow-500
  with a yellow-600 border while unselected days stay transparent/grey-300. Provider nav tabs
  resolve to real values instead of inheriting `currentColor`.
