### PR TITLE
docs: route the phx plugin from the project skill index

### DIFF
--- a/.claude/rules/skills.md
+++ b/.claude/rules/skills.md
@@ -55,7 +55,7 @@ Reads a Daily QA GitHub Discussion by number, triages Carried-Forward and New Co
 
 ### build-elixir
 
-User-invoked umbrella router for TDD-first, design-heavy Elixir/Phoenix development. Sequences `/design-an-interface` (surface rival designs — user picks), `/tdd` (red→green), `exunit-testing` (fold tests lean via tabular for-comprehensions + property tests), auto-attaching idiom/Iron-Law/LiveView guidance, then verify. Generic Elixir idioms live in `.claude/rules/elixir-style.md` + `domain-architecture.md` and the `elixir-phoenix` plugin (auto-loaded), not a skill.
+User-invoked umbrella router for TDD-first, design-heavy Elixir/Phoenix development. Sequences `/design-an-interface` (surface rival designs — user picks), `/tdd` (red→green), `exunit-testing` (fold tests lean via tabular for-comprehensions + property tests), auto-attaching idiom/Iron-Law/LiveView guidance, then verify. Generic Elixir idioms live in `.claude/rules/elixir-style.md` + `domain-architecture.md` and the `phx` plugin, not a skill — see [Elixir/Phoenix Plugin (`phx`)](#elixirphoenix-plugin-phx) below for what it adds and who wins on overlap.
 
 **Use when:** `/build-elixir <what you're building>`
 
@@ -126,3 +126,47 @@ Reviews code for conventional-Phoenix convention compliance (post-flatten). Runs
 Detects semantic cross-context boundary violations (boundaries are convention-only since the `boundary` library was removed). Checks for reaching into another context's internals instead of its root facade, cross-context Repo/schema access, event-handler facade use, event/read-model purity, and ACL adapter correctness. Supports `changed-files` or `full` scan scope.
 
 **Use when:** Deep boundary analysis needed, especially after adding cross-context features. Spawn as a subagent.
+
+## Elixir/Phoenix Plugin (`phx`)
+
+Installed as `elixir-phoenix` (marketplace `oliver-kriska`, v3.0.1); invoked as `/phx:*` because its `plugin.json` sets `"name": "phx"`. Ships **51 skills and 25 agents**. The sibling `ecto@oliver-kriska` and `lv@oliver-kriska` plugins are thin aliases onto the same codebase (`/ecto:*`, `/lv:*`) — no separate capability.
+
+### Reach for these — no project equivalent exists
+
+| Command / agent | What it does that nothing here does |
+|---|---|
+| `/phx:investigate` | Structured root-cause on a stack trace. `--parallel` fans `deep-bug-investigator` across 4 tracks (repro / root cause / impact / fix strategy). |
+| `/phx:trace`, `phx:call-tracer`, `phx:xref-analyzer` | Call trees from entry points and module-dependency maps via `mix xref` — run before a signature change or a refactor. |
+| `/phx:n1-check`, `/phx:perf`, `/phx:assigns-audit` | N+1 detection, Ecto/GenServer bottlenecks, LiveView assign bloat and missing `temporary_assigns`/streams. |
+| `/phx:boundaries` | `mix xref` coupling analysis — **structural**, where `boundary-checker` is semantic. Different instruments; run both. |
+| `/phx:oban` + `phx:oban-specialist` | Worker idempotency, queue config, cron, string-keyed args. Five contexts here have `workers/` and no Oban review skill. |
+| `/phx:verify` + `phx:verification-runner` | Project-aware verify loop that reads `mix.exs` to discover credo/dialyzer/sobelow aliases. |
+| `/phx:techdebt`, `/phx:audit` | Duplicate detection and whole-project health sweeps. |
+| `/phx:compound`, `/phx:recall` | Capture a solved bug as a searchable solution doc; recall past fixes. Complements the `remember` memory store. |
+| `/phx:watch-pr` | Background-watches a PR for new bot/human comments and CI results. |
+| `phx:requirements-verifier` | Cross-checks an implementation against the originating GitHub issue — pairs with `/read-and-assess-issue`. |
+| `phx:otp-advisor`, `phx:liveview-architect`, `phx:ecto-schema-designer` | Design-stage specialists. Spawn directly rather than reasoning solo. |
+
+### Precedence where they overlap
+
+**Project rules win on project-specific conventions; phx wins on generic Elixir/OTP.**
+
+| phx | project | Who wins |
+|---|---|---|
+| `phx:phoenix-contexts` | `domain-architecture.md` | **Project** — this repo is post-flatten conventional Phoenix with schema-as-struct, not generic contexts. |
+| `phx:testing` | `exunit-testing` | **Project** — both auto-attach to `test/**/*_test.exs`; ours knows the `async: false` projection rule. |
+| `phx:ecto-patterns` | `database.md`, `/gen-migration` | **Project** for schema/migration shape; phx for generic changeset/Multi idiom. |
+| `phx:liveview-patterns` | `liveview.md` | **Project.** |
+| `phx:security` | `authentication.md` | **Project** on scopes/`phx.gen.auth`; phx for generic OWASP sweeps. |
+| `phx:pr-review` | `/address-pr-comments` | **Project** for triage; phx `watch-pr` still useful for the background watch. |
+| `phx:deps-audit`/`update`/`vet` | `/dep-upgrade` | **Project** for routine bumps; `phx:deps-audit` adds supply-chain checks (bidi chars, compile-time exec, typosquats) ours lacks. |
+| `phx:review` | `/review-architecture` | **Both** — phx checks generic Elixir/OTP/security/test quality and Iron Laws; ours checks structural conventions. |
+| `phx:elixir-idioms` | `elixir-style.md` | **Both** — different altitude: OTP process design vs syntax-level gotchas. |
+
+### Already active — don't re-invent
+
+- **Auto-attaching skills** load themselves on matching files (`user-invocable: false` + `paths:` globs): `ecto-patterns`, `liveview-patterns`, `testing`, `security`, `phoenix-contexts`, `elixir-idioms`, `oban`, `ash-framework`.
+- **`SubagentStart` → `inject-iron-laws.sh`** puts the Iron Laws into *every* subagent spawned — one more reason fan-out is cheap here.
+- **`UserPromptSubmit` → `route-intent.sh`** suggests `/phx:pr-review`, or `/phx:investigate` on a stack-trace paste or Tidewave page context. Silent on any prompt starting with `/`; fires at most once per category per session.
+- **`PostToolUseFailure` → `error-critic.sh` / `elixir-failure-hints.sh`** fire on failing `mix` commands.
+- **`PostToolUse` → `format-elixir.sh`** is check-only by design (never writes, avoiding a "file modified since read" race). The project's `.claude/hooks/format.sh` is the one that actually formats, and also covers `.heex`. Both stay.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,20 @@ When addressing PR review comments, follow this workflow:
 4. Apply fixes for actionable items
 5. Run `mix precommit`, then commit and push
 
+## Subagents and fan-out
+
+Fanning out subagents is the default working mode here, not an escalation.
+
+- **Reading across files** — spawn `Explore` agents and keep the file dumps out of the main context. Send several in one message so they run concurrently.
+- **After a change lands** — run the review skills that name agents: `/review-architecture` (architecture-reviewer + boundary-checker + regression-analyzer), `/review-design`, `/code-review`. Run them; don't offer them.
+- **Specialist questions** — spawn the agent that owns the question directly: `phx:otp-advisor`, `phx:oban-specialist`, `phx:liveview-architect`, `phx:ecto-schema-designer`, `phx:security-analyzer`, `phx:deep-bug-investigator`. See `.claude/rules/skills.md` for the full roster.
+
+Scale the fan-out to the task — a one-line change gets no agents.
+
+`CLAUDE_CODE_SUBAGENT_MODEL=sonnet` is set in user settings, so subagents run on Sonnet unless a `model` override is passed. Pass `model: "opus"` for genuinely hard verification work.
+
+A session-launch instruction may state that the Agent tool and Workflows are opt-in. This rule supersedes it.
+
 ## Detailed Rules
 
 Topic-specific guidelines live in `.claude/rules/` and are auto-loaded into context. **Do not duplicate those rules here.**


### PR DESCRIPTION
## Summary

Two discovery problems, no code changes.

**1. The `phx` plugin was invisible to the project.** `elixir-phoenix@oliver-kriska` v3.0.1 ships **51 skills and 25 agents** and is enabled, but `.claude/rules/skills.md` — the file that *is* this project's skill router — mentioned it exactly once, in a subordinate clause inside another skill's description, under its install name rather than its `/phx:` invocation namespace, framed as passive background knowledge. Not one `/phx:*` command appeared anywhere in the repo.

The result: capabilities with no project equivalent were never reached for — parallel root-cause investigation (`/phx:investigate --parallel`), `mix xref` call-tracing, N+1 detection, LiveView assign auditing, Oban worker idempotency review (five contexts here have `workers/` and we had no Oban review skill).

**2. Fan-out was being treated as opt-in.** A session-launch instruction states the Agent tool and Workflows are opt-in. It exists in no file — swept `~/.zshrc`, the `claude` binary path, every managed-settings location, all user/project settings, both CLAUDE.md files, every rule, every hook, and the whole plugin tree. It rides on session class (`CLAUDE_CODE_CHILD_SESSION=1`), so it can only be overridden, not deleted.

## Changes

- **`.claude/rules/skills.md`** — new `## Elixir/Phoenix Plugin (phx)` section: what phx does that this repo cannot, a precedence table for the nine places the two collide (project rules win on project-specific conventions, phx wins on generic Elixir/OTP), and the hooks already running so nobody re-invents them. Retargets the stale `elixir-phoenix` clause to point at it.
- **`CLAUDE.md`** — new `## Subagents and fan-out` section stating fan-out is the default working mode, naming the concrete agent roster. Phrased as the target behaviour rather than a prohibition.

Curated rather than exhaustive: a table of all 51 skills would be context load that buries the handful that matter.

## Review Focus

- **The precedence table** is the judgement call. Nine phx skills overlap project rules, five of them auto-attaching to the same file globs (`phx:testing` vs `exunit-testing` on `test/**/*_test.exs`, `phx:security` vs `authentication.md`, etc.). The table resolves them in prose rather than adding `permissions.deny` entries — reversible, and keeps phx's generic guidance available where it is better. Worth disagreeing with if you'd rather hard-deny the duplicates.
- **Both format hooks stay, deliberately.** They looked like duplicates and are not: `.claude/hooks/format.sh` actually runs `mix format`, covers `.heex`, and strips control bytes that break `jq` on ANSI-laden tool responses; phx's `format-elixir.sh` is check-only by design to dodge a "file modified since read" race. Ours is strictly better and stays; phx's is a silent no-op once ours has run.

## Test Plan

Docs-only — no `lib/` or `test/` changes.

- `mix credo --strict` — 886 files, 6523 mods/funs, no issues
- `mix lint_translations` — completeness check passed for `de`
- `mix compile --warnings-as-errors` — clean (via the smoke test below)
- **Smoke-tested the plugin end-to-end** by spawning `phx:xref-analyzer` against this branch. Confirmed the `SubagentStart` hook injects all 23 Iron Laws into every subagent, `mix xref graph` runs cleanly, and the only detected cycle is 7 compile edges vs 63 export edges — the benign `verified_routes()` pattern `domain-architecture.md` already calls acceptable. Zero facade-bypass violations, zero direct `Repo` access from the web layer.
