### PR TITLE
feat: render provider branding on the parent-facing profile card

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -216,6 +216,12 @@ anything bouncing that is not the hero logo
 states, mini for inline-with-text. Sizes come from `Theme.icon_size/1`.
 _Avoid_: a second icon set; icons at arbitrary sizes
 
+**Brand marks are the one exception** to "no second icon set" — that rule guards against
+mixing generic icon *libraries* with inconsistent weight and style, and Heroicons ships no
+Instagram, Facebook, TikTok, YouTube or LinkedIn glyph at all. They live as inline SVG in
+`kh_social_icon`, keyed on the network atom, and nowhere else.
+_Avoid_: a brand mark inlined at a call site instead of added to that component
+
 **Gradient icon chips** are the signature motif — a rounded chip with a gradient background
 and a white icon, used for features, provider steps, and empty states. `kh_icon_chip`.
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -402,6 +402,16 @@ config :klass_hero, :scopes,
 # Configure Shared bounded context (critical event infrastructure)
 config :klass_hero, :shared, for_tracking_processed_events: ProcessedEventRepository
 
+# Klass Hero's own social accounts. All nil today — none exist yet — so the
+# footer's "Connect" block does not render. Paste a URL here and it appears;
+# no template change. See KlassHero.SocialLinks.
+config :klass_hero, :social_links,
+  instagram: nil,
+  facebook: nil,
+  tiktok: nil,
+  youtube: nil,
+  linkedin: nil
+
 # Configure Storage (defaults, overridden per environment)
 config :klass_hero, :storage,
   adapter: S3StorageAdapter,

--- a/lib/klass_hero/social_links.ex
+++ b/lib/klass_hero/social_links.ex
@@ -1,0 +1,63 @@
+defmodule KlassHero.SocialLinks do
+  @moduledoc """
+  Klass Hero's own social accounts, from application config, plus the supported
+  network set both Klass Hero and providers share.
+
+  Same shape as `KlassHero.Contact`: a config-backed accessor so a surface renders
+  what is set and omits what is not.
+
+  No accounts exist yet, so `all/0` returns `[]` and the footer's icon row does not
+  render. Adding one is a single line in `config/config.exs`.
+  """
+
+  @networks [:instagram, :facebook, :tiktok, :youtube, :linkedin]
+
+  @labels %{
+    instagram: "Instagram",
+    facebook: "Facebook",
+    tiktok: "TikTok",
+    youtube: "YouTube",
+    linkedin: "LinkedIn"
+  }
+
+  @doc """
+  Supported networks, in display order.
+
+  The single source for the set. `kh_social_icon/1` and
+  `ProviderPresenter.social_networks/0` both assert against it at compile time.
+  """
+  @spec networks() :: [atom()]
+  def networks, do: @networks
+
+  @doc """
+  A network's brand name.
+
+  Never run through gettext — translating "Instagram" would be wrong in every
+  locale.
+  """
+  @spec label(atom()) :: String.t()
+  def label(network), do: Map.fetch!(@labels, network)
+
+  @doc """
+  Klass Hero's configured accounts as `{network, label, url}`, omitting any unset
+  or blank.
+
+  Same shape as `ProviderPresenter.social_links/1` so one row component renders
+  either source.
+  """
+  @spec all() :: [{atom(), String.t(), String.t()}]
+  def all do
+    for network <- @networks,
+        url = get(network),
+        is_binary(url),
+        trimmed = String.trim(url),
+        trimmed != "",
+        do: {network, label(network), trimmed}
+  end
+
+  defp get(key) do
+    :klass_hero
+    |> Application.get_env(:social_links, [])
+    |> Keyword.get(key)
+  end
+end

--- a/lib/klass_hero_web/components/composite_components.ex
+++ b/lib/klass_hero_web/components/composite_components.ex
@@ -652,13 +652,13 @@ defmodule KlassHeroWeb.CompositeComponents do
           </div>
           <p
             :if={present?(@provider[:tagline])}
-            class={["text-sm mt-1", Theme.text_color(:secondary)]}
+            class={["text-sm mt-1", Theme.text_color(:secondary_dark)]}
           >
             {@provider.tagline}
           </p>
           <p
             :if={present?(@provider[:description])}
-            class={["text-sm leading-relaxed mt-1", Theme.text_color(:secondary)]}
+            class={["text-sm leading-relaxed mt-1", Theme.text_color(:secondary_dark)]}
           >
             {@provider.description}
           </p>
@@ -710,7 +710,7 @@ defmodule KlassHeroWeb.CompositeComponents do
           </div>
           <p
             :if={present?(@provider[:tagline])}
-            class={["mt-2", Theme.typography(:body), Theme.text_color(:secondary)]}
+            class={["mt-2", Theme.typography(:body), "text-[var(--fg-muted-on-light)]"]}
           >
             {@provider.tagline}
           </p>
@@ -768,7 +768,7 @@ defmodule KlassHeroWeb.CompositeComponents do
         class={[
           "inline-flex items-center justify-center w-11 h-11",
           Theme.rounded(:full),
-          Theme.text_color(:secondary),
+          Theme.text_color(:secondary_dark),
           "hover:bg-hero-grey-100 hover:text-hero-blue-600",
           Theme.transition(:normal)
         ]}

--- a/lib/klass_hero_web/components/composite_components.ex
+++ b/lib/klass_hero_web/components/composite_components.ex
@@ -455,28 +455,21 @@ defmodule KlassHeroWeb.CompositeComponents do
 
         <div class="text-left">
           <h4 class="font-semibold mb-4">{gettext("Connect")}</h4>
-          <div class="flex gap-2 mb-4">
-            <a href="#facebook" class="btn btn-circle btn-sm btn-ghost">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="20"
-                height="20"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-              >
-                <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z" />
-              </svg>
-            </a>
-            <a href="#instagram" class="btn btn-circle btn-sm btn-ghost">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="20"
-                height="20"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-              >
-                <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z" />
-              </svg>
+          <div :if={KlassHero.SocialLinks.all() != []} class="flex gap-2 mb-4">
+            <a
+              :for={{network, label, url} <- KlassHero.SocialLinks.all()}
+              href={url}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={gettext("Klass Hero on %{network}", network: label)}
+              class={[
+                "inline-flex items-center justify-center w-11 h-11",
+                Theme.rounded(:full),
+                "hover:bg-base-200",
+                Theme.transition(:normal)
+              ]}
+            >
+              <.kh_social_icon network={network} />
             </a>
           </div>
           <div class="text-sm">
@@ -609,29 +602,32 @@ defmodule KlassHeroWeb.CompositeComponents do
   end
 
   @doc """
-  Renders a public, read-only provider business profile card.
+  Renders a public, read-only provider identity at two densities: `:compact` for a
+  sidebar card (program detail), `:full` for a page hero.
 
-  Used on parent-facing pages (e.g. program detail) to surface the provider's
-  business identity. Takes a plain view map so the component stays decoupled
-  from any domain struct.
+  Takes a plain view map from `ProviderPresenter.to_public_view/2`. Everything
+  except `business_name` and `initials` is optional — a provider who has filled in
+  nothing still renders, which is the common case today.
 
   ## Examples
 
-      <.provider_profile_card provider={%{
-        business_name: "Starlight Coaching",
-        description: "Empowering kids through play-based learning.",
-        logo_url: nil,
-        initials: "SC"
-      }} />
+      <.provider_hero provider={@provider_profile} />
+      <.provider_hero provider={@provider_profile} variant={:full} />
   """
   attr :provider, :map,
     required: true,
-    doc: "Public provider view: %{business_name, description, logo_url, initials}"
+    doc: """
+    Public provider view: %{business_name, initials, description, logo_url,
+    tagline, cover_image_url, social_links, trust_state}
+    """
 
-  def provider_profile_card(assigns) do
+  attr :variant, :atom, default: :compact, values: [:compact, :full]
+
+  def provider_hero(%{variant: :compact} = assigns) do
     ~H"""
     <section
       id="provider-profile-card"
+      data-variant="compact"
       class={[
         Theme.bg(:surface),
         Theme.rounded(:xl),
@@ -646,35 +642,149 @@ defmodule KlassHeroWeb.CompositeComponents do
         </h3>
       </div>
       <div class="p-6 flex items-start gap-4">
-        <img
-          :if={@provider.logo_url}
-          src={@provider.logo_url}
-          alt={@provider.business_name}
-          class={["w-16 h-16 object-cover flex-shrink-0", Theme.rounded(:full)]}
-        />
-        <div
-          :if={!@provider.logo_url}
-          class={[
-            "w-16 h-16 flex items-center justify-center text-white text-xl font-bold flex-shrink-0",
-            Theme.rounded(:full),
-            Theme.gradient(:primary)
-          ]}
-        >
-          {@provider.initials}
-        </div>
-        <div class="flex-1">
-          <h4 class={[Theme.typography(:card_title), Theme.text_color(:heading)]}>
-            {@provider.business_name}
-          </h4>
+        <.provider_avatar provider={@provider} size="w-16 h-16" text="text-xl" />
+        <div class="flex-1 min-w-0">
+          <div class="flex flex-wrap items-center gap-2">
+            <h4 class={[Theme.typography(:card_title), Theme.text_color(:heading)]}>
+              {@provider.business_name}
+            </h4>
+            <.kh_trust_mark state={trust_state(@provider)} variant={:compact} />
+          </div>
           <p
-            :if={@provider.description}
+            :if={present?(@provider[:tagline])}
+            class={["text-sm mt-1", Theme.text_color(:secondary)]}
+          >
+            {@provider.tagline}
+          </p>
+          <p
+            :if={present?(@provider[:description])}
             class={["text-sm leading-relaxed mt-1", Theme.text_color(:secondary)]}
           >
             {@provider.description}
           </p>
+          <.provider_social_row provider={@provider} class="mt-3" />
         </div>
       </div>
     </section>
     """
   end
+
+  def provider_hero(%{variant: :full} = assigns) do
+    ~H"""
+    <section
+      id="provider-hero"
+      data-variant="full"
+      class={[
+        Theme.rounded(:xl),
+        "relative overflow-hidden shadow-sm border",
+        Theme.border_color(:light)
+      ]}
+    >
+      <div class="absolute inset-0" aria-hidden="true">
+        <img
+          :if={present?(@provider[:cover_image_url])}
+          src={@provider.cover_image_url}
+          alt=""
+          data-band="cover"
+          class="w-full h-full object-cover"
+        />
+        <div
+          :if={!present?(@provider[:cover_image_url])}
+          data-band="gradient"
+          class={["w-full h-full", Theme.gradient(:primary)]}
+        >
+        </div>
+        <%!-- Scrim. The cover is an arbitrary upload; without this, contrast is
+              unbounded. Don't lower the opacity to show the photo better. --%>
+        <div class="absolute inset-0 bg-white/90"></div>
+      </div>
+
+      <div class="relative p-6 sm:p-8 flex flex-col sm:flex-row items-center sm:items-start gap-4 sm:gap-6 text-center sm:text-left">
+        <.provider_avatar provider={@provider} size="w-20 h-20 sm:w-24 sm:h-24" text="text-2xl" />
+        <div class="flex-1 min-w-0">
+          <div class="flex flex-wrap items-center justify-center sm:justify-start gap-2">
+            <h1 class={[Theme.typography(:section_title), Theme.text_color(:heading)]}>
+              {@provider.business_name}
+            </h1>
+            <.kh_trust_mark state={trust_state(@provider)} />
+          </div>
+          <p
+            :if={present?(@provider[:tagline])}
+            class={["mt-2", Theme.typography(:body), Theme.text_color(:secondary)]}
+          >
+            {@provider.tagline}
+          </p>
+          <.provider_social_row
+            provider={@provider}
+            class="mt-4 justify-center sm:justify-start"
+          />
+        </div>
+      </div>
+    </section>
+    """
+  end
+
+  attr :provider, :map, required: true
+  attr :size, :string, required: true
+  attr :text, :string, required: true
+
+  defp provider_avatar(assigns) do
+    ~H"""
+    <img
+      :if={present?(@provider[:logo_url])}
+      src={@provider.logo_url}
+      alt={@provider.business_name}
+      class={[@size, "object-cover flex-shrink-0", Theme.rounded(:full)]}
+    />
+    <div
+      :if={!present?(@provider[:logo_url])}
+      class={[
+        @size,
+        @text,
+        "flex items-center justify-center text-white font-bold flex-shrink-0",
+        Theme.rounded(:full),
+        Theme.gradient(:primary)
+      ]}
+    >
+      {@provider.initials}
+    </div>
+    """
+  end
+
+  attr :provider, :map, required: true
+  attr :class, :string, default: ""
+
+  defp provider_social_row(assigns) do
+    ~H"""
+    <div :if={social_links(@provider) != []} class={["flex flex-wrap items-center gap-1", @class]}>
+      <a
+        :for={{network, label, url} <- social_links(@provider)}
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={
+          gettext("%{business} on %{network}", business: @provider.business_name, network: label)
+        }
+        class={[
+          "inline-flex items-center justify-center w-11 h-11",
+          Theme.rounded(:full),
+          Theme.text_color(:secondary),
+          "hover:bg-hero-grey-100 hover:text-hero-blue-600",
+          Theme.transition(:normal)
+        ]}
+      >
+        <.kh_social_icon network={network} />
+      </a>
+    </div>
+    """
+  end
+
+  # Access with a default: a hand-built map from a test or preview must not crash
+  # the page the way a missing key would (#1073).
+  defp social_links(provider), do: provider[:social_links] || []
+  defp trust_state(provider), do: provider[:trust_state] || :unverified
+
+  defp present?(nil), do: false
+  defp present?(value) when is_binary(value), do: String.trim(value) != ""
+  defp present?(_), do: true
 end

--- a/lib/klass_hero_web/components/ui_components.ex
+++ b/lib/klass_hero_web/components/ui_components.ex
@@ -1884,4 +1884,67 @@ defmodule KlassHeroWeb.UIComponents do
   defp kh_list_row_meta_items([]), do: []
   defp kh_list_row_meta_items(list) when is_list(list), do: Enum.reject(list, &is_nil/1)
   defp kh_list_row_meta_items(other), do: [other]
+
+  # Brand marks, 24x24, single-path, `fill="currentColor"` so they take the link's
+  # colour. DESIGN.md's "no second icon set" rule is about icon *libraries* —
+  # Heroicons ships no brand glyphs, and these five are not a library. Facebook and
+  # Instagram are the paths the footer already carried before this was extracted.
+  @social_paths %{
+    facebook:
+      "M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z",
+    instagram:
+      "M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z",
+    tiktok:
+      "M12.525.02c1.31-.02 2.61-.01 3.91-.02.08 1.53.63 3.09 1.75 4.17 1.12 1.11 2.7 1.62 4.24 1.79v4.03c-1.44-.05-2.89-.35-4.2-.97-.57-.26-1.1-.59-1.62-.93-.01 2.92.01 5.84-.02 8.75-.08 1.4-.54 2.79-1.35 3.94-1.31 1.92-3.58 3.17-5.91 3.21-1.43.08-2.86-.31-4.08-1.03-2.02-1.19-3.44-3.37-3.65-5.71-.02-.5-.03-1-.01-1.49.18-1.9 1.12-3.72 2.58-4.96 1.66-1.44 3.98-2.13 6.15-1.72.02 1.48-.04 2.96-.04 4.44-.99-.32-2.15-.23-3.02.37-.63.41-1.11 1.04-1.36 1.75-.21.51-.15 1.07-.14 1.61.24 1.64 1.82 3.02 3.5 2.87 1.12-.01 2.19-.66 2.77-1.61.19-.33.4-.67.41-1.06.1-1.79.06-3.57.07-5.36.01-4.03-.01-8.05.02-12.07z",
+    youtube:
+      "M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z",
+    linkedin:
+      "M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.225 0z"
+  }
+
+  # Every network `KlassHero.SocialLinks` declares must have a glyph here. Without
+  # this, adding a network would render an empty `<svg>` — no error, no test
+  # failure, just a missing icon nobody notices.
+  for network <- KlassHero.SocialLinks.networks() do
+    if !Map.has_key?(@social_paths, network) do
+      raise "kh_social_icon/1 has no SVG path for #{inspect(network)} — add one to @social_paths"
+    end
+  end
+
+  @doc """
+  Renders a social network's brand mark as an inline SVG.
+
+  Keyed on the network **atom**, never on a display label — a glyph lookup keyed on
+  translatable or editable text breaks silently the first time that text changes.
+
+  The glyph alone is not an accessible name, so every caller must supply one. This
+  component renders only the mark; the `<a>`, its `aria-label` and its
+  `rel="noopener noreferrer"` belong to the caller, which is the only place that
+  knows whether the link is Klass Hero's own (`KlassHero.SocialLinks`) or a
+  provider's (`ProviderPresenter.social_links/1`).
+
+  ## Examples
+
+      <.kh_social_icon network={:instagram} />
+      <.kh_social_icon network={:tiktok} class="w-6 h-6" />
+  """
+  attr :network, :atom, required: true, values: KlassHero.SocialLinks.networks()
+  attr :class, :string, default: "w-5 h-5"
+
+  def kh_social_icon(assigns) do
+    assigns = assign(assigns, :path, Map.fetch!(@social_paths, assigns.network))
+
+    ~H"""
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      focusable="false"
+      class={@class}
+    >
+      <path d={@path} />
+    </svg>
+    """
+  end
 end

--- a/lib/klass_hero_web/live/program_detail_live.ex
+++ b/lib/klass_hero_web/live/program_detail_live.ex
@@ -15,6 +15,8 @@ defmodule KlassHeroWeb.ProgramDetailLive do
   alias KlassHeroWeb.Presenters.ProviderPresenter
   alias KlassHeroWeb.Theme
 
+  require Logger
+
   @impl true
   def mount(%{"id" => program_id}, _session, socket) do
     case ProgramCatalog.get_program_by_id(program_id) do
@@ -133,11 +135,19 @@ defmodule KlassHeroWeb.ProgramDetailLive do
   end
 
   # get_trust_states/1 is batch-only; a missing entry means unverified.
+  #
+  # Rescued because this call shares `safe_await`'s fallback with the profile read
+  # above: without it, a vetting-lookup failure blanks the whole provider card
+  # rather than just its badge. The badge is additive, the identity is the
+  # content, so this degrades to :unverified — which under-claims, never over-.
   defp trust_state(provider_id) do
-    provider_id
-    |> List.wrap()
+    [provider_id]
     |> Provider.get_trust_states()
     |> Map.get(provider_id, :unverified)
+  rescue
+    error ->
+      Logger.warning("trust state lookup failed for provider #{provider_id}: #{inspect(error)}")
+      :unverified
   end
 
   defp load_participant_policy(program_id) do

--- a/lib/klass_hero_web/live/program_detail_live.ex
+++ b/lib/klass_hero_web/live/program_detail_live.ex
@@ -124,9 +124,20 @@ defmodule KlassHeroWeb.ProgramDetailLive do
   defp load_provider_profile(provider_id) do
     case Provider.get_provider_profile(provider_id) do
       # Only :active providers are surfaced to parents; nil suppresses the card.
-      {:ok, %{profile_status: :active} = provider} -> ProviderPresenter.to_public_view(provider)
-      _ -> nil
+      {:ok, %{profile_status: :active} = provider} ->
+        ProviderPresenter.to_public_view(provider, trust_state(provider_id))
+
+      _ ->
+        nil
     end
+  end
+
+  # get_trust_states/1 is batch-only; a missing entry means unverified.
+  defp trust_state(provider_id) do
+    provider_id
+    |> List.wrap()
+    |> Provider.get_trust_states()
+    |> Map.get(provider_id, :unverified)
   end
 
   defp load_participant_policy(program_id) do
@@ -427,7 +438,7 @@ defmodule KlassHeroWeb.ProgramDetailLive do
         </section>
 
         <%!-- Provider Profile Card — rendered only when an active provider profile is available --%>
-        <.provider_profile_card :if={@provider_profile} provider={@provider_profile} />
+        <.provider_hero :if={@provider_profile} provider={@provider_profile} />
 
         <%!-- TODO: "What Other Parents Say" reviews section — re-enable when review data is available.
              Dependencies: <.review_card> component import (removed), @reviews assign. --%>

--- a/lib/klass_hero_web/presenters/provider_presenter.ex
+++ b/lib/klass_hero_web/presenters/provider_presenter.ex
@@ -5,8 +5,8 @@ defmodule KlassHeroWeb.Presenters.ProviderPresenter do
 
   use Gettext, backend: KlassHeroWeb.Gettext
 
+  alias KlassHero.Provider
   alias KlassHero.Provider.ProviderProfile
-  alias KlassHero.Provider.Vetting
   alias KlassHero.Shared.NameUtils
   alias KlassHero.SocialLinks
 
@@ -52,7 +52,7 @@ defmodule KlassHeroWeb.Presenters.ProviderPresenter do
   `Provider.get_trust_states/1` is a DB read. It defaults to `:unverified` so an
   unthreaded caller shows no badge rather than one the provider has not earned.
   """
-  @spec to_public_view(ProviderProfile.t(), Vetting.trust_state()) :: map()
+  @spec to_public_view(ProviderProfile.t(), Provider.trust_state()) :: map()
   def to_public_view(%ProviderProfile{} = provider, trust_state \\ :unverified) do
     %{
       id: provider.id,

--- a/lib/klass_hero_web/presenters/provider_presenter.ex
+++ b/lib/klass_hero_web/presenters/provider_presenter.ex
@@ -6,7 +6,9 @@ defmodule KlassHeroWeb.Presenters.ProviderPresenter do
   use Gettext, backend: KlassHeroWeb.Gettext
 
   alias KlassHero.Provider.ProviderProfile
+  alias KlassHero.Provider.Vetting
   alias KlassHero.Shared.NameUtils
+  alias KlassHero.SocialLinks
 
   @doc """
   Transforms a Provider domain model to business view format.
@@ -41,14 +43,17 @@ defmodule KlassHeroWeb.Presenters.ProviderPresenter do
   tier/verification/slot data is not relevant — only the business identity.
 
   Returns a map with: id, business_name, description, logo_url, initials,
-  plus the branding fields (tagline, cover_image_url, social_links).
+  trust_state, plus the branding fields (tagline, cover_image_url, social_links).
 
-  `social_links` is a keyword-style list of `{network, url}` for the networks
-  the provider actually filled in, so a caller can render the row by iterating
-  rather than testing six fields for nil.
+  `social_links` is a list of `{network, label, url}` for the networks the provider
+  filled in; the atom is what `kh_social_icon/1` keys on.
+
+  `trust_state` is passed in, not fetched — this module is a pure transform and
+  `Provider.get_trust_states/1` is a DB read. It defaults to `:unverified` so an
+  unthreaded caller shows no badge rather than one the provider has not earned.
   """
-  @spec to_public_view(ProviderProfile.t()) :: map()
-  def to_public_view(%ProviderProfile{} = provider) do
+  @spec to_public_view(ProviderProfile.t(), Vetting.trust_state()) :: map()
+  def to_public_view(%ProviderProfile{} = provider, trust_state \\ :unverified) do
     %{
       id: provider.id,
       business_name: provider.business_name,
@@ -57,27 +62,39 @@ defmodule KlassHeroWeb.Presenters.ProviderPresenter do
       initials: NameUtils.initials_from_name(provider.business_name),
       tagline: provider.tagline,
       cover_image_url: provider.cover_image_url,
-      social_links: social_links(provider)
+      social_links: social_links(provider),
+      trust_state: trust_state
     }
   end
 
-  # The entity owns which networks exist; this module owns only their labels.
-  # Zipping the two means adding a network is a one-line change in the schema —
-  # and forgetting the label here fails the build rather than rendering a blank
-  # one. Re-listing the field atoms would have made this the third hand-kept
-  # copy of the same set.
-  @social_labels %{
-    instagram_url: "Instagram",
-    facebook_url: "Facebook",
-    tiktok_url: "TikTok",
-    youtube_url: "YouTube",
-    linkedin_url: "LinkedIn"
+  # The entity owns which networks exist; this maps its column to the short atom
+  # `kh_social_icon/1` keys on. Spelled out rather than derived by stripping
+  # "_url", so a renamed column fails loudly here. Labels live in SocialLinks.
+  @social_field_networks %{
+    instagram_url: :instagram,
+    facebook_url: :facebook,
+    tiktok_url: :tiktok,
+    youtube_url: :youtube,
+    linkedin_url: :linkedin
   }
 
-  @social_networks Enum.map(
-                     ProviderProfile.social_link_fields(),
-                     &{&1, Map.fetch!(@social_labels, &1)}
-                   )
+  @social_networks Enum.map(ProviderProfile.social_link_fields(), fn field ->
+                     network = Map.fetch!(@social_field_networks, field)
+                     {field, network, SocialLinks.label(network)}
+                   end)
+
+  @social_field_labels Enum.map(@social_networks, fn {field, _network, label} ->
+                         {field, label}
+                       end)
+
+  # Both sources share one `kh_social_icon/1`; a network with no glyph renders an
+  # empty `<svg>` with no error and no failing test.
+  @provider_network_atoms Enum.map(@social_networks, fn {_f, network, _l} -> network end)
+
+  if Enum.sort(@provider_network_atoms) != Enum.sort(KlassHero.SocialLinks.networks()) do
+    raise "provider social networks #{inspect(@provider_network_atoms)} have drifted from " <>
+            "KlassHero.SocialLinks.networks() #{inspect(KlassHero.SocialLinks.networks())}"
+  end
 
   @doc """
   Supported social networks as `{schema_field, label}`.
@@ -86,13 +103,13 @@ defmodule KlassHeroWeb.Presenters.ProviderPresenter do
   "Instagram" would be wrong in every locale.
   """
   @spec social_networks() :: [{atom(), String.t()}]
-  def social_networks, do: @social_networks
+  def social_networks, do: @social_field_labels
 
   defp social_links(%ProviderProfile{} = provider) do
-    for {field, label} <- @social_networks,
+    for {field, network, label} <- @social_networks,
         url = Map.fetch!(provider, field),
         url not in [nil, ""],
-        do: {label, url}
+        do: {network, label, url}
   end
 
   @doc """

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -145,7 +145,7 @@ msgstr "schließen"
 msgid "%{name} (Age %{age})"
 msgstr "%{name} (Alter %{age})"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:378
+#: lib/klass_hero_web/live/program_detail_live.ex:389
 #, elixir-autogen, elixir-format
 msgid "About This Program"
 msgstr "Über dieses Programm"
@@ -165,7 +165,7 @@ msgstr "Weiteres Kind hinzufügen"
 msgid "Add another program"
 msgstr "Weiteres Programm hinzufügen"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:223
+#: lib/klass_hero_web/live/program_detail_live.ex:234
 #, elixir-autogen, elixir-format
 msgid "Ages %{range}"
 msgstr "Alter %{range}"
@@ -225,7 +225,7 @@ msgstr "Dauer:"
 msgid "Easy Scheduling"
 msgstr "Einfache Terminplanung"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:481
+#: lib/klass_hero_web/live/program_detail_live.ex:492
 #, elixir-autogen, elixir-format
 msgid "Enroll Now - %{price}"
 msgstr "Jetzt anmelden - %{price}"
@@ -282,7 +282,7 @@ msgstr "Rechnung & Zahlungsbestätigung"
 msgid "Loading..."
 msgstr "Laden..."
 
-#: lib/klass_hero_web/live/program_detail_live.ex:418
+#: lib/klass_hero_web/live/program_detail_live.ex:429
 #, elixir-autogen, elixir-format
 msgid "Meet the Hero"
 msgid_plural "Meet the Heroes"
@@ -392,7 +392,7 @@ msgstr "Heute fällig:"
 msgid "View All Programs →"
 msgstr "Alle Programme ansehen →"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:235
+#: lib/klass_hero_web/live/program_detail_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "✓ No hidden fees"
 msgstr "✓ Keine versteckten Gebühren"
@@ -510,7 +510,7 @@ msgstr "Wird bestätigt..."
 msgid "Contact Information"
 msgstr "Kontaktdaten"
 
-#: lib/klass_hero_web/components/composite_components.ex:604
+#: lib/klass_hero_web/components/composite_components.ex:597
 #: lib/klass_hero_web/live/contact_live.ex:16
 #: lib/klass_hero_web/live/contact_live.ex:107
 #: lib/klass_hero_web/live/privacy_policy_live.ex:221
@@ -698,7 +698,7 @@ msgstr "Ungültiges Passwort."
 msgid "Keep me logged in on this device"
 msgstr "Auf diesem Gerät angemeldet bleiben"
 
-#: lib/klass_hero_web/components/composite_components.ex:555
+#: lib/klass_hero_web/components/composite_components.ex:548
 #, elixir-autogen, elixir-format
 msgid "Last Updated:"
 msgstr "Zuletzt aktualisiert:"
@@ -793,7 +793,7 @@ msgstr "Oder Passwort verwenden"
 #: lib/klass_hero_web/live/contact_live.ex:100
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:241
 #: lib/klass_hero_web/live/provider/verification_live.ex:626
-#: lib/klass_hero_web/presenters/provider_presenter.ex:143
+#: lib/klass_hero_web/presenters/provider_presenter.ex:160
 #, elixir-autogen, elixir-format
 msgid "Other"
 msgstr "Sonstiges"
@@ -816,7 +816,7 @@ msgstr "Zahlungsbedingungen"
 msgid "Phone"
 msgstr "Telefon"
 
-#: lib/klass_hero_web/components/composite_components.ex:494
+#: lib/klass_hero_web/components/composite_components.ex:487
 #: lib/klass_hero_web/live/privacy_policy_live.ex:11
 #: lib/klass_hero_web/live/privacy_policy_live.ex:239
 #, elixir-autogen, elixir-format
@@ -916,7 +916,7 @@ msgstr "Sitzung erfolgreich gestartet"
 msgid "Subject"
 msgstr "Betreff"
 
-#: lib/klass_hero_web/components/composite_components.ex:563
+#: lib/klass_hero_web/components/composite_components.ex:556
 #, elixir-autogen, elixir-format
 msgid "Table of Contents"
 msgstr "Inhaltsverzeichnis"
@@ -926,7 +926,7 @@ msgstr "Inhaltsverzeichnis"
 msgid "Technical Issue"
 msgstr "Technisches Problem"
 
-#: lib/klass_hero_web/components/composite_components.ex:496
+#: lib/klass_hero_web/components/composite_components.ex:489
 #: lib/klass_hero_web/live/terms_of_service_live.ex:11
 #: lib/klass_hero_web/live/terms_of_service_live.ex:260
 #, elixir-autogen, elixir-format
@@ -1034,7 +1034,7 @@ msgstr "die Postfach-Seite"
 msgid "Afterschool"
 msgstr "Nachmittagsbetreuung"
 
-#: lib/klass_hero_web/components/composite_components.ex:491
+#: lib/klass_hero_web/components/composite_components.ex:484
 #, elixir-autogen, elixir-format
 msgid "All rights reserved."
 msgstr "Alle Rechte vorbehalten."
@@ -1354,14 +1354,14 @@ msgstr "Alle Mitarbeiter"
 msgid "Assigned Staff"
 msgstr "Zugewiesenes Personal"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:345
-#: lib/klass_hero_web/live/program_detail_live.ex:505
+#: lib/klass_hero_web/live/program_detail_live.ex:356
+#: lib/klass_hero_web/live/program_detail_live.ex:516
 #, elixir-autogen, elixir-format
 msgid "Book Now"
 msgstr "Jetzt buchen"
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:129
-#: lib/klass_hero_web/presenters/provider_presenter.ex:139
+#: lib/klass_hero_web/presenters/provider_presenter.ex:146
+#: lib/klass_hero_web/presenters/provider_presenter.ex:156
 #, elixir-autogen, elixir-format
 msgid "Business Registration"
 msgstr "Gewerbeanmeldung"
@@ -1442,7 +1442,7 @@ msgstr "Programmname"
 msgid "Provider Dashboard"
 msgstr "Anbieter-Dashboard"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:358
+#: lib/klass_hero_web/live/program_detail_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "Save for Later"
 msgstr "Für später speichern"
@@ -1484,7 +1484,7 @@ msgstr "Nicht zugewiesen"
 #: lib/klass_hero_web/components/provider_components.ex:51
 #: lib/klass_hero_web/components/provider_components.ex:1646
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:455
-#: lib/klass_hero_web/presenters/provider_presenter.ex:149
+#: lib/klass_hero_web/presenters/provider_presenter.ex:166
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr "Unbekannt"
@@ -2311,7 +2311,7 @@ msgstr "E-Mail des Erziehungsberechtigten"
 msgid "Headshot Photo"
 msgstr "Porträtfoto"
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:141
+#: lib/klass_hero_web/presenters/provider_presenter.ex:158
 #, elixir-autogen, elixir-format
 msgid "ID Document"
 msgstr "Ausweisdokument"
@@ -2321,7 +2321,7 @@ msgstr "Ausweisdokument"
 msgid "Import"
 msgstr "Importieren"
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:140
+#: lib/klass_hero_web/presenters/provider_presenter.ex:157
 #, elixir-autogen, elixir-format
 msgid "Insurance Certificate"
 msgstr "Versicherungsnachweis"
@@ -2637,7 +2637,7 @@ msgstr "Registriert"
 msgid "Registration"
 msgstr "Anmeldung"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:172
+#: lib/klass_hero_web/live/program_detail_live.ex:183
 #, elixir-autogen, elixir-format
 msgid "Registration Closed"
 msgstr "Anmeldung geschlossen"
@@ -2647,7 +2647,7 @@ msgstr "Anmeldung geschlossen"
 msgid "Registration Closes"
 msgstr "Anmeldeschluss"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:170
+#: lib/klass_hero_web/live/program_detail_live.ex:181
 #, elixir-autogen, elixir-format
 msgid "Registration Not Open Yet"
 msgstr "Anmeldung noch nicht geöffnet"
@@ -2667,7 +2667,7 @@ msgstr "Anmeldezeitraum (optional)"
 msgid "Registration has closed for this program."
 msgstr "Die Anmeldung für dieses Programm ist geschlossen."
 
-#: lib/klass_hero_web/live/program_detail_live.ex:144
+#: lib/klass_hero_web/live/program_detail_live.ex:155
 #, elixir-autogen, elixir-format
 msgid "Registration is closed"
 msgstr "Anmeldung geschlossen"
@@ -2682,7 +2682,7 @@ msgstr "Die Anmeldung für dieses Programm ist derzeit nicht geöffnet."
 msgid "Registration is not open for this program."
 msgstr "Die Anmeldung für dieses Programm ist nicht geöffnet."
 
-#: lib/klass_hero_web/live/program_detail_live.ex:140
+#: lib/klass_hero_web/live/program_detail_live.ex:151
 #, elixir-autogen, elixir-format
 msgid "Registration opens %{date}"
 msgstr "Anmeldung öffnet am %{date}"
@@ -2749,7 +2749,7 @@ msgstr "Programm speichern"
 msgid "Schedule (optional)"
 msgstr "Zeitplan (optional)"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:218
+#: lib/klass_hero_web/live/program_detail_live.ex:229
 #, elixir-autogen, elixir-format
 msgid "Schedule TBD"
 msgstr "Zeitplan noch offen"
@@ -2831,7 +2831,7 @@ msgstr "Eingereicht"
 msgid "TBD"
 msgstr "Noch offen"
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:142
+#: lib/klass_hero_web/presenters/provider_presenter.ex:159
 #, elixir-autogen, elixir-format
 msgid "Tax Certificate"
 msgstr "Steuerbescheinigung"
@@ -3135,7 +3135,7 @@ msgid "This child is already enrolled in this program."
 msgstr "Dieses Kind ist bereits für dieses Programm angemeldet."
 
 #: lib/klass_hero_web/components/composite_components.ex:430
-#: lib/klass_hero_web/components/composite_components.ex:499
+#: lib/klass_hero_web/components/composite_components.ex:492
 #: lib/klass_hero_web/components/layouts/app.html.heex:60
 #: lib/klass_hero_web/components/layouts/app.html.heex:199
 #: lib/klass_hero_web/components/marketing_components.ex:204
@@ -4408,7 +4408,7 @@ msgstr "Sie sind diesem Programm nicht zugewiesen"
 msgid "+1234567890"
 msgstr "+1234567890"
 
-#: lib/klass_hero_web/components/composite_components.ex:645
+#: lib/klass_hero_web/components/composite_components.ex:641
 #, elixir-autogen, elixir-format
 msgid "About the Provider"
 msgstr "Über den Anbieter"
@@ -6572,7 +6572,7 @@ msgstr "Jeder Anbieter erhält: Profilseite, Buchungssystem, Zahlungsabwicklung,
 msgid "A short video so we can meet you."
 msgstr "Ein kurzes Video, damit wir dich kennenlernen können."
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:145
+#: lib/klass_hero_web/presenters/provider_presenter.ex:162
 #: lib/klass_hero_web/presenters/vetting_checklist_presenter.ex:77
 #, elixir-autogen, elixir-format
 msgid "Background check"
@@ -6740,7 +6740,7 @@ msgstr "Verifiziere deine Identität mit unserem Partner Stripe, um freigegeben 
 msgid "Verifying your identity… this can take a moment."
 msgstr "Deine Identität wird überprüft … das kann einen Moment dauern."
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:146
+#: lib/klass_hero_web/presenters/provider_presenter.ex:163
 #: lib/klass_hero_web/presenters/vetting_checklist_presenter.ex:85
 #, elixir-autogen, elixir-format
 msgid "Video screening"
@@ -6761,7 +6761,7 @@ msgstr "Wir konnten deine Identität nicht verifizieren. Bitte versuche es erneu
 msgid "Your identity is verified."
 msgstr "Deine Identität ist verifiziert."
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:144
+#: lib/klass_hero_web/presenters/provider_presenter.ex:161
 #, elixir-autogen, elixir-format
 msgid "Experience validation"
 msgstr "Erfahrungsnachweis"
@@ -6776,7 +6776,7 @@ msgstr "MP4, MOV oder WEBM. Max. 100 MB."
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr "Nimm ein kurzes Video auf, in dem du dich vorstellst. Unser Team prüft es, um Kommunikationsfähigkeit und Übereinstimmung mit unseren Werten einzuschätzen."
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:147
+#: lib/klass_hero_web/presenters/provider_presenter.ex:164
 #, elixir-autogen, elixir-format
 msgid "Safeguarding certificate"
 msgstr "Kinderschutz-Zertifikat"
@@ -8040,3 +8040,13 @@ msgstr "Grund für die Abwesenheit (optional)"
 #, elixir-autogen, elixir-format
 msgid "e.g. Mum called — off sick today"
 msgstr "z. B. Mutter hat angerufen — heute krank"
+
+#: lib/klass_hero_web/components/composite_components.ex:766
+#, elixir-autogen, elixir-format
+msgid "%{business} on %{network}"
+msgstr "%{business} auf %{network}"
+
+#: lib/klass_hero_web/components/composite_components.ex:464
+#, elixir-autogen, elixir-format
+msgid "Klass Hero on %{network}"
+msgstr "Klass Hero auf %{network}"

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -145,7 +145,7 @@ msgstr "schließen"
 msgid "%{name} (Age %{age})"
 msgstr "%{name} (Alter %{age})"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:389
+#: lib/klass_hero_web/live/program_detail_live.ex:399
 #, elixir-autogen, elixir-format
 msgid "About This Program"
 msgstr "Über dieses Programm"
@@ -165,7 +165,7 @@ msgstr "Weiteres Kind hinzufügen"
 msgid "Add another program"
 msgstr "Weiteres Programm hinzufügen"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:234
+#: lib/klass_hero_web/live/program_detail_live.ex:244
 #, elixir-autogen, elixir-format
 msgid "Ages %{range}"
 msgstr "Alter %{range}"
@@ -225,7 +225,7 @@ msgstr "Dauer:"
 msgid "Easy Scheduling"
 msgstr "Einfache Terminplanung"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:492
+#: lib/klass_hero_web/live/program_detail_live.ex:502
 #, elixir-autogen, elixir-format
 msgid "Enroll Now - %{price}"
 msgstr "Jetzt anmelden - %{price}"
@@ -282,7 +282,7 @@ msgstr "Rechnung & Zahlungsbestätigung"
 msgid "Loading..."
 msgstr "Laden..."
 
-#: lib/klass_hero_web/live/program_detail_live.ex:429
+#: lib/klass_hero_web/live/program_detail_live.ex:439
 #, elixir-autogen, elixir-format
 msgid "Meet the Hero"
 msgid_plural "Meet the Heroes"
@@ -336,7 +336,7 @@ msgstr "Klass Hero - Wir verbinden Familien mit vertrauenswürdigen Jugendpädag
 msgid "Program not found"
 msgstr "Programm nicht gefunden"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:69
+#: lib/klass_hero_web/live/program_detail_live.ex:71
 #, elixir-autogen, elixir-format
 msgid "Program not found. It may have been removed or is no longer available."
 msgstr "Programm nicht gefunden. Es wurde möglicherweise entfernt oder ist nicht mehr verfügbar."
@@ -392,7 +392,7 @@ msgstr "Heute fällig:"
 msgid "View All Programs →"
 msgstr "Alle Programme ansehen →"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:246
+#: lib/klass_hero_web/live/program_detail_live.ex:256
 #, elixir-autogen, elixir-format
 msgid "✓ No hidden fees"
 msgstr "✓ Keine versteckten Gebühren"
@@ -1354,8 +1354,8 @@ msgstr "Alle Mitarbeiter"
 msgid "Assigned Staff"
 msgstr "Zugewiesenes Personal"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:356
-#: lib/klass_hero_web/live/program_detail_live.ex:516
+#: lib/klass_hero_web/live/program_detail_live.ex:366
+#: lib/klass_hero_web/live/program_detail_live.ex:526
 #, elixir-autogen, elixir-format
 msgid "Book Now"
 msgstr "Jetzt buchen"
@@ -1442,7 +1442,7 @@ msgstr "Programmname"
 msgid "Provider Dashboard"
 msgstr "Anbieter-Dashboard"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:369
+#: lib/klass_hero_web/live/program_detail_live.ex:379
 #, elixir-autogen, elixir-format
 msgid "Save for Later"
 msgstr "Für später speichern"
@@ -2637,7 +2637,7 @@ msgstr "Registriert"
 msgid "Registration"
 msgstr "Anmeldung"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:183
+#: lib/klass_hero_web/live/program_detail_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "Registration Closed"
 msgstr "Anmeldung geschlossen"
@@ -2647,7 +2647,7 @@ msgstr "Anmeldung geschlossen"
 msgid "Registration Closes"
 msgstr "Anmeldeschluss"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:181
+#: lib/klass_hero_web/live/program_detail_live.ex:191
 #, elixir-autogen, elixir-format
 msgid "Registration Not Open Yet"
 msgstr "Anmeldung noch nicht geöffnet"
@@ -2667,7 +2667,7 @@ msgstr "Anmeldezeitraum (optional)"
 msgid "Registration has closed for this program."
 msgstr "Die Anmeldung für dieses Programm ist geschlossen."
 
-#: lib/klass_hero_web/live/program_detail_live.ex:155
+#: lib/klass_hero_web/live/program_detail_live.ex:165
 #, elixir-autogen, elixir-format
 msgid "Registration is closed"
 msgstr "Anmeldung geschlossen"
@@ -2677,12 +2677,12 @@ msgstr "Anmeldung geschlossen"
 msgid "Registration is not currently open for this program."
 msgstr "Die Anmeldung für dieses Programm ist derzeit nicht geöffnet."
 
-#: lib/klass_hero_web/live/program_detail_live.ex:85
+#: lib/klass_hero_web/live/program_detail_live.ex:87
 #, elixir-autogen, elixir-format
 msgid "Registration is not open for this program."
 msgstr "Die Anmeldung für dieses Programm ist nicht geöffnet."
 
-#: lib/klass_hero_web/live/program_detail_live.ex:151
+#: lib/klass_hero_web/live/program_detail_live.ex:161
 #, elixir-autogen, elixir-format
 msgid "Registration opens %{date}"
 msgstr "Anmeldung öffnet am %{date}"
@@ -2749,7 +2749,7 @@ msgstr "Programm speichern"
 msgid "Schedule (optional)"
 msgstr "Zeitplan (optional)"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:229
+#: lib/klass_hero_web/live/program_detail_live.ex:239
 #, elixir-autogen, elixir-format
 msgid "Schedule TBD"
 msgstr "Zeitplan noch offen"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -145,7 +145,7 @@ msgstr ""
 msgid "%{name} (Age %{age})"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:389
+#: lib/klass_hero_web/live/program_detail_live.ex:399
 #, elixir-autogen, elixir-format
 msgid "About This Program"
 msgstr ""
@@ -165,7 +165,7 @@ msgstr ""
 msgid "Add another program"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:234
+#: lib/klass_hero_web/live/program_detail_live.ex:244
 #, elixir-autogen, elixir-format
 msgid "Ages %{range}"
 msgstr ""
@@ -225,7 +225,7 @@ msgstr ""
 msgid "Easy Scheduling"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:492
+#: lib/klass_hero_web/live/program_detail_live.ex:502
 #, elixir-autogen, elixir-format
 msgid "Enroll Now - %{price}"
 msgstr ""
@@ -282,7 +282,7 @@ msgstr ""
 msgid "Loading..."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:429
+#: lib/klass_hero_web/live/program_detail_live.ex:439
 #, elixir-autogen, elixir-format
 msgid "Meet the Hero"
 msgid_plural "Meet the Heroes"
@@ -336,7 +336,7 @@ msgstr ""
 msgid "Program not found"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:69
+#: lib/klass_hero_web/live/program_detail_live.ex:71
 #, elixir-autogen, elixir-format
 msgid "Program not found. It may have been removed or is no longer available."
 msgstr ""
@@ -392,7 +392,7 @@ msgstr ""
 msgid "View All Programs →"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:246
+#: lib/klass_hero_web/live/program_detail_live.ex:256
 #, elixir-autogen, elixir-format
 msgid "✓ No hidden fees"
 msgstr ""
@@ -1354,8 +1354,8 @@ msgstr ""
 msgid "Assigned Staff"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:356
-#: lib/klass_hero_web/live/program_detail_live.ex:516
+#: lib/klass_hero_web/live/program_detail_live.ex:366
+#: lib/klass_hero_web/live/program_detail_live.ex:526
 #, elixir-autogen, elixir-format
 msgid "Book Now"
 msgstr ""
@@ -1442,7 +1442,7 @@ msgstr ""
 msgid "Provider Dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:369
+#: lib/klass_hero_web/live/program_detail_live.ex:379
 #, elixir-autogen, elixir-format
 msgid "Save for Later"
 msgstr ""
@@ -2637,7 +2637,7 @@ msgstr ""
 msgid "Registration"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:183
+#: lib/klass_hero_web/live/program_detail_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "Registration Closed"
 msgstr ""
@@ -2647,7 +2647,7 @@ msgstr ""
 msgid "Registration Closes"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:181
+#: lib/klass_hero_web/live/program_detail_live.ex:191
 #, elixir-autogen, elixir-format
 msgid "Registration Not Open Yet"
 msgstr ""
@@ -2667,7 +2667,7 @@ msgstr ""
 msgid "Registration has closed for this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:155
+#: lib/klass_hero_web/live/program_detail_live.ex:165
 #, elixir-autogen, elixir-format
 msgid "Registration is closed"
 msgstr ""
@@ -2677,12 +2677,12 @@ msgstr ""
 msgid "Registration is not currently open for this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:85
+#: lib/klass_hero_web/live/program_detail_live.ex:87
 #, elixir-autogen, elixir-format
 msgid "Registration is not open for this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:151
+#: lib/klass_hero_web/live/program_detail_live.ex:161
 #, elixir-autogen, elixir-format
 msgid "Registration opens %{date}"
 msgstr ""
@@ -2749,7 +2749,7 @@ msgstr ""
 msgid "Schedule (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:229
+#: lib/klass_hero_web/live/program_detail_live.ex:239
 #, elixir-autogen, elixir-format
 msgid "Schedule TBD"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -145,7 +145,7 @@ msgstr ""
 msgid "%{name} (Age %{age})"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:378
+#: lib/klass_hero_web/live/program_detail_live.ex:389
 #, elixir-autogen, elixir-format
 msgid "About This Program"
 msgstr ""
@@ -165,7 +165,7 @@ msgstr ""
 msgid "Add another program"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:223
+#: lib/klass_hero_web/live/program_detail_live.ex:234
 #, elixir-autogen, elixir-format
 msgid "Ages %{range}"
 msgstr ""
@@ -225,7 +225,7 @@ msgstr ""
 msgid "Easy Scheduling"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:481
+#: lib/klass_hero_web/live/program_detail_live.ex:492
 #, elixir-autogen, elixir-format
 msgid "Enroll Now - %{price}"
 msgstr ""
@@ -282,7 +282,7 @@ msgstr ""
 msgid "Loading..."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:418
+#: lib/klass_hero_web/live/program_detail_live.ex:429
 #, elixir-autogen, elixir-format
 msgid "Meet the Hero"
 msgid_plural "Meet the Heroes"
@@ -392,7 +392,7 @@ msgstr ""
 msgid "View All Programs →"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:235
+#: lib/klass_hero_web/live/program_detail_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "✓ No hidden fees"
 msgstr ""
@@ -510,7 +510,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:604
+#: lib/klass_hero_web/components/composite_components.ex:597
 #: lib/klass_hero_web/live/contact_live.ex:16
 #: lib/klass_hero_web/live/contact_live.ex:107
 #: lib/klass_hero_web/live/privacy_policy_live.ex:221
@@ -698,7 +698,7 @@ msgstr ""
 msgid "Keep me logged in on this device"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:555
+#: lib/klass_hero_web/components/composite_components.ex:548
 #, elixir-autogen, elixir-format
 msgid "Last Updated:"
 msgstr ""
@@ -793,7 +793,7 @@ msgstr ""
 #: lib/klass_hero_web/live/contact_live.ex:100
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:241
 #: lib/klass_hero_web/live/provider/verification_live.ex:626
-#: lib/klass_hero_web/presenters/provider_presenter.ex:143
+#: lib/klass_hero_web/presenters/provider_presenter.ex:160
 #, elixir-autogen, elixir-format
 msgid "Other"
 msgstr ""
@@ -816,7 +816,7 @@ msgstr ""
 msgid "Phone"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:494
+#: lib/klass_hero_web/components/composite_components.ex:487
 #: lib/klass_hero_web/live/privacy_policy_live.ex:11
 #: lib/klass_hero_web/live/privacy_policy_live.ex:239
 #, elixir-autogen, elixir-format
@@ -916,7 +916,7 @@ msgstr ""
 msgid "Subject"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:563
+#: lib/klass_hero_web/components/composite_components.ex:556
 #, elixir-autogen, elixir-format
 msgid "Table of Contents"
 msgstr ""
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Technical Issue"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:496
+#: lib/klass_hero_web/components/composite_components.ex:489
 #: lib/klass_hero_web/live/terms_of_service_live.ex:11
 #: lib/klass_hero_web/live/terms_of_service_live.ex:260
 #, elixir-autogen, elixir-format
@@ -1034,7 +1034,7 @@ msgstr ""
 msgid "Afterschool"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:491
+#: lib/klass_hero_web/components/composite_components.ex:484
 #, elixir-autogen, elixir-format
 msgid "All rights reserved."
 msgstr ""
@@ -1354,14 +1354,14 @@ msgstr ""
 msgid "Assigned Staff"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:345
-#: lib/klass_hero_web/live/program_detail_live.ex:505
+#: lib/klass_hero_web/live/program_detail_live.ex:356
+#: lib/klass_hero_web/live/program_detail_live.ex:516
 #, elixir-autogen, elixir-format
 msgid "Book Now"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:129
-#: lib/klass_hero_web/presenters/provider_presenter.ex:139
+#: lib/klass_hero_web/presenters/provider_presenter.ex:146
+#: lib/klass_hero_web/presenters/provider_presenter.ex:156
 #, elixir-autogen, elixir-format
 msgid "Business Registration"
 msgstr ""
@@ -1442,7 +1442,7 @@ msgstr ""
 msgid "Provider Dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:358
+#: lib/klass_hero_web/live/program_detail_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "Save for Later"
 msgstr ""
@@ -1484,7 +1484,7 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:51
 #: lib/klass_hero_web/components/provider_components.ex:1646
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:455
-#: lib/klass_hero_web/presenters/provider_presenter.ex:149
+#: lib/klass_hero_web/presenters/provider_presenter.ex:166
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
@@ -2311,7 +2311,7 @@ msgstr ""
 msgid "Headshot Photo"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:141
+#: lib/klass_hero_web/presenters/provider_presenter.ex:158
 #, elixir-autogen, elixir-format
 msgid "ID Document"
 msgstr ""
@@ -2321,7 +2321,7 @@ msgstr ""
 msgid "Import"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:140
+#: lib/klass_hero_web/presenters/provider_presenter.ex:157
 #, elixir-autogen, elixir-format
 msgid "Insurance Certificate"
 msgstr ""
@@ -2637,7 +2637,7 @@ msgstr ""
 msgid "Registration"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:172
+#: lib/klass_hero_web/live/program_detail_live.ex:183
 #, elixir-autogen, elixir-format
 msgid "Registration Closed"
 msgstr ""
@@ -2647,7 +2647,7 @@ msgstr ""
 msgid "Registration Closes"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:170
+#: lib/klass_hero_web/live/program_detail_live.ex:181
 #, elixir-autogen, elixir-format
 msgid "Registration Not Open Yet"
 msgstr ""
@@ -2667,7 +2667,7 @@ msgstr ""
 msgid "Registration has closed for this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:144
+#: lib/klass_hero_web/live/program_detail_live.ex:155
 #, elixir-autogen, elixir-format
 msgid "Registration is closed"
 msgstr ""
@@ -2682,7 +2682,7 @@ msgstr ""
 msgid "Registration is not open for this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:140
+#: lib/klass_hero_web/live/program_detail_live.ex:151
 #, elixir-autogen, elixir-format
 msgid "Registration opens %{date}"
 msgstr ""
@@ -2749,7 +2749,7 @@ msgstr ""
 msgid "Schedule (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:218
+#: lib/klass_hero_web/live/program_detail_live.ex:229
 #, elixir-autogen, elixir-format
 msgid "Schedule TBD"
 msgstr ""
@@ -2831,7 +2831,7 @@ msgstr ""
 msgid "TBD"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:142
+#: lib/klass_hero_web/presenters/provider_presenter.ex:159
 #, elixir-autogen, elixir-format
 msgid "Tax Certificate"
 msgstr ""
@@ -3135,7 +3135,7 @@ msgid "This child is already enrolled in this program."
 msgstr ""
 
 #: lib/klass_hero_web/components/composite_components.ex:430
-#: lib/klass_hero_web/components/composite_components.ex:499
+#: lib/klass_hero_web/components/composite_components.ex:492
 #: lib/klass_hero_web/components/layouts/app.html.heex:60
 #: lib/klass_hero_web/components/layouts/app.html.heex:199
 #: lib/klass_hero_web/components/marketing_components.ex:204
@@ -4408,7 +4408,7 @@ msgstr ""
 msgid "+1234567890"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:645
+#: lib/klass_hero_web/components/composite_components.ex:641
 #, elixir-autogen, elixir-format
 msgid "About the Provider"
 msgstr ""
@@ -6572,7 +6572,7 @@ msgstr ""
 msgid "A short video so we can meet you."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:145
+#: lib/klass_hero_web/presenters/provider_presenter.ex:162
 #: lib/klass_hero_web/presenters/vetting_checklist_presenter.ex:77
 #, elixir-autogen, elixir-format
 msgid "Background check"
@@ -6740,7 +6740,7 @@ msgstr ""
 msgid "Verifying your identity… this can take a moment."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:146
+#: lib/klass_hero_web/presenters/provider_presenter.ex:163
 #: lib/klass_hero_web/presenters/vetting_checklist_presenter.ex:85
 #, elixir-autogen, elixir-format
 msgid "Video screening"
@@ -6761,7 +6761,7 @@ msgstr ""
 msgid "Your identity is verified."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:144
+#: lib/klass_hero_web/presenters/provider_presenter.ex:161
 #, elixir-autogen, elixir-format
 msgid "Experience validation"
 msgstr ""
@@ -6776,7 +6776,7 @@ msgstr ""
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:147
+#: lib/klass_hero_web/presenters/provider_presenter.ex:164
 #, elixir-autogen, elixir-format
 msgid "Safeguarding certificate"
 msgstr ""
@@ -8021,4 +8021,14 @@ msgstr ""
 #: lib/klass_hero_web/components/participation_components.ex:596
 #, elixir-autogen, elixir-format
 msgid "e.g. Mum called — off sick today"
+msgstr ""
+
+#: lib/klass_hero_web/components/composite_components.ex:766
+#, elixir-autogen, elixir-format
+msgid "%{business} on %{network}"
+msgstr ""
+
+#: lib/klass_hero_web/components/composite_components.ex:464
+#, elixir-autogen, elixir-format
+msgid "Klass Hero on %{network}"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -145,7 +145,7 @@ msgstr ""
 msgid "%{name} (Age %{age})"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:378
+#: lib/klass_hero_web/live/program_detail_live.ex:389
 #, elixir-autogen, elixir-format
 msgid "About This Program"
 msgstr ""
@@ -165,7 +165,7 @@ msgstr ""
 msgid "Add another program"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:223
+#: lib/klass_hero_web/live/program_detail_live.ex:234
 #, elixir-autogen, elixir-format
 msgid "Ages %{range}"
 msgstr ""
@@ -225,7 +225,7 @@ msgstr ""
 msgid "Easy Scheduling"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:481
+#: lib/klass_hero_web/live/program_detail_live.ex:492
 #, elixir-autogen, elixir-format
 msgid "Enroll Now - %{price}"
 msgstr ""
@@ -282,7 +282,7 @@ msgstr ""
 msgid "Loading..."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:418
+#: lib/klass_hero_web/live/program_detail_live.ex:429
 #, elixir-autogen, elixir-format
 msgid "Meet the Hero"
 msgid_plural "Meet the Heroes"
@@ -392,7 +392,7 @@ msgstr ""
 msgid "View All Programs →"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:235
+#: lib/klass_hero_web/live/program_detail_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "✓ No hidden fees"
 msgstr ""
@@ -510,7 +510,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:604
+#: lib/klass_hero_web/components/composite_components.ex:597
 #: lib/klass_hero_web/live/contact_live.ex:16
 #: lib/klass_hero_web/live/contact_live.ex:107
 #: lib/klass_hero_web/live/privacy_policy_live.ex:221
@@ -698,7 +698,7 @@ msgstr ""
 msgid "Keep me logged in on this device"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:555
+#: lib/klass_hero_web/components/composite_components.ex:548
 #, elixir-autogen, elixir-format
 msgid "Last Updated:"
 msgstr ""
@@ -793,7 +793,7 @@ msgstr ""
 #: lib/klass_hero_web/live/contact_live.ex:100
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:241
 #: lib/klass_hero_web/live/provider/verification_live.ex:626
-#: lib/klass_hero_web/presenters/provider_presenter.ex:143
+#: lib/klass_hero_web/presenters/provider_presenter.ex:160
 #, elixir-autogen, elixir-format
 msgid "Other"
 msgstr ""
@@ -816,7 +816,7 @@ msgstr ""
 msgid "Phone"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:494
+#: lib/klass_hero_web/components/composite_components.ex:487
 #: lib/klass_hero_web/live/privacy_policy_live.ex:11
 #: lib/klass_hero_web/live/privacy_policy_live.ex:239
 #, elixir-autogen, elixir-format
@@ -916,7 +916,7 @@ msgstr ""
 msgid "Subject"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:563
+#: lib/klass_hero_web/components/composite_components.ex:556
 #, elixir-autogen, elixir-format
 msgid "Table of Contents"
 msgstr ""
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Technical Issue"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:496
+#: lib/klass_hero_web/components/composite_components.ex:489
 #: lib/klass_hero_web/live/terms_of_service_live.ex:11
 #: lib/klass_hero_web/live/terms_of_service_live.ex:260
 #, elixir-autogen, elixir-format
@@ -1034,7 +1034,7 @@ msgstr ""
 msgid "Afterschool"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:491
+#: lib/klass_hero_web/components/composite_components.ex:484
 #, elixir-autogen, elixir-format
 msgid "All rights reserved."
 msgstr ""
@@ -1354,14 +1354,14 @@ msgstr ""
 msgid "Assigned Staff"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:345
-#: lib/klass_hero_web/live/program_detail_live.ex:505
+#: lib/klass_hero_web/live/program_detail_live.ex:356
+#: lib/klass_hero_web/live/program_detail_live.ex:516
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Book Now"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:129
-#: lib/klass_hero_web/presenters/provider_presenter.ex:139
+#: lib/klass_hero_web/presenters/provider_presenter.ex:146
+#: lib/klass_hero_web/presenters/provider_presenter.ex:156
 #, elixir-autogen, elixir-format
 msgid "Business Registration"
 msgstr ""
@@ -1442,7 +1442,7 @@ msgstr ""
 msgid "Provider Dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:358
+#: lib/klass_hero_web/live/program_detail_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "Save for Later"
 msgstr ""
@@ -1484,7 +1484,7 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:51
 #: lib/klass_hero_web/components/provider_components.ex:1646
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:455
-#: lib/klass_hero_web/presenters/provider_presenter.ex:149
+#: lib/klass_hero_web/presenters/provider_presenter.ex:166
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
@@ -2311,7 +2311,7 @@ msgstr ""
 msgid "Headshot Photo"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:141
+#: lib/klass_hero_web/presenters/provider_presenter.ex:158
 #, elixir-autogen, elixir-format
 msgid "ID Document"
 msgstr ""
@@ -2321,7 +2321,7 @@ msgstr ""
 msgid "Import"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:140
+#: lib/klass_hero_web/presenters/provider_presenter.ex:157
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Insurance Certificate"
 msgstr ""
@@ -2637,7 +2637,7 @@ msgstr ""
 msgid "Registration"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:172
+#: lib/klass_hero_web/live/program_detail_live.ex:183
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration Closed"
 msgstr ""
@@ -2647,7 +2647,7 @@ msgstr ""
 msgid "Registration Closes"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:170
+#: lib/klass_hero_web/live/program_detail_live.ex:181
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration Not Open Yet"
 msgstr ""
@@ -2667,7 +2667,7 @@ msgstr ""
 msgid "Registration has closed for this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:144
+#: lib/klass_hero_web/live/program_detail_live.ex:155
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration is closed"
 msgstr ""
@@ -2682,7 +2682,7 @@ msgstr ""
 msgid "Registration is not open for this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:140
+#: lib/klass_hero_web/live/program_detail_live.ex:151
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration opens %{date}"
 msgstr ""
@@ -2749,7 +2749,7 @@ msgstr ""
 msgid "Schedule (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:218
+#: lib/klass_hero_web/live/program_detail_live.ex:229
 #, elixir-autogen, elixir-format
 msgid "Schedule TBD"
 msgstr ""
@@ -2831,7 +2831,7 @@ msgstr ""
 msgid "TBD"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:142
+#: lib/klass_hero_web/presenters/provider_presenter.ex:159
 #, elixir-autogen, elixir-format
 msgid "Tax Certificate"
 msgstr ""
@@ -3135,7 +3135,7 @@ msgid "This child is already enrolled in this program."
 msgstr ""
 
 #: lib/klass_hero_web/components/composite_components.ex:430
-#: lib/klass_hero_web/components/composite_components.ex:499
+#: lib/klass_hero_web/components/composite_components.ex:492
 #: lib/klass_hero_web/components/layouts/app.html.heex:60
 #: lib/klass_hero_web/components/layouts/app.html.heex:199
 #: lib/klass_hero_web/components/marketing_components.ex:204
@@ -4408,7 +4408,7 @@ msgstr ""
 msgid "+1234567890"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:645
+#: lib/klass_hero_web/components/composite_components.ex:641
 #, elixir-autogen, elixir-format
 msgid "About the Provider"
 msgstr ""
@@ -6572,7 +6572,7 @@ msgstr ""
 msgid "A short video so we can meet you."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:145
+#: lib/klass_hero_web/presenters/provider_presenter.ex:162
 #: lib/klass_hero_web/presenters/vetting_checklist_presenter.ex:77
 #, elixir-autogen, elixir-format
 msgid "Background check"
@@ -6740,7 +6740,7 @@ msgstr ""
 msgid "Verifying your identity… this can take a moment."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:146
+#: lib/klass_hero_web/presenters/provider_presenter.ex:163
 #: lib/klass_hero_web/presenters/vetting_checklist_presenter.ex:85
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Video screening"
@@ -6761,7 +6761,7 @@ msgstr ""
 msgid "Your identity is verified."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:144
+#: lib/klass_hero_web/presenters/provider_presenter.ex:161
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Experience validation"
 msgstr ""
@@ -6776,7 +6776,7 @@ msgstr ""
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:147
+#: lib/klass_hero_web/presenters/provider_presenter.ex:164
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Safeguarding certificate"
 msgstr ""
@@ -8021,4 +8021,14 @@ msgstr ""
 #: lib/klass_hero_web/components/participation_components.ex:596
 #, elixir-autogen, elixir-format
 msgid "e.g. Mum called — off sick today"
+msgstr ""
+
+#: lib/klass_hero_web/components/composite_components.ex:766
+#, elixir-autogen, elixir-format
+msgid "%{business} on %{network}"
+msgstr ""
+
+#: lib/klass_hero_web/components/composite_components.ex:464
+#, elixir-autogen, elixir-format
+msgid "Klass Hero on %{network}"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -145,7 +145,7 @@ msgstr ""
 msgid "%{name} (Age %{age})"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:389
+#: lib/klass_hero_web/live/program_detail_live.ex:399
 #, elixir-autogen, elixir-format
 msgid "About This Program"
 msgstr ""
@@ -165,7 +165,7 @@ msgstr ""
 msgid "Add another program"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:234
+#: lib/klass_hero_web/live/program_detail_live.ex:244
 #, elixir-autogen, elixir-format
 msgid "Ages %{range}"
 msgstr ""
@@ -225,7 +225,7 @@ msgstr ""
 msgid "Easy Scheduling"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:492
+#: lib/klass_hero_web/live/program_detail_live.ex:502
 #, elixir-autogen, elixir-format
 msgid "Enroll Now - %{price}"
 msgstr ""
@@ -282,7 +282,7 @@ msgstr ""
 msgid "Loading..."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:429
+#: lib/klass_hero_web/live/program_detail_live.ex:439
 #, elixir-autogen, elixir-format
 msgid "Meet the Hero"
 msgid_plural "Meet the Heroes"
@@ -336,7 +336,7 @@ msgstr ""
 msgid "Program not found"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:69
+#: lib/klass_hero_web/live/program_detail_live.ex:71
 #, elixir-autogen, elixir-format
 msgid "Program not found. It may have been removed or is no longer available."
 msgstr ""
@@ -392,7 +392,7 @@ msgstr ""
 msgid "View All Programs →"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:246
+#: lib/klass_hero_web/live/program_detail_live.ex:256
 #, elixir-autogen, elixir-format
 msgid "✓ No hidden fees"
 msgstr ""
@@ -1354,8 +1354,8 @@ msgstr ""
 msgid "Assigned Staff"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:356
-#: lib/klass_hero_web/live/program_detail_live.ex:516
+#: lib/klass_hero_web/live/program_detail_live.ex:366
+#: lib/klass_hero_web/live/program_detail_live.ex:526
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Book Now"
 msgstr ""
@@ -1442,7 +1442,7 @@ msgstr ""
 msgid "Provider Dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:369
+#: lib/klass_hero_web/live/program_detail_live.ex:379
 #, elixir-autogen, elixir-format
 msgid "Save for Later"
 msgstr ""
@@ -2637,7 +2637,7 @@ msgstr ""
 msgid "Registration"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:183
+#: lib/klass_hero_web/live/program_detail_live.ex:193
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration Closed"
 msgstr ""
@@ -2647,7 +2647,7 @@ msgstr ""
 msgid "Registration Closes"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:181
+#: lib/klass_hero_web/live/program_detail_live.ex:191
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration Not Open Yet"
 msgstr ""
@@ -2667,7 +2667,7 @@ msgstr ""
 msgid "Registration has closed for this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:155
+#: lib/klass_hero_web/live/program_detail_live.ex:165
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration is closed"
 msgstr ""
@@ -2677,12 +2677,12 @@ msgstr ""
 msgid "Registration is not currently open for this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:85
+#: lib/klass_hero_web/live/program_detail_live.ex:87
 #, elixir-autogen, elixir-format
 msgid "Registration is not open for this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:151
+#: lib/klass_hero_web/live/program_detail_live.ex:161
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration opens %{date}"
 msgstr ""
@@ -2749,7 +2749,7 @@ msgstr ""
 msgid "Schedule (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:229
+#: lib/klass_hero_web/live/program_detail_live.ex:239
 #, elixir-autogen, elixir-format
 msgid "Schedule TBD"
 msgstr ""

--- a/test/klass_hero/social_links_test.exs
+++ b/test/klass_hero/social_links_test.exs
@@ -1,0 +1,66 @@
+defmodule KlassHero.SocialLinksTest do
+  # async: false — mutates application env, which is global.
+  use ExUnit.Case, async: false
+
+  alias KlassHero.SocialLinks
+
+  setup do
+    original = Application.get_env(:klass_hero, :social_links)
+    on_exit(fn -> Application.put_env(:klass_hero, :social_links, original) end)
+    :ok
+  end
+
+  defp configure(links), do: Application.put_env(:klass_hero, :social_links, links)
+
+  describe "all/0" do
+    test "is empty with the shipped config, so the footer row does not render" do
+      # Klass Hero has no accounts yet. This asserts the shipped default, which is
+      # what keeps dead placeholder anchors off the page.
+      assert SocialLinks.all() == []
+    end
+
+    test "returns only the networks that carry a url" do
+      configure(instagram: "https://instagram.com/klasshero", facebook: nil, tiktok: nil)
+
+      assert SocialLinks.all() == [
+               {:instagram, "Instagram", "https://instagram.com/klasshero"}
+             ]
+    end
+
+    test "treats blank and whitespace-only as unset" do
+      configure(instagram: "", facebook: "   ", tiktok: nil)
+
+      assert SocialLinks.all() == []
+    end
+
+    test "trims surrounding whitespace from a pasted url" do
+      configure(youtube: "  https://youtube.com/@klasshero  ")
+
+      assert [{:youtube, "YouTube", "https://youtube.com/@klasshero"}] = SocialLinks.all()
+    end
+
+    test "ignores a non-string value rather than crashing the footer" do
+      configure(instagram: :not_a_url)
+
+      assert SocialLinks.all() == []
+    end
+
+    test "returns networks in declared display order, not config order" do
+      configure(linkedin: "https://linkedin.com/company/kh", instagram: "https://instagram.com/kh")
+
+      assert [{:instagram, _, _}, {:linkedin, _, _}] = SocialLinks.all()
+    end
+  end
+
+  describe "networks/0 and label/1" do
+    test "every declared network has a brand label" do
+      for network <- SocialLinks.networks() do
+        assert is_binary(SocialLinks.label(network))
+      end
+    end
+
+    test "raises on an unknown network rather than rendering a blank" do
+      assert_raise KeyError, fn -> SocialLinks.label(:mastodon) end
+    end
+  end
+end

--- a/test/klass_hero_web/components/provider_hero_test.exs
+++ b/test/klass_hero_web/components/provider_hero_test.exs
@@ -75,6 +75,19 @@ defmodule KlassHeroWeb.ProviderHeroTest do
       assert render_hero(@filled, variant: :full) =~ "bg-white/90"
     end
 
+    test "uses the on-light token for the tagline, not the plain muted one" do
+      # Measured over a black cover behind the bg-white/90 scrim:
+      #   hero-grey-600 (:secondary)      2.92:1  fails
+      #   hero-grey-700 (:secondary_dark) 4.40:1  fails
+      #   hero-grey-800 (--fg-muted-on-light) 6.77:1  passes
+      # Only the third clears AA, so this token is not interchangeable with the
+      # ones the rest of the component uses.
+      html = render_hero(@filled, variant: :full)
+
+      assert html =~ "text-[var(--fg-muted-on-light)]"
+      refute html =~ "text-hero-grey-600"
+    end
+
     test "omits the description, which belongs to the About section" do
       refute render_hero(@filled, variant: :full) =~
                "Empowering kids through play-based learning."

--- a/test/klass_hero_web/components/provider_hero_test.exs
+++ b/test/klass_hero_web/components/provider_hero_test.exs
@@ -1,0 +1,120 @@
+defmodule KlassHeroWeb.ProviderHeroTest do
+  use KlassHeroWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias KlassHeroWeb.CompositeComponents
+
+  @filled %{
+    business_name: "Starlight Coaching",
+    initials: "SC",
+    description: "Empowering kids through play-based learning.",
+    logo_url: "https://cdn.example.com/logo.png",
+    tagline: "Move. Play. Grow.",
+    cover_image_url: "https://cdn.example.com/cover.png",
+    social_links: [
+      {:instagram, "Instagram", "https://instagram.com/starlight"},
+      {:youtube, "YouTube", "https://youtube.com/@starlight"}
+    ],
+    trust_state: :verified
+  }
+
+  # The realistic state today: a provider who has filled in none of #1302's fields.
+  @bare %{business_name: "Starlight Coaching", initials: "SC"}
+
+  defp render_hero(provider, opts \\ []) do
+    assigns = %{provider: provider, variant: Keyword.get(opts, :variant, :compact)}
+
+    render_component(&CompositeComponents.provider_hero/1, assigns)
+  end
+
+  describe "compact variant" do
+    test "renders identity, tagline, description and the trust mark" do
+      html = render_hero(@filled)
+
+      assert html =~ "Starlight Coaching"
+      assert html =~ "Move. Play. Grow."
+      assert html =~ "Empowering kids through play-based learning."
+      assert html =~ ~s(data-trust-state="verified")
+      assert html =~ ~s(data-variant="compact")
+    end
+
+    test "keeps the id the program detail page and its tests target" do
+      assert render_hero(@filled) =~ ~s(id="provider-profile-card")
+    end
+
+    test "renders the logo when present, initials when not" do
+      assert render_hero(@filled) =~ "https://cdn.example.com/logo.png"
+
+      bare = render_hero(@bare)
+      refute bare =~ "<img"
+      assert bare =~ "SC"
+    end
+  end
+
+  describe "full variant" do
+    test "renders the cover image as the background band" do
+      html = render_hero(@filled, variant: :full)
+
+      assert html =~ "https://cdn.example.com/cover.png"
+      assert html =~ ~s(data-band="cover")
+      refute html =~ ~s(data-band="gradient")
+      assert html =~ ~s(data-variant="full")
+    end
+
+    test "falls back to a gradient band when there is no cover" do
+      html = render_hero(@bare, variant: :full)
+
+      # data-band, not a bare "gradient" match: the avatar fallback carries the
+      # same gradient class, so a looser assertion would pass with no band at all.
+      assert html =~ ~s(data-band="gradient")
+      refute html =~ ~s(data-band="cover")
+    end
+
+    test "keeps the scrim that bounds contrast over an arbitrary cover" do
+      assert render_hero(@filled, variant: :full) =~ "bg-white/90"
+    end
+
+    test "omits the description, which belongs to the About section" do
+      refute render_hero(@filled, variant: :full) =~
+               "Empowering kids through play-based learning."
+    end
+  end
+
+  describe "social links" do
+    test "renders one accessible, safely-targeted link per filled network" do
+      html = render_hero(@filled)
+
+      assert html =~ "https://instagram.com/starlight"
+      assert html =~ "https://youtube.com/@starlight"
+      assert html =~ ~s(rel="noopener noreferrer")
+      # The glyph is aria-hidden, so the link needs its own accessible name.
+      assert html =~ "Starlight Coaching on Instagram"
+    end
+
+    test "renders no row at all when the provider filled in none" do
+      refute render_hero(@bare) =~ ~s(rel="noopener noreferrer")
+    end
+  end
+
+  describe "empty and partial states" do
+    test "renders both variants for a provider with nothing filled in" do
+      for variant <- [:compact, :full] do
+        html = render_hero(@bare, variant: variant)
+
+        assert html =~ "Starlight Coaching"
+        # :unverified renders nothing rather than a negative badge.
+        refute html =~ "data-trust-state"
+      end
+    end
+
+    test "treats a blank string as absent, not as content" do
+      blank = Map.merge(@bare, %{tagline: "   ", logo_url: "", cover_image_url: ""})
+
+      html = render_hero(blank, variant: :full)
+
+      refute html =~ "<img"
+      assert html =~ "Starlight Coaching"
+    end
+  end
+end

--- a/test/klass_hero_web/live/program_detail_live_test.exs
+++ b/test/klass_hero_web/live/program_detail_live_test.exs
@@ -485,6 +485,23 @@ defmodule KlassHeroWeb.ProgramDetailLiveTest do
 
       refute has_element?(view, "#provider-profile-card")
     end
+
+    test "keeps the card when the trust-state lookup fails", %{conn: conn} do
+      # The trust read shares safe_await's fallback with the profile read, so
+      # without the rescue in trust_state/1 this blanks the whole card instead of
+      # just its badge.
+      provider = provider_profile_fixture(business_name: "Starlight Coaching")
+      program = insert(:program_schema, provider_id: provider.id)
+
+      Mimic.stub(KlassHero.Provider, :get_trust_states, fn _ids ->
+        raise DBConnection.ConnectionError, "vetting lookup exploded"
+      end)
+
+      {:ok, view, _html} = live(conn, ~p"/programs/#{program.id}")
+
+      assert has_element?(view, "#provider-profile-card h4", "Starlight Coaching")
+      refute render(view) =~ "data-trust-state"
+    end
   end
 
   describe "pricing display" do

--- a/test/klass_hero_web/presenters/provider_presenter_test.exs
+++ b/test/klass_hero_web/presenters/provider_presenter_test.exs
@@ -122,10 +122,30 @@ defmodule KlassHeroWeb.Presenters.ProviderPresenterTest do
 
       # An empty string is as absent as nil here: a cleared input reaches the
       # column as nil, but a legacy row may still hold "".
+      #
+      # The leading atom is what `kh_social_icon/1` keys on — asserted explicitly
+      # because a glyph lookup keyed on the label string instead would still pass
+      # a shape check while breaking the first time a label is edited.
       assert ProviderPresenter.to_public_view(provider).social_links == [
-               {"Instagram", "https://instagram.com/starlight"},
-               {"YouTube", "https://youtube.com/@starlight"}
+               {:instagram, "Instagram", "https://instagram.com/starlight"},
+               {:youtube, "YouTube", "https://youtube.com/@starlight"}
              ]
+    end
+
+    test "defaults trust_state to :unverified when none is passed" do
+      provider = %ProviderProfile{id: "p-e", identity_id: "i-e", business_name: "Starlight"}
+
+      # Under-claiming is the safe default: kh_trust_mark/1 renders nothing for
+      # :unverified, so an unthreaded caller shows no badge rather than a badge
+      # the provider has not earned.
+      assert ProviderPresenter.to_public_view(provider).trust_state == :unverified
+    end
+
+    test "carries the trust state it is given" do
+      provider = %ProviderProfile{id: "p-f", identity_id: "i-f", business_name: "Starlight"}
+
+      assert ProviderPresenter.to_public_view(provider, :verified).trust_state == :verified
+      assert ProviderPresenter.to_public_view(provider, :in_progress).trust_state == :in_progress
     end
 
     test "social_links is empty when no network is set" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -20,3 +20,4 @@ Registry.start_link(keys: :unique, name: KlassHero.StorageRegistry)
 # unless a test sets an explicit stub/expect.
 Mimic.copy(KlassHero.Shared.Tracing.ObanEnqueue)
 Mimic.copy(KlassHero.Accounts)
+Mimic.copy(KlassHero.Provider)


### PR DESCRIPTION
Slice A1 of the provider profile work. Design decisions for the whole sequence are in #1303.

## Why

Both provider forms tell the provider the fields added in #1302 are *"shown on your public profile page"*. **That has been false since #1488 merged** — and not because no page exists:

```
program_detail_live.ex:127   ProviderPresenter.to_public_view(provider)
                             → returns tagline, cover_image_url, social_links
program_detail_live.ex:430   <.provider_profile_card provider={@provider_profile} />
composite_components.ex:631  renders business_name, description, logo_url, initials
                             → three of the keys it is handed are discarded
```

The render path was already live on a parent-facing page. The component just ignored the new keys.

## What

`provider_hero/1` replaces `provider_profile_card`, at two densities:

| Variant | Surface | State |
|---|---|---|
| `:compact` | program detail sidebar | live (keeps `#provider-profile-card`) |
| `:full` | band-style page hero | built + tested, routed in slice B |

One definition on purpose: the two provider *edit* forms were hand-copied and now disagree on every colour. Two surfaces rendering the same entity shouldn't repeat that.

Reuses `kh_trust_mark/1` and the cover-or-gradient split from `program_card`; no new badge, no new fallback pattern.

**`kh_social_icon/1`** — the footer already carried inline Facebook and Instagram brand marks, so this extracts them and adds TikTok, YouTube, LinkedIn. Keyed on the network **atom**, never the label, so the glyph lookup can't break when display text changes. A compile-time check fails the build if a declared network has no glyph.

**`KlassHero.SocialLinks`** — Klass Hero's own accounts, config-backed in the shape of the existing `KlassHero.Contact`. All `nil` today, so the icon row doesn't render and the dead `href="#facebook"` / `href="#instagram"` anchors are gone. Adding an account is one line in `config/config.exs`. Only the icon row is conditional — the "Connect" heading and contact email stay, since hiding the section would have hidden a configured email.

## Review focus

**`to_public_view/2` takes the trust state, it doesn't fetch it.** The presenter is a pure transform; `get_trust_states/1` is a DB read *and* batch-only (`[id] -> %{id => state}`), so program detail looks its own id up. It defaults to `:unverified`, which under-claims — `kh_trust_mark/1` renders nothing for that, so a caller who forgets shows no badge rather than one the provider hasn't earned.

**The scrim on `:full` is load-bearing.** The cover is an arbitrary user upload, so contrast over it is unbounded. `bg-white/90` is what makes the text legible; lowering it to "show the photo better" trades a guaranteed pass for an unbounded one.

**`social_links` widened to `{network, label, url}`.** `social_networks/0` deliberately keeps its `{field, label}` shape so the two edit forms are untouched.

## Verified

- `mix precommit` green: **5016 passed**, all lints
- **Both a11y-relevant details measured in the browser**, not inferred: social links are exactly `44x44`, carry `rel="noopener noreferrer"`, and the `<svg>` is `aria-hidden` with the accessible name on the link
- **Every glyph checked visually.** Three of the five paths were written from scratch; a wrong `d` attribute compiles, lints and tests clean and renders as garbage, so rendering was the only oracle. All five are correct at 20px.
- `:full` verified at 375px (stacked) and 1280px (side-by-side), and in both cover and gradient-fallback states
- Footer verified in both states: 5 icons when configured, zero links and an intact "Connect" + email when not
- German checked **by hand**: `mix gettext.merge` fuzzy-filled `"Klass Hero on %{network}"` as `"Klass Hero"`, silently dropping the interpolation — `lint_translations` passes that, since it only fails on empty or fuzzy-flagged entries. Corrected to `"Klass Hero auf %{network}"` and confirmed rendered under `?locale=de`.
- Mutation-tested: breaking the blank-string guard and the `:unverified` default each fail a test

## Notes

- The 4 existing program-detail card tests pass unchanged — the swap is behaviour-preserving. Coverage of `tagline`, `cover_image_url` and `social_links` is net-new; nothing tested them before.
- `app_footer` turns out to be reachable only from `/admin/verifications`, so those dead links were barely user-visible. The extraction was needed for the hero regardless.

Refs #1303
