### PR TITLE
feat: share one branding section between both provider forms, with a live preview

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -186,8 +186,11 @@
   --fg-inverse:    #ffffff;
   /* Link text. Deliberately darker than --brand-primary: hero-blue-600 is 2.66:1
      and hero-blue-700 is 3.99:1, both below AA as foreground. blue-800 is 6.10:1
-     on white and 4.93:1 on the warm shells. The brand cyan stays the CTA *fill*,
-     which carries white text and is unaffected. */
+     on white and 4.93:1 on the warm shells.
+     This used to add "the brand cyan stays the CTA *fill*, which carries white
+     text and is unaffected". Contrast is symmetric, so white-on-blue-600 is the
+     same 2.66:1 — see #1459, which still owns fixing Theme.button_variant/1.
+     `kh_button`'s primary is black on hero-blue-500 (~11.45:1) and is fine. */
   --fg-link:       var(--color-hero-blue-800);
 
   /* Focus indicator. Non-text, so the floor is 3:1 (WCAG 2.1 SC 1.4.11), not 4.5.

--- a/lib/klass_hero/provider/provider_profile.ex
+++ b/lib/klass_hero/provider/provider_profile.ex
@@ -57,6 +57,29 @@ defmodule KlassHero.Provider.ProviderProfile do
   @spec social_link_fields() :: [atom()]
   def social_link_fields, do: @social_link_fields
 
+  @doc """
+  Prepends `https://` to a URL typed without a scheme.
+
+  An explicit `http://` is passed through unchanged so it still reaches — and
+  fails — the https validator. That is a deliberate insecure choice, not the
+  missing-scheme typo this exists to absorb.
+  """
+  @spec normalize_url(String.t() | nil) :: String.t() | nil
+  def normalize_url(nil), do: nil
+
+  def normalize_url(url) when is_binary(url) do
+    case String.trim(url) do
+      "" -> nil
+      trimmed -> ensure_scheme(trimmed)
+    end
+  end
+
+  def normalize_url(url), do: url
+
+  defp ensure_scheme("https://" <> _ = url), do: url
+  defp ensure_scheme("http://" <> _ = url), do: url
+  defp ensure_scheme(url), do: "https://" <> url
+
   schema "providers" do
     field :identity_id, :binary_id
     field :entity_type, Ecto.Enum, values: @entity_types, default: :individual
@@ -213,6 +236,7 @@ defmodule KlassHero.Provider.ProviderProfile do
 
     Enum.reduce(@url_branding_fields, changeset, fn field, acc ->
       acc
+      |> update_change(field, &normalize_url/1)
       |> validate_length(field, max: @branding_url_max_length)
       |> validate_https_url(field)
     end)
@@ -233,6 +257,8 @@ defmodule KlassHero.Provider.ProviderProfile do
   end
 
   defp validate_website_protocol(changeset) do
+    changeset = update_change(changeset, :website, &normalize_url/1)
+
     case get_change(changeset, :website) do
       website when is_binary(website) ->
         if String.starts_with?(website, "https://") do
@@ -360,12 +386,23 @@ defmodule KlassHero.Provider.ProviderProfile do
   """
   @spec new(map()) :: {:ok, t()} | {:error, [String.t()]}
   def new(attrs) do
-    profile = struct!(__MODULE__, apply_defaults(attrs))
+    profile = __MODULE__ |> struct!(apply_defaults(attrs)) |> normalize_urls()
 
     case validate(profile) do
       [] -> {:ok, profile}
       errors -> {:error, errors}
     end
+  end
+
+  # The changesets normalize per-field via `update_change`; the pure core builds a
+  # whole struct, so it normalizes the same fields on the struct instead. Both
+  # builders below do this identically — what differs is the caller:
+  # `update_provider_profile/2` discards `new/1`'s struct and persists the
+  # changeset's, while `complete_provider_profile/2` persists this one.
+  defp normalize_urls(%__MODULE__{} = profile) do
+    Enum.reduce([:website | @url_branding_fields], profile, fn field, acc ->
+      Map.update!(acc, field, &normalize_url/1)
+    end)
   end
 
   defp apply_defaults(attrs) do
@@ -434,6 +471,7 @@ defmodule KlassHero.Provider.ProviderProfile do
     updated =
       profile
       |> struct(Map.take(attrs, @completion_fields))
+      |> normalize_urls()
       |> Map.put(:profile_status, :active)
       |> Map.put(:updated_at, now)
 

--- a/lib/klass_hero/provider/provider_profile.ex
+++ b/lib/klass_hero/provider/provider_profile.ex
@@ -40,6 +40,13 @@ defmodule KlassHero.Provider.ProviderProfile do
   @url_branding_fields [:cover_image_url | @social_link_fields]
   @branding_fields [:tagline | @url_branding_fields]
 
+  # The URL fields a *person* types. `cover_image_url` is deliberately absent: it
+  # is set from a storage upload, so scheme-prepending it cannot repair a typo —
+  # it can only launder an adapter URL past the https check that would have caught
+  # it (the test stub returns `stub://…`, which became `https://stub://…`, valid
+  # by inspection and wrong).
+  @typed_url_fields [:website | @social_link_fields]
+
   @tagline_max_length 150
   @branding_url_max_length 500
 
@@ -234,9 +241,13 @@ defmodule KlassHero.Provider.ProviderProfile do
   defp validate_branding_fields(changeset) do
     changeset = validate_length(changeset, :tagline, max: @tagline_max_length)
 
+    changeset =
+      Enum.reduce(@social_link_fields, changeset, fn field, acc ->
+        update_change(acc, field, &normalize_url/1)
+      end)
+
     Enum.reduce(@url_branding_fields, changeset, fn field, acc ->
       acc
-      |> update_change(field, &normalize_url/1)
       |> validate_length(field, max: @branding_url_max_length)
       |> validate_https_url(field)
     end)
@@ -400,7 +411,7 @@ defmodule KlassHero.Provider.ProviderProfile do
   # `update_provider_profile/2` discards `new/1`'s struct and persists the
   # changeset's, while `complete_provider_profile/2` persists this one.
   defp normalize_urls(%__MODULE__{} = profile) do
-    Enum.reduce([:website | @url_branding_fields], profile, fn field, acc ->
+    Enum.reduce(@typed_url_fields, profile, fn field, acc ->
       Map.update!(acc, field, &normalize_url/1)
     end)
   end

--- a/lib/klass_hero_web/components/provider_components.ex
+++ b/lib/klass_hero_web/components/provider_components.ex
@@ -3175,23 +3175,17 @@ defmodule KlassHeroWeb.ProviderComponents do
         />
 
         <div :if={@pending != []} class="flex flex-wrap gap-2">
-          <button
+          <.kh_button
             :for={{field, network, label} <- @pending}
+            variant={:ghost}
             type="button"
             id={"add-#{field}"}
             phx-click="add_social_link"
             phx-value-network={field}
-            class={[
-              "inline-flex items-center gap-2 min-h-11 px-4 border border-hero-grey-300",
-              "bg-white hover:bg-hero-grey-50 text-hero-black-100 text-sm font-medium",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]",
-              Theme.rounded(:lg),
-              Theme.transition(:normal)
-            ]}
           >
             <.kh_social_icon network={network} class="w-4 h-4" />
             {gettext("Add %{network}", network: label)}
-          </button>
+          </.kh_button>
         </div>
       </div>
     </div>

--- a/lib/klass_hero_web/components/provider_components.ex
+++ b/lib/klass_hero_web/components/provider_components.ex
@@ -409,7 +409,7 @@ defmodule KlassHeroWeb.ProviderComponents do
         <div class="relative group">
           <.kh_button
             id="new-program-btn"
-            variant={:yellow}
+            variant={:primary}
             size={:sm}
             icon="hero-plus-mini"
             phx-click="add_program"
@@ -3160,10 +3160,16 @@ defmodule KlassHeroWeb.ProviderComponents do
       </div>
 
       <div class="space-y-4" id="social-links">
+        <%!-- `type="text"`, not `type="url"`: the browser's own constraint validation
+              rejects a scheme-less value and blocks submit, so `instagram.com/handle`
+              would never reach the normalizer built to accept it. No LiveView test
+              can see that — `Phoenix.LiveViewTest` does not run browser validation.
+              `inputmode` keeps the URL keyboard on mobile without the constraint. --%>
         <.input
           :for={{field, _network, label} <- revealed_networks(@revealed)}
           field={@form[field]}
-          type="url"
+          type="text"
+          inputmode="url"
           label={label}
           placeholder={gettext("e.g. %{example}", example: "instagram.com/yourhandle")}
         />

--- a/lib/klass_hero_web/components/provider_components.ex
+++ b/lib/klass_hero_web/components/provider_components.ex
@@ -542,20 +542,16 @@ defmodule KlassHeroWeb.ProviderComponents do
           >
             {gettext("Edit")}
           </button>
-          <button
+          <.kh_button
             :if={@member.can_resend?}
-            type="button"
+            variant={:primary}
+            size={:sm}
             id={"resend-invitation-#{@member.id}"}
             phx-click="resend_invitation"
             phx-value-id={@member.id}
-            class={[
-              "px-3 py-2 bg-hero-yellow-500 hover:bg-hero-yellow-600 text-hero-black-100 text-xs font-medium",
-              Theme.rounded(:lg),
-              Theme.transition(:normal)
-            ]}
           >
             {gettext("Resend")}
-          </button>
+          </.kh_button>
           <%!-- Ending employment is routine and reversible, so it reads as an
                 ordinary action rather than a red destructive one. --%>
           <button
@@ -831,23 +827,13 @@ defmodule KlassHeroWeb.ProviderComponents do
         </div>
 
         <div class="flex items-center gap-3 pt-2">
-          <button
-            type="submit"
-            id="save-staff-btn"
-            class={[
-              "flex items-center gap-2 px-6 py-2.5 bg-hero-yellow-500 hover:bg-hero-yellow-600",
-              "text-hero-black-100 font-semibold active:scale-[0.98]",
-              Theme.rounded(:lg),
-              Theme.transition(:normal)
-            ]}
-          >
-            <.icon name="hero-check-mini" class="w-5 h-5" />
+          <.kh_button variant={:primary} type="submit" id="save-staff-btn" icon="hero-check-mini">
             <%= if @editing do %>
               {gettext("Save Changes")}
             <% else %>
               {gettext("Add Member")}
             <% end %>
-          </button>
+          </.kh_button>
           <button
             type="button"
             phx-click="close_staff_form"
@@ -1274,19 +1260,9 @@ defmodule KlassHeroWeb.ProviderComponents do
           >
             {gettext("Cancel")}
           </button>
-          <button
-            type="submit"
-            id="save-program-btn"
-            class={[
-              "flex items-center gap-2 px-6 py-2.5 bg-hero-yellow-500 hover:bg-hero-yellow-600",
-              "text-hero-black-100 font-semibold",
-              Theme.rounded(:lg),
-              Theme.transition(:normal)
-            ]}
-          >
-            <.icon name="hero-check-mini" class="w-5 h-5" />
+          <.kh_button variant={:primary} type="submit" id="save-program-btn" icon="hero-check-mini">
             {gettext("Save Program")}
-          </button>
+          </.kh_button>
         </div>
       </.form>
     </div>
@@ -2117,21 +2093,15 @@ defmodule KlassHeroWeb.ProviderComponents do
                   {label}
                 </option>
               </select>
-              <button
+              <.kh_button
+                variant={:primary}
                 type="submit"
                 id="staffing-add-btn"
+                icon="hero-plus-mini"
                 disabled={@modal.assignable_options == []}
-                class={[
-                  "flex items-center justify-center gap-2 px-4 py-2 font-semibold",
-                  "bg-hero-yellow-500 hover:bg-hero-yellow-600 text-hero-black-100",
-                  "disabled:bg-hero-grey-100 disabled:text-hero-grey-400",
-                  Theme.rounded(:lg),
-                  Theme.transition(:normal)
-                ]}
               >
-                <.icon name="hero-plus-mini" class="w-5 h-5" />
                 {gettext("Add")}
-              </button>
+              </.kh_button>
             </form>
 
             <p class="mt-2 text-xs text-[var(--fg-muted)]">
@@ -2299,22 +2269,16 @@ defmodule KlassHeroWeb.ProviderComponents do
                   disabled={@modal.assignable_options == []}
                 />
               </div>
-              <button
+              <.kh_button
+                variant={:primary}
                 type="submit"
                 id="session-staffing-add-btn"
+                icon="hero-plus-mini"
+                class="w-full sm:w-auto"
                 disabled={@modal.assignable_options == []}
-                class={[
-                  "flex min-h-11 w-full items-center justify-center gap-2 px-4 py-2 font-semibold sm:w-auto",
-                  "bg-hero-yellow-500 hover:bg-hero-yellow-600 text-hero-grey-900",
-                  "active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hero-yellow-700",
-                  "disabled:bg-hero-grey-100 disabled:text-hero-grey-400 disabled:active:scale-100",
-                  Theme.rounded(:md),
-                  Theme.transition(:fast)
-                ]}
               >
-                <.icon name="hero-plus-mini" class="w-5 h-5" />
                 {gettext("Add")}
-              </button>
+              </.kh_button>
             </.form>
 
             <p

--- a/lib/klass_hero_web/components/provider_components.ex
+++ b/lib/klass_hero_web/components/provider_components.ex
@@ -18,6 +18,7 @@ defmodule KlassHeroWeb.ProviderComponents do
   alias KlassHero.Shared.ChangesetErrors
   alias KlassHeroWeb.Presenters.ProviderPresenter
   alias KlassHeroWeb.Theme
+  alias Phoenix.HTML.Form
 
   @doc """
   Renders a colored status badge for a verification document status.
@@ -3124,6 +3125,115 @@ defmodule KlassHeroWeb.ProviderComponents do
       <p class="text-xs text-[var(--fg-muted)] mt-2">{@hint}</p>
     </div>
     """
+  end
+
+  @doc """
+  The "Branding & Presence" block both provider forms collect.
+
+  One definition because the two forms have drifted twice already — the field
+  list stayed in sync (both derive it from `ProviderProfile`) while the markup
+  did not, leaving one form on the shared dropzone and the other on a
+  hand-rolled copy of it.
+
+  Social links are added on demand: a row renders only for a network in
+  `@revealed`, and the rest sit behind one picker. Five always-visible URL
+  inputs cost ~330px of mobile scroll for fields most providers leave blank.
+
+  `@revealed` is caller state rather than a JS toggle because this form fires
+  `phx-change` on every keystroke, and a LiveView patch wipes the inline
+  `display:none` a `JS.toggle` writes — a revealed row would vanish mid-typing.
+
+  An unrevealed field is not rendered at all, so it submits nothing and
+  `ProviderBranding.attrs_from_params/1` leaves it out of the update entirely:
+  hiding a network never clears it.
+
+  ## Examples
+
+      <.pv_branding_section form={@form} revealed={@revealed_socials} uploads={@uploads} />
+  """
+  attr :form, Form, required: true
+  attr :revealed, :list, required: true, doc: "Social field atoms whose row is shown"
+
+  attr :uploads, :any,
+    default: nil,
+    doc: "The `@uploads` struct; omit to render no cover upload (profile completion)"
+
+  def pv_branding_section(assigns) do
+    assigns = assign(assigns, :pending, pending_networks(assigns.revealed))
+
+    ~H"""
+    <div class="pt-6 border-t border-hero-grey-200 space-y-6">
+      <div>
+        <h3 class={[Theme.typography(:card_title), "text-hero-black-100"]}>
+          {gettext("Branding & Presence")}
+        </h3>
+        <p class="text-sm text-[var(--fg-muted)] mt-1">
+          {gettext("Shown on your public profile page.")}
+        </p>
+      </div>
+
+      <.input
+        field={@form[:tagline]}
+        type="text"
+        label={gettext("Tagline")}
+        placeholder={gettext("A short line that sums you up")}
+        maxlength="150"
+      />
+
+      <div :if={@uploads}>
+        <label class="block text-sm font-semibold text-hero-black-100 mb-2">
+          {gettext("Cover Image")}
+        </label>
+
+        <.pv_upload_dropzone
+          id="cover-upload"
+          upload={@uploads.cover}
+          name="cover"
+          trigger={gettext("Choose Cover Image")}
+          hint={gettext("JPG, PNG or WebP. Max 5MB.")}
+          preview_class="w-full max-w-md mx-auto h-32 object-cover rounded-lg"
+        />
+      </div>
+
+      <div class="space-y-4" id="social-links">
+        <.input
+          :for={{field, _network, label} <- revealed_networks(@revealed)}
+          field={@form[field]}
+          type="url"
+          label={label}
+          placeholder={gettext("e.g. %{example}", example: "instagram.com/yourhandle")}
+        />
+
+        <div :if={@pending != []} class="flex flex-wrap gap-2">
+          <button
+            :for={{field, network, label} <- @pending}
+            type="button"
+            id={"add-#{field}"}
+            phx-click="add_social_link"
+            phx-value-network={field}
+            class={[
+              "inline-flex items-center gap-2 min-h-11 px-4 border border-hero-grey-300",
+              "bg-white hover:bg-hero-grey-50 text-hero-black-100 text-sm font-medium",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]",
+              Theme.rounded(:lg),
+              Theme.transition(:normal)
+            ]}
+          >
+            <.kh_social_icon network={network} class="w-4 h-4" />
+            {gettext("Add %{network}", network: label)}
+          </button>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  defp revealed_networks(revealed) do
+    Enum.filter(ProviderPresenter.social_networks(), fn {field, _n, _l} -> field in revealed end)
+  end
+
+  defp pending_networks(revealed) do
+    Enum.reject(ProviderPresenter.social_networks(), fn {field, _n, _l} -> field in revealed end)
   end
 
   @doc """

--- a/lib/klass_hero_web/helpers/provider_branding.ex
+++ b/lib/klass_hero_web/helpers/provider_branding.ex
@@ -33,6 +33,41 @@ defmodule KlassHeroWeb.Helpers.ProviderBranding do
         do: {field, blank_to_nil(params[Atom.to_string(field)])}
   end
 
+  @doc """
+  The social-link fields this provider has already filled in.
+
+  Seeds which rows the branding form shows on first render. A field with no
+  value is offered by the picker instead, so the form starts at the length of
+  what the provider actually has.
+  """
+  @spec filled_networks(map()) :: [atom()]
+  def filled_networks(provider) do
+    # `Enum.filter`, not a `for` with an assignment: a bare `value = ...` clause
+    # in a comprehension filters on truthiness as well as binding, so a nil
+    # column would drop out for a reason the code does not state (#1408).
+    Enum.filter(ProviderProfile.social_link_fields(), fn field ->
+      case Map.get(provider, field) do
+        value when is_binary(value) -> String.trim(value) != ""
+        _ -> false
+      end
+    end)
+  end
+
+  @doc """
+  Adds a network to the revealed list, given the picker's raw param.
+
+  Resolves the string against `social_link_fields/0` rather than calling
+  `String.to_existing_atom/1` on it: the param comes from the client, and an
+  unknown value should be ignored, not raise.
+  """
+  @spec reveal([atom()], String.t()) :: [atom()]
+  def reveal(revealed, network) when is_binary(network) do
+    case Enum.find(ProviderProfile.social_link_fields(), &(Atom.to_string(&1) == network)) do
+      nil -> revealed
+      field -> Enum.uniq(revealed ++ [field])
+    end
+  end
+
   defp blank_to_nil(value) when is_binary(value) do
     case String.trim(value) do
       "" -> nil

--- a/lib/klass_hero_web/live/provider/edit_profile_live.ex
+++ b/lib/klass_hero_web/live/provider/edit_profile_live.ex
@@ -14,6 +14,7 @@ defmodule KlassHeroWeb.Provider.EditProfileLive do
 
   alias KlassHero.Provider
   alias KlassHeroWeb.Helpers.ProviderBranding
+  alias KlassHeroWeb.Presenters.ProviderPresenter
   alias KlassHeroWeb.Provider.Dashboard.Chrome
   alias KlassHeroWeb.Provider.Dashboard.Uploads
   alias KlassHeroWeb.Theme
@@ -25,6 +26,7 @@ defmodule KlassHeroWeb.Provider.EditProfileLive do
     provider = socket.assigns.current_scope.provider
     changeset = Provider.change_provider_profile(provider)
     docs = fetch_verification_docs(provider.id)
+    trust_state = trust_state(provider.id)
 
     socket =
       socket
@@ -33,6 +35,9 @@ defmodule KlassHeroWeb.Provider.EditProfileLive do
       |> assign(active_nav: :home)
       |> assign(form: to_form(changeset, as: :provider_profile_schema))
       |> assign(revealed_socials: ProviderBranding.filled_networks(provider))
+      |> assign(trust_state: trust_state)
+      |> assign(preview: preview_view(changeset, trust_state))
+      |> assign(preview_open?: false)
       |> assign(doc_type: "business_registration")
       |> assign(document_types: Provider.valid_document_types())
       |> stream(:verification_docs, docs, dom_id: &"vdoc-#{&1.id}")
@@ -61,9 +66,14 @@ defmodule KlassHeroWeb.Provider.EditProfileLive do
     changeset = Provider.change_provider_profile(provider, params)
 
     {:noreply,
-     assign(socket,
-       form: to_form(Map.put(changeset, :action, :validate), as: :provider_profile_schema)
-     )}
+     socket
+     |> assign(form: to_form(Map.put(changeset, :action, :validate), as: :provider_profile_schema))
+     |> assign(preview: preview_view(changeset, socket.assigns.trust_state))}
+  end
+
+  @impl true
+  def handle_event("toggle_preview", _params, socket) do
+    {:noreply, update(socket, :preview_open?, &(!&1))}
   end
 
   @impl true
@@ -186,6 +196,24 @@ defmodule KlassHeroWeb.Provider.EditProfileLive do
     {:noreply, cancel_upload(socket, String.to_existing_atom(upload_name), ref)}
   end
 
+  # The preview renders the same component the public page does, fed by the same
+  # presenter — `to_public_view/2` takes a struct, so applying the in-flight
+  # changeset is enough and costs no query. A preview that re-implements the hero
+  # is a preview that lies.
+  defp preview_view(changeset, trust_state) do
+    changeset
+    |> Ecto.Changeset.apply_changes()
+    |> ProviderPresenter.to_public_view(trust_state)
+  end
+
+  # get_trust_states/1 is batch-only; a missing entry means unverified. The badge
+  # is not editable here, so this is read once at mount.
+  defp trust_state(provider_id) do
+    [provider_id]
+    |> Provider.get_trust_states()
+    |> Map.get(provider_id, :unverified)
+  end
+
   defp fetch_verification_docs(provider_id) do
     {:ok, docs} = Provider.get_provider_verification_documents(provider_id)
     docs
@@ -212,76 +240,115 @@ defmodule KlassHeroWeb.Provider.EditProfileLive do
 
           <h1 class="text-2xl font-bold text-hero-black-100">{gettext("Edit Profile")}</h1>
 
-          <div class={["bg-white p-6 shadow-sm border border-hero-grey-200", Theme.rounded(:xl)]}>
-            <h2 class="text-lg font-semibold text-hero-black-100 mb-4">
-              {gettext("Provider Information")}
-            </h2>
+          <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 items-start">
+            <div class={["bg-white p-6 shadow-sm border border-hero-grey-200", Theme.rounded(:xl)]}>
+              <h2 class="text-lg font-semibold text-hero-black-100 mb-4">
+                {gettext("Provider Information")}
+              </h2>
 
-            <.form
-              for={@form}
-              id="profile-form"
-              phx-change="validate_profile"
-              phx-submit="save_profile"
-              class="space-y-6"
-            >
-              <.input
-                field={@form[:description]}
-                type="textarea"
-                label={gettext("Provider Description")}
-                placeholder={gettext("Tell parents about your organization...")}
-                rows="4"
-              />
+              <.form
+                for={@form}
+                id="profile-form"
+                phx-change="validate_profile"
+                phx-submit="save_profile"
+                class="space-y-6"
+              >
+                <.input
+                  field={@form[:description]}
+                  type="textarea"
+                  label={gettext("Provider Description")}
+                  placeholder={gettext("Tell parents about your organization...")}
+                  rows="4"
+                />
 
-              <div>
-                <label class="block text-sm font-semibold text-hero-black-100 mb-2">
-                  {gettext("Provider Logo")}
-                </label>
+                <div>
+                  <label class="block text-sm font-semibold text-hero-black-100 mb-2">
+                    {gettext("Provider Logo")}
+                  </label>
 
-                <.pv_upload_dropzone
-                  id="logo-upload"
-                  upload={@uploads.logo}
-                  name="logo"
-                  trigger={gettext("Choose Logo")}
-                  hint={gettext("JPG, PNG or WebP. Max 2MB.")}
-                  preview_class="w-16 h-16 mx-auto rounded-full object-cover"
-                >
-                  <:placeholder>
-                    <div
-                      :if={@business.initials}
-                      class={[
-                        "w-16 h-16 mx-auto flex items-center justify-center text-white text-xl font-bold",
-                        Theme.rounded(:full),
-                        Theme.gradient(:primary)
-                      ]}
-                    >
-                      {@business.initials}
-                    </div>
-                  </:placeholder>
-                </.pv_upload_dropzone>
+                  <.pv_upload_dropzone
+                    id="logo-upload"
+                    upload={@uploads.logo}
+                    name="logo"
+                    trigger={gettext("Choose Logo")}
+                    hint={gettext("JPG, PNG or WebP. Max 2MB.")}
+                    preview_class="w-16 h-16 mx-auto rounded-full object-cover"
+                  >
+                    <:placeholder>
+                      <div
+                        :if={@business.initials}
+                        class={[
+                          "w-16 h-16 mx-auto flex items-center justify-center text-white text-xl font-bold",
+                          Theme.rounded(:full),
+                          Theme.gradient(:primary)
+                        ]}
+                      >
+                        {@business.initials}
+                      </div>
+                    </:placeholder>
+                  </.pv_upload_dropzone>
+                </div>
+
+                <.pv_branding_section
+                  form={@form}
+                  revealed={@revealed_socials}
+                  uploads={@uploads}
+                />
+
+                <div class="flex justify-end">
+                  <.kh_button
+                    variant={:primary}
+                    type="submit"
+                    id="save-profile-btn"
+                    icon="hero-check-mini"
+                  >
+                    {gettext("Save Changes")}
+                  </.kh_button>
+                </div>
+              </.form>
+            </div>
+
+            <div class="lg:sticky lg:top-6">
+              <%!-- A server assign, not a JS toggle: this form fires phx-change on
+                    every keystroke and the resulting patch wipes an inline
+                    display:none, so a JS-collapsed panel would reopen as you type. --%>
+              <button
+                type="button"
+                id="toggle-preview"
+                phx-click="toggle_preview"
+                aria-expanded={to_string(@preview_open?)}
+                aria-controls="profile-preview"
+                class={[
+                  "lg:hidden w-full inline-flex items-center justify-center gap-2 min-h-11 px-4",
+                  "border border-hero-grey-300 bg-white hover:bg-hero-grey-50 text-hero-black-100",
+                  "text-sm font-medium",
+                  Theme.rounded(:lg)
+                ]}
+              >
+                <.icon name="hero-eye-mini" class="w-4 h-4" />
+                {if @preview_open?, do: gettext("Hide preview"), else: gettext("Show preview")}
+              </button>
+
+              <div
+                id="profile-preview"
+                class={[
+                  "mt-4 lg:mt-0 overflow-hidden bg-white shadow-sm border border-hero-grey-200",
+                  Theme.rounded(:xl),
+                  !@preview_open? && "hidden lg:block"
+                ]}
+              >
+                <div class="px-6 pt-6">
+                  <h2 class="text-lg font-semibold text-hero-black-100">
+                    {gettext("Public profile preview")}
+                  </h2>
+                  <p class="text-sm text-[var(--fg-muted)] mt-1">
+                    {gettext("A newly chosen cover or logo appears here after you save.")}
+                  </p>
+                </div>
+
+                <.provider_hero provider={@preview} variant={:full} />
               </div>
-
-              <.pv_branding_section
-                form={@form}
-                revealed={@revealed_socials}
-                uploads={@uploads}
-              />
-
-              <div class="flex justify-end">
-                <button
-                  type="submit"
-                  id="save-profile-btn"
-                  class={[
-                    "flex items-center gap-2 px-6 py-2.5 bg-hero-yellow-500 hover:bg-hero-yellow-600",
-                    "text-hero-black-100 font-semibold",
-                    Theme.rounded(:lg),
-                    Theme.transition(:normal)
-                  ]}
-                >
-                  <.icon name="hero-check-mini" class="w-5 h-5" />
-                  {gettext("Save Changes")}
-                </button>
-              </div>
-            </.form>
+            </div>
           </div>
 
           <.verification_documents_panel

--- a/lib/klass_hero_web/live/provider/edit_profile_live.ex
+++ b/lib/klass_hero_web/live/provider/edit_profile_live.ex
@@ -14,7 +14,6 @@ defmodule KlassHeroWeb.Provider.EditProfileLive do
 
   alias KlassHero.Provider
   alias KlassHeroWeb.Helpers.ProviderBranding
-  alias KlassHeroWeb.Presenters.ProviderPresenter
   alias KlassHeroWeb.Provider.Dashboard.Chrome
   alias KlassHeroWeb.Provider.Dashboard.Uploads
   alias KlassHeroWeb.Theme
@@ -33,6 +32,7 @@ defmodule KlassHeroWeb.Provider.EditProfileLive do
       |> assign(page_title: gettext("Edit Profile"))
       |> assign(active_nav: :home)
       |> assign(form: to_form(changeset, as: :provider_profile_schema))
+      |> assign(revealed_socials: ProviderBranding.filled_networks(provider))
       |> assign(doc_type: "business_registration")
       |> assign(document_types: Provider.valid_document_types())
       |> stream(:verification_docs, docs, dom_id: &"vdoc-#{&1.id}")
@@ -64,6 +64,11 @@ defmodule KlassHeroWeb.Provider.EditProfileLive do
      assign(socket,
        form: to_form(Map.put(changeset, :action, :validate), as: :provider_profile_schema)
      )}
+  end
+
+  @impl true
+  def handle_event("add_social_link", %{"network" => network}, socket) do
+    {:noreply, update(socket, :revealed_socials, &ProviderBranding.reveal(&1, network))}
   end
 
   @impl true
@@ -255,47 +260,11 @@ defmodule KlassHeroWeb.Provider.EditProfileLive do
                 </.pv_upload_dropzone>
               </div>
 
-              <div class="pt-6 border-t border-hero-grey-200 space-y-6">
-                <div>
-                  <h3 class={[Theme.typography(:card_title), "text-hero-black-100"]}>
-                    {gettext("Branding & Presence")}
-                  </h3>
-                  <p class="text-sm text-[var(--fg-muted)] mt-1">
-                    {gettext("Shown on your public profile page.")}
-                  </p>
-                </div>
-
-                <.input
-                  field={@form[:tagline]}
-                  type="text"
-                  label={gettext("Tagline")}
-                  placeholder={gettext("A short line that sums you up")}
-                  maxlength="150"
-                />
-
-                <div>
-                  <label class="block text-sm font-semibold text-hero-black-100 mb-2">
-                    {gettext("Cover Image")}
-                  </label>
-
-                  <.pv_upload_dropzone
-                    id="cover-upload"
-                    upload={@uploads.cover}
-                    name="cover"
-                    trigger={gettext("Choose Cover Image")}
-                    hint={gettext("JPG, PNG or WebP. Max 5MB.")}
-                    preview_class="w-full max-w-md mx-auto h-32 object-cover rounded-lg"
-                  />
-                </div>
-
-                <.input
-                  :for={{field, label} <- ProviderPresenter.social_networks()}
-                  field={@form[field]}
-                  type="url"
-                  label={label}
-                  placeholder="https://"
-                />
-              </div>
+              <.pv_branding_section
+                form={@form}
+                revealed={@revealed_socials}
+                uploads={@uploads}
+              />
 
               <div class="flex justify-end">
                 <button

--- a/lib/klass_hero_web/live/provider/edit_profile_live.ex
+++ b/lib/klass_hero_web/live/provider/edit_profile_live.ex
@@ -312,22 +312,18 @@ defmodule KlassHeroWeb.Provider.EditProfileLive do
               <%!-- A server assign, not a JS toggle: this form fires phx-change on
                     every keystroke and the resulting patch wipes an inline
                     display:none, so a JS-collapsed panel would reopen as you type. --%>
-              <button
+              <.kh_button
+                variant={:ghost}
                 type="button"
                 id="toggle-preview"
+                icon="hero-eye-mini"
+                class="lg:hidden w-full"
                 phx-click="toggle_preview"
                 aria-expanded={to_string(@preview_open?)}
                 aria-controls="profile-preview"
-                class={[
-                  "lg:hidden w-full inline-flex items-center justify-center gap-2 min-h-11 px-4",
-                  "border border-hero-grey-300 bg-white hover:bg-hero-grey-50 text-hero-black-100",
-                  "text-sm font-medium",
-                  Theme.rounded(:lg)
-                ]}
               >
-                <.icon name="hero-eye-mini" class="w-4 h-4" />
                 {if @preview_open?, do: gettext("Hide preview"), else: gettext("Show preview")}
-              </button>
+              </.kh_button>
 
               <div
                 id="profile-preview"

--- a/lib/klass_hero_web/live/provider/profile_completion_live.ex
+++ b/lib/klass_hero_web/live/provider/profile_completion_live.ex
@@ -10,13 +10,14 @@ defmodule KlassHeroWeb.Provider.ProfileCompletionLive do
   """
   use KlassHeroWeb, :live_view
 
+  import KlassHeroWeb.ProviderComponents
+
   alias KlassHero.Provider
   alias KlassHero.Provider.ProviderProfile
   alias KlassHero.Shared.Categories
   alias KlassHero.Shared.FeatureFlags
   alias KlassHero.Shared.Storage
   alias KlassHeroWeb.Helpers.ProviderBranding
-  alias KlassHeroWeb.Presenters.ProviderPresenter
   alias KlassHeroWeb.Theme
 
   require Logger
@@ -45,6 +46,7 @@ defmodule KlassHeroWeb.Provider.ProfileCompletionLive do
           |> assign(provider: provider)
           |> assign(business_vetting?: business_vetting_enabled?())
           |> assign(form: to_form(changeset, as: :provider_profile_schema))
+          |> assign(revealed_socials: ProviderBranding.filled_networks(provider))
           |> assign(categories: Categories.categories())
           |> allow_upload(:logo,
             accept: ~w(.jpg .jpeg .png .webp),
@@ -109,10 +111,18 @@ defmodule KlassHeroWeb.Provider.ProfileCompletionLive do
              |> put_flash(:error, gettext("Please fix the errors below."))
              |> assign(form: to_form(Map.put(changeset, :action, :validate), as: :provider_profile_schema))}
 
+          {:error, %Ecto.Changeset{} = changeset} ->
+            {:noreply, assign(socket, form: to_form(changeset, as: :provider_profile_schema))}
+
           {:error, _reason} ->
             {:noreply, put_flash(socket, :error, gettext("Something went wrong. Please try again."))}
         end
     end
+  end
+
+  @impl true
+  def handle_event("add_social_link", %{"network" => network}, socket) do
+    {:noreply, update(socket, :revealed_socials, &ProviderBranding.reveal(&1, network))}
   end
 
   @impl true
@@ -217,7 +227,7 @@ defmodule KlassHeroWeb.Provider.ProfileCompletionLive do
         <div class="mb-6">
           <.link
             navigate={~p"/provider/dashboard"}
-            class="flex items-center gap-1 text-gray-500 hover:text-gray-700 transition-colors"
+            class="flex items-center gap-1 text-[var(--fg-muted)] hover:text-hero-black-100 transition-colors"
           >
             <.icon name="hero-arrow-left-mini" class="w-5 h-5" />
             {gettext("Back to Dashboard")}
@@ -227,13 +237,13 @@ defmodule KlassHeroWeb.Provider.ProfileCompletionLive do
         <h1 class={["text-2xl font-bold mb-2", Theme.typography(:page_title)]}>
           {gettext("Complete Your Provider Profile")}
         </h1>
-        <p class="text-gray-500 mb-8">
+        <p class="text-[var(--fg-muted)] mb-8">
           {gettext(
             "Fill in your business details. Your profile will be reviewed by Klass Hero before going live."
           )}
         </p>
 
-        <div class={["bg-white p-6 shadow-sm border border-gray-200", Theme.rounded(:xl)]}>
+        <div class={["bg-white p-6 shadow-sm border border-hero-grey-200", Theme.rounded(:xl)]}>
           <.form
             for={@form}
             id="profile-completion-form"
@@ -242,7 +252,7 @@ defmodule KlassHeroWeb.Provider.ProfileCompletionLive do
             class="space-y-6"
           >
             <div :if={@business_vetting?}>
-              <label class="block text-sm font-semibold text-gray-700 mb-2">
+              <label class="block text-sm font-semibold text-hero-black-100 mb-2">
                 {gettext("What are you registering as?")}
               </label>
               <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
@@ -256,7 +266,7 @@ defmodule KlassHeroWeb.Provider.ProfileCompletionLive do
                     ]
                   }
                   class={[
-                    "flex items-start gap-3 p-3 border cursor-pointer hover:bg-gray-50 transition-colors",
+                    "flex items-start gap-3 p-3 border cursor-pointer hover:bg-hero-grey-50 transition-colors",
                     Theme.rounded(:lg)
                   ]}
                 >
@@ -265,11 +275,11 @@ defmodule KlassHeroWeb.Provider.ProfileCompletionLive do
                     name="provider_profile_schema[entity_type]"
                     value={value}
                     checked={to_string(@form[:entity_type].value) == value}
-                    class="mt-1 border-gray-300 text-brand focus:ring-brand"
+                    class="mt-1 border-hero-grey-300 text-[var(--brand-primary)] focus:ring-[var(--focus-ring)]"
                   />
                   <span class="flex flex-col">
-                    <span class="text-sm font-medium text-gray-900">{title}</span>
-                    <span class="text-xs text-gray-500">{hint}</span>
+                    <span class="text-sm font-medium text-hero-black">{title}</span>
+                    <span class="text-xs text-[var(--fg-muted)]">{hint}</span>
                   </span>
                 </label>
               </div>
@@ -316,7 +326,7 @@ defmodule KlassHeroWeb.Provider.ProfileCompletionLive do
             />
 
             <div>
-              <label class="block text-sm font-semibold text-gray-700 mb-2">
+              <label class="block text-sm font-semibold text-hero-black-100 mb-2">
                 {gettext("Categories")}
               </label>
               <div class="flex flex-wrap gap-2">
@@ -325,7 +335,7 @@ defmodule KlassHeroWeb.Provider.ProfileCompletionLive do
                   class={[
                     "inline-flex items-center gap-1.5 px-3 py-1.5 text-sm border cursor-pointer",
                     Theme.rounded(:lg),
-                    "hover:bg-gray-50 transition-colors"
+                    "hover:bg-hero-grey-50 transition-colors"
                   ]}
                 >
                   <input
@@ -333,7 +343,7 @@ defmodule KlassHeroWeb.Provider.ProfileCompletionLive do
                     name="provider_profile_schema[categories][]"
                     value={category}
                     checked={category in (@form[:categories].value || [])}
-                    class="rounded border-gray-300 text-brand focus:ring-brand"
+                    class="rounded border-hero-grey-300 text-[var(--brand-primary)] focus:ring-[var(--focus-ring)]"
                   />
                   <span class="capitalize">{category}</span>
                 </label>
@@ -341,79 +351,27 @@ defmodule KlassHeroWeb.Provider.ProfileCompletionLive do
               <input type="hidden" name="provider_profile_schema[categories][]" value="" />
             </div>
 
-            <%!-- Logo Upload --%>
             <div>
-              <label class="block text-sm font-semibold text-gray-700 mb-2">
+              <label class="block text-sm font-semibold text-hero-black-100 mb-2">
                 {gettext("Provider Logo")}
               </label>
-              <div
+
+              <.pv_upload_dropzone
                 id="logo-upload"
-                class={[
-                  "border-2 border-dashed border-gray-300 p-6 text-center",
-                  "has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-[var(--focus-ring)] has-[:focus-visible]:ring-offset-2",
-                  Theme.rounded(:lg)
-                ]}
-                phx-drop-target={@uploads.logo.ref}
-              >
-                <.live_file_input upload={@uploads.logo} class="sr-only peer" />
-                <label for={@uploads.logo.ref} class="cursor-pointer">
-                  <.icon name="hero-cloud-arrow-up" class="w-8 h-8 mx-auto text-gray-400 mb-2" />
-                  <p class="text-sm text-gray-500">
-                    {gettext("Drag and drop or click to upload")}
-                  </p>
-                  <p class="text-xs text-gray-400 mt-1">
-                    {gettext("JPG, PNG or WebP. Max 2MB.")}
-                  </p>
-                </label>
-              </div>
-
-              <div :for={entry <- @uploads.logo.entries} class="mt-3 flex items-center gap-3">
-                <.live_img_preview entry={entry} class="w-12 h-12 rounded object-cover" />
-                <span class="text-sm text-gray-600">{entry.client_name}</span>
-                <button
-                  type="button"
-                  phx-click="cancel_upload"
-                  phx-value-ref={entry.ref}
-                  phx-value-upload="logo"
-                  class="text-red-500 hover:text-red-700 text-sm"
-                >
-                  {gettext("Remove")}
-                </button>
-              </div>
-            </div>
-
-            <%!-- Branding & Presence (#1302) — all optional, shown on the public profile --%>
-            <div class="pt-4 border-t border-gray-200 space-y-6">
-              <div>
-                <h3 class={[Theme.typography(:card_title), "text-gray-900"]}>
-                  {gettext("Branding & Presence")}
-                </h3>
-                <p class="text-sm text-gray-500 mt-1">
-                  {gettext("Optional — shown on your public profile page.")}
-                </p>
-              </div>
-
-              <.input
-                field={@form[:tagline]}
-                type="text"
-                label={gettext("Tagline")}
-                placeholder={gettext("A short line that sums you up")}
-                maxlength="150"
-              />
-
-              <.input
-                :for={{field, label} <- ProviderPresenter.social_networks()}
-                field={@form[field]}
-                type="url"
-                label={label}
-                placeholder="https://"
+                upload={@uploads.logo}
+                name="logo"
+                trigger={gettext("Choose Logo")}
+                hint={gettext("JPG, PNG or WebP. Max 2MB.")}
+                preview_class="w-16 h-16 mx-auto rounded-full object-cover"
               />
             </div>
 
-            <div class="flex justify-end pt-4 border-t border-gray-200">
-              <.button type="submit" phx-disable-with={gettext("Saving...")}>
+            <.pv_branding_section form={@form} revealed={@revealed_socials} />
+
+            <div class="flex justify-end pt-4 border-t border-hero-grey-200">
+              <.kh_button variant={:primary} type="submit" phx-disable-with={gettext("Saving...")}>
                 {gettext("Complete Profile")}
-              </.button>
+              </.kh_button>
             </div>
           </.form>
         </div>

--- a/lib/klass_hero_web/live/provider/team_live.ex
+++ b/lib/klass_hero_web/live/provider/team_live.ex
@@ -619,7 +619,7 @@ defmodule KlassHeroWeb.Provider.TeamLive do
             </.kh_button>
             <.kh_button
               id="add-member-btn"
-              variant={:yellow}
+              variant={:primary}
               size={:sm}
               icon="hero-user-plus-mini"
               phx-click="add_member"

--- a/lib/klass_hero_web/presenters/provider_presenter.ex
+++ b/lib/klass_hero_web/presenters/provider_presenter.ex
@@ -89,10 +89,6 @@ defmodule KlassHeroWeb.Presenters.ProviderPresenter do
                      {field, network, SocialLinks.label(network)}
                    end)
 
-  @social_field_labels Enum.map(@social_networks, fn {field, _network, label} ->
-                         {field, label}
-                       end)
-
   # Both sources share one `kh_social_icon/1`; a network with no glyph renders an
   # empty `<svg>` with no error and no failing test.
   @provider_network_atoms Enum.map(@social_networks, fn {_f, network, _l} -> network end)
@@ -103,13 +99,17 @@ defmodule KlassHeroWeb.Presenters.ProviderPresenter do
   end
 
   @doc """
-  Supported social networks as `{schema_field, label}`.
+  Supported social networks as `{schema_field, network, label}`.
+
+  Carries the network atom as well as the label because `kh_social_icon/1` keys
+  on the atom — a `{field, label}` pair forces every caller wanting a glyph to
+  re-derive it.
 
   Labels are brand names and deliberately not run through gettext — translating
   "Instagram" would be wrong in every locale.
   """
-  @spec social_networks() :: [{atom(), String.t()}]
-  def social_networks, do: @social_field_labels
+  @spec social_networks() :: [{atom(), atom(), String.t()}]
+  def social_networks, do: @social_networks
 
   defp social_links(%ProviderProfile{} = provider) do
     for {field, network, label} <- @social_networks,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -45,7 +45,7 @@ msgstr "Kontakt"
 #: lib/klass_hero_web/components/layouts/app.html.heex:131
 #: lib/klass_hero_web/components/layouts/app.html.heex:206
 #: lib/klass_hero_web/components/layouts/app.html.heex:231
-#: lib/klass_hero_web/components/provider_components.ex:391
+#: lib/klass_hero_web/components/provider_components.ex:392
 #: lib/klass_hero_web/components/ui_components.ex:277
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
@@ -136,7 +136,7 @@ msgid "Your Data"
 msgstr "Ihre Daten"
 
 #: lib/klass_hero_web/components/core_components.ex:71
-#: lib/klass_hero_web/components/provider_components.ex:1705
+#: lib/klass_hero_web/components/provider_components.ex:1682
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr "schließen"
@@ -231,7 +231,7 @@ msgstr "Einfache Terminplanung"
 msgid "Enroll Now - %{price}"
 msgstr "Jetzt anmelden - %{price}"
 
-#: lib/klass_hero_web/components/provider_components.ex:1424
+#: lib/klass_hero_web/components/provider_components.ex:1401
 #: lib/klass_hero_web/live/booking_live.ex:305
 #, elixir-autogen, elixir-format
 msgid "Enrollment"
@@ -415,7 +415,7 @@ msgid "Account Termination"
 msgstr "Kontobeendigung"
 
 #: lib/klass_hero_web/live/contact_live.ex:85
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:314
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:324
 #: lib/klass_hero_web/live/provider_profile_live.ex:107
 #, elixir-autogen, elixir-format
 msgid "Address"
@@ -576,9 +576,9 @@ msgstr "Wird gelöscht..."
 msgid "Dispute Resolution"
 msgstr "Streitbeilegung"
 
-#: lib/klass_hero_web/components/provider_components.ex:722
-#: lib/klass_hero_web/components/provider_components.ex:2801
-#: lib/klass_hero_web/components/provider_components.ex:2819
+#: lib/klass_hero_web/components/provider_components.ex:719
+#: lib/klass_hero_web/components/provider_components.ex:2766
+#: lib/klass_hero_web/components/provider_components.ex:2784
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
@@ -813,7 +813,7 @@ msgid "Payment Terms"
 msgstr "Zahlungsbedingungen"
 
 #: lib/klass_hero_web/live/contact_live.ex:78
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:299
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:309
 #: lib/klass_hero_web/live/provider_profile_live.ex:113
 #, elixir-autogen, elixir-format
 msgid "Phone"
@@ -869,7 +869,7 @@ msgstr "Registrieren"
 msgid "Save Password"
 msgstr "Passwort speichern"
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:414
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:372
 #: lib/klass_hero_web/live/settings/children_live.ex:708
 #: lib/klass_hero_web/live/user_live/settings.ex:153
 #, elixir-autogen, elixir-format
@@ -881,9 +881,9 @@ msgstr "Speichern..."
 msgid "Select one or both options"
 msgstr "Wählen Sie eine oder beide Optionen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2451
-#: lib/klass_hero_web/components/provider_components.ex:2452
-#: lib/klass_hero_web/components/provider_components.ex:2489
+#: lib/klass_hero_web/components/provider_components.ex:2416
+#: lib/klass_hero_web/components/provider_components.ex:2417
+#: lib/klass_hero_web/components/provider_components.ex:2454
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:468
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:469
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:505
@@ -1106,7 +1106,7 @@ msgstr "Fortschritt"
 
 #: lib/klass_hero_web/components/composite_components.ex:56
 #: lib/klass_hero_web/components/layouts/admin.html.heex:85
-#: lib/klass_hero_web/components/provider_components.ex:121
+#: lib/klass_hero_web/components/provider_components.ex:122
 #: lib/klass_hero_web/live/admin/sessions_live.ex:26
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:3
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:341
@@ -1210,7 +1210,7 @@ msgstr "Lebenskompetenzen"
 msgid "Music"
 msgstr "Musik"
 
-#: lib/klass_hero_web/components/provider_components.ex:758
+#: lib/klass_hero_web/components/provider_components.ex:755
 #: lib/klass_hero_web/live/for_providers_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "Qualifications"
@@ -1332,19 +1332,19 @@ msgstr "Profil"
 msgid "Quick Navigation"
 msgstr "Schnellnavigation"
 
-#: lib/klass_hero_web/components/provider_components.ex:1427
-#: lib/klass_hero_web/components/provider_components.ex:2411
-#: lib/klass_hero_web/components/provider_components.ex:2688
+#: lib/klass_hero_web/components/provider_components.ex:1404
+#: lib/klass_hero_web/components/provider_components.ex:2376
+#: lib/klass_hero_web/components/provider_components.ex:2653
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr "Aktionen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1573
+#: lib/klass_hero_web/components/provider_components.ex:1550
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr "Aktiv"
 
-#: lib/klass_hero_web/components/provider_components.ex:675
+#: lib/klass_hero_web/components/provider_components.ex:672
 #: lib/klass_hero_web/live/provider/team_live.ex:627
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
@@ -1355,7 +1355,7 @@ msgstr "Teammitglied hinzufügen"
 msgid "All Staff"
 msgstr "Alle Mitarbeiter"
 
-#: lib/klass_hero_web/components/provider_components.ex:1418
+#: lib/klass_hero_web/components/provider_components.ex:1395
 #, elixir-autogen, elixir-format
 msgid "Assigned Staff"
 msgstr "Zugewiesenes Personal"
@@ -1377,8 +1377,8 @@ msgstr "Gewerbeanmeldung"
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr "Erstellen Sie Profile für Ihr Personal. Diese werden für Eltern sichtbar sein, wenn sie Programmen zugewiesen werden."
 
-#: lib/klass_hero_web/components/provider_components.ex:542
-#: lib/klass_hero_web/components/provider_components.ex:1536
+#: lib/klass_hero_web/components/provider_components.ex:543
+#: lib/klass_hero_web/components/provider_components.ex:1513
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:65
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:92
 #: lib/klass_hero_web/live/settings/children_live.ex:413
@@ -1388,57 +1388,57 @@ msgstr "Erstellen Sie Profile für Ihr Personal. Diese werden für Eltern sichtb
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: lib/klass_hero_web/components/provider_components.ex:225
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:33
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:208
+#: lib/klass_hero_web/components/provider_components.ex:226
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:34
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "Edit Profile"
 msgstr "Profil bearbeiten"
 
-#: lib/klass_hero_web/components/provider_components.ex:1575
+#: lib/klass_hero_web/components/provider_components.ex:1552
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr "Inaktiv"
 
-#: lib/klass_hero_web/components/provider_components.ex:114
+#: lib/klass_hero_web/components/provider_components.ex:115
 #: lib/klass_hero_web/live/provider/programs_live.ex:55
 #, elixir-autogen, elixir-format
 msgid "My Programs"
 msgstr "Meine Programme"
 
-#: lib/klass_hero_web/components/provider_components.ex:417
-#: lib/klass_hero_web/components/provider_components.ex:923
+#: lib/klass_hero_web/components/provider_components.ex:418
+#: lib/klass_hero_web/components/provider_components.ex:910
 #, elixir-autogen, elixir-format
 msgid "New Program"
 msgstr "Neues Programm"
 
-#: lib/klass_hero_web/components/provider_components.ex:100
+#: lib/klass_hero_web/components/provider_components.ex:101
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr "Übersicht"
 
-#: lib/klass_hero_web/components/provider_components.ex:48
-#: lib/klass_hero_web/components/provider_components.ex:74
-#: lib/klass_hero_web/components/provider_components.ex:1574
-#: lib/klass_hero_web/components/provider_components.ex:2895
-#: lib/klass_hero_web/components/provider_components.ex:2913
+#: lib/klass_hero_web/components/provider_components.ex:49
+#: lib/klass_hero_web/components/provider_components.ex:75
+#: lib/klass_hero_web/components/provider_components.ex:1551
+#: lib/klass_hero_web/components/provider_components.ex:2860
+#: lib/klass_hero_web/components/provider_components.ex:2878
 #: lib/klass_hero_web/live/admin/sessions_live.ex:293
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr "Ausstehend"
 
-#: lib/klass_hero_web/components/provider_components.ex:1505
+#: lib/klass_hero_web/components/provider_components.ex:1482
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr "Vorschau"
 
-#: lib/klass_hero_web/components/provider_components.ex:1358
+#: lib/klass_hero_web/components/provider_components.ex:1335
 #, elixir-autogen, elixir-format
 msgid "Program Inventory"
 msgstr "Programmübersicht"
 
-#: lib/klass_hero_web/components/provider_components.ex:1415
+#: lib/klass_hero_web/components/provider_components.ex:1392
 #, elixir-autogen, elixir-format
 msgid "Program Name"
 msgstr "Programmname"
@@ -1453,15 +1453,15 @@ msgstr "Anbieter-Dashboard"
 msgid "Save for Later"
 msgstr "Für später speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:1375
+#: lib/klass_hero_web/components/provider_components.ex:1352
 #, elixir-autogen, elixir-format
 msgid "Search by name..."
 msgstr "Nach Namen suchen..."
 
-#: lib/klass_hero_web/components/provider_components.ex:1421
-#: lib/klass_hero_web/components/provider_components.ex:1824
-#: lib/klass_hero_web/components/provider_components.ex:2402
-#: lib/klass_hero_web/components/provider_components.ex:2685
+#: lib/klass_hero_web/components/provider_components.ex:1398
+#: lib/klass_hero_web/components/provider_components.ex:1801
+#: lib/klass_hero_web/components/provider_components.ex:2367
+#: lib/klass_hero_web/components/provider_components.ex:2650
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1469,7 +1469,7 @@ msgstr "Nach Namen suchen..."
 msgid "Status"
 msgstr "Status"
 
-#: lib/klass_hero_web/components/provider_components.ex:107
+#: lib/klass_hero_web/components/provider_components.ex:108
 #: lib/klass_hero_web/live/provider/team_live.ex:36
 #, elixir-autogen, elixir-format
 msgid "Team & Profiles"
@@ -1480,22 +1480,22 @@ msgstr "Team & Profile"
 msgid "Team & Provider Profiles"
 msgstr "Team- & Anbieterprofile"
 
-#: lib/klass_hero_web/components/provider_components.ex:1478
-#: lib/klass_hero_web/components/provider_components.ex:1839
+#: lib/klass_hero_web/components/provider_components.ex:1455
+#: lib/klass_hero_web/components/provider_components.ex:1816
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr "Nicht zugewiesen"
 
 #: lib/klass_hero_web/components/messaging_components.ex:729
-#: lib/klass_hero_web/components/provider_components.ex:51
-#: lib/klass_hero_web/components/provider_components.ex:1576
+#: lib/klass_hero_web/components/provider_components.ex:52
+#: lib/klass_hero_web/components/provider_components.ex:1553
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:455
 #: lib/klass_hero_web/presenters/provider_presenter.ex:172
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr "Unbekannt"
 
-#: lib/klass_hero_web/components/provider_components.ex:1516
+#: lib/klass_hero_web/components/provider_components.ex:1493
 #, elixir-autogen, elixir-format
 msgid "View Roster"
 msgstr "Teilnehmerliste"
@@ -1555,10 +1555,10 @@ msgstr "Rundnachricht an %{count} Eltern gesendet"
 #: lib/klass_hero_web/components/participation_components.ex:456
 #: lib/klass_hero_web/components/participation_components.ex:681
 #: lib/klass_hero_web/components/participation_components.ex:772
-#: lib/klass_hero_web/components/provider_components.ex:860
-#: lib/klass_hero_web/components/provider_components.ex:1274
-#: lib/klass_hero_web/components/provider_components.ex:1991
-#: lib/klass_hero_web/components/provider_components.ex:2593
+#: lib/klass_hero_web/components/provider_components.ex:847
+#: lib/klass_hero_web/components/provider_components.ex:1261
+#: lib/klass_hero_web/components/provider_components.ex:1968
+#: lib/klass_hero_web/components/provider_components.ex:2558
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:478
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
@@ -1614,7 +1614,7 @@ msgstr "Kind konnte nicht entfernt werden. Bitte versuchen Sie es erneut."
 msgid "Data sharing consent"
 msgstr "Einwilligung zur Datenweitergabe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2782
+#: lib/klass_hero_web/components/provider_components.ex:2747
 #: lib/klass_hero_web/live/settings/children_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1662,17 +1662,17 @@ msgstr "Rundnachricht konnte nicht gesendet werden"
 msgid "Failed to submit note"
 msgstr "Notiz konnte nicht eingereicht werden"
 
-#: lib/klass_hero_web/components/provider_components.ex:2776
-#: lib/klass_hero_web/components/provider_components.ex:2805
-#: lib/klass_hero_web/components/provider_components.ex:2821
+#: lib/klass_hero_web/components/provider_components.ex:2741
+#: lib/klass_hero_web/components/provider_components.ex:2770
+#: lib/klass_hero_web/components/provider_components.ex:2786
 #: lib/klass_hero_web/live/settings/children_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr "Vorname"
 
-#: lib/klass_hero_web/components/provider_components.ex:2777
-#: lib/klass_hero_web/components/provider_components.ex:2806
-#: lib/klass_hero_web/components/provider_components.ex:2822
+#: lib/klass_hero_web/components/provider_components.ex:2742
+#: lib/klass_hero_web/components/provider_components.ex:2771
+#: lib/klass_hero_web/components/provider_components.ex:2787
 #: lib/klass_hero_web/live/settings/children_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -1803,15 +1803,15 @@ msgstr "Programm-Rundnachricht"
 msgid "Provider data sharing consent"
 msgstr "Einwilligung zur Datenweitergabe an Anbieter"
 
-#: lib/klass_hero_web/components/provider_components.ex:845
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:312
+#: lib/klass_hero_web/components/provider_components.ex:832
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:305
 #: lib/klass_hero_web/live/settings/children_live.ex:719
 #, elixir-autogen, elixir-format
 msgid "Save Changes"
 msgstr "Änderungen speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:1683
-#: lib/klass_hero_web/components/provider_components.ex:1684
+#: lib/klass_hero_web/components/provider_components.ex:1660
+#: lib/klass_hero_web/components/provider_components.ex:1661
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:43
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:151
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:252
@@ -1829,7 +1829,7 @@ msgstr "Rundnachricht senden"
 msgid "Send a message to start the conversation"
 msgstr "Senden Sie eine Nachricht, um die Unterhaltung zu beginnen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2876
+#: lib/klass_hero_web/components/provider_components.ex:2841
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:249
 #, elixir-autogen, elixir-format
@@ -1935,12 +1935,12 @@ msgstr[1] "%{count} Jahre"
 msgid "%{gender} only"
 msgstr "Nur %{gender}"
 
-#: lib/klass_hero_web/components/provider_components.ex:310
+#: lib/klass_hero_web/components/provider_components.ex:311
 #, elixir-autogen, elixir-format
 msgid "Action Required"
 msgstr "Aktion erforderlich"
 
-#: lib/klass_hero_web/components/provider_components.ex:847
+#: lib/klass_hero_web/components/provider_components.ex:834
 #, elixir-autogen, elixir-format
 msgid "Add Member"
 msgstr "Mitglied hinzufügen"
@@ -1960,12 +1960,12 @@ msgstr "Alter %{min} bis %{max}"
 msgid "Ages %{min}+"
 msgstr "Alter %{min}+"
 
-#: lib/klass_hero_web/components/provider_components.ex:1175
+#: lib/klass_hero_web/components/provider_components.ex:1162
 #, elixir-autogen, elixir-format
 msgid "Allowed Genders"
 msgstr "Zulässige Geschlechter"
 
-#: lib/klass_hero_web/components/provider_components.ex:2935
+#: lib/klass_hero_web/components/provider_components.ex:2900
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred during import."
 msgstr "Beim Import ist ein unerwarteter Fehler aufgetreten."
@@ -1978,7 +1978,7 @@ msgid "Approve"
 msgstr "Genehmigen"
 
 #: lib/klass_hero_web/components/participation_components.ex:881
-#: lib/klass_hero_web/components/provider_components.ex:49
+#: lib/klass_hero_web/components/provider_components.ex:50
 #: lib/klass_hero_web/live/admin/sessions_live.ex:290
 #: lib/klass_hero_web/live/admin/verifications_live.ex:202
 #: lib/klass_hero_web/presenters/vetting_checklist_presenter.ex:141
@@ -1996,9 +1996,9 @@ msgstr "Möchten Sie dieses Dokument wirklich genehmigen?"
 msgid "As fathers and partners of teachers in Berlin, we saw and heard firsthand how hard it is to find, book, and manage quality youth activities outside the classroom. Klass Hero is the complete platform connecting Berlin families and schools with trusted, vetted activity providers — offering safe, supervised, and enriching experiences across sports, arts, tutoring, and more. We verify every provider, structure every booking, and support every step — so parents know their child is in good hands, and providers can focus on what they do best: inspiring kids."
 msgstr "Als Väter und Partner von Lehrkräften in Berlin haben wir aus erster Hand erlebt, wie schwer es ist, hochwertige außerschulische Aktivitäten für Kinder zu finden, zu buchen und zu organisieren. Klass Hero ist die umfassende Plattform, die Berliner Familien und Schulen mit vertrauenswürdigen, geprüften Anbietern verbindet — und bietet sichere, betreute und bereichernde Erlebnisse in den Bereichen Sport, Kunst, Nachhilfe und mehr. Wir überprüfen jeden Anbieter, strukturieren jede Buchung und unterstützen bei jedem Schritt — damit Eltern wissen, dass ihr Kind in guten Händen ist, und Anbieter sich auf das konzentrieren können, was sie am besten können: Kinder zu begeistern."
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:204
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:237
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:263
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:223
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:233
 #, elixir-autogen, elixir-format
 msgid "Back to Dashboard"
 msgstr "Zurück zum Dashboard"
@@ -2008,7 +2008,7 @@ msgstr "Zurück zum Dashboard"
 msgid "Back to verifications"
 msgstr "Zurück zu den Verifizierungen"
 
-#: lib/klass_hero_web/components/provider_components.ex:731
+#: lib/klass_hero_web/components/provider_components.ex:728
 #, elixir-autogen, elixir-format
 msgid "Bio"
 msgstr "Biografie"
@@ -2018,7 +2018,7 @@ msgstr "Biografie"
 msgid "Book a Program"
 msgstr "Programm buchen"
 
-#: lib/klass_hero_web/components/provider_components.ex:732
+#: lib/klass_hero_web/components/provider_components.ex:729
 #, elixir-autogen, elixir-format
 msgid "Brief description of experience and specialties..."
 msgstr "Kurze Beschreibung der Erfahrung und Spezialgebiete..."
@@ -2033,19 +2033,19 @@ msgstr "Von Eltern entwickelt, um Pädagogen zu stärken."
 msgid "Business"
 msgstr "Business"
 
-#: lib/klass_hero_web/components/provider_components.ex:953
+#: lib/klass_hero_web/components/provider_components.ex:940
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "Category"
 msgstr "Kategorie"
 
-#: lib/klass_hero_web/components/provider_components.ex:1124
+#: lib/klass_hero_web/components/provider_components.ex:1111
 #, elixir-autogen, elixir-format
 msgid "Check eligibility at"
 msgstr "Berechtigung prüfen unter"
 
-#: lib/klass_hero_web/components/provider_components.ex:2399
-#: lib/klass_hero_web/components/provider_components.ex:2671
+#: lib/klass_hero_web/components/provider_components.ex:2364
+#: lib/klass_hero_web/components/provider_components.ex:2636
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr "Name des Kindes"
@@ -2060,22 +2060,23 @@ msgstr "Kind erfüllt die Programmanforderungen nicht"
 msgid "Child meets all program requirements"
 msgstr "Kind erfüllt alle Programmanforderungen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1247
+#: lib/klass_hero_web/components/provider_components.ex:1234
 #, elixir-autogen, elixir-format
 msgid "Choose Image"
 msgstr "Bild auswählen"
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:239
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:273
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:363
 #, elixir-autogen, elixir-format
 msgid "Choose Logo"
 msgstr "Logo auswählen"
 
-#: lib/klass_hero_web/components/provider_components.ex:826
+#: lib/klass_hero_web/components/provider_components.ex:823
 #, elixir-autogen, elixir-format
 msgid "Choose Photo"
 msgstr "Foto auswählen"
 
-#: lib/klass_hero_web/components/provider_components.ex:955
+#: lib/klass_hero_web/components/provider_components.ex:942
 #, elixir-autogen, elixir-format
 msgid "Choose a category"
 msgstr "Kategorie auswählen"
@@ -2085,7 +2086,7 @@ msgstr "Kategorie auswählen"
 msgid "Confirm rejection"
 msgstr "Ablehnung bestätigen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2896
+#: lib/klass_hero_web/components/provider_components.ex:2861
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr "Bestätigt"
@@ -2105,37 +2106,37 @@ msgstr "Die hochgeladene Datei konnte nicht gelesen werden."
 msgid "Could not remove invite."
 msgstr "Einladung konnte nicht entfernt werden."
 
-#: lib/klass_hero_web/components/provider_components.ex:1241
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:278
+#: lib/klass_hero_web/components/provider_components.ex:1228
+#: lib/klass_hero_web/components/provider_components.ex:3149
 #, elixir-autogen, elixir-format
 msgid "Cover Image"
 msgstr "Titelbild"
 
-#: lib/klass_hero_web/components/provider_components.ex:1118
+#: lib/klass_hero_web/components/provider_components.ex:1105
 #, elixir-autogen, elixir-format
 msgid "Define age, gender, or grade restrictions for eligible participants."
 msgstr "Legen Sie Alters-, Geschlechts- oder Klassenstufenbeschränkungen für teilnahmeberechtigte Teilnehmer fest."
 
-#: lib/klass_hero_web/components/provider_components.ex:1234
+#: lib/klass_hero_web/components/provider_components.ex:1221
 #, elixir-autogen, elixir-format
 msgid "Describe your program..."
 msgstr "Beschreiben Sie Ihr Programm..."
 
-#: lib/klass_hero_web/components/provider_components.ex:1233
+#: lib/klass_hero_web/components/provider_components.ex:1220
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:323
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:288
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:298
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr "Beschreibung"
 
 #: lib/klass_hero_web/components/program_components.ex:696
-#: lib/klass_hero_web/components/provider_components.ex:1186
+#: lib/klass_hero_web/components/provider_components.ex:1173
 #: lib/klass_hero_web/live/settings/children_live.ex:635
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr "Divers"
 
-#: lib/klass_hero_web/components/provider_components.ex:3204
+#: lib/klass_hero_web/components/provider_components.ex:3278
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr "Dokumenttyp"
@@ -2163,13 +2164,13 @@ msgstr "Dokumentvorschau"
 msgid "Document rejected."
 msgstr "Dokument abgelehnt."
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:156
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:171
 #: lib/klass_hero_web/live/provider/verification_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "Document uploaded successfully."
 msgstr "Dokument erfolgreich hochgeladen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2612
+#: lib/klass_hero_web/components/provider_components.ex:2577
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr "Vorlage herunterladen"
@@ -2179,40 +2180,40 @@ msgstr "Vorlage herunterladen"
 msgid "Download document"
 msgstr "Dokument herunterladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:921
+#: lib/klass_hero_web/components/provider_components.ex:908
 #, elixir-autogen, elixir-format
 msgid "Edit Program"
 msgstr "Programm bearbeiten"
 
-#: lib/klass_hero_web/components/provider_components.ex:673
+#: lib/klass_hero_web/components/provider_components.ex:670
 #, elixir-autogen, elixir-format
 msgid "Edit Team Member"
 msgstr "Teammitglied bearbeiten"
 
-#: lib/klass_hero_web/components/provider_components.ex:1039
+#: lib/klass_hero_web/components/provider_components.ex:1026
 #, elixir-autogen, elixir-format
 msgid "End Date"
 msgstr "Enddatum"
 
-#: lib/klass_hero_web/components/provider_components.ex:1026
+#: lib/klass_hero_web/components/provider_components.ex:1013
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "End Time"
 msgstr "Endzeit"
 
-#: lib/klass_hero_web/components/provider_components.ex:2408
-#: lib/klass_hero_web/components/provider_components.ex:2916
+#: lib/klass_hero_web/components/provider_components.ex:2373
+#: lib/klass_hero_web/components/provider_components.ex:2881
 #: lib/klass_hero_web/components/provider_layout_components.ex:612
 #, elixir-autogen, elixir-format
 msgid "Enrolled"
 msgstr "Angemeldet"
 
-#: lib/klass_hero_web/components/provider_components.ex:1729
+#: lib/klass_hero_web/components/provider_components.ex:1706
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr "Angemeldet (%{count})"
 
-#: lib/klass_hero_web/components/provider_components.ex:1067
+#: lib/klass_hero_web/components/provider_components.ex:1054
 #, elixir-autogen, elixir-format
 msgid "Enrollment Capacity (optional)"
 msgstr "Anmeldekapazität (optional)"
@@ -2222,8 +2223,8 @@ msgstr "Anmeldekapazität (optional)"
 msgid "Explain why this document is being rejected..."
 msgstr "Erklären Sie, warum dieses Dokument abgelehnt wird..."
 
-#: lib/klass_hero_web/components/provider_components.ex:72
-#: lib/klass_hero_web/components/provider_components.ex:2917
+#: lib/klass_hero_web/components/provider_components.ex:73
+#: lib/klass_hero_web/components/provider_components.ex:2882
 #: lib/klass_hero_web/live/admin/emails_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2244,7 +2245,7 @@ msgstr "Dokument konnte nicht abgelehnt werden."
 msgid "Failed to resend invite."
 msgstr "Einladung konnte nicht erneut gesendet werden."
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:165
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:180
 #: lib/klass_hero_web/live/provider/verification_live.ex:254
 #, elixir-autogen, elixir-format
 msgid "Failed to upload document."
@@ -2256,7 +2257,7 @@ msgid "Family Programs"
 msgstr "Familienprogramme"
 
 #: lib/klass_hero_web/components/program_components.ex:694
-#: lib/klass_hero_web/components/provider_components.ex:1185
+#: lib/klass_hero_web/components/provider_components.ex:1172
 #: lib/klass_hero_web/live/settings/children_live.ex:634
 #, elixir-autogen, elixir-format
 msgid "Female"
@@ -2267,22 +2268,22 @@ msgstr "Weiblich"
 msgid "File"
 msgstr "Datei"
 
-#: lib/klass_hero_web/components/provider_components.ex:3137
+#: lib/klass_hero_web/components/provider_components.ex:3211
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr "Die Datei ist zu groß."
 
-#: lib/klass_hero_web/components/provider_components.ex:3139
+#: lib/klass_hero_web/components/provider_components.ex:3213
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr "Dateityp wird nicht akzeptiert."
 
-#: lib/klass_hero_web/components/provider_components.ex:759
+#: lib/klass_hero_web/components/provider_components.ex:756
 #, elixir-autogen, elixir-format
 msgid "First Aid, UEFA B License, Child Care Cert"
 msgstr "Erste Hilfe, UEFA-B-Lizenz, Kinderbetreuungszertifikat"
 
-#: lib/klass_hero_web/components/provider_components.ex:701
+#: lib/klass_hero_web/components/provider_components.ex:698
 #, elixir-autogen, elixir-format
 msgid "First Name"
 msgstr "Vorname"
@@ -2307,12 +2308,12 @@ msgstr "Klassenstufe %{min}+"
 msgid "Grades %{min} – %{max}"
 msgstr "Klassenstufen %{min} – %{max}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2682
+#: lib/klass_hero_web/components/provider_components.ex:2647
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr "E-Mail des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:820
+#: lib/klass_hero_web/components/provider_components.ex:817
 #, elixir-autogen, elixir-format
 msgid "Headshot Photo"
 msgstr "Porträtfoto"
@@ -2322,7 +2323,7 @@ msgstr "Porträtfoto"
 msgid "ID Document"
 msgstr "Ausweisdokument"
 
-#: lib/klass_hero_web/components/provider_components.ex:2585
+#: lib/klass_hero_web/components/provider_components.ex:2550
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Importieren"
@@ -2347,19 +2348,19 @@ msgstr "Einladung entfernt."
 msgid "Invite resent successfully."
 msgstr "Einladung erfolgreich erneut gesendet."
 
-#: lib/klass_hero_web/components/provider_components.ex:1746
+#: lib/klass_hero_web/components/provider_components.ex:1723
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr "Einladungen (%{count})"
 
-#: lib/klass_hero_web/components/provider_components.ex:827
+#: lib/klass_hero_web/components/provider_components.ex:824
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 1MB."
 msgstr "JPG, PNG oder WebP. Max. 1 MB."
 
-#: lib/klass_hero_web/components/provider_components.ex:1248
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:240
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:365
+#: lib/klass_hero_web/components/provider_components.ex:1235
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:274
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:364
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 2MB."
 msgstr "JPG, PNG oder WebP. Max. 2 MB."
@@ -2374,71 +2375,71 @@ msgstr "Klass Hero wurde genau dafür entwickelt. Eine umfassende Betriebsplattf
 msgid "Klasse %{n}"
 msgstr "Klasse %{n}"
 
-#: lib/klass_hero_web/components/provider_components.ex:707
+#: lib/klass_hero_web/components/provider_components.ex:704
 #, elixir-autogen, elixir-format
 msgid "Last Name"
 msgstr "Nachname"
 
-#: lib/klass_hero_web/components/provider_components.ex:1049
+#: lib/klass_hero_web/components/provider_components.ex:1036
 #, elixir-autogen, elixir-format
 msgid "Leave blank for open registration at any time."
 msgstr "Leer lassen für eine jederzeit offene Anmeldung."
 
-#: lib/klass_hero_web/components/provider_components.ex:1178
+#: lib/klass_hero_web/components/provider_components.ex:1165
 #, elixir-autogen, elixir-format
 msgid "Leave unchecked to allow all genders."
 msgstr "Nicht markiert lassen, um alle Geschlechter zuzulassen."
 
-#: lib/klass_hero_web/components/provider_components.ex:982
+#: lib/klass_hero_web/components/provider_components.ex:969
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:191
 #, elixir-autogen, elixir-format
 msgid "Location"
 msgstr "Ort"
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:81
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:81
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:96
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:83
 #, elixir-autogen, elixir-format
 msgid "Logo upload failed. Please try again."
 msgstr "Logo-Upload fehlgeschlagen. Bitte versuchen Sie es erneut."
 
 #: lib/klass_hero_web/components/program_components.ex:695
-#: lib/klass_hero_web/components/provider_components.ex:1184
+#: lib/klass_hero_web/components/provider_components.ex:1171
 #: lib/klass_hero_web/live/settings/children_live.ex:633
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr "Männlich"
 
-#: lib/klass_hero_web/components/provider_components.ex:1168
+#: lib/klass_hero_web/components/provider_components.ex:1155
 #, elixir-autogen, elixir-format
 msgid "Maximum Age (months)"
 msgstr "Höchstalter (Monate)"
 
-#: lib/klass_hero_web/components/provider_components.ex:1082
+#: lib/klass_hero_web/components/provider_components.ex:1069
 #, elixir-autogen, elixir-format
 msgid "Maximum Enrollment"
 msgstr "Maximale Anmeldekapazität"
 
-#: lib/klass_hero_web/components/provider_components.ex:1223
+#: lib/klass_hero_web/components/provider_components.ex:1210
 #, elixir-autogen, elixir-format
 msgid "Maximum Grade"
 msgstr "Höchste Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:991
+#: lib/klass_hero_web/components/provider_components.ex:978
 #, elixir-autogen, elixir-format
 msgid "Meeting Days"
 msgstr "Wochentage"
 
-#: lib/klass_hero_web/components/provider_components.ex:1162
+#: lib/klass_hero_web/components/provider_components.ex:1149
 #, elixir-autogen, elixir-format
 msgid "Minimum Age (months)"
 msgstr "Mindestalter (Monate)"
 
-#: lib/klass_hero_web/components/provider_components.ex:1076
+#: lib/klass_hero_web/components/provider_components.ex:1063
 #, elixir-autogen, elixir-format
 msgid "Minimum Enrollment"
 msgstr "Minimale Anmeldekapazität"
 
-#: lib/klass_hero_web/components/provider_components.ex:1216
+#: lib/klass_hero_web/components/provider_components.ex:1203
 #, elixir-autogen, elixir-format
 msgid "Minimum Grade"
 msgstr "Niedrigste Klassenstufe"
@@ -2448,12 +2449,12 @@ msgstr "Niedrigste Klassenstufe"
 msgid "No approved documents."
 msgstr "Keine genehmigten Dokumente."
 
-#: lib/klass_hero_web/components/provider_components.ex:3166
+#: lib/klass_hero_web/components/provider_components.ex:3240
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr "Noch keine Dokumente hochgeladen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2392
+#: lib/klass_hero_web/components/provider_components.ex:2357
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
@@ -2469,17 +2470,17 @@ msgstr "Keine Datei ausgewählt."
 msgid "No grade"
 msgstr "Keine Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2636
+#: lib/klass_hero_web/components/provider_components.ex:2601
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr "Noch keine Einladungen. Laden Sie eine CSV-Datei hoch, um Familien einzuladen."
 
-#: lib/klass_hero_web/components/provider_components.ex:1225
+#: lib/klass_hero_web/components/provider_components.ex:1212
 #, elixir-autogen, elixir-format
 msgid "No maximum"
 msgstr "Kein Maximum"
 
-#: lib/klass_hero_web/components/provider_components.ex:1218
+#: lib/klass_hero_web/components/provider_components.ex:1205
 #, elixir-autogen, elixir-format
 msgid "No minimum"
 msgstr "Kein Minimum"
@@ -2510,18 +2511,18 @@ msgstr "Noch keine Teammitglieder"
 msgid "No verification documents found."
 msgstr "Keine Verifizierungsdokumente gefunden."
 
-#: lib/klass_hero_web/components/provider_components.ex:1260
+#: lib/klass_hero_web/components/provider_components.ex:1247
 #, elixir-autogen, elixir-format
 msgid "None (optional)"
 msgstr "Keine (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:326
+#: lib/klass_hero_web/components/provider_components.ex:327
 #, elixir-autogen, elixir-format
 msgid "Not Verified"
 msgstr "Nicht verifiziert"
 
 #: lib/klass_hero_web/components/program_components.ex:697
-#: lib/klass_hero_web/components/provider_components.ex:1187
+#: lib/klass_hero_web/components/provider_components.ex:1174
 #: lib/klass_hero_web/live/settings/children_live.ex:632
 #, elixir-autogen, elixir-format
 msgid "Not specified"
@@ -2532,7 +2533,7 @@ msgstr "Nicht angegeben"
 msgid "Our Story"
 msgstr "Unsere Geschichte"
 
-#: lib/klass_hero_web/components/provider_components.ex:3242
+#: lib/klass_hero_web/components/provider_components.ex:3316
 #: lib/klass_hero_web/live/provider/verification_live.ex:699
 #: lib/klass_hero_web/live/provider/verification_live.ex:773
 #, elixir-autogen, elixir-format
@@ -2544,21 +2545,21 @@ msgstr "PDF, JPG oder PNG. Max. 10 MB."
 msgid "Participant Requirements"
 msgstr "Teilnahmevoraussetzungen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1115
+#: lib/klass_hero_web/components/provider_components.ex:1102
 #, elixir-autogen, elixir-format
 msgid "Participant Restrictions (optional)"
 msgstr "Teilnahmebeschränkungen (optional)"
 
 #: lib/klass_hero_web/components/participation_components.ex:880
-#: lib/klass_hero_web/components/provider_components.ex:294
+#: lib/klass_hero_web/components/provider_components.ex:295
 #, elixir-autogen, elixir-format
 msgid "Pending Review"
 msgstr "Ausstehende Überprüfung"
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:102
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:117
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:109
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:111
 #: lib/klass_hero_web/live/provider/programs_live.ex:739
 #: lib/klass_hero_web/live/provider/programs_live.ex:808
 #: lib/klass_hero_web/live/provider/team_live.ex:305
@@ -2578,17 +2579,17 @@ msgstr "Bitte geben Sie einen Ablehnungsgrund an."
 msgid "Preview not available for this file type."
 msgstr "Vorschau für diesen Dateityp nicht verfügbar."
 
-#: lib/klass_hero_web/components/provider_components.ex:973
+#: lib/klass_hero_web/components/provider_components.ex:960
 #, elixir-autogen, elixir-format
 msgid "Price (EUR)"
 msgstr "Preis (EUR)"
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:98
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:113
 #, elixir-autogen, elixir-format
 msgid "Profile updated successfully."
 msgstr "Profil erfolgreich aktualisiert."
 
-#: lib/klass_hero_web/components/provider_components.ex:1153
+#: lib/klass_hero_web/components/provider_components.ex:1140
 #, elixir-autogen, elixir-format
 msgid "Program Start"
 msgstr "Programmbeginn"
@@ -2619,7 +2620,7 @@ msgstr "Programm nicht gefunden."
 msgid "Program updated successfully."
 msgstr "Programm erfolgreich aktualisiert."
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:107
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:122
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:32
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:27
 #, elixir-autogen, elixir-format
@@ -2632,13 +2633,13 @@ msgid "Read our founding story →"
 msgstr "Lesen Sie unsere Gründungsgeschichte →"
 
 #: lib/klass_hero_web/components/participation_components.ex:860
-#: lib/klass_hero_web/components/provider_components.ex:2915
+#: lib/klass_hero_web/components/provider_components.ex:2880
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Registered"
 msgstr "Registriert"
 
-#: lib/klass_hero_web/components/provider_components.ex:1140
+#: lib/klass_hero_web/components/provider_components.ex:1127
 #, elixir-autogen, elixir-format
 msgid "Registration"
 msgstr "Anmeldung"
@@ -2648,7 +2649,7 @@ msgstr "Anmeldung"
 msgid "Registration Closed"
 msgstr "Anmeldung geschlossen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1060
+#: lib/klass_hero_web/components/provider_components.ex:1047
 #, elixir-autogen, elixir-format
 msgid "Registration Closes"
 msgstr "Anmeldeschluss"
@@ -2658,12 +2659,12 @@ msgstr "Anmeldeschluss"
 msgid "Registration Not Open Yet"
 msgstr "Anmeldung noch nicht geöffnet"
 
-#: lib/klass_hero_web/components/provider_components.ex:1055
+#: lib/klass_hero_web/components/provider_components.ex:1042
 #, elixir-autogen, elixir-format
 msgid "Registration Opens"
 msgstr "Anmeldebeginn"
 
-#: lib/klass_hero_web/components/provider_components.ex:1046
+#: lib/klass_hero_web/components/provider_components.ex:1033
 #, elixir-autogen, elixir-format
 msgid "Registration Period (optional)"
 msgstr "Anmeldezeitraum (optional)"
@@ -2700,7 +2701,7 @@ msgid "Reject"
 msgstr "Ablehnen"
 
 #: lib/klass_hero_web/components/participation_components.ex:882
-#: lib/klass_hero_web/components/provider_components.ex:50
+#: lib/klass_hero_web/components/provider_components.ex:51
 #: lib/klass_hero_web/live/admin/verifications_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Rejected"
@@ -2712,16 +2713,15 @@ msgstr "Abgelehnt"
 msgid "Rejection reason"
 msgstr "Ablehnungsgrund"
 
-#: lib/klass_hero_web/components/provider_components.ex:2738
-#: lib/klass_hero_web/components/provider_components.ex:3102
-#: lib/klass_hero_web/components/provider_components.ex:3261
-#: lib/klass_hero_web/components/provider_components.ex:3341
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:380
+#: lib/klass_hero_web/components/provider_components.ex:2703
+#: lib/klass_hero_web/components/provider_components.ex:3067
+#: lib/klass_hero_web/components/provider_components.ex:3335
+#: lib/klass_hero_web/components/provider_components.ex:3415
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr "Entfernen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2731
+#: lib/klass_hero_web/components/provider_components.ex:2696
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr "Einladung erneut senden"
@@ -2731,23 +2731,23 @@ msgstr "Einladung erneut senden"
 msgid "Reviewed"
 msgstr "Überprüft"
 
-#: lib/klass_hero_web/components/provider_components.ex:716
+#: lib/klass_hero_web/components/provider_components.ex:713
 #, elixir-autogen, elixir-format
 msgid "Role"
 msgstr "Rolle"
 
-#: lib/klass_hero_web/components/provider_components.ex:1675
+#: lib/klass_hero_web/components/provider_components.ex:1652
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:407
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
 msgstr "Teilnehmerliste: %{name}"
 
-#: lib/klass_hero_web/components/provider_components.ex:1287
+#: lib/klass_hero_web/components/provider_components.ex:1264
 #, elixir-autogen, elixir-format
 msgid "Save Program"
 msgstr "Programm speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:988
+#: lib/klass_hero_web/components/provider_components.ex:975
 #, elixir-autogen, elixir-format
 msgid "Schedule (optional)"
 msgstr "Zeitplan (optional)"
@@ -2762,7 +2762,7 @@ msgstr "Zeitplan noch offen"
 msgid "School Grade (optional)"
 msgstr "Klassenstufe (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:3239
+#: lib/klass_hero_web/components/provider_components.ex:3313
 #, elixir-autogen, elixir-format
 msgid "Select File"
 msgstr "Datei auswählen"
@@ -2779,23 +2779,23 @@ msgstr "Das ausgewählte Kind erfüllt die Programmanforderungen nicht."
 msgid "Selected instructor could not be found. Please try again."
 msgstr "Der ausgewählte Kursleiter konnte nicht gefunden werden. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2914
+#: lib/klass_hero_web/components/provider_components.ex:2879
 #: lib/klass_hero_web/live/admin/emails_live.ex:206
 #, elixir-autogen, elixir-format
 msgid "Sent"
 msgstr "Gesendet"
 
-#: lib/klass_hero_web/components/provider_components.ex:763
+#: lib/klass_hero_web/components/provider_components.ex:760
 #, elixir-autogen, elixir-format
 msgid "Separate multiple qualifications with commas"
 msgstr "Trennen Sie mehrere Qualifikationen durch Kommas"
 
-#: lib/klass_hero_web/components/provider_components.ex:1070
+#: lib/klass_hero_web/components/provider_components.ex:1057
 #, elixir-autogen, elixir-format
 msgid "Set minimum and maximum enrollment for this program."
 msgstr "Legen Sie die minimale und maximale Anmeldekapazität für dieses Programm fest."
 
-#: lib/klass_hero_web/components/provider_components.ex:737
+#: lib/klass_hero_web/components/provider_components.ex:734
 #, elixir-autogen, elixir-format
 msgid "Specialties"
 msgstr "Spezialisierungen"
@@ -2813,12 +2813,12 @@ msgstr "Der Mitarbeiter existiert nicht mehr."
 msgid "Staff member not found."
 msgstr "Mitarbeiter nicht gefunden."
 
-#: lib/klass_hero_web/components/provider_components.ex:1034
+#: lib/klass_hero_web/components/provider_components.ex:1021
 #, elixir-autogen, elixir-format
 msgid "Start Date"
 msgstr "Startdatum"
 
-#: lib/klass_hero_web/components/provider_components.ex:1021
+#: lib/klass_hero_web/components/provider_components.ex:1008
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:184
 #, elixir-autogen, elixir-format
 msgid "Start Time"
@@ -2864,7 +2864,7 @@ msgstr "Teammitglied aktualisiert, aber der Upload des Profilfotos ist fehlgesch
 msgid "Team member updated."
 msgstr "Teammitglied aktualisiert."
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:226
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "Tell parents about your organization..."
 msgstr "Erzählen Sie Eltern von Ihrer Organisation..."
@@ -2884,13 +2884,13 @@ msgstr "Diese Einladung kann nicht erneut gesendet werden."
 msgid "This program was modified by someone else. Please close and try again."
 msgstr "Dieses Programm wurde von jemand anderem geändert. Bitte schließen Sie es und versuchen Sie es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:946
-#: lib/klass_hero_web/components/provider_components.ex:1957
+#: lib/klass_hero_web/components/provider_components.ex:933
+#: lib/klass_hero_web/components/provider_components.ex:1934
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr "Titel"
 
-#: lib/klass_hero_web/components/provider_components.ex:3138
+#: lib/klass_hero_web/components/provider_components.ex:3212
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr "Zu viele Dateien."
@@ -2910,27 +2910,27 @@ msgstr "Bis zu %{max}"
 msgid "Up to Grade %{max}"
 msgstr "Bis Klassenstufe %{max}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2572
+#: lib/klass_hero_web/components/provider_components.ex:2537
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr "CSV hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3285
+#: lib/klass_hero_web/components/provider_components.ex:3359
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr "Dokument hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3193
+#: lib/klass_hero_web/components/provider_components.ex:3267
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr "Neues Dokument hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3141
+#: lib/klass_hero_web/components/provider_components.ex:3215
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr "Upload-Fehler."
 
-#: lib/klass_hero_web/components/provider_components.ex:3158
+#: lib/klass_hero_web/components/provider_components.ex:3232
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr "Verifizierungsdokumente"
@@ -2952,7 +2952,7 @@ msgstr "Verifizierungsdokument nicht gefunden."
 msgid "Verifications"
 msgstr "Verifizierungen"
 
-#: lib/klass_hero_web/components/provider_components.ex:278
+#: lib/klass_hero_web/components/provider_components.ex:279
 #: lib/klass_hero_web/components/provider_layout_components.ex:217
 #: lib/klass_hero_web/components/ui_components.ex:1671
 #, elixir-autogen, elixir-format
@@ -2969,32 +2969,32 @@ msgstr "Wir sind Klass Hero — Eltern, Brüder und Partner von Pädagogen — u
 msgid "You don't have access to that page."
 msgstr "Sie haben keinen Zugriff auf diese Seite."
 
-#: lib/klass_hero_web/components/provider_components.ex:717
+#: lib/klass_hero_web/components/provider_components.ex:714
 #, elixir-autogen, elixir-format
 msgid "e.g. Head Coach"
 msgstr "z. B. Cheftrainer"
 
-#: lib/klass_hero_web/components/provider_components.ex:708
+#: lib/klass_hero_web/components/provider_components.ex:705
 #, elixir-autogen, elixir-format
 msgid "e.g. Johnson"
 msgstr "z. B. Johnson"
 
-#: lib/klass_hero_web/components/provider_components.ex:702
+#: lib/klass_hero_web/components/provider_components.ex:699
 #, elixir-autogen, elixir-format
 msgid "e.g. Mike"
 msgstr "z. B. Mike"
 
-#: lib/klass_hero_web/components/provider_components.ex:723
+#: lib/klass_hero_web/components/provider_components.ex:720
 #, elixir-autogen, elixir-format
 msgid "e.g. mike@example.com"
 msgstr "z. B. mike@example.com"
 
-#: lib/klass_hero_web/components/provider_components.ex:947
+#: lib/klass_hero_web/components/provider_components.ex:934
 #, elixir-autogen, elixir-format
 msgid "e.g., Art Adventures"
 msgstr "z. B. Art Adventures"
 
-#: lib/klass_hero_web/components/provider_components.ex:983
+#: lib/klass_hero_web/components/provider_components.ex:970
 #, elixir-autogen, elixir-format
 msgid "e.g., Community Center, Main St"
 msgstr "z. B. Gemeindezentrum, Hauptstraße"
@@ -3020,7 +3020,7 @@ msgid "Child Safeguarding Training"
 msgstr "Kinderschutzschulung"
 
 #: lib/klass_hero_web/components/marketing_components.ex:1505
-#: lib/klass_hero_web/components/provider_components.ex:3508
+#: lib/klass_hero_web/components/provider_components.ex:3582
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr "Vereinbarung zu Community-Standards"
@@ -3171,7 +3171,7 @@ msgid "Vetted with Care"
 msgstr "Mit Sorgfalt geprüft"
 
 #: lib/klass_hero_web/components/marketing_components.ex:1489
-#: lib/klass_hero_web/components/provider_components.ex:3292
+#: lib/klass_hero_web/components/provider_components.ex:3366
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr "Video-Überprüfung"
@@ -3345,7 +3345,7 @@ msgstr "Eingecheckt"
 msgid "Checked Out"
 msgstr "Ausgecheckt"
 
-#: lib/klass_hero_web/components/provider_components.ex:2773
+#: lib/klass_hero_web/components/provider_components.ex:2738
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Child"
@@ -3391,7 +3391,7 @@ msgstr "Benötige ich ein Konto, um zu buchen?"
 msgid "Download monthly statements for taxes"
 msgstr "Monatliche Abrechnungen für die Steuer herunterladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2488
+#: lib/klass_hero_web/components/provider_components.ex:2453
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:504
 #, elixir-autogen, elixir-format
 msgid "Enrollment not confirmed"
@@ -3464,7 +3464,7 @@ msgstr "Keine Änderungen erkannt"
 msgid "No chasing payments or sending invoices"
 msgstr "Kein Nachfassen bei Zahlungen oder Versenden von Rechnungen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1698
+#: lib/klass_hero_web/components/provider_components.ex:1675
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:428
 #, elixir-autogen, elixir-format
 msgid "No enrolled parents"
@@ -3487,7 +3487,7 @@ msgstr "Notizen"
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr "Oder: Jederzeit eine Sofortauszahlung anfordern (mindestens 50 €)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2487
+#: lib/klass_hero_web/components/provider_components.ex:2452
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:503
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -4117,7 +4117,7 @@ msgstr "Bitte füllen Sie alle erforderlichen Felder aus"
 msgid "Post"
 msgstr "Absenden"
 
-#: lib/klass_hero_web/components/provider_components.ex:2679
+#: lib/klass_hero_web/components/provider_components.ex:2644
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:24
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
@@ -4176,7 +4176,7 @@ msgstr "Privates Antworten ist nur für Broadcast-Nachrichten verfügbar"
 msgid "Reply sent successfully"
 msgstr "Antwort erfolgreich gesendet"
 
-#: lib/klass_hero_web/components/provider_components.ex:556
+#: lib/klass_hero_web/components/provider_components.ex:553
 #, elixir-autogen, elixir-format
 msgid "Resend"
 msgstr "Erneut senden"
@@ -4321,7 +4321,7 @@ msgstr "Ungelesen"
 msgid "Update your observation..."
 msgstr "Aktualisieren Sie Ihre Beobachtung..."
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:149
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:164
 #: lib/klass_hero_web/live/provider/programs_live.ex:492
 #: lib/klass_hero_web/live/provider/verification_live.ex:240
 #: lib/klass_hero_web/live/provider/verification_live.ex:556
@@ -4406,7 +4406,7 @@ msgstr "Ihre zugewiesenen Sitzungen anzeigen und verwalten"
 msgid "You are not assigned to this program"
 msgstr "Sie sind diesem Programm nicht zugewiesen"
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:300
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:310
 #, elixir-autogen, elixir-format
 msgid "+1234567890"
 msgstr "+1234567890"
@@ -4427,23 +4427,23 @@ msgstr "Entwickelt für die internationale Berliner Gemeinschaft. Integriertes s
 msgid "Cancelled"
 msgstr "Abgesagt"
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:320
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:330
 #, elixir-autogen, elixir-format
 msgid "Categories"
 msgstr "Kategorien"
 
 #: lib/klass_hero_web/components/provider_layout_components.ex:372
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:415
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:373
 #, elixir-autogen, elixir-format
 msgid "Complete Profile"
 msgstr "Profil vervollständigen"
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:43
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:44
 #, elixir-autogen, elixir-format
 msgid "Complete Your Profile"
 msgstr "Vervollständigen Sie Ihr Profil"
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:228
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:238
 #, elixir-autogen, elixir-format
 msgid "Complete Your Provider Profile"
 msgstr "Vervollständigen Sie Ihr Anbieterprofil"
@@ -4452,11 +4452,6 @@ msgstr "Vervollständigen Sie Ihr Anbieterprofil"
 #, elixir-autogen, elixir-format
 msgid "Complete your provider profile"
 msgstr "Vervollständigen Sie Ihr Anbieterprofil"
-
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:362
-#, elixir-autogen, elixir-format
-msgid "Drag and drop or click to upload"
-msgstr "Ziehen und ablegen oder klicken zum Hochladen"
 
 #: lib/klass_hero_web/live/messaging_live_helper.ex:526
 #, elixir-autogen, elixir-format
@@ -4483,7 +4478,7 @@ msgstr "Dateityp nicht akzeptiert (nur Bilder)"
 msgid "Fill in your business details so parents can find you. Your profile will be reviewed by Klass Hero before going live."
 msgstr "Geben Sie Ihre Unternehmensdaten ein, damit Eltern Sie finden können. Ihr Profil wird von Klass Hero geprüft, bevor es veröffentlicht wird."
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:231
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "Fill in your business details. Your profile will be reviewed by Klass Hero before going live."
 msgstr "Geben Sie Ihre Unternehmensdaten ein. Ihr Profil wird von Klass Hero geprüft, bevor es veröffentlicht wird."
@@ -4504,7 +4499,7 @@ msgstr "Foto"
 msgid "Please enter a message or attach a photo."
 msgstr "Bitte geben Sie eine Nachricht ein oder fügen Sie ein Foto hinzu."
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:101
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:103
 #, elixir-autogen, elixir-format
 msgid "Profile completed! Klass Hero will review your profile shortly."
 msgstr "Profil vervollständigt! Klass Hero wird Ihr Profil in Kürze prüfen."
@@ -4523,13 +4518,13 @@ msgstr "Anhang entfernen"
 #: lib/klass_hero_web/controllers/invite_claim_controller.ex:67
 #: lib/klass_hero_web/live/messaging_live_helper.ex:527
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:132
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:113
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:118
 #: lib/klass_hero_web/live/user_live/settings.ex:512
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Please try again."
 msgstr "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:290
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:300
 #, elixir-autogen, elixir-format
 msgid "Tell parents about your organization and what makes you unique..."
 msgstr "Erzählen Sie Eltern von Ihrer Organisation und was Sie einzigartig macht..."
@@ -4559,13 +4554,13 @@ msgstr "Hochladen fehlgeschlagen"
 msgid "View your assignments"
 msgstr "Ihre Zuweisungen anzeigen"
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:306
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:316
 #: lib/klass_hero_web/live/provider_profile_live.ex:120
 #, elixir-autogen, elixir-format
 msgid "Website"
 msgstr "Website"
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:32
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:33
 #, elixir-autogen, elixir-format
 msgid "Your profile is already complete."
 msgstr "Ihr Profil ist bereits vollständig."
@@ -4576,41 +4571,41 @@ msgstr "Ihr Profil ist bereits vollständig."
 msgid "for"
 msgstr "für"
 
-#: lib/klass_hero_web/components/provider_components.ex:1822
+#: lib/klass_hero_web/components/provider_components.ex:1799
 #, elixir-autogen, elixir-format
 msgid "Assigned staff"
 msgstr "Zugewiesenes Personal"
 
-#: lib/klass_hero_web/components/provider_components.ex:1823
+#: lib/klass_hero_web/components/provider_components.ex:1800
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr "Anwesenheit"
 
-#: lib/klass_hero_web/components/provider_components.ex:1806
-#: lib/klass_hero_web/components/provider_components.ex:1891
-#: lib/klass_hero_web/components/provider_components.ex:2033
-#: lib/klass_hero_web/components/provider_components.ex:2187
+#: lib/klass_hero_web/components/provider_components.ex:1783
+#: lib/klass_hero_web/components/provider_components.ex:1868
+#: lib/klass_hero_web/components/provider_components.ex:2010
+#: lib/klass_hero_web/components/provider_components.ex:2158
 #: lib/klass_hero_web/live/provider/overview_live.ex:403
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr "Schließen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1821
+#: lib/klass_hero_web/components/provider_components.ex:1798
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr "Datum / Uhrzeit"
 
-#: lib/klass_hero_web/components/provider_components.ex:1815
+#: lib/klass_hero_web/components/provider_components.ex:1792
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled yet."
 msgstr "Noch keine Sessions geplant."
 
-#: lib/klass_hero_web/components/provider_components.ex:1804
+#: lib/klass_hero_web/components/provider_components.ex:1781
 #, elixir-autogen, elixir-format
 msgid "Sessions — %{title}"
 msgstr "Sessions — %{title}"
 
-#: lib/klass_hero_web/components/provider_components.ex:1509
+#: lib/klass_hero_web/components/provider_components.ex:1486
 #, elixir-autogen, elixir-format
 msgid "View sessions"
 msgstr "Sessions anzeigen"
@@ -4642,17 +4637,17 @@ msgstr "Abreisezeit ist kein gültiges Datum oder keine gültige Uhrzeit"
 msgid "Failed to update record"
 msgstr "Aktualisieren des Datensatzes fehlgeschlagen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2837
+#: lib/klass_hero_web/components/provider_components.ex:2802
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr "Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2510
+#: lib/klass_hero_web/components/provider_components.ex:2475
 #, elixir-autogen, elixir-format
 msgid "Invite mode"
 msgstr "Einladungsmodus"
 
-#: lib/klass_hero_web/components/provider_components.ex:2529
+#: lib/klass_hero_web/components/provider_components.ex:2494
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr "Einzelperson einladen"
@@ -4667,12 +4662,12 @@ msgstr "Einladung verschickt."
 msgid "Leave blank to keep this child marked as present."
 msgstr "Leer lassen, um dieses Kind als anwesend markiert zu lassen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2850
+#: lib/klass_hero_web/components/provider_components.ex:2815
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr "Gesundheit & Einwilligungen (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2856
+#: lib/klass_hero_web/components/provider_components.ex:2821
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr "Gesundheitliche Besonderheiten"
@@ -4683,17 +4678,17 @@ msgstr "Gesundheitliche Besonderheiten"
 msgid "Nothing to update"
 msgstr "Nichts zu aktualisieren"
 
-#: lib/klass_hero_web/components/provider_components.ex:2858
+#: lib/klass_hero_web/components/provider_components.ex:2823
 #, elixir-autogen, elixir-format
 msgid "Nut allergy"
 msgstr "Nussallergie"
 
-#: lib/klass_hero_web/components/provider_components.ex:2862
+#: lib/klass_hero_web/components/provider_components.ex:2827
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr "Fotos dürfen in Marketingmaterialien verwendet werden"
 
-#: lib/klass_hero_web/components/provider_components.ex:2867
+#: lib/klass_hero_web/components/provider_components.ex:2832
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr "Fotos dürfen in sozialen Medien erscheinen"
@@ -4703,7 +4698,7 @@ msgstr "Fotos dürfen in sozialen Medien erscheinen"
 msgid "Present"
 msgstr "Anwesend"
 
-#: lib/klass_hero_web/components/provider_components.ex:2794
+#: lib/klass_hero_web/components/provider_components.ex:2759
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr "Hauptansprechpartner"
@@ -4730,22 +4725,22 @@ msgstr "Datensatz aktualisiert"
 msgid "Save changes"
 msgstr "Änderungen speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:2831
+#: lib/klass_hero_web/components/provider_components.ex:2796
 #, elixir-autogen, elixir-format
 msgid "School (optional)"
 msgstr "Schule (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2841
+#: lib/klass_hero_web/components/provider_components.ex:2806
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr "Schulname"
 
-#: lib/klass_hero_web/components/provider_components.ex:2815
+#: lib/klass_hero_web/components/provider_components.ex:2780
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr "Zweiter Ansprechpartner (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2884
+#: lib/klass_hero_web/components/provider_components.ex:2849
 #, elixir-autogen, elixir-format
 msgid "Send invite"
 msgstr "Einladung senden"
@@ -4755,7 +4750,7 @@ msgstr "Einladung senden"
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr "Aktualisieren Sie die Notiz für dieses Kind (z. B. um zu klären, was passiert ist)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2547
+#: lib/klass_hero_web/components/provider_components.ex:2512
 #, elixir-autogen, elixir-format
 msgid "Upload a list"
 msgstr "Liste hochladen"
@@ -4790,7 +4785,7 @@ msgstr "Foto hierher ziehen oder klicken zum Auswählen"
 msgid "High"
 msgstr "Hoch"
 
-#: lib/klass_hero_web/components/provider_components.ex:790
+#: lib/klass_hero_web/components/provider_components.ex:787
 #, elixir-autogen, elixir-format
 msgid "Hourly"
 msgstr "Stündlich"
@@ -4815,22 +4810,22 @@ msgstr "Niedrig"
 msgid "Medium"
 msgstr "Mittel"
 
-#: lib/klass_hero_web/components/provider_components.ex:780
+#: lib/klass_hero_web/components/provider_components.ex:777
 #, elixir-autogen, elixir-format
 msgid "None"
 msgstr "Keine"
 
-#: lib/klass_hero_web/components/provider_components.ex:769
+#: lib/klass_hero_web/components/provider_components.ex:766
 #, elixir-autogen, elixir-format
 msgid "Pay Rate"
 msgstr "Vergütung"
 
-#: lib/klass_hero_web/components/provider_components.ex:527
+#: lib/klass_hero_web/components/provider_components.ex:528
 #, elixir-autogen, elixir-format
 msgid "Pay rate"
 msgstr "Vergütung"
 
-#: lib/klass_hero_web/components/provider_components.ex:800
+#: lib/klass_hero_web/components/provider_components.ex:797
 #, elixir-autogen, elixir-format
 msgid "Per Session"
 msgstr "Pro Sitzung"
@@ -4855,7 +4850,7 @@ msgstr "Programm oder Session nicht gefunden."
 msgid "Property Damage"
 msgstr "Sachschaden"
 
-#: lib/klass_hero_web/components/provider_components.ex:1546
+#: lib/klass_hero_web/components/provider_components.ex:1523
 #, elixir-autogen, elixir-format
 msgid "Report Incident"
 msgstr "Vorfall melden"
@@ -5523,7 +5518,7 @@ msgstr[1] "%{count} Familien importiert."
 msgid "In 2025, Shane connected with his friend"
 msgstr "2025 tat sich Shane mit seinem Freund zusammen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1555
+#: lib/klass_hero_web/components/provider_components.ex:1532
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:43
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:74
 #, elixir-autogen, elixir-format
@@ -5593,7 +5588,7 @@ msgstr "Klass Hero ist das operative Rückgrat für Berlins Jugendpädagogen. Wi
 msgid "Last 8 weeks"
 msgstr "Letzte 8 Wochen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1258
+#: lib/klass_hero_web/components/provider_components.ex:1245
 #: lib/klass_hero_web/presenters/hero_cards_presenter.ex:27
 #, elixir-autogen, elixir-format
 msgid "Lead Instructor"
@@ -6032,17 +6027,17 @@ msgstr "Umsatz (diese Woche)"
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr "Strenge Überprüfung, damit Familien immer wissen, wer die Gruppe leitet."
 
-#: lib/klass_hero_web/components/provider_components.ex:2923
+#: lib/klass_hero_web/components/provider_components.ex:2888
 #, elixir-autogen, elixir-format
 msgid "Row %{row}"
 msgstr "Zeile %{row}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2923
+#: lib/klass_hero_web/components/provider_components.ex:2888
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr "Zeile —"
 
-#: lib/klass_hero_web/components/provider_components.ex:2624
+#: lib/klass_hero_web/components/provider_components.ex:2589
 #, elixir-autogen, elixir-format
 msgid "Rows with errors"
 msgstr "Zeilen mit Fehlern"
@@ -6625,7 +6620,7 @@ msgstr "Identitäts- und Altersverifizierung"
 msgid "Identity verifications"
 msgstr "Identitätsprüfungen"
 
-#: lib/klass_hero_web/components/provider_components.ex:73
+#: lib/klass_hero_web/components/provider_components.ex:74
 #, elixir-autogen, elixir-format
 msgid "In progress"
 msgstr "In Bearbeitung"
@@ -6655,7 +6650,7 @@ msgstr "Noch keine Identitätsprüfungen."
 msgid "Not started"
 msgstr "Nicht begonnen"
 
-#: lib/klass_hero_web/components/provider_components.ex:71
+#: lib/klass_hero_web/components/provider_components.ex:72
 #, elixir-autogen, elixir-format
 msgid "Passed"
 msgstr "Bestanden"
@@ -6772,12 +6767,12 @@ msgstr "Deine Identität ist verifiziert."
 msgid "Experience validation"
 msgstr "Erfahrungsnachweis"
 
-#: lib/klass_hero_web/components/provider_components.ex:3322
+#: lib/klass_hero_web/components/provider_components.ex:3396
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr "MP4, MOV oder WEBM. Max. 100 MB."
 
-#: lib/klass_hero_web/components/provider_components.ex:3295
+#: lib/klass_hero_web/components/provider_components.ex:3369
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr "Nimm ein kurzes Video auf, in dem du dich vorstellst. Unser Team prüft es, um Kommunikationsfähigkeit und Übereinstimmung mit unseren Werten einzuschätzen."
@@ -6787,12 +6782,12 @@ msgstr "Nimm ein kurzes Video auf, in dem du dich vorstellst. Unser Team prüft 
 msgid "Safeguarding certificate"
 msgstr "Kinderschutz-Zertifikat"
 
-#: lib/klass_hero_web/components/provider_components.ex:3319
+#: lib/klass_hero_web/components/provider_components.ex:3393
 #, elixir-autogen, elixir-format
 msgid "Select Video"
 msgstr "Video auswählen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3365
+#: lib/klass_hero_web/components/provider_components.ex:3439
 #, elixir-autogen, elixir-format
 msgid "Upload Video"
 msgstr "Video hochladen"
@@ -6802,7 +6797,7 @@ msgstr "Video hochladen"
 msgid "Your browser does not support video playback."
 msgstr "Dein Browser unterstützt keine Videowiedergabe."
 
-#: lib/klass_hero_web/components/provider_components.ex:3512
+#: lib/klass_hero_web/components/provider_components.ex:3586
 #, elixir-autogen, elixir-format
 msgid "Confirm agreement"
 msgstr "Zustimmung bestätigen"
@@ -6812,12 +6807,12 @@ msgstr "Zustimmung bestätigen"
 msgid "Couldn't record your agreement. Please try again."
 msgstr "Deine Zustimmung konnte nicht gespeichert werden. Bitte versuche es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:3535
+#: lib/klass_hero_web/components/provider_components.ex:3609
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr "Vereinbarung herunterladen (PDF)"
 
-#: lib/klass_hero_web/components/provider_components.ex:3511
+#: lib/klass_hero_web/components/provider_components.ex:3585
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr "Ich habe die Klass Hero Community-Richtlinien gelesen und stimme ihnen zu."
@@ -6827,7 +6822,7 @@ msgstr "Ich habe die Klass Hero Community-Richtlinien gelesen und stimme ihnen z
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr "Bitte bestätige, dass du die Community-Richtlinien gelesen hast und ihnen zustimmst."
 
-#: lib/klass_hero_web/components/provider_components.ex:3420
+#: lib/klass_hero_web/components/provider_components.ex:3494
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr "Unterzeichnet von %{name} am %{date} (v%{version})."
@@ -6837,17 +6832,17 @@ msgstr "Unterzeichnet von %{name} am %{date} (v%{version})."
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr "Danke – deine Zustimmung zu den Community-Richtlinien wurde gespeichert."
 
-#: lib/klass_hero_web/components/provider_components.ex:3520
+#: lib/klass_hero_web/components/provider_components.ex:3594
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr "Die Community-Richtlinien wurden seit deiner letzten Zustimmung aktualisiert (v%{old}). Bitte lies sie erneut und stimme erneut zu."
 
-#: lib/klass_hero_web/components/provider_components.ex:3509
+#: lib/klass_hero_web/components/provider_components.ex:3583
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr "Der letzte Schritt: Lies die Klass Hero Community-Richtlinien und stimme ihnen zu."
 
-#: lib/klass_hero_web/components/provider_components.ex:3510
+#: lib/klass_hero_web/components/provider_components.ex:3584
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr "Du hast den Community-Richtlinien zugestimmt."
@@ -6857,12 +6852,12 @@ msgstr "Du hast den Community-Richtlinien zugestimmt."
 msgid "Applicants submit a short recorded video (max 2 minutes) so we can assess communication skills and alignment with our values before approving their profile."
 msgstr "Bewerber reichen ein kurzes aufgezeichnetes Video (max. 2 Minuten) ein, damit wir vor der Freigabe ihres Profils Kommunikationsfähigkeiten und die Übereinstimmung mit unseren Werten beurteilen können."
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:254
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:264
 #, elixir-autogen, elixir-format
 msgid "A business"
 msgstr "Ein Unternehmen"
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:252
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:262
 #, elixir-autogen, elixir-format
 msgid "An individual"
 msgstr "Eine Einzelperson"
@@ -6907,17 +6902,17 @@ msgstr "Laden Sie Ihre Haftpflichtversicherungsbescheinigung hoch."
 msgid "Verify the owner or director accountable for the business."
 msgstr "Verifizieren Sie den Inhaber oder Geschäftsführer, der für das Unternehmen verantwortlich ist."
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:246
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:256
 #, elixir-autogen, elixir-format
 msgid "What are you registering as?"
 msgstr "Als was registrieren Sie sich?"
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:253
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:263
 #, elixir-autogen, elixir-format
 msgid "You'll be vetted personally."
 msgstr "Sie werden persönlich überprüft."
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:255
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:265
 #, elixir-autogen, elixir-format
 msgid "Your business and its responsible person will be vetted."
 msgstr "Ihr Unternehmen und die verantwortliche Person werden überprüft."
@@ -7116,12 +7111,12 @@ msgstr "Ihre Versicherungsbescheinigung wird geprüft."
 msgid "Your insurance is verified."
 msgstr "Ihre Versicherung ist verifiziert."
 
-#: lib/klass_hero_web/components/provider_components.ex:3464
+#: lib/klass_hero_web/components/provider_components.ex:3538
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr "Unterzeichnung durch %{name} im Namen des Unternehmens."
 
-#: lib/klass_hero_web/components/provider_components.ex:3567
+#: lib/klass_hero_web/components/provider_components.ex:3641
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr "Bestätige im Namen deines Unternehmens, dass alle Mitarbeitenden gemäß dem deutschen Kinderschutzrecht überprüft sind."
@@ -7131,7 +7126,7 @@ msgstr "Bestätige im Namen deines Unternehmens, dass alle Mitarbeitenden gemä�
 msgid "Couldn't record your declaration. Please try again."
 msgstr "Deine Erklärung konnte nicht gespeichert werden. Bitte versuche es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:3573
+#: lib/klass_hero_web/components/provider_components.ex:3647
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr "Ich bestätige im Namen des Unternehmens, dass die obige Erklärung zutrifft und ich zu ihrer Unterzeichnung berechtigt bin."
@@ -7141,17 +7136,17 @@ msgstr "Ich bestätige im Namen des Unternehmens, dass die obige Erklärung zutr
 msgid "Please confirm the declaration before signing."
 msgstr "Bitte bestätige die Erklärung vor der Unterzeichnung."
 
-#: lib/klass_hero_web/components/provider_components.ex:3598
+#: lib/klass_hero_web/components/provider_components.ex:3672
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr "Vorläufiger Text — vor der Freischaltung noch von einer in Deutschland zugelassenen Anwältin bzw. einem Anwalt zu prüfen."
 
-#: lib/klass_hero_web/components/provider_components.ex:3577
+#: lib/klass_hero_web/components/provider_components.ex:3651
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr "Erklärung unterzeichnen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3565
+#: lib/klass_hero_web/components/provider_components.ex:3639
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr "Erklärung zur Mitarbeiter-Compliance"
@@ -7161,12 +7156,12 @@ msgstr "Erklärung zur Mitarbeiter-Compliance"
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr "Danke — deine Erklärung zur Mitarbeiter-Compliance wurde erfasst."
 
-#: lib/klass_hero_web/components/provider_components.ex:3585
+#: lib/klass_hero_web/components/provider_components.ex:3659
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr "Die Erklärung zur Mitarbeiter-Compliance wurde seit deiner letzten Unterzeichnung aktualisiert (v%{old}). Bitte prüfe sie und unterzeichne erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:3571
+#: lib/klass_hero_web/components/provider_components.ex:3645
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr "Du hast die Erklärung zur Mitarbeiter-Compliance unterzeichnet."
@@ -7233,15 +7228,15 @@ msgstr "In Prüfung"
 msgid "Undelivered Events"
 msgstr "Nicht zugestellte Ereignisse"
 
-#: lib/klass_hero_web/components/provider_components.ex:2132
-#: lib/klass_hero_web/components/provider_components.ex:2315
+#: lib/klass_hero_web/components/provider_components.ex:2103
+#: lib/klass_hero_web/components/provider_components.ex:2280
 #: lib/klass_hero_web/live/user_live/settings.ex:273
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2055
-#: lib/klass_hero_web/components/provider_components.ex:2241
+#: lib/klass_hero_web/components/provider_components.ex:2032
+#: lib/klass_hero_web/components/provider_components.ex:2212
 #, elixir-autogen, elixir-format
 msgid "Lead"
 msgstr "Leitung"
@@ -7251,17 +7246,17 @@ msgstr "Leitung"
 msgid "Lead instructor updated."
 msgstr "Leitender Kursleiter aktualisiert."
 
-#: lib/klass_hero_web/components/provider_components.ex:2067
+#: lib/klass_hero_web/components/provider_components.ex:2044
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor"
 msgstr "Als leitenden Kursleiter festlegen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1523
+#: lib/klass_hero_web/components/provider_components.ex:1500
 #, elixir-autogen, elixir-format
 msgid "Manage Staffing"
 msgstr "Programmteam verwalten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2096
+#: lib/klass_hero_web/components/provider_components.ex:2073
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this program yet."
 msgstr "Diesem Programm ist noch niemand zugewiesen."
@@ -7272,19 +7267,19 @@ msgstr "Diesem Programm ist noch niemand zugewiesen."
 msgid "Pick a staff member to add."
 msgstr "Bitte ein Teammitglied zum Hinzufügen auswählen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2079
-#: lib/klass_hero_web/components/provider_components.ex:2354
+#: lib/klass_hero_web/components/provider_components.ex:2056
+#: lib/klass_hero_web/components/provider_components.ex:2319
 #, elixir-autogen, elixir-format
 msgid "Reassign the lead before removing them"
 msgstr "Vor dem Entfernen einen anderen leitenden Kursleiter festlegen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2080
+#: lib/klass_hero_web/components/provider_components.ex:2057
 #, elixir-autogen, elixir-format
 msgid "Remove from program"
 msgstr "Aus dem Programm entfernen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2114
-#: lib/klass_hero_web/components/provider_components.ex:2296
+#: lib/klass_hero_web/components/provider_components.ex:2091
+#: lib/klass_hero_web/components/provider_components.ex:2267
 #, elixir-autogen, elixir-format
 msgid "Select a staff member…"
 msgstr "Teammitglied auswählen …"
@@ -7299,14 +7294,14 @@ msgstr "Teammitglied zum Programm hinzugefügt."
 msgid "Staff member removed from the program."
 msgstr "Teammitglied aus dem Programm entfernt."
 
-#: lib/klass_hero_web/components/provider_components.ex:2137
+#: lib/klass_hero_web/components/provider_components.ex:2108
 #, elixir-autogen, elixir-format
 msgid "Staff you add can read and reply to this program's parent conversations."
 msgstr ""
 "Hinzugefügte Teammitglieder können die Elterngespräche dieses Programms lesen "
 "und beantworten."
 
-#: lib/klass_hero_web/components/provider_components.ex:2031
+#: lib/klass_hero_web/components/provider_components.ex:2008
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{title}"
 msgstr "Programmteam — %{title}"
@@ -7328,19 +7323,19 @@ msgstr ""
 "Diese Person ist der leitende Kursleiter. Bitte zuerst eine andere Person als "
 "Leitung festlegen."
 
-#: lib/klass_hero_web/components/provider_components.ex:1467
+#: lib/klass_hero_web/components/provider_components.ex:1444
 #, elixir-autogen, elixir-format
 msgid "%{count} staff member · no lead"
 msgid_plural "%{count} staff · no lead"
 msgstr[0] "%{count} Mitarbeiter*in · keine Leitung"
 msgstr[1] "%{count} Mitarbeitende · keine Leitung"
 
-#: lib/klass_hero_web/components/provider_components.ex:566
+#: lib/klass_hero_web/components/provider_components.ex:563
 #, elixir-autogen, elixir-format
 msgid "%{name} will be unassigned from every program and removed from those conversations. Their history is kept and you can add them back later."
 msgstr "%{name} wird aus allen Programmen und den zugehörigen Unterhaltungen entfernt. Der Verlauf bleibt erhalten und du kannst die Person später wieder hinzufügen."
 
-#: lib/klass_hero_web/components/provider_components.ex:642
+#: lib/klass_hero_web/components/provider_components.ex:639
 #, elixir-autogen, elixir-format
 msgid "Add back to team"
 msgstr "Wieder ins Team aufnehmen"
@@ -7350,7 +7345,7 @@ msgstr "Wieder ins Team aufnehmen"
 msgid "Could not bring this team member back. Please try again."
 msgstr "Teammitglied konnte nicht zurückgeholt werden. Bitte versuche es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:604
+#: lib/klass_hero_web/components/provider_components.ex:601
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr "Eintrag löschen"
@@ -7360,7 +7355,7 @@ msgstr "Eintrag löschen"
 msgid "Former team members"
 msgstr "Ehemalige Teammitglieder"
 
-#: lib/klass_hero_web/components/provider_components.ex:578
+#: lib/klass_hero_web/components/provider_components.ex:575
 #, elixir-autogen, elixir-format
 msgid "Remove from team"
 msgstr "Aus dem Team entfernen"
@@ -7375,7 +7370,7 @@ msgstr "Teammitglied ist zurück. Weise die Person wieder Programmen zu, wenn du
 msgid "Team member removed from the team."
 msgstr "Teammitglied aus dem Team entfernt."
 
-#: lib/klass_hero_web/components/provider_components.ex:594
+#: lib/klass_hero_web/components/provider_components.ex:591
 #, elixir-autogen, elixir-format
 msgid "This deletes %{name} permanently — there's nothing to undo. Use it only for an entry added by mistake."
 msgstr "Damit wird %{name} endgültig gelöscht – das lässt sich nicht rückgängig machen. Nutze das nur für einen versehentlich angelegten Eintrag."
@@ -7406,7 +7401,7 @@ msgstr ""
 "Programm aktualisiert, aber die Anmeldekapazität wurde abgelehnt. Es gelten "
 "weiterhin die bisherigen Grenzwerte."
 
-#: lib/klass_hero_web/components/provider_components.ex:889
+#: lib/klass_hero_web/components/provider_components.ex:876
 #, elixir-autogen, elixir-format
 msgid "%{count} child is already enrolled. Confirm you want this program to have no capacity limit."
 msgid_plural "%{count} children are already enrolled. Confirm you want this program to have no capacity limit."
@@ -7417,18 +7412,18 @@ msgstr[1] ""
 "%{count} Kinder sind bereits angemeldet. Bestätigen Sie, dass dieses "
 "Programm keine Teilnehmerbegrenzung haben soll."
 
-#: lib/klass_hero_web/components/provider_components.ex:1100
+#: lib/klass_hero_web/components/provider_components.ex:1087
 #, elixir-autogen, elixir-format
 msgid "Anyone will be able to book a place until you set a new maximum."
 msgstr ""
 "Bis Sie ein neues Maximum festlegen, kann jede Person einen Platz buchen."
 
-#: lib/klass_hero_web/components/provider_components.ex:1105
+#: lib/klass_hero_web/components/provider_components.ex:1092
 #, elixir-autogen, elixir-format
 msgid "I understand this program will have no capacity limit."
 msgstr "Ich verstehe, dass dieses Programm keine Teilnehmerbegrenzung haben wird."
 
-#: lib/klass_hero_web/components/provider_components.ex:2342
+#: lib/klass_hero_web/components/provider_components.ex:2307
 #, elixir-autogen, elixir-format
 msgid "Go back to the program's usual team"
 msgstr "Zurück zum üblichen Programmteam"
@@ -7438,17 +7433,17 @@ msgstr "Zurück zum üblichen Programmteam"
 msgid "Lead instructor for this session updated."
 msgstr "Leitung für diesen Termin aktualisiert."
 
-#: lib/klass_hero_web/components/provider_components.ex:2256
+#: lib/klass_hero_web/components/provider_components.ex:2227
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor for this session"
 msgstr "Als Leitung für diesen Termin festlegen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2278
+#: lib/klass_hero_web/components/provider_components.ex:2249
 #, elixir-autogen, elixir-format
 msgid "Nobody is working this session yet."
 msgstr "Für diesen Termin ist noch niemand eingeteilt."
 
-#: lib/klass_hero_web/components/provider_components.ex:2359
+#: lib/klass_hero_web/components/provider_components.ex:2324
 #, elixir-autogen, elixir-format
 msgid "Remove from this session"
 msgstr "Von diesem Termin entfernen"
@@ -7468,7 +7463,7 @@ msgstr "Teammitglied von diesem Termin entfernt."
 msgid "Staffing"
 msgstr "Team"
 
-#: lib/klass_hero_web/components/provider_components.ex:2180
+#: lib/klass_hero_web/components/provider_components.ex:2151
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{date}"
 msgstr "Team — %{date}"
@@ -7498,22 +7493,22 @@ msgstr "Dieser Termin nutzt wieder das übliche Programmteam."
 msgid "A session needs at least one person. Use “Go back to the program's usual team” to drop this session's own roster."
 msgstr "Ein Termin braucht mindestens eine Person. Nutze „Zurück zum üblichen Programmteam“, um die eigene Besetzung dieses Termins aufzuheben."
 
-#: lib/klass_hero_web/components/provider_components.ex:2357
+#: lib/klass_hero_web/components/provider_components.ex:2322
 #, elixir-autogen, elixir-format
 msgid "A session needs someone — use “Go back to the program's usual team” instead"
 msgstr "Ein Termin braucht jemanden — nutze stattdessen „Zurück zum üblichen Programmteam“"
 
-#: lib/klass_hero_web/components/provider_components.ex:2324
+#: lib/klass_hero_web/components/provider_components.ex:2289
 #, elixir-autogen, elixir-format
 msgid "Everyone on your team is already working this session."
 msgstr "Alle aus deinem Team arbeiten bereits bei diesem Termin."
 
-#: lib/klass_hero_web/components/provider_components.ex:2212
+#: lib/klass_hero_web/components/provider_components.ex:2183
 #, elixir-autogen, elixir-format
 msgid "Staffed just for this session. Changes here do not touch the program."
 msgstr "Nur für diesen Termin eingeteilt. Änderungen hier wirken sich nicht auf das Programm aus."
 
-#: lib/klass_hero_web/components/provider_components.ex:2214
+#: lib/klass_hero_web/components/provider_components.ex:2185
 #, elixir-autogen, elixir-format
 msgid "Using the program's usual team. The first change here copies them onto this session, so later program changes stop reaching it."
 msgstr "Es gilt das übliche Programmteam. Die erste Änderung hier übernimmt das Team in diesen Termin — spätere Änderungen am Programm greifen dann nicht mehr."
@@ -7523,12 +7518,12 @@ msgstr "Es gilt das übliche Programmteam. Die erste Änderung hier übernimmt d
 msgid "(optional)"
 msgstr "(optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:1950
+#: lib/klass_hero_web/components/provider_components.ex:1927
 #, elixir-autogen, elixir-format
 msgid "Add a waiver"
 msgstr "Verzichtserklärung hinzufügen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1982
+#: lib/klass_hero_web/components/provider_components.ex:1959
 #, elixir-autogen, elixir-format
 msgid "Add waiver"
 msgstr "Hinzufügen"
@@ -7550,22 +7545,22 @@ msgstr "Anmeldung nicht gefunden."
 msgid "I have read and agree to %{title}"
 msgstr "Ich habe %{title} gelesen und stimme zu"
 
-#: lib/klass_hero_web/components/provider_components.ex:1964
+#: lib/klass_hero_web/components/provider_components.ex:1941
 #, elixir-autogen, elixir-format
 msgid "Legal text"
 msgstr "Rechtstext"
 
-#: lib/klass_hero_web/components/provider_components.ex:1530
+#: lib/klass_hero_web/components/provider_components.ex:1507
 #, elixir-autogen, elixir-format
 msgid "Manage Waivers"
 msgstr "Verzichtserklärungen verwalten"
 
-#: lib/klass_hero_web/components/provider_components.ex:1898
+#: lib/klass_hero_web/components/provider_components.ex:1875
 #, elixir-autogen, elixir-format
 msgid "No waivers yet. Parents enrol without signing anything."
 msgstr "Noch keine Verzichtserklärungen. Eltern melden sich ohne Unterschrift an."
 
-#: lib/klass_hero_web/components/provider_components.ex:1971
+#: lib/klass_hero_web/components/provider_components.ex:1948
 #, elixir-autogen, elixir-format
 msgid "Parents must sign this before enrolling"
 msgstr "Eltern müssen dies vor der Anmeldung unterschreiben"
@@ -7585,17 +7580,17 @@ msgstr "Bitte lies und unterschreibe diese, bevor %{program} beginnt."
 msgid "Please tick a waiver to sign it."
 msgstr "Bitte wähle eine Verzichtserklärung aus, um sie zu unterschreiben."
 
-#: lib/klass_hero_web/components/provider_components.ex:1949
+#: lib/klass_hero_web/components/provider_components.ex:1926
 #, elixir-autogen, elixir-format
 msgid "Publish a new version"
 msgstr "Neue Version veröffentlichen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1982
+#: lib/klass_hero_web/components/provider_components.ex:1959
 #, elixir-autogen, elixir-format
 msgid "Publish version"
 msgstr "Version veröffentlichen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1975
+#: lib/klass_hero_web/components/provider_components.ex:1952
 #, elixir-autogen, elixir-format
 msgid "Publishing keeps every earlier version on record; signatures already given stay bound to the wording they were shown."
 msgstr "Beim Veröffentlichen bleibt jede frühere Version erhalten; bereits geleistete Unterschriften bleiben an den damals gezeigten Wortlaut gebunden."
@@ -7605,12 +7600,12 @@ msgstr "Beim Veröffentlichen bleibt jede frühere Version erhalten; bereits gel
 msgid "Required"
 msgstr "Erforderlich"
 
-#: lib/klass_hero_web/components/provider_components.ex:1932
+#: lib/klass_hero_web/components/provider_components.ex:1909
 #, elixir-autogen, elixir-format
 msgid "Retire this waiver"
 msgstr "Diese Verzichtserklärung zurückziehen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1923
+#: lib/klass_hero_web/components/provider_components.ex:1900
 #, elixir-autogen, elixir-format
 msgid "Revise text"
 msgstr "Text überarbeiten"
@@ -7625,7 +7620,7 @@ msgstr "Verzichtserklärungen für %{program} unterschreiben"
 msgid "Sign waivers"
 msgstr "Verzichtserklärungen unterschreiben"
 
-#: lib/klass_hero_web/components/provider_components.ex:2437
+#: lib/klass_hero_web/components/provider_components.ex:2402
 #: lib/klass_hero_web/live/enrollment_waivers_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "Signed"
@@ -7641,12 +7636,12 @@ msgstr "Danke — deine Verzichtserklärungen sind erfasst."
 msgid "There is nothing to sign for this enrollment."
 msgstr "Für diese Anmeldung gibt es nichts zu unterschreiben."
 
-#: lib/klass_hero_web/components/provider_components.ex:2437
+#: lib/klass_hero_web/components/provider_components.ex:2402
 #, elixir-autogen, elixir-format
 msgid "Unsigned"
 msgstr "Nicht unterschrieben"
 
-#: lib/klass_hero_web/components/provider_components.ex:1915
+#: lib/klass_hero_web/components/provider_components.ex:1892
 #, elixir-autogen, elixir-format
 msgid "Version %{number}"
 msgstr "Version %{number}"
@@ -7656,7 +7651,7 @@ msgstr "Version %{number}"
 msgid "Waiver not found."
 msgstr "Verzichtserklärung nicht gefunden."
 
-#: lib/klass_hero_web/components/provider_components.ex:2405
+#: lib/klass_hero_web/components/provider_components.ex:2370
 #: lib/klass_hero_web/live/booking_live.ex:431
 #: lib/klass_hero_web/live/enrollment_waivers_live.ex:33
 #: lib/klass_hero_web/live/enrollment_waivers_live.ex:105
@@ -7669,7 +7664,7 @@ msgstr "Verzichtserklärungen"
 msgid "Waivers waiting for your signature"
 msgstr "Verzichtserklärungen warten auf deine Unterschrift"
 
-#: lib/klass_hero_web/components/provider_components.ex:1889
+#: lib/klass_hero_web/components/provider_components.ex:1866
 #, elixir-autogen, elixir-format
 msgid "Waivers — %{title}"
 msgstr "Verzichtserklärungen — %{title}"
@@ -7684,7 +7679,7 @@ msgstr "dieses Programm"
 msgid "New version published. It applies to future enrolments."
 msgstr "Neue Fassung veröffentlicht. Sie gilt für künftige Anmeldungen."
 
-#: lib/klass_hero_web/components/provider_components.ex:1936
+#: lib/klass_hero_web/components/provider_components.ex:1913
 #, elixir-autogen, elixir-format
 msgid "Retire \"%{title}\"? Parents will no longer be asked to sign it. Signatures already collected are kept."
 msgstr "\"%{title}\" zurückziehen? Eltern werden nicht mehr um eine Unterschrift gebeten. Bereits erteilte Unterschriften bleiben erhalten."
@@ -7704,7 +7699,7 @@ msgstr "Einverständniserklärung zurückgezogen. Bereits erteilte Unterschrifte
 msgid "You are not assigned to this session"
 msgstr "Sie sind diesem Termin nicht zugewiesen"
 
-#: lib/klass_hero_web/components/provider_components.ex:429
+#: lib/klass_hero_web/components/provider_components.ex:430
 #, elixir-autogen, elixir-format
 msgid "Complete verification to create programs."
 msgstr "Schließen Sie die Verifizierung ab, um Programme zu erstellen."
@@ -7714,28 +7709,28 @@ msgstr "Schließen Sie die Verifizierung ab, um Programme zu erstellen."
 msgid "Manage your provider profile"
 msgstr "Ihr Anbieterprofil verwalten"
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:225
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:259
 #, elixir-autogen, elixir-format
 msgid "Provider Description"
 msgstr "Anbieterbeschreibung"
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:212
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "Provider Information"
 msgstr "Anbieterinformationen"
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:232
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:347
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:266
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:356
 #, elixir-autogen, elixir-format
 msgid "Provider Logo"
 msgstr "Anbieterlogo"
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:281
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:291
 #, elixir-autogen, elixir-format
 msgid "Provider Name"
 msgstr "Anbietername"
 
-#: lib/klass_hero_web/components/provider_components.ex:207
+#: lib/klass_hero_web/components/provider_components.ex:208
 #, elixir-autogen, elixir-format
 msgid "Provider Profile"
 msgstr "Anbieterprofil"
@@ -7755,17 +7750,17 @@ msgstr "Der mit Ihrem Konto verknüpfte Anbieter konnte nicht gefunden werden."
 msgid "This invitation has expired. Please ask your provider to resend it."
 msgstr "Diese Einladung ist abgelaufen. Bitte bitten Sie Ihren Anbieter, sie erneut zu senden."
 
-#: lib/klass_hero_web/components/provider_components.ex:210
+#: lib/klass_hero_web/components/provider_components.ex:211
 #, elixir-autogen, elixir-format
 msgid "This is your main provider identity. Verification is required to list programs."
 msgstr "Dies ist Ihr Hauptprofil als Anbieter. Eine Verifizierung ist erforderlich, um Programme anzubieten."
 
-#: lib/klass_hero_web/components/provider_components.ex:3161
+#: lib/klass_hero_web/components/provider_components.ex:3235
 #, elixir-autogen, elixir-format
 msgid "Upload documents to be verified. Documents are reviewed by our team."
 msgstr "Laden Sie Dokumente hoch, um verifiziert zu werden. Die Dokumente werden von unserem Team überprüft."
 
-#: lib/klass_hero_web/components/provider_components.ex:402
+#: lib/klass_hero_web/components/provider_components.ex:403
 #, elixir-autogen, elixir-format
 msgid "Verified Provider"
 msgstr "Verifizierter Anbieter"
@@ -7781,12 +7776,12 @@ msgstr "Willkommen an Bord! Lassen Sie uns Ihr Anbieterprofil einrichten."
 msgid "You'll get your own provider profile to fill in, and your account will open on your provider dashboard from now on. You stay on %{business}'s team."
 msgstr "Sie erhalten Ihr eigenes Anbieterprofil zum Ausfüllen, und Ihr Konto öffnet sich ab sofort auf Ihrem Anbieter-Dashboard. Sie bleiben im Team von %{business}."
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:315
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:325
 #, elixir-autogen, elixir-format
 msgid "Your address"
 msgstr "Ihre Adresse"
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:282
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:292
 #, elixir-autogen, elixir-format
 msgid "Your provider or organization name"
 msgstr "Name Ihres Anbieters oder Ihrer Organisation"
@@ -7904,8 +7899,8 @@ msgstr "Einladungen ohne Antwort"
 msgid "Review invitations"
 msgstr "Einladungen prüfen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2700
-#: lib/klass_hero_web/components/provider_components.ex:2707
+#: lib/klass_hero_web/components/provider_components.ex:2665
+#: lib/klass_hero_web/components/provider_components.ex:2672
 #, elixir-autogen, elixir-format
 msgid "Unknown program"
 msgstr "Unbekanntes Programm"
@@ -7953,12 +7948,12 @@ msgstr "Neue Nachricht"
 msgid "You can't start a conversation with this person"
 msgstr "Mit dieser Person kannst du kein Gespräch beginnen"
 
-#: lib/klass_hero_web/components/provider_components.ex:965
+#: lib/klass_hero_web/components/provider_components.ex:952
 #, elixir-autogen, elixir-format
 msgid "Subtitle"
 msgstr "Untertitel"
 
-#: lib/klass_hero_web/components/provider_components.ex:966
+#: lib/klass_hero_web/components/provider_components.ex:953
 #, elixir-autogen, elixir-format
 msgid "e.g., For beginners, no experience needed"
 msgstr "z. B. Für Anfänger, keine Vorkenntnisse nötig"
@@ -7973,45 +7968,37 @@ msgstr "Kostenlos"
 msgid "N/A"
 msgstr "k. A."
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:272
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:400
+#: lib/klass_hero_web/components/provider_components.ex:3143
 #, elixir-autogen, elixir-format
 msgid "A short line that sums you up"
 msgstr "Ein kurzer Satz, der euch beschreibt"
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:261
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:389
+#: lib/klass_hero_web/components/provider_components.ex:3132
 #, elixir-autogen, elixir-format
 msgid "Branding & Presence"
 msgstr "Marke & Auftritt"
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:285
+#: lib/klass_hero_web/components/provider_components.ex:3156
 #, elixir-autogen, elixir-format
 msgid "Choose Cover Image"
 msgstr "Titelbild auswählen"
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:84
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:99
 #, elixir-autogen, elixir-format
 msgid "Cover image upload failed. Please try again."
 msgstr "Titelbild konnte nicht hochgeladen werden. Bitte versucht es erneut."
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:286
+#: lib/klass_hero_web/components/provider_components.ex:3157
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 5MB."
 msgstr "JPG, PNG oder WebP. Max. 5 MB."
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:392
-#, elixir-autogen, elixir-format
-msgid "Optional — shown on your public profile page."
-msgstr "Optional – erscheint auf eurer öffentlichen Profilseite."
-
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:264
+#: lib/klass_hero_web/components/provider_components.ex:3135
 #, elixir-autogen, elixir-format
 msgid "Shown on your public profile page."
 msgstr "Erscheint auf eurer öffentlichen Profilseite."
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:271
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:399
+#: lib/klass_hero_web/components/provider_components.ex:3142
 #, elixir-autogen, elixir-format
 msgid "Tagline"
 msgstr "Slogan"
@@ -8057,7 +8044,7 @@ msgstr "%{business} auf %{network}"
 msgid "Klass Hero on %{network}"
 msgstr "Klass Hero auf %{network}"
 
-#: lib/klass_hero_web/components/provider_components.ex:3140
+#: lib/klass_hero_web/components/provider_components.ex:3214
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr "Hochladen fehlgeschlagen."
@@ -8091,3 +8078,33 @@ msgstr "Dieser Anbieter hat derzeit keine offenen Programme. Schauen Sie bald wi
 #, elixir-autogen, elixir-format
 msgid "General"
 msgstr "Allgemein"
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:345
+#, elixir-autogen, elixir-format
+msgid "A newly chosen cover or logo appears here after you save."
+msgstr "Ein neu gewähltes Titelbild oder Logo erscheint hier nach dem Speichern."
+
+#: lib/klass_hero_web/components/provider_components.ex:3187
+#, elixir-autogen, elixir-format
+msgid "Add %{network}"
+msgstr "%{network} hinzufügen"
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:329
+#, elixir-autogen, elixir-format
+msgid "Hide preview"
+msgstr "Vorschau ausblenden"
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:342
+#, elixir-autogen, elixir-format
+msgid "Public profile preview"
+msgstr "Vorschau des öffentlichen Profils"
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:329
+#, elixir-autogen, elixir-format
+msgid "Show preview"
+msgstr "Vorschau anzeigen"
+
+#: lib/klass_hero_web/components/provider_components.ex:3168
+#, elixir-autogen, elixir-format
+msgid "e.g. %{example}"
+msgstr "z. B. %{example}"

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -2136,7 +2136,7 @@ msgstr "Beschreibung"
 msgid "Diverse"
 msgstr "Divers"
 
-#: lib/klass_hero_web/components/provider_components.ex:3284
+#: lib/klass_hero_web/components/provider_components.ex:3278
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr "Dokumenttyp"
@@ -2268,12 +2268,12 @@ msgstr "Weiblich"
 msgid "File"
 msgstr "Datei"
 
-#: lib/klass_hero_web/components/provider_components.ex:3217
+#: lib/klass_hero_web/components/provider_components.ex:3211
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr "Die Datei ist zu groß."
 
-#: lib/klass_hero_web/components/provider_components.ex:3219
+#: lib/klass_hero_web/components/provider_components.ex:3213
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr "Dateityp wird nicht akzeptiert."
@@ -2449,7 +2449,7 @@ msgstr "Niedrigste Klassenstufe"
 msgid "No approved documents."
 msgstr "Keine genehmigten Dokumente."
 
-#: lib/klass_hero_web/components/provider_components.ex:3246
+#: lib/klass_hero_web/components/provider_components.ex:3240
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr "Noch keine Dokumente hochgeladen."
@@ -2533,7 +2533,7 @@ msgstr "Nicht angegeben"
 msgid "Our Story"
 msgstr "Unsere Geschichte"
 
-#: lib/klass_hero_web/components/provider_components.ex:3322
+#: lib/klass_hero_web/components/provider_components.ex:3316
 #: lib/klass_hero_web/live/provider/verification_live.ex:699
 #: lib/klass_hero_web/live/provider/verification_live.ex:773
 #, elixir-autogen, elixir-format
@@ -2715,8 +2715,8 @@ msgstr "Ablehnungsgrund"
 
 #: lib/klass_hero_web/components/provider_components.ex:2703
 #: lib/klass_hero_web/components/provider_components.ex:3067
-#: lib/klass_hero_web/components/provider_components.ex:3341
-#: lib/klass_hero_web/components/provider_components.ex:3421
+#: lib/klass_hero_web/components/provider_components.ex:3335
+#: lib/klass_hero_web/components/provider_components.ex:3415
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr "Entfernen"
@@ -2762,7 +2762,7 @@ msgstr "Zeitplan noch offen"
 msgid "School Grade (optional)"
 msgstr "Klassenstufe (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:3319
+#: lib/klass_hero_web/components/provider_components.ex:3313
 #, elixir-autogen, elixir-format
 msgid "Select File"
 msgstr "Datei auswählen"
@@ -2890,7 +2890,7 @@ msgstr "Dieses Programm wurde von jemand anderem geändert. Bitte schließen Sie
 msgid "Title"
 msgstr "Titel"
 
-#: lib/klass_hero_web/components/provider_components.ex:3218
+#: lib/klass_hero_web/components/provider_components.ex:3212
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr "Zu viele Dateien."
@@ -2915,22 +2915,22 @@ msgstr "Bis Klassenstufe %{max}"
 msgid "Upload CSV"
 msgstr "CSV hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3365
+#: lib/klass_hero_web/components/provider_components.ex:3359
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr "Dokument hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3273
+#: lib/klass_hero_web/components/provider_components.ex:3267
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr "Neues Dokument hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3221
+#: lib/klass_hero_web/components/provider_components.ex:3215
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr "Upload-Fehler."
 
-#: lib/klass_hero_web/components/provider_components.ex:3238
+#: lib/klass_hero_web/components/provider_components.ex:3232
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr "Verifizierungsdokumente"
@@ -3020,7 +3020,7 @@ msgid "Child Safeguarding Training"
 msgstr "Kinderschutzschulung"
 
 #: lib/klass_hero_web/components/marketing_components.ex:1505
-#: lib/klass_hero_web/components/provider_components.ex:3588
+#: lib/klass_hero_web/components/provider_components.ex:3582
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr "Vereinbarung zu Community-Standards"
@@ -3171,7 +3171,7 @@ msgid "Vetted with Care"
 msgstr "Mit Sorgfalt geprüft"
 
 #: lib/klass_hero_web/components/marketing_components.ex:1489
-#: lib/klass_hero_web/components/provider_components.ex:3372
+#: lib/klass_hero_web/components/provider_components.ex:3366
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr "Video-Überprüfung"
@@ -6767,12 +6767,12 @@ msgstr "Deine Identität ist verifiziert."
 msgid "Experience validation"
 msgstr "Erfahrungsnachweis"
 
-#: lib/klass_hero_web/components/provider_components.ex:3402
+#: lib/klass_hero_web/components/provider_components.ex:3396
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr "MP4, MOV oder WEBM. Max. 100 MB."
 
-#: lib/klass_hero_web/components/provider_components.ex:3375
+#: lib/klass_hero_web/components/provider_components.ex:3369
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr "Nimm ein kurzes Video auf, in dem du dich vorstellst. Unser Team prüft es, um Kommunikationsfähigkeit und Übereinstimmung mit unseren Werten einzuschätzen."
@@ -6782,12 +6782,12 @@ msgstr "Nimm ein kurzes Video auf, in dem du dich vorstellst. Unser Team prüft 
 msgid "Safeguarding certificate"
 msgstr "Kinderschutz-Zertifikat"
 
-#: lib/klass_hero_web/components/provider_components.ex:3399
+#: lib/klass_hero_web/components/provider_components.ex:3393
 #, elixir-autogen, elixir-format
 msgid "Select Video"
 msgstr "Video auswählen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3445
+#: lib/klass_hero_web/components/provider_components.ex:3439
 #, elixir-autogen, elixir-format
 msgid "Upload Video"
 msgstr "Video hochladen"
@@ -6797,7 +6797,7 @@ msgstr "Video hochladen"
 msgid "Your browser does not support video playback."
 msgstr "Dein Browser unterstützt keine Videowiedergabe."
 
-#: lib/klass_hero_web/components/provider_components.ex:3592
+#: lib/klass_hero_web/components/provider_components.ex:3586
 #, elixir-autogen, elixir-format
 msgid "Confirm agreement"
 msgstr "Zustimmung bestätigen"
@@ -6807,12 +6807,12 @@ msgstr "Zustimmung bestätigen"
 msgid "Couldn't record your agreement. Please try again."
 msgstr "Deine Zustimmung konnte nicht gespeichert werden. Bitte versuche es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:3615
+#: lib/klass_hero_web/components/provider_components.ex:3609
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr "Vereinbarung herunterladen (PDF)"
 
-#: lib/klass_hero_web/components/provider_components.ex:3591
+#: lib/klass_hero_web/components/provider_components.ex:3585
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr "Ich habe die Klass Hero Community-Richtlinien gelesen und stimme ihnen zu."
@@ -6822,7 +6822,7 @@ msgstr "Ich habe die Klass Hero Community-Richtlinien gelesen und stimme ihnen z
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr "Bitte bestätige, dass du die Community-Richtlinien gelesen hast und ihnen zustimmst."
 
-#: lib/klass_hero_web/components/provider_components.ex:3500
+#: lib/klass_hero_web/components/provider_components.ex:3494
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr "Unterzeichnet von %{name} am %{date} (v%{version})."
@@ -6832,17 +6832,17 @@ msgstr "Unterzeichnet von %{name} am %{date} (v%{version})."
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr "Danke – deine Zustimmung zu den Community-Richtlinien wurde gespeichert."
 
-#: lib/klass_hero_web/components/provider_components.ex:3600
+#: lib/klass_hero_web/components/provider_components.ex:3594
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr "Die Community-Richtlinien wurden seit deiner letzten Zustimmung aktualisiert (v%{old}). Bitte lies sie erneut und stimme erneut zu."
 
-#: lib/klass_hero_web/components/provider_components.ex:3589
+#: lib/klass_hero_web/components/provider_components.ex:3583
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr "Der letzte Schritt: Lies die Klass Hero Community-Richtlinien und stimme ihnen zu."
 
-#: lib/klass_hero_web/components/provider_components.ex:3590
+#: lib/klass_hero_web/components/provider_components.ex:3584
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr "Du hast den Community-Richtlinien zugestimmt."
@@ -7111,12 +7111,12 @@ msgstr "Ihre Versicherungsbescheinigung wird geprüft."
 msgid "Your insurance is verified."
 msgstr "Ihre Versicherung ist verifiziert."
 
-#: lib/klass_hero_web/components/provider_components.ex:3544
+#: lib/klass_hero_web/components/provider_components.ex:3538
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr "Unterzeichnung durch %{name} im Namen des Unternehmens."
 
-#: lib/klass_hero_web/components/provider_components.ex:3647
+#: lib/klass_hero_web/components/provider_components.ex:3641
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr "Bestätige im Namen deines Unternehmens, dass alle Mitarbeitenden gemäß dem deutschen Kinderschutzrecht überprüft sind."
@@ -7126,7 +7126,7 @@ msgstr "Bestätige im Namen deines Unternehmens, dass alle Mitarbeitenden gemä�
 msgid "Couldn't record your declaration. Please try again."
 msgstr "Deine Erklärung konnte nicht gespeichert werden. Bitte versuche es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:3653
+#: lib/klass_hero_web/components/provider_components.ex:3647
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr "Ich bestätige im Namen des Unternehmens, dass die obige Erklärung zutrifft und ich zu ihrer Unterzeichnung berechtigt bin."
@@ -7136,17 +7136,17 @@ msgstr "Ich bestätige im Namen des Unternehmens, dass die obige Erklärung zutr
 msgid "Please confirm the declaration before signing."
 msgstr "Bitte bestätige die Erklärung vor der Unterzeichnung."
 
-#: lib/klass_hero_web/components/provider_components.ex:3678
+#: lib/klass_hero_web/components/provider_components.ex:3672
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr "Vorläufiger Text — vor der Freischaltung noch von einer in Deutschland zugelassenen Anwältin bzw. einem Anwalt zu prüfen."
 
-#: lib/klass_hero_web/components/provider_components.ex:3657
+#: lib/klass_hero_web/components/provider_components.ex:3651
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr "Erklärung unterzeichnen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3645
+#: lib/klass_hero_web/components/provider_components.ex:3639
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr "Erklärung zur Mitarbeiter-Compliance"
@@ -7156,12 +7156,12 @@ msgstr "Erklärung zur Mitarbeiter-Compliance"
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr "Danke — deine Erklärung zur Mitarbeiter-Compliance wurde erfasst."
 
-#: lib/klass_hero_web/components/provider_components.ex:3665
+#: lib/klass_hero_web/components/provider_components.ex:3659
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr "Die Erklärung zur Mitarbeiter-Compliance wurde seit deiner letzten Unterzeichnung aktualisiert (v%{old}). Bitte prüfe sie und unterzeichne erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:3651
+#: lib/klass_hero_web/components/provider_components.ex:3645
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr "Du hast die Erklärung zur Mitarbeiter-Compliance unterzeichnet."
@@ -7755,7 +7755,7 @@ msgstr "Diese Einladung ist abgelaufen. Bitte bitten Sie Ihren Anbieter, sie ern
 msgid "This is your main provider identity. Verification is required to list programs."
 msgstr "Dies ist Ihr Hauptprofil als Anbieter. Eine Verifizierung ist erforderlich, um Programme anzubieten."
 
-#: lib/klass_hero_web/components/provider_components.ex:3241
+#: lib/klass_hero_web/components/provider_components.ex:3235
 #, elixir-autogen, elixir-format
 msgid "Upload documents to be verified. Documents are reviewed by our team."
 msgstr "Laden Sie Dokumente hoch, um verifiziert zu werden. Die Dokumente werden von unserem Team überprüft."
@@ -8044,7 +8044,7 @@ msgstr "%{business} auf %{network}"
 msgid "Klass Hero on %{network}"
 msgstr "Klass Hero auf %{network}"
 
-#: lib/klass_hero_web/components/provider_components.ex:3220
+#: lib/klass_hero_web/components/provider_components.ex:3214
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr "Hochladen fehlgeschlagen."
@@ -8079,27 +8079,27 @@ msgstr "Dieser Anbieter hat derzeit keine offenen Programme. Schauen Sie bald wi
 msgid "General"
 msgstr "Allgemein"
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:345
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:341
 #, elixir-autogen, elixir-format
 msgid "A newly chosen cover or logo appears here after you save."
 msgstr "Ein neu gewähltes Titelbild oder Logo erscheint hier nach dem Speichern."
 
-#: lib/klass_hero_web/components/provider_components.ex:3193
+#: lib/klass_hero_web/components/provider_components.ex:3187
 #, elixir-autogen, elixir-format
 msgid "Add %{network}"
 msgstr "%{network} hinzufügen"
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:329
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:325
 #, elixir-autogen, elixir-format
 msgid "Hide preview"
 msgstr "Vorschau ausblenden"
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:342
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "Public profile preview"
 msgstr "Vorschau des öffentlichen Profils"
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:329
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:325
 #, elixir-autogen, elixir-format
 msgid "Show preview"
 msgstr "Vorschau anzeigen"

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -2136,7 +2136,7 @@ msgstr "Beschreibung"
 msgid "Diverse"
 msgstr "Divers"
 
-#: lib/klass_hero_web/components/provider_components.ex:3278
+#: lib/klass_hero_web/components/provider_components.ex:3284
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr "Dokumenttyp"
@@ -2268,12 +2268,12 @@ msgstr "Weiblich"
 msgid "File"
 msgstr "Datei"
 
-#: lib/klass_hero_web/components/provider_components.ex:3211
+#: lib/klass_hero_web/components/provider_components.ex:3217
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr "Die Datei ist zu groß."
 
-#: lib/klass_hero_web/components/provider_components.ex:3213
+#: lib/klass_hero_web/components/provider_components.ex:3219
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr "Dateityp wird nicht akzeptiert."
@@ -2449,7 +2449,7 @@ msgstr "Niedrigste Klassenstufe"
 msgid "No approved documents."
 msgstr "Keine genehmigten Dokumente."
 
-#: lib/klass_hero_web/components/provider_components.ex:3240
+#: lib/klass_hero_web/components/provider_components.ex:3246
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr "Noch keine Dokumente hochgeladen."
@@ -2533,7 +2533,7 @@ msgstr "Nicht angegeben"
 msgid "Our Story"
 msgstr "Unsere Geschichte"
 
-#: lib/klass_hero_web/components/provider_components.ex:3316
+#: lib/klass_hero_web/components/provider_components.ex:3322
 #: lib/klass_hero_web/live/provider/verification_live.ex:699
 #: lib/klass_hero_web/live/provider/verification_live.ex:773
 #, elixir-autogen, elixir-format
@@ -2715,8 +2715,8 @@ msgstr "Ablehnungsgrund"
 
 #: lib/klass_hero_web/components/provider_components.ex:2703
 #: lib/klass_hero_web/components/provider_components.ex:3067
-#: lib/klass_hero_web/components/provider_components.ex:3335
-#: lib/klass_hero_web/components/provider_components.ex:3415
+#: lib/klass_hero_web/components/provider_components.ex:3341
+#: lib/klass_hero_web/components/provider_components.ex:3421
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr "Entfernen"
@@ -2762,7 +2762,7 @@ msgstr "Zeitplan noch offen"
 msgid "School Grade (optional)"
 msgstr "Klassenstufe (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:3313
+#: lib/klass_hero_web/components/provider_components.ex:3319
 #, elixir-autogen, elixir-format
 msgid "Select File"
 msgstr "Datei auswählen"
@@ -2890,7 +2890,7 @@ msgstr "Dieses Programm wurde von jemand anderem geändert. Bitte schließen Sie
 msgid "Title"
 msgstr "Titel"
 
-#: lib/klass_hero_web/components/provider_components.ex:3212
+#: lib/klass_hero_web/components/provider_components.ex:3218
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr "Zu viele Dateien."
@@ -2915,22 +2915,22 @@ msgstr "Bis Klassenstufe %{max}"
 msgid "Upload CSV"
 msgstr "CSV hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3359
+#: lib/klass_hero_web/components/provider_components.ex:3365
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr "Dokument hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3267
+#: lib/klass_hero_web/components/provider_components.ex:3273
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr "Neues Dokument hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3215
+#: lib/klass_hero_web/components/provider_components.ex:3221
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr "Upload-Fehler."
 
-#: lib/klass_hero_web/components/provider_components.ex:3232
+#: lib/klass_hero_web/components/provider_components.ex:3238
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr "Verifizierungsdokumente"
@@ -3020,7 +3020,7 @@ msgid "Child Safeguarding Training"
 msgstr "Kinderschutzschulung"
 
 #: lib/klass_hero_web/components/marketing_components.ex:1505
-#: lib/klass_hero_web/components/provider_components.ex:3582
+#: lib/klass_hero_web/components/provider_components.ex:3588
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr "Vereinbarung zu Community-Standards"
@@ -3171,7 +3171,7 @@ msgid "Vetted with Care"
 msgstr "Mit Sorgfalt geprüft"
 
 #: lib/klass_hero_web/components/marketing_components.ex:1489
-#: lib/klass_hero_web/components/provider_components.ex:3366
+#: lib/klass_hero_web/components/provider_components.ex:3372
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr "Video-Überprüfung"
@@ -6767,12 +6767,12 @@ msgstr "Deine Identität ist verifiziert."
 msgid "Experience validation"
 msgstr "Erfahrungsnachweis"
 
-#: lib/klass_hero_web/components/provider_components.ex:3396
+#: lib/klass_hero_web/components/provider_components.ex:3402
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr "MP4, MOV oder WEBM. Max. 100 MB."
 
-#: lib/klass_hero_web/components/provider_components.ex:3369
+#: lib/klass_hero_web/components/provider_components.ex:3375
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr "Nimm ein kurzes Video auf, in dem du dich vorstellst. Unser Team prüft es, um Kommunikationsfähigkeit und Übereinstimmung mit unseren Werten einzuschätzen."
@@ -6782,12 +6782,12 @@ msgstr "Nimm ein kurzes Video auf, in dem du dich vorstellst. Unser Team prüft 
 msgid "Safeguarding certificate"
 msgstr "Kinderschutz-Zertifikat"
 
-#: lib/klass_hero_web/components/provider_components.ex:3393
+#: lib/klass_hero_web/components/provider_components.ex:3399
 #, elixir-autogen, elixir-format
 msgid "Select Video"
 msgstr "Video auswählen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3439
+#: lib/klass_hero_web/components/provider_components.ex:3445
 #, elixir-autogen, elixir-format
 msgid "Upload Video"
 msgstr "Video hochladen"
@@ -6797,7 +6797,7 @@ msgstr "Video hochladen"
 msgid "Your browser does not support video playback."
 msgstr "Dein Browser unterstützt keine Videowiedergabe."
 
-#: lib/klass_hero_web/components/provider_components.ex:3586
+#: lib/klass_hero_web/components/provider_components.ex:3592
 #, elixir-autogen, elixir-format
 msgid "Confirm agreement"
 msgstr "Zustimmung bestätigen"
@@ -6807,12 +6807,12 @@ msgstr "Zustimmung bestätigen"
 msgid "Couldn't record your agreement. Please try again."
 msgstr "Deine Zustimmung konnte nicht gespeichert werden. Bitte versuche es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:3609
+#: lib/klass_hero_web/components/provider_components.ex:3615
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr "Vereinbarung herunterladen (PDF)"
 
-#: lib/klass_hero_web/components/provider_components.ex:3585
+#: lib/klass_hero_web/components/provider_components.ex:3591
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr "Ich habe die Klass Hero Community-Richtlinien gelesen und stimme ihnen zu."
@@ -6822,7 +6822,7 @@ msgstr "Ich habe die Klass Hero Community-Richtlinien gelesen und stimme ihnen z
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr "Bitte bestätige, dass du die Community-Richtlinien gelesen hast und ihnen zustimmst."
 
-#: lib/klass_hero_web/components/provider_components.ex:3494
+#: lib/klass_hero_web/components/provider_components.ex:3500
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr "Unterzeichnet von %{name} am %{date} (v%{version})."
@@ -6832,17 +6832,17 @@ msgstr "Unterzeichnet von %{name} am %{date} (v%{version})."
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr "Danke – deine Zustimmung zu den Community-Richtlinien wurde gespeichert."
 
-#: lib/klass_hero_web/components/provider_components.ex:3594
+#: lib/klass_hero_web/components/provider_components.ex:3600
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr "Die Community-Richtlinien wurden seit deiner letzten Zustimmung aktualisiert (v%{old}). Bitte lies sie erneut und stimme erneut zu."
 
-#: lib/klass_hero_web/components/provider_components.ex:3583
+#: lib/klass_hero_web/components/provider_components.ex:3589
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr "Der letzte Schritt: Lies die Klass Hero Community-Richtlinien und stimme ihnen zu."
 
-#: lib/klass_hero_web/components/provider_components.ex:3584
+#: lib/klass_hero_web/components/provider_components.ex:3590
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr "Du hast den Community-Richtlinien zugestimmt."
@@ -7111,12 +7111,12 @@ msgstr "Ihre Versicherungsbescheinigung wird geprüft."
 msgid "Your insurance is verified."
 msgstr "Ihre Versicherung ist verifiziert."
 
-#: lib/klass_hero_web/components/provider_components.ex:3538
+#: lib/klass_hero_web/components/provider_components.ex:3544
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr "Unterzeichnung durch %{name} im Namen des Unternehmens."
 
-#: lib/klass_hero_web/components/provider_components.ex:3641
+#: lib/klass_hero_web/components/provider_components.ex:3647
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr "Bestätige im Namen deines Unternehmens, dass alle Mitarbeitenden gemäß dem deutschen Kinderschutzrecht überprüft sind."
@@ -7126,7 +7126,7 @@ msgstr "Bestätige im Namen deines Unternehmens, dass alle Mitarbeitenden gemä�
 msgid "Couldn't record your declaration. Please try again."
 msgstr "Deine Erklärung konnte nicht gespeichert werden. Bitte versuche es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:3647
+#: lib/klass_hero_web/components/provider_components.ex:3653
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr "Ich bestätige im Namen des Unternehmens, dass die obige Erklärung zutrifft und ich zu ihrer Unterzeichnung berechtigt bin."
@@ -7136,17 +7136,17 @@ msgstr "Ich bestätige im Namen des Unternehmens, dass die obige Erklärung zutr
 msgid "Please confirm the declaration before signing."
 msgstr "Bitte bestätige die Erklärung vor der Unterzeichnung."
 
-#: lib/klass_hero_web/components/provider_components.ex:3672
+#: lib/klass_hero_web/components/provider_components.ex:3678
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr "Vorläufiger Text — vor der Freischaltung noch von einer in Deutschland zugelassenen Anwältin bzw. einem Anwalt zu prüfen."
 
-#: lib/klass_hero_web/components/provider_components.ex:3651
+#: lib/klass_hero_web/components/provider_components.ex:3657
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr "Erklärung unterzeichnen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3639
+#: lib/klass_hero_web/components/provider_components.ex:3645
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr "Erklärung zur Mitarbeiter-Compliance"
@@ -7156,12 +7156,12 @@ msgstr "Erklärung zur Mitarbeiter-Compliance"
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr "Danke — deine Erklärung zur Mitarbeiter-Compliance wurde erfasst."
 
-#: lib/klass_hero_web/components/provider_components.ex:3659
+#: lib/klass_hero_web/components/provider_components.ex:3665
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr "Die Erklärung zur Mitarbeiter-Compliance wurde seit deiner letzten Unterzeichnung aktualisiert (v%{old}). Bitte prüfe sie und unterzeichne erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:3645
+#: lib/klass_hero_web/components/provider_components.ex:3651
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr "Du hast die Erklärung zur Mitarbeiter-Compliance unterzeichnet."
@@ -7755,7 +7755,7 @@ msgstr "Diese Einladung ist abgelaufen. Bitte bitten Sie Ihren Anbieter, sie ern
 msgid "This is your main provider identity. Verification is required to list programs."
 msgstr "Dies ist Ihr Hauptprofil als Anbieter. Eine Verifizierung ist erforderlich, um Programme anzubieten."
 
-#: lib/klass_hero_web/components/provider_components.ex:3235
+#: lib/klass_hero_web/components/provider_components.ex:3241
 #, elixir-autogen, elixir-format
 msgid "Upload documents to be verified. Documents are reviewed by our team."
 msgstr "Laden Sie Dokumente hoch, um verifiziert zu werden. Die Dokumente werden von unserem Team überprüft."
@@ -8044,7 +8044,7 @@ msgstr "%{business} auf %{network}"
 msgid "Klass Hero on %{network}"
 msgstr "Klass Hero auf %{network}"
 
-#: lib/klass_hero_web/components/provider_components.ex:3214
+#: lib/klass_hero_web/components/provider_components.ex:3220
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr "Hochladen fehlgeschlagen."
@@ -8084,7 +8084,7 @@ msgstr "Allgemein"
 msgid "A newly chosen cover or logo appears here after you save."
 msgstr "Ein neu gewähltes Titelbild oder Logo erscheint hier nach dem Speichern."
 
-#: lib/klass_hero_web/components/provider_components.ex:3187
+#: lib/klass_hero_web/components/provider_components.ex:3193
 #, elixir-autogen, elixir-format
 msgid "Add %{network}"
 msgstr "%{network} hinzufügen"
@@ -8104,7 +8104,7 @@ msgstr "Vorschau des öffentlichen Profils"
 msgid "Show preview"
 msgstr "Vorschau anzeigen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3168
+#: lib/klass_hero_web/components/provider_components.ex:3174
 #, elixir-autogen, elixir-format
 msgid "e.g. %{example}"
 msgstr "z. B. %{example}"

--- a/priv/gettext/de/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/de/LC_MESSAGES/enrollment.po
@@ -11,105 +11,105 @@ msgstr ""
 "Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:3017
-#: lib/klass_hero_web/components/provider_components.ex:3034
+#: lib/klass_hero_web/components/provider_components.ex:2982
+#: lib/klass_hero_web/components/provider_components.ex:2999
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr "Vorname des Kindes"
 
-#: lib/klass_hero_web/components/provider_components.ex:3018
-#: lib/klass_hero_web/components/provider_components.ex:3035
+#: lib/klass_hero_web/components/provider_components.ex:2983
+#: lib/klass_hero_web/components/provider_components.ex:3000
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr "Nachname des Kindes"
 
-#: lib/klass_hero_web/components/provider_components.ex:3019
-#: lib/klass_hero_web/components/provider_components.ex:3036
+#: lib/klass_hero_web/components/provider_components.ex:2984
+#: lib/klass_hero_web/components/provider_components.ex:3001
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr "Geburtsdatum"
 
-#: lib/klass_hero_web/components/provider_components.ex:3030
+#: lib/klass_hero_web/components/provider_components.ex:2995
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr "Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:3020
+#: lib/klass_hero_web/components/provider_components.ex:2985
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr "E-Mail des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:3021
+#: lib/klass_hero_web/components/provider_components.ex:2986
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr "Vorname des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:3022
+#: lib/klass_hero_web/components/provider_components.ex:2987
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr "Nachname des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:3029
+#: lib/klass_hero_web/components/provider_components.ex:2994
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr "Programm"
 
-#: lib/klass_hero_web/components/provider_components.ex:3031
+#: lib/klass_hero_web/components/provider_components.ex:2996
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr "Schule"
 
-#: lib/klass_hero_web/components/provider_components.ex:3023
+#: lib/klass_hero_web/components/provider_components.ex:2988
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr "E-Mail des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:3025
+#: lib/klass_hero_web/components/provider_components.ex:2990
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr "Vorname des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:3027
+#: lib/klass_hero_web/components/provider_components.ex:2992
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr "Nachname des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2957
+#: lib/klass_hero_web/components/provider_components.ex:2922
 #, elixir-autogen, elixir-format
 msgid "Date of birth \"%{value}\" is not a valid date. Please correct it and resend."
 msgstr ""
 "Das Geburtsdatum „%{value}“ ist kein gültiges Datum. Bitte korrigieren Sie es "
 "und senden Sie die Einladung erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2951
+#: lib/klass_hero_web/components/provider_components.ex:2916
 #, elixir-autogen, elixir-format
 msgid "Invite link could not be generated (no token). Please resend."
 msgstr ""
 "Der Einladungslink konnte nicht erzeugt werden (kein Token). Bitte erneut "
 "senden."
 
-#: lib/klass_hero_web/components/provider_components.ex:2965
+#: lib/klass_hero_web/components/provider_components.ex:2930
 #, elixir-autogen, elixir-format
 msgid "The invitation email could not be delivered. Please check the address and resend."
 msgstr ""
 "Die Einladungs-E-Mail konnte nicht zugestellt werden. Bitte prüfen Sie die "
 "Adresse und senden Sie die Einladung erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2954
+#: lib/klass_hero_web/components/provider_components.ex:2919
 #, elixir-autogen, elixir-format
 msgid "The program is full, so this child could not be enrolled."
 msgstr ""
 "Das Programm ist ausgebucht, daher konnte dieses Kind nicht angemeldet "
 "werden."
 
-#: lib/klass_hero_web/components/provider_components.ex:2968
+#: lib/klass_hero_web/components/provider_components.ex:2933
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed and no retries remain. Please resend."
 msgstr ""
 "Diese Einladung konnte nicht abgeschlossen werden und es sind keine weiteren "
 "Versuche möglich. Bitte erneut senden."
 
-#: lib/klass_hero_web/components/provider_components.ex:2977
+#: lib/klass_hero_web/components/provider_components.ex:2942
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed. Please resend."
 msgstr "Diese Einladung konnte nicht abgeschlossen werden. Bitte erneut senden."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -2136,7 +2136,7 @@ msgstr ""
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3278
+#: lib/klass_hero_web/components/provider_components.ex:3284
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2268,12 +2268,12 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3211
+#: lib/klass_hero_web/components/provider_components.ex:3217
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3213
+#: lib/klass_hero_web/components/provider_components.ex:3219
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
@@ -2449,7 +2449,7 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3240
+#: lib/klass_hero_web/components/provider_components.ex:3246
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
@@ -2533,7 +2533,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3316
+#: lib/klass_hero_web/components/provider_components.ex:3322
 #: lib/klass_hero_web/live/provider/verification_live.ex:699
 #: lib/klass_hero_web/live/provider/verification_live.ex:773
 #, elixir-autogen, elixir-format
@@ -2715,8 +2715,8 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:2703
 #: lib/klass_hero_web/components/provider_components.ex:3067
-#: lib/klass_hero_web/components/provider_components.ex:3335
-#: lib/klass_hero_web/components/provider_components.ex:3415
+#: lib/klass_hero_web/components/provider_components.ex:3341
+#: lib/klass_hero_web/components/provider_components.ex:3421
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
@@ -2762,7 +2762,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3313
+#: lib/klass_hero_web/components/provider_components.ex:3319
 #, elixir-autogen, elixir-format
 msgid "Select File"
 msgstr ""
@@ -2890,7 +2890,7 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3212
+#: lib/klass_hero_web/components/provider_components.ex:3218
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -2915,22 +2915,22 @@ msgstr ""
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3359
+#: lib/klass_hero_web/components/provider_components.ex:3365
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3267
+#: lib/klass_hero_web/components/provider_components.ex:3273
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3215
+#: lib/klass_hero_web/components/provider_components.ex:3221
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3232
+#: lib/klass_hero_web/components/provider_components.ex:3238
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -3020,7 +3020,7 @@ msgid "Child Safeguarding Training"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1505
-#: lib/klass_hero_web/components/provider_components.ex:3582
+#: lib/klass_hero_web/components/provider_components.ex:3588
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr ""
@@ -3171,7 +3171,7 @@ msgid "Vetted with Care"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1489
-#: lib/klass_hero_web/components/provider_components.ex:3366
+#: lib/klass_hero_web/components/provider_components.ex:3372
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr ""
@@ -6767,12 +6767,12 @@ msgstr ""
 msgid "Experience validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3396
+#: lib/klass_hero_web/components/provider_components.ex:3402
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3369
+#: lib/klass_hero_web/components/provider_components.ex:3375
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
@@ -6782,12 +6782,12 @@ msgstr ""
 msgid "Safeguarding certificate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3393
+#: lib/klass_hero_web/components/provider_components.ex:3399
 #, elixir-autogen, elixir-format
 msgid "Select Video"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3439
+#: lib/klass_hero_web/components/provider_components.ex:3445
 #, elixir-autogen, elixir-format
 msgid "Upload Video"
 msgstr ""
@@ -6797,7 +6797,7 @@ msgstr ""
 msgid "Your browser does not support video playback."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3586
+#: lib/klass_hero_web/components/provider_components.ex:3592
 #, elixir-autogen, elixir-format
 msgid "Confirm agreement"
 msgstr ""
@@ -6807,12 +6807,12 @@ msgstr ""
 msgid "Couldn't record your agreement. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3609
+#: lib/klass_hero_web/components/provider_components.ex:3615
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3585
+#: lib/klass_hero_web/components/provider_components.ex:3591
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr ""
@@ -6822,7 +6822,7 @@ msgstr ""
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3494
+#: lib/klass_hero_web/components/provider_components.ex:3500
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr ""
@@ -6832,17 +6832,17 @@ msgstr ""
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3594
+#: lib/klass_hero_web/components/provider_components.ex:3600
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3583
+#: lib/klass_hero_web/components/provider_components.ex:3589
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3584
+#: lib/klass_hero_web/components/provider_components.ex:3590
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
@@ -7111,12 +7111,12 @@ msgstr ""
 msgid "Your insurance is verified."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3538
+#: lib/klass_hero_web/components/provider_components.ex:3544
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3641
+#: lib/klass_hero_web/components/provider_components.ex:3647
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr ""
@@ -7126,7 +7126,7 @@ msgstr ""
 msgid "Couldn't record your declaration. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3647
+#: lib/klass_hero_web/components/provider_components.ex:3653
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr ""
@@ -7136,17 +7136,17 @@ msgstr ""
 msgid "Please confirm the declaration before signing."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3672
+#: lib/klass_hero_web/components/provider_components.ex:3678
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3651
+#: lib/klass_hero_web/components/provider_components.ex:3657
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3639
+#: lib/klass_hero_web/components/provider_components.ex:3645
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr ""
@@ -7156,12 +7156,12 @@ msgstr ""
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3659
+#: lib/klass_hero_web/components/provider_components.ex:3665
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3645
+#: lib/klass_hero_web/components/provider_components.ex:3651
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
@@ -7740,7 +7740,7 @@ msgstr ""
 msgid "This is your main provider identity. Verification is required to list programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3235
+#: lib/klass_hero_web/components/provider_components.ex:3241
 #, elixir-autogen, elixir-format
 msgid "Upload documents to be verified. Documents are reviewed by our team."
 msgstr ""
@@ -8026,7 +8026,7 @@ msgstr ""
 msgid "Klass Hero on %{network}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3214
+#: lib/klass_hero_web/components/provider_components.ex:3220
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr ""
@@ -8066,7 +8066,7 @@ msgstr ""
 msgid "A newly chosen cover or logo appears here after you save."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3187
+#: lib/klass_hero_web/components/provider_components.ex:3193
 #, elixir-autogen, elixir-format
 msgid "Add %{network}"
 msgstr ""
@@ -8086,7 +8086,7 @@ msgstr ""
 msgid "Show preview"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3168
+#: lib/klass_hero_web/components/provider_components.ex:3174
 #, elixir-autogen, elixir-format
 msgid "e.g. %{example}"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -45,7 +45,7 @@ msgstr ""
 #: lib/klass_hero_web/components/layouts/app.html.heex:131
 #: lib/klass_hero_web/components/layouts/app.html.heex:206
 #: lib/klass_hero_web/components/layouts/app.html.heex:231
-#: lib/klass_hero_web/components/provider_components.ex:391
+#: lib/klass_hero_web/components/provider_components.ex:392
 #: lib/klass_hero_web/components/ui_components.ex:277
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
@@ -136,7 +136,7 @@ msgid "Your Data"
 msgstr ""
 
 #: lib/klass_hero_web/components/core_components.ex:71
-#: lib/klass_hero_web/components/provider_components.ex:1705
+#: lib/klass_hero_web/components/provider_components.ex:1682
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr ""
@@ -231,7 +231,7 @@ msgstr ""
 msgid "Enroll Now - %{price}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1424
+#: lib/klass_hero_web/components/provider_components.ex:1401
 #: lib/klass_hero_web/live/booking_live.ex:305
 #, elixir-autogen, elixir-format
 msgid "Enrollment"
@@ -415,7 +415,7 @@ msgid "Account Termination"
 msgstr ""
 
 #: lib/klass_hero_web/live/contact_live.ex:85
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:314
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:324
 #: lib/klass_hero_web/live/provider_profile_live.ex:107
 #, elixir-autogen, elixir-format
 msgid "Address"
@@ -576,9 +576,9 @@ msgstr ""
 msgid "Dispute Resolution"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:722
-#: lib/klass_hero_web/components/provider_components.ex:2801
-#: lib/klass_hero_web/components/provider_components.ex:2819
+#: lib/klass_hero_web/components/provider_components.ex:719
+#: lib/klass_hero_web/components/provider_components.ex:2766
+#: lib/klass_hero_web/components/provider_components.ex:2784
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
@@ -813,7 +813,7 @@ msgid "Payment Terms"
 msgstr ""
 
 #: lib/klass_hero_web/live/contact_live.ex:78
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:299
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:309
 #: lib/klass_hero_web/live/provider_profile_live.ex:113
 #, elixir-autogen, elixir-format
 msgid "Phone"
@@ -869,7 +869,7 @@ msgstr ""
 msgid "Save Password"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:414
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:372
 #: lib/klass_hero_web/live/settings/children_live.ex:708
 #: lib/klass_hero_web/live/user_live/settings.ex:153
 #, elixir-autogen, elixir-format
@@ -881,9 +881,9 @@ msgstr ""
 msgid "Select one or both options"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2451
-#: lib/klass_hero_web/components/provider_components.ex:2452
-#: lib/klass_hero_web/components/provider_components.ex:2489
+#: lib/klass_hero_web/components/provider_components.ex:2416
+#: lib/klass_hero_web/components/provider_components.ex:2417
+#: lib/klass_hero_web/components/provider_components.ex:2454
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:468
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:469
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:505
@@ -1106,7 +1106,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/composite_components.ex:56
 #: lib/klass_hero_web/components/layouts/admin.html.heex:85
-#: lib/klass_hero_web/components/provider_components.ex:121
+#: lib/klass_hero_web/components/provider_components.ex:122
 #: lib/klass_hero_web/live/admin/sessions_live.ex:26
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:3
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:341
@@ -1210,7 +1210,7 @@ msgstr ""
 msgid "Music"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:758
+#: lib/klass_hero_web/components/provider_components.ex:755
 #: lib/klass_hero_web/live/for_providers_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "Qualifications"
@@ -1332,19 +1332,19 @@ msgstr ""
 msgid "Quick Navigation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1427
-#: lib/klass_hero_web/components/provider_components.ex:2411
-#: lib/klass_hero_web/components/provider_components.ex:2688
+#: lib/klass_hero_web/components/provider_components.ex:1404
+#: lib/klass_hero_web/components/provider_components.ex:2376
+#: lib/klass_hero_web/components/provider_components.ex:2653
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1573
+#: lib/klass_hero_web/components/provider_components.ex:1550
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:675
+#: lib/klass_hero_web/components/provider_components.ex:672
 #: lib/klass_hero_web/live/provider/team_live.ex:627
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
@@ -1355,7 +1355,7 @@ msgstr ""
 msgid "All Staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1418
+#: lib/klass_hero_web/components/provider_components.ex:1395
 #, elixir-autogen, elixir-format
 msgid "Assigned Staff"
 msgstr ""
@@ -1377,8 +1377,8 @@ msgstr ""
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:542
-#: lib/klass_hero_web/components/provider_components.ex:1536
+#: lib/klass_hero_web/components/provider_components.ex:543
+#: lib/klass_hero_web/components/provider_components.ex:1513
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:65
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:92
 #: lib/klass_hero_web/live/settings/children_live.ex:413
@@ -1388,57 +1388,57 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:225
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:33
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:208
+#: lib/klass_hero_web/components/provider_components.ex:226
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:34
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "Edit Profile"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1575
+#: lib/klass_hero_web/components/provider_components.ex:1552
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:114
+#: lib/klass_hero_web/components/provider_components.ex:115
 #: lib/klass_hero_web/live/provider/programs_live.ex:55
 #, elixir-autogen, elixir-format
 msgid "My Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:417
-#: lib/klass_hero_web/components/provider_components.ex:923
+#: lib/klass_hero_web/components/provider_components.ex:418
+#: lib/klass_hero_web/components/provider_components.ex:910
 #, elixir-autogen, elixir-format
 msgid "New Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:100
+#: lib/klass_hero_web/components/provider_components.ex:101
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:48
-#: lib/klass_hero_web/components/provider_components.ex:74
-#: lib/klass_hero_web/components/provider_components.ex:1574
-#: lib/klass_hero_web/components/provider_components.ex:2895
-#: lib/klass_hero_web/components/provider_components.ex:2913
+#: lib/klass_hero_web/components/provider_components.ex:49
+#: lib/klass_hero_web/components/provider_components.ex:75
+#: lib/klass_hero_web/components/provider_components.ex:1551
+#: lib/klass_hero_web/components/provider_components.ex:2860
+#: lib/klass_hero_web/components/provider_components.ex:2878
 #: lib/klass_hero_web/live/admin/sessions_live.ex:293
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1505
+#: lib/klass_hero_web/components/provider_components.ex:1482
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1358
+#: lib/klass_hero_web/components/provider_components.ex:1335
 #, elixir-autogen, elixir-format
 msgid "Program Inventory"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1415
+#: lib/klass_hero_web/components/provider_components.ex:1392
 #, elixir-autogen, elixir-format
 msgid "Program Name"
 msgstr ""
@@ -1453,15 +1453,15 @@ msgstr ""
 msgid "Save for Later"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1375
+#: lib/klass_hero_web/components/provider_components.ex:1352
 #, elixir-autogen, elixir-format
 msgid "Search by name..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1421
-#: lib/klass_hero_web/components/provider_components.ex:1824
-#: lib/klass_hero_web/components/provider_components.ex:2402
-#: lib/klass_hero_web/components/provider_components.ex:2685
+#: lib/klass_hero_web/components/provider_components.ex:1398
+#: lib/klass_hero_web/components/provider_components.ex:1801
+#: lib/klass_hero_web/components/provider_components.ex:2367
+#: lib/klass_hero_web/components/provider_components.ex:2650
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:107
+#: lib/klass_hero_web/components/provider_components.ex:108
 #: lib/klass_hero_web/live/provider/team_live.ex:36
 #, elixir-autogen, elixir-format
 msgid "Team & Profiles"
@@ -1480,22 +1480,22 @@ msgstr ""
 msgid "Team & Provider Profiles"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1478
-#: lib/klass_hero_web/components/provider_components.ex:1839
+#: lib/klass_hero_web/components/provider_components.ex:1455
+#: lib/klass_hero_web/components/provider_components.ex:1816
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr ""
 
 #: lib/klass_hero_web/components/messaging_components.ex:729
-#: lib/klass_hero_web/components/provider_components.ex:51
-#: lib/klass_hero_web/components/provider_components.ex:1576
+#: lib/klass_hero_web/components/provider_components.ex:52
+#: lib/klass_hero_web/components/provider_components.ex:1553
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:455
 #: lib/klass_hero_web/presenters/provider_presenter.ex:172
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1516
+#: lib/klass_hero_web/components/provider_components.ex:1493
 #, elixir-autogen, elixir-format
 msgid "View Roster"
 msgstr ""
@@ -1555,10 +1555,10 @@ msgstr ""
 #: lib/klass_hero_web/components/participation_components.ex:456
 #: lib/klass_hero_web/components/participation_components.ex:681
 #: lib/klass_hero_web/components/participation_components.ex:772
-#: lib/klass_hero_web/components/provider_components.ex:860
-#: lib/klass_hero_web/components/provider_components.ex:1274
-#: lib/klass_hero_web/components/provider_components.ex:1991
-#: lib/klass_hero_web/components/provider_components.ex:2593
+#: lib/klass_hero_web/components/provider_components.ex:847
+#: lib/klass_hero_web/components/provider_components.ex:1261
+#: lib/klass_hero_web/components/provider_components.ex:1968
+#: lib/klass_hero_web/components/provider_components.ex:2558
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:478
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
@@ -1614,7 +1614,7 @@ msgstr ""
 msgid "Data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2782
+#: lib/klass_hero_web/components/provider_components.ex:2747
 #: lib/klass_hero_web/live/settings/children_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1662,17 +1662,17 @@ msgstr ""
 msgid "Failed to submit note"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2776
-#: lib/klass_hero_web/components/provider_components.ex:2805
-#: lib/klass_hero_web/components/provider_components.ex:2821
+#: lib/klass_hero_web/components/provider_components.ex:2741
+#: lib/klass_hero_web/components/provider_components.ex:2770
+#: lib/klass_hero_web/components/provider_components.ex:2786
 #: lib/klass_hero_web/live/settings/children_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2777
-#: lib/klass_hero_web/components/provider_components.ex:2806
-#: lib/klass_hero_web/components/provider_components.ex:2822
+#: lib/klass_hero_web/components/provider_components.ex:2742
+#: lib/klass_hero_web/components/provider_components.ex:2771
+#: lib/klass_hero_web/components/provider_components.ex:2787
 #: lib/klass_hero_web/live/settings/children_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -1803,15 +1803,15 @@ msgstr ""
 msgid "Provider data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:845
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:312
+#: lib/klass_hero_web/components/provider_components.ex:832
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:305
 #: lib/klass_hero_web/live/settings/children_live.ex:719
 #, elixir-autogen, elixir-format
 msgid "Save Changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1683
-#: lib/klass_hero_web/components/provider_components.ex:1684
+#: lib/klass_hero_web/components/provider_components.ex:1660
+#: lib/klass_hero_web/components/provider_components.ex:1661
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:43
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:151
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:252
@@ -1829,7 +1829,7 @@ msgstr ""
 msgid "Send a message to start the conversation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2876
+#: lib/klass_hero_web/components/provider_components.ex:2841
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:249
 #, elixir-autogen, elixir-format
@@ -1935,12 +1935,12 @@ msgstr[1] ""
 msgid "%{gender} only"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:310
+#: lib/klass_hero_web/components/provider_components.ex:311
 #, elixir-autogen, elixir-format
 msgid "Action Required"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:847
+#: lib/klass_hero_web/components/provider_components.ex:834
 #, elixir-autogen, elixir-format
 msgid "Add Member"
 msgstr ""
@@ -1960,12 +1960,12 @@ msgstr ""
 msgid "Ages %{min}+"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1175
+#: lib/klass_hero_web/components/provider_components.ex:1162
 #, elixir-autogen, elixir-format
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2935
+#: lib/klass_hero_web/components/provider_components.ex:2900
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred during import."
 msgstr ""
@@ -1978,7 +1978,7 @@ msgid "Approve"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:881
-#: lib/klass_hero_web/components/provider_components.ex:49
+#: lib/klass_hero_web/components/provider_components.ex:50
 #: lib/klass_hero_web/live/admin/sessions_live.ex:290
 #: lib/klass_hero_web/live/admin/verifications_live.ex:202
 #: lib/klass_hero_web/presenters/vetting_checklist_presenter.ex:141
@@ -1996,9 +1996,9 @@ msgstr ""
 msgid "As fathers and partners of teachers in Berlin, we saw and heard firsthand how hard it is to find, book, and manage quality youth activities outside the classroom. Klass Hero is the complete platform connecting Berlin families and schools with trusted, vetted activity providers — offering safe, supervised, and enriching experiences across sports, arts, tutoring, and more. We verify every provider, structure every booking, and support every step — so parents know their child is in good hands, and providers can focus on what they do best: inspiring kids."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:204
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:237
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:263
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:223
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:233
 #, elixir-autogen, elixir-format
 msgid "Back to Dashboard"
 msgstr ""
@@ -2008,7 +2008,7 @@ msgstr ""
 msgid "Back to verifications"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:731
+#: lib/klass_hero_web/components/provider_components.ex:728
 #, elixir-autogen, elixir-format
 msgid "Bio"
 msgstr ""
@@ -2018,7 +2018,7 @@ msgstr ""
 msgid "Book a Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:732
+#: lib/klass_hero_web/components/provider_components.ex:729
 #, elixir-autogen, elixir-format
 msgid "Brief description of experience and specialties..."
 msgstr ""
@@ -2033,19 +2033,19 @@ msgstr ""
 msgid "Business"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:953
+#: lib/klass_hero_web/components/provider_components.ex:940
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "Category"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1124
+#: lib/klass_hero_web/components/provider_components.ex:1111
 #, elixir-autogen, elixir-format
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2399
-#: lib/klass_hero_web/components/provider_components.ex:2671
+#: lib/klass_hero_web/components/provider_components.ex:2364
+#: lib/klass_hero_web/components/provider_components.ex:2636
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2060,22 +2060,23 @@ msgstr ""
 msgid "Child meets all program requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1247
+#: lib/klass_hero_web/components/provider_components.ex:1234
 #, elixir-autogen, elixir-format
 msgid "Choose Image"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:239
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:273
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:363
 #, elixir-autogen, elixir-format
 msgid "Choose Logo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:826
+#: lib/klass_hero_web/components/provider_components.ex:823
 #, elixir-autogen, elixir-format
 msgid "Choose Photo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:955
+#: lib/klass_hero_web/components/provider_components.ex:942
 #, elixir-autogen, elixir-format
 msgid "Choose a category"
 msgstr ""
@@ -2085,7 +2086,7 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2896
+#: lib/klass_hero_web/components/provider_components.ex:2861
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
@@ -2105,37 +2106,37 @@ msgstr ""
 msgid "Could not remove invite."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1241
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:278
+#: lib/klass_hero_web/components/provider_components.ex:1228
+#: lib/klass_hero_web/components/provider_components.ex:3149
 #, elixir-autogen, elixir-format
 msgid "Cover Image"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1118
+#: lib/klass_hero_web/components/provider_components.ex:1105
 #, elixir-autogen, elixir-format
 msgid "Define age, gender, or grade restrictions for eligible participants."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1234
+#: lib/klass_hero_web/components/provider_components.ex:1221
 #, elixir-autogen, elixir-format
 msgid "Describe your program..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1233
+#: lib/klass_hero_web/components/provider_components.ex:1220
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:323
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:288
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:298
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:696
-#: lib/klass_hero_web/components/provider_components.ex:1186
+#: lib/klass_hero_web/components/provider_components.ex:1173
 #: lib/klass_hero_web/live/settings/children_live.ex:635
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3204
+#: lib/klass_hero_web/components/provider_components.ex:3278
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2163,13 +2164,13 @@ msgstr ""
 msgid "Document rejected."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:156
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:171
 #: lib/klass_hero_web/live/provider/verification_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2612
+#: lib/klass_hero_web/components/provider_components.ex:2577
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
@@ -2179,40 +2180,40 @@ msgstr ""
 msgid "Download document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:921
+#: lib/klass_hero_web/components/provider_components.ex:908
 #, elixir-autogen, elixir-format
 msgid "Edit Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:673
+#: lib/klass_hero_web/components/provider_components.ex:670
 #, elixir-autogen, elixir-format
 msgid "Edit Team Member"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1039
+#: lib/klass_hero_web/components/provider_components.ex:1026
 #, elixir-autogen, elixir-format
 msgid "End Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1026
+#: lib/klass_hero_web/components/provider_components.ex:1013
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2408
-#: lib/klass_hero_web/components/provider_components.ex:2916
+#: lib/klass_hero_web/components/provider_components.ex:2373
+#: lib/klass_hero_web/components/provider_components.ex:2881
 #: lib/klass_hero_web/components/provider_layout_components.ex:612
 #, elixir-autogen, elixir-format
 msgid "Enrolled"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1729
+#: lib/klass_hero_web/components/provider_components.ex:1706
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1067
+#: lib/klass_hero_web/components/provider_components.ex:1054
 #, elixir-autogen, elixir-format
 msgid "Enrollment Capacity (optional)"
 msgstr ""
@@ -2222,8 +2223,8 @@ msgstr ""
 msgid "Explain why this document is being rejected..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:72
-#: lib/klass_hero_web/components/provider_components.ex:2917
+#: lib/klass_hero_web/components/provider_components.ex:73
+#: lib/klass_hero_web/components/provider_components.ex:2882
 #: lib/klass_hero_web/live/admin/emails_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2244,7 +2245,7 @@ msgstr ""
 msgid "Failed to resend invite."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:165
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:180
 #: lib/klass_hero_web/live/provider/verification_live.ex:254
 #, elixir-autogen, elixir-format
 msgid "Failed to upload document."
@@ -2256,7 +2257,7 @@ msgid "Family Programs"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:694
-#: lib/klass_hero_web/components/provider_components.ex:1185
+#: lib/klass_hero_web/components/provider_components.ex:1172
 #: lib/klass_hero_web/live/settings/children_live.ex:634
 #, elixir-autogen, elixir-format
 msgid "Female"
@@ -2267,22 +2268,22 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3137
+#: lib/klass_hero_web/components/provider_components.ex:3211
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3139
+#: lib/klass_hero_web/components/provider_components.ex:3213
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:759
+#: lib/klass_hero_web/components/provider_components.ex:756
 #, elixir-autogen, elixir-format
 msgid "First Aid, UEFA B License, Child Care Cert"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:701
+#: lib/klass_hero_web/components/provider_components.ex:698
 #, elixir-autogen, elixir-format
 msgid "First Name"
 msgstr ""
@@ -2307,12 +2308,12 @@ msgstr ""
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2682
+#: lib/klass_hero_web/components/provider_components.ex:2647
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:820
+#: lib/klass_hero_web/components/provider_components.ex:817
 #, elixir-autogen, elixir-format
 msgid "Headshot Photo"
 msgstr ""
@@ -2322,7 +2323,7 @@ msgstr ""
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2585
+#: lib/klass_hero_web/components/provider_components.ex:2550
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -2347,19 +2348,19 @@ msgstr ""
 msgid "Invite resent successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1746
+#: lib/klass_hero_web/components/provider_components.ex:1723
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:827
+#: lib/klass_hero_web/components/provider_components.ex:824
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 1MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1248
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:240
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:365
+#: lib/klass_hero_web/components/provider_components.ex:1235
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:274
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:364
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 2MB."
 msgstr ""
@@ -2374,71 +2375,71 @@ msgstr ""
 msgid "Klasse %{n}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:707
+#: lib/klass_hero_web/components/provider_components.ex:704
 #, elixir-autogen, elixir-format
 msgid "Last Name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1049
+#: lib/klass_hero_web/components/provider_components.ex:1036
 #, elixir-autogen, elixir-format
 msgid "Leave blank for open registration at any time."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1178
+#: lib/klass_hero_web/components/provider_components.ex:1165
 #, elixir-autogen, elixir-format
 msgid "Leave unchecked to allow all genders."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:982
+#: lib/klass_hero_web/components/provider_components.ex:969
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:191
 #, elixir-autogen, elixir-format
 msgid "Location"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:81
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:81
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:96
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:83
 #, elixir-autogen, elixir-format
 msgid "Logo upload failed. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:695
-#: lib/klass_hero_web/components/provider_components.ex:1184
+#: lib/klass_hero_web/components/provider_components.ex:1171
 #: lib/klass_hero_web/live/settings/children_live.ex:633
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1168
+#: lib/klass_hero_web/components/provider_components.ex:1155
 #, elixir-autogen, elixir-format
 msgid "Maximum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1082
+#: lib/klass_hero_web/components/provider_components.ex:1069
 #, elixir-autogen, elixir-format
 msgid "Maximum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1223
+#: lib/klass_hero_web/components/provider_components.ex:1210
 #, elixir-autogen, elixir-format
 msgid "Maximum Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:991
+#: lib/klass_hero_web/components/provider_components.ex:978
 #, elixir-autogen, elixir-format
 msgid "Meeting Days"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1162
+#: lib/klass_hero_web/components/provider_components.ex:1149
 #, elixir-autogen, elixir-format
 msgid "Minimum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1076
+#: lib/klass_hero_web/components/provider_components.ex:1063
 #, elixir-autogen, elixir-format
 msgid "Minimum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1216
+#: lib/klass_hero_web/components/provider_components.ex:1203
 #, elixir-autogen, elixir-format
 msgid "Minimum Grade"
 msgstr ""
@@ -2448,12 +2449,12 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3166
+#: lib/klass_hero_web/components/provider_components.ex:3240
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2392
+#: lib/klass_hero_web/components/provider_components.ex:2357
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
@@ -2469,17 +2470,17 @@ msgstr ""
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2636
+#: lib/klass_hero_web/components/provider_components.ex:2601
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1225
+#: lib/klass_hero_web/components/provider_components.ex:1212
 #, elixir-autogen, elixir-format
 msgid "No maximum"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1218
+#: lib/klass_hero_web/components/provider_components.ex:1205
 #, elixir-autogen, elixir-format
 msgid "No minimum"
 msgstr ""
@@ -2510,18 +2511,18 @@ msgstr ""
 msgid "No verification documents found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1260
+#: lib/klass_hero_web/components/provider_components.ex:1247
 #, elixir-autogen, elixir-format
 msgid "None (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:326
+#: lib/klass_hero_web/components/provider_components.ex:327
 #, elixir-autogen, elixir-format
 msgid "Not Verified"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:697
-#: lib/klass_hero_web/components/provider_components.ex:1187
+#: lib/klass_hero_web/components/provider_components.ex:1174
 #: lib/klass_hero_web/live/settings/children_live.ex:632
 #, elixir-autogen, elixir-format
 msgid "Not specified"
@@ -2532,7 +2533,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3242
+#: lib/klass_hero_web/components/provider_components.ex:3316
 #: lib/klass_hero_web/live/provider/verification_live.ex:699
 #: lib/klass_hero_web/live/provider/verification_live.ex:773
 #, elixir-autogen, elixir-format
@@ -2544,21 +2545,21 @@ msgstr ""
 msgid "Participant Requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1115
+#: lib/klass_hero_web/components/provider_components.ex:1102
 #, elixir-autogen, elixir-format
 msgid "Participant Restrictions (optional)"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:880
-#: lib/klass_hero_web/components/provider_components.ex:294
+#: lib/klass_hero_web/components/provider_components.ex:295
 #, elixir-autogen, elixir-format
 msgid "Pending Review"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:102
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:117
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:109
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:111
 #: lib/klass_hero_web/live/provider/programs_live.ex:739
 #: lib/klass_hero_web/live/provider/programs_live.ex:808
 #: lib/klass_hero_web/live/provider/team_live.ex:305
@@ -2578,17 +2579,17 @@ msgstr ""
 msgid "Preview not available for this file type."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:973
+#: lib/klass_hero_web/components/provider_components.ex:960
 #, elixir-autogen, elixir-format
 msgid "Price (EUR)"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:98
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:113
 #, elixir-autogen, elixir-format
 msgid "Profile updated successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1153
+#: lib/klass_hero_web/components/provider_components.ex:1140
 #, elixir-autogen, elixir-format
 msgid "Program Start"
 msgstr ""
@@ -2619,7 +2620,7 @@ msgstr ""
 msgid "Program updated successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:107
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:122
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:32
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:27
 #, elixir-autogen, elixir-format
@@ -2632,13 +2633,13 @@ msgid "Read our founding story →"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:860
-#: lib/klass_hero_web/components/provider_components.ex:2915
+#: lib/klass_hero_web/components/provider_components.ex:2880
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Registered"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1140
+#: lib/klass_hero_web/components/provider_components.ex:1127
 #, elixir-autogen, elixir-format
 msgid "Registration"
 msgstr ""
@@ -2648,7 +2649,7 @@ msgstr ""
 msgid "Registration Closed"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1060
+#: lib/klass_hero_web/components/provider_components.ex:1047
 #, elixir-autogen, elixir-format
 msgid "Registration Closes"
 msgstr ""
@@ -2658,12 +2659,12 @@ msgstr ""
 msgid "Registration Not Open Yet"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1055
+#: lib/klass_hero_web/components/provider_components.ex:1042
 #, elixir-autogen, elixir-format
 msgid "Registration Opens"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1046
+#: lib/klass_hero_web/components/provider_components.ex:1033
 #, elixir-autogen, elixir-format
 msgid "Registration Period (optional)"
 msgstr ""
@@ -2700,7 +2701,7 @@ msgid "Reject"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:882
-#: lib/klass_hero_web/components/provider_components.ex:50
+#: lib/klass_hero_web/components/provider_components.ex:51
 #: lib/klass_hero_web/live/admin/verifications_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Rejected"
@@ -2712,16 +2713,15 @@ msgstr ""
 msgid "Rejection reason"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2738
-#: lib/klass_hero_web/components/provider_components.ex:3102
-#: lib/klass_hero_web/components/provider_components.ex:3261
-#: lib/klass_hero_web/components/provider_components.ex:3341
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:380
+#: lib/klass_hero_web/components/provider_components.ex:2703
+#: lib/klass_hero_web/components/provider_components.ex:3067
+#: lib/klass_hero_web/components/provider_components.ex:3335
+#: lib/klass_hero_web/components/provider_components.ex:3415
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2731
+#: lib/klass_hero_web/components/provider_components.ex:2696
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -2731,23 +2731,23 @@ msgstr ""
 msgid "Reviewed"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:716
+#: lib/klass_hero_web/components/provider_components.ex:713
 #, elixir-autogen, elixir-format
 msgid "Role"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1675
+#: lib/klass_hero_web/components/provider_components.ex:1652
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:407
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1287
+#: lib/klass_hero_web/components/provider_components.ex:1264
 #, elixir-autogen, elixir-format
 msgid "Save Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:988
+#: lib/klass_hero_web/components/provider_components.ex:975
 #, elixir-autogen, elixir-format
 msgid "Schedule (optional)"
 msgstr ""
@@ -2762,7 +2762,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3239
+#: lib/klass_hero_web/components/provider_components.ex:3313
 #, elixir-autogen, elixir-format
 msgid "Select File"
 msgstr ""
@@ -2779,23 +2779,23 @@ msgstr ""
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2914
+#: lib/klass_hero_web/components/provider_components.ex:2879
 #: lib/klass_hero_web/live/admin/emails_live.ex:206
 #, elixir-autogen, elixir-format
 msgid "Sent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:763
+#: lib/klass_hero_web/components/provider_components.ex:760
 #, elixir-autogen, elixir-format
 msgid "Separate multiple qualifications with commas"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1070
+#: lib/klass_hero_web/components/provider_components.ex:1057
 #, elixir-autogen, elixir-format
 msgid "Set minimum and maximum enrollment for this program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:737
+#: lib/klass_hero_web/components/provider_components.ex:734
 #, elixir-autogen, elixir-format
 msgid "Specialties"
 msgstr ""
@@ -2813,12 +2813,12 @@ msgstr ""
 msgid "Staff member not found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1034
+#: lib/klass_hero_web/components/provider_components.ex:1021
 #, elixir-autogen, elixir-format
 msgid "Start Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1021
+#: lib/klass_hero_web/components/provider_components.ex:1008
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:184
 #, elixir-autogen, elixir-format
 msgid "Start Time"
@@ -2864,7 +2864,7 @@ msgstr ""
 msgid "Team member updated."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:226
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "Tell parents about your organization..."
 msgstr ""
@@ -2884,13 +2884,13 @@ msgstr ""
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:946
-#: lib/klass_hero_web/components/provider_components.ex:1957
+#: lib/klass_hero_web/components/provider_components.ex:933
+#: lib/klass_hero_web/components/provider_components.ex:1934
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3138
+#: lib/klass_hero_web/components/provider_components.ex:3212
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -2910,27 +2910,27 @@ msgstr ""
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2572
+#: lib/klass_hero_web/components/provider_components.ex:2537
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3285
+#: lib/klass_hero_web/components/provider_components.ex:3359
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3193
+#: lib/klass_hero_web/components/provider_components.ex:3267
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3141
+#: lib/klass_hero_web/components/provider_components.ex:3215
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3158
+#: lib/klass_hero_web/components/provider_components.ex:3232
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -2952,7 +2952,7 @@ msgstr ""
 msgid "Verifications"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:278
+#: lib/klass_hero_web/components/provider_components.ex:279
 #: lib/klass_hero_web/components/provider_layout_components.ex:217
 #: lib/klass_hero_web/components/ui_components.ex:1671
 #, elixir-autogen, elixir-format
@@ -2969,32 +2969,32 @@ msgstr ""
 msgid "You don't have access to that page."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:717
+#: lib/klass_hero_web/components/provider_components.ex:714
 #, elixir-autogen, elixir-format
 msgid "e.g. Head Coach"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:708
+#: lib/klass_hero_web/components/provider_components.ex:705
 #, elixir-autogen, elixir-format
 msgid "e.g. Johnson"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:702
+#: lib/klass_hero_web/components/provider_components.ex:699
 #, elixir-autogen, elixir-format
 msgid "e.g. Mike"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:723
+#: lib/klass_hero_web/components/provider_components.ex:720
 #, elixir-autogen, elixir-format
 msgid "e.g. mike@example.com"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:947
+#: lib/klass_hero_web/components/provider_components.ex:934
 #, elixir-autogen, elixir-format
 msgid "e.g., Art Adventures"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:983
+#: lib/klass_hero_web/components/provider_components.ex:970
 #, elixir-autogen, elixir-format
 msgid "e.g., Community Center, Main St"
 msgstr ""
@@ -3020,7 +3020,7 @@ msgid "Child Safeguarding Training"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1505
-#: lib/klass_hero_web/components/provider_components.ex:3508
+#: lib/klass_hero_web/components/provider_components.ex:3582
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr ""
@@ -3171,7 +3171,7 @@ msgid "Vetted with Care"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1489
-#: lib/klass_hero_web/components/provider_components.ex:3292
+#: lib/klass_hero_web/components/provider_components.ex:3366
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr ""
@@ -3345,7 +3345,7 @@ msgstr ""
 msgid "Checked Out"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2773
+#: lib/klass_hero_web/components/provider_components.ex:2738
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Child"
@@ -3391,7 +3391,7 @@ msgstr ""
 msgid "Download monthly statements for taxes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2488
+#: lib/klass_hero_web/components/provider_components.ex:2453
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:504
 #, elixir-autogen, elixir-format
 msgid "Enrollment not confirmed"
@@ -3464,7 +3464,7 @@ msgstr ""
 msgid "No chasing payments or sending invoices"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1698
+#: lib/klass_hero_web/components/provider_components.ex:1675
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:428
 #, elixir-autogen, elixir-format
 msgid "No enrolled parents"
@@ -3487,7 +3487,7 @@ msgstr ""
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2487
+#: lib/klass_hero_web/components/provider_components.ex:2452
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:503
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -4117,7 +4117,7 @@ msgstr ""
 msgid "Post"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2679
+#: lib/klass_hero_web/components/provider_components.ex:2644
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:24
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
@@ -4176,7 +4176,7 @@ msgstr ""
 msgid "Reply sent successfully"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:556
+#: lib/klass_hero_web/components/provider_components.ex:553
 #, elixir-autogen, elixir-format
 msgid "Resend"
 msgstr ""
@@ -4321,7 +4321,7 @@ msgstr ""
 msgid "Update your observation..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:149
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:164
 #: lib/klass_hero_web/live/provider/programs_live.ex:492
 #: lib/klass_hero_web/live/provider/verification_live.ex:240
 #: lib/klass_hero_web/live/provider/verification_live.ex:556
@@ -4406,7 +4406,7 @@ msgstr ""
 msgid "You are not assigned to this program"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:300
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:310
 #, elixir-autogen, elixir-format
 msgid "+1234567890"
 msgstr ""
@@ -4427,23 +4427,23 @@ msgstr ""
 msgid "Cancelled"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:320
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:330
 #, elixir-autogen, elixir-format
 msgid "Categories"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_layout_components.ex:372
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:415
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:373
 #, elixir-autogen, elixir-format
 msgid "Complete Profile"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:43
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:44
 #, elixir-autogen, elixir-format
 msgid "Complete Your Profile"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:228
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:238
 #, elixir-autogen, elixir-format
 msgid "Complete Your Provider Profile"
 msgstr ""
@@ -4451,11 +4451,6 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_layout_components.ex:355
 #, elixir-autogen, elixir-format
 msgid "Complete your provider profile"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:362
-#, elixir-autogen, elixir-format
-msgid "Drag and drop or click to upload"
 msgstr ""
 
 #: lib/klass_hero_web/live/messaging_live_helper.ex:526
@@ -4483,7 +4478,7 @@ msgstr ""
 msgid "Fill in your business details so parents can find you. Your profile will be reviewed by Klass Hero before going live."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:231
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "Fill in your business details. Your profile will be reviewed by Klass Hero before going live."
 msgstr ""
@@ -4504,7 +4499,7 @@ msgstr ""
 msgid "Please enter a message or attach a photo."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:101
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:103
 #, elixir-autogen, elixir-format
 msgid "Profile completed! Klass Hero will review your profile shortly."
 msgstr ""
@@ -4523,13 +4518,13 @@ msgstr ""
 #: lib/klass_hero_web/controllers/invite_claim_controller.ex:67
 #: lib/klass_hero_web/live/messaging_live_helper.ex:527
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:132
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:113
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:118
 #: lib/klass_hero_web/live/user_live/settings.ex:512
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:290
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:300
 #, elixir-autogen, elixir-format
 msgid "Tell parents about your organization and what makes you unique..."
 msgstr ""
@@ -4559,13 +4554,13 @@ msgstr ""
 msgid "View your assignments"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:306
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:316
 #: lib/klass_hero_web/live/provider_profile_live.ex:120
 #, elixir-autogen, elixir-format
 msgid "Website"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:32
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:33
 #, elixir-autogen, elixir-format
 msgid "Your profile is already complete."
 msgstr ""
@@ -4576,41 +4571,41 @@ msgstr ""
 msgid "for"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1822
+#: lib/klass_hero_web/components/provider_components.ex:1799
 #, elixir-autogen, elixir-format
 msgid "Assigned staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1823
+#: lib/klass_hero_web/components/provider_components.ex:1800
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1806
-#: lib/klass_hero_web/components/provider_components.ex:1891
-#: lib/klass_hero_web/components/provider_components.ex:2033
-#: lib/klass_hero_web/components/provider_components.ex:2187
+#: lib/klass_hero_web/components/provider_components.ex:1783
+#: lib/klass_hero_web/components/provider_components.ex:1868
+#: lib/klass_hero_web/components/provider_components.ex:2010
+#: lib/klass_hero_web/components/provider_components.ex:2158
 #: lib/klass_hero_web/live/provider/overview_live.ex:403
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1821
+#: lib/klass_hero_web/components/provider_components.ex:1798
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1815
+#: lib/klass_hero_web/components/provider_components.ex:1792
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1804
+#: lib/klass_hero_web/components/provider_components.ex:1781
 #, elixir-autogen, elixir-format
 msgid "Sessions — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1509
+#: lib/klass_hero_web/components/provider_components.ex:1486
 #, elixir-autogen, elixir-format
 msgid "View sessions"
 msgstr ""
@@ -4642,17 +4637,17 @@ msgstr ""
 msgid "Failed to update record"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2837
+#: lib/klass_hero_web/components/provider_components.ex:2802
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2510
+#: lib/klass_hero_web/components/provider_components.ex:2475
 #, elixir-autogen, elixir-format
 msgid "Invite mode"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2529
+#: lib/klass_hero_web/components/provider_components.ex:2494
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr ""
@@ -4667,12 +4662,12 @@ msgstr ""
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2850
+#: lib/klass_hero_web/components/provider_components.ex:2815
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2856
+#: lib/klass_hero_web/components/provider_components.ex:2821
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr ""
@@ -4683,17 +4678,17 @@ msgstr ""
 msgid "Nothing to update"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2858
+#: lib/klass_hero_web/components/provider_components.ex:2823
 #, elixir-autogen, elixir-format
 msgid "Nut allergy"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2862
+#: lib/klass_hero_web/components/provider_components.ex:2827
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2867
+#: lib/klass_hero_web/components/provider_components.ex:2832
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr ""
@@ -4703,7 +4698,7 @@ msgstr ""
 msgid "Present"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2794
+#: lib/klass_hero_web/components/provider_components.ex:2759
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr ""
@@ -4730,22 +4725,22 @@ msgstr ""
 msgid "Save changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2831
+#: lib/klass_hero_web/components/provider_components.ex:2796
 #, elixir-autogen, elixir-format
 msgid "School (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2841
+#: lib/klass_hero_web/components/provider_components.ex:2806
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2815
+#: lib/klass_hero_web/components/provider_components.ex:2780
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2884
+#: lib/klass_hero_web/components/provider_components.ex:2849
 #, elixir-autogen, elixir-format
 msgid "Send invite"
 msgstr ""
@@ -4755,7 +4750,7 @@ msgstr ""
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2547
+#: lib/klass_hero_web/components/provider_components.ex:2512
 #, elixir-autogen, elixir-format
 msgid "Upload a list"
 msgstr ""
@@ -4790,7 +4785,7 @@ msgstr ""
 msgid "High"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:790
+#: lib/klass_hero_web/components/provider_components.ex:787
 #, elixir-autogen, elixir-format
 msgid "Hourly"
 msgstr ""
@@ -4815,22 +4810,22 @@ msgstr ""
 msgid "Medium"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:780
+#: lib/klass_hero_web/components/provider_components.ex:777
 #, elixir-autogen, elixir-format
 msgid "None"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:769
+#: lib/klass_hero_web/components/provider_components.ex:766
 #, elixir-autogen, elixir-format
 msgid "Pay Rate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:527
+#: lib/klass_hero_web/components/provider_components.ex:528
 #, elixir-autogen, elixir-format
 msgid "Pay rate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:800
+#: lib/klass_hero_web/components/provider_components.ex:797
 #, elixir-autogen, elixir-format
 msgid "Per Session"
 msgstr ""
@@ -4855,7 +4850,7 @@ msgstr ""
 msgid "Property Damage"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1546
+#: lib/klass_hero_web/components/provider_components.ex:1523
 #, elixir-autogen, elixir-format
 msgid "Report Incident"
 msgstr ""
@@ -5523,7 +5518,7 @@ msgstr[1] ""
 msgid "In 2025, Shane connected with his friend"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1555
+#: lib/klass_hero_web/components/provider_components.ex:1532
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:43
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:74
 #, elixir-autogen, elixir-format
@@ -5593,7 +5588,7 @@ msgstr ""
 msgid "Last 8 weeks"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1258
+#: lib/klass_hero_web/components/provider_components.ex:1245
 #: lib/klass_hero_web/presenters/hero_cards_presenter.ex:27
 #, elixir-autogen, elixir-format
 msgid "Lead Instructor"
@@ -6032,17 +6027,17 @@ msgstr ""
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2923
+#: lib/klass_hero_web/components/provider_components.ex:2888
 #, elixir-autogen, elixir-format
 msgid "Row %{row}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2923
+#: lib/klass_hero_web/components/provider_components.ex:2888
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2624
+#: lib/klass_hero_web/components/provider_components.ex:2589
 #, elixir-autogen, elixir-format
 msgid "Rows with errors"
 msgstr ""
@@ -6625,7 +6620,7 @@ msgstr ""
 msgid "Identity verifications"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:73
+#: lib/klass_hero_web/components/provider_components.ex:74
 #, elixir-autogen, elixir-format
 msgid "In progress"
 msgstr ""
@@ -6655,7 +6650,7 @@ msgstr ""
 msgid "Not started"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:71
+#: lib/klass_hero_web/components/provider_components.ex:72
 #, elixir-autogen, elixir-format
 msgid "Passed"
 msgstr ""
@@ -6772,12 +6767,12 @@ msgstr ""
 msgid "Experience validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3322
+#: lib/klass_hero_web/components/provider_components.ex:3396
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3295
+#: lib/klass_hero_web/components/provider_components.ex:3369
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
@@ -6787,12 +6782,12 @@ msgstr ""
 msgid "Safeguarding certificate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3319
+#: lib/klass_hero_web/components/provider_components.ex:3393
 #, elixir-autogen, elixir-format
 msgid "Select Video"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3365
+#: lib/klass_hero_web/components/provider_components.ex:3439
 #, elixir-autogen, elixir-format
 msgid "Upload Video"
 msgstr ""
@@ -6802,7 +6797,7 @@ msgstr ""
 msgid "Your browser does not support video playback."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3512
+#: lib/klass_hero_web/components/provider_components.ex:3586
 #, elixir-autogen, elixir-format
 msgid "Confirm agreement"
 msgstr ""
@@ -6812,12 +6807,12 @@ msgstr ""
 msgid "Couldn't record your agreement. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3535
+#: lib/klass_hero_web/components/provider_components.ex:3609
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3511
+#: lib/klass_hero_web/components/provider_components.ex:3585
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr ""
@@ -6827,7 +6822,7 @@ msgstr ""
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3420
+#: lib/klass_hero_web/components/provider_components.ex:3494
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr ""
@@ -6837,17 +6832,17 @@ msgstr ""
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3520
+#: lib/klass_hero_web/components/provider_components.ex:3594
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3509
+#: lib/klass_hero_web/components/provider_components.ex:3583
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3510
+#: lib/klass_hero_web/components/provider_components.ex:3584
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
@@ -6857,12 +6852,12 @@ msgstr ""
 msgid "Applicants submit a short recorded video (max 2 minutes) so we can assess communication skills and alignment with our values before approving their profile."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:254
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:264
 #, elixir-autogen, elixir-format
 msgid "A business"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:252
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:262
 #, elixir-autogen, elixir-format
 msgid "An individual"
 msgstr ""
@@ -6907,17 +6902,17 @@ msgstr ""
 msgid "Verify the owner or director accountable for the business."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:246
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:256
 #, elixir-autogen, elixir-format
 msgid "What are you registering as?"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:253
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:263
 #, elixir-autogen, elixir-format
 msgid "You'll be vetted personally."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:255
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:265
 #, elixir-autogen, elixir-format
 msgid "Your business and its responsible person will be vetted."
 msgstr ""
@@ -7116,12 +7111,12 @@ msgstr ""
 msgid "Your insurance is verified."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3464
+#: lib/klass_hero_web/components/provider_components.ex:3538
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3567
+#: lib/klass_hero_web/components/provider_components.ex:3641
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr ""
@@ -7131,7 +7126,7 @@ msgstr ""
 msgid "Couldn't record your declaration. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3573
+#: lib/klass_hero_web/components/provider_components.ex:3647
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr ""
@@ -7141,17 +7136,17 @@ msgstr ""
 msgid "Please confirm the declaration before signing."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3598
+#: lib/klass_hero_web/components/provider_components.ex:3672
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3577
+#: lib/klass_hero_web/components/provider_components.ex:3651
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3565
+#: lib/klass_hero_web/components/provider_components.ex:3639
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr ""
@@ -7161,12 +7156,12 @@ msgstr ""
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3585
+#: lib/klass_hero_web/components/provider_components.ex:3659
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3571
+#: lib/klass_hero_web/components/provider_components.ex:3645
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
@@ -7233,15 +7228,15 @@ msgstr ""
 msgid "Undelivered Events"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2132
-#: lib/klass_hero_web/components/provider_components.ex:2315
+#: lib/klass_hero_web/components/provider_components.ex:2103
+#: lib/klass_hero_web/components/provider_components.ex:2280
 #: lib/klass_hero_web/live/user_live/settings.ex:273
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2055
-#: lib/klass_hero_web/components/provider_components.ex:2241
+#: lib/klass_hero_web/components/provider_components.ex:2032
+#: lib/klass_hero_web/components/provider_components.ex:2212
 #, elixir-autogen, elixir-format
 msgid "Lead"
 msgstr ""
@@ -7251,17 +7246,17 @@ msgstr ""
 msgid "Lead instructor updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2067
+#: lib/klass_hero_web/components/provider_components.ex:2044
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1523
+#: lib/klass_hero_web/components/provider_components.ex:1500
 #, elixir-autogen, elixir-format
 msgid "Manage Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2096
+#: lib/klass_hero_web/components/provider_components.ex:2073
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this program yet."
 msgstr ""
@@ -7272,19 +7267,19 @@ msgstr ""
 msgid "Pick a staff member to add."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2079
-#: lib/klass_hero_web/components/provider_components.ex:2354
+#: lib/klass_hero_web/components/provider_components.ex:2056
+#: lib/klass_hero_web/components/provider_components.ex:2319
 #, elixir-autogen, elixir-format
 msgid "Reassign the lead before removing them"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2080
+#: lib/klass_hero_web/components/provider_components.ex:2057
 #, elixir-autogen, elixir-format
 msgid "Remove from program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2114
-#: lib/klass_hero_web/components/provider_components.ex:2296
+#: lib/klass_hero_web/components/provider_components.ex:2091
+#: lib/klass_hero_web/components/provider_components.ex:2267
 #, elixir-autogen, elixir-format
 msgid "Select a staff member…"
 msgstr ""
@@ -7299,12 +7294,12 @@ msgstr ""
 msgid "Staff member removed from the program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2137
+#: lib/klass_hero_web/components/provider_components.ex:2108
 #, elixir-autogen, elixir-format
 msgid "Staff you add can read and reply to this program's parent conversations."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2031
+#: lib/klass_hero_web/components/provider_components.ex:2008
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{title}"
 msgstr ""
@@ -7324,19 +7319,19 @@ msgstr ""
 msgid "This person is the lead instructor. Make someone else lead before removing them."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1467
+#: lib/klass_hero_web/components/provider_components.ex:1444
 #, elixir-autogen, elixir-format
 msgid "%{count} staff member · no lead"
 msgid_plural "%{count} staff · no lead"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/components/provider_components.ex:566
+#: lib/klass_hero_web/components/provider_components.ex:563
 #, elixir-autogen, elixir-format
 msgid "%{name} will be unassigned from every program and removed from those conversations. Their history is kept and you can add them back later."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:642
+#: lib/klass_hero_web/components/provider_components.ex:639
 #, elixir-autogen, elixir-format
 msgid "Add back to team"
 msgstr ""
@@ -7346,7 +7341,7 @@ msgstr ""
 msgid "Could not bring this team member back. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:604
+#: lib/klass_hero_web/components/provider_components.ex:601
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr ""
@@ -7356,7 +7351,7 @@ msgstr ""
 msgid "Former team members"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:578
+#: lib/klass_hero_web/components/provider_components.ex:575
 #, elixir-autogen, elixir-format
 msgid "Remove from team"
 msgstr ""
@@ -7371,7 +7366,7 @@ msgstr ""
 msgid "Team member removed from the team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:594
+#: lib/klass_hero_web/components/provider_components.ex:591
 #, elixir-autogen, elixir-format
 msgid "This deletes %{name} permanently — there's nothing to undo. Use it only for an entry added by mistake."
 msgstr ""
@@ -7396,24 +7391,24 @@ msgstr ""
 msgid "Program updated, but the enrollment capacity was rejected. The previous limits still apply."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:889
+#: lib/klass_hero_web/components/provider_components.ex:876
 #, elixir-autogen, elixir-format
 msgid "%{count} child is already enrolled. Confirm you want this program to have no capacity limit."
 msgid_plural "%{count} children are already enrolled. Confirm you want this program to have no capacity limit."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1100
+#: lib/klass_hero_web/components/provider_components.ex:1087
 #, elixir-autogen, elixir-format
 msgid "Anyone will be able to book a place until you set a new maximum."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1105
+#: lib/klass_hero_web/components/provider_components.ex:1092
 #, elixir-autogen, elixir-format
 msgid "I understand this program will have no capacity limit."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2342
+#: lib/klass_hero_web/components/provider_components.ex:2307
 #, elixir-autogen, elixir-format
 msgid "Go back to the program's usual team"
 msgstr ""
@@ -7423,17 +7418,17 @@ msgstr ""
 msgid "Lead instructor for this session updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2256
+#: lib/klass_hero_web/components/provider_components.ex:2227
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor for this session"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2278
+#: lib/klass_hero_web/components/provider_components.ex:2249
 #, elixir-autogen, elixir-format
 msgid "Nobody is working this session yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2359
+#: lib/klass_hero_web/components/provider_components.ex:2324
 #, elixir-autogen, elixir-format
 msgid "Remove from this session"
 msgstr ""
@@ -7453,7 +7448,7 @@ msgstr ""
 msgid "Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2180
+#: lib/klass_hero_web/components/provider_components.ex:2151
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{date}"
 msgstr ""
@@ -7483,22 +7478,22 @@ msgstr ""
 msgid "A session needs at least one person. Use “Go back to the program's usual team” to drop this session's own roster."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2357
+#: lib/klass_hero_web/components/provider_components.ex:2322
 #, elixir-autogen, elixir-format
 msgid "A session needs someone — use “Go back to the program's usual team” instead"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2324
+#: lib/klass_hero_web/components/provider_components.ex:2289
 #, elixir-autogen, elixir-format
 msgid "Everyone on your team is already working this session."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2212
+#: lib/klass_hero_web/components/provider_components.ex:2183
 #, elixir-autogen, elixir-format
 msgid "Staffed just for this session. Changes here do not touch the program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2214
+#: lib/klass_hero_web/components/provider_components.ex:2185
 #, elixir-autogen, elixir-format
 msgid "Using the program's usual team. The first change here copies them onto this session, so later program changes stop reaching it."
 msgstr ""
@@ -7508,12 +7503,12 @@ msgstr ""
 msgid "(optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1950
+#: lib/klass_hero_web/components/provider_components.ex:1927
 #, elixir-autogen, elixir-format
 msgid "Add a waiver"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1982
+#: lib/klass_hero_web/components/provider_components.ex:1959
 #, elixir-autogen, elixir-format
 msgid "Add waiver"
 msgstr ""
@@ -7535,22 +7530,22 @@ msgstr ""
 msgid "I have read and agree to %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1964
+#: lib/klass_hero_web/components/provider_components.ex:1941
 #, elixir-autogen, elixir-format
 msgid "Legal text"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1530
+#: lib/klass_hero_web/components/provider_components.ex:1507
 #, elixir-autogen, elixir-format
 msgid "Manage Waivers"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1898
+#: lib/klass_hero_web/components/provider_components.ex:1875
 #, elixir-autogen, elixir-format
 msgid "No waivers yet. Parents enrol without signing anything."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1971
+#: lib/klass_hero_web/components/provider_components.ex:1948
 #, elixir-autogen, elixir-format
 msgid "Parents must sign this before enrolling"
 msgstr ""
@@ -7570,17 +7565,17 @@ msgstr ""
 msgid "Please tick a waiver to sign it."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1949
+#: lib/klass_hero_web/components/provider_components.ex:1926
 #, elixir-autogen, elixir-format
 msgid "Publish a new version"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1982
+#: lib/klass_hero_web/components/provider_components.ex:1959
 #, elixir-autogen, elixir-format
 msgid "Publish version"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1975
+#: lib/klass_hero_web/components/provider_components.ex:1952
 #, elixir-autogen, elixir-format
 msgid "Publishing keeps every earlier version on record; signatures already given stay bound to the wording they were shown."
 msgstr ""
@@ -7590,12 +7585,12 @@ msgstr ""
 msgid "Required"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1932
+#: lib/klass_hero_web/components/provider_components.ex:1909
 #, elixir-autogen, elixir-format
 msgid "Retire this waiver"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1923
+#: lib/klass_hero_web/components/provider_components.ex:1900
 #, elixir-autogen, elixir-format
 msgid "Revise text"
 msgstr ""
@@ -7610,7 +7605,7 @@ msgstr ""
 msgid "Sign waivers"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2437
+#: lib/klass_hero_web/components/provider_components.ex:2402
 #: lib/klass_hero_web/live/enrollment_waivers_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "Signed"
@@ -7626,12 +7621,12 @@ msgstr ""
 msgid "There is nothing to sign for this enrollment."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2437
+#: lib/klass_hero_web/components/provider_components.ex:2402
 #, elixir-autogen, elixir-format
 msgid "Unsigned"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1915
+#: lib/klass_hero_web/components/provider_components.ex:1892
 #, elixir-autogen, elixir-format
 msgid "Version %{number}"
 msgstr ""
@@ -7641,7 +7636,7 @@ msgstr ""
 msgid "Waiver not found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2405
+#: lib/klass_hero_web/components/provider_components.ex:2370
 #: lib/klass_hero_web/live/booking_live.ex:431
 #: lib/klass_hero_web/live/enrollment_waivers_live.ex:33
 #: lib/klass_hero_web/live/enrollment_waivers_live.ex:105
@@ -7654,7 +7649,7 @@ msgstr ""
 msgid "Waivers waiting for your signature"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1889
+#: lib/klass_hero_web/components/provider_components.ex:1866
 #, elixir-autogen, elixir-format
 msgid "Waivers — %{title}"
 msgstr ""
@@ -7669,7 +7664,7 @@ msgstr ""
 msgid "New version published. It applies to future enrolments."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1936
+#: lib/klass_hero_web/components/provider_components.ex:1913
 #, elixir-autogen, elixir-format
 msgid "Retire \"%{title}\"? Parents will no longer be asked to sign it. Signatures already collected are kept."
 msgstr ""
@@ -7689,7 +7684,7 @@ msgstr ""
 msgid "You are not assigned to this session"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:429
+#: lib/klass_hero_web/components/provider_components.ex:430
 #, elixir-autogen, elixir-format
 msgid "Complete verification to create programs."
 msgstr ""
@@ -7699,28 +7694,28 @@ msgstr ""
 msgid "Manage your provider profile"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:225
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:259
 #, elixir-autogen, elixir-format
 msgid "Provider Description"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:212
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "Provider Information"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:232
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:347
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:266
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:356
 #, elixir-autogen, elixir-format
 msgid "Provider Logo"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:281
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:291
 #, elixir-autogen, elixir-format
 msgid "Provider Name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:207
+#: lib/klass_hero_web/components/provider_components.ex:208
 #, elixir-autogen, elixir-format
 msgid "Provider Profile"
 msgstr ""
@@ -7740,17 +7735,17 @@ msgstr ""
 msgid "This invitation has expired. Please ask your provider to resend it."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:210
+#: lib/klass_hero_web/components/provider_components.ex:211
 #, elixir-autogen, elixir-format
 msgid "This is your main provider identity. Verification is required to list programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3161
+#: lib/klass_hero_web/components/provider_components.ex:3235
 #, elixir-autogen, elixir-format
 msgid "Upload documents to be verified. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:402
+#: lib/klass_hero_web/components/provider_components.ex:403
 #, elixir-autogen, elixir-format
 msgid "Verified Provider"
 msgstr ""
@@ -7766,12 +7761,12 @@ msgstr ""
 msgid "You'll get your own provider profile to fill in, and your account will open on your provider dashboard from now on. You stay on %{business}'s team."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:315
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:325
 #, elixir-autogen, elixir-format
 msgid "Your address"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:282
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:292
 #, elixir-autogen, elixir-format
 msgid "Your provider or organization name"
 msgstr ""
@@ -7889,8 +7884,8 @@ msgstr ""
 msgid "Review invitations"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2700
-#: lib/klass_hero_web/components/provider_components.ex:2707
+#: lib/klass_hero_web/components/provider_components.ex:2665
+#: lib/klass_hero_web/components/provider_components.ex:2672
 #, elixir-autogen, elixir-format
 msgid "Unknown program"
 msgstr ""
@@ -7935,12 +7930,12 @@ msgstr ""
 msgid "You can't start a conversation with this person"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:965
+#: lib/klass_hero_web/components/provider_components.ex:952
 #, elixir-autogen, elixir-format
 msgid "Subtitle"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:966
+#: lib/klass_hero_web/components/provider_components.ex:953
 #, elixir-autogen, elixir-format
 msgid "e.g., For beginners, no experience needed"
 msgstr ""
@@ -7955,45 +7950,37 @@ msgstr ""
 msgid "N/A"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:272
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:400
+#: lib/klass_hero_web/components/provider_components.ex:3143
 #, elixir-autogen, elixir-format
 msgid "A short line that sums you up"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:261
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:389
+#: lib/klass_hero_web/components/provider_components.ex:3132
 #, elixir-autogen, elixir-format
 msgid "Branding & Presence"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:285
+#: lib/klass_hero_web/components/provider_components.ex:3156
 #, elixir-autogen, elixir-format
 msgid "Choose Cover Image"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:84
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:99
 #, elixir-autogen, elixir-format
 msgid "Cover image upload failed. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:286
+#: lib/klass_hero_web/components/provider_components.ex:3157
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 5MB."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:392
-#, elixir-autogen, elixir-format
-msgid "Optional — shown on your public profile page."
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:264
+#: lib/klass_hero_web/components/provider_components.ex:3135
 #, elixir-autogen, elixir-format
 msgid "Shown on your public profile page."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:271
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:399
+#: lib/klass_hero_web/components/provider_components.ex:3142
 #, elixir-autogen, elixir-format
 msgid "Tagline"
 msgstr ""
@@ -8039,7 +8026,7 @@ msgstr ""
 msgid "Klass Hero on %{network}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3140
+#: lib/klass_hero_web/components/provider_components.ex:3214
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr ""
@@ -8072,4 +8059,34 @@ msgstr ""
 #: lib/klass_hero_web/presenters/program_presenter.ex:350
 #, elixir-autogen, elixir-format
 msgid "General"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:345
+#, elixir-autogen, elixir-format
+msgid "A newly chosen cover or logo appears here after you save."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:3187
+#, elixir-autogen, elixir-format
+msgid "Add %{network}"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:329
+#, elixir-autogen, elixir-format
+msgid "Hide preview"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:342
+#, elixir-autogen, elixir-format
+msgid "Public profile preview"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:329
+#, elixir-autogen, elixir-format
+msgid "Show preview"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:3168
+#, elixir-autogen, elixir-format
+msgid "e.g. %{example}"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -2136,7 +2136,7 @@ msgstr ""
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3284
+#: lib/klass_hero_web/components/provider_components.ex:3278
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2268,12 +2268,12 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3217
+#: lib/klass_hero_web/components/provider_components.ex:3211
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3219
+#: lib/klass_hero_web/components/provider_components.ex:3213
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
@@ -2449,7 +2449,7 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3246
+#: lib/klass_hero_web/components/provider_components.ex:3240
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
@@ -2533,7 +2533,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3322
+#: lib/klass_hero_web/components/provider_components.ex:3316
 #: lib/klass_hero_web/live/provider/verification_live.ex:699
 #: lib/klass_hero_web/live/provider/verification_live.ex:773
 #, elixir-autogen, elixir-format
@@ -2715,8 +2715,8 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:2703
 #: lib/klass_hero_web/components/provider_components.ex:3067
-#: lib/klass_hero_web/components/provider_components.ex:3341
-#: lib/klass_hero_web/components/provider_components.ex:3421
+#: lib/klass_hero_web/components/provider_components.ex:3335
+#: lib/klass_hero_web/components/provider_components.ex:3415
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
@@ -2762,7 +2762,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3319
+#: lib/klass_hero_web/components/provider_components.ex:3313
 #, elixir-autogen, elixir-format
 msgid "Select File"
 msgstr ""
@@ -2890,7 +2890,7 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3218
+#: lib/klass_hero_web/components/provider_components.ex:3212
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -2915,22 +2915,22 @@ msgstr ""
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3365
+#: lib/klass_hero_web/components/provider_components.ex:3359
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3273
+#: lib/klass_hero_web/components/provider_components.ex:3267
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3221
+#: lib/klass_hero_web/components/provider_components.ex:3215
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3238
+#: lib/klass_hero_web/components/provider_components.ex:3232
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -3020,7 +3020,7 @@ msgid "Child Safeguarding Training"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1505
-#: lib/klass_hero_web/components/provider_components.ex:3588
+#: lib/klass_hero_web/components/provider_components.ex:3582
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr ""
@@ -3171,7 +3171,7 @@ msgid "Vetted with Care"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1489
-#: lib/klass_hero_web/components/provider_components.ex:3372
+#: lib/klass_hero_web/components/provider_components.ex:3366
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr ""
@@ -6767,12 +6767,12 @@ msgstr ""
 msgid "Experience validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3402
+#: lib/klass_hero_web/components/provider_components.ex:3396
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3375
+#: lib/klass_hero_web/components/provider_components.ex:3369
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
@@ -6782,12 +6782,12 @@ msgstr ""
 msgid "Safeguarding certificate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3399
+#: lib/klass_hero_web/components/provider_components.ex:3393
 #, elixir-autogen, elixir-format
 msgid "Select Video"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3445
+#: lib/klass_hero_web/components/provider_components.ex:3439
 #, elixir-autogen, elixir-format
 msgid "Upload Video"
 msgstr ""
@@ -6797,7 +6797,7 @@ msgstr ""
 msgid "Your browser does not support video playback."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3592
+#: lib/klass_hero_web/components/provider_components.ex:3586
 #, elixir-autogen, elixir-format
 msgid "Confirm agreement"
 msgstr ""
@@ -6807,12 +6807,12 @@ msgstr ""
 msgid "Couldn't record your agreement. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3615
+#: lib/klass_hero_web/components/provider_components.ex:3609
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3591
+#: lib/klass_hero_web/components/provider_components.ex:3585
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr ""
@@ -6822,7 +6822,7 @@ msgstr ""
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3500
+#: lib/klass_hero_web/components/provider_components.ex:3494
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr ""
@@ -6832,17 +6832,17 @@ msgstr ""
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3600
+#: lib/klass_hero_web/components/provider_components.ex:3594
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3589
+#: lib/klass_hero_web/components/provider_components.ex:3583
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3590
+#: lib/klass_hero_web/components/provider_components.ex:3584
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
@@ -7111,12 +7111,12 @@ msgstr ""
 msgid "Your insurance is verified."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3544
+#: lib/klass_hero_web/components/provider_components.ex:3538
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3647
+#: lib/klass_hero_web/components/provider_components.ex:3641
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr ""
@@ -7126,7 +7126,7 @@ msgstr ""
 msgid "Couldn't record your declaration. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3653
+#: lib/klass_hero_web/components/provider_components.ex:3647
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr ""
@@ -7136,17 +7136,17 @@ msgstr ""
 msgid "Please confirm the declaration before signing."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3678
+#: lib/klass_hero_web/components/provider_components.ex:3672
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3657
+#: lib/klass_hero_web/components/provider_components.ex:3651
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3645
+#: lib/klass_hero_web/components/provider_components.ex:3639
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr ""
@@ -7156,12 +7156,12 @@ msgstr ""
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3665
+#: lib/klass_hero_web/components/provider_components.ex:3659
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3651
+#: lib/klass_hero_web/components/provider_components.ex:3645
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
@@ -7740,7 +7740,7 @@ msgstr ""
 msgid "This is your main provider identity. Verification is required to list programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3241
+#: lib/klass_hero_web/components/provider_components.ex:3235
 #, elixir-autogen, elixir-format
 msgid "Upload documents to be verified. Documents are reviewed by our team."
 msgstr ""
@@ -8026,7 +8026,7 @@ msgstr ""
 msgid "Klass Hero on %{network}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3220
+#: lib/klass_hero_web/components/provider_components.ex:3214
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr ""
@@ -8061,27 +8061,27 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:345
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:341
 #, elixir-autogen, elixir-format
 msgid "A newly chosen cover or logo appears here after you save."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3193
+#: lib/klass_hero_web/components/provider_components.ex:3187
 #, elixir-autogen, elixir-format
 msgid "Add %{network}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:329
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:325
 #, elixir-autogen, elixir-format
 msgid "Hide preview"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:342
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "Public profile preview"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:329
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:325
 #, elixir-autogen, elixir-format
 msgid "Show preview"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -2136,7 +2136,7 @@ msgstr ""
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3284
+#: lib/klass_hero_web/components/provider_components.ex:3278
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2268,12 +2268,12 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3217
+#: lib/klass_hero_web/components/provider_components.ex:3211
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3219
+#: lib/klass_hero_web/components/provider_components.ex:3213
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
@@ -2449,7 +2449,7 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3246
+#: lib/klass_hero_web/components/provider_components.ex:3240
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
@@ -2533,7 +2533,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3322
+#: lib/klass_hero_web/components/provider_components.ex:3316
 #: lib/klass_hero_web/live/provider/verification_live.ex:699
 #: lib/klass_hero_web/live/provider/verification_live.ex:773
 #, elixir-autogen, elixir-format
@@ -2715,8 +2715,8 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:2703
 #: lib/klass_hero_web/components/provider_components.ex:3067
-#: lib/klass_hero_web/components/provider_components.ex:3341
-#: lib/klass_hero_web/components/provider_components.ex:3421
+#: lib/klass_hero_web/components/provider_components.ex:3335
+#: lib/klass_hero_web/components/provider_components.ex:3415
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
@@ -2762,7 +2762,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3319
+#: lib/klass_hero_web/components/provider_components.ex:3313
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select File"
 msgstr ""
@@ -2890,7 +2890,7 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3218
+#: lib/klass_hero_web/components/provider_components.ex:3212
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -2915,22 +2915,22 @@ msgstr ""
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3365
+#: lib/klass_hero_web/components/provider_components.ex:3359
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3273
+#: lib/klass_hero_web/components/provider_components.ex:3267
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3221
+#: lib/klass_hero_web/components/provider_components.ex:3215
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3238
+#: lib/klass_hero_web/components/provider_components.ex:3232
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -3020,7 +3020,7 @@ msgid "Child Safeguarding Training"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1505
-#: lib/klass_hero_web/components/provider_components.ex:3588
+#: lib/klass_hero_web/components/provider_components.ex:3582
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr ""
@@ -3171,7 +3171,7 @@ msgid "Vetted with Care"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1489
-#: lib/klass_hero_web/components/provider_components.ex:3372
+#: lib/klass_hero_web/components/provider_components.ex:3366
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr ""
@@ -6767,12 +6767,12 @@ msgstr ""
 msgid "Experience validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3402
+#: lib/klass_hero_web/components/provider_components.ex:3396
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3375
+#: lib/klass_hero_web/components/provider_components.ex:3369
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
@@ -6782,12 +6782,12 @@ msgstr ""
 msgid "Safeguarding certificate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3399
+#: lib/klass_hero_web/components/provider_components.ex:3393
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select Video"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3445
+#: lib/klass_hero_web/components/provider_components.ex:3439
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload Video"
 msgstr ""
@@ -6797,7 +6797,7 @@ msgstr ""
 msgid "Your browser does not support video playback."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3592
+#: lib/klass_hero_web/components/provider_components.ex:3586
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Confirm agreement"
 msgstr ""
@@ -6807,12 +6807,12 @@ msgstr ""
 msgid "Couldn't record your agreement. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3615
+#: lib/klass_hero_web/components/provider_components.ex:3609
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3591
+#: lib/klass_hero_web/components/provider_components.ex:3585
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr ""
@@ -6822,7 +6822,7 @@ msgstr ""
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3500
+#: lib/klass_hero_web/components/provider_components.ex:3494
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr ""
@@ -6832,17 +6832,17 @@ msgstr ""
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3600
+#: lib/klass_hero_web/components/provider_components.ex:3594
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3589
+#: lib/klass_hero_web/components/provider_components.ex:3583
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3590
+#: lib/klass_hero_web/components/provider_components.ex:3584
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
@@ -7111,12 +7111,12 @@ msgstr ""
 msgid "Your insurance is verified."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3544
+#: lib/klass_hero_web/components/provider_components.ex:3538
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3647
+#: lib/klass_hero_web/components/provider_components.ex:3641
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr ""
@@ -7126,7 +7126,7 @@ msgstr ""
 msgid "Couldn't record your declaration. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3653
+#: lib/klass_hero_web/components/provider_components.ex:3647
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr ""
@@ -7136,17 +7136,17 @@ msgstr ""
 msgid "Please confirm the declaration before signing."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3678
+#: lib/klass_hero_web/components/provider_components.ex:3672
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3657
+#: lib/klass_hero_web/components/provider_components.ex:3651
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3645
+#: lib/klass_hero_web/components/provider_components.ex:3639
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr ""
@@ -7156,12 +7156,12 @@ msgstr ""
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3665
+#: lib/klass_hero_web/components/provider_components.ex:3659
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3651
+#: lib/klass_hero_web/components/provider_components.ex:3645
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
@@ -7740,7 +7740,7 @@ msgstr ""
 msgid "This is your main provider identity. Verification is required to list programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3241
+#: lib/klass_hero_web/components/provider_components.ex:3235
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload documents to be verified. Documents are reviewed by our team."
 msgstr ""
@@ -8026,7 +8026,7 @@ msgstr ""
 msgid "Klass Hero on %{network}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3220
+#: lib/klass_hero_web/components/provider_components.ex:3214
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr ""
@@ -8061,27 +8061,27 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:345
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:341
 #, elixir-autogen, elixir-format
 msgid "A newly chosen cover or logo appears here after you save."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3193
+#: lib/klass_hero_web/components/provider_components.ex:3187
 #, elixir-autogen, elixir-format
 msgid "Add %{network}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:329
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:325
 #, elixir-autogen, elixir-format
 msgid "Hide preview"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:342
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "Public profile preview"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:329
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:325
 #, elixir-autogen, elixir-format
 msgid "Show preview"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -45,7 +45,7 @@ msgstr ""
 #: lib/klass_hero_web/components/layouts/app.html.heex:131
 #: lib/klass_hero_web/components/layouts/app.html.heex:206
 #: lib/klass_hero_web/components/layouts/app.html.heex:231
-#: lib/klass_hero_web/components/provider_components.ex:391
+#: lib/klass_hero_web/components/provider_components.ex:392
 #: lib/klass_hero_web/components/ui_components.ex:277
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
@@ -136,7 +136,7 @@ msgid "Your Data"
 msgstr ""
 
 #: lib/klass_hero_web/components/core_components.ex:71
-#: lib/klass_hero_web/components/provider_components.ex:1705
+#: lib/klass_hero_web/components/provider_components.ex:1682
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr ""
@@ -231,7 +231,7 @@ msgstr ""
 msgid "Enroll Now - %{price}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1424
+#: lib/klass_hero_web/components/provider_components.ex:1401
 #: lib/klass_hero_web/live/booking_live.ex:305
 #, elixir-autogen, elixir-format
 msgid "Enrollment"
@@ -415,7 +415,7 @@ msgid "Account Termination"
 msgstr ""
 
 #: lib/klass_hero_web/live/contact_live.ex:85
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:314
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:324
 #: lib/klass_hero_web/live/provider_profile_live.ex:107
 #, elixir-autogen, elixir-format
 msgid "Address"
@@ -576,9 +576,9 @@ msgstr ""
 msgid "Dispute Resolution"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:722
-#: lib/klass_hero_web/components/provider_components.ex:2801
-#: lib/klass_hero_web/components/provider_components.ex:2819
+#: lib/klass_hero_web/components/provider_components.ex:719
+#: lib/klass_hero_web/components/provider_components.ex:2766
+#: lib/klass_hero_web/components/provider_components.ex:2784
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:60
@@ -813,7 +813,7 @@ msgid "Payment Terms"
 msgstr ""
 
 #: lib/klass_hero_web/live/contact_live.ex:78
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:299
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:309
 #: lib/klass_hero_web/live/provider_profile_live.ex:113
 #, elixir-autogen, elixir-format
 msgid "Phone"
@@ -869,7 +869,7 @@ msgstr ""
 msgid "Save Password"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:414
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:372
 #: lib/klass_hero_web/live/settings/children_live.ex:708
 #: lib/klass_hero_web/live/user_live/settings.ex:153
 #, elixir-autogen, elixir-format, fuzzy
@@ -881,9 +881,9 @@ msgstr ""
 msgid "Select one or both options"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2451
-#: lib/klass_hero_web/components/provider_components.ex:2452
-#: lib/klass_hero_web/components/provider_components.ex:2489
+#: lib/klass_hero_web/components/provider_components.ex:2416
+#: lib/klass_hero_web/components/provider_components.ex:2417
+#: lib/klass_hero_web/components/provider_components.ex:2454
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:468
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:469
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:505
@@ -1106,7 +1106,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/composite_components.ex:56
 #: lib/klass_hero_web/components/layouts/admin.html.heex:85
-#: lib/klass_hero_web/components/provider_components.ex:121
+#: lib/klass_hero_web/components/provider_components.ex:122
 #: lib/klass_hero_web/live/admin/sessions_live.ex:26
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:3
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:341
@@ -1210,7 +1210,7 @@ msgstr ""
 msgid "Music"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:758
+#: lib/klass_hero_web/components/provider_components.ex:755
 #: lib/klass_hero_web/live/for_providers_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "Qualifications"
@@ -1332,19 +1332,19 @@ msgstr ""
 msgid "Quick Navigation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1427
-#: lib/klass_hero_web/components/provider_components.ex:2411
-#: lib/klass_hero_web/components/provider_components.ex:2688
+#: lib/klass_hero_web/components/provider_components.ex:1404
+#: lib/klass_hero_web/components/provider_components.ex:2376
+#: lib/klass_hero_web/components/provider_components.ex:2653
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1573
+#: lib/klass_hero_web/components/provider_components.ex:1550
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Active"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:675
+#: lib/klass_hero_web/components/provider_components.ex:672
 #: lib/klass_hero_web/live/provider/team_live.ex:627
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
@@ -1355,7 +1355,7 @@ msgstr ""
 msgid "All Staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1418
+#: lib/klass_hero_web/components/provider_components.ex:1395
 #, elixir-autogen, elixir-format
 msgid "Assigned Staff"
 msgstr ""
@@ -1377,8 +1377,8 @@ msgstr ""
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:542
-#: lib/klass_hero_web/components/provider_components.ex:1536
+#: lib/klass_hero_web/components/provider_components.ex:543
+#: lib/klass_hero_web/components/provider_components.ex:1513
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:65
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:92
 #: lib/klass_hero_web/live/settings/children_live.ex:413
@@ -1388,57 +1388,57 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:225
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:33
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:208
+#: lib/klass_hero_web/components/provider_components.ex:226
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:34
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "Edit Profile"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1575
+#: lib/klass_hero_web/components/provider_components.ex:1552
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:114
+#: lib/klass_hero_web/components/provider_components.ex:115
 #: lib/klass_hero_web/live/provider/programs_live.ex:55
 #, elixir-autogen, elixir-format, fuzzy
 msgid "My Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:417
-#: lib/klass_hero_web/components/provider_components.ex:923
+#: lib/klass_hero_web/components/provider_components.ex:418
+#: lib/klass_hero_web/components/provider_components.ex:910
 #, elixir-autogen, elixir-format, fuzzy
 msgid "New Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:100
+#: lib/klass_hero_web/components/provider_components.ex:101
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:48
-#: lib/klass_hero_web/components/provider_components.ex:74
-#: lib/klass_hero_web/components/provider_components.ex:1574
-#: lib/klass_hero_web/components/provider_components.ex:2895
-#: lib/klass_hero_web/components/provider_components.ex:2913
+#: lib/klass_hero_web/components/provider_components.ex:49
+#: lib/klass_hero_web/components/provider_components.ex:75
+#: lib/klass_hero_web/components/provider_components.ex:1551
+#: lib/klass_hero_web/components/provider_components.ex:2860
+#: lib/klass_hero_web/components/provider_components.ex:2878
 #: lib/klass_hero_web/live/admin/sessions_live.ex:293
 #: lib/klass_hero_web/live/admin/verifications_live.ex:197
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1505
+#: lib/klass_hero_web/components/provider_components.ex:1482
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1358
+#: lib/klass_hero_web/components/provider_components.ex:1335
 #, elixir-autogen, elixir-format
 msgid "Program Inventory"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1415
+#: lib/klass_hero_web/components/provider_components.ex:1392
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program Name"
 msgstr ""
@@ -1453,15 +1453,15 @@ msgstr ""
 msgid "Save for Later"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1375
+#: lib/klass_hero_web/components/provider_components.ex:1352
 #, elixir-autogen, elixir-format
 msgid "Search by name..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1421
-#: lib/klass_hero_web/components/provider_components.ex:1824
-#: lib/klass_hero_web/components/provider_components.ex:2402
-#: lib/klass_hero_web/components/provider_components.ex:2685
+#: lib/klass_hero_web/components/provider_components.ex:1398
+#: lib/klass_hero_web/components/provider_components.ex:1801
+#: lib/klass_hero_web/components/provider_components.ex:2367
+#: lib/klass_hero_web/components/provider_components.ex:2650
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:107
+#: lib/klass_hero_web/components/provider_components.ex:108
 #: lib/klass_hero_web/live/provider/team_live.ex:36
 #, elixir-autogen, elixir-format
 msgid "Team & Profiles"
@@ -1480,22 +1480,22 @@ msgstr ""
 msgid "Team & Provider Profiles"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1478
-#: lib/klass_hero_web/components/provider_components.ex:1839
+#: lib/klass_hero_web/components/provider_components.ex:1455
+#: lib/klass_hero_web/components/provider_components.ex:1816
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr ""
 
 #: lib/klass_hero_web/components/messaging_components.ex:729
-#: lib/klass_hero_web/components/provider_components.ex:51
-#: lib/klass_hero_web/components/provider_components.ex:1576
+#: lib/klass_hero_web/components/provider_components.ex:52
+#: lib/klass_hero_web/components/provider_components.ex:1553
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:455
 #: lib/klass_hero_web/presenters/provider_presenter.ex:172
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1516
+#: lib/klass_hero_web/components/provider_components.ex:1493
 #, elixir-autogen, elixir-format
 msgid "View Roster"
 msgstr ""
@@ -1555,10 +1555,10 @@ msgstr ""
 #: lib/klass_hero_web/components/participation_components.ex:456
 #: lib/klass_hero_web/components/participation_components.ex:681
 #: lib/klass_hero_web/components/participation_components.ex:772
-#: lib/klass_hero_web/components/provider_components.ex:860
-#: lib/klass_hero_web/components/provider_components.ex:1274
-#: lib/klass_hero_web/components/provider_components.ex:1991
-#: lib/klass_hero_web/components/provider_components.ex:2593
+#: lib/klass_hero_web/components/provider_components.ex:847
+#: lib/klass_hero_web/components/provider_components.ex:1261
+#: lib/klass_hero_web/components/provider_components.ex:1968
+#: lib/klass_hero_web/components/provider_components.ex:2558
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:478
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
@@ -1614,7 +1614,7 @@ msgstr ""
 msgid "Data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2782
+#: lib/klass_hero_web/components/provider_components.ex:2747
 #: lib/klass_hero_web/live/settings/children_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1662,17 +1662,17 @@ msgstr ""
 msgid "Failed to submit note"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2776
-#: lib/klass_hero_web/components/provider_components.ex:2805
-#: lib/klass_hero_web/components/provider_components.ex:2821
+#: lib/klass_hero_web/components/provider_components.ex:2741
+#: lib/klass_hero_web/components/provider_components.ex:2770
+#: lib/klass_hero_web/components/provider_components.ex:2786
 #: lib/klass_hero_web/live/settings/children_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2777
-#: lib/klass_hero_web/components/provider_components.ex:2806
-#: lib/klass_hero_web/components/provider_components.ex:2822
+#: lib/klass_hero_web/components/provider_components.ex:2742
+#: lib/klass_hero_web/components/provider_components.ex:2771
+#: lib/klass_hero_web/components/provider_components.ex:2787
 #: lib/klass_hero_web/live/settings/children_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -1803,15 +1803,15 @@ msgstr ""
 msgid "Provider data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:845
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:312
+#: lib/klass_hero_web/components/provider_components.ex:832
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:305
 #: lib/klass_hero_web/live/settings/children_live.ex:719
 #, elixir-autogen, elixir-format
 msgid "Save Changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1683
-#: lib/klass_hero_web/components/provider_components.ex:1684
+#: lib/klass_hero_web/components/provider_components.ex:1660
+#: lib/klass_hero_web/components/provider_components.ex:1661
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:43
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:151
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:252
@@ -1829,7 +1829,7 @@ msgstr ""
 msgid "Send a message to start the conversation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2876
+#: lib/klass_hero_web/components/provider_components.ex:2841
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:249
 #, elixir-autogen, elixir-format, fuzzy
@@ -1935,12 +1935,12 @@ msgstr[1] ""
 msgid "%{gender} only"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:310
+#: lib/klass_hero_web/components/provider_components.ex:311
 #, elixir-autogen, elixir-format
 msgid "Action Required"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:847
+#: lib/klass_hero_web/components/provider_components.ex:834
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add Member"
 msgstr ""
@@ -1960,12 +1960,12 @@ msgstr ""
 msgid "Ages %{min}+"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1175
+#: lib/klass_hero_web/components/provider_components.ex:1162
 #, elixir-autogen, elixir-format
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2935
+#: lib/klass_hero_web/components/provider_components.ex:2900
 #, elixir-autogen, elixir-format, fuzzy
 msgid "An unexpected error occurred during import."
 msgstr ""
@@ -1978,7 +1978,7 @@ msgid "Approve"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:881
-#: lib/klass_hero_web/components/provider_components.ex:49
+#: lib/klass_hero_web/components/provider_components.ex:50
 #: lib/klass_hero_web/live/admin/sessions_live.ex:290
 #: lib/klass_hero_web/live/admin/verifications_live.ex:202
 #: lib/klass_hero_web/presenters/vetting_checklist_presenter.ex:141
@@ -1996,9 +1996,9 @@ msgstr ""
 msgid "As fathers and partners of teachers in Berlin, we saw and heard firsthand how hard it is to find, book, and manage quality youth activities outside the classroom. Klass Hero is the complete platform connecting Berlin families and schools with trusted, vetted activity providers — offering safe, supervised, and enriching experiences across sports, arts, tutoring, and more. We verify every provider, structure every booking, and support every step — so parents know their child is in good hands, and providers can focus on what they do best: inspiring kids."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:204
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:237
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:263
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:223
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:233
 #, elixir-autogen, elixir-format
 msgid "Back to Dashboard"
 msgstr ""
@@ -2008,7 +2008,7 @@ msgstr ""
 msgid "Back to verifications"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:731
+#: lib/klass_hero_web/components/provider_components.ex:728
 #, elixir-autogen, elixir-format
 msgid "Bio"
 msgstr ""
@@ -2018,7 +2018,7 @@ msgstr ""
 msgid "Book a Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:732
+#: lib/klass_hero_web/components/provider_components.ex:729
 #, elixir-autogen, elixir-format
 msgid "Brief description of experience and specialties..."
 msgstr ""
@@ -2033,19 +2033,19 @@ msgstr ""
 msgid "Business"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:953
+#: lib/klass_hero_web/components/provider_components.ex:940
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "Category"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1124
+#: lib/klass_hero_web/components/provider_components.ex:1111
 #, elixir-autogen, elixir-format
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2399
-#: lib/klass_hero_web/components/provider_components.ex:2671
+#: lib/klass_hero_web/components/provider_components.ex:2364
+#: lib/klass_hero_web/components/provider_components.ex:2636
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2060,22 +2060,23 @@ msgstr ""
 msgid "Child meets all program requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1247
+#: lib/klass_hero_web/components/provider_components.ex:1234
 #, elixir-autogen, elixir-format
 msgid "Choose Image"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:239
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:273
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:363
 #, elixir-autogen, elixir-format
 msgid "Choose Logo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:826
+#: lib/klass_hero_web/components/provider_components.ex:823
 #, elixir-autogen, elixir-format
 msgid "Choose Photo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:955
+#: lib/klass_hero_web/components/provider_components.ex:942
 #, elixir-autogen, elixir-format
 msgid "Choose a category"
 msgstr ""
@@ -2085,7 +2086,7 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2896
+#: lib/klass_hero_web/components/provider_components.ex:2861
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
@@ -2105,37 +2106,37 @@ msgstr ""
 msgid "Could not remove invite."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1241
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:278
+#: lib/klass_hero_web/components/provider_components.ex:1228
+#: lib/klass_hero_web/components/provider_components.ex:3149
 #, elixir-autogen, elixir-format
 msgid "Cover Image"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1118
+#: lib/klass_hero_web/components/provider_components.ex:1105
 #, elixir-autogen, elixir-format
 msgid "Define age, gender, or grade restrictions for eligible participants."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1234
+#: lib/klass_hero_web/components/provider_components.ex:1221
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Describe your program..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1233
+#: lib/klass_hero_web/components/provider_components.ex:1220
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:323
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:288
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:298
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:696
-#: lib/klass_hero_web/components/provider_components.ex:1186
+#: lib/klass_hero_web/components/provider_components.ex:1173
 #: lib/klass_hero_web/live/settings/children_live.ex:635
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3204
+#: lib/klass_hero_web/components/provider_components.ex:3278
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2163,13 +2164,13 @@ msgstr ""
 msgid "Document rejected."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:156
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:171
 #: lib/klass_hero_web/live/provider/verification_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2612
+#: lib/klass_hero_web/components/provider_components.ex:2577
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
@@ -2179,40 +2180,40 @@ msgstr ""
 msgid "Download document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:921
+#: lib/klass_hero_web/components/provider_components.ex:908
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:673
+#: lib/klass_hero_web/components/provider_components.ex:670
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit Team Member"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1039
+#: lib/klass_hero_web/components/provider_components.ex:1026
 #, elixir-autogen, elixir-format
 msgid "End Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1026
+#: lib/klass_hero_web/components/provider_components.ex:1013
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2408
-#: lib/klass_hero_web/components/provider_components.ex:2916
+#: lib/klass_hero_web/components/provider_components.ex:2373
+#: lib/klass_hero_web/components/provider_components.ex:2881
 #: lib/klass_hero_web/components/provider_layout_components.ex:612
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrolled"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1729
+#: lib/klass_hero_web/components/provider_components.ex:1706
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1067
+#: lib/klass_hero_web/components/provider_components.ex:1054
 #, elixir-autogen, elixir-format
 msgid "Enrollment Capacity (optional)"
 msgstr ""
@@ -2222,8 +2223,8 @@ msgstr ""
 msgid "Explain why this document is being rejected..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:72
-#: lib/klass_hero_web/components/provider_components.ex:2917
+#: lib/klass_hero_web/components/provider_components.ex:73
+#: lib/klass_hero_web/components/provider_components.ex:2882
 #: lib/klass_hero_web/live/admin/emails_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2244,7 +2245,7 @@ msgstr ""
 msgid "Failed to resend invite."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:165
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:180
 #: lib/klass_hero_web/live/provider/verification_live.ex:254
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to upload document."
@@ -2256,7 +2257,7 @@ msgid "Family Programs"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:694
-#: lib/klass_hero_web/components/provider_components.ex:1185
+#: lib/klass_hero_web/components/provider_components.ex:1172
 #: lib/klass_hero_web/live/settings/children_live.ex:634
 #, elixir-autogen, elixir-format
 msgid "Female"
@@ -2267,22 +2268,22 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3137
+#: lib/klass_hero_web/components/provider_components.ex:3211
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3139
+#: lib/klass_hero_web/components/provider_components.ex:3213
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:759
+#: lib/klass_hero_web/components/provider_components.ex:756
 #, elixir-autogen, elixir-format
 msgid "First Aid, UEFA B License, Child Care Cert"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:701
+#: lib/klass_hero_web/components/provider_components.ex:698
 #, elixir-autogen, elixir-format, fuzzy
 msgid "First Name"
 msgstr ""
@@ -2307,12 +2308,12 @@ msgstr ""
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2682
+#: lib/klass_hero_web/components/provider_components.ex:2647
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:820
+#: lib/klass_hero_web/components/provider_components.ex:817
 #, elixir-autogen, elixir-format
 msgid "Headshot Photo"
 msgstr ""
@@ -2322,7 +2323,7 @@ msgstr ""
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2585
+#: lib/klass_hero_web/components/provider_components.ex:2550
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import"
 msgstr ""
@@ -2347,19 +2348,19 @@ msgstr ""
 msgid "Invite resent successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1746
+#: lib/klass_hero_web/components/provider_components.ex:1723
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:827
+#: lib/klass_hero_web/components/provider_components.ex:824
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 1MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1248
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:240
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:365
+#: lib/klass_hero_web/components/provider_components.ex:1235
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:274
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:364
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 2MB."
 msgstr ""
@@ -2374,71 +2375,71 @@ msgstr ""
 msgid "Klasse %{n}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:707
+#: lib/klass_hero_web/components/provider_components.ex:704
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Last Name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1049
+#: lib/klass_hero_web/components/provider_components.ex:1036
 #, elixir-autogen, elixir-format
 msgid "Leave blank for open registration at any time."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1178
+#: lib/klass_hero_web/components/provider_components.ex:1165
 #, elixir-autogen, elixir-format
 msgid "Leave unchecked to allow all genders."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:982
+#: lib/klass_hero_web/components/provider_components.ex:969
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:191
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Location"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:81
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:81
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:96
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:83
 #, elixir-autogen, elixir-format
 msgid "Logo upload failed. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:695
-#: lib/klass_hero_web/components/provider_components.ex:1184
+#: lib/klass_hero_web/components/provider_components.ex:1171
 #: lib/klass_hero_web/live/settings/children_live.ex:633
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1168
+#: lib/klass_hero_web/components/provider_components.ex:1155
 #, elixir-autogen, elixir-format
 msgid "Maximum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1082
+#: lib/klass_hero_web/components/provider_components.ex:1069
 #, elixir-autogen, elixir-format
 msgid "Maximum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1223
+#: lib/klass_hero_web/components/provider_components.ex:1210
 #, elixir-autogen, elixir-format
 msgid "Maximum Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:991
+#: lib/klass_hero_web/components/provider_components.ex:978
 #, elixir-autogen, elixir-format
 msgid "Meeting Days"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1162
+#: lib/klass_hero_web/components/provider_components.ex:1149
 #, elixir-autogen, elixir-format
 msgid "Minimum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1076
+#: lib/klass_hero_web/components/provider_components.ex:1063
 #, elixir-autogen, elixir-format
 msgid "Minimum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1216
+#: lib/klass_hero_web/components/provider_components.ex:1203
 #, elixir-autogen, elixir-format
 msgid "Minimum Grade"
 msgstr ""
@@ -2448,12 +2449,12 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3166
+#: lib/klass_hero_web/components/provider_components.ex:3240
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2392
+#: lib/klass_hero_web/components/provider_components.ex:2357
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
@@ -2469,17 +2470,17 @@ msgstr ""
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2636
+#: lib/klass_hero_web/components/provider_components.ex:2601
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1225
+#: lib/klass_hero_web/components/provider_components.ex:1212
 #, elixir-autogen, elixir-format
 msgid "No maximum"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1218
+#: lib/klass_hero_web/components/provider_components.ex:1205
 #, elixir-autogen, elixir-format
 msgid "No minimum"
 msgstr ""
@@ -2510,18 +2511,18 @@ msgstr ""
 msgid "No verification documents found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1260
+#: lib/klass_hero_web/components/provider_components.ex:1247
 #, elixir-autogen, elixir-format
 msgid "None (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:326
+#: lib/klass_hero_web/components/provider_components.ex:327
 #, elixir-autogen, elixir-format
 msgid "Not Verified"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:697
-#: lib/klass_hero_web/components/provider_components.ex:1187
+#: lib/klass_hero_web/components/provider_components.ex:1174
 #: lib/klass_hero_web/live/settings/children_live.ex:632
 #, elixir-autogen, elixir-format
 msgid "Not specified"
@@ -2532,7 +2533,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3242
+#: lib/klass_hero_web/components/provider_components.ex:3316
 #: lib/klass_hero_web/live/provider/verification_live.ex:699
 #: lib/klass_hero_web/live/provider/verification_live.ex:773
 #, elixir-autogen, elixir-format
@@ -2544,21 +2545,21 @@ msgstr ""
 msgid "Participant Requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1115
+#: lib/klass_hero_web/components/provider_components.ex:1102
 #, elixir-autogen, elixir-format
 msgid "Participant Restrictions (optional)"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:880
-#: lib/klass_hero_web/components/provider_components.ex:294
+#: lib/klass_hero_web/components/provider_components.ex:295
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Pending Review"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:102
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:117
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:109
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:111
 #: lib/klass_hero_web/live/provider/programs_live.ex:739
 #: lib/klass_hero_web/live/provider/programs_live.ex:808
 #: lib/klass_hero_web/live/provider/team_live.ex:305
@@ -2578,17 +2579,17 @@ msgstr ""
 msgid "Preview not available for this file type."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:973
+#: lib/klass_hero_web/components/provider_components.ex:960
 #, elixir-autogen, elixir-format
 msgid "Price (EUR)"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:98
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:113
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Profile updated successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1153
+#: lib/klass_hero_web/components/provider_components.ex:1140
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program Start"
 msgstr ""
@@ -2619,7 +2620,7 @@ msgstr ""
 msgid "Program updated successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:107
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:122
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:32
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:27
 #, elixir-autogen, elixir-format
@@ -2632,13 +2633,13 @@ msgid "Read our founding story →"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:860
-#: lib/klass_hero_web/components/provider_components.ex:2915
+#: lib/klass_hero_web/components/provider_components.ex:2880
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registered"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1140
+#: lib/klass_hero_web/components/provider_components.ex:1127
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration"
 msgstr ""
@@ -2648,7 +2649,7 @@ msgstr ""
 msgid "Registration Closed"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1060
+#: lib/klass_hero_web/components/provider_components.ex:1047
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration Closes"
 msgstr ""
@@ -2658,12 +2659,12 @@ msgstr ""
 msgid "Registration Not Open Yet"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1055
+#: lib/klass_hero_web/components/provider_components.ex:1042
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration Opens"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1046
+#: lib/klass_hero_web/components/provider_components.ex:1033
 #, elixir-autogen, elixir-format
 msgid "Registration Period (optional)"
 msgstr ""
@@ -2700,7 +2701,7 @@ msgid "Reject"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:882
-#: lib/klass_hero_web/components/provider_components.ex:50
+#: lib/klass_hero_web/components/provider_components.ex:51
 #: lib/klass_hero_web/live/admin/verifications_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Rejected"
@@ -2712,16 +2713,15 @@ msgstr ""
 msgid "Rejection reason"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2738
-#: lib/klass_hero_web/components/provider_components.ex:3102
-#: lib/klass_hero_web/components/provider_components.ex:3261
-#: lib/klass_hero_web/components/provider_components.ex:3341
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:380
+#: lib/klass_hero_web/components/provider_components.ex:2703
+#: lib/klass_hero_web/components/provider_components.ex:3067
+#: lib/klass_hero_web/components/provider_components.ex:3335
+#: lib/klass_hero_web/components/provider_components.ex:3415
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2731
+#: lib/klass_hero_web/components/provider_components.ex:2696
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -2731,23 +2731,23 @@ msgstr ""
 msgid "Reviewed"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:716
+#: lib/klass_hero_web/components/provider_components.ex:713
 #, elixir-autogen, elixir-format
 msgid "Role"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1675
+#: lib/klass_hero_web/components/provider_components.ex:1652
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:407
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1287
+#: lib/klass_hero_web/components/provider_components.ex:1264
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Save Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:988
+#: lib/klass_hero_web/components/provider_components.ex:975
 #, elixir-autogen, elixir-format
 msgid "Schedule (optional)"
 msgstr ""
@@ -2762,7 +2762,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3239
+#: lib/klass_hero_web/components/provider_components.ex:3313
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select File"
 msgstr ""
@@ -2779,23 +2779,23 @@ msgstr ""
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2914
+#: lib/klass_hero_web/components/provider_components.ex:2879
 #: lib/klass_hero_web/live/admin/emails_live.ex:206
 #, elixir-autogen, elixir-format
 msgid "Sent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:763
+#: lib/klass_hero_web/components/provider_components.ex:760
 #, elixir-autogen, elixir-format
 msgid "Separate multiple qualifications with commas"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1070
+#: lib/klass_hero_web/components/provider_components.ex:1057
 #, elixir-autogen, elixir-format
 msgid "Set minimum and maximum enrollment for this program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:737
+#: lib/klass_hero_web/components/provider_components.ex:734
 #, elixir-autogen, elixir-format
 msgid "Specialties"
 msgstr ""
@@ -2813,12 +2813,12 @@ msgstr ""
 msgid "Staff member not found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1034
+#: lib/klass_hero_web/components/provider_components.ex:1021
 #, elixir-autogen, elixir-format
 msgid "Start Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1021
+#: lib/klass_hero_web/components/provider_components.ex:1008
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:184
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Start Time"
@@ -2864,7 +2864,7 @@ msgstr ""
 msgid "Team member updated."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:226
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "Tell parents about your organization..."
 msgstr ""
@@ -2884,13 +2884,13 @@ msgstr ""
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:946
-#: lib/klass_hero_web/components/provider_components.ex:1957
+#: lib/klass_hero_web/components/provider_components.ex:933
+#: lib/klass_hero_web/components/provider_components.ex:1934
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3138
+#: lib/klass_hero_web/components/provider_components.ex:3212
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -2910,27 +2910,27 @@ msgstr ""
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2572
+#: lib/klass_hero_web/components/provider_components.ex:2537
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3285
+#: lib/klass_hero_web/components/provider_components.ex:3359
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3193
+#: lib/klass_hero_web/components/provider_components.ex:3267
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3141
+#: lib/klass_hero_web/components/provider_components.ex:3215
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3158
+#: lib/klass_hero_web/components/provider_components.ex:3232
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -2952,7 +2952,7 @@ msgstr ""
 msgid "Verifications"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:278
+#: lib/klass_hero_web/components/provider_components.ex:279
 #: lib/klass_hero_web/components/provider_layout_components.ex:217
 #: lib/klass_hero_web/components/ui_components.ex:1671
 #, elixir-autogen, elixir-format, fuzzy
@@ -2969,32 +2969,32 @@ msgstr ""
 msgid "You don't have access to that page."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:717
+#: lib/klass_hero_web/components/provider_components.ex:714
 #, elixir-autogen, elixir-format, fuzzy
 msgid "e.g. Head Coach"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:708
+#: lib/klass_hero_web/components/provider_components.ex:705
 #, elixir-autogen, elixir-format
 msgid "e.g. Johnson"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:702
+#: lib/klass_hero_web/components/provider_components.ex:699
 #, elixir-autogen, elixir-format
 msgid "e.g. Mike"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:723
+#: lib/klass_hero_web/components/provider_components.ex:720
 #, elixir-autogen, elixir-format
 msgid "e.g. mike@example.com"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:947
+#: lib/klass_hero_web/components/provider_components.ex:934
 #, elixir-autogen, elixir-format
 msgid "e.g., Art Adventures"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:983
+#: lib/klass_hero_web/components/provider_components.ex:970
 #, elixir-autogen, elixir-format
 msgid "e.g., Community Center, Main St"
 msgstr ""
@@ -3020,7 +3020,7 @@ msgid "Child Safeguarding Training"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1505
-#: lib/klass_hero_web/components/provider_components.ex:3508
+#: lib/klass_hero_web/components/provider_components.ex:3582
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr ""
@@ -3171,7 +3171,7 @@ msgid "Vetted with Care"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1489
-#: lib/klass_hero_web/components/provider_components.ex:3292
+#: lib/klass_hero_web/components/provider_components.ex:3366
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr ""
@@ -3345,7 +3345,7 @@ msgstr ""
 msgid "Checked Out"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2773
+#: lib/klass_hero_web/components/provider_components.ex:2738
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Child"
@@ -3391,7 +3391,7 @@ msgstr ""
 msgid "Download monthly statements for taxes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2488
+#: lib/klass_hero_web/components/provider_components.ex:2453
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:504
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrollment not confirmed"
@@ -3464,7 +3464,7 @@ msgstr ""
 msgid "No chasing payments or sending invoices"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1698
+#: lib/klass_hero_web/components/provider_components.ex:1675
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:428
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No enrolled parents"
@@ -3487,7 +3487,7 @@ msgstr ""
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2487
+#: lib/klass_hero_web/components/provider_components.ex:2452
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:503
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -4117,7 +4117,7 @@ msgstr ""
 msgid "Post"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2679
+#: lib/klass_hero_web/components/provider_components.ex:2644
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:24
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:297
@@ -4176,7 +4176,7 @@ msgstr ""
 msgid "Reply sent successfully"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:556
+#: lib/klass_hero_web/components/provider_components.ex:553
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Resend"
 msgstr ""
@@ -4321,7 +4321,7 @@ msgstr ""
 msgid "Update your observation..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:149
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:164
 #: lib/klass_hero_web/live/provider/programs_live.ex:492
 #: lib/klass_hero_web/live/provider/verification_live.ex:240
 #: lib/klass_hero_web/live/provider/verification_live.ex:556
@@ -4406,7 +4406,7 @@ msgstr ""
 msgid "You are not assigned to this program"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:300
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:310
 #, elixir-autogen, elixir-format
 msgid "+1234567890"
 msgstr ""
@@ -4427,23 +4427,23 @@ msgstr ""
 msgid "Cancelled"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:320
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:330
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Categories"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_layout_components.ex:372
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:415
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:373
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Complete Profile"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:43
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:44
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Complete Your Profile"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:228
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:238
 #, elixir-autogen, elixir-format
 msgid "Complete Your Provider Profile"
 msgstr ""
@@ -4451,11 +4451,6 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_layout_components.ex:355
 #, elixir-autogen, elixir-format
 msgid "Complete your provider profile"
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:362
-#, elixir-autogen, elixir-format
-msgid "Drag and drop or click to upload"
 msgstr ""
 
 #: lib/klass_hero_web/live/messaging_live_helper.ex:526
@@ -4483,7 +4478,7 @@ msgstr ""
 msgid "Fill in your business details so parents can find you. Your profile will be reviewed by Klass Hero before going live."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:231
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "Fill in your business details. Your profile will be reviewed by Klass Hero before going live."
 msgstr ""
@@ -4504,7 +4499,7 @@ msgstr ""
 msgid "Please enter a message or attach a photo."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:101
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:103
 #, elixir-autogen, elixir-format
 msgid "Profile completed! Klass Hero will review your profile shortly."
 msgstr ""
@@ -4523,13 +4518,13 @@ msgstr ""
 #: lib/klass_hero_web/controllers/invite_claim_controller.ex:67
 #: lib/klass_hero_web/live/messaging_live_helper.ex:527
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:132
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:113
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:118
 #: lib/klass_hero_web/live/user_live/settings.ex:512
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Something went wrong. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:290
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:300
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Tell parents about your organization and what makes you unique..."
 msgstr ""
@@ -4559,13 +4554,13 @@ msgstr ""
 msgid "View your assignments"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:306
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:316
 #: lib/klass_hero_web/live/provider_profile_live.ex:120
 #, elixir-autogen, elixir-format
 msgid "Website"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:32
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:33
 #, elixir-autogen, elixir-format
 msgid "Your profile is already complete."
 msgstr ""
@@ -4576,41 +4571,41 @@ msgstr ""
 msgid "for"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1822
+#: lib/klass_hero_web/components/provider_components.ex:1799
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assigned staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1823
+#: lib/klass_hero_web/components/provider_components.ex:1800
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1806
-#: lib/klass_hero_web/components/provider_components.ex:1891
-#: lib/klass_hero_web/components/provider_components.ex:2033
-#: lib/klass_hero_web/components/provider_components.ex:2187
+#: lib/klass_hero_web/components/provider_components.ex:1783
+#: lib/klass_hero_web/components/provider_components.ex:1868
+#: lib/klass_hero_web/components/provider_components.ex:2010
+#: lib/klass_hero_web/components/provider_components.ex:2158
 #: lib/klass_hero_web/live/provider/overview_live.ex:403
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Close"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1821
+#: lib/klass_hero_web/components/provider_components.ex:1798
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1815
+#: lib/klass_hero_web/components/provider_components.ex:1792
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No sessions scheduled yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1804
+#: lib/klass_hero_web/components/provider_components.ex:1781
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sessions — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1509
+#: lib/klass_hero_web/components/provider_components.ex:1486
 #, elixir-autogen, elixir-format
 msgid "View sessions"
 msgstr ""
@@ -4642,17 +4637,17 @@ msgstr ""
 msgid "Failed to update record"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2837
+#: lib/klass_hero_web/components/provider_components.ex:2802
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2510
+#: lib/klass_hero_web/components/provider_components.ex:2475
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invite mode"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2529
+#: lib/klass_hero_web/components/provider_components.ex:2494
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr ""
@@ -4667,12 +4662,12 @@ msgstr ""
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2850
+#: lib/klass_hero_web/components/provider_components.ex:2815
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2856
+#: lib/klass_hero_web/components/provider_components.ex:2821
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr ""
@@ -4683,17 +4678,17 @@ msgstr ""
 msgid "Nothing to update"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2858
+#: lib/klass_hero_web/components/provider_components.ex:2823
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nut allergy"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2862
+#: lib/klass_hero_web/components/provider_components.ex:2827
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2867
+#: lib/klass_hero_web/components/provider_components.ex:2832
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr ""
@@ -4703,7 +4698,7 @@ msgstr ""
 msgid "Present"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2794
+#: lib/klass_hero_web/components/provider_components.ex:2759
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr ""
@@ -4730,22 +4725,22 @@ msgstr ""
 msgid "Save changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2831
+#: lib/klass_hero_web/components/provider_components.ex:2796
 #, elixir-autogen, elixir-format, fuzzy
 msgid "School (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2841
+#: lib/klass_hero_web/components/provider_components.ex:2806
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2815
+#: lib/klass_hero_web/components/provider_components.ex:2780
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2884
+#: lib/klass_hero_web/components/provider_components.ex:2849
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Send invite"
 msgstr ""
@@ -4755,7 +4750,7 @@ msgstr ""
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2547
+#: lib/klass_hero_web/components/provider_components.ex:2512
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload a list"
 msgstr ""
@@ -4790,7 +4785,7 @@ msgstr ""
 msgid "High"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:790
+#: lib/klass_hero_web/components/provider_components.ex:787
 #, elixir-autogen, elixir-format
 msgid "Hourly"
 msgstr ""
@@ -4815,22 +4810,22 @@ msgstr ""
 msgid "Medium"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:780
+#: lib/klass_hero_web/components/provider_components.ex:777
 #, elixir-autogen, elixir-format
 msgid "None"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:769
+#: lib/klass_hero_web/components/provider_components.ex:766
 #, elixir-autogen, elixir-format
 msgid "Pay Rate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:527
+#: lib/klass_hero_web/components/provider_components.ex:528
 #, elixir-autogen, elixir-format
 msgid "Pay rate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:800
+#: lib/klass_hero_web/components/provider_components.ex:797
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Per Session"
 msgstr ""
@@ -4855,7 +4850,7 @@ msgstr ""
 msgid "Property Damage"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1546
+#: lib/klass_hero_web/components/provider_components.ex:1523
 #, elixir-autogen, elixir-format
 msgid "Report Incident"
 msgstr ""
@@ -5523,7 +5518,7 @@ msgstr[1] ""
 msgid "In 2025, Shane connected with his friend"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1555
+#: lib/klass_hero_web/components/provider_components.ex:1532
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:43
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:74
 #, elixir-autogen, elixir-format
@@ -5593,7 +5588,7 @@ msgstr ""
 msgid "Last 8 weeks"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1258
+#: lib/klass_hero_web/components/provider_components.ex:1245
 #: lib/klass_hero_web/presenters/hero_cards_presenter.ex:27
 #, elixir-autogen, elixir-format
 msgid "Lead Instructor"
@@ -6032,17 +6027,17 @@ msgstr ""
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2923
+#: lib/klass_hero_web/components/provider_components.ex:2888
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Row %{row}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2923
+#: lib/klass_hero_web/components/provider_components.ex:2888
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2624
+#: lib/klass_hero_web/components/provider_components.ex:2589
 #, elixir-autogen, elixir-format
 msgid "Rows with errors"
 msgstr ""
@@ -6625,7 +6620,7 @@ msgstr ""
 msgid "Identity verifications"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:73
+#: lib/klass_hero_web/components/provider_components.ex:74
 #, elixir-autogen, elixir-format, fuzzy
 msgid "In progress"
 msgstr ""
@@ -6655,7 +6650,7 @@ msgstr ""
 msgid "Not started"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:71
+#: lib/klass_hero_web/components/provider_components.ex:72
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Passed"
 msgstr ""
@@ -6772,12 +6767,12 @@ msgstr ""
 msgid "Experience validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3322
+#: lib/klass_hero_web/components/provider_components.ex:3396
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3295
+#: lib/klass_hero_web/components/provider_components.ex:3369
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
@@ -6787,12 +6782,12 @@ msgstr ""
 msgid "Safeguarding certificate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3319
+#: lib/klass_hero_web/components/provider_components.ex:3393
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select Video"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3365
+#: lib/klass_hero_web/components/provider_components.ex:3439
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload Video"
 msgstr ""
@@ -6802,7 +6797,7 @@ msgstr ""
 msgid "Your browser does not support video playback."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3512
+#: lib/klass_hero_web/components/provider_components.ex:3586
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Confirm agreement"
 msgstr ""
@@ -6812,12 +6807,12 @@ msgstr ""
 msgid "Couldn't record your agreement. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3535
+#: lib/klass_hero_web/components/provider_components.ex:3609
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3511
+#: lib/klass_hero_web/components/provider_components.ex:3585
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr ""
@@ -6827,7 +6822,7 @@ msgstr ""
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3420
+#: lib/klass_hero_web/components/provider_components.ex:3494
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr ""
@@ -6837,17 +6832,17 @@ msgstr ""
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3520
+#: lib/klass_hero_web/components/provider_components.ex:3594
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3509
+#: lib/klass_hero_web/components/provider_components.ex:3583
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3510
+#: lib/klass_hero_web/components/provider_components.ex:3584
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
@@ -6857,12 +6852,12 @@ msgstr ""
 msgid "Applicants submit a short recorded video (max 2 minutes) so we can assess communication skills and alignment with our values before approving their profile."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:254
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:264
 #, elixir-autogen, elixir-format, fuzzy
 msgid "A business"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:252
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:262
 #, elixir-autogen, elixir-format
 msgid "An individual"
 msgstr ""
@@ -6907,17 +6902,17 @@ msgstr ""
 msgid "Verify the owner or director accountable for the business."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:246
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:256
 #, elixir-autogen, elixir-format
 msgid "What are you registering as?"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:253
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:263
 #, elixir-autogen, elixir-format
 msgid "You'll be vetted personally."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:255
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:265
 #, elixir-autogen, elixir-format
 msgid "Your business and its responsible person will be vetted."
 msgstr ""
@@ -7116,12 +7111,12 @@ msgstr ""
 msgid "Your insurance is verified."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3464
+#: lib/klass_hero_web/components/provider_components.ex:3538
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3567
+#: lib/klass_hero_web/components/provider_components.ex:3641
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr ""
@@ -7131,7 +7126,7 @@ msgstr ""
 msgid "Couldn't record your declaration. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3573
+#: lib/klass_hero_web/components/provider_components.ex:3647
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr ""
@@ -7141,17 +7136,17 @@ msgstr ""
 msgid "Please confirm the declaration before signing."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3598
+#: lib/klass_hero_web/components/provider_components.ex:3672
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3577
+#: lib/klass_hero_web/components/provider_components.ex:3651
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3565
+#: lib/klass_hero_web/components/provider_components.ex:3639
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr ""
@@ -7161,12 +7156,12 @@ msgstr ""
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3585
+#: lib/klass_hero_web/components/provider_components.ex:3659
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3571
+#: lib/klass_hero_web/components/provider_components.ex:3645
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
@@ -7233,15 +7228,15 @@ msgstr ""
 msgid "Undelivered Events"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2132
-#: lib/klass_hero_web/components/provider_components.ex:2315
+#: lib/klass_hero_web/components/provider_components.ex:2103
+#: lib/klass_hero_web/components/provider_components.ex:2280
 #: lib/klass_hero_web/live/user_live/settings.ex:273
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2055
-#: lib/klass_hero_web/components/provider_components.ex:2241
+#: lib/klass_hero_web/components/provider_components.ex:2032
+#: lib/klass_hero_web/components/provider_components.ex:2212
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Lead"
 msgstr ""
@@ -7251,17 +7246,17 @@ msgstr ""
 msgid "Lead instructor updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2067
+#: lib/klass_hero_web/components/provider_components.ex:2044
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1523
+#: lib/klass_hero_web/components/provider_components.ex:1500
 #, elixir-autogen, elixir-format
 msgid "Manage Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2096
+#: lib/klass_hero_web/components/provider_components.ex:2073
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this program yet."
 msgstr ""
@@ -7272,19 +7267,19 @@ msgstr ""
 msgid "Pick a staff member to add."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2079
-#: lib/klass_hero_web/components/provider_components.ex:2354
+#: lib/klass_hero_web/components/provider_components.ex:2056
+#: lib/klass_hero_web/components/provider_components.ex:2319
 #, elixir-autogen, elixir-format
 msgid "Reassign the lead before removing them"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2080
+#: lib/klass_hero_web/components/provider_components.ex:2057
 #, elixir-autogen, elixir-format
 msgid "Remove from program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2114
-#: lib/klass_hero_web/components/provider_components.ex:2296
+#: lib/klass_hero_web/components/provider_components.ex:2091
+#: lib/klass_hero_web/components/provider_components.ex:2267
 #, elixir-autogen, elixir-format
 msgid "Select a staff member…"
 msgstr ""
@@ -7299,12 +7294,12 @@ msgstr ""
 msgid "Staff member removed from the program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2137
+#: lib/klass_hero_web/components/provider_components.ex:2108
 #, elixir-autogen, elixir-format
 msgid "Staff you add can read and reply to this program's parent conversations."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2031
+#: lib/klass_hero_web/components/provider_components.ex:2008
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Staffing — %{title}"
 msgstr ""
@@ -7324,19 +7319,19 @@ msgstr ""
 msgid "This person is the lead instructor. Make someone else lead before removing them."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1467
+#: lib/klass_hero_web/components/provider_components.ex:1444
 #, elixir-autogen, elixir-format
 msgid "%{count} staff member · no lead"
 msgid_plural "%{count} staff · no lead"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/components/provider_components.ex:566
+#: lib/klass_hero_web/components/provider_components.ex:563
 #, elixir-autogen, elixir-format
 msgid "%{name} will be unassigned from every program and removed from those conversations. Their history is kept and you can add them back later."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:642
+#: lib/klass_hero_web/components/provider_components.ex:639
 #, elixir-autogen, elixir-format
 msgid "Add back to team"
 msgstr ""
@@ -7346,7 +7341,7 @@ msgstr ""
 msgid "Could not bring this team member back. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:604
+#: lib/klass_hero_web/components/provider_components.ex:601
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Delete entry"
 msgstr ""
@@ -7356,7 +7351,7 @@ msgstr ""
 msgid "Former team members"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:578
+#: lib/klass_hero_web/components/provider_components.ex:575
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove from team"
 msgstr ""
@@ -7371,7 +7366,7 @@ msgstr ""
 msgid "Team member removed from the team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:594
+#: lib/klass_hero_web/components/provider_components.ex:591
 #, elixir-autogen, elixir-format
 msgid "This deletes %{name} permanently — there's nothing to undo. Use it only for an entry added by mistake."
 msgstr ""
@@ -7396,24 +7391,24 @@ msgstr ""
 msgid "Program updated, but the enrollment capacity was rejected. The previous limits still apply."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:889
+#: lib/klass_hero_web/components/provider_components.ex:876
 #, elixir-autogen, elixir-format
 msgid "%{count} child is already enrolled. Confirm you want this program to have no capacity limit."
 msgid_plural "%{count} children are already enrolled. Confirm you want this program to have no capacity limit."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1100
+#: lib/klass_hero_web/components/provider_components.ex:1087
 #, elixir-autogen, elixir-format
 msgid "Anyone will be able to book a place until you set a new maximum."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1105
+#: lib/klass_hero_web/components/provider_components.ex:1092
 #, elixir-autogen, elixir-format
 msgid "I understand this program will have no capacity limit."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2342
+#: lib/klass_hero_web/components/provider_components.ex:2307
 #, elixir-autogen, elixir-format
 msgid "Go back to the program's usual team"
 msgstr ""
@@ -7423,17 +7418,17 @@ msgstr ""
 msgid "Lead instructor for this session updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2256
+#: lib/klass_hero_web/components/provider_components.ex:2227
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Make lead instructor for this session"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2278
+#: lib/klass_hero_web/components/provider_components.ex:2249
 #, elixir-autogen, elixir-format
 msgid "Nobody is working this session yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2359
+#: lib/klass_hero_web/components/provider_components.ex:2324
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove from this session"
 msgstr ""
@@ -7453,7 +7448,7 @@ msgstr ""
 msgid "Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2180
+#: lib/klass_hero_web/components/provider_components.ex:2151
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Staffing — %{date}"
 msgstr ""
@@ -7483,22 +7478,22 @@ msgstr ""
 msgid "A session needs at least one person. Use “Go back to the program's usual team” to drop this session's own roster."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2357
+#: lib/klass_hero_web/components/provider_components.ex:2322
 #, elixir-autogen, elixir-format
 msgid "A session needs someone — use “Go back to the program's usual team” instead"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2324
+#: lib/klass_hero_web/components/provider_components.ex:2289
 #, elixir-autogen, elixir-format
 msgid "Everyone on your team is already working this session."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2212
+#: lib/klass_hero_web/components/provider_components.ex:2183
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Staffed just for this session. Changes here do not touch the program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2214
+#: lib/klass_hero_web/components/provider_components.ex:2185
 #, elixir-autogen, elixir-format
 msgid "Using the program's usual team. The first change here copies them onto this session, so later program changes stop reaching it."
 msgstr ""
@@ -7508,12 +7503,12 @@ msgstr ""
 msgid "(optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1950
+#: lib/klass_hero_web/components/provider_components.ex:1927
 #, elixir-autogen, elixir-format
 msgid "Add a waiver"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1982
+#: lib/klass_hero_web/components/provider_components.ex:1959
 #, elixir-autogen, elixir-format
 msgid "Add waiver"
 msgstr ""
@@ -7535,22 +7530,22 @@ msgstr ""
 msgid "I have read and agree to %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1964
+#: lib/klass_hero_web/components/provider_components.ex:1941
 #, elixir-autogen, elixir-format
 msgid "Legal text"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1530
+#: lib/klass_hero_web/components/provider_components.ex:1507
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Manage Waivers"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1898
+#: lib/klass_hero_web/components/provider_components.ex:1875
 #, elixir-autogen, elixir-format
 msgid "No waivers yet. Parents enrol without signing anything."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1971
+#: lib/klass_hero_web/components/provider_components.ex:1948
 #, elixir-autogen, elixir-format
 msgid "Parents must sign this before enrolling"
 msgstr ""
@@ -7570,17 +7565,17 @@ msgstr ""
 msgid "Please tick a waiver to sign it."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1949
+#: lib/klass_hero_web/components/provider_components.ex:1926
 #, elixir-autogen, elixir-format
 msgid "Publish a new version"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1982
+#: lib/klass_hero_web/components/provider_components.ex:1959
 #, elixir-autogen, elixir-format
 msgid "Publish version"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1975
+#: lib/klass_hero_web/components/provider_components.ex:1952
 #, elixir-autogen, elixir-format
 msgid "Publishing keeps every earlier version on record; signatures already given stay bound to the wording they were shown."
 msgstr ""
@@ -7590,12 +7585,12 @@ msgstr ""
 msgid "Required"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1932
+#: lib/klass_hero_web/components/provider_components.ex:1909
 #, elixir-autogen, elixir-format
 msgid "Retire this waiver"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1923
+#: lib/klass_hero_web/components/provider_components.ex:1900
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Revise text"
 msgstr ""
@@ -7610,7 +7605,7 @@ msgstr ""
 msgid "Sign waivers"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2437
+#: lib/klass_hero_web/components/provider_components.ex:2402
 #: lib/klass_hero_web/live/enrollment_waivers_live.ex:143
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Signed"
@@ -7626,12 +7621,12 @@ msgstr ""
 msgid "There is nothing to sign for this enrollment."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2437
+#: lib/klass_hero_web/components/provider_components.ex:2402
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Unsigned"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1915
+#: lib/klass_hero_web/components/provider_components.ex:1892
 #, elixir-autogen, elixir-format
 msgid "Version %{number}"
 msgstr ""
@@ -7641,7 +7636,7 @@ msgstr ""
 msgid "Waiver not found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2405
+#: lib/klass_hero_web/components/provider_components.ex:2370
 #: lib/klass_hero_web/live/booking_live.ex:431
 #: lib/klass_hero_web/live/enrollment_waivers_live.ex:33
 #: lib/klass_hero_web/live/enrollment_waivers_live.ex:105
@@ -7654,7 +7649,7 @@ msgstr ""
 msgid "Waivers waiting for your signature"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1889
+#: lib/klass_hero_web/components/provider_components.ex:1866
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Waivers — %{title}"
 msgstr ""
@@ -7669,7 +7664,7 @@ msgstr ""
 msgid "New version published. It applies to future enrolments."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1936
+#: lib/klass_hero_web/components/provider_components.ex:1913
 #, elixir-autogen, elixir-format
 msgid "Retire \"%{title}\"? Parents will no longer be asked to sign it. Signatures already collected are kept."
 msgstr ""
@@ -7689,7 +7684,7 @@ msgstr ""
 msgid "You are not assigned to this session"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:429
+#: lib/klass_hero_web/components/provider_components.ex:430
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Complete verification to create programs."
 msgstr ""
@@ -7699,28 +7694,28 @@ msgstr ""
 msgid "Manage your provider profile"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:225
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:259
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Provider Description"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:212
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:246
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Provider Information"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:232
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:347
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:266
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:356
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Provider Logo"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:281
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:291
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Provider Name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:207
+#: lib/klass_hero_web/components/provider_components.ex:208
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Provider Profile"
 msgstr ""
@@ -7740,17 +7735,17 @@ msgstr ""
 msgid "This invitation has expired. Please ask your provider to resend it."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:210
+#: lib/klass_hero_web/components/provider_components.ex:211
 #, elixir-autogen, elixir-format, fuzzy
 msgid "This is your main provider identity. Verification is required to list programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3161
+#: lib/klass_hero_web/components/provider_components.ex:3235
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload documents to be verified. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:402
+#: lib/klass_hero_web/components/provider_components.ex:403
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Verified Provider"
 msgstr ""
@@ -7766,12 +7761,12 @@ msgstr ""
 msgid "You'll get your own provider profile to fill in, and your account will open on your provider dashboard from now on. You stay on %{business}'s team."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:315
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:325
 #, elixir-autogen, elixir-format
 msgid "Your address"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:282
+#: lib/klass_hero_web/live/provider/profile_completion_live.ex:292
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Your provider or organization name"
 msgstr ""
@@ -7889,8 +7884,8 @@ msgstr ""
 msgid "Review invitations"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2700
-#: lib/klass_hero_web/components/provider_components.ex:2707
+#: lib/klass_hero_web/components/provider_components.ex:2665
+#: lib/klass_hero_web/components/provider_components.ex:2672
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Unknown program"
 msgstr ""
@@ -7935,12 +7930,12 @@ msgstr ""
 msgid "You can't start a conversation with this person"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:965
+#: lib/klass_hero_web/components/provider_components.ex:952
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Subtitle"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:966
+#: lib/klass_hero_web/components/provider_components.ex:953
 #, elixir-autogen, elixir-format
 msgid "e.g., For beginners, no experience needed"
 msgstr ""
@@ -7955,45 +7950,37 @@ msgstr ""
 msgid "N/A"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:272
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:400
+#: lib/klass_hero_web/components/provider_components.ex:3143
 #, elixir-autogen, elixir-format
 msgid "A short line that sums you up"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:261
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:389
+#: lib/klass_hero_web/components/provider_components.ex:3132
 #, elixir-autogen, elixir-format
 msgid "Branding & Presence"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:285
+#: lib/klass_hero_web/components/provider_components.ex:3156
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Choose Cover Image"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:84
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:99
 #, elixir-autogen, elixir-format
 msgid "Cover image upload failed. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:286
+#: lib/klass_hero_web/components/provider_components.ex:3157
 #, elixir-autogen, elixir-format, fuzzy
 msgid "JPG, PNG or WebP. Max 5MB."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:392
-#, elixir-autogen, elixir-format
-msgid "Optional — shown on your public profile page."
-msgstr ""
-
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:264
+#: lib/klass_hero_web/components/provider_components.ex:3135
 #, elixir-autogen, elixir-format
 msgid "Shown on your public profile page."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/edit_profile_live.ex:271
-#: lib/klass_hero_web/live/provider/profile_completion_live.ex:399
+#: lib/klass_hero_web/components/provider_components.ex:3142
 #, elixir-autogen, elixir-format
 msgid "Tagline"
 msgstr ""
@@ -8039,7 +8026,7 @@ msgstr ""
 msgid "Klass Hero on %{network}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3140
+#: lib/klass_hero_web/components/provider_components.ex:3214
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr ""
@@ -8072,4 +8059,34 @@ msgstr ""
 #: lib/klass_hero_web/presenters/program_presenter.ex:350
 #, elixir-autogen, elixir-format, fuzzy
 msgid "General"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:345
+#, elixir-autogen, elixir-format
+msgid "A newly chosen cover or logo appears here after you save."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:3187
+#, elixir-autogen, elixir-format
+msgid "Add %{network}"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:329
+#, elixir-autogen, elixir-format
+msgid "Hide preview"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:342
+#, elixir-autogen, elixir-format
+msgid "Public profile preview"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/edit_profile_live.ex:329
+#, elixir-autogen, elixir-format
+msgid "Show preview"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:3168
+#, elixir-autogen, elixir-format
+msgid "e.g. %{example}"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -2136,7 +2136,7 @@ msgstr ""
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3278
+#: lib/klass_hero_web/components/provider_components.ex:3284
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2268,12 +2268,12 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3211
+#: lib/klass_hero_web/components/provider_components.ex:3217
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3213
+#: lib/klass_hero_web/components/provider_components.ex:3219
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
@@ -2449,7 +2449,7 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3240
+#: lib/klass_hero_web/components/provider_components.ex:3246
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
@@ -2533,7 +2533,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3316
+#: lib/klass_hero_web/components/provider_components.ex:3322
 #: lib/klass_hero_web/live/provider/verification_live.ex:699
 #: lib/klass_hero_web/live/provider/verification_live.ex:773
 #, elixir-autogen, elixir-format
@@ -2715,8 +2715,8 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:2703
 #: lib/klass_hero_web/components/provider_components.ex:3067
-#: lib/klass_hero_web/components/provider_components.ex:3335
-#: lib/klass_hero_web/components/provider_components.ex:3415
+#: lib/klass_hero_web/components/provider_components.ex:3341
+#: lib/klass_hero_web/components/provider_components.ex:3421
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
@@ -2762,7 +2762,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3313
+#: lib/klass_hero_web/components/provider_components.ex:3319
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select File"
 msgstr ""
@@ -2890,7 +2890,7 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3212
+#: lib/klass_hero_web/components/provider_components.ex:3218
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -2915,22 +2915,22 @@ msgstr ""
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3359
+#: lib/klass_hero_web/components/provider_components.ex:3365
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3267
+#: lib/klass_hero_web/components/provider_components.ex:3273
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3215
+#: lib/klass_hero_web/components/provider_components.ex:3221
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3232
+#: lib/klass_hero_web/components/provider_components.ex:3238
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -3020,7 +3020,7 @@ msgid "Child Safeguarding Training"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1505
-#: lib/klass_hero_web/components/provider_components.ex:3582
+#: lib/klass_hero_web/components/provider_components.ex:3588
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr ""
@@ -3171,7 +3171,7 @@ msgid "Vetted with Care"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1489
-#: lib/klass_hero_web/components/provider_components.ex:3366
+#: lib/klass_hero_web/components/provider_components.ex:3372
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr ""
@@ -6767,12 +6767,12 @@ msgstr ""
 msgid "Experience validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3396
+#: lib/klass_hero_web/components/provider_components.ex:3402
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3369
+#: lib/klass_hero_web/components/provider_components.ex:3375
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
@@ -6782,12 +6782,12 @@ msgstr ""
 msgid "Safeguarding certificate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3393
+#: lib/klass_hero_web/components/provider_components.ex:3399
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select Video"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3439
+#: lib/klass_hero_web/components/provider_components.ex:3445
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload Video"
 msgstr ""
@@ -6797,7 +6797,7 @@ msgstr ""
 msgid "Your browser does not support video playback."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3586
+#: lib/klass_hero_web/components/provider_components.ex:3592
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Confirm agreement"
 msgstr ""
@@ -6807,12 +6807,12 @@ msgstr ""
 msgid "Couldn't record your agreement. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3609
+#: lib/klass_hero_web/components/provider_components.ex:3615
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3585
+#: lib/klass_hero_web/components/provider_components.ex:3591
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr ""
@@ -6822,7 +6822,7 @@ msgstr ""
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3494
+#: lib/klass_hero_web/components/provider_components.ex:3500
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr ""
@@ -6832,17 +6832,17 @@ msgstr ""
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3594
+#: lib/klass_hero_web/components/provider_components.ex:3600
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3583
+#: lib/klass_hero_web/components/provider_components.ex:3589
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3584
+#: lib/klass_hero_web/components/provider_components.ex:3590
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
@@ -7111,12 +7111,12 @@ msgstr ""
 msgid "Your insurance is verified."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3538
+#: lib/klass_hero_web/components/provider_components.ex:3544
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3641
+#: lib/klass_hero_web/components/provider_components.ex:3647
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr ""
@@ -7126,7 +7126,7 @@ msgstr ""
 msgid "Couldn't record your declaration. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3647
+#: lib/klass_hero_web/components/provider_components.ex:3653
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr ""
@@ -7136,17 +7136,17 @@ msgstr ""
 msgid "Please confirm the declaration before signing."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3672
+#: lib/klass_hero_web/components/provider_components.ex:3678
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3651
+#: lib/klass_hero_web/components/provider_components.ex:3657
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3639
+#: lib/klass_hero_web/components/provider_components.ex:3645
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr ""
@@ -7156,12 +7156,12 @@ msgstr ""
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3659
+#: lib/klass_hero_web/components/provider_components.ex:3665
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3645
+#: lib/klass_hero_web/components/provider_components.ex:3651
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
@@ -7740,7 +7740,7 @@ msgstr ""
 msgid "This is your main provider identity. Verification is required to list programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3235
+#: lib/klass_hero_web/components/provider_components.ex:3241
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload documents to be verified. Documents are reviewed by our team."
 msgstr ""
@@ -8026,7 +8026,7 @@ msgstr ""
 msgid "Klass Hero on %{network}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3214
+#: lib/klass_hero_web/components/provider_components.ex:3220
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr ""
@@ -8066,7 +8066,7 @@ msgstr ""
 msgid "A newly chosen cover or logo appears here after you save."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3187
+#: lib/klass_hero_web/components/provider_components.ex:3193
 #, elixir-autogen, elixir-format
 msgid "Add %{network}"
 msgstr ""
@@ -8086,7 +8086,7 @@ msgstr ""
 msgid "Show preview"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3168
+#: lib/klass_hero_web/components/provider_components.ex:3174
 #, elixir-autogen, elixir-format
 msgid "e.g. %{example}"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/en/LC_MESSAGES/enrollment.po
@@ -11,95 +11,95 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:3017
-#: lib/klass_hero_web/components/provider_components.ex:3034
+#: lib/klass_hero_web/components/provider_components.ex:2982
+#: lib/klass_hero_web/components/provider_components.ex:2999
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3018
-#: lib/klass_hero_web/components/provider_components.ex:3035
+#: lib/klass_hero_web/components/provider_components.ex:2983
+#: lib/klass_hero_web/components/provider_components.ex:3000
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3019
-#: lib/klass_hero_web/components/provider_components.ex:3036
+#: lib/klass_hero_web/components/provider_components.ex:2984
+#: lib/klass_hero_web/components/provider_components.ex:3001
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3030
+#: lib/klass_hero_web/components/provider_components.ex:2995
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3020
+#: lib/klass_hero_web/components/provider_components.ex:2985
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3021
+#: lib/klass_hero_web/components/provider_components.ex:2986
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3022
+#: lib/klass_hero_web/components/provider_components.ex:2987
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3029
+#: lib/klass_hero_web/components/provider_components.ex:2994
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3031
+#: lib/klass_hero_web/components/provider_components.ex:2996
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3023
+#: lib/klass_hero_web/components/provider_components.ex:2988
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3025
+#: lib/klass_hero_web/components/provider_components.ex:2990
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3027
+#: lib/klass_hero_web/components/provider_components.ex:2992
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2957
+#: lib/klass_hero_web/components/provider_components.ex:2922
 #, elixir-autogen, elixir-format
 msgid "Date of birth \"%{value}\" is not a valid date. Please correct it and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2951
+#: lib/klass_hero_web/components/provider_components.ex:2916
 #, elixir-autogen, elixir-format
 msgid "Invite link could not be generated (no token). Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2965
+#: lib/klass_hero_web/components/provider_components.ex:2930
 #, elixir-autogen, elixir-format
 msgid "The invitation email could not be delivered. Please check the address and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2954
+#: lib/klass_hero_web/components/provider_components.ex:2919
 #, elixir-autogen, elixir-format
 msgid "The program is full, so this child could not be enrolled."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2968
+#: lib/klass_hero_web/components/provider_components.ex:2933
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed and no retries remain. Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2977
+#: lib/klass_hero_web/components/provider_components.ex:2942
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed. Please resend."
 msgstr ""

--- a/priv/gettext/enrollment.pot
+++ b/priv/gettext/enrollment.pot
@@ -11,95 +11,95 @@
 msgid ""
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3017
-#: lib/klass_hero_web/components/provider_components.ex:3034
+#: lib/klass_hero_web/components/provider_components.ex:2982
+#: lib/klass_hero_web/components/provider_components.ex:2999
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3018
-#: lib/klass_hero_web/components/provider_components.ex:3035
+#: lib/klass_hero_web/components/provider_components.ex:2983
+#: lib/klass_hero_web/components/provider_components.ex:3000
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3019
-#: lib/klass_hero_web/components/provider_components.ex:3036
+#: lib/klass_hero_web/components/provider_components.ex:2984
+#: lib/klass_hero_web/components/provider_components.ex:3001
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3030
+#: lib/klass_hero_web/components/provider_components.ex:2995
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3020
+#: lib/klass_hero_web/components/provider_components.ex:2985
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3021
+#: lib/klass_hero_web/components/provider_components.ex:2986
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3022
+#: lib/klass_hero_web/components/provider_components.ex:2987
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3029
+#: lib/klass_hero_web/components/provider_components.ex:2994
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3031
+#: lib/klass_hero_web/components/provider_components.ex:2996
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3023
+#: lib/klass_hero_web/components/provider_components.ex:2988
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3025
+#: lib/klass_hero_web/components/provider_components.ex:2990
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3027
+#: lib/klass_hero_web/components/provider_components.ex:2992
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2957
+#: lib/klass_hero_web/components/provider_components.ex:2922
 #, elixir-autogen, elixir-format
 msgid "Date of birth \"%{value}\" is not a valid date. Please correct it and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2951
+#: lib/klass_hero_web/components/provider_components.ex:2916
 #, elixir-autogen, elixir-format
 msgid "Invite link could not be generated (no token). Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2965
+#: lib/klass_hero_web/components/provider_components.ex:2930
 #, elixir-autogen, elixir-format
 msgid "The invitation email could not be delivered. Please check the address and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2954
+#: lib/klass_hero_web/components/provider_components.ex:2919
 #, elixir-autogen, elixir-format
 msgid "The program is full, so this child could not be enrolled."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2968
+#: lib/klass_hero_web/components/provider_components.ex:2933
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed and no retries remain. Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2977
+#: lib/klass_hero_web/components/provider_components.ex:2942
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed. Please resend."
 msgstr ""

--- a/test/klass_hero/provider/profiles/complete_provider_profile_test.exs
+++ b/test/klass_hero/provider/profiles/complete_provider_profile_test.exs
@@ -51,6 +51,22 @@ defmodule KlassHero.Provider.Profiles.CompleteProviderProfileTest do
                Provider.complete_provider_profile(domain.id, %{description: "test"})
     end
 
+    test "persists a scheme-less website and social link as https", %{provider: provider} do
+      # The mirror of update_provider_profile_test.exs's normalization case: this
+      # path persists the struct the pure core returns, so the rewrite has to
+      # happen there rather than in the changeset.
+      attrs = %{
+        business_name: "Starlight",
+        description: "Sports for kids",
+        website: "starlight.de",
+        instagram_url: "instagram.com/starlight"
+      }
+
+      assert {:ok, completed} = Provider.complete_provider_profile(provider.id, attrs)
+      assert completed.website == "https://starlight.de"
+      assert completed.instagram_url == "https://instagram.com/starlight"
+    end
+
     test "returns validation error for invalid attrs", %{provider: provider} do
       attrs = %{business_name: "", description: "Valid"}
 

--- a/test/klass_hero/provider/profiles/update_provider_profile_test.exs
+++ b/test/klass_hero/provider/profiles/update_provider_profile_test.exs
@@ -113,6 +113,18 @@ defmodule KlassHero.Provider.Profiles.UpdateProviderProfileTest do
       assert Repo.get!(ProviderProfile, provider.id).description == "Still editable"
     end
 
+    test "persists a scheme-less social link as https", %{provider: provider} do
+      # This path discards the pure core's struct and persists the changeset's,
+      # so it is the changeset that has to rewrite. Its sibling in
+      # complete_provider_profile_test.exs covers the opposite arrangement —
+      # normalizing only one of the two looks like a whole fix.
+      assert {:ok, _} =
+               Provider.update_provider_profile(provider.id, %{instagram_url: "instagram.com/starlight"})
+
+      assert Repo.get!(ProviderProfile, provider.id).instagram_url ==
+               "https://instagram.com/starlight"
+    end
+
     test "leaves branding fields nil when never set", %{provider: provider} do
       assert {:ok, _} = Provider.update_provider_profile(provider.id, %{description: "unrelated"})
 

--- a/test/klass_hero/provider/provider_profile_test.exs
+++ b/test/klass_hero/provider/provider_profile_test.exs
@@ -328,4 +328,106 @@ defmodule KlassHero.Provider.ProviderProfileTest do
       assert %ProviderProfile{}.profile_status == :active
     end
   end
+
+  describe "normalize_url/1" do
+    @normalize_cases [
+      {"instagram.com/handle", "https://instagram.com/handle"},
+      {"www.starlight.de", "https://www.starlight.de"},
+      {"  facebook.com/x  ", "https://facebook.com/x"},
+      {"https://tiktok.com/@x", "https://tiktok.com/@x"},
+      # Left alone on purpose: an explicit http:// is a deliberate insecure
+      # choice, so it must still reach — and fail — the https validator.
+      {"http://insecure.example.com", "http://insecure.example.com"},
+      {"", nil},
+      {"   ", nil},
+      {nil, nil}
+    ]
+
+    for {input, expected} <- @normalize_cases do
+      test "normalizes #{inspect(input)} to #{inspect(expected)}" do
+        assert ProviderProfile.normalize_url(unquote(input)) == unquote(expected)
+      end
+    end
+  end
+
+  describe "scheme-less URLs through the changesets" do
+    test "edit_changeset/2 prepends https:// to every branding URL" do
+      changeset =
+        ProviderProfile.edit_changeset(%ProviderProfile{}, %{
+          instagram_url: "instagram.com/starlight",
+          facebook_url: "facebook.com/starlight"
+        })
+
+      assert changeset.valid?
+      assert Ecto.Changeset.get_change(changeset, :instagram_url) == "https://instagram.com/starlight"
+      assert Ecto.Changeset.get_change(changeset, :facebook_url) == "https://facebook.com/starlight"
+    end
+
+    test "completion_changeset/2 prepends https:// to the website too" do
+      changeset =
+        ProviderProfile.completion_changeset(%ProviderProfile{}, %{
+          business_name: "Starlight",
+          description: "Sports",
+          website: "starlight.de"
+        })
+
+      assert changeset.valid?
+      assert Ecto.Changeset.get_change(changeset, :website) == "https://starlight.de"
+    end
+
+    test "an explicit http:// is still rejected, not upgraded" do
+      changeset =
+        ProviderProfile.edit_changeset(%ProviderProfile{}, %{
+          instagram_url: "http://instagram.com/starlight"
+        })
+
+      refute changeset.valid?
+      assert "must start with https://" in errors_on(changeset).instagram_url
+    end
+  end
+
+  describe "scheme-less URLs through the pure core" do
+    test "new/1 accepts a scheme-less social link" do
+      assert {:ok, _} =
+               ProviderProfile.new(%{
+                 identity_id: Ecto.UUID.generate(),
+                 business_name: "Starlight",
+                 instagram_url: "instagram.com/starlight"
+               })
+    end
+
+    test "new/1 still rejects an explicit http://" do
+      assert {:error, errors} =
+               ProviderProfile.new(%{
+                 identity_id: Ecto.UUID.generate(),
+                 business_name: "Starlight",
+                 instagram_url: "http://instagram.com/starlight"
+               })
+
+      assert Enum.any?(errors, &(&1 =~ "must start with https://"))
+    end
+
+    test "complete_profile/2 normalizes into the struct it returns" do
+      # This path persists the struct the pure core returns, where the update
+      # path discards it and persists the changeset's instead. Normalizing one
+      # and not the other is a half-fix that looks whole.
+      draft = %ProviderProfile{
+        id: Ecto.UUID.generate(),
+        identity_id: Ecto.UUID.generate(),
+        business_name: "Starlight",
+        profile_status: :draft
+      }
+
+      assert {:ok, completed} =
+               ProviderProfile.complete_profile(draft, %{
+                 business_name: "Starlight",
+                 description: "Sports for kids",
+                 website: "starlight.de",
+                 instagram_url: "instagram.com/starlight"
+               })
+
+      assert completed.website == "https://starlight.de"
+      assert completed.instagram_url == "https://instagram.com/starlight"
+    end
+  end
 end

--- a/test/klass_hero/provider/provider_profile_test.exs
+++ b/test/klass_hero/provider/provider_profile_test.exs
@@ -407,6 +407,23 @@ defmodule KlassHero.Provider.ProviderProfileTest do
       assert Enum.any?(errors, &(&1 =~ "must start with https://"))
     end
 
+    test "leaves cover_image_url alone — it is uploaded, not typed" do
+      # The storage stub returns `stub://public/...`. Scheme-prepending that
+      # cannot repair a typo the user never made; it only produces
+      # `https://stub://...`, which then passes the https check by inspection.
+      # A normalizer on a system-set field launders bad data past its own gate.
+      stub_url = "stub://public/covers/providers/abc/cover.png"
+
+      assert {:error, errors} =
+               ProviderProfile.new(%{
+                 identity_id: Ecto.UUID.generate(),
+                 business_name: "Starlight",
+                 cover_image_url: stub_url
+               })
+
+      assert Enum.any?(errors, &(&1 =~ "Cover image URL must start with https://"))
+    end
+
     test "complete_profile/2 normalizes into the struct it returns" do
       # This path persists the struct the pure core returns, where the update
       # path discards it and persists the changeset's instead. Normalizing one

--- a/test/klass_hero_web/components/provider_components_test.exs
+++ b/test/klass_hero_web/components/provider_components_test.exs
@@ -3,6 +3,7 @@ defmodule KlassHeroWeb.ProviderComponentsTest do
 
   import Phoenix.LiveViewTest
 
+  alias KlassHero.Provider.ProviderProfile
   alias KlassHero.Provider.SessionDetail
 
   describe "programs_table/1" do
@@ -247,6 +248,47 @@ defmodule KlassHeroWeb.ProviderComponentsTest do
 
       refute html =~ "resend_invite"
       refute html =~ "delete_invite"
+    end
+  end
+
+  describe "pv_branding_section/1" do
+    test "renders an input per revealed network and a picker button for the rest" do
+      html = render_branding(revealed: [:instagram_url])
+
+      assert html =~ ~s(name="provider_profile_schema[instagram_url]")
+      refute html =~ ~s(name="provider_profile_schema[facebook_url]")
+
+      refute html =~ ~s(id="add-instagram_url")
+      assert html =~ ~s(id="add-facebook_url")
+    end
+
+    test "drops the picker entirely once every network is revealed" do
+      # Not reachable from the LiveView tests without five clicks, and an empty
+      # button row would still render its wrapper and its gap.
+      html = render_branding(revealed: ProviderProfile.social_link_fields())
+
+      for field <- ProviderProfile.social_link_fields() do
+        assert html =~ ~s(name="provider_profile_schema[#{field}]")
+        refute html =~ ~s(id="add-#{field}")
+      end
+    end
+
+    test "renders no cover upload when given no uploads" do
+      # The completion form has no :cover upload configured, so reading
+      # @uploads.cover there would raise.
+      html = render_branding(revealed: [])
+
+      refute html =~ ~s(id="cover-upload")
+      assert html =~ ~s(name="provider_profile_schema[tagline]")
+    end
+
+    defp render_branding(opts) do
+      assigns = %{
+        form: Phoenix.Component.to_form(%{}, as: :provider_profile_schema),
+        revealed: Keyword.fetch!(opts, :revealed)
+      }
+
+      render_component(&KlassHeroWeb.ProviderComponents.pv_branding_section/1, assigns)
     end
   end
 end

--- a/test/klass_hero_web/components/provider_components_test.exs
+++ b/test/klass_hero_web/components/provider_components_test.exs
@@ -273,6 +273,17 @@ defmodule KlassHeroWeb.ProviderComponentsTest do
       end
     end
 
+    test "social inputs are not type=url, which would block a scheme-less value" do
+      # The strongest guard available here. The real failure is the browser's own
+      # constraint validation refusing to submit `instagram.com/handle` — which
+      # Phoenix.LiveViewTest does not run, so no behavioural test can see it. This
+      # pins the structure that caused it instead.
+      html = render_branding(revealed: [:instagram_url])
+
+      refute html =~ ~s(type="url")
+      assert html =~ ~s(inputmode="url")
+    end
+
     test "renders no cover upload when given no uploads" do
       # The completion form has no :cover upload configured, so reading
       # @uploads.cover there would raise.

--- a/test/klass_hero_web/helpers/provider_branding_test.exs
+++ b/test/klass_hero_web/helpers/provider_branding_test.exs
@@ -1,0 +1,70 @@
+defmodule KlassHeroWeb.Helpers.ProviderBrandingTest do
+  use ExUnit.Case, async: true
+
+  alias KlassHero.Provider.ProviderProfile
+  alias KlassHeroWeb.Helpers.ProviderBranding
+
+  describe "filled_networks/1" do
+    test "returns only the networks carrying a value" do
+      provider = %ProviderProfile{
+        instagram_url: "https://instagram.com/x",
+        linkedin_url: "https://linkedin.com/company/x"
+      }
+
+      assert ProviderBranding.filled_networks(provider) == [:instagram_url, :linkedin_url]
+    end
+
+    test "treats nil and blank the same as unset" do
+      # A blank column is reachable through a backfill or raw SQL, and it must
+      # open the picker rather than an empty row the provider did not ask for.
+      provider = %ProviderProfile{instagram_url: nil, facebook_url: "", tiktok_url: "   "}
+
+      assert ProviderBranding.filled_networks(provider) == []
+    end
+
+    test "preserves the entity's display order, not the struct's" do
+      provider = %ProviderProfile{
+        linkedin_url: "https://linkedin.com/company/x",
+        instagram_url: "https://instagram.com/x"
+      }
+
+      assert ProviderBranding.filled_networks(provider) == [:instagram_url, :linkedin_url]
+    end
+  end
+
+  describe "reveal/2" do
+    test "adds a known network" do
+      assert ProviderBranding.reveal([], "instagram_url") == [:instagram_url]
+    end
+
+    test "appends rather than prepends, so rows do not reorder as they are added" do
+      assert ProviderBranding.reveal([:instagram_url], "facebook_url") == [
+               :instagram_url,
+               :facebook_url
+             ]
+    end
+
+    test "is idempotent" do
+      assert ProviderBranding.reveal([:instagram_url], "instagram_url") == [:instagram_url]
+    end
+
+    test "ignores a value that is not a social field" do
+      # The param comes from the client. Resolving against social_link_fields/0
+      # rather than String.to_existing_atom/1 means a crafted value is dropped,
+      # not raised on — and can never name a non-social column.
+      for junk <- ["business_name", "not_a_field", "", "Elixir.Kernel"] do
+        assert ProviderBranding.reveal([:instagram_url], junk) == [:instagram_url]
+      end
+    end
+
+    test "covers every network the entity declares" do
+      # Guards against the picker silently dropping a network added to the schema.
+      revealed =
+        Enum.reduce(ProviderProfile.social_link_fields(), [], fn field, acc ->
+          ProviderBranding.reveal(acc, Atom.to_string(field))
+        end)
+
+      assert revealed == ProviderProfile.social_link_fields()
+    end
+  end
+end

--- a/test/klass_hero_web/live/provider/edit_profile_live_test.exs
+++ b/test/klass_hero_web/live/provider/edit_profile_live_test.exs
@@ -14,6 +14,99 @@ defmodule KlassHeroWeb.Provider.EditProfileLiveTest do
       assert has_element?(view, "#save-profile-btn")
     end
 
+    test "renders the public profile preview", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/edit")
+
+      assert has_element?(view, "#provider-hero[data-variant='full']")
+    end
+
+    test "the preview follows what is typed, not what is saved", %{conn: conn, provider: provider} do
+      # The assertion that separates a preview from a static render of the saved
+      # row: both would pass a bare "the hero is present" check.
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/edit")
+
+      refute render(view) =~ "Move. Play. Grow."
+
+      html =
+        view
+        |> form("#profile-form", %{
+          provider_profile_schema: %{description: "A description", tagline: "Move. Play. Grow."}
+        })
+        |> render_change()
+
+      assert html =~ "Move. Play. Grow."
+
+      assert {:ok, reloaded} = KlassHero.Provider.get_provider_profile(provider.id)
+      assert is_nil(reloaded.tagline), "phx-change must not persist"
+    end
+
+    test "adds a social row on demand and keeps it through a re-render", %{conn: conn} do
+      # A JS toggle would pass the first assertion and fail the second: the
+      # phx-change patch wipes the inline display:none it writes.
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/edit")
+
+      refute has_element?(view, "#provider_profile_schema_instagram_url")
+      assert has_element?(view, "#add-instagram_url")
+
+      view |> element("#add-instagram_url") |> render_click()
+
+      assert has_element?(view, "#provider_profile_schema_instagram_url")
+      refute has_element?(view, "#add-instagram_url")
+
+      view
+      |> form("#profile-form", %{provider_profile_schema: %{description: "Still typing"}})
+      |> render_change()
+
+      assert has_element?(view, "#provider_profile_schema_instagram_url")
+    end
+
+    test "a network already filled in starts revealed", %{conn: conn, provider: provider} do
+      {:ok, _} =
+        KlassHero.Provider.update_provider_profile(provider.id, %{
+          instagram_url: "https://instagram.com/starlight"
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/edit")
+
+      assert has_element?(view, "#provider_profile_schema_instagram_url")
+      refute has_element?(view, "#add-instagram_url")
+    end
+
+    test "an unrevealed network is left untouched by a save", %{conn: conn, provider: provider} do
+      {:ok, _} =
+        KlassHero.Provider.update_provider_profile(provider.id, %{
+          facebook_url: "https://facebook.com/starlight"
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/edit")
+
+      view
+      |> form("#profile-form", %{provider_profile_schema: %{description: "Unrelated edit"}})
+      |> render_submit()
+
+      assert {:ok, reloaded} = KlassHero.Provider.get_provider_profile(provider.id)
+      assert reloaded.instagram_url == nil
+      assert reloaded.facebook_url == "https://facebook.com/starlight"
+    end
+
+    test "saves a scheme-less social link as https", %{conn: conn, provider: provider} do
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/edit")
+
+      view |> element("#add-instagram_url") |> render_click()
+
+      view
+      |> form("#profile-form", %{
+        provider_profile_schema: %{
+          description: "A description",
+          instagram_url: "instagram.com/starlight"
+        }
+      })
+      |> render_submit()
+
+      assert {:ok, reloaded} = KlassHero.Provider.get_provider_profile(provider.id)
+      assert reloaded.instagram_url == "https://instagram.com/starlight"
+    end
+
     test "renders back to dashboard link", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/provider/dashboard/edit")
 

--- a/test/klass_hero_web/live/provider/edit_profile_live_test.exs
+++ b/test/klass_hero_web/live/provider/edit_profile_live_test.exs
@@ -59,6 +59,11 @@ defmodule KlassHeroWeb.Provider.EditProfileLiveTest do
     test "saves branding fields through the form to the database", %{conn: conn, provider: provider} do
       {:ok, view, _html} = live(conn, ~p"/provider/dashboard/edit")
 
+      # Social rows are added on demand, so an unrevealed network has no input to
+      # submit into. This provider has none filled in, hence both clicks.
+      view |> element("#add-instagram_url") |> render_click()
+      view |> element("#add-linkedin_url") |> render_click()
+
       view
       |> form("#profile-form", %{
         provider_profile_schema: %{
@@ -103,6 +108,8 @@ defmodule KlassHeroWeb.Provider.EditProfileLiveTest do
 
     test "rejects a social link that is not https", %{conn: conn, provider: provider} do
       {:ok, view, _html} = live(conn, ~p"/provider/dashboard/edit")
+
+      view |> element("#add-instagram_url") |> render_click()
 
       view
       |> form("#profile-form", %{

--- a/test/klass_hero_web/live/provider/profile_completion_live_test.exs
+++ b/test/klass_hero_web/live/provider/profile_completion_live_test.exs
@@ -14,6 +14,48 @@ defmodule KlassHeroWeb.Provider.ProfileCompletionLiveTest do
       assert has_element?(view, ~s(textarea[name="provider_profile_schema[description]"]))
     end
 
+    test "renders the shared branding section", %{conn: conn} do
+      # This form had no branding coverage at all, which is how it kept a
+      # hand-rolled copy of the dropzone and a raw-grey palette while its sibling
+      # moved on.
+      {:ok, view, _html} = live(conn, ~p"/provider/complete-profile")
+
+      assert has_element?(view, "#social-links")
+      assert has_element?(view, ~s(input[name="provider_profile_schema[tagline]"]))
+      assert has_element?(view, "#add-instagram_url")
+      assert has_element?(view, "#logo-upload")
+    end
+
+    test "has no cover upload — that field belongs to the edit form", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/provider/complete-profile")
+
+      refute has_element?(view, "#cover-upload")
+    end
+
+    test "saves branding fields, prepending https:// to a scheme-less link", %{
+      conn: conn,
+      provider: provider
+    } do
+      {:ok, view, _html} = live(conn, ~p"/provider/complete-profile")
+
+      view |> element("#add-instagram_url") |> render_click()
+
+      view
+      |> form("#profile-completion-form", %{
+        provider_profile_schema: %{
+          business_name: "Starlight Coaching",
+          description: "Sports for kids",
+          tagline: "Move. Play. Grow.",
+          instagram_url: "instagram.com/starlight"
+        }
+      })
+      |> render_submit()
+
+      assert {:ok, reloaded} = KlassHero.Provider.get_provider_profile(provider.id)
+      assert reloaded.tagline == "Move. Play. Grow."
+      assert reloaded.instagram_url == "https://instagram.com/starlight"
+    end
+
     test "pre-fills description from staff member bio", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/provider/complete-profile")
 


### PR DESCRIPTION
Slice C of the public-provider-profile sequence, and the provider-side half of it. Slices A and B made the branding fields render; this fixes the forms that collect them.

## What was wrong

**`https://` was required and nothing prepended it.** Typing `instagram.com/handle` errored. The rule was implemented four times across two parallel validation pipelines, and the two write paths consume them differently — `update_provider_profile/2` discards the pure core's struct and persists the changeset's, while `complete_provider_profile/2` persists the core's. A normalizer in one place alone is a half-fix that looks whole, so there are two tests, one per path; each dies to a different mutation.

**The two provider forms had drifted again.** Both derived the same field list from `ProviderProfile`, so the *data* stayed in sync while the markup did not: one used the shared upload dropzone, the other a hand-rolled copy; one used design tokens, the other raw Tailwind greys plus `text-brand`/`ring-brand`, which emit no CSS rule at all under Tailwind v4 because no `--color-brand` exists. The completion form had zero branding test coverage, which is how it drifted unobserved.

**Five always-visible URL inputs** cost ~330px of mobile scroll for fields most providers leave blank.

**No preview.** The form promised "Shown on your public profile page" with no way to see it.

## What changed

`pv_branding_section/1` is now the single definition both forms render. Social links are added on demand. Visibility is a server assign, not a JS toggle — this form fires `phx-change` on every keystroke and the patch wipes an inline `display:none`, so a JS-collapsed row would vanish mid-typing. An unrevealed field is not rendered, so it submits nothing and `attrs_from_params/1` leaves it out: hiding a network never clears it.

The preview renders the `:full` `provider_hero` the public page renders, fed by the same `to_public_view/2` — which takes a struct, so applying the in-flight changeset feeds it unsaved state with no query and no second rendering path. A preview that re-implements the hero is a preview that lies.

Also folded in: the completion form's catch-all `{:error, _}` save clause, which never re-derived per-field errors, and its `gray-*` sweep.

## Two bugs found while verifying, both worth naming

**The social inputs were `type="url"`.** The browser's own constraint validation refuses to submit `instagram.com/handle` — the exact input the normalizer exists to accept. The two halves were individually correct and jointly useless. Found by driving the form; no test could see it, because `Phoenix.LiveViewTest` does not run browser constraint validation. The added test pins the structure instead.

**`normalize_urls/1` reached `cover_image_url`,** which is set from a storage upload rather than typed. The test stub returns `stub://public/…`, which became `https://stub://public/…`. Worse than it looks: that path previously returned a loud `must start with https://` error, and the mangled value passes that same check by inspection — so the change converted a visible failure into silent corruption. Normalization now covers only the fields a person types. Production was unaffected because `S3StorageAdapter` returns a real `https://` URL, but that was incidental rather than enforced.

## Yellow CTAs (#1444)

The obvious target was wrong. `Theme.button_variant(:primary)` is white on `hero-blue-600` at **2.66:1** (open #1459), so converting would have traded a 16.42:1 button for a failing one. `kh_button`'s primary is black on `hero-blue-500` at **≈11.45:1**, and is what DESIGN.md don't #2 mandates anyway — one change satisfies don'ts #2 and #5 and stays clear of #1459.

Eight sites, not six: #1444 enumerated its list by grepping raw `bg-hero-yellow-500` classes, which missed two spelled `kh_button variant={:yellow}`. `team_live.ex` already rendered a yellow CTA beside a default-primary cyan one in the same button group.

`assets/css/app.css` carried a comment asserting the CTA fill "carries white text and is unaffected". Contrast is symmetric, so it has the identical failing ratio the comment was written to avoid; corrected to point at #1459, token untouched.

## Verification

`mix precommit` green — 5092 passed, credo clean, all six lints. Driven in a browser at 375px and 1280px as a real provider: `instagram.com/hartmannsport` now persists as `https://instagram.com/hartmannsport`, the preview follows typing without saving, and the mobile preview collapses behind a toggle.

Reviewed by `architecture-reviewer` (8/8, no violations), `regression-analyzer` (found the `cover_image_url` regression above), and `design-system-guardian` (found the two new outline buttons had drifted apart on focus styling — both now `kh_button variant={:ghost}`).

## Left alone deliberately

- **#1459** — `Theme.button_variant(:primary)` at 2.66:1. Three call sites, none of them these; `kh_button` routes around it.
- **`cover_image_url` must be `https://`** — a pre-existing rule that a non-https storage adapter would fail. Restored, not fixed; changing what is *valid* for a system-set field is its own decision.
- **#1485**, **#1458**, shared-component tap targets, and a staged-cover preview override.

Closes #1444
