### PR TITLE
feat: seat late joiners in program broadcasts with read state starting at arrival

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -18,6 +18,7 @@ alias KlassHero.Family.InviteClaimedHandler
 alias KlassHero.Family.ProcessInviteClaimWorker
 alias KlassHero.Messaging.ConversationSummaries
 alias KlassHero.Messaging.EnrolledChildren
+alias KlassHero.Messaging.EnrollmentParticipationHandler
 alias KlassHero.Messaging.MessagingEventHandler
 alias KlassHero.Messaging.StaffAssignmentHandler
 alias KlassHero.Messaging.Workers.FetchEmailContentWorker
@@ -245,7 +246,8 @@ config :klass_hero, :event_consumers, %{
   # Enrollment
   "integration:enrollment:enrollment_created" => [
     {ParticipationEventHandler, :handle_event},
-    {EnrolledChildren, :project}
+    {EnrolledChildren, :project},
+    {EnrollmentParticipationHandler, :handle_event}
   ],
   "integration:enrollment:enrollment_cancelled" => [
     {EnrolledChildren, :project}

--- a/lib/klass_hero/messaging.ex
+++ b/lib/klass_hero/messaging.ex
@@ -957,7 +957,16 @@ defmodule KlassHero.Messaging do
     end
   end
 
-  @doc "Ids of active program conversations the user is NOT a participant of."
+  @doc """
+  Ids of active program conversations the user is NOT a participant of.
+
+  **Staff only.** "Program conversation" means every type scoped to the program, and a
+  `:direct` parent↔provider conversation carries a `program_id` too
+  (`StartProgramConversation`). Back-filling a *parent* from this list would seat a
+  newly enrolled family in every other family's private thread. Staff legitimately
+  belong in both kinds, which is what makes the width correct for them and only them;
+  parents get `list_active_broadcast_ids_without_participant/2`.
+  """
   @spec list_active_program_conversation_ids_without_participant(String.t(), String.t()) :: [String.t()]
   def list_active_program_conversation_ids_without_participant(program_id, user_id) do
     ConversationQueries.base()
@@ -971,12 +980,10 @@ defmodule KlassHero.Messaging do
   @doc """
   Ids of the program's active *broadcast* conversations the user is NOT a participant of.
 
-  Deliberately narrower than `list_active_program_conversation_ids_without_participant/2`,
-  which must not be reused for parents: a `:direct` parent↔provider conversation also
-  carries a `program_id` (`StartProgramConversation`), so the program-wide list would
-  back-fill a newly enrolled family into every *other* family's private thread. Staff
-  belong in both kinds, which is why their path can use the wider query and this one
-  cannot be folded into it.
+  The parent-safe counterpart to
+  `list_active_program_conversation_ids_without_participant/2`, which must not be
+  reused here — see its doc for the privacy trap the `:program_broadcast` filter
+  closes. The two cannot be folded together.
   """
   @spec list_active_broadcast_ids_without_participant(String.t(), String.t()) :: [String.t()]
   def list_active_broadcast_ids_without_participant(program_id, user_id) do
@@ -989,7 +996,12 @@ defmodule KlassHero.Messaging do
     |> Repo.all()
   end
 
-  @doc "Ids of active program conversations the user IS a participant of."
+  @doc """
+  Ids of active program conversations the user IS a participant of.
+
+  Every type, `:direct` included — see
+  `list_active_program_conversation_ids_without_participant/2` for why that matters.
+  """
   @spec list_active_program_conversation_ids_with_participant(String.t(), String.t()) :: [String.t()]
   def list_active_program_conversation_ids_with_participant(program_id, user_id) do
     ConversationQueries.base()
@@ -1383,12 +1395,26 @@ defmodule KlassHero.Messaging do
 
   # === Persistence — participants ===
 
-  @doc "Adds a participant to a conversation. Defaults `joined_at` to now."
+  @doc """
+  Adds a participant to a conversation. Defaults `joined_at` to now.
+
+  Seats them with their read cursor at whatever the conversation already contained —
+  the same rule as the two batch functions, see `seating_cursors/1`. Today's callers
+  all seat into a conversation their own transaction just created, so the cursor is
+  `nil` for them either way; it is applied here so that a caller adding someone to a
+  *populated* conversation cannot silently reintroduce #381. An explicit
+  `:last_read_at` in `attrs` still wins.
+  """
   @spec add_participant(map()) ::
           {:ok, Participant.t()} | {:error, :already_participant | Ecto.Changeset.t()}
   def add_participant(attrs) do
     context_span entity: "participant" do
-      attrs = Map.put_new(attrs, :joined_at, DateTime.utc_now())
+      cursor = Map.get(seating_cursors([attrs.conversation_id]), attrs.conversation_id)
+
+      attrs =
+        attrs
+        |> Map.put_new(:joined_at, DateTime.utc_now())
+        |> Map.put_new(:last_read_at, cursor)
 
       %Participant{}
       |> Participant.create_changeset(attrs)
@@ -1408,38 +1434,6 @@ defmodule KlassHero.Messaging do
             {"has already been taken", _} -> {:error, :already_participant}
             _ -> result
           end
-      end
-    end
-  end
-
-  @doc "Adds a participant, or returns the existing one on conflict (transaction-safe)."
-  @spec add_or_get_participant(map()) :: {:ok, Participant.t()} | {:error, :not_found}
-  def add_or_get_participant(attrs) do
-    context_span entity: "participant" do
-      now = DateTime.utc_now() |> DateTime.truncate(:second)
-
-      entry =
-        attrs
-        |> Map.take([:conversation_id, :user_id, :last_read_at])
-        |> Map.merge(%{
-          id: Ecto.UUID.generate(),
-          joined_at: now,
-          inserted_at: now,
-          updated_at: now
-        })
-
-      case Repo.insert_all(Participant, [entry],
-             returning: true,
-             on_conflict: :nothing,
-             conflict_target: [:conversation_id, :user_id]
-           ) do
-        {1, [participant]} ->
-          {:ok, participant}
-
-        # on_conflict: :nothing skipped the insert; fetch existing row to avoid
-        # poisoning the caller's transaction with a unique-constraint failure.
-        {0, _} ->
-          get_participant(attrs.conversation_id, attrs.user_id)
       end
     end
   end
@@ -1631,7 +1625,8 @@ defmodule KlassHero.Messaging do
     end
   end
 
-  # Re-activation: clear left_at, bump updated_at; preserve original joined_at (audit trail).
+  # `joined_at` is absent from the `set:` list deliberately: the original stays as the
+  # audit trail of when this person first entered the conversation.
   #
   # The cursor is re-stamped because rejoining is joining: someone re-added to a
   # conversation was not entitled to it while they were away, so what happened in the
@@ -1657,16 +1652,11 @@ defmodule KlassHero.Messaging do
   # written in the same second would fall on the wrong side of the `>` comparison every
   # unread counter makes and be silently marked read.
   #
-  # Deleted messages count towards the anchor even though they are invisible:
-  # `ConversationSummaries` computes its unread count without a `deleted_at` filter, so
-  # anchoring on the newest *visible* message would leave a soft-deleted newer one
-  # badged as unread — a notification for something the reader cannot open.
+  # Soft-deleted messages count towards the anchor even though they are invisible — see
+  # `MessageQueries.newest_inserted_at_by_conversation/1` for why.
   defp seating_cursors(conversation_ids) do
-    from(m in Message,
-      where: m.conversation_id in ^conversation_ids,
-      group_by: m.conversation_id,
-      select: {m.conversation_id, max(m.inserted_at)}
-    )
+    conversation_ids
+    |> MessageQueries.newest_inserted_at_by_conversation()
     |> Repo.all()
     |> Map.new()
   end

--- a/lib/klass_hero/messaging.ex
+++ b/lib/klass_hero/messaging.ex
@@ -1547,11 +1547,18 @@ defmodule KlassHero.Messaging do
       {:error, :database_query_error}
   end
 
-  @doc "Adds a batch of users as participants of a conversation (skips existing)."
+  @doc """
+  Adds a batch of users as participants of a conversation (skips existing).
+
+  Seats them with their read cursor at whatever the conversation already contained,
+  so anything said before they arrived is history rather than a notification. See
+  `seating_cursors/1`.
+  """
   @spec add_participants(String.t(), [String.t()]) :: {:ok, [Participant.t()]}
   def add_participants(conversation_id, user_ids) do
     context_span entity: "participant" do
       now = DateTime.utc_now() |> DateTime.truncate(:second)
+      cursor = Map.get(seating_cursors([conversation_id]), conversation_id)
 
       entries =
         Enum.map(user_ids, fn user_id ->
@@ -1559,6 +1566,7 @@ defmodule KlassHero.Messaging do
             id: Ecto.UUID.generate(),
             conversation_id: conversation_id,
             user_id: user_id,
+            last_read_at: cursor,
             joined_at: now,
             inserted_at: now,
             updated_at: now
@@ -1584,23 +1592,15 @@ defmodule KlassHero.Messaging do
   @doc """
   Adds a user to a batch of conversations, re-activating any they had left.
 
-  ## Options
-
-  - `:last_read_at` — stamps the participant's read cursor at join instead of leaving it
-    `nil`. A `nil` cursor means "everything is unread", so a late joiner would otherwise
-    land on a thread badged with its entire back-catalogue. Pass the timestamp of the
-    newest message that already existed, never `DateTime.utc_now/0`: `messages.inserted_at`
-    is `:utc_datetime`, so a same-second message would fall on the wrong side of the
-    `>` comparison every unread counter makes and be silently marked read.
+  Each conversation gets its own read cursor — see `seating_cursors/1`.
   """
-  @spec add_user_to_conversations(String.t(), [String.t()], keyword()) :: {:ok, non_neg_integer()}
-  def add_user_to_conversations(user_id, conversation_ids, opts \\ [])
+  @spec add_user_to_conversations(String.t(), [String.t()]) :: {:ok, non_neg_integer()}
+  def add_user_to_conversations(_user_id, []), do: {:ok, 0}
 
-  def add_user_to_conversations(_user_id, [], _opts), do: {:ok, 0}
-
-  def add_user_to_conversations(user_id, conversation_ids, opts) do
+  def add_user_to_conversations(user_id, conversation_ids) do
     context_span entity: "participant" do
       now = DateTime.utc_now() |> DateTime.truncate(:second)
+      cursors = seating_cursors(conversation_ids)
 
       entries =
         Enum.map(conversation_ids, fn conversation_id ->
@@ -1608,7 +1608,7 @@ defmodule KlassHero.Messaging do
             id: Ecto.UUID.generate(),
             conversation_id: conversation_id,
             user_id: user_id,
-            last_read_at: Keyword.get(opts, :last_read_at),
+            last_read_at: Map.get(cursors, conversation_id),
             joined_at: now,
             inserted_at: now,
             updated_at: now
@@ -1617,7 +1617,7 @@ defmodule KlassHero.Messaging do
 
       {count, _} =
         Repo.insert_all(Participant, entries,
-          on_conflict: participant_reactivation(opts),
+          on_conflict: participant_reactivation(),
           conflict_target: [:conversation_id, :user_id]
         )
 
@@ -1633,27 +1633,42 @@ defmodule KlassHero.Messaging do
 
   # Re-activation: clear left_at, bump updated_at; preserve original joined_at (audit trail).
   #
-  # `last_read_at` is only re-stamped when the caller supplied one. Adding it
-  # unconditionally would push a NULL over the staff path's existing cursor on every
-  # re-assignment, resetting a staff member's whole thread to unread. Only a soft-left
-  # row can reach this branch — `where_user_is_not_participant/2` filters out active
-  # participants — so re-stamping means "rejoining is joining", not "replay wipes reads".
-  defp participant_reactivation(opts) do
-    if Keyword.has_key?(opts, :last_read_at) do
-      from(p in Participant,
-        update: [
-          set: [
-            left_at: nil,
-            last_read_at: fragment("EXCLUDED.last_read_at"),
-            updated_at: fragment("EXCLUDED.updated_at")
-          ]
+  # The cursor is re-stamped because rejoining is joining: someone re-added to a
+  # conversation was not entitled to it while they were away, so what happened in the
+  # meantime is history, not a backlog. Only a soft-left row reaches this branch —
+  # `where_user_is_not_participant/2` filters out active participants — so a replayed
+  # event cannot use it to wipe a live participant's read state.
+  defp participant_reactivation do
+    from(p in Participant,
+      update: [
+        set: [
+          left_at: nil,
+          last_read_at: fragment("EXCLUDED.last_read_at"),
+          updated_at: fragment("EXCLUDED.updated_at")
         ]
-      )
-    else
-      from(p in Participant,
-        update: [set: [left_at: nil, updated_at: fragment("EXCLUDED.updated_at")]]
-      )
-    end
+      ]
+    )
+  end
+
+  # The read cursor someone gets when they are seated into a conversation: the newest
+  # message already in it, or nil when it is empty.
+  #
+  # Never `DateTime.utc_now/0`. `messages.inserted_at` is `:utc_datetime`, so a message
+  # written in the same second would fall on the wrong side of the `>` comparison every
+  # unread counter makes and be silently marked read.
+  #
+  # Deleted messages count towards the anchor even though they are invisible:
+  # `ConversationSummaries` computes its unread count without a `deleted_at` filter, so
+  # anchoring on the newest *visible* message would leave a soft-deleted newer one
+  # badged as unread — a notification for something the reader cannot open.
+  defp seating_cursors(conversation_ids) do
+    from(m in Message,
+      where: m.conversation_id in ^conversation_ids,
+      group_by: m.conversation_id,
+      select: {m.conversation_id, max(m.inserted_at)}
+    )
+    |> Repo.all()
+    |> Map.new()
   end
 
   @doc "Fetches a participant by conversation and user."

--- a/lib/klass_hero/messaging.ex
+++ b/lib/klass_hero/messaging.ex
@@ -968,6 +968,27 @@ defmodule KlassHero.Messaging do
     |> Repo.all()
   end
 
+  @doc """
+  Ids of the program's active *broadcast* conversations the user is NOT a participant of.
+
+  Deliberately narrower than `list_active_program_conversation_ids_without_participant/2`,
+  which must not be reused for parents: a `:direct` parent↔provider conversation also
+  carries a `program_id` (`StartProgramConversation`), so the program-wide list would
+  back-fill a newly enrolled family into every *other* family's private thread. Staff
+  belong in both kinds, which is why their path can use the wider query and this one
+  cannot be folded into it.
+  """
+  @spec list_active_broadcast_ids_without_participant(String.t(), String.t()) :: [String.t()]
+  def list_active_broadcast_ids_without_participant(program_id, user_id) do
+    ConversationQueries.base()
+    |> ConversationQueries.by_program(program_id)
+    |> ConversationQueries.by_type(:program_broadcast)
+    |> ConversationQueries.active_only()
+    |> ConversationQueries.where_user_is_not_participant(user_id)
+    |> ConversationQueries.select_ids()
+    |> Repo.all()
+  end
+
   @doc "Ids of active program conversations the user IS a participant of."
   @spec list_active_program_conversation_ids_with_participant(String.t(), String.t()) :: [String.t()]
   def list_active_program_conversation_ids_with_participant(program_id, user_id) do
@@ -1560,11 +1581,24 @@ defmodule KlassHero.Messaging do
     end
   end
 
-  @doc "Adds a user to a batch of conversations, re-activating any they had left."
-  @spec add_user_to_conversations(String.t(), [String.t()]) :: {:ok, non_neg_integer()}
-  def add_user_to_conversations(_user_id, []), do: {:ok, 0}
+  @doc """
+  Adds a user to a batch of conversations, re-activating any they had left.
 
-  def add_user_to_conversations(user_id, conversation_ids) do
+  ## Options
+
+  - `:last_read_at` — stamps the participant's read cursor at join instead of leaving it
+    `nil`. A `nil` cursor means "everything is unread", so a late joiner would otherwise
+    land on a thread badged with its entire back-catalogue. Pass the timestamp of the
+    newest message that already existed, never `DateTime.utc_now/0`: `messages.inserted_at`
+    is `:utc_datetime`, so a same-second message would fall on the wrong side of the
+    `>` comparison every unread counter makes and be silently marked read.
+  """
+  @spec add_user_to_conversations(String.t(), [String.t()], keyword()) :: {:ok, non_neg_integer()}
+  def add_user_to_conversations(user_id, conversation_ids, opts \\ [])
+
+  def add_user_to_conversations(_user_id, [], _opts), do: {:ok, 0}
+
+  def add_user_to_conversations(user_id, conversation_ids, opts) do
     context_span entity: "participant" do
       now = DateTime.utc_now() |> DateTime.truncate(:second)
 
@@ -1574,6 +1608,7 @@ defmodule KlassHero.Messaging do
             id: Ecto.UUID.generate(),
             conversation_id: conversation_id,
             user_id: user_id,
+            last_read_at: Keyword.get(opts, :last_read_at),
             joined_at: now,
             inserted_at: now,
             updated_at: now
@@ -1582,21 +1617,42 @@ defmodule KlassHero.Messaging do
 
       {count, _} =
         Repo.insert_all(Participant, entries,
-          # Re-activation: clear left_at, bump updated_at; preserve original joined_at (audit trail).
-          on_conflict:
-            from(p in Participant,
-              update: [set: [left_at: nil, updated_at: fragment("EXCLUDED.updated_at")]]
-            ),
+          on_conflict: participant_reactivation(opts),
           conflict_target: [:conversation_id, :user_id]
         )
 
-      Logger.debug("Added staff user to conversations in batch",
+      Logger.debug("Added user to conversations in batch",
         user_id: user_id,
         conversation_count: length(conversation_ids),
         added_count: count
       )
 
       {:ok, count}
+    end
+  end
+
+  # Re-activation: clear left_at, bump updated_at; preserve original joined_at (audit trail).
+  #
+  # `last_read_at` is only re-stamped when the caller supplied one. Adding it
+  # unconditionally would push a NULL over the staff path's existing cursor on every
+  # re-assignment, resetting a staff member's whole thread to unread. Only a soft-left
+  # row can reach this branch — `where_user_is_not_participant/2` filters out active
+  # participants — so re-stamping means "rejoining is joining", not "replay wipes reads".
+  defp participant_reactivation(opts) do
+    if Keyword.has_key?(opts, :last_read_at) do
+      from(p in Participant,
+        update: [
+          set: [
+            left_at: nil,
+            last_read_at: fragment("EXCLUDED.last_read_at"),
+            updated_at: fragment("EXCLUDED.updated_at")
+          ]
+        ]
+      )
+    else
+      from(p in Participant,
+        update: [set: [left_at: nil, updated_at: fragment("EXCLUDED.updated_at")]]
+      )
     end
   end
 

--- a/lib/klass_hero/messaging/enrollment_participation_handler.ex
+++ b/lib/klass_hero/messaging/enrollment_participation_handler.ex
@@ -21,8 +21,7 @@ defmodule KlassHero.Messaging.EnrollmentParticipationHandler do
 
   Nothing to do here: `add_user_to_conversations/2` seats everyone with their cursor
   at whatever the conversation already held, so the history stays readable while the
-  unread badge starts at zero. Joining late should not arrive as twenty
-  notifications — and that rule belongs to seating, not to this one caller.
+  unread badge starts at zero.
 
   ## A nil parent_user_id is skipped, not dropped
 

--- a/lib/klass_hero/messaging/enrollment_participation_handler.ex
+++ b/lib/klass_hero/messaging/enrollment_participation_handler.ex
@@ -19,16 +19,10 @@ defmodule KlassHero.Messaging.EnrollmentParticipationHandler do
 
   ## Read state at join
 
-  The participant is stamped with the timestamp of the newest message that already
-  existed, so the history stays readable while the unread badge starts at zero —
-  joining late should not arrive as twenty notifications. All three unread
-  implementations key off `last_read_at`, so this one field settles all of them
-  without touching any of them.
-
-  When the broadcast has no messages yet the stamp is `nil`, which is both correct
-  and reachable: `BroadcastToProgram` creates the conversation, adds participants and
-  sends the message in three separately-committing steps, so an enrollment can land
-  inside that window.
+  Nothing to do here: `add_user_to_conversations/2` seats everyone with their cursor
+  at whatever the conversation already held, so the history stays readable while the
+  unread badge starts at zero. Joining late should not arrive as twenty
+  notifications — and that rule belongs to seating, not to this one caller.
 
   ## A nil parent_user_id is skipped, not dropped
 
@@ -99,32 +93,13 @@ defmodule KlassHero.Messaging.EnrollmentParticipationHandler do
   end
 
   defp backfill_participants(parent_user_id, ids) do
-    with {:ok, _count} <-
-           Messaging.add_user_to_conversations(parent_user_id, ids, last_read_at: read_cursor_at_join(ids)) do
+    with {:ok, _count} <- Messaging.add_user_to_conversations(parent_user_id, ids) do
       events =
         Enum.map(ids, fn conversation_id ->
           Events.participant_added(conversation_id, [parent_user_id], :later_enrollment)
         end)
 
       {:ok, :ok, events}
-    end
-  end
-
-  # A program has at most one active broadcast, so one cursor covers the batch.
-  defp read_cursor_at_join(ids) do
-    ids
-    |> Enum.map(&latest_message_at/1)
-    |> Enum.reject(&is_nil/1)
-    |> case do
-      [] -> nil
-      timestamps -> Enum.max(timestamps, DateTime)
-    end
-  end
-
-  defp latest_message_at(conversation_id) do
-    case Messaging.get_latest_message(conversation_id) do
-      {:ok, message} -> message.inserted_at
-      {:error, :not_found} -> nil
     end
   end
 end

--- a/lib/klass_hero/messaging/enrollment_participation_handler.ex
+++ b/lib/klass_hero/messaging/enrollment_participation_handler.ex
@@ -1,0 +1,130 @@
+defmodule KlassHero.Messaging.EnrollmentParticipationHandler do
+  @moduledoc """
+  Handles Enrollment's `:enrollment_created` event by adding the newly enrolled
+  parent to their program's broadcast conversation.
+
+  `BroadcastToProgram` adds participants from the enrollee list *as it stands when the
+  broadcast is sent*. Nothing maintained that membership afterwards, so a family who
+  enrolled between two broadcasts was not a participant, and `verify_participant/2`
+  hid the thread from them entirely (#381). This handler is the missing half: the
+  add path for parents, mirroring `StaffAssignmentHandler`'s for staff.
+
+  ## Broadcasts only
+
+  Unlike the staff path this must **not** use
+  `list_active_program_conversation_ids_without_participant/2`. A `:direct`
+  parent↔provider conversation also carries a `program_id`, so the program-wide list
+  would seat a new family in every other family's private thread. Staff legitimately
+  belong in both kinds; parents belong only in the broadcast.
+
+  ## Read state at join
+
+  The participant is stamped with the timestamp of the newest message that already
+  existed, so the history stays readable while the unread badge starts at zero —
+  joining late should not arrive as twenty notifications. All three unread
+  implementations key off `last_read_at`, so this one field settles all of them
+  without touching any of them.
+
+  When the broadcast has no messages yet the stamp is `nil`, which is both correct
+  and reachable: `BroadcastToProgram` creates the conversation, adds participants and
+  sends the message in three separately-committing steps, so an enrollment can land
+  inside that window.
+
+  ## A nil parent_user_id is skipped, not dropped
+
+  `Enrollment.do_create_enrollment/2` resolves the parent's user id late, and a parent
+  profile with no user behind it yields `nil`. `conversation_participants.user_id` is
+  `NOT NULL` with an FK, so an unguarded insert *raises* — and `RetryHelpers` only
+  classifies returned error tuples, so a raise skips the backoff path and rides Oban's
+  attempts straight to a discard. Unlike #1312's unclaimed staff invite there is no
+  later claim to replay: the invite claim is what creates the parent, so by the time
+  `InviteFamilyReadyHandler` enrolls them the user already exists. A `nil` here means a
+  genuinely orphaned parent row, not a pending one.
+  """
+
+  @behaviour KlassHero.Shared.ForHandlingEvents
+
+  alias KlassHero.Messaging
+  alias KlassHero.Messaging.Events
+  alias KlassHero.Shared.Adapters.Driven.Events.RetryHelpers
+  alias KlassHero.Shared.Outbox
+
+  require Logger
+
+  @context Messaging
+
+  @impl true
+  def subscribed_events, do: [:enrollment_created]
+
+  @impl true
+  def handle_event(%{event_type: :enrollment_created, payload: payload}) do
+    case Map.get(payload, :parent_user_id) do
+      nil ->
+        Logger.debug("Skipping enrollment_created — enrollment has no parent user",
+          program_id: Map.get(payload, :program_id),
+          enrollment_id: Map.get(payload, :enrollment_id)
+        )
+
+        :ok
+
+      parent_user_id ->
+        with_retry(payload.program_id, parent_user_id, Map.get(payload, :enrollment_id))
+    end
+  end
+
+  def handle_event(_event), do: :ignore
+
+  defp with_retry(program_id, parent_user_id, enrollment_id) do
+    operation = fn -> add_parent_to_broadcast(program_id, parent_user_id) end
+
+    context = %{
+      operation_name: "handle enrollment participation",
+      aggregate_id: enrollment_id,
+      backoff_ms: 100
+    }
+
+    RetryHelpers.retry_and_normalize(operation, context)
+  end
+
+  # Participants and their events commit together, so the delivery job reaches
+  # ConversationSummaries only after the rows it describes exist.
+  defp add_parent_to_broadcast(program_id, parent_user_id) do
+    case Messaging.list_active_broadcast_ids_without_participant(program_id, parent_user_id) do
+      [] ->
+        :ok
+
+      ids ->
+        Outbox.transact(@context, fn -> backfill_participants(parent_user_id, ids) end)
+    end
+  end
+
+  defp backfill_participants(parent_user_id, ids) do
+    with {:ok, _count} <-
+           Messaging.add_user_to_conversations(parent_user_id, ids, last_read_at: read_cursor_at_join(ids)) do
+      events =
+        Enum.map(ids, fn conversation_id ->
+          Events.participant_added(conversation_id, [parent_user_id], :later_enrollment)
+        end)
+
+      {:ok, :ok, events}
+    end
+  end
+
+  # A program has at most one active broadcast, so one cursor covers the batch.
+  defp read_cursor_at_join(ids) do
+    ids
+    |> Enum.map(&latest_message_at/1)
+    |> Enum.reject(&is_nil/1)
+    |> case do
+      [] -> nil
+      timestamps -> Enum.max(timestamps, DateTime)
+    end
+  end
+
+  defp latest_message_at(conversation_id) do
+    case Messaging.get_latest_message(conversation_id) do
+      {:ok, message} -> message.inserted_at
+      {:error, :not_found} -> nil
+    end
+  end
+end

--- a/lib/klass_hero/messaging/events.ex
+++ b/lib/klass_hero/messaging/events.ex
@@ -159,7 +159,8 @@ defmodule KlassHero.Messaging.Events do
   end
 
   @typedoc "Provenance of a participant_added event."
-  @type participant_added_source :: :initial_staff | :later_assignment | :broadcast_setup
+  @type participant_added_source ::
+          :initial_staff | :later_assignment | :broadcast_setup | :later_enrollment
 
   @doc """
   Creates a participant_added event.

--- a/lib/klass_hero/messaging/queries/message_queries.ex
+++ b/lib/klass_hero/messaging/queries/message_queries.ex
@@ -98,6 +98,22 @@ defmodule KlassHero.Messaging.Queries.MessageQueries do
   end
 
   @doc """
+  Newest `inserted_at` per conversation, as `{conversation_id, inserted_at}` rows.
+
+  Counts soft-deleted messages on purpose, so `not_deleted/1` is absent here where
+  every other read applies it. Callers use this as a read cursor, and
+  `ConversationSummaries` counts unread without a `deleted_at` filter — anchoring on
+  the newest *visible* message would badge a soft-deleted newer one as unread, a
+  notification for something the reader cannot open.
+  """
+  def newest_inserted_at_by_conversation(conversation_ids) do
+    base()
+    |> where([message: m], m.conversation_id in ^conversation_ids)
+    |> group_by([message: m], m.conversation_id)
+    |> select([message: m], {m.conversation_id, max(m.inserted_at)})
+  end
+
+  @doc """
   Apply pagination with limit.
   """
   def paginate(query, opts) do

--- a/test/flows/messaging_broadcast_test.exs
+++ b/test/flows/messaging_broadcast_test.exs
@@ -51,6 +51,62 @@ defmodule KlassHeroWeb.Flows.MessagingBroadcastTest do
     |> assert_has("[data-role=conversation-card]", text: "Field trip tomorrow at 9am!")
   end
 
+  # #381: membership used to be a send-time snapshot, so a family who enrolled between
+  # two broadcasts was not a participant and the thread was invisible to them. The
+  # badge assertion is the other half of the requirement — the history is readable,
+  # but arriving late must not arrive as a pile of notifications.
+  test "a parent who enrolls after the broadcast sees its history, unbadged", %{
+    conn: conn,
+    provider_user: provider_user,
+    program: program
+  } do
+    with_real_outbox(fn ->
+      conn
+      |> log_in_user(provider_user)
+      |> visit(~p"/provider/programs/#{program.id}/broadcast")
+      |> fill_in("#content", "Message", with: "Swimming kit needed on Friday", exact: false)
+      |> click_button("Send Broadcast")
+      |> assert_has("[data-role=message]", text: "Swimming kit needed on Friday")
+    end)
+
+    late_user = user_fixture(%{intended_roles: [:parent]})
+    late_parent = insert(:parent_profile_schema, identity_id: late_user.id)
+    {late_child, _} = insert_child_with_guardian(parent: late_parent)
+
+    with_real_outbox(fn ->
+      {:ok, _enrollment} =
+        KlassHero.Enrollment.create_enrollment(%{
+          program_id: program.id,
+          child_id: late_child.id,
+          parent_id: late_parent.id,
+          status: :confirmed,
+          payment_method: "transfer",
+          waivers: :deferred
+        })
+    end)
+
+    build_conn()
+    |> log_in_user(late_user)
+    |> visit(~p"/messages")
+    |> assert_has("[data-role=conversation-card]", text: "Swimming kit needed on Friday")
+    |> refute_has("[data-role=unread-count]")
+
+    # Pins the refute above: the badge is absent because the pre-join broadcast is
+    # already read, not because this card never renders one.
+    with_real_outbox(fn ->
+      build_conn()
+      |> log_in_user(provider_user)
+      |> visit(~p"/provider/programs/#{program.id}/broadcast")
+      |> fill_in("#content", "Message", with: "Bus leaves at 8am sharp", exact: false)
+      |> click_button("Send Broadcast")
+    end)
+
+    build_conn()
+    |> log_in_user(late_user)
+    |> visit(~p"/messages")
+    |> assert_has("[data-role=unread-count]", text: "1")
+  end
+
   test "a parent's private reply to a broadcast reaches the provider's inbox", %{
     conn: conn,
     provider_user: provider_user,

--- a/test/klass_hero/messaging/add_user_to_conversations_test.exs
+++ b/test/klass_hero/messaging/add_user_to_conversations_test.exs
@@ -1,12 +1,12 @@
 defmodule KlassHero.Messaging.AddUserToConversationsTest do
   @moduledoc """
-  Guards the two branches of `add_user_to_conversations`' upsert.
+  Guards the seating rule shared by every path that adds someone to a conversation:
+  they arrive with their read cursor at whatever the conversation already held.
 
-  The `:last_read_at` option was added for #381's parent back-fill, but the
-  function is shared with `StaffAssignmentHandler`. Re-stamping the cursor
-  unconditionally would push a NULL over a returning staff member's read state and
-  reset their whole thread to unread — a regression with no user-visible symptom
-  until someone opens a conversation they had already read.
+  Both callers depend on it — `StaffAssignmentHandler` for a mid-programme
+  assignment, `EnrollmentParticipationHandler` for a late enrolment — so neither
+  passes a cursor of its own. That is deliberate: a rule each caller has to remember
+  is a rule the next caller forgets.
   """
 
   use KlassHero.DataCase, async: true
@@ -18,53 +18,92 @@ defmodule KlassHero.Messaging.AddUserToConversationsTest do
   alias KlassHero.Messaging.Participant
   alias KlassHero.Repo
 
-  @cursor ~U[2026-01-01 00:00:00Z]
-
   setup do
     conversation = insert(:conversation_schema)
+    speaker = insert(:participant_schema, conversation_id: conversation.id)
     user = KlassHero.AccountsFixtures.user_fixture()
-    participant = insert(:participant_schema, conversation_id: conversation.id, user_id: user.id)
 
-    depart(participant, @cursor)
-
-    %{conversation: conversation, user: user, participant: participant}
+    %{conversation: conversation, speaker: speaker, user: user}
   end
 
-  test "the staff path re-activates without touching the read cursor", ctx do
+  test "a fresh join is stamped at the newest existing message", ctx do
+    insert(:message_schema, conversation_id: ctx.conversation.id, sender_id: ctx.speaker.user_id)
+    newest = insert(:message_schema, conversation_id: ctx.conversation.id, sender_id: ctx.speaker.user_id)
+
     assert {:ok, _} = Messaging.add_user_to_conversations(ctx.user.id, [ctx.conversation.id])
 
-    assert %{last_read_at: @cursor, left_at: nil} = reload(ctx.participant)
+    assert {:ok, %{last_read_at: cursor}} =
+             Messaging.get_participant(ctx.conversation.id, ctx.user.id)
+
+    assert cursor == newest.inserted_at
+    assert Messaging.count_unread_messages(ctx.conversation.id, cursor) == 0
   end
 
-  test "the parent path re-activates and re-stamps the read cursor", ctx do
-    rejoined_at = ~U[2026-06-01 00:00:00Z]
+  test "an empty conversation leaves the cursor nil, so what comes next is unread", ctx do
+    assert {:ok, _} = Messaging.add_user_to_conversations(ctx.user.id, [ctx.conversation.id])
 
-    assert {:ok, _} =
-             Messaging.add_user_to_conversations(ctx.user.id, [ctx.conversation.id], last_read_at: rejoined_at)
-
-    assert %{last_read_at: ^rejoined_at, left_at: nil} = reload(ctx.participant)
+    assert {:ok, %{last_read_at: nil}} =
+             Messaging.get_participant(ctx.conversation.id, ctx.user.id)
   end
 
-  test "an explicit nil cursor on a fresh join means everything is unread", ctx do
-    other = insert(:conversation_schema)
+  # A soft-deleted message is invisible but still counts towards the anchor:
+  # ConversationSummaries counts unread without a deleted_at filter, so anchoring on
+  # the newest *visible* message would badge a message the reader cannot open.
+  test "a soft-deleted newest message still anchors the cursor", ctx do
+    insert(:message_schema, conversation_id: ctx.conversation.id, sender_id: ctx.speaker.user_id)
 
-    assert {:ok, _} =
-             Messaging.add_user_to_conversations(ctx.user.id, [other.id], last_read_at: nil)
+    deleted =
+      insert(:message_schema,
+        conversation_id: ctx.conversation.id,
+        sender_id: ctx.speaker.user_id,
+        deleted_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      )
 
-    assert {:ok, %{last_read_at: nil}} = Messaging.get_participant(other.id, ctx.user.id)
+    assert {:ok, _} = Messaging.add_user_to_conversations(ctx.user.id, [ctx.conversation.id])
+
+    assert {:ok, %{last_read_at: cursor}} =
+             Messaging.get_participant(ctx.conversation.id, ctx.user.id)
+
+    assert cursor == deleted.inserted_at
   end
 
-  defp depart(participant, at) do
+  # Distinguished by presence, not by clock: `messages.inserted_at` is second-precision,
+  # so two messages written in one test would share a timestamp and prove nothing.
+  test "each conversation in a batch gets its own cursor" do
+    spoken = insert(:conversation_schema)
+    speaker = insert(:participant_schema, conversation_id: spoken.id)
+    silent = insert(:conversation_schema)
+    user = KlassHero.AccountsFixtures.user_fixture()
+
+    message = insert(:message_schema, conversation_id: spoken.id, sender_id: speaker.user_id)
+
+    assert {:ok, _} = Messaging.add_user_to_conversations(user.id, [spoken.id, silent.id])
+
+    assert {:ok, %{last_read_at: cursor}} = Messaging.get_participant(spoken.id, user.id)
+    assert cursor == message.inserted_at
+
+    assert {:ok, %{last_read_at: nil}} = Messaging.get_participant(silent.id, user.id)
+  end
+
+  # Rejoining is joining: someone re-added was not entitled to the conversation while
+  # away, so what happened in the meantime is history, not a backlog.
+  test "re-activating a departed participant re-stamps the cursor", ctx do
+    departed_at = ~U[2026-01-01 00:00:00Z]
+
+    participant =
+      insert(:participant_schema, conversation_id: ctx.conversation.id, user_id: ctx.user.id)
+
     Repo.update_all(from(p in Participant, where: p.id == ^participant.id),
-      set: [last_read_at: at, left_at: at]
+      set: [last_read_at: departed_at, left_at: departed_at]
     )
-  end
 
-  defp reload(participant) do
-    Repo.one(
-      from p in Participant,
-        where: p.id == ^participant.id,
-        select: %{last_read_at: p.last_read_at, left_at: p.left_at}
-    )
+    missed = insert(:message_schema, conversation_id: ctx.conversation.id, sender_id: ctx.speaker.user_id)
+
+    assert {:ok, _} = Messaging.add_user_to_conversations(ctx.user.id, [ctx.conversation.id])
+
+    assert {:ok, %{last_read_at: cursor, left_at: nil}} =
+             Messaging.get_participant(ctx.conversation.id, ctx.user.id)
+
+    assert cursor == missed.inserted_at
   end
 end

--- a/test/klass_hero/messaging/add_user_to_conversations_test.exs
+++ b/test/klass_hero/messaging/add_user_to_conversations_test.exs
@@ -15,6 +15,7 @@ defmodule KlassHero.Messaging.AddUserToConversationsTest do
   import KlassHero.Factory
 
   alias KlassHero.Messaging
+  alias KlassHero.Messaging.Message
   alias KlassHero.Messaging.Participant
   alias KlassHero.Repo
 
@@ -36,7 +37,7 @@ defmodule KlassHero.Messaging.AddUserToConversationsTest do
              Messaging.get_participant(ctx.conversation.id, ctx.user.id)
 
     assert cursor == newest.inserted_at
-    assert Messaging.count_unread_messages(ctx.conversation.id, cursor) == 0
+    refute anything_after?(ctx.conversation.id, cursor)
   end
 
   test "an empty conversation leaves the cursor nil, so what comes next is unread", ctx do
@@ -65,6 +66,21 @@ defmodule KlassHero.Messaging.AddUserToConversationsTest do
              Messaging.get_participant(ctx.conversation.id, ctx.user.id)
 
     assert cursor == deleted.inserted_at
+    refute anything_after?(ctx.conversation.id, cursor)
+  end
+
+  # Counter-agnostic on purpose. The badge users see comes from
+  # `ConversationSummaries.unread_count`, which counts deleted messages;
+  # `Messaging.count_unread_messages/2` does not. Asserting through either would
+  # prove the invariant only for the counter that happens to agree with it —
+  # "nothing in this conversation postdates the cursor" is what makes both read
+  # zero. The live badge itself is covered end-to-end in
+  # `test/flows/messaging_broadcast_test.exs`.
+  defp anything_after?(conversation_id, cursor) do
+    Repo.exists?(
+      from m in Message,
+        where: m.conversation_id == ^conversation_id and m.inserted_at > ^cursor
+    )
   end
 
   # Distinguished by presence, not by clock: `messages.inserted_at` is second-precision,

--- a/test/klass_hero/messaging/add_user_to_conversations_test.exs
+++ b/test/klass_hero/messaging/add_user_to_conversations_test.exs
@@ -1,0 +1,70 @@
+defmodule KlassHero.Messaging.AddUserToConversationsTest do
+  @moduledoc """
+  Guards the two branches of `add_user_to_conversations`' upsert.
+
+  The `:last_read_at` option was added for #381's parent back-fill, but the
+  function is shared with `StaffAssignmentHandler`. Re-stamping the cursor
+  unconditionally would push a NULL over a returning staff member's read state and
+  reset their whole thread to unread — a regression with no user-visible symptom
+  until someone opens a conversation they had already read.
+  """
+
+  use KlassHero.DataCase, async: true
+
+  import Ecto.Query
+  import KlassHero.Factory
+
+  alias KlassHero.Messaging
+  alias KlassHero.Messaging.Participant
+  alias KlassHero.Repo
+
+  @cursor ~U[2026-01-01 00:00:00Z]
+
+  setup do
+    conversation = insert(:conversation_schema)
+    user = KlassHero.AccountsFixtures.user_fixture()
+    participant = insert(:participant_schema, conversation_id: conversation.id, user_id: user.id)
+
+    depart(participant, @cursor)
+
+    %{conversation: conversation, user: user, participant: participant}
+  end
+
+  test "the staff path re-activates without touching the read cursor", ctx do
+    assert {:ok, _} = Messaging.add_user_to_conversations(ctx.user.id, [ctx.conversation.id])
+
+    assert %{last_read_at: @cursor, left_at: nil} = reload(ctx.participant)
+  end
+
+  test "the parent path re-activates and re-stamps the read cursor", ctx do
+    rejoined_at = ~U[2026-06-01 00:00:00Z]
+
+    assert {:ok, _} =
+             Messaging.add_user_to_conversations(ctx.user.id, [ctx.conversation.id], last_read_at: rejoined_at)
+
+    assert %{last_read_at: ^rejoined_at, left_at: nil} = reload(ctx.participant)
+  end
+
+  test "an explicit nil cursor on a fresh join means everything is unread", ctx do
+    other = insert(:conversation_schema)
+
+    assert {:ok, _} =
+             Messaging.add_user_to_conversations(ctx.user.id, [other.id], last_read_at: nil)
+
+    assert {:ok, %{last_read_at: nil}} = Messaging.get_participant(other.id, ctx.user.id)
+  end
+
+  defp depart(participant, at) do
+    Repo.update_all(from(p in Participant, where: p.id == ^participant.id),
+      set: [last_read_at: at, left_at: at]
+    )
+  end
+
+  defp reload(participant) do
+    Repo.one(
+      from p in Participant,
+        where: p.id == ^participant.id,
+        select: %{last_read_at: p.last_read_at, left_at: p.left_at}
+    )
+  end
+end

--- a/test/klass_hero/messaging/enrollment_participation_handler_test.exs
+++ b/test/klass_hero/messaging/enrollment_participation_handler_test.exs
@@ -106,8 +106,9 @@ defmodule KlassHero.Messaging.EnrollmentParticipationHandlerTest do
 
       {:ok, participant} = Messaging.get_participant(conversation.id, parent_user.id)
 
+      # The cursor is the contract; that it zeroes the badge is covered end-to-end
+      # in test/flows/messaging_broadcast_test.exs, against the counter the UI reads.
       assert participant.last_read_at == older.inserted_at
-      assert Messaging.count_unread_messages(conversation.id, participant.last_read_at) == 0
     end
 
     # BroadcastToProgram creates the conversation, adds participants and sends the

--- a/test/klass_hero/messaging/enrollment_participation_handler_test.exs
+++ b/test/klass_hero/messaging/enrollment_participation_handler_test.exs
@@ -1,0 +1,167 @@
+defmodule KlassHero.Messaging.EnrollmentParticipationHandlerTest do
+  use KlassHero.DataCase, async: false
+
+  import KlassHero.EventTestHelper
+  import KlassHero.Factory
+
+  alias KlassHero.Enrollment.Domain.Events.EnrollmentEvents
+  alias KlassHero.Messaging
+  alias KlassHero.Messaging.EnrollmentParticipationHandler
+
+  setup do
+    setup_test_integration_events()
+    :ok
+  end
+
+  describe "handle_event/1 - enrollment_created" do
+    test "adds the late enrollee to the program's active broadcast conversation" do
+      %{program: program, conversation: conversation} = program_with_broadcast()
+      parent_user = KlassHero.AccountsFixtures.user_fixture()
+
+      assert :ok = handle(program.id, parent_user.id)
+
+      assert Messaging.participant?(conversation.id, parent_user.id)
+    end
+
+    # The privacy trap: `:direct` conversations also carry a program_id (set by
+    # StartProgramConversation), so a program-wide backfill would drop the new
+    # parent into other families' private threads.
+    test "does not add the enrollee to a direct conversation for the same program" do
+      %{provider: provider, program: program} = program_with_broadcast()
+      other_family = KlassHero.AccountsFixtures.user_fixture()
+      parent_user = KlassHero.AccountsFixtures.user_fixture()
+
+      direct =
+        insert(:conversation_schema,
+          provider_id: provider.id,
+          type: :direct,
+          program_id: program.id
+        )
+
+      insert(:participant_schema, conversation_id: direct.id, user_id: other_family.id)
+
+      assert :ok = handle(program.id, parent_user.id)
+
+      refute Messaging.participant?(direct.id, parent_user.id)
+    end
+
+    test "emits :participant_added with source :later_enrollment" do
+      %{program: program, conversation: conversation} = program_with_broadcast()
+      parent_user = KlassHero.AccountsFixtures.user_fixture()
+
+      assert :ok = handle(program.id, parent_user.id)
+
+      assert_integration_event_published(:participant_added, %{
+        conversation_id: conversation.id,
+        participant_user_ids: [parent_user.id],
+        source: :later_enrollment
+      })
+    end
+
+    test "is inert when the program has no broadcast conversation" do
+      program = insert(:program_schema)
+      parent_user = KlassHero.AccountsFixtures.user_fixture()
+
+      assert :ok = handle(program.id, parent_user.id)
+
+      refute_participant_added()
+    end
+
+    test "is inert when the enrollee is already an active participant" do
+      %{program: program, conversation: conversation} = program_with_broadcast()
+      parent_user = KlassHero.AccountsFixtures.user_fixture()
+      insert(:participant_schema, conversation_id: conversation.id, user_id: parent_user.id)
+
+      assert :ok = handle(program.id, parent_user.id)
+
+      refute_participant_added()
+    end
+
+    # `parent_user_id` is resolved late for invite-created enrollments
+    # (Enrollment.do_create_enrollment/2), so a parent profile with no user behind
+    # it yields nil. conversation_participants.user_id is NOT NULL with an FK, so
+    # an unguarded insert raises past RetryHelpers straight into an Oban discard.
+    test "skips when parent_user_id is nil" do
+      %{program: program} = program_with_broadcast()
+
+      assert :ok = handle(program.id, nil)
+
+      refute_participant_added()
+    end
+
+    test "ignores unrelated events" do
+      assert :ignore = EnrollmentParticipationHandler.handle_event(%{event_type: :something_else})
+    end
+  end
+
+  describe "handle_event/1 - read state at join" do
+    test "stamps last_read_at so pre-join broadcasts do not count as unread" do
+      %{conversation: conversation, program: program, provider_user: provider_user} =
+        program_with_broadcast()
+
+      older = insert(:message_schema, conversation_id: conversation.id, sender_id: provider_user.id)
+      parent_user = KlassHero.AccountsFixtures.user_fixture()
+
+      assert :ok = handle(program.id, parent_user.id)
+
+      {:ok, participant} = Messaging.get_participant(conversation.id, parent_user.id)
+
+      assert participant.last_read_at == older.inserted_at
+      assert Messaging.count_unread_messages(conversation.id, participant.last_read_at) == 0
+    end
+
+    # BroadcastToProgram creates the conversation, adds participants and sends the
+    # message in three separately-committing steps, so an enrollment landing in
+    # that window finds a broadcast with no messages yet.
+    test "leaves last_read_at nil when the broadcast has no messages yet" do
+      %{program: program, conversation: conversation} = program_with_broadcast()
+      parent_user = KlassHero.AccountsFixtures.user_fixture()
+
+      assert :ok = handle(program.id, parent_user.id)
+
+      {:ok, participant} = Messaging.get_participant(conversation.id, parent_user.id)
+      assert is_nil(participant.last_read_at)
+    end
+  end
+
+  defp refute_participant_added do
+    refute Enum.any?(get_published_integration_events(), &(&1.event_type == :participant_added)),
+           "Expected no :participant_added event to be staged."
+  end
+
+  defp handle(program_id, parent_user_id) do
+    Ecto.UUID.generate()
+    |> EnrollmentEvents.enrollment_created(%{
+      enrollment_id: Ecto.UUID.generate(),
+      child_id: Ecto.UUID.generate(),
+      parent_id: Ecto.UUID.generate(),
+      parent_user_id: parent_user_id,
+      program_id: program_id,
+      status: :confirmed
+    })
+    |> through_outbox()
+    |> EnrollmentParticipationHandler.handle_event()
+  end
+
+  defp program_with_broadcast do
+    provider = insert(:provider_profile_schema)
+    provider_user = KlassHero.AccountsFixtures.user_fixture()
+    program = insert(:program_schema, provider_id: provider.id)
+
+    conversation =
+      insert(:conversation_schema,
+        provider_id: provider.id,
+        type: :program_broadcast,
+        program_id: program.id
+      )
+
+    insert(:participant_schema, conversation_id: conversation.id, user_id: provider_user.id)
+
+    %{
+      provider: provider,
+      provider_user: provider_user,
+      program: program,
+      conversation: conversation
+    }
+  end
+end

--- a/test/klass_hero/messaging/participant_seating_test.exs
+++ b/test/klass_hero/messaging/participant_seating_test.exs
@@ -1,12 +1,12 @@
-defmodule KlassHero.Messaging.AddUserToConversationsTest do
+defmodule KlassHero.Messaging.ParticipantSeatingTest do
   @moduledoc """
   Guards the seating rule shared by every path that adds someone to a conversation:
   they arrive with their read cursor at whatever the conversation already held.
 
-  Both callers depend on it — `StaffAssignmentHandler` for a mid-programme
-  assignment, `EnrollmentParticipationHandler` for a late enrolment — so neither
-  passes a cursor of its own. That is deliberate: a rule each caller has to remember
-  is a rule the next caller forgets.
+  No caller passes a cursor of its own — not `StaffAssignmentHandler` for a
+  mid-programme assignment, not `EnrollmentParticipationHandler` for a late enrolment,
+  not the conversation-creation flows behind `add_participant/1`. That is deliberate:
+  a rule each caller has to remember is a rule the next caller forgets.
   """
 
   use KlassHero.DataCase, async: true
@@ -99,6 +99,37 @@ defmodule KlassHero.Messaging.AddUserToConversationsTest do
     assert cursor == message.inserted_at
 
     assert {:ok, %{last_read_at: nil}} = Messaging.get_participant(silent.id, user.id)
+  end
+
+  # The singular path matters as much as the batch ones. Its three callers today all seat
+  # into a conversation they just created, so the cursor is nil for them either way —
+  # which is exactly why the rule needs pinning here: nothing else would notice if the
+  # next caller reached for the shorter name and seated someone into a populated thread.
+  test "add_participant/1 seats by the same rule", ctx do
+    newest = insert(:message_schema, conversation_id: ctx.conversation.id, sender_id: ctx.speaker.user_id)
+
+    assert {:ok, participant} =
+             Messaging.add_participant(%{
+               conversation_id: ctx.conversation.id,
+               user_id: ctx.user.id
+             })
+
+    assert participant.last_read_at == newest.inserted_at
+    refute anything_after?(ctx.conversation.id, participant.last_read_at)
+  end
+
+  test "add_participant/1 honours an explicit last_read_at", ctx do
+    insert(:message_schema, conversation_id: ctx.conversation.id, sender_id: ctx.speaker.user_id)
+    explicit = ~U[2026-01-01 00:00:00Z]
+
+    assert {:ok, participant} =
+             Messaging.add_participant(%{
+               conversation_id: ctx.conversation.id,
+               user_id: ctx.user.id,
+               last_read_at: explicit
+             })
+
+    assert participant.last_read_at == explicit
   end
 
   # Rejoining is joining: someone re-added was not entitled to the conversation while

--- a/test/klass_hero/messaging/staff_assignment_handler_test.exs
+++ b/test/klass_hero/messaging/staff_assignment_handler_test.exs
@@ -87,6 +87,38 @@ defmodule KlassHero.Messaging.StaffAssignmentHandlerTest do
              end)
     end
 
+    # Same rule as the parent back-fill (#381): arriving mid-programme should not
+    # arrive as a wall of notifications. History stays readable; the badge starts
+    # at the moment of assignment.
+    test "stamps the read cursor at assignment so prior messages are not unread" do
+      provider = insert(:provider_profile_schema)
+      program = insert(:program_schema, provider_id: provider.id)
+      parent_user = KlassHero.AccountsFixtures.user_fixture()
+      staff_user = KlassHero.AccountsFixtures.user_fixture()
+
+      conversation =
+        insert(:conversation_schema,
+          provider_id: provider.id,
+          type: "direct",
+          program_id: program.id
+        )
+
+      insert(:participant_schema, conversation_id: conversation.id, user_id: parent_user.id)
+      older = insert(:message_schema, conversation_id: conversation.id, sender_id: parent_user.id)
+
+      event = build_assignment_event(provider.id, program.id, staff_user.id)
+      assert :ok = StaffAssignmentHandler.handle_event(event)
+
+      {:ok, participant} = KlassHero.Messaging.get_participant(conversation.id, staff_user.id)
+
+      assert participant.last_read_at == older.inserted_at
+
+      assert KlassHero.Messaging.count_unread_messages(
+               conversation.id,
+               participant.last_read_at
+             ) == 0
+    end
+
     test "emits no :participant_added when staff is already in every program conversation" do
       provider = insert(:provider_profile_schema)
       program = insert(:program_schema, provider_id: provider.id)

--- a/test/klass_hero/messaging/staff_assignment_handler_test.exs
+++ b/test/klass_hero/messaging/staff_assignment_handler_test.exs
@@ -111,12 +111,9 @@ defmodule KlassHero.Messaging.StaffAssignmentHandlerTest do
 
       {:ok, participant} = KlassHero.Messaging.get_participant(conversation.id, staff_user.id)
 
+      # The cursor is the contract; that it zeroes the badge is covered end-to-end
+      # in test/flows/messaging_broadcast_test.exs, against the counter the UI reads.
       assert participant.last_read_at == older.inserted_at
-
-      assert KlassHero.Messaging.count_unread_messages(
-               conversation.id,
-               participant.last_read_at
-             ) == 0
     end
 
     test "emits no :participant_added when staff is already in every program conversation" do


### PR DESCRIPTION
Closes #381.

## Summary

Two related things, because the second falls out of the first.

**1. Late enrollees were never seated.** Broadcast membership was a send-time snapshot: `BroadcastToProgram` added the parents enrolled *at the moment of sending*, and nothing maintained it afterwards. A family enrolling between two broadcasts was not a participant, `verify_participant/2` rejected them, and the thread never appeared in their inbox. `EnrollmentParticipationHandler` is the missing add path — the parent-side mirror of `StaffAssignmentHandler`'s.

**2. Anyone seated into a conversation now arrives with a read cursor.** The history stays readable; the unread badge starts at arrival. Joining late should not arrive as twenty notifications. This applies to **staff as well as parents** — same rule, one place.

## Review Focus

**The privacy trap — why a new query rather than the existing one.**
`list_active_program_conversation_ids_without_participant/2` returns *every* active program-scoped conversation, and `:direct` parent↔provider threads also carry a `program_id` (set by `StartProgramConversation`). Reusing it would seat a newly enrolled family in every *other* family's private thread. Staff legitimately belong in both kinds, which is why their path can use the wider query and this one cannot. Verified on dev data: program-wide returned both conversations, broadcast-only returned one.

**Why the rule lives in the seating functions, not at call sites.**
The first commit added a `last_read_at:` option and passed it from one caller. Extending that to staff would have meant a third and fourth call site each remembering to pass it — the shape that guarantees the fifth forgets. Moving it into `add_participants/2` and `add_user_to_conversations/2` **removes** the option: the latter returns to arity 2 and the conditional `on_conflict` collapses to one clause. `StaffAssignmentHandler` and `AddAssignedStaff` get the behaviour without changing a line.

**Why the anchor is not `DateTime.utc_now()`.**
`messages.inserted_at` is `:utc_datetime` — second precision. A message written in the same second as the join would fail the `m.inserted_at > ^last_read_at` comparison every unread counter makes, and be silently marked read. The anchor is the newest message already in that conversation, or `nil` when it is empty.

**Why the anchor counts soft-deleted messages.**
`ConversationSummaries` computes its unread count with no `deleted_at` filter. Anchoring on the newest *visible* message would leave a soft-deleted newer one badged as unread — a notification for something the reader cannot open.

**One field settles three counters.**
There are three independent unread implementations (`ConversationSummary.unread_count` behind the nav badge and inbox rows, `ConversationQueries.total_unread_count/1`, `MessageQueries.count_unread/2`). All key off `last_read_at` being nil-or-dated, and `ConversationSummaries.project_participant_added/1` re-reads participant rows and routes on that value — so stamping at insert lands all three at zero with **no change to any projection or counter**.

**Re-activation now re-stamps rather than preserving the old cursor.**
Rejoining is joining: someone re-added was not entitled to the conversation while away, so the gap is history, not a backlog. Only a soft-left row can reach that `on_conflict` branch (`where_user_is_not_participant/2` filters active participants out first), so a replayed event cannot use it to wipe a live participant's read state.

**A nil `parent_user_id` is skipped, not dropped.**
Enrollment resolves that id late for invite-created enrollments, and `conversation_participants.user_id` is `NOT NULL` with an FK — an unguarded insert *raises*, and `RetryHelpers` only classifies returned error tuples, so a raise skips backoff and rides Oban's attempts to a discard. Unlike #1312's unclaimed staff invite there is nothing to replay: the invite claim is what creates the parent.

## Test Plan

- `mix precommit` — 5112 passed, credo clean, zero warnings.
- **Mutation-checked:** disabling the consumer registration makes the new flow test fail on the missing conversation card, so it proves the fix rather than passing incidentally.
- The `refute_has("[data-role=unread-count]")` assertion is pinned by a follow-up broadcast that makes the badge appear with `1` — otherwise it would prove nothing.
- `add_user_to_conversations_test.exs` pins the seating rule directly: fresh join, empty conversation, soft-deleted anchor, per-conversation cursors in a batch, and re-activation.
- **Verified on dev data via Tidewave.** Parent path: cursor stamped to the newest pre-join message, 3 historical messages readable, unread 0, **not** seated in the other family's private thread; after a new broadcast, summary `unread_count` 1 and nav badge 1. Staff path: both seating functions stamp identically, unread 0, history readable.
- `/review-architecture`: 21/21 clean on the first commit; regression-analyzer re-run against the widened diff.

## Follow-up

#1511 — the symmetric gap: a parent who *cancels* their enrollment stays a participant and keeps receiving broadcasts.

Noted, not fixed here: `ConversationSummaries.fetch_unread_counts_*` counts soft-deleted messages. Pre-existing; the anchor choice above works around it rather than depending on it.
