### PR TITLE
fix: scrub historical error_tracker context

### DIFF
--- a/lib/klass_hero/shared/error_context_filter.ex
+++ b/lib/klass_hero/shared/error_context_filter.ex
@@ -25,9 +25,24 @@ defmodule KlassHero.Shared.ErrorContextFilter do
   Everything else in the context passes through — `KlassHeroWeb.Router.set_error_tracker_context/2`'s
   user_id/email predate this filter and are deliberate.
 
-  `sanitize/1` is called once, on the fully merged context at report time, so a single
+  On the report path `sanitize/1` is called once, on the fully merged context, so a single
   LiveView crash can arrive carrying mount, `handle_params` and `handle_event` params at
   once. Each key is narrowed independently.
+
+  ## Idempotence
+
+  `sanitize/1` is a fixpoint: narrowing an already-narrowed context returns it unchanged. The
+  report path never needed that, but a backfill does — #1406 narrows the rows written before
+  this filter existed, and cannot avoid meeting rows it has already narrowed. Without the
+  property, a second pass would read a params marker as an unlisted *string* and collapse
+  `"[8 keys redacted: allergies, …]"` to `"[redacted]"`, destroying the field names that are the
+  entire point of the params half.
+
+  The args half is a fixpoint for free — `Map.take/2` of an already-taken map keeps everything,
+  so nothing is dropped and no sibling key is rewritten. The params half needs `already_narrowed?/1`,
+  which recognises a marker by its exact shape. The cost is that a value the user typed which
+  matches that shape survives verbatim; `@nested_marker` is anchored end to end to keep that
+  surface as small as it can be without changing what a marker *is*.
 
   Wired via `config :error_tracker, filter: KlassHero.Shared.ErrorContextFilter`.
 
@@ -52,6 +67,12 @@ defmodule KlassHero.Shared.ErrorContextFilter do
   @param_keys ~w(live_view.event_params live_view.params request.params)
 
   @scalar_marker "[redacted]"
+
+  # Exactly what nested_marker/1 emits, anchored end to end. Recognising a marker by its shape
+  # is what makes sanitize/1 idempotent, and the anchoring is what keeps that cheap: a value
+  # the user typed passes through only if it matches this whole string, which no name, date or
+  # medical note does.
+  @nested_marker ~r/^\[\d+ keys redacted: [^\[\]]*\]$/
 
   # Correlation ids only — enough to find the row this job was about, never its contents.
   # "trace_context" carries OTel propagation (`Shared.Tracing.Context.inject_into_args/1`);
@@ -111,10 +132,17 @@ defmodule KlassHero.Shared.ErrorContextFilter do
   defp narrow_param({key, value}) do
     cond do
       to_string(key) in @allowed_params -> {key, value}
+      already_narrowed?(value) -> {key, value}
       is_map(value) -> {key, nested_marker(value)}
       true -> {key, @scalar_marker}
     end
   end
+
+  defp already_narrowed?(value) when is_binary(value) do
+    value == @scalar_marker or Regex.match?(@nested_marker, value)
+  end
+
+  defp already_narrowed?(_value), do: false
 
   defp nested_marker(map) do
     names = map |> Map.keys() |> Enum.map(&to_string/1) |> Enum.sort()

--- a/lib/klass_hero/shared/error_context_filter.ex
+++ b/lib/klass_hero/shared/error_context_filter.ex
@@ -68,11 +68,20 @@ defmodule KlassHero.Shared.ErrorContextFilter do
 
   @scalar_marker "[redacted]"
 
-  # Exactly what nested_marker/1 emits, anchored end to end. Recognising a marker by its shape
-  # is what makes sanitize/1 idempotent, and the anchoring is what keeps that cheap: a value
-  # the user typed passes through only if it matches this whole string, which no name, date or
-  # medical note does.
-  @nested_marker ~r/^\[\d+ keys redacted: [^\[\]]*\]$/
+  # Exactly what nested_marker/1 emits: a count, then its sorted field names joined by ", ".
+  # Recognising a marker by its shape is what makes sanitize/1 idempotent, and every part of
+  # this pattern is holding that surface down:
+  #
+  #   * `\A`/`\z`, not `^`/`$` — the latter also match either side of a trailing newline.
+  #   * Tokens may not contain whitespace. Field names never do; typed prose always does, so
+  #     this is what stops "[3 keys redacted: severe peanut allergy, born 2015-01-01]" from
+  #     being mistaken for a marker and stored verbatim.
+  #
+  # The charset is otherwise left open on purpose. Names come from form fields, so `_target`,
+  # `Child-Name` and any casing are all real, and a marker this fails to recognise is worse
+  # than a permissive one: it gets collapsed to `@scalar_marker`, losing the names — the very
+  # bug idempotence exists to prevent.
+  @nested_marker ~r/\A\[\d+ keys redacted: (?:[^,\s\[\]]+(?:, [^,\s\[\]]+)*)?\]\z/
 
   # Correlation ids only — enough to find the row this job was about, never its contents.
   # "trace_context" carries OTel propagation (`Shared.Tracing.Context.inject_into_args/1`);

--- a/priv/repo/migrations/20260821064030_scrub_error_tracker_context.exs
+++ b/priv/repo/migrations/20260821064030_scrub_error_tracker_context.exs
@@ -1,0 +1,54 @@
+defmodule KlassHero.Repo.Migrations.ScrubErrorTrackerContext do
+  @moduledoc """
+  Narrows `context` on the rows written before #1392 was fixed.
+
+  `ErrorContextFilter` narrows context as it is written and was never applied to the rows that
+  predate it, so 181 of the 182 production occurrences still carry user-submitted data verbatim —
+  Oban job args and the params of the request or LiveView event that crashed.
+  `ProcessInviteClaimWorker`'s args and the children form both carry a child's name, date of
+  birth and medical conditions. The forward path is closed by the filter; this closes the
+  history (#1406).
+
+  Context-side twin of `20260818070001_scrub_error_tracker_reasons`, and the same three
+  properties hold: it calls the filter rather than reimplementing it in SQL, the `Logger.info`
+  count is the gate a human reads at deploy, and it is irreversible — the original values are
+  the thing being destroyed, so `down/0` is a no-op.
+
+  Only `error_tracker_occurrences` has a `context` column; the sibling scrub touched two tables
+  because `reason` lives on both.
+
+  `sanitize/1` is a fixpoint (see its moduledoc), so a row the filter has already narrowed
+  survives this unchanged and re-running costs nothing but a read.
+
+  This pins the migration to `KlassHero.Shared.ErrorContextFilter`. If that module is ever
+  renamed or removed, replace this body with `:ok` — by then every environment has already run
+  it.
+  """
+
+  use Ecto.Migration
+
+  import Ecto.Query
+
+  alias KlassHero.Shared.ErrorContextFilter
+
+  require Logger
+
+  @table "error_tracker_occurrences"
+
+  def up do
+    rows = repo().all(from(o in @table, select: {o.id, o.context}))
+
+    narrowed =
+      for {id, context} <- rows,
+          is_map(context),
+          scrubbed = ErrorContextFilter.sanitize(context),
+          scrubbed != context do
+        repo().update_all(from(o in @table, where: o.id == ^id), set: [context: scrubbed])
+        id
+      end
+
+    Logger.info("#{@table}: narrowed #{length(narrowed)} of #{length(rows)} contexts")
+  end
+
+  def down, do: :ok
+end

--- a/test/klass_hero/shared/error_context_filter_test.exs
+++ b/test/klass_hero/shared/error_context_filter_test.exs
@@ -194,11 +194,10 @@ defmodule KlassHero.Shared.ErrorContextFilterTest do
       assert ErrorContextFilter.sanitize(once) == once
     end
 
-    # The cost of recognising the marker by its shape: a value the user typed that happens to
-    # look like one survives verbatim. Bounded on purpose — the regex is anchored to the exact
-    # string nested_marker/1 emits, and no plausible PII (a name, a date, an allergy) matches it.
-    # Only a structural marker could close this, and that would change the shape every stored
-    # context is read in.
+    # The cost of recognising a marker by its shape: a value the user typed that matches it
+    # survives verbatim. Bounded on purpose, and this test is where that bound is stated.
+    # Closing it entirely would need a structural marker, which would change the shape every
+    # stored context is read in.
     test "passes through a user-submitted string shaped like a marker" do
       context = %{"live_view.event_params" => %{"note" => "[2 keys redacted: a, b]"}}
 
@@ -206,18 +205,60 @@ defmodule KlassHero.Shared.ErrorContextFilterTest do
       assert params["note"] == "[2 keys redacted: a, b]"
     end
 
-    # ...but only that exact shape. Anything merely resembling it is still redacted.
+    # ...but only that exact shape. The interesting cases are the last three: whitespace inside
+    # a token is what separates a field-name list from typed prose, and it is the whole reason
+    # @nested_marker forbids it. Without that, wrapping health data in the marker's syntax
+    # would smuggle it past the filter verbatim.
     test "redacts a string that only resembles a marker" do
       context = %{
         "live_view.event_params" => %{
           "a" => "[keys redacted: allergies]",
           "b" => "see [2 keys redacted: x, y]",
-          "c" => "[2 keys redacted: x, y] and more"
+          "c" => "[2 keys redacted: x, y] and more",
+          "d" => "[3 keys redacted: severe peanut allergy, born 2015-01-01, asthma]",
+          "e" => "[2 keys redacted: a, b]\nleaked",
+          "f" => "[2 keys redacted: a, b]\n"
         }
       }
 
       assert %{"live_view.event_params" => params} = ErrorContextFilter.sanitize(context)
-      assert params == %{"a" => "[redacted]", "b" => "[redacted]", "c" => "[redacted]"}
+
+      assert params ==
+               %{
+                 "a" => "[redacted]",
+                 "b" => "[redacted]",
+                 "c" => "[redacted]",
+                 "d" => "[redacted]",
+                 "e" => "[redacted]",
+                 "f" => "[redacted]"
+               }
+    end
+
+    # Field names come from form inputs, so they are not restricted to a tidy charset. A marker
+    # this failed to recognise would be collapsed to "[redacted]" on the next pass — the bug
+    # idempotence exists to prevent — so the recognised charset stays wide.
+    test "recognises a marker whose field names are not plain lowercase words" do
+      context = %{
+        "live_view.event_params" => %{
+          "child" => %{"_target" => 1, "Child-Name" => 2, "school.grade" => 3}
+        }
+      }
+
+      once = ErrorContextFilter.sanitize(context)
+
+      assert once["live_view.event_params"]["child"] ==
+               "[3 keys redacted: Child-Name, _target, school.grade]"
+
+      assert ErrorContextFilter.sanitize(once) == once
+    end
+
+    # Map.keys/1 of an empty map joins to nothing, so the marker carries a trailing space before
+    # the bracket. It still has to be recognised as one.
+    test "recognises the marker for an empty nested map" do
+      once = ErrorContextFilter.sanitize(%{"request.params" => %{"child" => %{}}})
+
+      assert once["request.params"]["child"] == "[0 keys redacted: ]"
+      assert ErrorContextFilter.sanitize(once) == once
     end
   end
 

--- a/test/klass_hero/shared/error_context_filter_test.exs
+++ b/test/klass_hero/shared/error_context_filter_test.exs
@@ -1,7 +1,14 @@
 defmodule KlassHero.Shared.ErrorContextFilterTest do
   use ExUnit.Case, async: true
+  use ExUnitProperties
 
   alias KlassHero.Shared.ErrorContextFilter
+
+  @param_keys ~w(live_view.event_params live_view.params request.params)
+
+  # Every generated value the filter is supposed to destroy carries this prefix, so a single
+  # substring check over the whole sanitized context is a complete oracle for "nothing leaked".
+  @pii_prefix "pii-"
 
   describe "sanitize/1 on Oban job args" do
     test "keeps correlation ids and the trace context" do
@@ -150,6 +157,70 @@ defmodule KlassHero.Shared.ErrorContextFilterTest do
     end
   end
 
+  # The report path calls sanitize/1 exactly once, so idempotence never mattered until
+  # #1406 added a second caller: a migration narrowing the rows written before this filter
+  # existed, which necessarily also meets rows the filter has already narrowed.
+  describe "sanitize/1 on already-narrowed context" do
+    # Without this, a second pass sees a string rather than a map and collapses the marker
+    # to "[redacted]" — destroying the field names that are the whole point of the params half.
+    test "keeps a nested marker instead of collapsing it to the scalar marker" do
+      context = %{
+        "live_view.event_params" => %{
+          "child" => %{"first_name" => "Louis", "allergies" => "none"}
+        }
+      }
+
+      once = ErrorContextFilter.sanitize(context)
+
+      assert once["live_view.event_params"]["child"] == "[2 keys redacted: allergies, first_name]"
+      assert ErrorContextFilter.sanitize(once) == once
+    end
+
+    test "keeps a scalar marker" do
+      once = ErrorContextFilter.sanitize(%{"request.params" => %{"email" => "a@example.com"}})
+
+      assert once["request.params"] == %{"email" => "[redacted]"}
+      assert ErrorContextFilter.sanitize(once) == once
+    end
+
+    test "is idempotent across both halves of one context" do
+      context = %{
+        "job.args" => %{"invite_id" => "inv-1", "medical_conditions" => "Asthma"},
+        "live_view.event_params" => %{"child" => %{"allergies" => "none"}, "email" => "a@b.c"}
+      }
+
+      once = ErrorContextFilter.sanitize(context)
+
+      assert ErrorContextFilter.sanitize(once) == once
+    end
+
+    # The cost of recognising the marker by its shape: a value the user typed that happens to
+    # look like one survives verbatim. Bounded on purpose — the regex is anchored to the exact
+    # string nested_marker/1 emits, and no plausible PII (a name, a date, an allergy) matches it.
+    # Only a structural marker could close this, and that would change the shape every stored
+    # context is read in.
+    test "passes through a user-submitted string shaped like a marker" do
+      context = %{"live_view.event_params" => %{"note" => "[2 keys redacted: a, b]"}}
+
+      assert %{"live_view.event_params" => params} = ErrorContextFilter.sanitize(context)
+      assert params["note"] == "[2 keys redacted: a, b]"
+    end
+
+    # ...but only that exact shape. Anything merely resembling it is still redacted.
+    test "redacts a string that only resembles a marker" do
+      context = %{
+        "live_view.event_params" => %{
+          "a" => "[keys redacted: allergies]",
+          "b" => "see [2 keys redacted: x, y]",
+          "c" => "[2 keys redacted: x, y] and more"
+        }
+      }
+
+      assert %{"live_view.event_params" => params} = ErrorContextFilter.sanitize(context)
+      assert params == %{"a" => "[redacted]", "b" => "[redacted]", "c" => "[redacted]"}
+    end
+  end
+
   describe "sanitize/1 on everything else" do
     # The router sets user_id/email via ErrorTracker.set_context/1. Those are deliberate
     # and pre-date this filter; narrowing to job args must leave them alone.
@@ -180,4 +251,80 @@ defmodule KlassHero.Shared.ErrorContextFilterTest do
       assert sanitized["live_view.event_params"]["child"] == "[1 keys redacted: allergies]"
     end
   end
+
+  describe "sanitize/1 properties" do
+    property "is a fixpoint — narrowing an already-narrowed context changes nothing" do
+      check all(context <- context_gen()) do
+        once = ErrorContextFilter.sanitize(context)
+
+        assert ErrorContextFilter.sanitize(once) == once
+      end
+    end
+
+    # Closed by default, over generated input rather than the named fields of the example
+    # tests: whatever a new worker or a new form adds, its values do not reach the error store.
+    property "no value the filter is meant to destroy survives" do
+      check all(context <- context_gen()) do
+        sanitized = context |> ErrorContextFilter.sanitize() |> Jason.encode!()
+
+        refute sanitized =~ @pii_prefix
+      end
+    end
+  end
+
+  defp context_gen do
+    gen all(
+          args <- one_of([args_gen(), constant(nil), constant("not-a-map")]),
+          params <- submap_gen(@param_keys, params_gen()),
+          passthrough <- map_of(name_gen(), string(:alphanumeric), max_length: 2)
+        ) do
+      params
+      |> Map.put("job.args", args)
+      |> Map.merge(passthrough)
+    end
+  end
+
+  defp args_gen do
+    gen all(
+          allowed <- submap_gen(allowed_args(), safe_value_gen()),
+          dropped <- map_of(name_gen(), pii_value_gen(), max_length: 3)
+        ) do
+      Map.merge(dropped, allowed)
+    end
+  end
+
+  defp params_gen do
+    gen all(
+          allowed <- submap_gen(allowed_params(), safe_value_gen()),
+          redacted <-
+            map_of(name_gen(), one_of([pii_value_gen(), nested_gen()]), max_length: 3)
+        ) do
+      Map.merge(redacted, allowed)
+    end
+  end
+
+  defp nested_gen, do: map_of(name_gen(), pii_value_gen(), max_length: 4)
+
+  # Each key is independently present or absent. `map_of(member_of(keys), ...)` would be the
+  # obvious spelling and is a trap: it draws *unique* keys from a handful of terms and dies with
+  # StreamData.TooManyDuplicatesError long before it exhausts them.
+  defp submap_gen(keys, value_gen) do
+    absent = make_ref()
+
+    gen all(drawn <- fixed_map(Map.new(keys, &{&1, one_of([value_gen, constant(absent)])}))) do
+      for {key, value} <- drawn, value != absent, into: %{}, do: {key, value}
+    end
+  end
+
+  # Deliberately disjoint from the allowlists, so a generated "dropped" key is never one the
+  # filter is supposed to keep.
+  defp name_gen, do: map(string(?a..?z, min_length: 1, max_length: 6), &("field_" <> &1))
+
+  defp pii_value_gen, do: map(string(?a..?z, min_length: 1, max_length: 8), &(@pii_prefix <> &1))
+
+  defp safe_value_gen, do: map(string(?a..?z, min_length: 1, max_length: 8), &("ok-" <> &1))
+
+  defp allowed_args, do: ~w(invite_id user_id program_id child_id trace_context)
+
+  defp allowed_params, do: ~w(invite_id user_id child_id consent page _target)
 end


### PR DESCRIPTION
Closes #1406.

## Summary

`ErrorContextFilter` narrows error context *as it is written* and was never applied to the rows that predate it. **181 of the 182 production occurrences** still store user-submitted data verbatim — Oban job args and the params of the request or LiveView event that crashed — including a child's name, date of birth and medical conditions from `ProcessInviteClaimWorker` and the children form.

Context-side twin of #1398, whose `reason` scrub shipped as `20260818070001` (already applied in prod, so this is a standalone second pass over the same small table).

Two commits:

1. **The migration.** Reads each occurrence's context, runs it through `sanitize/1`, writes back where it changed. Mirrors the `reason` scrub: calls the filter rather than reimplementing it in SQL, keeps the `Logger.info` count as the deploy gate, and `down/0` is a no-op because the original values *are* what is being destroyed.

2. **Idempotence, which the migration forced.** That backfill is the filter's second caller and the first that can meet already-narrowed context. `sanitize/1` was not a fixpoint: a nested params marker is a *string*, so a second pass read it as an unlisted scalar and collapsed `"[8 keys redacted: allergies, …]"` to `"[redacted]"` — destroying the field names that are the point of the params half. The filter now recognises its own markers.

## Review Focus

**The marker regex is the whole security surface of this change.** Recognising a marker by its shape is what buys idempotence, and it is also the one thing that widens: a value the user typed which matches the marker is now stored verbatim.

```elixir
@nested_marker ~r/\A\[\d+ keys redacted: (?:[^,\s\[\]]+(?:, [^,\s\[\]]+)*)?\]\z/
```

Two deliberate calls worth disagreeing with:

- **`\A`/`\z`, and no whitespace inside a token.** `^`/`$` also match either side of a trailing newline. Forbidding whitespace is what stops `"[3 keys redacted: severe peanut allergy, born 2015-01-01]"` from being taken for a marker — field names never contain spaces, typed prose always does.
- **The charset stays open.** Narrowing it to `[a-z0-9_.]` was suggested and rejected: names come from form fields, so `_target` and `Child-Name` are real, and a marker the filter *fails* to recognise is worse than a permissive one — it gets collapsed to `"[redacted]"`, which is the bug idempotence exists to prevent.

The residual hole is bracket-free, space-free text wrapped in the exact marker syntax. Closing it entirely needs a structural marker, which would change the shape every stored context is read in. Pinned as a known bound in `"passes through a user-submitted string shaped like a marker"`.

## Test Plan

- `mix precommit` — 4837 passed, credo clean.
- Two `stream_data` properties: `sanitize(sanitize(ctx)) == sanitize(ctx)`, and "no value the filter is meant to destroy survives" (every generated PII value carries a `pii-` prefix, so one substring check over the encoded context is a complete oracle). Mutation-checked: reverting the fix fails the fixpoint property after 3 runs.
- Dev dry-run of the migration against three seeded rows — raw job args, a raw children form, and one row already narrowed by the forward filter. Result: `narrowed 2 of 3`, with the pre-narrowed row untouched. `mix ecto.rollback` then re-migrate reports `narrowed 0 of 3`, confirming the fixpoint end to end.
- The `jsonb` write was verified against a live DB before being relied on: a schemaless `update_all(set: [context: ^map])` encodes correctly, so no `type/2` or `fragment` is needed.

## Post-deploy

Read the `Logger.info` line in the release logs — expect ~181 of 182 — then re-run the issue's key-presence census via `bin/prod-db`.

## Follow-up (not in this PR)

`ErrorReasonFilter.sanitize/1` is non-idempotent the same way: an already-marked reason no longer matches `@safe_shapes` and degrades to `@unrecognised_marker`. `20260818070001` has already run, so nothing is pending, but the next `reason` backfill would hit it.
