### PR TITLE
feat: add cover image, tagline, and social links to the provider profile

### DIFF
--- a/lib/klass_hero/provider/profiles.ex
+++ b/lib/klass_hero/provider/profiles.ex
@@ -22,11 +22,17 @@ defmodule KlassHero.Provider.Profiles do
   # Fields a caller may change via update_provider_profile/2 (all other keys stripped).
   @context KlassHero.Provider
 
-  @profile_update_fields ~w(description logo_url)a
+  # Both lists must carry every field a caller can change, and they are separate
+  # gates: the first strips the caller's attrs, the second strips again on the way
+  # to the changeset. Omitting a field from either makes the write a silent no-op
+  # rather than an error — the shape of #1481. `branding_fields/0` is spliced into
+  # both so the entity stays the single place the set is declared.
+  @profile_update_fields ~w(description logo_url)a ++ ProviderProfile.branding_fields()
 
   # Scalar fields re-cast when persisting a transitioned profile struct. identity_id
   # and id never change, so they stay out; Ecto only stages actual diffs.
-  @profile_persist_fields ~w(business_name business_owner_email description phone website address logo_url verified verified_at verified_by_id categories profile_status entity_type)a
+  @profile_persist_fields ~w(business_name business_owner_email description phone website address logo_url verified verified_at verified_by_id categories profile_status entity_type)a ++
+                            ProviderProfile.branding_fields()
 
   @doc """
   Creates a new provider profile.

--- a/lib/klass_hero/provider/provider_profile.ex
+++ b/lib/klass_hero/provider/provider_profile.ex
@@ -34,6 +34,19 @@ defmodule KlassHero.Provider.ProviderProfile do
   @profile_statuses [:draft, :active]
   @entity_types [:individual, :business]
 
+  # Branding & presence (#1302). Every URL here follows the `website` rules —
+  # https-only, 500 chars — so they validate as one group; `tagline` is prose.
+  @social_link_fields ~w(instagram_url facebook_url tiktok_url youtube_url linkedin_url)a
+  @url_branding_fields [:cover_image_url | @social_link_fields]
+  @branding_fields [:tagline | @url_branding_fields]
+
+  @tagline_max_length 150
+  @branding_url_max_length 500
+
+  @doc "Fields a provider may set to brand their public profile (#1302)."
+  @spec branding_fields() :: [atom()]
+  def branding_fields, do: @branding_fields
+
   schema "providers" do
     field :identity_id, :binary_id
     field :entity_type, Ecto.Enum, values: @entity_types, default: :individual
@@ -53,6 +66,15 @@ defmodule KlassHero.Provider.ProviderProfile do
     field :verified_at, :utc_datetime
     field :categories, {:array, :string}, default: []
     field :profile_status, Ecto.Enum, values: @profile_statuses, default: :active
+
+    # Branding & presence, shown on the public profile page (#1302). All optional.
+    field :tagline, :string
+    field :cover_image_url, :string
+    field :instagram_url, :string
+    field :facebook_url, :string
+    field :tiktok_url, :string
+    field :youtube_url, :string
+    field :linkedin_url, :string
 
     belongs_to :verified_by, User, type: :binary_id
 
@@ -85,6 +107,7 @@ defmodule KlassHero.Provider.ProviderProfile do
       :verified_by_id,
       :categories,
       :profile_status
+      | @branding_fields
     ])
     |> validate_required([:identity_id, :business_name])
     |> validate_profile_fields()
@@ -98,13 +121,15 @@ defmodule KlassHero.Provider.ProviderProfile do
   @doc """
   Form changeset for provider profile editing via LiveView.
 
-  Only casts `:description` — logo_url is set programmatically after upload,
-  and other fields (business_name, phone, etc.) are not editable in this form.
+  Casts `:description` plus the branding fields (#1302). logo_url and
+  cover_image_url are set programmatically after upload; other fields
+  (business_name, phone, etc.) are not editable in this form.
   """
   def edit_changeset(schema, attrs) do
     schema
-    |> cast(attrs, [:description])
+    |> cast(attrs, [:description | @branding_fields])
     |> validate_length(:description, max: 1000)
+    |> validate_branding_fields()
   end
 
   @doc """
@@ -114,7 +139,8 @@ defmodule KlassHero.Provider.ProviderProfile do
   business_name, description, phone, website, address, categories.
   Logo URL is set programmatically after upload (not in this changeset).
   """
-  @completion_cast_fields ~w(business_name description phone website address categories entity_type)a
+  @completion_cast_fields ~w(business_name description phone website address categories entity_type)a ++
+                            @branding_fields
 
   def completion_changeset(schema, attrs) do
     schema
@@ -169,6 +195,31 @@ defmodule KlassHero.Provider.ProviderProfile do
     |> validate_length(:website, min: 1, max: 500)
     |> validate_website_protocol()
     |> validate_length(:address, min: 1, max: 500)
+    |> validate_branding_fields()
+  end
+
+  defp validate_branding_fields(changeset) do
+    changeset = validate_length(changeset, :tagline, max: @tagline_max_length)
+
+    Enum.reduce(@url_branding_fields, changeset, fn field, acc ->
+      acc
+      |> validate_length(field, max: @branding_url_max_length)
+      |> validate_https_url(field)
+    end)
+  end
+
+  defp validate_https_url(changeset, field) do
+    case get_change(changeset, field) do
+      url when is_binary(url) ->
+        if String.starts_with?(url, "https://") do
+          changeset
+        else
+          add_error(changeset, field, "must start with https://")
+        end
+
+      _ ->
+        changeset
+    end
   end
 
   defp validate_website_protocol(changeset) do
@@ -400,7 +451,49 @@ defmodule KlassHero.Provider.ProviderProfile do
     |> validate_profile_status(profile.profile_status)
     |> validate_entity_type(profile.entity_type)
     |> validate_business_owner_email(profile.business_owner_email)
+    |> validate_tagline(profile.tagline)
+    |> validate_branding_urls(profile)
   end
+
+  defp validate_tagline(errors, nil), do: errors
+
+  defp validate_tagline(errors, tagline) when is_binary(tagline) do
+    if String.length(tagline) > @tagline_max_length do
+      ["Tagline must be #{@tagline_max_length} characters or less" | errors]
+    else
+      errors
+    end
+  end
+
+  defp validate_tagline(errors, _), do: ["Tagline must be a string" | errors]
+
+  defp validate_branding_urls(errors, profile) do
+    Enum.reduce(@url_branding_fields, errors, fn field, acc ->
+      validate_branding_url(acc, label_for(field), Map.fetch!(profile, field))
+    end)
+  end
+
+  defp validate_branding_url(errors, _label, nil), do: errors
+
+  defp validate_branding_url(errors, label, url) when is_binary(url) do
+    trimmed = String.trim(url)
+
+    cond do
+      trimmed == "" -> ["#{label} cannot be empty if provided" | errors]
+      not String.starts_with?(trimmed, "https://") -> ["#{label} must start with https://" | errors]
+      String.length(trimmed) > @branding_url_max_length -> ["#{label} must be 500 characters or less" | errors]
+      true -> errors
+    end
+  end
+
+  defp validate_branding_url(errors, label, _), do: ["#{label} must be a string" | errors]
+
+  defp label_for(:cover_image_url), do: "Cover image URL"
+  defp label_for(:instagram_url), do: "Instagram URL"
+  defp label_for(:facebook_url), do: "Facebook URL"
+  defp label_for(:tiktok_url), do: "TikTok URL"
+  defp label_for(:youtube_url), do: "YouTube URL"
+  defp label_for(:linkedin_url), do: "LinkedIn URL"
 
   defp validate_business_owner_email(errors, nil), do: errors
 

--- a/lib/klass_hero/provider/provider_profile.ex
+++ b/lib/klass_hero/provider/provider_profile.ex
@@ -414,7 +414,8 @@ defmodule KlassHero.Provider.ProviderProfile do
   - `{:error, :already_active}` if profile_status is not :draft
   - `{:error, [message]}` if validation fails
   """
-  @completion_fields ~w(business_name description phone website address logo_url categories entity_type)a
+  @completion_fields ~w(business_name description phone website address logo_url categories entity_type)a ++
+                       @branding_fields
 
   @spec complete_profile(t(), map()) :: {:ok, t()} | {:error, :already_active | [String.t()]}
   def complete_profile(%__MODULE__{profile_status: :draft} = profile, attrs) when is_map(attrs) do

--- a/lib/klass_hero/provider/provider_profile.ex
+++ b/lib/klass_hero/provider/provider_profile.ex
@@ -47,6 +47,16 @@ defmodule KlassHero.Provider.ProviderProfile do
   @spec branding_fields() :: [atom()]
   def branding_fields, do: @branding_fields
 
+  @doc """
+  The social-link fields, in display order.
+
+  The entity owns *which* networks exist; the web layer owns what each is
+  called. Anything pairing a label with a network derives the field list from
+  here rather than re-listing the atoms.
+  """
+  @spec social_link_fields() :: [atom()]
+  def social_link_fields, do: @social_link_fields
+
   schema "providers" do
     field :identity_id, :binary_id
     field :entity_type, Ecto.Enum, values: @entity_types, default: :individual
@@ -476,11 +486,17 @@ defmodule KlassHero.Provider.ProviderProfile do
 
   defp validate_branding_url(errors, _label, nil), do: errors
 
+  # A blank value means "not set", never "invalid". These are optional fields, and
+  # `validate/1` re-validates the WHOLE struct on every update — so rejecting ""
+  # would mean a single blank column, however it got there (a backfill, an import,
+  # raw SQL), permanently blocks every later edit of that provider, including edits
+  # to unrelated fields. Ecto's cast already collapses "" to nil on the changeset
+  # side; this keeps the pure path idempotent in the same way.
   defp validate_branding_url(errors, label, url) when is_binary(url) do
     trimmed = String.trim(url)
 
     cond do
-      trimmed == "" -> ["#{label} cannot be empty if provided" | errors]
+      trimmed == "" -> errors
       not String.starts_with?(trimmed, "https://") -> ["#{label} must start with https://" | errors]
       String.length(trimmed) > @branding_url_max_length -> ["#{label} must be 500 characters or less" | errors]
       true -> errors

--- a/lib/klass_hero_web/helpers/provider_branding.ex
+++ b/lib/klass_hero_web/helpers/provider_branding.ex
@@ -1,0 +1,44 @@
+defmodule KlassHeroWeb.Helpers.ProviderBranding do
+  @moduledoc """
+  Reads the branding section of the provider profile forms (#1302).
+
+  Both provider-facing forms — profile completion and dashboard edit — capture
+  the same branding fields, so both read them the same way here. Splitting that
+  across the two LiveViews is what let the earlier version of this change grow
+  three hand-kept copies of the same field list.
+
+  `cover_image_url` is deliberately absent: it comes from an upload, not a form
+  param, and each form handles its own upload.
+  """
+
+  alias KlassHero.Provider.ProviderProfile
+
+  @param_fields ProviderProfile.branding_fields() -- [:cover_image_url]
+
+  @doc """
+  Extracts the branding fields from raw form params, keyed by schema field.
+
+  A blank input means "unset", so it maps to `nil` rather than `""` — that is
+  what makes clearing a social link actually clear it instead of failing
+  validation on an empty string.
+  """
+  @spec attrs_from_params(map()) :: map()
+  def attrs_from_params(params) when is_map(params) do
+    for field <- @param_fields,
+        # Explicit membership test, not the bare-assignment filter a `for` would
+        # otherwise apply — a missing key should be absent from the result for a
+        # visible reason, not because nil silently dropped the element (#1408).
+        Map.has_key?(params, Atom.to_string(field)),
+        into: %{},
+        do: {field, blank_to_nil(params[Atom.to_string(field)])}
+  end
+
+  defp blank_to_nil(value) when is_binary(value) do
+    case String.trim(value) do
+      "" -> nil
+      trimmed -> trimmed
+    end
+  end
+
+  defp blank_to_nil(value), do: value
+end

--- a/lib/klass_hero_web/live/provider/edit_profile_live.ex
+++ b/lib/klass_hero_web/live/provider/edit_profile_live.ex
@@ -13,6 +13,8 @@ defmodule KlassHeroWeb.Provider.EditProfileLive do
   import KlassHeroWeb.ProviderComponents
 
   alias KlassHero.Provider
+  alias KlassHero.Provider.ProviderProfile
+  alias KlassHeroWeb.Presenters.ProviderPresenter
   alias KlassHeroWeb.Provider.Dashboard.Chrome
   alias KlassHeroWeb.Provider.Dashboard.Uploads
   alias KlassHeroWeb.Theme
@@ -38,6 +40,11 @@ defmodule KlassHeroWeb.Provider.EditProfileLive do
         accept: ~w(.jpg .jpeg .png .webp),
         max_entries: 1,
         max_file_size: 2_000_000
+      )
+      |> allow_upload(:cover,
+        accept: ~w(.jpg .jpeg .png .webp),
+        max_entries: 1,
+        max_file_size: 5_000_000
       )
       |> allow_upload(:verification_doc,
         accept: ~w(.pdf .jpg .jpeg .png),
@@ -67,18 +74,22 @@ defmodule KlassHeroWeb.Provider.EditProfileLive do
     logo_result = Uploads.consume_single_upload(socket, :logo, "logos", provider.id)
     Logger.info("save_profile: logo upload result", provider_id: provider.id, result: logo_result)
 
-    case logo_result do
-      :upload_error ->
+    cover_result = Uploads.consume_single_upload(socket, :cover, "covers", provider.id)
+
+    case {logo_result, cover_result} do
+      {:upload_error, _} ->
         {:noreply, put_flash(socket, :error, gettext("Logo upload failed. Please try again."))}
 
-      logo_result ->
-        attrs = %{description: params["description"]}
+      {_, :upload_error} ->
+        {:noreply, put_flash(socket, :error, gettext("Cover image upload failed. Please try again."))}
 
+      {logo_result, cover_result} ->
         attrs =
-          case logo_result do
-            {:ok, url} -> Map.put(attrs, :logo_url, url)
-            :no_upload -> attrs
-          end
+          params
+          |> branding_attrs()
+          |> Map.put(:description, params["description"])
+          |> put_uploaded(:logo_url, logo_result)
+          |> put_uploaded(:cover_image_url, cover_result)
 
         case Provider.update_provider_profile(provider.id, attrs) do
           {:ok, _updated} ->
@@ -174,6 +185,33 @@ defmodule KlassHeroWeb.Provider.EditProfileLive do
     {:ok, docs} = Provider.get_provider_verification_documents(provider_id)
     docs
   end
+
+  # Derived from the entity's own list so a new branding field reaches the form
+  # without a second place to remember. cover_image_url comes from the upload,
+  # not the params, so it is excluded here.
+  @branding_param_fields ProviderProfile.branding_fields() -- [:cover_image_url]
+
+  defp branding_attrs(params) do
+    for field <- @branding_param_fields,
+        value = params[Atom.to_string(field)],
+        into: %{},
+        do: {field, blank_to_nil(value)}
+  end
+
+  # An untouched input posts "", which must mean "leave it unset" — and a cleared
+  # one must actually clear. Without this every save of the form fails validation
+  # on the empty social inputs it submits.
+  defp blank_to_nil(value) when is_binary(value) do
+    case String.trim(value) do
+      "" -> nil
+      trimmed -> trimmed
+    end
+  end
+
+  defp blank_to_nil(value), do: value
+
+  defp put_uploaded(attrs, _key, :no_upload), do: attrs
+  defp put_uploaded(attrs, key, {:ok, url}), do: Map.put(attrs, key, url)
 
   @impl true
   def render(assigns) do
@@ -277,6 +315,88 @@ defmodule KlassHeroWeb.Provider.EditProfileLive do
                     {gettext("JPG, PNG or WebP. Max 2MB.")}
                   </p>
                 </div>
+              </div>
+
+              <div class="pt-6 border-t border-hero-grey-200 space-y-6">
+                <div>
+                  <h3 class={[Theme.typography(:card_title), "text-hero-black-100"]}>
+                    {gettext("Branding & Presence")}
+                  </h3>
+                  <p class="text-sm text-hero-grey-500 mt-1">
+                    {gettext("Shown on your public profile page.")}
+                  </p>
+                </div>
+
+                <.input
+                  field={@form[:tagline]}
+                  type="text"
+                  label={gettext("Tagline")}
+                  placeholder={gettext("A short line that sums you up")}
+                  maxlength="150"
+                />
+
+                <div>
+                  <label class="block text-sm font-semibold text-hero-black-100 mb-2">
+                    {gettext("Cover Image")}
+                  </label>
+
+                  <div
+                    id="cover-upload"
+                    class={[
+                      "border-2 border-dashed border-hero-grey-300 p-6 text-center",
+                      Theme.rounded(:lg)
+                    ]}
+                    phx-drop-target={@uploads.cover.ref}
+                  >
+                    <div :for={entry <- @uploads.cover.entries} class="mb-4">
+                      <.live_img_preview
+                        entry={entry}
+                        class="w-full max-w-md mx-auto h-32 object-cover rounded-lg"
+                      />
+                      <p class="text-sm text-hero-grey-500 mt-1">{entry.client_name}</p>
+                      <button
+                        type="button"
+                        phx-click="cancel_upload"
+                        phx-value-ref={entry.ref}
+                        phx-value-upload="cover"
+                        class="text-xs text-red-500 hover:text-red-700 mt-1"
+                      >
+                        {gettext("Remove")}
+                      </button>
+                      <div
+                        :for={err <- upload_errors(@uploads.cover, entry)}
+                        class="text-xs text-red-500 mt-1"
+                      >
+                        {upload_error_to_string(err)}
+                      </div>
+                    </div>
+
+                    <.live_file_input upload={@uploads.cover} class="hidden" />
+                    <label
+                      for={@uploads.cover.ref}
+                      class={[
+                        "inline-flex items-center gap-2 px-4 py-2 border border-hero-grey-300",
+                        "bg-white hover:bg-hero-grey-50 text-hero-black-100 text-sm font-medium cursor-pointer",
+                        Theme.rounded(:lg),
+                        Theme.transition(:normal)
+                      ]}
+                    >
+                      <.icon name="hero-photo-mini" class="w-4 h-4" />
+                      {gettext("Choose Cover Image")}
+                    </label>
+                    <p class="text-xs text-hero-grey-400 mt-2">
+                      {gettext("JPG, PNG or WebP. Max 5MB.")}
+                    </p>
+                  </div>
+                </div>
+
+                <.input
+                  :for={{field, label} <- ProviderPresenter.social_networks()}
+                  field={@form[field]}
+                  type="url"
+                  label={label}
+                  placeholder="https://"
+                />
               </div>
 
               <div class="flex justify-end">

--- a/lib/klass_hero_web/live/provider/edit_profile_live.ex
+++ b/lib/klass_hero_web/live/provider/edit_profile_live.ex
@@ -13,7 +13,7 @@ defmodule KlassHeroWeb.Provider.EditProfileLive do
   import KlassHeroWeb.ProviderComponents
 
   alias KlassHero.Provider
-  alias KlassHero.Provider.ProviderProfile
+  alias KlassHeroWeb.Helpers.ProviderBranding
   alias KlassHeroWeb.Presenters.ProviderPresenter
   alias KlassHeroWeb.Provider.Dashboard.Chrome
   alias KlassHeroWeb.Provider.Dashboard.Uploads
@@ -86,7 +86,7 @@ defmodule KlassHeroWeb.Provider.EditProfileLive do
       {logo_result, cover_result} ->
         attrs =
           params
-          |> branding_attrs()
+          |> ProviderBranding.attrs_from_params()
           |> Map.put(:description, params["description"])
           |> put_uploaded(:logo_url, logo_result)
           |> put_uploaded(:cover_image_url, cover_result)
@@ -185,30 +185,6 @@ defmodule KlassHeroWeb.Provider.EditProfileLive do
     {:ok, docs} = Provider.get_provider_verification_documents(provider_id)
     docs
   end
-
-  # Derived from the entity's own list so a new branding field reaches the form
-  # without a second place to remember. cover_image_url comes from the upload,
-  # not the params, so it is excluded here.
-  @branding_param_fields ProviderProfile.branding_fields() -- [:cover_image_url]
-
-  defp branding_attrs(params) do
-    for field <- @branding_param_fields,
-        value = params[Atom.to_string(field)],
-        into: %{},
-        do: {field, blank_to_nil(value)}
-  end
-
-  # An untouched input posts "", which must mean "leave it unset" — and a cleared
-  # one must actually clear. Without this every save of the form fails validation
-  # on the empty social inputs it submits.
-  defp blank_to_nil(value) when is_binary(value) do
-    case String.trim(value) do
-      "" -> nil
-      trimmed -> trimmed
-    end
-  end
-
-  defp blank_to_nil(value), do: value
 
   defp put_uploaded(attrs, _key, :no_upload), do: attrs
   defp put_uploaded(attrs, key, {:ok, url}), do: Map.put(attrs, key, url)

--- a/lib/klass_hero_web/live/provider/profile_completion_live.ex
+++ b/lib/klass_hero_web/live/provider/profile_completion_live.ex
@@ -15,6 +15,7 @@ defmodule KlassHeroWeb.Provider.ProfileCompletionLive do
   alias KlassHero.Shared.Categories
   alias KlassHero.Shared.FeatureFlags
   alias KlassHero.Shared.Storage
+  alias KlassHeroWeb.Helpers.ProviderBranding
   alias KlassHeroWeb.Presenters.ProviderPresenter
   alias KlassHeroWeb.Theme
 
@@ -87,14 +88,9 @@ defmodule KlassHeroWeb.Provider.ProfileCompletionLive do
             phone: blank_to_nil(params["phone"]),
             website: blank_to_nil(params["website"]),
             address: blank_to_nil(params["address"]),
-            categories: parse_categories(params["categories"]),
-            tagline: blank_to_nil(params["tagline"]),
-            instagram_url: blank_to_nil(params["instagram_url"]),
-            facebook_url: blank_to_nil(params["facebook_url"]),
-            tiktok_url: blank_to_nil(params["tiktok_url"]),
-            youtube_url: blank_to_nil(params["youtube_url"]),
-            linkedin_url: blank_to_nil(params["linkedin_url"])
+            categories: parse_categories(params["categories"])
           }
+          |> Map.merge(ProviderBranding.attrs_from_params(params))
           |> maybe_put_logo(logo_result)
           |> maybe_put_entity_type(socket.assigns.business_vetting?, params)
 

--- a/lib/klass_hero_web/live/provider/profile_completion_live.ex
+++ b/lib/klass_hero_web/live/provider/profile_completion_live.ex
@@ -15,6 +15,7 @@ defmodule KlassHeroWeb.Provider.ProfileCompletionLive do
   alias KlassHero.Shared.Categories
   alias KlassHero.Shared.FeatureFlags
   alias KlassHero.Shared.Storage
+  alias KlassHeroWeb.Presenters.ProviderPresenter
   alias KlassHeroWeb.Theme
 
   require Logger
@@ -86,7 +87,13 @@ defmodule KlassHeroWeb.Provider.ProfileCompletionLive do
             phone: blank_to_nil(params["phone"]),
             website: blank_to_nil(params["website"]),
             address: blank_to_nil(params["address"]),
-            categories: parse_categories(params["categories"])
+            categories: parse_categories(params["categories"]),
+            tagline: blank_to_nil(params["tagline"]),
+            instagram_url: blank_to_nil(params["instagram_url"]),
+            facebook_url: blank_to_nil(params["facebook_url"]),
+            tiktok_url: blank_to_nil(params["tiktok_url"]),
+            youtube_url: blank_to_nil(params["youtube_url"]),
+            linkedin_url: blank_to_nil(params["linkedin_url"])
           }
           |> maybe_put_logo(logo_result)
           |> maybe_put_entity_type(socket.assigns.business_vetting?, params)
@@ -375,6 +382,34 @@ defmodule KlassHeroWeb.Provider.ProfileCompletionLive do
                   {gettext("Remove")}
                 </button>
               </div>
+            </div>
+
+            <%!-- Branding & Presence (#1302) — all optional, shown on the public profile --%>
+            <div class="pt-4 border-t border-gray-200 space-y-6">
+              <div>
+                <h3 class={[Theme.typography(:card_title), "text-gray-900"]}>
+                  {gettext("Branding & Presence")}
+                </h3>
+                <p class="text-sm text-gray-500 mt-1">
+                  {gettext("Optional — shown on your public profile page.")}
+                </p>
+              </div>
+
+              <.input
+                field={@form[:tagline]}
+                type="text"
+                label={gettext("Tagline")}
+                placeholder={gettext("A short line that sums you up")}
+                maxlength="150"
+              />
+
+              <.input
+                :for={{field, label} <- ProviderPresenter.social_networks()}
+                field={@form[field]}
+                type="url"
+                label={label}
+                placeholder="https://"
+              />
             </div>
 
             <div class="flex justify-end pt-4 border-t border-gray-200">

--- a/lib/klass_hero_web/presenters/provider_presenter.ex
+++ b/lib/klass_hero_web/presenters/provider_presenter.ex
@@ -21,6 +21,10 @@ defmodule KlassHeroWeb.Presenters.ProviderPresenter do
     %{
       id: provider.id,
       name: provider.business_name,
+      # NOT ProviderProfile.tagline — this key predates that field (#1302) and
+      # still carries the description. The dashboard header and business card
+      # render it under this name. Renaming it means touching those shared
+      # components, so it is tracked separately rather than done here.
       tagline: provider.description,
       verified: provider.verified || false,
       verification_badges: build_verification_badges(provider),
@@ -57,16 +61,23 @@ defmodule KlassHeroWeb.Presenters.ProviderPresenter do
     }
   end
 
-  # One list, used by the public view below and by the two provider-facing forms
-  # that capture these. Keeping it in a single place is what stops the form and
-  # the profile page from drifting apart on which networks exist.
-  @social_networks [
-    {:instagram_url, "Instagram"},
-    {:facebook_url, "Facebook"},
-    {:tiktok_url, "TikTok"},
-    {:youtube_url, "YouTube"},
-    {:linkedin_url, "LinkedIn"}
-  ]
+  # The entity owns which networks exist; this module owns only their labels.
+  # Zipping the two means adding a network is a one-line change in the schema —
+  # and forgetting the label here fails the build rather than rendering a blank
+  # one. Re-listing the field atoms would have made this the third hand-kept
+  # copy of the same set.
+  @social_labels %{
+    instagram_url: "Instagram",
+    facebook_url: "Facebook",
+    tiktok_url: "TikTok",
+    youtube_url: "YouTube",
+    linkedin_url: "LinkedIn"
+  }
+
+  @social_networks Enum.map(
+                     ProviderProfile.social_link_fields(),
+                     &{&1, Map.fetch!(@social_labels, &1)}
+                   )
 
   @doc """
   Supported social networks as `{schema_field, label}`.

--- a/lib/klass_hero_web/presenters/provider_presenter.ex
+++ b/lib/klass_hero_web/presenters/provider_presenter.ex
@@ -36,7 +36,12 @@ defmodule KlassHeroWeb.Presenters.ProviderPresenter do
   Used for surfaces shown to parents (e.g. the program detail page) where
   tier/verification/slot data is not relevant — only the business identity.
 
-  Returns a map with: id, business_name, description, logo_url, initials.
+  Returns a map with: id, business_name, description, logo_url, initials,
+  plus the branding fields (tagline, cover_image_url, social_links).
+
+  `social_links` is a keyword-style list of `{network, url}` for the networks
+  the provider actually filled in, so a caller can render the row by iterating
+  rather than testing six fields for nil.
   """
   @spec to_public_view(ProviderProfile.t()) :: map()
   def to_public_view(%ProviderProfile{} = provider) do
@@ -45,8 +50,38 @@ defmodule KlassHeroWeb.Presenters.ProviderPresenter do
       business_name: provider.business_name,
       description: provider.description,
       logo_url: provider.logo_url,
-      initials: NameUtils.initials_from_name(provider.business_name)
+      initials: NameUtils.initials_from_name(provider.business_name),
+      tagline: provider.tagline,
+      cover_image_url: provider.cover_image_url,
+      social_links: social_links(provider)
     }
+  end
+
+  # One list, used by the public view below and by the two provider-facing forms
+  # that capture these. Keeping it in a single place is what stops the form and
+  # the profile page from drifting apart on which networks exist.
+  @social_networks [
+    {:instagram_url, "Instagram"},
+    {:facebook_url, "Facebook"},
+    {:tiktok_url, "TikTok"},
+    {:youtube_url, "YouTube"},
+    {:linkedin_url, "LinkedIn"}
+  ]
+
+  @doc """
+  Supported social networks as `{schema_field, label}`.
+
+  Labels are brand names and deliberately not run through gettext — translating
+  "Instagram" would be wrong in every locale.
+  """
+  @spec social_networks() :: [{atom(), String.t()}]
+  def social_networks, do: @social_networks
+
+  defp social_links(%ProviderProfile{} = provider) do
+    for {field, label} <- @social_networks,
+        url = Map.fetch!(provider, field),
+        url not in [nil, ""],
+        do: {label, url}
   end
 
   @doc """

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -414,7 +414,7 @@ msgid "Account Termination"
 msgstr "Kontobeendigung"
 
 #: lib/klass_hero_web/live/contact_live.ex:85
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:311
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:314
 #, elixir-autogen, elixir-format
 msgid "Address"
 msgstr "Adresse"
@@ -618,7 +618,7 @@ msgstr "Einchecken fehlgeschlagen: %{reason}"
 msgid "Failed to check out: %{reason}"
 msgstr "Auschecken fehlgeschlagen: %{reason}"
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:169
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:168
 #: lib/klass_hero_web/live/provider/sessions_live.ex:167
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:117
 #, elixir-autogen, elixir-format
@@ -793,7 +793,7 @@ msgstr "Oder Passwort verwenden"
 #: lib/klass_hero_web/live/contact_live.ex:100
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:241
 #: lib/klass_hero_web/live/provider/verification_live.ex:626
-#: lib/klass_hero_web/presenters/provider_presenter.ex:97
+#: lib/klass_hero_web/presenters/provider_presenter.ex:143
 #, elixir-autogen, elixir-format
 msgid "Other"
 msgstr "Sonstiges"
@@ -811,7 +811,7 @@ msgid "Payment Terms"
 msgstr "Zahlungsbedingungen"
 
 #: lib/klass_hero_web/live/contact_live.ex:78
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:296
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "Phone"
 msgstr "Telefon"
@@ -847,8 +847,8 @@ msgstr "Fragen zu diesen Bedingungen?"
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:73
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:105
 #: lib/klass_hero_web/live/admin/sessions_live.ex:247
-#: lib/klass_hero_web/live/provider/participation_live.ex:178
-#: lib/klass_hero_web/live/provider/participation_live.ex:224
+#: lib/klass_hero_web/live/provider/participation_live.ex:177
+#: lib/klass_hero_web/live/provider/participation_live.ex:223
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:117
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:163
 #, elixir-autogen, elixir-format
@@ -865,7 +865,7 @@ msgstr "Registrieren"
 msgid "Save Password"
 msgstr "Passwort speichern"
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:381
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:412
 #: lib/klass_hero_web/live/settings/children_live.ex:708
 #: lib/klass_hero_web/live/user_live/settings.ex:153
 #, elixir-autogen, elixir-format
@@ -887,7 +887,7 @@ msgstr "Wählen Sie eine oder beide Optionen"
 msgid "Send Message"
 msgstr "Nachricht senden"
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:157
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:156
 #: lib/klass_hero_web/live/provider/sessions_live.ex:150
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:100
 #, elixir-autogen, elixir-format
@@ -896,7 +896,7 @@ msgstr "Sitzung erfolgreich abgeschlossen"
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:62
 #: lib/klass_hero_web/live/admin/sessions_live.ex:68
-#: lib/klass_hero_web/live/provider/participation_live.ex:294
+#: lib/klass_hero_web/live/provider/participation_live.ex:293
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:248
 #, elixir-autogen, elixir-format
 msgid "Session not found"
@@ -1125,7 +1125,7 @@ msgstr "Benutzer erfolgreich bestätigt."
 msgid "Welcome back!"
 msgstr "Willkommen zurück"
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:147
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:145
 #, elixir-autogen, elixir-format
 msgid "Failed to load participation history"
 msgstr "Teilnahmeverlauf konnte nicht geladen werden"
@@ -1359,8 +1359,8 @@ msgstr "Zugewiesenes Personal"
 msgid "Book Now"
 msgstr "Jetzt buchen"
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:83
-#: lib/klass_hero_web/presenters/provider_presenter.ex:93
+#: lib/klass_hero_web/presenters/provider_presenter.ex:129
+#: lib/klass_hero_web/presenters/provider_presenter.ex:139
 #, elixir-autogen, elixir-format
 msgid "Business Registration"
 msgstr "Gewerbeanmeldung"
@@ -1382,8 +1382,8 @@ msgid "Edit"
 msgstr "Bearbeiten"
 
 #: lib/klass_hero_web/components/provider_components.ex:225
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:31
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:194
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:33
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "Edit Profile"
 msgstr "Profil bearbeiten"
@@ -1483,7 +1483,7 @@ msgstr "Nicht zugewiesen"
 #: lib/klass_hero_web/components/provider_components.ex:51
 #: lib/klass_hero_web/components/provider_components.ex:1646
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:455
-#: lib/klass_hero_web/presenters/provider_presenter.ex:103
+#: lib/klass_hero_web/presenters/provider_presenter.ex:149
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr "Unbekannt"
@@ -1629,17 +1629,17 @@ msgstr "Kind bearbeiten"
 msgid "Emergency contact"
 msgstr "Notfallkontakt"
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:56
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:55
 #, elixir-autogen, elixir-format
 msgid "Failed to approve note"
 msgstr "Notiz konnte nicht genehmigt werden"
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:107
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:105
 #, elixir-autogen, elixir-format
 msgid "Failed to reject note"
 msgstr "Notiz konnte nicht abgelehnt werden"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:170
+#: lib/klass_hero_web/live/provider/participation_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Failed to resubmit note"
 msgstr "Notiz konnte nicht erneut eingereicht werden"
@@ -1650,7 +1650,7 @@ msgstr "Notiz konnte nicht erneut eingereicht werden"
 msgid "Failed to send broadcast"
 msgstr "Rundnachricht konnte nicht gesendet werden"
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:135
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:134
 #, elixir-autogen, elixir-format
 msgid "Failed to submit note"
 msgstr "Notiz konnte nicht eingereicht werden"
@@ -1724,23 +1724,23 @@ msgstr "Noch keine Nachrichten"
 msgid "No parents are enrolled in this program"
 msgstr "Für dieses Programm sind keine Eltern angemeldet"
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:47
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:46
 #, elixir-autogen, elixir-format
 msgid "Note approved"
 msgstr "Notiz genehmigt"
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:124
-#: lib/klass_hero_web/live/provider/participation_live.ex:162
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:123
+#: lib/klass_hero_web/live/provider/participation_live.ex:161
 #, elixir-autogen, elixir-format
 msgid "Note content cannot be blank"
 msgstr "Notizinhalt darf nicht leer sein"
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:96
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:94
 #, elixir-autogen, elixir-format
 msgid "Note rejected"
 msgstr "Notiz abgelehnt"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:156
+#: lib/klass_hero_web/live/provider/participation_live.ex:155
 #, elixir-autogen, elixir-format
 msgid "Note resubmitted for review"
 msgstr "Notiz erneut zur Überprüfung eingereicht"
@@ -1797,7 +1797,7 @@ msgid "Provider data sharing consent"
 msgstr "Einwilligung zur Datenweitergabe an Anbieter"
 
 #: lib/klass_hero_web/components/provider_components.ex:875
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:294
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:390
 #: lib/klass_hero_web/live/settings/children_live.ex:719
 #, elixir-autogen, elixir-format
 msgid "Save Changes"
@@ -1846,7 +1846,7 @@ msgstr "Diese Nachricht wird an alle Eltern mit aktiven Anmeldungen in diesem Pr
 msgid "Type a message..."
 msgstr "Nachricht eingeben..."
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:314
+#: lib/klass_hero_web/live/provider/participation_live.ex:313
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "Unable to refresh roster. Please reload."
@@ -1858,7 +1858,7 @@ msgstr "Teilnehmerliste konnte nicht aktualisiert werden. Bitte laden Sie die Se
 msgid "Write your message to all enrolled parents..."
 msgstr "Schreiben Sie Ihre Nachricht an alle angemeldeten Eltern..."
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:127
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:126
 #, elixir-autogen, elixir-format
 msgid "You already submitted a note for this record"
 msgstr "Sie haben bereits eine Notiz für diesen Eintrag eingereicht"
@@ -1989,9 +1989,9 @@ msgstr "Möchten Sie dieses Dokument wirklich genehmigen?"
 msgid "As fathers and partners of teachers in Berlin, we saw and heard firsthand how hard it is to find, book, and manage quality youth activities outside the classroom. Klass Hero is the complete platform connecting Berlin families and schools with trusted, vetted activity providers — offering safe, supervised, and enriching experiences across sports, arts, tutoring, and more. We verify every provider, structure every booking, and support every step — so parents know their child is in good hands, and providers can focus on what they do best: inspiring kids."
 msgstr "Als Väter und Partner von Lehrkräften in Berlin haben wir aus erster Hand erlebt, wie schwer es ist, hochwertige außerschulische Aktivitäten für Kinder zu finden, zu buchen und zu organisieren. Klass Hero ist die umfassende Plattform, die Berliner Familien und Schulen mit vertrauenswürdigen, geprüften Anbietern verbindet — und bietet sichere, betreute und bereichernde Erlebnisse in den Bereichen Sport, Kunst, Nachhilfe und mehr. Wir überprüfen jeden Anbieter, strukturieren jede Buchung und unterstützen bei jedem Schritt — damit Eltern wissen, dass ihr Kind in guten Händen ist, und Anbieter sich auf das konzentrieren können, was sie am besten können: Kinder zu begeistern."
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:190
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:204
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:263
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:220
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:223
 #, elixir-autogen, elixir-format
 msgid "Back to Dashboard"
 msgstr "Zurück zum Dashboard"
@@ -2058,7 +2058,7 @@ msgstr "Kind erfüllt alle Programmanforderungen"
 msgid "Choose Image"
 msgstr "Bild auswählen"
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:274
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:288
 #, elixir-autogen, elixir-format
 msgid "Choose Logo"
 msgstr "Logo auswählen"
@@ -2099,6 +2099,7 @@ msgid "Could not remove invite."
 msgstr "Einladung konnte nicht entfernt werden."
 
 #: lib/klass_hero_web/components/provider_components.ex:1271
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:316
 #, elixir-autogen, elixir-format
 msgid "Cover Image"
 msgstr "Titelbild"
@@ -2115,7 +2116,7 @@ msgstr "Beschreiben Sie Ihr Programm..."
 
 #: lib/klass_hero_web/components/provider_components.ex:1263
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:323
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:285
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:288
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr "Beschreibung"
@@ -2155,7 +2156,7 @@ msgstr "Dokumentvorschau"
 msgid "Document rejected."
 msgstr "Dokument abgelehnt."
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:145
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:156
 #: lib/klass_hero_web/live/provider/verification_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "Document uploaded successfully."
@@ -2236,7 +2237,7 @@ msgstr "Dokument konnte nicht abgelehnt werden."
 msgid "Failed to resend invite."
 msgstr "Einladung konnte nicht erneut gesendet werden."
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:154
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:165
 #: lib/klass_hero_web/live/provider/verification_live.ex:254
 #, elixir-autogen, elixir-format
 msgid "Failed to upload document."
@@ -2309,7 +2310,7 @@ msgstr "E-Mail des Erziehungsberechtigten"
 msgid "Headshot Photo"
 msgstr "Porträtfoto"
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:95
+#: lib/klass_hero_web/presenters/provider_presenter.ex:141
 #, elixir-autogen, elixir-format
 msgid "ID Document"
 msgstr "Ausweisdokument"
@@ -2319,7 +2320,7 @@ msgstr "Ausweisdokument"
 msgid "Import"
 msgstr "Importieren"
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:94
+#: lib/klass_hero_web/presenters/provider_presenter.ex:140
 #, elixir-autogen, elixir-format
 msgid "Insurance Certificate"
 msgstr "Versicherungsnachweis"
@@ -2350,8 +2351,8 @@ msgid "JPG, PNG or WebP. Max 1MB."
 msgstr "JPG, PNG oder WebP. Max. 1 MB."
 
 #: lib/klass_hero_web/components/provider_components.ex:1318
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:277
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:361
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:291
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:364
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 2MB."
 msgstr "JPG, PNG oder WebP. Max. 2 MB."
@@ -2387,8 +2388,8 @@ msgstr "Nicht markiert lassen, um alle Geschlechter zuzulassen."
 msgid "Location"
 msgstr "Ort"
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:72
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:79
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:81
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:81
 #, elixir-autogen, elixir-format
 msgid "Logo upload failed. Please try again."
 msgstr "Logo-Upload fehlgeschlagen. Bitte versuchen Sie es erneut."
@@ -2547,10 +2548,10 @@ msgstr "Teilnahmebeschränkungen (optional)"
 msgid "Pending Review"
 msgstr "Ausstehende Überprüfung"
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:91
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:102
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:106
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:109
 #: lib/klass_hero_web/live/provider/programs_live.ex:739
 #: lib/klass_hero_web/live/provider/programs_live.ex:808
 #: lib/klass_hero_web/live/provider/team_live.ex:305
@@ -2575,7 +2576,7 @@ msgstr "Vorschau für diesen Dateityp nicht verfügbar."
 msgid "Price (EUR)"
 msgstr "Preis (EUR)"
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:87
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:98
 #, elixir-autogen, elixir-format
 msgid "Profile updated successfully."
 msgstr "Profil erfolgreich aktualisiert."
@@ -2611,7 +2612,7 @@ msgstr "Programm nicht gefunden."
 msgid "Program updated successfully."
 msgstr "Programm erfolgreich aktualisiert."
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:96
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:107
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:32
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:27
 #, elixir-autogen, elixir-format
@@ -2709,8 +2710,9 @@ msgstr "Ablehnungsgrund"
 #: lib/klass_hero_web/components/provider_components.ex:2804
 #: lib/klass_hero_web/components/provider_components.ex:3233
 #: lib/klass_hero_web/components/provider_components.ex:3312
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:253
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:375
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:267
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:340
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:378
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr "Entfernen"
@@ -2828,7 +2830,7 @@ msgstr "Eingereicht"
 msgid "TBD"
 msgstr "Noch offen"
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:96
+#: lib/klass_hero_web/presenters/provider_presenter.ex:142
 #, elixir-autogen, elixir-format
 msgid "Tax Certificate"
 msgstr "Steuerbescheinigung"
@@ -2858,7 +2860,7 @@ msgstr "Teammitglied aktualisiert, aber der Upload des Profilfotos ist fehlgesch
 msgid "Team member updated."
 msgstr "Teammitglied aktualisiert."
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:212
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:226
 #, elixir-autogen, elixir-format
 msgid "Tell parents about your organization..."
 msgstr "Erzählen Sie Eltern von Ihrer Organisation..."
@@ -4296,7 +4298,7 @@ msgstr "An"
 msgid "Type your reply..."
 msgstr "Ihre Antwort eingeben..."
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:194
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:193
 #: lib/klass_hero_web/live/provider/sessions_live.ex:190
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:126
 #, elixir-autogen, elixir-format
@@ -4315,7 +4317,7 @@ msgstr "Ungelesen"
 msgid "Update your observation..."
 msgstr "Aktualisieren Sie Ihre Beobachtung..."
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:138
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:149
 #: lib/klass_hero_web/live/provider/programs_live.ex:492
 #: lib/klass_hero_web/live/provider/verification_live.ex:240
 #: lib/klass_hero_web/live/provider/verification_live.ex:556
@@ -4393,13 +4395,13 @@ msgstr "Ihre zugewiesenen Sitzungen anzeigen und verwalten"
 
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:52
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:86
-#: lib/klass_hero_web/live/provider/participation_live.ex:283
+#: lib/klass_hero_web/live/provider/participation_live.ex:282
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:53
 #, elixir-autogen, elixir-format
 msgid "You are not assigned to this program"
 msgstr "Sie sind diesem Programm nicht zugewiesen"
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:297
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:300
 #, elixir-autogen, elixir-format
 msgid "+1234567890"
 msgstr "+1234567890"
@@ -4419,23 +4421,23 @@ msgstr "Entwickelt für die internationale Berliner Gemeinschaft. Integriertes s
 msgid "Cancelled"
 msgstr "Abgesagt"
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:317
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:320
 #, elixir-autogen, elixir-format
 msgid "Categories"
 msgstr "Kategorien"
 
 #: lib/klass_hero_web/components/provider_layout_components.ex:372
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:382
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:413
 #, elixir-autogen, elixir-format
 msgid "Complete Profile"
 msgstr "Profil vervollständigen"
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:41
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:43
 #, elixir-autogen, elixir-format
 msgid "Complete Your Profile"
 msgstr "Vervollständigen Sie Ihr Profil"
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:225
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:228
 #, elixir-autogen, elixir-format
 msgid "Complete Your Provider Profile"
 msgstr "Vervollständigen Sie Ihr Anbieterprofil"
@@ -4445,7 +4447,7 @@ msgstr "Vervollständigen Sie Ihr Anbieterprofil"
 msgid "Complete your provider profile"
 msgstr "Vervollständigen Sie Ihr Anbieterprofil"
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:358
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:361
 #, elixir-autogen, elixir-format
 msgid "Drag and drop or click to upload"
 msgstr "Ziehen und ablegen oder klicken zum Hochladen"
@@ -4475,7 +4477,7 @@ msgstr "Dateityp nicht akzeptiert (nur Bilder)"
 msgid "Fill in your business details so parents can find you. Your profile will be reviewed by Klass Hero before going live."
 msgstr "Geben Sie Ihre Unternehmensdaten ein, damit Eltern Sie finden können. Ihr Profil wird von Klass Hero geprüft, bevor es veröffentlicht wird."
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:228
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:231
 #, elixir-autogen, elixir-format
 msgid "Fill in your business details. Your profile will be reviewed by Klass Hero before going live."
 msgstr "Geben Sie Ihre Unternehmensdaten ein. Ihr Profil wird von Klass Hero geprüft, bevor es veröffentlicht wird."
@@ -4496,7 +4498,7 @@ msgstr "Foto"
 msgid "Please enter a message or attach a photo."
 msgstr "Bitte geben Sie eine Nachricht ein oder fügen Sie ein Foto hinzu."
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:98
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:101
 #, elixir-autogen, elixir-format
 msgid "Profile completed! Klass Hero will review your profile shortly."
 msgstr "Profil vervollständigt! Klass Hero wird Ihr Profil in Kürze prüfen."
@@ -4515,13 +4517,13 @@ msgstr "Anhang entfernen"
 #: lib/klass_hero_web/controllers/invite_claim_controller.ex:67
 #: lib/klass_hero_web/live/messaging_live_helper.ex:527
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:132
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:110
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:113
 #: lib/klass_hero_web/live/user_live/settings.ex:512
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Please try again."
 msgstr "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:287
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:290
 #, elixir-autogen, elixir-format
 msgid "Tell parents about your organization and what makes you unique..."
 msgstr "Erzählen Sie Eltern von Ihrer Organisation und was Sie einzigartig macht..."
@@ -4551,12 +4553,12 @@ msgstr "Hochladen fehlgeschlagen"
 msgid "View your assignments"
 msgstr "Ihre Zuweisungen anzeigen"
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:303
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "Website"
 msgstr "Website"
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:30
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:32
 #, elixir-autogen, elixir-format
 msgid "Your profile is already complete."
 msgstr "Ihr Profil ist bereits vollständig."
@@ -4621,13 +4623,13 @@ msgstr "Abgereist"
 msgid "Departure notes"
 msgstr "Notizen zur Abreise"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:227
+#: lib/klass_hero_web/live/provider/participation_live.ex:226
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Departure time is not a valid date and time"
 msgstr "Abreisezeit ist kein gültiges Datum oder keine gültige Uhrzeit"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:238
+#: lib/klass_hero_web/live/provider/participation_live.ex:237
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:177
 #, elixir-autogen, elixir-format
 msgid "Failed to update record"
@@ -4668,7 +4670,7 @@ msgstr "Gesundheit & Einwilligungen (optional)"
 msgid "Medical conditions"
 msgstr "Gesundheitliche Besonderheiten"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:230
+#: lib/klass_hero_web/live/provider/participation_live.ex:229
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Nothing to update"
@@ -4710,7 +4712,7 @@ msgstr "Abreise erfassen"
 msgid "Record departure time (optional)"
 msgstr "Abreisezeit erfassen (optional)"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:218
+#: lib/klass_hero_web/live/provider/participation_live.ex:217
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:157
 #, elixir-autogen, elixir-format
 msgid "Record updated"
@@ -6565,7 +6567,7 @@ msgstr "Jeder Anbieter erhält: Profilseite, Buchungssystem, Zahlungsabwicklung,
 msgid "A short video so we can meet you."
 msgstr "Ein kurzes Video, damit wir dich kennenlernen können."
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:99
+#: lib/klass_hero_web/presenters/provider_presenter.ex:145
 #: lib/klass_hero_web/presenters/vetting_checklist_presenter.ex:77
 #, elixir-autogen, elixir-format
 msgid "Background check"
@@ -6733,7 +6735,7 @@ msgstr "Verifiziere deine Identität mit unserem Partner Stripe, um freigegeben 
 msgid "Verifying your identity… this can take a moment."
 msgstr "Deine Identität wird überprüft … das kann einen Moment dauern."
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:100
+#: lib/klass_hero_web/presenters/provider_presenter.ex:146
 #: lib/klass_hero_web/presenters/vetting_checklist_presenter.ex:85
 #, elixir-autogen, elixir-format
 msgid "Video screening"
@@ -6754,7 +6756,7 @@ msgstr "Wir konnten deine Identität nicht verifizieren. Bitte versuche es erneu
 msgid "Your identity is verified."
 msgstr "Deine Identität ist verifiziert."
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:98
+#: lib/klass_hero_web/presenters/provider_presenter.ex:144
 #, elixir-autogen, elixir-format
 msgid "Experience validation"
 msgstr "Erfahrungsnachweis"
@@ -6769,7 +6771,7 @@ msgstr "MP4, MOV oder WEBM. Max. 100 MB."
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr "Nimm ein kurzes Video auf, in dem du dich vorstellst. Unser Team prüft es, um Kommunikationsfähigkeit und Übereinstimmung mit unseren Werten einzuschätzen."
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:101
+#: lib/klass_hero_web/presenters/provider_presenter.ex:147
 #, elixir-autogen, elixir-format
 msgid "Safeguarding certificate"
 msgstr "Kinderschutz-Zertifikat"
@@ -6844,12 +6846,12 @@ msgstr "Du hast den Community-Richtlinien zugestimmt."
 msgid "Applicants submit a short recorded video (max 2 minutes) so we can assess communication skills and alignment with our values before approving their profile."
 msgstr "Bewerber reichen ein kurzes aufgezeichnetes Video (max. 2 Minuten) ein, damit wir vor der Freigabe ihres Profils Kommunikationsfähigkeiten und die Übereinstimmung mit unseren Werten beurteilen können."
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:251
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:254
 #, elixir-autogen, elixir-format
 msgid "A business"
 msgstr "Ein Unternehmen"
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:249
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:252
 #, elixir-autogen, elixir-format
 msgid "An individual"
 msgstr "Eine Einzelperson"
@@ -6894,17 +6896,17 @@ msgstr "Laden Sie Ihre Haftpflichtversicherungsbescheinigung hoch."
 msgid "Verify the owner or director accountable for the business."
 msgstr "Verifizieren Sie den Inhaber oder Geschäftsführer, der für das Unternehmen verantwortlich ist."
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:243
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "What are you registering as?"
 msgstr "Als was registrieren Sie sich?"
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:250
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:253
 #, elixir-autogen, elixir-format
 msgid "You'll be vetted personally."
 msgstr "Sie werden persönlich überprüft."
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:252
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:255
 #, elixir-autogen, elixir-format
 msgid "Your business and its responsible person will be vetted."
 msgstr "Ihr Unternehmen und die verantwortliche Person werden überprüft."
@@ -7163,7 +7165,7 @@ msgstr "Du hast die Erklärung zur Mitarbeiter-Compliance unterzeichnet."
 msgid "Session Note"
 msgstr "Sitzungsnotiz"
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:118
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:117
 #, elixir-autogen, elixir-format
 msgid "Session note submitted for review"
 msgstr "Sitzungsnotiz zur Überprüfung eingereicht"
@@ -7701,23 +7703,23 @@ msgstr "Schließen Sie die Verifizierung ab, um Programme zu erstellen."
 msgid "Manage your provider profile"
 msgstr "Ihr Anbieterprofil verwalten"
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:211
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:225
 #, elixir-autogen, elixir-format
 msgid "Provider Description"
 msgstr "Anbieterbeschreibung"
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:198
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Provider Information"
 msgstr "Anbieterinformationen"
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:218
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:344
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:232
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:347
 #, elixir-autogen, elixir-format
 msgid "Provider Logo"
 msgstr "Anbieterlogo"
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:278
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:281
 #, elixir-autogen, elixir-format
 msgid "Provider Name"
 msgstr "Anbietername"
@@ -7768,12 +7770,12 @@ msgstr "Willkommen an Bord! Lassen Sie uns Ihr Anbieterprofil einrichten."
 msgid "You'll get your own provider profile to fill in, and your account will open on your provider dashboard from now on. You stay on %{business}'s team."
 msgstr "Sie erhalten Ihr eigenes Anbieterprofil zum Ausfüllen, und Ihr Konto öffnet sich ab sofort auf Ihrem Anbieter-Dashboard. Sie bleiben im Team von %{business}."
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:312
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:315
 #, elixir-autogen, elixir-format
 msgid "Your address"
 msgstr "Ihre Adresse"
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:279
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "Your provider or organization name"
 msgstr "Name Ihres Anbieters oder Ihrer Organisation"
@@ -7914,7 +7916,7 @@ msgstr ""
 "Diese Programme sind beendet. Ihre Termine und Teilnehmerlisten sind nicht "
 "mehr verfügbar."
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:192
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:191
 #, elixir-autogen, elixir-format
 msgid "This program has closed. Its sessions are no longer available."
 msgstr ""
@@ -7959,3 +7961,46 @@ msgstr "Kostenlos"
 #, elixir-autogen, elixir-format
 msgid "N/A"
 msgstr "k. A."
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:310
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:398
+#, elixir-autogen, elixir-format
+msgid "A short line that sums you up"
+msgstr "Ein kurzer Satz, der euch beschreibt"
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:299
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:387
+#, elixir-autogen, elixir-format
+msgid "Branding & Presence"
+msgstr "Marke & Auftritt"
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:361
+#, elixir-autogen, elixir-format
+msgid "Choose Cover Image"
+msgstr "Titelbild auswählen"
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:84
+#, elixir-autogen, elixir-format
+msgid "Cover image upload failed. Please try again."
+msgstr "Titelbild konnte nicht hochgeladen werden. Bitte versucht es erneut."
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:364
+#, elixir-autogen, elixir-format
+msgid "JPG, PNG or WebP. Max 5MB."
+msgstr "JPG, PNG oder WebP. Max. 5 MB."
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:390
+#, elixir-autogen, elixir-format
+msgid "Optional — shown on your public profile page."
+msgstr "Optional – erscheint auf eurer öffentlichen Profilseite."
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:302
+#, elixir-autogen, elixir-format
+msgid "Shown on your public profile page."
+msgstr "Erscheint auf eurer öffentlichen Profilseite."
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:309
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:397
+#, elixir-autogen, elixir-format
+msgid "Tagline"
+msgstr "Slogan"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -414,7 +414,7 @@ msgid "Account Termination"
 msgstr ""
 
 #: lib/klass_hero_web/live/contact_live.ex:85
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:311
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:314
 #, elixir-autogen, elixir-format
 msgid "Address"
 msgstr ""
@@ -793,7 +793,7 @@ msgstr ""
 #: lib/klass_hero_web/live/contact_live.ex:100
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:241
 #: lib/klass_hero_web/live/provider/verification_live.ex:626
-#: lib/klass_hero_web/presenters/provider_presenter.ex:97
+#: lib/klass_hero_web/presenters/provider_presenter.ex:143
 #, elixir-autogen, elixir-format
 msgid "Other"
 msgstr ""
@@ -811,7 +811,7 @@ msgid "Payment Terms"
 msgstr ""
 
 #: lib/klass_hero_web/live/contact_live.ex:78
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:296
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "Phone"
 msgstr ""
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Save Password"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:381
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:412
 #: lib/klass_hero_web/live/settings/children_live.ex:708
 #: lib/klass_hero_web/live/user_live/settings.ex:153
 #, elixir-autogen, elixir-format
@@ -1359,8 +1359,8 @@ msgstr ""
 msgid "Book Now"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:83
-#: lib/klass_hero_web/presenters/provider_presenter.ex:93
+#: lib/klass_hero_web/presenters/provider_presenter.ex:129
+#: lib/klass_hero_web/presenters/provider_presenter.ex:139
 #, elixir-autogen, elixir-format
 msgid "Business Registration"
 msgstr ""
@@ -1382,8 +1382,8 @@ msgid "Edit"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:225
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:31
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:194
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:33
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "Edit Profile"
 msgstr ""
@@ -1483,7 +1483,7 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:51
 #: lib/klass_hero_web/components/provider_components.ex:1646
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:455
-#: lib/klass_hero_web/presenters/provider_presenter.ex:103
+#: lib/klass_hero_web/presenters/provider_presenter.ex:149
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
@@ -1797,7 +1797,7 @@ msgid "Provider data sharing consent"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:875
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:294
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:390
 #: lib/klass_hero_web/live/settings/children_live.ex:719
 #, elixir-autogen, elixir-format
 msgid "Save Changes"
@@ -1989,9 +1989,9 @@ msgstr ""
 msgid "As fathers and partners of teachers in Berlin, we saw and heard firsthand how hard it is to find, book, and manage quality youth activities outside the classroom. Klass Hero is the complete platform connecting Berlin families and schools with trusted, vetted activity providers — offering safe, supervised, and enriching experiences across sports, arts, tutoring, and more. We verify every provider, structure every booking, and support every step — so parents know their child is in good hands, and providers can focus on what they do best: inspiring kids."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:190
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:204
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:263
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:220
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:223
 #, elixir-autogen, elixir-format
 msgid "Back to Dashboard"
 msgstr ""
@@ -2058,7 +2058,7 @@ msgstr ""
 msgid "Choose Image"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:274
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:288
 #, elixir-autogen, elixir-format
 msgid "Choose Logo"
 msgstr ""
@@ -2099,6 +2099,7 @@ msgid "Could not remove invite."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1271
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:316
 #, elixir-autogen, elixir-format
 msgid "Cover Image"
 msgstr ""
@@ -2115,7 +2116,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1263
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:323
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:285
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:288
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
@@ -2155,7 +2156,7 @@ msgstr ""
 msgid "Document rejected."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:145
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:156
 #: lib/klass_hero_web/live/provider/verification_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "Document uploaded successfully."
@@ -2236,7 +2237,7 @@ msgstr ""
 msgid "Failed to resend invite."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:154
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:165
 #: lib/klass_hero_web/live/provider/verification_live.ex:254
 #, elixir-autogen, elixir-format
 msgid "Failed to upload document."
@@ -2309,7 +2310,7 @@ msgstr ""
 msgid "Headshot Photo"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:95
+#: lib/klass_hero_web/presenters/provider_presenter.ex:141
 #, elixir-autogen, elixir-format
 msgid "ID Document"
 msgstr ""
@@ -2319,7 +2320,7 @@ msgstr ""
 msgid "Import"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:94
+#: lib/klass_hero_web/presenters/provider_presenter.ex:140
 #, elixir-autogen, elixir-format
 msgid "Insurance Certificate"
 msgstr ""
@@ -2350,8 +2351,8 @@ msgid "JPG, PNG or WebP. Max 1MB."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1318
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:277
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:361
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:291
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:364
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 2MB."
 msgstr ""
@@ -2387,8 +2388,8 @@ msgstr ""
 msgid "Location"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:72
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:79
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:81
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:81
 #, elixir-autogen, elixir-format
 msgid "Logo upload failed. Please try again."
 msgstr ""
@@ -2547,10 +2548,10 @@ msgstr ""
 msgid "Pending Review"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:91
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:102
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:106
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:109
 #: lib/klass_hero_web/live/provider/programs_live.ex:739
 #: lib/klass_hero_web/live/provider/programs_live.ex:808
 #: lib/klass_hero_web/live/provider/team_live.ex:305
@@ -2575,7 +2576,7 @@ msgstr ""
 msgid "Price (EUR)"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:87
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:98
 #, elixir-autogen, elixir-format
 msgid "Profile updated successfully."
 msgstr ""
@@ -2611,7 +2612,7 @@ msgstr ""
 msgid "Program updated successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:96
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:107
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:32
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:27
 #, elixir-autogen, elixir-format
@@ -2709,8 +2710,9 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:2804
 #: lib/klass_hero_web/components/provider_components.ex:3233
 #: lib/klass_hero_web/components/provider_components.ex:3312
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:253
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:375
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:267
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:340
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:378
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
@@ -2828,7 +2830,7 @@ msgstr ""
 msgid "TBD"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:96
+#: lib/klass_hero_web/presenters/provider_presenter.ex:142
 #, elixir-autogen, elixir-format
 msgid "Tax Certificate"
 msgstr ""
@@ -2858,7 +2860,7 @@ msgstr ""
 msgid "Team member updated."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:212
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:226
 #, elixir-autogen, elixir-format
 msgid "Tell parents about your organization..."
 msgstr ""
@@ -4315,7 +4317,7 @@ msgstr ""
 msgid "Update your observation..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:138
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:149
 #: lib/klass_hero_web/live/provider/programs_live.ex:492
 #: lib/klass_hero_web/live/provider/verification_live.ex:240
 #: lib/klass_hero_web/live/provider/verification_live.ex:556
@@ -4399,7 +4401,7 @@ msgstr ""
 msgid "You are not assigned to this program"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:297
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:300
 #, elixir-autogen, elixir-format
 msgid "+1234567890"
 msgstr ""
@@ -4419,23 +4421,23 @@ msgstr ""
 msgid "Cancelled"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:317
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:320
 #, elixir-autogen, elixir-format
 msgid "Categories"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_layout_components.ex:372
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:382
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:413
 #, elixir-autogen, elixir-format
 msgid "Complete Profile"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:41
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:43
 #, elixir-autogen, elixir-format
 msgid "Complete Your Profile"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:225
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:228
 #, elixir-autogen, elixir-format
 msgid "Complete Your Provider Profile"
 msgstr ""
@@ -4445,7 +4447,7 @@ msgstr ""
 msgid "Complete your provider profile"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:358
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:361
 #, elixir-autogen, elixir-format
 msgid "Drag and drop or click to upload"
 msgstr ""
@@ -4475,7 +4477,7 @@ msgstr ""
 msgid "Fill in your business details so parents can find you. Your profile will be reviewed by Klass Hero before going live."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:228
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:231
 #, elixir-autogen, elixir-format
 msgid "Fill in your business details. Your profile will be reviewed by Klass Hero before going live."
 msgstr ""
@@ -4496,7 +4498,7 @@ msgstr ""
 msgid "Please enter a message or attach a photo."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:98
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:101
 #, elixir-autogen, elixir-format
 msgid "Profile completed! Klass Hero will review your profile shortly."
 msgstr ""
@@ -4515,13 +4517,13 @@ msgstr ""
 #: lib/klass_hero_web/controllers/invite_claim_controller.ex:67
 #: lib/klass_hero_web/live/messaging_live_helper.ex:527
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:132
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:110
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:113
 #: lib/klass_hero_web/live/user_live/settings.ex:512
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:287
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:290
 #, elixir-autogen, elixir-format
 msgid "Tell parents about your organization and what makes you unique..."
 msgstr ""
@@ -4551,12 +4553,12 @@ msgstr ""
 msgid "View your assignments"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:303
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "Website"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:30
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:32
 #, elixir-autogen, elixir-format
 msgid "Your profile is already complete."
 msgstr ""
@@ -6565,7 +6567,7 @@ msgstr ""
 msgid "A short video so we can meet you."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:99
+#: lib/klass_hero_web/presenters/provider_presenter.ex:145
 #: lib/klass_hero_web/presenters/vetting_checklist_presenter.ex:77
 #, elixir-autogen, elixir-format
 msgid "Background check"
@@ -6733,7 +6735,7 @@ msgstr ""
 msgid "Verifying your identity… this can take a moment."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:100
+#: lib/klass_hero_web/presenters/provider_presenter.ex:146
 #: lib/klass_hero_web/presenters/vetting_checklist_presenter.ex:85
 #, elixir-autogen, elixir-format
 msgid "Video screening"
@@ -6754,7 +6756,7 @@ msgstr ""
 msgid "Your identity is verified."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:98
+#: lib/klass_hero_web/presenters/provider_presenter.ex:144
 #, elixir-autogen, elixir-format
 msgid "Experience validation"
 msgstr ""
@@ -6769,7 +6771,7 @@ msgstr ""
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:101
+#: lib/klass_hero_web/presenters/provider_presenter.ex:147
 #, elixir-autogen, elixir-format
 msgid "Safeguarding certificate"
 msgstr ""
@@ -6844,12 +6846,12 @@ msgstr ""
 msgid "Applicants submit a short recorded video (max 2 minutes) so we can assess communication skills and alignment with our values before approving their profile."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:251
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:254
 #, elixir-autogen, elixir-format
 msgid "A business"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:249
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:252
 #, elixir-autogen, elixir-format
 msgid "An individual"
 msgstr ""
@@ -6894,17 +6896,17 @@ msgstr ""
 msgid "Verify the owner or director accountable for the business."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:243
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "What are you registering as?"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:250
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:253
 #, elixir-autogen, elixir-format
 msgid "You'll be vetted personally."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:252
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:255
 #, elixir-autogen, elixir-format
 msgid "Your business and its responsible person will be vetted."
 msgstr ""
@@ -7686,23 +7688,23 @@ msgstr ""
 msgid "Manage your provider profile"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:211
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:225
 #, elixir-autogen, elixir-format
 msgid "Provider Description"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:198
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Provider Information"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:218
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:344
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:232
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:347
 #, elixir-autogen, elixir-format
 msgid "Provider Logo"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:278
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:281
 #, elixir-autogen, elixir-format
 msgid "Provider Name"
 msgstr ""
@@ -7753,12 +7755,12 @@ msgstr ""
 msgid "You'll get your own provider profile to fill in, and your account will open on your provider dashboard from now on. You stay on %{business}'s team."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:312
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:315
 #, elixir-autogen, elixir-format
 msgid "Your address"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:279
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "Your provider or organization name"
 msgstr ""
@@ -7940,4 +7942,47 @@ msgstr ""
 #: lib/klass_hero_web/presenters/program_presenter.ex:291
 #, elixir-autogen, elixir-format
 msgid "N/A"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:310
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:398
+#, elixir-autogen, elixir-format
+msgid "A short line that sums you up"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:299
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:387
+#, elixir-autogen, elixir-format
+msgid "Branding & Presence"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:361
+#, elixir-autogen, elixir-format
+msgid "Choose Cover Image"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:84
+#, elixir-autogen, elixir-format
+msgid "Cover image upload failed. Please try again."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:364
+#, elixir-autogen, elixir-format
+msgid "JPG, PNG or WebP. Max 5MB."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:390
+#, elixir-autogen, elixir-format
+msgid "Optional — shown on your public profile page."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:302
+#, elixir-autogen, elixir-format
+msgid "Shown on your public profile page."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:309
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:397
+#, elixir-autogen, elixir-format
+msgid "Tagline"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -414,7 +414,7 @@ msgid "Account Termination"
 msgstr ""
 
 #: lib/klass_hero_web/live/contact_live.ex:85
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:311
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:314
 #, elixir-autogen, elixir-format
 msgid "Address"
 msgstr ""
@@ -618,7 +618,7 @@ msgstr ""
 msgid "Failed to check out: %{reason}"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:169
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:168
 #: lib/klass_hero_web/live/provider/sessions_live.ex:167
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:117
 #, elixir-autogen, elixir-format
@@ -793,7 +793,7 @@ msgstr ""
 #: lib/klass_hero_web/live/contact_live.ex:100
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:241
 #: lib/klass_hero_web/live/provider/verification_live.ex:626
-#: lib/klass_hero_web/presenters/provider_presenter.ex:97
+#: lib/klass_hero_web/presenters/provider_presenter.ex:143
 #, elixir-autogen, elixir-format
 msgid "Other"
 msgstr ""
@@ -811,7 +811,7 @@ msgid "Payment Terms"
 msgstr ""
 
 #: lib/klass_hero_web/live/contact_live.ex:78
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:296
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "Phone"
 msgstr ""
@@ -847,8 +847,8 @@ msgstr ""
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:73
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:105
 #: lib/klass_hero_web/live/admin/sessions_live.ex:247
-#: lib/klass_hero_web/live/provider/participation_live.ex:178
-#: lib/klass_hero_web/live/provider/participation_live.ex:224
+#: lib/klass_hero_web/live/provider/participation_live.ex:177
+#: lib/klass_hero_web/live/provider/participation_live.ex:223
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:117
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:163
 #, elixir-autogen, elixir-format
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Save Password"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:381
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:412
 #: lib/klass_hero_web/live/settings/children_live.ex:708
 #: lib/klass_hero_web/live/user_live/settings.ex:153
 #, elixir-autogen, elixir-format, fuzzy
@@ -887,7 +887,7 @@ msgstr ""
 msgid "Send Message"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:157
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:156
 #: lib/klass_hero_web/live/provider/sessions_live.ex:150
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:100
 #, elixir-autogen, elixir-format
@@ -896,7 +896,7 @@ msgstr ""
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:62
 #: lib/klass_hero_web/live/admin/sessions_live.ex:68
-#: lib/klass_hero_web/live/provider/participation_live.ex:294
+#: lib/klass_hero_web/live/provider/participation_live.ex:293
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:248
 #, elixir-autogen, elixir-format
 msgid "Session not found"
@@ -1125,7 +1125,7 @@ msgstr ""
 msgid "Welcome back!"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:147
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:145
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to load participation history"
 msgstr ""
@@ -1359,8 +1359,8 @@ msgstr ""
 msgid "Book Now"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:83
-#: lib/klass_hero_web/presenters/provider_presenter.ex:93
+#: lib/klass_hero_web/presenters/provider_presenter.ex:129
+#: lib/klass_hero_web/presenters/provider_presenter.ex:139
 #, elixir-autogen, elixir-format
 msgid "Business Registration"
 msgstr ""
@@ -1382,8 +1382,8 @@ msgid "Edit"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:225
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:31
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:194
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:33
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "Edit Profile"
 msgstr ""
@@ -1483,7 +1483,7 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:51
 #: lib/klass_hero_web/components/provider_components.ex:1646
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:455
-#: lib/klass_hero_web/presenters/provider_presenter.ex:103
+#: lib/klass_hero_web/presenters/provider_presenter.ex:149
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
@@ -1629,17 +1629,17 @@ msgstr ""
 msgid "Emergency contact"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:56
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:55
 #, elixir-autogen, elixir-format
 msgid "Failed to approve note"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:107
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:105
 #, elixir-autogen, elixir-format
 msgid "Failed to reject note"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:170
+#: lib/klass_hero_web/live/provider/participation_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Failed to resubmit note"
 msgstr ""
@@ -1650,7 +1650,7 @@ msgstr ""
 msgid "Failed to send broadcast"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:135
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:134
 #, elixir-autogen, elixir-format
 msgid "Failed to submit note"
 msgstr ""
@@ -1724,23 +1724,23 @@ msgstr ""
 msgid "No parents are enrolled in this program"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:47
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:46
 #, elixir-autogen, elixir-format
 msgid "Note approved"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:124
-#: lib/klass_hero_web/live/provider/participation_live.ex:162
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:123
+#: lib/klass_hero_web/live/provider/participation_live.ex:161
 #, elixir-autogen, elixir-format
 msgid "Note content cannot be blank"
 msgstr ""
 
-#: lib/klass_hero_web/live/parent/participation_history_live.ex:96
+#: lib/klass_hero_web/live/parent/participation_history_live.ex:94
 #, elixir-autogen, elixir-format
 msgid "Note rejected"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:156
+#: lib/klass_hero_web/live/provider/participation_live.ex:155
 #, elixir-autogen, elixir-format
 msgid "Note resubmitted for review"
 msgstr ""
@@ -1797,7 +1797,7 @@ msgid "Provider data sharing consent"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:875
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:294
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:390
 #: lib/klass_hero_web/live/settings/children_live.ex:719
 #, elixir-autogen, elixir-format
 msgid "Save Changes"
@@ -1846,7 +1846,7 @@ msgstr ""
 msgid "Type a message..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:314
+#: lib/klass_hero_web/live/provider/participation_live.ex:313
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "Unable to refresh roster. Please reload."
@@ -1858,7 +1858,7 @@ msgstr ""
 msgid "Write your message to all enrolled parents..."
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:127
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:126
 #, elixir-autogen, elixir-format
 msgid "You already submitted a note for this record"
 msgstr ""
@@ -1989,9 +1989,9 @@ msgstr ""
 msgid "As fathers and partners of teachers in Berlin, we saw and heard firsthand how hard it is to find, book, and manage quality youth activities outside the classroom. Klass Hero is the complete platform connecting Berlin families and schools with trusted, vetted activity providers — offering safe, supervised, and enriching experiences across sports, arts, tutoring, and more. We verify every provider, structure every booking, and support every step — so parents know their child is in good hands, and providers can focus on what they do best: inspiring kids."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:190
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:204
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:263
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:220
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:223
 #, elixir-autogen, elixir-format
 msgid "Back to Dashboard"
 msgstr ""
@@ -2058,7 +2058,7 @@ msgstr ""
 msgid "Choose Image"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:274
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:288
 #, elixir-autogen, elixir-format
 msgid "Choose Logo"
 msgstr ""
@@ -2099,6 +2099,7 @@ msgid "Could not remove invite."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1271
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:316
 #, elixir-autogen, elixir-format
 msgid "Cover Image"
 msgstr ""
@@ -2115,7 +2116,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1263
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:323
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:285
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:288
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
@@ -2155,7 +2156,7 @@ msgstr ""
 msgid "Document rejected."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:145
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:156
 #: lib/klass_hero_web/live/provider/verification_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "Document uploaded successfully."
@@ -2236,7 +2237,7 @@ msgstr ""
 msgid "Failed to resend invite."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:154
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:165
 #: lib/klass_hero_web/live/provider/verification_live.ex:254
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to upload document."
@@ -2309,7 +2310,7 @@ msgstr ""
 msgid "Headshot Photo"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:95
+#: lib/klass_hero_web/presenters/provider_presenter.ex:141
 #, elixir-autogen, elixir-format
 msgid "ID Document"
 msgstr ""
@@ -2319,7 +2320,7 @@ msgstr ""
 msgid "Import"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:94
+#: lib/klass_hero_web/presenters/provider_presenter.ex:140
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Insurance Certificate"
 msgstr ""
@@ -2350,8 +2351,8 @@ msgid "JPG, PNG or WebP. Max 1MB."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1318
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:277
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:361
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:291
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:364
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 2MB."
 msgstr ""
@@ -2387,8 +2388,8 @@ msgstr ""
 msgid "Location"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:72
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:79
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:81
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:81
 #, elixir-autogen, elixir-format
 msgid "Logo upload failed. Please try again."
 msgstr ""
@@ -2547,10 +2548,10 @@ msgstr ""
 msgid "Pending Review"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:91
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:102
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:106
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:109
 #: lib/klass_hero_web/live/provider/programs_live.ex:739
 #: lib/klass_hero_web/live/provider/programs_live.ex:808
 #: lib/klass_hero_web/live/provider/team_live.ex:305
@@ -2575,7 +2576,7 @@ msgstr ""
 msgid "Price (EUR)"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:87
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:98
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Profile updated successfully."
 msgstr ""
@@ -2611,7 +2612,7 @@ msgstr ""
 msgid "Program updated successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:96
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:107
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:32
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:27
 #, elixir-autogen, elixir-format
@@ -2709,8 +2710,9 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:2804
 #: lib/klass_hero_web/components/provider_components.ex:3233
 #: lib/klass_hero_web/components/provider_components.ex:3312
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:253
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:375
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:267
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:340
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:378
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
@@ -2828,7 +2830,7 @@ msgstr ""
 msgid "TBD"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:96
+#: lib/klass_hero_web/presenters/provider_presenter.ex:142
 #, elixir-autogen, elixir-format
 msgid "Tax Certificate"
 msgstr ""
@@ -2858,7 +2860,7 @@ msgstr ""
 msgid "Team member updated."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:212
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:226
 #, elixir-autogen, elixir-format
 msgid "Tell parents about your organization..."
 msgstr ""
@@ -4296,7 +4298,7 @@ msgstr ""
 msgid "Type your reply..."
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:194
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:193
 #: lib/klass_hero_web/live/provider/sessions_live.ex:190
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:126
 #, elixir-autogen, elixir-format
@@ -4315,7 +4317,7 @@ msgstr ""
 msgid "Update your observation..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:138
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:149
 #: lib/klass_hero_web/live/provider/programs_live.ex:492
 #: lib/klass_hero_web/live/provider/verification_live.ex:240
 #: lib/klass_hero_web/live/provider/verification_live.ex:556
@@ -4393,13 +4395,13 @@ msgstr ""
 
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:52
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:86
-#: lib/klass_hero_web/live/provider/participation_live.ex:283
+#: lib/klass_hero_web/live/provider/participation_live.ex:282
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:53
 #, elixir-autogen, elixir-format
 msgid "You are not assigned to this program"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:297
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:300
 #, elixir-autogen, elixir-format
 msgid "+1234567890"
 msgstr ""
@@ -4419,23 +4421,23 @@ msgstr ""
 msgid "Cancelled"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:317
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:320
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Categories"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_layout_components.ex:372
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:382
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:413
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Complete Profile"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:41
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:43
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Complete Your Profile"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:225
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:228
 #, elixir-autogen, elixir-format
 msgid "Complete Your Provider Profile"
 msgstr ""
@@ -4445,7 +4447,7 @@ msgstr ""
 msgid "Complete your provider profile"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:358
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:361
 #, elixir-autogen, elixir-format
 msgid "Drag and drop or click to upload"
 msgstr ""
@@ -4475,7 +4477,7 @@ msgstr ""
 msgid "Fill in your business details so parents can find you. Your profile will be reviewed by Klass Hero before going live."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:228
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:231
 #, elixir-autogen, elixir-format
 msgid "Fill in your business details. Your profile will be reviewed by Klass Hero before going live."
 msgstr ""
@@ -4496,7 +4498,7 @@ msgstr ""
 msgid "Please enter a message or attach a photo."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:98
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:101
 #, elixir-autogen, elixir-format
 msgid "Profile completed! Klass Hero will review your profile shortly."
 msgstr ""
@@ -4515,13 +4517,13 @@ msgstr ""
 #: lib/klass_hero_web/controllers/invite_claim_controller.ex:67
 #: lib/klass_hero_web/live/messaging_live_helper.ex:527
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:132
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:110
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:113
 #: lib/klass_hero_web/live/user_live/settings.ex:512
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Something went wrong. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:287
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:290
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Tell parents about your organization and what makes you unique..."
 msgstr ""
@@ -4551,12 +4553,12 @@ msgstr ""
 msgid "View your assignments"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:303
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "Website"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:30
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:32
 #, elixir-autogen, elixir-format
 msgid "Your profile is already complete."
 msgstr ""
@@ -4621,13 +4623,13 @@ msgstr ""
 msgid "Departure notes"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:227
+#: lib/klass_hero_web/live/provider/participation_live.ex:226
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Departure time is not a valid date and time"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:238
+#: lib/klass_hero_web/live/provider/participation_live.ex:237
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:177
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to update record"
@@ -4668,7 +4670,7 @@ msgstr ""
 msgid "Medical conditions"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:230
+#: lib/klass_hero_web/live/provider/participation_live.ex:229
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Nothing to update"
@@ -4710,7 +4712,7 @@ msgstr ""
 msgid "Record departure time (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:218
+#: lib/klass_hero_web/live/provider/participation_live.ex:217
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:157
 #, elixir-autogen, elixir-format
 msgid "Record updated"
@@ -6565,7 +6567,7 @@ msgstr ""
 msgid "A short video so we can meet you."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:99
+#: lib/klass_hero_web/presenters/provider_presenter.ex:145
 #: lib/klass_hero_web/presenters/vetting_checklist_presenter.ex:77
 #, elixir-autogen, elixir-format
 msgid "Background check"
@@ -6733,7 +6735,7 @@ msgstr ""
 msgid "Verifying your identity… this can take a moment."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:100
+#: lib/klass_hero_web/presenters/provider_presenter.ex:146
 #: lib/klass_hero_web/presenters/vetting_checklist_presenter.ex:85
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Video screening"
@@ -6754,7 +6756,7 @@ msgstr ""
 msgid "Your identity is verified."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:98
+#: lib/klass_hero_web/presenters/provider_presenter.ex:144
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Experience validation"
 msgstr ""
@@ -6769,7 +6771,7 @@ msgstr ""
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:101
+#: lib/klass_hero_web/presenters/provider_presenter.ex:147
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Safeguarding certificate"
 msgstr ""
@@ -6844,12 +6846,12 @@ msgstr ""
 msgid "Applicants submit a short recorded video (max 2 minutes) so we can assess communication skills and alignment with our values before approving their profile."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:251
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:254
 #, elixir-autogen, elixir-format, fuzzy
 msgid "A business"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:249
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:252
 #, elixir-autogen, elixir-format
 msgid "An individual"
 msgstr ""
@@ -6894,17 +6896,17 @@ msgstr ""
 msgid "Verify the owner or director accountable for the business."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:243
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "What are you registering as?"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:250
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:253
 #, elixir-autogen, elixir-format
 msgid "You'll be vetted personally."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:252
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:255
 #, elixir-autogen, elixir-format
 msgid "Your business and its responsible person will be vetted."
 msgstr ""
@@ -7163,7 +7165,7 @@ msgstr ""
 msgid "Session Note"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:118
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:117
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Session note submitted for review"
 msgstr ""
@@ -7686,23 +7688,23 @@ msgstr ""
 msgid "Manage your provider profile"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:211
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:225
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Provider Description"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:198
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:212
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Provider Information"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:218
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:344
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:232
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:347
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Provider Logo"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:278
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:281
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Provider Name"
 msgstr ""
@@ -7753,12 +7755,12 @@ msgstr ""
 msgid "You'll get your own provider profile to fill in, and your account will open on your provider dashboard from now on. You stay on %{business}'s team."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:312
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:315
 #, elixir-autogen, elixir-format
 msgid "Your address"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:279
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:282
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Your provider or organization name"
 msgstr ""
@@ -7897,7 +7899,7 @@ msgstr ""
 msgid "These programs have finished. Their sessions and rosters are no longer available."
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:192
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:191
 #, elixir-autogen, elixir-format
 msgid "This program has closed. Its sessions are no longer available."
 msgstr ""
@@ -7940,4 +7942,47 @@ msgstr ""
 #: lib/klass_hero_web/presenters/program_presenter.ex:291
 #, elixir-autogen, elixir-format
 msgid "N/A"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:310
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:398
+#, elixir-autogen, elixir-format
+msgid "A short line that sums you up"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:299
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:387
+#, elixir-autogen, elixir-format
+msgid "Branding & Presence"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:361
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Choose Cover Image"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:84
+#, elixir-autogen, elixir-format
+msgid "Cover image upload failed. Please try again."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:364
+#, elixir-autogen, elixir-format, fuzzy
+msgid "JPG, PNG or WebP. Max 5MB."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:390
+#, elixir-autogen, elixir-format
+msgid "Optional — shown on your public profile page."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:302
+#, elixir-autogen, elixir-format
+msgid "Shown on your public profile page."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:309
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:397
+#, elixir-autogen, elixir-format
+msgid "Tagline"
 msgstr ""

--- a/priv/repo/migrations/20260823113000_add_branding_fields_to_providers.exs
+++ b/priv/repo/migrations/20260823113000_add_branding_fields_to_providers.exs
@@ -1,0 +1,21 @@
+defmodule KlassHero.Repo.Migrations.AddBrandingFieldsToProviders do
+  use Ecto.Migration
+
+  # Branding fields for the public provider profile page (#1302, epic #1301).
+  # All nullable: every existing provider predates them and stays valid.
+  #
+  # :text rather than a capped varchar. The length caps live in the changeset,
+  # where they surface as a user-visible form error; a DB cap here could only
+  # raise 22001 from whatever writes it (#1376).
+  def change do
+    alter table(:providers) do
+      add :tagline, :text
+      add :cover_image_url, :text
+      add :instagram_url, :text
+      add :facebook_url, :text
+      add :tiktok_url, :text
+      add :youtube_url, :text
+      add :linkedin_url, :text
+    end
+  end
+end

--- a/test/klass_hero/provider/profiles/update_provider_profile_test.exs
+++ b/test/klass_hero/provider/profiles/update_provider_profile_test.exs
@@ -98,6 +98,21 @@ defmodule KlassHero.Provider.Profiles.UpdateProviderProfileTest do
                Provider.update_provider_profile(provider.id, %{instagram_url: "http://example.com"})
     end
 
+    test "a blank value already in the column does not block unrelated edits", %{provider: provider} do
+      # validate/1 re-validates the whole struct on every update, so treating ""
+      # as invalid would let one blank column — however it got there — permanently
+      # block every later edit of this provider. Write "" past the form path to
+      # prove it does not.
+      Repo.update_all(
+        from(p in ProviderProfile, where: p.id == ^provider.id),
+        set: [instagram_url: "", tagline: ""]
+      )
+
+      assert {:ok, _} = Provider.update_provider_profile(provider.id, %{description: "Still editable"})
+
+      assert Repo.get!(ProviderProfile, provider.id).description == "Still editable"
+    end
+
     test "leaves branding fields nil when never set", %{provider: provider} do
       assert {:ok, _} = Provider.update_provider_profile(provider.id, %{description: "unrelated"})
 

--- a/test/klass_hero/provider/profiles/update_provider_profile_test.exs
+++ b/test/klass_hero/provider/profiles/update_provider_profile_test.exs
@@ -2,6 +2,7 @@ defmodule KlassHero.Provider.Profiles.UpdateProviderProfileTest do
   use KlassHero.DataCase, async: true
 
   alias KlassHero.Provider
+  alias KlassHero.Provider.ProviderProfile
 
   setup do
     provider = KlassHero.Factory.insert(:provider_profile_schema)
@@ -60,6 +61,49 @@ defmodule KlassHero.Provider.Profiles.UpdateProviderProfileTest do
       assert {:ok, updated} = Provider.update_provider_profile(provider.id, attrs)
       assert updated.business_name == original_name
       assert updated.description == "Only updating description"
+    end
+  end
+
+  describe "update_provider_profile/2 branding fields (#1302)" do
+    # Reloads from the DB rather than asserting the returned struct. Three
+    # independent allowlists can drop a field on the way to the table
+    # (@profile_update_fields, @profile_persist_fields, changeset/2's cast), and
+    # the latter two still return the in-memory value they never persisted — so a
+    # return-value assertion goes green on a field that was silently discarded.
+    for {field, value} <- [
+          tagline: "Play-based learning",
+          cover_image_url: "https://example.com/cover.png",
+          instagram_url: "https://instagram.com/example",
+          facebook_url: "https://facebook.com/example",
+          tiktok_url: "https://tiktok.com/@example",
+          youtube_url: "https://youtube.com/@example",
+          linkedin_url: "https://linkedin.com/company/example"
+        ] do
+      test "persists #{field} through to the database", %{provider: provider} do
+        assert {:ok, _} =
+                 Provider.update_provider_profile(provider.id, %{unquote(field) => unquote(value)})
+
+        reloaded = Repo.get!(ProviderProfile, provider.id)
+        assert Map.fetch!(reloaded, unquote(field)) == unquote(value)
+      end
+    end
+
+    test "rejects a tagline over 150 characters", %{provider: provider} do
+      assert {:error, {:validation_error, _}} =
+               Provider.update_provider_profile(provider.id, %{tagline: String.duplicate("a", 151)})
+    end
+
+    test "rejects a social link that is not https", %{provider: provider} do
+      assert {:error, {:validation_error, _}} =
+               Provider.update_provider_profile(provider.id, %{instagram_url: "http://example.com"})
+    end
+
+    test "leaves branding fields nil when never set", %{provider: provider} do
+      assert {:ok, _} = Provider.update_provider_profile(provider.id, %{description: "unrelated"})
+
+      reloaded = Repo.get!(ProviderProfile, provider.id)
+      assert is_nil(reloaded.tagline)
+      assert is_nil(reloaded.cover_image_url)
     end
   end
 end

--- a/test/klass_hero_web/live/provider/edit_profile_live_test.exs
+++ b/test/klass_hero_web/live/provider/edit_profile_live_test.exs
@@ -56,6 +56,67 @@ defmodule KlassHeroWeb.Provider.EditProfileLiveTest do
       assert_redirect(view, ~p"/provider/dashboard")
     end
 
+    test "saves branding fields through the form to the database", %{conn: conn, provider: provider} do
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/edit")
+
+      view
+      |> form("#profile-form", %{
+        provider_profile_schema: %{
+          description: "A description",
+          tagline: "Play-based learning",
+          instagram_url: "https://instagram.com/example",
+          linkedin_url: "https://linkedin.com/company/example"
+        }
+      })
+      |> render_submit()
+
+      assert_redirect(view, ~p"/provider/dashboard")
+
+      # Reloaded, not the submitted params — four separate allowlists sit between
+      # this form and the column, and three of them drop silently (#1481).
+      assert {:ok, reloaded} = KlassHero.Provider.get_provider_profile(provider.id)
+      assert reloaded.tagline == "Play-based learning"
+      assert reloaded.instagram_url == "https://instagram.com/example"
+      assert reloaded.linkedin_url == "https://linkedin.com/company/example"
+    end
+
+    test "clearing a branding field blanks it rather than failing validation", %{
+      conn: conn,
+      provider: provider
+    } do
+      {:ok, _} =
+        KlassHero.Provider.update_provider_profile(provider.id, %{tagline: "Old tagline"})
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/edit")
+
+      view
+      |> form("#profile-form", %{
+        provider_profile_schema: %{description: "A description", tagline: ""}
+      })
+      |> render_submit()
+
+      assert_redirect(view, ~p"/provider/dashboard")
+
+      assert {:ok, reloaded} = KlassHero.Provider.get_provider_profile(provider.id)
+      assert is_nil(reloaded.tagline)
+    end
+
+    test "rejects a social link that is not https", %{conn: conn, provider: provider} do
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/edit")
+
+      view
+      |> form("#profile-form", %{
+        provider_profile_schema: %{
+          description: "A description",
+          instagram_url: "http://insecure.example.com"
+        }
+      })
+      |> render_submit()
+
+      assert {:ok, reloaded} = KlassHero.Provider.get_provider_profile(provider.id)
+      assert is_nil(reloaded.instagram_url)
+    end
+
     test "displays existing verification documents", %{conn: conn, provider: provider} do
       # Create a verification document for this provider
       KlassHero.Factory.insert(:verification_document_schema,

--- a/test/klass_hero_web/presenters/provider_presenter_test.exs
+++ b/test/klass_hero_web/presenters/provider_presenter_test.exs
@@ -93,6 +93,47 @@ defmodule KlassHeroWeb.Presenters.ProviderPresenterTest do
       assert view.logo_url == "https://cdn.example.com/starlight.png"
     end
 
+    test "carries tagline and cover image through to the view" do
+      provider = %ProviderProfile{
+        id: "p-b",
+        identity_id: "i-b",
+        business_name: "Starlight Coaching",
+        tagline: "Play-based learning",
+        cover_image_url: "https://cdn.example.com/cover.png"
+      }
+
+      view = ProviderPresenter.to_public_view(provider)
+
+      assert view.tagline == "Play-based learning"
+      assert view.cover_image_url == "https://cdn.example.com/cover.png"
+    end
+
+    test "lists only the social networks the provider filled in" do
+      provider = %ProviderProfile{
+        id: "p-c",
+        identity_id: "i-c",
+        business_name: "Starlight Coaching",
+        instagram_url: "https://instagram.com/starlight",
+        youtube_url: "https://youtube.com/@starlight",
+        facebook_url: nil,
+        tiktok_url: "",
+        linkedin_url: nil
+      }
+
+      # An empty string is as absent as nil here: a cleared input reaches the
+      # column as nil, but a legacy row may still hold "".
+      assert ProviderPresenter.to_public_view(provider).social_links == [
+               {"Instagram", "https://instagram.com/starlight"},
+               {"YouTube", "https://youtube.com/@starlight"}
+             ]
+    end
+
+    test "social_links is empty when no network is set" do
+      provider = %ProviderProfile{id: "p-d", identity_id: "i-d", business_name: "Starlight"}
+
+      assert ProviderPresenter.to_public_view(provider).social_links == []
+    end
+
     test "derives two-letter initials from a multi-word business name" do
       provider = %ProviderProfile{
         id: "p-2",


### PR DESCRIPTION
Closes #1302. Part of epic #1301.

Adds the branding fields the public provider profile page will render: a tagline,
a cover image, and five social links. All nullable — existing providers stay valid.

## Review focus

**The five gates.** The issue said these could be "persisted via the existing
`save_profile` handler". They cannot: a write to these columns passes five
independent allowlists, and each drops an unlisted field *silently*.

| Gate | Location |
|---|---|
| hand-built attrs map | `edit_profile_live.ex` |
| `@profile_update_fields` | `profiles.ex` |
| `@profile_persist_fields` | `profiles.ex` |
| `changeset/2` cast list | `provider_profile.ex` |
| `@completion_fields` | `provider_profile.ex` |

The last three are the dangerous ones — they return the in-memory value they never
wrote, so a test asserting the returned struct goes green on a field that vanished.
Every test here reloads from the database instead. All five now derive from
`ProviderProfile.branding_fields/0`.

This is the #1481 shape, which is why it got the belt-and-braces treatment.

**Blank means unset, not invalid.** `validate/1` re-validates the whole struct on
every update, so rejecting `""` would let a single blank column — however it got
there — permanently block every later edit of that provider, including edits to
unrelated fields. Ecto's `cast` already collapses `""` to nil on the changeset side;
the pure path now matches. Covered by a test that writes `""` past the form path.

**Where the lists live.** The entity owns *which* social networks exist
(`social_link_fields/0`); `ProviderPresenter` owns only their labels and zips the
two, so forgetting a label fails the build rather than rendering a blank one. Both
provider forms read branding params through one helper.

## Not in this PR

- **Nothing renders these publicly yet.** `to_public_view/1` exposes them;
  `/providers/:id` (#1303) is what will show them. Deliberate — this is the
  prerequisite half.
- **#1485** — `to_business_view/1` has a `tagline` key that carries the
  *description* and predates the real field. Renaming it touches shared components
  on other pages, so it is tracked separately.

## Test plan

- `mix precommit` green: 4945 passed, credo clean, all six lints pass
- Every new guard is mutation-tested — removing the branding fields from
  `@profile_persist_fields` or from the `cast` list fails 7 tests each; reverting the
  blank-value fix fails its test
- Driven in a real browser end to end: form → five allowlists → DB → presenter,
  with untouched fields confirmed still `nil`
- German locale verified rendering. Two catalog entries needed correcting:
  `gettext.merge` fuzzy-filled the 5MB upload hint as "Max. 1 MB." and dropped
  "Titel" from the cover-image label. `lint_translations` only fails on empty or
  fuzzy-flagged entries, so a confidently-wrong auto-fill passes silently
- Mobile 375x667 clean, no console errors

## Migration

Seven nullable `:text` columns, no defaults — metadata-only on Postgres, no table
rewrite. Length caps live in the changeset where they surface as a form error,
per the #1376 lesson.
