### PR TITLE
refactor: flatten the family context layout

### DIFF
--- a/.claude/agents/architecture-reviewer.md
+++ b/.claude/agents/architecture-reviewer.md
@@ -22,13 +22,13 @@ convention and does NOT reintroduce the removed layering.
 ---
 
 > **Migration window (read before running checks 5–8).** A repo-wide flatten is
-> in progress: `accounts` has been converted to the new one-level layout below;
-> the other six contexts (provider, family, messaging, participation,
+> in progress: `accounts`, `provider` and `family` have been converted to the
+> new one-level layout below; the other four contexts (messaging, participation,
 > enrollment, program_catalog) and `shared` still carry the old
 > `adapters/{driven,driving}/` + `domain/` tree. **Both shapes are legal at
 > once** until the migration finishes — never flag an unconverted context for
-> keeping the old tree, and never flag `accounts` (or any newly-converted
-> context) for lacking `adapters/`/`domain/`. Checks below identify a kind by
+> keeping the old tree, and never flag a converted one for lacking
+> `adapters/`/`domain/`. Checks below identify a kind by
 > what it **is** (a `use`/behaviour/naming signature) first, then accept
 > either shape's legal location — a check written as "for each file in
 > `adapters/driven/projections/`" would pass vacuously on a flattened context

--- a/.claude/agents/boundary-checker.md
+++ b/.claude/agents/boundary-checker.md
@@ -22,13 +22,13 @@ internals. This agent enforces that convention.
 ---
 
 > **Migration window (read before running checks 1–5).** A repo-wide flatten of the
-> `adapters/{driven,driving}/` + `domain/` tree is in progress: `accounts` has already
-> converted to a one-level layout (`adapters/driven/acl/` → `acl/`, `adapters/driving/events/`
-> → handler files named for what they consume, sitting at the context root, etc.); the
-> other six contexts (provider, family, messaging, participation, enrollment,
+> `adapters/{driven,driving}/` + `domain/` tree is in progress: `accounts`, `provider` and
+> `family` have already converted to a one-level layout (`adapters/driven/acl/` → `acl/`,
+> or the context root below three files; `adapters/driving/events/` → handler files sitting
+> at the context root, etc.); the other four contexts (messaging, participation, enrollment,
 > program_catalog) and `shared` still carry the old tree. **Both shapes are legal at once**
 > until the migration finishes — never flag an unconverted context for keeping the old
-> paths, and never flag `accounts` (or any newly-converted context) for lacking
+> paths, and never flag a converted one for lacking
 > `adapters/`/`domain/`. Checks below identify a module by what it **does** (a
 > `use`/registration/naming signature) first, then accept either shape's legal location —
 > a check written as "for each file in `adapters/driving/events/`" would pass vacuously on

--- a/.claude/rules/domain-architecture.md
+++ b/.claude/rules/domain-architecture.md
@@ -57,7 +57,7 @@ context is flat.
 
 See ADR 0018 for the reasoning.
 
-> **Migration in progress.** Accounts is flat. The other six contexts still carry
+> **Migration in progress.** Accounts, Provider and Family are flat. The other four contexts still carry
 > the old `adapters/{driven,driving}/…` + `domain/…` tree and are being converted
 > one PR at a time. **Both shapes are legal until that finishes** — do not flag an
 > unconverted context as a violation, and do not half-convert one as a drive-by.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ context/
 
 **Key rule — one level, only when earned:** a kind gets its own directory at **3+ files**; below that its modules sit at the context root. There is no `adapters/` or `domain/` layer and no `driven`/`driving` split — the kind name already carries directionality. `accounts/` is the reference: nothing reaches three files there, so it is entirely flat. The threshold covers only the kinds listed above — `services/`/`helpers/` are not kinds, so pure domain-logic modules (`program_pricing.ex`, `csv_parser.ex`) go at the context root however many there are.
 
-> **Migration in progress.** Accounts is flat; the other six contexts still carry the old `adapters/{driven,driving}/…` + `domain/…` tree and convert one PR at a time. **Both shapes are legal until that finishes** — don't flag an unconverted context, and don't half-convert one as a drive-by.
+> **Migration in progress.** Accounts, Provider and Family are flat; the other four contexts still carry the old `adapters/{driven,driving}/…` + `domain/…` tree and convert one PR at a time. **Both shapes are legal until that finishes** — don't flag an unconverted context, and don't half-convert one as a drive-by.
 
 **Active contexts:**
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -13,9 +13,9 @@ alias KlassHero.Accounts.Scope
 alias KlassHero.Accounts.StaffInvitationHandler
 alias KlassHero.Enrollment.Adapters.Driving.Events.InviteFamilyReadyHandler
 alias KlassHero.Enrollment.Adapters.Driving.Workers.SendInviteEmailWorker
-alias KlassHero.Family.Adapters.Driving.Events.FamilyEventHandler
-alias KlassHero.Family.Adapters.Driving.Events.InviteClaimedHandler
-alias KlassHero.Family.Adapters.Driving.Workers.ProcessInviteClaimWorker
+alias KlassHero.Family.FamilyEventHandler
+alias KlassHero.Family.InviteClaimedHandler
+alias KlassHero.Family.ProcessInviteClaimWorker
 alias KlassHero.Messaging.Adapters.Driven.Projections.ConversationSummaries
 alias KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildren
 alias KlassHero.Messaging.Adapters.Driving.Events.MessagingEventHandler

--- a/docs/adr/0015-cross-context-reads-call-the-facade-directly.md
+++ b/docs/adr/0015-cross-context-reads-call-the-facade-directly.md
@@ -37,7 +37,7 @@ Keep — or add — an ACL under `adapters/driven/acl/` when it does real work:
   `ProgramCatalog.get_programs_by_ids/1` result into `:program_not_found`.
 - **Cycle-breaking direct table access.** `enrollment/…/program_catalog_acl.ex` and
   `…/program_schedule_acl.ex` query `programs` directly because ProgramCatalog already depends on
-  Enrollment for capacity; `family/…/child_enrollment_acl.ex` and `…/child_participation_acl.ex`
+  Enrollment for capacity; `family/child_enrollment_acl.ex` and `family/child_participation_acl.ex`
   do the same for cross-context *writes* during child deletion. Each says so in its moduledoc —
   that justification is a requirement, not a courtesy.
 - **A query no facade expresses.** `provider/…/participation_session_stats_acl.ex` runs a

--- a/lib/klass_hero/family.ex
+++ b/lib/klass_hero/family.ex
@@ -22,14 +22,14 @@ defmodule KlassHero.Family do
 
   import Ecto.Query
 
-  alias KlassHero.Family.Adapters.Driven.ACL.ChildEnrollmentACL
-  alias KlassHero.Family.Adapters.Driven.ACL.ChildParticipationACL
   alias KlassHero.Family.Child
+  alias KlassHero.Family.ChildEnrollmentACL
   alias KlassHero.Family.ChildGuardian
+  alias KlassHero.Family.ChildParticipationACL
   alias KlassHero.Family.Consent
-  alias KlassHero.Family.Domain.Events.FamilyEvents
-  alias KlassHero.Family.Domain.Services.ReferralCodeGenerator
+  alias KlassHero.Family.Events
   alias KlassHero.Family.ParentProfile
+  alias KlassHero.Family.ReferralCodeGenerator
   alias KlassHero.Repo
   alias KlassHero.Shared.Adapters.Driven.Persistence.EctoErrorHelpers
   alias KlassHero.Shared.Adapters.Driven.Persistence.RepositoryHelpers
@@ -623,13 +623,13 @@ defmodule KlassHero.Family do
     Outbox.transact(@context, fn ->
       with {:ok, consent_count} <- delete_all_consents_for_child(child.id),
            {:ok, _anonymized} <- child |> Child.anonymize_changeset(anonymized_attrs) |> Repo.update() do
-        {:ok, consent_count, [FamilyEvents.child_data_anonymized(child.id)]}
+        {:ok, consent_count, [Events.child_data_anonymized(child.id)]}
       end
     end)
   end
 
   defp child_created_event(child, parent_id) do
-    FamilyEvents.child_created(child.id, %{
+    Events.child_created(child.id, %{
       child_id: child.id,
       parent_id: parent_id,
       first_name: child.first_name,
@@ -639,7 +639,7 @@ defmodule KlassHero.Family do
 
   defp child_updated_event(child) do
     # Downstream contexts (e.g. Messaging) refresh local child name lookups.
-    FamilyEvents.child_updated(child.id, %{
+    Events.child_updated(child.id, %{
       child_id: child.id,
       first_name: child.first_name,
       last_name: child.last_name

--- a/lib/klass_hero/family/child_enrollment_acl.ex
+++ b/lib/klass_hero/family/child_enrollment_acl.ex
@@ -1,4 +1,4 @@
-defmodule KlassHero.Family.Adapters.Driven.ACL.ChildEnrollmentACL do
+defmodule KlassHero.Family.ChildEnrollmentACL do
   @moduledoc """
   ACL adapter that manages enrollment data for child deletion.
 

--- a/lib/klass_hero/family/child_participation_acl.ex
+++ b/lib/klass_hero/family/child_participation_acl.ex
@@ -1,4 +1,4 @@
-defmodule KlassHero.Family.Adapters.Driven.ACL.ChildParticipationACL do
+defmodule KlassHero.Family.ChildParticipationACL do
   @moduledoc """
   ACL adapter that cleans up participation data for child deletion.
 

--- a/lib/klass_hero/family/events.ex
+++ b/lib/klass_hero/family/events.ex
@@ -1,4 +1,4 @@
-defmodule KlassHero.Family.Domain.Events.FamilyEvents do
+defmodule KlassHero.Family.Events do
   @moduledoc """
   Factory module for creating Family events.
 
@@ -56,7 +56,7 @@ defmodule KlassHero.Family.Domain.Events.FamilyEvents do
   @doc """
   Creates a `child_created` event.
 
-      iex> event = FamilyEvents.child_created("child-uuid", %{first_name: "Emma"})
+      iex> event = Events.child_created("child-uuid", %{first_name: "Emma"})
       iex> {event.event_type, event.source_context, event.entity_type}
       {:child_created, :family, :child}
   """
@@ -71,7 +71,7 @@ defmodule KlassHero.Family.Domain.Events.FamilyEvents do
   @doc """
   Creates a `child_updated` event.
 
-      iex> event = FamilyEvents.child_updated("child-uuid", %{first_name: "Emily"})
+      iex> event = Events.child_updated("child-uuid", %{first_name: "Emily"})
       iex> event.event_type
       :child_updated
   """
@@ -89,7 +89,7 @@ defmodule KlassHero.Family.Domain.Events.FamilyEvents do
   Part of the GDPR deletion cascade, so it must not be lost — which every staged
   event is guaranteed since ADR-0014, not something this factory opts into.
 
-      iex> event = FamilyEvents.child_data_anonymized("child-uuid")
+      iex> event = Events.child_data_anonymized("child-uuid")
       iex> event.event_type
       :child_data_anonymized
   """
@@ -109,7 +109,7 @@ defmodule KlassHero.Family.Domain.Events.FamilyEvents do
   Carries entity_type `:invite` rather than `:child`, because it marks an
   invite lifecycle transition rather than a change to a child.
 
-      iex> event = FamilyEvents.invite_family_ready("invite-uuid", %{user_id: "u1"})
+      iex> event = Events.invite_family_ready("invite-uuid", %{user_id: "u1"})
       iex> {event.event_type, event.entity_type}
       {:invite_family_ready, :invite}
   """

--- a/lib/klass_hero/family/family_event_handler.ex
+++ b/lib/klass_hero/family/family_event_handler.ex
@@ -1,4 +1,4 @@
-defmodule KlassHero.Family.Adapters.Driving.Events.FamilyEventHandler do
+defmodule KlassHero.Family.FamilyEventHandler do
   @moduledoc """
   Integration event handler for the Family context.
 

--- a/lib/klass_hero/family/invite_claimed_handler.ex
+++ b/lib/klass_hero/family/invite_claimed_handler.ex
@@ -1,4 +1,4 @@
-defmodule KlassHero.Family.Adapters.Driving.Events.InviteClaimedHandler do
+defmodule KlassHero.Family.InviteClaimedHandler do
   @moduledoc """
   Integration event handler for `:invite_claimed` events from the Enrollment context.
 
@@ -11,7 +11,7 @@ defmodule KlassHero.Family.Adapters.Driving.Events.InviteClaimedHandler do
 
   @behaviour KlassHero.Shared.ForHandlingEvents
 
-  alias KlassHero.Family.Adapters.Driving.Workers.ProcessInviteClaimWorker
+  alias KlassHero.Family.ProcessInviteClaimWorker
   alias KlassHero.Shared.Domain.Events.Event
   alias KlassHero.Shared.Tracing.Context
 

--- a/lib/klass_hero/family/process_invite_claim.ex
+++ b/lib/klass_hero/family/process_invite_claim.ex
@@ -8,7 +8,7 @@ defmodule KlassHero.Family.ProcessInviteClaim do
   """
 
   alias KlassHero.Family
-  alias KlassHero.Family.Domain.Events.FamilyEvents
+  alias KlassHero.Family.Events
   alias KlassHero.Shared.Outbox
 
   require Logger
@@ -166,7 +166,7 @@ defmodule KlassHero.Family.ProcessInviteClaim do
   defp map_nut_allergy(_), do: nil
 
   defp family_ready_event(invite_id, user_id, child_id, parent_id, program_id) do
-    FamilyEvents.invite_family_ready(invite_id, %{
+    Events.invite_family_ready(invite_id, %{
       invite_id: invite_id,
       user_id: user_id,
       child_id: child_id,

--- a/lib/klass_hero/family/process_invite_claim_worker.ex
+++ b/lib/klass_hero/family/process_invite_claim_worker.ex
@@ -1,4 +1,4 @@
-defmodule KlassHero.Family.Adapters.Driving.Workers.ProcessInviteClaimWorker do
+defmodule KlassHero.Family.ProcessInviteClaimWorker do
   @moduledoc """
   Oban worker that processes invite claims.
 

--- a/lib/klass_hero/family/referral_code_generator.ex
+++ b/lib/klass_hero/family/referral_code_generator.ex
@@ -1,4 +1,4 @@
-defmodule KlassHero.Family.Domain.Services.ReferralCodeGenerator do
+defmodule KlassHero.Family.ReferralCodeGenerator do
   @moduledoc """
   Domain service for generating user referral codes.
   Referral codes follow the format: {FIRST_NAME}-{LOCATION}-{YEAR_SUFFIX}

--- a/lib/klass_hero/messaging/adapters/driven/projections/enrolled_children.ex
+++ b/lib/klass_hero/messaging/adapters/driven/projections/enrolled_children.ex
@@ -42,7 +42,7 @@ defmodule KlassHero.Messaging.Adapters.Driven.Projections.EnrolledChildren do
   `acl_span` on each, enforced by `mix lint_acl_boundary`.
 
   Both paths mirror the precedent set by
-  `Family.Adapters.Driven.ACL.ChildEnrollmentACL` and
+  `Family.ChildEnrollmentACL` and
   `Enrollment.Adapters.Driven.ACL.ProgramCatalogACL`.
   """
 

--- a/lib/klass_hero/provider/participation_session_stats_acl.ex
+++ b/lib/klass_hero/provider/participation_session_stats_acl.ex
@@ -24,7 +24,7 @@ defmodule KlassHero.Provider.ParticipationSessionStatsACL do
   require Logger
 
   # Two foreign contexts, one span on the `FROM` table's — the shape
-  # `family/…/acl/child_enrollment_acl.ex` already uses for its two-table join.
+  # `family/child_enrollment_acl.ex` already uses for its two-table join.
   def list_completed_session_counts do
     results =
       acl_span source: "provider", target: "participation" do

--- a/lib/klass_hero/shared/tracing.ex
+++ b/lib/klass_hero/shared/tracing.ex
@@ -29,6 +29,15 @@ defmodule KlassHero.Shared.Tracing do
   # with it — but only once *every* context is flat. While contexts still carry
   # `Adapters.Driven.Projections.*` and friends in their module names, pruning
   # an entry here silently renames live production spans (#1259).
+  #
+  # `ACL` is deliberately absent, and stays absent (#1466). Adding it would be the
+  # same hazard in the opposite direction: it would relocate the spans of every ACL
+  # in a context that has not flattened yet, in whichever PR happened to add it.
+  # Instead each ACL span renames in the PR that flattens its own context, where the
+  # change is attributable — `Provider.ACL.X` → `Provider.X` (#1425),
+  # `Family.ACL.X` → `Family.X` (#1426). Enrollment's two are the last remaining.
+  # Only the span *name* moves; the `acl.source`/`acl.target`/`acl.operation`
+  # attributes that queries filter on are unaffected.
   @noise_segments ~w[
     Elixir KlassHero Adapters Driven Driving Persistence Repositories
     Schemas Mappers Queries Events EventHandlers Workers Projections

--- a/lib/klass_hero_web/live/admin/undelivered_event_live.ex
+++ b/lib/klass_hero_web/live/admin/undelivered_event_live.ex
@@ -177,7 +177,7 @@ defmodule KlassHeroWeb.Admin.UndeliveredEventLive do
   end
 
   # `EventDeliveryWorker` stores a fully-qualified handler ref
-  # ("Elixir.KlassHero.Family.Adapters.Driving.Events.FamilyEventHandler:handle_event").
+  # ("Elixir.KlassHero.Messaging.Adapters.Driving.Events.MessagingEventHandler:handle_event").
   # The context and the handler name are the signal; the fixed `Adapters.Driving.Events`
   # path in between is boilerplate that pushed every other column off the table.
   defp short_consumer(ref) when is_binary(ref) do

--- a/lib/mix/tasks/lint_acl_boundary.ex
+++ b/lib/mix/tasks/lint_acl_boundary.ex
@@ -24,7 +24,7 @@ defmodule Mix.Tasks.LintAclBoundary do
   ## Granularity: one `acl_span` per reading function, not per table or per file
 
   A cross-context query frequently spans three tables and two foreign contexts.
-  `family/…/acl/child_enrollment_acl.ex` joins `enrollments` and `programs` under a
+  `family/child_enrollment_acl.ex` joins `enrollments` and `programs` under a
   single `target: "enrollment"` — the `FROM` table's context — and that is the
   established shape. Requiring a span per foreign table would flag code that follows
   the precedent.

--- a/test/klass_hero/family/child_enrollment_acl_test.exs
+++ b/test/klass_hero/family/child_enrollment_acl_test.exs
@@ -1,10 +1,10 @@
-defmodule KlassHero.Family.Adapters.Driven.ACL.ChildEnrollmentACLTest do
+defmodule KlassHero.Family.ChildEnrollmentACLTest do
   use KlassHero.DataCase, async: true
 
   import Ecto.Query
   import KlassHero.Factory
 
-  alias KlassHero.Family.Adapters.Driven.ACL.ChildEnrollmentACL
+  alias KlassHero.Family.ChildEnrollmentACL
   alias KlassHero.Repo
 
   describe "list_active_with_program_titles/1" do

--- a/test/klass_hero/family/child_participation_acl_test.exs
+++ b/test/klass_hero/family/child_participation_acl_test.exs
@@ -1,10 +1,10 @@
-defmodule KlassHero.Family.Adapters.Driven.ACL.ChildParticipationACLTest do
+defmodule KlassHero.Family.ChildParticipationACLTest do
   use KlassHero.DataCase, async: true
 
   import Ecto.Query
   import KlassHero.Factory
 
-  alias KlassHero.Family.Adapters.Driven.ACL.ChildParticipationACL
+  alias KlassHero.Family.ChildParticipationACL
   alias KlassHero.Participation.ParticipationRecord
   alias KlassHero.Participation.SessionNote
   alias KlassHero.Repo

--- a/test/klass_hero/family/events_test.exs
+++ b/test/klass_hero/family/events_test.exs
@@ -1,9 +1,9 @@
-defmodule KlassHero.Family.Domain.Events.FamilyEventsTest do
-  @moduledoc "Tests for the FamilyEvents factory module."
+defmodule KlassHero.Family.EventsTest do
+  @moduledoc "Tests for the Events factory module."
 
   use ExUnit.Case, async: true
 
-  alias KlassHero.Family.Domain.Events.FamilyEvents
+  alias KlassHero.Family.Events
   alias KlassHero.Shared.Domain.Events.Event
 
   # Every family event factory shares one contract: build a :family event with
@@ -24,7 +24,7 @@ defmodule KlassHero.Family.Domain.Events.FamilyEventsTest do
       @entity_type entity_type
 
       test "builds an event with the right type and entity" do
-        event = apply(FamilyEvents, @fun, ["id-1"])
+        event = apply(Events, @fun, ["id-1"])
 
         assert %Event{} = event
         assert event.event_type == @fun
@@ -36,7 +36,7 @@ defmodule KlassHero.Family.Domain.Events.FamilyEventsTest do
 
       test "the id argument wins over a caller-supplied one and preserves extras" do
         payload = %{@id => "overridden", extra: "data"}
-        event = apply(FamilyEvents, @fun, ["real-id", payload])
+        event = apply(Events, @fun, ["real-id", payload])
 
         assert Map.get(event.payload, @id) == "real-id"
         assert event.payload.extra == "data"
@@ -45,7 +45,7 @@ defmodule KlassHero.Family.Domain.Events.FamilyEventsTest do
       test "raises for a nil or blank id" do
         for bad_id <- [nil, ""] do
           assert_raise ArgumentError, ~r/requires a non-empty #{@id} string/, fn ->
-            apply(FamilyEvents, @fun, [bad_id])
+            apply(Events, @fun, [bad_id])
           end
         end
       end
@@ -57,7 +57,7 @@ defmodule KlassHero.Family.Domain.Events.FamilyEventsTest do
       child_id = Ecto.UUID.generate()
 
       event =
-        FamilyEvents.child_created(child_id, %{
+        Events.child_created(child_id, %{
           parent_id: Ecto.UUID.generate(),
           first_name: "Emma",
           last_name: "Johnson"
@@ -71,7 +71,7 @@ defmodule KlassHero.Family.Domain.Events.FamilyEventsTest do
       child_id = Ecto.UUID.generate()
 
       event =
-        FamilyEvents.child_updated(child_id, %{
+        Events.child_updated(child_id, %{
           parent_id: Ecto.UUID.generate(),
           first_name: "Emily",
           last_name: "Johnson"
@@ -91,7 +91,7 @@ defmodule KlassHero.Family.Domain.Events.FamilyEventsTest do
         program_id: Ecto.UUID.generate()
       }
 
-      event = FamilyEvents.invite_family_ready(invite_id, payload)
+      event = Events.invite_family_ready(invite_id, payload)
 
       assert event.payload.user_id == payload.user_id
       assert event.payload.child_id == payload.child_id

--- a/test/klass_hero/family/family_event_handler_test.exs
+++ b/test/klass_hero/family/family_event_handler_test.exs
@@ -1,4 +1,4 @@
-defmodule KlassHero.Family.Adapters.Driving.Events.FamilyEventHandlerTest do
+defmodule KlassHero.Family.FamilyEventHandlerTest do
   @moduledoc """
   Tests for FamilyEventHandler integration event handling.
   """
@@ -10,9 +10,9 @@ defmodule KlassHero.Family.Adapters.Driving.Events.FamilyEventHandlerTest do
 
   alias KlassHero.Accounts
   alias KlassHero.AccountsFixtures
-  alias KlassHero.Family.Adapters.Driving.Events.FamilyEventHandler
   alias KlassHero.Family.Child
   alias KlassHero.Family.Consent
+  alias KlassHero.Family.FamilyEventHandler
   alias KlassHero.Shared.Adapters.Driven.Persistence.Repositories.ProcessedEventRepository
   alias KlassHero.Shared.Adapters.Driven.Persistence.Schemas.ProcessedEvent
 

--- a/test/klass_hero/family/invite_claimed_handler_test.exs
+++ b/test/klass_hero/family/invite_claimed_handler_test.exs
@@ -1,4 +1,4 @@
-defmodule KlassHero.Family.Adapters.Driving.Events.InviteClaimedHandlerTest do
+defmodule KlassHero.Family.InviteClaimedHandlerTest do
   @moduledoc """
   Tests for InviteClaimedHandler -- enqueues Oban job for invite processing.
 
@@ -11,7 +11,7 @@ defmodule KlassHero.Family.Adapters.Driving.Events.InviteClaimedHandlerTest do
   import KlassHero.AccountsFixtures
 
   alias KlassHero.Family
-  alias KlassHero.Family.Adapters.Driving.Events.InviteClaimedHandler
+  alias KlassHero.Family.InviteClaimedHandler
   alias KlassHero.Shared.Domain.Events.Event
 
   defp build_invite_claimed_event(attrs) do

--- a/test/klass_hero/family/process_invite_claim_worker_test.exs
+++ b/test/klass_hero/family/process_invite_claim_worker_test.exs
@@ -1,4 +1,4 @@
-defmodule KlassHero.Family.Adapters.Driving.Workers.ProcessInviteClaimWorkerTest do
+defmodule KlassHero.Family.ProcessInviteClaimWorkerTest do
   use KlassHero.DataCase, async: true
 
   import KlassHero.AccountsFixtures
@@ -7,7 +7,7 @@ defmodule KlassHero.Family.Adapters.Driving.Workers.ProcessInviteClaimWorkerTest
   alias KlassHero.Enrollment
   alias KlassHero.Enrollment.BulkEnrollmentInvite
   alias KlassHero.Family
-  alias KlassHero.Family.Adapters.Driving.Workers.ProcessInviteClaimWorker
+  alias KlassHero.Family.ProcessInviteClaimWorker
 
   @max_attempts 3
 

--- a/test/klass_hero/family/referral_code_generator_test.exs
+++ b/test/klass_hero/family/referral_code_generator_test.exs
@@ -1,4 +1,4 @@
-defmodule KlassHero.Family.Domain.Services.ReferralCodeGeneratorTest do
+defmodule KlassHero.Family.ReferralCodeGeneratorTest do
   @moduledoc """
   Tests for the ReferralCodeGenerator domain service.
 
@@ -8,7 +8,7 @@ defmodule KlassHero.Family.Domain.Services.ReferralCodeGeneratorTest do
   use ExUnit.Case, async: true
   use ExUnitProperties
 
-  alias KlassHero.Family.Domain.Services.ReferralCodeGenerator
+  alias KlassHero.Family.ReferralCodeGenerator
 
   # Every row exercises the same contract: generate/2 uppercases the
   # extracted first word, then joins it with location and year_suffix as-is.

--- a/test/klass_hero/shared/adapters/driven/persistence/repositories/job_compensation_repository_test.exs
+++ b/test/klass_hero/shared/adapters/driven/persistence/repositories/job_compensation_repository_test.exs
@@ -17,7 +17,7 @@ defmodule KlassHero.Shared.Adapters.Driven.Persistence.Repositories.JobCompensat
   alias KlassHero.Shared.Adapters.Driven.Persistence.Repositories.JobCompensationRepository
   alias KlassHero.Shared.Adapters.Driven.Persistence.Schemas.JobCompensation
 
-  @worker "KlassHero.Family.Adapters.Driving.Workers.ProcessInviteClaimWorker"
+  @worker "KlassHero.Family.ProcessInviteClaimWorker"
 
   describe "compensate_once/3" do
     test "runs the compensation and records it" do

--- a/test/klass_hero_web/live/admin/undelivered_event_live_test.exs
+++ b/test/klass_hero_web/live/admin/undelivered_event_live_test.exs
@@ -92,24 +92,28 @@ defmodule KlassHeroWeb.Admin.UndeliveredEventLiveTest do
     #
     # Both fixtures are load-bearing and neither is redundant, because the contexts
     # are mid-migration to the flat layout (ADR 0018) and produce two ref shapes:
-    # Family is still nested, so it is the case that actually exercises the strip;
-    # Provider is flattened, so it proves a ref with no boilerplate passes through
+    # Messaging is still nested, so it is the case that actually exercises the strip;
+    # Family is flattened, so it proves a ref with no boilerplate passes through
     # unharmed. Deleting either one silently drops a shape from coverage — and
     # because these are string literals, no compiler will tell you.
+    #
+    # The nested fixture must name a context that is *still* nested. Point it at the
+    # next one to convert and this test keeps passing while exercising nothing: with
+    # no boilerplate left to strip, prefix removal alone satisfies the assertion.
     test "shortens nested consumer refs and leaves already-flat ones alone",
          %{conn: conn} do
       record(
         topic: "integration:accounts:user_registered",
         missed_consumers: [
-          "Elixir.KlassHero.Family.Adapters.Driving.Events.FamilyEventHandler:handle_event",
-          "Elixir.KlassHero.Provider.ProviderEventHandler:handle_event"
+          "Elixir.KlassHero.Messaging.Adapters.Driving.Events.MessagingEventHandler:handle_event",
+          "Elixir.KlassHero.Family.FamilyEventHandler:handle_event"
         ]
       )
 
       {:ok, _view, html} = live(conn, ~p"/admin/undelivered-events")
 
+      assert html =~ "Messaging.MessagingEventHandler:handle_event"
       assert html =~ "Family.FamilyEventHandler:handle_event"
-      assert html =~ "Provider.ProviderEventHandler:handle_event"
       refute html =~ "Adapters.Driving.Events"
       refute html =~ "Elixir.KlassHero"
     end


### PR DESCRIPTION
Adopts the flat one-level layout (ADR 0018) for `family` — the third context to convert, after `accounts` (#1432) and `provider` (#1425 / #1469).

No kind reaches the three-file threshold, so every module lands at the context root: two ACLs, two event handlers, one worker, the event factory, and `referral_code_generator.ex` — which ADR 0018 names explicitly, since `domain/services/` is not a kind. 14 files moved with `git mv`; `git log --follow` verified on both `events.ex` (traces back through #1366, #1354, #1211) and `child_enrollment_acl.ex` (back through #986).

`family` has no projections, so `projection_supervisor.ex` is untouched despite #1426 listing it as a lockstep site.

## Review focus

**1. `FamilyEvents` → `Events` is the one rename whose call sites move.** Elixir resolves an aliased module by its last segment, so every other rename here needed one `alias` line and zero call-site edits. This one changes the last segment, so all 14 sites moved too. Every one is in-context, so the bare `Events.*` form applies throughout — no cross-context test needed the `alias KlassHero.Family` + `Family.Events.…` form #1469 used.

**2. Handler names are deliberately unchanged.** `FamilyEventHandler` keeps the consuming-context catch-all its siblings use. #1469's commit message justified keeping `ProviderEventHandler` on exactly this basis, citing `FamilyEventHandler` as the sibling to match. `InviteClaimedHandler` was already consumer-named.

**3. A test fixture would have gone silently vacuous.** `undelivered_event_live_test.exs` exercises `short_consumer/1` with two ref shapes, and used **Family** as its *nested* example. Once Family flattens there is no boilerplate left to strip, so prefix removal alone satisfies the assertion — green, testing nothing. Swapped the nested fixture to Messaging (still nested); Family now serves as the flat example. The implementation-side comment moved in lockstep. `short_consumer/1` itself stays: it is still live code for the four contexts that remain nested.

## Accepted consequence: two ACL span names move

`ACL` is not in `Shared.Tracing`'s `@noise_segments`, so flattening an ACL renames its span:

```
Family.ACL.ChildEnrollmentACL.list_active_with_program_titles/1
  -> Family.ChildEnrollmentACL.list_active_with_program_titles/1

Family.ACL.ChildParticipationACL.delete_all_for_child/1
  -> Family.ChildParticipationACL.delete_all_for_child/1
```

Three `acl_span` call sites across the two modules. The `acl.source` / `acl.target` / `acl.operation` attributes that queries filter on are unaffected — only the span name.

This takes **#1466's option A** and records it as a comment above `@noise_segments`, rather than adding `ACL` to the list. Adding it would relocate Enrollment's two ACL spans from a PR that does not touch Enrollment — the same hazard as pruning the list early (#1259), in the opposite direction. Enrollment's two are now the last remaining.

## Prod pre-flatten check (#1467) — all three stores clear

Ran before starting, via `bin/prod-db` (`debug-ro`, SELECT-only):

| Store | Family rows | Verdict |
|---|---|---|
| `undelivered_events` | **0** (6 total, all other contexts) | The irreversible store is clean — no replay-vs-accept call needed |
| `oban_jobs` | **0**, and the queue is empty in *every* live state | Nothing in flight can fail to resolve a moved module |

| `processed_events` | 60, newest `2026-08-22 13:53` | Benign — see below |

`processed_events` already holds refs from a **previous rename of this same handler**:

```
Elixir.KlassHero.Family.Adapters.Driven.Events.FamilyEventHandler:handle_event    13 rows
Elixir.KlassHero.Family.Adapters.Driving.Events.FamilyEventHandler:handle_event   46 rows
```

`Driven.` → `Driving.` already happened once; the stale refs sit inert. With the Oban queue at zero, the "event in flight across the deploy loses its exactly-once gate" window is currently empty.

This also settles the deploy-sequencing question that prior flattens accepted on faith. `ProcessInviteClaimWorker`'s persisted `oban_jobs.worker` string changes, so a job enqueued under the old name would fail to resolve after deploy — but there are no such rows, and no rows at all in any live state. The window is measured at zero rather than assumed small. Worth a glance at the queue immediately before merge, since that is a live number, not a frozen one.

## Also refreshed: migration-status notes that were a context behind

`CLAUDE.md`, `.claude/rules/domain-architecture.md` and both review-agent specs still said "Accounts is flat; the other six contexts…" — stale since #1469. All four now read "Accounts, Provider and Family are flat; the other four…".

This is not tidying. `.claude/agents/architecture-reviewer.md` and `boundary-checker.md` are what `/review-architecture` spawns, and a stale spec produces false findings (#1255).

`docs/adr/0015`'s two Family ACL paths were updated (live pointers). Its generic `adapters/driven/acl/` prose was left alone — still accurate for the four nested contexts. `docs/adr/0018` is untouched: its long-name example is a historical quotation whose argument shortening would invert (#1468).

## Test plan

- `mix compile --warnings-as-errors` — clean, zero warnings
- `mix precommit` — **4909 passed** (3 doctests, 41 properties, 4865 tests), 2 skipped, 0 failures; credo `--strict` clean across 68 checks / 886 files
- `mix lint_read_tables` and `mix lint_acl_boundary` pass **unchanged**, confirming they are layout-agnostic (the latter derives context from the first path segment only)
- `git grep -E "Family\.(Adapters|Domain|Types)\."` returns only `CHANGELOG.md`; `git grep -E "family/(adapters|domain)/"` returns nothing
- `/review-architecture` — architecture-reviewer, boundary-checker and regression-analyzer run in parallel

Closes #1426
Closes #1466
