### PR TITLE
chore: pin error_tracker to ~> 0.9.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -58,7 +58,7 @@ defmodule KlassHero.MixProject do
   # Type `mix help deps` for examples and options.
   defp deps do
     [
-      {:error_tracker, "~> 0.7"},
+      {:error_tracker, "~> 0.9.0"},
       {:fun_with_flags, "~> 1.12"},
       {:usage_rules, "~> 1.0", only: [:dev]},
       {:bcrypt_elixir, "~> 3.0"},


### PR DESCRIPTION
## Summary

`mix.exs` pinned `{:error_tracker, "~> 0.7"}` while `mix.lock` held **0.9.0**. On a pre-1.0 Hex package the *minor* is the breaking-change axis, so that constraint spanned four releases (0.7.0, 0.7.1, 0.8.0, 0.9.0) the codebase has never run.

Pinned to `~> 0.9.0` — the version actually in use.

## Review Focus

**Why three segments, not `~> 0.9`.** `~> 0.9` still admits `< 1.0.0`, i.e. 0.10 and 0.11 — exactly the boundary that matters for a pre-1.0 package. `~> 0.9.0` admits `< 0.10.0` only. This is also the config `mix hex.info error_tracker` itself suggests, and it matches existing three-segment pins in this file (`phoenix ~> 1.8.1`, `dns_cluster ~> 0.2.0`).

**Why the pin is load-bearing here.** Since #1403, `config :error_tracker, repo:` points at `KlassHero.Shared.ErrorStoreRepo`. That shim is **duck-typed, not an `Ecto.Repo` behaviour** — `ErrorTracker.Repo` reaches it through `apply(config_repo, action, args ++ [opts])` over a fixed list of nine functions plus `__adapter__/0`, and nothing checks that list at compile time. A version dispatching a tenth would raise `UndefinedFunctionError` *at report time* — error reporting breaking precisely when something else is already broken.

That divergence is already guarded: `test/klass_hero/shared/error_store_repo_test.exs` parses the dependency's `repo.ex` and fails when the dispatch list outgrows the shim. What remained was that `~> 0.7` let `mix deps.update` cross a minor boundary without anyone deciding to.

**Deliberately not included:** the issue suggested a moduledoc note that bumping `error_tracker` means re-reading `repo.ex`. The moduledoc already says *"`KlassHero.Shared.ErrorStoreRepoTest` fails if a dependency upgrade adds to that set"* — restating it would be a comment restating code.

## Test Plan

- [x] `mix deps.get` produces **no `mix.lock` diff** — the load-bearing check. Proves the new constraint narrows what is already resolved rather than re-solving the subtree.
- [x] `mix test test/klass_hero/shared/error_store_repo_test.exs` — dispatch-coverage guard green (7 passed)
- [x] `mix precommit` — 4828 passed, credo clean, all five lints pass

Closes #1407