### PR TITLE
fix: attendance corrections announce themselves

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -327,6 +327,9 @@ config :klass_hero, :event_consumers, %{
   "integration:participation:child_marked_absent" => [
     {ProviderSessionDetails, :project}
   ],
+  "integration:participation:attendance_corrected" => [
+    {ProviderSessionDetails, :project}
+  ],
 
   # Messaging
   "integration:messaging:conversation_created" => [

--- a/lib/klass_hero/participation.ex
+++ b/lib/klass_hero/participation.ex
@@ -660,6 +660,11 @@ defmodule KlassHero.Participation do
   The correction rules follow the scope's derived role: an `:admin` must supply a
   `:reason`, which is appended to the notes of whichever field changed; a
   `:provider` or `:staff` actor corrects their own roster without one.
+
+  Announces itself like every other attendance write. Until #1329 it ended at a
+  bare update: no event, no broadcast — so a correction reached neither the other
+  connected clients nor `ProviderSessionDetails`, whose `checked_in_count` then
+  drifted from what a rebuild would compute.
   """
   @spec correct_attendance(Scope.t(), String.t(), map()) ::
           {:ok, ParticipationRecord.t()} | {:error, atom()}
@@ -669,8 +674,10 @@ defmodule KlassHero.Participation do
            {:ok, actor_role} <- authorize_for_record(scope, record),
            :ok <- validate_correction_reason(actor_role, attrs),
            correction_attrs = build_correction_attrs(actor_role, record, attrs),
-           {:ok, corrected} <- ParticipationRecord.admin_correct(record, correction_attrs) do
-        update_record(corrected)
+           {:ok, corrected} <- ParticipationRecord.admin_correct(record, correction_attrs),
+           {:ok, {persisted, events}} <- correct_record_with_event(corrected, record.status) do
+        Notifications.notify_all(events)
+        {:ok, persisted}
       end
     end
   end
@@ -1113,6 +1120,18 @@ defmodule KlassHero.Participation do
       with {:ok, persisted} <- update_session(completed),
            {:ok, absence_events} <- mark_remaining_as_absent(persisted) do
         {:ok, persisted, absence_events ++ [session_completed_event(persisted)]}
+      end
+    end)
+  end
+
+  # `previous_status` is read off the record as it was *before* `admin_correct/2`,
+  # and has to be: the corrected struct no longer knows where it came from, and the
+  # row is about to stop knowing too.
+  defp correct_record_with_event(corrected, previous_status) do
+    Outbox.transact_with_events(@context, fn ->
+      with {:ok, persisted} <- update_record(corrected) do
+        session = resolve_session_best_effort(persisted.session_id)
+        {:ok, persisted, [ParticipationEvents.attendance_corrected(persisted, session, previous_status)]}
       end
     end)
   end

--- a/lib/klass_hero/participation/domain/events/participation_events.ex
+++ b/lib/klass_hero/participation/domain/events/participation_events.ex
@@ -45,6 +45,7 @@ defmodule KlassHero.Participation.Domain.Events.ParticipationEvents do
     child_checked_in: :participation_record,
     child_checked_out: :participation_record,
     child_marked_absent: :participation_record,
+    attendance_corrected: :participation_record,
     session_note_submitted: :session_note,
     session_note_approved: :session_note,
     session_note_rejected: :session_note
@@ -256,6 +257,28 @@ defmodule KlassHero.Participation.Domain.Events.ParticipationEvents do
     }
 
     new_event(:child_marked_absent, record.id, payload, [])
+  end
+
+  @doc """
+  Creates an attendance_corrected event.
+
+  Carries **both** statuses. A correction can move a record in either direction
+  across the set a consumer counts, and the corrected record alone cannot say which
+  happened — only the pair can. `ProviderSessionDetails` reads exactly this to
+  decide `+1`, `-1` or nothing.
+  """
+  @spec attendance_corrected(ParticipationRecord.t(), ProgramSession.t() | nil, atom()) :: Event.t()
+  def attendance_corrected(%ParticipationRecord{} = record, session, previous_status) do
+    payload = %{
+      record_id: record.id,
+      session_id: record.session_id,
+      child_id: record.child_id,
+      program_id: session && session.program_id,
+      previous_status: previous_status,
+      new_status: record.status
+    }
+
+    new_event(:attendance_corrected, record.id, payload, [])
   end
 
   @doc "Creates a session_note_submitted event."

--- a/lib/klass_hero/participation/notifications.ex
+++ b/lib/klass_hero/participation/notifications.ex
@@ -44,7 +44,8 @@ defmodule KlassHero.Participation.Notifications do
   @attendance_kinds %{
     child_checked_in: :checked_in,
     child_checked_out: :checked_out,
-    child_marked_absent: :marked_absent
+    child_marked_absent: :marked_absent,
+    attendance_corrected: :corrected
   }
 
   @note_events [:session_note_submitted, :session_note_approved, :session_note_rejected]

--- a/lib/klass_hero/provider/projections/provider_session_details.ex
+++ b/lib/klass_hero/provider/projections/provider_session_details.ex
@@ -18,9 +18,12 @@ defmodule KlassHero.Provider.Projections.ProviderSessionDetails do
   - `:session_completed` — sets status to `:completed`.
   - `:session_cancelled` — sets status to `:cancelled`.
   - `:roster_seeded` — sets total_count from the seeded roster size.
-  - `:child_checked_in` — increments checked_in_count (monotonic; not reversed).
-  - `:child_checked_out` — intentional no-op (counter is monotonic).
-  - `:child_marked_absent` — intentional no-op (no effect on checked_in_count).
+  - `:child_checked_in` — increments checked_in_count.
+  - `:child_checked_out` — intentional no-op (a departure does not un-attend).
+  - `:child_marked_absent` — intentional no-op. Absence only ever follows
+    `:registered`, so the record was never counted; `ParticipationRecord.mark_absent/1`
+    is what holds that invariant, and this no-op depends on it.
+  - `:attendance_corrected` — applies a delta from `previous_status`/`new_status`.
   - `:staff_assigned_to_program` / `:staff_unassigned_from_program` — re-resolve
     current_assigned_staff_* on the program's `:scheduled` rows that are **not**
     overridden, from the assignment table rather than from the event.
@@ -30,6 +33,16 @@ defmodule KlassHero.Provider.Projections.ProviderSessionDetails do
     to mention.
   - `:staff_assigned_to_session` / `:staff_unassigned_from_session` — re-resolve
     the one named session through `Assignments.get_session_attribution/1`.
+
+  ## The counter is monotonic under attendance, not under correction
+
+  Forward attendance only ever adds: a check-out leaves the record counted, because
+  the question is "how many showed up", not "how many are still here". A
+  *correction* is the one thing that can subtract, and must — it says the check-in
+  did not happen. Bootstrap recomputes
+  `COUNT(*) FILTER (WHERE status IN ('checked_in','checked_out'))` from current
+  rows, so without the delta the live counter and a rebuilt one disagree, and the
+  number silently jumps at the next restart with no event explaining it (#1329).
 
   ## Attribution has two grains
 
@@ -52,6 +65,7 @@ defmodule KlassHero.Provider.Projections.ProviderSessionDetails do
       "integration:participation:child_checked_in",
       "integration:participation:child_checked_out",
       "integration:participation:child_marked_absent",
+      "integration:participation:attendance_corrected",
       "integration:provider:staff_assigned_to_program",
       "integration:provider:staff_unassigned_from_program",
       "integration:provider:staff_assigned_to_session",
@@ -128,11 +142,30 @@ defmodule KlassHero.Provider.Projections.ProviderSessionDetails do
     )
   end
 
-  # Intentional no-op: absences are the complement of check-in and don't affect the counter.
+  # Intentional no-op: absence only ever follows :registered, so the record was
+  # never counted. This rests on `ParticipationRecord.mark_absent/1` refusing any
+  # other source status — widen that and this clause becomes wrong.
   def handle_event(:child_marked_absent, %Event{} = event) do
     Logger.debug("ProviderSessionDetails ignoring child_marked_absent (no effect on checked_in_count)",
       record_id: event.entity_id
     )
+  end
+
+  # The only event that can subtract — a correction says the check-in did not happen.
+  def handle_event(:attendance_corrected, %Event{payload: payload} = event) do
+    session_id = payload.session_id
+
+    case delta(payload.previous_status, payload.new_status) do
+      0 ->
+        :ok
+
+      delta ->
+        now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+        from(d in SessionDetail, where: d.session_id == ^session_id)
+        |> Repo.update_all(inc: [checked_in_count: delta], set: [updated_at: now])
+        |> warn_if_missing("attendance_corrected", session_id: session_id, record_id: event.entity_id)
+    end
   end
 
   # Both directions re-resolve the program's attribution from
@@ -455,6 +488,18 @@ defmodule KlassHero.Provider.Projections.ProviderSessionDetails do
   end
 
   defp warn_if_missing(_result, _event_name, _metadata), do: :ok
+
+  defp delta(previous, new) do
+    case {counted?(previous), counted?(new)} do
+      {false, true} -> 1
+      {true, false} -> -1
+      _unchanged -> 0
+    end
+  end
+
+  # Mirrors bootstrap's `status IN ('checked_in','checked_out')` filter. The two
+  # must keep agreeing, or the live counter and a rebuilt one diverge.
+  defp counted?(status), do: status in [:checked_in, :checked_out]
 
   # Deliberately the same LATERAL shape as bootstrap_session_details/0, not a
   # second spelling of it: both answer "which staff member is currently assigned

--- a/test/klass_hero/participation/correct_attendance_test.exs
+++ b/test/klass_hero/participation/correct_attendance_test.exs
@@ -7,6 +7,7 @@ defmodule KlassHero.Participation.CorrectAttendanceTest do
   alias KlassHero.AccountsFixtures
   alias KlassHero.Participation
   alias KlassHero.ProviderFixtures
+  alias KlassHero.Shared.Adapters.Driven.Events.TestOutbox
 
   describe "correct_attendance/3" do
     setup do
@@ -237,6 +238,64 @@ defmodule KlassHero.Participation.CorrectAttendanceTest do
         check_in_by: user.id,
         check_in_notes: notes
       )
+    end
+  end
+
+  # A correction used to end at a bare `update_record/1`: no event, no broadcast.
+  # Five LiveViews subscribe to `{:attendance_changed, …}` and none of them heard
+  # one, and `ProviderSessionDetails.checked_in_count` drifted from what a rebuild
+  # would compute (#1329).
+  describe "correct_attendance/3 announces the correction" do
+    setup do
+      user = AccountsFixtures.unconfirmed_user_fixture()
+      provider = ProviderFixtures.provider_profile_fixture()
+      program = insert(:program_schema, provider_id: provider.id)
+      session = insert(:program_session_schema, program_id: program.id, status: "in_progress")
+      {child, parent} = insert_child_with_guardian()
+
+      record =
+        insert(:participation_record_schema,
+          session_id: session.id,
+          child_id: child.id,
+          parent_id: parent.id,
+          status: :checked_in,
+          check_in_at: ~U[2026-03-13 09:00:00Z],
+          check_in_by: user.id
+        )
+
+      %{record: record, provider: provider, scope: %Scope{user: user, provider: provider}}
+    end
+
+    test "reaches the child topic carrying kind :corrected", %{record: record, scope: scope} do
+      Phoenix.PubSub.subscribe(KlassHero.PubSub, Participation.child_topic(record.child_id))
+
+      assert {:ok, _} = Participation.correct_attendance(scope, record.id, %{status: :absent})
+
+      record_id = record.id
+      assert_receive {:attendance_changed, %{record_id: ^record_id, kind: :corrected}}, 200
+    end
+
+    test "reaches the provider topic", %{record: record, provider: provider, scope: scope} do
+      Phoenix.PubSub.subscribe(KlassHero.PubSub, Participation.provider_topic(provider.id))
+
+      assert {:ok, _} = Participation.correct_attendance(scope, record.id, %{status: :absent})
+
+      assert_receive {:attendance_changed, %{kind: :corrected}}, 200
+    end
+
+    # The delta a projection needs cannot be recovered from the corrected record
+    # alone — only the pair says whether the row entered or left the counted set.
+    test "carries both the previous and the new status", %{record: record, scope: scope} do
+      Phoenix.PubSub.subscribe(KlassHero.PubSub, Participation.child_topic(record.child_id))
+      TestOutbox.setup()
+
+      assert {:ok, _} = Participation.correct_attendance(scope, record.id, %{status: :absent})
+
+      assert [event] = TestOutbox.staged()
+      assert event.event_type == :attendance_corrected
+      assert event.payload.previous_status == :checked_in
+      assert event.payload.new_status == :absent
+      assert event.payload.program_id
     end
   end
 end

--- a/test/klass_hero/participation/notifications_test.exs
+++ b/test/klass_hero/participation/notifications_test.exs
@@ -12,7 +12,8 @@ defmodule KlassHero.Participation.NotificationsTest do
   @attendance_kinds %{
     child_checked_in: :checked_in,
     child_checked_out: :checked_out,
-    child_marked_absent: :marked_absent
+    child_marked_absent: :marked_absent,
+    attendance_corrected: :corrected
   }
 
   @note_events [:session_note_submitted, :session_note_approved, :session_note_rejected]

--- a/test/klass_hero/provider/projections/provider_session_details_test.exs
+++ b/test/klass_hero/provider/projections/provider_session_details_test.exs
@@ -343,6 +343,38 @@ defmodule KlassHero.Provider.Projections.ProviderSessionDetailsTest do
       assert %{checked_in_count: 0} = reload(session_id)
     end
 
+    # A correction is the one event that can move a record across the counted set in
+    # either direction, so the counter has to follow it both ways or a rebuild
+    # silently disagrees with the live value (#1329).
+    test "a correction out of the counted set decrements", %{session_id: session_id} do
+      broadcast(:child_checked_in, "rec-1", %{record_id: "rec-1", session_id: session_id, child_id: "c-1"})
+      assert %{checked_in_count: 1} = reload(session_id)
+
+      correct(session_id, :checked_in, :registered)
+
+      assert %{checked_in_count: 0} = reload(session_id)
+    end
+
+    test "a correction into the counted set increments", %{session_id: session_id} do
+      correct(session_id, :registered, :checked_in)
+
+      assert %{checked_in_count: 1} = reload(session_id)
+    end
+
+    test "a correction within the counted set leaves it alone", %{session_id: session_id} do
+      broadcast(:child_checked_in, "rec-1", %{record_id: "rec-1", session_id: session_id, child_id: "c-1"})
+
+      correct(session_id, :checked_in, :checked_out)
+
+      assert %{checked_in_count: 1} = reload(session_id)
+    end
+
+    test "a correction outside the counted set leaves it alone", %{session_id: session_id} do
+      correct(session_id, :registered, :absent)
+
+      assert %{checked_in_count: 0} = reload(session_id)
+    end
+
     test "logs a warning when child_checked_in arrives for an unknown session" do
       unknown_id = Ecto.UUID.generate()
 
@@ -627,6 +659,16 @@ defmodule KlassHero.Provider.Projections.ProviderSessionDetailsTest do
     event = Event.new(event_type, :participation, :session, entity_id, payload)
 
     ProviderSessionDetails.project(event)
+  end
+
+  defp correct(session_id, previous_status, new_status) do
+    broadcast(:attendance_corrected, "rec-1", %{
+      record_id: "rec-1",
+      session_id: session_id,
+      child_id: "c-1",
+      previous_status: previous_status,
+      new_status: new_status
+    })
   end
 
   defp broadcast_provider(event_type, entity_id, payload) do


### PR DESCRIPTION
## Summary

`correct_attendance/3` ended at a bare `update_record/1` — no outbox event, no PubSub — while every sibling attendance write goes through `Outbox.transact_with_events/2` + `Notifications.notify_all/1`. Second of the three defects found while scoping #1329.

### Nobody heard a correction

Five LiveViews subscribe to `{:attendance_changed, …}` and none of them received one: provider and staff `ParticipationLive`, provider and staff `SessionsLive`, and the parent's `ParticipationHistoryLive`. A correction made in one tab needed a manual reload everywhere else.

### `checked_in_count` drifted from what a rebuild computes

The incremental counter only ever `+1`s on `child_checked_in`. Bootstrap recomputes `COUNT(*) FILTER (WHERE status IN ('checked_in','checked_out'))` from current rows. A correction that moved a record into or out of that set changed one and not the other — so the number silently jumped at the next restart with no event to explain it.

Reachable today only through the admin correction UI, which is the only caller that can set an arbitrary status: the roster edit form's `build_edit_correction/2` only ever emits `:checked_out` or notes-only, both of which stay inside the counted set.

## What changed

A new `attendance_corrected` event carrying **both** statuses. The corrected record alone cannot say which direction it moved across the counted set — only the pair can — so `previous_status` is read off the record before `admin_correct/2` runs.

`ProviderSessionDetails` gains a delta handler: `+1` entering the counted set, `-1` leaving it, nothing otherwise. `counted?/1` deliberately mirrors bootstrap's filter, and the moduledoc now says so — those two must keep agreeing.

## Review focus

- **A new event has three registries and none of them fail loudly.** This is the part worth checking:
  - `@event_entities` in `ParticipationEvents` — omitted, `new_event/4` raises.
  - `@attendance_kinds` in `Notifications` — omitted, `message/1` falls through to its `nil` catch-all and **nothing broadcasts, silently**.
  - `:event_consumers` in `config/config.exs` — omitted, `Outbox.stage/2` drops the event entirely, because that registry is also the staging filter.
- **The counter is no longer monotonic**, and the moduledoc's claim that it is has been rewritten rather than deleted. Forward attendance still only adds; a correction is the one thing that can subtract, because it says the check-in did not happen. Worth confirming that reading is right.
- **The `child_marked_absent` no-op now documents its dependency.** It is only correct because `ParticipationRecord.mark_absent/1` accepts `:registered` alone. That invariant becomes load-bearing for the #1329 feature branch, which adds a second caller.

## Test plan

- `mix precommit` — 4956 passed, 0 failures.
- Three new tests in `correct_attendance_test.exs` (child topic, provider topic, staged payload) — all three red before the change, with "The process mailbox is empty" as the failure, which is the defect stated exactly. That file had 15 tests and no assertion on events, outbox rows or broadcasts.
- Four new projection tests covering both delta directions and both no-op cases.
- **Mutation-checked**, because two of those four assert an unchanged count and would pass against a `delta/2` that always returned 0. Flipping `{false, true} -> 0` kills one test; flipping `{true, false} -> 0` kills another. Both directions are genuinely covered.
- Verified end-to-end against a running app (Tidewave, on a dev server restarted *after* the config change, since `:event_consumers` is read at boot):

  ```
  registry for attendance_corrected -> [{ProviderSessionDetails, :project}]
  projection topics include it      -> true

  correct :checked_in -> :registered
    broadcast received  -> %{kind: :corrected, record_id: ..., child_id: ...}
    projection count    -> 1 -> 0
    bootstrap computes  -> 0     # agree

  correct back -> :checked_in
    projection count    -> 0 -> 1
    bootstrap computes  -> 1     # agree
  ```

  The agreement between the live counter and the bootstrap value is the assertion that matters — before this change the projection would have held 1 while a rebuild computed 0.

Refs #1329
