### PR TITLE
feat: complete a session from the Participant Management page

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -27,7 +27,7 @@ _Avoid_: Net price, Fee (reserved for the platform's success-based fee), Cost
 ## Scheduling
 
 **Session**:
-A single dated occurrence of a Program (a date plus start/end time) that children attend and staff run. The Program attachment is implicit — we just say "Session", never "Program Session". Has its own lifecycle: `scheduled → in_progress → completed`, or `cancelled`.
+A single dated occurrence of a Program (a date plus start/end time) that children attend and staff run. The Program attachment is implicit — we just say "Session", never "Program Session". Has its own lifecycle: `scheduled → in_progress → completed`, or `cancelled`. Who may drive that lifecycle is decided inside the Participation context, from the actor's Scope, in the same Provider → Staff Member → admin order as **Attendance** — see [ADR-0017](docs/adr/0017-attendance-writes-authorize-at-the-context-boundary.md). Completing a Session marks every still-`registered` **Participation Record** `absent`, which is why it is a guarded write and not a display change.
 _Avoid_: Class, Meeting, Occurrence, Program Session; and never reuse "Session" for the authentication session
 
 ## Enrollment & Attendance

--- a/docs/adr/0017-attendance-writes-authorize-at-the-context-boundary.md
+++ b/docs/adr/0017-attendance-writes-authorize-at-the-context-boundary.md
@@ -105,6 +105,63 @@ that, unassigning someone from the program would evict them from conversations f
 still run — #784 through the opposite door — and it is the exact mirror of the failure OR-ing
 would have caused here.
 
+## Amended by #1373: session lifecycle joined the gate, and refusals name their reason
+
+`start_session/1` and `complete_session/1` were never brought in. They took a bare session
+id and authorized nothing, which meant the provider sessions list handed a client-supplied
+`phx-value-session_id` straight to a write that marks **every remaining registered child
+absent**. Staff was covered only because `StaffSessionsLive` had hand-rolled
+`authorize_session_action/2` in the LiveView — the same "guard that lives in one of four
+callers" this ADR rejected, re-grown on the write path it did not cover.
+
+Both now take the scope:
+
+```elixir
+Participation.start_session(scope, session_id)
+Participation.complete_session(scope, session_id)
+```
+
+The module was renamed `AttendanceAuthorization` → **`SessionAuthorization`**, because it
+now answers two questions rather than one, and both are about a `ProgramSession`. It holds
+a single private `resolve/2` — the fall-through above, unchanged — under two entry points:
+
+| Entry point | Refusals |
+|---|---|
+| `authorize/2` | always `:unauthorized` |
+| `authorize_lifecycle/2` | `:unauthorized` or `:program_closed` |
+
+**The narrowing is the design, not a leftover.** Widening `authorize/2` itself was smaller
+and wrong: `:program_closed` would reach the attendance path, where
+`ParticipationLiveHandlers` matches only `{:error, :unauthorized}` and everything else falls
+to `"Failed to check in: …"`. A closed-program check-in would silently change its message,
+compile clean, and break no test. So attendance keeps the contract it has, and the ~10
+assertions in `session_authorization_test.exs` pass untouched — which is how we know it kept
+it.
+
+Only the lifecycle path needs the distinction, and only because the staff sessions list has
+said "This program has closed." since #1082 and should keep saying it.
+
+### The reason is narrower than the rule
+
+`Provider.get_session_staffing/1` answers for **any** session id. A reason read off
+`program_closed?` alone would therefore tell any staff-persona caller the closure state of a
+program they had merely guessed an id for — a disclosure introduced by the change that closes
+the IDOR. `refused_for_closure?/2` asks instead whether the caller is in `member_ids`, which
+ADR-0019 deliberately left ungated, so `:program_closed` means *you would have been staff,
+but the program closed*. A stranger gets a bare `:unauthorized`.
+
+Closure is also asked **after** the admin branch. It is a staff rule, and asking it earlier
+would take the broader persona from someone who holds both.
+
+### Consequences
+
+- `StaffSessionsLive.authorize_session_action/2` is deleted; both sessions lists are now the
+  same three-clause `case`. `staffs_session?/2` stays — it filters PubSub messages.
+- The closed-program sentence lived at three call sites as a literal. It is now
+  `ParticipationLiveHandlers.session_refusal_message/1`.
+- Providers and admins remain ungated by closure (ADR-0019). A provider completing their own
+  Closed Program's session is pinned by tests at both the authorizer and the use case.
+
 ## Derived, not declared
 
 `is_admin` lives on the user and is deliberately absent from `registration_changeset`'s cast

--- a/docs/adr/0017-attendance-writes-authorize-at-the-context-boundary.md
+++ b/docs/adr/0017-attendance-writes-authorize-at-the-context-boundary.md
@@ -14,7 +14,7 @@ Participation.correct_attendance(scope, record_id, attrs)
 
 No caller names the actor or declares its own role any more. `checked_in_by`, `checked_out_by`
 and `actor_role` are gone from the interface; identity is `scope.user.id` and the role is
-resolved by `Participation.AttendanceAuthorization`.
+resolved by `Participation.SessionAuthorization`.
 
 ## Why
 
@@ -36,7 +36,7 @@ one of four callers is not a guard.
 ## The fall-through order
 
 A person is one User and may hold several personas at once, so *which* rule applies needs a
-deterministic answer. `AttendanceAuthorization.authorize/2` takes the first that matches:
+deterministic answer. `SessionAuthorization.authorize/2` takes the first that matches:
 
 | Order | Rule | Cost |
 |---|---|---|

--- a/docs/adr/0017-attendance-writes-authorize-at-the-context-boundary.md
+++ b/docs/adr/0017-attendance-writes-authorize-at-the-context-boundary.md
@@ -161,6 +161,13 @@ would take the broader persona from someone who holds both.
   `ParticipationLiveHandlers.session_refusal_message/1`.
 - Providers and admins remain ungated by closure (ADR-0019). A provider completing their own
   Closed Program's session is pinned by tests at both the authorizer and the use case.
+- **A refusal must not say whether the session exists.** Authorizing at the context boundary
+  means resolving the session *first*, so `:not_found` and `:unauthorized` become two
+  distinguishable answers to a caller who supplied the id — an enumeration oracle the deleted
+  LiveView guard had closed by accident, by treating every lookup failure as a refusal.
+  `ParticipationLiveHandlers.session_refusal_message/1` answers both identically. The reason
+  still reaches the log; only the user-visible answer is flattened. Any future write that
+  takes a client-supplied id and authorizes after fetching inherits this problem.
 
 ## Derived, not declared
 

--- a/docs/adr/0019-closed-programs-revoke-staff-access.md
+++ b/docs/adr/0019-closed-programs-revoke-staff-access.md
@@ -44,7 +44,7 @@ at all and became correct:
 
 | Surface | Change |
 |---|---|
-| `Participation.AttendanceAuthorization` | none |
+| `Participation.SessionAuthorization` | none |
 | `StaffBroadcastLive` | none |
 | `StaffDashboardLive` roster handler | none |
 | `StaffSessionsLive` list + action gate | none for the gate; message copy only |

--- a/lib/klass_hero/participation.ex
+++ b/lib/klass_hero/participation.ex
@@ -126,13 +126,20 @@ defmodule KlassHero.Participation do
   end
 
   @doc """
-  Starts a scheduled session.
+  Starts a scheduled session on behalf of `scope`.
 
-  Returns `{:ok, session}`, `{:error, :not_found}`, or `{:error, :invalid_status_transition}`.
+  Gated like `complete_session/2` and for the same reason (#1373): both took a
+  bare session id until the guard moved here.
+
+  Returns `{:ok, session}`, `{:error, :not_found}`, `{:error, :unauthorized}`,
+  `{:error, :program_closed}`, or `{:error, :invalid_status_transition}`.
   """
-  def start_session(session_id) when is_binary(session_id) do
+  @spec start_session(Scope.t(), String.t()) ::
+          {:ok, ProgramSession.t()} | {:error, :not_found | SessionAuthorization.refusal() | :invalid_status_transition}
+  def start_session(%Scope{} = scope, session_id) when is_binary(session_id) do
     context_span entity: "session" do
       with {:ok, session} <- fetch_session(session_id),
+           {:ok, _role} <- SessionAuthorization.authorize_lifecycle(scope, session),
            {:ok, started} <- ProgramSession.start(session),
            {:ok, {persisted, events}} <- update_session_with_event(started, &ParticipationEvents.session_started/1) do
         Notifications.notify_all(events)

--- a/lib/klass_hero/participation.ex
+++ b/lib/klass_hero/participation.ex
@@ -142,13 +142,24 @@ defmodule KlassHero.Participation do
   end
 
   @doc """
-  Completes an in-progress session, marking all registered (not checked-in) children as absent.
+  Completes an in-progress session on behalf of `scope`, marking all registered
+  (not checked-in) children as absent.
 
-  Returns `{:ok, session}`, `{:error, :not_found}`, or `{:error, :invalid_status_transition}`.
+  Authorized at this boundary rather than by the caller, for the reason ADR-0017
+  gives for attendance: a guard that lives in one of four callers is not a guard.
+  Completing a session marks every remaining registered child absent, and until
+  #1373 the provider sessions list handed this function a client-supplied id with
+  no check at all.
+
+  Returns `{:ok, session}`, `{:error, :not_found}`, `{:error, :unauthorized}`,
+  `{:error, :program_closed}`, or `{:error, :invalid_status_transition}`.
   """
-  def complete_session(session_id) when is_binary(session_id) do
+  @spec complete_session(Scope.t(), String.t()) ::
+          {:ok, ProgramSession.t()} | {:error, :not_found | SessionAuthorization.refusal() | :invalid_status_transition}
+  def complete_session(%Scope{} = scope, session_id) when is_binary(session_id) do
     context_span entity: "session" do
       with {:ok, session} <- fetch_session(session_id),
+           {:ok, _role} <- SessionAuthorization.authorize_lifecycle(scope, session),
            {:ok, completed} <- ProgramSession.complete(session),
            {:ok, {persisted, events}} <- complete_session_with_events(completed) do
         Notifications.notify_all(events)

--- a/lib/klass_hero/participation.ex
+++ b/lib/klass_hero/participation.ex
@@ -23,11 +23,11 @@ defmodule KlassHero.Participation do
   alias KlassHero.Participation.Adapters.Driven.ACL.ProgramProviderResolver
   alias KlassHero.Participation.Adapters.Driven.Persistence.Queries.ParticipationQueries
   alias KlassHero.Participation.Adapters.Driven.Persistence.Queries.SessionNoteQueries
-  alias KlassHero.Participation.AttendanceAuthorization
   alias KlassHero.Participation.Domain.Events.ParticipationEvents
   alias KlassHero.Participation.Notifications
   alias KlassHero.Participation.ParticipationRecord
   alias KlassHero.Participation.ProgramSession
+  alias KlassHero.Participation.SessionAuthorization
   alias KlassHero.Participation.SessionNote
   alias KlassHero.ProgramCatalog
   alias KlassHero.Provider
@@ -833,7 +833,7 @@ defmodule KlassHero.Participation do
   # of this context's own tables.
   defp authorize_for_record(%Scope{} = scope, %ParticipationRecord{} = record) do
     with {:ok, session} <- fetch_session(record.session_id) do
-      AttendanceAuthorization.authorize(scope, session)
+      SessionAuthorization.authorize(scope, session)
     end
   end
 

--- a/lib/klass_hero/participation/session_authorization.ex
+++ b/lib/klass_hero/participation/session_authorization.ex
@@ -1,13 +1,28 @@
 defmodule KlassHero.Participation.SessionAuthorization do
   @moduledoc """
-  Who may write a child's attendance record.
+  What standing a `Scope` has on a `ProgramSession`.
+
+  Two questions are asked of this module, and they differ only in how much of the
+  answer they need:
+
+  - **`authorize/2`** — who may write a child's attendance record. Every refusal is
+    `:unauthorized`; no attendance caller has ever needed to tell them apart.
+  - **`authorize_lifecycle/2`** — who may start or complete a Session. A refusal keeps
+    its reason, because the staff sessions list says "This program has closed" rather
+    than "Unauthorized", and that copy is the only thing this distinction buys (#1373).
+
+  Both are thin over one private `resolve/2`. Neither contains rule-shaped code, which
+  is the point: ADR-0019 argues that a rule respelled at each of N surfaces is a rule
+  one surface eventually omits (#1323), and two authorizers that each re-derived "who
+  are you here" would be exactly that shape.
 
   Attendance writes used to be guarded only by the web layer — and not even by a
   check there, but by the fact that `ParticipationLiveHandlers` looked records up
   in an assign an authorized query had populated at mount. The guard was emergent
   from the load path and stated nowhere, so any caller reaching the context
-  directly had none (#1353). This module is that check, at the boundary where the
-  write happens.
+  directly had none (#1353). Session lifecycle writes were in the same state until
+  #1373: `complete_session/1` took a bare id, and completing a Session marks every
+  remaining `registered` child `absent`.
 
   ## Fall-through order
 
@@ -35,19 +50,29 @@ defmodule KlassHero.Participation.SessionAuthorization do
   it has any and falls back to the program roster when it does not — one question,
   with the program grain as its fallback rather than as a second rule beside it.
 
-  ## A Closed Program refuses staff, and this module does not mention it (#1082)
+  ## A Closed Program refuses staff, and only staff (#1082)
 
   Once a program has been over for longer than the access grace window, its staff
-  lose it. That rule is enforced here, but no line below states it: it arrives
-  inside `SessionStaffing.staffed_by?/2`, which answers `false` for a closed
-  program's session however genuinely staffed it is.
+  lose it. The refusal itself is not spelled out below: it arrives inside
+  `SessionStaffing.staffed_by?/2`, which answers `false` for a closed program's
+  session however genuinely staffed the caller is. That is deliberate, and it is why
+  the *provider* and *admin* branches need no mention of closure — the provider owns
+  the roster and still corrects it after the season, and an admin correction still
+  demands its reason.
 
-  Deliberate. The staff branch is one of five places that ask the same question,
-  and a rule spelled out at each of them is a rule one of them eventually omits —
-  the failure #1323 was. So closure is folded into the read model every asker
-  already uses, and the *provider* and *admin* branches are untouched: the
-  provider owns the roster and still corrects it after the season, and an admin
-  correction still demands its reason.
+  What `refused_for_closure?/2` adds is not the rule but the *reason*, and it is
+  narrower than the rule on purpose. `get_session_staffing/1` answers for any session
+  id at all, so a reason read off `program_closed?` alone would tell any staff-persona
+  caller the closure state of a program they had merely guessed an id for. Membership
+  is still readable on a closed program — ADR-0019 gated only `staffed_by?/2` and
+  `led_by?/2`, leaving `member_ids` alone so the provider's staffing panel keeps
+  working — so the reason can say the true thing: *you would have been staff, but the
+  program closed*. A stranger falls through to a bare `:unauthorized` and learns
+  nothing.
+
+  Closure is also asked **after** the admin branch, not before it. It is a staff rule,
+  and asking it earlier would take the broader persona away from someone who happens
+  to hold both.
 
   That distinction is the point, and it is *not* what #783 originally specified.
   OR-ing a session check onto a program check reads as more permissive in the
@@ -65,9 +90,13 @@ defmodule KlassHero.Participation.SessionAuthorization do
   alias KlassHero.Provider.ReadModels.SessionStaffing
 
   @type role :: :provider | :staff | :admin
+  @type refusal :: :unauthorized | :program_closed
 
   @doc """
   Resolves the scope's role for `session`, or refuses.
+
+  Every refusal collapses to `:unauthorized`. Callers that need to tell a Closed
+  Program apart from a program you were never on want `authorize_lifecycle/2`.
 
   Takes the session rather than its program id because the staff rule is answered
   at session grain; ownership and the admin flag are still program-wide facts, so
@@ -75,12 +104,47 @@ defmodule KlassHero.Participation.SessionAuthorization do
   """
   @spec authorize(Scope.t(), ProgramSession.t()) :: {:ok, role()} | {:error, :unauthorized}
   def authorize(%Scope{} = scope, %ProgramSession{} = session) do
+    case resolve(scope, session) do
+      {:ok, role} -> {:ok, role}
+      {:error, _reason} -> {:error, :unauthorized}
+    end
+  end
+
+  @doc """
+  Resolves the scope's role for `session`, or refuses **with the reason**.
+
+  Same question as `authorize/2`, same answer, one more fact: a staff member who
+  would have been authorized but for the program's closure gets `:program_closed`
+  rather than `:unauthorized`, so the surface can say which it was.
+  """
+  @spec authorize_lifecycle(Scope.t(), ProgramSession.t()) :: {:ok, role()} | {:error, refusal()}
+  def authorize_lifecycle(%Scope{} = scope, %ProgramSession{} = session), do: resolve(scope, session)
+
+  # The one place a scope's standing on a session is decided.
+  defp resolve(%Scope{} = scope, %ProgramSession{} = session) do
     cond do
       provider_owns?(scope, session.program_id) -> {:ok, :provider}
-      staff_on_session?(scope, session) -> {:ok, :staff}
+      is_nil(scope.staff_member) -> admin_or_refuse(scope)
+      true -> resolve_staff(scope, session)
+    end
+  end
+
+  # Reached only when the scope holds a staff persona, so the staffing read that
+  # both the grant and the reason come from is never paid by a caller who cannot
+  # use it.
+  defp resolve_staff(%Scope{staff_member: staff_member} = scope, session) do
+    staffing = Provider.get_session_staffing(session.id)
+
+    cond do
+      SessionStaffing.staffed_by?(staffing, staff_member.id) -> {:ok, :staff}
       admin?(scope) -> {:ok, :admin}
+      refused_for_closure?(staff_member, staffing) -> {:error, :program_closed}
       true -> {:error, :unauthorized}
     end
+  end
+
+  defp admin_or_refuse(%Scope{} = scope) do
+    if admin?(scope), do: {:ok, :admin}, else: {:error, :unauthorized}
   end
 
   defp provider_owns?(%Scope{provider: nil}, _program_id), do: false
@@ -89,13 +153,10 @@ defmodule KlassHero.Participation.SessionAuthorization do
     ProgramProviderResolver.resolve_provider_id(program_id) == {:ok, provider.id}
   end
 
-  defp staff_on_session?(%Scope{staff_member: nil}, _session), do: false
+  defp refused_for_closure?(staff_member, %SessionStaffing{program_closed?: true} = staffing),
+    do: staff_member.id in staffing.member_ids
 
-  defp staff_on_session?(%Scope{staff_member: staff_member}, session) do
-    session.id
-    |> Provider.get_session_staffing()
-    |> SessionStaffing.staffed_by?(staff_member.id)
-  end
+  defp refused_for_closure?(_staff_member, _staffing), do: false
 
   defp admin?(%Scope{user: %{is_admin: true}}), do: true
   defp admin?(%Scope{}), do: false

--- a/lib/klass_hero/participation/session_authorization.ex
+++ b/lib/klass_hero/participation/session_authorization.ex
@@ -1,4 +1,4 @@
-defmodule KlassHero.Participation.AttendanceAuthorization do
+defmodule KlassHero.Participation.SessionAuthorization do
   @moduledoc """
   Who may write a child's attendance record.
 

--- a/lib/klass_hero/provider/assignments.ex
+++ b/lib/klass_hero/provider/assignments.ex
@@ -336,7 +336,7 @@ defmodule KlassHero.Provider.Assignments do
     # Over the batch's *distinct* programs, so a full day of sessions costs one
     # closure question rather than one per row (#1082).
     # Unscoped on purpose: the caller hands us session ids, and a session's
-    # provider is only knowable by resolving it. `AttendanceAuthorization` asks
+    # provider is only knowable by resolving it. `SessionAuthorization` asks
     # this for admins too, so there is no one provider to narrow by.
     open_ids = open_program_ids(program_ids)
 

--- a/lib/klass_hero_web/helpers/participation_live_handlers.ex
+++ b/lib/klass_hero_web/helpers/participation_live_handlers.ex
@@ -132,4 +132,18 @@ defmodule KlassHeroWeb.Helpers.ParticipationLiveHandlers do
         end
     end
   end
+
+  @doc """
+  The flash for a session write `KlassHero.Participation` refused.
+
+  One function rather than a literal at each surface. Before #1373 the closed-program
+  sentence was copy-pasted at three call sites and the two sessions lists disagreed
+  about whether the distinction existed at all — ADR-0019's argument about a rule
+  respelled at N surfaces, applied to the copy that reports it.
+  """
+  @spec session_refusal_message(:unauthorized | :program_closed) :: String.t()
+  def session_refusal_message(:program_closed),
+    do: gettext("This program has closed. Its sessions are no longer available.")
+
+  def session_refusal_message(:unauthorized), do: gettext("Unauthorized")
 end

--- a/lib/klass_hero_web/helpers/participation_live_handlers.ex
+++ b/lib/klass_hero_web/helpers/participation_live_handlers.ex
@@ -157,7 +157,7 @@ defmodule KlassHeroWeb.Helpers.ParticipationLiveHandlers do
          |> put_flash(:info, gettext("Session completed successfully"))
          |> reload_fn.()}
 
-      {:error, reason} when reason in [:unauthorized, :program_closed] ->
+      {:error, reason} when reason in [:unauthorized, :not_found, :program_closed] ->
         {:noreply, put_flash(socket, :error, session_refusal_message(reason))}
 
       {:error, reason} ->
@@ -177,10 +177,19 @@ defmodule KlassHeroWeb.Helpers.ParticipationLiveHandlers do
   sentence was copy-pasted at three call sites and the two sessions lists disagreed
   about whether the distinction existed at all — ADR-0019's argument about a rule
   respelled at N surfaces, applied to the copy that reports it.
+
+  `:not_found` deliberately answers the same as `:unauthorized`. The sessions lists
+  send a client-supplied session id, and `Participation` resolves the session before
+  it authorizes, so a distinct "no such session" would let a tampering client tell
+  *exists but is not yours* from *does not exist* and enumerate ids. The staffing
+  panel in the same file already states the rule — "foreign and unknown are
+  indistinguishable, leaking no oracle" — and the guard this replaced happened to
+  honour it by collapsing every lookup failure into a refusal. The reason still
+  reaches the log; only the user-visible answer is flattened.
   """
-  @spec session_refusal_message(:unauthorized | :program_closed) :: String.t()
+  @spec session_refusal_message(:unauthorized | :not_found | :program_closed) :: String.t()
   def session_refusal_message(:program_closed),
     do: gettext("This program has closed. Its sessions are no longer available.")
 
-  def session_refusal_message(:unauthorized), do: gettext("Unauthorized")
+  def session_refusal_message(reason) when reason in [:unauthorized, :not_found], do: gettext("Unauthorized")
 end

--- a/lib/klass_hero_web/helpers/participation_live_handlers.ex
+++ b/lib/klass_hero_web/helpers/participation_live_handlers.ex
@@ -8,6 +8,10 @@ defmodule KlassHeroWeb.Helpers.ParticipationLiveHandlers do
   (a `socket -> socket` function, typically `&load_session_data/1`) so that
   divergence stays in the LiveView while the orchestration lives here.
 
+  `session_refusal_message/1` is the one exception to "these two surfaces": the two
+  *sessions list* LiveViews call it too, because a refused session write should not
+  read differently depending on which page asked.
+
   The `find_participation_record/2` lookup below is **not** the authorization
   check. It reads the roster already in the socket, for the "Record not found"
   flash and the `child_id` on the failure log. Until #1353 it was the only thing
@@ -130,6 +134,39 @@ defmodule KlassHeroWeb.Helpers.ParticipationLiveHandlers do
 
             {:noreply, put_flash(socket, :error, gettext("Failed to submit note"))}
         end
+    end
+  end
+
+  @doc """
+  Completes the session the page is showing, then reloads via `reload_fn`.
+
+  The session id comes from `socket.assigns`, where a mount-time guard put it —
+  never from the event params. The sessions lists have to send it from the client
+  because they render one row per session; a roster page showing exactly one
+  session does not, and taking it back off the client here would hand a tampered
+  event the id the context gate exists to check (#1373).
+  """
+  @spec complete_session(Socket.t(), reload_fn()) :: {:noreply, Socket.t()}
+  def complete_session(socket, reload_fn) do
+    session_id = socket.assigns.session_id
+
+    case KlassHero.Participation.complete_session(socket.assigns.current_scope, session_id) do
+      {:ok, _session} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, gettext("Session completed successfully"))
+         |> reload_fn.()}
+
+      {:error, reason} when reason in [:unauthorized, :program_closed] ->
+        {:noreply, put_flash(socket, :error, session_refusal_message(reason))}
+
+      {:error, reason} ->
+        Logger.error("[ParticipationLiveHandlers.complete_session] Failed to complete session",
+          session_id: session_id,
+          reason: inspect(reason)
+        )
+
+        {:noreply, put_flash(socket, :error, gettext("Failed to complete session: %{reason}", reason: inspect(reason)))}
     end
   end
 

--- a/lib/klass_hero_web/live/provider/participation_live.ex
+++ b/lib/klass_hero_web/live/provider/participation_live.ex
@@ -58,6 +58,13 @@ defmodule KlassHeroWeb.Provider.ParticipationLive do
     ParticipationLiveHandlers.check_in(socket, record_id, &load_session_data/1)
   end
 
+  # No session id in the params: this page shows one session and already holds its
+  # id, put there by the mount-time guard.
+  @impl true
+  def handle_event("complete_session", _params, socket) do
+    ParticipationLiveHandlers.complete_session(socket, &load_session_data/1)
+  end
+
   @impl true
   def handle_event("expand_checkout_form", %{"id" => record_id}, socket) do
     {:noreply,

--- a/lib/klass_hero_web/live/provider/participation_live.html.heex
+++ b/lib/klass_hero_web/live/provider/participation_live.html.heex
@@ -22,7 +22,18 @@
         session={@session}
         role={:provider}
         attendance={Participation.attendance_from_records(@participation_records)}
-      />
+      >
+        <:actions>
+          <.kh_button
+            :if={@session.status == :in_progress}
+            id="complete-session-btn"
+            variant={:dark}
+            phx-click="complete_session"
+          >
+            {gettext("Complete Session")}
+          </.kh_button>
+        </:actions>
+      </.participation_card>
     </div>
 
     <div class="mt-6">
@@ -32,7 +43,7 @@
       <.roster_list
         participation_records={@participation_records}
         session={@session}
-        editable={true}
+        editable={@session.status == :in_progress}
         checkout_form_expanded={@checkout_form_expanded}
         checkout_forms={@checkout_forms}
       >

--- a/lib/klass_hero_web/live/provider/sessions_live.ex
+++ b/lib/klass_hero_web/live/provider/sessions_live.ex
@@ -118,7 +118,7 @@ defmodule KlassHeroWeb.Provider.SessionsLive do
 
   @impl true
   def handle_event("start_session", %{"session_id" => session_id}, socket) do
-    case Participation.start_session(session_id) do
+    case Participation.start_session(socket.assigns.current_scope, session_id) do
       {:ok, _session} ->
         {:noreply, put_flash(socket, :info, gettext("Session started successfully"))}
 

--- a/lib/klass_hero_web/live/provider/sessions_live.ex
+++ b/lib/klass_hero_web/live/provider/sessions_live.ex
@@ -123,7 +123,7 @@ defmodule KlassHeroWeb.Provider.SessionsLive do
       {:ok, _session} ->
         {:noreply, put_flash(socket, :info, gettext("Session started successfully"))}
 
-      {:error, reason} when reason in [:unauthorized, :program_closed] ->
+      {:error, reason} when reason in [:unauthorized, :not_found, :program_closed] ->
         {:noreply, put_flash(socket, :error, ParticipationLiveHandlers.session_refusal_message(reason))}
 
       {:error, reason} ->
@@ -149,7 +149,7 @@ defmodule KlassHeroWeb.Provider.SessionsLive do
       {:ok, _session} ->
         {:noreply, put_flash(socket, :info, gettext("Session completed successfully"))}
 
-      {:error, reason} when reason in [:unauthorized, :program_closed] ->
+      {:error, reason} when reason in [:unauthorized, :not_found, :program_closed] ->
         {:noreply, put_flash(socket, :error, ParticipationLiveHandlers.session_refusal_message(reason))}
 
       {:error, reason} ->

--- a/lib/klass_hero_web/live/provider/sessions_live.ex
+++ b/lib/klass_hero_web/live/provider/sessions_live.ex
@@ -7,6 +7,7 @@ defmodule KlassHeroWeb.Provider.SessionsLive do
   alias KlassHero.ProgramCatalog
   alias KlassHero.Provider
   alias KlassHero.Provider.ReadModels.SessionStaffing
+  alias KlassHeroWeb.Helpers.ParticipationLiveHandlers
   alias KlassHeroWeb.Helpers.TaskHelpers
   alias KlassHeroWeb.Presenters.ProgramStaffingPresenter
   alias KlassHeroWeb.Presenters.ProviderPresenter
@@ -122,6 +123,9 @@ defmodule KlassHeroWeb.Provider.SessionsLive do
       {:ok, _session} ->
         {:noreply, put_flash(socket, :info, gettext("Session started successfully"))}
 
+      {:error, reason} when reason in [:unauthorized, :program_closed] ->
+        {:noreply, put_flash(socket, :error, ParticipationLiveHandlers.session_refusal_message(reason))}
+
       {:error, reason} ->
         Logger.error(
           "[SessionsLive.start_session] Failed to start session",
@@ -144,6 +148,9 @@ defmodule KlassHeroWeb.Provider.SessionsLive do
     case Participation.complete_session(socket.assigns.current_scope, session_id) do
       {:ok, _session} ->
         {:noreply, put_flash(socket, :info, gettext("Session completed successfully"))}
+
+      {:error, reason} when reason in [:unauthorized, :program_closed] ->
+        {:noreply, put_flash(socket, :error, ParticipationLiveHandlers.session_refusal_message(reason))}
 
       {:error, reason} ->
         Logger.error(

--- a/lib/klass_hero_web/live/provider/sessions_live.ex
+++ b/lib/klass_hero_web/live/provider/sessions_live.ex
@@ -141,7 +141,7 @@ defmodule KlassHeroWeb.Provider.SessionsLive do
 
   @impl true
   def handle_event("complete_session", %{"session_id" => session_id}, socket) do
-    case Participation.complete_session(session_id) do
+    case Participation.complete_session(socket.assigns.current_scope, session_id) do
       {:ok, _session} ->
         {:noreply, put_flash(socket, :info, gettext("Session completed successfully"))}
 

--- a/lib/klass_hero_web/live/staff/staff_participation_live.ex
+++ b/lib/klass_hero_web/live/staff/staff_participation_live.ex
@@ -54,6 +54,13 @@ defmodule KlassHeroWeb.Staff.StaffParticipationLive do
     ParticipationLiveHandlers.check_in(socket, record_id, &load_session_data/1)
   end
 
+  # No session id in the params: this page shows one session and already holds its
+  # id, put there by the mount-time guard.
+  @impl true
+  def handle_event("complete_session", _params, socket) do
+    ParticipationLiveHandlers.complete_session(socket, &load_session_data/1)
+  end
+
   @impl true
   def handle_event("expand_checkout_form", %{"id" => record_id}, socket) do
     {:noreply,
@@ -193,7 +200,7 @@ defmodule KlassHeroWeb.Staff.StaffParticipationLive do
   defp refusal_reason(%SessionStaffing{program_closed?: true}), do: :program_closed
   defp refusal_reason(_staffing), do: :not_assigned
 
-  defp refusal_message(:program_closed), do: gettext("This program has closed. Its sessions are no longer available.")
+  defp refusal_message(:program_closed), do: ParticipationLiveHandlers.session_refusal_message(:program_closed)
 
   defp refusal_message(:not_assigned), do: gettext("You are not assigned to this session")
 

--- a/lib/klass_hero_web/live/staff/staff_participation_live.html.heex
+++ b/lib/klass_hero_web/live/staff/staff_participation_live.html.heex
@@ -22,7 +22,18 @@
         session={@session}
         role={:staff}
         attendance={Participation.attendance_from_records(@participation_records)}
-      />
+      >
+        <:actions>
+          <.kh_button
+            :if={@session.status == :in_progress}
+            id="complete-session-btn"
+            variant={:dark}
+            phx-click="complete_session"
+          >
+            {gettext("Complete Session")}
+          </.kh_button>
+        </:actions>
+      </.participation_card>
     </div>
 
     <div class="mt-6">
@@ -32,7 +43,7 @@
       <.roster_list
         participation_records={@participation_records}
         session={@session}
-        editable={true}
+        editable={@session.status == :in_progress}
         checkout_form_expanded={@checkout_form_expanded}
         checkout_forms={@checkout_forms}
       >

--- a/lib/klass_hero_web/live/staff/staff_sessions_live.ex
+++ b/lib/klass_hero_web/live/staff/staff_sessions_live.ex
@@ -4,6 +4,7 @@ defmodule KlassHeroWeb.Staff.StaffSessionsLive do
   alias KlassHero.Participation
   alias KlassHero.Provider
   alias KlassHero.Provider.ReadModels.SessionStaffing
+  alias KlassHeroWeb.Helpers.ParticipationLiveHandlers
   alias KlassHeroWeb.Helpers.StaffLiveHelpers
   alias KlassHeroWeb.Theme
 
@@ -68,75 +69,53 @@ defmodule KlassHeroWeb.Staff.StaffSessionsLive do
 
   @impl true
   def handle_event("start_session", %{"session_id" => session_id}, socket) do
-    case authorize_session_action(session_id, socket) do
-      :ok ->
-        case Participation.start_session(socket.assigns.current_scope, session_id) do
-          {:ok, _session} ->
-            {:noreply, put_flash(socket, :info, gettext("Session started successfully"))}
+    case Participation.start_session(socket.assigns.current_scope, session_id) do
+      {:ok, _session} ->
+        {:noreply, put_flash(socket, :info, gettext("Session started successfully"))}
 
-          {:error, reason} ->
-            Logger.error(
-              "[StaffSessionsLive.start_session] Failed to start session",
-              session_id: session_id,
-              reason: inspect(reason),
-              staff_member_id: socket.assigns.staff_member.id
-            )
+      {:error, reason} when reason in [:unauthorized, :program_closed] ->
+        {:noreply, put_flash(socket, :error, ParticipationLiveHandlers.session_refusal_message(reason))}
 
-            {:noreply,
-             put_flash(
-               socket,
-               :error,
-               gettext("Failed to start session: %{reason}", reason: inspect(reason))
-             )}
-        end
+      {:error, reason} ->
+        Logger.error(
+          "[StaffSessionsLive.start_session] Failed to start session",
+          session_id: session_id,
+          reason: inspect(reason),
+          staff_member_id: socket.assigns.staff_member.id
+        )
 
-      {:error, :program_closed} ->
         {:noreply,
          put_flash(
            socket,
            :error,
-           gettext("This program has closed. Its sessions are no longer available.")
+           gettext("Failed to start session: %{reason}", reason: inspect(reason))
          )}
-
-      {:error, :unauthorized} ->
-        {:noreply, put_flash(socket, :error, gettext("Unauthorized"))}
     end
   end
 
   @impl true
   def handle_event("complete_session", %{"session_id" => session_id}, socket) do
-    case authorize_session_action(session_id, socket) do
-      :ok ->
-        case Participation.complete_session(socket.assigns.current_scope, session_id) do
-          {:ok, _session} ->
-            {:noreply, put_flash(socket, :info, gettext("Session completed successfully"))}
+    case Participation.complete_session(socket.assigns.current_scope, session_id) do
+      {:ok, _session} ->
+        {:noreply, put_flash(socket, :info, gettext("Session completed successfully"))}
 
-          {:error, reason} ->
-            Logger.error(
-              "[StaffSessionsLive.complete_session] Failed to complete session",
-              session_id: session_id,
-              reason: inspect(reason),
-              staff_member_id: socket.assigns.staff_member.id
-            )
+      {:error, reason} when reason in [:unauthorized, :program_closed] ->
+        {:noreply, put_flash(socket, :error, ParticipationLiveHandlers.session_refusal_message(reason))}
 
-            {:noreply,
-             put_flash(
-               socket,
-               :error,
-               gettext("Failed to complete session: %{reason}", reason: inspect(reason))
-             )}
-        end
+      {:error, reason} ->
+        Logger.error(
+          "[StaffSessionsLive.complete_session] Failed to complete session",
+          session_id: session_id,
+          reason: inspect(reason),
+          staff_member_id: socket.assigns.staff_member.id
+        )
 
-      {:error, :program_closed} ->
         {:noreply,
          put_flash(
            socket,
            :error,
-           gettext("This program has closed. Its sessions are no longer available.")
+           gettext("Failed to complete session: %{reason}", reason: inspect(reason))
          )}
-
-      {:error, :unauthorized} ->
-        {:noreply, put_flash(socket, :error, gettext("Unauthorized"))}
     end
   end
 
@@ -194,22 +173,6 @@ defmodule KlassHeroWeb.Staff.StaffSessionsLive do
 
   defp maybe_filter_by_program(sessions, program_id) do
     Enum.filter(sessions, &(&1.program_id == program_id))
-  end
-
-  defp authorize_session_action(session_id, socket) do
-    case Participation.get_session_with_roster(session_id) do
-      {:ok, %{session: session}} ->
-        staffing = Provider.get_session_staffing(session.id)
-
-        cond do
-          SessionStaffing.staffed_by?(staffing, socket.assigns.staff_member.id) -> :ok
-          match?(%SessionStaffing{program_closed?: true}, staffing) -> {:error, :program_closed}
-          true -> {:error, :unauthorized}
-        end
-
-      {:error, _reason} ->
-        {:error, :unauthorized}
-    end
   end
 
   defp staffs_session?(socket, session_id) do

--- a/lib/klass_hero_web/live/staff/staff_sessions_live.ex
+++ b/lib/klass_hero_web/live/staff/staff_sessions_live.ex
@@ -73,7 +73,7 @@ defmodule KlassHeroWeb.Staff.StaffSessionsLive do
       {:ok, _session} ->
         {:noreply, put_flash(socket, :info, gettext("Session started successfully"))}
 
-      {:error, reason} when reason in [:unauthorized, :program_closed] ->
+      {:error, reason} when reason in [:unauthorized, :not_found, :program_closed] ->
         {:noreply, put_flash(socket, :error, ParticipationLiveHandlers.session_refusal_message(reason))}
 
       {:error, reason} ->
@@ -99,7 +99,7 @@ defmodule KlassHeroWeb.Staff.StaffSessionsLive do
       {:ok, _session} ->
         {:noreply, put_flash(socket, :info, gettext("Session completed successfully"))}
 
-      {:error, reason} when reason in [:unauthorized, :program_closed] ->
+      {:error, reason} when reason in [:unauthorized, :not_found, :program_closed] ->
         {:noreply, put_flash(socket, :error, ParticipationLiveHandlers.session_refusal_message(reason))}
 
       {:error, reason} ->

--- a/lib/klass_hero_web/live/staff/staff_sessions_live.ex
+++ b/lib/klass_hero_web/live/staff/staff_sessions_live.ex
@@ -107,7 +107,7 @@ defmodule KlassHeroWeb.Staff.StaffSessionsLive do
   def handle_event("complete_session", %{"session_id" => session_id}, socket) do
     case authorize_session_action(session_id, socket) do
       :ok ->
-        case Participation.complete_session(session_id) do
+        case Participation.complete_session(socket.assigns.current_scope, session_id) do
           {:ok, _session} ->
             {:noreply, put_flash(socket, :info, gettext("Session completed successfully"))}
 

--- a/lib/klass_hero_web/live/staff/staff_sessions_live.ex
+++ b/lib/klass_hero_web/live/staff/staff_sessions_live.ex
@@ -70,7 +70,7 @@ defmodule KlassHeroWeb.Staff.StaffSessionsLive do
   def handle_event("start_session", %{"session_id" => session_id}, socket) do
     case authorize_session_action(session_id, socket) do
       :ok ->
-        case Participation.start_session(session_id) do
+        case Participation.start_session(socket.assigns.current_scope, session_id) do
           {:ok, _session} ->
             {:noreply, put_flash(socket, :info, gettext("Session started successfully"))}
 

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -464,12 +464,12 @@ msgstr "Änderungen dieser Richtlinie"
 msgid "Changing..."
 msgstr "Wird geändert..."
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:44
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:48
 #, elixir-autogen, elixir-format
 msgid "Child checked in successfully"
 msgstr "Kind erfolgreich eingecheckt"
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:76
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:80
 #, elixir-autogen, elixir-format
 msgid "Child checked out successfully"
 msgstr "Kind erfolgreich ausgecheckt"
@@ -608,18 +608,19 @@ msgstr "Kinder für Programme anmelden"
 msgid "Enter your password to confirm"
 msgstr "Geben Sie Ihr Passwort zur Bestätigung ein"
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:57
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:61
 #, elixir-autogen, elixir-format
 msgid "Failed to check in: %{reason}"
 msgstr "Einchecken fehlgeschlagen: %{reason}"
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:91
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:95
 #, elixir-autogen, elixir-format
 msgid "Failed to check out: %{reason}"
 msgstr "Auschecken fehlgeschlagen: %{reason}"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:160
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:126
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:169
+#: lib/klass_hero_web/live/provider/sessions_live.ex:167
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:117
 #, elixir-autogen, elixir-format
 msgid "Failed to complete session: %{reason}"
 msgstr "Sitzung konnte nicht abgeschlossen werden: %{reason}"
@@ -629,8 +630,8 @@ msgstr "Sitzung konnte nicht abgeschlossen werden: %{reason}"
 msgid "Failed to delete account. Please try again."
 msgstr "Konto konnte nicht gelöscht werden. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:137
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:89
+#: lib/klass_hero_web/live/provider/sessions_live.ex:141
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:91
 #, elixir-autogen, elixir-format
 msgid "Failed to start session: %{reason}"
 msgstr "Sitzung konnte nicht gestartet werden: %{reason}"
@@ -680,9 +681,9 @@ msgstr "Geistiges Eigentum"
 msgid "Introduction"
 msgstr "Einleitung"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:115
-#: lib/klass_hero_web/live/provider/sessions_live.ex:565
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:65
+#: lib/klass_hero_web/live/provider/sessions_live.ex:116
+#: lib/klass_hero_web/live/provider/sessions_live.ex:572
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:66
 #, elixir-autogen, elixir-format
 msgid "Invalid date format"
 msgstr "Ungültiges Datumsformat"
@@ -754,10 +755,10 @@ msgstr "Nachricht"
 msgid "Message sent successfully!"
 msgstr "Nachricht erfolgreich gesendet!"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:50
+#: lib/klass_hero_web/live/provider/sessions_live.ex:51
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:4
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:20
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:260
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:21
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:223
 #, elixir-autogen, elixir-format
 msgid "My Sessions"
 msgstr "Meine Sitzungen"
@@ -842,14 +843,14 @@ msgstr "Fragen zum Datenschutz?"
 msgid "Questions About These Terms?"
 msgstr "Fragen zu diesen Bedingungen?"
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:37
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:69
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:101
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:41
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:73
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:105
 #: lib/klass_hero_web/live/admin/sessions_live.ex:247
-#: lib/klass_hero_web/live/provider/participation_live.ex:171
-#: lib/klass_hero_web/live/provider/participation_live.ex:217
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:110
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:156
+#: lib/klass_hero_web/live/provider/participation_live.ex:178
+#: lib/klass_hero_web/live/provider/participation_live.ex:224
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:117
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:163
 #, elixir-autogen, elixir-format
 msgid "Record not found"
 msgstr "Eintrag nicht gefunden"
@@ -886,22 +887,23 @@ msgstr "Wählen Sie eine oder beide Optionen"
 msgid "Send Message"
 msgstr "Nachricht senden"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:146
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:112
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:157
+#: lib/klass_hero_web/live/provider/sessions_live.ex:150
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:100
 #, elixir-autogen, elixir-format
 msgid "Session completed successfully"
 msgstr "Sitzung erfolgreich abgeschlossen"
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:62
 #: lib/klass_hero_web/live/admin/sessions_live.ex:68
-#: lib/klass_hero_web/live/provider/participation_live.ex:287
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:241
+#: lib/klass_hero_web/live/provider/participation_live.ex:294
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:248
 #, elixir-autogen, elixir-format
 msgid "Session not found"
 msgstr "Sitzung nicht gefunden"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:123
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:75
+#: lib/klass_hero_web/live/provider/sessions_live.ex:124
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:74
 #, elixir-autogen, elixir-format
 msgid "Session started successfully"
 msgstr "Sitzung erfolgreich gestartet"
@@ -1131,7 +1133,7 @@ msgstr "Teilnahmeverlauf konnte nicht geladen werden"
 #: lib/klass_hero_web/live/provider/participation_live.ex:27
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:65
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:27
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:308
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:271
 #, elixir-autogen, elixir-format
 msgid "Manage Participation"
 msgstr "Teilnahme verwalten"
@@ -1370,11 +1372,11 @@ msgstr "Erstellen Sie Profile für Ihr Personal. Diese werden für Eltern sichtb
 
 #: lib/klass_hero_web/components/provider_components.ex:540
 #: lib/klass_hero_web/components/provider_components.ex:1597
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:54
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:81
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:65
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:92
 #: lib/klass_hero_web/live/settings/children_live.ex:413
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:54
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:81
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:65
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:92
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr "Bearbeiten"
@@ -1637,7 +1639,7 @@ msgstr "Notiz konnte nicht genehmigt werden"
 msgid "Failed to reject note"
 msgstr "Notiz konnte nicht abgelehnt werden"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:163
+#: lib/klass_hero_web/live/provider/participation_live.ex:170
 #, elixir-autogen, elixir-format
 msgid "Failed to resubmit note"
 msgstr "Notiz konnte nicht erneut eingereicht werden"
@@ -1648,7 +1650,7 @@ msgstr "Notiz konnte nicht erneut eingereicht werden"
 msgid "Failed to send broadcast"
 msgstr "Rundnachricht konnte nicht gesendet werden"
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:131
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:135
 #, elixir-autogen, elixir-format
 msgid "Failed to submit note"
 msgstr "Notiz konnte nicht eingereicht werden"
@@ -1727,8 +1729,8 @@ msgstr "Für dieses Programm sind keine Eltern angemeldet"
 msgid "Note approved"
 msgstr "Notiz genehmigt"
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:120
-#: lib/klass_hero_web/live/provider/participation_live.ex:155
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:124
+#: lib/klass_hero_web/live/provider/participation_live.ex:162
 #, elixir-autogen, elixir-format
 msgid "Note content cannot be blank"
 msgstr "Notizinhalt darf nicht leer sein"
@@ -1738,7 +1740,7 @@ msgstr "Notizinhalt darf nicht leer sein"
 msgid "Note rejected"
 msgstr "Notiz abgelehnt"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:149
+#: lib/klass_hero_web/live/provider/participation_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "Note resubmitted for review"
 msgstr "Notiz erneut zur Überprüfung eingereicht"
@@ -1844,8 +1846,8 @@ msgstr "Diese Nachricht wird an alle Eltern mit aktiven Anmeldungen in diesem Pr
 msgid "Type a message..."
 msgstr "Nachricht eingeben..."
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:307
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:261
+#: lib/klass_hero_web/live/provider/participation_live.ex:314
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "Unable to refresh roster. Please reload."
 msgstr "Teilnehmerliste konnte nicht aktualisiert werden. Bitte laden Sie die Seite neu."
@@ -1856,7 +1858,7 @@ msgstr "Teilnehmerliste konnte nicht aktualisiert werden. Bitte laden Sie die Se
 msgid "Write your message to all enrolled parents..."
 msgstr "Schreiben Sie Ihre Nachricht an alle angemeldeten Eltern..."
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:123
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:127
 #, elixir-autogen, elixir-format
 msgid "You already submitted a note for this record"
 msgstr "Sie haben bereits eine Notiz für diesen Eintrag eingereicht"
@@ -3662,7 +3664,7 @@ msgstr "%{checked_in} / %{total} eingecheckt"
 msgid "%{count} unread"
 msgstr "%{count} ungelesen"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:583
+#: lib/klass_hero_web/live/provider/sessions_live.ex:590
 #, elixir-autogen, elixir-format
 msgid "A session already exists at this time"
 msgstr "Zu dieser Zeit existiert bereits eine Sitzung"
@@ -3672,8 +3674,8 @@ msgstr "Zu dieser Zeit existiert bereits eine Sitzung"
 msgid "Account created! Check your email to confirm and log in."
 msgstr "Konto erstellt! Überprüfen Sie Ihre E-Mails, um zu bestätigen und sich anzumelden."
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:115
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:115
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:126
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:126
 #, elixir-autogen, elixir-format
 msgid "Add Note"
 msgstr "Notiz hinzufügen"
@@ -3738,8 +3740,8 @@ msgstr "Zurück zu E-Mails"
 msgid "Broadcast messages are one-way"
 msgstr "Broadcast-Nachrichten sind einseitig"
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:96
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:96
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:107
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Check In"
 msgstr "Einchecken"
@@ -3789,8 +3791,10 @@ msgstr "Auswahl aufheben"
 msgid "Complete Registration"
 msgstr "Registrierung abschließen"
 
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:33
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:76
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:319
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:33
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "Complete Session"
 msgstr "Sitzung abschließen"
@@ -3842,8 +3846,8 @@ msgstr "Sitzung erstellen"
 msgid "Date"
 msgstr "Datum"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:559
-#: lib/klass_hero_web/live/provider/sessions_live.ex:560
+#: lib/klass_hero_web/live/provider/sessions_live.ex:566
+#: lib/klass_hero_web/live/provider/sessions_live.ex:567
 #, elixir-autogen, elixir-format
 msgid "Date is required"
 msgstr "Datum ist erforderlich"
@@ -3853,7 +3857,7 @@ msgstr "Datum ist erforderlich"
 msgid "E.g., picked up by parent, gave medication reminder..."
 msgstr "Z.B. von Eltern abgeholt, Medikamentenerinnerung gegeben..."
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:144
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:155
 #, elixir-autogen, elixir-format
 msgid "Edit & Resubmit"
 msgstr "Bearbeiten & erneut einreichen"
@@ -3886,7 +3890,7 @@ msgstr "E-Mails"
 msgid "Emergency: %{details}"
 msgstr "Notfall: %{details}"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:582
+#: lib/klass_hero_web/live/provider/sessions_live.ex:589
 #, elixir-autogen, elixir-format
 msgid "End time must be after start time"
 msgstr "Die Endzeit muss nach der Startzeit liegen"
@@ -3901,7 +3905,7 @@ msgstr "Erwartet"
 msgid "Failed to archive email"
 msgstr "E-Mail konnte nicht archiviert werden"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:519
+#: lib/klass_hero_web/live/provider/sessions_live.ex:526
 #, elixir-autogen, elixir-format
 msgid "Failed to create session: %{reason}"
 msgstr "Sitzung konnte nicht erstellt werden: %{reason}"
@@ -3958,7 +3962,7 @@ msgid "Invalid Invitation"
 msgstr "Ungültige Einladung"
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:255
-#: lib/klass_hero_web/live/provider/sessions_live.ex:578
+#: lib/klass_hero_web/live/provider/sessions_live.ex:585
 #, elixir-autogen, elixir-format
 msgid "Invalid time format"
 msgstr "Ungültiges Zeitformat"
@@ -4020,7 +4024,7 @@ msgid "Max Capacity"
 msgstr "Maximale Kapazität"
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:90
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:333
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "No actions available"
 msgstr "Keine Aktionen verfügbar"
@@ -4056,7 +4060,7 @@ msgid "No sessions found for the selected filters."
 msgstr "Keine Sitzungen für die ausgewählten Filter gefunden."
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:122
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:348
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled"
 msgstr "Keine Sitzungen geplant"
@@ -4081,8 +4085,8 @@ msgstr "Aus: %{time}"
 msgid "Participation Check-In"
 msgstr "Teilnahme-Einchecken"
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:30
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:30
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:41
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Participation Management"
 msgstr "Teilnahmeverwaltung"
@@ -4097,7 +4101,7 @@ msgstr "Ausstehende Überprüfungen"
 msgid "Please explain why you're rejecting this note..."
 msgstr "Bitte erklären Sie, warum Sie diese Notiz ablehnen..."
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:585
+#: lib/klass_hero_web/live/provider/sessions_live.ex:592
 #, elixir-autogen, elixir-format
 msgid "Please fill in all required fields"
 msgstr "Bitte füllen Sie alle erforderlichen Felder aus"
@@ -4112,13 +4116,13 @@ msgstr "Absenden"
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
 #: lib/klass_hero_web/live/provider/programs_live.ex:226
-#: lib/klass_hero_web/live/provider/sessions_live.ex:381
+#: lib/klass_hero_web/live/provider/sessions_live.ex:388
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:175
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr "Programm"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:179
+#: lib/klass_hero_web/live/provider/sessions_live.ex:186
 #, elixir-autogen, elixir-format
 msgid "Program is required"
 msgstr "Programm ist erforderlich"
@@ -4208,7 +4212,7 @@ msgstr "Wird gesendet"
 
 #: lib/klass_hero_web/components/participation_components.ex:70
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:16
-#: lib/klass_hero_web/live/provider/sessions_live.ex:408
+#: lib/klass_hero_web/live/provider/sessions_live.ex:415
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:16
 #, elixir-autogen, elixir-format
 msgid "Session"
@@ -4225,7 +4229,7 @@ msgstr "Sitzungsnotizen (optional)"
 msgid "Session Roster"
 msgstr "Teilnehmerliste"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:501
+#: lib/klass_hero_web/live/provider/sessions_live.ex:508
 #, elixir-autogen, elixir-format
 msgid "Session created successfully"
 msgstr "Sitzung erfolgreich erstellt"
@@ -4236,7 +4240,7 @@ msgid "Staff Dashboard"
 msgstr "Mitarbeiter-Dashboard"
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:54
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:297
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "Start Session"
 msgstr "Sitzung starten"
@@ -4276,8 +4280,8 @@ msgstr "Diese Einladung wurde bereits verwendet."
 msgid "This invite link is invalid or has expired."
 msgstr "Dieser Einladungslink ist ungültig oder abgelaufen."
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:569
-#: lib/klass_hero_web/live/provider/sessions_live.ex:570
+#: lib/klass_hero_web/live/provider/sessions_live.ex:576
+#: lib/klass_hero_web/live/provider/sessions_live.ex:577
 #, elixir-autogen, elixir-format
 msgid "Time is required"
 msgstr "Uhrzeit ist erforderlich"
@@ -4292,10 +4296,9 @@ msgstr "An"
 msgid "Type your reply..."
 msgstr "Ihre Antwort eingeben..."
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:183
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:185
+#: lib/klass_hero_web/live/provider/sessions_live.ex:190
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:126
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:102
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:139
 #, elixir-autogen, elixir-format
 msgid "Unauthorized"
 msgstr "Nicht autorisiert"
@@ -4322,7 +4325,7 @@ msgid "Upload connection lost. Please try again."
 msgstr "Upload-Verbindung unterbrochen. Bitte versuchen Sie es erneut."
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:87
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:330
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:293
 #, elixir-autogen, elixir-format
 msgid "View Participation"
 msgstr "Teilnahme anzeigen"
@@ -4348,7 +4351,7 @@ msgid "You already have an account. Log in to see your new enrollment."
 msgstr "Sie haben bereits ein Konto. Melden Sie sich an, um Ihre neue Anmeldung zu sehen."
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:125
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:351
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:314
 #, elixir-autogen, elixir-format
 msgid "You have no sessions scheduled for %{date}"
 msgstr "Sie haben keine Sitzungen geplant für %{date}"
@@ -4383,14 +4386,14 @@ msgstr "Teilnehmerliste"
 msgid "Unlimited team seats"
 msgstr "Unbegrenzte Team-Plätze"
 
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:261
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:224
 #, elixir-autogen, elixir-format
 msgid "View and manage your assigned sessions"
 msgstr "Ihre zugewiesenen Sitzungen anzeigen und verwalten"
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:48
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:82
-#: lib/klass_hero_web/live/provider/participation_live.ex:276
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:52
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:86
+#: lib/klass_hero_web/live/provider/participation_live.ex:283
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:53
 #, elixir-autogen, elixir-format
 msgid "You are not assigned to this program"
@@ -4618,14 +4621,14 @@ msgstr "Abgereist"
 msgid "Departure notes"
 msgstr "Notizen zur Abreise"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:220
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:159
+#: lib/klass_hero_web/live/provider/participation_live.ex:227
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Departure time is not a valid date and time"
 msgstr "Abreisezeit ist kein gültiges Datum oder keine gültige Uhrzeit"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:231
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:170
+#: lib/klass_hero_web/live/provider/participation_live.ex:238
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:177
 #, elixir-autogen, elixir-format
 msgid "Failed to update record"
 msgstr "Aktualisieren des Datensatzes fehlgeschlagen"
@@ -4665,8 +4668,8 @@ msgstr "Gesundheit & Einwilligungen (optional)"
 msgid "Medical conditions"
 msgstr "Gesundheitliche Besonderheiten"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:223
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:162
+#: lib/klass_hero_web/live/provider/participation_live.ex:230
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Nothing to update"
 msgstr "Nichts zu aktualisieren"
@@ -4696,8 +4699,8 @@ msgstr "Anwesend"
 msgid "Primary guardian"
 msgstr "Hauptansprechpartner"
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:66
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:66
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:77
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:77
 #, elixir-autogen, elixir-format
 msgid "Record departure"
 msgstr "Abreise erfassen"
@@ -4707,8 +4710,8 @@ msgstr "Abreise erfassen"
 msgid "Record departure time (optional)"
 msgstr "Abreisezeit erfassen (optional)"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:211
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:150
+#: lib/klass_hero_web/live/provider/participation_live.ex:218
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:157
 #, elixir-autogen, elixir-format
 msgid "Record updated"
 msgstr "Datensatz aktualisiert"
@@ -7160,7 +7163,7 @@ msgstr "Du hast die Erklärung zur Mitarbeiter-Compliance unterzeichnet."
 msgid "Session Note"
 msgstr "Sitzungsnotiz"
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:114
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:118
 #, elixir-autogen, elixir-format
 msgid "Session note submitted for review"
 msgstr "Sitzungsnotiz zur Überprüfung eingereicht"
@@ -7251,7 +7254,7 @@ msgid "Nobody is on this program yet."
 msgstr "Diesem Programm ist noch niemand zugewiesen."
 
 #: lib/klass_hero_web/live/provider/programs_live.ex:353
-#: lib/klass_hero_web/live/provider/sessions_live.ex:213
+#: lib/klass_hero_web/live/provider/sessions_live.ex:220
 #, elixir-autogen, elixir-format
 msgid "Pick a staff member to add."
 msgstr "Bitte ein Teammitglied zum Hinzufügen auswählen."
@@ -7417,7 +7420,7 @@ msgstr "Ich verstehe, dass dieses Programm keine Teilnehmerbegrenzung haben wird
 msgid "Go back to the program's usual team"
 msgstr "Zurück zum üblichen Programmteam"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:295
+#: lib/klass_hero_web/live/provider/sessions_live.ex:302
 #, elixir-autogen, elixir-format
 msgid "Lead instructor for this session updated."
 msgstr "Leitung für diesen Termin aktualisiert."
@@ -7437,12 +7440,12 @@ msgstr "Für diesen Termin ist noch niemand eingeteilt."
 msgid "Remove from this session"
 msgstr "Von diesem Termin entfernen"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:231
+#: lib/klass_hero_web/live/provider/sessions_live.ex:238
 #, elixir-autogen, elixir-format
 msgid "Staff member added to this session."
 msgstr "Teammitglied zu diesem Termin hinzugefügt."
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:255
+#: lib/klass_hero_web/live/provider/sessions_live.ex:262
 #, elixir-autogen, elixir-format
 msgid "Staff member removed from this session."
 msgstr "Teammitglied von diesem Termin entfernt."
@@ -7457,27 +7460,27 @@ msgstr "Team"
 msgid "Staffing — %{date}"
 msgstr "Team — %{date}"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:424
+#: lib/klass_hero_web/live/provider/sessions_live.ex:431
 #, elixir-autogen, elixir-format
 msgid "That session could not be found."
 msgstr "Dieser Termin konnte nicht gefunden werden."
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:239
+#: lib/klass_hero_web/live/provider/sessions_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "They are already working this session."
 msgstr "Diese Person ist bereits für diesen Termin eingeteilt."
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:263
+#: lib/klass_hero_web/live/provider/sessions_live.ex:270
 #, elixir-autogen, elixir-format
 msgid "This person leads the session. Make someone else lead before removing them."
 msgstr "Diese Person leitet den Termin. Bitte zuerst eine andere Person als Leitung festlegen."
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:311
+#: lib/klass_hero_web/live/provider/sessions_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "This session is back on the program's usual team."
 msgstr "Dieser Termin nutzt wieder das übliche Programmteam."
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:274
+#: lib/klass_hero_web/live/provider/sessions_live.ex:281
 #, elixir-autogen, elixir-format
 msgid "A session needs at least one person. Use “Go back to the program's usual team” to drop this session's own roster."
 msgstr "Ein Termin braucht mindestens eine Person. Nutze „Zurück zum üblichen Programmteam“, um die eigene Besetzung dieses Termins aufzuheben."
@@ -7683,7 +7686,7 @@ msgstr "Einverständniserklärung hinzugefügt."
 msgid "Waiver retired. Signatures already collected are kept."
 msgstr "Einverständniserklärung zurückgezogen. Bereits erteilte Unterschriften bleiben erhalten."
 
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:198
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:205
 #, elixir-autogen, elixir-format
 msgid "You are not assigned to this session"
 msgstr "Sie sind diesem Termin nicht zugewiesen"
@@ -7911,9 +7914,7 @@ msgstr ""
 "Diese Programme sind beendet. Ihre Termine und Teilnehmerlisten sind nicht "
 "mehr verfügbar."
 
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:196
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:98
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:135
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:183
 #, elixir-autogen, elixir-format
 msgid "This program has closed. Its sessions are no longer available."
 msgstr ""

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -4296,7 +4296,7 @@ msgstr "An"
 msgid "Type your reply..."
 msgstr "Ihre Antwort eingeben..."
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:185
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:194
 #: lib/klass_hero_web/live/provider/sessions_live.ex:190
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:126
 #, elixir-autogen, elixir-format
@@ -7914,7 +7914,7 @@ msgstr ""
 "Diese Programme sind beendet. Ihre Termine und Teilnehmerlisten sind nicht "
 "mehr verfügbar."
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:183
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:192
 #, elixir-autogen, elixir-format
 msgid "This program has closed. Its sessions are no longer available."
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -4296,7 +4296,7 @@ msgstr ""
 msgid "Type your reply..."
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:185
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:194
 #: lib/klass_hero_web/live/provider/sessions_live.ex:190
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:126
 #, elixir-autogen, elixir-format
@@ -7897,7 +7897,7 @@ msgstr ""
 msgid "These programs have finished. Their sessions and rosters are no longer available."
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:183
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:192
 #, elixir-autogen, elixir-format
 msgid "This program has closed. Its sessions are no longer available."
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -464,12 +464,12 @@ msgstr ""
 msgid "Changing..."
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:44
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:48
 #, elixir-autogen, elixir-format
 msgid "Child checked in successfully"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:76
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:80
 #, elixir-autogen, elixir-format
 msgid "Child checked out successfully"
 msgstr ""
@@ -608,18 +608,19 @@ msgstr ""
 msgid "Enter your password to confirm"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:57
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:61
 #, elixir-autogen, elixir-format
 msgid "Failed to check in: %{reason}"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:91
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:95
 #, elixir-autogen, elixir-format
 msgid "Failed to check out: %{reason}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:160
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:126
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:169
+#: lib/klass_hero_web/live/provider/sessions_live.ex:167
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:117
 #, elixir-autogen, elixir-format
 msgid "Failed to complete session: %{reason}"
 msgstr ""
@@ -629,8 +630,8 @@ msgstr ""
 msgid "Failed to delete account. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:137
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:89
+#: lib/klass_hero_web/live/provider/sessions_live.ex:141
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:91
 #, elixir-autogen, elixir-format
 msgid "Failed to start session: %{reason}"
 msgstr ""
@@ -680,9 +681,9 @@ msgstr ""
 msgid "Introduction"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:115
-#: lib/klass_hero_web/live/provider/sessions_live.ex:565
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:65
+#: lib/klass_hero_web/live/provider/sessions_live.ex:116
+#: lib/klass_hero_web/live/provider/sessions_live.ex:572
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:66
 #, elixir-autogen, elixir-format
 msgid "Invalid date format"
 msgstr ""
@@ -754,10 +755,10 @@ msgstr ""
 msgid "Message sent successfully!"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:50
+#: lib/klass_hero_web/live/provider/sessions_live.ex:51
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:4
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:20
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:260
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:21
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:223
 #, elixir-autogen, elixir-format
 msgid "My Sessions"
 msgstr ""
@@ -842,14 +843,14 @@ msgstr ""
 msgid "Questions About These Terms?"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:37
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:69
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:101
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:41
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:73
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:105
 #: lib/klass_hero_web/live/admin/sessions_live.ex:247
-#: lib/klass_hero_web/live/provider/participation_live.ex:171
-#: lib/klass_hero_web/live/provider/participation_live.ex:217
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:110
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:156
+#: lib/klass_hero_web/live/provider/participation_live.ex:178
+#: lib/klass_hero_web/live/provider/participation_live.ex:224
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:117
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:163
 #, elixir-autogen, elixir-format
 msgid "Record not found"
 msgstr ""
@@ -886,22 +887,23 @@ msgstr ""
 msgid "Send Message"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:146
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:112
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:157
+#: lib/klass_hero_web/live/provider/sessions_live.ex:150
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:100
 #, elixir-autogen, elixir-format
 msgid "Session completed successfully"
 msgstr ""
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:62
 #: lib/klass_hero_web/live/admin/sessions_live.ex:68
-#: lib/klass_hero_web/live/provider/participation_live.ex:287
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:241
+#: lib/klass_hero_web/live/provider/participation_live.ex:294
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:248
 #, elixir-autogen, elixir-format
 msgid "Session not found"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:123
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:75
+#: lib/klass_hero_web/live/provider/sessions_live.ex:124
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:74
 #, elixir-autogen, elixir-format
 msgid "Session started successfully"
 msgstr ""
@@ -1131,7 +1133,7 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/participation_live.ex:27
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:65
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:27
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:308
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:271
 #, elixir-autogen, elixir-format
 msgid "Manage Participation"
 msgstr ""
@@ -1370,11 +1372,11 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:540
 #: lib/klass_hero_web/components/provider_components.ex:1597
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:54
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:81
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:65
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:92
 #: lib/klass_hero_web/live/settings/children_live.ex:413
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:54
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:81
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:65
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:92
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
@@ -1637,7 +1639,7 @@ msgstr ""
 msgid "Failed to reject note"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:163
+#: lib/klass_hero_web/live/provider/participation_live.ex:170
 #, elixir-autogen, elixir-format
 msgid "Failed to resubmit note"
 msgstr ""
@@ -1648,7 +1650,7 @@ msgstr ""
 msgid "Failed to send broadcast"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:131
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:135
 #, elixir-autogen, elixir-format
 msgid "Failed to submit note"
 msgstr ""
@@ -1727,8 +1729,8 @@ msgstr ""
 msgid "Note approved"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:120
-#: lib/klass_hero_web/live/provider/participation_live.ex:155
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:124
+#: lib/klass_hero_web/live/provider/participation_live.ex:162
 #, elixir-autogen, elixir-format
 msgid "Note content cannot be blank"
 msgstr ""
@@ -1738,7 +1740,7 @@ msgstr ""
 msgid "Note rejected"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:149
+#: lib/klass_hero_web/live/provider/participation_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "Note resubmitted for review"
 msgstr ""
@@ -1844,8 +1846,8 @@ msgstr ""
 msgid "Type a message..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:307
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:261
+#: lib/klass_hero_web/live/provider/participation_live.ex:314
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "Unable to refresh roster. Please reload."
 msgstr ""
@@ -1856,7 +1858,7 @@ msgstr ""
 msgid "Write your message to all enrolled parents..."
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:123
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:127
 #, elixir-autogen, elixir-format
 msgid "You already submitted a note for this record"
 msgstr ""
@@ -3662,7 +3664,7 @@ msgstr ""
 msgid "%{count} unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:583
+#: lib/klass_hero_web/live/provider/sessions_live.ex:590
 #, elixir-autogen, elixir-format
 msgid "A session already exists at this time"
 msgstr ""
@@ -3672,8 +3674,8 @@ msgstr ""
 msgid "Account created! Check your email to confirm and log in."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:115
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:115
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:126
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:126
 #, elixir-autogen, elixir-format
 msgid "Add Note"
 msgstr ""
@@ -3738,8 +3740,8 @@ msgstr ""
 msgid "Broadcast messages are one-way"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:96
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:96
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:107
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:107
 #, elixir-autogen, elixir-format
 msgid "Check In"
 msgstr ""
@@ -3789,8 +3791,10 @@ msgstr ""
 msgid "Complete Registration"
 msgstr ""
 
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:33
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:76
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:319
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:33
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "Complete Session"
 msgstr ""
@@ -3842,8 +3846,8 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:559
-#: lib/klass_hero_web/live/provider/sessions_live.ex:560
+#: lib/klass_hero_web/live/provider/sessions_live.ex:566
+#: lib/klass_hero_web/live/provider/sessions_live.ex:567
 #, elixir-autogen, elixir-format
 msgid "Date is required"
 msgstr ""
@@ -3853,7 +3857,7 @@ msgstr ""
 msgid "E.g., picked up by parent, gave medication reminder..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:144
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:155
 #, elixir-autogen, elixir-format
 msgid "Edit & Resubmit"
 msgstr ""
@@ -3886,7 +3890,7 @@ msgstr ""
 msgid "Emergency: %{details}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:582
+#: lib/klass_hero_web/live/provider/sessions_live.ex:589
 #, elixir-autogen, elixir-format
 msgid "End time must be after start time"
 msgstr ""
@@ -3901,7 +3905,7 @@ msgstr ""
 msgid "Failed to archive email"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:519
+#: lib/klass_hero_web/live/provider/sessions_live.ex:526
 #, elixir-autogen, elixir-format
 msgid "Failed to create session: %{reason}"
 msgstr ""
@@ -3958,7 +3962,7 @@ msgid "Invalid Invitation"
 msgstr ""
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:255
-#: lib/klass_hero_web/live/provider/sessions_live.ex:578
+#: lib/klass_hero_web/live/provider/sessions_live.ex:585
 #, elixir-autogen, elixir-format
 msgid "Invalid time format"
 msgstr ""
@@ -4020,7 +4024,7 @@ msgid "Max Capacity"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:90
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:333
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "No actions available"
 msgstr ""
@@ -4056,7 +4060,7 @@ msgid "No sessions found for the selected filters."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:122
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:348
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled"
 msgstr ""
@@ -4081,8 +4085,8 @@ msgstr ""
 msgid "Participation Check-In"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:30
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:30
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:41
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Participation Management"
 msgstr ""
@@ -4097,7 +4101,7 @@ msgstr ""
 msgid "Please explain why you're rejecting this note..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:585
+#: lib/klass_hero_web/live/provider/sessions_live.ex:592
 #, elixir-autogen, elixir-format
 msgid "Please fill in all required fields"
 msgstr ""
@@ -4112,13 +4116,13 @@ msgstr ""
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
 #: lib/klass_hero_web/live/provider/programs_live.ex:226
-#: lib/klass_hero_web/live/provider/sessions_live.ex:381
+#: lib/klass_hero_web/live/provider/sessions_live.ex:388
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:175
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:179
+#: lib/klass_hero_web/live/provider/sessions_live.ex:186
 #, elixir-autogen, elixir-format
 msgid "Program is required"
 msgstr ""
@@ -4208,7 +4212,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:70
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:16
-#: lib/klass_hero_web/live/provider/sessions_live.ex:408
+#: lib/klass_hero_web/live/provider/sessions_live.ex:415
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:16
 #, elixir-autogen, elixir-format
 msgid "Session"
@@ -4225,7 +4229,7 @@ msgstr ""
 msgid "Session Roster"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:501
+#: lib/klass_hero_web/live/provider/sessions_live.ex:508
 #, elixir-autogen, elixir-format
 msgid "Session created successfully"
 msgstr ""
@@ -4236,7 +4240,7 @@ msgid "Staff Dashboard"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:54
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:297
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "Start Session"
 msgstr ""
@@ -4276,8 +4280,8 @@ msgstr ""
 msgid "This invite link is invalid or has expired."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:569
-#: lib/klass_hero_web/live/provider/sessions_live.ex:570
+#: lib/klass_hero_web/live/provider/sessions_live.ex:576
+#: lib/klass_hero_web/live/provider/sessions_live.ex:577
 #, elixir-autogen, elixir-format
 msgid "Time is required"
 msgstr ""
@@ -4292,10 +4296,9 @@ msgstr ""
 msgid "Type your reply..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:183
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:185
+#: lib/klass_hero_web/live/provider/sessions_live.ex:190
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:126
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:102
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:139
 #, elixir-autogen, elixir-format
 msgid "Unauthorized"
 msgstr ""
@@ -4322,7 +4325,7 @@ msgid "Upload connection lost. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:87
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:330
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:293
 #, elixir-autogen, elixir-format
 msgid "View Participation"
 msgstr ""
@@ -4348,7 +4351,7 @@ msgid "You already have an account. Log in to see your new enrollment."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:125
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:351
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:314
 #, elixir-autogen, elixir-format
 msgid "You have no sessions scheduled for %{date}"
 msgstr ""
@@ -4383,14 +4386,14 @@ msgstr ""
 msgid "Unlimited team seats"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:261
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:224
 #, elixir-autogen, elixir-format
 msgid "View and manage your assigned sessions"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:48
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:82
-#: lib/klass_hero_web/live/provider/participation_live.ex:276
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:52
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:86
+#: lib/klass_hero_web/live/provider/participation_live.ex:283
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:53
 #, elixir-autogen, elixir-format
 msgid "You are not assigned to this program"
@@ -4618,14 +4621,14 @@ msgstr ""
 msgid "Departure notes"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:220
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:159
+#: lib/klass_hero_web/live/provider/participation_live.ex:227
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Departure time is not a valid date and time"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:231
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:170
+#: lib/klass_hero_web/live/provider/participation_live.ex:238
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:177
 #, elixir-autogen, elixir-format
 msgid "Failed to update record"
 msgstr ""
@@ -4665,8 +4668,8 @@ msgstr ""
 msgid "Medical conditions"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:223
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:162
+#: lib/klass_hero_web/live/provider/participation_live.ex:230
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Nothing to update"
 msgstr ""
@@ -4696,8 +4699,8 @@ msgstr ""
 msgid "Primary guardian"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:66
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:66
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:77
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:77
 #, elixir-autogen, elixir-format
 msgid "Record departure"
 msgstr ""
@@ -4707,8 +4710,8 @@ msgstr ""
 msgid "Record departure time (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:211
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:150
+#: lib/klass_hero_web/live/provider/participation_live.ex:218
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:157
 #, elixir-autogen, elixir-format
 msgid "Record updated"
 msgstr ""
@@ -7160,7 +7163,7 @@ msgstr ""
 msgid "Session Note"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:114
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:118
 #, elixir-autogen, elixir-format
 msgid "Session note submitted for review"
 msgstr ""
@@ -7251,7 +7254,7 @@ msgid "Nobody is on this program yet."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/programs_live.ex:353
-#: lib/klass_hero_web/live/provider/sessions_live.ex:213
+#: lib/klass_hero_web/live/provider/sessions_live.ex:220
 #, elixir-autogen, elixir-format
 msgid "Pick a staff member to add."
 msgstr ""
@@ -7402,7 +7405,7 @@ msgstr ""
 msgid "Go back to the program's usual team"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:295
+#: lib/klass_hero_web/live/provider/sessions_live.ex:302
 #, elixir-autogen, elixir-format
 msgid "Lead instructor for this session updated."
 msgstr ""
@@ -7422,12 +7425,12 @@ msgstr ""
 msgid "Remove from this session"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:231
+#: lib/klass_hero_web/live/provider/sessions_live.ex:238
 #, elixir-autogen, elixir-format
 msgid "Staff member added to this session."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:255
+#: lib/klass_hero_web/live/provider/sessions_live.ex:262
 #, elixir-autogen, elixir-format
 msgid "Staff member removed from this session."
 msgstr ""
@@ -7442,27 +7445,27 @@ msgstr ""
 msgid "Staffing — %{date}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:424
+#: lib/klass_hero_web/live/provider/sessions_live.ex:431
 #, elixir-autogen, elixir-format
 msgid "That session could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:239
+#: lib/klass_hero_web/live/provider/sessions_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "They are already working this session."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:263
+#: lib/klass_hero_web/live/provider/sessions_live.ex:270
 #, elixir-autogen, elixir-format
 msgid "This person leads the session. Make someone else lead before removing them."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:311
+#: lib/klass_hero_web/live/provider/sessions_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "This session is back on the program's usual team."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:274
+#: lib/klass_hero_web/live/provider/sessions_live.ex:281
 #, elixir-autogen, elixir-format
 msgid "A session needs at least one person. Use “Go back to the program's usual team” to drop this session's own roster."
 msgstr ""
@@ -7668,7 +7671,7 @@ msgstr ""
 msgid "Waiver retired. Signatures already collected are kept."
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:198
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:205
 #, elixir-autogen, elixir-format
 msgid "You are not assigned to this session"
 msgstr ""
@@ -7894,9 +7897,7 @@ msgstr ""
 msgid "These programs have finished. Their sessions and rosters are no longer available."
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:196
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:98
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:135
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:183
 #, elixir-autogen, elixir-format
 msgid "This program has closed. Its sessions are no longer available."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -464,12 +464,12 @@ msgstr ""
 msgid "Changing..."
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:44
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:48
 #, elixir-autogen, elixir-format
 msgid "Child checked in successfully"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:76
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:80
 #, elixir-autogen, elixir-format
 msgid "Child checked out successfully"
 msgstr ""
@@ -608,18 +608,19 @@ msgstr ""
 msgid "Enter your password to confirm"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:57
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:61
 #, elixir-autogen, elixir-format
 msgid "Failed to check in: %{reason}"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:91
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:95
 #, elixir-autogen, elixir-format
 msgid "Failed to check out: %{reason}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:160
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:126
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:169
+#: lib/klass_hero_web/live/provider/sessions_live.ex:167
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:117
 #, elixir-autogen, elixir-format
 msgid "Failed to complete session: %{reason}"
 msgstr ""
@@ -629,8 +630,8 @@ msgstr ""
 msgid "Failed to delete account. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:137
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:89
+#: lib/klass_hero_web/live/provider/sessions_live.ex:141
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:91
 #, elixir-autogen, elixir-format
 msgid "Failed to start session: %{reason}"
 msgstr ""
@@ -680,9 +681,9 @@ msgstr ""
 msgid "Introduction"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:115
-#: lib/klass_hero_web/live/provider/sessions_live.ex:565
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:65
+#: lib/klass_hero_web/live/provider/sessions_live.ex:116
+#: lib/klass_hero_web/live/provider/sessions_live.ex:572
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:66
 #, elixir-autogen, elixir-format
 msgid "Invalid date format"
 msgstr ""
@@ -754,10 +755,10 @@ msgstr ""
 msgid "Message sent successfully!"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:50
+#: lib/klass_hero_web/live/provider/sessions_live.ex:51
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:4
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:20
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:260
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:21
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:223
 #, elixir-autogen, elixir-format
 msgid "My Sessions"
 msgstr ""
@@ -842,14 +843,14 @@ msgstr ""
 msgid "Questions About These Terms?"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:37
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:69
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:101
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:41
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:73
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:105
 #: lib/klass_hero_web/live/admin/sessions_live.ex:247
-#: lib/klass_hero_web/live/provider/participation_live.ex:171
-#: lib/klass_hero_web/live/provider/participation_live.ex:217
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:110
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:156
+#: lib/klass_hero_web/live/provider/participation_live.ex:178
+#: lib/klass_hero_web/live/provider/participation_live.ex:224
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:117
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:163
 #, elixir-autogen, elixir-format
 msgid "Record not found"
 msgstr ""
@@ -886,22 +887,23 @@ msgstr ""
 msgid "Send Message"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:146
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:112
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:157
+#: lib/klass_hero_web/live/provider/sessions_live.ex:150
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:100
 #, elixir-autogen, elixir-format
 msgid "Session completed successfully"
 msgstr ""
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:62
 #: lib/klass_hero_web/live/admin/sessions_live.ex:68
-#: lib/klass_hero_web/live/provider/participation_live.ex:287
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:241
+#: lib/klass_hero_web/live/provider/participation_live.ex:294
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:248
 #, elixir-autogen, elixir-format
 msgid "Session not found"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:123
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:75
+#: lib/klass_hero_web/live/provider/sessions_live.ex:124
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:74
 #, elixir-autogen, elixir-format
 msgid "Session started successfully"
 msgstr ""
@@ -1131,7 +1133,7 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/participation_live.ex:27
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:65
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:27
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:308
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:271
 #, elixir-autogen, elixir-format
 msgid "Manage Participation"
 msgstr ""
@@ -1370,11 +1372,11 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:540
 #: lib/klass_hero_web/components/provider_components.ex:1597
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:54
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:81
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:65
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:92
 #: lib/klass_hero_web/live/settings/children_live.ex:413
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:54
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:81
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:65
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:92
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
@@ -1637,7 +1639,7 @@ msgstr ""
 msgid "Failed to reject note"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:163
+#: lib/klass_hero_web/live/provider/participation_live.ex:170
 #, elixir-autogen, elixir-format
 msgid "Failed to resubmit note"
 msgstr ""
@@ -1648,7 +1650,7 @@ msgstr ""
 msgid "Failed to send broadcast"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:131
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:135
 #, elixir-autogen, elixir-format
 msgid "Failed to submit note"
 msgstr ""
@@ -1727,8 +1729,8 @@ msgstr ""
 msgid "Note approved"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:120
-#: lib/klass_hero_web/live/provider/participation_live.ex:155
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:124
+#: lib/klass_hero_web/live/provider/participation_live.ex:162
 #, elixir-autogen, elixir-format
 msgid "Note content cannot be blank"
 msgstr ""
@@ -1738,7 +1740,7 @@ msgstr ""
 msgid "Note rejected"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:149
+#: lib/klass_hero_web/live/provider/participation_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "Note resubmitted for review"
 msgstr ""
@@ -1844,8 +1846,8 @@ msgstr ""
 msgid "Type a message..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:307
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:261
+#: lib/klass_hero_web/live/provider/participation_live.ex:314
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "Unable to refresh roster. Please reload."
 msgstr ""
@@ -1856,7 +1858,7 @@ msgstr ""
 msgid "Write your message to all enrolled parents..."
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:123
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:127
 #, elixir-autogen, elixir-format
 msgid "You already submitted a note for this record"
 msgstr ""
@@ -3662,7 +3664,7 @@ msgstr ""
 msgid "%{count} unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:583
+#: lib/klass_hero_web/live/provider/sessions_live.ex:590
 #, elixir-autogen, elixir-format
 msgid "A session already exists at this time"
 msgstr ""
@@ -3672,8 +3674,8 @@ msgstr ""
 msgid "Account created! Check your email to confirm and log in."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:115
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:115
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:126
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:126
 #, elixir-autogen, elixir-format
 msgid "Add Note"
 msgstr ""
@@ -3738,8 +3740,8 @@ msgstr ""
 msgid "Broadcast messages are one-way"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:96
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:96
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:107
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:107
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Check In"
 msgstr ""
@@ -3789,8 +3791,10 @@ msgstr ""
 msgid "Complete Registration"
 msgstr ""
 
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:33
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:76
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:319
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:33
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "Complete Session"
 msgstr ""
@@ -3842,8 +3846,8 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:559
-#: lib/klass_hero_web/live/provider/sessions_live.ex:560
+#: lib/klass_hero_web/live/provider/sessions_live.ex:566
+#: lib/klass_hero_web/live/provider/sessions_live.ex:567
 #, elixir-autogen, elixir-format
 msgid "Date is required"
 msgstr ""
@@ -3853,7 +3857,7 @@ msgstr ""
 msgid "E.g., picked up by parent, gave medication reminder..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:144
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:155
 #, elixir-autogen, elixir-format
 msgid "Edit & Resubmit"
 msgstr ""
@@ -3886,7 +3890,7 @@ msgstr ""
 msgid "Emergency: %{details}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:582
+#: lib/klass_hero_web/live/provider/sessions_live.ex:589
 #, elixir-autogen, elixir-format
 msgid "End time must be after start time"
 msgstr ""
@@ -3901,7 +3905,7 @@ msgstr ""
 msgid "Failed to archive email"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:519
+#: lib/klass_hero_web/live/provider/sessions_live.ex:526
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to create session: %{reason}"
 msgstr ""
@@ -3958,7 +3962,7 @@ msgid "Invalid Invitation"
 msgstr ""
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:255
-#: lib/klass_hero_web/live/provider/sessions_live.ex:578
+#: lib/klass_hero_web/live/provider/sessions_live.ex:585
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invalid time format"
 msgstr ""
@@ -4020,7 +4024,7 @@ msgid "Max Capacity"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:90
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:333
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "No actions available"
 msgstr ""
@@ -4056,7 +4060,7 @@ msgid "No sessions found for the selected filters."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:122
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:348
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled"
 msgstr ""
@@ -4081,8 +4085,8 @@ msgstr ""
 msgid "Participation Check-In"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:30
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:30
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:41
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Participation Management"
 msgstr ""
@@ -4097,7 +4101,7 @@ msgstr ""
 msgid "Please explain why you're rejecting this note..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:585
+#: lib/klass_hero_web/live/provider/sessions_live.ex:592
 #, elixir-autogen, elixir-format
 msgid "Please fill in all required fields"
 msgstr ""
@@ -4112,13 +4116,13 @@ msgstr ""
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
 #: lib/klass_hero_web/live/provider/programs_live.ex:226
-#: lib/klass_hero_web/live/provider/sessions_live.ex:381
+#: lib/klass_hero_web/live/provider/sessions_live.ex:388
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:175
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:179
+#: lib/klass_hero_web/live/provider/sessions_live.ex:186
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program is required"
 msgstr ""
@@ -4208,7 +4212,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:70
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:16
-#: lib/klass_hero_web/live/provider/sessions_live.ex:408
+#: lib/klass_hero_web/live/provider/sessions_live.ex:415
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:16
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Session"
@@ -4225,7 +4229,7 @@ msgstr ""
 msgid "Session Roster"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:501
+#: lib/klass_hero_web/live/provider/sessions_live.ex:508
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Session created successfully"
 msgstr ""
@@ -4236,7 +4240,7 @@ msgid "Staff Dashboard"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:54
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:297
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "Start Session"
 msgstr ""
@@ -4276,8 +4280,8 @@ msgstr ""
 msgid "This invite link is invalid or has expired."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:569
-#: lib/klass_hero_web/live/provider/sessions_live.ex:570
+#: lib/klass_hero_web/live/provider/sessions_live.ex:576
+#: lib/klass_hero_web/live/provider/sessions_live.ex:577
 #, elixir-autogen, elixir-format
 msgid "Time is required"
 msgstr ""
@@ -4292,10 +4296,9 @@ msgstr ""
 msgid "Type your reply..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:183
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:185
+#: lib/klass_hero_web/live/provider/sessions_live.ex:190
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:126
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:102
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:139
 #, elixir-autogen, elixir-format
 msgid "Unauthorized"
 msgstr ""
@@ -4322,7 +4325,7 @@ msgid "Upload connection lost. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:87
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:330
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:293
 #, elixir-autogen, elixir-format
 msgid "View Participation"
 msgstr ""
@@ -4348,7 +4351,7 @@ msgid "You already have an account. Log in to see your new enrollment."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:125
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:351
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:314
 #, elixir-autogen, elixir-format
 msgid "You have no sessions scheduled for %{date}"
 msgstr ""
@@ -4383,14 +4386,14 @@ msgstr ""
 msgid "Unlimited team seats"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:261
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:224
 #, elixir-autogen, elixir-format
 msgid "View and manage your assigned sessions"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:48
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:82
-#: lib/klass_hero_web/live/provider/participation_live.ex:276
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:52
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:86
+#: lib/klass_hero_web/live/provider/participation_live.ex:283
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:53
 #, elixir-autogen, elixir-format
 msgid "You are not assigned to this program"
@@ -4618,14 +4621,14 @@ msgstr ""
 msgid "Departure notes"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:220
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:159
+#: lib/klass_hero_web/live/provider/participation_live.ex:227
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Departure time is not a valid date and time"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:231
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:170
+#: lib/klass_hero_web/live/provider/participation_live.ex:238
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:177
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to update record"
 msgstr ""
@@ -4665,8 +4668,8 @@ msgstr ""
 msgid "Medical conditions"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:223
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:162
+#: lib/klass_hero_web/live/provider/participation_live.ex:230
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Nothing to update"
 msgstr ""
@@ -4696,8 +4699,8 @@ msgstr ""
 msgid "Primary guardian"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:66
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:66
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:77
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:77
 #, elixir-autogen, elixir-format
 msgid "Record departure"
 msgstr ""
@@ -4707,8 +4710,8 @@ msgstr ""
 msgid "Record departure time (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:211
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:150
+#: lib/klass_hero_web/live/provider/participation_live.ex:218
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:157
 #, elixir-autogen, elixir-format
 msgid "Record updated"
 msgstr ""
@@ -7160,7 +7163,7 @@ msgstr ""
 msgid "Session Note"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:114
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:118
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Session note submitted for review"
 msgstr ""
@@ -7251,7 +7254,7 @@ msgid "Nobody is on this program yet."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/programs_live.ex:353
-#: lib/klass_hero_web/live/provider/sessions_live.ex:213
+#: lib/klass_hero_web/live/provider/sessions_live.ex:220
 #, elixir-autogen, elixir-format
 msgid "Pick a staff member to add."
 msgstr ""
@@ -7402,7 +7405,7 @@ msgstr ""
 msgid "Go back to the program's usual team"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:295
+#: lib/klass_hero_web/live/provider/sessions_live.ex:302
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Lead instructor for this session updated."
 msgstr ""
@@ -7422,12 +7425,12 @@ msgstr ""
 msgid "Remove from this session"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:231
+#: lib/klass_hero_web/live/provider/sessions_live.ex:238
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Staff member added to this session."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:255
+#: lib/klass_hero_web/live/provider/sessions_live.ex:262
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Staff member removed from this session."
 msgstr ""
@@ -7442,27 +7445,27 @@ msgstr ""
 msgid "Staffing — %{date}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:424
+#: lib/klass_hero_web/live/provider/sessions_live.ex:431
 #, elixir-autogen, elixir-format
 msgid "That session could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:239
+#: lib/klass_hero_web/live/provider/sessions_live.ex:246
 #, elixir-autogen, elixir-format, fuzzy
 msgid "They are already working this session."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:263
+#: lib/klass_hero_web/live/provider/sessions_live.ex:270
 #, elixir-autogen, elixir-format, fuzzy
 msgid "This person leads the session. Make someone else lead before removing them."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:311
+#: lib/klass_hero_web/live/provider/sessions_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "This session is back on the program's usual team."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:274
+#: lib/klass_hero_web/live/provider/sessions_live.ex:281
 #, elixir-autogen, elixir-format
 msgid "A session needs at least one person. Use “Go back to the program's usual team” to drop this session's own roster."
 msgstr ""
@@ -7668,7 +7671,7 @@ msgstr ""
 msgid "Waiver retired. Signatures already collected are kept."
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:198
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:205
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You are not assigned to this session"
 msgstr ""
@@ -7894,9 +7897,7 @@ msgstr ""
 msgid "These programs have finished. Their sessions and rosters are no longer available."
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:196
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:98
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:135
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:183
 #, elixir-autogen, elixir-format
 msgid "This program has closed. Its sessions are no longer available."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -4296,7 +4296,7 @@ msgstr ""
 msgid "Type your reply..."
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:185
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:194
 #: lib/klass_hero_web/live/provider/sessions_live.ex:190
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:126
 #, elixir-autogen, elixir-format
@@ -7897,7 +7897,7 @@ msgstr ""
 msgid "These programs have finished. Their sessions and rosters are no longer available."
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:183
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:192
 #, elixir-autogen, elixir-format
 msgid "This program has closed. Its sessions are no longer available."
 msgstr ""

--- a/test/klass_hero/participation/complete_session_test.exs
+++ b/test/klass_hero/participation/complete_session_test.exs
@@ -9,14 +9,18 @@ defmodule KlassHero.Participation.CompleteSessionTest do
 
   import KlassHero.Factory
 
+  alias KlassHero.Accounts.Scope
+  alias KlassHero.AccountsFixtures
+  alias KlassHero.Participation
   alias KlassHero.Participation.ParticipationRecord
   alias KlassHero.Participation.ProgramSession
+  alias KlassHero.ProviderFixtures
 
   describe "execute/1" do
     test "successfully completes an in_progress session" do
       session_schema = insert(:program_session_schema, status: :in_progress)
 
-      assert {:ok, session} = KlassHero.Participation.complete_session(session_schema.id)
+      assert {:ok, session} = KlassHero.Participation.complete_session(admin_scope(), session_schema.id)
       assert %ProgramSession{} = session
       assert session.id == session_schema.id
       assert session.status == :completed
@@ -25,31 +29,34 @@ defmodule KlassHero.Participation.CompleteSessionTest do
     test "returns error when session not found" do
       non_existent_id = Ecto.UUID.generate()
 
-      assert {:error, :not_found} = KlassHero.Participation.complete_session(non_existent_id)
+      assert {:error, :not_found} = KlassHero.Participation.complete_session(admin_scope(), non_existent_id)
     end
 
     test "returns error when completing a scheduled session" do
       session_schema = insert(:program_session_schema, status: :scheduled)
 
-      assert {:error, :invalid_status_transition} = KlassHero.Participation.complete_session(session_schema.id)
+      assert {:error, :invalid_status_transition} =
+               KlassHero.Participation.complete_session(admin_scope(), session_schema.id)
     end
 
     test "returns error when completing a completed session" do
       session_schema = insert(:program_session_schema, status: :completed)
 
-      assert {:error, :invalid_status_transition} = KlassHero.Participation.complete_session(session_schema.id)
+      assert {:error, :invalid_status_transition} =
+               KlassHero.Participation.complete_session(admin_scope(), session_schema.id)
     end
 
     test "returns error when completing a cancelled session" do
       session_schema = insert(:program_session_schema, status: :cancelled)
 
-      assert {:error, :invalid_status_transition} = KlassHero.Participation.complete_session(session_schema.id)
+      assert {:error, :invalid_status_transition} =
+               KlassHero.Participation.complete_session(admin_scope(), session_schema.id)
     end
 
     test "persists status change to database" do
       session_schema = insert(:program_session_schema, status: :in_progress)
 
-      {:ok, completed_session} = KlassHero.Participation.complete_session(session_schema.id)
+      {:ok, completed_session} = KlassHero.Participation.complete_session(admin_scope(), session_schema.id)
 
       reloaded =
         KlassHero.Repo.get(
@@ -72,7 +79,7 @@ defmodule KlassHero.Participation.CompleteSessionTest do
           status: :registered
         )
 
-      assert {:ok, _session} = KlassHero.Participation.complete_session(session_schema.id)
+      assert {:ok, _session} = KlassHero.Participation.complete_session(admin_scope(), session_schema.id)
 
       reloaded = KlassHero.Repo.get(ParticipationRecord, record.id)
       assert reloaded.status == :absent
@@ -105,7 +112,7 @@ defmodule KlassHero.Participation.CompleteSessionTest do
           check_out_by: staff_user.id
         )
 
-      assert {:ok, _session} = KlassHero.Participation.complete_session(session_schema.id)
+      assert {:ok, _session} = KlassHero.Participation.complete_session(admin_scope(), session_schema.id)
 
       assert KlassHero.Repo.get(ParticipationRecord, checked_in.id).status == :checked_in
       assert KlassHero.Repo.get(ParticipationRecord, checked_out.id).status == :checked_out
@@ -143,8 +150,84 @@ defmodule KlassHero.Participation.CompleteSessionTest do
         status: :registered
       )
 
-      assert {:ok, session} = KlassHero.Participation.complete_session(session_schema.id)
+      assert {:ok, session} = KlassHero.Participation.complete_session(admin_scope(), session_schema.id)
       assert session.status == :completed
     end
   end
+
+  # The gate the use case never had: until #1373 this function took a bare id and
+  # authorized nothing, so any provider could complete any other business's session
+  # -- which marks every remaining registered child absent.
+  describe "complete_session/2 authorization" do
+    test "the owning provider may complete their own session" do
+      %{provider: provider, session: session} = provider_with_in_progress_session()
+
+      assert {:ok, completed} =
+               Participation.complete_session(%Scope{user: user_fixture(), provider: provider}, session.id)
+
+      assert completed.status == :completed
+    end
+
+    test "refuses a provider who does not own the session's program" do
+      %{session: session} = provider_with_in_progress_session()
+      stranger = ProviderFixtures.provider_profile_fixture()
+
+      assert {:error, :unauthorized} =
+               Participation.complete_session(%Scope{user: user_fixture(), provider: stranger}, session.id)
+
+      assert Repo.get!(ProgramSession, session.id).status == :in_progress
+    end
+
+    test "refuses an actor holding no persona" do
+      %{session: session} = provider_with_in_progress_session()
+
+      assert {:error, :unauthorized} =
+               Participation.complete_session(%Scope{user: user_fixture()}, session.id)
+    end
+
+    # ADR-0019: closure gates the staff branch and only the staff branch. The
+    # provider owns the roster and closes out their own season.
+    test "the owning provider may still complete a Closed Program's session" do
+      %{provider: provider, session: session} = provider_with_in_progress_session(closed: true)
+
+      assert {:ok, completed} =
+               Participation.complete_session(%Scope{user: user_fixture(), provider: provider}, session.id)
+
+      assert completed.status == :completed
+    end
+
+    test "refuses a staff member on a Closed Program, naming closure as the reason" do
+      %{provider: provider, program: program, session: session} =
+        provider_with_in_progress_session(closed: true)
+
+      staff = ProviderFixtures.staff_member_fixture(%{provider_id: provider.id})
+
+      ProviderFixtures.program_assignment_fixture(%{
+        provider_id: provider.id,
+        staff_member_id: staff.id,
+        program_id: program.id
+      })
+
+      assert {:error, :program_closed} =
+               Participation.complete_session(%Scope{user: user_fixture(), staff_member: staff}, session.id)
+    end
+  end
+
+  defp provider_with_in_progress_session(opts \\ []) do
+    provider = ProviderFixtures.provider_profile_fixture()
+
+    end_date = if Keyword.get(opts, :closed, false), do: Date.add(Date.utc_today(), -20)
+    program = insert(:program_schema, provider_id: provider.id, end_date: end_date)
+    session = insert(:program_session_schema, program_id: program.id, status: :in_progress)
+
+    %{provider: provider, program: program, session: session}
+  end
+
+  defp user_fixture, do: AccountsFixtures.unconfirmed_user_fixture()
+
+  # These tests are about what completing a session *does*, not who may do it, so
+  # they use the persona that is authorized everywhere and stays out of the way.
+  # Authorization itself is the describe block above, which builds the persona it
+  # means.
+  defp admin_scope, do: AccountsFixtures.admin_scope_fixture()
 end

--- a/test/klass_hero/participation/outbox_staging_test.exs
+++ b/test/klass_hero/participation/outbox_staging_test.exs
@@ -62,7 +62,7 @@ defmodule KlassHero.Participation.OutboxStagingTest do
     {:ok, _started} = Participation.start_session(session.id)
     TestOutbox.setup()
 
-    {:ok, _completed} = Participation.complete_session(session.id)
+    {:ok, _completed} = Participation.complete_session(admin_scope(), session.id)
 
     assert :session_completed in staged_types()
   end
@@ -115,4 +115,8 @@ defmodule KlassHero.Participation.OutboxStagingTest do
 
     assert [] = TestOutbox.staged()
   end
+
+  # An admin is authorized everywhere, so the scope stays out of a test whose
+  # subject is not authorization.
+  defp admin_scope, do: KlassHero.AccountsFixtures.admin_scope_fixture()
 end

--- a/test/klass_hero/participation/outbox_staging_test.exs
+++ b/test/klass_hero/participation/outbox_staging_test.exs
@@ -50,19 +50,23 @@ defmodule KlassHero.Participation.OutboxStagingTest do
 
   test "start_session stages session_started", %{program: program} do
     session = create_session(program)
+    # Built before the outbox is armed: the fixture creates a User, and user
+    # creation stages user_registered/user_confirmed of its own.
+    scope = admin_scope()
     TestOutbox.setup()
 
-    {:ok, _started} = Participation.start_session(session.id)
+    {:ok, _started} = Participation.start_session(scope, session.id)
 
     assert [:session_started] = staged_types()
   end
 
   test "complete_session stages session_completed", %{program: program} do
     session = create_session(program)
-    {:ok, _started} = Participation.start_session(session.id)
+    scope = admin_scope()
+    {:ok, _started} = Participation.start_session(scope, session.id)
     TestOutbox.setup()
 
-    {:ok, _completed} = Participation.complete_session(admin_scope(), session.id)
+    {:ok, _completed} = Participation.complete_session(scope, session.id)
 
     assert :session_completed in staged_types()
   end

--- a/test/klass_hero/participation/session_authorization_test.exs
+++ b/test/klass_hero/participation/session_authorization_test.exs
@@ -1,4 +1,4 @@
-defmodule KlassHero.Participation.AttendanceAuthorizationTest do
+defmodule KlassHero.Participation.SessionAuthorizationTest do
   @moduledoc """
   Who may write a child's attendance record (#1353).
 
@@ -12,7 +12,7 @@ defmodule KlassHero.Participation.AttendanceAuthorizationTest do
 
   alias KlassHero.Accounts.Scope
   alias KlassHero.AccountsFixtures
-  alias KlassHero.Participation.AttendanceAuthorization
+  alias KlassHero.Participation.SessionAuthorization
   alias KlassHero.Provider
   alias KlassHero.ProviderFixtures
 
@@ -21,7 +21,7 @@ defmodule KlassHero.Participation.AttendanceAuthorizationTest do
       %{provider: provider, session: session} = provider_with_session()
       scope = scope_for(provider_profile: provider)
 
-      assert {:ok, :provider} = AttendanceAuthorization.authorize(scope, session)
+      assert {:ok, :provider} = SessionAuthorization.authorize(scope, session)
     end
 
     test "a provider is refused on another provider's program" do
@@ -29,7 +29,7 @@ defmodule KlassHero.Participation.AttendanceAuthorizationTest do
       %{session: foreign_session} = provider_with_session()
       scope = scope_for(provider_profile: provider)
 
-      assert {:error, :unauthorized} = AttendanceAuthorization.authorize(scope, foreign_session)
+      assert {:error, :unauthorized} = SessionAuthorization.authorize(scope, foreign_session)
     end
 
     test "a staff member assigned to the program is authorized as :staff" do
@@ -37,7 +37,7 @@ defmodule KlassHero.Participation.AttendanceAuthorizationTest do
       staff = assigned_staff(provider, program)
       scope = scope_for(staff_member: staff)
 
-      assert {:ok, :staff} = AttendanceAuthorization.authorize(scope, session)
+      assert {:ok, :staff} = SessionAuthorization.authorize(scope, session)
     end
 
     test "a staff member with no assignment to the program is refused" do
@@ -45,7 +45,7 @@ defmodule KlassHero.Participation.AttendanceAuthorizationTest do
       staff = ProviderFixtures.staff_member_fixture(%{provider_id: provider.id})
       scope = scope_for(staff_member: staff)
 
-      assert {:error, :unauthorized} = AttendanceAuthorization.authorize(scope, session)
+      assert {:error, :unauthorized} = SessionAuthorization.authorize(scope, session)
     end
 
     test "a platform admin holding no persona is authorized as :admin" do
@@ -54,13 +54,13 @@ defmodule KlassHero.Participation.AttendanceAuthorizationTest do
       # never casts `is_admin`, so the unconfirmed variant drops the flag silently.
       scope = scope_for(user: AccountsFixtures.user_fixture(is_admin: true))
 
-      assert {:ok, :admin} = AttendanceAuthorization.authorize(scope, session)
+      assert {:ok, :admin} = SessionAuthorization.authorize(scope, session)
     end
 
     test "a user with no persona and no admin flag is refused" do
       %{session: session} = provider_with_session()
 
-      assert {:error, :unauthorized} = AttendanceAuthorization.authorize(scope_for([]), session)
+      assert {:error, :unauthorized} = SessionAuthorization.authorize(scope_for([]), session)
     end
   end
 
@@ -72,7 +72,7 @@ defmodule KlassHero.Participation.AttendanceAuthorizationTest do
       %{provider: provider, program: program, session: session} = provider_with_closed_session()
       scope = scope_for(staff_member: assigned_staff(provider, program))
 
-      assert {:error, :unauthorized} = AttendanceAuthorization.authorize(scope, session)
+      assert {:error, :unauthorized} = SessionAuthorization.authorize(scope, session)
     end
 
     test "a staff member overridden onto that one session is refused too" do
@@ -88,21 +88,21 @@ defmodule KlassHero.Participation.AttendanceAuthorizationTest do
         })
 
       assert {:error, :unauthorized} =
-               AttendanceAuthorization.authorize(scope_for(staff_member: staff), session)
+               SessionAuthorization.authorize(scope_for(staff_member: staff), session)
     end
 
     test "the owning provider still corrects their own closed roster" do
       %{provider: provider, session: session} = provider_with_closed_session()
 
       assert {:ok, :provider} =
-               AttendanceAuthorization.authorize(scope_for(provider_profile: provider), session)
+               SessionAuthorization.authorize(scope_for(provider_profile: provider), session)
     end
 
     test "an admin still reaches a closed program" do
       %{session: session} = provider_with_closed_session()
       scope = scope_for(user: AccountsFixtures.user_fixture(is_admin: true))
 
-      assert {:ok, :admin} = AttendanceAuthorization.authorize(scope, session)
+      assert {:ok, :admin} = SessionAuthorization.authorize(scope, session)
     end
 
     test "a staff member keeps access while the program is inside its grace window" do
@@ -114,7 +114,7 @@ defmodule KlassHero.Participation.AttendanceAuthorizationTest do
       session = insert(:program_session_schema, program_id: program.id)
       scope = scope_for(staff_member: assigned_staff(provider, program))
 
-      assert {:ok, :staff} = AttendanceAuthorization.authorize(scope, session)
+      assert {:ok, :staff} = SessionAuthorization.authorize(scope, session)
     end
   end
 
@@ -131,7 +131,7 @@ defmodule KlassHero.Participation.AttendanceAuthorizationTest do
           provider_profile: provider
         )
 
-      assert {:ok, :provider} = AttendanceAuthorization.authorize(scope, session)
+      assert {:ok, :provider} = SessionAuthorization.authorize(scope, session)
     end
 
     test "an admin who does not own the program falls through to :admin" do
@@ -144,7 +144,7 @@ defmodule KlassHero.Participation.AttendanceAuthorizationTest do
           provider_profile: provider
         )
 
-      assert {:ok, :admin} = AttendanceAuthorization.authorize(scope, foreign_session)
+      assert {:ok, :admin} = SessionAuthorization.authorize(scope, foreign_session)
     end
 
     test "a provider who is also staff is authorized as :provider on their own program" do
@@ -152,7 +152,7 @@ defmodule KlassHero.Participation.AttendanceAuthorizationTest do
       staff = assigned_staff(provider, program)
       scope = scope_for(provider_profile: provider, staff_member: staff)
 
-      assert {:ok, :provider} = AttendanceAuthorization.authorize(scope, session)
+      assert {:ok, :provider} = SessionAuthorization.authorize(scope, session)
     end
 
     test "a provider who is also staff elsewhere is authorized as :staff on that program" do
@@ -164,7 +164,7 @@ defmodule KlassHero.Participation.AttendanceAuthorizationTest do
       staff = assigned_staff(other_provider, other_program)
       scope = scope_for(provider_profile: own_provider, staff_member: staff)
 
-      assert {:ok, :staff} = AttendanceAuthorization.authorize(scope, other_session)
+      assert {:ok, :staff} = SessionAuthorization.authorize(scope, other_session)
     end
   end
 
@@ -183,10 +183,10 @@ defmodule KlassHero.Participation.AttendanceAuthorizationTest do
       assert {:ok, _} = Provider.unassign_staff_from_session(session.id, staff.id, provider.id)
 
       assert {:error, :unauthorized} =
-               AttendanceAuthorization.authorize(scope_for(staff_member: staff), session)
+               SessionAuthorization.authorize(scope_for(staff_member: staff), session)
 
       assert {:ok, :staff} =
-               AttendanceAuthorization.authorize(scope_for(staff_member: colleague), session)
+               SessionAuthorization.authorize(scope_for(staff_member: colleague), session)
     end
 
     test "a staff member on the session but not the program is authorized as :staff" do
@@ -201,7 +201,7 @@ defmodule KlassHero.Participation.AttendanceAuthorizationTest do
                })
 
       assert {:ok, :staff} =
-               AttendanceAuthorization.authorize(scope_for(staff_member: staff), session)
+               SessionAuthorization.authorize(scope_for(staff_member: staff), session)
     end
 
     test "a deactivated staff member on the session is refused" do
@@ -218,7 +218,7 @@ defmodule KlassHero.Participation.AttendanceAuthorizationTest do
       {:ok, _} = Provider.deactivate_staff_member(staff)
 
       assert {:error, :unauthorized} =
-               AttendanceAuthorization.authorize(scope_for(staff_member: staff), session)
+               SessionAuthorization.authorize(scope_for(staff_member: staff), session)
     end
   end
 

--- a/test/klass_hero/participation/session_authorization_test.exs
+++ b/test/klass_hero/participation/session_authorization_test.exs
@@ -222,6 +222,78 @@ defmodule KlassHero.Participation.SessionAuthorizationTest do
     end
   end
 
+  # `authorize/2` collapses every refusal to `:unauthorized`, because no attendance
+  # caller ever needed to tell them apart. Session lifecycle does: the staff sessions
+  # list says "This program has closed" rather than "Unauthorized", and that copy is
+  # the only reason this second entry point exists. Same `resolve/2` underneath — the
+  # two differ in how much of its answer they pass on, never in how they get it.
+  describe "authorize_lifecycle/2" do
+    test "grants the same three roles authorize/2 grants" do
+      %{provider: provider, program: program, session: session} = provider_with_session()
+      admin = AccountsFixtures.user_fixture(is_admin: true)
+
+      assert {:ok, :provider} =
+               SessionAuthorization.authorize_lifecycle(scope_for(provider_profile: provider), session)
+
+      assert {:ok, :staff} =
+               SessionAuthorization.authorize_lifecycle(
+                 scope_for(staff_member: assigned_staff(provider, program)),
+                 session
+               )
+
+      assert {:ok, :admin} =
+               SessionAuthorization.authorize_lifecycle(scope_for(user: admin), session)
+    end
+
+    test "names closure as the reason a staff member was refused" do
+      %{provider: provider, program: program, session: session} = provider_with_closed_session()
+      scope = scope_for(staff_member: assigned_staff(provider, program))
+
+      assert {:error, :program_closed} = SessionAuthorization.authorize_lifecycle(scope, session)
+    end
+
+    test "the owning provider is untouched by closure" do
+      %{provider: provider, session: session} = provider_with_closed_session()
+
+      assert {:ok, :provider} =
+               SessionAuthorization.authorize_lifecycle(scope_for(provider_profile: provider), session)
+    end
+
+    # Closure is a staff rule, so it must be asked after the admin branch, not
+    # before it — otherwise a person who happens to hold both personas loses the
+    # broader one to the narrower one's refusal.
+    test "an admin refused as staff is still authorized as :admin" do
+      %{provider: provider, program: program, session: session} = provider_with_closed_session()
+      staff = assigned_staff(provider, program)
+      admin = AccountsFixtures.user_fixture(is_admin: true)
+
+      assert {:ok, :admin} =
+               SessionAuthorization.authorize_lifecycle(
+                 scope_for(user: admin, staff_member: staff),
+                 session
+               )
+    end
+
+    # `Provider.get_session_staffing/1` answers for any session id at all, so a
+    # reason read off `program_closed?` alone would tell any staff-persona caller
+    # the closure state of a program they had merely guessed an id for. The reason
+    # is "you would have been staff", not "this program is closed".
+    test "a staff member who was never on the session learns nothing about closure" do
+      %{session: session} = provider_with_closed_session()
+      other_provider = ProviderFixtures.provider_profile_fixture()
+      stranger = ProviderFixtures.staff_member_fixture(%{provider_id: other_provider.id})
+
+      assert {:error, :unauthorized} =
+               SessionAuthorization.authorize_lifecycle(scope_for(staff_member: stranger), session)
+    end
+
+    test "an actor with no persona is refused without a reason" do
+      %{session: session} = provider_with_closed_session()
+
+      assert {:error, :unauthorized} = SessionAuthorization.authorize_lifecycle(scope_for([]), session)
+    end
+  end
+
   defp provider_with_program do
     provider = ProviderFixtures.provider_profile_fixture()
     program = insert(:program_schema, provider_id: provider.id)

--- a/test/klass_hero/participation/start_session_test.exs
+++ b/test/klass_hero/participation/start_session_test.exs
@@ -9,13 +9,17 @@ defmodule KlassHero.Participation.StartSessionTest do
 
   import KlassHero.Factory
 
+  alias KlassHero.Accounts.Scope
+  alias KlassHero.AccountsFixtures
+  alias KlassHero.Participation
   alias KlassHero.Participation.ProgramSession
+  alias KlassHero.ProviderFixtures
 
   describe "execute/1" do
     test "successfully starts a scheduled session" do
       session_schema = insert(:program_session_schema, status: :scheduled)
 
-      assert {:ok, session} = KlassHero.Participation.start_session(session_schema.id)
+      assert {:ok, session} = KlassHero.Participation.start_session(admin_scope(), session_schema.id)
       assert %ProgramSession{} = session
       assert session.id == session_schema.id
       assert session.status == :in_progress
@@ -24,31 +28,34 @@ defmodule KlassHero.Participation.StartSessionTest do
     test "returns error when session not found" do
       non_existent_id = Ecto.UUID.generate()
 
-      assert {:error, :not_found} = KlassHero.Participation.start_session(non_existent_id)
+      assert {:error, :not_found} = KlassHero.Participation.start_session(admin_scope(), non_existent_id)
     end
 
     test "returns error when starting an in_progress session" do
       session_schema = insert(:program_session_schema, status: :in_progress)
 
-      assert {:error, :invalid_status_transition} = KlassHero.Participation.start_session(session_schema.id)
+      assert {:error, :invalid_status_transition} =
+               KlassHero.Participation.start_session(admin_scope(), session_schema.id)
     end
 
     test "returns error when starting a completed session" do
       session_schema = insert(:program_session_schema, status: :completed)
 
-      assert {:error, :invalid_status_transition} = KlassHero.Participation.start_session(session_schema.id)
+      assert {:error, :invalid_status_transition} =
+               KlassHero.Participation.start_session(admin_scope(), session_schema.id)
     end
 
     test "returns error when starting a cancelled session" do
       session_schema = insert(:program_session_schema, status: :cancelled)
 
-      assert {:error, :invalid_status_transition} = KlassHero.Participation.start_session(session_schema.id)
+      assert {:error, :invalid_status_transition} =
+               KlassHero.Participation.start_session(admin_scope(), session_schema.id)
     end
 
     test "persists status change to database" do
       session_schema = insert(:program_session_schema, status: :scheduled)
 
-      {:ok, started_session} = KlassHero.Participation.start_session(session_schema.id)
+      {:ok, started_session} = KlassHero.Participation.start_session(admin_scope(), session_schema.id)
 
       reloaded =
         KlassHero.Repo.get(
@@ -60,4 +67,67 @@ defmodule KlassHero.Participation.StartSessionTest do
       assert started_session.status == :in_progress
     end
   end
+
+  # start_session shares complete_session's gate and its history: both took a bare
+  # id until #1373. Starting a session is the less destructive of the two, but an
+  # ungated write on someone else's roster is still theirs to make, not ours.
+  describe "start_session/2 authorization" do
+    test "the owning provider may start their own session" do
+      %{provider: provider, session: session} = provider_with_scheduled_session()
+
+      assert {:ok, started} =
+               Participation.start_session(%Scope{user: user_fixture(), provider: provider}, session.id)
+
+      assert started.status == :in_progress
+    end
+
+    test "refuses a provider who does not own the session's program" do
+      %{session: session} = provider_with_scheduled_session()
+      stranger = ProviderFixtures.provider_profile_fixture()
+
+      assert {:error, :unauthorized} =
+               Participation.start_session(%Scope{user: user_fixture(), provider: stranger}, session.id)
+
+      assert KlassHero.Repo.get!(ProgramSession, session.id).status == :scheduled
+    end
+
+    test "refuses an actor holding no persona" do
+      %{session: session} = provider_with_scheduled_session()
+
+      assert {:error, :unauthorized} =
+               Participation.start_session(%Scope{user: user_fixture()}, session.id)
+    end
+
+    test "refuses a staff member on a Closed Program, naming closure as the reason" do
+      %{provider: provider, program: program, session: session} =
+        provider_with_scheduled_session(closed: true)
+
+      staff = ProviderFixtures.staff_member_fixture(%{provider_id: provider.id})
+
+      ProviderFixtures.program_assignment_fixture(%{
+        provider_id: provider.id,
+        staff_member_id: staff.id,
+        program_id: program.id
+      })
+
+      assert {:error, :program_closed} =
+               Participation.start_session(%Scope{user: user_fixture(), staff_member: staff}, session.id)
+    end
+  end
+
+  defp provider_with_scheduled_session(opts \\ []) do
+    provider = ProviderFixtures.provider_profile_fixture()
+
+    end_date = if Keyword.get(opts, :closed, false), do: Date.add(Date.utc_today(), -20)
+    program = insert(:program_schema, provider_id: provider.id, end_date: end_date)
+    session = insert(:program_session_schema, program_id: program.id, status: :scheduled)
+
+    %{provider: provider, program: program, session: session}
+  end
+
+  defp user_fixture, do: AccountsFixtures.unconfirmed_user_fixture()
+
+  # These tests are about what starting a session *does*, not who may do it, so
+  # they use the persona that is authorized everywhere and stays out of the way.
+  defp admin_scope, do: AccountsFixtures.admin_scope_fixture()
 end

--- a/test/klass_hero/participation/sync_sessions_for_program_test.exs
+++ b/test/klass_hero/participation/sync_sessions_for_program_test.exs
@@ -127,7 +127,7 @@ defmodule KlassHero.Participation.SyncSessionsForProgramTest do
       assert {:ok, %{generated: 2}} = Participation.sync_sessions_for_program(program.id)
 
       [first | _] = sessions_for(program.id)
-      {:ok, _} = Participation.start_session(first.id)
+      {:ok, _} = Participation.start_session(admin_scope(), first.id)
       {:ok, _} = Participation.complete_session(admin_scope(), first.id)
 
       tomorrow = Date.add(Date.utc_today(), 1)

--- a/test/klass_hero/participation/sync_sessions_for_program_test.exs
+++ b/test/klass_hero/participation/sync_sessions_for_program_test.exs
@@ -128,7 +128,7 @@ defmodule KlassHero.Participation.SyncSessionsForProgramTest do
 
       [first | _] = sessions_for(program.id)
       {:ok, _} = Participation.start_session(first.id)
-      {:ok, _} = Participation.complete_session(first.id)
+      {:ok, _} = Participation.complete_session(admin_scope(), first.id)
 
       tomorrow = Date.add(Date.utc_today(), 1)
       {:ok, program} = update_meeting_days(program, [weekday_name(tomorrow)])
@@ -154,4 +154,8 @@ defmodule KlassHero.Participation.SyncSessionsForProgramTest do
     |> Ecto.Changeset.change(%{meeting_days: days})
     |> Repo.update()
   end
+
+  # An admin is authorized everywhere, so the scope stays out of a test whose
+  # subject is not authorization.
+  defp admin_scope, do: KlassHero.AccountsFixtures.admin_scope_fixture()
 end

--- a/test/klass_hero_web/live/provider/participation_live_test.exs
+++ b/test/klass_hero_web/live/provider/participation_live_test.exs
@@ -7,7 +7,9 @@ defmodule KlassHeroWeb.Provider.ParticipationLiveTest do
   alias KlassHero.Accounts.Scope
   alias KlassHero.Participation
   alias KlassHero.Participation.ParticipationRecord
+  alias KlassHero.Participation.ProgramSession
   alias KlassHero.Participation.SessionNote
+  alias KlassHero.Repo
 
   setup :register_and_log_in_provider
 
@@ -817,6 +819,52 @@ defmodule KlassHeroWeb.Provider.ParticipationLiveTest do
       )
 
       assert render(view) =~ "edit-btn-#{record.id}"
+    end
+  end
+
+  describe "completing the session from the roster" do
+    setup [:create_session_with_child]
+
+    test "offers Complete Session while the session is in progress", %{conn: conn, session: session} do
+      {:ok, view, _html} = live(conn, ~p"/provider/participation/#{session.id}")
+
+      assert has_element?(view, "#complete-session-btn")
+    end
+
+    test "does not offer it once the session is completed", %{conn: conn, session: session} do
+      {:ok, _} = Repo.update(Ecto.Changeset.change(session, status: :completed))
+
+      {:ok, view, _html} = live(conn, ~p"/provider/participation/#{session.id}")
+
+      refute has_element?(view, "#complete-session-btn")
+    end
+
+    test "completing absents the stragglers without leaving the page", %{
+      conn: conn,
+      session: session,
+      record: record
+    } do
+      {:ok, view, _html} = live(conn, ~p"/provider/participation/#{session.id}")
+
+      view |> element("#complete-session-btn") |> render_click()
+
+      assert_flash(view, :info, "Session completed successfully")
+      assert Repo.get!(ProgramSession, session.id).status == :completed
+      assert Repo.get!(ParticipationRecord, record.id).status == :absent
+      refute has_element?(view, "#complete-session-btn")
+    end
+
+    # The check-in is what makes this non-vacuous: an absent row has no actions to
+    # lose, so a roster asserted read-only without one proves nothing.
+    test "the roster stops being editable", %{conn: conn, session: session, record: record, scope: scope} do
+      {:ok, _} = Participation.record_check_in(scope, record.id)
+
+      {:ok, view, _html} = live(conn, ~p"/provider/participation/#{session.id}")
+      assert has_element?(view, "#edit-btn-#{record.id}")
+
+      view |> element("#complete-session-btn") |> render_click()
+
+      refute has_element?(view, "#edit-btn-#{record.id}")
     end
   end
 end

--- a/test/klass_hero_web/live/provider/sessions_live_test.exs
+++ b/test/klass_hero_web/live/provider/sessions_live_test.exs
@@ -5,6 +5,8 @@ defmodule KlassHeroWeb.Provider.SessionsLiveTest do
   import Phoenix.LiveViewTest
 
   alias KlassHero.Participation
+  alias KlassHero.Participation.ProgramSession
+  alias KlassHero.Repo
 
   describe "authentication and authorization" do
     test "redirects unauthenticated users to login", %{conn: conn} do
@@ -583,6 +585,44 @@ defmodule KlassHeroWeb.Provider.SessionsLiveTest do
 
   describe "session actions" do
     setup :register_and_log_in_provider
+
+    # Both buttons carry the session id in a phx-value, so a tampered client can
+    # name any session it likes. Until #1373 nothing between that event and the
+    # write checked whose session it was -- and completing one marks every
+    # remaining registered child absent.
+    test "a foreign session cannot be started or completed", %{conn: conn} do
+      other_provider = insert(:provider_profile_schema)
+      other_program = insert(:program_schema, provider_id: other_provider.id)
+
+      scheduled =
+        insert(:program_session_schema,
+          program_id: other_program.id,
+          session_date: Date.utc_today(),
+          status: :scheduled
+        )
+
+      in_progress =
+        insert(:program_session_schema,
+          program_id: other_program.id,
+          session_date: Date.utc_today(),
+          # Distinct from the session above: (program_id, session_date, start_time)
+          # is uniquely indexed.
+          start_time: ~T[14:00:00],
+          end_time: ~T[16:00:00],
+          status: :in_progress
+        )
+
+      {:ok, view, _html} = live(conn, ~p"/provider/sessions")
+
+      render_click(view, "start_session", %{"session_id" => scheduled.id})
+      assert_flash(view, :error, "Unauthorized")
+
+      render_click(view, "complete_session", %{"session_id" => in_progress.id})
+      assert_flash(view, :error, "Unauthorized")
+
+      assert Repo.get!(ProgramSession, scheduled.id).status == :scheduled
+      assert Repo.get!(ProgramSession, in_progress.id).status == :in_progress
+    end
 
     test "start_session transitions scheduled session to in_progress", %{
       conn: conn,

--- a/test/klass_hero_web/live/provider/sessions_live_test.exs
+++ b/test/klass_hero_web/live/provider/sessions_live_test.exs
@@ -200,7 +200,8 @@ defmodule KlassHeroWeb.Provider.SessionsLiveTest do
 
     test "updates session in stream when session_started event received", %{
       conn: conn,
-      provider: provider
+      provider: provider,
+      scope: scope
     } do
       program = insert(:program_schema, provider_id: provider.id)
       # Need listing so mount can build provider_program_ids MapSet
@@ -219,7 +220,7 @@ defmodule KlassHeroWeb.Provider.SessionsLiveTest do
       assert has_element?(view, "button", "Start Session")
 
       # Transition the session in DB so the re-fetch picks it up
-      {:ok, _} = Participation.start_session(session.id)
+      {:ok, _} = Participation.start_session(scope, session.id)
 
       send(view.pid, {:session_changed, session.id})
 

--- a/test/klass_hero_web/live/provider/sessions_live_test.exs
+++ b/test/klass_hero_web/live/provider/sessions_live_test.exs
@@ -590,6 +590,34 @@ defmodule KlassHeroWeb.Provider.SessionsLiveTest do
     # name any session it likes. Until #1373 nothing between that event and the
     # write checked whose session it was -- and completing one marks every
     # remaining registered child absent.
+    # sessions_live.ex states the rule for the staffing panel: "foreign and unknown
+    # are indistinguishable, leaking no oracle." The lifecycle events send a
+    # client-supplied id the same way, so they answer the same. Without this,
+    # fetch_session/1 running before the gate lets a tampering client tell "exists
+    # but is not yours" from "does not exist" and enumerate session ids.
+    test "an unknown session is refused exactly like a foreign one", %{conn: conn} do
+      other_provider = insert(:provider_profile_schema)
+      other_program = insert(:program_schema, provider_id: other_provider.id)
+
+      foreign =
+        insert(:program_session_schema,
+          program_id: other_program.id,
+          session_date: Date.utc_today(),
+          status: :in_progress
+        )
+
+      {:ok, view, _html} = live(conn, ~p"/provider/sessions")
+
+      render_click(view, "complete_session", %{"session_id" => foreign.id})
+      foreign_flash = flash_error(view)
+
+      render_click(view, "complete_session", %{"session_id" => Ecto.UUID.generate()})
+      unknown_flash = flash_error(view)
+
+      assert unknown_flash == foreign_flash
+      assert unknown_flash =~ "Unauthorized"
+    end
+
     test "a foreign session cannot be started or completed", %{conn: conn} do
       other_provider = insert(:provider_profile_schema)
       other_program = insert(:program_schema, provider_id: other_provider.id)
@@ -843,5 +871,12 @@ defmodule KlassHeroWeb.Provider.SessionsLiveTest do
       refute has_element?(view, "#session-staffing-modal")
       assert_flash(view, :error, "That session could not be found.")
     end
+  end
+
+  # Reads the current :error flash without asserting on it, so two refusals can be
+  # compared to each other rather than each to a literal. Same source
+  # `assert_flash/3` uses — the socket, not the rendered HTML.
+  defp flash_error(view) do
+    Phoenix.Flash.get(:sys.get_state(view.pid).socket.assigns.flash, :error)
   end
 end

--- a/test/klass_hero_web/live/staff/staff_participation_live_test.exs
+++ b/test/klass_hero_web/live/staff/staff_participation_live_test.exs
@@ -6,8 +6,10 @@ defmodule KlassHeroWeb.Staff.StaffParticipationLiveTest do
 
   alias KlassHero.Accounts.Scope
   alias KlassHero.Participation.ParticipationRecord
+  alias KlassHero.Participation.ProgramSession
   alias KlassHero.Participation.SessionNote
   alias KlassHero.ProviderFixtures
+  alias KlassHero.Repo
 
   describe "authentication and authorization" do
     test "redirects unauthenticated users to login", %{conn: conn} do
@@ -188,6 +190,31 @@ defmodule KlassHeroWeb.Staff.StaffParticipationLiveTest do
       scope = %Scope{user: user, staff_member: staff}
 
       %{session: session, parent: parent, child: child, record: record, program: program, scope: scope}
+    end
+
+    test "offers Complete Session while the session is in progress", %{conn: conn, session: session} do
+      {:ok, view, _html} = live(conn, ~p"/staff/participation/#{session.id}")
+
+      assert has_element?(view, "#complete-session-btn")
+    end
+
+    test "completing absents the stragglers and locks the roster", %{
+      conn: conn,
+      session: session,
+      record: record,
+      scope: scope
+    } do
+      {:ok, _} = KlassHero.Participation.record_check_in(scope, record.id)
+
+      {:ok, view, _html} = live(conn, ~p"/staff/participation/#{session.id}")
+      assert has_element?(view, "#edit-btn-#{record.id}")
+
+      view |> element("#complete-session-btn") |> render_click()
+
+      assert_flash(view, :info, "Session completed successfully")
+      assert Repo.get!(ProgramSession, session.id).status == :completed
+      refute has_element?(view, "#complete-session-btn")
+      refute has_element?(view, "#edit-btn-#{record.id}")
     end
 
     test "renders staff-participation element and child names in roster", %{

--- a/test/klass_hero_web/live/staff/staff_sessions_live_test.exs
+++ b/test/klass_hero_web/live/staff/staff_sessions_live_test.exs
@@ -371,6 +371,35 @@ defmodule KlassHeroWeb.Staff.StaffSessionsLiveTest do
       assert_flash(view, :info, "Session completed successfully")
     end
 
+    # Twins of the two start_session refusals above. Completing is the destructive
+    # half of the pair -- it marks every remaining registered child absent -- and
+    # until #1373 only start_session had either refusal pinned.
+    test "rejects complete_session on a Closed Program, naming the reason",
+         %{conn: conn} = ctx do
+      closed = assigned_program(ctx, title: "Autumn Term", end_date: Date.add(Date.utc_today(), -20))
+      session = session_on(closed, Date.utc_today(), :in_progress)
+
+      {:ok, view, _html} = live(conn, ~p"/staff/sessions")
+
+      render_click(view, "complete_session", %{"session_id" => session.id})
+
+      assert render(view) =~ "This program has closed"
+    end
+
+    test "rejects complete_session for a program the staff member is not assigned to",
+         %{conn: conn} = ctx do
+      session =
+        ctx
+        |> unassigned_program(category: "sports")
+        |> session_on(Date.utc_today(), :in_progress)
+
+      {:ok, view, _html} = live(conn, ~p"/staff/sessions")
+
+      render_hook(view, "complete_session", %{"session_id" => session.id})
+
+      assert_flash(view, :error, "Unauthorized")
+    end
+
     test "rejects start_session for a program the staff member is not assigned to",
          %{conn: conn} = ctx do
       # Category "sports" matches the staff member's Specialties on purpose: a matching


### PR DESCRIPTION
Closes #1373.

## Summary

The Participant Management page had no way to close out the session it was showing — a provider or staff member had to navigate back to the sessions list mid check-out. Adding the button meant wiring it to `Participation.complete_session/1`, which **authorized nothing**:

```elixir
# lib/klass_hero_web/live/provider/sessions_live.ex:143 (before)
def handle_event("complete_session", %{"session_id" => session_id}, socket) do
  case Participation.complete_session(session_id) do   # no ownership check, anywhere
```

`ProgramSession.complete/1` only checks the status transition. Any authenticated provider could complete any other business's `:in_progress` session — which marks **every remaining `registered` child `absent`**. `start_session/1` had the same shape. Staff was covered only because `StaffSessionsLive` had hand-rolled its own guard in the LiveView.

ADR-0017 moved *attendance* writes behind a scope-based gate. Session **lifecycle** writes were never brought in. This does that, and the button is a consequence of the gate rather than something bolted beside it.

## Review focus

**1. `SessionAuthorization` — one `cond`, two entry points.** The module (renamed from `AttendanceAuthorization`, since it now answers two questions about the same aggregate) holds a single private `resolve/2` under:

| Entry point | Refusals |
|---|---|
| `authorize/2` | always `:unauthorized` — attendance's existing contract |
| `authorize_lifecycle/2` | `:unauthorized` or `:program_closed` |

Widening `authorize/2` itself was smaller and wrong: `:program_closed` would reach the attendance path, where `ParticipationLiveHandlers` matches only `{:error, :unauthorized}` and everything else falls to `"Failed to check in: …"`. That compiles clean and breaks no test. **Its ~10 existing assertions pass untouched** — that is the evidence the contract held.

**2. The closure reason is narrower than the closure rule.** `Provider.get_session_staffing/1` answers for *any* session id, so deriving `:program_closed` from `program_closed?` alone would tell any staff-persona caller the closure state of a program they merely guessed an id for. `refused_for_closure?/2` asks whether the caller is in `member_ids` (which ADR-0019 deliberately left ungated), so the reason means *you would have been staff, but the program closed*. A stranger gets a bare `:unauthorized`.

**3. Closure is asked after the admin branch** — it is a staff rule, and asking it earlier would take the broader persona from someone holding both.

**4. The refusal must not reveal whether the session exists.** Authorizing at the context boundary means resolving the session first, so `:not_found` and `:unauthorized` became distinguishable — an enumeration oracle the deleted guard had closed by accident. `sessions_live.ex:200` already states the rule ("foreign and unknown are indistinguishable, leaking no oracle"). Both now answer identically; the reason still reaches the log. **Found by review, not by the suite.**

**5. The UI fills a designed hole.** `participation_card/1` already had an `:actions` slot and already rendered the session status; both roster pages called it without the slot. `roster_list/1`'s `editable` already gated the whole per-record action slot, so "roster goes read-only" is that attribute no longer being hardcoded `true`.

## Test plan

- `mix precommit` green: **4909 passed**, 0 failures, every lint clean.
- Verified at runtime against a genuinely closed program with real staff — `authorize/2` returns what the old code returned for all seven persona combinations; the two entry points differ in **exactly one cell** (assigned staff on a closed program); foreign staff gets `:unauthorized`, not the closure reason; `staff + admin` still resolves `{:ok, :admin}`; the owning provider is still authorized.
- Driven end to end in the browser: status flipped In Progress → Completed, the button disappeared, the roster went read-only, and the remaining `registered` child became `absent`.
- New coverage: tampered `start_session`/`complete_session` events with a foreign session id; unknown-vs-foreign indistinguishability; `complete_session` twins of the two staff refusal tests (both previously covered `start_session` only); button visibility by status; roster read-only after completion (with a check-in first, so it is not vacuous).
- Reviews: architecture 8/8, boundaries 5/5, regression 7/8 — the one warning is fixed in `da312f27`.

## Notes

- No migration. No new German strings — all four msgids already existed translated.
- `StaffSessionsLive.authorize_session_action/2` deleted; both sessions lists are now the same three-clause `case`. `staffs_session?/2` stays — it filters PubSub messages.
- The closed-program sentence lived at three call sites as a literal; it is now one function.
- ADR-0017 amended (matching how #783 and #784 were recorded there) and `CONTEXT.md`'s **Session** entry now says who may drive the lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)