### PR TITLE
feat: admin can monitor all conversations, and participants are told

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -165,8 +165,12 @@ An authentication identity in the Accounts context — email, password, `intende
 _Avoid_: Account, Login, Member
 
 **Admin**:
-A platform operator (not a **Parent** or **Provider**) who reviews **Verification Documents** and **Incident Reports** and approves pending **Enrollments**. The reviewer behind `reviewed_by_id`.
+A platform operator (not a **Parent** or **Provider**) who reviews **Verification Documents** and **Incident Reports**, approves pending **Enrollments**, and may read any **Conversation** under **Monitoring**. The reviewer behind `reviewed_by_id`.
 _Avoid_: Moderator, Superuser, Staff (Staff belongs to a Provider)
+
+**Monitoring**:
+An **Admin**'s read-only access to any **Conversation**, for safety, abuse prevention and compliance. Deliberately *not* moderation: monitoring reads, and has no power to write, delete or intervene in a thread. An Admin monitoring a Conversation does not become a **Participant** — no membership is created, and no read receipt moves — so monitoring is invisible to participant counts and unread badges. Disclosed to participants by a **System Message** in every provider-context Conversation.
+_Avoid_: Moderation (that implies intervention), Surveillance, Oversight, Audit (that names the trail, not the act)
 
 **Parent**:
 The account-holding persona who manages **Children**, books **Programs**, and pays. A Parent is a **Guardian** who holds a **User** account.
@@ -206,7 +210,7 @@ A file attached to a **Message** — a photo or document with a filename, conten
 _Avoid_: Upload, File, Media, Document (that's a **Verification Document**, unrelated)
 
 **Participant** (Messaging):
-A **User**'s membership in a **Direct Conversation** — tracks join/leave and read receipts. Applies to Direct Conversations only; a **Broadcast** has a derived audience, not Participants. This is the *only* meaning of "Participant" in the system; it is **not** a child attending a Session.
+A **User**'s membership in a **Direct Conversation** — tracks join/leave and read receipts. Applies to Direct Conversations only; a **Broadcast** has a derived audience, not Participants. This is the *only* meaning of "Participant" in the system; it is **not** a child attending a Session. An **Admin** reading a Conversation under **Monitoring** is not a Participant either: reading it seats nobody and moves no read receipt.
 _Avoid_: using "Participant" for a child on a **Roster** (that's a **Participation Record**), or for a **Broadcast** recipient
 
 **Archival**:

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -279,7 +279,9 @@ destination is added once.
 **Provider app** — **black sidebar with a yellow active accent**, an intentional inversion
 of the parent surface's white-with-blue. Business-minded density.
 
-**Admin** — Backpex. Functional, not branded; do not spend design effort here.
+**Admin** — mostly Backpex, plus a few hand-rolled LiveViews (Emails, Sessions,
+Messages, Verifications) that borrow the Backpex shell. Functional, not branded; do
+not spend design effort here either way.
 
 ---
 

--- a/bin/worktree-gc
+++ b/bin/worktree-gc
@@ -27,7 +27,14 @@ source bin/lib/worktree-common.sh
 PRUNE=false
 [[ "${1:-}" == "--prune" ]] && PRUNE=true
 
-main_root=$(repo_root)
+# NOT repo_root(): that is `git rev-parse --show-toplevel`, which inside a linked
+# worktree returns *that worktree*. Running this script from a worktree therefore
+# skipped the worktree it was run from and offered the MAIN CHECKOUT for removal —
+# main is on `main`, so `git cherry` finds nothing and it classifies as "merged —
+# removable". `--prune` then tried to remove it and drop klass_hero_dev; only
+# worktree-down's main-checkout refusal and Postgres declining to drop an in-use
+# database stopped it. `git worktree list` always names the main worktree first.
+main_root=$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')
 git fetch origin --quiet 2>/dev/null || true
 
 candidates=()

--- a/docs/adr/0021-admin-conversation-reads-authorize-at-the-messaging-boundary.md
+++ b/docs/adr/0021-admin-conversation-reads-authorize-at-the-messaging-boundary.md
@@ -1,0 +1,136 @@
+# Admin conversation reads authorize at the Messaging boundary
+
+**Date:** 2026-08-25 · **Issue:** #744
+
+A platform admin may read any conversation. That permission is granted inside
+`KlassHero.Messaging`, against the caller's `Accounts.Scope`, by a named gate:
+
+```elixir
+Messaging.monitor_conversations(scope, opts)
+Messaging.get_monitored_conversation(scope, conversation_id, opts)
+```
+
+Both fail closed with `{:error, :unauthorized}` unless `scope.user.is_admin`. The
+router's `:require_admin` on_mount stays, as defence in depth rather than as the
+guarantee.
+
+## Why not the router alone
+
+Every other admin surface in this app authorizes at the router and nowhere else.
+`EmailsLive` calls `Messaging.list_inbound_emails/1`, which takes no scope; the
+Backpex resources go straight to Ecto. That is a defensible trade for inbound
+support mail and for admin dropdown labels.
+
+Conversations are different in kind. They are private correspondence between
+parents and the people looking after their children, and Messaging gates *every
+other* read of them on a participant row (`Authorization.verify_participant/2`).
+An ungated `list_all_conversations/1` sitting in that same facade would be an IDOR
+primitive: correct as long as the only caller is a LiveView behind `:require_admin`,
+and wrong the first time anything else calls it. This repository has already paid
+for that pattern seven times (#1125, #1373, #1477 among them), and ADR-0017 records
+the same lesson on the write side — a guard that lives in one of four callers is
+not a guard.
+
+So the gate moves to where the data is, and the web layer keeps its own check.
+
+## One clause, not a fall-through
+
+`Participation.SessionAuthorization.authorize/2` resolves an actor through an
+ordered table — provider, then staff, then admin — because there, admin is the
+broadest rule you reach after narrower ones fail, and the resolved role selects
+*behaviour* (an admin correction demands a written reason; a provider's does not).
+
+`Messaging.Authorization.authorize_admin/1` is a single clause instead:
+
+```elixir
+def authorize_admin(%Scope{user: %{is_admin: true}}), do: :ok
+def authorize_admin(%Scope{} = scope), do: {:error, :unauthorized}
+```
+
+Nobody is *narrowly* authorized to read every conversation on the platform, so
+there is nothing to fall through from. Modelling it as a table would imply a
+precedence that does not exist.
+
+`is_admin` is derived, not declared: it lives on the user row and is absent from
+`registration_changeset`'s cast list, so no request can grant it to itself.
+
+## Authorization runs before the id is read
+
+`GetConversation.execute/3` fetches the conversation *first* and checks the
+participant row second, so `{:error, :not_found}` and `{:error, :not_participant}`
+are distinguishable to a caller — the enumeration oracle ADR-0017 warns about. That
+is pre-existing and is not fixed here; collapsing it would change the flash contract
+on all six parent/provider/staff message surfaces.
+
+The admin path does not inherit it. `authorize_admin/1` is the first thing both use
+cases call, so a non-admin gets `:unauthorized` whatever id they supply. Past the
+gate an admin has blanket visibility, so a later `:not_found` discloses nothing they
+were not already entitled to know.
+
+## A parallel path, not a widened gate
+
+The alternative was to generalize `verify_participant/2` into a scope-taking
+fall-through so `get_conversation/3` would serve admins unchanged. It was rejected:
+that function has three callers, and two of them — `SendMessage` and `MarkAsRead` —
+must **not** gain an admin branch. "One gate" would immediately have become "one
+gate with an exception list", on the child-safety read path, while also migrating
+six LiveViews from `user_id` to `%Scope{}`.
+
+Keeping the paths separate makes the write-side property checkable instead of
+argued: `SendMessage` and `MarkAsRead` never call `authorize_admin/1`, and a test in
+`get_monitored_conversation_test.exs` pins that a non-participant admin still gets
+`{:error, :not_participant}` from `send_message/4`.
+
+## Reading marks nothing
+
+`GetMonitoredConversation.execute/3` has **no `:mark_as_read` option at all**, where
+`GetConversation.execute/3` has one that can be passed by mistake.
+
+This is not fastidiousness. `Participant.last_read_at` is read by three independent
+unread implementations — `ConversationSummary.unread_count` behind the nav badge,
+`ConversationQueries.total_unread_count/1`, and the `ConversationSummaries`
+projection, which re-reads participant rows and routes on whether `last_read_at` is
+nil or dated. An admin view that touched it would silently move somebody else's
+unread count. Omitting the option makes that unexpressible rather than merely
+unused.
+
+For the same reason the listing reads the write-side `conversations` table and not
+`conversation_summaries`: that projection is keyed `(conversation_id, user_id)`, so
+an admin has no row in it, and reading it anyway would return one row per
+participant per conversation.
+
+## The access trail
+
+There is no durable admin-access log, here or anywhere in the app —
+`KlassHeroWeb.AuditInfo` is waiver-specific, and `IncidentLive` and
+`UndeliveredEventLive` both keep no record of which admin viewed what.
+
+Monitoring reads emit an OpenTelemetry span carrying `messaging.monitoring.admin_id`
+and `messaging.monitoring.conversation_id`, plus a `Logger.info` line on the thread
+read. That gives a queryable trail with no new infrastructure, bounded by Honeycomb
+retention.
+
+That is weaker than a table, and weaker than ADR-0017's admin branch, which demands
+a written reason for an attendance correction. It is a deliberate first cut: if a
+subject access request ever has to answer "who read my messages", the span retention
+window is the limit, and a durable log becomes the follow-up.
+
+## Disclosure is part of the feature
+
+Monitoring ships with #745 — a `:system` message in every provider-context
+conversation — and with a "Platform Administrators" clause in the privacy policy,
+whose Data Sharing section previously named only Program Providers and Payment
+Processors.
+
+The capability and its disclosure are one change. Shipping the read path alone would
+create a processing activity disclosed nowhere.
+
+## Consequences
+
+- Messaging now has two read gates. `verify_participant/2` guards everything
+  participant-scoped; `authorize_admin/1` guards monitoring, and nothing else may
+  use it without an ADR amendment.
+- `/admin/messages` is the first admin surface whose authorization lives in a
+  context. The others are unchanged; this is not a call to migrate them.
+- The enumeration oracle in `GetConversation.execute/3` remains open and wants its
+  own issue.

--- a/docs/adr/0021-admin-conversation-reads-authorize-at-the-messaging-boundary.md
+++ b/docs/adr/0021-admin-conversation-reads-authorize-at-the-messaging-boundary.md
@@ -132,5 +132,4 @@ create a processing activity disclosed nowhere.
   use it without an ADR amendment.
 - `/admin/messages` is the first admin surface whose authorization lives in a
   context. The others are unchanged; this is not a call to migrate them.
-- The enumeration oracle in `GetConversation.execute/3` remains open and wants its
-  own issue.
+- The enumeration oracle in `GetConversation.execute/3` remains open; filed as #1515.

--- a/lib/klass_hero/messaging.ex
+++ b/lib/klass_hero/messaging.ex
@@ -39,8 +39,10 @@ defmodule KlassHero.Messaging do
     GetConversation,
     GetConversationContext,
     GetInboundEmail,
+    GetMonitoredConversation,
     GetTotalUnreadCount,
     MarkAsRead,
+    MonitorConversations,
     ReceiveInboundEmail,
     ReplyPrivatelyToBroadcast,
     ReplyToEmail,
@@ -532,6 +534,36 @@ defmodule KlassHero.Messaging do
           | {:error, :not_found | :not_participant}
   defdelegate get_conversation(conversation_id, user_id, opts \\ []),
     to: GetConversation,
+    as: :execute
+
+  @doc """
+  Lists every conversation on the platform, for a platform admin.
+
+  Read-only monitoring (#744). Fails closed for a non-admin scope. Unlike
+  `list_conversations/2` this does not read the per-user `conversation_summaries`
+  projection — an admin has no row there.
+
+  ## Options
+  `:provider_id`, `:type`, `:limit`, `:before`. See
+  `KlassHero.Messaging.MonitorConversations`.
+  """
+  @spec monitor_conversations(Scope.t(), keyword()) ::
+          {:ok, [Conversation.t()], boolean()} | {:error, :unauthorized}
+  defdelegate monitor_conversations(scope, opts \\ []),
+    to: MonitorConversations,
+    as: :execute
+
+  @doc """
+  Reads one conversation's thread for a platform admin who is not a participant.
+
+  Read-only monitoring (#744). Fails closed for a non-admin scope. Deliberately has
+  no `:mark_as_read` option: `last_read_at` feeds three separate unread counters, and
+  an admin viewing a thread must not disturb any of them.
+  """
+  @spec get_monitored_conversation(Scope.t(), String.t(), keyword()) ::
+          {:ok, map()} | {:error, :unauthorized | :not_found}
+  defdelegate get_monitored_conversation(scope, conversation_id, opts \\ []),
+    to: GetMonitoredConversation,
     as: :execute
 
   @doc """

--- a/lib/klass_hero/messaging/authorization.ex
+++ b/lib/klass_hero/messaging/authorization.ex
@@ -1,11 +1,15 @@
 defmodule KlassHero.Messaging.Authorization do
   @moduledoc """
-  The authorisation gate Messaging write commands pass through.
+  The authorisation gate Messaging commands and reads pass through.
 
-  Answers the three questions a command asks before it writes: which provider
-  is this scope acting as, is this user a participant of this conversation, and
-  does this scope's plan permit messaging at all. Staff-addition is owned by
-  `KlassHero.Messaging.AddAssignedStaff`.
+  Answers the three questions a command asks before it writes: which provider is
+  this scope acting as, is this user a participant of this conversation, and does
+  this scope's plan permit messaging at all.
+
+  Plus the one read gate that is not participant-based — `authorize_admin/1`, for
+  platform monitoring. Every other read in this context is gated on a participant
+  row; that one is gated on `is_admin` alone, and is deliberately the only such
+  exception. Staff-addition is owned by `KlassHero.Messaging.AddAssignedStaff`.
   """
 
   use KlassHero.Shared.Tracing
@@ -83,6 +87,32 @@ defmodule KlassHero.Messaging.Authorization do
 
       {:error, :not_participant}
     end
+  end
+
+  @doc """
+  Authorises a platform admin to read conversations they are not a participant of.
+
+  One clause, not an ordered fall-through like `Participation.SessionAuthorization`:
+  admin is not a fallback from some narrower rule here, it *is* the rule. Nobody is
+  narrowly authorised to read every conversation on the platform.
+
+  Callers must ask this **before** they look at a conversation id, so that a
+  non-admin's refusal cannot depend on whether the conversation exists (ADR-0017's
+  enumeration oracle). Past this gate an admin sees everything, so a later
+  `:not_found` discloses nothing they were not already entitled to know.
+
+  `is_admin` is derived, never declared: it lives on the user row and is absent from
+  `registration_changeset`'s cast list, so no request can grant it to itself.
+  """
+  @spec authorize_admin(Scope.t()) :: :ok | {:error, :unauthorized}
+  def authorize_admin(%Scope{user: %{is_admin: true}}), do: :ok
+
+  def authorize_admin(%Scope{} = scope) do
+    Logger.warning("Non-admin scope attempted an admin conversation read",
+      user_id: scope.user.id
+    )
+
+    {:error, :unauthorized}
   end
 
   @doc """

--- a/lib/klass_hero/messaging/get_monitored_conversation.ex
+++ b/lib/klass_hero/messaging/get_monitored_conversation.ex
@@ -1,0 +1,66 @@
+defmodule KlassHero.Messaging.GetMonitoredConversation do
+  @moduledoc """
+  Reads one conversation's full thread for a platform admin who is not a participant.
+
+  The admin counterpart to `KlassHero.Messaging.GetConversation`, and deliberately not
+  a flag on it. Two differences from that module are load-bearing:
+
+  **Authorization runs first.** `GetConversation` fetches the conversation *before*
+  checking the participant row, so its `:not_found` and `:not_participant` are
+  distinguishable to a caller — the enumeration oracle ADR-0017 warns about. Here the
+  admin check comes first, so a non-admin gets `:unauthorized` whatever id they pass,
+  and past the gate an admin is entitled to know whether a conversation exists anyway.
+
+  **There is no `:mark_as_read` option.** `GetConversation.execute/3` has one, so it
+  can be passed by mistake. `Participant.last_read_at` feeds three independent unread
+  counters — `ConversationSummary.unread_count` behind the nav badge,
+  `ConversationQueries.total_unread_count/1`, and the `ConversationSummaries`
+  projection — so an admin viewing a thread must never touch it. Omitting the option
+  makes that unexpressible rather than merely unused.
+  """
+
+  use KlassHero.Shared.Tracing
+
+  alias KlassHero.Accounts.Scope
+  alias KlassHero.Messaging.Authorization
+
+  require Logger
+
+  @doc """
+  Returns `%{conversation:, messages:, has_more:, sender_names:}` for any conversation.
+
+  ## Options
+
+    * `:limit` - messages per page
+    * `:before` - exclusive `inserted_at` cursor for older messages
+  """
+  @spec execute(Scope.t(), String.t(), keyword()) ::
+          {:ok, map()} | {:error, :unauthorized | :not_found}
+  def execute(%Scope{} = scope, conversation_id, opts \\ []) do
+    # The span and the log line together are the access trail: who read which
+    # conversation, when. There is no durable access-log table — see ADR-0021.
+    span do
+      OpenTelemetry.Tracer.set_attribute("messaging.monitoring.admin_id", scope.user.id)
+      OpenTelemetry.Tracer.set_attribute("messaging.monitoring.conversation_id", conversation_id)
+
+      with :ok <- Authorization.authorize_admin(scope),
+           {:ok, conversation} <-
+             KlassHero.Messaging.get_conversation_by_id(conversation_id, preload: [:participants]),
+           {:ok, messages, sender_names, has_more} <-
+             KlassHero.Messaging.list_messages_with_senders(conversation_id, opts) do
+        Logger.info("Admin read a conversation they are not a participant of",
+          conversation_id: conversation_id,
+          user_id: scope.user.id
+        )
+
+        {:ok,
+         %{
+           conversation: conversation,
+           messages: messages,
+           has_more: has_more,
+           sender_names: sender_names
+         }}
+      end
+    end
+  end
+end

--- a/lib/klass_hero/messaging/monitor_conversations.ex
+++ b/lib/klass_hero/messaging/monitor_conversations.ex
@@ -1,0 +1,73 @@
+defmodule KlassHero.Messaging.MonitorConversations do
+  @moduledoc """
+  Lists every conversation on the platform, for a platform admin.
+
+  This is the one read in Messaging that is not scoped to a participant. It exists
+  for safety, abuse prevention and compliance — see #744 and ADR-0021 — and it is
+  strictly read-only: it creates no `Participant` row, writes no `last_read_at`, and
+  subscribes to nothing.
+
+  It deliberately does **not** read the `conversation_summaries` projection. That
+  table is keyed `(conversation_id, user_id)`, so an admin has no row in it, and
+  reading it anyway would yield one row per participant per conversation. The
+  write-side `conversations` table is the only correct source for a platform-wide
+  view.
+  """
+
+  use KlassHero.Shared.Tracing
+
+  alias KlassHero.Accounts.Scope
+  alias KlassHero.Messaging.Authorization
+  alias KlassHero.Messaging.Conversation
+  alias KlassHero.Messaging.Queries.ConversationQueries
+  alias KlassHero.Repo
+
+  @default_limit 25
+
+  @doc """
+  Returns a page of conversations, newest first.
+
+  ## Options
+
+    * `:provider_id` - restrict to one provider
+    * `:type` - `:direct` or `:program_broadcast`
+    * `:limit` - page size, defaults to #{@default_limit}
+    * `:before` - exclusive `inserted_at` cursor for the next (older) page
+
+  Authorization resolves before any option is read, so a non-admin's refusal cannot
+  depend on what they asked for.
+  """
+  @spec execute(Scope.t(), keyword()) ::
+          {:ok, [Conversation.t()], boolean()} | {:error, :unauthorized}
+  def execute(%Scope{} = scope, opts \\ []) do
+    span do
+      OpenTelemetry.Tracer.set_attribute("messaging.monitoring.admin_id", scope.user.id)
+
+      list(scope, opts)
+    end
+  end
+
+  defp list(%Scope{} = scope, opts) do
+    with :ok <- Authorization.authorize_admin(scope) do
+      limit = Keyword.get(opts, :limit, @default_limit)
+
+      rows =
+        ConversationQueries.base()
+        |> maybe_by_provider(Keyword.get(opts, :provider_id))
+        |> maybe_by_type(Keyword.get(opts, :type))
+        |> ConversationQueries.order_by_newest()
+        |> ConversationQueries.paginate(Keyword.put(opts, :limit, limit))
+        |> ConversationQueries.preload_assocs([:participants])
+        |> Repo.all()
+
+      {:ok, Enum.take(rows, limit), length(rows) > limit}
+    end
+  end
+
+  defp maybe_by_provider(query, nil), do: query
+
+  defp maybe_by_provider(query, provider_id), do: ConversationQueries.by_provider(query, provider_id)
+
+  defp maybe_by_type(query, nil), do: query
+  defp maybe_by_type(query, type), do: ConversationQueries.by_type(query, type)
+end

--- a/lib/klass_hero/messaging/queries/conversation_queries.ex
+++ b/lib/klass_hero/messaging/queries/conversation_queries.ex
@@ -138,6 +138,34 @@ defmodule KlassHero.Messaging.Queries.ConversationQueries do
   end
 
   @doc """
+  Order newest first, by creation time.
+  """
+  def order_by_newest(query) do
+    order_by(query, [conversation: c], desc: c.inserted_at, desc: c.id)
+  end
+
+  @doc """
+  Apply seek pagination, newest-first.
+
+  Fetches `limit + 1` rows so the caller can detect a next page without a second
+  `COUNT` — the same trick `MessageQueries.paginate/2` and `list_inbound_emails/1`
+  use. `:before` is an exclusive `inserted_at` cursor.
+  """
+  def paginate(query, opts) do
+    limit = Keyword.get(opts, :limit, 25)
+
+    query
+    |> before(Keyword.get(opts, :before))
+    |> limit(^(limit + 1))
+  end
+
+  defp before(query, nil), do: query
+
+  defp before(query, timestamp) do
+    where(query, [conversation: c], c.inserted_at < ^timestamp)
+  end
+
+  @doc """
   Select only conversation IDs for bulk operations.
   """
   def select_ids(query) do

--- a/lib/klass_hero_web/components/layouts/admin.html.heex
+++ b/lib/klass_hero_web/components/layouts/admin.html.heex
@@ -86,6 +86,11 @@
         "Sessions"
       )}
     </Backpex.HTML.Layout.sidebar_item>
+    <Backpex.HTML.Layout.sidebar_item current_url={@current_url} navigate={~p"/admin/messages"}>
+      <Backpex.HTML.CoreComponents.icon name="hero-chat-bubble-left-right" class="h-5 w-5" /> {gettext(
+        "Messages"
+      )}
+    </Backpex.HTML.Layout.sidebar_item>
   </:sidebar>
 
   <Backpex.HTML.Layout.flash_messages flash={@flash} />

--- a/lib/klass_hero_web/components/messaging_components.ex
+++ b/lib/klass_hero_web/components/messaging_components.ex
@@ -649,6 +649,7 @@ defmodule KlassHeroWeb.MessagingComponents do
       class="flex-1 overflow-y-auto p-4 space-y-3"
       phx-hook="ScrollToBottom"
     >
+      <.monitoring_notice />
       <div id="messages" phx-update="stream" class="space-y-3">
         <.message_bubble
           :for={{dom_id, message} <- @streams.messages}
@@ -670,6 +671,43 @@ defmodule KlassHeroWeb.MessagingComponents do
       <% true -> %>
         <.message_input form={@form} uploads={@uploads} />
     <% end %>
+    """
+  end
+
+  @doc """
+  Renders the standing monitoring notice shown at the top of every conversation.
+
+  A banner rather than a `:system` message (#745 allows either). Three reasons: it
+  needs no write on any of the four conversation-creation paths, all of which run
+  inside a transaction; it covers conversations that already exist, where a
+  create-time message would have needed a backfill; and being rendered rather than
+  stored, it is undeletable by construction.
+
+  Every conversation is anchored to a provider — `provider_id` is required on the
+  schema — so there is no non-provider conversation to exclude yet. When
+  provider-less direct messages exist, gate this on `conversation.provider_id`.
+
+  > The wording is PROVISIONAL and must not ship before legal review (#745).
+  """
+  def monitoring_notice(assigns) do
+    ~H"""
+    <div
+      id="monitoring-notice"
+      data-role="monitoring-notice"
+      class={[
+        "flex items-start gap-2 p-3 mb-3",
+        Theme.bg(:light),
+        Theme.rounded(:lg),
+        Theme.text_color(:muted)
+      ]}
+    >
+      <.icon name="hero-information-circle" class="w-4 h-4 shrink-0 mt-0.5" />
+      <p class={Theme.typography(:caption)}>
+        {gettext(
+          "Messages here may be reviewed by the activity provider and by Klass Hero staff, to keep children safe."
+        )}
+      </p>
+    </div>
     """
   end
 

--- a/lib/klass_hero_web/components/messaging_components.ex
+++ b/lib/klass_hero_web/components/messaging_components.ex
@@ -644,12 +644,12 @@ defmodule KlassHeroWeb.MessagingComponents do
 
   defp message_area(assigns) do
     ~H"""
+    <.monitoring_notice />
     <div
       id="messages-container"
       class="flex-1 overflow-y-auto p-4 space-y-3"
       phx-hook="ScrollToBottom"
     >
-      <.monitoring_notice />
       <div id="messages" phx-update="stream" class="space-y-3">
         <.message_bubble
           :for={{dom_id, message} <- @streams.messages}
@@ -683,6 +683,11 @@ defmodule KlassHeroWeb.MessagingComponents do
   create-time message would have needed a backfill; and being rendered rather than
   stored, it is undeletable by construction.
 
+  Rendered *above* `#messages-container`, not inside it. Inside, it scrolls away with
+  the thread and the `ScrollToBottom` hook lands the reader past it, so on any
+  conversation longer than a screen the notice would never be seen — which for a
+  disclosure is the same as not having one.
+
   Every conversation is anchored to a provider — `provider_id` is required on the
   schema — so there is no non-provider conversation to exclude yet. When
   provider-less direct messages exist, gate this on `conversation.provider_id`.
@@ -695,9 +700,9 @@ defmodule KlassHeroWeb.MessagingComponents do
       id="monitoring-notice"
       data-role="monitoring-notice"
       class={[
-        "flex items-start gap-2 p-3 mb-3",
+        "flex items-start gap-2 px-4 py-2.5 border-b",
         Theme.bg(:light),
-        Theme.rounded(:lg),
+        Theme.border_color(:light),
         Theme.text_color(:muted)
       ]}
     >

--- a/lib/klass_hero_web/live/admin/messages_live.ex
+++ b/lib/klass_hero_web/live/admin/messages_live.ex
@@ -1,0 +1,154 @@
+defmodule KlassHeroWeb.Admin.MessagesLive do
+  @moduledoc """
+  Read-only browser over every conversation on the platform (#744).
+
+  Monitoring, not moderation: this surface lists and reads, and offers no action
+  that writes. It never uses `KlassHeroWeb.MessagingLiveHelper` — that macro injects
+  `send_message`, `validate` and `cancel-upload` handlers into whatever module uses
+  it, so adopting it here would wire a write path into a read-only screen even if no
+  markup triggered it. The thread is composed from `message_bubble/1`, which is
+  purely presentational, rather than from `conversation_show/1`, which requires a
+  form and renders a composer.
+
+  Authorization is `Messaging.authorize_admin/1` inside the context, reached through
+  `monitor_conversations/2` and `get_monitored_conversation/3`. The router's
+  `:require_admin` on_mount stays as defence in depth, not as the guarantee.
+  """
+
+  use KlassHeroWeb, :live_view
+
+  # Only the presentational bubble — importing the whole module would put
+  # `message_input/1` and `conversation_show/1` in scope on a read-only screen.
+  import KlassHeroWeb.MessagingComponents, only: [message_bubble: 1]
+
+  alias KlassHero.Admin.Queries
+  alias KlassHero.Messaging
+  alias KlassHeroWeb.Admin.Components.SearchableSelect
+  alias KlassHeroWeb.Theme
+
+  @page_size 25
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(:fluid?, false)
+     |> assign(:live_resource, nil)
+     |> assign(:page_title, gettext("Messages"))
+     |> assign(:providers, Queries.list_providers_for_select())
+     |> assign(:provider_id, nil)
+     |> assign(:has_more, false)
+     |> assign(:cursor, nil)
+     |> stream(:conversations, [])}
+  end
+
+  # @current_url is assigned by Backpex.InitAssigns' handle_params hook, attached in
+  # the :admin_custom live_session.
+  @impl true
+  def handle_params(params, _uri, socket) do
+    {:noreply, apply_action(socket, socket.assigns.live_action, params)}
+  end
+
+  defp apply_action(socket, :index, params) do
+    provider_id = normalize_uuid(params["provider_id"])
+
+    socket
+    |> assign(:page_title, gettext("Messages"))
+    |> assign(:provider_id, provider_id)
+    |> assign(:selected_provider, find_provider(socket.assigns.providers, provider_id))
+    |> load_page(reset: true)
+  end
+
+  defp apply_action(socket, :show, %{"id" => id}) do
+    with {:ok, uuid} <- Ecto.UUID.cast(id),
+         {:ok, result} <-
+           Messaging.get_monitored_conversation(socket.assigns.current_scope, uuid) do
+      socket
+      |> assign(:conversation, result.conversation)
+      |> assign(:sender_names, result.sender_names)
+      |> assign(:provider_name, provider_name(result.conversation.provider_id))
+      |> assign(:page_title, gettext("Conversation"))
+      |> stream(:messages, Enum.reverse(result.messages), reset: true)
+    else
+      _ ->
+        socket
+        |> put_flash(:error, gettext("Conversation not found."))
+        |> push_navigate(to: ~p"/admin/messages")
+    end
+  end
+
+  @impl true
+  def handle_event("load_more", _params, socket) do
+    {:noreply, load_page(socket, reset: false)}
+  end
+
+  @impl true
+  def handle_info({:select, "provider_id", selected}, socket) do
+    params = if selected, do: %{"provider_id" => selected.id}, else: %{}
+
+    {:noreply, push_patch(socket, to: ~p"/admin/messages?#{params}")}
+  end
+
+  defp load_page(socket, reset: reset?) do
+    opts =
+      [limit: @page_size, provider_id: socket.assigns.provider_id]
+      |> maybe_cursor(reset?, socket.assigns.cursor)
+
+    case Messaging.monitor_conversations(socket.assigns.current_scope, opts) do
+      {:ok, conversations, has_more} ->
+        socket
+        |> stream(:conversations, conversations, reset: reset?)
+        |> assign(:has_more, has_more)
+        |> assign(:cursor, cursor_from(conversations))
+        |> assign(:conversations_empty?, reset? and conversations == [])
+
+      {:error, :unauthorized} ->
+        socket
+        |> put_flash(:error, gettext("You don't have access to that page."))
+        |> push_navigate(to: ~p"/")
+    end
+  end
+
+  defp maybe_cursor(opts, true, _cursor), do: opts
+  defp maybe_cursor(opts, false, nil), do: opts
+  defp maybe_cursor(opts, false, cursor), do: Keyword.put(opts, :before, cursor)
+
+  defp cursor_from([]), do: nil
+  defp cursor_from(conversations), do: List.last(conversations).inserted_at
+
+  defp find_provider(_providers, nil), do: nil
+  defp find_provider(providers, provider_id), do: Enum.find(providers, &(&1.id == provider_id))
+
+  # Row labels come from the dropdown's own list rather than a second query — it is
+  # already loaded, and the filter and the rows then cannot disagree about a name.
+  defp provider_label(providers, provider_id) do
+    case find_provider(providers, provider_id) do
+      %{label: label} -> label
+      nil -> gettext("Unknown provider")
+    end
+  end
+
+  defp provider_name(provider_id) do
+    provider_id
+    |> List.wrap()
+    |> KlassHero.Provider.get_business_names()
+    |> Map.get(provider_id)
+  end
+
+  # A hand-typed `?provider_id=` must not reach Ecto as a malformed UUID.
+  defp normalize_uuid(nil), do: nil
+
+  defp normalize_uuid(value) do
+    case Ecto.UUID.cast(value) do
+      {:ok, uuid} -> uuid
+      :error -> nil
+    end
+  end
+
+  defp conversation_label(%{type: :program_broadcast}), do: gettext("Broadcast")
+  defp conversation_label(%{type: :direct}), do: gettext("Direct")
+
+  defp participant_count(%{participants: participants}) when is_list(participants), do: length(participants)
+
+  defp participant_count(_conversation), do: 0
+end

--- a/lib/klass_hero_web/live/admin/messages_live.html.heex
+++ b/lib/klass_hero_web/live/admin/messages_live.html.heex
@@ -1,0 +1,116 @@
+<div class="p-4 sm:p-6">
+  <%= if @live_action == :index do %>
+    <div class="mb-6">
+      <h1 class={[Theme.typography(:page_title), Theme.text_color(:heading)]}>
+        {gettext("Messages")}
+      </h1>
+      <p class={[Theme.typography(:body_small), Theme.text_color(:muted), "mt-1"]}>
+        {gettext("Read-only view of conversations across all providers.")}
+      </p>
+    </div>
+
+    <div class="mb-4 max-w-sm">
+      <.live_component
+        module={SearchableSelect}
+        id="provider-filter"
+        label={gettext("Provider")}
+        placeholder={gettext("All providers")}
+        field_name="provider_id"
+        options={@providers}
+        selected={@selected_provider}
+      />
+    </div>
+
+    <div id="conversations-table" phx-update="stream">
+      <div
+        id="conversations-empty-state"
+        class="hidden only:block p-8 text-center text-sm opacity-50"
+      >
+        {gettext("No conversations found.")}
+      </div>
+
+      <.link
+        :for={{dom_id, conversation} <- @streams.conversations}
+        id={dom_id}
+        data-role="conversation-row"
+        navigate={~p"/admin/messages/#{conversation.id}"}
+        class="block p-4 rounded-lg border border-base-300 hover:bg-base-200 transition mb-1"
+      >
+        <div class="flex items-start justify-between gap-3">
+          <div class="min-w-0">
+            <p class={[Theme.typography(:card_title), Theme.text_color(:heading), "truncate"]}>
+              {provider_label(@providers, conversation.provider_id)}
+            </p>
+            <p class={[Theme.typography(:body_small), Theme.text_color(:muted), "truncate"]}>
+              {conversation.subject || gettext("No subject")}
+            </p>
+          </div>
+
+          <div class="flex flex-col items-end gap-1 shrink-0">
+            <span class="badge badge-sm">{conversation_label(conversation)}</span>
+            <span class={[Theme.typography(:caption), Theme.text_color(:muted)]}>
+              {ngettext(
+                "%{count} participant",
+                "%{count} participants",
+                participant_count(conversation)
+              )}
+            </span>
+          </div>
+        </div>
+      </.link>
+    </div>
+
+    <div :if={@has_more} class="flex justify-center mt-6">
+      <button
+        type="button"
+        phx-click="load_more"
+        data-role="load-more"
+        class="btn btn-sm btn-outline"
+      >
+        {gettext("Load more")}
+      </button>
+    </div>
+  <% else %>
+    <div class="mb-6">
+      <.link navigate={~p"/admin/messages"} class="text-sm hover:underline">
+        {gettext("← Back to messages")}
+      </.link>
+
+      <h1 class={[Theme.typography(:page_title), Theme.text_color(:heading), "mt-2"]}>
+        {@provider_name || gettext("Conversation")}
+      </h1>
+
+      <p class={[Theme.typography(:body_small), Theme.text_color(:muted), "mt-1"]}>
+        {@conversation.subject || conversation_label(@conversation)}
+      </p>
+
+      <p
+        data-role="monitoring-note"
+        class={[Theme.typography(:caption), Theme.text_color(:muted), "mt-2"]}
+      >
+        {gettext("Read-only. Viewing this thread does not mark anything as read.")}
+      </p>
+    </div>
+
+    <div
+      id="conversation-thread"
+      data-role="conversation-thread"
+      phx-update="stream"
+      class="space-y-3"
+    >
+      <div id="messages-empty-state" class="hidden only:block p-8 text-center text-sm opacity-50">
+        {gettext("No messages in this conversation.")}
+      </div>
+
+      <.message_bubble
+        :for={{dom_id, message} <- @streams.messages}
+        id={dom_id}
+        message={message}
+        is_own={false}
+        sender_name={Map.get(@sender_names, message.sender_id, gettext("Unknown"))}
+        provider_name={@provider_name}
+        is_provider_side={message.sender_role in [:provider, :staff]}
+      />
+    </div>
+  <% end %>
+</div>

--- a/lib/klass_hero_web/live/admin/messages_live.html.heex
+++ b/lib/klass_hero_web/live/admin/messages_live.html.heex
@@ -85,7 +85,7 @@
       </p>
 
       <p
-        data-role="monitoring-note"
+        data-role="admin-readonly-note"
         class={[Theme.typography(:caption), Theme.text_color(:muted), "mt-2"]}
       >
         {gettext("Read-only. Viewing this thread does not mark anything as read.")}

--- a/lib/klass_hero_web/live/privacy_policy_live.ex
+++ b/lib/klass_hero_web/live/privacy_policy_live.ex
@@ -99,6 +99,8 @@ defmodule KlassHeroWeb.PrivacyPolicyLive do
         <p class="mb-4">Providers see enrolled children's names for program management. Optional safety information (support needs, allergies) is visible to providers only when a parent explicitly consents to share it. Session notes written by providers about a child require parent approval before being displayed.</p>
         <h4 class="font-semibold text-gray-900 mb-2">Payment Processors:</h4>
         <p class="mb-4">For credit card payments, we work with third-party payment processors who handle transaction processing securely. They only receive the information necessary to process payments.</p>
+        <h4 class="font-semibold text-gray-900 mb-2">Platform Administrators:</h4>
+        <p class="mb-4">Our staff can read messages exchanged on the platform, for child safety, abuse prevention and to meet our legal obligations. Access is read-only — administrators cannot post, edit or delete messages in your conversations — and every access is logged. Conversations with a provider display a notice telling you this. We look at message content only when there is a safeguarding, abuse or legal reason to.</p>
         <h4 class="font-semibold text-gray-900 mb-2">What We Don't Do:</h4>
         <ul class="list-disc pl-6 space-y-1">
           <li><strong>We never sell your personal data</strong> to third parties</li>

--- a/lib/klass_hero_web/router.ex
+++ b/lib/klass_hero_web/router.ex
@@ -247,6 +247,9 @@ defmodule KlassHeroWeb.Router do
 
         live "/emails", EmailsLive, :index
         live "/emails/:id", EmailsLive, :show
+
+        live "/messages", MessagesLive, :index
+        live "/messages/:id", MessagesLive, :show
       end
     end
   end

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -1489,6 +1489,7 @@ msgstr "Nicht zugewiesen"
 #: lib/klass_hero_web/components/messaging_components.ex:729
 #: lib/klass_hero_web/components/provider_components.ex:52
 #: lib/klass_hero_web/components/provider_components.ex:1553
+#: lib/klass_hero_web/live/admin/messages_live.html.heex:110
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:455
 #: lib/klass_hero_web/presenters/provider_presenter.ex:172
 #, elixir-autogen, elixir-format
@@ -1542,6 +1543,7 @@ msgid "Back to Settings"
 msgstr "Zurück zu Einstellungen"
 
 #: lib/klass_hero_web/components/messaging_components.ex:153
+#: lib/klass_hero_web/live/admin/messages_live.ex:148
 #, elixir-autogen, elixir-format
 msgid "Broadcast"
 msgstr "Rundnachricht"
@@ -1593,6 +1595,8 @@ msgstr "Kind erfolgreich entfernt."
 msgid "Child updated successfully."
 msgstr "Kind erfolgreich aktualisiert."
 
+#: lib/klass_hero_web/live/admin/messages_live.ex:70
+#: lib/klass_hero_web/live/admin/messages_live.html.heex:80
 #: lib/klass_hero_web/live/dashboard_live.ex:178
 #: lib/klass_hero_web/live/messaging_live_helper.ex:413
 #, elixir-autogen, elixir-format
@@ -1699,9 +1703,13 @@ msgstr "Verwalten Sie die Profile Ihrer Kinder"
 msgid "Message content is required"
 msgstr "Nachrichteninhalt ist erforderlich"
 
+#: lib/klass_hero_web/components/layouts/admin.html.heex:90
 #: lib/klass_hero_web/components/layouts/app.html.heex:214
 #: lib/klass_hero_web/components/messaging_components.ex:506
 #: lib/klass_hero_web/components/messaging_components.ex:529
+#: lib/klass_hero_web/live/admin/messages_live.ex:37
+#: lib/klass_hero_web/live/admin/messages_live.ex:56
+#: lib/klass_hero_web/live/admin/messages_live.html.heex:5
 #: lib/klass_hero_web/live/messages_live/index.ex:19
 #: lib/klass_hero_web/live/messaging_live_helper.ex:365
 #, elixir-autogen, elixir-format
@@ -2964,6 +2972,7 @@ msgstr "Verifiziert"
 msgid "We are Klass Hero — parents, brothers, and partners of educators — building the infrastructure that helps every child learn and thrive."
 msgstr "Wir sind Klass Hero — Eltern, Brüder und Partner von Pädagogen — und bauen die Infrastruktur auf, die jedem Kind hilft, zu lernen und zu wachsen."
 
+#: lib/klass_hero_web/live/admin/messages_live.ex:107
 #: lib/klass_hero_web/user_auth.ex:298
 #, elixir-autogen, elixir-format
 msgid "You don't have access to that page."
@@ -3699,6 +3708,7 @@ msgstr "Admin"
 msgid "All programs"
 msgstr "Alle Programme"
 
+#: lib/klass_hero_web/live/admin/messages_live.html.heex:17
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "All providers"
@@ -4134,6 +4144,7 @@ msgid "Program is required"
 msgstr "Programm ist erforderlich"
 
 #: lib/klass_hero_web/components/provider_layout_components.ex:76
+#: lib/klass_hero_web/live/admin/messages_live.html.heex:16
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:12
 #: lib/klass_hero_web/persona.ex:123
 #, elixir-autogen, elixir-format
@@ -8108,3 +8119,60 @@ msgstr "Vorschau anzeigen"
 #, elixir-autogen, elixir-format
 msgid "e.g. %{example}"
 msgstr "z. B. %{example}"
+
+#: lib/klass_hero_web/live/admin/messages_live.html.heex:52
+#, elixir-autogen, elixir-format
+msgid "%{count} participant"
+msgid_plural "%{count} participants"
+msgstr[0] "%{count} Teilnehmer"
+msgstr[1] "%{count} Teilnehmer"
+
+#: lib/klass_hero_web/live/admin/messages_live.ex:75
+#, elixir-autogen, elixir-format
+msgid "Conversation not found."
+msgstr "Unterhaltung nicht gefunden."
+
+#: lib/klass_hero_web/live/admin/messages_live.ex:149
+#, elixir-autogen, elixir-format
+msgid "Direct"
+msgstr "Direktnachricht"
+
+#: lib/klass_hero_web/live/admin/messages_live.html.heex:70
+#, elixir-autogen, elixir-format
+msgid "Load more"
+msgstr "Mehr laden"
+
+#: lib/klass_hero_web/live/admin/messages_live.html.heex:29
+#, elixir-autogen, elixir-format
+msgid "No conversations found."
+msgstr "Keine Unterhaltungen gefunden."
+
+#: lib/klass_hero_web/live/admin/messages_live.html.heex:102
+#, elixir-autogen, elixir-format
+msgid "No messages in this conversation."
+msgstr "Keine Nachrichten in dieser Unterhaltung."
+
+#: lib/klass_hero_web/live/admin/messages_live.html.heex:45
+#, elixir-autogen, elixir-format
+msgid "No subject"
+msgstr "Kein Betreff"
+
+#: lib/klass_hero_web/live/admin/messages_live.html.heex:8
+#, elixir-autogen, elixir-format
+msgid "Read-only view of conversations across all providers."
+msgstr "Schreibgeschützte Ansicht aller Unterhaltungen über alle Anbieter hinweg."
+
+#: lib/klass_hero_web/live/admin/messages_live.html.heex:91
+#, elixir-autogen, elixir-format
+msgid "Read-only. Viewing this thread does not mark anything as read."
+msgstr "Schreibgeschützt. Das Ansehen dieser Unterhaltung markiert nichts als gelesen."
+
+#: lib/klass_hero_web/live/admin/messages_live.ex:127
+#, elixir-autogen, elixir-format
+msgid "Unknown provider"
+msgstr "Unbekannter Anbieter"
+
+#: lib/klass_hero_web/live/admin/messages_live.html.heex:76
+#, elixir-autogen, elixir-format
+msgid "← Back to messages"
+msgstr "← Zurück zu den Nachrichten"

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -456,7 +456,7 @@ msgstr "E-Mail ändern"
 msgid "Changes to Terms"
 msgstr "Änderungen der Bedingungen"
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:205
+#: lib/klass_hero_web/live/privacy_policy_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Changes to This Policy"
 msgstr "Änderungen dieser Richtlinie"
@@ -476,7 +476,7 @@ msgstr "Kind erfolgreich eingecheckt"
 msgid "Child checked out successfully"
 msgstr "Kind erfolgreich ausgecheckt"
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:153
+#: lib/klass_hero_web/live/privacy_policy_live.ex:155
 #, elixir-autogen, elixir-format
 msgid "Children's Privacy"
 msgstr "Datenschutz für Kinder"
@@ -515,12 +515,12 @@ msgstr "Kontaktdaten"
 #: lib/klass_hero_web/components/composite_components.ex:601
 #: lib/klass_hero_web/live/contact_live.ex:16
 #: lib/klass_hero_web/live/contact_live.ex:107
-#: lib/klass_hero_web/live/privacy_policy_live.ex:221
+#: lib/klass_hero_web/live/privacy_policy_live.ex:223
 #, elixir-autogen, elixir-format
 msgid "Contact Us"
 msgstr "Kontakt"
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:174
+#: lib/klass_hero_web/live/privacy_policy_live.ex:176
 #, elixir-autogen, elixir-format
 msgid "Cookies & Tracking"
 msgstr "Cookies & Tracking"
@@ -541,12 +541,12 @@ msgstr "Programme, Aktivitäten und Dienstleistungen für Familien erstellen und
 msgid "Creating account..."
 msgstr "Konto wird erstellt..."
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:190
+#: lib/klass_hero_web/live/privacy_policy_live.ex:192
 #, elixir-autogen, elixir-format
 msgid "Data Retention"
 msgstr "Datenspeicherung"
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:136
+#: lib/klass_hero_web/live/privacy_policy_live.ex:138
 #, elixir-autogen, elixir-format
 msgid "Data Security"
 msgstr "Datensicherheit"
@@ -821,7 +821,7 @@ msgstr "Telefon"
 
 #: lib/klass_hero_web/components/composite_components.ex:487
 #: lib/klass_hero_web/live/privacy_policy_live.ex:11
-#: lib/klass_hero_web/live/privacy_policy_live.ex:239
+#: lib/klass_hero_web/live/privacy_policy_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "Privacy Policy"
 msgstr "Datenschutzerklärung"
@@ -836,7 +836,7 @@ msgstr "Programm-Anmeldung & Buchungen"
 msgid "Program Question"
 msgstr "Programmfrage"
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:243
+#: lib/klass_hero_web/live/privacy_policy_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "Questions About Privacy?"
 msgstr "Fragen zum Datenschutz?"
@@ -971,7 +971,7 @@ msgstr "Nutzerverhalten & Verantwortlichkeiten"
 msgid "We're here to clarify any questions you may have."
 msgstr "Wir sind hier, um alle Ihre Fragen zu klären."
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:244
+#: lib/klass_hero_web/live/privacy_policy_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "We're here to help with any privacy-related concerns."
 msgstr "Wir sind hier, um bei allen datenschutzbezogenen Fragen zu helfen."
@@ -1012,7 +1012,7 @@ msgstr "Sie müssen sich erneut authentifizieren, um auf diese Seite zuzugreifen
 msgid "You need to reauthenticate to perform sensitive actions on your account."
 msgstr "Sie müssen sich erneut authentifizieren, um sensible Aktionen auf Ihrem Konto durchzuführen."
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:114
+#: lib/klass_hero_web/live/privacy_policy_live.ex:116
 #, elixir-autogen, elixir-format
 msgid "Your Privacy Rights"
 msgstr "Ihre Datenschutzrechte"
@@ -1022,7 +1022,7 @@ msgstr "Ihre Datenschutzrechte"
 msgid "Your account has been deleted."
 msgstr "Ihr Konto wurde gelöscht."
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:240
+#: lib/klass_hero_web/live/privacy_policy_live.ex:242
 #, elixir-autogen, elixir-format
 msgid "Your privacy matters to us"
 msgstr "Ihre Privatsphäre ist uns wichtig"
@@ -1486,7 +1486,7 @@ msgstr "Team- & Anbieterprofile"
 msgid "Unassigned"
 msgstr "Nicht zugewiesen"
 
-#: lib/klass_hero_web/components/messaging_components.ex:729
+#: lib/klass_hero_web/components/messaging_components.ex:767
 #: lib/klass_hero_web/components/provider_components.ex:52
 #: lib/klass_hero_web/components/provider_components.ex:1553
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:110
@@ -1506,7 +1506,7 @@ msgstr "Teilnehmerliste"
 msgid "%{age} years old"
 msgstr "%{age} Jahre alt"
 
-#: lib/klass_hero_web/components/messaging_components.ex:749
+#: lib/klass_hero_web/components/messaging_components.ex:787
 #, elixir-autogen, elixir-format
 msgid "%{n}m ago"
 msgstr "vor %{n} Min."
@@ -1728,7 +1728,7 @@ msgid "No conversations yet"
 msgstr "Noch keine Unterhaltungen"
 
 #: lib/klass_hero_web/components/messaging_components.ex:445
-#: lib/klass_hero_web/components/messaging_components.ex:771
+#: lib/klass_hero_web/components/messaging_components.ex:809
 #, elixir-autogen, elixir-format
 msgid "No messages yet"
 msgstr "Noch keine Nachrichten"
@@ -1760,7 +1760,7 @@ msgstr "Notiz abgelehnt"
 msgid "Note resubmitted for review"
 msgstr "Notiz erneut zur Überprüfung eingereicht"
 
-#: lib/klass_hero_web/components/messaging_components.ex:748
+#: lib/klass_hero_web/components/messaging_components.ex:786
 #, elixir-autogen, elixir-format
 msgid "Now"
 msgstr "Jetzt"
@@ -1800,7 +1800,7 @@ msgstr "Bitte authentifizieren Sie sich erneut, um Ihr Konto zu löschen."
 msgid "Please set up your parent profile to manage children."
 msgstr "Bitte richten Sie Ihr Elternprofil ein, um Kinder zu verwalten."
 
-#: lib/klass_hero_web/components/messaging_components.ex:722
+#: lib/klass_hero_web/components/messaging_components.ex:760
 #: lib/klass_hero_web/live/messaging_live_helper.ex:409
 #, elixir-autogen, elixir-format
 msgid "Program Broadcast"
@@ -2099,7 +2099,7 @@ msgstr "Ablehnung bestätigen"
 msgid "Confirmed"
 msgstr "Bestätigt"
 
-#: lib/klass_hero_web/components/messaging_components.ex:823
+#: lib/klass_hero_web/components/messaging_components.ex:861
 #, elixir-autogen, elixir-format
 msgid "Contact Provider"
 msgstr "Anbieter kontaktieren"
@@ -3751,7 +3751,7 @@ msgstr "Zurück zu Sitzungen"
 msgid "Back to emails"
 msgstr "Zurück zu E-Mails"
 
-#: lib/klass_hero_web/components/messaging_components.ex:689
+#: lib/klass_hero_web/components/messaging_components.ex:727
 #, elixir-autogen, elixir-format
 msgid "Broadcast messages are one-way"
 msgstr "Broadcast-Nachrichten sind einseitig"
@@ -4172,7 +4172,7 @@ msgstr "Grund für die Ablehnung (optional)"
 msgid "Reply"
 msgstr "Antworten"
 
-#: lib/klass_hero_web/components/messaging_components.ex:700
+#: lib/klass_hero_web/components/messaging_components.ex:738
 #, elixir-autogen, elixir-format
 msgid "Reply privately"
 msgstr "Privat antworten"
@@ -4469,7 +4469,7 @@ msgstr "Vervollständigen Sie Ihr Anbieterprofil"
 msgid "Failed to upload files. Please try again."
 msgstr "Hochladen der Dateien fehlgeschlagen. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/components/messaging_components.ex:775
+#: lib/klass_hero_web/components/messaging_components.ex:813
 #, elixir-autogen, elixir-format
 msgid "File is too large (max %{mb} MB)"
 msgstr "Datei ist zu groß (max. %{mb} MB)"
@@ -4479,7 +4479,7 @@ msgstr "Datei ist zu groß (max. %{mb} MB)"
 msgid "File is too large (max %{mb} MB)."
 msgstr "Datei ist zu groß (max. %{mb} MB)."
 
-#: lib/klass_hero_web/components/messaging_components.ex:778
+#: lib/klass_hero_web/components/messaging_components.ex:816
 #, elixir-autogen, elixir-format
 msgid "File type not accepted (images only)"
 msgstr "Dateityp nicht akzeptiert (nur Bilder)"
@@ -4499,8 +4499,8 @@ msgstr "Geben Sie Ihre Unternehmensdaten ein. Ihr Profil wird von Klass Hero gep
 msgid "Only images are accepted (JPG, PNG, GIF, WebP)."
 msgstr "Nur Bilder werden akzeptiert (JPG, PNG, GIF, WebP)."
 
-#: lib/klass_hero_web/components/messaging_components.ex:760
-#: lib/klass_hero_web/components/messaging_components.ex:764
+#: lib/klass_hero_web/components/messaging_components.ex:798
+#: lib/klass_hero_web/components/messaging_components.ex:802
 #, elixir-autogen, elixir-format
 msgid "Photo"
 msgstr "Foto"
@@ -4540,7 +4540,7 @@ msgstr "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut."
 msgid "Tell parents about your organization and what makes you unique..."
 msgstr "Erzählen Sie Eltern von Ihrer Organisation und was Sie einzigartig macht..."
 
-#: lib/klass_hero_web/components/messaging_components.ex:782
+#: lib/klass_hero_web/components/messaging_components.ex:820
 #, elixir-autogen, elixir-format
 msgid "Too many files (max %{max})"
 msgstr "Zu viele Dateien (max. %{max})"
@@ -4550,12 +4550,12 @@ msgstr "Zu viele Dateien (max. %{max})"
 msgid "Too many files (max %{max})."
 msgstr "Zu viele Dateien (max. %{max})."
 
-#: lib/klass_hero_web/components/messaging_components.ex:786
+#: lib/klass_hero_web/components/messaging_components.ex:824
 #, elixir-autogen, elixir-format
 msgid "Upload error"
 msgstr "Upload-Fehler"
 
-#: lib/klass_hero_web/components/messaging_components.ex:785
+#: lib/klass_hero_web/components/messaging_components.ex:823
 #, elixir-autogen, elixir-format
 msgid "Upload failed"
 msgstr "Hochladen fehlgeschlagen"
@@ -5941,7 +5941,7 @@ msgstr "Primär"
 
 #: lib/klass_hero_web/components/marketing_components.ex:810
 #: lib/klass_hero_web/components/marketing_components.ex:857
-#: lib/klass_hero_web/live/privacy_policy_live.ex:238
+#: lib/klass_hero_web/live/privacy_policy_live.ex:240
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr "Datenschutz"
@@ -8176,3 +8176,8 @@ msgstr "Unbekannter Anbieter"
 #, elixir-autogen, elixir-format
 msgid "← Back to messages"
 msgstr "← Zurück zu den Nachrichten"
+
+#: lib/klass_hero_web/components/messaging_components.ex:706
+#, elixir-autogen, elixir-format
+msgid "Messages here may be reviewed by the activity provider and by Klass Hero staff, to keep children safe."
+msgstr "Nachrichten hier können vom Anbieter und von Klass Hero-Mitarbeitenden eingesehen werden, um Kinder zu schützen."

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -1486,7 +1486,7 @@ msgstr "Team- & Anbieterprofile"
 msgid "Unassigned"
 msgstr "Nicht zugewiesen"
 
-#: lib/klass_hero_web/components/messaging_components.ex:767
+#: lib/klass_hero_web/components/messaging_components.ex:772
 #: lib/klass_hero_web/components/provider_components.ex:52
 #: lib/klass_hero_web/components/provider_components.ex:1553
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:110
@@ -1506,7 +1506,7 @@ msgstr "Teilnehmerliste"
 msgid "%{age} years old"
 msgstr "%{age} Jahre alt"
 
-#: lib/klass_hero_web/components/messaging_components.ex:787
+#: lib/klass_hero_web/components/messaging_components.ex:792
 #, elixir-autogen, elixir-format
 msgid "%{n}m ago"
 msgstr "vor %{n} Min."
@@ -1728,7 +1728,7 @@ msgid "No conversations yet"
 msgstr "Noch keine Unterhaltungen"
 
 #: lib/klass_hero_web/components/messaging_components.ex:445
-#: lib/klass_hero_web/components/messaging_components.ex:809
+#: lib/klass_hero_web/components/messaging_components.ex:814
 #, elixir-autogen, elixir-format
 msgid "No messages yet"
 msgstr "Noch keine Nachrichten"
@@ -1760,7 +1760,7 @@ msgstr "Notiz abgelehnt"
 msgid "Note resubmitted for review"
 msgstr "Notiz erneut zur Überprüfung eingereicht"
 
-#: lib/klass_hero_web/components/messaging_components.ex:786
+#: lib/klass_hero_web/components/messaging_components.ex:791
 #, elixir-autogen, elixir-format
 msgid "Now"
 msgstr "Jetzt"
@@ -1800,7 +1800,7 @@ msgstr "Bitte authentifizieren Sie sich erneut, um Ihr Konto zu löschen."
 msgid "Please set up your parent profile to manage children."
 msgstr "Bitte richten Sie Ihr Elternprofil ein, um Kinder zu verwalten."
 
-#: lib/klass_hero_web/components/messaging_components.ex:760
+#: lib/klass_hero_web/components/messaging_components.ex:765
 #: lib/klass_hero_web/live/messaging_live_helper.ex:409
 #, elixir-autogen, elixir-format
 msgid "Program Broadcast"
@@ -2099,7 +2099,7 @@ msgstr "Ablehnung bestätigen"
 msgid "Confirmed"
 msgstr "Bestätigt"
 
-#: lib/klass_hero_web/components/messaging_components.ex:861
+#: lib/klass_hero_web/components/messaging_components.ex:866
 #, elixir-autogen, elixir-format
 msgid "Contact Provider"
 msgstr "Anbieter kontaktieren"
@@ -3751,7 +3751,7 @@ msgstr "Zurück zu Sitzungen"
 msgid "Back to emails"
 msgstr "Zurück zu E-Mails"
 
-#: lib/klass_hero_web/components/messaging_components.ex:727
+#: lib/klass_hero_web/components/messaging_components.ex:732
 #, elixir-autogen, elixir-format
 msgid "Broadcast messages are one-way"
 msgstr "Broadcast-Nachrichten sind einseitig"
@@ -4172,7 +4172,7 @@ msgstr "Grund für die Ablehnung (optional)"
 msgid "Reply"
 msgstr "Antworten"
 
-#: lib/klass_hero_web/components/messaging_components.ex:738
+#: lib/klass_hero_web/components/messaging_components.ex:743
 #, elixir-autogen, elixir-format
 msgid "Reply privately"
 msgstr "Privat antworten"
@@ -4469,7 +4469,7 @@ msgstr "Vervollständigen Sie Ihr Anbieterprofil"
 msgid "Failed to upload files. Please try again."
 msgstr "Hochladen der Dateien fehlgeschlagen. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/components/messaging_components.ex:813
+#: lib/klass_hero_web/components/messaging_components.ex:818
 #, elixir-autogen, elixir-format
 msgid "File is too large (max %{mb} MB)"
 msgstr "Datei ist zu groß (max. %{mb} MB)"
@@ -4479,7 +4479,7 @@ msgstr "Datei ist zu groß (max. %{mb} MB)"
 msgid "File is too large (max %{mb} MB)."
 msgstr "Datei ist zu groß (max. %{mb} MB)."
 
-#: lib/klass_hero_web/components/messaging_components.ex:816
+#: lib/klass_hero_web/components/messaging_components.ex:821
 #, elixir-autogen, elixir-format
 msgid "File type not accepted (images only)"
 msgstr "Dateityp nicht akzeptiert (nur Bilder)"
@@ -4499,8 +4499,8 @@ msgstr "Geben Sie Ihre Unternehmensdaten ein. Ihr Profil wird von Klass Hero gep
 msgid "Only images are accepted (JPG, PNG, GIF, WebP)."
 msgstr "Nur Bilder werden akzeptiert (JPG, PNG, GIF, WebP)."
 
-#: lib/klass_hero_web/components/messaging_components.ex:798
-#: lib/klass_hero_web/components/messaging_components.ex:802
+#: lib/klass_hero_web/components/messaging_components.ex:803
+#: lib/klass_hero_web/components/messaging_components.ex:807
 #, elixir-autogen, elixir-format
 msgid "Photo"
 msgstr "Foto"
@@ -4540,7 +4540,7 @@ msgstr "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut."
 msgid "Tell parents about your organization and what makes you unique..."
 msgstr "Erzählen Sie Eltern von Ihrer Organisation und was Sie einzigartig macht..."
 
-#: lib/klass_hero_web/components/messaging_components.ex:820
+#: lib/klass_hero_web/components/messaging_components.ex:825
 #, elixir-autogen, elixir-format
 msgid "Too many files (max %{max})"
 msgstr "Zu viele Dateien (max. %{max})"
@@ -4550,12 +4550,12 @@ msgstr "Zu viele Dateien (max. %{max})"
 msgid "Too many files (max %{max})."
 msgstr "Zu viele Dateien (max. %{max})."
 
-#: lib/klass_hero_web/components/messaging_components.ex:824
+#: lib/klass_hero_web/components/messaging_components.ex:829
 #, elixir-autogen, elixir-format
 msgid "Upload error"
 msgstr "Upload-Fehler"
 
-#: lib/klass_hero_web/components/messaging_components.ex:823
+#: lib/klass_hero_web/components/messaging_components.ex:828
 #, elixir-autogen, elixir-format
 msgid "Upload failed"
 msgstr "Hochladen fehlgeschlagen"
@@ -8177,7 +8177,7 @@ msgstr "Unbekannter Anbieter"
 msgid "← Back to messages"
 msgstr "← Zurück zu den Nachrichten"
 
-#: lib/klass_hero_web/components/messaging_components.ex:706
+#: lib/klass_hero_web/components/messaging_components.ex:711
 #, elixir-autogen, elixir-format
 msgid "Messages here may be reviewed by the activity provider and by Klass Hero staff, to keep children safe."
 msgstr "Nachrichten hier können vom Anbieter und von Klass Hero-Mitarbeitenden eingesehen werden, um Kinder zu schützen."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -1486,7 +1486,7 @@ msgstr ""
 msgid "Unassigned"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:767
+#: lib/klass_hero_web/components/messaging_components.ex:772
 #: lib/klass_hero_web/components/provider_components.ex:52
 #: lib/klass_hero_web/components/provider_components.ex:1553
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:110
@@ -1506,7 +1506,7 @@ msgstr ""
 msgid "%{age} years old"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:787
+#: lib/klass_hero_web/components/messaging_components.ex:792
 #, elixir-autogen, elixir-format
 msgid "%{n}m ago"
 msgstr ""
@@ -1728,7 +1728,7 @@ msgid "No conversations yet"
 msgstr ""
 
 #: lib/klass_hero_web/components/messaging_components.ex:445
-#: lib/klass_hero_web/components/messaging_components.ex:809
+#: lib/klass_hero_web/components/messaging_components.ex:814
 #, elixir-autogen, elixir-format
 msgid "No messages yet"
 msgstr ""
@@ -1760,7 +1760,7 @@ msgstr ""
 msgid "Note resubmitted for review"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:786
+#: lib/klass_hero_web/components/messaging_components.ex:791
 #, elixir-autogen, elixir-format
 msgid "Now"
 msgstr ""
@@ -1800,7 +1800,7 @@ msgstr ""
 msgid "Please set up your parent profile to manage children."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:760
+#: lib/klass_hero_web/components/messaging_components.ex:765
 #: lib/klass_hero_web/live/messaging_live_helper.ex:409
 #, elixir-autogen, elixir-format
 msgid "Program Broadcast"
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "Confirmed"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:861
+#: lib/klass_hero_web/components/messaging_components.ex:866
 #, elixir-autogen, elixir-format
 msgid "Contact Provider"
 msgstr ""
@@ -3751,7 +3751,7 @@ msgstr ""
 msgid "Back to emails"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:727
+#: lib/klass_hero_web/components/messaging_components.ex:732
 #, elixir-autogen, elixir-format
 msgid "Broadcast messages are one-way"
 msgstr ""
@@ -4172,7 +4172,7 @@ msgstr ""
 msgid "Reply"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:738
+#: lib/klass_hero_web/components/messaging_components.ex:743
 #, elixir-autogen, elixir-format
 msgid "Reply privately"
 msgstr ""
@@ -4469,7 +4469,7 @@ msgstr ""
 msgid "Failed to upload files. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:813
+#: lib/klass_hero_web/components/messaging_components.ex:818
 #, elixir-autogen, elixir-format
 msgid "File is too large (max %{mb} MB)"
 msgstr ""
@@ -4479,7 +4479,7 @@ msgstr ""
 msgid "File is too large (max %{mb} MB)."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:816
+#: lib/klass_hero_web/components/messaging_components.ex:821
 #, elixir-autogen, elixir-format
 msgid "File type not accepted (images only)"
 msgstr ""
@@ -4499,8 +4499,8 @@ msgstr ""
 msgid "Only images are accepted (JPG, PNG, GIF, WebP)."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:798
-#: lib/klass_hero_web/components/messaging_components.ex:802
+#: lib/klass_hero_web/components/messaging_components.ex:803
+#: lib/klass_hero_web/components/messaging_components.ex:807
 #, elixir-autogen, elixir-format
 msgid "Photo"
 msgstr ""
@@ -4540,7 +4540,7 @@ msgstr ""
 msgid "Tell parents about your organization and what makes you unique..."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:820
+#: lib/klass_hero_web/components/messaging_components.ex:825
 #, elixir-autogen, elixir-format
 msgid "Too many files (max %{max})"
 msgstr ""
@@ -4550,12 +4550,12 @@ msgstr ""
 msgid "Too many files (max %{max})."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:824
+#: lib/klass_hero_web/components/messaging_components.ex:829
 #, elixir-autogen, elixir-format
 msgid "Upload error"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:823
+#: lib/klass_hero_web/components/messaging_components.ex:828
 #, elixir-autogen, elixir-format
 msgid "Upload failed"
 msgstr ""
@@ -8159,7 +8159,7 @@ msgstr ""
 msgid "← Back to messages"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:706
+#: lib/klass_hero_web/components/messaging_components.ex:711
 #, elixir-autogen, elixir-format
 msgid "Messages here may be reviewed by the activity provider and by Klass Hero staff, to keep children safe."
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -1489,6 +1489,7 @@ msgstr ""
 #: lib/klass_hero_web/components/messaging_components.ex:729
 #: lib/klass_hero_web/components/provider_components.ex:52
 #: lib/klass_hero_web/components/provider_components.ex:1553
+#: lib/klass_hero_web/live/admin/messages_live.html.heex:110
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:455
 #: lib/klass_hero_web/presenters/provider_presenter.ex:172
 #, elixir-autogen, elixir-format
@@ -1542,6 +1543,7 @@ msgid "Back to Settings"
 msgstr ""
 
 #: lib/klass_hero_web/components/messaging_components.ex:153
+#: lib/klass_hero_web/live/admin/messages_live.ex:148
 #, elixir-autogen, elixir-format
 msgid "Broadcast"
 msgstr ""
@@ -1593,6 +1595,8 @@ msgstr ""
 msgid "Child updated successfully."
 msgstr ""
 
+#: lib/klass_hero_web/live/admin/messages_live.ex:70
+#: lib/klass_hero_web/live/admin/messages_live.html.heex:80
 #: lib/klass_hero_web/live/dashboard_live.ex:178
 #: lib/klass_hero_web/live/messaging_live_helper.ex:413
 #, elixir-autogen, elixir-format
@@ -1699,9 +1703,13 @@ msgstr ""
 msgid "Message content is required"
 msgstr ""
 
+#: lib/klass_hero_web/components/layouts/admin.html.heex:90
 #: lib/klass_hero_web/components/layouts/app.html.heex:214
 #: lib/klass_hero_web/components/messaging_components.ex:506
 #: lib/klass_hero_web/components/messaging_components.ex:529
+#: lib/klass_hero_web/live/admin/messages_live.ex:37
+#: lib/klass_hero_web/live/admin/messages_live.ex:56
+#: lib/klass_hero_web/live/admin/messages_live.html.heex:5
 #: lib/klass_hero_web/live/messages_live/index.ex:19
 #: lib/klass_hero_web/live/messaging_live_helper.ex:365
 #, elixir-autogen, elixir-format
@@ -2964,6 +2972,7 @@ msgstr ""
 msgid "We are Klass Hero — parents, brothers, and partners of educators — building the infrastructure that helps every child learn and thrive."
 msgstr ""
 
+#: lib/klass_hero_web/live/admin/messages_live.ex:107
 #: lib/klass_hero_web/user_auth.ex:298
 #, elixir-autogen, elixir-format
 msgid "You don't have access to that page."
@@ -3699,6 +3708,7 @@ msgstr ""
 msgid "All programs"
 msgstr ""
 
+#: lib/klass_hero_web/live/admin/messages_live.html.heex:17
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:13
 #, elixir-autogen, elixir-format
 msgid "All providers"
@@ -4134,6 +4144,7 @@ msgid "Program is required"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_layout_components.ex:76
+#: lib/klass_hero_web/live/admin/messages_live.html.heex:16
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:12
 #: lib/klass_hero_web/persona.ex:123
 #, elixir-autogen, elixir-format
@@ -8089,4 +8100,61 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:3174
 #, elixir-autogen, elixir-format
 msgid "e.g. %{example}"
+msgstr ""
+
+#: lib/klass_hero_web/live/admin/messages_live.html.heex:52
+#, elixir-autogen, elixir-format
+msgid "%{count} participant"
+msgid_plural "%{count} participants"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/klass_hero_web/live/admin/messages_live.ex:75
+#, elixir-autogen, elixir-format
+msgid "Conversation not found."
+msgstr ""
+
+#: lib/klass_hero_web/live/admin/messages_live.ex:149
+#, elixir-autogen, elixir-format
+msgid "Direct"
+msgstr ""
+
+#: lib/klass_hero_web/live/admin/messages_live.html.heex:70
+#, elixir-autogen, elixir-format
+msgid "Load more"
+msgstr ""
+
+#: lib/klass_hero_web/live/admin/messages_live.html.heex:29
+#, elixir-autogen, elixir-format
+msgid "No conversations found."
+msgstr ""
+
+#: lib/klass_hero_web/live/admin/messages_live.html.heex:102
+#, elixir-autogen, elixir-format
+msgid "No messages in this conversation."
+msgstr ""
+
+#: lib/klass_hero_web/live/admin/messages_live.html.heex:45
+#, elixir-autogen, elixir-format
+msgid "No subject"
+msgstr ""
+
+#: lib/klass_hero_web/live/admin/messages_live.html.heex:8
+#, elixir-autogen, elixir-format
+msgid "Read-only view of conversations across all providers."
+msgstr ""
+
+#: lib/klass_hero_web/live/admin/messages_live.html.heex:91
+#, elixir-autogen, elixir-format
+msgid "Read-only. Viewing this thread does not mark anything as read."
+msgstr ""
+
+#: lib/klass_hero_web/live/admin/messages_live.ex:127
+#, elixir-autogen, elixir-format
+msgid "Unknown provider"
+msgstr ""
+
+#: lib/klass_hero_web/live/admin/messages_live.html.heex:76
+#, elixir-autogen, elixir-format
+msgid "← Back to messages"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -456,7 +456,7 @@ msgstr ""
 msgid "Changes to Terms"
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:205
+#: lib/klass_hero_web/live/privacy_policy_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Changes to This Policy"
 msgstr ""
@@ -476,7 +476,7 @@ msgstr ""
 msgid "Child checked out successfully"
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:153
+#: lib/klass_hero_web/live/privacy_policy_live.ex:155
 #, elixir-autogen, elixir-format
 msgid "Children's Privacy"
 msgstr ""
@@ -515,12 +515,12 @@ msgstr ""
 #: lib/klass_hero_web/components/composite_components.ex:601
 #: lib/klass_hero_web/live/contact_live.ex:16
 #: lib/klass_hero_web/live/contact_live.ex:107
-#: lib/klass_hero_web/live/privacy_policy_live.ex:221
+#: lib/klass_hero_web/live/privacy_policy_live.ex:223
 #, elixir-autogen, elixir-format
 msgid "Contact Us"
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:174
+#: lib/klass_hero_web/live/privacy_policy_live.ex:176
 #, elixir-autogen, elixir-format
 msgid "Cookies & Tracking"
 msgstr ""
@@ -541,12 +541,12 @@ msgstr ""
 msgid "Creating account..."
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:190
+#: lib/klass_hero_web/live/privacy_policy_live.ex:192
 #, elixir-autogen, elixir-format
 msgid "Data Retention"
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:136
+#: lib/klass_hero_web/live/privacy_policy_live.ex:138
 #, elixir-autogen, elixir-format
 msgid "Data Security"
 msgstr ""
@@ -821,7 +821,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/composite_components.ex:487
 #: lib/klass_hero_web/live/privacy_policy_live.ex:11
-#: lib/klass_hero_web/live/privacy_policy_live.ex:239
+#: lib/klass_hero_web/live/privacy_policy_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "Privacy Policy"
 msgstr ""
@@ -836,7 +836,7 @@ msgstr ""
 msgid "Program Question"
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:243
+#: lib/klass_hero_web/live/privacy_policy_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "Questions About Privacy?"
 msgstr ""
@@ -971,7 +971,7 @@ msgstr ""
 msgid "We're here to clarify any questions you may have."
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:244
+#: lib/klass_hero_web/live/privacy_policy_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "We're here to help with any privacy-related concerns."
 msgstr ""
@@ -1012,7 +1012,7 @@ msgstr ""
 msgid "You need to reauthenticate to perform sensitive actions on your account."
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:114
+#: lib/klass_hero_web/live/privacy_policy_live.ex:116
 #, elixir-autogen, elixir-format
 msgid "Your Privacy Rights"
 msgstr ""
@@ -1022,7 +1022,7 @@ msgstr ""
 msgid "Your account has been deleted."
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:240
+#: lib/klass_hero_web/live/privacy_policy_live.ex:242
 #, elixir-autogen, elixir-format
 msgid "Your privacy matters to us"
 msgstr ""
@@ -1486,7 +1486,7 @@ msgstr ""
 msgid "Unassigned"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:729
+#: lib/klass_hero_web/components/messaging_components.ex:767
 #: lib/klass_hero_web/components/provider_components.ex:52
 #: lib/klass_hero_web/components/provider_components.ex:1553
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:110
@@ -1506,7 +1506,7 @@ msgstr ""
 msgid "%{age} years old"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:749
+#: lib/klass_hero_web/components/messaging_components.ex:787
 #, elixir-autogen, elixir-format
 msgid "%{n}m ago"
 msgstr ""
@@ -1728,7 +1728,7 @@ msgid "No conversations yet"
 msgstr ""
 
 #: lib/klass_hero_web/components/messaging_components.ex:445
-#: lib/klass_hero_web/components/messaging_components.ex:771
+#: lib/klass_hero_web/components/messaging_components.ex:809
 #, elixir-autogen, elixir-format
 msgid "No messages yet"
 msgstr ""
@@ -1760,7 +1760,7 @@ msgstr ""
 msgid "Note resubmitted for review"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:748
+#: lib/klass_hero_web/components/messaging_components.ex:786
 #, elixir-autogen, elixir-format
 msgid "Now"
 msgstr ""
@@ -1800,7 +1800,7 @@ msgstr ""
 msgid "Please set up your parent profile to manage children."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:722
+#: lib/klass_hero_web/components/messaging_components.ex:760
 #: lib/klass_hero_web/live/messaging_live_helper.ex:409
 #, elixir-autogen, elixir-format
 msgid "Program Broadcast"
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "Confirmed"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:823
+#: lib/klass_hero_web/components/messaging_components.ex:861
 #, elixir-autogen, elixir-format
 msgid "Contact Provider"
 msgstr ""
@@ -3751,7 +3751,7 @@ msgstr ""
 msgid "Back to emails"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:689
+#: lib/klass_hero_web/components/messaging_components.ex:727
 #, elixir-autogen, elixir-format
 msgid "Broadcast messages are one-way"
 msgstr ""
@@ -4172,7 +4172,7 @@ msgstr ""
 msgid "Reply"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:700
+#: lib/klass_hero_web/components/messaging_components.ex:738
 #, elixir-autogen, elixir-format
 msgid "Reply privately"
 msgstr ""
@@ -4469,7 +4469,7 @@ msgstr ""
 msgid "Failed to upload files. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:775
+#: lib/klass_hero_web/components/messaging_components.ex:813
 #, elixir-autogen, elixir-format
 msgid "File is too large (max %{mb} MB)"
 msgstr ""
@@ -4479,7 +4479,7 @@ msgstr ""
 msgid "File is too large (max %{mb} MB)."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:778
+#: lib/klass_hero_web/components/messaging_components.ex:816
 #, elixir-autogen, elixir-format
 msgid "File type not accepted (images only)"
 msgstr ""
@@ -4499,8 +4499,8 @@ msgstr ""
 msgid "Only images are accepted (JPG, PNG, GIF, WebP)."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:760
-#: lib/klass_hero_web/components/messaging_components.ex:764
+#: lib/klass_hero_web/components/messaging_components.ex:798
+#: lib/klass_hero_web/components/messaging_components.ex:802
 #, elixir-autogen, elixir-format
 msgid "Photo"
 msgstr ""
@@ -4540,7 +4540,7 @@ msgstr ""
 msgid "Tell parents about your organization and what makes you unique..."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:782
+#: lib/klass_hero_web/components/messaging_components.ex:820
 #, elixir-autogen, elixir-format
 msgid "Too many files (max %{max})"
 msgstr ""
@@ -4550,12 +4550,12 @@ msgstr ""
 msgid "Too many files (max %{max})."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:786
+#: lib/klass_hero_web/components/messaging_components.ex:824
 #, elixir-autogen, elixir-format
 msgid "Upload error"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:785
+#: lib/klass_hero_web/components/messaging_components.ex:823
 #, elixir-autogen, elixir-format
 msgid "Upload failed"
 msgstr ""
@@ -5941,7 +5941,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:810
 #: lib/klass_hero_web/components/marketing_components.ex:857
-#: lib/klass_hero_web/live/privacy_policy_live.ex:238
+#: lib/klass_hero_web/live/privacy_policy_live.ex:240
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr ""
@@ -8157,4 +8157,9 @@ msgstr ""
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "← Back to messages"
+msgstr ""
+
+#: lib/klass_hero_web/components/messaging_components.ex:706
+#, elixir-autogen, elixir-format
+msgid "Messages here may be reviewed by the activity provider and by Klass Hero staff, to keep children safe."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -456,7 +456,7 @@ msgstr ""
 msgid "Changes to Terms"
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:205
+#: lib/klass_hero_web/live/privacy_policy_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Changes to This Policy"
 msgstr ""
@@ -476,7 +476,7 @@ msgstr ""
 msgid "Child checked out successfully"
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:153
+#: lib/klass_hero_web/live/privacy_policy_live.ex:155
 #, elixir-autogen, elixir-format
 msgid "Children's Privacy"
 msgstr ""
@@ -515,12 +515,12 @@ msgstr ""
 #: lib/klass_hero_web/components/composite_components.ex:601
 #: lib/klass_hero_web/live/contact_live.ex:16
 #: lib/klass_hero_web/live/contact_live.ex:107
-#: lib/klass_hero_web/live/privacy_policy_live.ex:221
+#: lib/klass_hero_web/live/privacy_policy_live.ex:223
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Contact Us"
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:174
+#: lib/klass_hero_web/live/privacy_policy_live.ex:176
 #, elixir-autogen, elixir-format
 msgid "Cookies & Tracking"
 msgstr ""
@@ -541,12 +541,12 @@ msgstr ""
 msgid "Creating account..."
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:190
+#: lib/klass_hero_web/live/privacy_policy_live.ex:192
 #, elixir-autogen, elixir-format
 msgid "Data Retention"
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:136
+#: lib/klass_hero_web/live/privacy_policy_live.ex:138
 #, elixir-autogen, elixir-format
 msgid "Data Security"
 msgstr ""
@@ -821,7 +821,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/composite_components.ex:487
 #: lib/klass_hero_web/live/privacy_policy_live.ex:11
-#: lib/klass_hero_web/live/privacy_policy_live.ex:239
+#: lib/klass_hero_web/live/privacy_policy_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "Privacy Policy"
 msgstr ""
@@ -836,7 +836,7 @@ msgstr ""
 msgid "Program Question"
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:243
+#: lib/klass_hero_web/live/privacy_policy_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "Questions About Privacy?"
 msgstr ""
@@ -971,7 +971,7 @@ msgstr ""
 msgid "We're here to clarify any questions you may have."
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:244
+#: lib/klass_hero_web/live/privacy_policy_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "We're here to help with any privacy-related concerns."
 msgstr ""
@@ -1012,7 +1012,7 @@ msgstr ""
 msgid "You need to reauthenticate to perform sensitive actions on your account."
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:114
+#: lib/klass_hero_web/live/privacy_policy_live.ex:116
 #, elixir-autogen, elixir-format
 msgid "Your Privacy Rights"
 msgstr ""
@@ -1022,7 +1022,7 @@ msgstr ""
 msgid "Your account has been deleted."
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:240
+#: lib/klass_hero_web/live/privacy_policy_live.ex:242
 #, elixir-autogen, elixir-format
 msgid "Your privacy matters to us"
 msgstr ""
@@ -1486,7 +1486,7 @@ msgstr ""
 msgid "Unassigned"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:729
+#: lib/klass_hero_web/components/messaging_components.ex:767
 #: lib/klass_hero_web/components/provider_components.ex:52
 #: lib/klass_hero_web/components/provider_components.ex:1553
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:110
@@ -1506,7 +1506,7 @@ msgstr ""
 msgid "%{age} years old"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:749
+#: lib/klass_hero_web/components/messaging_components.ex:787
 #, elixir-autogen, elixir-format
 msgid "%{n}m ago"
 msgstr ""
@@ -1728,7 +1728,7 @@ msgid "No conversations yet"
 msgstr ""
 
 #: lib/klass_hero_web/components/messaging_components.ex:445
-#: lib/klass_hero_web/components/messaging_components.ex:771
+#: lib/klass_hero_web/components/messaging_components.ex:809
 #, elixir-autogen, elixir-format
 msgid "No messages yet"
 msgstr ""
@@ -1760,7 +1760,7 @@ msgstr ""
 msgid "Note resubmitted for review"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:748
+#: lib/klass_hero_web/components/messaging_components.ex:786
 #, elixir-autogen, elixir-format
 msgid "Now"
 msgstr ""
@@ -1800,7 +1800,7 @@ msgstr ""
 msgid "Please set up your parent profile to manage children."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:722
+#: lib/klass_hero_web/components/messaging_components.ex:760
 #: lib/klass_hero_web/live/messaging_live_helper.ex:409
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program Broadcast"
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "Confirmed"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:823
+#: lib/klass_hero_web/components/messaging_components.ex:861
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Contact Provider"
 msgstr ""
@@ -3751,7 +3751,7 @@ msgstr ""
 msgid "Back to emails"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:689
+#: lib/klass_hero_web/components/messaging_components.ex:727
 #, elixir-autogen, elixir-format
 msgid "Broadcast messages are one-way"
 msgstr ""
@@ -4172,7 +4172,7 @@ msgstr ""
 msgid "Reply"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:700
+#: lib/klass_hero_web/components/messaging_components.ex:738
 #, elixir-autogen, elixir-format
 msgid "Reply privately"
 msgstr ""
@@ -4469,7 +4469,7 @@ msgstr ""
 msgid "Failed to upload files. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:775
+#: lib/klass_hero_web/components/messaging_components.ex:813
 #, elixir-autogen, elixir-format, fuzzy
 msgid "File is too large (max %{mb} MB)"
 msgstr ""
@@ -4479,7 +4479,7 @@ msgstr ""
 msgid "File is too large (max %{mb} MB)."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:778
+#: lib/klass_hero_web/components/messaging_components.ex:816
 #, elixir-autogen, elixir-format, fuzzy
 msgid "File type not accepted (images only)"
 msgstr ""
@@ -4499,8 +4499,8 @@ msgstr ""
 msgid "Only images are accepted (JPG, PNG, GIF, WebP)."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:760
-#: lib/klass_hero_web/components/messaging_components.ex:764
+#: lib/klass_hero_web/components/messaging_components.ex:798
+#: lib/klass_hero_web/components/messaging_components.ex:802
 #, elixir-autogen, elixir-format
 msgid "Photo"
 msgstr ""
@@ -4540,7 +4540,7 @@ msgstr ""
 msgid "Tell parents about your organization and what makes you unique..."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:782
+#: lib/klass_hero_web/components/messaging_components.ex:820
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Too many files (max %{max})"
 msgstr ""
@@ -4550,12 +4550,12 @@ msgstr ""
 msgid "Too many files (max %{max})."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:786
+#: lib/klass_hero_web/components/messaging_components.ex:824
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload error"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:785
+#: lib/klass_hero_web/components/messaging_components.ex:823
 #, elixir-autogen, elixir-format
 msgid "Upload failed"
 msgstr ""
@@ -5941,7 +5941,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:810
 #: lib/klass_hero_web/components/marketing_components.ex:857
-#: lib/klass_hero_web/live/privacy_policy_live.ex:238
+#: lib/klass_hero_web/live/privacy_policy_live.ex:240
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Privacy"
 msgstr ""
@@ -8157,4 +8157,9 @@ msgstr ""
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:76
 #, elixir-autogen, elixir-format
 msgid "← Back to messages"
+msgstr ""
+
+#: lib/klass_hero_web/components/messaging_components.ex:706
+#, elixir-autogen, elixir-format
+msgid "Messages here may be reviewed by the activity provider and by Klass Hero staff, to keep children safe."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -1489,6 +1489,7 @@ msgstr ""
 #: lib/klass_hero_web/components/messaging_components.ex:729
 #: lib/klass_hero_web/components/provider_components.ex:52
 #: lib/klass_hero_web/components/provider_components.ex:1553
+#: lib/klass_hero_web/live/admin/messages_live.html.heex:110
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:455
 #: lib/klass_hero_web/presenters/provider_presenter.ex:172
 #, elixir-autogen, elixir-format
@@ -1542,6 +1543,7 @@ msgid "Back to Settings"
 msgstr ""
 
 #: lib/klass_hero_web/components/messaging_components.ex:153
+#: lib/klass_hero_web/live/admin/messages_live.ex:148
 #, elixir-autogen, elixir-format
 msgid "Broadcast"
 msgstr ""
@@ -1593,6 +1595,8 @@ msgstr ""
 msgid "Child updated successfully."
 msgstr ""
 
+#: lib/klass_hero_web/live/admin/messages_live.ex:70
+#: lib/klass_hero_web/live/admin/messages_live.html.heex:80
 #: lib/klass_hero_web/live/dashboard_live.ex:178
 #: lib/klass_hero_web/live/messaging_live_helper.ex:413
 #, elixir-autogen, elixir-format
@@ -1699,9 +1703,13 @@ msgstr ""
 msgid "Message content is required"
 msgstr ""
 
+#: lib/klass_hero_web/components/layouts/admin.html.heex:90
 #: lib/klass_hero_web/components/layouts/app.html.heex:214
 #: lib/klass_hero_web/components/messaging_components.ex:506
 #: lib/klass_hero_web/components/messaging_components.ex:529
+#: lib/klass_hero_web/live/admin/messages_live.ex:37
+#: lib/klass_hero_web/live/admin/messages_live.ex:56
+#: lib/klass_hero_web/live/admin/messages_live.html.heex:5
 #: lib/klass_hero_web/live/messages_live/index.ex:19
 #: lib/klass_hero_web/live/messaging_live_helper.ex:365
 #, elixir-autogen, elixir-format, fuzzy
@@ -2964,6 +2972,7 @@ msgstr ""
 msgid "We are Klass Hero — parents, brothers, and partners of educators — building the infrastructure that helps every child learn and thrive."
 msgstr ""
 
+#: lib/klass_hero_web/live/admin/messages_live.ex:107
 #: lib/klass_hero_web/user_auth.ex:298
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You don't have access to that page."
@@ -3699,6 +3708,7 @@ msgstr ""
 msgid "All programs"
 msgstr ""
 
+#: lib/klass_hero_web/live/admin/messages_live.html.heex:17
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:13
 #, elixir-autogen, elixir-format, fuzzy
 msgid "All providers"
@@ -4134,6 +4144,7 @@ msgid "Program is required"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_layout_components.ex:76
+#: lib/klass_hero_web/live/admin/messages_live.html.heex:16
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:12
 #: lib/klass_hero_web/persona.ex:123
 #, elixir-autogen, elixir-format, fuzzy
@@ -8089,4 +8100,61 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:3174
 #, elixir-autogen, elixir-format
 msgid "e.g. %{example}"
+msgstr ""
+
+#: lib/klass_hero_web/live/admin/messages_live.html.heex:52
+#, elixir-autogen, elixir-format
+msgid "%{count} participant"
+msgid_plural "%{count} participants"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/klass_hero_web/live/admin/messages_live.ex:75
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Conversation not found."
+msgstr ""
+
+#: lib/klass_hero_web/live/admin/messages_live.ex:149
+#, elixir-autogen, elixir-format
+msgid "Direct"
+msgstr ""
+
+#: lib/klass_hero_web/live/admin/messages_live.html.heex:70
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Load more"
+msgstr ""
+
+#: lib/klass_hero_web/live/admin/messages_live.html.heex:29
+#, elixir-autogen, elixir-format, fuzzy
+msgid "No conversations found."
+msgstr ""
+
+#: lib/klass_hero_web/live/admin/messages_live.html.heex:102
+#, elixir-autogen, elixir-format
+msgid "No messages in this conversation."
+msgstr ""
+
+#: lib/klass_hero_web/live/admin/messages_live.html.heex:45
+#, elixir-autogen, elixir-format, fuzzy
+msgid "No subject"
+msgstr ""
+
+#: lib/klass_hero_web/live/admin/messages_live.html.heex:8
+#, elixir-autogen, elixir-format
+msgid "Read-only view of conversations across all providers."
+msgstr ""
+
+#: lib/klass_hero_web/live/admin/messages_live.html.heex:91
+#, elixir-autogen, elixir-format
+msgid "Read-only. Viewing this thread does not mark anything as read."
+msgstr ""
+
+#: lib/klass_hero_web/live/admin/messages_live.ex:127
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Unknown provider"
+msgstr ""
+
+#: lib/klass_hero_web/live/admin/messages_live.html.heex:76
+#, elixir-autogen, elixir-format
+msgid "← Back to messages"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -1486,7 +1486,7 @@ msgstr ""
 msgid "Unassigned"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:767
+#: lib/klass_hero_web/components/messaging_components.ex:772
 #: lib/klass_hero_web/components/provider_components.ex:52
 #: lib/klass_hero_web/components/provider_components.ex:1553
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:110
@@ -1506,7 +1506,7 @@ msgstr ""
 msgid "%{age} years old"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:787
+#: lib/klass_hero_web/components/messaging_components.ex:792
 #, elixir-autogen, elixir-format
 msgid "%{n}m ago"
 msgstr ""
@@ -1728,7 +1728,7 @@ msgid "No conversations yet"
 msgstr ""
 
 #: lib/klass_hero_web/components/messaging_components.ex:445
-#: lib/klass_hero_web/components/messaging_components.ex:809
+#: lib/klass_hero_web/components/messaging_components.ex:814
 #, elixir-autogen, elixir-format
 msgid "No messages yet"
 msgstr ""
@@ -1760,7 +1760,7 @@ msgstr ""
 msgid "Note resubmitted for review"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:786
+#: lib/klass_hero_web/components/messaging_components.ex:791
 #, elixir-autogen, elixir-format
 msgid "Now"
 msgstr ""
@@ -1800,7 +1800,7 @@ msgstr ""
 msgid "Please set up your parent profile to manage children."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:760
+#: lib/klass_hero_web/components/messaging_components.ex:765
 #: lib/klass_hero_web/live/messaging_live_helper.ex:409
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program Broadcast"
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "Confirmed"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:861
+#: lib/klass_hero_web/components/messaging_components.ex:866
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Contact Provider"
 msgstr ""
@@ -3751,7 +3751,7 @@ msgstr ""
 msgid "Back to emails"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:727
+#: lib/klass_hero_web/components/messaging_components.ex:732
 #, elixir-autogen, elixir-format
 msgid "Broadcast messages are one-way"
 msgstr ""
@@ -4172,7 +4172,7 @@ msgstr ""
 msgid "Reply"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:738
+#: lib/klass_hero_web/components/messaging_components.ex:743
 #, elixir-autogen, elixir-format
 msgid "Reply privately"
 msgstr ""
@@ -4469,7 +4469,7 @@ msgstr ""
 msgid "Failed to upload files. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:813
+#: lib/klass_hero_web/components/messaging_components.ex:818
 #, elixir-autogen, elixir-format, fuzzy
 msgid "File is too large (max %{mb} MB)"
 msgstr ""
@@ -4479,7 +4479,7 @@ msgstr ""
 msgid "File is too large (max %{mb} MB)."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:816
+#: lib/klass_hero_web/components/messaging_components.ex:821
 #, elixir-autogen, elixir-format, fuzzy
 msgid "File type not accepted (images only)"
 msgstr ""
@@ -4499,8 +4499,8 @@ msgstr ""
 msgid "Only images are accepted (JPG, PNG, GIF, WebP)."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:798
-#: lib/klass_hero_web/components/messaging_components.ex:802
+#: lib/klass_hero_web/components/messaging_components.ex:803
+#: lib/klass_hero_web/components/messaging_components.ex:807
 #, elixir-autogen, elixir-format
 msgid "Photo"
 msgstr ""
@@ -4540,7 +4540,7 @@ msgstr ""
 msgid "Tell parents about your organization and what makes you unique..."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:820
+#: lib/klass_hero_web/components/messaging_components.ex:825
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Too many files (max %{max})"
 msgstr ""
@@ -4550,12 +4550,12 @@ msgstr ""
 msgid "Too many files (max %{max})."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:824
+#: lib/klass_hero_web/components/messaging_components.ex:829
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload error"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:823
+#: lib/klass_hero_web/components/messaging_components.ex:828
 #, elixir-autogen, elixir-format
 msgid "Upload failed"
 msgstr ""
@@ -8159,7 +8159,7 @@ msgstr ""
 msgid "← Back to messages"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:706
+#: lib/klass_hero_web/components/messaging_components.ex:711
 #, elixir-autogen, elixir-format
 msgid "Messages here may be reviewed by the activity provider and by Klass Hero staff, to keep children safe."
 msgstr ""

--- a/test/flows/admin_conversation_monitoring_test.exs
+++ b/test/flows/admin_conversation_monitoring_test.exs
@@ -1,0 +1,164 @@
+defmodule KlassHeroWeb.Flows.AdminConversationMonitoringTest do
+  @moduledoc """
+  Flow tests for admin conversation monitoring (#744).
+
+  The load-bearing assertions here are the negative ones. Monitoring is read-only,
+  and "read-only" is not a property of the context alone — it is a property of what
+  the page renders. If a future change reuses `conversation_show/1` or the
+  `MessagingLiveHelper, :show` macro on this surface, the composer comes back with
+  it, and `refute_has("#message-input")` is what notices.
+  """
+
+  use KlassHeroWeb.FlowCase, async: false
+
+  alias KlassHero.Accounts.Scope
+  alias KlassHero.Messaging
+
+  setup do
+    provider_user = user_fixture(%{intended_roles: [:provider]})
+    provider = insert(:provider_profile_schema, identity_id: provider_user.id, business_name: "Bouldering Bees")
+
+    parent_user = user_fixture(%{intended_roles: [:parent]})
+    insert(:parent_profile_schema, identity_id: parent_user.id)
+
+    provider_scope = provider_user |> Scope.for_user() |> Scope.resolve_roles()
+
+    conversation =
+      with_real_outbox(fn ->
+        {:ok, conversation} =
+          Messaging.create_direct_conversation(provider_scope, provider.id, parent_user.id)
+
+        {:ok, _} =
+          Messaging.send_message(conversation.id, parent_user.id, "Concern about pickup time")
+
+        conversation
+      end)
+
+    %{
+      admin: user_fixture(%{is_admin: true}),
+      parent_user: parent_user,
+      provider: provider,
+      conversation: conversation
+    }
+  end
+
+  describe "access" do
+    test "a parent cannot reach the monitoring index", %{parent_user: parent_user} do
+      build_conn()
+      |> log_in_user(parent_user)
+      |> visit(~p"/admin/messages")
+      |> assert_path(~p"/")
+    end
+
+    test "a parent cannot reach a thread they are not looking at as a participant", %{
+      parent_user: parent_user,
+      conversation: conversation
+    } do
+      build_conn()
+      |> log_in_user(parent_user)
+      |> visit(~p"/admin/messages/#{conversation.id}")
+      |> assert_path(~p"/")
+    end
+  end
+
+  describe "the index" do
+    test "lists conversations with their provider, across providers", %{
+      admin: admin,
+      conversation: conversation
+    } do
+      other = insert(:conversation_schema)
+
+      build_conn()
+      |> log_in_user(admin)
+      |> visit(~p"/admin/messages")
+      |> assert_has("[data-role=conversation-row]", text: "Bouldering Bees")
+      |> assert_has("a[href='/admin/messages/#{conversation.id}']")
+      |> assert_has("a[href='/admin/messages/#{other.id}']")
+    end
+
+    test "filters to one provider", %{admin: admin, conversation: conversation, provider: provider} do
+      other = insert(:conversation_schema)
+
+      build_conn()
+      |> log_in_user(admin)
+      |> visit(~p"/admin/messages?provider_id=#{provider.id}")
+      |> assert_has("a[href='/admin/messages/#{conversation.id}']")
+      |> refute_has("a[href='/admin/messages/#{other.id}']")
+    end
+
+    test "shows an empty state when nothing matches", %{admin: admin} do
+      build_conn()
+      |> log_in_user(admin)
+      |> visit(~p"/admin/messages?provider_id=#{Ecto.UUID.generate()}")
+      |> assert_has("#conversations-empty-state")
+    end
+
+    test "opens a thread from the list", %{admin: admin, conversation: conversation} do
+      build_conn()
+      |> log_in_user(admin)
+      |> visit(~p"/admin/messages")
+      |> click_link("a[href='/admin/messages/#{conversation.id}']", "Bouldering Bees")
+      |> assert_has("[data-role=message]", text: "Concern about pickup time")
+    end
+  end
+
+  describe "the thread" do
+    test "renders messages of a conversation the admin is not a participant of", %{
+      admin: admin,
+      conversation: conversation
+    } do
+      refute Messaging.participant?(conversation.id, admin.id)
+
+      build_conn()
+      |> log_in_user(admin)
+      |> visit(~p"/admin/messages/#{conversation.id}")
+      |> assert_has("[data-role=conversation-thread]")
+      |> assert_has("[data-role=message]", text: "Concern about pickup time")
+    end
+
+    test "renders no composer, no send button and no reply action", %{
+      admin: admin,
+      conversation: conversation
+    } do
+      build_conn()
+      |> log_in_user(admin)
+      |> visit(~p"/admin/messages/#{conversation.id}")
+      |> refute_has("#message-input")
+      |> refute_has("[data-role=send-message-btn]")
+      |> refute_has("textarea")
+    end
+
+    test "viewing a thread seats no participant and disturbs no read receipt", %{
+      admin: admin,
+      conversation: conversation,
+      parent_user: parent_user
+    } do
+      {:ok, participant} = Messaging.get_participant(conversation.id, parent_user.id)
+      last_read_at = participant.last_read_at
+
+      build_conn()
+      |> log_in_user(admin)
+      |> visit(~p"/admin/messages/#{conversation.id}")
+      |> assert_has("[data-role=conversation-thread]")
+
+      refute Messaging.participant?(conversation.id, admin.id)
+
+      {:ok, after_view} = Messaging.get_participant(conversation.id, parent_user.id)
+      assert after_view.last_read_at == last_read_at
+    end
+
+    test "an unknown conversation returns to the index", %{admin: admin} do
+      build_conn()
+      |> log_in_user(admin)
+      |> visit(~p"/admin/messages/#{Ecto.UUID.generate()}")
+      |> assert_path(~p"/admin/messages")
+    end
+
+    test "a malformed id returns to the index", %{admin: admin} do
+      build_conn()
+      |> log_in_user(admin)
+      |> visit(~p"/admin/messages/not-a-uuid")
+      |> assert_path(~p"/admin/messages")
+    end
+  end
+end

--- a/test/flows/messaging_direct_message_test.exs
+++ b/test/flows/messaging_direct_message_test.exs
@@ -83,4 +83,23 @@ defmodule KlassHeroWeb.Flows.MessagingDirectMessageTest do
     |> visit(~p"/provider/messages/#{conversation.id}")
     |> assert_has("[data-role=message]", text: "Thanks! What time should we arrive?")
   end
+
+  # #745 — the disclosure half of admin monitoring (#744). Both sides must see it:
+  # the notice is what makes platform-staff read access something participants were
+  # told about rather than something done to them.
+  test "both sides see the monitoring notice", %{
+    provider_user: provider_user,
+    parent_user: parent_user,
+    conversation: conversation
+  } do
+    build_conn()
+    |> log_in_user(parent_user)
+    |> visit(~p"/messages/#{conversation.id}")
+    |> assert_has("[data-role=monitoring-notice]", text: "Klass Hero staff")
+
+    build_conn()
+    |> log_in_user(provider_user)
+    |> visit(~p"/provider/messages/#{conversation.id}")
+    |> assert_has("[data-role=monitoring-notice]", text: "Klass Hero staff")
+  end
 end

--- a/test/klass_hero/messaging/authorization_test.exs
+++ b/test/klass_hero/messaging/authorization_test.exs
@@ -1,0 +1,17 @@
+defmodule KlassHero.Messaging.AuthorizationTest do
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.AccountsFixtures
+
+  alias KlassHero.Messaging.Authorization
+
+  describe "authorize_admin/1" do
+    test "authorizes a platform admin" do
+      assert :ok = Authorization.authorize_admin(admin_scope_fixture())
+    end
+
+    test "refuses a non-admin scope" do
+      assert {:error, :unauthorized} = Authorization.authorize_admin(user_scope_fixture())
+    end
+  end
+end

--- a/test/klass_hero/messaging/get_monitored_conversation_test.exs
+++ b/test/klass_hero/messaging/get_monitored_conversation_test.exs
@@ -1,0 +1,123 @@
+defmodule KlassHero.Messaging.GetMonitoredConversationTest do
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+
+  alias KlassHero.AccountsFixtures
+  alias KlassHero.Messaging
+  alias KlassHero.Messaging.Conversation
+  alias KlassHero.Messaging.GetMonitoredConversation
+  alias KlassHero.Messaging.Participant
+
+  defp admin_scope, do: AccountsFixtures.admin_scope_fixture()
+
+  defp conversation_with_message do
+    conversation = insert(:conversation_schema)
+    parent = AccountsFixtures.user_fixture()
+
+    insert(:participant_schema, conversation_id: conversation.id, user_id: parent.id)
+
+    {:ok, _message} =
+      Messaging.create_message(%{
+        conversation_id: conversation.id,
+        sender_id: parent.id,
+        content: "Private message about my child"
+      })
+
+    %{conversation: conversation, parent: parent}
+  end
+
+  describe "execute/3 authorization" do
+    test "refuses a non-admin scope" do
+      %{conversation: conversation} = conversation_with_message()
+
+      assert {:error, :unauthorized} =
+               GetMonitoredConversation.execute(
+                 AccountsFixtures.user_scope_fixture(),
+                 conversation.id
+               )
+    end
+
+    test "refuses a non-admin scope before looking at the conversation id" do
+      assert {:error, :unauthorized} =
+               GetMonitoredConversation.execute(
+                 AccountsFixtures.user_scope_fixture(),
+                 Ecto.UUID.generate()
+               )
+    end
+
+    test "returns not_found for an admin asking for a conversation that does not exist" do
+      assert {:error, :not_found} =
+               GetMonitoredConversation.execute(admin_scope(), Ecto.UUID.generate())
+    end
+  end
+
+  describe "execute/3 reading" do
+    test "returns the thread of a conversation the admin is not a participant of" do
+      %{conversation: conversation} = conversation_with_message()
+      scope = admin_scope()
+
+      refute Messaging.participant?(conversation.id, scope.user.id)
+
+      assert {:ok, result} = GetMonitoredConversation.execute(scope, conversation.id)
+
+      assert %Conversation{id: id} = result.conversation
+      assert id == conversation.id
+      assert [message] = result.messages
+      assert message.content == "Private message about my child"
+      assert is_map(result.sender_names)
+      assert is_boolean(result.has_more)
+    end
+  end
+
+  describe "execute/3 is strictly read-only" do
+    test "creates no participant row for the admin" do
+      %{conversation: conversation} = conversation_with_message()
+      scope = admin_scope()
+
+      before = Repo.aggregate(Participant, :count)
+
+      assert {:ok, _result} = GetMonitoredConversation.execute(scope, conversation.id)
+
+      assert Repo.aggregate(Participant, :count) == before
+      refute Messaging.participant?(conversation.id, scope.user.id)
+    end
+
+    test "leaves the real participants' last_read_at untouched" do
+      conversation = insert(:conversation_schema)
+      parent = AccountsFixtures.user_fixture()
+      read_at = ~U[2026-01-01 12:00:00Z]
+
+      participant =
+        insert(:participant_schema,
+          conversation_id: conversation.id,
+          user_id: parent.id,
+          last_read_at: read_at
+        )
+
+      {:ok, _message} =
+        Messaging.create_message(%{
+          conversation_id: conversation.id,
+          sender_id: parent.id,
+          content: "Hello"
+        })
+
+      assert {:ok, _result} = GetMonitoredConversation.execute(admin_scope(), conversation.id)
+
+      assert Repo.get!(Participant, participant.id).last_read_at == read_at
+    end
+  end
+
+  describe "the write path gained no admin branch" do
+    # Design guard, not a feature test: admin monitoring must be readable-only.
+    # If someone ever widens `verify_participant/2` instead of adding a separate
+    # read gate, this is what notices.
+    test "an admin who is not a participant still cannot send a message" do
+      %{conversation: conversation} = conversation_with_message()
+      admin = AccountsFixtures.user_fixture(is_admin: true)
+
+      assert {:error, :not_participant} =
+               Messaging.send_message(conversation.id, admin.id, "I should not be able to do this")
+    end
+  end
+end

--- a/test/klass_hero/messaging/monitor_conversations_test.exs
+++ b/test/klass_hero/messaging/monitor_conversations_test.exs
@@ -1,0 +1,104 @@
+defmodule KlassHero.Messaging.MonitorConversationsTest do
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+
+  alias KlassHero.AccountsFixtures
+  alias KlassHero.Messaging.Conversation
+  alias KlassHero.Messaging.MonitorConversations
+
+  defp admin_scope, do: AccountsFixtures.admin_scope_fixture()
+
+  describe "execute/2 authorization" do
+    test "refuses a non-admin scope" do
+      insert(:conversation_schema)
+
+      assert {:error, :unauthorized} =
+               MonitorConversations.execute(AccountsFixtures.user_scope_fixture())
+    end
+
+    test "refuses a non-admin scope even when no conversations exist" do
+      assert {:error, :unauthorized} =
+               MonitorConversations.execute(AccountsFixtures.user_scope_fixture())
+    end
+  end
+
+  describe "execute/2 listing" do
+    test "lists conversations across different providers" do
+      one = insert(:conversation_schema)
+      two = insert(:conversation_schema)
+
+      refute one.provider_id == two.provider_id
+
+      assert {:ok, conversations, false} = MonitorConversations.execute(admin_scope())
+
+      ids = Enum.map(conversations, & &1.id)
+      assert one.id in ids
+      assert two.id in ids
+      assert Enum.all?(conversations, &match?(%Conversation{}, &1))
+    end
+
+    test "returns conversations the admin is not a participant of" do
+      conversation = insert(:conversation_schema)
+
+      assert {:ok, [listed], false} = MonitorConversations.execute(admin_scope())
+      assert listed.id == conversation.id
+      refute KlassHero.Messaging.participant?(conversation.id, admin_scope().user.id)
+    end
+
+    test "filters by provider" do
+      wanted = insert(:conversation_schema)
+      _other = insert(:conversation_schema)
+
+      assert {:ok, [listed], false} =
+               MonitorConversations.execute(admin_scope(), provider_id: wanted.provider_id)
+
+      assert listed.id == wanted.id
+    end
+
+    # `participant_schema_factory` inserts a conversation of its own (factory.ex:1443)
+    # even when `conversation_id` is overridden, so this asserts on the row it wants
+    # rather than on the size of the page.
+    test "preloads participants for the list rows" do
+      conversation = insert(:conversation_schema)
+      user = AccountsFixtures.user_fixture()
+      insert(:participant_schema, conversation_id: conversation.id, user_id: user.id)
+
+      assert {:ok, conversations, false} = MonitorConversations.execute(admin_scope())
+
+      listed = Enum.find(conversations, &(&1.id == conversation.id))
+      assert [%{user_id: participant_user_id}] = listed.participants
+      assert participant_user_id == user.id
+    end
+  end
+
+  describe "execute/2 pagination" do
+    test "reports has_more when more rows exist than the limit" do
+      for _ <- 1..3, do: insert(:conversation_schema)
+
+      assert {:ok, listed, true} = MonitorConversations.execute(admin_scope(), limit: 2)
+      assert length(listed) == 2
+    end
+
+    test "reports has_more false when the page is the last one" do
+      for _ <- 1..2, do: insert(:conversation_schema)
+
+      assert {:ok, listed, false} = MonitorConversations.execute(admin_scope(), limit: 2)
+      assert length(listed) == 2
+    end
+
+    test "newest first, and :before walks to the older page" do
+      older = insert(:conversation_schema, inserted_at: ~N[2026-01-01 10:00:00])
+      newer = insert(:conversation_schema, inserted_at: ~N[2026-02-01 10:00:00])
+
+      assert {:ok, [first, second], false} = MonitorConversations.execute(admin_scope())
+      assert first.id == newer.id
+      assert second.id == older.id
+
+      assert {:ok, [only], false} =
+               MonitorConversations.execute(admin_scope(), before: newer.inserted_at)
+
+      assert only.id == older.id
+    end
+  end
+end


### PR DESCRIPTION
Platform admins can now read any conversation, from a read-only browser at
`/admin/messages` — and the people writing those messages are told so.

Closes #744. Refs #745.

## Summary

`Messaging.Authorization.verify_participant/2` was the single read gate for every
conversation path, and an admin can never satisfy it. The question this PR answers
is not "how do we query" — the builders already compose — but **where the second
authorization answer lives**.

It lives in the context, not the router:

```elixir
Messaging.monitor_conversations(scope, opts)
Messaging.get_monitored_conversation(scope, conversation_id, opts)
```

Both fail closed unless `scope.user.is_admin`. The router's `:require_admin` stays
as defence in depth. This diverges from every other admin surface here — `EmailsLive`
calls a scope-less facade function and relies on the router alone — and ADR-0021
records why: conversations are private correspondence about children, Messaging gates
every *other* read of them on a participant row, and an ungated
`list_all_conversations/1` in that same facade would be an IDOR primitive one careless
caller away. This repo has already paid for that pattern seven times.

## Review focus

**Three properties are structural, not conventional.** Worth checking I actually got
them:

1. **Authorization runs before the conversation id is read**, so a non-admin's refusal
   cannot depend on whether the conversation exists (ADR-0017's enumeration oracle).
   `GetConversation.execute/3` gets this wrong today — filed as #1515, deliberately
   not fixed here because it changes the flash contract on six live surfaces.

2. **`get_monitored_conversation/3` has no `:mark_as_read` option at all.**
   `Participant.last_read_at` feeds three independent unread counters — the nav badge
   via `ConversationSummary.unread_count`, `ConversationQueries.total_unread_count/1`,
   and the `ConversationSummaries` projection. An admin view touching it would move
   somebody else's unread count. Omitting the option makes that unexpressible rather
   than merely unused.

3. **The write path gained no admin branch.** `SendMessage` and `MarkAsRead` never
   call `authorize_admin/1`. `get_monitored_conversation_test.exs` pins that a
   non-participant admin still gets `{:error, :not_participant}` from `send_message/4`.

**The riskiest hunk is the shared component, not the new surface.**
`message_area/1` is reached only through `conversation_show/1`, so it backs the three
parent/provider/staff *conversation* views (the three Index views do not render it), and now renders
the monitoring notice above `#messages-container`. It is deliberately *outside* the
scroll container: inside, it scrolls away and `ScrollToBottom` lands the reader past
it, so on any thread longer than a screen nobody would ever see it. No test caught
that — the element was present either way; a browser did.

**The admin LiveView does not `use MessagingLiveHelper`.** That macro injects
`send_message`, `validate` and `cancel-upload` handlers into whatever module uses it,
which would wire a write path into a read-only screen even with no markup to trigger
it. It also imports only `message_bubble/1` rather than the whole component module,
so `message_input/1` and `conversation_show/1` are not in scope.

## Disclosure ships with the capability

Monitoring and its disclosure are one change, not two:

- a standing notice at the top of every conversation (#745)
- a "Platform Administrators" clause in the privacy policy, whose Data Sharing
  section previously named only Program Providers and Payment Processors

> **The notice wording is PROVISIONAL and must not ship before legal review**, per
> #745's own acceptance criteria. That is the critical path for this release, not the
> code.

## One unrelated commit

`fix: stop worktree-gc offering the main checkout for removal` is a data-loss fix
found while running `bin/worktree-gc --prune` during this work: `repo_root()` returns
the *current* worktree, so running the script from a worktree offered the **main
checkout** for deletion and tried to drop `klass_hero_dev`. Only `worktree-down`'s
refusal and Postgres declining to drop an in-use database stopped it. Happy to split
it into its own PR if you'd rather.

## Test plan

- `mix precommit` green — credo clean, 5126 tests, all lints including
  `lint_translations` and `lint_acl_boundary`.
- New flow tests (`test/flows/admin_conversation_monitoring_test.exs`, phoenix_test
  per ADR-0020) assert the negatives: no `#message-input`, no send button, no
  textarea, no participant row, no read-receipt change.
- Verified in the browser against seeded data: cross-provider listing, provider
  filter, thread render, no composer, 375px mobile, and the German strings.
- Verified via Tidewave against real rows: non-admin refused on both functions,
  `:not_found` for a missing conversation, admin not seated as a participant,
  participant rows and read receipts unchanged after an admin view.

## Follow-ups filed

- **#1514** — messages sent in the same second render in arbitrary order. Pre-existing
  and shared by the participant path; `messages.inserted_at` is second-precision and
  the tiebreaker is a random UUID.
- **#1515** — `get_conversation` leaks conversation existence to non-participants.

