### PR TITLE
feat: mark a child absent by hand, with a reason

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -65,6 +65,14 @@ _Avoid_: Attendance record, Booking
 The act and result of checking a child in and out of a **Session** (the state changes recorded on a **Participation Record**). Who may record it is decided inside the Participation context, from the actor's Scope, in the order Provider → Staff Member → admin — see [ADR-0017](docs/adr/0017-attendance-writes-authorize-at-the-context-boundary.md). The Staff Member's authority comes from a **Program Staff Assignment**, never from their **Specialties**.
 _Avoid_: Presence, Sign-in
 
+**Absence Reason**:
+Why a child was marked absent, in the Instructor's own words ("mum called, off sick"). Operational and immediate — it tells whoever is running the Session where the child is, and it is deliberately **not** a **Session Note**: a note is feedback about the child that the **Parent** must approve before it is shared, and nobody should have to approve a dispatch note. Recorded against the **Attendance Transition** that made the child absent, not stored on the Participation Record, so a child marked absent twice keeps both reasons. Absent only when someone chose it: completing a Session sweeps every still-`registered` child to `absent` with no reason and no actor, which is how an automatic absence is told from a deliberate one.
+_Avoid_: Absence Note, Excuse, Sick Note
+
+**Attendance Transition**:
+One recorded change to a **Participation Record**'s state — from and to, by whom, when, and why. Every attendance write appends one, so the roster's history survives the record only holding its latest state. A transition with no actor was made by the system, not a person.
+_Avoid_: Attendance Event ("Event" means an integration event here), Audit Log entry
+
 ## Payments & Invoicing
 
 **Invoice**:

--- a/lib/klass_hero/participation.ex
+++ b/lib/klass_hero/participation.ex
@@ -1188,8 +1188,7 @@ defmodule KlassHero.Participation do
   defp correct_record_with_event(record, corrected, actor_id, reason) do
     Outbox.transact_with_events(@context, fn ->
       with {:ok, persisted} <- update_record(corrected),
-           {:ok, _transition} <-
-             Repo.insert(AttendanceTransition.between(record, persisted, actor_id, reason)) do
+           :ok <- insert_transition(AttendanceTransition.between(record, persisted, actor_id, reason)) do
         session = resolve_session_best_effort(persisted.session_id)
         {:ok, persisted, [ParticipationEvents.attendance_corrected(persisted, session, record.status)]}
       end
@@ -1199,7 +1198,7 @@ defmodule KlassHero.Participation do
   defp update_record_with_event(updated, event_fn, transition) do
     Outbox.transact_with_events(@context, fn ->
       with {:ok, persisted} <- update_record(updated),
-           {:ok, _transition} <- Repo.insert(transition) do
+           :ok <- insert_transition(transition) do
         # Best-effort: attendance already succeeded; a session fetch failure enriches
         # the event less, it does not fail the write.
         session = resolve_session_best_effort(persisted.session_id)
@@ -1350,6 +1349,17 @@ defmodule KlassHero.Participation do
     |> ParticipationQueries.by_date_range(start_date, end_date)
     |> ParticipationQueries.order_by_session_date_desc()
     |> Repo.all()
+  end
+
+  # `Repo.insert/1` answers with a changeset on failure, but every attendance verb's
+  # `@spec` promises `{:error, atom()}` to its callers. `between/4` fills all four
+  # required fields from two valid records, so this cannot fail on validation — a
+  # failure here is the database refusing the row, and it stays an atom either way.
+  defp insert_transition(transition) do
+    case Repo.insert(transition) do
+      {:ok, _transition} -> :ok
+      {:error, %Ecto.Changeset{}} -> {:error, :transition_log_failed}
+    end
   end
 
   # The sweep is a bulk `update_all`, so its log entries are a bulk `insert_all` —

--- a/lib/klass_hero/participation.ex
+++ b/lib/klass_hero/participation.ex
@@ -24,6 +24,7 @@ defmodule KlassHero.Participation do
   alias KlassHero.Participation.Adapters.Driven.ACL.ProgramProviderResolver
   alias KlassHero.Participation.Adapters.Driven.Persistence.Queries.ParticipationQueries
   alias KlassHero.Participation.Adapters.Driven.Persistence.Queries.SessionNoteQueries
+  alias KlassHero.Participation.AttendanceTransition
   alias KlassHero.Participation.Domain.Events.ParticipationEvents
   alias KlassHero.Participation.Notifications
   alias KlassHero.Participation.ParticipationRecord
@@ -423,14 +424,17 @@ defmodule KlassHero.Participation do
   def get_session_with_roster(session_id) when is_binary(session_id) do
     with {:ok, session} <- fetch_session(session_id) do
       records = list_records_by_session(session_id)
-      {child_info_map, notes_map} = batch_resolve_roster(records)
+      {child_info_map, notes_map, absence_reasons} = batch_resolve_roster(records)
 
       roster =
         Enum.map(records, fn record ->
           info = Map.get(child_info_map, record.child_id, unknown_child_info())
           notes = Map.get(notes_map, record.child_id, [])
 
-          Map.merge(%{record: record}, build_enrichment_fields(info, notes))
+          Map.merge(
+            %{record: record},
+            build_enrichment_fields(info, notes, Map.get(absence_reasons, record.id))
+          )
         end)
 
       {:ok, %{session: session, roster: roster}}
@@ -445,7 +449,7 @@ defmodule KlassHero.Participation do
   def get_session_with_roster_enriched(session_id) when is_binary(session_id) do
     with {:ok, session} <- fetch_session(session_id) do
       records = list_records_by_session(session_id)
-      {child_info_map, notes_map} = batch_resolve_roster(records)
+      {child_info_map, notes_map, absence_reasons} = batch_resolve_roster(records)
 
       enriched_records =
         Enum.map(records, fn record ->
@@ -455,7 +459,7 @@ defmodule KlassHero.Participation do
           # Convert struct to plain map so presentation fields can be merged without struct enforcement.
           record
           |> Map.from_struct()
-          |> Map.merge(build_enrichment_fields(info, notes))
+          |> Map.merge(build_enrichment_fields(info, notes, Map.get(absence_reasons, record.id)))
         end)
 
       enriched_session =
@@ -655,6 +659,30 @@ defmodule KlassHero.Participation do
   end
 
   @doc """
+  Marks a child absent by hand, on behalf of `scope`.
+
+  The deliberate counterpart to the batch absence that `complete_session/2`
+  applies to every straggler: this one names an actor and takes a reason, and
+  the `AttendanceTransition` it writes is where the two are told apart (#1329).
+
+  Options: `:reason`. Returns `{:ok, record}`, `{:error, :unauthorized}`,
+  `{:error, :not_found}`, or `{:error, :invalid_status_transition}`.
+  """
+  @spec record_absence(Scope.t(), String.t(), keyword()) ::
+          {:ok, ParticipationRecord.t()} | {:error, atom()}
+  def record_absence(%Scope{} = scope, record_id, opts \\ []) when is_binary(record_id) do
+    context_span entity: "participation_record" do
+      run_attendance_action(
+        scope,
+        record_id,
+        Keyword.get(opts, :reason),
+        &ParticipationRecord.mark_absent/3,
+        &ParticipationEvents.child_marked_absent/2
+      )
+    end
+  end
+
+  @doc """
   Corrects a participation record's attendance data, on behalf of `scope`.
 
   The correction rules follow the scope's derived role: an `:admin` must supply a
@@ -675,7 +703,8 @@ defmodule KlassHero.Participation do
            :ok <- validate_correction_reason(actor_role, attrs),
            correction_attrs = build_correction_attrs(actor_role, record, attrs),
            {:ok, corrected} <- ParticipationRecord.admin_correct(record, correction_attrs),
-           {:ok, {persisted, events}} <- correct_record_with_event(corrected, record.status) do
+           {:ok, {persisted, events}} <-
+             correct_record_with_event(record, corrected, scope.user.id, Map.get(attrs, :reason)) do
         Notifications.notify_all(events)
         {:ok, persisted}
       end
@@ -873,7 +902,10 @@ defmodule KlassHero.Participation do
     with {:ok, record} <- fetch_record(record_id),
          {:ok, _role} <- authorize_for_record(scope, record),
          {:ok, updated} <- domain_fn.(record, scope.user.id, notes),
-         {:ok, {persisted, events}} <- update_record_with_event(updated, event_fn) do
+         # Every verb logs its transition, so there is no condition here to get
+         # wrong and a new verb is covered by using this path (#1329).
+         transition = AttendanceTransition.between(record, updated, scope.user.id, notes),
+         {:ok, {persisted, events}} <- update_record_with_event(updated, event_fn, transition) do
       Notifications.notify_all(events)
       {:ok, persisted}
     end
@@ -934,6 +966,7 @@ defmodule KlassHero.Participation do
       |> Enum.filter(&(&1.status == :registered))
 
     {:ok, _count} = mark_records_absent(Enum.map(registered, & &1.id))
+    {:ok, _logged} = log_batch_absences(registered)
 
     events =
       Enum.map(registered, &ParticipationEvents.child_marked_absent(%{&1 | status: :absent}, session))
@@ -1037,10 +1070,30 @@ defmodule KlassHero.Participation do
         list_notes_approved_by_children(consented_child_ids)
       end
 
-    {child_info_map, notes_map}
+    {child_info_map, notes_map, latest_absence_reasons(records)}
   end
 
-  defp build_enrichment_fields(child_info, notes) do
+  # Why each currently-absent child is absent, in one query for the whole roster
+  # rather than one per row. Only the latest `:absent` transition counts — a child
+  # marked absent, checked in late, then absented again should show the second
+  # reason, not the first.
+  defp latest_absence_reasons(records) do
+    absent_ids = for %{status: :absent, id: id} <- records, do: id
+
+    if absent_ids == [] do
+      %{}
+    else
+      AttendanceTransition
+      |> where([t], t.record_id in ^absent_ids and t.to_status == :absent)
+      |> distinct([t], t.record_id)
+      |> order_by([t], asc: t.record_id, desc: t.occurred_at, desc: t.inserted_at)
+      |> select([t], {t.record_id, t.reason})
+      |> Repo.all()
+      |> Map.new()
+    end
+  end
+
+  defp build_enrichment_fields(child_info, notes, absence_reason) do
     %{
       child_name: "#{child_info.first_name} #{child_info.last_name}",
       child_first_name: child_info.first_name,
@@ -1048,7 +1101,8 @@ defmodule KlassHero.Participation do
       allergies: child_info.allergies,
       support_needs: child_info.support_needs,
       emergency_contact: child_info.emergency_contact,
-      session_notes: notes
+      session_notes: notes,
+      absence_reason: absence_reason
     }
   end
 
@@ -1127,18 +1181,25 @@ defmodule KlassHero.Participation do
   # `previous_status` is read off the record as it was *before* `admin_correct/2`,
   # and has to be: the corrected struct no longer knows where it came from, and the
   # row is about to stop knowing too.
-  defp correct_record_with_event(corrected, previous_status) do
+  # The one attendance write that does not ride `run_attendance_action/5`, so it
+  # logs its own transition. Keeping the two in step is a live obligation, not a
+  # one-off — a correction missing from the log is a hole exactly where someone
+  # would look for it (#1329).
+  defp correct_record_with_event(record, corrected, actor_id, reason) do
     Outbox.transact_with_events(@context, fn ->
-      with {:ok, persisted} <- update_record(corrected) do
+      with {:ok, persisted} <- update_record(corrected),
+           {:ok, _transition} <-
+             Repo.insert(AttendanceTransition.between(record, persisted, actor_id, reason)) do
         session = resolve_session_best_effort(persisted.session_id)
-        {:ok, persisted, [ParticipationEvents.attendance_corrected(persisted, session, previous_status)]}
+        {:ok, persisted, [ParticipationEvents.attendance_corrected(persisted, session, record.status)]}
       end
     end)
   end
 
-  defp update_record_with_event(updated, event_fn) do
+  defp update_record_with_event(updated, event_fn, transition) do
     Outbox.transact_with_events(@context, fn ->
-      with {:ok, persisted} <- update_record(updated) do
+      with {:ok, persisted} <- update_record(updated),
+           {:ok, _transition} <- Repo.insert(transition) do
         # Best-effort: attendance already succeeded; a session fetch failure enriches
         # the event less, it does not fail the write.
         session = resolve_session_best_effort(persisted.session_id)
@@ -1289,6 +1350,34 @@ defmodule KlassHero.Participation do
     |> ParticipationQueries.by_date_range(start_date, end_date)
     |> ParticipationQueries.order_by_session_date_desc()
     |> Repo.all()
+  end
+
+  # The sweep is a bulk `update_all`, so its log entries are a bulk `insert_all` —
+  # neither goes through a changeset, and `insert_all` autogenerates nothing, so
+  # ids and timestamps are set here. NULL actor and reason are the record of the
+  # fact that nobody decided these child by child (#1329).
+  defp log_batch_absences([]), do: {:ok, 0}
+
+  defp log_batch_absences(records) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    rows =
+      for record <- records do
+        %{
+          id: Ecto.UUID.generate(),
+          record_id: record.id,
+          from_status: :registered,
+          to_status: :absent,
+          actor_id: nil,
+          reason: nil,
+          occurred_at: now,
+          inserted_at: now,
+          updated_at: now
+        }
+      end
+
+    {count, _} = Repo.insert_all(AttendanceTransition, rows)
+    {:ok, count}
   end
 
   defp mark_records_absent([]), do: {:ok, 0}

--- a/lib/klass_hero/participation/attendance_transition.ex
+++ b/lib/klass_hero/participation/attendance_transition.ex
@@ -1,0 +1,78 @@
+defmodule KlassHero.Participation.AttendanceTransition do
+  @moduledoc """
+  One recorded change of a `ParticipationRecord`'s status — who made it, when,
+  and why.
+
+  A sidecar to the record, not a replacement: `participation_records.status`
+  stays authoritative. This table answers what a column cannot, because a column
+  holds only the latest value and an attendance history is a sequence (#1329).
+
+  Every attendance verb appends here through the single write path in
+  `KlassHero.Participation` that all of them share. That is deliberate rather
+  than incidental: a check-in also writes `check_in_at`/`check_in_by` on the
+  record, so the same fact lives in two places, and keeping both writes inside
+  one function is what stops them disagreeing.
+
+  A NULL `actor_id` carries meaning — no human did this. It marks the batch
+  absence that session completion applies to every still-registered child, and
+  is how an automatic absence is told from a deliberate one.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias KlassHero.Participation.ParticipationRecord
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  @statuses [:registered, :checked_in, :checked_out, :absent]
+
+  schema "attendance_transitions" do
+    field :record_id, :binary_id
+    field :from_status, Ecto.Enum, values: @statuses
+    field :to_status, Ecto.Enum, values: @statuses
+    field :actor_id, :binary_id
+    field :reason, :string
+    field :occurred_at, :utc_datetime
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @type t :: %__MODULE__{}
+
+  @required_fields [:record_id, :from_status, :to_status, :occurred_at]
+  @optional_fields [:actor_id, :reason]
+
+  @doc """
+  Builds the transition between two states of the same record.
+
+  Takes both states rather than a `from`/`to` status pair: a pair lets a caller
+  record a direction it did not make, two structs cannot.
+  """
+  @spec between(ParticipationRecord.t(), ParticipationRecord.t(), String.t() | nil, String.t() | nil) ::
+          Ecto.Changeset.t()
+  def between(%ParticipationRecord{} = before, %ParticipationRecord{} = later, actor_id, reason) do
+    changeset(%__MODULE__{}, %{
+      record_id: later.id,
+      from_status: before.status,
+      to_status: later.status,
+      actor_id: actor_id,
+      reason: reason,
+      # When the status changed — which is now, even for a correction that
+      # asserts an arrival time hours in the past. Deriving this from the
+      # record's own `check_in_at` would agree on the forward verbs and lie on
+      # `correct_attendance/3`, where that column is admin-editable.
+      occurred_at: DateTime.utc_now() |> DateTime.truncate(:second)
+    })
+  end
+
+  @doc false
+  @spec changeset(t(), map()) :: Ecto.Changeset.t()
+  def changeset(%__MODULE__{} = transition, attrs) do
+    transition
+    |> cast(attrs, @required_fields ++ @optional_fields)
+    |> validate_required(@required_fields)
+  end
+end

--- a/lib/klass_hero/participation/domain/events/participation_events.ex
+++ b/lib/klass_hero/participation/domain/events/participation_events.ex
@@ -2,18 +2,10 @@ defmodule KlassHero.Participation.Domain.Events.ParticipationEvents do
   @moduledoc """
   Factory module for creating participation domain events.
 
-  ## Event Types
-
-  - `session_created` - A new program session was created
-  - `session_started` - A session has begun
-  - `session_completed` - A session has ended
-  - `roster_seeded` - Participation records were bulk-seeded for a session
-  - `child_checked_in` - A child was checked into a session
-  - `child_checked_out` - A child was checked out of a session
-  - `child_marked_absent` - A child was marked absent from a session
-  - `session_note_submitted` - A session note was submitted for review
-  - `session_note_approved` - A session note was approved by a parent
-  - `session_note_rejected` - A session note was rejected by a parent
+  `@event_entities` below is the authoritative list of what this module emits,
+  and `entity_type_for/1` raises on anything missing from it. A prose copy of
+  that list used to live here and had silently fallen three events behind, so
+  there is deliberately no second list to keep in step.
 
   All events are returned as `Event` structs.
   """

--- a/lib/klass_hero/participation/participation_record.ex
+++ b/lib/klass_hero/participation/participation_record.ex
@@ -6,10 +6,19 @@ defmodule KlassHero.Participation.ParticipationRecord do
   ## Status Lifecycle
 
   ```
-  :registered → :checked_in → :checked_out
-                    ↓
-               :absent (if session completed without check-in)
+  :registered ──→ :checked_in ──→ :checked_out
+       │               ▲
+       ↓               │ arrived late
+    :absent ───────────┘
   ```
+
+  A child becomes `:absent` two ways: marked by hand with a reason, or swept
+  there when the session is completed with them still `:registered`. The record
+  itself cannot tell those apart — who marked it, when, and why live on
+  `AttendanceTransition` (#1329).
+
+  `admin_correct/2` bypasses all of this on purpose; it is the only way back
+  from `:checked_out`.
   """
 
   use Ecto.Schema
@@ -100,12 +109,19 @@ defmodule KlassHero.Participation.ParticipationRecord do
     end
   end
 
-  @doc "Checks in the child. Errors unless `:registered`."
+  @doc """
+  Checks in the child. Errors once the child has already arrived.
+
+  Accepted from `:absent` as well as `:registered` (#1329): a child marked absent
+  at 09:05 who walks in at 09:20 is checked in from the roster, not corrected by
+  an admin. The count a provider sees stays right either way — `:absent` is not
+  counted as present, so the check-in still adds one.
+  """
   @spec check_in(t(), String.t(), String.t() | nil) ::
           {:ok, t()} | {:error, :invalid_status_transition}
   def check_in(record, checked_in_by, notes \\ nil)
 
-  def check_in(%__MODULE__{status: :registered} = record, checked_in_by, notes) do
+  def check_in(%__MODULE__{status: status} = record, checked_in_by, notes) when status in [:registered, :absent] do
     {:ok,
      %{
        record
@@ -140,6 +156,16 @@ defmodule KlassHero.Participation.ParticipationRecord do
   @spec mark_absent(t()) :: {:ok, t()} | {:error, :invalid_status_transition}
   def mark_absent(%__MODULE__{status: :registered} = record), do: {:ok, %{record | status: :absent}}
   def mark_absent(%__MODULE__{}), do: {:error, :invalid_status_transition}
+
+  @doc """
+  Marks the child absent, in the shape the shared attendance path expects.
+
+  The actor and reason are accepted to match `check_in/3` — `run_attendance_action/5`
+  calls every verb with `(record, actor_id, notes)` — but are not stored on the
+  record. An absence's who and why live on `AttendanceTransition` (#1329).
+  """
+  @spec mark_absent(t(), String.t(), String.t() | nil) :: {:ok, t()} | {:error, :invalid_status_transition}
+  def mark_absent(%__MODULE__{} = record, _absent_by, _reason), do: mark_absent(record)
 
   @doc "Returns true if the child is currently checked in."
   @spec checked_in?(t()) :: boolean()

--- a/lib/klass_hero_web/components/participation_components.ex
+++ b/lib/klass_hero_web/components/participation_components.ex
@@ -385,6 +385,18 @@ defmodule KlassHeroWeb.ParticipationComponents do
                   <% end %>
                 </div>
               <% end %>
+
+              <%!--
+                Only ever present on an absent row, and only when a person gave
+                one — the batch sweep at session completion records no reason
+                (#1329).
+              --%>
+              <%= if Map.get(record, :absence_reason) do %>
+                <div id={"absence-reason-#{record.id}"} class="mt-2 text-sm text-hero-grey-600 italic">
+                  <span class="font-medium text-hero-black-100">{gettext("Absent:")}</span>
+                  "{record.absence_reason}"
+                </div>
+              <% end %>
             </div>
 
             <div class="flex flex-col items-end gap-2">
@@ -524,7 +536,7 @@ defmodule KlassHeroWeb.ParticipationComponents do
         cancel_event: "cancel_note"
       )
 
-    session_note_inline_form(assigns)
+    inline_text_form(assigns)
   end
 
   @doc """
@@ -554,7 +566,41 @@ defmodule KlassHeroWeb.ParticipationComponents do
         cancel_event: "cancel_revision"
       )
 
-    session_note_inline_form(assigns)
+    inline_text_form(assigns)
+  end
+
+  @doc """
+  Renders an inline form for the reason a child is being marked absent.
+
+  Operational, and deliberately not a session note: a note is parent-approved
+  feedback about the child, while "mum called, sick" is dispatch information
+  nobody should be asked to approve (#1329).
+
+  ## Examples
+
+      <.absence_reason_form
+        form={@absence_forms["record-id"]}
+        record_id="record-id"
+      />
+  """
+  attr :form, Form, required: true, doc: "Form struct from to_form/2"
+  attr :record_id, :string, required: true, doc: "Participation record ID"
+
+  def absence_reason_form(assigns) do
+    assigns =
+      assign(assigns,
+        entity_id: assigns.record_id,
+        id_prefix: "absence-form",
+        wrapper_id_prefix: "absence-reason",
+        label: gettext("Reason for absence (optional)"),
+        placeholder: gettext("e.g. Mum called — off sick today"),
+        submit_label: gettext("Mark absent"),
+        submit_event: "confirm_absence",
+        change_event: "update_absence_reason",
+        cancel_event: "cancel_absence"
+      )
+
+    inline_text_form(assigns)
   end
 
   @doc """
@@ -563,7 +609,8 @@ defmodule KlassHeroWeb.ParticipationComponents do
   Lets the caller patch the record's primary notes field and, when the child
   hasn't departed yet, optionally record a departure time. Submits the
   `submit_edit` event with the form values; the LiveView wires that to
-  `Participation.correct_attendance/1` with the appropriate `actor_role`.
+  `Participation.correct_attendance/3`, which derives the actor's role from the
+  scope rather than taking it from the caller (ADR-0017).
 
   ## Examples
 
@@ -662,6 +709,11 @@ defmodule KlassHeroWeb.ParticipationComponents do
     """
   end
 
+  # One expandable textarea keyed by an entity id. Named for its shape rather
+  # than for session notes since #1329, when the absence reason became a third
+  # caller that is not a note.
+  #
+  # The field is always `:content`, so every wrapper's form must use that key.
   attr :form, Form, required: true
   attr :entity_id, :string, required: true
   attr :id_prefix, :string, required: true
@@ -673,7 +725,7 @@ defmodule KlassHeroWeb.ParticipationComponents do
   attr :change_event, :string, required: true
   attr :cancel_event, :string, required: true
 
-  defp session_note_inline_form(assigns) do
+  defp inline_text_form(assigns) do
     ~H"""
     <div class="mt-3 border-t border-hero-grey-200 pt-3" id={"#{@wrapper_id_prefix}-#{@entity_id}"}>
       <.form

--- a/lib/klass_hero_web/helpers/participation_live_handlers.ex
+++ b/lib/klass_hero_web/helpers/participation_live_handlers.ex
@@ -63,6 +63,40 @@ defmodule KlassHeroWeb.Helpers.ParticipationLiveHandlers do
     end
   end
 
+  @doc "Marks the given record absent with an optional reason, clearing its form, then reloads."
+  @spec mark_absent(Socket.t(), String.t(), map(), reload_fn()) :: {:noreply, Socket.t()}
+  def mark_absent(socket, record_id, params, reload_fn) do
+    reason = Map.get(params, "content")
+
+    case ParticipationEditHelpers.find_participation_record(socket, record_id) do
+      nil ->
+        {:noreply, put_flash(socket, :error, gettext("Record not found"))}
+
+      record ->
+        case KlassHero.Participation.record_absence(socket.assigns.current_scope, record.id, reason: reason) do
+          {:ok, _record} ->
+            {:noreply,
+             socket
+             |> put_flash(:info, gettext("Child marked absent"))
+             |> assign(:absence_form_expanded, nil)
+             |> assign(:absence_forms, Map.delete(socket.assigns.absence_forms, record_id))
+             |> reload_fn.()}
+
+          {:error, :unauthorized} ->
+            {:noreply, put_flash(socket, :error, gettext("You are not assigned to this program"))}
+
+          {:error, reason} ->
+            Logger.error("[ParticipationLiveHandlers.mark_absent] Failed to mark absent",
+              record_id: record_id,
+              child_id: record.child_id,
+              reason: inspect(reason)
+            )
+
+            {:noreply, put_flash(socket, :error, gettext("Failed to mark absent: %{reason}", reason: inspect(reason)))}
+        end
+    end
+  end
+
   @doc "Records a check-out for the given record, clearing its checkout form, then reloads."
   @spec confirm_checkout(Socket.t(), String.t(), map(), reload_fn()) :: {:noreply, Socket.t()}
   def confirm_checkout(socket, record_id, params, reload_fn) do

--- a/lib/klass_hero_web/live/provider/participation_live.ex
+++ b/lib/klass_hero_web/live/provider/participation_live.ex
@@ -34,6 +34,8 @@ defmodule KlassHeroWeb.Provider.ParticipationLive do
       |> assign(:participation_records, [])
       |> assign(:checkout_form_expanded, nil)
       |> assign(:checkout_forms, %{})
+      |> assign(:absence_form_expanded, nil)
+      |> assign(:absence_forms, %{})
       |> assign(:note_form_expanded, nil)
       |> assign(:note_forms, %{})
       |> assign(:revision_form_expanded, nil)
@@ -92,6 +94,26 @@ defmodule KlassHeroWeb.Provider.ParticipationLive do
   @impl true
   def handle_event("confirm_checkout", %{"id" => record_id, "checkout" => params}, socket) do
     ParticipationLiveHandlers.confirm_checkout(socket, record_id, params, &load_session_data/1)
+  end
+
+  @impl true
+  def handle_event("expand_absence_form", %{"id" => record_id}, socket) do
+    {:noreply, expand_form(socket, record_id, "absence", "content", "", :absence_form_expanded, :absence_forms)}
+  end
+
+  @impl true
+  def handle_event("cancel_absence", %{"id" => record_id}, socket) do
+    {:noreply, cancel_form(socket, record_id, :absence_form_expanded, :absence_forms)}
+  end
+
+  @impl true
+  def handle_event("update_absence_reason", %{"id" => record_id, "absence" => %{"content" => reason}}, socket) do
+    {:noreply, update_form(socket, record_id, reason, "absence", "content", :absence_forms)}
+  end
+
+  @impl true
+  def handle_event("confirm_absence", %{"id" => record_id, "absence" => params}, socket) do
+    ParticipationLiveHandlers.mark_absent(socket, record_id, params, &load_session_data/1)
   end
 
   @impl true

--- a/lib/klass_hero_web/live/provider/participation_live.html.heex
+++ b/lib/klass_hero_web/live/provider/participation_live.html.heex
@@ -93,6 +93,27 @@
               </button>
               <%!-- A form for this record is expanded — suppress row actions while editing. --%>
             <% record.status in [:checked_in, :checked_out] -> %>
+            <% @absence_form_expanded == to_string(record.id) -> %>
+              <%!-- The absence reason form is open below this row. --%>
+            <% record.status == :absent -> %>
+              <%!--
+                Absent rows used to fall through to "Check In" below, a button
+                the state machine rejected every time. It was invisible because
+                absences only existed after a session was completed, when no
+                actions render at all (#1329).
+              --%>
+              <button
+                phx-click="check_in"
+                phx-value-id={record.id}
+                class={[
+                  "px-3 py-1.5 text-sm bg-white text-hero-black-100 font-medium border border-hero-grey-300",
+                  "hover:bg-hero-grey-50 focus:outline-none focus:ring-2 focus:ring-hero-blue-500 focus:ring-offset-2",
+                  Theme.rounded(:md),
+                  Theme.transition(:normal)
+                ]}
+              >
+                {gettext("Arrived late")}
+              </button>
             <% true -> %>
               <button
                 phx-click="check_in"
@@ -105,6 +126,19 @@
                 ]}
               >
                 {gettext("Check In")}
+              </button>
+              <button
+                id={"mark-absent-btn-#{record.id}"}
+                phx-click="expand_absence_form"
+                phx-value-id={record.id}
+                class={[
+                  "px-3 py-1.5 text-sm bg-white text-hero-black-100 font-medium border border-hero-grey-300",
+                  "hover:bg-hero-grey-50 focus:outline-none focus:ring-2 focus:ring-hero-blue-500 focus:ring-offset-2",
+                  Theme.rounded(:md),
+                  Theme.transition(:normal)
+                ]}
+              >
+                {gettext("Mark absent")}
               </button>
           <% end %>
 
@@ -161,6 +195,14 @@
         </:actions>
 
         <:expanded_content :let={record}>
+          <%!-- Inline absence reason form (full-width below record row) --%>
+          <%= if @absence_form_expanded == to_string(record.id) do %>
+            <.absence_reason_form
+              form={Map.get(@absence_forms, to_string(record.id))}
+              record_id={to_string(record.id)}
+            />
+          <% end %>
+
           <%!-- Inline edit form (notes + optional departure time) --%>
           <%= if @edit_form_expanded == to_string(record.id) do %>
             <.edit_record_form

--- a/lib/klass_hero_web/live/staff/staff_participation_live.ex
+++ b/lib/klass_hero_web/live/staff/staff_participation_live.ex
@@ -33,6 +33,8 @@ defmodule KlassHeroWeb.Staff.StaffParticipationLive do
       |> assign(:participation_records, [])
       |> assign(:checkout_form_expanded, nil)
       |> assign(:checkout_forms, %{})
+      |> assign(:absence_form_expanded, nil)
+      |> assign(:absence_forms, %{})
       |> assign(:note_form_expanded, nil)
       |> assign(:note_forms, %{})
       |> assign(:edit_form_expanded, nil)
@@ -88,6 +90,26 @@ defmodule KlassHeroWeb.Staff.StaffParticipationLive do
   @impl true
   def handle_event("confirm_checkout", %{"id" => record_id, "checkout" => params}, socket) do
     ParticipationLiveHandlers.confirm_checkout(socket, record_id, params, &load_session_data/1)
+  end
+
+  @impl true
+  def handle_event("expand_absence_form", %{"id" => record_id}, socket) do
+    {:noreply, expand_form(socket, record_id, "absence", "content", "", :absence_form_expanded, :absence_forms)}
+  end
+
+  @impl true
+  def handle_event("cancel_absence", %{"id" => record_id}, socket) do
+    {:noreply, cancel_form(socket, record_id, :absence_form_expanded, :absence_forms)}
+  end
+
+  @impl true
+  def handle_event("update_absence_reason", %{"id" => record_id, "absence" => %{"content" => reason}}, socket) do
+    {:noreply, update_form(socket, record_id, reason, "absence", "content", :absence_forms)}
+  end
+
+  @impl true
+  def handle_event("confirm_absence", %{"id" => record_id, "absence" => params}, socket) do
+    ParticipationLiveHandlers.mark_absent(socket, record_id, params, &load_session_data/1)
   end
 
   @impl true

--- a/lib/klass_hero_web/live/staff/staff_participation_live.html.heex
+++ b/lib/klass_hero_web/live/staff/staff_participation_live.html.heex
@@ -93,6 +93,27 @@
               </button>
               <%!-- A form for this record is expanded — suppress row actions while editing. --%>
             <% record.status in [:checked_in, :checked_out] -> %>
+            <% @absence_form_expanded == to_string(record.id) -> %>
+              <%!-- The absence reason form is open below this row. --%>
+            <% record.status == :absent -> %>
+              <%!--
+                Absent rows used to fall through to "Check In" below, a button
+                the state machine rejected every time. It was invisible because
+                absences only existed after a session was completed, when no
+                actions render at all (#1329).
+              --%>
+              <button
+                phx-click="check_in"
+                phx-value-id={record.id}
+                class={[
+                  "px-3 py-1.5 text-sm bg-white text-hero-black-100 font-medium border border-hero-grey-300",
+                  "hover:bg-hero-grey-50 focus:outline-none focus:ring-2 focus:ring-hero-blue-500 focus:ring-offset-2",
+                  Theme.rounded(:md),
+                  Theme.transition(:normal)
+                ]}
+              >
+                {gettext("Arrived late")}
+              </button>
             <% true -> %>
               <button
                 phx-click="check_in"
@@ -105,6 +126,19 @@
                 ]}
               >
                 {gettext("Check In")}
+              </button>
+              <button
+                id={"mark-absent-btn-#{record.id}"}
+                phx-click="expand_absence_form"
+                phx-value-id={record.id}
+                class={[
+                  "px-3 py-1.5 text-sm bg-white text-hero-black-100 font-medium border border-hero-grey-300",
+                  "hover:bg-hero-grey-50 focus:outline-none focus:ring-2 focus:ring-hero-blue-500 focus:ring-offset-2",
+                  Theme.rounded(:md),
+                  Theme.transition(:normal)
+                ]}
+              >
+                {gettext("Mark absent")}
               </button>
           <% end %>
 
@@ -136,6 +170,14 @@
         </:actions>
 
         <:expanded_content :let={record}>
+          <%!-- Inline absence reason form (full-width below record row) --%>
+          <%= if @absence_form_expanded == to_string(record.id) do %>
+            <.absence_reason_form
+              form={Map.get(@absence_forms, to_string(record.id))}
+              record_id={to_string(record.id)}
+            />
+          <% end %>
+
           <%!-- Inline edit form (notes + optional departure time) --%>
           <%= if @edit_form_expanded == to_string(record.id) do %>
             <.edit_record_form

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -469,7 +469,7 @@ msgstr "Wird geändert..."
 msgid "Child checked in successfully"
 msgstr "Kind erfolgreich eingecheckt"
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:80
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:114
 #, elixir-autogen, elixir-format
 msgid "Child checked out successfully"
 msgstr "Kind erfolgreich ausgecheckt"
@@ -613,12 +613,12 @@ msgstr "Geben Sie Ihr Passwort zur Bestätigung ein"
 msgid "Failed to check in: %{reason}"
 msgstr "Einchecken fehlgeschlagen: %{reason}"
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:95
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:129
 #, elixir-autogen, elixir-format
 msgid "Failed to check out: %{reason}"
 msgstr "Auschecken fehlgeschlagen: %{reason}"
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:168
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:202
 #: lib/klass_hero_web/live/provider/sessions_live.ex:167
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:117
 #, elixir-autogen, elixir-format
@@ -845,12 +845,13 @@ msgstr "Fragen zu diesen Bedingungen?"
 
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:41
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:73
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:105
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:107
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:139
 #: lib/klass_hero_web/live/admin/sessions_live.ex:247
-#: lib/klass_hero_web/live/provider/participation_live.ex:177
-#: lib/klass_hero_web/live/provider/participation_live.ex:223
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:117
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:163
+#: lib/klass_hero_web/live/provider/participation_live.ex:199
+#: lib/klass_hero_web/live/provider/participation_live.ex:245
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:139
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:185
 #, elixir-autogen, elixir-format
 msgid "Record not found"
 msgstr "Eintrag nicht gefunden"
@@ -887,7 +888,7 @@ msgstr "Wählen Sie eine oder beide Optionen"
 msgid "Send Message"
 msgstr "Nachricht senden"
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:156
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:190
 #: lib/klass_hero_web/live/provider/sessions_live.ex:150
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:100
 #, elixir-autogen, elixir-format
@@ -896,8 +897,8 @@ msgstr "Sitzung erfolgreich abgeschlossen"
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:62
 #: lib/klass_hero_web/live/admin/sessions_live.ex:68
-#: lib/klass_hero_web/live/provider/participation_live.ex:293
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:248
+#: lib/klass_hero_web/live/provider/participation_live.ex:315
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:270
 #, elixir-autogen, elixir-format
 msgid "Session not found"
 msgstr "Sitzung nicht gefunden"
@@ -1545,9 +1546,9 @@ msgstr "Rundnachricht"
 msgid "Broadcast sent to %{count} parents"
 msgstr "Rundnachricht an %{count} Eltern gesendet"
 
-#: lib/klass_hero_web/components/participation_components.ex:441
-#: lib/klass_hero_web/components/participation_components.ex:631
-#: lib/klass_hero_web/components/participation_components.ex:717
+#: lib/klass_hero_web/components/participation_components.ex:453
+#: lib/klass_hero_web/components/participation_components.ex:678
+#: lib/klass_hero_web/components/participation_components.ex:769
 #: lib/klass_hero_web/components/provider_components.ex:890
 #: lib/klass_hero_web/components/provider_components.ex:1344
 #: lib/klass_hero_web/components/provider_components.ex:2061
@@ -1639,7 +1640,7 @@ msgstr "Notiz konnte nicht genehmigt werden"
 msgid "Failed to reject note"
 msgstr "Notiz konnte nicht abgelehnt werden"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:169
+#: lib/klass_hero_web/live/provider/participation_live.ex:191
 #, elixir-autogen, elixir-format
 msgid "Failed to resubmit note"
 msgstr "Notiz konnte nicht erneut eingereicht werden"
@@ -1650,7 +1651,7 @@ msgstr "Notiz konnte nicht erneut eingereicht werden"
 msgid "Failed to send broadcast"
 msgstr "Rundnachricht konnte nicht gesendet werden"
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:134
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:168
 #, elixir-autogen, elixir-format
 msgid "Failed to submit note"
 msgstr "Notiz konnte nicht eingereicht werden"
@@ -1729,8 +1730,8 @@ msgstr "Für dieses Programm sind keine Eltern angemeldet"
 msgid "Note approved"
 msgstr "Notiz genehmigt"
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:123
-#: lib/klass_hero_web/live/provider/participation_live.ex:161
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:157
+#: lib/klass_hero_web/live/provider/participation_live.ex:183
 #, elixir-autogen, elixir-format
 msgid "Note content cannot be blank"
 msgstr "Notizinhalt darf nicht leer sein"
@@ -1740,7 +1741,7 @@ msgstr "Notizinhalt darf nicht leer sein"
 msgid "Note rejected"
 msgstr "Notiz abgelehnt"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:155
+#: lib/klass_hero_web/live/provider/participation_live.ex:177
 #, elixir-autogen, elixir-format
 msgid "Note resubmitted for review"
 msgstr "Notiz erneut zur Überprüfung eingereicht"
@@ -1846,8 +1847,8 @@ msgstr "Diese Nachricht wird an alle Eltern mit aktiven Anmeldungen in diesem Pr
 msgid "Type a message..."
 msgstr "Nachricht eingeben..."
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:313
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:268
+#: lib/klass_hero_web/live/provider/participation_live.ex:335
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:290
 #, elixir-autogen, elixir-format
 msgid "Unable to refresh roster. Please reload."
 msgstr "Teilnehmerliste konnte nicht aktualisiert werden. Bitte laden Sie die Seite neu."
@@ -1858,7 +1859,7 @@ msgstr "Teilnehmerliste konnte nicht aktualisiert werden. Bitte laden Sie die Se
 msgid "Write your message to all enrolled parents..."
 msgstr "Schreiben Sie Ihre Nachricht an alle angemeldeten Eltern..."
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:126
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:160
 #, elixir-autogen, elixir-format
 msgid "You already submitted a note for this record"
 msgstr "Sie haben bereits eine Notiz für diesen Eintrag eingereicht"
@@ -1970,7 +1971,7 @@ msgstr "Beim Import ist ein unerwarteter Fehler aufgetreten."
 msgid "Approve"
 msgstr "Genehmigen"
 
-#: lib/klass_hero_web/components/participation_components.ex:826
+#: lib/klass_hero_web/components/participation_components.ex:878
 #: lib/klass_hero_web/components/provider_components.ex:49
 #: lib/klass_hero_web/live/admin/sessions_live.ex:290
 #: lib/klass_hero_web/live/admin/verifications_live.ex:202
@@ -2542,7 +2543,7 @@ msgstr "Teilnahmevoraussetzungen"
 msgid "Participant Restrictions (optional)"
 msgstr "Teilnahmebeschränkungen (optional)"
 
-#: lib/klass_hero_web/components/participation_components.ex:825
+#: lib/klass_hero_web/components/participation_components.ex:877
 #: lib/klass_hero_web/components/provider_components.ex:294
 #, elixir-autogen, elixir-format
 msgid "Pending Review"
@@ -2624,7 +2625,7 @@ msgstr "Anbieterprofil nicht gefunden."
 msgid "Read our founding story →"
 msgstr "Lesen Sie unsere Gründungsgeschichte →"
 
-#: lib/klass_hero_web/components/participation_components.ex:805
+#: lib/klass_hero_web/components/participation_components.ex:857
 #: lib/klass_hero_web/components/provider_components.ex:2981
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
@@ -2692,7 +2693,7 @@ msgstr "Anmeldung öffnet am %{date}"
 msgid "Reject"
 msgstr "Ablehnen"
 
-#: lib/klass_hero_web/components/participation_components.ex:827
+#: lib/klass_hero_web/components/participation_components.ex:879
 #: lib/klass_hero_web/components/provider_components.ex:50
 #: lib/klass_hero_web/live/admin/verifications_live.ex:207
 #, elixir-autogen, elixir-format
@@ -3222,7 +3223,7 @@ msgstr "Diese Löschanfrage ist abgelaufen. Bitte versuchen Sie es erneut."
 msgid "A reason is required for corrections"
 msgstr "Ein Grund für die Korrektur ist erforderlich"
 
-#: lib/klass_hero_web/components/participation_components.ex:811
+#: lib/klass_hero_web/components/participation_components.ex:863
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:201
 #, elixir-autogen, elixir-format
 msgid "Absent"
@@ -3352,7 +3353,7 @@ msgstr "Kind"
 msgid "Coming soon! Sign up for our newsletter to be notified when gift vouchers launch."
 msgstr "Demnächst verfügbar! Melden Sie sich für unseren Newsletter an, um benachrichtigt zu werden, sobald Geschenkgutscheine verfügbar sind."
 
-#: lib/klass_hero_web/components/participation_components.ex:808
+#: lib/klass_hero_web/components/participation_components.ex:860
 #, elixir-autogen, elixir-format
 msgid "Completed"
 msgstr "Abgeschlossen"
@@ -3418,7 +3419,7 @@ msgstr "So werden Sie bezahlt:"
 msgid "How does the booking system work?"
 msgstr "Wie funktioniert das Buchungssystem?"
 
-#: lib/klass_hero_web/components/participation_components.ex:807
+#: lib/klass_hero_web/components/participation_components.ex:859
 #: lib/klass_hero_web/live/admin/sessions_live.ex:271
 #, elixir-autogen, elixir-format
 msgid "In Progress"
@@ -3471,7 +3472,7 @@ msgstr "Keine angemeldeten Eltern"
 msgid "No risk of non-payment"
 msgstr "Kein Risiko von Zahlungsausfällen"
 
-#: lib/klass_hero_web/components/participation_components.ex:830
+#: lib/klass_hero_web/components/participation_components.ex:882
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:155
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:197
 #, elixir-autogen, elixir-format
@@ -3560,7 +3561,7 @@ msgstr "SEPA-Lastschrift"
 msgid "Save Correction"
 msgstr "Korrektur speichern"
 
-#: lib/klass_hero_web/components/participation_components.ex:806
+#: lib/klass_hero_web/components/participation_components.ex:858
 #, elixir-autogen, elixir-format
 msgid "Scheduled"
 msgstr "Geplant"
@@ -3676,8 +3677,8 @@ msgstr "Zu dieser Zeit existiert bereits eine Sitzung"
 msgid "Account created! Check your email to confirm and log in."
 msgstr "Konto erstellt! Überprüfen Sie Ihre E-Mails, um zu bestätigen und sich anzumelden."
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:126
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:126
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:160
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:160
 #, elixir-autogen, elixir-format
 msgid "Add Note"
 msgstr "Notiz hinzufügen"
@@ -3700,7 +3701,7 @@ msgstr "Alle Programme"
 msgid "All providers"
 msgstr "Alle Anbieter"
 
-#: lib/klass_hero_web/components/participation_components.ex:737
+#: lib/klass_hero_web/components/participation_components.ex:789
 #, elixir-autogen, elixir-format
 msgid "Allergies: %{details}"
 msgstr "Allergien: %{details}"
@@ -3742,8 +3743,8 @@ msgstr "Zurück zu E-Mails"
 msgid "Broadcast messages are one-way"
 msgstr "Broadcast-Nachrichten sind einseitig"
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:107
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:107
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:128
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "Check In"
 msgstr "Einchecken"
@@ -3758,7 +3759,7 @@ msgstr "Die Eincheckzeit muss vor der Auscheckzeit liegen"
 msgid "Check-in:"
 msgstr "Einchecken:"
 
-#: lib/klass_hero_web/components/participation_components.ex:413
+#: lib/klass_hero_web/components/participation_components.ex:425
 #, elixir-autogen, elixir-format
 msgid "Check-out notes (optional)"
 msgstr "Auschecken-Notizen (optional)"
@@ -3801,7 +3802,7 @@ msgstr "Registrierung abschließen"
 msgid "Complete Session"
 msgstr "Sitzung abschließen"
 
-#: lib/klass_hero_web/components/participation_components.ex:428
+#: lib/klass_hero_web/components/participation_components.ex:440
 #, elixir-autogen, elixir-format
 msgid "Confirm Check Out"
 msgstr "Auschecken bestätigen"
@@ -3854,12 +3855,12 @@ msgstr "Datum"
 msgid "Date is required"
 msgstr "Datum ist erforderlich"
 
-#: lib/klass_hero_web/components/participation_components.ex:414
+#: lib/klass_hero_web/components/participation_components.ex:426
 #, elixir-autogen, elixir-format
 msgid "E.g., picked up by parent, gave medication reminder..."
 msgstr "Z.B. von Eltern abgeholt, Medikamentenerinnerung gegeben..."
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:155
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Edit & Resubmit"
 msgstr "Bearbeiten & erneut einreichen"
@@ -3887,7 +3888,7 @@ msgstr "E-Mail nicht gefunden"
 msgid "Emails"
 msgstr "E-Mails"
 
-#: lib/klass_hero_web/components/participation_components.ex:749
+#: lib/klass_hero_web/components/participation_components.ex:801
 #, elixir-autogen, elixir-format
 msgid "Emergency: %{details}"
 msgstr "Notfall: %{details}"
@@ -3897,7 +3898,7 @@ msgstr "Notfall: %{details}"
 msgid "End time must be after start time"
 msgstr "Die Endzeit muss nach der Startzeit liegen"
 
-#: lib/klass_hero_web/components/participation_components.ex:812
+#: lib/klass_hero_web/components/participation_components.ex:864
 #, elixir-autogen, elixir-format
 msgid "Expected"
 msgstr "Erwartet"
@@ -4031,7 +4032,7 @@ msgstr "Maximale Kapazität"
 msgid "No actions available"
 msgstr "Keine Aktionen verfügbar"
 
-#: lib/klass_hero_web/components/participation_components.ex:458
+#: lib/klass_hero_web/components/participation_components.ex:470
 #, elixir-autogen, elixir-format
 msgid "No children enrolled in this session"
 msgstr "Keine Kinder in dieser Sitzung angemeldet"
@@ -4067,12 +4068,12 @@ msgstr "Keine Sitzungen für die ausgewählten Filter gefunden."
 msgid "No sessions scheduled"
 msgstr "Keine Sitzungen geplant"
 
-#: lib/klass_hero_web/components/participation_components.ex:658
+#: lib/klass_hero_web/components/participation_components.ex:705
 #, elixir-autogen, elixir-format
 msgid "Note:"
 msgstr "Notiz:"
 
-#: lib/klass_hero_web/components/participation_components.ex:520
+#: lib/klass_hero_web/components/participation_components.ex:532
 #, elixir-autogen, elixir-format
 msgid "Observation about the child's participation..."
 msgstr "Beobachtung zur Teilnahme des Kindes..."
@@ -4182,7 +4183,7 @@ msgstr "Erneut senden"
 msgid "Reset to today"
 msgstr "Auf heute zurücksetzen"
 
-#: lib/klass_hero_web/components/participation_components.ex:551
+#: lib/klass_hero_web/components/participation_components.ex:563
 #, elixir-autogen, elixir-format
 msgid "Resubmit Note"
 msgstr "Notiz erneut einreichen"
@@ -4192,7 +4193,7 @@ msgstr "Notiz erneut einreichen"
 msgid "Retry"
 msgstr "Erneut versuchen"
 
-#: lib/klass_hero_web/components/participation_components.ex:549
+#: lib/klass_hero_web/components/participation_components.ex:561
 #, elixir-autogen, elixir-format
 msgid "Revised Note"
 msgstr "Überarbeitete Notiz"
@@ -4247,7 +4248,7 @@ msgstr "Mitarbeiter-Dashboard"
 msgid "Start Session"
 msgstr "Sitzung starten"
 
-#: lib/klass_hero_web/components/participation_components.ex:521
+#: lib/klass_hero_web/components/participation_components.ex:533
 #, elixir-autogen, elixir-format
 msgid "Submit Note"
 msgstr "Notiz absenden"
@@ -4257,7 +4258,7 @@ msgstr "Notiz absenden"
 msgid "Submit Participation"
 msgstr "Teilnahme bestätigen"
 
-#: lib/klass_hero_web/components/participation_components.ex:743
+#: lib/klass_hero_web/components/participation_components.ex:795
 #, elixir-autogen, elixir-format
 msgid "Support: %{details}"
 msgstr "Unterstützung: %{details}"
@@ -4298,7 +4299,7 @@ msgstr "An"
 msgid "Type your reply..."
 msgstr "Ihre Antwort eingeben..."
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:193
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:227
 #: lib/klass_hero_web/live/provider/sessions_live.ex:190
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:126
 #, elixir-autogen, elixir-format
@@ -4312,7 +4313,7 @@ msgstr "Nicht autorisiert"
 msgid "Unread"
 msgstr "Ungelesen"
 
-#: lib/klass_hero_web/components/participation_components.ex:550
+#: lib/klass_hero_web/components/participation_components.ex:562
 #, elixir-autogen, elixir-format
 msgid "Update your observation..."
 msgstr "Aktualisieren Sie Ihre Beobachtung..."
@@ -4395,7 +4396,8 @@ msgstr "Ihre zugewiesenen Sitzungen anzeigen und verwalten"
 
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:52
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:86
-#: lib/klass_hero_web/live/provider/participation_live.ex:282
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:120
+#: lib/klass_hero_web/live/provider/participation_live.ex:304
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:53
 #, elixir-autogen, elixir-format
 msgid "You are not assigned to this program"
@@ -4416,7 +4418,7 @@ msgstr "Über den Anbieter"
 msgid "Built for the Berlin international community. Integrated secure encrypted messaging to connect with local families and trusted educators nearby."
 msgstr "Entwickelt für die internationale Berliner Gemeinschaft. Integriertes sicheres verschlüsseltes Messaging, um sich mit lokalen Familien und vertrauenswürdigen Pädagogen in Ihrer Nähe zu verbinden."
 
-#: lib/klass_hero_web/components/participation_components.ex:813
+#: lib/klass_hero_web/components/participation_components.ex:865
 #, elixir-autogen, elixir-format
 msgid "Cancelled"
 msgstr "Abgesagt"
@@ -4613,24 +4615,24 @@ msgstr "Sessions anzeigen"
 msgid "Create a program before inviting participants."
 msgstr "Erstellen Sie zuerst ein Programm, bevor Sie Teilnehmer einladen."
 
-#: lib/klass_hero_web/components/participation_components.ex:810
+#: lib/klass_hero_web/components/participation_components.ex:862
 #, elixir-autogen, elixir-format
 msgid "Departed"
 msgstr "Abgereist"
 
-#: lib/klass_hero_web/components/participation_components.ex:829
+#: lib/klass_hero_web/components/participation_components.ex:881
 #, elixir-autogen, elixir-format
 msgid "Departure notes"
 msgstr "Notizen zur Abreise"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:226
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:166
+#: lib/klass_hero_web/live/provider/participation_live.ex:248
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:188
 #, elixir-autogen, elixir-format
 msgid "Departure time is not a valid date and time"
 msgstr "Abreisezeit ist kein gültiges Datum oder keine gültige Uhrzeit"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:237
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:177
+#: lib/klass_hero_web/live/provider/participation_live.ex:259
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:199
 #, elixir-autogen, elixir-format
 msgid "Failed to update record"
 msgstr "Aktualisieren des Datensatzes fehlgeschlagen"
@@ -4655,7 +4657,7 @@ msgstr "Einzelperson einladen"
 msgid "Invite sent."
 msgstr "Einladung verschickt."
 
-#: lib/klass_hero_web/components/participation_components.ex:604
+#: lib/klass_hero_web/components/participation_components.ex:651
 #, elixir-autogen, elixir-format
 msgid "Leave blank to keep this child marked as present."
 msgstr "Leer lassen, um dieses Kind als anwesend markiert zu lassen."
@@ -4670,8 +4672,8 @@ msgstr "Gesundheit & Einwilligungen (optional)"
 msgid "Medical conditions"
 msgstr "Gesundheitliche Besonderheiten"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:229
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:169
+#: lib/klass_hero_web/live/provider/participation_live.ex:251
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:191
 #, elixir-autogen, elixir-format
 msgid "Nothing to update"
 msgstr "Nichts zu aktualisieren"
@@ -4691,7 +4693,7 @@ msgstr "Fotos dürfen in Marketingmaterialien verwendet werden"
 msgid "Photos may appear on social media"
 msgstr "Fotos dürfen in sozialen Medien erscheinen"
 
-#: lib/klass_hero_web/components/participation_components.ex:809
+#: lib/klass_hero_web/components/participation_components.ex:861
 #, elixir-autogen, elixir-format
 msgid "Present"
 msgstr "Anwesend"
@@ -4707,18 +4709,18 @@ msgstr "Hauptansprechpartner"
 msgid "Record departure"
 msgstr "Abreise erfassen"
 
-#: lib/klass_hero_web/components/participation_components.ex:601
+#: lib/klass_hero_web/components/participation_components.ex:648
 #, elixir-autogen, elixir-format
 msgid "Record departure time (optional)"
 msgstr "Abreisezeit erfassen (optional)"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:217
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:157
+#: lib/klass_hero_web/live/provider/participation_live.ex:239
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "Record updated"
 msgstr "Datensatz aktualisiert"
 
-#: lib/klass_hero_web/components/participation_components.ex:618
+#: lib/klass_hero_web/components/participation_components.ex:665
 #, elixir-autogen, elixir-format
 msgid "Save changes"
 msgstr "Änderungen speichern"
@@ -4743,7 +4745,7 @@ msgstr "Zweiter Ansprechpartner (optional)"
 msgid "Send invite"
 msgstr "Einladung senden"
 
-#: lib/klass_hero_web/components/participation_components.ex:593
+#: lib/klass_hero_web/components/participation_components.ex:640
 #, elixir-autogen, elixir-format
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr "Aktualisieren Sie die Notiz für dieses Kind (z. B. um zu klären, was passiert ist)"
@@ -5692,7 +5694,10 @@ msgstr "Weniger verwalten."
 msgid "Mandatory child-protection course before going live."
 msgstr "Verpflichtender Kinderschutzkurs vor der Freischaltung."
 
+#: lib/klass_hero_web/components/participation_components.ex:597
 #: lib/klass_hero_web/components/provider_layout_components.ex:578
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:141
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:141
 #, elixir-autogen, elixir-format
 msgid "Mark absent"
 msgstr "Als abwesend markieren"
@@ -7160,12 +7165,12 @@ msgstr "Die Erklärung zur Mitarbeiter-Compliance wurde seit deiner letzten Unte
 msgid "You have signed the Staff Compliance Declaration."
 msgstr "Du hast die Erklärung zur Mitarbeiter-Compliance unterzeichnet."
 
-#: lib/klass_hero_web/components/participation_components.ex:519
+#: lib/klass_hero_web/components/participation_components.ex:531
 #, elixir-autogen, elixir-format
 msgid "Session Note"
 msgstr "Sitzungsnotiz"
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:117
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:151
 #, elixir-autogen, elixir-format
 msgid "Session note submitted for review"
 msgstr "Sitzungsnotiz zur Überprüfung eingereicht"
@@ -7688,7 +7693,7 @@ msgstr "Einverständniserklärung hinzugefügt."
 msgid "Waiver retired. Signatures already collected are kept."
 msgstr "Einverständniserklärung zurückgezogen. Bereits erteilte Unterschriften bleiben erhalten."
 
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:205
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:227
 #, elixir-autogen, elixir-format
 msgid "You are not assigned to this session"
 msgstr "Sie sind diesem Termin nicht zugewiesen"
@@ -7916,7 +7921,7 @@ msgstr ""
 "Diese Programme sind beendet. Ihre Termine und Teilnehmerlisten sind nicht "
 "mehr verfügbar."
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:191
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:225
 #, elixir-autogen, elixir-format
 msgid "This program has closed. Its sessions are no longer available."
 msgstr ""
@@ -8004,3 +8009,34 @@ msgstr "Erscheint auf eurer öffentlichen Profilseite."
 #, elixir-autogen, elixir-format
 msgid "Tagline"
 msgstr "Slogan"
+
+#: lib/klass_hero_web/components/participation_components.ex:396
+#, elixir-autogen, elixir-format
+msgid "Absent:"
+msgstr "Abwesend:"
+
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:115
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:115
+#, elixir-autogen, elixir-format
+msgid "Arrived late"
+msgstr "Nachträglich eingetroffen"
+
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:80
+#, elixir-autogen, elixir-format
+msgid "Child marked absent"
+msgstr "Kind als abwesend markiert"
+
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:95
+#, elixir-autogen, elixir-format
+msgid "Failed to mark absent: %{reason}"
+msgstr "Kind konnte nicht als abwesend markiert werden: %{reason}"
+
+#: lib/klass_hero_web/components/participation_components.ex:595
+#, elixir-autogen, elixir-format
+msgid "Reason for absence (optional)"
+msgstr "Grund für die Abwesenheit (optional)"
+
+#: lib/klass_hero_web/components/participation_components.ex:596
+#, elixir-autogen, elixir-format
+msgid "e.g. Mum called — off sick today"
+msgstr "z. B. Mutter hat angerufen — heute krank"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -469,7 +469,7 @@ msgstr ""
 msgid "Child checked in successfully"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:80
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:114
 #, elixir-autogen, elixir-format
 msgid "Child checked out successfully"
 msgstr ""
@@ -613,12 +613,12 @@ msgstr ""
 msgid "Failed to check in: %{reason}"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:95
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:129
 #, elixir-autogen, elixir-format
 msgid "Failed to check out: %{reason}"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:168
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:202
 #: lib/klass_hero_web/live/provider/sessions_live.ex:167
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:117
 #, elixir-autogen, elixir-format
@@ -845,12 +845,13 @@ msgstr ""
 
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:41
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:73
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:105
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:107
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:139
 #: lib/klass_hero_web/live/admin/sessions_live.ex:247
-#: lib/klass_hero_web/live/provider/participation_live.ex:177
-#: lib/klass_hero_web/live/provider/participation_live.ex:223
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:117
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:163
+#: lib/klass_hero_web/live/provider/participation_live.ex:199
+#: lib/klass_hero_web/live/provider/participation_live.ex:245
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:139
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:185
 #, elixir-autogen, elixir-format
 msgid "Record not found"
 msgstr ""
@@ -887,7 +888,7 @@ msgstr ""
 msgid "Send Message"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:156
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:190
 #: lib/klass_hero_web/live/provider/sessions_live.ex:150
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:100
 #, elixir-autogen, elixir-format
@@ -896,8 +897,8 @@ msgstr ""
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:62
 #: lib/klass_hero_web/live/admin/sessions_live.ex:68
-#: lib/klass_hero_web/live/provider/participation_live.ex:293
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:248
+#: lib/klass_hero_web/live/provider/participation_live.ex:315
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:270
 #, elixir-autogen, elixir-format
 msgid "Session not found"
 msgstr ""
@@ -1545,9 +1546,9 @@ msgstr ""
 msgid "Broadcast sent to %{count} parents"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:441
-#: lib/klass_hero_web/components/participation_components.ex:631
-#: lib/klass_hero_web/components/participation_components.ex:717
+#: lib/klass_hero_web/components/participation_components.ex:453
+#: lib/klass_hero_web/components/participation_components.ex:678
+#: lib/klass_hero_web/components/participation_components.ex:769
 #: lib/klass_hero_web/components/provider_components.ex:890
 #: lib/klass_hero_web/components/provider_components.ex:1344
 #: lib/klass_hero_web/components/provider_components.ex:2061
@@ -1639,7 +1640,7 @@ msgstr ""
 msgid "Failed to reject note"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:169
+#: lib/klass_hero_web/live/provider/participation_live.ex:191
 #, elixir-autogen, elixir-format
 msgid "Failed to resubmit note"
 msgstr ""
@@ -1650,7 +1651,7 @@ msgstr ""
 msgid "Failed to send broadcast"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:134
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:168
 #, elixir-autogen, elixir-format
 msgid "Failed to submit note"
 msgstr ""
@@ -1729,8 +1730,8 @@ msgstr ""
 msgid "Note approved"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:123
-#: lib/klass_hero_web/live/provider/participation_live.ex:161
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:157
+#: lib/klass_hero_web/live/provider/participation_live.ex:183
 #, elixir-autogen, elixir-format
 msgid "Note content cannot be blank"
 msgstr ""
@@ -1740,7 +1741,7 @@ msgstr ""
 msgid "Note rejected"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:155
+#: lib/klass_hero_web/live/provider/participation_live.ex:177
 #, elixir-autogen, elixir-format
 msgid "Note resubmitted for review"
 msgstr ""
@@ -1846,8 +1847,8 @@ msgstr ""
 msgid "Type a message..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:313
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:268
+#: lib/klass_hero_web/live/provider/participation_live.ex:335
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:290
 #, elixir-autogen, elixir-format
 msgid "Unable to refresh roster. Please reload."
 msgstr ""
@@ -1858,7 +1859,7 @@ msgstr ""
 msgid "Write your message to all enrolled parents..."
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:126
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:160
 #, elixir-autogen, elixir-format
 msgid "You already submitted a note for this record"
 msgstr ""
@@ -1970,7 +1971,7 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:826
+#: lib/klass_hero_web/components/participation_components.ex:878
 #: lib/klass_hero_web/components/provider_components.ex:49
 #: lib/klass_hero_web/live/admin/sessions_live.ex:290
 #: lib/klass_hero_web/live/admin/verifications_live.ex:202
@@ -2542,7 +2543,7 @@ msgstr ""
 msgid "Participant Restrictions (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:825
+#: lib/klass_hero_web/components/participation_components.ex:877
 #: lib/klass_hero_web/components/provider_components.ex:294
 #, elixir-autogen, elixir-format
 msgid "Pending Review"
@@ -2624,7 +2625,7 @@ msgstr ""
 msgid "Read our founding story →"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:805
+#: lib/klass_hero_web/components/participation_components.ex:857
 #: lib/klass_hero_web/components/provider_components.ex:2981
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
@@ -2692,7 +2693,7 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:827
+#: lib/klass_hero_web/components/participation_components.ex:879
 #: lib/klass_hero_web/components/provider_components.ex:50
 #: lib/klass_hero_web/live/admin/verifications_live.ex:207
 #, elixir-autogen, elixir-format
@@ -3222,7 +3223,7 @@ msgstr ""
 msgid "A reason is required for corrections"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:811
+#: lib/klass_hero_web/components/participation_components.ex:863
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:201
 #, elixir-autogen, elixir-format
 msgid "Absent"
@@ -3352,7 +3353,7 @@ msgstr ""
 msgid "Coming soon! Sign up for our newsletter to be notified when gift vouchers launch."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:808
+#: lib/klass_hero_web/components/participation_components.ex:860
 #, elixir-autogen, elixir-format
 msgid "Completed"
 msgstr ""
@@ -3418,7 +3419,7 @@ msgstr ""
 msgid "How does the booking system work?"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:807
+#: lib/klass_hero_web/components/participation_components.ex:859
 #: lib/klass_hero_web/live/admin/sessions_live.ex:271
 #, elixir-autogen, elixir-format
 msgid "In Progress"
@@ -3471,7 +3472,7 @@ msgstr ""
 msgid "No risk of non-payment"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:830
+#: lib/klass_hero_web/components/participation_components.ex:882
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:155
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:197
 #, elixir-autogen, elixir-format
@@ -3560,7 +3561,7 @@ msgstr ""
 msgid "Save Correction"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:806
+#: lib/klass_hero_web/components/participation_components.ex:858
 #, elixir-autogen, elixir-format
 msgid "Scheduled"
 msgstr ""
@@ -3676,8 +3677,8 @@ msgstr ""
 msgid "Account created! Check your email to confirm and log in."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:126
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:126
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:160
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:160
 #, elixir-autogen, elixir-format
 msgid "Add Note"
 msgstr ""
@@ -3700,7 +3701,7 @@ msgstr ""
 msgid "All providers"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:737
+#: lib/klass_hero_web/components/participation_components.ex:789
 #, elixir-autogen, elixir-format
 msgid "Allergies: %{details}"
 msgstr ""
@@ -3742,8 +3743,8 @@ msgstr ""
 msgid "Broadcast messages are one-way"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:107
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:107
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:128
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "Check In"
 msgstr ""
@@ -3758,7 +3759,7 @@ msgstr ""
 msgid "Check-in:"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:413
+#: lib/klass_hero_web/components/participation_components.ex:425
 #, elixir-autogen, elixir-format
 msgid "Check-out notes (optional)"
 msgstr ""
@@ -3801,7 +3802,7 @@ msgstr ""
 msgid "Complete Session"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:428
+#: lib/klass_hero_web/components/participation_components.ex:440
 #, elixir-autogen, elixir-format
 msgid "Confirm Check Out"
 msgstr ""
@@ -3854,12 +3855,12 @@ msgstr ""
 msgid "Date is required"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:414
+#: lib/klass_hero_web/components/participation_components.ex:426
 #, elixir-autogen, elixir-format
 msgid "E.g., picked up by parent, gave medication reminder..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:155
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Edit & Resubmit"
 msgstr ""
@@ -3887,7 +3888,7 @@ msgstr ""
 msgid "Emails"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:749
+#: lib/klass_hero_web/components/participation_components.ex:801
 #, elixir-autogen, elixir-format
 msgid "Emergency: %{details}"
 msgstr ""
@@ -3897,7 +3898,7 @@ msgstr ""
 msgid "End time must be after start time"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:812
+#: lib/klass_hero_web/components/participation_components.ex:864
 #, elixir-autogen, elixir-format
 msgid "Expected"
 msgstr ""
@@ -4031,7 +4032,7 @@ msgstr ""
 msgid "No actions available"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:458
+#: lib/klass_hero_web/components/participation_components.ex:470
 #, elixir-autogen, elixir-format
 msgid "No children enrolled in this session"
 msgstr ""
@@ -4067,12 +4068,12 @@ msgstr ""
 msgid "No sessions scheduled"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:658
+#: lib/klass_hero_web/components/participation_components.ex:705
 #, elixir-autogen, elixir-format
 msgid "Note:"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:520
+#: lib/klass_hero_web/components/participation_components.ex:532
 #, elixir-autogen, elixir-format
 msgid "Observation about the child's participation..."
 msgstr ""
@@ -4182,7 +4183,7 @@ msgstr ""
 msgid "Reset to today"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:551
+#: lib/klass_hero_web/components/participation_components.ex:563
 #, elixir-autogen, elixir-format
 msgid "Resubmit Note"
 msgstr ""
@@ -4192,7 +4193,7 @@ msgstr ""
 msgid "Retry"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:549
+#: lib/klass_hero_web/components/participation_components.ex:561
 #, elixir-autogen, elixir-format
 msgid "Revised Note"
 msgstr ""
@@ -4247,7 +4248,7 @@ msgstr ""
 msgid "Start Session"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:521
+#: lib/klass_hero_web/components/participation_components.ex:533
 #, elixir-autogen, elixir-format
 msgid "Submit Note"
 msgstr ""
@@ -4257,7 +4258,7 @@ msgstr ""
 msgid "Submit Participation"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:743
+#: lib/klass_hero_web/components/participation_components.ex:795
 #, elixir-autogen, elixir-format
 msgid "Support: %{details}"
 msgstr ""
@@ -4298,7 +4299,7 @@ msgstr ""
 msgid "Type your reply..."
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:193
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:227
 #: lib/klass_hero_web/live/provider/sessions_live.ex:190
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:126
 #, elixir-autogen, elixir-format
@@ -4312,7 +4313,7 @@ msgstr ""
 msgid "Unread"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:550
+#: lib/klass_hero_web/components/participation_components.ex:562
 #, elixir-autogen, elixir-format
 msgid "Update your observation..."
 msgstr ""
@@ -4395,7 +4396,8 @@ msgstr ""
 
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:52
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:86
-#: lib/klass_hero_web/live/provider/participation_live.ex:282
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:120
+#: lib/klass_hero_web/live/provider/participation_live.ex:304
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:53
 #, elixir-autogen, elixir-format
 msgid "You are not assigned to this program"
@@ -4416,7 +4418,7 @@ msgstr ""
 msgid "Built for the Berlin international community. Integrated secure encrypted messaging to connect with local families and trusted educators nearby."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:813
+#: lib/klass_hero_web/components/participation_components.ex:865
 #, elixir-autogen, elixir-format
 msgid "Cancelled"
 msgstr ""
@@ -4613,24 +4615,24 @@ msgstr ""
 msgid "Create a program before inviting participants."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:810
+#: lib/klass_hero_web/components/participation_components.ex:862
 #, elixir-autogen, elixir-format
 msgid "Departed"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:829
+#: lib/klass_hero_web/components/participation_components.ex:881
 #, elixir-autogen, elixir-format
 msgid "Departure notes"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:226
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:166
+#: lib/klass_hero_web/live/provider/participation_live.ex:248
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:188
 #, elixir-autogen, elixir-format
 msgid "Departure time is not a valid date and time"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:237
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:177
+#: lib/klass_hero_web/live/provider/participation_live.ex:259
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:199
 #, elixir-autogen, elixir-format
 msgid "Failed to update record"
 msgstr ""
@@ -4655,7 +4657,7 @@ msgstr ""
 msgid "Invite sent."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:604
+#: lib/klass_hero_web/components/participation_components.ex:651
 #, elixir-autogen, elixir-format
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
@@ -4670,8 +4672,8 @@ msgstr ""
 msgid "Medical conditions"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:229
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:169
+#: lib/klass_hero_web/live/provider/participation_live.ex:251
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:191
 #, elixir-autogen, elixir-format
 msgid "Nothing to update"
 msgstr ""
@@ -4691,7 +4693,7 @@ msgstr ""
 msgid "Photos may appear on social media"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:809
+#: lib/klass_hero_web/components/participation_components.ex:861
 #, elixir-autogen, elixir-format
 msgid "Present"
 msgstr ""
@@ -4707,18 +4709,18 @@ msgstr ""
 msgid "Record departure"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:601
+#: lib/klass_hero_web/components/participation_components.ex:648
 #, elixir-autogen, elixir-format
 msgid "Record departure time (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:217
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:157
+#: lib/klass_hero_web/live/provider/participation_live.ex:239
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "Record updated"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:618
+#: lib/klass_hero_web/components/participation_components.ex:665
 #, elixir-autogen, elixir-format
 msgid "Save changes"
 msgstr ""
@@ -4743,7 +4745,7 @@ msgstr ""
 msgid "Send invite"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:593
+#: lib/klass_hero_web/components/participation_components.ex:640
 #, elixir-autogen, elixir-format
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr ""
@@ -5692,7 +5694,10 @@ msgstr ""
 msgid "Mandatory child-protection course before going live."
 msgstr ""
 
+#: lib/klass_hero_web/components/participation_components.ex:597
 #: lib/klass_hero_web/components/provider_layout_components.ex:578
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:141
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:141
 #, elixir-autogen, elixir-format
 msgid "Mark absent"
 msgstr ""
@@ -7160,12 +7165,12 @@ msgstr ""
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:519
+#: lib/klass_hero_web/components/participation_components.ex:531
 #, elixir-autogen, elixir-format
 msgid "Session Note"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:117
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:151
 #, elixir-autogen, elixir-format
 msgid "Session note submitted for review"
 msgstr ""
@@ -7673,7 +7678,7 @@ msgstr ""
 msgid "Waiver retired. Signatures already collected are kept."
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:205
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:227
 #, elixir-autogen, elixir-format
 msgid "You are not assigned to this session"
 msgstr ""
@@ -7899,7 +7904,7 @@ msgstr ""
 msgid "These programs have finished. Their sessions and rosters are no longer available."
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:191
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:225
 #, elixir-autogen, elixir-format
 msgid "This program has closed. Its sessions are no longer available."
 msgstr ""
@@ -7985,4 +7990,35 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:397
 #, elixir-autogen, elixir-format
 msgid "Tagline"
+msgstr ""
+
+#: lib/klass_hero_web/components/participation_components.ex:396
+#, elixir-autogen, elixir-format
+msgid "Absent:"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:115
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:115
+#, elixir-autogen, elixir-format
+msgid "Arrived late"
+msgstr ""
+
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:80
+#, elixir-autogen, elixir-format
+msgid "Child marked absent"
+msgstr ""
+
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:95
+#, elixir-autogen, elixir-format
+msgid "Failed to mark absent: %{reason}"
+msgstr ""
+
+#: lib/klass_hero_web/components/participation_components.ex:595
+#, elixir-autogen, elixir-format
+msgid "Reason for absence (optional)"
+msgstr ""
+
+#: lib/klass_hero_web/components/participation_components.ex:596
+#, elixir-autogen, elixir-format
+msgid "e.g. Mum called — off sick today"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -469,7 +469,7 @@ msgstr ""
 msgid "Child checked in successfully"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:80
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:114
 #, elixir-autogen, elixir-format
 msgid "Child checked out successfully"
 msgstr ""
@@ -613,12 +613,12 @@ msgstr ""
 msgid "Failed to check in: %{reason}"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:95
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:129
 #, elixir-autogen, elixir-format
 msgid "Failed to check out: %{reason}"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:168
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:202
 #: lib/klass_hero_web/live/provider/sessions_live.ex:167
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:117
 #, elixir-autogen, elixir-format
@@ -845,12 +845,13 @@ msgstr ""
 
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:41
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:73
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:105
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:107
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:139
 #: lib/klass_hero_web/live/admin/sessions_live.ex:247
-#: lib/klass_hero_web/live/provider/participation_live.ex:177
-#: lib/klass_hero_web/live/provider/participation_live.ex:223
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:117
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:163
+#: lib/klass_hero_web/live/provider/participation_live.ex:199
+#: lib/klass_hero_web/live/provider/participation_live.ex:245
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:139
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:185
 #, elixir-autogen, elixir-format
 msgid "Record not found"
 msgstr ""
@@ -887,7 +888,7 @@ msgstr ""
 msgid "Send Message"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:156
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:190
 #: lib/klass_hero_web/live/provider/sessions_live.ex:150
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:100
 #, elixir-autogen, elixir-format
@@ -896,8 +897,8 @@ msgstr ""
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:62
 #: lib/klass_hero_web/live/admin/sessions_live.ex:68
-#: lib/klass_hero_web/live/provider/participation_live.ex:293
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:248
+#: lib/klass_hero_web/live/provider/participation_live.ex:315
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:270
 #, elixir-autogen, elixir-format
 msgid "Session not found"
 msgstr ""
@@ -1545,9 +1546,9 @@ msgstr ""
 msgid "Broadcast sent to %{count} parents"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:441
-#: lib/klass_hero_web/components/participation_components.ex:631
-#: lib/klass_hero_web/components/participation_components.ex:717
+#: lib/klass_hero_web/components/participation_components.ex:453
+#: lib/klass_hero_web/components/participation_components.ex:678
+#: lib/klass_hero_web/components/participation_components.ex:769
 #: lib/klass_hero_web/components/provider_components.ex:890
 #: lib/klass_hero_web/components/provider_components.ex:1344
 #: lib/klass_hero_web/components/provider_components.ex:2061
@@ -1639,7 +1640,7 @@ msgstr ""
 msgid "Failed to reject note"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:169
+#: lib/klass_hero_web/live/provider/participation_live.ex:191
 #, elixir-autogen, elixir-format
 msgid "Failed to resubmit note"
 msgstr ""
@@ -1650,7 +1651,7 @@ msgstr ""
 msgid "Failed to send broadcast"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:134
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:168
 #, elixir-autogen, elixir-format
 msgid "Failed to submit note"
 msgstr ""
@@ -1729,8 +1730,8 @@ msgstr ""
 msgid "Note approved"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:123
-#: lib/klass_hero_web/live/provider/participation_live.ex:161
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:157
+#: lib/klass_hero_web/live/provider/participation_live.ex:183
 #, elixir-autogen, elixir-format
 msgid "Note content cannot be blank"
 msgstr ""
@@ -1740,7 +1741,7 @@ msgstr ""
 msgid "Note rejected"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:155
+#: lib/klass_hero_web/live/provider/participation_live.ex:177
 #, elixir-autogen, elixir-format
 msgid "Note resubmitted for review"
 msgstr ""
@@ -1846,8 +1847,8 @@ msgstr ""
 msgid "Type a message..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:313
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:268
+#: lib/klass_hero_web/live/provider/participation_live.ex:335
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:290
 #, elixir-autogen, elixir-format
 msgid "Unable to refresh roster. Please reload."
 msgstr ""
@@ -1858,7 +1859,7 @@ msgstr ""
 msgid "Write your message to all enrolled parents..."
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:126
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:160
 #, elixir-autogen, elixir-format
 msgid "You already submitted a note for this record"
 msgstr ""
@@ -1970,7 +1971,7 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:826
+#: lib/klass_hero_web/components/participation_components.ex:878
 #: lib/klass_hero_web/components/provider_components.ex:49
 #: lib/klass_hero_web/live/admin/sessions_live.ex:290
 #: lib/klass_hero_web/live/admin/verifications_live.ex:202
@@ -2542,7 +2543,7 @@ msgstr ""
 msgid "Participant Restrictions (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:825
+#: lib/klass_hero_web/components/participation_components.ex:877
 #: lib/klass_hero_web/components/provider_components.ex:294
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Pending Review"
@@ -2624,7 +2625,7 @@ msgstr ""
 msgid "Read our founding story →"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:805
+#: lib/klass_hero_web/components/participation_components.ex:857
 #: lib/klass_hero_web/components/provider_components.ex:2981
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format, fuzzy
@@ -2692,7 +2693,7 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:827
+#: lib/klass_hero_web/components/participation_components.ex:879
 #: lib/klass_hero_web/components/provider_components.ex:50
 #: lib/klass_hero_web/live/admin/verifications_live.ex:207
 #, elixir-autogen, elixir-format
@@ -3222,7 +3223,7 @@ msgstr ""
 msgid "A reason is required for corrections"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:811
+#: lib/klass_hero_web/components/participation_components.ex:863
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:201
 #, elixir-autogen, elixir-format
 msgid "Absent"
@@ -3352,7 +3353,7 @@ msgstr ""
 msgid "Coming soon! Sign up for our newsletter to be notified when gift vouchers launch."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:808
+#: lib/klass_hero_web/components/participation_components.ex:860
 #, elixir-autogen, elixir-format
 msgid "Completed"
 msgstr ""
@@ -3418,7 +3419,7 @@ msgstr ""
 msgid "How does the booking system work?"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:807
+#: lib/klass_hero_web/components/participation_components.ex:859
 #: lib/klass_hero_web/live/admin/sessions_live.ex:271
 #, elixir-autogen, elixir-format, fuzzy
 msgid "In Progress"
@@ -3471,7 +3472,7 @@ msgstr ""
 msgid "No risk of non-payment"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:830
+#: lib/klass_hero_web/components/participation_components.ex:882
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:155
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:197
 #, elixir-autogen, elixir-format
@@ -3560,7 +3561,7 @@ msgstr ""
 msgid "Save Correction"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:806
+#: lib/klass_hero_web/components/participation_components.ex:858
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Scheduled"
 msgstr ""
@@ -3676,8 +3677,8 @@ msgstr ""
 msgid "Account created! Check your email to confirm and log in."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:126
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:126
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:160
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:160
 #, elixir-autogen, elixir-format
 msgid "Add Note"
 msgstr ""
@@ -3700,7 +3701,7 @@ msgstr ""
 msgid "All providers"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:737
+#: lib/klass_hero_web/components/participation_components.ex:789
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Allergies: %{details}"
 msgstr ""
@@ -3742,8 +3743,8 @@ msgstr ""
 msgid "Broadcast messages are one-way"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:107
-#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:107
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:128
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:128
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Check In"
 msgstr ""
@@ -3758,7 +3759,7 @@ msgstr ""
 msgid "Check-in:"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:413
+#: lib/klass_hero_web/components/participation_components.ex:425
 #, elixir-autogen, elixir-format
 msgid "Check-out notes (optional)"
 msgstr ""
@@ -3801,7 +3802,7 @@ msgstr ""
 msgid "Complete Session"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:428
+#: lib/klass_hero_web/components/participation_components.ex:440
 #, elixir-autogen, elixir-format
 msgid "Confirm Check Out"
 msgstr ""
@@ -3854,12 +3855,12 @@ msgstr ""
 msgid "Date is required"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:414
+#: lib/klass_hero_web/components/participation_components.ex:426
 #, elixir-autogen, elixir-format
 msgid "E.g., picked up by parent, gave medication reminder..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:155
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:189
 #, elixir-autogen, elixir-format
 msgid "Edit & Resubmit"
 msgstr ""
@@ -3887,7 +3888,7 @@ msgstr ""
 msgid "Emails"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:749
+#: lib/klass_hero_web/components/participation_components.ex:801
 #, elixir-autogen, elixir-format
 msgid "Emergency: %{details}"
 msgstr ""
@@ -3897,7 +3898,7 @@ msgstr ""
 msgid "End time must be after start time"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:812
+#: lib/klass_hero_web/components/participation_components.ex:864
 #, elixir-autogen, elixir-format
 msgid "Expected"
 msgstr ""
@@ -4031,7 +4032,7 @@ msgstr ""
 msgid "No actions available"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:458
+#: lib/klass_hero_web/components/participation_components.ex:470
 #, elixir-autogen, elixir-format
 msgid "No children enrolled in this session"
 msgstr ""
@@ -4067,12 +4068,12 @@ msgstr ""
 msgid "No sessions scheduled"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:658
+#: lib/klass_hero_web/components/participation_components.ex:705
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Note:"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:520
+#: lib/klass_hero_web/components/participation_components.ex:532
 #, elixir-autogen, elixir-format
 msgid "Observation about the child's participation..."
 msgstr ""
@@ -4182,7 +4183,7 @@ msgstr ""
 msgid "Reset to today"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:551
+#: lib/klass_hero_web/components/participation_components.ex:563
 #, elixir-autogen, elixir-format
 msgid "Resubmit Note"
 msgstr ""
@@ -4192,7 +4193,7 @@ msgstr ""
 msgid "Retry"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:549
+#: lib/klass_hero_web/components/participation_components.ex:561
 #, elixir-autogen, elixir-format
 msgid "Revised Note"
 msgstr ""
@@ -4247,7 +4248,7 @@ msgstr ""
 msgid "Start Session"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:521
+#: lib/klass_hero_web/components/participation_components.ex:533
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Submit Note"
 msgstr ""
@@ -4257,7 +4258,7 @@ msgstr ""
 msgid "Submit Participation"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:743
+#: lib/klass_hero_web/components/participation_components.ex:795
 #, elixir-autogen, elixir-format
 msgid "Support: %{details}"
 msgstr ""
@@ -4298,7 +4299,7 @@ msgstr ""
 msgid "Type your reply..."
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:193
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:227
 #: lib/klass_hero_web/live/provider/sessions_live.ex:190
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:126
 #, elixir-autogen, elixir-format
@@ -4312,7 +4313,7 @@ msgstr ""
 msgid "Unread"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:550
+#: lib/klass_hero_web/components/participation_components.ex:562
 #, elixir-autogen, elixir-format
 msgid "Update your observation..."
 msgstr ""
@@ -4395,7 +4396,8 @@ msgstr ""
 
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:52
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:86
-#: lib/klass_hero_web/live/provider/participation_live.ex:282
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:120
+#: lib/klass_hero_web/live/provider/participation_live.ex:304
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:53
 #, elixir-autogen, elixir-format
 msgid "You are not assigned to this program"
@@ -4416,7 +4418,7 @@ msgstr ""
 msgid "Built for the Berlin international community. Integrated secure encrypted messaging to connect with local families and trusted educators nearby."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:813
+#: lib/klass_hero_web/components/participation_components.ex:865
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cancelled"
 msgstr ""
@@ -4613,24 +4615,24 @@ msgstr ""
 msgid "Create a program before inviting participants."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:810
+#: lib/klass_hero_web/components/participation_components.ex:862
 #, elixir-autogen, elixir-format
 msgid "Departed"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:829
+#: lib/klass_hero_web/components/participation_components.ex:881
 #, elixir-autogen, elixir-format
 msgid "Departure notes"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:226
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:166
+#: lib/klass_hero_web/live/provider/participation_live.ex:248
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:188
 #, elixir-autogen, elixir-format
 msgid "Departure time is not a valid date and time"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:237
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:177
+#: lib/klass_hero_web/live/provider/participation_live.ex:259
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:199
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to update record"
 msgstr ""
@@ -4655,7 +4657,7 @@ msgstr ""
 msgid "Invite sent."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:604
+#: lib/klass_hero_web/components/participation_components.ex:651
 #, elixir-autogen, elixir-format
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
@@ -4670,8 +4672,8 @@ msgstr ""
 msgid "Medical conditions"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:229
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:169
+#: lib/klass_hero_web/live/provider/participation_live.ex:251
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:191
 #, elixir-autogen, elixir-format
 msgid "Nothing to update"
 msgstr ""
@@ -4691,7 +4693,7 @@ msgstr ""
 msgid "Photos may appear on social media"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:809
+#: lib/klass_hero_web/components/participation_components.ex:861
 #, elixir-autogen, elixir-format
 msgid "Present"
 msgstr ""
@@ -4707,18 +4709,18 @@ msgstr ""
 msgid "Record departure"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:601
+#: lib/klass_hero_web/components/participation_components.ex:648
 #, elixir-autogen, elixir-format
 msgid "Record departure time (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:217
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:157
+#: lib/klass_hero_web/live/provider/participation_live.ex:239
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "Record updated"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:618
+#: lib/klass_hero_web/components/participation_components.ex:665
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Save changes"
 msgstr ""
@@ -4743,7 +4745,7 @@ msgstr ""
 msgid "Send invite"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:593
+#: lib/klass_hero_web/components/participation_components.ex:640
 #, elixir-autogen, elixir-format
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr ""
@@ -5692,7 +5694,10 @@ msgstr ""
 msgid "Mandatory child-protection course before going live."
 msgstr ""
 
+#: lib/klass_hero_web/components/participation_components.ex:597
 #: lib/klass_hero_web/components/provider_layout_components.ex:578
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:141
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:141
 #, elixir-autogen, elixir-format
 msgid "Mark absent"
 msgstr ""
@@ -7160,12 +7165,12 @@ msgstr ""
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:519
+#: lib/klass_hero_web/components/participation_components.ex:531
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Session Note"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:117
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:151
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Session note submitted for review"
 msgstr ""
@@ -7673,7 +7678,7 @@ msgstr ""
 msgid "Waiver retired. Signatures already collected are kept."
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_participation_live.ex:205
+#: lib/klass_hero_web/live/staff/staff_participation_live.ex:227
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You are not assigned to this session"
 msgstr ""
@@ -7899,7 +7904,7 @@ msgstr ""
 msgid "These programs have finished. Their sessions and rosters are no longer available."
 msgstr ""
 
-#: lib/klass_hero_web/helpers/participation_live_handlers.ex:191
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:225
 #, elixir-autogen, elixir-format
 msgid "This program has closed. Its sessions are no longer available."
 msgstr ""
@@ -7985,4 +7990,35 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:397
 #, elixir-autogen, elixir-format
 msgid "Tagline"
+msgstr ""
+
+#: lib/klass_hero_web/components/participation_components.ex:396
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Absent:"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:115
+#: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:115
+#, elixir-autogen, elixir-format
+msgid "Arrived late"
+msgstr ""
+
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:80
+#, elixir-autogen, elixir-format
+msgid "Child marked absent"
+msgstr ""
+
+#: lib/klass_hero_web/helpers/participation_live_handlers.ex:95
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Failed to mark absent: %{reason}"
+msgstr ""
+
+#: lib/klass_hero_web/components/participation_components.ex:595
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Reason for absence (optional)"
+msgstr ""
+
+#: lib/klass_hero_web/components/participation_components.ex:596
+#, elixir-autogen, elixir-format
+msgid "e.g. Mum called — off sick today"
 msgstr ""

--- a/priv/repo/migrations/20260823161000_create_attendance_transitions.exs
+++ b/priv/repo/migrations/20260823161000_create_attendance_transitions.exs
@@ -1,0 +1,37 @@
+defmodule KlassHero.Repo.Migrations.CreateAttendanceTransitions do
+  use Ecto.Migration
+
+  # A sidecar to `participation_records`, not a replacement: `status` on the
+  # record stays authoritative, and this table answers what the record cannot —
+  # who changed it, when, and why (#1329). Every attendance verb appends here.
+  #
+  # No backfill. Rows before this migration have no recorded history, and an
+  # empty log for an old record is honest; a synthesised one would not be.
+  def change do
+    create table(:attendance_transitions, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+
+      # Cascaded, unlike `actor_id` below: a transition whose record is gone
+      # describes nothing, and nothing can join back to it.
+      add :record_id,
+          references(:participation_records, type: :binary_id, on_delete: :delete_all),
+          null: false
+
+      add :from_status, :string, null: false
+      add :to_status, :string, null: false
+
+      # Nilified rather than cascaded — the transition outlives the account that
+      # made it. NULL also carries meaning: no human did this, i.e. the batch
+      # absence that session completion applies to every still-registered child.
+      add :actor_id, references(:users, type: :binary_id, on_delete: :nilify_all)
+
+      add :reason, :text
+      add :occurred_at, :utc_datetime, null: false
+
+      timestamps(type: :utc_datetime)
+    end
+
+    # Serves the only read this table has: the latest transition per record.
+    create index(:attendance_transitions, [:record_id, :occurred_at])
+  end
+end

--- a/test/klass_hero/participation/complete_session_test.exs
+++ b/test/klass_hero/participation/complete_session_test.exs
@@ -7,6 +7,7 @@ defmodule KlassHero.Participation.CompleteSessionTest do
 
   use KlassHero.DataCase, async: true
 
+  import KlassHero.AttendanceLogHelper
   import KlassHero.Factory
 
   alias KlassHero.Accounts.Scope
@@ -83,6 +84,48 @@ defmodule KlassHero.Participation.CompleteSessionTest do
 
       reloaded = KlassHero.Repo.get(ParticipationRecord, record.id)
       assert reloaded.status == :absent
+    end
+
+    # A log that skipped the batch would have a hole exactly where most absences
+    # are. The NULL actor and reason are what distinguish this from a provider
+    # deliberately marking one child absent (#1329).
+    test "logs each swept absence with no actor and no reason" do
+      session_schema = insert(:program_session_schema, status: :in_progress)
+
+      records =
+        for _ <- 1..2 do
+          insert(:participation_record_schema,
+            session_id: session_schema.id,
+            child_id: insert(:child_schema).id,
+            status: :registered
+          )
+        end
+
+      assert {:ok, _} = Participation.complete_session(admin_scope(), session_schema.id)
+
+      for record <- records do
+        assert transition = only_transition(record.id)
+        assert transition.from_status == :registered
+        assert transition.to_status == :absent
+        assert transition.actor_id == nil
+        assert transition.reason == nil
+      end
+    end
+
+    test "logs nothing for children who were already checked in" do
+      session_schema = insert(:program_session_schema, status: :in_progress)
+
+      record =
+        insert(:participation_record_schema,
+          session_id: session_schema.id,
+          child_id: insert(:child_schema).id,
+          status: :checked_in,
+          check_in_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        )
+
+      assert {:ok, _} = Participation.complete_session(admin_scope(), session_schema.id)
+
+      assert only_transition(record.id) == nil
     end
 
     test "leaves checked_in and checked_out participants unchanged when completing" do

--- a/test/klass_hero/participation/correct_attendance_test.exs
+++ b/test/klass_hero/participation/correct_attendance_test.exs
@@ -1,6 +1,7 @@
 defmodule KlassHero.Participation.CorrectAttendanceTest do
   use KlassHero.DataCase, async: true
 
+  import KlassHero.AttendanceLogHelper
   import KlassHero.Factory
 
   alias KlassHero.Accounts.Scope
@@ -296,6 +297,57 @@ defmodule KlassHero.Participation.CorrectAttendanceTest do
       assert event.payload.previous_status == :checked_in
       assert event.payload.new_status == :absent
       assert event.payload.program_id
+    end
+  end
+
+  # Corrections are the one attendance write that does not ride
+  # `run_attendance_action/5`, so their logging is wired separately and needs
+  # its own proof (#1329).
+  describe "correct_attendance/3 attendance log" do
+    setup do
+      user = AccountsFixtures.unconfirmed_user_fixture()
+      provider = ProviderFixtures.provider_profile_fixture()
+      program = insert(:program_schema, provider_id: provider.id)
+      session = insert(:program_session_schema, program_id: program.id, status: "in_progress")
+      {child, parent} = insert_child_with_guardian()
+
+      record =
+        insert(:participation_record_schema,
+          session_id: session.id,
+          child_id: child.id,
+          parent_id: parent.id,
+          status: :checked_in,
+          check_in_at: ~U[2026-03-13 09:00:00Z],
+          check_in_by: user.id
+        )
+
+      %{record: record, scope: %Scope{user: user, provider: provider}}
+    end
+
+    test "logs the correction with its direction, actor and reason", %{record: record, scope: scope} do
+      assert {:ok, _} =
+               Participation.correct_attendance(scope, record.id, %{status: :absent, reason: "Wrong child"})
+
+      assert transition = only_transition(record.id)
+      assert transition.from_status == :checked_in
+      assert transition.to_status == :absent
+      assert transition.actor_id == scope.user.id
+      assert transition.reason == "Wrong child"
+    end
+
+    # The case that caught a bug in this design: `occurred_at` is when the
+    # correction was made, not the arrival time the correction asserts. Deriving
+    # it from `check_in_at` would date this transition to 2026 and scramble the
+    # ordering of everything after it.
+    test "dates the transition to now, not to the corrected arrival time", %{record: record, scope: scope} do
+      backdated = ~U[2026-03-13 07:30:00Z]
+
+      assert {:ok, _} =
+               Participation.correct_attendance(scope, record.id, %{check_in_at: backdated, reason: "Clock wrong"})
+
+      assert transition = only_transition(record.id)
+      refute transition.occurred_at == backdated
+      assert DateTime.diff(DateTime.utc_now(), transition.occurred_at) <= 5
     end
   end
 end

--- a/test/klass_hero/participation/get_session_with_roster_test.exs
+++ b/test/klass_hero/participation/get_session_with_roster_test.exs
@@ -9,6 +9,7 @@ defmodule KlassHero.Participation.GetSessionWithRosterTest do
 
   import KlassHero.Factory
 
+  alias KlassHero.Participation
   alias KlassHero.Participation.ParticipationRecord
   alias KlassHero.Participation.ProgramSession
 
@@ -370,6 +371,56 @@ defmodule KlassHero.Participation.GetSessionWithRosterTest do
 
   # A guardian-linked child with an active provider_data_sharing consent.
   # child_attrs (allergies:, support_needs:, emergency_contact:, …) flow to the child.
+  # The roster is the only surface that reads the transition log (#1329), so the
+  # join that finds each absent child's reason is proven here.
+  describe "absence reasons in roster" do
+    setup do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+      session = insert(:program_session_schema, program_id: program.id, status: :in_progress)
+
+      record =
+        insert(:participation_record_schema,
+          session_id: session.id,
+          child_id: insert(:child_schema).id,
+          status: :registered
+        )
+
+      %{session: session, record: record, scope: KlassHero.AccountsFixtures.admin_scope_fixture()}
+    end
+
+    test "an absent child carries the reason given", ctx do
+      {:ok, _} = Participation.record_absence(ctx.scope, ctx.record.id, reason: "Mum called, sick")
+
+      assert {:ok, %{roster: roster}} = Participation.get_session_with_roster(ctx.session.id)
+      assert [%{absence_reason: "Mum called, sick"}] = roster
+    end
+
+    test "a child who never went absent carries no reason", ctx do
+      assert {:ok, %{roster: [entry]}} = Participation.get_session_with_roster(ctx.session.id)
+      assert entry.absence_reason == nil
+    end
+
+    # The reason must not outlive the absence it explains: once the child is
+    # checked in, the row is no longer absent and the roster stops citing it.
+    test "a late arrival stops showing the reason", ctx do
+      {:ok, _} = Participation.record_absence(ctx.scope, ctx.record.id, reason: "No-show")
+      {:ok, _} = Participation.record_check_in(ctx.scope, ctx.record.id)
+
+      assert {:ok, %{roster: [entry]}} = Participation.get_session_with_roster(ctx.session.id)
+      assert entry.absence_reason == nil
+    end
+
+    test "the enriched roster carries it too", ctx do
+      {:ok, _} = Participation.record_absence(ctx.scope, ctx.record.id, reason: "Family holiday")
+
+      assert {:ok, %{participation_records: [entry]}} =
+               Participation.get_session_with_roster_enriched(ctx.session.id)
+
+      assert entry.absence_reason == "Family holiday"
+    end
+  end
+
   defp consented_child(child_attrs \\ []) do
     parent = insert(:parent_profile_schema)
     {child, _parent} = insert_child_with_guardian(Keyword.put(child_attrs, :parent, parent))

--- a/test/klass_hero/participation/participation_record_test.exs
+++ b/test/klass_hero/participation/participation_record_test.exs
@@ -95,28 +95,27 @@ defmodule KlassHero.Participation.ParticipationRecordTest do
       assert checked_in.check_in_notes == nil
     end
 
-    test "returns error when checking in already checked-in record" do
-      record = build(:participation_record, status: :checked_in)
-      provider_id = Ecto.UUID.generate()
-
-      assert {:error, :invalid_status_transition} =
-               ParticipationRecord.check_in(record, provider_id)
-    end
-
-    test "returns error when checking in checked-out record" do
-      record = build(:participation_record, status: :checked_out)
-      provider_id = Ecto.UUID.generate()
-
-      assert {:error, :invalid_status_transition} =
-               ParticipationRecord.check_in(record, provider_id)
-    end
-
-    test "returns error when checking in absent record" do
+    # Reversed by #1329. An absent child who turns up late used to have no path
+    # back but an admin correction; now the roster's own button works.
+    test "checks in an absent record — the child arrived late" do
       record = build(:participation_record, status: :absent)
       provider_id = Ecto.UUID.generate()
 
-      assert {:error, :invalid_status_transition} =
-               ParticipationRecord.check_in(record, provider_id)
+      assert {:ok, checked_in} = ParticipationRecord.check_in(record, provider_id, "Arrived 09:20")
+
+      assert checked_in.status == :checked_in
+      assert checked_in.check_in_by == provider_id
+      assert %DateTime{} = checked_in.check_in_at
+    end
+
+    test "returns error when the child has already arrived" do
+      for status <- [:checked_in, :checked_out] do
+        record = build(:participation_record, status: status)
+
+        assert {:error, :invalid_status_transition} =
+                 ParticipationRecord.check_in(record, Ecto.UUID.generate()),
+               "a #{status} child should not be checkable in again"
+      end
     end
   end
 
@@ -188,22 +187,35 @@ defmodule KlassHero.Participation.ParticipationRecordTest do
       assert absent.status == :absent
     end
 
-    test "returns error when marking :checked_in as absent" do
-      record = build(:participation_record, status: :checked_in)
+    test "returns error from any status but :registered" do
+      for status <- [:checked_in, :checked_out, :absent] do
+        record = build(:participation_record, status: status)
 
-      assert {:error, :invalid_status_transition} = ParticipationRecord.mark_absent(record)
+        assert {:error, :invalid_status_transition} = ParticipationRecord.mark_absent(record),
+               "a #{status} child should not be markable absent"
+      end
     end
+  end
 
-    test "returns error when marking :checked_out as absent" do
-      record = build(:participation_record, status: :checked_out)
+  describe "mark_absent/3" do
+    # The extra arguments exist only so the verb fits the shared attendance path;
+    # neither is stored on the record. This pins that they are truly ignored,
+    # rather than silently landing in a field.
+    test "ignores the actor and reason, and gates exactly as mark_absent/1 does" do
+      registered = build(:participation_record, status: :registered)
 
-      assert {:error, :invalid_status_transition} = ParticipationRecord.mark_absent(record)
-    end
+      assert {:ok, absent} =
+               ParticipationRecord.mark_absent(registered, Ecto.UUID.generate(), "Mum called")
 
-    test "returns error when marking :absent as absent" do
-      record = build(:participation_record, status: :absent)
+      assert absent.status == :absent
+      assert Map.delete(absent, :status) == Map.delete(registered, :status)
 
-      assert {:error, :invalid_status_transition} = ParticipationRecord.mark_absent(record)
+      assert {:error, :invalid_status_transition} =
+               ParticipationRecord.mark_absent(
+                 build(:participation_record, status: :checked_in),
+                 Ecto.UUID.generate(),
+                 "Mum called"
+               )
     end
   end
 

--- a/test/klass_hero/participation/record_absence_test.exs
+++ b/test/klass_hero/participation/record_absence_test.exs
@@ -1,0 +1,135 @@
+defmodule KlassHero.Participation.RecordAbsenceTest do
+  @moduledoc """
+  Marking one child absent by hand, with a reason (#1329).
+
+  The batch path (`complete_session`) absents every straggler at once and records
+  no reason and no actor; this is the deliberate, per-child counterpart, and the
+  transition row is where the two are told apart.
+  """
+
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.AttendanceLogHelper
+  import KlassHero.Factory
+
+  alias KlassHero.Accounts.Scope
+  alias KlassHero.AccountsFixtures
+  alias KlassHero.Participation
+  alias KlassHero.Participation.AttendanceTransition
+  alias KlassHero.Participation.ParticipationRecord
+  alias KlassHero.Provider
+  alias KlassHero.ProviderFixtures
+
+  describe "record_absence/3" do
+    test "marks a registered child absent" do
+      %{record: record} = registered_record()
+      scope = AccountsFixtures.admin_scope_fixture()
+
+      assert {:ok, absent} = Participation.record_absence(scope, record.id, reason: "Mum called, sick")
+
+      assert %ParticipationRecord{} = absent
+      assert absent.status == :absent
+      assert Repo.get!(ParticipationRecord, record.id).status == :absent
+    end
+
+    test "records who marked the child absent, and why" do
+      %{record: record} = registered_record()
+      scope = AccountsFixtures.admin_scope_fixture()
+
+      {:ok, _} = Participation.record_absence(scope, record.id, reason: "Mum called, sick")
+
+      assert %AttendanceTransition{} = transition = only_transition(record.id)
+      assert transition.from_status == :registered
+      assert transition.to_status == :absent
+      assert transition.actor_id == scope.user.id
+      assert transition.reason == "Mum called, sick"
+    end
+
+    test "a reason is optional, and blank is the same as none" do
+      for reason <- [nil, "", "   "] do
+        %{record: record} = registered_record()
+        scope = AccountsFixtures.admin_scope_fixture()
+
+        assert {:ok, _} = Participation.record_absence(scope, record.id, reason: reason)
+
+        assert only_transition(record.id).reason == nil,
+               "a #{inspect(reason)} reason should be stored as nil"
+      end
+    end
+
+    # Absence stays forward-only from `registered`, exactly as before this feature.
+    # A provider undoing a check-in goes through `correct_attendance/3`.
+    test "refuses a child who is already checked in or out" do
+      for status <- [:checked_in, :checked_out] do
+        %{record: record} = registered_record(status: status)
+        scope = AccountsFixtures.admin_scope_fixture()
+
+        assert {:error, :invalid_status_transition} =
+                 Participation.record_absence(scope, record.id, reason: "too late"),
+               "a #{status} child should not be markable absent"
+
+        assert only_transition(record.id) == nil, "a refused write should log nothing"
+      end
+    end
+
+    test "returns not_found for an unknown record" do
+      scope = AccountsFixtures.admin_scope_fixture()
+
+      assert {:error, :not_found} = Participation.record_absence(scope, Ecto.UUID.generate())
+    end
+  end
+
+  # Mirrors `record_check_in_test.exs`: the write path is the authorization of
+  # record (ADR-0017), so a staff member's reach is proven here, not only at the
+  # LiveView gate that renders the roster.
+  describe "record_absence/3 staff authorization at session grain" do
+    test "a staff member on the session but not the program can mark a child absent" do
+      %{provider: provider, session: session, record: record} = registered_record()
+      staff = ProviderFixtures.staff_member_fixture(%{provider_id: provider.id})
+      user = AccountsFixtures.user_fixture()
+
+      assert {:ok, _} =
+               Provider.assign_staff_to_session(%{
+                 provider_id: provider.id,
+                 session_id: session.id,
+                 staff_member_id: staff.id
+               })
+
+      assert {:ok, absent} =
+               Participation.record_absence(
+                 %Scope{user: user, staff_member: staff},
+                 record.id,
+                 reason: "No-show"
+               )
+
+      assert absent.status == :absent
+      assert only_transition(record.id).actor_id == user.id
+    end
+
+    test "a stranger is refused" do
+      %{record: record} = registered_record()
+      user = AccountsFixtures.user_fixture()
+
+      assert {:error, :unauthorized} =
+               Participation.record_absence(%Scope{user: user}, record.id, reason: "No-show")
+
+      assert only_transition(record.id) == nil
+    end
+  end
+
+  defp registered_record(opts \\ []) do
+    provider = insert(:provider_profile_schema)
+    program = insert(:program_schema, provider_id: provider.id)
+    session = insert(:program_session_schema, program_id: program.id, status: :in_progress)
+    child = insert(:child_schema)
+
+    record =
+      insert(:participation_record_schema,
+        session_id: session.id,
+        child_id: child.id,
+        status: Keyword.get(opts, :status, :registered)
+      )
+
+    %{provider: provider, program: program, session: session, record: record}
+  end
+end

--- a/test/klass_hero/participation/record_check_in_test.exs
+++ b/test/klass_hero/participation/record_check_in_test.exs
@@ -7,6 +7,7 @@ defmodule KlassHero.Participation.RecordCheckInTest do
 
   use KlassHero.DataCase, async: true
 
+  import KlassHero.AttendanceLogHelper
   import KlassHero.Factory
 
   alias KlassHero.Accounts.Scope
@@ -174,6 +175,50 @@ defmodule KlassHero.Participation.RecordCheckInTest do
                  record.id,
                  notes: nil
                )
+    end
+  end
+
+  # The log is only worth having if every verb writes to it (#1329). Asserting it
+  # here, in the same shape as `record_absence_test.exs`, is what catches a later
+  # refactor that routes check-in around the shared write path.
+  describe "record_check_in/3 attendance log" do
+    test "logs the transition, its actor, and the notes as the reason" do
+      %{record: record} = staffed_session()
+      scope = AccountsFixtures.admin_scope_fixture()
+
+      {:ok, checked_in} =
+        KlassHero.Participation.record_check_in(scope, record.id, notes: "Arrived early")
+
+      assert transition = only_transition(record.id)
+      assert transition.from_status == :registered
+      assert transition.to_status == :checked_in
+      assert transition.reason == "Arrived early"
+
+      # The agreement that matters, and the one that is exact: the log and the
+      # column name the same actor. The timestamps are two clock reads, so they
+      # get a tolerance rather than an equality that would flake on a second
+      # boundary.
+      assert transition.actor_id == checked_in.check_in_by
+      assert abs(DateTime.diff(transition.occurred_at, checked_in.check_in_at)) <= 1
+    end
+
+    test "a late arrival logs both legs of the absence" do
+      %{record: record} = staffed_session()
+      scope = AccountsFixtures.admin_scope_fixture()
+
+      {:ok, _} = KlassHero.Participation.record_absence(scope, record.id, reason: "No-show")
+
+      assert {:ok, checked_in} =
+               KlassHero.Participation.record_check_in(scope, record.id, notes: "Arrived 09:20")
+
+      assert checked_in.status == :checked_in
+
+      # Both rows land in the same second, so assert on content, not position.
+      legs = record.id |> transitions_for() |> Enum.map(&{&1.from_status, &1.to_status})
+
+      assert length(legs) == 2
+      assert {:registered, :absent} in legs
+      assert {:absent, :checked_in} in legs
     end
   end
 

--- a/test/klass_hero/participation/record_check_out_test.exs
+++ b/test/klass_hero/participation/record_check_out_test.exs
@@ -7,6 +7,7 @@ defmodule KlassHero.Participation.RecordCheckOutTest do
 
   use KlassHero.DataCase, async: true
 
+  import KlassHero.AttendanceLogHelper
   import KlassHero.Factory
 
   alias KlassHero.AccountsFixtures
@@ -133,6 +134,34 @@ defmodule KlassHero.Participation.RecordCheckOutTest do
       assert reloaded.status == :checked_out
       assert reloaded.check_out_at != nil
       assert reloaded.check_out_by == scope.user.id
+    end
+  end
+
+  # Same assertion as its siblings, deliberately (#1329) — see
+  # `KlassHero.AttendanceLogHelper`.
+  describe "record_check_out/3 attendance log" do
+    test "logs the transition, its actor, and the notes as the reason" do
+      session = insert(:program_session_schema, status: :in_progress)
+      scope = AccountsFixtures.admin_scope_fixture()
+
+      record =
+        insert(:participation_record_schema,
+          session_id: session.id,
+          child_id: insert(:child_schema).id,
+          status: :checked_in,
+          check_in_at: DateTime.add(DateTime.utc_now(), -3600, :second),
+          check_in_by: AccountsFixtures.unconfirmed_user_fixture().id
+        )
+
+      {:ok, checked_out} =
+        KlassHero.Participation.record_check_out(scope, record.id, notes: "Picked up by parent")
+
+      assert transition = only_transition(record.id)
+      assert transition.from_status == :checked_in
+      assert transition.to_status == :checked_out
+      assert transition.reason == "Picked up by parent"
+      assert transition.actor_id == checked_out.check_out_by
+      assert abs(DateTime.diff(transition.occurred_at, checked_out.check_out_at)) <= 1
     end
   end
 end

--- a/test/klass_hero/provider/projections/provider_session_details_test.exs
+++ b/test/klass_hero/provider/projections/provider_session_details_test.exs
@@ -299,6 +299,28 @@ defmodule KlassHero.Provider.Projections.ProviderSessionDetailsTest do
       assert %{checked_in_count: 1} = reload(session_id)
     end
 
+    # #1329 widened `ParticipationRecord.check_in/3` to accept `:absent`, so a
+    # child marked absent who turns up late now emits `child_checked_in` from a
+    # status that was previously terminal. The +1 is still right — `:absent` is
+    # not counted as present — but nothing asserted that until this test.
+    test "a late arrival after an absence still counts as one", %{session_id: session_id} do
+      broadcast(:child_marked_absent, "rec-1", %{
+        record_id: "rec-1",
+        session_id: session_id,
+        child_id: "c-1"
+      })
+
+      assert %{checked_in_count: 0} = reload(session_id)
+
+      broadcast(:child_checked_in, "rec-1", %{
+        record_id: "rec-1",
+        session_id: session_id,
+        child_id: "c-1"
+      })
+
+      assert %{checked_in_count: 1} = reload(session_id)
+    end
+
     test "two check-ins increment to 2", %{session_id: session_id} do
       broadcast(:child_checked_in, "rec-1", %{
         record_id: "rec-1",

--- a/test/klass_hero_web/live/provider/participation_live_test.exs
+++ b/test/klass_hero_web/live/provider/participation_live_test.exs
@@ -857,4 +857,63 @@ defmodule KlassHeroWeb.Provider.ParticipationLiveTest do
       refute has_element?(view, "#edit-btn-#{record.id}")
     end
   end
+
+  describe "marking a child absent" do
+    setup [:create_session_with_child]
+
+    test "records the absence with its reason and shows it on the row", %{
+      conn: conn,
+      session: session,
+      record: record
+    } do
+      {:ok, view, _html} = live(conn, ~p"/provider/participation/#{session.id}")
+
+      view |> element("#mark-absent-btn-#{record.id}") |> render_click()
+
+      view
+      |> form("#absence-form-#{record.id}", %{"absence" => %{"content" => "Mum called — off sick"}})
+      |> render_submit()
+
+      assert_flash(view, :info, "Child marked absent")
+      assert KlassHero.Repo.get!(ParticipationRecord, record.id).status == :absent
+      assert has_element?(view, "#absence-reason-#{record.id}")
+      assert render(view) =~ "Mum called — off sick"
+    end
+
+    # Defect 4: an absent row used to render "Check In", which the state machine
+    # rejected every time. It now renders a working late-arrival action instead.
+    test "an absent row offers a late arrival, not a second Mark absent", %{
+      conn: conn,
+      session: session,
+      record: record,
+      scope: scope
+    } do
+      {:ok, _} = Participation.record_absence(scope, record.id, reason: "No-show")
+
+      {:ok, view, _html} = live(conn, ~p"/provider/participation/#{session.id}")
+
+      refute has_element?(view, "#mark-absent-btn-#{record.id}")
+      assert has_element?(view, "button[phx-click='check_in'][phx-value-id='#{record.id}']")
+
+      view
+      |> element("button[phx-click='check_in'][phx-value-id='#{record.id}']")
+      |> render_click()
+
+      assert_flash(view, :info, "Child checked in successfully")
+      assert KlassHero.Repo.get!(ParticipationRecord, record.id).status == :checked_in
+      refute has_element?(view, "#absence-reason-#{record.id}")
+    end
+
+    test "cancelling leaves the child on the roster", %{conn: conn, session: session, record: record} do
+      {:ok, view, _html} = live(conn, ~p"/provider/participation/#{session.id}")
+
+      view |> element("#mark-absent-btn-#{record.id}") |> render_click()
+      assert has_element?(view, "#absence-form-#{record.id}")
+
+      view |> element("button[phx-click='cancel_absence'][phx-value-id='#{record.id}']") |> render_click()
+
+      refute has_element?(view, "#absence-form-#{record.id}")
+      assert KlassHero.Repo.get!(ParticipationRecord, record.id).status == :registered
+    end
+  end
 end

--- a/test/klass_hero_web/live/staff/staff_participation_live_test.exs
+++ b/test/klass_hero_web/live/staff/staff_participation_live_test.exs
@@ -198,6 +198,46 @@ defmodule KlassHeroWeb.Staff.StaffParticipationLiveTest do
       assert has_element?(view, "#complete-session-btn")
     end
 
+    # One handler serves both surfaces, so this proves the staff wiring reaches
+    # it — not that the absence logic works, which `record_absence_test.exs` owns.
+    test "a staff member can mark a child absent with a reason", %{
+      conn: conn,
+      session: session,
+      record: record
+    } do
+      {:ok, view, _html} = live(conn, ~p"/staff/participation/#{session.id}")
+
+      view |> element("#mark-absent-btn-#{record.id}") |> render_click()
+
+      view
+      |> form("#absence-form-#{record.id}", %{"absence" => %{"content" => "Dentist appointment"}})
+      |> render_submit()
+
+      assert_flash(view, :info, "Child marked absent")
+      assert Repo.get!(ParticipationRecord, record.id).status == :absent
+      assert render(view) =~ "Dentist appointment"
+    end
+
+    # Defect 4, on the staff roster too.
+    test "an absent row offers a late arrival instead of a dead Check In", %{
+      conn: conn,
+      session: session,
+      record: record,
+      scope: scope
+    } do
+      {:ok, _} = KlassHero.Participation.record_absence(scope, record.id, reason: "No-show")
+
+      {:ok, view, _html} = live(conn, ~p"/staff/participation/#{session.id}")
+
+      refute has_element?(view, "#mark-absent-btn-#{record.id}")
+
+      view
+      |> element("button[phx-click='check_in'][phx-value-id='#{record.id}']")
+      |> render_click()
+
+      assert Repo.get!(ParticipationRecord, record.id).status == :checked_in
+    end
+
     test "completing absents the stragglers and locks the roster", %{
       conn: conn,
       session: session,

--- a/test/support/attendance_log_helper.ex
+++ b/test/support/attendance_log_helper.ex
@@ -1,0 +1,42 @@
+defmodule KlassHero.AttendanceLogHelper do
+  @moduledoc """
+  Reading the attendance transition log in tests.
+
+  Every attendance verb appends to `attendance_transitions` (#1329), so the same
+  assertion belongs in every verb's test file — and looking the same everywhere
+  is the point. A verb that quietly stops logging should fail a test that reads
+  identically to its siblings', not slip through because each file checked
+  something slightly different.
+  """
+
+  import Ecto.Query
+
+  alias KlassHero.Participation.AttendanceTransition
+  alias KlassHero.Repo
+
+  @doc """
+  Every transition logged for `record_id`, oldest first.
+
+  Two transitions inside the same second are not ordered relative to each other
+  — assert on their content, not their position.
+  """
+  @spec transitions_for(String.t()) :: [AttendanceTransition.t()]
+  def transitions_for(record_id) do
+    Repo.all(from t in AttendanceTransition, where: t.record_id == ^record_id, order_by: t.occurred_at)
+  end
+
+  @doc """
+  The one transition logged for `record_id`, or `nil` if the write was refused.
+
+  Raises on more than one: a verb that logs twice is a bug this helper should
+  surface, not average away.
+  """
+  @spec only_transition(String.t()) :: AttendanceTransition.t() | nil
+  def only_transition(record_id) do
+    case transitions_for(record_id) do
+      [] -> nil
+      [one] -> one
+      many -> raise "expected at most one transition for #{record_id}, found #{length(many)}"
+    end
+  end
+end


### PR DESCRIPTION
feat: mark a child absent by hand, with a reason

A provider who knows at 09:05 that a child is not coming had nothing to
click. The only route to `absent` was the bulk sweep at session completion,
which records no reason and no actor.

Adds `Participation.record_absence/3` beside the existing check-in and
check-out verbs, driven from the roster on both the provider and staff
surfaces by an inline reason form.

The reason lives on a new `attendance_transitions` table rather than on the
participation record. It is a sidecar: `participation_records.status` stays
authoritative, and the log answers what a column cannot, because a column
holds only the latest value and an attendance history is a sequence. Every
attendance verb appends — check-in, check-out, absence, the completion sweep
and admin corrections — so the log tells the whole story of a roster rather
than one verb's part of it. A NULL actor means no human did it, which is how
an automatic absence is told from a deliberate one.

The insert lives in the one write path every verb already shares, not at the
call sites. That matters: check-in also writes `check_in_at`/`check_in_by` on
the record, so the same fact now lives in two places, and keeping both writes
inside one function is what stops them disagreeing. Corrections are the single
exception — they do not use that path, so they log separately.

Also fixes two defects the feature would otherwise have exposed:

- An absent row rendered a Check In button that the state machine rejected
  every time. It was invisible because absences only existed after completion,
  when no row actions render at all. `:registered` and `:absent` shared the
  `cond`'s fallthrough; they now have separate clauses.

- A child marked absent who then turned up had no way back but an admin
  correction. `check_in/3` widens by one status to accept `:absent`, and the
  absent row offers "Arrived late". The provider's checked-in count stays
  correct either way: `:absent` is not counted, so the existing +1 is right.

Closes #1329

