### PR TITLE
feat: add the public provider profile page

### DIFF
--- a/lib/klass_hero/program_catalog.ex
+++ b/lib/klass_hero/program_catalog.ex
@@ -349,6 +349,24 @@ defmodule KlassHero.ProgramCatalog do
   end
 
   @doc """
+  Lists a provider's programs that have not ended, ordered by title.
+
+  The public counterpart to `list_programs_for_provider/1`, which deliberately
+  includes expired programs because the provider's own dashboard needs them.
+  Programs carry no published/draft flag — expiry is the only public axis — so
+  the two differ by this filter alone and are kept apart rather than merged
+  behind a boolean, which would make the wrong choice the quiet default.
+  """
+  @spec list_current_programs_for_provider(String.t()) :: [ProgramListing.t()]
+  def list_current_programs_for_provider(provider_id) when is_binary(provider_id) do
+    ProgramListing
+    |> where([l], l.provider_id == ^provider_id)
+    |> where([l], is_nil(l.end_date) or l.end_date >= ^Date.utc_today())
+    |> order_by([l], asc: l.title)
+    |> Repo.all()
+  end
+
+  @doc """
   Lists programs with cursor-based pagination.
 
   - `limit` - maximum programs to return

--- a/lib/klass_hero/provider.ex
+++ b/lib/klass_hero/provider.ex
@@ -67,6 +67,9 @@ defmodule KlassHero.Provider do
   @doc "Returns the provider profile by ID."
   defdelegate get_provider_profile(provider_id), to: Profiles
 
+  @doc "Returns a provider profile safe to show publicly: active only, malformed ids rejected."
+  defdelegate get_public_profile(provider_id), to: Profiles
+
   @doc "Gets the user (identity) ID that owns a provider profile ID (used by cross-context consumers)."
   defdelegate get_identity_id_for_provider(provider_id), to: Profiles
 

--- a/lib/klass_hero/provider/profiles.ex
+++ b/lib/klass_hero/provider/profiles.ex
@@ -154,6 +154,32 @@ defmodule KlassHero.Provider.Profiles do
   end
 
   @doc """
+  Returns a provider profile that is safe to show to a stranger.
+
+  Two rules the caller must not have to remember, because a public route makes
+  the id user-typed:
+
+  - A `:draft` profile reads as missing, so the id cannot be probed for
+    existence.
+  - A malformed id is rejected before it reaches the query. `Repo.get/2` on a
+    `binary_id` raises `Ecto.Query.CastError` for a non-UUID, which would be a
+    500 on `/providers/<anything>`. `dump/1` validates the format; `cast/1`
+    wrongly accepts any 16-byte binary.
+  """
+  @spec get_public_profile(term()) :: {:ok, ProviderProfile.t()} | {:error, :not_found}
+  def get_public_profile(provider_id) when is_binary(provider_id) do
+    with {:ok, _binary} <- Ecto.UUID.dump(provider_id),
+         %ProviderProfile{profile_status: :active} = profile <-
+           Repo.get(ProviderProfile, provider_id) do
+      {:ok, profile}
+    else
+      _ -> {:error, :not_found}
+    end
+  end
+
+  def get_public_profile(_provider_id), do: {:error, :not_found}
+
+  @doc """
   Resolves business names for a batch of provider IDs.
 
   Returns a map of `provider_id => business_name`. Unknown IDs are omitted.

--- a/lib/klass_hero_web/components/composite_components.ex
+++ b/lib/klass_hero_web/components/composite_components.ex
@@ -646,7 +646,17 @@ defmodule KlassHeroWeb.CompositeComponents do
         <div class="flex-1 min-w-0">
           <div class="flex flex-wrap items-center gap-2">
             <h4 class={[Theme.typography(:card_title), Theme.text_color(:heading)]}>
-              {@provider.business_name}
+              <%!-- Linked only when an id is present: a hand-built map from a test or
+                    preview must not crash the page (#1073). The :full variant is the
+                    profile page itself, so it never links. --%>
+              <.link
+                :if={@provider[:id]}
+                navigate={~p"/providers/#{@provider.id}"}
+                class="hover:text-[var(--fg-link)] hover:underline"
+              >
+                {@provider.business_name}
+              </.link>
+              <span :if={!@provider[:id]}>{@provider.business_name}</span>
             </h4>
             <.kh_trust_mark state={trust_state(@provider)} variant={:compact} />
           </div>

--- a/lib/klass_hero_web/components/marketing_components.ex
+++ b/lib/klass_hero_web/components/marketing_components.ex
@@ -1882,10 +1882,13 @@ defmodule KlassHeroWeb.MarketingComponents do
       <.kh_icon_chip icon={@icon} gradient={:primary} size={:sm} />
       <div class="min-w-0">
         <div class="font-semibold text-hero-black">{@title}</div>
+        <%!-- min-h-11 (44px) rather than the text's natural ~20px: this is the
+              control a mobile visitor taps to call or open the site, and the row's
+              own p-4 sits outside the anchor so it does not count toward the target. --%>
         <.link
           :if={@href}
           href={@href}
-          class="block text-sm text-[var(--fg-link)] underline truncate"
+          class="flex items-center min-h-11 text-sm text-[var(--fg-link)] underline truncate"
         >
           {@value}
         </.link>

--- a/lib/klass_hero_web/components/marketing_components.ex
+++ b/lib/klass_hero_web/components/marketing_components.ex
@@ -1874,6 +1874,7 @@ defmodule KlassHeroWeb.MarketingComponents do
   attr :title, :string, required: true
   attr :value, :string, required: true
   attr :note, :string, default: nil
+  attr :href, :string, default: nil, doc: "Makes the value actionable (tel:, mailto:, a URL)"
 
   def mk_method_row(assigns) do
     ~H"""
@@ -1881,7 +1882,14 @@ defmodule KlassHeroWeb.MarketingComponents do
       <.kh_icon_chip icon={@icon} gradient={:primary} size={:sm} />
       <div class="min-w-0">
         <div class="font-semibold text-hero-black">{@title}</div>
-        <div class="text-sm text-[var(--fg-muted)] truncate">{@value}</div>
+        <.link
+          :if={@href}
+          href={@href}
+          class="block text-sm text-[var(--fg-link)] underline truncate"
+        >
+          {@value}
+        </.link>
+        <div :if={!@href} class="text-sm text-[var(--fg-muted)] truncate">{@value}</div>
         <div :if={@note} class="text-xs text-[var(--fg-muted)] opacity-80 mt-0.5">{@note}</div>
       </div>
     </div>

--- a/lib/klass_hero_web/components/theme.ex
+++ b/lib/klass_hero_web/components/theme.ex
@@ -409,7 +409,10 @@ defmodule KlassHeroWeb.Theme do
   def typography(:card_title), do: "font-sans text-lg font-semibold"
   def typography(:body), do: "font-sans text-base"
   def typography(:body_small), do: "font-sans text-sm"
-  def typography(:caption), do: "font-sans text-xs text-gray-500"
+  # Type only, no colour. This used to carry `text-gray-500`, which is both a raw
+  # Tailwind grey and ~4.02:1 on white — failing AA at this size. A colour inside a
+  # typography helper also hides from a palette sweep, which is how it survived one.
+  def typography(:caption), do: "font-sans text-xs"
 
   @doc """
   Returns the border radius class for the specified size.

--- a/lib/klass_hero_web/helpers/provider_display.ex
+++ b/lib/klass_hero_web/helpers/provider_display.ex
@@ -13,6 +13,9 @@ defmodule KlassHeroWeb.Helpers.ProviderDisplay do
   """
 
   alias KlassHero.Provider
+  alias KlassHeroWeb.Presenters.ProviderPresenter
+
+  require Logger
 
   @unknown %{name: nil, trust: :unverified}
 
@@ -45,6 +48,35 @@ defmodule KlassHeroWeb.Helpers.ProviderDisplay do
           trust: Provider.trust_state()
         }
   def fetch(providers, program), do: Map.get(providers, program.provider_id, @unknown)
+
+  @doc """
+  Builds the public hero view for one provider, or `nil` when there is none to show.
+
+  Both `provider_hero/1` variants take this map. `Provider.get_public_profile/1`
+  owns which profiles are public; this adds the trust state and the presenter.
+
+  The trust read is rescued so a vetting-lookup failure costs the badge rather
+  than the whole card — the badge is additive, the identity is the content, and
+  degrading to `:unverified` under-claims rather than over-claims.
+  """
+  @spec public_view(term()) :: map() | nil
+  def public_view(provider_id) do
+    case Provider.get_public_profile(provider_id) do
+      {:ok, profile} -> ProviderPresenter.to_public_view(profile, trust_state(provider_id))
+      {:error, :not_found} -> nil
+    end
+  end
+
+  # get_trust_states/1 is batch-only; a missing entry means unverified.
+  defp trust_state(provider_id) do
+    [provider_id]
+    |> Provider.get_trust_states()
+    |> Map.get(provider_id, :unverified)
+  rescue
+    error ->
+      Logger.warning("trust state lookup failed for provider #{provider_id}: #{inspect(error)}")
+      :unverified
+  end
 
   @doc "The fallback used when a provider cannot be resolved."
   @spec unknown() :: %{name: nil, trust: :unverified}

--- a/lib/klass_hero_web/live/home_live.ex
+++ b/lib/klass_hero_web/live/home_live.ex
@@ -4,16 +4,17 @@ defmodule KlassHeroWeb.HomeLive do
   import KlassHeroWeb.MarketingComponents
 
   alias KlassHero.ProgramCatalog
-  alias KlassHero.ProgramCatalog.ProgramListing
   alias KlassHeroWeb.Helpers.ProviderDisplay
   alias KlassHeroWeb.Presenters.ProgramPresenter
-  alias KlassHeroWeb.Theme
 
   @impl true
   def mount(_params, _session, socket) do
     featured = ProgramCatalog.list_featured_programs()
     providers = ProviderDisplay.for_programs(featured)
-    featured_maps = Enum.map(featured, &listing_to_card_map(&1, ProviderDisplay.fetch(providers, &1)))
+
+    featured_maps =
+      Enum.map(featured, &ProgramPresenter.to_card_view(&1, ProviderDisplay.fetch(providers, &1)))
+
     trending_tags = ProgramCatalog.trending_searches()
 
     socket =
@@ -52,28 +53,6 @@ defmodule KlassHeroWeb.HomeLive do
   @impl true
   def handle_event("view_program", %{"program-id" => program_id}, socket) do
     {:noreply, push_navigate(socket, to: ~p"/programs/#{program_id}")}
-  end
-
-  defp listing_to_card_map(%ProgramListing{} = program, provider) do
-    %{
-      id: program.id,
-      title: program.title,
-      subtitle: program.subtitle,
-      provider_name: provider.name,
-      verification_state: provider.trust,
-      description: program.description,
-      category: ProgramPresenter.format_category_for_display(program.category),
-      age_range: program.age_range,
-      price: program.price,
-      cover_image_url: program.cover_image_url,
-      meeting_days: program.meeting_days || [],
-      meeting_start_time: program.meeting_start_time,
-      meeting_end_time: program.meeting_end_time,
-      start_date: program.start_date,
-      end_date: program.end_date,
-      gradient_class: Theme.gradient(:primary),
-      icon_name: ProgramPresenter.icon_name(program.category)
-    }
   end
 
   @impl true

--- a/lib/klass_hero_web/live/program_detail_live.ex
+++ b/lib/klass_hero_web/live/program_detail_live.ex
@@ -8,14 +8,12 @@ defmodule KlassHeroWeb.ProgramDetailLive do
   alias KlassHero.Enrollment
   alias KlassHero.ProgramCatalog
   alias KlassHero.Provider
+  alias KlassHeroWeb.Helpers.ProviderDisplay
   alias KlassHeroWeb.Helpers.TaskHelpers
   alias KlassHeroWeb.Presenters.HeroCardsPresenter
   alias KlassHeroWeb.Presenters.ParticipantPolicyPresenter
   alias KlassHeroWeb.Presenters.ProgramPresenter
-  alias KlassHeroWeb.Presenters.ProviderPresenter
   alias KlassHeroWeb.Theme
-
-  require Logger
 
   @impl true
   def mount(%{"id" => program_id}, _session, socket) do
@@ -37,7 +35,7 @@ defmodule KlassHeroWeb.ProgramDetailLive do
 
         provider_task =
           Task.Supervisor.async_nolink(KlassHero.TaskSupervisor, fn ->
-            load_provider_profile(program.provider_id)
+            ProviderDisplay.public_view(program.provider_id)
           end)
 
         team =
@@ -119,35 +117,6 @@ defmodule KlassHeroWeb.ProgramDetailLive do
       end
 
     %{staff: staff, lead_id: lead_id}
-  end
-
-  defp load_provider_profile(nil), do: nil
-
-  defp load_provider_profile(provider_id) do
-    case Provider.get_provider_profile(provider_id) do
-      # Only :active providers are surfaced to parents; nil suppresses the card.
-      {:ok, %{profile_status: :active} = provider} ->
-        ProviderPresenter.to_public_view(provider, trust_state(provider_id))
-
-      _ ->
-        nil
-    end
-  end
-
-  # get_trust_states/1 is batch-only; a missing entry means unverified.
-  #
-  # Rescued because this call shares `safe_await`'s fallback with the profile read
-  # above: without it, a vetting-lookup failure blanks the whole provider card
-  # rather than just its badge. The badge is additive, the identity is the
-  # content, so this degrades to :unverified — which under-claims, never over-.
-  defp trust_state(provider_id) do
-    [provider_id]
-    |> Provider.get_trust_states()
-    |> Map.get(provider_id, :unverified)
-  rescue
-    error ->
-      Logger.warning("trust state lookup failed for provider #{provider_id}: #{inspect(error)}")
-      :unverified
   end
 
   defp load_participant_policy(program_id) do

--- a/lib/klass_hero_web/live/programs_live.ex
+++ b/lib/klass_hero_web/live/programs_live.ex
@@ -9,7 +9,6 @@ defmodule KlassHeroWeb.ProgramsLive do
   alias KlassHero.Shared.ErrorIds
   alias KlassHeroWeb.Helpers.ProviderDisplay
   alias KlassHeroWeb.Presenters.ProgramPresenter
-  alias KlassHeroWeb.Theme
 
   require Logger
 
@@ -115,26 +114,8 @@ defmodule KlassHeroWeb.ProgramsLive do
   defp program_to_map(%ProgramListing{} = program, capacities, providers) do
     remaining = Map.get(capacities, program.id)
     spots_left = if remaining != :unlimited, do: remaining
-    provider = ProviderDisplay.fetch(providers, program)
 
-    %{
-      id: program.id,
-      provider_name: provider.name,
-      verification_state: provider.trust,
-      title: program.title,
-      subtitle: program.subtitle,
-      description: program.description,
-      category: ProgramPresenter.format_category_for_display(program.category),
-      meeting_days: program.meeting_days || [],
-      meeting_start_time: program.meeting_start_time,
-      meeting_end_time: program.meeting_end_time,
-      age_range: program.age_range,
-      price: program.price,
-      spots_left: spots_left,
-      cover_image_url: program.cover_image_url,
-      gradient_class: Theme.gradient(:primary),
-      icon_name: ProgramPresenter.icon_name(program.category)
-    }
+    ProgramPresenter.to_card_view(program, ProviderDisplay.fetch(providers, program), spots_left)
   end
 
   @impl true

--- a/lib/klass_hero_web/live/provider/verification_live.ex
+++ b/lib/klass_hero_web/live/provider/verification_live.ex
@@ -680,7 +680,7 @@ defmodule KlassHeroWeb.Provider.VerificationLive do
           label={gettext("Country of registration")}
           options={country_options()}
         />
-        <p class={["mt-1 mb-3", Theme.typography(:caption)]}>
+        <p class={["mt-1 mb-3", Theme.typography(:caption), Theme.text_color(:muted)]}>
           {registration_guidance(@form[:registration_country].value)}
         </p>
         <.input
@@ -695,7 +695,9 @@ defmodule KlassHeroWeb.Provider.VerificationLive do
         />
 
         <.live_file_input upload={@uploads.business_registration_doc} class="mt-2 block" />
-        <p class={["mt-1", Theme.typography(:caption)]}>{gettext("PDF, JPG or PNG. Max 10MB.")}</p>
+        <p class={["mt-1", Theme.typography(:caption), Theme.text_color(:muted)]}>
+          {gettext("PDF, JPG or PNG. Max 10MB.")}
+        </p>
 
         <.button id="business-registration-submit" class="mt-3">{gettext("Submit for review")}</.button>
       </.form>
@@ -767,7 +769,9 @@ defmodule KlassHeroWeb.Provider.VerificationLive do
         <% end %>
 
         <.live_file_input upload={@uploads.insurance_doc} class="mt-2 block" />
-        <p class={["mt-1", Theme.typography(:caption)]}>{gettext("PDF, JPG or PNG. Max 10MB.")}</p>
+        <p class={["mt-1", Theme.typography(:caption), Theme.text_color(:muted)]}>
+          {gettext("PDF, JPG or PNG. Max 10MB.")}
+        </p>
 
         <.button id="insurance-submit" class="mt-3">{gettext("Submit for review")}</.button>
       </.form>
@@ -792,7 +796,7 @@ defmodule KlassHeroWeb.Provider.VerificationLive do
             <.button id="identity-verify-start" phx-click="start_identity_verification">
               {gettext("Verify identity")}
             </.button>
-            <p class={["mt-3", Theme.typography(:caption)]}>
+            <p class={["mt-3", Theme.typography(:caption), Theme.text_color(:muted)]}>
               {gettext("Takes about 2 minutes. Once verified, your provider account can be approved.")}
             </p>
           </div>

--- a/lib/klass_hero_web/live/provider_profile_live.ex
+++ b/lib/klass_hero_web/live/provider_profile_live.ex
@@ -1,0 +1,174 @@
+defmodule KlassHeroWeb.ProviderProfileLive do
+  @moduledoc """
+  The public provider profile: identity, then what they run.
+
+  Reads happen synchronously in `mount/3` so the disconnected render already
+  carries the content — this is a crawlable marketing page, and `assign_async`
+  would serve an empty first byte.
+  """
+
+  use KlassHeroWeb, :live_view
+
+  import KlassHeroWeb.CompositeComponents
+  import KlassHeroWeb.MarketingComponents
+
+  alias KlassHero.ProgramCatalog
+  alias KlassHero.Provider
+  alias KlassHeroWeb.Helpers.ProviderDisplay
+  alias KlassHeroWeb.Presenters.ProgramPresenter
+  alias KlassHeroWeb.Theme
+
+  @impl true
+  def mount(%{"id" => provider_id}, _session, socket) do
+    case ProviderDisplay.public_view(provider_id) do
+      nil ->
+        {:ok,
+         socket
+         |> put_flash(
+           :error,
+           gettext("Provider not found. They may have been removed or are no longer listed.")
+         )
+         |> redirect(to: ~p"/programs")}
+
+      provider ->
+        {:ok, mount_profile(socket, provider_id, provider)}
+    end
+  end
+
+  defp mount_profile(socket, provider_id, provider) do
+    contact = contact_facts(provider_id)
+
+    programs =
+      provider_id
+      |> ProgramCatalog.list_current_programs_for_provider()
+      # No provider passed: the card's provider row would repeat the name of the
+      # page it is on, once per card.
+      |> Enum.map(&ProgramPresenter.to_card_view/1)
+
+    socket
+    |> assign(:page_title, provider.business_name)
+    |> assign(:provider, provider)
+    |> assign(:contact, contact)
+    |> assign(:programs_empty?, programs == [])
+    |> stream(:programs, programs)
+  end
+
+  # Read a second time rather than widening the public view: the hero takes a
+  # deliberately slim map, and these fields belong to About, not to identity.
+  defp contact_facts(provider_id) do
+    case Provider.get_public_profile(provider_id) do
+      {:ok, profile} -> Map.take(profile, [:description, :address, :phone, :website])
+      {:error, :not_found} -> %{}
+    end
+  end
+
+  defp present?(value) when is_binary(value), do: String.trim(value) != ""
+  defp present?(_), do: false
+
+  defp any_contact?(contact) do
+    Enum.any?([:description, :address, :phone, :website], &present?(Map.get(contact, &1)))
+  end
+
+  @impl true
+  def handle_event("view_program", %{"program-id" => program_id}, socket) do
+    {:noreply, push_navigate(socket, to: ~p"/programs/#{program_id}")}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="max-w-5xl mx-auto px-4 sm:px-6 py-8 sm:py-12">
+      <.provider_hero provider={@provider} variant={:full} />
+    </div>
+
+    <section :if={any_contact?(@contact)} id="provider-about" class="py-12 lg:py-16 bg-hero-cream-100">
+      <div class="max-w-5xl mx-auto px-4 sm:px-6">
+        <h2 class={[Theme.typography(:section_title), Theme.text_color(:heading), "mb-6"]}>
+          <%!-- Not the bare "About", whose German is "Über uns" — this section is
+                about someone else, and the reader is a parent. --%>
+          {gettext("About the Provider")}
+        </h2>
+
+        <p
+          :if={present?(@contact[:description])}
+          class={[Theme.typography(:body), "text-[var(--fg-muted-on-light)] max-w-3xl mb-8"]}
+        >
+          {@contact.description}
+        </p>
+
+        <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <.mk_method_row
+            :if={present?(@contact[:address])}
+            icon="hero-map-pin"
+            title={gettext("Address")}
+            value={@contact.address}
+          />
+          <.mk_method_row
+            :if={present?(@contact[:phone])}
+            icon="hero-phone"
+            title={gettext("Phone")}
+            value={@contact.phone}
+            href={"tel:#{@contact[:phone]}"}
+          />
+          <.mk_method_row
+            :if={present?(@contact[:website])}
+            icon="hero-globe-alt"
+            title={gettext("Website")}
+            value={@contact.website}
+            href={@contact[:website]}
+          />
+        </div>
+      </div>
+    </section>
+
+    <section id="provider-programs" class="py-12 lg:py-16 bg-white">
+      <div class="max-w-5xl mx-auto px-4 sm:px-6">
+        <h2 class={[Theme.typography(:section_title), Theme.text_color(:heading), "mb-6"]}>
+          {gettext("Programs")}
+        </h2>
+
+        <.mk_empty_state
+          :if={@programs_empty?}
+          icon="hero-calendar"
+          title={gettext("No programs running right now")}
+          description={gettext("This provider has no open programs at the moment. Check back soon.")}
+        />
+
+        <div
+          :if={!@programs_empty?}
+          id="provider-programs-grid"
+          phx-update="stream"
+          class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
+        >
+          <.mk_program_card
+            :for={{dom_id, program} <- @streams.programs}
+            id={dom_id}
+            program={program}
+          />
+        </div>
+      </div>
+    </section>
+
+    <section class="py-12 lg:py-16 bg-hero-cream-100">
+      <div class="max-w-5xl mx-auto px-4 sm:px-6 text-center">
+        <h2 class={[Theme.typography(:section_title), Theme.text_color(:heading), "mb-3"]}>
+          {gettext("Have questions?")}
+        </h2>
+        <p class={[Theme.typography(:body), "text-[var(--fg-muted-on-light)] mb-6"]}>
+          {gettext("Message %{provider} directly about their programs.",
+            provider: @provider.business_name
+          )}
+        </p>
+        <%!-- A link, not a gated button. Messaging.build_compose_target/3 owns who may
+              write to whom ("the gate lives here rather than in the callers"), and an
+              anonymous visitor is bounced to log in by the target live_session. A
+              pre-check here would only add a second copy of the rule and turn the CTA
+              into a dead end for logged-out traffic. --%>
+        <.link id="provider-message-cta" navigate={~p"/messages/new?provider_id=#{@provider.id}"}>
+          <.kh_button variant={:primary}>{gettext("Message this provider")}</.kh_button>
+        </.link>
+      </div>
+    </section>
+    """
+  end
+end

--- a/lib/klass_hero_web/live/provider_profile_live.ex
+++ b/lib/klass_hero_web/live/provider_profile_live.ex
@@ -13,7 +13,6 @@ defmodule KlassHeroWeb.ProviderProfileLive do
   import KlassHeroWeb.MarketingComponents
 
   alias KlassHero.ProgramCatalog
-  alias KlassHero.Provider
   alias KlassHeroWeb.Helpers.ProviderDisplay
   alias KlassHeroWeb.Presenters.ProgramPresenter
   alias KlassHeroWeb.Theme
@@ -36,8 +35,6 @@ defmodule KlassHeroWeb.ProviderProfileLive do
   end
 
   defp mount_profile(socket, provider_id, provider) do
-    contact = contact_facts(provider_id)
-
     programs =
       provider_id
       |> ProgramCatalog.list_current_programs_for_provider()
@@ -48,25 +45,15 @@ defmodule KlassHeroWeb.ProviderProfileLive do
     socket
     |> assign(:page_title, provider.business_name)
     |> assign(:provider, provider)
-    |> assign(:contact, contact)
     |> assign(:programs_empty?, programs == [])
     |> stream(:programs, programs)
-  end
-
-  # Read a second time rather than widening the public view: the hero takes a
-  # deliberately slim map, and these fields belong to About, not to identity.
-  defp contact_facts(provider_id) do
-    case Provider.get_public_profile(provider_id) do
-      {:ok, profile} -> Map.take(profile, [:description, :address, :phone, :website])
-      {:error, :not_found} -> %{}
-    end
   end
 
   defp present?(value) when is_binary(value), do: String.trim(value) != ""
   defp present?(_), do: false
 
-  defp any_contact?(contact) do
-    Enum.any?([:description, :address, :phone, :website], &present?(Map.get(contact, &1)))
+  defp any_contact?(provider) do
+    Enum.any?([:description, :address, :phone, :website], &present?(provider[&1]))
   end
 
   @impl true
@@ -74,91 +61,105 @@ defmodule KlassHeroWeb.ProviderProfileLive do
     {:noreply, push_navigate(socket, to: ~p"/programs/#{program_id}")}
   end
 
+  attr :id, :string, default: nil
+  attr :background, :string, required: true
+  slot :inner_block, required: true
+
+  defp profile_section(assigns) do
+    ~H"""
+    <section id={@id} class={["py-12 lg:py-16", @background]}>
+      <div class="max-w-5xl mx-auto px-6">
+        {render_slot(@inner_block)}
+      </div>
+    </section>
+    """
+  end
+
   @impl true
   def render(assigns) do
     ~H"""
-    <div class="max-w-5xl mx-auto px-4 sm:px-6 py-8 sm:py-12">
+    <%!-- The hero carries the marketing surface's warm pink base, and it also keeps
+          the bands alternating when About is absent — which is the common case, since
+          most providers have filled none of this in. Alternation that depends on
+          optional content collapses into two flush white sections exactly then. --%>
+    <.profile_section background={Theme.gradient(:base_fade)}>
       <.provider_hero provider={@provider} variant={:full} />
-    </div>
+    </.profile_section>
 
-    <section :if={any_contact?(@contact)} id="provider-about" class="py-12 lg:py-16 bg-hero-cream-100">
-      <div class="max-w-5xl mx-auto px-4 sm:px-6">
-        <h2 class={[Theme.typography(:section_title), Theme.text_color(:heading), "mb-6"]}>
-          <%!-- Not the bare "About", whose German is "Über uns" — this section is
-                about someone else, and the reader is a parent. --%>
-          {gettext("About the Provider")}
-        </h2>
+    <.profile_section :if={any_contact?(@provider)} id="provider-about" background="bg-hero-cream-100">
+      <h2 class={[Theme.typography(:section_title), Theme.text_color(:heading), "mb-6"]}>
+        <%!-- Not the bare "About", whose German is "Über uns" — this section is
+              about someone else, and the reader is a parent. --%>
+        {gettext("About the Provider")}
+      </h2>
 
-        <p
-          :if={present?(@contact[:description])}
-          class={[Theme.typography(:body), "text-[var(--fg-muted-on-light)] max-w-3xl mb-8"]}
-        >
-          {@contact.description}
-        </p>
+      <p
+        :if={present?(@provider[:description])}
+        class={[Theme.typography(:body), "text-[var(--fg-muted-on-light)] max-w-3xl mb-8"]}
+      >
+        {@provider.description}
+      </p>
 
-        <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
-          <.mk_method_row
-            :if={present?(@contact[:address])}
-            icon="hero-map-pin"
-            title={gettext("Address")}
-            value={@contact.address}
-          />
-          <.mk_method_row
-            :if={present?(@contact[:phone])}
-            icon="hero-phone"
-            title={gettext("Phone")}
-            value={@contact.phone}
-            href={"tel:#{@contact[:phone]}"}
-          />
-          <.mk_method_row
-            :if={present?(@contact[:website])}
-            icon="hero-globe-alt"
-            title={gettext("Website")}
-            value={@contact.website}
-            href={@contact[:website]}
-          />
-        </div>
-      </div>
-    </section>
-
-    <section id="provider-programs" class="py-12 lg:py-16 bg-white">
-      <div class="max-w-5xl mx-auto px-4 sm:px-6">
-        <h2 class={[Theme.typography(:section_title), Theme.text_color(:heading), "mb-6"]}>
-          {gettext("Programs")}
-        </h2>
-
-        <.mk_empty_state
-          :if={@programs_empty?}
-          icon="hero-calendar"
-          title={gettext("No programs running right now")}
-          description={gettext("This provider has no open programs at the moment. Check back soon.")}
+      <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <.mk_method_row
+          :if={present?(@provider[:address])}
+          icon="hero-map-pin"
+          title={gettext("Address")}
+          value={@provider.address}
         />
-
-        <div
-          :if={!@programs_empty?}
-          id="provider-programs-grid"
-          phx-update="stream"
-          class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
-        >
-          <.mk_program_card
-            :for={{dom_id, program} <- @streams.programs}
-            id={dom_id}
-            program={program}
-          />
-        </div>
+        <.mk_method_row
+          :if={present?(@provider[:phone])}
+          icon="hero-phone"
+          title={gettext("Phone")}
+          value={@provider.phone}
+          href={"tel:#{@provider[:phone]}"}
+        />
+        <.mk_method_row
+          :if={present?(@provider[:website])}
+          icon="hero-globe-alt"
+          title={gettext("Website")}
+          value={@provider.website}
+          href={@provider[:website]}
+        />
       </div>
-    </section>
+    </.profile_section>
 
-    <section class="py-12 lg:py-16 bg-hero-cream-100">
-      <div class="max-w-5xl mx-auto px-4 sm:px-6 text-center">
-        <h2 class={[Theme.typography(:section_title), Theme.text_color(:heading), "mb-3"]}>
-          {gettext("Have questions?")}
-        </h2>
-        <p class={[Theme.typography(:body), "text-[var(--fg-muted-on-light)] mb-6"]}>
-          {gettext("Message %{provider} directly about their programs.",
-            provider: @provider.business_name
-          )}
-        </p>
+    <.profile_section id="provider-programs" background="bg-white">
+      <h2 class={[Theme.typography(:section_title), Theme.text_color(:heading), "mb-6"]}>
+        {gettext("Programs")}
+      </h2>
+
+      <.mk_empty_state
+        :if={@programs_empty?}
+        icon="hero-calendar"
+        title={gettext("No programs running right now")}
+        description={gettext("This provider has no open programs at the moment. Check back soon.")}
+      />
+
+      <div
+        :if={!@programs_empty?}
+        id="provider-programs-grid"
+        phx-update="stream"
+        class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
+      >
+        <.mk_program_card
+          :for={{dom_id, program} <- @streams.programs}
+          id={dom_id}
+          program={program}
+        />
+      </div>
+    </.profile_section>
+
+    <.mk_cta_section
+      id="provider-cta"
+      title={gettext("Have questions?")}
+      lede={
+        gettext("Message %{provider} directly about their programs.",
+          provider: @provider.business_name
+        )
+      }
+    >
+      <:cta>
         <%!-- A link, not a gated button. Messaging.build_compose_target/3 owns who may
               write to whom ("the gate lives here rather than in the callers"), and an
               anonymous visitor is bounced to log in by the target live_session. A
@@ -167,8 +168,8 @@ defmodule KlassHeroWeb.ProviderProfileLive do
         <.link id="provider-message-cta" navigate={~p"/messages/new?provider_id=#{@provider.id}"}>
           <.kh_button variant={:primary}>{gettext("Message this provider")}</.kh_button>
         </.link>
-      </div>
-    </section>
+      </:cta>
+    </.mk_cta_section>
     """
   end
 end

--- a/lib/klass_hero_web/presenters/program_presenter.ex
+++ b/lib/klass_hero_web/presenters/program_presenter.ex
@@ -339,33 +339,24 @@ defmodule KlassHeroWeb.Presenters.ProgramPresenter do
   end
 
   @doc """
-  Formats a category slug for display by splitting on hyphens and capitalizing each word.
-
-  ## Examples
-
-      iex> KlassHeroWeb.Presenters.ProgramPresenter.format_category_for_display("life-skills")
-      "Life Skills"
-
-      iex> KlassHeroWeb.Presenters.ProgramPresenter.format_category_for_display(nil)
-      "Education"
-  """
-  @spec format_category_for_display(String.t() | nil) :: String.t()
-  def format_category_for_display(category) when is_binary(category) do
-    category
-    |> String.split("-")
-    |> Enum.map_join(" ", &String.capitalize/1)
-  end
-
-  def format_category_for_display(_), do: "Education"
-
-  @doc """
   Transforms a category code to a human-readable label.
   """
+  # Every category in `Shared.Categories` has a clause, so the fallback is only
+  # reached by an unknown value. It splits on "-" because `String.capitalize/1`
+  # alone renders "life-skills" as "Life-skills" — which is what cards showed
+  # after the two per-LiveView builders were folded into `to_card/3`, since the
+  # deleted copies used a second, hyphen-aware formatter that this one replaced.
   @spec humanize_category(String.t() | nil) :: String.t()
-  def humanize_category(nil), do: "General"
+  def humanize_category(nil), do: gettext("General")
   def humanize_category("arts"), do: gettext("Arts")
   def humanize_category("education"), do: gettext("Education")
   def humanize_category("sports"), do: gettext("Sports")
   def humanize_category("music"), do: gettext("Music")
-  def humanize_category(category), do: String.capitalize(category)
+  def humanize_category("life-skills"), do: gettext("Life Skills")
+  def humanize_category("camps"), do: gettext("Camps")
+  def humanize_category("workshops"), do: gettext("Workshops")
+
+  def humanize_category(category) do
+    category |> String.split("-") |> Enum.map_join(" ", &String.capitalize/1)
+  end
 end

--- a/lib/klass_hero_web/presenters/program_presenter.ex
+++ b/lib/klass_hero_web/presenters/program_presenter.ex
@@ -68,10 +68,25 @@ defmodule KlassHeroWeb.Presenters.ProgramPresenter do
 
   Returns a map matching the attrs expected by `ProgramComponents.program_card/1`.
   """
-  @spec to_card_view(Program.t(), %{name: String.t() | nil, trust: atom()}) :: map()
-  def to_card_view(program, provider \\ %{name: nil, trust: :unverified})
+  @spec to_card_view(
+          Program.t() | ProgramListing.t(),
+          %{name: String.t() | nil, trust: atom()},
+          non_neg_integer() | nil
+        ) :: map()
+  def to_card_view(program, provider \\ %{name: nil, trust: :unverified}, spots_left \\ nil)
 
-  def to_card_view(%Program{} = program, provider) do
+  def to_card_view(%Program{} = program, provider, spots_left) do
+    to_card(program, provider, spots_left)
+  end
+
+  # ProgramListing is the read-model twin every public surface lists from, and both
+  # cards read the same keys — so one builder serves both rather than a private copy
+  # per LiveView, which is how the home and catalog copies drifted apart.
+  def to_card_view(%ProgramListing{} = listing, provider, spots_left) do
+    to_card(listing, provider, spots_left)
+  end
+
+  defp to_card(program, provider, spots_left) do
     %{
       id: program.id,
       provider_name: provider.name,
@@ -85,6 +100,7 @@ defmodule KlassHeroWeb.Presenters.ProgramPresenter do
       # unpriced program from a free one. Coercing nil to zero here would label an
       # incomplete program "Free", which is a claim about money, not a missing value.
       price: program.price,
+      cover_image_url: program.cover_image_url,
       icon_name: icon_name(program.category),
       gradient_class: default_gradient_class(),
       meeting_days: program.meeting_days || [],
@@ -92,7 +108,7 @@ defmodule KlassHeroWeb.Presenters.ProgramPresenter do
       meeting_end_time: program.meeting_end_time,
       start_date: program.start_date,
       end_date: program.end_date,
-      spots_left: nil
+      spots_left: spots_left
     }
   end
 

--- a/lib/klass_hero_web/presenters/provider_presenter.ex
+++ b/lib/klass_hero_web/presenters/provider_presenter.ex
@@ -43,7 +43,10 @@ defmodule KlassHeroWeb.Presenters.ProviderPresenter do
   tier/verification/slot data is not relevant — only the business identity.
 
   Returns a map with: id, business_name, description, logo_url, initials,
-  trust_state, plus the branding fields (tagline, cover_image_url, social_links).
+  trust_state, the branding fields (tagline, cover_image_url, social_links), and
+  the public contact facts (address, phone, website). The hero variants read a
+  subset; the profile page's About section reads the rest, so one read serves
+  both rather than the page querying the same row twice.
 
   `social_links` is a list of `{network, label, url}` for the networks the provider
   filled in; the atom is what `kh_social_icon/1` keys on.
@@ -63,7 +66,10 @@ defmodule KlassHeroWeb.Presenters.ProviderPresenter do
       tagline: provider.tagline,
       cover_image_url: provider.cover_image_url,
       social_links: social_links(provider),
-      trust_state: trust_state
+      trust_state: trust_state,
+      address: provider.address,
+      phone: provider.phone,
+      website: provider.website
     }
   end
 

--- a/lib/klass_hero_web/router.ex
+++ b/lib/klass_hero_web/router.ex
@@ -77,6 +77,7 @@ defmodule KlassHeroWeb.Router do
       live "/", HomeLive, :index
       live "/programs", ProgramsLive, :index
       live "/programs/:id", ProgramDetailLive, :show
+      live "/providers/:id", ProviderProfileLive, :show
       live "/trust-safety", TrustSafetyLive, :index
       live "/about", AboutLive, :index
       live "/contact", ContactLive, :index

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -94,7 +94,7 @@ msgstr "Anmelden"
 #: lib/klass_hero_web/components/layouts/app.html.heex:36
 #: lib/klass_hero_web/components/layouts/app.html.heex:198
 #: lib/klass_hero_web/components/marketing_components.ex:202
-#: lib/klass_hero_web/live/provider_profile_live.ex:127
+#: lib/klass_hero_web/live/provider_profile_live.ex:129
 #, elixir-autogen, elixir-format
 msgid "Programs"
 msgstr "Programme"
@@ -416,7 +416,7 @@ msgstr "Kontobeendigung"
 
 #: lib/klass_hero_web/live/contact_live.ex:85
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:314
-#: lib/klass_hero_web/live/provider_profile_live.ex:103
+#: lib/klass_hero_web/live/provider_profile_live.ex:107
 #, elixir-autogen, elixir-format
 msgid "Address"
 msgstr "Adresse"
@@ -795,7 +795,7 @@ msgstr "Oder Passwort verwenden"
 #: lib/klass_hero_web/live/contact_live.ex:100
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:241
 #: lib/klass_hero_web/live/provider/verification_live.ex:626
-#: lib/klass_hero_web/presenters/provider_presenter.ex:160
+#: lib/klass_hero_web/presenters/provider_presenter.ex:166
 #, elixir-autogen, elixir-format
 msgid "Other"
 msgstr "Sonstiges"
@@ -814,7 +814,7 @@ msgstr "Zahlungsbedingungen"
 
 #: lib/klass_hero_web/live/contact_live.ex:78
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:299
-#: lib/klass_hero_web/live/provider_profile_live.ex:109
+#: lib/klass_hero_web/live/provider_profile_live.ex:113
 #, elixir-autogen, elixir-format
 msgid "Phone"
 msgstr "Telefon"
@@ -1156,7 +1156,7 @@ msgid "All"
 msgstr "Alle"
 
 #: lib/klass_hero_web/live/programs_live.ex:21
-#: lib/klass_hero_web/presenters/program_presenter.ex:366
+#: lib/klass_hero_web/presenters/program_presenter.ex:351
 #, elixir-autogen, elixir-format
 msgid "Arts"
 msgstr "Kunst"
@@ -1167,12 +1167,13 @@ msgid "Built for Berlin Families"
 msgstr "Für Berliner Familien entwickelt"
 
 #: lib/klass_hero_web/live/programs_live.ex:25
+#: lib/klass_hero_web/presenters/program_presenter.ex:356
 #, elixir-autogen, elixir-format
 msgid "Camps"
 msgstr "Camps"
 
 #: lib/klass_hero_web/live/programs_live.ex:23
-#: lib/klass_hero_web/presenters/program_presenter.ex:367
+#: lib/klass_hero_web/presenters/program_presenter.ex:352
 #, elixir-autogen, elixir-format
 msgid "Education"
 msgstr "Bildung"
@@ -1198,12 +1199,13 @@ msgid "Get Paid & Grow"
 msgstr "Verdienen & Wachsen"
 
 #: lib/klass_hero_web/live/programs_live.ex:24
+#: lib/klass_hero_web/presenters/program_presenter.ex:355
 #, elixir-autogen, elixir-format
 msgid "Life Skills"
 msgstr "Lebenskompetenzen"
 
 #: lib/klass_hero_web/live/programs_live.ex:22
-#: lib/klass_hero_web/presenters/program_presenter.ex:369
+#: lib/klass_hero_web/presenters/program_presenter.ex:354
 #, elixir-autogen, elixir-format
 msgid "Music"
 msgstr "Musik"
@@ -1230,7 +1232,7 @@ msgid "Set up your teaching profile and list your programs in minutes. Share you
 msgstr "Richten Sie Ihr Kursleiterprofil ein und veröffentlichen Sie Ihre Programme in wenigen Minuten. Teilen Sie Ihr Fachwissen mit Familien, die es brauchen."
 
 #: lib/klass_hero_web/live/programs_live.ex:20
-#: lib/klass_hero_web/presenters/program_presenter.ex:368
+#: lib/klass_hero_web/presenters/program_presenter.ex:353
 #, elixir-autogen, elixir-format
 msgid "Sports"
 msgstr "Sport"
@@ -1251,6 +1253,7 @@ msgid "We understand the unique needs of Berlin's diverse families. Our platform
 msgstr "Wir verstehen die einzigartigen Bedürfnisse der vielfältigen Familien Berlins. Unsere Plattform verbindet Sie mit geprüften, hochwertigen Programmen, die zu Ihren Werten und den Interessen Ihrer Kinder passen."
 
 #: lib/klass_hero_web/live/programs_live.ex:26
+#: lib/klass_hero_web/presenters/program_presenter.ex:357
 #, elixir-autogen, elixir-format
 msgid "Workshops"
 msgstr "Workshops"
@@ -1363,8 +1366,8 @@ msgstr "Zugewiesenes Personal"
 msgid "Book Now"
 msgstr "Jetzt buchen"
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:146
-#: lib/klass_hero_web/presenters/provider_presenter.ex:156
+#: lib/klass_hero_web/presenters/provider_presenter.ex:152
+#: lib/klass_hero_web/presenters/provider_presenter.ex:162
 #, elixir-autogen, elixir-format
 msgid "Business Registration"
 msgstr "Gewerbeanmeldung"
@@ -1487,7 +1490,7 @@ msgstr "Nicht zugewiesen"
 #: lib/klass_hero_web/components/provider_components.ex:51
 #: lib/klass_hero_web/components/provider_components.ex:1576
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:455
-#: lib/klass_hero_web/presenters/provider_presenter.ex:166
+#: lib/klass_hero_web/presenters/provider_presenter.ex:172
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr "Unbekannt"
@@ -2314,7 +2317,7 @@ msgstr "E-Mail des Erziehungsberechtigten"
 msgid "Headshot Photo"
 msgstr "Porträtfoto"
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:158
+#: lib/klass_hero_web/presenters/provider_presenter.ex:164
 #, elixir-autogen, elixir-format
 msgid "ID Document"
 msgstr "Ausweisdokument"
@@ -2324,7 +2327,7 @@ msgstr "Ausweisdokument"
 msgid "Import"
 msgstr "Importieren"
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:157
+#: lib/klass_hero_web/presenters/provider_presenter.ex:163
 #, elixir-autogen, elixir-format
 msgid "Insurance Certificate"
 msgstr "Versicherungsnachweis"
@@ -2831,7 +2834,7 @@ msgstr "Eingereicht"
 msgid "TBD"
 msgstr "Noch offen"
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:159
+#: lib/klass_hero_web/presenters/provider_presenter.ex:165
 #, elixir-autogen, elixir-format
 msgid "Tax Certificate"
 msgstr "Steuerbescheinigung"
@@ -4409,7 +4412,7 @@ msgid "+1234567890"
 msgstr "+1234567890"
 
 #: lib/klass_hero_web/components/composite_components.ex:641
-#: lib/klass_hero_web/live/provider_profile_live.ex:89
+#: lib/klass_hero_web/live/provider_profile_live.ex:93
 #, elixir-autogen, elixir-format
 msgid "About the Provider"
 msgstr "Über den Anbieter"
@@ -4557,7 +4560,7 @@ msgid "View your assignments"
 msgstr "Ihre Zuweisungen anzeigen"
 
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:306
-#: lib/klass_hero_web/live/provider_profile_live.ex:116
+#: lib/klass_hero_web/live/provider_profile_live.ex:120
 #, elixir-autogen, elixir-format
 msgid "Website"
 msgstr "Website"
@@ -6575,7 +6578,7 @@ msgstr "Jeder Anbieter erhält: Profilseite, Buchungssystem, Zahlungsabwicklung,
 msgid "A short video so we can meet you."
 msgstr "Ein kurzes Video, damit wir dich kennenlernen können."
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:162
+#: lib/klass_hero_web/presenters/provider_presenter.ex:168
 #: lib/klass_hero_web/presenters/vetting_checklist_presenter.ex:77
 #, elixir-autogen, elixir-format
 msgid "Background check"
@@ -6743,7 +6746,7 @@ msgstr "Verifiziere deine Identität mit unserem Partner Stripe, um freigegeben 
 msgid "Verifying your identity… this can take a moment."
 msgstr "Deine Identität wird überprüft … das kann einen Moment dauern."
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:163
+#: lib/klass_hero_web/presenters/provider_presenter.ex:169
 #: lib/klass_hero_web/presenters/vetting_checklist_presenter.ex:85
 #, elixir-autogen, elixir-format
 msgid "Video screening"
@@ -6764,7 +6767,7 @@ msgstr "Wir konnten deine Identität nicht verifizieren. Bitte versuche es erneu
 msgid "Your identity is verified."
 msgstr "Deine Identität ist verifiziert."
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:161
+#: lib/klass_hero_web/presenters/provider_presenter.ex:167
 #, elixir-autogen, elixir-format
 msgid "Experience validation"
 msgstr "Erfahrungsnachweis"
@@ -6779,7 +6782,7 @@ msgstr "MP4, MOV oder WEBM. Max. 100 MB."
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr "Nimm ein kurzes Video auf, in dem du dich vorstellst. Unser Team prüft es, um Kommunikationsfähigkeit und Übereinstimmung mit unseren Werten einzuschätzen."
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:164
+#: lib/klass_hero_web/presenters/provider_presenter.ex:170
 #, elixir-autogen, elixir-format
 msgid "Safeguarding certificate"
 msgstr "Kinderschutz-Zertifikat"
@@ -8059,27 +8062,32 @@ msgstr "Klass Hero auf %{network}"
 msgid "Upload failed."
 msgstr "Hochladen fehlgeschlagen."
 
-#: lib/klass_hero_web/live/provider_profile_live.ex:158
+#: lib/klass_hero_web/live/provider_profile_live.ex:157
 #, elixir-autogen, elixir-format
 msgid "Message %{provider} directly about their programs."
 msgstr "Schreiben Sie %{provider} direkt zu den Programmen."
 
-#: lib/klass_hero_web/live/provider_profile_live.ex:168
+#: lib/klass_hero_web/live/provider_profile_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Message this provider"
 msgstr "Anbieter kontaktieren"
 
-#: lib/klass_hero_web/live/provider_profile_live.ex:133
+#: lib/klass_hero_web/live/provider_profile_live.ex:135
 #, elixir-autogen, elixir-format
 msgid "No programs running right now"
 msgstr "Zurzeit keine laufenden Programme"
 
-#: lib/klass_hero_web/live/provider_profile_live.ex:29
+#: lib/klass_hero_web/live/provider_profile_live.ex:28
 #, elixir-autogen, elixir-format
 msgid "Provider not found. They may have been removed or are no longer listed."
 msgstr "Anbieter nicht gefunden. Möglicherweise wurde er entfernt oder ist nicht mehr gelistet."
 
-#: lib/klass_hero_web/live/provider_profile_live.ex:134
+#: lib/klass_hero_web/live/provider_profile_live.ex:136
 #, elixir-autogen, elixir-format
 msgid "This provider has no open programs at the moment. Check back soon."
 msgstr "Dieser Anbieter hat derzeit keine offenen Programme. Schauen Sie bald wieder vorbei."
+
+#: lib/klass_hero_web/presenters/program_presenter.ex:350
+#, elixir-autogen, elixir-format
+msgid "General"
+msgstr "Allgemein"

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -94,6 +94,7 @@ msgstr "Anmelden"
 #: lib/klass_hero_web/components/layouts/app.html.heex:36
 #: lib/klass_hero_web/components/layouts/app.html.heex:198
 #: lib/klass_hero_web/components/marketing_components.ex:202
+#: lib/klass_hero_web/live/provider_profile_live.ex:127
 #, elixir-autogen, elixir-format
 msgid "Programs"
 msgstr "Programme"
@@ -145,7 +146,7 @@ msgstr "schließen"
 msgid "%{name} (Age %{age})"
 msgstr "%{name} (Alter %{age})"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:399
+#: lib/klass_hero_web/live/program_detail_live.ex:368
 #, elixir-autogen, elixir-format
 msgid "About This Program"
 msgstr "Über dieses Programm"
@@ -165,7 +166,7 @@ msgstr "Weiteres Kind hinzufügen"
 msgid "Add another program"
 msgstr "Weiteres Programm hinzufügen"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:244
+#: lib/klass_hero_web/live/program_detail_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "Ages %{range}"
 msgstr "Alter %{range}"
@@ -225,7 +226,7 @@ msgstr "Dauer:"
 msgid "Easy Scheduling"
 msgstr "Einfache Terminplanung"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:502
+#: lib/klass_hero_web/live/program_detail_live.ex:471
 #, elixir-autogen, elixir-format
 msgid "Enroll Now - %{price}"
 msgstr "Jetzt anmelden - %{price}"
@@ -257,7 +258,7 @@ msgid "Every provider is rigorously vetted. We prioritize child safety above all
 msgstr "Jeder Anbieter wird sorgfältig geprüft. Wir stellen die Sicherheit der Kinder an erste Stelle und geben Eltern die nötige Sicherheit."
 
 #: lib/klass_hero_web/components/marketing_components.ex:986
-#: lib/klass_hero_web/live/programs_live.ex:35
+#: lib/klass_hero_web/live/programs_live.ex:34
 #, elixir-autogen, elixir-format
 msgid "Explore Programs"
 msgstr "Programme entdecken"
@@ -267,7 +268,7 @@ msgstr "Programme entdecken"
 msgid "Featured Programs"
 msgstr "Empfohlene Programme"
 
-#: lib/klass_hero_web/live/programs_live.ex:227
+#: lib/klass_hero_web/live/programs_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "Invalid pagination state. Please refresh the page."
 msgstr "Ungültiger Seitenstatus. Bitte laden Sie die Seite neu."
@@ -277,19 +278,19 @@ msgstr "Ungültiger Seitenstatus. Bitte laden Sie die Seite neu."
 msgid "Invoice & Payment Confirmation"
 msgstr "Rechnung & Zahlungsbestätigung"
 
-#: lib/klass_hero_web/live/programs_live.ex:367
+#: lib/klass_hero_web/live/programs_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "Loading..."
 msgstr "Laden..."
 
-#: lib/klass_hero_web/live/program_detail_live.ex:439
+#: lib/klass_hero_web/live/program_detail_live.ex:408
 #, elixir-autogen, elixir-format
 msgid "Meet the Hero"
 msgid_plural "Meet the Heroes"
 msgstr[0] "Lernen Sie den Helden kennen"
 msgstr[1] "Lernen Sie die Helden kennen"
 
-#: lib/klass_hero_web/live/programs_live.ex:312
+#: lib/klass_hero_web/live/programs_live.ex:293
 #, elixir-autogen, elixir-format
 msgid "No programs found"
 msgstr "Keine Programme gefunden"
@@ -324,7 +325,7 @@ msgstr "Zahlungsinformationen ungültig. Bitte überprüfen Sie Ihre Angaben."
 msgid "Please select a child for enrollment."
 msgstr "Bitte wählen Sie ein Kind für die Anmeldung aus."
 
-#: lib/klass_hero_web/live/home_live.ex:22
+#: lib/klass_hero_web/live/home_live.ex:23
 #, elixir-autogen, elixir-format
 msgid "Klass Hero - Connecting Families with Trusted Youth Educators"
 msgstr "Klass Hero - Wir verbinden Familien mit vertrauenswürdigen Jugendpädagogen"
@@ -336,7 +337,7 @@ msgstr "Klass Hero - Wir verbinden Familien mit vertrauenswürdigen Jugendpädag
 msgid "Program not found"
 msgstr "Programm nicht gefunden"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:71
+#: lib/klass_hero_web/live/program_detail_live.ex:69
 #, elixir-autogen, elixir-format
 msgid "Program not found. It may have been removed or is no longer available."
 msgstr "Programm nicht gefunden. Es wurde möglicherweise entfernt oder ist nicht mehr verfügbar."
@@ -392,7 +393,7 @@ msgstr "Heute fällig:"
 msgid "View All Programs →"
 msgstr "Alle Programme ansehen →"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:256
+#: lib/klass_hero_web/live/program_detail_live.ex:225
 #, elixir-autogen, elixir-format
 msgid "✓ No hidden fees"
 msgstr "✓ Keine versteckten Gebühren"
@@ -415,6 +416,7 @@ msgstr "Kontobeendigung"
 
 #: lib/klass_hero_web/live/contact_live.ex:85
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:314
+#: lib/klass_hero_web/live/provider_profile_live.ex:103
 #, elixir-autogen, elixir-format
 msgid "Address"
 msgstr "Adresse"
@@ -812,6 +814,7 @@ msgstr "Zahlungsbedingungen"
 
 #: lib/klass_hero_web/live/contact_live.ex:78
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:299
+#: lib/klass_hero_web/live/provider_profile_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "Phone"
 msgstr "Telefon"
@@ -1147,13 +1150,13 @@ msgstr "Teilnahmeübersicht"
 
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:24
 #: lib/klass_hero_web/live/admin/verifications_live.ex:192
-#: lib/klass_hero_web/live/programs_live.ex:20
+#: lib/klass_hero_web/live/programs_live.ex:19
 #, elixir-autogen, elixir-format
 msgid "All"
 msgstr "Alle"
 
-#: lib/klass_hero_web/live/programs_live.ex:22
-#: lib/klass_hero_web/presenters/program_presenter.ex:350
+#: lib/klass_hero_web/live/programs_live.ex:21
+#: lib/klass_hero_web/presenters/program_presenter.ex:366
 #, elixir-autogen, elixir-format
 msgid "Arts"
 msgstr "Kunst"
@@ -1163,13 +1166,13 @@ msgstr "Kunst"
 msgid "Built for Berlin Families"
 msgstr "Für Berliner Familien entwickelt"
 
-#: lib/klass_hero_web/live/programs_live.ex:26
+#: lib/klass_hero_web/live/programs_live.ex:25
 #, elixir-autogen, elixir-format
 msgid "Camps"
 msgstr "Camps"
 
-#: lib/klass_hero_web/live/programs_live.ex:24
-#: lib/klass_hero_web/presenters/program_presenter.ex:351
+#: lib/klass_hero_web/live/programs_live.ex:23
+#: lib/klass_hero_web/presenters/program_presenter.ex:367
 #, elixir-autogen, elixir-format
 msgid "Education"
 msgstr "Bildung"
@@ -1194,13 +1197,13 @@ msgstr "Von Sport über Kunst, Technologie bis Sprachen – wir machen es einfac
 msgid "Get Paid & Grow"
 msgstr "Verdienen & Wachsen"
 
-#: lib/klass_hero_web/live/programs_live.ex:25
+#: lib/klass_hero_web/live/programs_live.ex:24
 #, elixir-autogen, elixir-format
 msgid "Life Skills"
 msgstr "Lebenskompetenzen"
 
-#: lib/klass_hero_web/live/programs_live.ex:23
-#: lib/klass_hero_web/presenters/program_presenter.ex:353
+#: lib/klass_hero_web/live/programs_live.ex:22
+#: lib/klass_hero_web/presenters/program_presenter.ex:369
 #, elixir-autogen, elixir-format
 msgid "Music"
 msgstr "Musik"
@@ -1226,8 +1229,8 @@ msgstr "Suche"
 msgid "Set up your teaching profile and list your programs in minutes. Share your expertise with families who need it."
 msgstr "Richten Sie Ihr Kursleiterprofil ein und veröffentlichen Sie Ihre Programme in wenigen Minuten. Teilen Sie Ihr Fachwissen mit Familien, die es brauchen."
 
-#: lib/klass_hero_web/live/programs_live.ex:21
-#: lib/klass_hero_web/presenters/program_presenter.ex:352
+#: lib/klass_hero_web/live/programs_live.ex:20
+#: lib/klass_hero_web/presenters/program_presenter.ex:368
 #, elixir-autogen, elixir-format
 msgid "Sports"
 msgstr "Sport"
@@ -1247,7 +1250,7 @@ msgstr "Beliebt in Berlin:"
 msgid "We understand the unique needs of Berlin's diverse families. Our platform connects you with vetted, high-quality programs that match your values and your children's interests."
 msgstr "Wir verstehen die einzigartigen Bedürfnisse der vielfältigen Familien Berlins. Unsere Plattform verbindet Sie mit geprüften, hochwertigen Programmen, die zu Ihren Werten und den Interessen Ihrer Kinder passen."
 
-#: lib/klass_hero_web/live/programs_live.ex:27
+#: lib/klass_hero_web/live/programs_live.ex:26
 #, elixir-autogen, elixir-format
 msgid "Workshops"
 msgstr "Workshops"
@@ -1354,8 +1357,8 @@ msgstr "Alle Mitarbeiter"
 msgid "Assigned Staff"
 msgstr "Zugewiesenes Personal"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:366
-#: lib/klass_hero_web/live/program_detail_live.ex:526
+#: lib/klass_hero_web/live/program_detail_live.ex:335
+#: lib/klass_hero_web/live/program_detail_live.ex:495
 #, elixir-autogen, elixir-format
 msgid "Book Now"
 msgstr "Jetzt buchen"
@@ -1442,7 +1445,7 @@ msgstr "Programmname"
 msgid "Provider Dashboard"
 msgstr "Anbieter-Dashboard"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:379
+#: lib/klass_hero_web/live/program_detail_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "Save for Later"
 msgstr "Für später speichern"
@@ -2527,8 +2530,8 @@ msgid "Our Story"
 msgstr "Unsere Geschichte"
 
 #: lib/klass_hero_web/components/provider_components.ex:3242
-#: lib/klass_hero_web/live/provider/verification_live.ex:698
-#: lib/klass_hero_web/live/provider/verification_live.ex:770
+#: lib/klass_hero_web/live/provider/verification_live.ex:699
+#: lib/klass_hero_web/live/provider/verification_live.ex:773
 #, elixir-autogen, elixir-format
 msgid "PDF, JPG or PNG. Max 10MB."
 msgstr "PDF, JPG oder PNG. Max. 10 MB."
@@ -2637,7 +2640,7 @@ msgstr "Registriert"
 msgid "Registration"
 msgstr "Anmeldung"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:193
+#: lib/klass_hero_web/live/program_detail_live.ex:162
 #, elixir-autogen, elixir-format
 msgid "Registration Closed"
 msgstr "Anmeldung geschlossen"
@@ -2647,7 +2650,7 @@ msgstr "Anmeldung geschlossen"
 msgid "Registration Closes"
 msgstr "Anmeldeschluss"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:191
+#: lib/klass_hero_web/live/program_detail_live.ex:160
 #, elixir-autogen, elixir-format
 msgid "Registration Not Open Yet"
 msgstr "Anmeldung noch nicht geöffnet"
@@ -2667,7 +2670,7 @@ msgstr "Anmeldezeitraum (optional)"
 msgid "Registration has closed for this program."
 msgstr "Die Anmeldung für dieses Programm ist geschlossen."
 
-#: lib/klass_hero_web/live/program_detail_live.ex:165
+#: lib/klass_hero_web/live/program_detail_live.ex:134
 #, elixir-autogen, elixir-format
 msgid "Registration is closed"
 msgstr "Anmeldung geschlossen"
@@ -2677,12 +2680,12 @@ msgstr "Anmeldung geschlossen"
 msgid "Registration is not currently open for this program."
 msgstr "Die Anmeldung für dieses Programm ist derzeit nicht geöffnet."
 
-#: lib/klass_hero_web/live/program_detail_live.ex:87
+#: lib/klass_hero_web/live/program_detail_live.ex:85
 #, elixir-autogen, elixir-format
 msgid "Registration is not open for this program."
 msgstr "Die Anmeldung für dieses Programm ist nicht geöffnet."
 
-#: lib/klass_hero_web/live/program_detail_live.ex:161
+#: lib/klass_hero_web/live/program_detail_live.ex:130
 #, elixir-autogen, elixir-format
 msgid "Registration opens %{date}"
 msgstr "Anmeldung öffnet am %{date}"
@@ -2746,7 +2749,7 @@ msgstr "Programm speichern"
 msgid "Schedule (optional)"
 msgstr "Zeitplan (optional)"
 
-#: lib/klass_hero_web/live/program_detail_live.ex:239
+#: lib/klass_hero_web/live/program_detail_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "Schedule TBD"
 msgstr "Zeitplan noch offen"
@@ -3170,12 +3173,12 @@ msgstr "Mit Sorgfalt geprüft"
 msgid "Video Screening"
 msgstr "Video-Überprüfung"
 
-#: lib/klass_hero_web/live/home_live.ex:98
+#: lib/klass_hero_web/live/home_live.ex:77
 #, elixir-autogen, elixir-format
 msgid "Every provider completes identity and age verification, experience validation, an extended background check, video screening, child safeguarding training, and agreement to our Community Guidelines before being approved."
 msgstr "Jeder Anbieter durchläuft vor der Freigabe eine Identitäts- und Altersprüfung, eine Erfahrungsvalidierung, eine erweiterte Hintergrundüberprüfung, eine Video-Überprüfung, eine Schulung zum Kinderschutz und die Zustimmung zu unseren Community-Richtlinien."
 
-#: lib/klass_hero_web/live/home_live.ex:95
+#: lib/klass_hero_web/live/home_live.ex:74
 #, elixir-autogen, elixir-format
 msgid "How does the 6-step provider vetting process work?"
 msgstr "Wie funktioniert der 6-stufige Anbieter-Prüfprozess?"
@@ -3236,7 +3239,7 @@ msgstr "Konten"
 msgid "All Statuses"
 msgstr "Alle Status"
 
-#: lib/klass_hero_web/live/home_live.ex:146
+#: lib/klass_hero_web/live/home_live.ex:125
 #, elixir-autogen, elixir-format
 msgid "All payments processed securely through Stripe."
 msgstr "Alle Zahlungen werden sicher über Stripe abgewickelt."
@@ -3246,7 +3249,7 @@ msgstr "Alle Zahlungen werden sicher über Stripe abgewickelt."
 msgid "An error occurred"
 msgstr "Ein Fehler ist aufgetreten"
 
-#: lib/klass_hero_web/live/home_live.ex:142
+#: lib/klass_hero_web/live/home_live.ex:121
 #, elixir-autogen, elixir-format
 msgid "Apple Pay / Google Pay"
 msgstr "Apple Pay / Google Pay"
@@ -3256,7 +3259,7 @@ msgstr "Apple Pay / Google Pay"
 msgid "Attendance corrected successfully"
 msgstr "Anwesenheit erfolgreich korrigiert"
 
-#: lib/klass_hero_web/live/home_live.ex:164
+#: lib/klass_hero_web/live/home_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "Automatic fee calculation (no surprises)"
 msgstr "Automatische Gebührenberechnung (keine Überraschungen)"
@@ -3276,22 +3279,22 @@ msgstr "Zurück zu Sitzungen"
 msgid "Bookings"
 msgstr "Buchungen"
 
-#: lib/klass_hero_web/live/home_live.ex:112
+#: lib/klass_hero_web/live/home_live.ex:91
 #, elixir-autogen, elixir-format
 msgid "Camps and holiday programs"
 msgstr "Camps und Ferienprogramme"
 
-#: lib/klass_hero_web/live/home_live.ex:209
+#: lib/klass_hero_web/live/home_live.ex:188
 #, elixir-autogen, elixir-format
 msgid "Can I buy a gift voucher?"
 msgstr "Kann ich einen Geschenkgutschein kaufen?"
 
-#: lib/klass_hero_web/live/home_live.ex:187
+#: lib/klass_hero_web/live/home_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Can I change my booking date?"
 msgstr "Kann ich mein Buchungsdatum ändern?"
 
-#: lib/klass_hero_web/live/home_live.ex:106
+#: lib/klass_hero_web/live/home_live.ex:85
 #, elixir-autogen, elixir-format
 msgid "Can I list my programs on Klass Hero and what does it cost?"
 msgstr "Kann ich meine Programme auf Klass Hero listen und was kostet das?"
@@ -3345,7 +3348,7 @@ msgstr "Ausgecheckt"
 msgid "Child"
 msgstr "Kind"
 
-#: lib/klass_hero_web/live/home_live.ex:211
+#: lib/klass_hero_web/live/home_live.ex:190
 #, elixir-autogen, elixir-format
 msgid "Coming soon! Sign up for our newsletter to be notified when gift vouchers launch."
 msgstr "Demnächst verfügbar! Melden Sie sich für unseren Newsletter an, um benachrichtigt zu werden, sobald Geschenkgutscheine verfügbar sind."
@@ -3355,7 +3358,7 @@ msgstr "Demnächst verfügbar! Melden Sie sich für unseren Newsletter an, um be
 msgid "Completed"
 msgstr "Abgeschlossen"
 
-#: lib/klass_hero_web/live/home_live.ex:189
+#: lib/klass_hero_web/live/home_live.ex:168
 #, elixir-autogen, elixir-format
 msgid "Contact the provider directly (details in confirmation email). Most providers are flexible if you ask in advance."
 msgstr "Kontaktieren Sie den Anbieter direkt (Details in der Bestätigungs-E-Mail). Die meisten Anbieter sind flexibel, wenn Sie im Voraus fragen."
@@ -3365,22 +3368,22 @@ msgstr "Kontaktieren Sie den Anbieter direkt (Details in der Bestätigungs-E-Mai
 msgid "Correct"
 msgstr "Korrigieren"
 
-#: lib/klass_hero_web/live/home_live.ex:141
+#: lib/klass_hero_web/live/home_live.ex:120
 #, elixir-autogen, elixir-format
 msgid "Credit/debit card (Visa, Mastercard, Amex)"
 msgstr "Kredit-/Debitkarte (Visa, Mastercard, Amex)"
 
-#: lib/klass_hero_web/live/home_live.ex:205
+#: lib/klass_hero_web/live/home_live.ex:184
 #, elixir-autogen, elixir-format
 msgid "Currently serving Berlin, with expansion to other German cities coming soon."
 msgstr "Derzeit verfügbar in Berlin, die Erweiterung auf weitere deutsche Städte folgt in Kürze."
 
-#: lib/klass_hero_web/live/home_live.ex:181
+#: lib/klass_hero_web/live/home_live.ex:160
 #, elixir-autogen, elixir-format
 msgid "Do I need an account to book?"
 msgstr "Benötige ich ein Konto, um zu buchen?"
 
-#: lib/klass_hero_web/live/home_live.ex:171
+#: lib/klass_hero_web/live/home_live.ex:150
 #, elixir-autogen, elixir-format
 msgid "Download monthly statements for taxes"
 msgstr "Monatliche Abrechnungen für die Steuer herunterladen"
@@ -3396,22 +3399,22 @@ msgstr "Anmeldung nicht bestätigt"
 msgid "Explain why this correction is needed..."
 msgstr "Erklären Sie, warum diese Korrektur nötig ist..."
 
-#: lib/klass_hero_web/live/home_live.ex:169
+#: lib/klass_hero_web/live/home_live.ex:148
 #, elixir-autogen, elixir-format
 msgid "Export participant lists anytime"
 msgstr "Teilnehmerlisten jederzeit exportieren"
 
-#: lib/klass_hero_web/live/home_live.ex:136
+#: lib/klass_hero_web/live/home_live.ex:115
 #, elixir-autogen, elixir-format
 msgid "Funds are immediately available in your Klass Hero account"
 msgstr "Guthaben ist sofort in Ihrem Klass Hero-Konto verfügbar"
 
-#: lib/klass_hero_web/live/home_live.ex:147
+#: lib/klass_hero_web/live/home_live.ex:126
 #, elixir-autogen, elixir-format
 msgid "How You Get Paid:"
 msgstr "So werden Sie bezahlt:"
 
-#: lib/klass_hero_web/live/home_live.ex:129
+#: lib/klass_hero_web/live/home_live.ex:108
 #, elixir-autogen, elixir-format
 msgid "How does the booking system work?"
 msgstr "Wie funktioniert das Buchungssystem?"
@@ -3422,17 +3425,17 @@ msgstr "Wie funktioniert das Buchungssystem?"
 msgid "In Progress"
 msgstr "In Bearbeitung"
 
-#: lib/klass_hero_web/live/home_live.ex:150
+#: lib/klass_hero_web/live/home_live.ex:129
 #, elixir-autogen, elixir-format
 msgid "Instant availability: Funds are in your Klass Hero balance immediately after booking"
 msgstr "Sofortige Verfügbarkeit: Das Guthaben steht direkt nach der Buchung in Ihrem Klass Hero-Guthaben zur Verfügung"
 
-#: lib/klass_hero_web/live/home_live.ex:175
+#: lib/klass_hero_web/live/home_live.ex:154
 #, elixir-autogen, elixir-format
 msgid "Is Klass Hero free for parents to use?"
 msgstr "Ist die Nutzung von Klass Hero für Eltern kostenlos?"
 
-#: lib/klass_hero_web/live/home_live.ex:144
+#: lib/klass_hero_web/live/home_live.ex:123
 #, elixir-autogen, elixir-format
 msgid "Klarna (pay later options)"
 msgstr "Klarna (Optionen für spätere Zahlung)"
@@ -3453,7 +3456,7 @@ msgstr "Keine Änderung"
 msgid "No changes detected"
 msgstr "Keine Änderungen erkannt"
 
-#: lib/klass_hero_web/live/home_live.ex:162
+#: lib/klass_hero_web/live/home_live.ex:141
 #, elixir-autogen, elixir-format
 msgid "No chasing payments or sending invoices"
 msgstr "Kein Nachfassen bei Zahlungen oder Versenden von Rechnungen"
@@ -3464,7 +3467,7 @@ msgstr "Kein Nachfassen bei Zahlungen oder Versenden von Rechnungen"
 msgid "No enrolled parents"
 msgstr "Keine angemeldeten Eltern"
 
-#: lib/klass_hero_web/live/home_live.ex:163
+#: lib/klass_hero_web/live/home_live.ex:142
 #, elixir-autogen, elixir-format
 msgid "No risk of non-payment"
 msgstr "Kein Risiko von Zahlungsausfällen"
@@ -3476,7 +3479,7 @@ msgstr "Kein Risiko von Zahlungsausfällen"
 msgid "Notes"
 msgstr "Notizen"
 
-#: lib/klass_hero_web/live/home_live.ex:155
+#: lib/klass_hero_web/live/home_live.ex:134
 #, elixir-autogen, elixir-format
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr "Oder: Jederzeit eine Sofortauszahlung anfordern (mindestens 50 €)"
@@ -3487,37 +3490,37 @@ msgstr "Oder: Jederzeit eine Sofortauszahlung anfordern (mindestens 50 €)"
 msgid "Parent account not available"
 msgstr "Elternkonto nicht verfügbar"
 
-#: lib/klass_hero_web/live/home_live.ex:133
+#: lib/klass_hero_web/live/home_live.ex:112
 #, elixir-autogen, elixir-format
 msgid "Parent books and pays through Klass Hero (via Stripe)"
 msgstr "Eltern buchen und bezahlen über Klass Hero (via Stripe)"
 
-#: lib/klass_hero_web/live/home_live.ex:135
+#: lib/klass_hero_web/live/home_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "Parent receives confirmation with your contact details"
 msgstr "Eltern erhalten eine Bestätigung mit Ihren Kontaktdaten"
 
-#: lib/klass_hero_web/live/home_live.ex:161
+#: lib/klass_hero_web/live/home_live.ex:140
 #, elixir-autogen, elixir-format
 msgid "Parents pay upfront when booking (reduces no-shows by 85%)"
 msgstr "Eltern zahlen bei der Buchung im Voraus (reduziert Nichterscheinen um 85 %)"
 
-#: lib/klass_hero_web/live/home_live.ex:139
+#: lib/klass_hero_web/live/home_live.ex:118
 #, elixir-autogen, elixir-format
 msgid "Payment Options for Parents:"
 msgstr "Zahlungsoptionen für Eltern:"
 
-#: lib/klass_hero_web/live/home_live.ex:156
+#: lib/klass_hero_web/live/home_live.ex:135
 #, elixir-autogen, elixir-format
 msgid "Platform fee automatically deducted when parent pays"
 msgstr "Plattformgebühr wird automatisch abgezogen, wenn Eltern bezahlen"
 
-#: lib/klass_hero_web/live/home_live.ex:116
+#: lib/klass_hero_web/live/home_live.ex:95
 #, elixir-autogen, elixir-format
 msgid "Pricing:"
 msgstr "Preise:"
 
-#: lib/klass_hero_web/live/home_live.ex:114
+#: lib/klass_hero_web/live/home_live.ex:93
 #, elixir-autogen, elixir-format
 msgid "Private lessons and tutoring"
 msgstr "Privatunterricht und Nachhilfe"
@@ -3528,7 +3531,7 @@ msgstr "Privatunterricht und Nachhilfe"
 msgid "Providers"
 msgstr "Anbieter"
 
-#: lib/klass_hero_web/live/home_live.ex:168
+#: lib/klass_hero_web/live/home_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Real-time dashboard shows all bookings and available balance"
 msgstr "Echtzeit-Dashboard zeigt alle Buchungen und das verfügbare Guthaben"
@@ -3543,12 +3546,12 @@ msgstr "Grund für die Korrektur"
 msgid "Record was modified by someone else. Please refresh."
 msgstr "Datensatz wurde von jemand anderem geändert. Bitte aktualisieren."
 
-#: lib/klass_hero_web/live/home_live.ex:111
+#: lib/klass_hero_web/live/home_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "Regular classes and courses (weekly/monthly)"
 msgstr "Regelmäßige Klassen und Kurse (wöchentlich/monatlich)"
 
-#: lib/klass_hero_web/live/home_live.ex:143
+#: lib/klass_hero_web/live/home_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "SEPA direct debit"
 msgstr "SEPA-Lastschrift"
@@ -3563,12 +3566,12 @@ msgstr "Korrektur speichern"
 msgid "Scheduled"
 msgstr "Geplant"
 
-#: lib/klass_hero_web/live/home_live.ex:170
+#: lib/klass_hero_web/live/home_live.ex:149
 #, elixir-autogen, elixir-format
 msgid "See payment history and upcoming payouts"
 msgstr "Zahlungsverlauf und bevorstehende Auszahlungen einsehen"
 
-#: lib/klass_hero_web/live/home_live.ex:130
+#: lib/klass_hero_web/live/home_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "Simple and automated - we handle everything."
 msgstr "Einfach und automatisiert – wir kümmern uns um alles."
@@ -3578,7 +3581,7 @@ msgstr "Einfach und automatisiert – wir kümmern uns um alles."
 msgid "Staff Members"
 msgstr "Mitarbeiter"
 
-#: lib/klass_hero_web/live/home_live.ex:166
+#: lib/klass_hero_web/live/home_live.ex:145
 #, elixir-autogen, elixir-format
 msgid "Track Everything:"
 msgstr "Alles im Überblick:"
@@ -3589,67 +3592,67 @@ msgstr "Alles im Überblick:"
 msgid "Upgrade your plan to send messages."
 msgstr "Aktualisieren Sie Ihren Plan, um Nachrichten zu senden."
 
-#: lib/klass_hero_web/live/home_live.ex:154
+#: lib/klass_hero_web/live/home_live.ex:133
 #, elixir-autogen, elixir-format
 msgid "Weekly payouts: Transferred to your bank account every Friday"
 msgstr "Wöchentliche Auszahlungen: Jeden Freitag auf Ihr Bankkonto überwiesen"
 
-#: lib/klass_hero_web/live/home_live.ex:109
+#: lib/klass_hero_web/live/home_live.ex:88
 #, elixir-autogen, elixir-format
 msgid "What You Can List:"
 msgstr "Was Sie anbieten können:"
 
-#: lib/klass_hero_web/live/home_live.ex:195
+#: lib/klass_hero_web/live/home_live.ex:174
 #, elixir-autogen, elixir-format
 msgid "What if my child gets sick?"
 msgstr "Was ist, wenn mein Kind krank wird?"
 
-#: lib/klass_hero_web/live/home_live.ex:131
+#: lib/klass_hero_web/live/home_live.ex:110
 #, elixir-autogen, elixir-format
 msgid "When Someone Books:"
 msgstr "Wenn jemand bucht:"
 
-#: lib/klass_hero_web/live/home_live.ex:203
+#: lib/klass_hero_web/live/home_live.ex:182
 #, elixir-autogen, elixir-format
 msgid "Where is Klass Hero available?"
 msgstr "Wo ist Klass Hero verfügbar?"
 
-#: lib/klass_hero_web/live/home_live.ex:158
+#: lib/klass_hero_web/live/home_live.ex:137
 #, elixir-autogen, elixir-format
 msgid "Why This Works Better:"
 msgstr "Warum das besser funktioniert:"
 
-#: lib/klass_hero_web/live/home_live.ex:113
+#: lib/klass_hero_web/live/home_live.ex:92
 #, elixir-autogen, elixir-format
 msgid "Workshops and one-time events"
 msgstr "Workshops und einmalige Veranstaltungen"
 
-#: lib/klass_hero_web/live/home_live.ex:177
+#: lib/klass_hero_web/live/home_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "Yes! Browsing and booking are completely free. No subscription, no booking fees."
 msgstr "Ja! Stöbern und Buchen sind völlig kostenlos. Kein Abonnement, keine Buchungsgebühren."
 
-#: lib/klass_hero_web/live/home_live.ex:108
+#: lib/klass_hero_web/live/home_live.ex:87
 #, elixir-autogen, elixir-format
 msgid "Yes! Register for free and start listing immediately."
 msgstr "Ja! Registrieren Sie sich kostenlos und beginnen Sie sofort damit, Ihre Programme zu listen."
 
-#: lib/klass_hero_web/live/home_live.ex:183
+#: lib/klass_hero_web/live/home_live.ex:162
 #, elixir-autogen, elixir-format
 msgid "Yes, you need a free account to complete a booking and manage your reservations."
 msgstr "Ja, Sie benötigen ein kostenloses Konto, um eine Buchung abzuschließen und Ihre Reservierungen zu verwalten."
 
-#: lib/klass_hero_web/live/home_live.ex:137
+#: lib/klass_hero_web/live/home_live.ex:116
 #, elixir-autogen, elixir-format
 msgid "You deliver the program"
 msgstr "Sie führen das Programm durch"
 
-#: lib/klass_hero_web/live/home_live.ex:160
+#: lib/klass_hero_web/live/home_live.ex:139
 #, elixir-autogen, elixir-format
 msgid "You get paid BEFORE delivering the program (no waiting)"
 msgstr "Sie werden bezahlt, BEVOR Sie das Programm durchführen (kein Warten)"
 
-#: lib/klass_hero_web/live/home_live.ex:134
+#: lib/klass_hero_web/live/home_live.ex:113
 #, elixir-autogen, elixir-format
 msgid "You receive instant email with booking details and parent contact info"
 msgstr "Sie erhalten sofort eine E-Mail mit den Buchungsdetails und den Kontaktdaten der Eltern"
@@ -4406,6 +4409,7 @@ msgid "+1234567890"
 msgstr "+1234567890"
 
 #: lib/klass_hero_web/components/composite_components.ex:641
+#: lib/klass_hero_web/live/provider_profile_live.ex:89
 #, elixir-autogen, elixir-format
 msgid "About the Provider"
 msgstr "Über den Anbieter"
@@ -4553,6 +4557,7 @@ msgid "View your assignments"
 msgstr "Ihre Zuweisungen anzeigen"
 
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:306
+#: lib/klass_hero_web/live/provider_profile_live.ex:116
 #, elixir-autogen, elixir-format
 msgid "Website"
 msgstr "Website"
@@ -5282,7 +5287,7 @@ msgstr "Einnahmenentwicklung"
 msgid "Edit program"
 msgstr "Programm bearbeiten"
 
-#: lib/klass_hero_web/live/home_live.ex:197
+#: lib/klass_hero_web/live/home_live.ex:176
 #, elixir-autogen, elixir-format
 msgid "Email the provider and us (support@mail.klasshero.com) as soon as you can — we'll help you and the provider work it out."
 msgstr "Schreiben Sie dem Anbieter und uns (support@mail.klasshero.com) so schnell wie möglich eine E-Mail — wir helfen Ihnen und dem Anbieter, eine Lösung zu finden."
@@ -5342,7 +5347,7 @@ msgstr "Alle Funktionen inklusive. Kein Abo, keine Einrichtungsgebühren."
 msgid "Everything parents need, nothing they don't"
 msgstr "Alles, was Eltern brauchen – nichts, was sie nicht brauchen"
 
-#: lib/klass_hero_web/live/home_live.ex:92
+#: lib/klass_hero_web/live/home_live.ex:71
 #, elixir-autogen, elixir-format
 msgid "Everything you need to know about Klass Hero."
 msgstr "Alles, was Sie über Klass Hero wissen müssen."
@@ -5445,6 +5450,7 @@ msgstr "Handverlesene Programme diese Woche in ganz Berlin."
 msgid "Hand-picked, vetted programs across Berlin — filter by category, age, or schedule."
 msgstr "Handverlesene, geprüfte Programme in ganz Berlin — filtern Sie nach Kategorie, Alter oder Zeitplan."
 
+#: lib/klass_hero_web/live/provider_profile_live.ex:155
 #: lib/klass_hero_web/live/trust_safety_live.ex:103
 #, elixir-autogen, elixir-format
 msgid "Have questions?"
@@ -5559,7 +5565,7 @@ msgid "Join the team"
 msgstr "Treten Sie dem Team bei"
 
 #: lib/klass_hero_web/live/for_providers_live.ex:182
-#: lib/klass_hero_web/live/home_live.ex:118
+#: lib/klass_hero_web/live/home_live.ex:97
 #, elixir-autogen, elixir-format
 msgid "Joining Klass Hero costs nothing — unlimited programs, your whole team, all media, and direct parent messaging are included for everyone. A simple success-based fee on bookings made through the platform is coming; we'll share the details transparently before it launches."
 msgstr "Die Teilnahme an Klass Hero kostet nichts — unbegrenzte Programme, Ihr gesamtes Team, alle Medien und direkte Eltern-Kommunikation sind für alle inklusive. Eine einfache erfolgsbasierte Gebühr auf Buchungen über die Plattform kommt; wir teilen die Details transparent vor dem Start mit."
@@ -5645,7 +5651,7 @@ msgstr "Ihr Programm eintragen"
 msgid "Live video screen with our safeguarding lead."
 msgstr "Live-Video-Screening mit unserer Kinderschutzbeauftragten."
 
-#: lib/klass_hero_web/live/programs_live.ex:369
+#: lib/klass_hero_web/live/programs_live.ex:350
 #, elixir-autogen, elixir-format
 msgid "Load more programs"
 msgstr "Weitere Programme laden"
@@ -6279,7 +6285,7 @@ msgstr "Vertrauen &"
 msgid "Trusted Heroes"
 msgstr "Vertrauenswürdige Heroes"
 
-#: lib/klass_hero_web/live/programs_live.ex:314
+#: lib/klass_hero_web/live/programs_live.ex:295
 #, elixir-autogen, elixir-format
 msgid "Try adjusting your search or filter criteria — there's plenty more in Berlin."
 msgstr "Versuchen Sie, Ihre Such- oder Filterkriterien anzupassen — in Berlin gibt es noch viel mehr."
@@ -6559,7 +6565,7 @@ msgstr "— eine Mutter mit über einem Jahrzehnt Erfahrung in Kindersicherheit 
 msgid "You don't have permission to send broadcasts"
 msgstr "Sie haben keine Berechtigung, Rundnachrichten zu senden."
 
-#: lib/klass_hero_web/live/home_live.ex:123
+#: lib/klass_hero_web/live/home_live.ex:102
 #, elixir-autogen, elixir-format
 msgid "Every provider gets: Profile page, booking system, payment processing, messaging, and marketing to Berlin families."
 msgstr "Jeder Anbieter erhält: Profilseite, Buchungssystem, Zahlungsabwicklung, Nachrichten und Marketing an Berliner Familien."
@@ -6621,12 +6627,12 @@ msgstr "Identitätsprüfungen"
 msgid "In progress"
 msgstr "In Bearbeitung"
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:830
+#: lib/klass_hero_web/live/provider/verification_live.ex:834
 #, elixir-autogen, elixir-format
 msgid "Klass Hero is only open to providers aged 18 and over, so we can't approve this account."
 msgstr "Klass Hero steht nur Anbietern ab 18 Jahren offen, daher können wir dieses Konto nicht freigeben."
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:840
+#: lib/klass_hero_web/live/provider/verification_live.ex:844
 #, elixir-autogen, elixir-format
 msgid "Looks like the check didn't finish. Pick up where you left off whenever you're ready."
 msgstr "Die Prüfung wurde offenbar nicht abgeschlossen. Mach weiter, wann immer du bereit bist."
@@ -6666,7 +6672,7 @@ msgstr "Lies und unterschreibe die Vereinbarung zu den Gemeinschaftsstandards."
 msgid "Resubmit"
 msgstr "Erneut einreichen"
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:819
+#: lib/klass_hero_web/live/provider/verification_live.ex:823
 #, elixir-autogen, elixir-format
 msgid "Retry verification"
 msgstr "Verifizierung erneut versuchen"
@@ -6686,12 +6692,12 @@ msgstr "Kinderschutz"
 msgid "Show relevant experience working with children."
 msgstr "Weise einschlägige Erfahrung in der Arbeit mit Kindern nach."
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:837
+#: lib/klass_hero_web/live/provider/verification_live.ex:841
 #, elixir-autogen, elixir-format
 msgid "Something tripped up the check — usually a blurry photo. Give it another go."
 msgstr "Bei der Prüfung ist etwas schiefgelaufen – meist ein unscharfes Foto. Versuche es noch einmal."
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:796
+#: lib/klass_hero_web/live/provider/verification_live.ex:800
 #, elixir-autogen, elixir-format
 msgid "Takes about 2 minutes. Once verified, your provider account can be approved."
 msgstr "Dauert etwa 2 Minuten. Nach der Verifizierung kann dein Anbieterkonto freigegeben werden."
@@ -6717,7 +6723,7 @@ msgid "Upload your safeguarding certificate."
 msgstr "Lade dein Kinderschutz-Zertifikat hoch."
 
 #: lib/klass_hero_web/live/provider/verification_live.ex:513
-#: lib/klass_hero_web/live/provider/verification_live.ex:793
+#: lib/klass_hero_web/live/provider/verification_live.ex:797
 #, elixir-autogen, elixir-format
 msgid "Verify identity"
 msgstr "Identität verifizieren"
@@ -6727,12 +6733,12 @@ msgstr "Identität verifizieren"
 msgid "Verify your identity to get approved"
 msgstr "Verifiziere deine Identität, um freigegeben zu werden"
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:788
+#: lib/klass_hero_web/live/provider/verification_live.ex:792
 #, elixir-autogen, elixir-format
 msgid "Verify your identity with our partner Stripe to get approved. You'll be sent to a secure page and brought back here."
 msgstr "Verifiziere deine Identität mit unserem Partner Stripe, um freigegeben zu werden. Du wirst auf eine sichere Seite geleitet und danach hierher zurückgebracht."
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:802
+#: lib/klass_hero_web/live/provider/verification_live.ex:806
 #, elixir-autogen, elixir-format
 msgid "Verifying your identity… this can take a moment."
 msgstr "Deine Identität wird überprüft … das kann einen Moment dauern."
@@ -6743,17 +6749,17 @@ msgstr "Deine Identität wird überprüft … das kann einen Moment dauern."
 msgid "Video screening"
 msgstr "Video-Screening"
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:834
+#: lib/klass_hero_web/live/provider/verification_live.ex:838
 #, elixir-autogen, elixir-format
 msgid "We couldn't read your date of birth from your ID. A clearer photo of your document should do the trick."
 msgstr "Wir konnten dein Geburtsdatum nicht von deinem Ausweis lesen. Ein schärferes Foto deines Dokuments sollte helfen."
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:842
+#: lib/klass_hero_web/live/provider/verification_live.ex:846
 #, elixir-autogen, elixir-format
 msgid "We couldn't verify your identity. Please try again."
 msgstr "Wir konnten deine Identität nicht verifizieren. Bitte versuche es erneut."
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:812
+#: lib/klass_hero_web/live/provider/verification_live.ex:816
 #, elixir-autogen, elixir-format
 msgid "Your identity is verified."
 msgstr "Deine Identität ist verifiziert."
@@ -7011,8 +7017,8 @@ msgstr "Registernummer"
 msgid "Select your country to see which document to upload."
 msgstr "Wählen Sie Ihr Land, um zu sehen, welches Dokument hochzuladen ist."
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:700
-#: lib/klass_hero_web/live/provider/verification_live.ex:772
+#: lib/klass_hero_web/live/provider/verification_live.ex:702
+#: lib/klass_hero_web/live/provider/verification_live.ex:776
 #, elixir-autogen, elixir-format
 msgid "Submit for review"
 msgstr "Zur Prüfung einreichen"
@@ -7072,22 +7078,22 @@ msgstr "Bitte geben Sie das Ablaufdatum der Bescheinigung ein."
 msgid "Policy expiry"
 msgstr "Ablauf der Police"
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:756
+#: lib/klass_hero_web/live/provider/verification_live.ex:758
 #, elixir-autogen, elixir-format
 msgid "Policy expiry date"
 msgstr "Ablaufdatum der Police"
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:764
+#: lib/klass_hero_web/live/provider/verification_live.ex:766
 #, elixir-autogen, elixir-format
 msgid "This certificate expires within 30 days. Please renew it soon."
 msgstr "Diese Bescheinigung läuft innerhalb von 30 Tagen ab. Bitte erneuern Sie sie bald."
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:760
+#: lib/klass_hero_web/live/provider/verification_live.ex:762
 #, elixir-autogen, elixir-format
 msgid "This certificate has already expired. Please upload a current policy."
 msgstr "Diese Bescheinigung ist bereits abgelaufen. Bitte laden Sie eine aktuelle Police hoch."
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:745
+#: lib/klass_hero_web/live/provider/verification_live.ex:747
 #, elixir-autogen, elixir-format
 msgid "Upload your public liability insurance certificate and enter its policy expiry date so we can confirm cover is current."
 msgstr "Laden Sie Ihre Betriebshaftpflichtversicherungsbescheinigung hoch und geben Sie das Ablaufdatum der Police ein, damit wir bestätigen können, dass der Versicherungsschutz aktuell ist."
@@ -7097,12 +7103,12 @@ msgstr "Laden Sie Ihre Betriebshaftpflichtversicherungsbescheinigung hoch und ge
 msgid "Valid"
 msgstr "Gültig"
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:728
+#: lib/klass_hero_web/live/provider/verification_live.ex:730
 #, elixir-autogen, elixir-format
 msgid "Your insurance certificate is under review."
 msgstr "Ihre Versicherungsbescheinigung wird geprüft."
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:734
+#: lib/klass_hero_web/live/provider/verification_live.ex:736
 #, elixir-autogen, elixir-format
 msgid "Your insurance is verified."
 msgstr "Ihre Versicherung ist verifiziert."
@@ -7954,12 +7960,12 @@ msgstr "Untertitel"
 msgid "e.g., For beginners, no experience needed"
 msgstr "z. B. Für Anfänger, keine Vorkenntnisse nötig"
 
-#: lib/klass_hero_web/presenters/program_presenter.ex:292
+#: lib/klass_hero_web/presenters/program_presenter.ex:308
 #, elixir-autogen, elixir-format
 msgid "Free"
 msgstr "Kostenlos"
 
-#: lib/klass_hero_web/presenters/program_presenter.ex:291
+#: lib/klass_hero_web/presenters/program_presenter.ex:307
 #, elixir-autogen, elixir-format
 msgid "N/A"
 msgstr "k. A."
@@ -8038,7 +8044,7 @@ msgstr "Grund für die Abwesenheit (optional)"
 msgid "e.g. Mum called — off sick today"
 msgstr "z. B. Mutter hat angerufen — heute krank"
 
-#: lib/klass_hero_web/components/composite_components.ex:766
+#: lib/klass_hero_web/components/composite_components.ex:776
 #, elixir-autogen, elixir-format
 msgid "%{business} on %{network}"
 msgstr "%{business} auf %{network}"
@@ -8052,3 +8058,28 @@ msgstr "Klass Hero auf %{network}"
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr "Hochladen fehlgeschlagen."
+
+#: lib/klass_hero_web/live/provider_profile_live.ex:158
+#, elixir-autogen, elixir-format
+msgid "Message %{provider} directly about their programs."
+msgstr "Schreiben Sie %{provider} direkt zu den Programmen."
+
+#: lib/klass_hero_web/live/provider_profile_live.ex:168
+#, elixir-autogen, elixir-format
+msgid "Message this provider"
+msgstr "Anbieter kontaktieren"
+
+#: lib/klass_hero_web/live/provider_profile_live.ex:133
+#, elixir-autogen, elixir-format
+msgid "No programs running right now"
+msgstr "Zurzeit keine laufenden Programme"
+
+#: lib/klass_hero_web/live/provider_profile_live.ex:29
+#, elixir-autogen, elixir-format
+msgid "Provider not found. They may have been removed or are no longer listed."
+msgstr "Anbieter nicht gefunden. Möglicherweise wurde er entfernt oder ist nicht mehr gelistet."
+
+#: lib/klass_hero_web/live/provider_profile_live.ex:134
+#, elixir-autogen, elixir-format
+msgid "This provider has no open programs at the moment. Check back soon."
+msgstr "Dieser Anbieter hat derzeit keine offenen Programme. Schauen Sie bald wieder vorbei."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -94,6 +94,7 @@ msgstr ""
 #: lib/klass_hero_web/components/layouts/app.html.heex:36
 #: lib/klass_hero_web/components/layouts/app.html.heex:198
 #: lib/klass_hero_web/components/marketing_components.ex:202
+#: lib/klass_hero_web/live/provider_profile_live.ex:127
 #, elixir-autogen, elixir-format
 msgid "Programs"
 msgstr ""
@@ -145,7 +146,7 @@ msgstr ""
 msgid "%{name} (Age %{age})"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:399
+#: lib/klass_hero_web/live/program_detail_live.ex:368
 #, elixir-autogen, elixir-format
 msgid "About This Program"
 msgstr ""
@@ -165,7 +166,7 @@ msgstr ""
 msgid "Add another program"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:244
+#: lib/klass_hero_web/live/program_detail_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "Ages %{range}"
 msgstr ""
@@ -225,7 +226,7 @@ msgstr ""
 msgid "Easy Scheduling"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:502
+#: lib/klass_hero_web/live/program_detail_live.ex:471
 #, elixir-autogen, elixir-format
 msgid "Enroll Now - %{price}"
 msgstr ""
@@ -257,7 +258,7 @@ msgid "Every provider is rigorously vetted. We prioritize child safety above all
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:986
-#: lib/klass_hero_web/live/programs_live.ex:35
+#: lib/klass_hero_web/live/programs_live.ex:34
 #, elixir-autogen, elixir-format
 msgid "Explore Programs"
 msgstr ""
@@ -267,7 +268,7 @@ msgstr ""
 msgid "Featured Programs"
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:227
+#: lib/klass_hero_web/live/programs_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "Invalid pagination state. Please refresh the page."
 msgstr ""
@@ -277,19 +278,19 @@ msgstr ""
 msgid "Invoice & Payment Confirmation"
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:367
+#: lib/klass_hero_web/live/programs_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "Loading..."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:439
+#: lib/klass_hero_web/live/program_detail_live.ex:408
 #, elixir-autogen, elixir-format
 msgid "Meet the Hero"
 msgid_plural "Meet the Heroes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/live/programs_live.ex:312
+#: lib/klass_hero_web/live/programs_live.ex:293
 #, elixir-autogen, elixir-format
 msgid "No programs found"
 msgstr ""
@@ -324,7 +325,7 @@ msgstr ""
 msgid "Please select a child for enrollment."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:22
+#: lib/klass_hero_web/live/home_live.ex:23
 #, elixir-autogen, elixir-format
 msgid "Klass Hero - Connecting Families with Trusted Youth Educators"
 msgstr ""
@@ -336,7 +337,7 @@ msgstr ""
 msgid "Program not found"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:71
+#: lib/klass_hero_web/live/program_detail_live.ex:69
 #, elixir-autogen, elixir-format
 msgid "Program not found. It may have been removed or is no longer available."
 msgstr ""
@@ -392,7 +393,7 @@ msgstr ""
 msgid "View All Programs →"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:256
+#: lib/klass_hero_web/live/program_detail_live.ex:225
 #, elixir-autogen, elixir-format
 msgid "✓ No hidden fees"
 msgstr ""
@@ -415,6 +416,7 @@ msgstr ""
 
 #: lib/klass_hero_web/live/contact_live.ex:85
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:314
+#: lib/klass_hero_web/live/provider_profile_live.ex:103
 #, elixir-autogen, elixir-format
 msgid "Address"
 msgstr ""
@@ -812,6 +814,7 @@ msgstr ""
 
 #: lib/klass_hero_web/live/contact_live.ex:78
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:299
+#: lib/klass_hero_web/live/provider_profile_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "Phone"
 msgstr ""
@@ -1147,13 +1150,13 @@ msgstr ""
 
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:24
 #: lib/klass_hero_web/live/admin/verifications_live.ex:192
-#: lib/klass_hero_web/live/programs_live.ex:20
+#: lib/klass_hero_web/live/programs_live.ex:19
 #, elixir-autogen, elixir-format
 msgid "All"
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:22
-#: lib/klass_hero_web/presenters/program_presenter.ex:350
+#: lib/klass_hero_web/live/programs_live.ex:21
+#: lib/klass_hero_web/presenters/program_presenter.ex:366
 #, elixir-autogen, elixir-format
 msgid "Arts"
 msgstr ""
@@ -1163,13 +1166,13 @@ msgstr ""
 msgid "Built for Berlin Families"
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:26
+#: lib/klass_hero_web/live/programs_live.ex:25
 #, elixir-autogen, elixir-format
 msgid "Camps"
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:24
-#: lib/klass_hero_web/presenters/program_presenter.ex:351
+#: lib/klass_hero_web/live/programs_live.ex:23
+#: lib/klass_hero_web/presenters/program_presenter.ex:367
 #, elixir-autogen, elixir-format
 msgid "Education"
 msgstr ""
@@ -1194,13 +1197,13 @@ msgstr ""
 msgid "Get Paid & Grow"
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:25
+#: lib/klass_hero_web/live/programs_live.ex:24
 #, elixir-autogen, elixir-format
 msgid "Life Skills"
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:23
-#: lib/klass_hero_web/presenters/program_presenter.ex:353
+#: lib/klass_hero_web/live/programs_live.ex:22
+#: lib/klass_hero_web/presenters/program_presenter.ex:369
 #, elixir-autogen, elixir-format
 msgid "Music"
 msgstr ""
@@ -1226,8 +1229,8 @@ msgstr ""
 msgid "Set up your teaching profile and list your programs in minutes. Share your expertise with families who need it."
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:21
-#: lib/klass_hero_web/presenters/program_presenter.ex:352
+#: lib/klass_hero_web/live/programs_live.ex:20
+#: lib/klass_hero_web/presenters/program_presenter.ex:368
 #, elixir-autogen, elixir-format
 msgid "Sports"
 msgstr ""
@@ -1247,7 +1250,7 @@ msgstr ""
 msgid "We understand the unique needs of Berlin's diverse families. Our platform connects you with vetted, high-quality programs that match your values and your children's interests."
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:27
+#: lib/klass_hero_web/live/programs_live.ex:26
 #, elixir-autogen, elixir-format
 msgid "Workshops"
 msgstr ""
@@ -1354,8 +1357,8 @@ msgstr ""
 msgid "Assigned Staff"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:366
-#: lib/klass_hero_web/live/program_detail_live.ex:526
+#: lib/klass_hero_web/live/program_detail_live.ex:335
+#: lib/klass_hero_web/live/program_detail_live.ex:495
 #, elixir-autogen, elixir-format
 msgid "Book Now"
 msgstr ""
@@ -1442,7 +1445,7 @@ msgstr ""
 msgid "Provider Dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:379
+#: lib/klass_hero_web/live/program_detail_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "Save for Later"
 msgstr ""
@@ -2527,8 +2530,8 @@ msgid "Our Story"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:3242
-#: lib/klass_hero_web/live/provider/verification_live.ex:698
-#: lib/klass_hero_web/live/provider/verification_live.ex:770
+#: lib/klass_hero_web/live/provider/verification_live.ex:699
+#: lib/klass_hero_web/live/provider/verification_live.ex:773
 #, elixir-autogen, elixir-format
 msgid "PDF, JPG or PNG. Max 10MB."
 msgstr ""
@@ -2637,7 +2640,7 @@ msgstr ""
 msgid "Registration"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:193
+#: lib/klass_hero_web/live/program_detail_live.ex:162
 #, elixir-autogen, elixir-format
 msgid "Registration Closed"
 msgstr ""
@@ -2647,7 +2650,7 @@ msgstr ""
 msgid "Registration Closes"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:191
+#: lib/klass_hero_web/live/program_detail_live.ex:160
 #, elixir-autogen, elixir-format
 msgid "Registration Not Open Yet"
 msgstr ""
@@ -2667,7 +2670,7 @@ msgstr ""
 msgid "Registration has closed for this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:165
+#: lib/klass_hero_web/live/program_detail_live.ex:134
 #, elixir-autogen, elixir-format
 msgid "Registration is closed"
 msgstr ""
@@ -2677,12 +2680,12 @@ msgstr ""
 msgid "Registration is not currently open for this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:87
+#: lib/klass_hero_web/live/program_detail_live.ex:85
 #, elixir-autogen, elixir-format
 msgid "Registration is not open for this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:161
+#: lib/klass_hero_web/live/program_detail_live.ex:130
 #, elixir-autogen, elixir-format
 msgid "Registration opens %{date}"
 msgstr ""
@@ -2746,7 +2749,7 @@ msgstr ""
 msgid "Schedule (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:239
+#: lib/klass_hero_web/live/program_detail_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "Schedule TBD"
 msgstr ""
@@ -3170,12 +3173,12 @@ msgstr ""
 msgid "Video Screening"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:98
+#: lib/klass_hero_web/live/home_live.ex:77
 #, elixir-autogen, elixir-format
 msgid "Every provider completes identity and age verification, experience validation, an extended background check, video screening, child safeguarding training, and agreement to our Community Guidelines before being approved."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:95
+#: lib/klass_hero_web/live/home_live.ex:74
 #, elixir-autogen, elixir-format
 msgid "How does the 6-step provider vetting process work?"
 msgstr ""
@@ -3236,7 +3239,7 @@ msgstr ""
 msgid "All Statuses"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:146
+#: lib/klass_hero_web/live/home_live.ex:125
 #, elixir-autogen, elixir-format
 msgid "All payments processed securely through Stripe."
 msgstr ""
@@ -3246,7 +3249,7 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:142
+#: lib/klass_hero_web/live/home_live.ex:121
 #, elixir-autogen, elixir-format
 msgid "Apple Pay / Google Pay"
 msgstr ""
@@ -3256,7 +3259,7 @@ msgstr ""
 msgid "Attendance corrected successfully"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:164
+#: lib/klass_hero_web/live/home_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "Automatic fee calculation (no surprises)"
 msgstr ""
@@ -3276,22 +3279,22 @@ msgstr ""
 msgid "Bookings"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:112
+#: lib/klass_hero_web/live/home_live.ex:91
 #, elixir-autogen, elixir-format
 msgid "Camps and holiday programs"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:209
+#: lib/klass_hero_web/live/home_live.ex:188
 #, elixir-autogen, elixir-format
 msgid "Can I buy a gift voucher?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:187
+#: lib/klass_hero_web/live/home_live.ex:166
 #, elixir-autogen, elixir-format
 msgid "Can I change my booking date?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:106
+#: lib/klass_hero_web/live/home_live.ex:85
 #, elixir-autogen, elixir-format
 msgid "Can I list my programs on Klass Hero and what does it cost?"
 msgstr ""
@@ -3345,7 +3348,7 @@ msgstr ""
 msgid "Child"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:211
+#: lib/klass_hero_web/live/home_live.ex:190
 #, elixir-autogen, elixir-format
 msgid "Coming soon! Sign up for our newsletter to be notified when gift vouchers launch."
 msgstr ""
@@ -3355,7 +3358,7 @@ msgstr ""
 msgid "Completed"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:189
+#: lib/klass_hero_web/live/home_live.ex:168
 #, elixir-autogen, elixir-format
 msgid "Contact the provider directly (details in confirmation email). Most providers are flexible if you ask in advance."
 msgstr ""
@@ -3365,22 +3368,22 @@ msgstr ""
 msgid "Correct"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:141
+#: lib/klass_hero_web/live/home_live.ex:120
 #, elixir-autogen, elixir-format
 msgid "Credit/debit card (Visa, Mastercard, Amex)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:205
+#: lib/klass_hero_web/live/home_live.ex:184
 #, elixir-autogen, elixir-format
 msgid "Currently serving Berlin, with expansion to other German cities coming soon."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:181
+#: lib/klass_hero_web/live/home_live.ex:160
 #, elixir-autogen, elixir-format
 msgid "Do I need an account to book?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:171
+#: lib/klass_hero_web/live/home_live.ex:150
 #, elixir-autogen, elixir-format
 msgid "Download monthly statements for taxes"
 msgstr ""
@@ -3396,22 +3399,22 @@ msgstr ""
 msgid "Explain why this correction is needed..."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:169
+#: lib/klass_hero_web/live/home_live.ex:148
 #, elixir-autogen, elixir-format
 msgid "Export participant lists anytime"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:136
+#: lib/klass_hero_web/live/home_live.ex:115
 #, elixir-autogen, elixir-format
 msgid "Funds are immediately available in your Klass Hero account"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:147
+#: lib/klass_hero_web/live/home_live.ex:126
 #, elixir-autogen, elixir-format
 msgid "How You Get Paid:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:129
+#: lib/klass_hero_web/live/home_live.ex:108
 #, elixir-autogen, elixir-format
 msgid "How does the booking system work?"
 msgstr ""
@@ -3422,17 +3425,17 @@ msgstr ""
 msgid "In Progress"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:150
+#: lib/klass_hero_web/live/home_live.ex:129
 #, elixir-autogen, elixir-format
 msgid "Instant availability: Funds are in your Klass Hero balance immediately after booking"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:175
+#: lib/klass_hero_web/live/home_live.ex:154
 #, elixir-autogen, elixir-format
 msgid "Is Klass Hero free for parents to use?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:144
+#: lib/klass_hero_web/live/home_live.ex:123
 #, elixir-autogen, elixir-format
 msgid "Klarna (pay later options)"
 msgstr ""
@@ -3453,7 +3456,7 @@ msgstr ""
 msgid "No changes detected"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:162
+#: lib/klass_hero_web/live/home_live.ex:141
 #, elixir-autogen, elixir-format
 msgid "No chasing payments or sending invoices"
 msgstr ""
@@ -3464,7 +3467,7 @@ msgstr ""
 msgid "No enrolled parents"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:163
+#: lib/klass_hero_web/live/home_live.ex:142
 #, elixir-autogen, elixir-format
 msgid "No risk of non-payment"
 msgstr ""
@@ -3476,7 +3479,7 @@ msgstr ""
 msgid "Notes"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:155
+#: lib/klass_hero_web/live/home_live.ex:134
 #, elixir-autogen, elixir-format
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
@@ -3487,37 +3490,37 @@ msgstr ""
 msgid "Parent account not available"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:133
+#: lib/klass_hero_web/live/home_live.ex:112
 #, elixir-autogen, elixir-format
 msgid "Parent books and pays through Klass Hero (via Stripe)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:135
+#: lib/klass_hero_web/live/home_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "Parent receives confirmation with your contact details"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:161
+#: lib/klass_hero_web/live/home_live.ex:140
 #, elixir-autogen, elixir-format
 msgid "Parents pay upfront when booking (reduces no-shows by 85%)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:139
+#: lib/klass_hero_web/live/home_live.ex:118
 #, elixir-autogen, elixir-format
 msgid "Payment Options for Parents:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:156
+#: lib/klass_hero_web/live/home_live.ex:135
 #, elixir-autogen, elixir-format
 msgid "Platform fee automatically deducted when parent pays"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:116
+#: lib/klass_hero_web/live/home_live.ex:95
 #, elixir-autogen, elixir-format
 msgid "Pricing:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:114
+#: lib/klass_hero_web/live/home_live.ex:93
 #, elixir-autogen, elixir-format
 msgid "Private lessons and tutoring"
 msgstr ""
@@ -3528,7 +3531,7 @@ msgstr ""
 msgid "Providers"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:168
+#: lib/klass_hero_web/live/home_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Real-time dashboard shows all bookings and available balance"
 msgstr ""
@@ -3543,12 +3546,12 @@ msgstr ""
 msgid "Record was modified by someone else. Please refresh."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:111
+#: lib/klass_hero_web/live/home_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "Regular classes and courses (weekly/monthly)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:143
+#: lib/klass_hero_web/live/home_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "SEPA direct debit"
 msgstr ""
@@ -3563,12 +3566,12 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:170
+#: lib/klass_hero_web/live/home_live.ex:149
 #, elixir-autogen, elixir-format
 msgid "See payment history and upcoming payouts"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:130
+#: lib/klass_hero_web/live/home_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "Simple and automated - we handle everything."
 msgstr ""
@@ -3578,7 +3581,7 @@ msgstr ""
 msgid "Staff Members"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:166
+#: lib/klass_hero_web/live/home_live.ex:145
 #, elixir-autogen, elixir-format
 msgid "Track Everything:"
 msgstr ""
@@ -3589,67 +3592,67 @@ msgstr ""
 msgid "Upgrade your plan to send messages."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:154
+#: lib/klass_hero_web/live/home_live.ex:133
 #, elixir-autogen, elixir-format
 msgid "Weekly payouts: Transferred to your bank account every Friday"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:109
+#: lib/klass_hero_web/live/home_live.ex:88
 #, elixir-autogen, elixir-format
 msgid "What You Can List:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:195
+#: lib/klass_hero_web/live/home_live.ex:174
 #, elixir-autogen, elixir-format
 msgid "What if my child gets sick?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:131
+#: lib/klass_hero_web/live/home_live.ex:110
 #, elixir-autogen, elixir-format
 msgid "When Someone Books:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:203
+#: lib/klass_hero_web/live/home_live.ex:182
 #, elixir-autogen, elixir-format
 msgid "Where is Klass Hero available?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:158
+#: lib/klass_hero_web/live/home_live.ex:137
 #, elixir-autogen, elixir-format
 msgid "Why This Works Better:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:113
+#: lib/klass_hero_web/live/home_live.ex:92
 #, elixir-autogen, elixir-format
 msgid "Workshops and one-time events"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:177
+#: lib/klass_hero_web/live/home_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "Yes! Browsing and booking are completely free. No subscription, no booking fees."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:108
+#: lib/klass_hero_web/live/home_live.ex:87
 #, elixir-autogen, elixir-format
 msgid "Yes! Register for free and start listing immediately."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:183
+#: lib/klass_hero_web/live/home_live.ex:162
 #, elixir-autogen, elixir-format
 msgid "Yes, you need a free account to complete a booking and manage your reservations."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:137
+#: lib/klass_hero_web/live/home_live.ex:116
 #, elixir-autogen, elixir-format
 msgid "You deliver the program"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:160
+#: lib/klass_hero_web/live/home_live.ex:139
 #, elixir-autogen, elixir-format
 msgid "You get paid BEFORE delivering the program (no waiting)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:134
+#: lib/klass_hero_web/live/home_live.ex:113
 #, elixir-autogen, elixir-format
 msgid "You receive instant email with booking details and parent contact info"
 msgstr ""
@@ -4406,6 +4409,7 @@ msgid "+1234567890"
 msgstr ""
 
 #: lib/klass_hero_web/components/composite_components.ex:641
+#: lib/klass_hero_web/live/provider_profile_live.ex:89
 #, elixir-autogen, elixir-format
 msgid "About the Provider"
 msgstr ""
@@ -4553,6 +4557,7 @@ msgid "View your assignments"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:306
+#: lib/klass_hero_web/live/provider_profile_live.ex:116
 #, elixir-autogen, elixir-format
 msgid "Website"
 msgstr ""
@@ -5282,7 +5287,7 @@ msgstr ""
 msgid "Edit program"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:197
+#: lib/klass_hero_web/live/home_live.ex:176
 #, elixir-autogen, elixir-format
 msgid "Email the provider and us (support@mail.klasshero.com) as soon as you can — we'll help you and the provider work it out."
 msgstr ""
@@ -5342,7 +5347,7 @@ msgstr ""
 msgid "Everything parents need, nothing they don't"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:92
+#: lib/klass_hero_web/live/home_live.ex:71
 #, elixir-autogen, elixir-format
 msgid "Everything you need to know about Klass Hero."
 msgstr ""
@@ -5445,6 +5450,7 @@ msgstr ""
 msgid "Hand-picked, vetted programs across Berlin — filter by category, age, or schedule."
 msgstr ""
 
+#: lib/klass_hero_web/live/provider_profile_live.ex:155
 #: lib/klass_hero_web/live/trust_safety_live.ex:103
 #, elixir-autogen, elixir-format
 msgid "Have questions?"
@@ -5559,7 +5565,7 @@ msgid "Join the team"
 msgstr ""
 
 #: lib/klass_hero_web/live/for_providers_live.ex:182
-#: lib/klass_hero_web/live/home_live.ex:118
+#: lib/klass_hero_web/live/home_live.ex:97
 #, elixir-autogen, elixir-format
 msgid "Joining Klass Hero costs nothing — unlimited programs, your whole team, all media, and direct parent messaging are included for everyone. A simple success-based fee on bookings made through the platform is coming; we'll share the details transparently before it launches."
 msgstr ""
@@ -5645,7 +5651,7 @@ msgstr ""
 msgid "Live video screen with our safeguarding lead."
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:369
+#: lib/klass_hero_web/live/programs_live.ex:350
 #, elixir-autogen, elixir-format
 msgid "Load more programs"
 msgstr ""
@@ -6279,7 +6285,7 @@ msgstr ""
 msgid "Trusted Heroes"
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:314
+#: lib/klass_hero_web/live/programs_live.ex:295
 #, elixir-autogen, elixir-format
 msgid "Try adjusting your search or filter criteria — there's plenty more in Berlin."
 msgstr ""
@@ -6559,7 +6565,7 @@ msgstr ""
 msgid "You don't have permission to send broadcasts"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:123
+#: lib/klass_hero_web/live/home_live.ex:102
 #, elixir-autogen, elixir-format
 msgid "Every provider gets: Profile page, booking system, payment processing, messaging, and marketing to Berlin families."
 msgstr ""
@@ -6621,12 +6627,12 @@ msgstr ""
 msgid "In progress"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:830
+#: lib/klass_hero_web/live/provider/verification_live.ex:834
 #, elixir-autogen, elixir-format
 msgid "Klass Hero is only open to providers aged 18 and over, so we can't approve this account."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:840
+#: lib/klass_hero_web/live/provider/verification_live.ex:844
 #, elixir-autogen, elixir-format
 msgid "Looks like the check didn't finish. Pick up where you left off whenever you're ready."
 msgstr ""
@@ -6666,7 +6672,7 @@ msgstr ""
 msgid "Resubmit"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:819
+#: lib/klass_hero_web/live/provider/verification_live.ex:823
 #, elixir-autogen, elixir-format
 msgid "Retry verification"
 msgstr ""
@@ -6686,12 +6692,12 @@ msgstr ""
 msgid "Show relevant experience working with children."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:837
+#: lib/klass_hero_web/live/provider/verification_live.ex:841
 #, elixir-autogen, elixir-format
 msgid "Something tripped up the check — usually a blurry photo. Give it another go."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:796
+#: lib/klass_hero_web/live/provider/verification_live.ex:800
 #, elixir-autogen, elixir-format
 msgid "Takes about 2 minutes. Once verified, your provider account can be approved."
 msgstr ""
@@ -6717,7 +6723,7 @@ msgid "Upload your safeguarding certificate."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/verification_live.ex:513
-#: lib/klass_hero_web/live/provider/verification_live.ex:793
+#: lib/klass_hero_web/live/provider/verification_live.ex:797
 #, elixir-autogen, elixir-format
 msgid "Verify identity"
 msgstr ""
@@ -6727,12 +6733,12 @@ msgstr ""
 msgid "Verify your identity to get approved"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:788
+#: lib/klass_hero_web/live/provider/verification_live.ex:792
 #, elixir-autogen, elixir-format
 msgid "Verify your identity with our partner Stripe to get approved. You'll be sent to a secure page and brought back here."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:802
+#: lib/klass_hero_web/live/provider/verification_live.ex:806
 #, elixir-autogen, elixir-format
 msgid "Verifying your identity… this can take a moment."
 msgstr ""
@@ -6743,17 +6749,17 @@ msgstr ""
 msgid "Video screening"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:834
+#: lib/klass_hero_web/live/provider/verification_live.ex:838
 #, elixir-autogen, elixir-format
 msgid "We couldn't read your date of birth from your ID. A clearer photo of your document should do the trick."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:842
+#: lib/klass_hero_web/live/provider/verification_live.ex:846
 #, elixir-autogen, elixir-format
 msgid "We couldn't verify your identity. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:812
+#: lib/klass_hero_web/live/provider/verification_live.ex:816
 #, elixir-autogen, elixir-format
 msgid "Your identity is verified."
 msgstr ""
@@ -7011,8 +7017,8 @@ msgstr ""
 msgid "Select your country to see which document to upload."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:700
-#: lib/klass_hero_web/live/provider/verification_live.ex:772
+#: lib/klass_hero_web/live/provider/verification_live.ex:702
+#: lib/klass_hero_web/live/provider/verification_live.ex:776
 #, elixir-autogen, elixir-format
 msgid "Submit for review"
 msgstr ""
@@ -7072,22 +7078,22 @@ msgstr ""
 msgid "Policy expiry"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:756
+#: lib/klass_hero_web/live/provider/verification_live.ex:758
 #, elixir-autogen, elixir-format
 msgid "Policy expiry date"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:764
+#: lib/klass_hero_web/live/provider/verification_live.ex:766
 #, elixir-autogen, elixir-format
 msgid "This certificate expires within 30 days. Please renew it soon."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:760
+#: lib/klass_hero_web/live/provider/verification_live.ex:762
 #, elixir-autogen, elixir-format
 msgid "This certificate has already expired. Please upload a current policy."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:745
+#: lib/klass_hero_web/live/provider/verification_live.ex:747
 #, elixir-autogen, elixir-format
 msgid "Upload your public liability insurance certificate and enter its policy expiry date so we can confirm cover is current."
 msgstr ""
@@ -7097,12 +7103,12 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:728
+#: lib/klass_hero_web/live/provider/verification_live.ex:730
 #, elixir-autogen, elixir-format
 msgid "Your insurance certificate is under review."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:734
+#: lib/klass_hero_web/live/provider/verification_live.ex:736
 #, elixir-autogen, elixir-format
 msgid "Your insurance is verified."
 msgstr ""
@@ -7936,12 +7942,12 @@ msgstr ""
 msgid "e.g., For beginners, no experience needed"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/program_presenter.ex:292
+#: lib/klass_hero_web/presenters/program_presenter.ex:308
 #, elixir-autogen, elixir-format
 msgid "Free"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/program_presenter.ex:291
+#: lib/klass_hero_web/presenters/program_presenter.ex:307
 #, elixir-autogen, elixir-format
 msgid "N/A"
 msgstr ""
@@ -8020,7 +8026,7 @@ msgstr ""
 msgid "e.g. Mum called — off sick today"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:766
+#: lib/klass_hero_web/components/composite_components.ex:776
 #, elixir-autogen, elixir-format
 msgid "%{business} on %{network}"
 msgstr ""
@@ -8033,4 +8039,29 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:3140
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider_profile_live.ex:158
+#, elixir-autogen, elixir-format
+msgid "Message %{provider} directly about their programs."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider_profile_live.ex:168
+#, elixir-autogen, elixir-format
+msgid "Message this provider"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider_profile_live.ex:133
+#, elixir-autogen, elixir-format
+msgid "No programs running right now"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider_profile_live.ex:29
+#, elixir-autogen, elixir-format
+msgid "Provider not found. They may have been removed or are no longer listed."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider_profile_live.ex:134
+#, elixir-autogen, elixir-format
+msgid "This provider has no open programs at the moment. Check back soon."
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -94,7 +94,7 @@ msgstr ""
 #: lib/klass_hero_web/components/layouts/app.html.heex:36
 #: lib/klass_hero_web/components/layouts/app.html.heex:198
 #: lib/klass_hero_web/components/marketing_components.ex:202
-#: lib/klass_hero_web/live/provider_profile_live.ex:127
+#: lib/klass_hero_web/live/provider_profile_live.ex:129
 #, elixir-autogen, elixir-format
 msgid "Programs"
 msgstr ""
@@ -416,7 +416,7 @@ msgstr ""
 
 #: lib/klass_hero_web/live/contact_live.ex:85
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:314
-#: lib/klass_hero_web/live/provider_profile_live.ex:103
+#: lib/klass_hero_web/live/provider_profile_live.ex:107
 #, elixir-autogen, elixir-format
 msgid "Address"
 msgstr ""
@@ -795,7 +795,7 @@ msgstr ""
 #: lib/klass_hero_web/live/contact_live.ex:100
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:241
 #: lib/klass_hero_web/live/provider/verification_live.ex:626
-#: lib/klass_hero_web/presenters/provider_presenter.ex:160
+#: lib/klass_hero_web/presenters/provider_presenter.ex:166
 #, elixir-autogen, elixir-format
 msgid "Other"
 msgstr ""
@@ -814,7 +814,7 @@ msgstr ""
 
 #: lib/klass_hero_web/live/contact_live.ex:78
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:299
-#: lib/klass_hero_web/live/provider_profile_live.ex:109
+#: lib/klass_hero_web/live/provider_profile_live.ex:113
 #, elixir-autogen, elixir-format
 msgid "Phone"
 msgstr ""
@@ -1156,7 +1156,7 @@ msgid "All"
 msgstr ""
 
 #: lib/klass_hero_web/live/programs_live.ex:21
-#: lib/klass_hero_web/presenters/program_presenter.ex:366
+#: lib/klass_hero_web/presenters/program_presenter.ex:351
 #, elixir-autogen, elixir-format
 msgid "Arts"
 msgstr ""
@@ -1167,12 +1167,13 @@ msgid "Built for Berlin Families"
 msgstr ""
 
 #: lib/klass_hero_web/live/programs_live.ex:25
+#: lib/klass_hero_web/presenters/program_presenter.ex:356
 #, elixir-autogen, elixir-format
 msgid "Camps"
 msgstr ""
 
 #: lib/klass_hero_web/live/programs_live.ex:23
-#: lib/klass_hero_web/presenters/program_presenter.ex:367
+#: lib/klass_hero_web/presenters/program_presenter.ex:352
 #, elixir-autogen, elixir-format
 msgid "Education"
 msgstr ""
@@ -1198,12 +1199,13 @@ msgid "Get Paid & Grow"
 msgstr ""
 
 #: lib/klass_hero_web/live/programs_live.ex:24
+#: lib/klass_hero_web/presenters/program_presenter.ex:355
 #, elixir-autogen, elixir-format
 msgid "Life Skills"
 msgstr ""
 
 #: lib/klass_hero_web/live/programs_live.ex:22
-#: lib/klass_hero_web/presenters/program_presenter.ex:369
+#: lib/klass_hero_web/presenters/program_presenter.ex:354
 #, elixir-autogen, elixir-format
 msgid "Music"
 msgstr ""
@@ -1230,7 +1232,7 @@ msgid "Set up your teaching profile and list your programs in minutes. Share you
 msgstr ""
 
 #: lib/klass_hero_web/live/programs_live.ex:20
-#: lib/klass_hero_web/presenters/program_presenter.ex:368
+#: lib/klass_hero_web/presenters/program_presenter.ex:353
 #, elixir-autogen, elixir-format
 msgid "Sports"
 msgstr ""
@@ -1251,6 +1253,7 @@ msgid "We understand the unique needs of Berlin's diverse families. Our platform
 msgstr ""
 
 #: lib/klass_hero_web/live/programs_live.ex:26
+#: lib/klass_hero_web/presenters/program_presenter.ex:357
 #, elixir-autogen, elixir-format
 msgid "Workshops"
 msgstr ""
@@ -1363,8 +1366,8 @@ msgstr ""
 msgid "Book Now"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:146
-#: lib/klass_hero_web/presenters/provider_presenter.ex:156
+#: lib/klass_hero_web/presenters/provider_presenter.ex:152
+#: lib/klass_hero_web/presenters/provider_presenter.ex:162
 #, elixir-autogen, elixir-format
 msgid "Business Registration"
 msgstr ""
@@ -1487,7 +1490,7 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:51
 #: lib/klass_hero_web/components/provider_components.ex:1576
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:455
-#: lib/klass_hero_web/presenters/provider_presenter.ex:166
+#: lib/klass_hero_web/presenters/provider_presenter.ex:172
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
@@ -2314,7 +2317,7 @@ msgstr ""
 msgid "Headshot Photo"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:158
+#: lib/klass_hero_web/presenters/provider_presenter.ex:164
 #, elixir-autogen, elixir-format
 msgid "ID Document"
 msgstr ""
@@ -2324,7 +2327,7 @@ msgstr ""
 msgid "Import"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:157
+#: lib/klass_hero_web/presenters/provider_presenter.ex:163
 #, elixir-autogen, elixir-format
 msgid "Insurance Certificate"
 msgstr ""
@@ -2831,7 +2834,7 @@ msgstr ""
 msgid "TBD"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:159
+#: lib/klass_hero_web/presenters/provider_presenter.ex:165
 #, elixir-autogen, elixir-format
 msgid "Tax Certificate"
 msgstr ""
@@ -4409,7 +4412,7 @@ msgid "+1234567890"
 msgstr ""
 
 #: lib/klass_hero_web/components/composite_components.ex:641
-#: lib/klass_hero_web/live/provider_profile_live.ex:89
+#: lib/klass_hero_web/live/provider_profile_live.ex:93
 #, elixir-autogen, elixir-format
 msgid "About the Provider"
 msgstr ""
@@ -4557,7 +4560,7 @@ msgid "View your assignments"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:306
-#: lib/klass_hero_web/live/provider_profile_live.ex:116
+#: lib/klass_hero_web/live/provider_profile_live.ex:120
 #, elixir-autogen, elixir-format
 msgid "Website"
 msgstr ""
@@ -6575,7 +6578,7 @@ msgstr ""
 msgid "A short video so we can meet you."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:162
+#: lib/klass_hero_web/presenters/provider_presenter.ex:168
 #: lib/klass_hero_web/presenters/vetting_checklist_presenter.ex:77
 #, elixir-autogen, elixir-format
 msgid "Background check"
@@ -6743,7 +6746,7 @@ msgstr ""
 msgid "Verifying your identity… this can take a moment."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:163
+#: lib/klass_hero_web/presenters/provider_presenter.ex:169
 #: lib/klass_hero_web/presenters/vetting_checklist_presenter.ex:85
 #, elixir-autogen, elixir-format
 msgid "Video screening"
@@ -6764,7 +6767,7 @@ msgstr ""
 msgid "Your identity is verified."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:161
+#: lib/klass_hero_web/presenters/provider_presenter.ex:167
 #, elixir-autogen, elixir-format
 msgid "Experience validation"
 msgstr ""
@@ -6779,7 +6782,7 @@ msgstr ""
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:164
+#: lib/klass_hero_web/presenters/provider_presenter.ex:170
 #, elixir-autogen, elixir-format
 msgid "Safeguarding certificate"
 msgstr ""
@@ -8041,27 +8044,32 @@ msgstr ""
 msgid "Upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider_profile_live.ex:158
+#: lib/klass_hero_web/live/provider_profile_live.ex:157
 #, elixir-autogen, elixir-format
 msgid "Message %{provider} directly about their programs."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider_profile_live.ex:168
+#: lib/klass_hero_web/live/provider_profile_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Message this provider"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider_profile_live.ex:133
+#: lib/klass_hero_web/live/provider_profile_live.ex:135
 #, elixir-autogen, elixir-format
 msgid "No programs running right now"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider_profile_live.ex:29
+#: lib/klass_hero_web/live/provider_profile_live.ex:28
 #, elixir-autogen, elixir-format
 msgid "Provider not found. They may have been removed or are no longer listed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider_profile_live.ex:134
+#: lib/klass_hero_web/live/provider_profile_live.ex:136
 #, elixir-autogen, elixir-format
 msgid "This provider has no open programs at the moment. Check back soon."
+msgstr ""
+
+#: lib/klass_hero_web/presenters/program_presenter.ex:350
+#, elixir-autogen, elixir-format
+msgid "General"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -94,6 +94,7 @@ msgstr ""
 #: lib/klass_hero_web/components/layouts/app.html.heex:36
 #: lib/klass_hero_web/components/layouts/app.html.heex:198
 #: lib/klass_hero_web/components/marketing_components.ex:202
+#: lib/klass_hero_web/live/provider_profile_live.ex:127
 #, elixir-autogen, elixir-format
 msgid "Programs"
 msgstr ""
@@ -145,7 +146,7 @@ msgstr ""
 msgid "%{name} (Age %{age})"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:399
+#: lib/klass_hero_web/live/program_detail_live.ex:368
 #, elixir-autogen, elixir-format
 msgid "About This Program"
 msgstr ""
@@ -165,7 +166,7 @@ msgstr ""
 msgid "Add another program"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:244
+#: lib/klass_hero_web/live/program_detail_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "Ages %{range}"
 msgstr ""
@@ -225,7 +226,7 @@ msgstr ""
 msgid "Easy Scheduling"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:502
+#: lib/klass_hero_web/live/program_detail_live.ex:471
 #, elixir-autogen, elixir-format
 msgid "Enroll Now - %{price}"
 msgstr ""
@@ -257,7 +258,7 @@ msgid "Every provider is rigorously vetted. We prioritize child safety above all
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:986
-#: lib/klass_hero_web/live/programs_live.ex:35
+#: lib/klass_hero_web/live/programs_live.ex:34
 #, elixir-autogen, elixir-format
 msgid "Explore Programs"
 msgstr ""
@@ -267,7 +268,7 @@ msgstr ""
 msgid "Featured Programs"
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:227
+#: lib/klass_hero_web/live/programs_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "Invalid pagination state. Please refresh the page."
 msgstr ""
@@ -277,19 +278,19 @@ msgstr ""
 msgid "Invoice & Payment Confirmation"
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:367
+#: lib/klass_hero_web/live/programs_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "Loading..."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:439
+#: lib/klass_hero_web/live/program_detail_live.ex:408
 #, elixir-autogen, elixir-format
 msgid "Meet the Hero"
 msgid_plural "Meet the Heroes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/live/programs_live.ex:312
+#: lib/klass_hero_web/live/programs_live.ex:293
 #, elixir-autogen, elixir-format
 msgid "No programs found"
 msgstr ""
@@ -324,7 +325,7 @@ msgstr ""
 msgid "Please select a child for enrollment."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:22
+#: lib/klass_hero_web/live/home_live.ex:23
 #, elixir-autogen, elixir-format
 msgid "Klass Hero - Connecting Families with Trusted Youth Educators"
 msgstr ""
@@ -336,7 +337,7 @@ msgstr ""
 msgid "Program not found"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:71
+#: lib/klass_hero_web/live/program_detail_live.ex:69
 #, elixir-autogen, elixir-format
 msgid "Program not found. It may have been removed or is no longer available."
 msgstr ""
@@ -392,7 +393,7 @@ msgstr ""
 msgid "View All Programs →"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:256
+#: lib/klass_hero_web/live/program_detail_live.ex:225
 #, elixir-autogen, elixir-format
 msgid "✓ No hidden fees"
 msgstr ""
@@ -415,6 +416,7 @@ msgstr ""
 
 #: lib/klass_hero_web/live/contact_live.ex:85
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:314
+#: lib/klass_hero_web/live/provider_profile_live.ex:103
 #, elixir-autogen, elixir-format
 msgid "Address"
 msgstr ""
@@ -812,6 +814,7 @@ msgstr ""
 
 #: lib/klass_hero_web/live/contact_live.ex:78
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:299
+#: lib/klass_hero_web/live/provider_profile_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "Phone"
 msgstr ""
@@ -1147,13 +1150,13 @@ msgstr ""
 
 #: lib/klass_hero_web/live/admin/emails_live.html.heex:24
 #: lib/klass_hero_web/live/admin/verifications_live.ex:192
-#: lib/klass_hero_web/live/programs_live.ex:20
+#: lib/klass_hero_web/live/programs_live.ex:19
 #, elixir-autogen, elixir-format
 msgid "All"
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:22
-#: lib/klass_hero_web/presenters/program_presenter.ex:350
+#: lib/klass_hero_web/live/programs_live.ex:21
+#: lib/klass_hero_web/presenters/program_presenter.ex:366
 #, elixir-autogen, elixir-format
 msgid "Arts"
 msgstr ""
@@ -1163,13 +1166,13 @@ msgstr ""
 msgid "Built for Berlin Families"
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:26
+#: lib/klass_hero_web/live/programs_live.ex:25
 #, elixir-autogen, elixir-format
 msgid "Camps"
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:24
-#: lib/klass_hero_web/presenters/program_presenter.ex:351
+#: lib/klass_hero_web/live/programs_live.ex:23
+#: lib/klass_hero_web/presenters/program_presenter.ex:367
 #, elixir-autogen, elixir-format
 msgid "Education"
 msgstr ""
@@ -1194,13 +1197,13 @@ msgstr ""
 msgid "Get Paid & Grow"
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:25
+#: lib/klass_hero_web/live/programs_live.ex:24
 #, elixir-autogen, elixir-format
 msgid "Life Skills"
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:23
-#: lib/klass_hero_web/presenters/program_presenter.ex:353
+#: lib/klass_hero_web/live/programs_live.ex:22
+#: lib/klass_hero_web/presenters/program_presenter.ex:369
 #, elixir-autogen, elixir-format
 msgid "Music"
 msgstr ""
@@ -1226,8 +1229,8 @@ msgstr ""
 msgid "Set up your teaching profile and list your programs in minutes. Share your expertise with families who need it."
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:21
-#: lib/klass_hero_web/presenters/program_presenter.ex:352
+#: lib/klass_hero_web/live/programs_live.ex:20
+#: lib/klass_hero_web/presenters/program_presenter.ex:368
 #, elixir-autogen, elixir-format
 msgid "Sports"
 msgstr ""
@@ -1247,7 +1250,7 @@ msgstr ""
 msgid "We understand the unique needs of Berlin's diverse families. Our platform connects you with vetted, high-quality programs that match your values and your children's interests."
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:27
+#: lib/klass_hero_web/live/programs_live.ex:26
 #, elixir-autogen, elixir-format
 msgid "Workshops"
 msgstr ""
@@ -1354,8 +1357,8 @@ msgstr ""
 msgid "Assigned Staff"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:366
-#: lib/klass_hero_web/live/program_detail_live.ex:526
+#: lib/klass_hero_web/live/program_detail_live.ex:335
+#: lib/klass_hero_web/live/program_detail_live.ex:495
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Book Now"
 msgstr ""
@@ -1442,7 +1445,7 @@ msgstr ""
 msgid "Provider Dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:379
+#: lib/klass_hero_web/live/program_detail_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "Save for Later"
 msgstr ""
@@ -2527,8 +2530,8 @@ msgid "Our Story"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:3242
-#: lib/klass_hero_web/live/provider/verification_live.ex:698
-#: lib/klass_hero_web/live/provider/verification_live.ex:770
+#: lib/klass_hero_web/live/provider/verification_live.ex:699
+#: lib/klass_hero_web/live/provider/verification_live.ex:773
 #, elixir-autogen, elixir-format
 msgid "PDF, JPG or PNG. Max 10MB."
 msgstr ""
@@ -2637,7 +2640,7 @@ msgstr ""
 msgid "Registration"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:193
+#: lib/klass_hero_web/live/program_detail_live.ex:162
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration Closed"
 msgstr ""
@@ -2647,7 +2650,7 @@ msgstr ""
 msgid "Registration Closes"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:191
+#: lib/klass_hero_web/live/program_detail_live.ex:160
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration Not Open Yet"
 msgstr ""
@@ -2667,7 +2670,7 @@ msgstr ""
 msgid "Registration has closed for this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:165
+#: lib/klass_hero_web/live/program_detail_live.ex:134
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration is closed"
 msgstr ""
@@ -2677,12 +2680,12 @@ msgstr ""
 msgid "Registration is not currently open for this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:87
+#: lib/klass_hero_web/live/program_detail_live.ex:85
 #, elixir-autogen, elixir-format
 msgid "Registration is not open for this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:161
+#: lib/klass_hero_web/live/program_detail_live.ex:130
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration opens %{date}"
 msgstr ""
@@ -2746,7 +2749,7 @@ msgstr ""
 msgid "Schedule (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/live/program_detail_live.ex:239
+#: lib/klass_hero_web/live/program_detail_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "Schedule TBD"
 msgstr ""
@@ -3170,12 +3173,12 @@ msgstr ""
 msgid "Video Screening"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:98
+#: lib/klass_hero_web/live/home_live.ex:77
 #, elixir-autogen, elixir-format
 msgid "Every provider completes identity and age verification, experience validation, an extended background check, video screening, child safeguarding training, and agreement to our Community Guidelines before being approved."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:95
+#: lib/klass_hero_web/live/home_live.ex:74
 #, elixir-autogen, elixir-format
 msgid "How does the 6-step provider vetting process work?"
 msgstr ""
@@ -3236,7 +3239,7 @@ msgstr ""
 msgid "All Statuses"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:146
+#: lib/klass_hero_web/live/home_live.ex:125
 #, elixir-autogen, elixir-format
 msgid "All payments processed securely through Stripe."
 msgstr ""
@@ -3246,7 +3249,7 @@ msgstr ""
 msgid "An error occurred"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:142
+#: lib/klass_hero_web/live/home_live.ex:121
 #, elixir-autogen, elixir-format
 msgid "Apple Pay / Google Pay"
 msgstr ""
@@ -3256,7 +3259,7 @@ msgstr ""
 msgid "Attendance corrected successfully"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:164
+#: lib/klass_hero_web/live/home_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "Automatic fee calculation (no surprises)"
 msgstr ""
@@ -3276,22 +3279,22 @@ msgstr ""
 msgid "Bookings"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:112
+#: lib/klass_hero_web/live/home_live.ex:91
 #, elixir-autogen, elixir-format
 msgid "Camps and holiday programs"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:209
+#: lib/klass_hero_web/live/home_live.ex:188
 #, elixir-autogen, elixir-format
 msgid "Can I buy a gift voucher?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:187
+#: lib/klass_hero_web/live/home_live.ex:166
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Can I change my booking date?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:106
+#: lib/klass_hero_web/live/home_live.ex:85
 #, elixir-autogen, elixir-format
 msgid "Can I list my programs on Klass Hero and what does it cost?"
 msgstr ""
@@ -3345,7 +3348,7 @@ msgstr ""
 msgid "Child"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:211
+#: lib/klass_hero_web/live/home_live.ex:190
 #, elixir-autogen, elixir-format
 msgid "Coming soon! Sign up for our newsletter to be notified when gift vouchers launch."
 msgstr ""
@@ -3355,7 +3358,7 @@ msgstr ""
 msgid "Completed"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:189
+#: lib/klass_hero_web/live/home_live.ex:168
 #, elixir-autogen, elixir-format
 msgid "Contact the provider directly (details in confirmation email). Most providers are flexible if you ask in advance."
 msgstr ""
@@ -3365,22 +3368,22 @@ msgstr ""
 msgid "Correct"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:141
+#: lib/klass_hero_web/live/home_live.ex:120
 #, elixir-autogen, elixir-format
 msgid "Credit/debit card (Visa, Mastercard, Amex)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:205
+#: lib/klass_hero_web/live/home_live.ex:184
 #, elixir-autogen, elixir-format
 msgid "Currently serving Berlin, with expansion to other German cities coming soon."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:181
+#: lib/klass_hero_web/live/home_live.ex:160
 #, elixir-autogen, elixir-format
 msgid "Do I need an account to book?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:171
+#: lib/klass_hero_web/live/home_live.ex:150
 #, elixir-autogen, elixir-format
 msgid "Download monthly statements for taxes"
 msgstr ""
@@ -3396,22 +3399,22 @@ msgstr ""
 msgid "Explain why this correction is needed..."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:169
+#: lib/klass_hero_web/live/home_live.ex:148
 #, elixir-autogen, elixir-format
 msgid "Export participant lists anytime"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:136
+#: lib/klass_hero_web/live/home_live.ex:115
 #, elixir-autogen, elixir-format
 msgid "Funds are immediately available in your Klass Hero account"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:147
+#: lib/klass_hero_web/live/home_live.ex:126
 #, elixir-autogen, elixir-format
 msgid "How You Get Paid:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:129
+#: lib/klass_hero_web/live/home_live.ex:108
 #, elixir-autogen, elixir-format
 msgid "How does the booking system work?"
 msgstr ""
@@ -3422,17 +3425,17 @@ msgstr ""
 msgid "In Progress"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:150
+#: lib/klass_hero_web/live/home_live.ex:129
 #, elixir-autogen, elixir-format
 msgid "Instant availability: Funds are in your Klass Hero balance immediately after booking"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:175
+#: lib/klass_hero_web/live/home_live.ex:154
 #, elixir-autogen, elixir-format
 msgid "Is Klass Hero free for parents to use?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:144
+#: lib/klass_hero_web/live/home_live.ex:123
 #, elixir-autogen, elixir-format
 msgid "Klarna (pay later options)"
 msgstr ""
@@ -3453,7 +3456,7 @@ msgstr ""
 msgid "No changes detected"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:162
+#: lib/klass_hero_web/live/home_live.ex:141
 #, elixir-autogen, elixir-format
 msgid "No chasing payments or sending invoices"
 msgstr ""
@@ -3464,7 +3467,7 @@ msgstr ""
 msgid "No enrolled parents"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:163
+#: lib/klass_hero_web/live/home_live.ex:142
 #, elixir-autogen, elixir-format
 msgid "No risk of non-payment"
 msgstr ""
@@ -3476,7 +3479,7 @@ msgstr ""
 msgid "Notes"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:155
+#: lib/klass_hero_web/live/home_live.ex:134
 #, elixir-autogen, elixir-format
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
@@ -3487,37 +3490,37 @@ msgstr ""
 msgid "Parent account not available"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:133
+#: lib/klass_hero_web/live/home_live.ex:112
 #, elixir-autogen, elixir-format
 msgid "Parent books and pays through Klass Hero (via Stripe)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:135
+#: lib/klass_hero_web/live/home_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "Parent receives confirmation with your contact details"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:161
+#: lib/klass_hero_web/live/home_live.ex:140
 #, elixir-autogen, elixir-format
 msgid "Parents pay upfront when booking (reduces no-shows by 85%)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:139
+#: lib/klass_hero_web/live/home_live.ex:118
 #, elixir-autogen, elixir-format
 msgid "Payment Options for Parents:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:156
+#: lib/klass_hero_web/live/home_live.ex:135
 #, elixir-autogen, elixir-format
 msgid "Platform fee automatically deducted when parent pays"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:116
+#: lib/klass_hero_web/live/home_live.ex:95
 #, elixir-autogen, elixir-format
 msgid "Pricing:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:114
+#: lib/klass_hero_web/live/home_live.ex:93
 #, elixir-autogen, elixir-format
 msgid "Private lessons and tutoring"
 msgstr ""
@@ -3528,7 +3531,7 @@ msgstr ""
 msgid "Providers"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:168
+#: lib/klass_hero_web/live/home_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Real-time dashboard shows all bookings and available balance"
 msgstr ""
@@ -3543,12 +3546,12 @@ msgstr ""
 msgid "Record was modified by someone else. Please refresh."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:111
+#: lib/klass_hero_web/live/home_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "Regular classes and courses (weekly/monthly)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:143
+#: lib/klass_hero_web/live/home_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "SEPA direct debit"
 msgstr ""
@@ -3563,12 +3566,12 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:170
+#: lib/klass_hero_web/live/home_live.ex:149
 #, elixir-autogen, elixir-format
 msgid "See payment history and upcoming payouts"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:130
+#: lib/klass_hero_web/live/home_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "Simple and automated - we handle everything."
 msgstr ""
@@ -3578,7 +3581,7 @@ msgstr ""
 msgid "Staff Members"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:166
+#: lib/klass_hero_web/live/home_live.ex:145
 #, elixir-autogen, elixir-format
 msgid "Track Everything:"
 msgstr ""
@@ -3589,67 +3592,67 @@ msgstr ""
 msgid "Upgrade your plan to send messages."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:154
+#: lib/klass_hero_web/live/home_live.ex:133
 #, elixir-autogen, elixir-format
 msgid "Weekly payouts: Transferred to your bank account every Friday"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:109
+#: lib/klass_hero_web/live/home_live.ex:88
 #, elixir-autogen, elixir-format
 msgid "What You Can List:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:195
+#: lib/klass_hero_web/live/home_live.ex:174
 #, elixir-autogen, elixir-format
 msgid "What if my child gets sick?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:131
+#: lib/klass_hero_web/live/home_live.ex:110
 #, elixir-autogen, elixir-format
 msgid "When Someone Books:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:203
+#: lib/klass_hero_web/live/home_live.ex:182
 #, elixir-autogen, elixir-format
 msgid "Where is Klass Hero available?"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:158
+#: lib/klass_hero_web/live/home_live.ex:137
 #, elixir-autogen, elixir-format
 msgid "Why This Works Better:"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:113
+#: lib/klass_hero_web/live/home_live.ex:92
 #, elixir-autogen, elixir-format
 msgid "Workshops and one-time events"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:177
+#: lib/klass_hero_web/live/home_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "Yes! Browsing and booking are completely free. No subscription, no booking fees."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:108
+#: lib/klass_hero_web/live/home_live.ex:87
 #, elixir-autogen, elixir-format
 msgid "Yes! Register for free and start listing immediately."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:183
+#: lib/klass_hero_web/live/home_live.ex:162
 #, elixir-autogen, elixir-format
 msgid "Yes, you need a free account to complete a booking and manage your reservations."
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:137
+#: lib/klass_hero_web/live/home_live.ex:116
 #, elixir-autogen, elixir-format
 msgid "You deliver the program"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:160
+#: lib/klass_hero_web/live/home_live.ex:139
 #, elixir-autogen, elixir-format
 msgid "You get paid BEFORE delivering the program (no waiting)"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:134
+#: lib/klass_hero_web/live/home_live.ex:113
 #, elixir-autogen, elixir-format
 msgid "You receive instant email with booking details and parent contact info"
 msgstr ""
@@ -4406,6 +4409,7 @@ msgid "+1234567890"
 msgstr ""
 
 #: lib/klass_hero_web/components/composite_components.ex:641
+#: lib/klass_hero_web/live/provider_profile_live.ex:89
 #, elixir-autogen, elixir-format
 msgid "About the Provider"
 msgstr ""
@@ -4553,6 +4557,7 @@ msgid "View your assignments"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:306
+#: lib/klass_hero_web/live/provider_profile_live.ex:116
 #, elixir-autogen, elixir-format
 msgid "Website"
 msgstr ""
@@ -5282,7 +5287,7 @@ msgstr ""
 msgid "Edit program"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:197
+#: lib/klass_hero_web/live/home_live.ex:176
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Email the provider and us (support@mail.klasshero.com) as soon as you can — we'll help you and the provider work it out."
 msgstr ""
@@ -5342,7 +5347,7 @@ msgstr ""
 msgid "Everything parents need, nothing they don't"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:92
+#: lib/klass_hero_web/live/home_live.ex:71
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Everything you need to know about Klass Hero."
 msgstr ""
@@ -5445,6 +5450,7 @@ msgstr ""
 msgid "Hand-picked, vetted programs across Berlin — filter by category, age, or schedule."
 msgstr ""
 
+#: lib/klass_hero_web/live/provider_profile_live.ex:155
 #: lib/klass_hero_web/live/trust_safety_live.ex:103
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Have questions?"
@@ -5559,7 +5565,7 @@ msgid "Join the team"
 msgstr ""
 
 #: lib/klass_hero_web/live/for_providers_live.ex:182
-#: lib/klass_hero_web/live/home_live.ex:118
+#: lib/klass_hero_web/live/home_live.ex:97
 #, elixir-autogen, elixir-format
 msgid "Joining Klass Hero costs nothing — unlimited programs, your whole team, all media, and direct parent messaging are included for everyone. A simple success-based fee on bookings made through the platform is coming; we'll share the details transparently before it launches."
 msgstr ""
@@ -5645,7 +5651,7 @@ msgstr ""
 msgid "Live video screen with our safeguarding lead."
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:369
+#: lib/klass_hero_web/live/programs_live.ex:350
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Load more programs"
 msgstr ""
@@ -6279,7 +6285,7 @@ msgstr ""
 msgid "Trusted Heroes"
 msgstr ""
 
-#: lib/klass_hero_web/live/programs_live.ex:314
+#: lib/klass_hero_web/live/programs_live.ex:295
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Try adjusting your search or filter criteria — there's plenty more in Berlin."
 msgstr ""
@@ -6559,7 +6565,7 @@ msgstr ""
 msgid "You don't have permission to send broadcasts"
 msgstr ""
 
-#: lib/klass_hero_web/live/home_live.ex:123
+#: lib/klass_hero_web/live/home_live.ex:102
 #, elixir-autogen, elixir-format
 msgid "Every provider gets: Profile page, booking system, payment processing, messaging, and marketing to Berlin families."
 msgstr ""
@@ -6621,12 +6627,12 @@ msgstr ""
 msgid "In progress"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:830
+#: lib/klass_hero_web/live/provider/verification_live.ex:834
 #, elixir-autogen, elixir-format
 msgid "Klass Hero is only open to providers aged 18 and over, so we can't approve this account."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:840
+#: lib/klass_hero_web/live/provider/verification_live.ex:844
 #, elixir-autogen, elixir-format
 msgid "Looks like the check didn't finish. Pick up where you left off whenever you're ready."
 msgstr ""
@@ -6666,7 +6672,7 @@ msgstr ""
 msgid "Resubmit"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:819
+#: lib/klass_hero_web/live/provider/verification_live.ex:823
 #, elixir-autogen, elixir-format
 msgid "Retry verification"
 msgstr ""
@@ -6686,12 +6692,12 @@ msgstr ""
 msgid "Show relevant experience working with children."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:837
+#: lib/klass_hero_web/live/provider/verification_live.ex:841
 #, elixir-autogen, elixir-format
 msgid "Something tripped up the check — usually a blurry photo. Give it another go."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:796
+#: lib/klass_hero_web/live/provider/verification_live.ex:800
 #, elixir-autogen, elixir-format
 msgid "Takes about 2 minutes. Once verified, your provider account can be approved."
 msgstr ""
@@ -6717,7 +6723,7 @@ msgid "Upload your safeguarding certificate."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/verification_live.ex:513
-#: lib/klass_hero_web/live/provider/verification_live.ex:793
+#: lib/klass_hero_web/live/provider/verification_live.ex:797
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Verify identity"
 msgstr ""
@@ -6727,12 +6733,12 @@ msgstr ""
 msgid "Verify your identity to get approved"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:788
+#: lib/klass_hero_web/live/provider/verification_live.ex:792
 #, elixir-autogen, elixir-format
 msgid "Verify your identity with our partner Stripe to get approved. You'll be sent to a secure page and brought back here."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:802
+#: lib/klass_hero_web/live/provider/verification_live.ex:806
 #, elixir-autogen, elixir-format
 msgid "Verifying your identity… this can take a moment."
 msgstr ""
@@ -6743,17 +6749,17 @@ msgstr ""
 msgid "Video screening"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:834
+#: lib/klass_hero_web/live/provider/verification_live.ex:838
 #, elixir-autogen, elixir-format
 msgid "We couldn't read your date of birth from your ID. A clearer photo of your document should do the trick."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:842
+#: lib/klass_hero_web/live/provider/verification_live.ex:846
 #, elixir-autogen, elixir-format
 msgid "We couldn't verify your identity. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:812
+#: lib/klass_hero_web/live/provider/verification_live.ex:816
 #, elixir-autogen, elixir-format
 msgid "Your identity is verified."
 msgstr ""
@@ -7011,8 +7017,8 @@ msgstr ""
 msgid "Select your country to see which document to upload."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:700
-#: lib/klass_hero_web/live/provider/verification_live.ex:772
+#: lib/klass_hero_web/live/provider/verification_live.ex:702
+#: lib/klass_hero_web/live/provider/verification_live.ex:776
 #, elixir-autogen, elixir-format
 msgid "Submit for review"
 msgstr ""
@@ -7072,22 +7078,22 @@ msgstr ""
 msgid "Policy expiry"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:756
+#: lib/klass_hero_web/live/provider/verification_live.ex:758
 #, elixir-autogen, elixir-format
 msgid "Policy expiry date"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:764
+#: lib/klass_hero_web/live/provider/verification_live.ex:766
 #, elixir-autogen, elixir-format
 msgid "This certificate expires within 30 days. Please renew it soon."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:760
+#: lib/klass_hero_web/live/provider/verification_live.ex:762
 #, elixir-autogen, elixir-format
 msgid "This certificate has already expired. Please upload a current policy."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:745
+#: lib/klass_hero_web/live/provider/verification_live.ex:747
 #, elixir-autogen, elixir-format
 msgid "Upload your public liability insurance certificate and enter its policy expiry date so we can confirm cover is current."
 msgstr ""
@@ -7097,12 +7103,12 @@ msgstr ""
 msgid "Valid"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:728
+#: lib/klass_hero_web/live/provider/verification_live.ex:730
 #, elixir-autogen, elixir-format
 msgid "Your insurance certificate is under review."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/verification_live.ex:734
+#: lib/klass_hero_web/live/provider/verification_live.ex:736
 #, elixir-autogen, elixir-format
 msgid "Your insurance is verified."
 msgstr ""
@@ -7936,12 +7942,12 @@ msgstr ""
 msgid "e.g., For beginners, no experience needed"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/program_presenter.ex:292
+#: lib/klass_hero_web/presenters/program_presenter.ex:308
 #, elixir-autogen, elixir-format
 msgid "Free"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/program_presenter.ex:291
+#: lib/klass_hero_web/presenters/program_presenter.ex:307
 #, elixir-autogen, elixir-format
 msgid "N/A"
 msgstr ""
@@ -8020,7 +8026,7 @@ msgstr ""
 msgid "e.g. Mum called — off sick today"
 msgstr ""
 
-#: lib/klass_hero_web/components/composite_components.ex:766
+#: lib/klass_hero_web/components/composite_components.ex:776
 #, elixir-autogen, elixir-format
 msgid "%{business} on %{network}"
 msgstr ""
@@ -8033,4 +8039,29 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:3140
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider_profile_live.ex:158
+#, elixir-autogen, elixir-format
+msgid "Message %{provider} directly about their programs."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider_profile_live.ex:168
+#, elixir-autogen, elixir-format
+msgid "Message this provider"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider_profile_live.ex:133
+#, elixir-autogen, elixir-format
+msgid "No programs running right now"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider_profile_live.ex:29
+#, elixir-autogen, elixir-format
+msgid "Provider not found. They may have been removed or are no longer listed."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider_profile_live.ex:134
+#, elixir-autogen, elixir-format
+msgid "This provider has no open programs at the moment. Check back soon."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -94,7 +94,7 @@ msgstr ""
 #: lib/klass_hero_web/components/layouts/app.html.heex:36
 #: lib/klass_hero_web/components/layouts/app.html.heex:198
 #: lib/klass_hero_web/components/marketing_components.ex:202
-#: lib/klass_hero_web/live/provider_profile_live.ex:127
+#: lib/klass_hero_web/live/provider_profile_live.ex:129
 #, elixir-autogen, elixir-format
 msgid "Programs"
 msgstr ""
@@ -416,7 +416,7 @@ msgstr ""
 
 #: lib/klass_hero_web/live/contact_live.ex:85
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:314
-#: lib/klass_hero_web/live/provider_profile_live.ex:103
+#: lib/klass_hero_web/live/provider_profile_live.ex:107
 #, elixir-autogen, elixir-format
 msgid "Address"
 msgstr ""
@@ -795,7 +795,7 @@ msgstr ""
 #: lib/klass_hero_web/live/contact_live.ex:100
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:241
 #: lib/klass_hero_web/live/provider/verification_live.ex:626
-#: lib/klass_hero_web/presenters/provider_presenter.ex:160
+#: lib/klass_hero_web/presenters/provider_presenter.ex:166
 #, elixir-autogen, elixir-format
 msgid "Other"
 msgstr ""
@@ -814,7 +814,7 @@ msgstr ""
 
 #: lib/klass_hero_web/live/contact_live.ex:78
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:299
-#: lib/klass_hero_web/live/provider_profile_live.ex:109
+#: lib/klass_hero_web/live/provider_profile_live.ex:113
 #, elixir-autogen, elixir-format
 msgid "Phone"
 msgstr ""
@@ -1156,7 +1156,7 @@ msgid "All"
 msgstr ""
 
 #: lib/klass_hero_web/live/programs_live.ex:21
-#: lib/klass_hero_web/presenters/program_presenter.ex:366
+#: lib/klass_hero_web/presenters/program_presenter.ex:351
 #, elixir-autogen, elixir-format
 msgid "Arts"
 msgstr ""
@@ -1167,12 +1167,13 @@ msgid "Built for Berlin Families"
 msgstr ""
 
 #: lib/klass_hero_web/live/programs_live.ex:25
+#: lib/klass_hero_web/presenters/program_presenter.ex:356
 #, elixir-autogen, elixir-format
 msgid "Camps"
 msgstr ""
 
 #: lib/klass_hero_web/live/programs_live.ex:23
-#: lib/klass_hero_web/presenters/program_presenter.ex:367
+#: lib/klass_hero_web/presenters/program_presenter.ex:352
 #, elixir-autogen, elixir-format
 msgid "Education"
 msgstr ""
@@ -1198,12 +1199,13 @@ msgid "Get Paid & Grow"
 msgstr ""
 
 #: lib/klass_hero_web/live/programs_live.ex:24
+#: lib/klass_hero_web/presenters/program_presenter.ex:355
 #, elixir-autogen, elixir-format
 msgid "Life Skills"
 msgstr ""
 
 #: lib/klass_hero_web/live/programs_live.ex:22
-#: lib/klass_hero_web/presenters/program_presenter.ex:369
+#: lib/klass_hero_web/presenters/program_presenter.ex:354
 #, elixir-autogen, elixir-format
 msgid "Music"
 msgstr ""
@@ -1230,7 +1232,7 @@ msgid "Set up your teaching profile and list your programs in minutes. Share you
 msgstr ""
 
 #: lib/klass_hero_web/live/programs_live.ex:20
-#: lib/klass_hero_web/presenters/program_presenter.ex:368
+#: lib/klass_hero_web/presenters/program_presenter.ex:353
 #, elixir-autogen, elixir-format
 msgid "Sports"
 msgstr ""
@@ -1251,6 +1253,7 @@ msgid "We understand the unique needs of Berlin's diverse families. Our platform
 msgstr ""
 
 #: lib/klass_hero_web/live/programs_live.ex:26
+#: lib/klass_hero_web/presenters/program_presenter.ex:357
 #, elixir-autogen, elixir-format
 msgid "Workshops"
 msgstr ""
@@ -1363,8 +1366,8 @@ msgstr ""
 msgid "Book Now"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:146
-#: lib/klass_hero_web/presenters/provider_presenter.ex:156
+#: lib/klass_hero_web/presenters/provider_presenter.ex:152
+#: lib/klass_hero_web/presenters/provider_presenter.ex:162
 #, elixir-autogen, elixir-format
 msgid "Business Registration"
 msgstr ""
@@ -1487,7 +1490,7 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:51
 #: lib/klass_hero_web/components/provider_components.ex:1576
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:455
-#: lib/klass_hero_web/presenters/provider_presenter.ex:166
+#: lib/klass_hero_web/presenters/provider_presenter.ex:172
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
@@ -2314,7 +2317,7 @@ msgstr ""
 msgid "Headshot Photo"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:158
+#: lib/klass_hero_web/presenters/provider_presenter.ex:164
 #, elixir-autogen, elixir-format
 msgid "ID Document"
 msgstr ""
@@ -2324,7 +2327,7 @@ msgstr ""
 msgid "Import"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:157
+#: lib/klass_hero_web/presenters/provider_presenter.ex:163
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Insurance Certificate"
 msgstr ""
@@ -2831,7 +2834,7 @@ msgstr ""
 msgid "TBD"
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:159
+#: lib/klass_hero_web/presenters/provider_presenter.ex:165
 #, elixir-autogen, elixir-format
 msgid "Tax Certificate"
 msgstr ""
@@ -4409,7 +4412,7 @@ msgid "+1234567890"
 msgstr ""
 
 #: lib/klass_hero_web/components/composite_components.ex:641
-#: lib/klass_hero_web/live/provider_profile_live.ex:89
+#: lib/klass_hero_web/live/provider_profile_live.ex:93
 #, elixir-autogen, elixir-format
 msgid "About the Provider"
 msgstr ""
@@ -4557,7 +4560,7 @@ msgid "View your assignments"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:306
-#: lib/klass_hero_web/live/provider_profile_live.ex:116
+#: lib/klass_hero_web/live/provider_profile_live.ex:120
 #, elixir-autogen, elixir-format
 msgid "Website"
 msgstr ""
@@ -6575,7 +6578,7 @@ msgstr ""
 msgid "A short video so we can meet you."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:162
+#: lib/klass_hero_web/presenters/provider_presenter.ex:168
 #: lib/klass_hero_web/presenters/vetting_checklist_presenter.ex:77
 #, elixir-autogen, elixir-format
 msgid "Background check"
@@ -6743,7 +6746,7 @@ msgstr ""
 msgid "Verifying your identity… this can take a moment."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:163
+#: lib/klass_hero_web/presenters/provider_presenter.ex:169
 #: lib/klass_hero_web/presenters/vetting_checklist_presenter.ex:85
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Video screening"
@@ -6764,7 +6767,7 @@ msgstr ""
 msgid "Your identity is verified."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:161
+#: lib/klass_hero_web/presenters/provider_presenter.ex:167
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Experience validation"
 msgstr ""
@@ -6779,7 +6782,7 @@ msgstr ""
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
 
-#: lib/klass_hero_web/presenters/provider_presenter.ex:164
+#: lib/klass_hero_web/presenters/provider_presenter.ex:170
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Safeguarding certificate"
 msgstr ""
@@ -8041,27 +8044,32 @@ msgstr ""
 msgid "Upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider_profile_live.ex:158
+#: lib/klass_hero_web/live/provider_profile_live.ex:157
 #, elixir-autogen, elixir-format
 msgid "Message %{provider} directly about their programs."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider_profile_live.ex:168
+#: lib/klass_hero_web/live/provider_profile_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "Message this provider"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider_profile_live.ex:133
+#: lib/klass_hero_web/live/provider_profile_live.ex:135
 #, elixir-autogen, elixir-format
 msgid "No programs running right now"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider_profile_live.ex:29
+#: lib/klass_hero_web/live/provider_profile_live.ex:28
 #, elixir-autogen, elixir-format
 msgid "Provider not found. They may have been removed or are no longer listed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider_profile_live.ex:134
+#: lib/klass_hero_web/live/provider_profile_live.ex:136
 #, elixir-autogen, elixir-format
 msgid "This provider has no open programs at the moment. Check back soon."
+msgstr ""
+
+#: lib/klass_hero_web/presenters/program_presenter.ex:350
+#, elixir-autogen, elixir-format, fuzzy
+msgid "General"
 msgstr ""

--- a/test/e2e/contrast_test.exs
+++ b/test/e2e/contrast_test.exs
@@ -42,6 +42,28 @@ defmodule KlassHeroWeb.E2E.ContrastTest do
       |> visit("/programs")
       |> assert_no_contrast_failures("/programs")
     end
+
+    test "the provider profile clears AA over a dark cover", %{session: session} do
+      # A solid black cover behind the hero's bg-white/90 scrim: the worst case the
+      # scrim exists to bound, and unreachable through the declared-token lint
+      # because the cover is an arbitrary upload rather than a palette colour.
+      # Inserted through the factory, which skips the https-only URL validation.
+      provider =
+        insert(:provider_profile_schema,
+          business_name: "Starlight Coaching",
+          tagline: "Move. Play. Grow.",
+          description: "Empowering kids through play-based learning.",
+          cover_image_url:
+            "data:image/png;base64," <>
+              "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGNgYGAAAAAEAAH2FzhVAAAAAElFTkSuQmCC"
+        )
+
+      insert(:program_listing_schema, provider_id: provider.id, title: "Youth Fitness")
+
+      session
+      |> visit("/providers/#{provider.id}")
+      |> assert_no_contrast_failures("/providers/:id")
+    end
   end
 
   describe "authenticated surfaces" do

--- a/test/e2e/support/contrast_audit.ex
+++ b/test/e2e/support/contrast_audit.ex
@@ -14,16 +14,36 @@ defmodule KlassHeroWeb.E2E.ContrastAudit do
   resolve the cascade, the `oklch()` values, and every semi-transparent layer
   between the text and an opaque background. Only a browser does that.
 
-  ## The compositing rule this exists to get right
+  ## The compositing rules this exists to get right
 
-  The first version of this walked up to the nearest non-transparent background
-  and used it directly. That reported `text-white/90` on a `bg-white/5` chip
-  inside a **black** sidebar as 1.00:1 — white on white — because a 5%-alpha
-  white composited over an assumed white base is white. The real ratio is 15.7:1.
+  A contrast test that invents dramatic failures is worse than no test: it teaches
+  everyone to ignore it. Each rule below was added because the version without it
+  either fabricated a failure or missed a real one.
 
-  So the whole ancestor stack is composited bottom-up onto an opaque base. A
-  contrast test that invents dramatic failures is worse than no test: it teaches
-  everyone to ignore it.
+  1. **Composite the whole stack, bottom-up.** The first version took the nearest
+     non-transparent background and used it directly, reporting `text-white/90` on
+     a `bg-white/5` chip inside a **black** sidebar as 1.00:1 — a 5%-alpha white
+     over an assumed white base is white. The real ratio is 15.7:1.
+
+  2. **Include positioned overlay siblings, not just ancestors.** A cover band and
+     its scrim are siblings of the text (`<div class="absolute inset-0">` beside
+     `<div class="relative">`), so an ancestor-only walk never sees them and reports
+     hero text as sitting on the page background. That made the one surface a scrim
+     exists to bound the one surface this could not measure.
+
+  3. **Apply each element's `opacity`.** It is a separate property from
+     `backgroundColor`, so a 20%-opacity blurred decorative blob was composited as a
+     solid fill — turning `text-white/70` on black into a fictional 1.47:1. Alpha is
+     carried per layer and applied via canvas `globalAlpha`, because canvas is also
+     what parses the colour: computed values come back as `oklch()` verbatim here,
+     and hand-parsing them fabricates ratios.
+
+  4. **Worst-case real images to black, but not gradients.** An `<img>` or a
+     `url()` background is an arbitrary upload, so the question is whether the text
+     survives *any* cover. A gradient is palette colours the declared-token lint
+     already governs; calling it black fails every dark text on a light gradient.
+     A gradient therefore contributes nothing and the layer beneath it is measured —
+     the same behaviour this harness shipped with.
 
   ## Thresholds
 
@@ -36,26 +56,80 @@ defmodule KlassHeroWeb.E2E.ContrastAudit do
   cv.width = cv.height = 1;
   const ctx = cv.getContext('2d', { willReadFrequently: true });
 
+  // Layers are {color, alpha}. Alpha is the element's `opacity`, which is a separate
+  // property from backgroundColor — a 20%-opacity decorative blob composited as a
+  // solid fill invents dramatic failures. globalAlpha does the blend because canvas
+  // is also what parses the colour: computed values come back as oklch() verbatim,
+  // and hand-parsing them is how you fabricate ratios.
   const paint = (layers) => {
     ctx.clearRect(0, 0, 1, 1);
+    ctx.globalAlpha = 1;
     ctx.fillStyle = '#FFFFFF';
     ctx.fillRect(0, 0, 1, 1);
-    for (const c of layers) { ctx.fillStyle = c; ctx.fillRect(0, 0, 1, 1); }
+    for (const l of layers) {
+      if (l.alpha < 0.01) continue;
+      ctx.globalAlpha = l.alpha;
+      ctx.fillStyle = l.color;
+      ctx.fillRect(0, 0, 1, 1);
+    }
+    ctx.globalAlpha = 1;
     const d = ctx.getImageData(0, 0, 1, 1).data;
     return [d[0], d[1], d[2]];
   };
 
-  const backgroundStack = (el) => {
-    const layers = [];
-    let n = el;
-    while (n && n !== document.documentElement) {
-      const c = getComputedStyle(n).backgroundColor;
-      if (c && c !== 'rgba(0, 0, 0, 0)' && c !== 'transparent') layers.push(c);
-      n = n.parentElement;
+  const opaqueish = (c) => c && c !== 'rgba(0, 0, 0, 0)' && c !== 'transparent';
+
+  const covers = (layer, el) => {
+    const l = layer.getBoundingClientRect();
+    const r = el.getBoundingClientRect();
+    const x = r.left + r.width / 2;
+    const y = r.top + r.height / 2;
+    return l.left <= x && l.right >= x && l.top <= y && l.bottom >= y;
+  };
+
+  // An <img> or a CSS background-image is an arbitrary upload. Worst-case it to
+  // black: the question a scrim exists to answer is whether the text survives ANY
+  // cover, not whether this particular photo happens to be light.
+  const pushPaint = (node, layers) => {
+    const cs = getComputedStyle(node);
+    if (cs.visibility === 'hidden' || cs.display === 'none') return;
+    const alpha = parseFloat(cs.opacity);
+    // Only a real image is worst-cased. url() and <img> are arbitrary uploads, so
+    // black is the bound a scrim has to survive. A gradient is palette colours the
+    // declared-token lint already governs — calling it black would fail every dark
+    // text on a light gradient, which is a fabricated failure, not a found one.
+    if (node.tagName === 'IMG' || cs.backgroundImage.includes('url(')) {
+      layers.push({ color: '#000000', alpha: alpha });
     }
-    const root = getComputedStyle(document.body).backgroundColor;
-    if (root && root !== 'rgba(0, 0, 0, 0)') layers.push(root);
-    return layers.reverse();
+    if (opaqueish(cs.backgroundColor)) layers.push({ color: cs.backgroundColor, alpha: alpha });
+  };
+
+  const paintSubtree = (root, layers) => {
+    for (const n of [root, ...root.querySelectorAll('*')]) pushPaint(n, layers);
+  };
+
+  const backgroundStack = (el) => {
+    const ancestors = [];
+    for (let n = el; n && n !== document.documentElement; n = n.parentElement) ancestors.push(n);
+    ancestors.reverse();
+
+    const layers = [];
+    for (const node of ancestors) {
+      pushPaint(node, layers);
+
+      // Overlay siblings. A cover band and its scrim are positioned siblings of the
+      // text, not ancestors, so an ancestor-only walk reports the text as sitting on
+      // the page background — the exact surface a scrim exists to bound.
+      for (const child of node.children) {
+        if (child === el || child.contains(el)) continue;
+        const ccs = getComputedStyle(child);
+        if (ccs.position !== 'absolute' && ccs.position !== 'fixed') continue;
+        if (ccs.visibility === 'hidden' || ccs.display === 'none') continue;
+        if (!covers(child, el)) continue;
+        paintSubtree(child, layers);
+      }
+    }
+    return layers;
   };
 
   const lum = ([r, g, b]) => {
@@ -82,7 +156,7 @@ defmodule KlassHeroWeb.E2E.ContrastAudit do
 
     const bgLayers = backgroundStack(el);
     const bg = paint(bgLayers);
-    const fg = paint(bgLayers.concat([cs.color]));
+    const fg = paint(bgLayers.concat([{ color: cs.color, alpha: parseFloat(cs.opacity) }]));
 
     const size = parseFloat(cs.fontSize);
     const bold = parseInt(cs.fontWeight, 10) >= 700;

--- a/test/klass_hero/program_catalog/list_current_programs_for_provider_test.exs
+++ b/test/klass_hero/program_catalog/list_current_programs_for_provider_test.exs
@@ -1,0 +1,67 @@
+defmodule KlassHero.ProgramCatalog.ListCurrentProgramsForProviderTest do
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+
+  alias KlassHero.ProgramCatalog
+
+  defp titles(provider_id) do
+    provider_id |> ProgramCatalog.list_current_programs_for_provider() |> Enum.map(& &1.title)
+  end
+
+  describe "list_current_programs_for_provider/1" do
+    test "returns only this provider's listings" do
+      provider_id = Ecto.UUID.generate()
+      insert(:program_listing_schema, provider_id: provider_id, title: "Ours")
+      insert(:program_listing_schema, title: "Theirs")
+
+      assert titles(provider_id) == ["Ours"]
+    end
+
+    test "orders by title ascending" do
+      provider_id = Ecto.UUID.generate()
+
+      for title <- ["Zebra", "Apple", "Mango"] do
+        insert(:program_listing_schema, provider_id: provider_id, title: title)
+      end
+
+      assert titles(provider_id) == ["Apple", "Mango", "Zebra"]
+    end
+
+    test "excludes expired listings, unlike list_programs_for_provider/1" do
+      provider_id = Ecto.UUID.generate()
+      insert(:program_listing_schema, provider_id: provider_id, title: "Open", end_date: nil)
+
+      insert(:program_listing_schema,
+        provider_id: provider_id,
+        title: "Over",
+        end_date: Date.add(Date.utc_today(), -1)
+      )
+
+      assert titles(provider_id) == ["Open"]
+
+      # Pin the contrast: the sibling function is documented as including expired
+      # (#610) and the provider dashboard depends on that, so this is a genuine
+      # second query rather than one that could replace it.
+      assert provider_id
+             |> ProgramCatalog.list_programs_for_provider()
+             |> Enum.map(& &1.title) == ["Open", "Over"]
+    end
+
+    test "a listing ending today is still current" do
+      provider_id = Ecto.UUID.generate()
+
+      insert(:program_listing_schema,
+        provider_id: provider_id,
+        title: "Last day",
+        end_date: Date.utc_today()
+      )
+
+      assert titles(provider_id) == ["Last day"]
+    end
+
+    test "returns an empty list for a provider with no listings" do
+      assert titles(Ecto.UUID.generate()) == []
+    end
+  end
+end

--- a/test/klass_hero/provider/profiles/get_public_profile_test.exs
+++ b/test/klass_hero/provider/profiles/get_public_profile_test.exs
@@ -1,0 +1,44 @@
+defmodule KlassHero.Provider.Profiles.GetPublicProfileTest do
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.ProviderFixtures
+
+  alias KlassHero.Provider
+
+  describe "get_public_profile/1" do
+    test "returns an active profile" do
+      profile = provider_profile_fixture(business_name: "Starlight Coaching")
+
+      assert {:ok, %{id: id, business_name: "Starlight Coaching"}} =
+               Provider.get_public_profile(profile.id)
+
+      assert id == profile.id
+    end
+
+    test "hides a draft profile" do
+      profile = provider_profile_fixture(profile_status: :draft)
+
+      # Not a distinct error: a draft profile is indistinguishable from a missing
+      # one to a stranger, so the id cannot be probed for existence.
+      assert Provider.get_public_profile(profile.id) == {:error, :not_found}
+      assert {:ok, _} = Provider.get_provider_profile(profile.id)
+    end
+
+    test "returns not_found for an unknown id" do
+      assert Provider.get_public_profile(Ecto.UUID.generate()) == {:error, :not_found}
+    end
+
+    test "returns not_found for a malformed id rather than raising" do
+      # A public route makes this id user-typed. Repo.get/2 on a binary_id raises
+      # Ecto.Query.CastError for a non-UUID, which would be a 500 on /providers/x.
+      for id <- ["not-a-uuid", "", "1234567890123456", "../etc/passwd"] do
+        assert Provider.get_public_profile(id) == {:error, :not_found},
+               "expected #{inspect(id)} to be rejected without raising"
+      end
+    end
+
+    test "returns not_found for a non-binary id" do
+      assert Provider.get_public_profile(nil) == {:error, :not_found}
+    end
+  end
+end

--- a/test/klass_hero_web/components/provider_hero_test.exs
+++ b/test/klass_hero_web/components/provider_hero_test.exs
@@ -5,7 +5,10 @@ defmodule KlassHeroWeb.ProviderHeroTest do
 
   alias KlassHeroWeb.CompositeComponents
 
+  @provider_id "11111111-2222-3333-4444-555555555555"
+
   @filled %{
+    id: @provider_id,
     business_name: "Starlight Coaching",
     initials: "SC",
     description: "Empowering kids through play-based learning.",
@@ -41,6 +44,18 @@ defmodule KlassHeroWeb.ProviderHeroTest do
 
     test "keeps the id the program detail page and its tests target" do
       assert render_hero(@filled) =~ ~s(id="provider-profile-card")
+    end
+
+    test "links the business name to the provider's public page" do
+      assert render_hero(@filled) =~ ~s(href="/providers/#{@provider_id}")
+    end
+
+    test "renders the name as plain text when the map carries no id" do
+      # A hand-built map from a preview or a test must not crash the page (#1073).
+      html = render_hero(@bare)
+
+      assert html =~ "Starlight Coaching"
+      refute html =~ "/providers/"
     end
 
     test "renders the logo when present, initials when not" do
@@ -91,6 +106,10 @@ defmodule KlassHeroWeb.ProviderHeroTest do
     test "omits the description, which belongs to the About section" do
       refute render_hero(@filled, variant: :full) =~
                "Empowering kids through play-based learning."
+    end
+
+    test "does not link the name — this variant is the page it would link to" do
+      refute render_hero(@filled, variant: :full) =~ "/providers/"
     end
   end
 

--- a/test/klass_hero_web/helpers/provider_display_test.exs
+++ b/test/klass_hero_web/helpers/provider_display_test.exs
@@ -1,0 +1,38 @@
+defmodule KlassHeroWeb.Helpers.ProviderDisplayTest do
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.ProviderFixtures
+
+  alias KlassHeroWeb.Helpers.ProviderDisplay
+
+  describe "public_view/1" do
+    test "returns the hero view map for an active provider" do
+      profile = provider_profile_fixture(business_name: "Starlight Coaching")
+
+      assert %{business_name: "Starlight Coaching", initials: "SC", trust_state: :unverified} =
+               ProviderDisplay.public_view(profile.id)
+    end
+
+    test "returns nil for draft, unknown and malformed ids" do
+      draft = provider_profile_fixture(profile_status: :draft)
+
+      for id <- [draft.id, Ecto.UUID.generate(), "not-a-uuid", nil] do
+        assert ProviderDisplay.public_view(id) == nil,
+               "expected #{inspect(id)} to have no public view"
+      end
+    end
+
+    test "keeps the identity when the trust lookup fails, dropping only the badge" do
+      # The badge is additive, the identity is the content. Without the rescue a
+      # vetting-lookup failure blanks the whole provider card.
+      profile = provider_profile_fixture(business_name: "Starlight Coaching")
+
+      Mimic.stub(KlassHero.Provider, :get_trust_states, fn _ids ->
+        raise DBConnection.ConnectionError, "vetting lookup exploded"
+      end)
+
+      assert %{business_name: "Starlight Coaching", trust_state: :unverified} =
+               ProviderDisplay.public_view(profile.id)
+    end
+  end
+end

--- a/test/klass_hero_web/live/provider_profile_live_test.exs
+++ b/test/klass_hero_web/live/provider_profile_live_test.exs
@@ -82,6 +82,18 @@ defmodule KlassHeroWeb.ProviderProfileLiveTest do
       refute has_element?(view, "#provider-about")
       assert has_element?(view, "#provider-hero")
     end
+
+    test "the hero band still separates from Programs when About is absent", %{conn: conn} do
+      # Most providers have filled none of this in, so About is usually missing.
+      # Asserting only that the section is gone says nothing about what is left:
+      # if the hero inherited the layout's white, hero and Programs would render
+      # as one flush white block on the page's most common state.
+      provider = active_provider(description: nil, address: nil, phone: nil, website: nil)
+
+      {:ok, _view, html} = live(conn, ~p"/providers/#{provider.id}")
+
+      assert html =~ KlassHeroWeb.Theme.gradient(:base_fade)
+    end
   end
 
   describe "programs" do

--- a/test/klass_hero_web/live/provider_profile_live_test.exs
+++ b/test/klass_hero_web/live/provider_profile_live_test.exs
@@ -1,0 +1,158 @@
+defmodule KlassHeroWeb.ProviderProfileLiveTest do
+  use KlassHeroWeb.ConnCase, async: true
+
+  import KlassHero.Factory
+  import KlassHero.ProviderFixtures
+  import Phoenix.LiveViewTest
+
+  defp active_provider(attrs \\ []) do
+    provider_profile_fixture(Keyword.merge([business_name: "Starlight Coaching"], attrs))
+  end
+
+  describe "identity" do
+    test "renders the full hero variant", %{conn: conn} do
+      provider = active_provider(tagline: "Move. Play. Grow.")
+
+      {:ok, view, _html} = live(conn, ~p"/providers/#{provider.id}")
+
+      assert has_element?(view, "#provider-hero[data-variant='full']")
+      assert has_element?(view, "#provider-hero h1", "Starlight Coaching")
+      assert render(view) =~ "Move. Play. Grow."
+    end
+
+    test "renders on the static mount, before the socket connects", %{conn: conn} do
+      # The SEO criterion. A live/2 assertion alone passes on a page that renders
+      # nothing on the first byte and fills in only after connecting.
+      provider = active_provider()
+
+      html = conn |> get(~p"/providers/#{provider.id}") |> html_response(200)
+
+      assert html =~ "Starlight Coaching"
+    end
+
+    test "sets the page title from the business name", %{conn: conn} do
+      provider = active_provider()
+
+      {:ok, _view, html} = live(conn, ~p"/providers/#{provider.id}")
+
+      assert html =~ "Starlight Coaching"
+    end
+  end
+
+  describe "fails closed" do
+    test "redirects for draft, unknown and malformed ids", %{conn: conn} do
+      draft = provider_profile_fixture(profile_status: :draft)
+
+      for id <- [draft.id, Ecto.UUID.generate(), "not-a-uuid"] do
+        assert {:error, {:redirect, %{to: "/programs", flash: %{"error" => message}}}} =
+                 live(conn, ~p"/providers/#{id}")
+
+        assert message =~ "not"
+      end
+    end
+
+    test "a malformed id is a redirect, not a 500", %{conn: conn} do
+      assert conn |> get(~p"/providers/not-a-uuid") |> redirected_to() == "/programs"
+    end
+  end
+
+  describe "about" do
+    test "renders description and the contact facts that are filled in", %{conn: conn} do
+      provider =
+        active_provider(
+          description: "Empowering kids through play-based learning.",
+          address: "123 Main St, Berlin",
+          phone: "+49 30 123456",
+          website: "https://starlight.example"
+        )
+
+      html = render(elem_view(conn, provider))
+
+      assert html =~ "Empowering kids through play-based learning."
+      assert html =~ "123 Main St, Berlin"
+      assert html =~ "+49 30 123456"
+      assert html =~ "https://starlight.example"
+    end
+
+    test "omits the about section entirely when nothing is filled in", %{conn: conn} do
+      provider = active_provider(description: nil, address: nil, phone: nil, website: nil)
+
+      {:ok, view, _html} = live(conn, ~p"/providers/#{provider.id}")
+
+      refute has_element?(view, "#provider-about")
+      assert has_element?(view, "#provider-hero")
+    end
+  end
+
+  describe "programs" do
+    test "lists current programs and excludes ended ones", %{conn: conn} do
+      provider = active_provider()
+      insert(:program_listing_schema, provider_id: provider.id, title: "Youth Fitness")
+
+      insert(:program_listing_schema,
+        provider_id: provider.id,
+        title: "Finished Camp",
+        end_date: Date.add(Date.utc_today(), -1)
+      )
+
+      html = render(elem_view(conn, provider))
+
+      assert html =~ "Youth Fitness"
+      refute html =~ "Finished Camp"
+    end
+
+    test "shows an empty state rather than a blank section", %{conn: conn} do
+      provider = active_provider()
+
+      {:ok, view, _html} = live(conn, ~p"/providers/#{provider.id}")
+
+      assert has_element?(view, "[data-testid='empty-state']")
+    end
+
+    test "navigates to a program", %{conn: conn} do
+      provider = active_provider()
+      program = insert(:program_listing_schema, provider_id: provider.id)
+
+      {:ok, view, _html} = live(conn, ~p"/providers/#{provider.id}")
+
+      view
+      |> element("[data-program-id='#{program.id}']")
+      |> render_click()
+
+      assert_redirect(view, ~p"/programs/#{program.id}")
+    end
+  end
+
+  describe "message CTA" do
+    test "points at compose for this provider", %{conn: conn} do
+      provider = active_provider()
+
+      {:ok, view, _html} = live(conn, ~p"/providers/#{provider.id}")
+
+      assert has_element?(
+               view,
+               ~s(#provider-message-cta[href="/messages/new?provider_id=#{provider.id}"])
+             )
+    end
+
+    test "is shown to an anonymous visitor, who is asked to log in on arrival", %{conn: conn} do
+      # Hiding the CTA would strip the page's only conversion action from
+      # logged-out traffic. Following it is a dead end only if the destination
+      # refuses without explanation, so assert the destination's own behaviour.
+      provider = active_provider()
+
+      {:ok, view, _html} = live(conn, ~p"/providers/#{provider.id}")
+      assert has_element?(view, "#provider-message-cta")
+
+      assert {:error, {:redirect, %{to: "/users/log-in", flash: %{"error" => message}}}} =
+               live(conn, ~p"/messages/new?provider_id=#{provider.id}")
+
+      assert message =~ "log in"
+    end
+  end
+
+  defp elem_view(conn, provider) do
+    {:ok, view, _html} = live(conn, ~p"/providers/#{provider.id}")
+    view
+  end
+end

--- a/test/klass_hero_web/presenters/program_presenter_test.exs
+++ b/test/klass_hero_web/presenters/program_presenter_test.exs
@@ -4,6 +4,7 @@ defmodule KlassHeroWeb.Presenters.ProgramPresenterTest do
   import ExUnit.CaptureLog
 
   alias KlassHero.ProgramCatalog.Program
+  alias KlassHero.ProgramCatalog.ProgramListing
   alias KlassHero.Provider.ReadModels.ProgramStaffing
   alias KlassHero.Shared.Categories
   alias KlassHeroWeb.Presenters.ProgramPresenter
@@ -259,6 +260,49 @@ defmodule KlassHeroWeb.Presenters.ProgramPresenterTest do
         result = ProgramPresenter.format_schedule(program)
         assert result.date_range == @expected
       end
+    end
+  end
+
+  describe "to_card_view/3 across both program shapes" do
+    test "carries the cover image from a write-model program" do
+      # Omitted until now, so the parent dashboard's family-programs cards fell
+      # back to the gradient placeholder even for programs that had a cover.
+      program = build_program(%{cover_image_url: "https://cdn.example.com/cover.png"})
+
+      assert ProgramPresenter.to_card_view(program).cover_image_url ==
+               "https://cdn.example.com/cover.png"
+    end
+
+    test "builds the same card keys from a read-model listing" do
+      listing = %ProgramListing{
+        id: "listing-1",
+        title: "Art Adventures",
+        description: "Creative art for kids",
+        category: "arts",
+        age_range: "6-12",
+        price: Decimal.new("15.00"),
+        cover_image_url: "https://cdn.example.com/cover.png",
+        meeting_days: ["Monday"],
+        start_date: ~D[2026-03-01],
+        end_date: ~D[2026-06-30]
+      }
+
+      program = build_program(%{id: "listing-1", title: "Art Adventures"})
+
+      # The point of the shared builder: the two surfaces cannot drift on which
+      # keys a card gets, only on the values behind them.
+      assert Map.keys(ProgramPresenter.to_card_view(listing)) ==
+               Map.keys(ProgramPresenter.to_card_view(program))
+
+      assert ProgramPresenter.to_card_view(listing).cover_image_url ==
+               "https://cdn.example.com/cover.png"
+    end
+
+    test "threads spots_left through, defaulting to nil" do
+      listing = %ProgramListing{id: "l", title: "T", category: "arts"}
+
+      assert ProgramPresenter.to_card_view(listing).spots_left == nil
+      assert ProgramPresenter.to_card_view(listing, %{name: nil, trust: :unverified}, 3).spots_left == 3
     end
   end
 

--- a/test/klass_hero_web/presenters/program_presenter_test.exs
+++ b/test/klass_hero_web/presenters/program_presenter_test.exs
@@ -127,16 +127,18 @@ defmodule KlassHeroWeb.Presenters.ProgramPresenterTest do
   end
 
   describe "humanize_category/1" do
-    # {category, expected label} — explicit mappings, capitalize fallback, and nil.
+    # {category, expected label} — every category in Shared.Categories, plus nil and
+    # an unknown value exercising the hyphen-aware fallback.
     @category_cases [
       {nil, "General"},
       {"arts", "Arts"},
       {"education", "Education"},
       {"sports", "Sports"},
       {"music", "Music"},
-      {"life-skills", "Life-skills"},
+      {"life-skills", "Life Skills"},
       {"camps", "Camps"},
-      {"workshops", "Workshops"}
+      {"workshops", "Workshops"},
+      {"water-sports-club", "Water Sports Club"}
     ]
 
     for {category, expected} <- @category_cases do
@@ -144,6 +146,15 @@ defmodule KlassHeroWeb.Presenters.ProgramPresenterTest do
       @expected expected
       test "#{inspect(category)} -> #{inspect(expected)}" do
         assert ProgramPresenter.humanize_category(@category) == @expected
+      end
+    end
+
+    test "every category in the shared list has an explicit clause" do
+      # The fallback only formats; it cannot translate. A category reaching it is
+      # rendered untranslated in German, silently.
+      for category <- Categories.categories() do
+        refute ProgramPresenter.humanize_category(category) =~ "-",
+               "#{inspect(category)} fell through to the formatting fallback"
       end
     end
   end
@@ -296,6 +307,17 @@ defmodule KlassHeroWeb.Presenters.ProgramPresenterTest do
 
       assert ProgramPresenter.to_card_view(listing).cover_image_url ==
                "https://cdn.example.com/cover.png"
+    end
+
+    test "renders a hyphenated category as words on both shapes" do
+      # Key-parity assertions cannot see this. Folding the two per-LiveView card
+      # builders into one swapped which category formatter backs the card, and
+      # "Life Skills" became "Life-skills" on three pages with every test green.
+      listing = %ProgramListing{id: "l", title: "T", category: "life-skills"}
+      program = build_program(%{category: "life-skills"})
+
+      assert ProgramPresenter.to_card_view(listing).category == "Life Skills"
+      assert ProgramPresenter.to_card_view(program).category == "Life Skills"
     end
 
     test "threads spots_left through, defaulting to nil" do


### PR DESCRIPTION
Slice B of #1303. Closes #1305.

Slice A shipped `provider_hero/1`'s `:full` variant with 11 tests and **no route**.
This is the page around it — so the provider edit form's promise that branding
fields are *"shown on your public profile page"* is finally true for the reader,
not just the writer.

`/providers/:id` lives in the `:marketing` live_session and reads synchronously in
`mount/3`, so the disconnected render already carries the content.

| Section | Built from |
|---|---|
| Hero | `provider_hero variant={:full}` — unchanged from slice A |
| About | description + `mk_method_row` per contact fact present |
| Programs | `mk_program_card`, current programs only |
| CTA | link to compose |

## Backend

Three new functions, each replacing something that would otherwise be copy-pasted.

- **`ProgramCatalog.list_current_programs_for_provider/1`** — the sibling includes
  expired programs *on purpose* (#610; the provider dashboard needs them), so this
  is a separate, honestly-named query rather than a flag on the existing one.
- **`Provider.get_public_profile/1`** — moves "a draft profile is not public" out of
  a LiveView and into the context, and guards the id. This one matters: a public
  route makes the id **user-typed**, and `Repo.get` on a `binary_id` raises
  `Ecto.Query.CastError` for a non-UUID — a 500 on `/providers/<anything>`.
  Confirmed against the real runtime, along with why `cast/1` is the wrong guard:

  ```
  Repo.get(ProviderProfile, "not-a-uuid")   #=> ** (Ecto.Query.CastError)
  Ecto.UUID.cast("1234567890123456")        #=> {:ok, "31323334-3536-..."}
  ```

  `cast/1` silently fabricates a valid UUID from arbitrary 16 bytes; `dump/1`
  validates the format. That string is in the test table.
- **`ProviderDisplay.public_view/1`** — composes both with the presenter and replaces
  `ProgramDetailLive`'s private pair, keeping its `rescue` so a vetting-lookup
  failure still costs the badge rather than the whole card.

## Fixes found on the way

- **`to_card_view/2` dropped `cover_image_url`** — the parent dashboard's
  family-programs cards could never show a cover. No test caught it, because a
  missing cover is invisible to `assert html =~`.
- **Two near-identical private card builders** in `HomeLive` and `ProgramsLive`
  collapse into a `%ProgramListing{}` clause on `to_card_view/3`. This page was the
  third caller — the repo's stated extraction threshold — and `ProviderDisplay`'s
  moduledoc already warns that sibling LiveViews rendering the same card have
  drifted before.
- **`Theme.typography(:caption)` carried `text-gray-500`** — a *colour* inside a
  *typography* helper, in raw Tailwind grey, at ~4.02:1 on white. A helper that
  crosses categories hides from whichever category is being audited, which is
  exactly how it survived the contrast sweep two PRs ago.
- **`mk_method_row` gains an optional `href`**, so a website is clickable.

## The contrast harness had a blind spot

The `:full` hero paints its cover and `bg-white/90` scrim in a sibling
`<div class="absolute inset-0">`, not in an ancestor. `ContrastAudit` walked
`parentElement` upward, so it measured the `<h1>` as sitting on the page
background and passed — **the one surface a scrim exists to bound was the one
surface the test could not see.** Found by mutating the scrim rather than trusting
the green.

Three rules added, each because the version without it fabricated or missed a
failure:

1. **Positioned overlay siblings** are now composited.
2. **Per-element `opacity`** is applied — it is separate from `backgroundColor`, so a
   20%-opacity blurred decorative blob was being composited as a *solid* fill,
   turning `text-white/70` on black into a fictional 1.47:1. Alpha is carried per
   layer and blended by canvas `globalAlpha`, because canvas is also what parses the
   colour: computed values come back as `oklch()` verbatim here.
3. **Real images are worst-cased to black, gradients are not.** An `<img>`/`url()` is
   an arbitrary upload; a gradient is palette colours the token lint already governs,
   and calling it black failed every dark text on a light gradient.

`/providers/:id` joins the audited routes, with a genuinely black 1×1 cover behind
the scrim.

## A documented capability that reaches zero routes

#1303 says *"login-and-return already works via the `:user_return_to` session key."*
It does not — for these routes. `maybe_store_return_to/1` is only called from the
**plug** `require_authenticated_user/2`, and that plug is wired into **no pipeline**;
every authenticated route gates via the LiveView `on_mount` instead, which redirects
without storing a path. Verified in the browser: a parent logging in lands on
`/dashboard`, not the page they came from.

So the CTA is a plain link rather than a pre-gated button. `Messaging.build_compose_target/3`
already owns who may write to whom (*"the gate lives here rather than in the callers"*),
and a pre-check would have added a second copy of that rule **and** made the button a
dead end for logged-out traffic — clicking it did nothing at all in the first cut.

Landing a real return-to is a cross-cutting auth change and is not in this PR.

## Verification

- `mix precommit` green — **5050 passed**, all six lints, credo clean.
- `mix test.e2e test/e2e/contrast_test.exs` — **8 passed**, zero failing text nodes
  on four routes.
- **Mutation-checked in both directions**: swapping in the expired-including query
  fails exactly one test; weakening the scrim to `bg-white/10` fails the hero at
  1.21:1 and restoring it passes.
- **Browser-driven** at 375px and 1280px: hero with cover, About with linked
  phone/website, programs grid, program-detail → profile link, CTA as anonymous
  (→ log in, with an explanation) and as a parent (→ compose for the right provider).
  No console errors.
- German shipped in the same PR. `gettext.merge` fuzzy-filled one entry, correctly
  as it happens; the near-duplicate msgid was folded into the existing
  `"Have questions?"` instead. `"About"` was rejected as a msgid because its German
  is *"Über uns"* — wrong on a page about someone else — in favour of
  `"About the Provider"`.

## Not in scope

- A real HTTP 404 convention — filed as #1503.
- Slice C (provider edit form) and #1304 (reviews).
