### PR TITLE
feat: provider owners can read the threads their staff conduct

### DIFF
--- a/docs/adr/0021-admin-conversation-reads-authorize-at-the-messaging-boundary.md
+++ b/docs/adr/0021-admin-conversation-reads-authorize-at-the-messaging-boundary.md
@@ -127,9 +127,98 @@ create a processing activity disclosed nowhere.
 
 ## Consequences
 
-- Messaging now has two read gates. `verify_participant/2` guards everything
-  participant-scoped; `authorize_admin/1` guards monitoring, and nothing else may
-  use it without an ADR amendment.
+- Messaging now has **three** read gates (amended — see below). `verify_participant/2`
+  guards everything participant-scoped; `authorize_admin/1` guards platform
+  monitoring; `authorize_provider_owner/1` guards a provider owner reading their own
+  business's threads. Nothing else may use any of them without a further amendment.
 - `/admin/messages` is the first admin surface whose authorization lives in a
   context. The others are unchanged; this is not a call to migrate them.
 - The enumeration oracle in `GetConversation.execute/3` remains open; filed as #1515.
+
+## Amended: provider owners (#746)
+
+**Date:** 2026-08-25
+
+A provider owner may read conversations their business owns but that they are not a
+participant of — chiefly the threads their staff conduct with parents. Granted inside
+`KlassHero.Messaging` by a second named gate:
+
+```elixir
+Messaging.list_staff_conversations(scope, opts)
+Messaging.get_staff_conversation(scope, conversation_id, opts)
+```
+
+This amendment exists because the section above reserved `authorize_admin/1` to
+monitoring and required an ADR amendment before any further non-participant read. The
+original is not superseded; only the two-gate count above changes.
+
+### Owner-only, and pointedly not staff
+
+```elixir
+def authorize_provider_owner(%Scope{provider: %{id: id}}), do: {:ok, id}
+def authorize_provider_owner(%Scope{} = scope), do: {:error, :unauthorized}
+```
+
+One clause, for the reason `authorize_admin/1` is one clause: nobody is *narrowly*
+entitled to read a whole business's correspondence, so there is nothing to fall
+through from.
+
+The tempting reuse was `Authorization.resolve_acting_provider/2`, which already binds
+a scope to a provider. It is the wrong function here. That one accepts a staff scope
+on purpose — a staff member carries no `scope.provider`, so the write path has to
+resolve their employer from a caller-supplied hint. Honouring that hint on this read
+would let one staff member read their colleagues' private threads with parents, which
+is the opposite of what this gate is for. The provider can only come from
+`scope.provider`.
+
+### Why this gate returns an id where the admin gate returns `:ok`
+
+`is_admin` grants blanket visibility: past that gate, every conversation is fair game,
+which is why `GetMonitoredConversation` can fetch by id alone. Provider ownership
+grants nothing of the sort — it proves the scope owns *a* provider, never that it owns
+*this* conversation. So the gate hands back the provider id, and it is the read
+predicate:
+
+```elixir
+ConversationQueries.base() |> by_id(id) |> by_provider(provider_id) |> Repo.one()
+```
+
+Both predicates ride in one query, so "belongs to another business" and "does not
+exist" collapse into the same `{:error, :not_found}` at no extra cost. Without that
+second predicate a pasted UUID would read a competitor's threads.
+
+### The predicate is `provider_id`, not a staff join
+
+#746 proposed listing conversations whose *participants* are active staff members.
+Rejected: `Messaging.get_provider_staff_user_ids/1` already documents that
+ever-employed staff lists "must never gate access", and its active-only sibling is the
+"may act now" gate. Keying an oversight view on *current* employment would hide the
+threads an owner remains accountable for the moment a staffer is deactivated.
+
+Every conversation already carries `provider_id` as a required field, bound to the
+acting scope at write time. The ownership fact is stored, not derived.
+
+Threads the owner already participates in are excluded via
+`where_user_is_not_participant/2` — those render in their own inbox, and listing them
+twice across two tabs helps nobody.
+
+### Read-only, and marking nothing
+
+`GetStaffConversation` has no `:mark_as_read` option, for the reason recorded above:
+`last_read_at` feeds three independent unread counters, and an owner must not move a
+parent's or a staff member's. `SendMessage` and `MarkAsRead` gained no owner branch,
+and a test in `get_staff_conversation_test.exs` pins that a non-participant owner
+still gets `{:error, :not_participant}` from `send_message/4`.
+
+The access trail is the same shape as monitoring's: an OpenTelemetry span carrying
+`messaging.staff_conversations.owner_id` and `…conversation_id`, plus a `Logger.info`
+on each thread read. Still no durable table.
+
+### Disclosure, inverted
+
+Monitoring shipped its disclosure with the capability. Here the disclosure shipped
+*first*: the notice added in #1516 already reads "may be reviewed by the activity
+provider and by Klass Hero staff", which was true of Klass Hero staff and not yet true
+of the provider. This change makes the shipped sentence honest, and adds the matching
+clause to the privacy policy's **Program Providers** section, which previously covered
+only children's names, safety information and session notes.

--- a/lib/klass_hero/messaging.ex
+++ b/lib/klass_hero/messaging.ex
@@ -40,7 +40,9 @@ defmodule KlassHero.Messaging do
     GetConversationContext,
     GetInboundEmail,
     GetMonitoredConversation,
+    GetStaffConversation,
     GetTotalUnreadCount,
+    ListStaffConversations,
     MarkAsRead,
     MonitorConversations,
     ReceiveInboundEmail,
@@ -65,6 +67,7 @@ defmodule KlassHero.Messaging do
   alias KlassHero.Messaging.Queries.ConversationQueries
   alias KlassHero.Messaging.Queries.InboundEmailQueries
   alias KlassHero.Messaging.Queries.MessageQueries
+  alias KlassHero.Messaging.StaffConversation
   alias KlassHero.Repo
 
   require Logger
@@ -564,6 +567,40 @@ defmodule KlassHero.Messaging do
           {:ok, map()} | {:error, :unauthorized | :not_found}
   defdelegate get_monitored_conversation(scope, conversation_id, opts \\ []),
     to: GetMonitoredConversation,
+    as: :execute
+
+  @doc """
+  Lists conversations the calling provider owns but is not a participant of.
+
+  The threads their staff conduct with parents (#746). Owner-only: fails closed
+  unless `scope.provider` is set, and never accepts a staff scope, so one staff
+  member cannot read another's threads with parents. Threads the owner *is* in are
+  excluded — those already appear in their own inbox via `list_conversations/2`.
+
+  Rows come back as `KlassHero.Messaging.StaffConversation`, field-shaped to render
+  through the same inbox card as the participant list.
+
+  ## Options
+  `:type`, `:limit`, `:before`. See `KlassHero.Messaging.ListStaffConversations`.
+  """
+  @spec list_staff_conversations(Scope.t(), keyword()) ::
+          {:ok, [StaffConversation.t()], boolean()} | {:error, :unauthorized}
+  defdelegate list_staff_conversations(scope, opts \\ []),
+    to: ListStaffConversations,
+    as: :execute
+
+  @doc """
+  Reads one staff-conducted thread for the provider owner whose business owns it.
+
+  Owner-only (#746). A conversation belonging to another provider returns
+  `:not_found`, indistinguishable from one that never existed, so a pasted id
+  discloses nothing. Deliberately has no `:mark_as_read` option, for the same reason
+  `get_monitored_conversation/3` has none.
+  """
+  @spec get_staff_conversation(Scope.t(), String.t(), keyword()) ::
+          {:ok, map()} | {:error, :unauthorized | :not_found}
+  defdelegate get_staff_conversation(scope, conversation_id, opts \\ []),
+    to: GetStaffConversation,
     as: :execute
 
   @doc """

--- a/lib/klass_hero/messaging/authorization.ex
+++ b/lib/klass_hero/messaging/authorization.ex
@@ -6,10 +6,13 @@ defmodule KlassHero.Messaging.Authorization do
   this scope acting as, is this user a participant of this conversation, and does
   this scope's plan permit messaging at all.
 
-  Plus the one read gate that is not participant-based — `authorize_admin/1`, for
-  platform monitoring. Every other read in this context is gated on a participant
-  row; that one is gated on `is_admin` alone, and is deliberately the only such
-  exception. Staff-addition is owned by `KlassHero.Messaging.AddAssignedStaff`.
+  Plus the two read gates that are not participant-based: `authorize_admin/1`, for
+  platform monitoring, and `authorize_provider_owner/1`, for a business owner reading
+  the threads their own staff conduct. Every other read in this context is gated on a
+  participant row; those two are gated on `is_admin` and on provider ownership, and
+  are deliberately the only such exceptions — see ADR-0021, which requires an
+  amendment before a third is added. Staff-addition is owned by
+  `KlassHero.Messaging.AddAssignedStaff`.
   """
 
   use KlassHero.Shared.Tracing
@@ -111,6 +114,33 @@ defmodule KlassHero.Messaging.Authorization do
     Logger.warning("Non-admin scope attempted an admin conversation read",
       user_id: scope.user.id
     )
+
+    {:error, :unauthorized}
+  end
+
+  @doc """
+  Authorises a provider owner to read conversations they are not a participant of.
+
+  The owner counterpart to `authorize_admin/1`, and one clause for the same reason:
+  nobody is *narrowly* authorised to read a whole business's correspondence, so there
+  is nothing to fall through from.
+
+  Deliberately accepts no `:provider_id` hint, unlike `resolve_acting_provider/2`.
+  That hint exists so a staff scope — which carries no `scope.provider` — can act *as*
+  its employer on the write path. Honouring it here would let one staff member read
+  their coworkers' private threads with parents, the opposite of what this gate is
+  for, so the provider can only come from `scope.provider`.
+
+  Returns the provider id rather than `:ok` because, unlike `is_admin`, this grants no
+  blanket visibility. The id *is* the read predicate, and a caller holding it must
+  still confirm the conversation carries it — see
+  `KlassHero.Messaging.GetStaffConversation`.
+  """
+  @spec authorize_provider_owner(Scope.t()) :: {:ok, String.t()} | {:error, :unauthorized}
+  def authorize_provider_owner(%Scope{provider: %{id: id}}), do: {:ok, id}
+
+  def authorize_provider_owner(%Scope{} = scope) do
+    Logger.warning("Non-owner scope attempted a staff-conversation read", user_id: scope.user.id)
 
     {:error, :unauthorized}
   end

--- a/lib/klass_hero/messaging/conversation_summaries.ex
+++ b/lib/klass_hero/messaging/conversation_summaries.ex
@@ -48,12 +48,12 @@ defmodule KlassHero.Messaging.ConversationSummaries do
   import Ecto.Query
 
   alias KlassHero.Accounts
-  alias KlassHero.Messaging.Attachment
   alias KlassHero.Messaging.Conversation
   alias KlassHero.Messaging.ConversationSummary
   alias KlassHero.Messaging.EnrolledChild
   alias KlassHero.Messaging.Message
   alias KlassHero.Messaging.Notifications
+  alias KlassHero.Messaging.Queries.MessageQueries
   alias KlassHero.ProgramCatalog
   alias KlassHero.Repo
   alias KlassHero.Shared.Domain.Events.Event
@@ -683,26 +683,11 @@ defmodule KlassHero.Messaging.ConversationSummaries do
 
   defp resolve_other_name(_type, _user_id, _participant_ids, _user_names), do: nil
 
-  # Subquery avoids loading N×M rows via :messages preload.
+  # The SQL lives in MessageQueries so this projection and ListStaffConversations
+  # cannot drift on what "latest message" means (#746).
   defp fetch_latest_messages(conversation_ids) when conversation_ids != [] do
-    latest_times =
-      from(m in Message,
-        where: m.conversation_id in ^conversation_ids,
-        group_by: m.conversation_id,
-        select: %{conversation_id: m.conversation_id, max_at: max(m.inserted_at)}
-      )
-
-    from(m in Message,
-      join: lt in subquery(latest_times),
-      on: m.conversation_id == lt.conversation_id and m.inserted_at == lt.max_at,
-      select: %{
-        id: m.id,
-        conversation_id: m.conversation_id,
-        content: m.content,
-        sender_id: m.sender_id,
-        inserted_at: m.inserted_at
-      }
-    )
+    conversation_ids
+    |> MessageQueries.latest_per_conversation()
     |> Repo.all()
     |> Map.new(&{&1.conversation_id, &1})
   end
@@ -710,13 +695,10 @@ defmodule KlassHero.Messaging.ConversationSummaries do
   defp fetch_latest_messages(_), do: %{}
 
   defp fetch_attachment_message_ids(latest_messages) when map_size(latest_messages) > 0 do
-    message_ids = latest_messages |> Map.values() |> Enum.map(& &1.id)
-
-    from(a in Attachment,
-      where: a.message_id in ^message_ids,
-      distinct: a.message_id,
-      select: a.message_id
-    )
+    latest_messages
+    |> Map.values()
+    |> Enum.map(& &1.id)
+    |> MessageQueries.message_ids_with_attachments()
     |> Repo.all()
     |> MapSet.new()
   end

--- a/lib/klass_hero/messaging/get_staff_conversation.ex
+++ b/lib/klass_hero/messaging/get_staff_conversation.ex
@@ -1,0 +1,89 @@
+defmodule KlassHero.Messaging.GetStaffConversation do
+  @moduledoc """
+  Reads one conversation's full thread for a provider owner who is not a participant.
+
+  The owner counterpart to `KlassHero.Messaging.GetMonitoredConversation`, and
+  deliberately not a flag on it. Two things differ, both load-bearing:
+
+  **Ownership is re-checked against the row.** `authorize_admin/1` grants blanket
+  visibility, so past that gate any conversation id is fair game. Owner authorization
+  proves only that the scope owns *a* provider — never that it owns *this*
+  conversation. The fetch therefore carries both predicates, and a row belonging to
+  another business comes back `nil`, indistinguishable from an id that never existed.
+  Without that, a pasted UUID would read a competitor's threads.
+
+  **`:not_found` is genuinely one answer.** Because both predicates ride in a single
+  `Repo.one/1`, "wrong owner" and "doesn't exist" cannot be told apart at any cost —
+  there is no enumeration oracle here of the kind ADR-0017 warns about and
+  `GetConversation` still carries (#1515).
+
+  **There is no `:mark_as_read` option**, for the reason `GetMonitoredConversation`
+  records: `Participant.last_read_at` feeds three independent unread counters, and an
+  owner viewing a thread must never move somebody else's. Omitting the option makes
+  that unexpressible rather than merely unused.
+  """
+
+  use KlassHero.Shared.Tracing
+
+  alias KlassHero.Accounts.Scope
+  alias KlassHero.Messaging.Authorization
+  alias KlassHero.Messaging.Queries.ConversationQueries
+  alias KlassHero.Repo
+
+  require Logger
+
+  @doc """
+  Returns `%{conversation:, messages:, has_more:, sender_names:}` for a conversation
+  the calling owner's provider owns.
+
+  ## Options
+
+    * `:limit` - messages per page
+    * `:before` - exclusive `inserted_at` cursor for older messages
+  """
+  @spec execute(Scope.t(), String.t(), keyword()) ::
+          {:ok, map()} | {:error, :unauthorized | :not_found}
+  def execute(%Scope{} = scope, conversation_id, opts \\ []) do
+    # The span and the log line together are the access trail: which owner read which
+    # thread, when. There is no durable access-log table — see ADR-0021.
+    span do
+      OpenTelemetry.Tracer.set_attribute("messaging.staff_conversations.owner_id", scope.user.id)
+
+      OpenTelemetry.Tracer.set_attribute(
+        "messaging.staff_conversations.conversation_id",
+        conversation_id
+      )
+
+      with {:ok, provider_id} <- Authorization.authorize_provider_owner(scope),
+           {:ok, conversation} <- fetch_owned(conversation_id, provider_id),
+           {:ok, messages, sender_names, has_more} <-
+             KlassHero.Messaging.list_messages_with_senders(conversation_id, opts) do
+        Logger.info("Provider owner read a staff conversation they are not a participant of",
+          conversation_id: conversation_id,
+          provider_id: provider_id,
+          user_id: scope.user.id
+        )
+
+        {:ok,
+         %{
+           conversation: conversation,
+           messages: messages,
+           has_more: has_more,
+           sender_names: sender_names
+         }}
+      end
+    end
+  end
+
+  defp fetch_owned(conversation_id, provider_id) do
+    ConversationQueries.base()
+    |> ConversationQueries.by_id(conversation_id)
+    |> ConversationQueries.by_provider(provider_id)
+    |> ConversationQueries.preload_assocs([:participants])
+    |> Repo.one()
+    |> case do
+      nil -> {:error, :not_found}
+      conversation -> {:ok, conversation}
+    end
+  end
+end

--- a/lib/klass_hero/messaging/list_staff_conversations.ex
+++ b/lib/klass_hero/messaging/list_staff_conversations.ex
@@ -1,0 +1,189 @@
+defmodule KlassHero.Messaging.ListStaffConversations do
+  @moduledoc """
+  Lists conversations a provider owns but is not a participant of — chiefly the
+  threads their staff conduct with parents (#746).
+
+  The owner counterpart to `KlassHero.Messaging.MonitorConversations`, and the same
+  shape: authorize first, read the write-side `conversations` table, stay strictly
+  read-only. It creates no `Participant` row, writes no `last_read_at`, and
+  subscribes to nothing.
+
+  One behavioural difference from the admin list: threads the owner *is* in are
+  excluded. Those already render as rich cards in their own inbox, so including them
+  would show the same conversation twice across two tabs.
+
+  ## Enrichment is batched
+
+  Rows are enriched into `KlassHero.Messaging.StaffConversation` with **six queries
+  per page — seven when the page holds a broadcast** — flat, regardless of page size.
+  Nothing here runs per conversation.
+
+  The staff lookup deserves a note: it uses
+  `KlassHero.Provider.list_staff_user_ids_for_provider/1`, which returns everyone who
+  has *ever* held a staff row, active or not. That is correct precisely because it
+  feeds **display attribution** and never the gate — the use its own docstring
+  sanctions. Naming a departed colleague on a thread they really did conduct is the
+  desired behaviour; letting their departure hide the thread is not.
+  """
+
+  use KlassHero.Shared.Tracing
+
+  alias KlassHero.Accounts
+  alias KlassHero.Accounts.Scope
+  alias KlassHero.Messaging.Authorization
+  alias KlassHero.Messaging.Queries.ConversationQueries
+  alias KlassHero.Messaging.Queries.MessageQueries
+  alias KlassHero.Messaging.StaffConversation
+  alias KlassHero.ProgramCatalog
+  alias KlassHero.Repo
+
+  @default_limit 25
+
+  @doc """
+  Returns a page of conversations, newest first.
+
+  ## Options
+
+    * `:type` - `:direct` or `:program_broadcast`
+    * `:limit` - page size, defaults to #{@default_limit}
+    * `:before` - exclusive `inserted_at` cursor for the next (older) page
+
+  Authorization resolves before any option is read, so a non-owner's refusal cannot
+  depend on what they asked for.
+  """
+  @spec execute(Scope.t(), keyword()) ::
+          {:ok, [StaffConversation.t()], boolean()} | {:error, :unauthorized}
+  def execute(%Scope{} = scope, opts \\ []) do
+    span do
+      with {:ok, provider_id} <- Authorization.authorize_provider_owner(scope) do
+        OpenTelemetry.Tracer.set_attribute("messaging.staff_conversations.provider_id", provider_id)
+        OpenTelemetry.Tracer.set_attribute("messaging.staff_conversations.owner_id", scope.user.id)
+
+        list(scope.user.id, provider_id, opts)
+      end
+    end
+  end
+
+  defp list(owner_user_id, provider_id, opts) do
+    limit = Keyword.get(opts, :limit, @default_limit)
+
+    rows =
+      ConversationQueries.base()
+      |> ConversationQueries.by_provider(provider_id)
+      |> ConversationQueries.where_user_is_not_participant(owner_user_id)
+      |> ConversationQueries.active_only()
+      |> maybe_by_type(Keyword.get(opts, :type))
+      |> ConversationQueries.order_by_newest()
+      |> ConversationQueries.paginate(Keyword.put(opts, :limit, limit))
+      |> ConversationQueries.preload_assocs([:participants])
+      |> Repo.all()
+
+    page = Enum.take(rows, limit)
+
+    {:ok, enrich(page, provider_id), length(rows) > limit}
+  end
+
+  defp maybe_by_type(query, nil), do: query
+  defp maybe_by_type(query, type), do: ConversationQueries.by_type(query, type)
+
+  defp enrich([], _provider_id), do: []
+
+  defp enrich(conversations, provider_id) do
+    latest_messages = latest_messages(conversations)
+
+    context = %{
+      user_names: user_names(conversations),
+      staff_ids: staff_user_ids(provider_id),
+      latest_messages: latest_messages,
+      attachment_ids: attachment_ids(latest_messages),
+      program_names: program_names(conversations)
+    }
+
+    Enum.map(conversations, &build_row(&1, context))
+  end
+
+  defp user_names(conversations) do
+    conversations
+    |> Enum.flat_map(fn conversation -> Enum.map(conversation.participants, & &1.user_id) end)
+    |> Enum.uniq()
+    |> Accounts.get_display_names()
+  end
+
+  defp staff_user_ids(provider_id) do
+    acl_span source: "messaging", target: "provider" do
+      provider_id
+      |> KlassHero.Provider.list_staff_user_ids_for_provider()
+      |> MapSet.new()
+    end
+  end
+
+  defp latest_messages(conversations) do
+    conversations
+    |> Enum.map(& &1.id)
+    |> MessageQueries.latest_per_conversation()
+    |> Repo.all()
+    |> Map.new(&{&1.conversation_id, &1})
+  end
+
+  defp attachment_ids(latest_messages) when map_size(latest_messages) == 0, do: MapSet.new()
+
+  defp attachment_ids(latest_messages) do
+    latest_messages
+    |> Map.values()
+    |> Enum.map(& &1.id)
+    |> MessageQueries.message_ids_with_attachments()
+    |> Repo.all()
+    |> MapSet.new()
+  end
+
+  # Skips the query entirely when the page holds no broadcast — `get_titles/1` has an
+  # empty-list clause, so this costs nothing on a page of direct threads.
+  defp program_names(conversations) do
+    for(
+      %{type: :program_broadcast, program_id: id} <- conversations,
+      not is_nil(id),
+      uniq: true,
+      do: id
+    )
+    |> ProgramCatalog.get_titles()
+  end
+
+  defp build_row(conversation, context) do
+    active = Enum.filter(conversation.participants, &is_nil(&1.left_at))
+    {staff, others} = Enum.split_with(active, &MapSet.member?(context.staff_ids, &1.user_id))
+    latest = Map.get(context.latest_messages, conversation.id)
+
+    %StaffConversation{
+      conversation_id: conversation.id,
+      conversation_type: conversation.type,
+      provider_id: conversation.provider_id,
+      program_id: conversation.program_id,
+      program_name: broadcast_program_name(conversation, context.program_names),
+      other_participant_name: other_participant_name(conversation.type, others, context.user_names),
+      staff_member_names: named(staff, context.user_names),
+      latest_message_content: latest && latest.content,
+      latest_message_at: latest && latest.inserted_at,
+      has_attachments: latest != nil and MapSet.member?(context.attachment_ids, latest.id),
+      inserted_at: conversation.inserted_at
+    }
+  end
+
+  defp broadcast_program_name(%{type: :program_broadcast, program_id: id}, names) when not is_nil(id) do
+    Map.get(names, id)
+  end
+
+  defp broadcast_program_name(_conversation, _names), do: nil
+
+  # A direct thread with anything other than exactly one non-staff party is ambiguous
+  # (two staff DMing, or a parent who left). `nil` lets the card fall back to its own
+  # "Unknown" rather than picking a party arbitrarily.
+  defp other_participant_name(:direct, [%{user_id: id}], names), do: Map.get(names, id)
+  defp other_participant_name(_type, _others, _names), do: nil
+
+  defp named(participants, names) do
+    participants
+    |> Enum.map(&Map.get(names, &1.user_id))
+    |> Enum.reject(&is_nil/1)
+    |> Enum.sort()
+  end
+end

--- a/lib/klass_hero/messaging/queries/message_queries.ex
+++ b/lib/klass_hero/messaging/queries/message_queries.ex
@@ -108,9 +108,8 @@ defmodule KlassHero.Messaging.Queries.MessageQueries do
   notification for something the reader cannot open.
   """
   def newest_inserted_at_by_conversation(conversation_ids) do
-    base()
-    |> where([message: m], m.conversation_id in ^conversation_ids)
-    |> group_by([message: m], m.conversation_id)
+    conversation_ids
+    |> grouped_by_conversation()
     |> select([message: m], {m.conversation_id, max(m.inserted_at)})
   end
 
@@ -119,19 +118,13 @@ defmodule KlassHero.Messaging.Queries.MessageQueries do
 
   A subquery join rather than a `:messages` preload, which would load N×M rows.
 
-  Counts soft-deleted messages, so `not_deleted/1` is deliberately absent here as it
-  is in `newest_inserted_at_by_conversation/1`. An inbox preview anchored on the
-  newest *visible* message would disagree with the unread badge rendered beside it,
-  which counts deleted ones.
-
   Returns a query. Callers execute and shape it — `ConversationSummaries` and
   `ListStaffConversations` both key the rows by `conversation_id`.
   """
   def latest_per_conversation(conversation_ids) do
     latest_times =
-      base()
-      |> where([message: m], m.conversation_id in ^conversation_ids)
-      |> group_by([message: m], m.conversation_id)
+      conversation_ids
+      |> grouped_by_conversation()
       |> select([message: m], %{conversation_id: m.conversation_id, max_at: max(m.inserted_at)})
 
     base()
@@ -145,6 +138,16 @@ defmodule KlassHero.Messaging.Queries.MessageQueries do
       sender_id: m.sender_id,
       inserted_at: m.inserted_at
     })
+  end
+
+  # The grouping both "newest per conversation" reads share. It carries the one
+  # decision that must not drift between them: no `not_deleted/1`. A preview or a
+  # cursor anchored on the newest *visible* message would disagree with the unread
+  # badge rendered beside it, which counts soft-deleted ones.
+  defp grouped_by_conversation(conversation_ids) do
+    base()
+    |> where([message: m], m.conversation_id in ^conversation_ids)
+    |> group_by([message: m], m.conversation_id)
   end
 
   @doc """

--- a/lib/klass_hero/messaging/queries/message_queries.ex
+++ b/lib/klass_hero/messaging/queries/message_queries.ex
@@ -5,6 +5,7 @@ defmodule KlassHero.Messaging.Queries.MessageQueries do
 
   import Ecto.Query
 
+  alias KlassHero.Messaging.Attachment
   alias KlassHero.Messaging.Message
 
   @doc """
@@ -111,6 +112,50 @@ defmodule KlassHero.Messaging.Queries.MessageQueries do
     |> where([message: m], m.conversation_id in ^conversation_ids)
     |> group_by([message: m], m.conversation_id)
     |> select([message: m], {m.conversation_id, max(m.inserted_at)})
+  end
+
+  @doc """
+  The newest message row per conversation — one row each, for a batch of ids.
+
+  A subquery join rather than a `:messages` preload, which would load N×M rows.
+
+  Counts soft-deleted messages, so `not_deleted/1` is deliberately absent here as it
+  is in `newest_inserted_at_by_conversation/1`. An inbox preview anchored on the
+  newest *visible* message would disagree with the unread badge rendered beside it,
+  which counts deleted ones.
+
+  Returns a query. Callers execute and shape it — `ConversationSummaries` and
+  `ListStaffConversations` both key the rows by `conversation_id`.
+  """
+  def latest_per_conversation(conversation_ids) do
+    latest_times =
+      base()
+      |> where([message: m], m.conversation_id in ^conversation_ids)
+      |> group_by([message: m], m.conversation_id)
+      |> select([message: m], %{conversation_id: m.conversation_id, max_at: max(m.inserted_at)})
+
+    base()
+    |> join(:inner, [message: m], lt in subquery(latest_times),
+      on: m.conversation_id == lt.conversation_id and m.inserted_at == lt.max_at
+    )
+    |> select([message: m], %{
+      id: m.id,
+      conversation_id: m.conversation_id,
+      content: m.content,
+      sender_id: m.sender_id,
+      inserted_at: m.inserted_at
+    })
+  end
+
+  @doc """
+  Of the given message ids, those carrying at least one attachment.
+  """
+  def message_ids_with_attachments(message_ids) do
+    from(a in Attachment,
+      where: a.message_id in ^message_ids,
+      distinct: a.message_id,
+      select: a.message_id
+    )
   end
 
   @doc """

--- a/lib/klass_hero/messaging/staff_conversation.ex
+++ b/lib/klass_hero/messaging/staff_conversation.ex
@@ -1,0 +1,70 @@
+defmodule KlassHero.Messaging.StaffConversation do
+  @moduledoc """
+  Read row for a provider owner's "Staff conversations" list (#746): a conversation
+  their business owns but that they are not a participant of.
+
+  A query-shaped struct over the **write** tables (`conversations`,
+  `conversation_participants`, `messages`), built by
+  `KlassHero.Messaging.ListStaffConversations`. Plain struct — no Ecto schema, no
+  table, no changeset. It sits at the context root rather than under `read_models/`
+  because that kind earns a directory at three files and Messaging has one.
+
+  It deliberately does **not** read `conversation_summaries`. That projection is keyed
+  `(conversation_id, user_id)`, so an owner who is not a participant has no row in it,
+  and reading it anyway would yield one row per participant per conversation — the
+  same reasoning `MonitorConversations` records for the admin list.
+
+  ## Why the field names match `ConversationSummary`
+
+  `KlassHeroWeb.MessagingComponents.conversation_card/1` is declared `attr :summary,
+  :map` and its helpers match on field *names*, not on a struct name. Carrying the
+  same names lets this row render through the identical card as the participant
+  inbox, so the two surfaces cannot drift apart visually.
+
+  `unread_count` and `enrolled_child_names` are pinned to `0` and `[]` and exist for
+  that reason alone:
+
+    * **`unread_count`** can never be anything else here. It is derived from
+      `Participant.last_read_at`, and the whole point of this surface is that the
+      reader has no participant row. The card hides its badge at zero.
+    * **`enrolled_child_names`** is the one field genuinely owned by Family and
+      Enrollment rather than Messaging, and it was left out of the first cut. The
+      card omits its caption when the list is empty, so nothing breaks — an owner
+      simply sees slightly less context here than on their own threads.
+  """
+
+  @typedoc "One conversation a provider owns but does not participate in."
+  @type t :: %__MODULE__{
+          conversation_id: String.t(),
+          conversation_type: :direct | :program_broadcast,
+          provider_id: String.t(),
+          program_id: String.t() | nil,
+          program_name: String.t() | nil,
+          other_participant_name: String.t() | nil,
+          staff_member_names: [String.t()],
+          latest_message_content: String.t() | nil,
+          latest_message_at: DateTime.t() | nil,
+          has_attachments: boolean(),
+          unread_count: non_neg_integer(),
+          enrolled_child_names: [String.t()],
+          inserted_at: DateTime.t()
+        }
+
+  @enforce_keys [:conversation_id, :conversation_type, :provider_id, :inserted_at]
+
+  defstruct [
+    :conversation_id,
+    :conversation_type,
+    :provider_id,
+    :program_id,
+    :program_name,
+    :other_participant_name,
+    :latest_message_content,
+    :latest_message_at,
+    :inserted_at,
+    staff_member_names: [],
+    has_attachments: false,
+    unread_count: 0,
+    enrolled_child_names: []
+  ]
+end

--- a/lib/klass_hero_web/components/messaging_components.ex
+++ b/lib/klass_hero_web/components/messaging_components.ex
@@ -500,6 +500,44 @@ defmodule KlassHeroWeb.MessagingComponents do
   defp empty_state_message(_parent), do: gettext("Your conversations with providers will appear here")
 
   @doc """
+  The provider Comms page frame: full-height page, centred surface column, and the
+  sticky header bar that sits above whatever the surface lists.
+
+  Every chrome-shaped thing the provider's own inbox and their read-only view of the
+  threads their staff conduct render *identically* lives here (#746). Those two are
+  tabs of one surface, so a layout class that drifts between them shows up to the user
+  as a jump on tab switch — and a duplicated class is exactly what drifts.
+
+  The `:header` slot is whatever belongs inside the sticky bar: a title plus the tab
+  strip on an index, a back link plus a thread title on a thread.
+
+  ## Examples
+
+      <.provider_comms_shell>
+        <:header>
+          <h1>{gettext("Messages")}</h1>
+          <.provider_message_tabs current_tab={:inbox} />
+        </:header>
+        <.conversation_list ... />
+      </.provider_comms_shell>
+  """
+  slot :header, required: true
+  slot :inner_block, required: true
+
+  def provider_comms_shell(assigns) do
+    ~H"""
+    <div class="min-h-screen bg-gray-50">
+      <div class="max-w-2xl mx-auto bg-white min-h-screen shadow-sm">
+        <header class="sticky top-0 z-10 bg-white border-b border-gray-200 px-4 py-3">
+          {render_slot(@header)}
+        </header>
+        {render_slot(@inner_block)}
+      </div>
+    </div>
+    """
+  end
+
+  @doc """
   Renders the conversation index page.
 
   Uses multi-clause dispatch on `variant` for parent vs provider chrome.
@@ -544,20 +582,20 @@ defmodule KlassHeroWeb.MessagingComponents do
 
   def conversation_index(%{variant: :provider} = assigns) do
     ~H"""
-    <div class="min-h-screen bg-gray-50">
-      <div class="max-w-2xl mx-auto bg-white min-h-screen shadow-sm">
-        <header class="sticky top-0 z-10 bg-white border-b border-gray-200 px-4 py-3">
-          <h1 class="text-xl font-semibold text-gray-900">{gettext("Messages")}</h1>
-          {render_slot(@tabs)}
-        </header>
-        <.conversation_list
-          streams={@streams}
-          conversations_empty?={@conversations_empty?}
-          navigate_base={@navigate_base}
-          user_type={:provider}
-        />
-      </div>
-    </div>
+    <.provider_comms_shell>
+      <:header>
+        <h1 class={["text-xl font-semibold", Theme.text_color(:heading)]}>
+          {gettext("Messages")}
+        </h1>
+        {render_slot(@tabs)}
+      </:header>
+      <.conversation_list
+        streams={@streams}
+        conversations_empty?={@conversations_empty?}
+        navigate_base={@navigate_base}
+        user_type={:provider}
+      />
+    </.provider_comms_shell>
     """
   end
 

--- a/lib/klass_hero_web/components/messaging_components.ex
+++ b/lib/klass_hero_web/components/messaging_components.ex
@@ -9,7 +9,6 @@ defmodule KlassHeroWeb.MessagingComponents do
   import KlassHeroWeb.UIComponents, only: [icon: 1]
 
   alias KlassHero.Messaging.Attachment
-  alias KlassHero.Messaging.ConversationSummary
   alias KlassHeroWeb.MessagingLiveHelper
   alias KlassHeroWeb.Theme
   alias Phoenix.LiveView.JS
@@ -25,10 +24,16 @@ defmodule KlassHeroWeb.MessagingComponents do
 
   ## Attributes
   - id: DOM id for the card
-  - summary: A `KlassHero.Messaging.ConversationSummary` read-table row. The schema
-    is the DTO, so the card reads its flat fields directly
+  - summary: A `KlassHero.Messaging.ConversationSummary` read-table row, or a
+    `KlassHero.Messaging.StaffConversation` read row. This component matches on field
+    *names*, never on a struct name, so any row carrying them renders — that is
+    deliberate, and it is what keeps the participant inbox and the owner's staff-
+    conversations list from drifting apart visually (#746)
   - user_type: `:parent` or `:provider` — parents do not see the enrolled child names
   - navigate: Target URL for the `<.link navigate=...>` wrapper
+
+  A row carrying a non-empty `staff_member_names` also renders a "via …" attribution
+  line; a row without that field simply omits it.
 
   ## Examples
 
@@ -51,6 +56,7 @@ defmodule KlassHeroWeb.MessagingComponents do
       |> assign(:display_name, derive_display_name(assigns.summary))
       |> assign(:unread_count, assigns.summary.unread_count)
       |> assign(:child_names, visible_child_names(assigns.summary, assigns.user_type))
+      |> assign(:staff_names, Map.get(assigns.summary, :staff_member_names, []))
 
     ~H"""
     <.link
@@ -88,6 +94,13 @@ defmodule KlassHeroWeb.MessagingComponents do
           </div>
           <p :if={@child_names != []} class={["text-xs mt-0.5", Theme.text_color(:muted)]}>
             {gettext("for")} {Enum.join(@child_names, ", ")}
+          </p>
+          <p
+            :if={@staff_names != []}
+            data-role="staff-attribution"
+            class={["text-xs mt-0.5", Theme.text_color(:muted)]}
+          >
+            {gettext("via")} {Enum.join(@staff_names, ", ")}
           </p>
 
           <div class="flex items-center justify-between gap-2 mt-1">
@@ -496,6 +509,14 @@ defmodule KlassHeroWeb.MessagingComponents do
   attr :conversations_empty?, :boolean, required: true
   attr :navigate_base, :string, required: true
 
+  slot :tabs,
+    doc: """
+    Optional strip rendered under the header, above the list. The provider surfaces
+    use it to switch between their own inbox and the threads their staff conduct
+    (#746); the routes live in the caller so this shared component stays
+    persona-agnostic.
+    """
+
   def conversation_index(%{variant: :parent} = assigns) do
     ~H"""
     <div class={["min-h-screen", Theme.bg(:muted)]}>
@@ -527,6 +548,7 @@ defmodule KlassHeroWeb.MessagingComponents do
       <div class="max-w-2xl mx-auto bg-white min-h-screen shadow-sm">
         <header class="sticky top-0 z-10 bg-white border-b border-gray-200 px-4 py-3">
           <h1 class="text-xl font-semibold text-gray-900">{gettext("Messages")}</h1>
+          {render_slot(@tabs)}
         </header>
         <.conversation_list
           streams={@streams}
@@ -773,13 +795,14 @@ defmodule KlassHeroWeb.MessagingComponents do
 
   # A row with no message at all still carries whatever latest_message_at the
   # projection last wrote, so the timestamp is gated on the message, not the column.
-  defp latest_message_timestamp(summary) do
-    if ConversationSummary.has_latest_message?(summary) do
-      format_timestamp(summary.latest_message_at)
-    else
-      ""
-    end
-  end
+  #
+  # Matched on field names rather than through `ConversationSummary.has_latest_message?/1`,
+  # which matches its own struct by name and so would raise on any other row shape.
+  # This is the single change that lets the card render a `StaffConversation` too (#746);
+  # the schema keeps its own copy for its own callers.
+  defp latest_message_timestamp(%{latest_message_content: nil, has_attachments: false}), do: ""
+
+  defp latest_message_timestamp(summary), do: format_timestamp(summary.latest_message_at)
 
   defp format_timestamp(nil), do: ""
 

--- a/lib/klass_hero_web/components/provider_components.ex
+++ b/lib/klass_hero_web/components/provider_components.ex
@@ -153,6 +153,42 @@ defmodule KlassHeroWeb.ProviderComponents do
   end
 
   @doc """
+  Renders the two tabs of the provider Comms surface (#746).
+
+  `current_tab` is `:inbox` for the provider's own conversations, or `:staff` for
+  the read-only view of the threads their staff conduct with parents.
+
+  Lives here rather than in `MessagingComponents` so the shared conversation
+  components stay persona-agnostic and carry no provider routes.
+
+  ## Examples
+
+      <.provider_message_tabs current_tab={:inbox} />
+  """
+  attr :current_tab, :atom, required: true, values: [:inbox, :staff]
+
+  def provider_message_tabs(assigns) do
+    ~H"""
+    <nav data-role="provider-message-tabs" class="flex gap-1 overflow-x-auto -mb-3 mt-2">
+      <.nav_tab
+        navigate={~p"/provider/messages"}
+        active={@current_tab == :inbox}
+        icon="hero-inbox-mini"
+      >
+        {gettext("My conversations")}
+      </.nav_tab>
+      <.nav_tab
+        navigate={~p"/provider/messages/staff"}
+        active={@current_tab == :staff}
+        icon="hero-user-group-mini"
+      >
+        {gettext("Staff conversations")}
+      </.nav_tab>
+    </nav>
+    """
+  end
+
+  @doc """
   Renders a stat card for the provider dashboard.
 
   ## Examples

--- a/lib/klass_hero_web/live/privacy_policy_live.ex
+++ b/lib/klass_hero_web/live/privacy_policy_live.ex
@@ -97,6 +97,7 @@ defmodule KlassHeroWeb.PrivacyPolicyLive do
         <p class="mb-4">We take your privacy seriously and limit data sharing to what's necessary:</p>
         <h4 class="font-semibold text-gray-900 mb-2">Program Providers:</h4>
         <p class="mb-4">Providers see enrolled children's names for program management. Optional safety information (support needs, allergies) is visible to providers only when a parent explicitly consents to share it. Session notes written by providers about a child require parent approval before being displayed.</p>
+        <p class="mb-4">The owner of a provider business can read the messages you exchange with that provider's staff, for child safety and because they are responsible for their team's conduct. Access is read-only — an owner cannot post, edit or delete messages in a conversation they are not part of, and doing so does not mark anything as read on your side. Every access is logged. Conversations with a provider display a notice telling you this.</p>
         <h4 class="font-semibold text-gray-900 mb-2">Payment Processors:</h4>
         <p class="mb-4">For credit card payments, we work with third-party payment processors who handle transaction processing securely. They only receive the information necessary to process payments.</p>
         <h4 class="font-semibold text-gray-900 mb-2">Platform Administrators:</h4>

--- a/lib/klass_hero_web/live/provider/messages_live/index.ex
+++ b/lib/klass_hero_web/live/provider/messages_live/index.ex
@@ -10,6 +10,7 @@ defmodule KlassHeroWeb.Provider.MessagesLive.Index do
   use KlassHeroWeb.MessagingLiveHelper, :index
 
   import KlassHeroWeb.MessagingComponents
+  import KlassHeroWeb.ProviderComponents, only: [provider_message_tabs: 1]
 
   @impl true
   def mount(_params, _session, socket) do
@@ -27,7 +28,11 @@ defmodule KlassHeroWeb.Provider.MessagesLive.Index do
       streams={@streams}
       conversations_empty?={@conversations_empty?}
       navigate_base={@navigate_base}
-    />
+    >
+      <:tabs>
+        <.provider_message_tabs current_tab={:inbox} />
+      </:tabs>
+    </.conversation_index>
     """
   end
 end

--- a/lib/klass_hero_web/live/provider/staff_conversations_live.ex
+++ b/lib/klass_hero_web/live/provider/staff_conversations_live.ex
@@ -27,9 +27,11 @@ defmodule KlassHeroWeb.Provider.StaffConversationsLive do
 
   use KlassHeroWeb, :live_view
 
-  # Only the two presentational pieces. Importing the whole module would put
+  # Only the presentational pieces. Importing the whole module would put
   # `message_input/1` and `conversation_show/1` in scope on a read-only screen.
-  import KlassHeroWeb.MessagingComponents, only: [conversation_card: 1, message_bubble: 1]
+  import KlassHeroWeb.MessagingComponents,
+    only: [conversation_card: 1, message_bubble: 1, provider_comms_shell: 1]
+
   import KlassHeroWeb.ProviderComponents, only: [provider_message_tabs: 1]
 
   alias KlassHero.Messaging
@@ -45,7 +47,6 @@ defmodule KlassHeroWeb.Provider.StaffConversationsLive do
      |> assign(:page_title, gettext("Staff conversations"))
      |> assign(:has_more, false)
      |> assign(:cursor, nil)
-     |> assign(:conversations_empty?, true)
      # A StaffConversation has no `:id` — it is a query-shaped row, not a table row —
      # so the DOM id has to come from the conversation it describes.
      |> stream_configure(:conversations, dom_id: &"staff-conversations-#{&1.conversation_id}")
@@ -91,7 +92,6 @@ defmodule KlassHeroWeb.Provider.StaffConversationsLive do
       {:ok, conversations, has_more} ->
         socket
         |> stream(:conversations, conversations, reset: reset?)
-        |> assign(:conversations_empty?, reset? and conversations == [])
         |> assign(:has_more, has_more)
         |> assign(:cursor, cursor_from(conversations))
 

--- a/lib/klass_hero_web/live/provider/staff_conversations_live.ex
+++ b/lib/klass_hero_web/live/provider/staff_conversations_live.ex
@@ -1,0 +1,115 @@
+defmodule KlassHeroWeb.Provider.StaffConversationsLive do
+  @moduledoc """
+  Read-only view of the conversations a provider owns but is not part of — the
+  threads their staff conduct with parents (#746).
+
+  Oversight, not participation: this surface lists and reads, and offers no action
+  that writes. Like `KlassHeroWeb.Admin.MessagesLive`, it never uses
+  `KlassHeroWeb.MessagingLiveHelper` — that macro injects `send_message`, `validate`
+  and `cancel-upload` handlers into whatever module uses it, and its
+  `mount_conversation_show/3` marks a thread read on every connected mount. Adopting
+  it here would wire both a write path and a read-receipt into a screen that must
+  have neither, whatever the markup does.
+
+  The thread is composed from `message_bubble/1`, which is purely presentational,
+  rather than from `conversation_show/1`, which requires a form and always renders a
+  composer for the `:provider` variant.
+
+  The list, by contrast, *does* reuse `conversation_card/1`: that component matches
+  on field names rather than a struct name, so a `StaffConversation` renders through
+  the identical card as the owner's own inbox and the two cannot drift apart.
+
+  Authorization is `Messaging.authorize_provider_owner/1` inside the context, reached
+  through `list_staff_conversations/2` and `get_staff_conversation/3`. The router's
+  `:require_provider` on_mount stays as defence in depth, not as the guarantee — it
+  proves the scope owns *a* provider, never that it owns the thread being read.
+  """
+
+  use KlassHeroWeb, :live_view
+
+  # Only the two presentational pieces. Importing the whole module would put
+  # `message_input/1` and `conversation_show/1` in scope on a read-only screen.
+  import KlassHeroWeb.MessagingComponents, only: [conversation_card: 1, message_bubble: 1]
+  import KlassHeroWeb.ProviderComponents, only: [provider_message_tabs: 1]
+
+  alias KlassHero.Messaging
+  alias KlassHeroWeb.Theme
+
+  @page_size 25
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(:active_nav, :messages)
+     |> assign(:page_title, gettext("Staff conversations"))
+     |> assign(:has_more, false)
+     |> assign(:cursor, nil)
+     |> assign(:conversations_empty?, true)
+     # A StaffConversation has no `:id` — it is a query-shaped row, not a table row —
+     # so the DOM id has to come from the conversation it describes.
+     |> stream_configure(:conversations, dom_id: &"staff-conversations-#{&1.conversation_id}")
+     |> stream(:conversations, [])}
+  end
+
+  @impl true
+  def handle_params(params, _uri, socket) do
+    {:noreply, apply_action(socket, socket.assigns.live_action, params)}
+  end
+
+  defp apply_action(socket, :index, _params) do
+    socket
+    |> assign(:page_title, gettext("Staff conversations"))
+    |> load_page(reset: true)
+  end
+
+  defp apply_action(socket, :show, %{"id" => id}) do
+    with {:ok, uuid} <- Ecto.UUID.cast(id),
+         {:ok, result} <- Messaging.get_staff_conversation(socket.assigns.current_scope, uuid) do
+      socket
+      |> assign(:conversation, result.conversation)
+      |> assign(:sender_names, result.sender_names)
+      |> assign(:page_title, gettext("Conversation"))
+      |> stream(:messages, Enum.reverse(result.messages), reset: true)
+    else
+      _ ->
+        socket
+        |> put_flash(:error, gettext("Conversation not found."))
+        |> push_navigate(to: ~p"/provider/messages/staff")
+    end
+  end
+
+  @impl true
+  def handle_event("load_more", _params, socket) do
+    {:noreply, load_page(socket, reset: false)}
+  end
+
+  defp load_page(socket, reset: reset?) do
+    opts = maybe_cursor([limit: @page_size], reset?, socket.assigns.cursor)
+
+    case Messaging.list_staff_conversations(socket.assigns.current_scope, opts) do
+      {:ok, conversations, has_more} ->
+        socket
+        |> stream(:conversations, conversations, reset: reset?)
+        |> assign(:conversations_empty?, reset? and conversations == [])
+        |> assign(:has_more, has_more)
+        |> assign(:cursor, cursor_from(conversations))
+
+      {:error, :unauthorized} ->
+        socket
+        |> put_flash(:error, gettext("You don't have access to that page."))
+        |> push_navigate(to: ~p"/provider/messages")
+    end
+  end
+
+  defp maybe_cursor(opts, true, _cursor), do: opts
+  defp maybe_cursor(opts, false, nil), do: opts
+  defp maybe_cursor(opts, false, cursor), do: Keyword.put(opts, :before, cursor)
+
+  defp cursor_from([]), do: nil
+  defp cursor_from(conversations), do: List.last(conversations).inserted_at
+
+  defp thread_title(%{subject: subject}) when is_binary(subject) and subject != "", do: subject
+  defp thread_title(%{type: :program_broadcast}), do: gettext("Broadcast")
+  defp thread_title(_conversation), do: gettext("Conversation")
+end

--- a/lib/klass_hero_web/live/provider/staff_conversations_live.ex
+++ b/lib/klass_hero_web/live/provider/staff_conversations_live.ex
@@ -4,12 +4,17 @@ defmodule KlassHeroWeb.Provider.StaffConversationsLive do
   threads their staff conduct with parents (#746).
 
   Oversight, not participation: this surface lists and reads, and offers no action
-  that writes. Like `KlassHeroWeb.Admin.MessagesLive`, it never uses
+  that writes. Like `KlassHeroWeb.Admin.MessagesLive`, it never `use`s
   `KlassHeroWeb.MessagingLiveHelper` — that macro injects `send_message`, `validate`
   and `cancel-upload` handlers into whatever module uses it, and its
   `mount_conversation_show/3` marks a thread read on every connected mount. Adopting
   it here would wire both a write path and a read-receipt into a screen that must
   have neither, whatever the markup does.
+
+  It does `import` one function from that module. `get_conversation_title/3` is a
+  plain `def` outside the `__using__` macro, so calling it pulls in none of the
+  above — and titles have no reason to read differently here than on every other
+  message surface.
 
   The thread is composed from `message_bubble/1`, which is purely presentational,
   rather than from `conversation_show/1`, which requires a form and always renders a
@@ -32,6 +37,7 @@ defmodule KlassHeroWeb.Provider.StaffConversationsLive do
   import KlassHeroWeb.MessagingComponents,
     only: [conversation_card: 1, message_bubble: 1, provider_comms_shell: 1]
 
+  import KlassHeroWeb.MessagingLiveHelper, only: [get_conversation_title: 3]
   import KlassHeroWeb.ProviderComponents, only: [provider_message_tabs: 1]
 
   alias KlassHero.Messaging
@@ -109,7 +115,10 @@ defmodule KlassHeroWeb.Provider.StaffConversationsLive do
   defp cursor_from([]), do: nil
   defp cursor_from(conversations), do: List.last(conversations).inserted_at
 
-  defp thread_title(%{subject: subject}) when is_binary(subject) and subject != "", do: subject
-  defp thread_title(%{type: :program_broadcast}), do: gettext("Broadcast")
-  defp thread_title(_conversation), do: gettext("Conversation")
+  # No enrolled child names and no other-party name: both are participant-relative,
+  # and the owner has no participant row here, so `get_conversation_context/2` — which
+  # reads `conversation_summaries`, keyed (conversation_id, user_id) — has nothing for
+  # them. A direct thread therefore titles generically. Deriving the parent's name from
+  # the owner's viewpoint needs Provider's staff list, as the index already does — #1523.
+  defp thread_title(conversation), do: get_conversation_title(conversation, [], nil)
 end

--- a/lib/klass_hero_web/live/provider/staff_conversations_live.html.heex
+++ b/lib/klass_hero_web/live/provider/staff_conversations_live.html.heex
@@ -1,0 +1,89 @@
+<div class="min-h-screen bg-gray-50">
+  <div class="max-w-2xl mx-auto bg-white min-h-screen shadow-sm">
+    <%= if @live_action == :index do %>
+      <header class="sticky top-0 z-10 bg-white border-b border-gray-200 px-4 py-3">
+        <h1 class={["text-xl font-semibold", Theme.text_color(:heading)]}>
+          {gettext("Messages")}
+        </h1>
+        <.provider_message_tabs current_tab={:staff} />
+      </header>
+
+      <p
+        data-role="oversight-note"
+        class={[Theme.typography(:caption), Theme.text_color(:muted), "px-4 pt-3"]}
+      >
+        {gettext(
+          "Conversations your staff have with parents. Read-only — opening a thread here does not mark anything as read."
+        )}
+      </p>
+
+      <div id="staff-conversations" phx-update="stream" class="divide-y divide-hero-grey-200">
+        <.conversation_card
+          :for={{dom_id, row} <- @streams.conversations}
+          id={dom_id}
+          summary={row}
+          user_type={:provider}
+          navigate={~p"/provider/messages/staff/#{row.conversation_id}"}
+        />
+        <div
+          :if={@conversations_empty?}
+          id="staff-conversations-empty-state"
+          class="p-8 text-center"
+        >
+          <p class={[Theme.typography(:body_small), Theme.text_color(:muted)]}>
+            {gettext("No staff conversations yet. Threads your team starts will appear here.")}
+          </p>
+        </div>
+      </div>
+
+      <div :if={@has_more} class="flex justify-center py-6">
+        <button
+          type="button"
+          phx-click="load_more"
+          data-role="load-more"
+          class="btn btn-sm btn-outline"
+        >
+          {gettext("Load more")}
+        </button>
+      </div>
+    <% else %>
+      <header class="sticky top-0 z-10 bg-white border-b border-gray-200 px-4 py-3">
+        <.link
+          navigate={~p"/provider/messages/staff"}
+          data-role="back-to-staff-conversations"
+          class={["text-sm hover:underline", Theme.text_color(:muted)]}
+        >
+          {gettext("Back to staff conversations")}
+        </.link>
+        <h1 class={["text-xl font-semibold mt-1", Theme.text_color(:heading)]}>
+          {thread_title(@conversation)}
+        </h1>
+        <p
+          data-role="read-only-note"
+          class={[Theme.typography(:caption), Theme.text_color(:muted), "mt-1"]}
+        >
+          {gettext(
+            "Read-only. You are viewing this as the business owner, not as a participant — nothing is marked as read."
+          )}
+        </p>
+      </header>
+
+      <div id="conversation-thread" phx-update="stream" class="p-4 space-y-3">
+        <div id="messages-empty-state" class="hidden only:block p-8 text-center">
+          <p class={[Theme.typography(:body_small), Theme.text_color(:muted)]}>
+            {gettext("No messages in this conversation.")}
+          </p>
+        </div>
+        <.message_bubble
+          :for={{dom_id, message} <- @streams.messages}
+          id={dom_id}
+          message={message}
+          is_own={false}
+          sender_name={Map.get(@sender_names, message.sender_id, gettext("Unknown"))}
+          provider_name={@current_scope.provider.business_name}
+          is_provider_side={message.sender_role in [:provider, :staff]}
+        />
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/lib/klass_hero_web/live/provider/staff_conversations_live.html.heex
+++ b/lib/klass_hero_web/live/provider/staff_conversations_live.html.heex
@@ -1,89 +1,85 @@
-<div class="min-h-screen bg-gray-50">
-  <div class="max-w-2xl mx-auto bg-white min-h-screen shadow-sm">
-    <%= if @live_action == :index do %>
-      <header class="sticky top-0 z-10 bg-white border-b border-gray-200 px-4 py-3">
-        <h1 class={["text-xl font-semibold", Theme.text_color(:heading)]}>
-          {gettext("Messages")}
-        </h1>
-        <.provider_message_tabs current_tab={:staff} />
-      </header>
+<%= if @live_action == :index do %>
+  <.provider_comms_shell>
+    <:header>
+      <h1 class={["text-xl font-semibold", Theme.text_color(:heading)]}>
+        {gettext("Messages")}
+      </h1>
+      <.provider_message_tabs current_tab={:staff} />
+    </:header>
 
+    <p
+      data-role="oversight-note"
+      class={[Theme.typography(:caption), Theme.text_color(:muted), "px-4 pt-3"]}
+    >
+      {gettext(
+        "Conversations your staff have with parents. Read-only — opening a thread here does not mark anything as read."
+      )}
+    </p>
+
+    <div id="staff-conversations" phx-update="stream" class="divide-y divide-hero-grey-200">
+      <.conversation_card
+        :for={{dom_id, row} <- @streams.conversations}
+        id={dom_id}
+        summary={row}
+        user_type={:provider}
+        navigate={~p"/provider/messages/staff/#{row.conversation_id}"}
+      />
+      <div id="staff-conversations-empty-state" class="hidden only:block p-8 text-center">
+        <p class={[Theme.typography(:body_small), Theme.text_color(:muted)]}>
+          {gettext("No staff conversations yet. Threads your team starts will appear here.")}
+        </p>
+      </div>
+    </div>
+
+    <div :if={@has_more} class="flex justify-center py-6">
+      <button
+        type="button"
+        phx-click="load_more"
+        data-role="load-more"
+        class="btn btn-sm btn-outline"
+      >
+        {gettext("Load more")}
+      </button>
+    </div>
+  </.provider_comms_shell>
+<% else %>
+  <.provider_comms_shell>
+    <:header>
+      <.link
+        navigate={~p"/provider/messages/staff"}
+        data-role="back-to-staff-conversations"
+        class={["text-sm hover:underline", Theme.text_color(:muted)]}
+      >
+        {gettext("Back to staff conversations")}
+      </.link>
+      <h1 class={["text-xl font-semibold mt-1", Theme.text_color(:heading)]}>
+        {thread_title(@conversation)}
+      </h1>
       <p
-        data-role="oversight-note"
-        class={[Theme.typography(:caption), Theme.text_color(:muted), "px-4 pt-3"]}
+        data-role="read-only-note"
+        class={[Theme.typography(:caption), Theme.text_color(:muted), "mt-1"]}
       >
         {gettext(
-          "Conversations your staff have with parents. Read-only — opening a thread here does not mark anything as read."
+          "Read-only. You are viewing this as the business owner, not as a participant — nothing is marked as read."
         )}
       </p>
+    </:header>
 
-      <div id="staff-conversations" phx-update="stream" class="divide-y divide-hero-grey-200">
-        <.conversation_card
-          :for={{dom_id, row} <- @streams.conversations}
-          id={dom_id}
-          summary={row}
-          user_type={:provider}
-          navigate={~p"/provider/messages/staff/#{row.conversation_id}"}
-        />
-        <div
-          :if={@conversations_empty?}
-          id="staff-conversations-empty-state"
-          class="p-8 text-center"
-        >
-          <p class={[Theme.typography(:body_small), Theme.text_color(:muted)]}>
-            {gettext("No staff conversations yet. Threads your team starts will appear here.")}
-          </p>
-        </div>
-      </div>
-
-      <div :if={@has_more} class="flex justify-center py-6">
-        <button
-          type="button"
-          phx-click="load_more"
-          data-role="load-more"
-          class="btn btn-sm btn-outline"
-        >
-          {gettext("Load more")}
-        </button>
-      </div>
-    <% else %>
-      <header class="sticky top-0 z-10 bg-white border-b border-gray-200 px-4 py-3">
-        <.link
-          navigate={~p"/provider/messages/staff"}
-          data-role="back-to-staff-conversations"
-          class={["text-sm hover:underline", Theme.text_color(:muted)]}
-        >
-          {gettext("Back to staff conversations")}
-        </.link>
-        <h1 class={["text-xl font-semibold mt-1", Theme.text_color(:heading)]}>
-          {thread_title(@conversation)}
-        </h1>
-        <p
-          data-role="read-only-note"
-          class={[Theme.typography(:caption), Theme.text_color(:muted), "mt-1"]}
-        >
-          {gettext(
-            "Read-only. You are viewing this as the business owner, not as a participant — nothing is marked as read."
-          )}
+    <div id="conversation-thread" phx-update="stream" class="p-4 space-y-3">
+      <div id="messages-empty-state" class="hidden only:block p-8 text-center">
+        <p class={[Theme.typography(:body_small), Theme.text_color(:muted)]}>
+          {gettext("No messages in this conversation.")}
         </p>
-      </header>
-
-      <div id="conversation-thread" phx-update="stream" class="p-4 space-y-3">
-        <div id="messages-empty-state" class="hidden only:block p-8 text-center">
-          <p class={[Theme.typography(:body_small), Theme.text_color(:muted)]}>
-            {gettext("No messages in this conversation.")}
-          </p>
-        </div>
-        <.message_bubble
-          :for={{dom_id, message} <- @streams.messages}
-          id={dom_id}
-          message={message}
-          is_own={false}
-          sender_name={Map.get(@sender_names, message.sender_id, gettext("Unknown"))}
-          provider_name={@current_scope.provider.business_name}
-          is_provider_side={message.sender_role in [:provider, :staff]}
-        />
       </div>
-    <% end %>
-  </div>
-</div>
+      <.message_bubble
+        :for={{dom_id, message} <- @streams.messages}
+        id={dom_id}
+        message={message}
+        is_own={false}
+        sender_name={Map.get(@sender_names, message.sender_id, gettext("Unknown"))}
+        provider_name={@current_scope.provider.business_name}
+        is_provider_side={message.sender_role in [:provider, :staff]}
+      />
+    </div>
+  </.provider_comms_shell>
+<% end %>

--- a/lib/klass_hero_web/router.ex
+++ b/lib/klass_hero_web/router.ex
@@ -142,6 +142,10 @@ defmodule KlassHeroWeb.Router do
 
         live "/messages", MessagesLive.Index, :index
         live "/messages/new", MessagesLive.Show, :new
+        # Both must precede "/messages/:id" — declaration order decides the match, and
+        # "staff" would otherwise be captured as an :id. Same reason "/messages/new" sits above.
+        live "/messages/staff", StaffConversationsLive, :index
+        live "/messages/staff/:id", StaffConversationsLive, :show
         live "/messages/:id", MessagesLive.Show, :show
         live "/programs/:program_id/broadcast", BroadcastLive, :new
       end

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -1486,11 +1486,11 @@ msgstr "Team- & Anbieterprofile"
 msgid "Unassigned"
 msgstr "Nicht zugewiesen"
 
-#: lib/klass_hero_web/components/messaging_components.ex:794
+#: lib/klass_hero_web/components/messaging_components.ex:832
 #: lib/klass_hero_web/components/provider_components.ex:52
 #: lib/klass_hero_web/components/provider_components.ex:1589
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:110
-#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:82
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:79
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:455
 #: lib/klass_hero_web/presenters/provider_presenter.ex:172
 #, elixir-autogen, elixir-format
@@ -1507,7 +1507,7 @@ msgstr "Teilnehmerliste"
 msgid "%{age} years old"
 msgstr "%{age} Jahre alt"
 
-#: lib/klass_hero_web/components/messaging_components.ex:815
+#: lib/klass_hero_web/components/messaging_components.ex:853
 #, elixir-autogen, elixir-format
 msgid "%{n}m ago"
 msgstr "vor %{n} Min."
@@ -1601,7 +1601,7 @@ msgstr "Kind erfolgreich aktualisiert."
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:80
 #: lib/klass_hero_web/live/dashboard_live.ex:175
 #: lib/klass_hero_web/live/messaging_live_helper.ex:413
-#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:72
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:73
 #: lib/klass_hero_web/live/provider/staff_conversations_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "Conversation"
@@ -1709,14 +1709,14 @@ msgstr "Nachrichteninhalt ist erforderlich"
 
 #: lib/klass_hero_web/components/layouts/admin.html.heex:90
 #: lib/klass_hero_web/components/layouts/app.html.heex:214
-#: lib/klass_hero_web/components/messaging_components.ex:527
-#: lib/klass_hero_web/components/messaging_components.ex:550
+#: lib/klass_hero_web/components/messaging_components.ex:565
+#: lib/klass_hero_web/components/messaging_components.ex:588
 #: lib/klass_hero_web/live/admin/messages_live.ex:37
 #: lib/klass_hero_web/live/admin/messages_live.ex:56
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:5
 #: lib/klass_hero_web/live/messages_live/index.ex:19
 #: lib/klass_hero_web/live/messaging_live_helper.ex:365
-#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:6
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr "Nachrichten"
@@ -1733,7 +1733,7 @@ msgid "No conversations yet"
 msgstr "Noch keine Unterhaltungen"
 
 #: lib/klass_hero_web/components/messaging_components.ex:458
-#: lib/klass_hero_web/components/messaging_components.ex:837
+#: lib/klass_hero_web/components/messaging_components.ex:875
 #, elixir-autogen, elixir-format
 msgid "No messages yet"
 msgstr "Noch keine Nachrichten"
@@ -1765,7 +1765,7 @@ msgstr "Notiz abgelehnt"
 msgid "Note resubmitted for review"
 msgstr "Notiz erneut zur Überprüfung eingereicht"
 
-#: lib/klass_hero_web/components/messaging_components.ex:814
+#: lib/klass_hero_web/components/messaging_components.ex:852
 #, elixir-autogen, elixir-format
 msgid "Now"
 msgstr "Jetzt"
@@ -1805,7 +1805,7 @@ msgstr "Bitte authentifizieren Sie sich erneut, um Ihr Konto zu löschen."
 msgid "Please set up your parent profile to manage children."
 msgstr "Bitte richten Sie Ihr Elternprofil ein, um Kinder zu verwalten."
 
-#: lib/klass_hero_web/components/messaging_components.ex:787
+#: lib/klass_hero_web/components/messaging_components.ex:825
 #: lib/klass_hero_web/live/messaging_live_helper.ex:409
 #, elixir-autogen, elixir-format
 msgid "Program Broadcast"
@@ -2104,7 +2104,7 @@ msgstr "Ablehnung bestätigen"
 msgid "Confirmed"
 msgstr "Bestätigt"
 
-#: lib/klass_hero_web/components/messaging_components.ex:889
+#: lib/klass_hero_web/components/messaging_components.ex:927
 #, elixir-autogen, elixir-format
 msgid "Contact Provider"
 msgstr "Anbieter kontaktieren"
@@ -3752,7 +3752,7 @@ msgstr "Zurück zu Sitzungen"
 msgid "Back to emails"
 msgstr "Zurück zu E-Mails"
 
-#: lib/klass_hero_web/components/messaging_components.ex:754
+#: lib/klass_hero_web/components/messaging_components.ex:792
 #, elixir-autogen, elixir-format
 msgid "Broadcast messages are one-way"
 msgstr "Broadcast-Nachrichten sind einseitig"
@@ -4158,7 +4158,7 @@ msgstr "Grund für die Ablehnung (optional)"
 msgid "Reply"
 msgstr "Antworten"
 
-#: lib/klass_hero_web/components/messaging_components.ex:765
+#: lib/klass_hero_web/components/messaging_components.ex:803
 #, elixir-autogen, elixir-format
 msgid "Reply privately"
 msgstr "Privat antworten"
@@ -4439,7 +4439,7 @@ msgstr "Vervollständigen Sie Ihr Anbieterprofil"
 msgid "Failed to upload files. Please try again."
 msgstr "Hochladen der Dateien fehlgeschlagen. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/components/messaging_components.ex:841
+#: lib/klass_hero_web/components/messaging_components.ex:879
 #, elixir-autogen, elixir-format
 msgid "File is too large (max %{mb} MB)"
 msgstr "Datei ist zu groß (max. %{mb} MB)"
@@ -4449,7 +4449,7 @@ msgstr "Datei ist zu groß (max. %{mb} MB)"
 msgid "File is too large (max %{mb} MB)."
 msgstr "Datei ist zu groß (max. %{mb} MB)."
 
-#: lib/klass_hero_web/components/messaging_components.ex:844
+#: lib/klass_hero_web/components/messaging_components.ex:882
 #, elixir-autogen, elixir-format
 msgid "File type not accepted (images only)"
 msgstr "Dateityp nicht akzeptiert (nur Bilder)"
@@ -4469,8 +4469,8 @@ msgstr "Geben Sie Ihre Unternehmensdaten ein. Ihr Profil wird von Klass Hero gep
 msgid "Only images are accepted (JPG, PNG, GIF, WebP)."
 msgstr "Nur Bilder werden akzeptiert (JPG, PNG, GIF, WebP)."
 
-#: lib/klass_hero_web/components/messaging_components.ex:826
-#: lib/klass_hero_web/components/messaging_components.ex:830
+#: lib/klass_hero_web/components/messaging_components.ex:864
+#: lib/klass_hero_web/components/messaging_components.ex:868
 #, elixir-autogen, elixir-format
 msgid "Photo"
 msgstr "Foto"
@@ -4510,7 +4510,7 @@ msgstr "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut."
 msgid "Tell parents about your organization and what makes you unique..."
 msgstr "Erzählen Sie Eltern von Ihrer Organisation und was Sie einzigartig macht..."
 
-#: lib/klass_hero_web/components/messaging_components.ex:848
+#: lib/klass_hero_web/components/messaging_components.ex:886
 #, elixir-autogen, elixir-format
 msgid "Too many files (max %{max})"
 msgstr "Zu viele Dateien (max. %{max})"
@@ -4520,12 +4520,12 @@ msgstr "Zu viele Dateien (max. %{max})"
 msgid "Too many files (max %{max})."
 msgstr "Zu viele Dateien (max. %{max})."
 
-#: lib/klass_hero_web/components/messaging_components.ex:852
+#: lib/klass_hero_web/components/messaging_components.ex:890
 #, elixir-autogen, elixir-format
 msgid "Upload error"
 msgstr "Upload-Fehler"
 
-#: lib/klass_hero_web/components/messaging_components.ex:851
+#: lib/klass_hero_web/components/messaging_components.ex:889
 #, elixir-autogen, elixir-format
 msgid "Upload failed"
 msgstr "Hochladen fehlgeschlagen"
@@ -8098,7 +8098,7 @@ msgstr[0] "%{count} Teilnehmer"
 msgstr[1] "%{count} Teilnehmer"
 
 #: lib/klass_hero_web/live/admin/messages_live.ex:75
-#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:77
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:78
 #, elixir-autogen, elixir-format
 msgid "Conversation not found."
 msgstr "Unterhaltung nicht gefunden."
@@ -8109,7 +8109,7 @@ msgid "Direct"
 msgstr "Direktnachricht"
 
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:70
-#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:46
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr "Mehr laden"
@@ -8120,7 +8120,7 @@ msgid "No conversations found."
 msgstr "Keine Unterhaltungen gefunden."
 
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:102
-#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:74
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:71
 #, elixir-autogen, elixir-format
 msgid "No messages in this conversation."
 msgstr "Keine Nachrichten in dieser Unterhaltung."
@@ -8150,17 +8150,17 @@ msgstr "Unbekannter Anbieter"
 msgid "← Back to messages"
 msgstr "← Zurück zu den Nachrichten"
 
-#: lib/klass_hero_web/components/messaging_components.ex:733
+#: lib/klass_hero_web/components/messaging_components.ex:771
 #, elixir-autogen, elixir-format
 msgid "Messages here may be reviewed by the activity provider and by Klass Hero staff, to keep children safe."
 msgstr "Nachrichten hier können vom Anbieter und von Klass Hero-Mitarbeitenden eingesehen werden, um Kinder zu schützen."
 
-#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:56
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "Back to staff conversations"
 msgstr "Zurück zu den Unterhaltungen des Teams"
 
-#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:15
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Conversations your staff have with parents. Read-only — opening a thread here does not mark anything as read."
 msgstr "Unterhaltungen, die Ihr Team mit Eltern führt. Nur lesbar — das Öffnen markiert hier nichts als gelesen."
@@ -8170,19 +8170,19 @@ msgstr "Unterhaltungen, die Ihr Team mit Eltern führt. Nur lesbar — das Öffn
 msgid "My conversations"
 msgstr "Meine Unterhaltungen"
 
-#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:34
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:29
 #, elixir-autogen, elixir-format
 msgid "No staff conversations yet. Threads your team starts will appear here."
 msgstr "Noch keine Unterhaltungen des Teams. Von Ihrem Team begonnene Unterhaltungen erscheinen hier."
 
-#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:65
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:62
 #, elixir-autogen, elixir-format
 msgid "Read-only. You are viewing this as the business owner, not as a participant — nothing is marked as read."
 msgstr "Nur lesbar. Sie sehen dies als Inhaber:in des Unternehmens, nicht als Teilnehmer:in — es wird nichts als gelesen markiert."
 
 #: lib/klass_hero_web/components/provider_components.ex:185
-#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:45
-#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:62
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:47
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:63
 #, elixir-autogen, elixir-format
 msgid "Staff conversations"
 msgstr "Unterhaltungen des Teams"

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -45,7 +45,7 @@ msgstr "Kontakt"
 #: lib/klass_hero_web/components/layouts/app.html.heex:131
 #: lib/klass_hero_web/components/layouts/app.html.heex:206
 #: lib/klass_hero_web/components/layouts/app.html.heex:231
-#: lib/klass_hero_web/components/provider_components.ex:392
+#: lib/klass_hero_web/components/provider_components.ex:428
 #: lib/klass_hero_web/components/ui_components.ex:277
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
@@ -136,7 +136,7 @@ msgid "Your Data"
 msgstr "Ihre Daten"
 
 #: lib/klass_hero_web/components/core_components.ex:71
-#: lib/klass_hero_web/components/provider_components.ex:1682
+#: lib/klass_hero_web/components/provider_components.ex:1718
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr "schließen"
@@ -231,7 +231,7 @@ msgstr "Einfache Terminplanung"
 msgid "Enroll Now - %{price}"
 msgstr "Jetzt anmelden - %{price}"
 
-#: lib/klass_hero_web/components/provider_components.ex:1401
+#: lib/klass_hero_web/components/provider_components.ex:1437
 #: lib/klass_hero_web/live/booking_live.ex:317
 #, elixir-autogen, elixir-format
 msgid "Enrollment"
@@ -456,7 +456,7 @@ msgstr "E-Mail ändern"
 msgid "Changes to Terms"
 msgstr "Änderungen der Bedingungen"
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:207
+#: lib/klass_hero_web/live/privacy_policy_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "Changes to This Policy"
 msgstr "Änderungen dieser Richtlinie"
@@ -476,7 +476,7 @@ msgstr "Kind erfolgreich eingecheckt"
 msgid "Child checked out successfully"
 msgstr "Kind erfolgreich ausgecheckt"
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:155
+#: lib/klass_hero_web/live/privacy_policy_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "Children's Privacy"
 msgstr "Datenschutz für Kinder"
@@ -515,12 +515,12 @@ msgstr "Kontaktdaten"
 #: lib/klass_hero_web/components/composite_components.ex:472
 #: lib/klass_hero_web/live/contact_live.ex:16
 #: lib/klass_hero_web/live/contact_live.ex:107
-#: lib/klass_hero_web/live/privacy_policy_live.ex:223
+#: lib/klass_hero_web/live/privacy_policy_live.ex:224
 #, elixir-autogen, elixir-format
 msgid "Contact Us"
 msgstr "Kontakt"
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:176
+#: lib/klass_hero_web/live/privacy_policy_live.ex:177
 #, elixir-autogen, elixir-format
 msgid "Cookies & Tracking"
 msgstr "Cookies & Tracking"
@@ -541,12 +541,12 @@ msgstr "Programme, Aktivitäten und Dienstleistungen für Familien erstellen und
 msgid "Creating account..."
 msgstr "Konto wird erstellt..."
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:192
+#: lib/klass_hero_web/live/privacy_policy_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "Data Retention"
 msgstr "Datenspeicherung"
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:138
+#: lib/klass_hero_web/live/privacy_policy_live.ex:139
 #, elixir-autogen, elixir-format
 msgid "Data Security"
 msgstr "Datensicherheit"
@@ -576,9 +576,9 @@ msgstr "Wird gelöscht..."
 msgid "Dispute Resolution"
 msgstr "Streitbeilegung"
 
-#: lib/klass_hero_web/components/provider_components.ex:719
-#: lib/klass_hero_web/components/provider_components.ex:2774
-#: lib/klass_hero_web/components/provider_components.ex:2792
+#: lib/klass_hero_web/components/provider_components.ex:755
+#: lib/klass_hero_web/components/provider_components.ex:2810
+#: lib/klass_hero_web/components/provider_components.ex:2828
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:61
@@ -744,7 +744,7 @@ msgstr "Anmeldung läuft..."
 msgid "Magic link is invalid or it has expired."
 msgstr "Der Magic-Link ist ungültig oder abgelaufen."
 
-#: lib/klass_hero_web/components/messaging_components.ex:391
+#: lib/klass_hero_web/components/messaging_components.ex:404
 #: lib/klass_hero_web/live/contact_live.ex:176
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:181
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:205
@@ -821,7 +821,7 @@ msgstr "Telefon"
 
 #: lib/klass_hero_web/components/composite_components.ex:358
 #: lib/klass_hero_web/live/privacy_policy_live.ex:11
-#: lib/klass_hero_web/live/privacy_policy_live.ex:241
+#: lib/klass_hero_web/live/privacy_policy_live.ex:242
 #, elixir-autogen, elixir-format
 msgid "Privacy Policy"
 msgstr "Datenschutzerklärung"
@@ -836,7 +836,7 @@ msgstr "Programm-Anmeldung & Buchungen"
 msgid "Program Question"
 msgstr "Programmfrage"
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:245
+#: lib/klass_hero_web/live/privacy_policy_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "Questions About Privacy?"
 msgstr "Fragen zum Datenschutz?"
@@ -881,9 +881,9 @@ msgstr "Speichern..."
 msgid "Select one or both options"
 msgstr "Wählen Sie eine oder beide Optionen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2424
-#: lib/klass_hero_web/components/provider_components.ex:2425
-#: lib/klass_hero_web/components/provider_components.ex:2462
+#: lib/klass_hero_web/components/provider_components.ex:2460
+#: lib/klass_hero_web/components/provider_components.ex:2461
+#: lib/klass_hero_web/components/provider_components.ex:2498
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:468
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:469
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:505
@@ -971,7 +971,7 @@ msgstr "Nutzerverhalten & Verantwortlichkeiten"
 msgid "We're here to clarify any questions you may have."
 msgstr "Wir sind hier, um alle Ihre Fragen zu klären."
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:246
+#: lib/klass_hero_web/live/privacy_policy_live.ex:247
 #, elixir-autogen, elixir-format
 msgid "We're here to help with any privacy-related concerns."
 msgstr "Wir sind hier, um bei allen datenschutzbezogenen Fragen zu helfen."
@@ -1012,7 +1012,7 @@ msgstr "Sie müssen sich erneut authentifizieren, um auf diese Seite zuzugreifen
 msgid "You need to reauthenticate to perform sensitive actions on your account."
 msgstr "Sie müssen sich erneut authentifizieren, um sensible Aktionen auf Ihrem Konto durchzuführen."
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:116
+#: lib/klass_hero_web/live/privacy_policy_live.ex:117
 #, elixir-autogen, elixir-format
 msgid "Your Privacy Rights"
 msgstr "Ihre Datenschutzrechte"
@@ -1022,7 +1022,7 @@ msgstr "Ihre Datenschutzrechte"
 msgid "Your account has been deleted."
 msgstr "Ihr Konto wurde gelöscht."
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:242
+#: lib/klass_hero_web/live/privacy_policy_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "Your privacy matters to us"
 msgstr "Ihre Privatsphäre ist uns wichtig"
@@ -1210,7 +1210,7 @@ msgstr "Lebenskompetenzen"
 msgid "Music"
 msgstr "Musik"
 
-#: lib/klass_hero_web/components/provider_components.ex:755
+#: lib/klass_hero_web/components/provider_components.ex:791
 #: lib/klass_hero_web/live/for_providers_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "Qualifications"
@@ -1332,19 +1332,19 @@ msgstr "Profil"
 msgid "Quick Navigation"
 msgstr "Schnellnavigation"
 
-#: lib/klass_hero_web/components/provider_components.ex:1404
-#: lib/klass_hero_web/components/provider_components.ex:2384
-#: lib/klass_hero_web/components/provider_components.ex:2661
+#: lib/klass_hero_web/components/provider_components.ex:1440
+#: lib/klass_hero_web/components/provider_components.ex:2420
+#: lib/klass_hero_web/components/provider_components.ex:2697
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr "Aktionen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1550
+#: lib/klass_hero_web/components/provider_components.ex:1586
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr "Aktiv"
 
-#: lib/klass_hero_web/components/provider_components.ex:672
+#: lib/klass_hero_web/components/provider_components.ex:708
 #: lib/klass_hero_web/live/provider/team_live.ex:627
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
@@ -1355,7 +1355,7 @@ msgstr "Teammitglied hinzufügen"
 msgid "All Staff"
 msgstr "Alle Mitarbeiter"
 
-#: lib/klass_hero_web/components/provider_components.ex:1395
+#: lib/klass_hero_web/components/provider_components.ex:1431
 #, elixir-autogen, elixir-format
 msgid "Assigned Staff"
 msgstr "Zugewiesenes Personal"
@@ -1377,8 +1377,8 @@ msgstr "Gewerbeanmeldung"
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr "Erstellen Sie Profile für Ihr Personal. Diese werden für Eltern sichtbar sein, wenn sie Programmen zugewiesen werden."
 
-#: lib/klass_hero_web/components/provider_components.ex:543
-#: lib/klass_hero_web/components/provider_components.ex:1513
+#: lib/klass_hero_web/components/provider_components.ex:579
+#: lib/klass_hero_web/components/provider_components.ex:1549
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:65
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:92
 #: lib/klass_hero_web/live/settings/children_live.ex:413
@@ -1388,14 +1388,14 @@ msgstr "Erstellen Sie Profile für Ihr Personal. Diese werden für Eltern sichtb
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: lib/klass_hero_web/components/provider_components.ex:226
+#: lib/klass_hero_web/components/provider_components.ex:262
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:34
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "Edit Profile"
 msgstr "Profil bearbeiten"
 
-#: lib/klass_hero_web/components/provider_components.ex:1552
+#: lib/klass_hero_web/components/provider_components.ex:1588
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr "Inaktiv"
@@ -1406,8 +1406,8 @@ msgstr "Inaktiv"
 msgid "My Programs"
 msgstr "Meine Programme"
 
-#: lib/klass_hero_web/components/provider_components.ex:418
-#: lib/klass_hero_web/components/provider_components.ex:910
+#: lib/klass_hero_web/components/provider_components.ex:454
+#: lib/klass_hero_web/components/provider_components.ex:946
 #, elixir-autogen, elixir-format
 msgid "New Program"
 msgstr "Neues Programm"
@@ -1419,26 +1419,26 @@ msgstr "Übersicht"
 
 #: lib/klass_hero_web/components/provider_components.ex:49
 #: lib/klass_hero_web/components/provider_components.ex:75
-#: lib/klass_hero_web/components/provider_components.ex:1551
-#: lib/klass_hero_web/components/provider_components.ex:2868
-#: lib/klass_hero_web/components/provider_components.ex:2886
+#: lib/klass_hero_web/components/provider_components.ex:1587
+#: lib/klass_hero_web/components/provider_components.ex:2904
+#: lib/klass_hero_web/components/provider_components.ex:2922
 #: lib/klass_hero_web/live/admin/sessions_live.ex:293
 #: lib/klass_hero_web/live/admin/verifications_live.ex:202
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr "Ausstehend"
 
-#: lib/klass_hero_web/components/provider_components.ex:1482
+#: lib/klass_hero_web/components/provider_components.ex:1518
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr "Vorschau"
 
-#: lib/klass_hero_web/components/provider_components.ex:1335
+#: lib/klass_hero_web/components/provider_components.ex:1371
 #, elixir-autogen, elixir-format
 msgid "Program Inventory"
 msgstr "Programmübersicht"
 
-#: lib/klass_hero_web/components/provider_components.ex:1392
+#: lib/klass_hero_web/components/provider_components.ex:1428
 #, elixir-autogen, elixir-format
 msgid "Program Name"
 msgstr "Programmname"
@@ -1453,15 +1453,15 @@ msgstr "Anbieter-Dashboard"
 msgid "Save for Later"
 msgstr "Für später speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:1352
+#: lib/klass_hero_web/components/provider_components.ex:1388
 #, elixir-autogen, elixir-format
 msgid "Search by name..."
 msgstr "Nach Namen suchen..."
 
-#: lib/klass_hero_web/components/provider_components.ex:1398
-#: lib/klass_hero_web/components/provider_components.ex:1801
-#: lib/klass_hero_web/components/provider_components.ex:2375
-#: lib/klass_hero_web/components/provider_components.ex:2658
+#: lib/klass_hero_web/components/provider_components.ex:1434
+#: lib/klass_hero_web/components/provider_components.ex:1837
+#: lib/klass_hero_web/components/provider_components.ex:2411
+#: lib/klass_hero_web/components/provider_components.ex:2694
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1480,23 +1480,24 @@ msgstr "Team & Profile"
 msgid "Team & Provider Profiles"
 msgstr "Team- & Anbieterprofile"
 
-#: lib/klass_hero_web/components/provider_components.ex:1455
-#: lib/klass_hero_web/components/provider_components.ex:1816
+#: lib/klass_hero_web/components/provider_components.ex:1491
+#: lib/klass_hero_web/components/provider_components.ex:1852
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr "Nicht zugewiesen"
 
-#: lib/klass_hero_web/components/messaging_components.ex:772
+#: lib/klass_hero_web/components/messaging_components.ex:794
 #: lib/klass_hero_web/components/provider_components.ex:52
-#: lib/klass_hero_web/components/provider_components.ex:1553
+#: lib/klass_hero_web/components/provider_components.ex:1589
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:110
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:82
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:455
 #: lib/klass_hero_web/presenters/provider_presenter.ex:172
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr "Unbekannt"
 
-#: lib/klass_hero_web/components/provider_components.ex:1493
+#: lib/klass_hero_web/components/provider_components.ex:1529
 #, elixir-autogen, elixir-format
 msgid "View Roster"
 msgstr "Teilnehmerliste"
@@ -1506,7 +1507,7 @@ msgstr "Teilnehmerliste"
 msgid "%{age} years old"
 msgstr "%{age} Jahre alt"
 
-#: lib/klass_hero_web/components/messaging_components.ex:792
+#: lib/klass_hero_web/components/messaging_components.ex:815
 #, elixir-autogen, elixir-format
 msgid "%{n}m ago"
 msgstr "vor %{n} Min."
@@ -1542,8 +1543,9 @@ msgstr "Besondere Bedürfnisse oder Unterstützungsbedarf..."
 msgid "Back to Settings"
 msgstr "Zurück zu Einstellungen"
 
-#: lib/klass_hero_web/components/messaging_components.ex:153
+#: lib/klass_hero_web/components/messaging_components.ex:166
 #: lib/klass_hero_web/live/admin/messages_live.ex:147
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:113
 #, elixir-autogen, elixir-format
 msgid "Broadcast"
 msgstr "Rundnachricht"
@@ -1557,10 +1559,10 @@ msgstr "Rundnachricht an %{count} Eltern gesendet"
 #: lib/klass_hero_web/components/participation_components.ex:346
 #: lib/klass_hero_web/components/participation_components.ex:571
 #: lib/klass_hero_web/components/participation_components.ex:662
-#: lib/klass_hero_web/components/provider_components.ex:847
-#: lib/klass_hero_web/components/provider_components.ex:1261
-#: lib/klass_hero_web/components/provider_components.ex:1974
-#: lib/klass_hero_web/components/provider_components.ex:2566
+#: lib/klass_hero_web/components/provider_components.ex:883
+#: lib/klass_hero_web/components/provider_components.ex:1297
+#: lib/klass_hero_web/components/provider_components.ex:2010
+#: lib/klass_hero_web/components/provider_components.ex:2602
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:489
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
@@ -1599,6 +1601,8 @@ msgstr "Kind erfolgreich aktualisiert."
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:80
 #: lib/klass_hero_web/live/dashboard_live.ex:175
 #: lib/klass_hero_web/live/messaging_live_helper.ex:413
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:72
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "Conversation"
 msgstr "Unterhaltung"
@@ -1618,7 +1622,7 @@ msgstr "Kind konnte nicht entfernt werden. Bitte versuchen Sie es erneut."
 msgid "Data sharing consent"
 msgstr "Einwilligung zur Datenweitergabe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2755
+#: lib/klass_hero_web/components/provider_components.ex:2791
 #: lib/klass_hero_web/live/settings/children_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1666,17 +1670,17 @@ msgstr "Rundnachricht konnte nicht gesendet werden"
 msgid "Failed to submit note"
 msgstr "Notiz konnte nicht eingereicht werden"
 
-#: lib/klass_hero_web/components/provider_components.ex:2749
-#: lib/klass_hero_web/components/provider_components.ex:2778
-#: lib/klass_hero_web/components/provider_components.ex:2794
+#: lib/klass_hero_web/components/provider_components.ex:2785
+#: lib/klass_hero_web/components/provider_components.ex:2814
+#: lib/klass_hero_web/components/provider_components.ex:2830
 #: lib/klass_hero_web/live/settings/children_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr "Vorname"
 
-#: lib/klass_hero_web/components/provider_components.ex:2750
-#: lib/klass_hero_web/components/provider_components.ex:2779
-#: lib/klass_hero_web/components/provider_components.ex:2795
+#: lib/klass_hero_web/components/provider_components.ex:2786
+#: lib/klass_hero_web/components/provider_components.ex:2815
+#: lib/klass_hero_web/components/provider_components.ex:2831
 #: lib/klass_hero_web/live/settings/children_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -1705,13 +1709,14 @@ msgstr "Nachrichteninhalt ist erforderlich"
 
 #: lib/klass_hero_web/components/layouts/admin.html.heex:90
 #: lib/klass_hero_web/components/layouts/app.html.heex:214
-#: lib/klass_hero_web/components/messaging_components.ex:506
-#: lib/klass_hero_web/components/messaging_components.ex:529
+#: lib/klass_hero_web/components/messaging_components.ex:527
+#: lib/klass_hero_web/components/messaging_components.ex:550
 #: lib/klass_hero_web/live/admin/messages_live.ex:37
 #: lib/klass_hero_web/live/admin/messages_live.ex:56
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:5
 #: lib/klass_hero_web/live/messages_live/index.ex:19
 #: lib/klass_hero_web/live/messaging_live_helper.ex:365
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:6
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr "Nachrichten"
@@ -1722,13 +1727,13 @@ msgstr "Nachrichten"
 msgid "No children yet"
 msgstr "Noch keine Kinder"
 
-#: lib/klass_hero_web/components/messaging_components.ex:476
+#: lib/klass_hero_web/components/messaging_components.ex:489
 #, elixir-autogen, elixir-format
 msgid "No conversations yet"
 msgstr "Noch keine Unterhaltungen"
 
-#: lib/klass_hero_web/components/messaging_components.ex:445
-#: lib/klass_hero_web/components/messaging_components.ex:814
+#: lib/klass_hero_web/components/messaging_components.ex:458
+#: lib/klass_hero_web/components/messaging_components.ex:837
 #, elixir-autogen, elixir-format
 msgid "No messages yet"
 msgstr "Noch keine Nachrichten"
@@ -1760,7 +1765,7 @@ msgstr "Notiz abgelehnt"
 msgid "Note resubmitted for review"
 msgstr "Notiz erneut zur Überprüfung eingereicht"
 
-#: lib/klass_hero_web/components/messaging_components.ex:791
+#: lib/klass_hero_web/components/messaging_components.ex:814
 #, elixir-autogen, elixir-format
 msgid "Now"
 msgstr "Jetzt"
@@ -1800,7 +1805,7 @@ msgstr "Bitte authentifizieren Sie sich erneut, um Ihr Konto zu löschen."
 msgid "Please set up your parent profile to manage children."
 msgstr "Bitte richten Sie Ihr Elternprofil ein, um Kinder zu verwalten."
 
-#: lib/klass_hero_web/components/messaging_components.ex:765
+#: lib/klass_hero_web/components/messaging_components.ex:787
 #: lib/klass_hero_web/live/messaging_live_helper.ex:409
 #, elixir-autogen, elixir-format
 msgid "Program Broadcast"
@@ -1811,15 +1816,15 @@ msgstr "Programm-Rundnachricht"
 msgid "Provider data sharing consent"
 msgstr "Einwilligung zur Datenweitergabe an Anbieter"
 
-#: lib/klass_hero_web/components/provider_components.ex:832
+#: lib/klass_hero_web/components/provider_components.ex:868
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:307
 #: lib/klass_hero_web/live/settings/children_live.ex:719
 #, elixir-autogen, elixir-format
 msgid "Save Changes"
 msgstr "Änderungen speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:1660
-#: lib/klass_hero_web/components/provider_components.ex:1661
+#: lib/klass_hero_web/components/provider_components.ex:1696
+#: lib/klass_hero_web/components/provider_components.ex:1697
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:43
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:151
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:252
@@ -1832,12 +1837,12 @@ msgstr "Änderungen speichern"
 msgid "Send Broadcast"
 msgstr "Rundnachricht senden"
 
-#: lib/klass_hero_web/components/messaging_components.ex:448
+#: lib/klass_hero_web/components/messaging_components.ex:461
 #, elixir-autogen, elixir-format
 msgid "Send a message to start the conversation"
 msgstr "Senden Sie eine Nachricht, um die Unterhaltung zu beginnen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2849
+#: lib/klass_hero_web/components/provider_components.ex:2885
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:249
 #, elixir-autogen, elixir-format
@@ -1856,7 +1861,7 @@ msgstr "Unterstützungsbedarf"
 msgid "This message will be sent to all parents with active enrollments in this program."
 msgstr "Diese Nachricht wird an alle Eltern mit aktiven Anmeldungen in diesem Programm gesendet."
 
-#: lib/klass_hero_web/components/messaging_components.ex:398
+#: lib/klass_hero_web/components/messaging_components.ex:411
 #, elixir-autogen, elixir-format
 msgid "Type a message..."
 msgstr "Nachricht eingeben..."
@@ -1893,12 +1898,12 @@ msgstr "Sie haben keine Berechtigung, dieses Kind zu löschen."
 msgid "You don't have permission to edit this child."
 msgstr "Sie haben keine Berechtigung, dieses Kind zu bearbeiten."
 
-#: lib/klass_hero_web/components/messaging_components.ex:485
+#: lib/klass_hero_web/components/messaging_components.ex:498
 #, elixir-autogen, elixir-format
 msgid "Your conversations with parents will appear here"
 msgstr "Ihre Unterhaltungen mit Eltern werden hier angezeigt"
 
-#: lib/klass_hero_web/components/messaging_components.ex:487
+#: lib/klass_hero_web/components/messaging_components.ex:500
 #, elixir-autogen, elixir-format
 msgid "Your conversations with providers will appear here"
 msgstr "Ihre Unterhaltungen mit Anbietern werden hier angezeigt"
@@ -1943,12 +1948,12 @@ msgstr[1] "%{count} Jahre"
 msgid "%{gender} only"
 msgstr "Nur %{gender}"
 
-#: lib/klass_hero_web/components/provider_components.ex:311
+#: lib/klass_hero_web/components/provider_components.ex:347
 #, elixir-autogen, elixir-format
 msgid "Action Required"
 msgstr "Aktion erforderlich"
 
-#: lib/klass_hero_web/components/provider_components.ex:834
+#: lib/klass_hero_web/components/provider_components.ex:870
 #, elixir-autogen, elixir-format
 msgid "Add Member"
 msgstr "Mitglied hinzufügen"
@@ -1968,12 +1973,12 @@ msgstr "Alter %{min} bis %{max}"
 msgid "Ages %{min}+"
 msgstr "Alter %{min}+"
 
-#: lib/klass_hero_web/components/provider_components.ex:1162
+#: lib/klass_hero_web/components/provider_components.ex:1198
 #, elixir-autogen, elixir-format
 msgid "Allowed Genders"
 msgstr "Zulässige Geschlechter"
 
-#: lib/klass_hero_web/components/provider_components.ex:2908
+#: lib/klass_hero_web/components/provider_components.ex:2944
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred during import."
 msgstr "Beim Import ist ein unerwarteter Fehler aufgetreten."
@@ -2016,7 +2021,7 @@ msgstr "Zurück zum Dashboard"
 msgid "Back to verifications"
 msgstr "Zurück zu den Verifizierungen"
 
-#: lib/klass_hero_web/components/provider_components.ex:728
+#: lib/klass_hero_web/components/provider_components.ex:764
 #, elixir-autogen, elixir-format
 msgid "Bio"
 msgstr "Biografie"
@@ -2026,7 +2031,7 @@ msgstr "Biografie"
 msgid "Book a Program"
 msgstr "Programm buchen"
 
-#: lib/klass_hero_web/components/provider_components.ex:729
+#: lib/klass_hero_web/components/provider_components.ex:765
 #, elixir-autogen, elixir-format
 msgid "Brief description of experience and specialties..."
 msgstr "Kurze Beschreibung der Erfahrung und Spezialgebiete..."
@@ -2041,19 +2046,19 @@ msgstr "Von Eltern entwickelt, um Pädagogen zu stärken."
 msgid "Business"
 msgstr "Business"
 
-#: lib/klass_hero_web/components/provider_components.ex:940
+#: lib/klass_hero_web/components/provider_components.ex:976
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "Category"
 msgstr "Kategorie"
 
-#: lib/klass_hero_web/components/provider_components.ex:1111
+#: lib/klass_hero_web/components/provider_components.ex:1147
 #, elixir-autogen, elixir-format
 msgid "Check eligibility at"
 msgstr "Berechtigung prüfen unter"
 
-#: lib/klass_hero_web/components/provider_components.ex:2372
-#: lib/klass_hero_web/components/provider_components.ex:2644
+#: lib/klass_hero_web/components/provider_components.ex:2408
+#: lib/klass_hero_web/components/provider_components.ex:2680
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr "Name des Kindes"
@@ -2068,7 +2073,7 @@ msgstr "Kind erfüllt die Programmanforderungen nicht"
 msgid "Child meets all program requirements"
 msgstr "Kind erfüllt alle Programmanforderungen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1234
+#: lib/klass_hero_web/components/provider_components.ex:1270
 #, elixir-autogen, elixir-format
 msgid "Choose Image"
 msgstr "Bild auswählen"
@@ -2079,12 +2084,12 @@ msgstr "Bild auswählen"
 msgid "Choose Logo"
 msgstr "Logo auswählen"
 
-#: lib/klass_hero_web/components/provider_components.ex:823
+#: lib/klass_hero_web/components/provider_components.ex:859
 #, elixir-autogen, elixir-format
 msgid "Choose Photo"
 msgstr "Foto auswählen"
 
-#: lib/klass_hero_web/components/provider_components.ex:942
+#: lib/klass_hero_web/components/provider_components.ex:978
 #, elixir-autogen, elixir-format
 msgid "Choose a category"
 msgstr "Kategorie auswählen"
@@ -2094,12 +2099,12 @@ msgstr "Kategorie auswählen"
 msgid "Confirm rejection"
 msgstr "Ablehnung bestätigen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2869
+#: lib/klass_hero_web/components/provider_components.ex:2905
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr "Bestätigt"
 
-#: lib/klass_hero_web/components/messaging_components.ex:866
+#: lib/klass_hero_web/components/messaging_components.ex:889
 #, elixir-autogen, elixir-format
 msgid "Contact Provider"
 msgstr "Anbieter kontaktieren"
@@ -2114,23 +2119,23 @@ msgstr "Die hochgeladene Datei konnte nicht gelesen werden."
 msgid "Could not remove invite."
 msgstr "Einladung konnte nicht entfernt werden."
 
-#: lib/klass_hero_web/components/provider_components.ex:1228
-#: lib/klass_hero_web/components/provider_components.ex:3157
+#: lib/klass_hero_web/components/provider_components.ex:1264
+#: lib/klass_hero_web/components/provider_components.ex:3193
 #, elixir-autogen, elixir-format
 msgid "Cover Image"
 msgstr "Titelbild"
 
-#: lib/klass_hero_web/components/provider_components.ex:1105
+#: lib/klass_hero_web/components/provider_components.ex:1141
 #, elixir-autogen, elixir-format
 msgid "Define age, gender, or grade restrictions for eligible participants."
 msgstr "Legen Sie Alters-, Geschlechts- oder Klassenstufenbeschränkungen für teilnahmeberechtigte Teilnehmer fest."
 
-#: lib/klass_hero_web/components/provider_components.ex:1221
+#: lib/klass_hero_web/components/provider_components.ex:1257
 #, elixir-autogen, elixir-format
 msgid "Describe your program..."
 msgstr "Beschreiben Sie Ihr Programm..."
 
-#: lib/klass_hero_web/components/provider_components.ex:1220
+#: lib/klass_hero_web/components/provider_components.ex:1256
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:325
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:300
 #, elixir-autogen, elixir-format
@@ -2138,13 +2143,13 @@ msgid "Description"
 msgstr "Beschreibung"
 
 #: lib/klass_hero_web/components/program_components.ex:696
-#: lib/klass_hero_web/components/provider_components.ex:1173
+#: lib/klass_hero_web/components/provider_components.ex:1209
 #: lib/klass_hero_web/live/settings/children_live.ex:635
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr "Divers"
 
-#: lib/klass_hero_web/components/provider_components.ex:3286
+#: lib/klass_hero_web/components/provider_components.ex:3322
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr "Dokumenttyp"
@@ -2178,7 +2183,7 @@ msgstr "Dokument abgelehnt."
 msgid "Document uploaded successfully."
 msgstr "Dokument erfolgreich hochgeladen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2585
+#: lib/klass_hero_web/components/provider_components.ex:2621
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr "Vorlage herunterladen"
@@ -2188,40 +2193,40 @@ msgstr "Vorlage herunterladen"
 msgid "Download document"
 msgstr "Dokument herunterladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:908
+#: lib/klass_hero_web/components/provider_components.ex:944
 #, elixir-autogen, elixir-format
 msgid "Edit Program"
 msgstr "Programm bearbeiten"
 
-#: lib/klass_hero_web/components/provider_components.ex:670
+#: lib/klass_hero_web/components/provider_components.ex:706
 #, elixir-autogen, elixir-format
 msgid "Edit Team Member"
 msgstr "Teammitglied bearbeiten"
 
-#: lib/klass_hero_web/components/provider_components.ex:1026
+#: lib/klass_hero_web/components/provider_components.ex:1062
 #, elixir-autogen, elixir-format
 msgid "End Date"
 msgstr "Enddatum"
 
-#: lib/klass_hero_web/components/provider_components.ex:1013
+#: lib/klass_hero_web/components/provider_components.ex:1049
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "End Time"
 msgstr "Endzeit"
 
-#: lib/klass_hero_web/components/provider_components.ex:2381
-#: lib/klass_hero_web/components/provider_components.ex:2889
+#: lib/klass_hero_web/components/provider_components.ex:2417
+#: lib/klass_hero_web/components/provider_components.ex:2925
 #: lib/klass_hero_web/components/provider_layout_components.ex:612
 #, elixir-autogen, elixir-format
 msgid "Enrolled"
 msgstr "Angemeldet"
 
-#: lib/klass_hero_web/components/provider_components.ex:1706
+#: lib/klass_hero_web/components/provider_components.ex:1742
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr "Angemeldet (%{count})"
 
-#: lib/klass_hero_web/components/provider_components.ex:1054
+#: lib/klass_hero_web/components/provider_components.ex:1090
 #, elixir-autogen, elixir-format
 msgid "Enrollment Capacity (optional)"
 msgstr "Anmeldekapazität (optional)"
@@ -2232,7 +2237,7 @@ msgid "Explain why this document is being rejected..."
 msgstr "Erklären Sie, warum dieses Dokument abgelehnt wird..."
 
 #: lib/klass_hero_web/components/provider_components.ex:73
-#: lib/klass_hero_web/components/provider_components.ex:2890
+#: lib/klass_hero_web/components/provider_components.ex:2926
 #: lib/klass_hero_web/live/admin/emails_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2265,7 +2270,7 @@ msgid "Family Programs"
 msgstr "Familienprogramme"
 
 #: lib/klass_hero_web/components/program_components.ex:694
-#: lib/klass_hero_web/components/provider_components.ex:1172
+#: lib/klass_hero_web/components/provider_components.ex:1208
 #: lib/klass_hero_web/live/settings/children_live.ex:634
 #, elixir-autogen, elixir-format
 msgid "Female"
@@ -2276,22 +2281,22 @@ msgstr "Weiblich"
 msgid "File"
 msgstr "Datei"
 
-#: lib/klass_hero_web/components/provider_components.ex:3219
+#: lib/klass_hero_web/components/provider_components.ex:3255
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr "Die Datei ist zu groß."
 
-#: lib/klass_hero_web/components/provider_components.ex:3221
+#: lib/klass_hero_web/components/provider_components.ex:3257
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr "Dateityp wird nicht akzeptiert."
 
-#: lib/klass_hero_web/components/provider_components.ex:756
+#: lib/klass_hero_web/components/provider_components.ex:792
 #, elixir-autogen, elixir-format
 msgid "First Aid, UEFA B License, Child Care Cert"
 msgstr "Erste Hilfe, UEFA-B-Lizenz, Kinderbetreuungszertifikat"
 
-#: lib/klass_hero_web/components/provider_components.ex:698
+#: lib/klass_hero_web/components/provider_components.ex:734
 #, elixir-autogen, elixir-format
 msgid "First Name"
 msgstr "Vorname"
@@ -2316,12 +2321,12 @@ msgstr "Klassenstufe %{min}+"
 msgid "Grades %{min} – %{max}"
 msgstr "Klassenstufen %{min} – %{max}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2655
+#: lib/klass_hero_web/components/provider_components.ex:2691
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr "E-Mail des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:817
+#: lib/klass_hero_web/components/provider_components.ex:853
 #, elixir-autogen, elixir-format
 msgid "Headshot Photo"
 msgstr "Porträtfoto"
@@ -2331,7 +2336,7 @@ msgstr "Porträtfoto"
 msgid "ID Document"
 msgstr "Ausweisdokument"
 
-#: lib/klass_hero_web/components/provider_components.ex:2558
+#: lib/klass_hero_web/components/provider_components.ex:2594
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Importieren"
@@ -2356,17 +2361,17 @@ msgstr "Einladung entfernt."
 msgid "Invite resent successfully."
 msgstr "Einladung erfolgreich erneut gesendet."
 
-#: lib/klass_hero_web/components/provider_components.ex:1723
+#: lib/klass_hero_web/components/provider_components.ex:1759
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr "Einladungen (%{count})"
 
-#: lib/klass_hero_web/components/provider_components.ex:824
+#: lib/klass_hero_web/components/provider_components.ex:860
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 1MB."
 msgstr "JPG, PNG oder WebP. Max. 1 MB."
 
-#: lib/klass_hero_web/components/provider_components.ex:1235
+#: lib/klass_hero_web/components/provider_components.ex:1271
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:276
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:366
 #, elixir-autogen, elixir-format
@@ -2383,22 +2388,22 @@ msgstr "Klass Hero wurde genau dafür entwickelt. Eine umfassende Betriebsplattf
 msgid "Klasse %{n}"
 msgstr "Klasse %{n}"
 
-#: lib/klass_hero_web/components/provider_components.ex:704
+#: lib/klass_hero_web/components/provider_components.ex:740
 #, elixir-autogen, elixir-format
 msgid "Last Name"
 msgstr "Nachname"
 
-#: lib/klass_hero_web/components/provider_components.ex:1036
+#: lib/klass_hero_web/components/provider_components.ex:1072
 #, elixir-autogen, elixir-format
 msgid "Leave blank for open registration at any time."
 msgstr "Leer lassen für eine jederzeit offene Anmeldung."
 
-#: lib/klass_hero_web/components/provider_components.ex:1165
+#: lib/klass_hero_web/components/provider_components.ex:1201
 #, elixir-autogen, elixir-format
 msgid "Leave unchecked to allow all genders."
 msgstr "Nicht markiert lassen, um alle Geschlechter zuzulassen."
 
-#: lib/klass_hero_web/components/provider_components.ex:969
+#: lib/klass_hero_web/components/provider_components.ex:1005
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:191
 #, elixir-autogen, elixir-format
 msgid "Location"
@@ -2411,43 +2416,43 @@ msgid "Logo upload failed. Please try again."
 msgstr "Logo-Upload fehlgeschlagen. Bitte versuchen Sie es erneut."
 
 #: lib/klass_hero_web/components/program_components.ex:695
-#: lib/klass_hero_web/components/provider_components.ex:1171
+#: lib/klass_hero_web/components/provider_components.ex:1207
 #: lib/klass_hero_web/live/settings/children_live.ex:633
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr "Männlich"
 
-#: lib/klass_hero_web/components/provider_components.ex:1155
+#: lib/klass_hero_web/components/provider_components.ex:1191
 #, elixir-autogen, elixir-format
 msgid "Maximum Age (months)"
 msgstr "Höchstalter (Monate)"
 
-#: lib/klass_hero_web/components/provider_components.ex:1069
+#: lib/klass_hero_web/components/provider_components.ex:1105
 #, elixir-autogen, elixir-format
 msgid "Maximum Enrollment"
 msgstr "Maximale Anmeldekapazität"
 
-#: lib/klass_hero_web/components/provider_components.ex:1210
+#: lib/klass_hero_web/components/provider_components.ex:1246
 #, elixir-autogen, elixir-format
 msgid "Maximum Grade"
 msgstr "Höchste Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:978
+#: lib/klass_hero_web/components/provider_components.ex:1014
 #, elixir-autogen, elixir-format
 msgid "Meeting Days"
 msgstr "Wochentage"
 
-#: lib/klass_hero_web/components/provider_components.ex:1149
+#: lib/klass_hero_web/components/provider_components.ex:1185
 #, elixir-autogen, elixir-format
 msgid "Minimum Age (months)"
 msgstr "Mindestalter (Monate)"
 
-#: lib/klass_hero_web/components/provider_components.ex:1063
+#: lib/klass_hero_web/components/provider_components.ex:1099
 #, elixir-autogen, elixir-format
 msgid "Minimum Enrollment"
 msgstr "Minimale Anmeldekapazität"
 
-#: lib/klass_hero_web/components/provider_components.ex:1203
+#: lib/klass_hero_web/components/provider_components.ex:1239
 #, elixir-autogen, elixir-format
 msgid "Minimum Grade"
 msgstr "Niedrigste Klassenstufe"
@@ -2457,12 +2462,12 @@ msgstr "Niedrigste Klassenstufe"
 msgid "No approved documents."
 msgstr "Keine genehmigten Dokumente."
 
-#: lib/klass_hero_web/components/provider_components.ex:3248
+#: lib/klass_hero_web/components/provider_components.ex:3284
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr "Noch keine Dokumente hochgeladen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2365
+#: lib/klass_hero_web/components/provider_components.ex:2401
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
@@ -2478,17 +2483,17 @@ msgstr "Keine Datei ausgewählt."
 msgid "No grade"
 msgstr "Keine Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2609
+#: lib/klass_hero_web/components/provider_components.ex:2645
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr "Noch keine Einladungen. Laden Sie eine CSV-Datei hoch, um Familien einzuladen."
 
-#: lib/klass_hero_web/components/provider_components.ex:1212
+#: lib/klass_hero_web/components/provider_components.ex:1248
 #, elixir-autogen, elixir-format
 msgid "No maximum"
 msgstr "Kein Maximum"
 
-#: lib/klass_hero_web/components/provider_components.ex:1205
+#: lib/klass_hero_web/components/provider_components.ex:1241
 #, elixir-autogen, elixir-format
 msgid "No minimum"
 msgstr "Kein Minimum"
@@ -2519,18 +2524,18 @@ msgstr "Noch keine Teammitglieder"
 msgid "No verification documents found."
 msgstr "Keine Verifizierungsdokumente gefunden."
 
-#: lib/klass_hero_web/components/provider_components.ex:1247
+#: lib/klass_hero_web/components/provider_components.ex:1283
 #, elixir-autogen, elixir-format
 msgid "None (optional)"
 msgstr "Keine (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:327
+#: lib/klass_hero_web/components/provider_components.ex:363
 #, elixir-autogen, elixir-format
 msgid "Not Verified"
 msgstr "Nicht verifiziert"
 
 #: lib/klass_hero_web/components/program_components.ex:697
-#: lib/klass_hero_web/components/provider_components.ex:1174
+#: lib/klass_hero_web/components/provider_components.ex:1210
 #: lib/klass_hero_web/live/settings/children_live.ex:632
 #, elixir-autogen, elixir-format
 msgid "Not specified"
@@ -2541,7 +2546,7 @@ msgstr "Nicht angegeben"
 msgid "Our Story"
 msgstr "Unsere Geschichte"
 
-#: lib/klass_hero_web/components/provider_components.ex:3324
+#: lib/klass_hero_web/components/provider_components.ex:3360
 #: lib/klass_hero_web/live/provider/verification_live.ex:707
 #: lib/klass_hero_web/live/provider/verification_live.ex:781
 #, elixir-autogen, elixir-format
@@ -2553,13 +2558,13 @@ msgstr "PDF, JPG oder PNG. Max. 10 MB."
 msgid "Participant Requirements"
 msgstr "Teilnahmevoraussetzungen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1102
+#: lib/klass_hero_web/components/provider_components.ex:1138
 #, elixir-autogen, elixir-format
 msgid "Participant Restrictions (optional)"
 msgstr "Teilnahmebeschränkungen (optional)"
 
 #: lib/klass_hero_web/components/participation_components.ex:770
-#: lib/klass_hero_web/components/provider_components.ex:295
+#: lib/klass_hero_web/components/provider_components.ex:331
 #, elixir-autogen, elixir-format
 msgid "Pending Review"
 msgstr "Ausstehende Überprüfung"
@@ -2587,7 +2592,7 @@ msgstr "Bitte geben Sie einen Ablehnungsgrund an."
 msgid "Preview not available for this file type."
 msgstr "Vorschau für diesen Dateityp nicht verfügbar."
 
-#: lib/klass_hero_web/components/provider_components.ex:960
+#: lib/klass_hero_web/components/provider_components.ex:996
 #, elixir-autogen, elixir-format
 msgid "Price (EUR)"
 msgstr "Preis (EUR)"
@@ -2597,7 +2602,7 @@ msgstr "Preis (EUR)"
 msgid "Profile updated successfully."
 msgstr "Profil erfolgreich aktualisiert."
 
-#: lib/klass_hero_web/components/provider_components.ex:1140
+#: lib/klass_hero_web/components/provider_components.ex:1176
 #, elixir-autogen, elixir-format
 msgid "Program Start"
 msgstr "Programmbeginn"
@@ -2641,13 +2646,13 @@ msgid "Read our founding story →"
 msgstr "Lesen Sie unsere Gründungsgeschichte →"
 
 #: lib/klass_hero_web/components/participation_components.ex:750
-#: lib/klass_hero_web/components/provider_components.ex:2888
+#: lib/klass_hero_web/components/provider_components.ex:2924
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Registered"
 msgstr "Registriert"
 
-#: lib/klass_hero_web/components/provider_components.ex:1127
+#: lib/klass_hero_web/components/provider_components.ex:1163
 #, elixir-autogen, elixir-format
 msgid "Registration"
 msgstr "Anmeldung"
@@ -2657,7 +2662,7 @@ msgstr "Anmeldung"
 msgid "Registration Closed"
 msgstr "Anmeldung geschlossen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1047
+#: lib/klass_hero_web/components/provider_components.ex:1083
 #, elixir-autogen, elixir-format
 msgid "Registration Closes"
 msgstr "Anmeldeschluss"
@@ -2667,12 +2672,12 @@ msgstr "Anmeldeschluss"
 msgid "Registration Not Open Yet"
 msgstr "Anmeldung noch nicht geöffnet"
 
-#: lib/klass_hero_web/components/provider_components.ex:1042
+#: lib/klass_hero_web/components/provider_components.ex:1078
 #, elixir-autogen, elixir-format
 msgid "Registration Opens"
 msgstr "Anmeldebeginn"
 
-#: lib/klass_hero_web/components/provider_components.ex:1033
+#: lib/klass_hero_web/components/provider_components.ex:1069
 #, elixir-autogen, elixir-format
 msgid "Registration Period (optional)"
 msgstr "Anmeldezeitraum (optional)"
@@ -2721,15 +2726,15 @@ msgstr "Abgelehnt"
 msgid "Rejection reason"
 msgstr "Ablehnungsgrund"
 
-#: lib/klass_hero_web/components/provider_components.ex:2711
-#: lib/klass_hero_web/components/provider_components.ex:3075
-#: lib/klass_hero_web/components/provider_components.ex:3343
-#: lib/klass_hero_web/components/provider_components.ex:3423
+#: lib/klass_hero_web/components/provider_components.ex:2747
+#: lib/klass_hero_web/components/provider_components.ex:3111
+#: lib/klass_hero_web/components/provider_components.ex:3379
+#: lib/klass_hero_web/components/provider_components.ex:3459
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr "Entfernen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2704
+#: lib/klass_hero_web/components/provider_components.ex:2740
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr "Einladung erneut senden"
@@ -2739,23 +2744,23 @@ msgstr "Einladung erneut senden"
 msgid "Reviewed"
 msgstr "Überprüft"
 
-#: lib/klass_hero_web/components/provider_components.ex:713
+#: lib/klass_hero_web/components/provider_components.ex:749
 #, elixir-autogen, elixir-format
 msgid "Role"
 msgstr "Rolle"
 
-#: lib/klass_hero_web/components/provider_components.ex:1652
+#: lib/klass_hero_web/components/provider_components.ex:1688
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:407
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
 msgstr "Teilnehmerliste: %{name}"
 
-#: lib/klass_hero_web/components/provider_components.ex:1264
+#: lib/klass_hero_web/components/provider_components.ex:1300
 #, elixir-autogen, elixir-format
 msgid "Save Program"
 msgstr "Programm speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:975
+#: lib/klass_hero_web/components/provider_components.ex:1011
 #, elixir-autogen, elixir-format
 msgid "Schedule (optional)"
 msgstr "Zeitplan (optional)"
@@ -2770,7 +2775,7 @@ msgstr "Zeitplan noch offen"
 msgid "School Grade (optional)"
 msgstr "Klassenstufe (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:3321
+#: lib/klass_hero_web/components/provider_components.ex:3357
 #, elixir-autogen, elixir-format
 msgid "Select File"
 msgstr "Datei auswählen"
@@ -2787,23 +2792,23 @@ msgstr "Das ausgewählte Kind erfüllt die Programmanforderungen nicht."
 msgid "Selected instructor could not be found. Please try again."
 msgstr "Der ausgewählte Kursleiter konnte nicht gefunden werden. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2887
+#: lib/klass_hero_web/components/provider_components.ex:2923
 #: lib/klass_hero_web/live/admin/emails_live.ex:206
 #, elixir-autogen, elixir-format
 msgid "Sent"
 msgstr "Gesendet"
 
-#: lib/klass_hero_web/components/provider_components.ex:760
+#: lib/klass_hero_web/components/provider_components.ex:796
 #, elixir-autogen, elixir-format
 msgid "Separate multiple qualifications with commas"
 msgstr "Trennen Sie mehrere Qualifikationen durch Kommas"
 
-#: lib/klass_hero_web/components/provider_components.ex:1057
+#: lib/klass_hero_web/components/provider_components.ex:1093
 #, elixir-autogen, elixir-format
 msgid "Set minimum and maximum enrollment for this program."
 msgstr "Legen Sie die minimale und maximale Anmeldekapazität für dieses Programm fest."
 
-#: lib/klass_hero_web/components/provider_components.ex:734
+#: lib/klass_hero_web/components/provider_components.ex:770
 #, elixir-autogen, elixir-format
 msgid "Specialties"
 msgstr "Spezialisierungen"
@@ -2821,12 +2826,12 @@ msgstr "Der Mitarbeiter existiert nicht mehr."
 msgid "Staff member not found."
 msgstr "Mitarbeiter nicht gefunden."
 
-#: lib/klass_hero_web/components/provider_components.ex:1021
+#: lib/klass_hero_web/components/provider_components.ex:1057
 #, elixir-autogen, elixir-format
 msgid "Start Date"
 msgstr "Startdatum"
 
-#: lib/klass_hero_web/components/provider_components.ex:1008
+#: lib/klass_hero_web/components/provider_components.ex:1044
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:184
 #, elixir-autogen, elixir-format
 msgid "Start Time"
@@ -2892,13 +2897,13 @@ msgstr "Diese Einladung kann nicht erneut gesendet werden."
 msgid "This program was modified by someone else. Please close and try again."
 msgstr "Dieses Programm wurde von jemand anderem geändert. Bitte schließen Sie es und versuchen Sie es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:933
-#: lib/klass_hero_web/components/provider_components.ex:1940
+#: lib/klass_hero_web/components/provider_components.ex:969
+#: lib/klass_hero_web/components/provider_components.ex:1976
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr "Titel"
 
-#: lib/klass_hero_web/components/provider_components.ex:3220
+#: lib/klass_hero_web/components/provider_components.ex:3256
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr "Zu viele Dateien."
@@ -2918,27 +2923,27 @@ msgstr "Bis zu %{max}"
 msgid "Up to Grade %{max}"
 msgstr "Bis Klassenstufe %{max}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2545
+#: lib/klass_hero_web/components/provider_components.ex:2581
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr "CSV hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3367
+#: lib/klass_hero_web/components/provider_components.ex:3403
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr "Dokument hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3275
+#: lib/klass_hero_web/components/provider_components.ex:3311
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr "Neues Dokument hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3223
+#: lib/klass_hero_web/components/provider_components.ex:3259
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr "Upload-Fehler."
 
-#: lib/klass_hero_web/components/provider_components.ex:3240
+#: lib/klass_hero_web/components/provider_components.ex:3276
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr "Verifizierungsdokumente"
@@ -2960,7 +2965,7 @@ msgstr "Verifizierungsdokument nicht gefunden."
 msgid "Verifications"
 msgstr "Verifizierungen"
 
-#: lib/klass_hero_web/components/provider_components.ex:279
+#: lib/klass_hero_web/components/provider_components.ex:315
 #: lib/klass_hero_web/components/provider_layout_components.ex:217
 #: lib/klass_hero_web/components/ui_components.ex:1671
 #, elixir-autogen, elixir-format
@@ -2973,37 +2978,38 @@ msgid "We are Klass Hero — parents, brothers, and partners of educators — bu
 msgstr "Wir sind Klass Hero — Eltern, Brüder und Partner von Pädagogen — und bauen die Infrastruktur auf, die jedem Kind hilft, zu lernen und zu wachsen."
 
 #: lib/klass_hero_web/live/admin/messages_live.ex:106
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:100
 #: lib/klass_hero_web/user_auth.ex:298
 #, elixir-autogen, elixir-format
 msgid "You don't have access to that page."
 msgstr "Sie haben keinen Zugriff auf diese Seite."
 
-#: lib/klass_hero_web/components/provider_components.ex:714
+#: lib/klass_hero_web/components/provider_components.ex:750
 #, elixir-autogen, elixir-format
 msgid "e.g. Head Coach"
 msgstr "z. B. Cheftrainer"
 
-#: lib/klass_hero_web/components/provider_components.ex:705
+#: lib/klass_hero_web/components/provider_components.ex:741
 #, elixir-autogen, elixir-format
 msgid "e.g. Johnson"
 msgstr "z. B. Johnson"
 
-#: lib/klass_hero_web/components/provider_components.ex:699
+#: lib/klass_hero_web/components/provider_components.ex:735
 #, elixir-autogen, elixir-format
 msgid "e.g. Mike"
 msgstr "z. B. Mike"
 
-#: lib/klass_hero_web/components/provider_components.ex:720
+#: lib/klass_hero_web/components/provider_components.ex:756
 #, elixir-autogen, elixir-format
 msgid "e.g. mike@example.com"
 msgstr "z. B. mike@example.com"
 
-#: lib/klass_hero_web/components/provider_components.ex:934
+#: lib/klass_hero_web/components/provider_components.ex:970
 #, elixir-autogen, elixir-format
 msgid "e.g., Art Adventures"
 msgstr "z. B. Art Adventures"
 
-#: lib/klass_hero_web/components/provider_components.ex:970
+#: lib/klass_hero_web/components/provider_components.ex:1006
 #, elixir-autogen, elixir-format
 msgid "e.g., Community Center, Main St"
 msgstr "z. B. Gemeindezentrum, Hauptstraße"
@@ -3029,7 +3035,7 @@ msgid "Child Safeguarding Training"
 msgstr "Kinderschutzschulung"
 
 #: lib/klass_hero_web/components/marketing_components.ex:1507
-#: lib/klass_hero_web/components/provider_components.ex:3596
+#: lib/klass_hero_web/components/provider_components.ex:3632
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr "Vereinbarung zu Community-Standards"
@@ -3180,7 +3186,7 @@ msgid "Vetted with Care"
 msgstr "Mit Sorgfalt geprüft"
 
 #: lib/klass_hero_web/components/marketing_components.ex:1491
-#: lib/klass_hero_web/components/provider_components.ex:3374
+#: lib/klass_hero_web/components/provider_components.ex:3410
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr "Video-Überprüfung"
@@ -3354,7 +3360,7 @@ msgstr "Eingecheckt"
 msgid "Checked Out"
 msgstr "Ausgecheckt"
 
-#: lib/klass_hero_web/components/provider_components.ex:2746
+#: lib/klass_hero_web/components/provider_components.ex:2782
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Child"
@@ -3400,7 +3406,7 @@ msgstr "Benötige ich ein Konto, um zu buchen?"
 msgid "Download monthly statements for taxes"
 msgstr "Monatliche Abrechnungen für die Steuer herunterladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2461
+#: lib/klass_hero_web/components/provider_components.ex:2497
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:504
 #, elixir-autogen, elixir-format
 msgid "Enrollment not confirmed"
@@ -3473,7 +3479,7 @@ msgstr "Keine Änderungen erkannt"
 msgid "No chasing payments or sending invoices"
 msgstr "Kein Nachfassen bei Zahlungen oder Versenden von Rechnungen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1675
+#: lib/klass_hero_web/components/provider_components.ex:1711
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:428
 #, elixir-autogen, elixir-format
 msgid "No enrolled parents"
@@ -3496,7 +3502,7 @@ msgstr "Notizen"
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr "Oder: Jederzeit eine Sofortauszahlung anfordern (mindestens 50 €)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2460
+#: lib/klass_hero_web/components/provider_components.ex:2496
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:503
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -3746,7 +3752,7 @@ msgstr "Zurück zu Sitzungen"
 msgid "Back to emails"
 msgstr "Zurück zu E-Mails"
 
-#: lib/klass_hero_web/components/messaging_components.ex:732
+#: lib/klass_hero_web/components/messaging_components.ex:754
 #, elixir-autogen, elixir-format
 msgid "Broadcast messages are one-way"
 msgstr "Broadcast-Nachrichten sind einseitig"
@@ -4107,7 +4113,7 @@ msgstr "Bitte erklären Sie, warum Sie diese Notiz ablehnen..."
 msgid "Please fill in all required fields"
 msgstr "Bitte füllen Sie alle erforderlichen Felder aus"
 
-#: lib/klass_hero_web/components/provider_components.ex:2652
+#: lib/klass_hero_web/components/provider_components.ex:2688
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:24
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:299
@@ -4152,7 +4158,7 @@ msgstr "Grund für die Ablehnung (optional)"
 msgid "Reply"
 msgstr "Antworten"
 
-#: lib/klass_hero_web/components/messaging_components.ex:743
+#: lib/klass_hero_web/components/messaging_components.ex:765
 #, elixir-autogen, elixir-format
 msgid "Reply privately"
 msgstr "Privat antworten"
@@ -4167,7 +4173,7 @@ msgstr "Privates Antworten ist nur für Broadcast-Nachrichten verfügbar"
 msgid "Reply sent successfully"
 msgstr "Antwort erfolgreich gesendet"
 
-#: lib/klass_hero_web/components/provider_components.ex:553
+#: lib/klass_hero_web/components/provider_components.ex:589
 #, elixir-autogen, elixir-format
 msgid "Resend"
 msgstr "Erneut senden"
@@ -4433,7 +4439,7 @@ msgstr "Vervollständigen Sie Ihr Anbieterprofil"
 msgid "Failed to upload files. Please try again."
 msgstr "Hochladen der Dateien fehlgeschlagen. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/components/messaging_components.ex:818
+#: lib/klass_hero_web/components/messaging_components.ex:841
 #, elixir-autogen, elixir-format
 msgid "File is too large (max %{mb} MB)"
 msgstr "Datei ist zu groß (max. %{mb} MB)"
@@ -4443,7 +4449,7 @@ msgstr "Datei ist zu groß (max. %{mb} MB)"
 msgid "File is too large (max %{mb} MB)."
 msgstr "Datei ist zu groß (max. %{mb} MB)."
 
-#: lib/klass_hero_web/components/messaging_components.ex:821
+#: lib/klass_hero_web/components/messaging_components.ex:844
 #, elixir-autogen, elixir-format
 msgid "File type not accepted (images only)"
 msgstr "Dateityp nicht akzeptiert (nur Bilder)"
@@ -4463,8 +4469,8 @@ msgstr "Geben Sie Ihre Unternehmensdaten ein. Ihr Profil wird von Klass Hero gep
 msgid "Only images are accepted (JPG, PNG, GIF, WebP)."
 msgstr "Nur Bilder werden akzeptiert (JPG, PNG, GIF, WebP)."
 
-#: lib/klass_hero_web/components/messaging_components.ex:803
-#: lib/klass_hero_web/components/messaging_components.ex:807
+#: lib/klass_hero_web/components/messaging_components.ex:826
+#: lib/klass_hero_web/components/messaging_components.ex:830
 #, elixir-autogen, elixir-format
 msgid "Photo"
 msgstr "Foto"
@@ -4484,8 +4490,8 @@ msgstr "Profil vervollständigt! Klass Hero wird Ihr Profil in Kürze prüfen."
 msgid "Provider not found"
 msgstr "Anbieter nicht gefunden"
 
-#: lib/klass_hero_web/components/messaging_components.ex:281
-#: lib/klass_hero_web/components/messaging_components.ex:352
+#: lib/klass_hero_web/components/messaging_components.ex:294
+#: lib/klass_hero_web/components/messaging_components.ex:365
 #, elixir-autogen, elixir-format
 msgid "Remove attachment"
 msgstr "Anhang entfernen"
@@ -4504,7 +4510,7 @@ msgstr "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut."
 msgid "Tell parents about your organization and what makes you unique..."
 msgstr "Erzählen Sie Eltern von Ihrer Organisation und was Sie einzigartig macht..."
 
-#: lib/klass_hero_web/components/messaging_components.ex:825
+#: lib/klass_hero_web/components/messaging_components.ex:848
 #, elixir-autogen, elixir-format
 msgid "Too many files (max %{max})"
 msgstr "Zu viele Dateien (max. %{max})"
@@ -4514,12 +4520,12 @@ msgstr "Zu viele Dateien (max. %{max})"
 msgid "Too many files (max %{max})."
 msgstr "Zu viele Dateien (max. %{max})."
 
-#: lib/klass_hero_web/components/messaging_components.ex:829
+#: lib/klass_hero_web/components/messaging_components.ex:852
 #, elixir-autogen, elixir-format
 msgid "Upload error"
 msgstr "Upload-Fehler"
 
-#: lib/klass_hero_web/components/messaging_components.ex:828
+#: lib/klass_hero_web/components/messaging_components.ex:851
 #, elixir-autogen, elixir-format
 msgid "Upload failed"
 msgstr "Hochladen fehlgeschlagen"
@@ -4540,47 +4546,47 @@ msgstr "Website"
 msgid "Your profile is already complete."
 msgstr "Ihr Profil ist bereits vollständig."
 
-#: lib/klass_hero_web/components/messaging_components.ex:90
+#: lib/klass_hero_web/components/messaging_components.ex:96
 #: lib/klass_hero_web/live/messaging_live_helper.ex:397
 #, elixir-autogen, elixir-format
 msgid "for"
 msgstr "für"
 
-#: lib/klass_hero_web/components/provider_components.ex:1799
+#: lib/klass_hero_web/components/provider_components.ex:1835
 #, elixir-autogen, elixir-format
 msgid "Assigned staff"
 msgstr "Zugewiesenes Personal"
 
-#: lib/klass_hero_web/components/provider_components.ex:1800
+#: lib/klass_hero_web/components/provider_components.ex:1836
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr "Anwesenheit"
 
-#: lib/klass_hero_web/components/provider_components.ex:1783
-#: lib/klass_hero_web/components/provider_components.ex:1868
-#: lib/klass_hero_web/components/provider_components.ex:2016
-#: lib/klass_hero_web/components/provider_components.ex:2165
+#: lib/klass_hero_web/components/provider_components.ex:1819
+#: lib/klass_hero_web/components/provider_components.ex:1904
+#: lib/klass_hero_web/components/provider_components.ex:2052
+#: lib/klass_hero_web/components/provider_components.ex:2201
 #: lib/klass_hero_web/live/provider/overview_live.ex:403
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr "Schließen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1798
+#: lib/klass_hero_web/components/provider_components.ex:1834
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr "Datum / Uhrzeit"
 
-#: lib/klass_hero_web/components/provider_components.ex:1792
+#: lib/klass_hero_web/components/provider_components.ex:1828
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled yet."
 msgstr "Noch keine Sessions geplant."
 
-#: lib/klass_hero_web/components/provider_components.ex:1781
+#: lib/klass_hero_web/components/provider_components.ex:1817
 #, elixir-autogen, elixir-format
 msgid "Sessions — %{title}"
 msgstr "Sessions — %{title}"
 
-#: lib/klass_hero_web/components/provider_components.ex:1486
+#: lib/klass_hero_web/components/provider_components.ex:1522
 #, elixir-autogen, elixir-format
 msgid "View sessions"
 msgstr "Sessions anzeigen"
@@ -4612,17 +4618,17 @@ msgstr "Abreisezeit ist kein gültiges Datum oder keine gültige Uhrzeit"
 msgid "Failed to update record"
 msgstr "Aktualisieren des Datensatzes fehlgeschlagen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2810
+#: lib/klass_hero_web/components/provider_components.ex:2846
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr "Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2483
+#: lib/klass_hero_web/components/provider_components.ex:2519
 #, elixir-autogen, elixir-format
 msgid "Invite mode"
 msgstr "Einladungsmodus"
 
-#: lib/klass_hero_web/components/provider_components.ex:2502
+#: lib/klass_hero_web/components/provider_components.ex:2538
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr "Einzelperson einladen"
@@ -4637,12 +4643,12 @@ msgstr "Einladung verschickt."
 msgid "Leave blank to keep this child marked as present."
 msgstr "Leer lassen, um dieses Kind als anwesend markiert zu lassen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2823
+#: lib/klass_hero_web/components/provider_components.ex:2859
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr "Gesundheit & Einwilligungen (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2829
+#: lib/klass_hero_web/components/provider_components.ex:2865
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr "Gesundheitliche Besonderheiten"
@@ -4653,17 +4659,17 @@ msgstr "Gesundheitliche Besonderheiten"
 msgid "Nothing to update"
 msgstr "Nichts zu aktualisieren"
 
-#: lib/klass_hero_web/components/provider_components.ex:2831
+#: lib/klass_hero_web/components/provider_components.ex:2867
 #, elixir-autogen, elixir-format
 msgid "Nut allergy"
 msgstr "Nussallergie"
 
-#: lib/klass_hero_web/components/provider_components.ex:2835
+#: lib/klass_hero_web/components/provider_components.ex:2871
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr "Fotos dürfen in Marketingmaterialien verwendet werden"
 
-#: lib/klass_hero_web/components/provider_components.ex:2840
+#: lib/klass_hero_web/components/provider_components.ex:2876
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr "Fotos dürfen in sozialen Medien erscheinen"
@@ -4673,7 +4679,7 @@ msgstr "Fotos dürfen in sozialen Medien erscheinen"
 msgid "Present"
 msgstr "Anwesend"
 
-#: lib/klass_hero_web/components/provider_components.ex:2767
+#: lib/klass_hero_web/components/provider_components.ex:2803
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr "Hauptansprechpartner"
@@ -4700,22 +4706,22 @@ msgstr "Datensatz aktualisiert"
 msgid "Save changes"
 msgstr "Änderungen speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:2804
+#: lib/klass_hero_web/components/provider_components.ex:2840
 #, elixir-autogen, elixir-format
 msgid "School (optional)"
 msgstr "Schule (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2814
+#: lib/klass_hero_web/components/provider_components.ex:2850
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr "Schulname"
 
-#: lib/klass_hero_web/components/provider_components.ex:2788
+#: lib/klass_hero_web/components/provider_components.ex:2824
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr "Zweiter Ansprechpartner (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2857
+#: lib/klass_hero_web/components/provider_components.ex:2893
 #, elixir-autogen, elixir-format
 msgid "Send invite"
 msgstr "Einladung senden"
@@ -4725,7 +4731,7 @@ msgstr "Einladung senden"
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr "Aktualisieren Sie die Notiz für dieses Kind (z. B. um zu klären, was passiert ist)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2520
+#: lib/klass_hero_web/components/provider_components.ex:2556
 #, elixir-autogen, elixir-format
 msgid "Upload a list"
 msgstr "Liste hochladen"
@@ -4760,7 +4766,7 @@ msgstr "Foto hierher ziehen oder klicken zum Auswählen"
 msgid "High"
 msgstr "Hoch"
 
-#: lib/klass_hero_web/components/provider_components.ex:787
+#: lib/klass_hero_web/components/provider_components.ex:823
 #, elixir-autogen, elixir-format
 msgid "Hourly"
 msgstr "Stündlich"
@@ -4785,22 +4791,22 @@ msgstr "Niedrig"
 msgid "Medium"
 msgstr "Mittel"
 
-#: lib/klass_hero_web/components/provider_components.ex:777
+#: lib/klass_hero_web/components/provider_components.ex:813
 #, elixir-autogen, elixir-format
 msgid "None"
 msgstr "Keine"
 
-#: lib/klass_hero_web/components/provider_components.ex:766
+#: lib/klass_hero_web/components/provider_components.ex:802
 #, elixir-autogen, elixir-format
 msgid "Pay Rate"
 msgstr "Vergütung"
 
-#: lib/klass_hero_web/components/provider_components.ex:528
+#: lib/klass_hero_web/components/provider_components.ex:564
 #, elixir-autogen, elixir-format
 msgid "Pay rate"
 msgstr "Vergütung"
 
-#: lib/klass_hero_web/components/provider_components.ex:797
+#: lib/klass_hero_web/components/provider_components.ex:833
 #, elixir-autogen, elixir-format
 msgid "Per Session"
 msgstr "Pro Sitzung"
@@ -4825,7 +4831,7 @@ msgstr "Programm oder Session nicht gefunden."
 msgid "Property Damage"
 msgstr "Sachschaden"
 
-#: lib/klass_hero_web/components/provider_components.ex:1523
+#: lib/klass_hero_web/components/provider_components.ex:1559
 #, elixir-autogen, elixir-format
 msgid "Report Incident"
 msgstr "Vorfall melden"
@@ -5000,7 +5006,7 @@ msgstr "Sind Sie Pädagog:in, Coach oder Künstler:in?"
 msgid "At Klass Hero, trust isn't a feature — it's the foundation of everything we do. We connect families, schools, and organizations with qualified, vetted, and safety-verified educators."
 msgstr "Bei Klass Hero ist Vertrauen kein Feature — es ist das Fundament von allem, was wir tun. Wir verbinden Familien, Schulen und Organisationen mit qualifizierten, geprüften und sicherheitsverifizierten Pädagogen."
 
-#: lib/klass_hero_web/components/messaging_components.ex:302
+#: lib/klass_hero_web/components/messaging_components.ex:315
 #, elixir-autogen, elixir-format
 msgid "Attach photo"
 msgstr "Foto anhängen"
@@ -5160,7 +5166,7 @@ msgstr "Demnächst verfügbar"
 msgid "Coming soon — track your family's weekly attendance."
 msgstr "Demnächst verfügbar — verfolgen Sie die wöchentliche Anwesenheit Ihrer Familie."
 
-#: lib/klass_hero_web/live/provider/messages_live/index.ex:19
+#: lib/klass_hero_web/live/provider/messages_live/index.ex:20
 #, elixir-autogen, elixir-format
 msgid "Comms"
 msgstr "Kommunikation"
@@ -5493,7 +5499,7 @@ msgstr[1] "%{count} Familien importiert."
 msgid "In 2025, Shane connected with his friend"
 msgstr "2025 tat sich Shane mit seinem Freund zusammen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1532
+#: lib/klass_hero_web/components/provider_components.ex:1568
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:43
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:72
 #, elixir-autogen, elixir-format
@@ -5563,7 +5569,7 @@ msgstr "Klass Hero ist das operative Rückgrat für Berlins Jugendpädagogen. Wi
 msgid "Last 8 weeks"
 msgstr "Letzte 8 Wochen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1245
+#: lib/klass_hero_web/components/provider_components.ex:1281
 #: lib/klass_hero_web/presenters/hero_cards_presenter.ex:27
 #, elixir-autogen, elixir-format
 msgid "Lead Instructor"
@@ -5905,7 +5911,7 @@ msgstr "Primär"
 
 #: lib/klass_hero_web/components/marketing_components.ex:812
 #: lib/klass_hero_web/components/marketing_components.ex:859
-#: lib/klass_hero_web/live/privacy_policy_live.ex:240
+#: lib/klass_hero_web/live/privacy_policy_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr "Datenschutz"
@@ -6002,17 +6008,17 @@ msgstr "Umsatz (diese Woche)"
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr "Strenge Überprüfung, damit Familien immer wissen, wer die Gruppe leitet."
 
-#: lib/klass_hero_web/components/provider_components.ex:2896
+#: lib/klass_hero_web/components/provider_components.ex:2932
 #, elixir-autogen, elixir-format
 msgid "Row %{row}"
 msgstr "Zeile %{row}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2896
+#: lib/klass_hero_web/components/provider_components.ex:2932
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr "Zeile —"
 
-#: lib/klass_hero_web/components/provider_components.ex:2597
+#: lib/klass_hero_web/components/provider_components.ex:2633
 #, elixir-autogen, elixir-format
 msgid "Rows with errors"
 msgstr "Zeilen mit Fehlern"
@@ -6742,12 +6748,12 @@ msgstr "Deine Identität ist verifiziert."
 msgid "Experience validation"
 msgstr "Erfahrungsnachweis"
 
-#: lib/klass_hero_web/components/provider_components.ex:3404
+#: lib/klass_hero_web/components/provider_components.ex:3440
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr "MP4, MOV oder WEBM. Max. 100 MB."
 
-#: lib/klass_hero_web/components/provider_components.ex:3377
+#: lib/klass_hero_web/components/provider_components.ex:3413
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr "Nimm ein kurzes Video auf, in dem du dich vorstellst. Unser Team prüft es, um Kommunikationsfähigkeit und Übereinstimmung mit unseren Werten einzuschätzen."
@@ -6757,12 +6763,12 @@ msgstr "Nimm ein kurzes Video auf, in dem du dich vorstellst. Unser Team prüft 
 msgid "Safeguarding certificate"
 msgstr "Kinderschutz-Zertifikat"
 
-#: lib/klass_hero_web/components/provider_components.ex:3401
+#: lib/klass_hero_web/components/provider_components.ex:3437
 #, elixir-autogen, elixir-format
 msgid "Select Video"
 msgstr "Video auswählen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3447
+#: lib/klass_hero_web/components/provider_components.ex:3483
 #, elixir-autogen, elixir-format
 msgid "Upload Video"
 msgstr "Video hochladen"
@@ -6772,7 +6778,7 @@ msgstr "Video hochladen"
 msgid "Your browser does not support video playback."
 msgstr "Dein Browser unterstützt keine Videowiedergabe."
 
-#: lib/klass_hero_web/components/provider_components.ex:3600
+#: lib/klass_hero_web/components/provider_components.ex:3636
 #, elixir-autogen, elixir-format
 msgid "Confirm agreement"
 msgstr "Zustimmung bestätigen"
@@ -6782,12 +6788,12 @@ msgstr "Zustimmung bestätigen"
 msgid "Couldn't record your agreement. Please try again."
 msgstr "Deine Zustimmung konnte nicht gespeichert werden. Bitte versuche es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:3623
+#: lib/klass_hero_web/components/provider_components.ex:3659
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr "Vereinbarung herunterladen (PDF)"
 
-#: lib/klass_hero_web/components/provider_components.ex:3599
+#: lib/klass_hero_web/components/provider_components.ex:3635
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr "Ich habe die Klass Hero Community-Richtlinien gelesen und stimme ihnen zu."
@@ -6797,7 +6803,7 @@ msgstr "Ich habe die Klass Hero Community-Richtlinien gelesen und stimme ihnen z
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr "Bitte bestätige, dass du die Community-Richtlinien gelesen hast und ihnen zustimmst."
 
-#: lib/klass_hero_web/components/provider_components.ex:3502
+#: lib/klass_hero_web/components/provider_components.ex:3538
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr "Unterzeichnet von %{name} am %{date} (v%{version})."
@@ -6807,17 +6813,17 @@ msgstr "Unterzeichnet von %{name} am %{date} (v%{version})."
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr "Danke – deine Zustimmung zu den Community-Richtlinien wurde gespeichert."
 
-#: lib/klass_hero_web/components/provider_components.ex:3608
+#: lib/klass_hero_web/components/provider_components.ex:3644
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr "Die Community-Richtlinien wurden seit deiner letzten Zustimmung aktualisiert (v%{old}). Bitte lies sie erneut und stimme erneut zu."
 
-#: lib/klass_hero_web/components/provider_components.ex:3597
+#: lib/klass_hero_web/components/provider_components.ex:3633
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr "Der letzte Schritt: Lies die Klass Hero Community-Richtlinien und stimme ihnen zu."
 
-#: lib/klass_hero_web/components/provider_components.ex:3598
+#: lib/klass_hero_web/components/provider_components.ex:3634
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr "Du hast den Community-Richtlinien zugestimmt."
@@ -7086,12 +7092,12 @@ msgstr "Ihre Versicherungsbescheinigung wird geprüft."
 msgid "Your insurance is verified."
 msgstr "Ihre Versicherung ist verifiziert."
 
-#: lib/klass_hero_web/components/provider_components.ex:3546
+#: lib/klass_hero_web/components/provider_components.ex:3582
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr "Unterzeichnung durch %{name} im Namen des Unternehmens."
 
-#: lib/klass_hero_web/components/provider_components.ex:3655
+#: lib/klass_hero_web/components/provider_components.ex:3691
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr "Bestätige im Namen deines Unternehmens, dass alle Mitarbeitenden gemäß dem deutschen Kinderschutzrecht überprüft sind."
@@ -7101,7 +7107,7 @@ msgstr "Bestätige im Namen deines Unternehmens, dass alle Mitarbeitenden gemä�
 msgid "Couldn't record your declaration. Please try again."
 msgstr "Deine Erklärung konnte nicht gespeichert werden. Bitte versuche es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:3661
+#: lib/klass_hero_web/components/provider_components.ex:3697
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr "Ich bestätige im Namen des Unternehmens, dass die obige Erklärung zutrifft und ich zu ihrer Unterzeichnung berechtigt bin."
@@ -7111,17 +7117,17 @@ msgstr "Ich bestätige im Namen des Unternehmens, dass die obige Erklärung zutr
 msgid "Please confirm the declaration before signing."
 msgstr "Bitte bestätige die Erklärung vor der Unterzeichnung."
 
-#: lib/klass_hero_web/components/provider_components.ex:3686
+#: lib/klass_hero_web/components/provider_components.ex:3722
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr "Vorläufiger Text — vor der Freischaltung noch von einer in Deutschland zugelassenen Anwältin bzw. einem Anwalt zu prüfen."
 
-#: lib/klass_hero_web/components/provider_components.ex:3665
+#: lib/klass_hero_web/components/provider_components.ex:3701
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr "Erklärung unterzeichnen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3653
+#: lib/klass_hero_web/components/provider_components.ex:3689
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr "Erklärung zur Mitarbeiter-Compliance"
@@ -7131,12 +7137,12 @@ msgstr "Erklärung zur Mitarbeiter-Compliance"
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr "Danke — deine Erklärung zur Mitarbeiter-Compliance wurde erfasst."
 
-#: lib/klass_hero_web/components/provider_components.ex:3673
+#: lib/klass_hero_web/components/provider_components.ex:3709
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr "Die Erklärung zur Mitarbeiter-Compliance wurde seit deiner letzten Unterzeichnung aktualisiert (v%{old}). Bitte prüfe sie und unterzeichne erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:3659
+#: lib/klass_hero_web/components/provider_components.ex:3695
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr "Du hast die Erklärung zur Mitarbeiter-Compliance unterzeichnet."
@@ -7203,15 +7209,15 @@ msgstr "In Prüfung"
 msgid "Undelivered Events"
 msgstr "Nicht zugestellte Ereignisse"
 
-#: lib/klass_hero_web/components/provider_components.ex:2110
-#: lib/klass_hero_web/components/provider_components.ex:2288
+#: lib/klass_hero_web/components/provider_components.ex:2146
+#: lib/klass_hero_web/components/provider_components.ex:2324
 #: lib/klass_hero_web/live/user_live/settings.ex:273
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2038
-#: lib/klass_hero_web/components/provider_components.ex:2219
+#: lib/klass_hero_web/components/provider_components.ex:2074
+#: lib/klass_hero_web/components/provider_components.ex:2255
 #, elixir-autogen, elixir-format
 msgid "Lead"
 msgstr "Leitung"
@@ -7221,17 +7227,17 @@ msgstr "Leitung"
 msgid "Lead instructor updated."
 msgstr "Leitender Kursleiter aktualisiert."
 
-#: lib/klass_hero_web/components/provider_components.ex:2050
+#: lib/klass_hero_web/components/provider_components.ex:2086
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor"
 msgstr "Als leitenden Kursleiter festlegen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1500
+#: lib/klass_hero_web/components/provider_components.ex:1536
 #, elixir-autogen, elixir-format
 msgid "Manage Staffing"
 msgstr "Programmteam verwalten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2079
+#: lib/klass_hero_web/components/provider_components.ex:2115
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this program yet."
 msgstr "Diesem Programm ist noch niemand zugewiesen."
@@ -7242,19 +7248,19 @@ msgstr "Diesem Programm ist noch niemand zugewiesen."
 msgid "Pick a staff member to add."
 msgstr "Bitte ein Teammitglied zum Hinzufügen auswählen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2062
-#: lib/klass_hero_web/components/provider_components.ex:2327
+#: lib/klass_hero_web/components/provider_components.ex:2098
+#: lib/klass_hero_web/components/provider_components.ex:2363
 #, elixir-autogen, elixir-format
 msgid "Reassign the lead before removing them"
 msgstr "Vor dem Entfernen einen anderen leitenden Kursleiter festlegen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2063
+#: lib/klass_hero_web/components/provider_components.ex:2099
 #, elixir-autogen, elixir-format
 msgid "Remove from program"
 msgstr "Aus dem Programm entfernen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2098
-#: lib/klass_hero_web/components/provider_components.ex:2275
+#: lib/klass_hero_web/components/provider_components.ex:2134
+#: lib/klass_hero_web/components/provider_components.ex:2311
 #, elixir-autogen, elixir-format
 msgid "Select a staff member…"
 msgstr "Teammitglied auswählen …"
@@ -7269,14 +7275,14 @@ msgstr "Teammitglied zum Programm hinzugefügt."
 msgid "Staff member removed from the program."
 msgstr "Teammitglied aus dem Programm entfernt."
 
-#: lib/klass_hero_web/components/provider_components.ex:2115
+#: lib/klass_hero_web/components/provider_components.ex:2151
 #, elixir-autogen, elixir-format
 msgid "Staff you add can read and reply to this program's parent conversations."
 msgstr ""
 "Hinzugefügte Teammitglieder können die Elterngespräche dieses Programms lesen "
 "und beantworten."
 
-#: lib/klass_hero_web/components/provider_components.ex:2014
+#: lib/klass_hero_web/components/provider_components.ex:2050
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{title}"
 msgstr "Programmteam — %{title}"
@@ -7298,19 +7304,19 @@ msgstr ""
 "Diese Person ist der leitende Kursleiter. Bitte zuerst eine andere Person als "
 "Leitung festlegen."
 
-#: lib/klass_hero_web/components/provider_components.ex:1444
+#: lib/klass_hero_web/components/provider_components.ex:1480
 #, elixir-autogen, elixir-format
 msgid "%{count} staff member · no lead"
 msgid_plural "%{count} staff · no lead"
 msgstr[0] "%{count} Mitarbeiter*in · keine Leitung"
 msgstr[1] "%{count} Mitarbeitende · keine Leitung"
 
-#: lib/klass_hero_web/components/provider_components.ex:563
+#: lib/klass_hero_web/components/provider_components.ex:599
 #, elixir-autogen, elixir-format
 msgid "%{name} will be unassigned from every program and removed from those conversations. Their history is kept and you can add them back later."
 msgstr "%{name} wird aus allen Programmen und den zugehörigen Unterhaltungen entfernt. Der Verlauf bleibt erhalten und du kannst die Person später wieder hinzufügen."
 
-#: lib/klass_hero_web/components/provider_components.ex:639
+#: lib/klass_hero_web/components/provider_components.ex:675
 #, elixir-autogen, elixir-format
 msgid "Add back to team"
 msgstr "Wieder ins Team aufnehmen"
@@ -7320,7 +7326,7 @@ msgstr "Wieder ins Team aufnehmen"
 msgid "Could not bring this team member back. Please try again."
 msgstr "Teammitglied konnte nicht zurückgeholt werden. Bitte versuche es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:601
+#: lib/klass_hero_web/components/provider_components.ex:637
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr "Eintrag löschen"
@@ -7330,7 +7336,7 @@ msgstr "Eintrag löschen"
 msgid "Former team members"
 msgstr "Ehemalige Teammitglieder"
 
-#: lib/klass_hero_web/components/provider_components.ex:575
+#: lib/klass_hero_web/components/provider_components.ex:611
 #, elixir-autogen, elixir-format
 msgid "Remove from team"
 msgstr "Aus dem Team entfernen"
@@ -7345,7 +7351,7 @@ msgstr "Teammitglied ist zurück. Weise die Person wieder Programmen zu, wenn du
 msgid "Team member removed from the team."
 msgstr "Teammitglied aus dem Team entfernt."
 
-#: lib/klass_hero_web/components/provider_components.ex:591
+#: lib/klass_hero_web/components/provider_components.ex:627
 #, elixir-autogen, elixir-format
 msgid "This deletes %{name} permanently — there's nothing to undo. Use it only for an entry added by mistake."
 msgstr "Damit wird %{name} endgültig gelöscht – das lässt sich nicht rückgängig machen. Nutze das nur für einen versehentlich angelegten Eintrag."
@@ -7376,7 +7382,7 @@ msgstr ""
 "Programm aktualisiert, aber die Anmeldekapazität wurde abgelehnt. Es gelten "
 "weiterhin die bisherigen Grenzwerte."
 
-#: lib/klass_hero_web/components/provider_components.ex:876
+#: lib/klass_hero_web/components/provider_components.ex:912
 #, elixir-autogen, elixir-format
 msgid "%{count} child is already enrolled. Confirm you want this program to have no capacity limit."
 msgid_plural "%{count} children are already enrolled. Confirm you want this program to have no capacity limit."
@@ -7387,18 +7393,18 @@ msgstr[1] ""
 "%{count} Kinder sind bereits angemeldet. Bestätigen Sie, dass dieses "
 "Programm keine Teilnehmerbegrenzung haben soll."
 
-#: lib/klass_hero_web/components/provider_components.ex:1087
+#: lib/klass_hero_web/components/provider_components.ex:1123
 #, elixir-autogen, elixir-format
 msgid "Anyone will be able to book a place until you set a new maximum."
 msgstr ""
 "Bis Sie ein neues Maximum festlegen, kann jede Person einen Platz buchen."
 
-#: lib/klass_hero_web/components/provider_components.ex:1092
+#: lib/klass_hero_web/components/provider_components.ex:1128
 #, elixir-autogen, elixir-format
 msgid "I understand this program will have no capacity limit."
 msgstr "Ich verstehe, dass dieses Programm keine Teilnehmerbegrenzung haben wird."
 
-#: lib/klass_hero_web/components/provider_components.ex:2315
+#: lib/klass_hero_web/components/provider_components.ex:2351
 #, elixir-autogen, elixir-format
 msgid "Go back to the program's usual team"
 msgstr "Zurück zum üblichen Programmteam"
@@ -7408,17 +7414,17 @@ msgstr "Zurück zum üblichen Programmteam"
 msgid "Lead instructor for this session updated."
 msgstr "Leitung für diesen Termin aktualisiert."
 
-#: lib/klass_hero_web/components/provider_components.ex:2234
+#: lib/klass_hero_web/components/provider_components.ex:2270
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor for this session"
 msgstr "Als Leitung für diesen Termin festlegen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2256
+#: lib/klass_hero_web/components/provider_components.ex:2292
 #, elixir-autogen, elixir-format
 msgid "Nobody is working this session yet."
 msgstr "Für diesen Termin ist noch niemand eingeteilt."
 
-#: lib/klass_hero_web/components/provider_components.ex:2332
+#: lib/klass_hero_web/components/provider_components.ex:2368
 #, elixir-autogen, elixir-format
 msgid "Remove from this session"
 msgstr "Von diesem Termin entfernen"
@@ -7438,7 +7444,7 @@ msgstr "Teammitglied von diesem Termin entfernt."
 msgid "Staffing"
 msgstr "Team"
 
-#: lib/klass_hero_web/components/provider_components.ex:2158
+#: lib/klass_hero_web/components/provider_components.ex:2194
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{date}"
 msgstr "Team — %{date}"
@@ -7468,22 +7474,22 @@ msgstr "Dieser Termin nutzt wieder das übliche Programmteam."
 msgid "A session needs at least one person. Use “Go back to the program's usual team” to drop this session's own roster."
 msgstr "Ein Termin braucht mindestens eine Person. Nutze „Zurück zum üblichen Programmteam“, um die eigene Besetzung dieses Termins aufzuheben."
 
-#: lib/klass_hero_web/components/provider_components.ex:2330
+#: lib/klass_hero_web/components/provider_components.ex:2366
 #, elixir-autogen, elixir-format
 msgid "A session needs someone — use “Go back to the program's usual team” instead"
 msgstr "Ein Termin braucht jemanden — nutze stattdessen „Zurück zum üblichen Programmteam“"
 
-#: lib/klass_hero_web/components/provider_components.ex:2297
+#: lib/klass_hero_web/components/provider_components.ex:2333
 #, elixir-autogen, elixir-format
 msgid "Everyone on your team is already working this session."
 msgstr "Alle aus deinem Team arbeiten bereits bei diesem Termin."
 
-#: lib/klass_hero_web/components/provider_components.ex:2190
+#: lib/klass_hero_web/components/provider_components.ex:2226
 #, elixir-autogen, elixir-format
 msgid "Staffed just for this session. Changes here do not touch the program."
 msgstr "Nur für diesen Termin eingeteilt. Änderungen hier wirken sich nicht auf das Programm aus."
 
-#: lib/klass_hero_web/components/provider_components.ex:2192
+#: lib/klass_hero_web/components/provider_components.ex:2228
 #, elixir-autogen, elixir-format
 msgid "Using the program's usual team. The first change here copies them onto this session, so later program changes stop reaching it."
 msgstr "Es gilt das übliche Programmteam. Die erste Änderung hier übernimmt das Team in diesen Termin — spätere Änderungen am Programm greifen dann nicht mehr."
@@ -7493,12 +7499,12 @@ msgstr "Es gilt das übliche Programmteam. Die erste Änderung hier übernimmt d
 msgid "(optional)"
 msgstr "(optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:1933
+#: lib/klass_hero_web/components/provider_components.ex:1969
 #, elixir-autogen, elixir-format
 msgid "Add a waiver"
 msgstr "Verzichtserklärung hinzufügen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1965
+#: lib/klass_hero_web/components/provider_components.ex:2001
 #, elixir-autogen, elixir-format
 msgid "Add waiver"
 msgstr "Hinzufügen"
@@ -7520,22 +7526,22 @@ msgstr "Anmeldung nicht gefunden."
 msgid "I have read and agree to %{title}"
 msgstr "Ich habe %{title} gelesen und stimme zu"
 
-#: lib/klass_hero_web/components/provider_components.ex:1947
+#: lib/klass_hero_web/components/provider_components.ex:1983
 #, elixir-autogen, elixir-format
 msgid "Legal text"
 msgstr "Rechtstext"
 
-#: lib/klass_hero_web/components/provider_components.ex:1507
+#: lib/klass_hero_web/components/provider_components.ex:1543
 #, elixir-autogen, elixir-format
 msgid "Manage Waivers"
 msgstr "Verzichtserklärungen verwalten"
 
-#: lib/klass_hero_web/components/provider_components.ex:1875
+#: lib/klass_hero_web/components/provider_components.ex:1911
 #, elixir-autogen, elixir-format
 msgid "No waivers yet. Parents enrol without signing anything."
 msgstr "Noch keine Verzichtserklärungen. Eltern melden sich ohne Unterschrift an."
 
-#: lib/klass_hero_web/components/provider_components.ex:1954
+#: lib/klass_hero_web/components/provider_components.ex:1990
 #, elixir-autogen, elixir-format
 msgid "Parents must sign this before enrolling"
 msgstr "Eltern müssen dies vor der Anmeldung unterschreiben"
@@ -7555,17 +7561,17 @@ msgstr "Bitte lies und unterschreibe diese, bevor %{program} beginnt."
 msgid "Please tick a waiver to sign it."
 msgstr "Bitte wähle eine Verzichtserklärung aus, um sie zu unterschreiben."
 
-#: lib/klass_hero_web/components/provider_components.ex:1932
+#: lib/klass_hero_web/components/provider_components.ex:1968
 #, elixir-autogen, elixir-format
 msgid "Publish a new version"
 msgstr "Neue Version veröffentlichen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1965
+#: lib/klass_hero_web/components/provider_components.ex:2001
 #, elixir-autogen, elixir-format
 msgid "Publish version"
 msgstr "Version veröffentlichen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1958
+#: lib/klass_hero_web/components/provider_components.ex:1994
 #, elixir-autogen, elixir-format
 msgid "Publishing keeps every earlier version on record; signatures already given stay bound to the wording they were shown."
 msgstr "Beim Veröffentlichen bleibt jede frühere Version erhalten; bereits geleistete Unterschriften bleiben an den damals gezeigten Wortlaut gebunden."
@@ -7575,12 +7581,12 @@ msgstr "Beim Veröffentlichen bleibt jede frühere Version erhalten; bereits gel
 msgid "Required"
 msgstr "Erforderlich"
 
-#: lib/klass_hero_web/components/provider_components.ex:1909
+#: lib/klass_hero_web/components/provider_components.ex:1945
 #, elixir-autogen, elixir-format
 msgid "Retire this waiver"
 msgstr "Diese Verzichtserklärung zurückziehen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1900
+#: lib/klass_hero_web/components/provider_components.ex:1936
 #, elixir-autogen, elixir-format
 msgid "Revise text"
 msgstr "Text überarbeiten"
@@ -7595,7 +7601,7 @@ msgstr "Verzichtserklärungen für %{program} unterschreiben"
 msgid "Sign waivers"
 msgstr "Verzichtserklärungen unterschreiben"
 
-#: lib/klass_hero_web/components/provider_components.ex:2410
+#: lib/klass_hero_web/components/provider_components.ex:2446
 #: lib/klass_hero_web/live/enrollment_waivers_live.ex:149
 #, elixir-autogen, elixir-format
 msgid "Signed"
@@ -7611,12 +7617,12 @@ msgstr "Danke — deine Verzichtserklärungen sind erfasst."
 msgid "There is nothing to sign for this enrollment."
 msgstr "Für diese Anmeldung gibt es nichts zu unterschreiben."
 
-#: lib/klass_hero_web/components/provider_components.ex:2410
+#: lib/klass_hero_web/components/provider_components.ex:2446
 #, elixir-autogen, elixir-format
 msgid "Unsigned"
 msgstr "Nicht unterschrieben"
 
-#: lib/klass_hero_web/components/provider_components.ex:1892
+#: lib/klass_hero_web/components/provider_components.ex:1928
 #, elixir-autogen, elixir-format
 msgid "Version %{number}"
 msgstr "Version %{number}"
@@ -7626,7 +7632,7 @@ msgstr "Version %{number}"
 msgid "Waiver not found."
 msgstr "Verzichtserklärung nicht gefunden."
 
-#: lib/klass_hero_web/components/provider_components.ex:2378
+#: lib/klass_hero_web/components/provider_components.ex:2414
 #: lib/klass_hero_web/live/booking_live.ex:447
 #: lib/klass_hero_web/live/enrollment_waivers_live.ex:33
 #: lib/klass_hero_web/live/enrollment_waivers_live.ex:105
@@ -7639,7 +7645,7 @@ msgstr "Verzichtserklärungen"
 msgid "Waivers waiting for your signature"
 msgstr "Verzichtserklärungen warten auf deine Unterschrift"
 
-#: lib/klass_hero_web/components/provider_components.ex:1866
+#: lib/klass_hero_web/components/provider_components.ex:1902
 #, elixir-autogen, elixir-format
 msgid "Waivers — %{title}"
 msgstr "Verzichtserklärungen — %{title}"
@@ -7654,7 +7660,7 @@ msgstr "dieses Programm"
 msgid "New version published. It applies to future enrolments."
 msgstr "Neue Fassung veröffentlicht. Sie gilt für künftige Anmeldungen."
 
-#: lib/klass_hero_web/components/provider_components.ex:1913
+#: lib/klass_hero_web/components/provider_components.ex:1949
 #, elixir-autogen, elixir-format
 msgid "Retire \"%{title}\"? Parents will no longer be asked to sign it. Signatures already collected are kept."
 msgstr "\"%{title}\" zurückziehen? Eltern werden nicht mehr um eine Unterschrift gebeten. Bereits erteilte Unterschriften bleiben erhalten."
@@ -7674,7 +7680,7 @@ msgstr "Einverständniserklärung zurückgezogen. Bereits erteilte Unterschrifte
 msgid "You are not assigned to this session"
 msgstr "Sie sind diesem Termin nicht zugewiesen"
 
-#: lib/klass_hero_web/components/provider_components.ex:430
+#: lib/klass_hero_web/components/provider_components.ex:466
 #, elixir-autogen, elixir-format
 msgid "Complete verification to create programs."
 msgstr "Schließen Sie die Verifizierung ab, um Programme zu erstellen."
@@ -7705,7 +7711,7 @@ msgstr "Anbieterlogo"
 msgid "Provider Name"
 msgstr "Anbietername"
 
-#: lib/klass_hero_web/components/provider_components.ex:208
+#: lib/klass_hero_web/components/provider_components.ex:244
 #, elixir-autogen, elixir-format
 msgid "Provider Profile"
 msgstr "Anbieterprofil"
@@ -7725,17 +7731,17 @@ msgstr "Der mit Ihrem Konto verknüpfte Anbieter konnte nicht gefunden werden."
 msgid "This invitation has expired. Please ask your provider to resend it."
 msgstr "Diese Einladung ist abgelaufen. Bitte bitten Sie Ihren Anbieter, sie erneut zu senden."
 
-#: lib/klass_hero_web/components/provider_components.ex:211
+#: lib/klass_hero_web/components/provider_components.ex:247
 #, elixir-autogen, elixir-format
 msgid "This is your main provider identity. Verification is required to list programs."
 msgstr "Dies ist Ihr Hauptprofil als Anbieter. Eine Verifizierung ist erforderlich, um Programme anzubieten."
 
-#: lib/klass_hero_web/components/provider_components.ex:3243
+#: lib/klass_hero_web/components/provider_components.ex:3279
 #, elixir-autogen, elixir-format
 msgid "Upload documents to be verified. Documents are reviewed by our team."
 msgstr "Laden Sie Dokumente hoch, um verifiziert zu werden. Die Dokumente werden von unserem Team überprüft."
 
-#: lib/klass_hero_web/components/provider_components.ex:403
+#: lib/klass_hero_web/components/provider_components.ex:439
 #, elixir-autogen, elixir-format
 msgid "Verified Provider"
 msgstr "Verifizierter Anbieter"
@@ -7874,8 +7880,8 @@ msgstr "Einladungen ohne Antwort"
 msgid "Review invitations"
 msgstr "Einladungen prüfen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2673
-#: lib/klass_hero_web/components/provider_components.ex:2680
+#: lib/klass_hero_web/components/provider_components.ex:2709
+#: lib/klass_hero_web/components/provider_components.ex:2716
 #, elixir-autogen, elixir-format
 msgid "Unknown program"
 msgstr "Unbekanntes Programm"
@@ -7903,12 +7909,12 @@ msgid "This program has closed. Its sessions are no longer available."
 msgstr ""
 "Dieses Programm ist abgeschlossen. Seine Termine sind nicht mehr verfügbar."
 
-#: lib/klass_hero_web/components/messaging_components.ex:384
+#: lib/klass_hero_web/components/messaging_components.ex:397
 #, elixir-autogen, elixir-format
 msgid "Attach files"
 msgstr "Dateien anhängen"
 
-#: lib/klass_hero_web/components/messaging_components.ex:408
+#: lib/klass_hero_web/components/messaging_components.ex:421
 #, elixir-autogen, elixir-format
 msgid "Send message"
 msgstr "Nachricht senden"
@@ -7923,12 +7929,12 @@ msgstr "Neue Nachricht"
 msgid "You can't start a conversation with this person"
 msgstr "Mit dieser Person kannst du kein Gespräch beginnen"
 
-#: lib/klass_hero_web/components/provider_components.ex:952
+#: lib/klass_hero_web/components/provider_components.ex:988
 #, elixir-autogen, elixir-format
 msgid "Subtitle"
 msgstr "Untertitel"
 
-#: lib/klass_hero_web/components/provider_components.ex:953
+#: lib/klass_hero_web/components/provider_components.ex:989
 #, elixir-autogen, elixir-format
 msgid "e.g., For beginners, no experience needed"
 msgstr "z. B. Für Anfänger, keine Vorkenntnisse nötig"
@@ -7943,17 +7949,17 @@ msgstr "Kostenlos"
 msgid "N/A"
 msgstr "k. A."
 
-#: lib/klass_hero_web/components/provider_components.ex:3151
+#: lib/klass_hero_web/components/provider_components.ex:3187
 #, elixir-autogen, elixir-format
 msgid "A short line that sums you up"
 msgstr "Ein kurzer Satz, der euch beschreibt"
 
-#: lib/klass_hero_web/components/provider_components.ex:3140
+#: lib/klass_hero_web/components/provider_components.ex:3176
 #, elixir-autogen, elixir-format
 msgid "Branding & Presence"
 msgstr "Marke & Auftritt"
 
-#: lib/klass_hero_web/components/provider_components.ex:3164
+#: lib/klass_hero_web/components/provider_components.ex:3200
 #, elixir-autogen, elixir-format
 msgid "Choose Cover Image"
 msgstr "Titelbild auswählen"
@@ -7963,17 +7969,17 @@ msgstr "Titelbild auswählen"
 msgid "Cover image upload failed. Please try again."
 msgstr "Titelbild konnte nicht hochgeladen werden. Bitte versucht es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:3165
+#: lib/klass_hero_web/components/provider_components.ex:3201
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 5MB."
 msgstr "JPG, PNG oder WebP. Max. 5 MB."
 
-#: lib/klass_hero_web/components/provider_components.ex:3143
+#: lib/klass_hero_web/components/provider_components.ex:3179
 #, elixir-autogen, elixir-format
 msgid "Shown on your public profile page."
 msgstr "Erscheint auf eurer öffentlichen Profilseite."
 
-#: lib/klass_hero_web/components/provider_components.ex:3150
+#: lib/klass_hero_web/components/provider_components.ex:3186
 #, elixir-autogen, elixir-format
 msgid "Tagline"
 msgstr "Slogan"
@@ -8019,7 +8025,7 @@ msgstr "%{business} auf %{network}"
 msgid "Klass Hero on %{network}"
 msgstr "Klass Hero auf %{network}"
 
-#: lib/klass_hero_web/components/provider_components.ex:3222
+#: lib/klass_hero_web/components/provider_components.ex:3258
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr "Hochladen fehlgeschlagen."
@@ -8059,7 +8065,7 @@ msgstr "Allgemein"
 msgid "A newly chosen cover or logo appears here after you save."
 msgstr "Ein neu gewähltes Titelbild oder Logo erscheint hier nach dem Speichern."
 
-#: lib/klass_hero_web/components/provider_components.ex:3195
+#: lib/klass_hero_web/components/provider_components.ex:3231
 #, elixir-autogen, elixir-format
 msgid "Add %{network}"
 msgstr "%{network} hinzufügen"
@@ -8079,7 +8085,7 @@ msgstr "Vorschau des öffentlichen Profils"
 msgid "Show preview"
 msgstr "Vorschau anzeigen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3182
+#: lib/klass_hero_web/components/provider_components.ex:3218
 #, elixir-autogen, elixir-format
 msgid "e.g. %{example}"
 msgstr "z. B. %{example}"
@@ -8092,6 +8098,7 @@ msgstr[0] "%{count} Teilnehmer"
 msgstr[1] "%{count} Teilnehmer"
 
 #: lib/klass_hero_web/live/admin/messages_live.ex:75
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:77
 #, elixir-autogen, elixir-format
 msgid "Conversation not found."
 msgstr "Unterhaltung nicht gefunden."
@@ -8102,6 +8109,7 @@ msgid "Direct"
 msgstr "Direktnachricht"
 
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:70
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr "Mehr laden"
@@ -8112,6 +8120,7 @@ msgid "No conversations found."
 msgstr "Keine Unterhaltungen gefunden."
 
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:102
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:74
 #, elixir-autogen, elixir-format
 msgid "No messages in this conversation."
 msgstr "Keine Nachrichten in dieser Unterhaltung."
@@ -8141,7 +8150,44 @@ msgstr "Unbekannter Anbieter"
 msgid "← Back to messages"
 msgstr "← Zurück zu den Nachrichten"
 
-#: lib/klass_hero_web/components/messaging_components.ex:711
+#: lib/klass_hero_web/components/messaging_components.ex:733
 #, elixir-autogen, elixir-format
 msgid "Messages here may be reviewed by the activity provider and by Klass Hero staff, to keep children safe."
 msgstr "Nachrichten hier können vom Anbieter und von Klass Hero-Mitarbeitenden eingesehen werden, um Kinder zu schützen."
+
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:56
+#, elixir-autogen, elixir-format
+msgid "Back to staff conversations"
+msgstr "Zurück zu den Unterhaltungen des Teams"
+
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:15
+#, elixir-autogen, elixir-format
+msgid "Conversations your staff have with parents. Read-only — opening a thread here does not mark anything as read."
+msgstr "Unterhaltungen, die Ihr Team mit Eltern führt. Nur lesbar — das Öffnen markiert hier nichts als gelesen."
+
+#: lib/klass_hero_web/components/provider_components.ex:178
+#, elixir-autogen, elixir-format
+msgid "My conversations"
+msgstr "Meine Unterhaltungen"
+
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:34
+#, elixir-autogen, elixir-format
+msgid "No staff conversations yet. Threads your team starts will appear here."
+msgstr "Noch keine Unterhaltungen des Teams. Von Ihrem Team begonnene Unterhaltungen erscheinen hier."
+
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:65
+#, elixir-autogen, elixir-format
+msgid "Read-only. You are viewing this as the business owner, not as a participant — nothing is marked as read."
+msgstr "Nur lesbar. Sie sehen dies als Inhaber:in des Unternehmens, nicht als Teilnehmer:in — es wird nichts als gelesen markiert."
+
+#: lib/klass_hero_web/components/provider_components.ex:185
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:45
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:62
+#, elixir-autogen, elixir-format
+msgid "Staff conversations"
+msgstr "Unterhaltungen des Teams"
+
+#: lib/klass_hero_web/components/messaging_components.ex:103
+#, elixir-autogen, elixir-format
+msgid "via"
+msgstr ""

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -1545,7 +1545,6 @@ msgstr "Zurück zu Einstellungen"
 
 #: lib/klass_hero_web/components/messaging_components.ex:166
 #: lib/klass_hero_web/live/admin/messages_live.ex:147
-#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:113
 #, elixir-autogen, elixir-format
 msgid "Broadcast"
 msgstr "Rundnachricht"
@@ -1601,8 +1600,7 @@ msgstr "Kind erfolgreich aktualisiert."
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:80
 #: lib/klass_hero_web/live/dashboard_live.ex:175
 #: lib/klass_hero_web/live/messaging_live_helper.ex:413
-#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:73
-#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:114
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:79
 #, elixir-autogen, elixir-format
 msgid "Conversation"
 msgstr "Unterhaltung"
@@ -2978,7 +2976,7 @@ msgid "We are Klass Hero — parents, brothers, and partners of educators — bu
 msgstr "Wir sind Klass Hero — Eltern, Brüder und Partner von Pädagogen — und bauen die Infrastruktur auf, die jedem Kind hilft, zu lernen und zu wachsen."
 
 #: lib/klass_hero_web/live/admin/messages_live.ex:106
-#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:100
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:106
 #: lib/klass_hero_web/user_auth.ex:298
 #, elixir-autogen, elixir-format
 msgid "You don't have access to that page."
@@ -8098,7 +8096,7 @@ msgstr[0] "%{count} Teilnehmer"
 msgstr[1] "%{count} Teilnehmer"
 
 #: lib/klass_hero_web/live/admin/messages_live.ex:75
-#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:78
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:84
 #, elixir-autogen, elixir-format
 msgid "Conversation not found."
 msgstr "Unterhaltung nicht gefunden."
@@ -8181,8 +8179,8 @@ msgid "Read-only. You are viewing this as the business owner, not as a participa
 msgstr "Nur lesbar. Sie sehen dies als Inhaber:in des Unternehmens, nicht als Teilnehmer:in — es wird nichts als gelesen markiert."
 
 #: lib/klass_hero_web/components/provider_components.ex:185
-#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:47
-#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:63
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:53
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:69
 #, elixir-autogen, elixir-format
 msgid "Staff conversations"
 msgstr "Unterhaltungen des Teams"

--- a/priv/gettext/de/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/de/LC_MESSAGES/enrollment.po
@@ -11,105 +11,105 @@ msgstr ""
 "Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:2990
-#: lib/klass_hero_web/components/provider_components.ex:3007
+#: lib/klass_hero_web/components/provider_components.ex:3026
+#: lib/klass_hero_web/components/provider_components.ex:3043
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr "Vorname des Kindes"
 
-#: lib/klass_hero_web/components/provider_components.ex:2991
-#: lib/klass_hero_web/components/provider_components.ex:3008
+#: lib/klass_hero_web/components/provider_components.ex:3027
+#: lib/klass_hero_web/components/provider_components.ex:3044
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr "Nachname des Kindes"
 
-#: lib/klass_hero_web/components/provider_components.ex:2992
-#: lib/klass_hero_web/components/provider_components.ex:3009
+#: lib/klass_hero_web/components/provider_components.ex:3028
+#: lib/klass_hero_web/components/provider_components.ex:3045
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr "Geburtsdatum"
 
-#: lib/klass_hero_web/components/provider_components.ex:3003
+#: lib/klass_hero_web/components/provider_components.ex:3039
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr "Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2993
+#: lib/klass_hero_web/components/provider_components.ex:3029
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr "E-Mail des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2994
+#: lib/klass_hero_web/components/provider_components.ex:3030
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr "Vorname des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2995
+#: lib/klass_hero_web/components/provider_components.ex:3031
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr "Nachname des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:3002
+#: lib/klass_hero_web/components/provider_components.ex:3038
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr "Programm"
 
-#: lib/klass_hero_web/components/provider_components.ex:3004
+#: lib/klass_hero_web/components/provider_components.ex:3040
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr "Schule"
 
-#: lib/klass_hero_web/components/provider_components.ex:2996
+#: lib/klass_hero_web/components/provider_components.ex:3032
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr "E-Mail des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2998
+#: lib/klass_hero_web/components/provider_components.ex:3034
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr "Vorname des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:3000
+#: lib/klass_hero_web/components/provider_components.ex:3036
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr "Nachname des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2930
+#: lib/klass_hero_web/components/provider_components.ex:2966
 #, elixir-autogen, elixir-format
 msgid "Date of birth \"%{value}\" is not a valid date. Please correct it and resend."
 msgstr ""
 "Das Geburtsdatum „%{value}“ ist kein gültiges Datum. Bitte korrigieren Sie es "
 "und senden Sie die Einladung erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2924
+#: lib/klass_hero_web/components/provider_components.ex:2960
 #, elixir-autogen, elixir-format
 msgid "Invite link could not be generated (no token). Please resend."
 msgstr ""
 "Der Einladungslink konnte nicht erzeugt werden (kein Token). Bitte erneut "
 "senden."
 
-#: lib/klass_hero_web/components/provider_components.ex:2938
+#: lib/klass_hero_web/components/provider_components.ex:2974
 #, elixir-autogen, elixir-format
 msgid "The invitation email could not be delivered. Please check the address and resend."
 msgstr ""
 "Die Einladungs-E-Mail konnte nicht zugestellt werden. Bitte prüfen Sie die "
 "Adresse und senden Sie die Einladung erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2927
+#: lib/klass_hero_web/components/provider_components.ex:2963
 #, elixir-autogen, elixir-format
 msgid "The program is full, so this child could not be enrolled."
 msgstr ""
 "Das Programm ist ausgebucht, daher konnte dieses Kind nicht angemeldet "
 "werden."
 
-#: lib/klass_hero_web/components/provider_components.ex:2941
+#: lib/klass_hero_web/components/provider_components.ex:2977
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed and no retries remain. Please resend."
 msgstr ""
 "Diese Einladung konnte nicht abgeschlossen werden und es sind keine weiteren "
 "Versuche möglich. Bitte erneut senden."
 
-#: lib/klass_hero_web/components/provider_components.ex:2950
+#: lib/klass_hero_web/components/provider_components.ex:2986
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed. Please resend."
 msgstr "Diese Einladung konnte nicht abgeschlossen werden. Bitte erneut senden."

--- a/priv/gettext/de/untranslated_allowlist.exs
+++ b/priv/gettext/de/untranslated_allowlist.exs
@@ -8,7 +8,11 @@
 %{
   "default" => [
     # Brand name — never translated in any market.
-    "Klass Hero"
+    "Klass Hero",
+    # Attribution connector ("via Sam Staff"). Idiomatic in German as-is, and
+    # `message_bubble/1` already renders a hardcoded "via" in the same attribution
+    # role — translating only this one would make the two disagree on screen.
+    "via"
   ],
   "enrollment" => [],
   "errors" => []

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -45,7 +45,7 @@ msgstr ""
 #: lib/klass_hero_web/components/layouts/app.html.heex:131
 #: lib/klass_hero_web/components/layouts/app.html.heex:206
 #: lib/klass_hero_web/components/layouts/app.html.heex:231
-#: lib/klass_hero_web/components/provider_components.ex:392
+#: lib/klass_hero_web/components/provider_components.ex:428
 #: lib/klass_hero_web/components/ui_components.ex:277
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
@@ -136,7 +136,7 @@ msgid "Your Data"
 msgstr ""
 
 #: lib/klass_hero_web/components/core_components.ex:71
-#: lib/klass_hero_web/components/provider_components.ex:1682
+#: lib/klass_hero_web/components/provider_components.ex:1718
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr ""
@@ -231,7 +231,7 @@ msgstr ""
 msgid "Enroll Now - %{price}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1401
+#: lib/klass_hero_web/components/provider_components.ex:1437
 #: lib/klass_hero_web/live/booking_live.ex:317
 #, elixir-autogen, elixir-format
 msgid "Enrollment"
@@ -456,7 +456,7 @@ msgstr ""
 msgid "Changes to Terms"
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:207
+#: lib/klass_hero_web/live/privacy_policy_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "Changes to This Policy"
 msgstr ""
@@ -476,7 +476,7 @@ msgstr ""
 msgid "Child checked out successfully"
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:155
+#: lib/klass_hero_web/live/privacy_policy_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "Children's Privacy"
 msgstr ""
@@ -515,12 +515,12 @@ msgstr ""
 #: lib/klass_hero_web/components/composite_components.ex:472
 #: lib/klass_hero_web/live/contact_live.ex:16
 #: lib/klass_hero_web/live/contact_live.ex:107
-#: lib/klass_hero_web/live/privacy_policy_live.ex:223
+#: lib/klass_hero_web/live/privacy_policy_live.ex:224
 #, elixir-autogen, elixir-format
 msgid "Contact Us"
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:176
+#: lib/klass_hero_web/live/privacy_policy_live.ex:177
 #, elixir-autogen, elixir-format
 msgid "Cookies & Tracking"
 msgstr ""
@@ -541,12 +541,12 @@ msgstr ""
 msgid "Creating account..."
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:192
+#: lib/klass_hero_web/live/privacy_policy_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "Data Retention"
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:138
+#: lib/klass_hero_web/live/privacy_policy_live.ex:139
 #, elixir-autogen, elixir-format
 msgid "Data Security"
 msgstr ""
@@ -576,9 +576,9 @@ msgstr ""
 msgid "Dispute Resolution"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:719
-#: lib/klass_hero_web/components/provider_components.ex:2774
-#: lib/klass_hero_web/components/provider_components.ex:2792
+#: lib/klass_hero_web/components/provider_components.ex:755
+#: lib/klass_hero_web/components/provider_components.ex:2810
+#: lib/klass_hero_web/components/provider_components.ex:2828
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:61
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Magic link is invalid or it has expired."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:391
+#: lib/klass_hero_web/components/messaging_components.ex:404
 #: lib/klass_hero_web/live/contact_live.ex:176
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:181
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:205
@@ -821,7 +821,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/composite_components.ex:358
 #: lib/klass_hero_web/live/privacy_policy_live.ex:11
-#: lib/klass_hero_web/live/privacy_policy_live.ex:241
+#: lib/klass_hero_web/live/privacy_policy_live.ex:242
 #, elixir-autogen, elixir-format
 msgid "Privacy Policy"
 msgstr ""
@@ -836,7 +836,7 @@ msgstr ""
 msgid "Program Question"
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:245
+#: lib/klass_hero_web/live/privacy_policy_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "Questions About Privacy?"
 msgstr ""
@@ -881,9 +881,9 @@ msgstr ""
 msgid "Select one or both options"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2424
-#: lib/klass_hero_web/components/provider_components.ex:2425
-#: lib/klass_hero_web/components/provider_components.ex:2462
+#: lib/klass_hero_web/components/provider_components.ex:2460
+#: lib/klass_hero_web/components/provider_components.ex:2461
+#: lib/klass_hero_web/components/provider_components.ex:2498
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:468
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:469
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:505
@@ -971,7 +971,7 @@ msgstr ""
 msgid "We're here to clarify any questions you may have."
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:246
+#: lib/klass_hero_web/live/privacy_policy_live.ex:247
 #, elixir-autogen, elixir-format
 msgid "We're here to help with any privacy-related concerns."
 msgstr ""
@@ -1012,7 +1012,7 @@ msgstr ""
 msgid "You need to reauthenticate to perform sensitive actions on your account."
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:116
+#: lib/klass_hero_web/live/privacy_policy_live.ex:117
 #, elixir-autogen, elixir-format
 msgid "Your Privacy Rights"
 msgstr ""
@@ -1022,7 +1022,7 @@ msgstr ""
 msgid "Your account has been deleted."
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:242
+#: lib/klass_hero_web/live/privacy_policy_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "Your privacy matters to us"
 msgstr ""
@@ -1210,7 +1210,7 @@ msgstr ""
 msgid "Music"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:755
+#: lib/klass_hero_web/components/provider_components.ex:791
 #: lib/klass_hero_web/live/for_providers_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "Qualifications"
@@ -1332,19 +1332,19 @@ msgstr ""
 msgid "Quick Navigation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1404
-#: lib/klass_hero_web/components/provider_components.ex:2384
-#: lib/klass_hero_web/components/provider_components.ex:2661
+#: lib/klass_hero_web/components/provider_components.ex:1440
+#: lib/klass_hero_web/components/provider_components.ex:2420
+#: lib/klass_hero_web/components/provider_components.ex:2697
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1550
+#: lib/klass_hero_web/components/provider_components.ex:1586
 #, elixir-autogen, elixir-format
 msgid "Active"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:672
+#: lib/klass_hero_web/components/provider_components.ex:708
 #: lib/klass_hero_web/live/provider/team_live.ex:627
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
@@ -1355,7 +1355,7 @@ msgstr ""
 msgid "All Staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1395
+#: lib/klass_hero_web/components/provider_components.ex:1431
 #, elixir-autogen, elixir-format
 msgid "Assigned Staff"
 msgstr ""
@@ -1377,8 +1377,8 @@ msgstr ""
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:543
-#: lib/klass_hero_web/components/provider_components.ex:1513
+#: lib/klass_hero_web/components/provider_components.ex:579
+#: lib/klass_hero_web/components/provider_components.ex:1549
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:65
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:92
 #: lib/klass_hero_web/live/settings/children_live.ex:413
@@ -1388,14 +1388,14 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:226
+#: lib/klass_hero_web/components/provider_components.ex:262
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:34
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "Edit Profile"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1552
+#: lib/klass_hero_web/components/provider_components.ex:1588
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr ""
@@ -1406,8 +1406,8 @@ msgstr ""
 msgid "My Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:418
-#: lib/klass_hero_web/components/provider_components.ex:910
+#: lib/klass_hero_web/components/provider_components.ex:454
+#: lib/klass_hero_web/components/provider_components.ex:946
 #, elixir-autogen, elixir-format
 msgid "New Program"
 msgstr ""
@@ -1419,26 +1419,26 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:49
 #: lib/klass_hero_web/components/provider_components.ex:75
-#: lib/klass_hero_web/components/provider_components.ex:1551
-#: lib/klass_hero_web/components/provider_components.ex:2868
-#: lib/klass_hero_web/components/provider_components.ex:2886
+#: lib/klass_hero_web/components/provider_components.ex:1587
+#: lib/klass_hero_web/components/provider_components.ex:2904
+#: lib/klass_hero_web/components/provider_components.ex:2922
 #: lib/klass_hero_web/live/admin/sessions_live.ex:293
 #: lib/klass_hero_web/live/admin/verifications_live.ex:202
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1482
+#: lib/klass_hero_web/components/provider_components.ex:1518
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1335
+#: lib/klass_hero_web/components/provider_components.ex:1371
 #, elixir-autogen, elixir-format
 msgid "Program Inventory"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1392
+#: lib/klass_hero_web/components/provider_components.ex:1428
 #, elixir-autogen, elixir-format
 msgid "Program Name"
 msgstr ""
@@ -1453,15 +1453,15 @@ msgstr ""
 msgid "Save for Later"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1352
+#: lib/klass_hero_web/components/provider_components.ex:1388
 #, elixir-autogen, elixir-format
 msgid "Search by name..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1398
-#: lib/klass_hero_web/components/provider_components.ex:1801
-#: lib/klass_hero_web/components/provider_components.ex:2375
-#: lib/klass_hero_web/components/provider_components.ex:2658
+#: lib/klass_hero_web/components/provider_components.ex:1434
+#: lib/klass_hero_web/components/provider_components.ex:1837
+#: lib/klass_hero_web/components/provider_components.ex:2411
+#: lib/klass_hero_web/components/provider_components.ex:2694
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1480,23 +1480,24 @@ msgstr ""
 msgid "Team & Provider Profiles"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1455
-#: lib/klass_hero_web/components/provider_components.ex:1816
+#: lib/klass_hero_web/components/provider_components.ex:1491
+#: lib/klass_hero_web/components/provider_components.ex:1852
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:772
+#: lib/klass_hero_web/components/messaging_components.ex:794
 #: lib/klass_hero_web/components/provider_components.ex:52
-#: lib/klass_hero_web/components/provider_components.ex:1553
+#: lib/klass_hero_web/components/provider_components.ex:1589
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:110
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:82
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:455
 #: lib/klass_hero_web/presenters/provider_presenter.ex:172
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1493
+#: lib/klass_hero_web/components/provider_components.ex:1529
 #, elixir-autogen, elixir-format
 msgid "View Roster"
 msgstr ""
@@ -1506,7 +1507,7 @@ msgstr ""
 msgid "%{age} years old"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:792
+#: lib/klass_hero_web/components/messaging_components.ex:815
 #, elixir-autogen, elixir-format
 msgid "%{n}m ago"
 msgstr ""
@@ -1542,8 +1543,9 @@ msgstr ""
 msgid "Back to Settings"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:153
+#: lib/klass_hero_web/components/messaging_components.ex:166
 #: lib/klass_hero_web/live/admin/messages_live.ex:147
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:113
 #, elixir-autogen, elixir-format
 msgid "Broadcast"
 msgstr ""
@@ -1557,10 +1559,10 @@ msgstr ""
 #: lib/klass_hero_web/components/participation_components.ex:346
 #: lib/klass_hero_web/components/participation_components.ex:571
 #: lib/klass_hero_web/components/participation_components.ex:662
-#: lib/klass_hero_web/components/provider_components.ex:847
-#: lib/klass_hero_web/components/provider_components.ex:1261
-#: lib/klass_hero_web/components/provider_components.ex:1974
-#: lib/klass_hero_web/components/provider_components.ex:2566
+#: lib/klass_hero_web/components/provider_components.ex:883
+#: lib/klass_hero_web/components/provider_components.ex:1297
+#: lib/klass_hero_web/components/provider_components.ex:2010
+#: lib/klass_hero_web/components/provider_components.ex:2602
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:489
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
@@ -1599,6 +1601,8 @@ msgstr ""
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:80
 #: lib/klass_hero_web/live/dashboard_live.ex:175
 #: lib/klass_hero_web/live/messaging_live_helper.ex:413
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:72
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "Conversation"
 msgstr ""
@@ -1618,7 +1622,7 @@ msgstr ""
 msgid "Data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2755
+#: lib/klass_hero_web/components/provider_components.ex:2791
 #: lib/klass_hero_web/live/settings/children_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1666,17 +1670,17 @@ msgstr ""
 msgid "Failed to submit note"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2749
-#: lib/klass_hero_web/components/provider_components.ex:2778
-#: lib/klass_hero_web/components/provider_components.ex:2794
+#: lib/klass_hero_web/components/provider_components.ex:2785
+#: lib/klass_hero_web/components/provider_components.ex:2814
+#: lib/klass_hero_web/components/provider_components.ex:2830
 #: lib/klass_hero_web/live/settings/children_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2750
-#: lib/klass_hero_web/components/provider_components.ex:2779
-#: lib/klass_hero_web/components/provider_components.ex:2795
+#: lib/klass_hero_web/components/provider_components.ex:2786
+#: lib/klass_hero_web/components/provider_components.ex:2815
+#: lib/klass_hero_web/components/provider_components.ex:2831
 #: lib/klass_hero_web/live/settings/children_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -1705,13 +1709,14 @@ msgstr ""
 
 #: lib/klass_hero_web/components/layouts/admin.html.heex:90
 #: lib/klass_hero_web/components/layouts/app.html.heex:214
-#: lib/klass_hero_web/components/messaging_components.ex:506
-#: lib/klass_hero_web/components/messaging_components.ex:529
+#: lib/klass_hero_web/components/messaging_components.ex:527
+#: lib/klass_hero_web/components/messaging_components.ex:550
 #: lib/klass_hero_web/live/admin/messages_live.ex:37
 #: lib/klass_hero_web/live/admin/messages_live.ex:56
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:5
 #: lib/klass_hero_web/live/messages_live/index.ex:19
 #: lib/klass_hero_web/live/messaging_live_helper.ex:365
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:6
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr ""
@@ -1722,13 +1727,13 @@ msgstr ""
 msgid "No children yet"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:476
+#: lib/klass_hero_web/components/messaging_components.ex:489
 #, elixir-autogen, elixir-format
 msgid "No conversations yet"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:445
-#: lib/klass_hero_web/components/messaging_components.ex:814
+#: lib/klass_hero_web/components/messaging_components.ex:458
+#: lib/klass_hero_web/components/messaging_components.ex:837
 #, elixir-autogen, elixir-format
 msgid "No messages yet"
 msgstr ""
@@ -1760,7 +1765,7 @@ msgstr ""
 msgid "Note resubmitted for review"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:791
+#: lib/klass_hero_web/components/messaging_components.ex:814
 #, elixir-autogen, elixir-format
 msgid "Now"
 msgstr ""
@@ -1800,7 +1805,7 @@ msgstr ""
 msgid "Please set up your parent profile to manage children."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:765
+#: lib/klass_hero_web/components/messaging_components.ex:787
 #: lib/klass_hero_web/live/messaging_live_helper.ex:409
 #, elixir-autogen, elixir-format
 msgid "Program Broadcast"
@@ -1811,15 +1816,15 @@ msgstr ""
 msgid "Provider data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:832
+#: lib/klass_hero_web/components/provider_components.ex:868
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:307
 #: lib/klass_hero_web/live/settings/children_live.ex:719
 #, elixir-autogen, elixir-format
 msgid "Save Changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1660
-#: lib/klass_hero_web/components/provider_components.ex:1661
+#: lib/klass_hero_web/components/provider_components.ex:1696
+#: lib/klass_hero_web/components/provider_components.ex:1697
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:43
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:151
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:252
@@ -1832,12 +1837,12 @@ msgstr ""
 msgid "Send Broadcast"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:448
+#: lib/klass_hero_web/components/messaging_components.ex:461
 #, elixir-autogen, elixir-format
 msgid "Send a message to start the conversation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2849
+#: lib/klass_hero_web/components/provider_components.ex:2885
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:249
 #, elixir-autogen, elixir-format
@@ -1856,7 +1861,7 @@ msgstr ""
 msgid "This message will be sent to all parents with active enrollments in this program."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:398
+#: lib/klass_hero_web/components/messaging_components.ex:411
 #, elixir-autogen, elixir-format
 msgid "Type a message..."
 msgstr ""
@@ -1893,12 +1898,12 @@ msgstr ""
 msgid "You don't have permission to edit this child."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:485
+#: lib/klass_hero_web/components/messaging_components.ex:498
 #, elixir-autogen, elixir-format
 msgid "Your conversations with parents will appear here"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:487
+#: lib/klass_hero_web/components/messaging_components.ex:500
 #, elixir-autogen, elixir-format
 msgid "Your conversations with providers will appear here"
 msgstr ""
@@ -1943,12 +1948,12 @@ msgstr[1] ""
 msgid "%{gender} only"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:311
+#: lib/klass_hero_web/components/provider_components.ex:347
 #, elixir-autogen, elixir-format
 msgid "Action Required"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:834
+#: lib/klass_hero_web/components/provider_components.ex:870
 #, elixir-autogen, elixir-format
 msgid "Add Member"
 msgstr ""
@@ -1968,12 +1973,12 @@ msgstr ""
 msgid "Ages %{min}+"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1162
+#: lib/klass_hero_web/components/provider_components.ex:1198
 #, elixir-autogen, elixir-format
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2908
+#: lib/klass_hero_web/components/provider_components.ex:2944
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred during import."
 msgstr ""
@@ -2016,7 +2021,7 @@ msgstr ""
 msgid "Back to verifications"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:728
+#: lib/klass_hero_web/components/provider_components.ex:764
 #, elixir-autogen, elixir-format
 msgid "Bio"
 msgstr ""
@@ -2026,7 +2031,7 @@ msgstr ""
 msgid "Book a Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:729
+#: lib/klass_hero_web/components/provider_components.ex:765
 #, elixir-autogen, elixir-format
 msgid "Brief description of experience and specialties..."
 msgstr ""
@@ -2041,19 +2046,19 @@ msgstr ""
 msgid "Business"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:940
+#: lib/klass_hero_web/components/provider_components.ex:976
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "Category"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1111
+#: lib/klass_hero_web/components/provider_components.ex:1147
 #, elixir-autogen, elixir-format
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2372
-#: lib/klass_hero_web/components/provider_components.ex:2644
+#: lib/klass_hero_web/components/provider_components.ex:2408
+#: lib/klass_hero_web/components/provider_components.ex:2680
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2068,7 +2073,7 @@ msgstr ""
 msgid "Child meets all program requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1234
+#: lib/klass_hero_web/components/provider_components.ex:1270
 #, elixir-autogen, elixir-format
 msgid "Choose Image"
 msgstr ""
@@ -2079,12 +2084,12 @@ msgstr ""
 msgid "Choose Logo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:823
+#: lib/klass_hero_web/components/provider_components.ex:859
 #, elixir-autogen, elixir-format
 msgid "Choose Photo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:942
+#: lib/klass_hero_web/components/provider_components.ex:978
 #, elixir-autogen, elixir-format
 msgid "Choose a category"
 msgstr ""
@@ -2094,12 +2099,12 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2869
+#: lib/klass_hero_web/components/provider_components.ex:2905
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:866
+#: lib/klass_hero_web/components/messaging_components.ex:889
 #, elixir-autogen, elixir-format
 msgid "Contact Provider"
 msgstr ""
@@ -2114,23 +2119,23 @@ msgstr ""
 msgid "Could not remove invite."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1228
-#: lib/klass_hero_web/components/provider_components.ex:3157
+#: lib/klass_hero_web/components/provider_components.ex:1264
+#: lib/klass_hero_web/components/provider_components.ex:3193
 #, elixir-autogen, elixir-format
 msgid "Cover Image"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1105
+#: lib/klass_hero_web/components/provider_components.ex:1141
 #, elixir-autogen, elixir-format
 msgid "Define age, gender, or grade restrictions for eligible participants."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1221
+#: lib/klass_hero_web/components/provider_components.ex:1257
 #, elixir-autogen, elixir-format
 msgid "Describe your program..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1220
+#: lib/klass_hero_web/components/provider_components.ex:1256
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:325
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:300
 #, elixir-autogen, elixir-format
@@ -2138,13 +2143,13 @@ msgid "Description"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:696
-#: lib/klass_hero_web/components/provider_components.ex:1173
+#: lib/klass_hero_web/components/provider_components.ex:1209
 #: lib/klass_hero_web/live/settings/children_live.ex:635
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3286
+#: lib/klass_hero_web/components/provider_components.ex:3322
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2178,7 +2183,7 @@ msgstr ""
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2585
+#: lib/klass_hero_web/components/provider_components.ex:2621
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
@@ -2188,40 +2193,40 @@ msgstr ""
 msgid "Download document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:908
+#: lib/klass_hero_web/components/provider_components.ex:944
 #, elixir-autogen, elixir-format
 msgid "Edit Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:670
+#: lib/klass_hero_web/components/provider_components.ex:706
 #, elixir-autogen, elixir-format
 msgid "Edit Team Member"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1026
+#: lib/klass_hero_web/components/provider_components.ex:1062
 #, elixir-autogen, elixir-format
 msgid "End Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1013
+#: lib/klass_hero_web/components/provider_components.ex:1049
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2381
-#: lib/klass_hero_web/components/provider_components.ex:2889
+#: lib/klass_hero_web/components/provider_components.ex:2417
+#: lib/klass_hero_web/components/provider_components.ex:2925
 #: lib/klass_hero_web/components/provider_layout_components.ex:612
 #, elixir-autogen, elixir-format
 msgid "Enrolled"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1706
+#: lib/klass_hero_web/components/provider_components.ex:1742
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1054
+#: lib/klass_hero_web/components/provider_components.ex:1090
 #, elixir-autogen, elixir-format
 msgid "Enrollment Capacity (optional)"
 msgstr ""
@@ -2232,7 +2237,7 @@ msgid "Explain why this document is being rejected..."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:73
-#: lib/klass_hero_web/components/provider_components.ex:2890
+#: lib/klass_hero_web/components/provider_components.ex:2926
 #: lib/klass_hero_web/live/admin/emails_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2265,7 +2270,7 @@ msgid "Family Programs"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:694
-#: lib/klass_hero_web/components/provider_components.ex:1172
+#: lib/klass_hero_web/components/provider_components.ex:1208
 #: lib/klass_hero_web/live/settings/children_live.ex:634
 #, elixir-autogen, elixir-format
 msgid "Female"
@@ -2276,22 +2281,22 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3219
+#: lib/klass_hero_web/components/provider_components.ex:3255
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3221
+#: lib/klass_hero_web/components/provider_components.ex:3257
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:756
+#: lib/klass_hero_web/components/provider_components.ex:792
 #, elixir-autogen, elixir-format
 msgid "First Aid, UEFA B License, Child Care Cert"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:698
+#: lib/klass_hero_web/components/provider_components.ex:734
 #, elixir-autogen, elixir-format
 msgid "First Name"
 msgstr ""
@@ -2316,12 +2321,12 @@ msgstr ""
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2655
+#: lib/klass_hero_web/components/provider_components.ex:2691
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:817
+#: lib/klass_hero_web/components/provider_components.ex:853
 #, elixir-autogen, elixir-format
 msgid "Headshot Photo"
 msgstr ""
@@ -2331,7 +2336,7 @@ msgstr ""
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2558
+#: lib/klass_hero_web/components/provider_components.ex:2594
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -2356,17 +2361,17 @@ msgstr ""
 msgid "Invite resent successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1723
+#: lib/klass_hero_web/components/provider_components.ex:1759
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:824
+#: lib/klass_hero_web/components/provider_components.ex:860
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 1MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1235
+#: lib/klass_hero_web/components/provider_components.ex:1271
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:276
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:366
 #, elixir-autogen, elixir-format
@@ -2383,22 +2388,22 @@ msgstr ""
 msgid "Klasse %{n}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:704
+#: lib/klass_hero_web/components/provider_components.ex:740
 #, elixir-autogen, elixir-format
 msgid "Last Name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1036
+#: lib/klass_hero_web/components/provider_components.ex:1072
 #, elixir-autogen, elixir-format
 msgid "Leave blank for open registration at any time."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1165
+#: lib/klass_hero_web/components/provider_components.ex:1201
 #, elixir-autogen, elixir-format
 msgid "Leave unchecked to allow all genders."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:969
+#: lib/klass_hero_web/components/provider_components.ex:1005
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:191
 #, elixir-autogen, elixir-format
 msgid "Location"
@@ -2411,43 +2416,43 @@ msgid "Logo upload failed. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:695
-#: lib/klass_hero_web/components/provider_components.ex:1171
+#: lib/klass_hero_web/components/provider_components.ex:1207
 #: lib/klass_hero_web/live/settings/children_live.ex:633
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1155
+#: lib/klass_hero_web/components/provider_components.ex:1191
 #, elixir-autogen, elixir-format
 msgid "Maximum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1069
+#: lib/klass_hero_web/components/provider_components.ex:1105
 #, elixir-autogen, elixir-format
 msgid "Maximum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1210
+#: lib/klass_hero_web/components/provider_components.ex:1246
 #, elixir-autogen, elixir-format
 msgid "Maximum Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:978
+#: lib/klass_hero_web/components/provider_components.ex:1014
 #, elixir-autogen, elixir-format
 msgid "Meeting Days"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1149
+#: lib/klass_hero_web/components/provider_components.ex:1185
 #, elixir-autogen, elixir-format
 msgid "Minimum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1063
+#: lib/klass_hero_web/components/provider_components.ex:1099
 #, elixir-autogen, elixir-format
 msgid "Minimum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1203
+#: lib/klass_hero_web/components/provider_components.ex:1239
 #, elixir-autogen, elixir-format
 msgid "Minimum Grade"
 msgstr ""
@@ -2457,12 +2462,12 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3248
+#: lib/klass_hero_web/components/provider_components.ex:3284
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2365
+#: lib/klass_hero_web/components/provider_components.ex:2401
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
@@ -2478,17 +2483,17 @@ msgstr ""
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2609
+#: lib/klass_hero_web/components/provider_components.ex:2645
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1212
+#: lib/klass_hero_web/components/provider_components.ex:1248
 #, elixir-autogen, elixir-format
 msgid "No maximum"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1205
+#: lib/klass_hero_web/components/provider_components.ex:1241
 #, elixir-autogen, elixir-format
 msgid "No minimum"
 msgstr ""
@@ -2519,18 +2524,18 @@ msgstr ""
 msgid "No verification documents found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1247
+#: lib/klass_hero_web/components/provider_components.ex:1283
 #, elixir-autogen, elixir-format
 msgid "None (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:327
+#: lib/klass_hero_web/components/provider_components.ex:363
 #, elixir-autogen, elixir-format
 msgid "Not Verified"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:697
-#: lib/klass_hero_web/components/provider_components.ex:1174
+#: lib/klass_hero_web/components/provider_components.ex:1210
 #: lib/klass_hero_web/live/settings/children_live.ex:632
 #, elixir-autogen, elixir-format
 msgid "Not specified"
@@ -2541,7 +2546,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3324
+#: lib/klass_hero_web/components/provider_components.ex:3360
 #: lib/klass_hero_web/live/provider/verification_live.ex:707
 #: lib/klass_hero_web/live/provider/verification_live.ex:781
 #, elixir-autogen, elixir-format
@@ -2553,13 +2558,13 @@ msgstr ""
 msgid "Participant Requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1102
+#: lib/klass_hero_web/components/provider_components.ex:1138
 #, elixir-autogen, elixir-format
 msgid "Participant Restrictions (optional)"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:770
-#: lib/klass_hero_web/components/provider_components.ex:295
+#: lib/klass_hero_web/components/provider_components.ex:331
 #, elixir-autogen, elixir-format
 msgid "Pending Review"
 msgstr ""
@@ -2587,7 +2592,7 @@ msgstr ""
 msgid "Preview not available for this file type."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:960
+#: lib/klass_hero_web/components/provider_components.ex:996
 #, elixir-autogen, elixir-format
 msgid "Price (EUR)"
 msgstr ""
@@ -2597,7 +2602,7 @@ msgstr ""
 msgid "Profile updated successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1140
+#: lib/klass_hero_web/components/provider_components.ex:1176
 #, elixir-autogen, elixir-format
 msgid "Program Start"
 msgstr ""
@@ -2641,13 +2646,13 @@ msgid "Read our founding story →"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:750
-#: lib/klass_hero_web/components/provider_components.ex:2888
+#: lib/klass_hero_web/components/provider_components.ex:2924
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Registered"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1127
+#: lib/klass_hero_web/components/provider_components.ex:1163
 #, elixir-autogen, elixir-format
 msgid "Registration"
 msgstr ""
@@ -2657,7 +2662,7 @@ msgstr ""
 msgid "Registration Closed"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1047
+#: lib/klass_hero_web/components/provider_components.ex:1083
 #, elixir-autogen, elixir-format
 msgid "Registration Closes"
 msgstr ""
@@ -2667,12 +2672,12 @@ msgstr ""
 msgid "Registration Not Open Yet"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1042
+#: lib/klass_hero_web/components/provider_components.ex:1078
 #, elixir-autogen, elixir-format
 msgid "Registration Opens"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1033
+#: lib/klass_hero_web/components/provider_components.ex:1069
 #, elixir-autogen, elixir-format
 msgid "Registration Period (optional)"
 msgstr ""
@@ -2721,15 +2726,15 @@ msgstr ""
 msgid "Rejection reason"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2711
-#: lib/klass_hero_web/components/provider_components.ex:3075
-#: lib/klass_hero_web/components/provider_components.ex:3343
-#: lib/klass_hero_web/components/provider_components.ex:3423
+#: lib/klass_hero_web/components/provider_components.ex:2747
+#: lib/klass_hero_web/components/provider_components.ex:3111
+#: lib/klass_hero_web/components/provider_components.ex:3379
+#: lib/klass_hero_web/components/provider_components.ex:3459
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2704
+#: lib/klass_hero_web/components/provider_components.ex:2740
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -2739,23 +2744,23 @@ msgstr ""
 msgid "Reviewed"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:713
+#: lib/klass_hero_web/components/provider_components.ex:749
 #, elixir-autogen, elixir-format
 msgid "Role"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1652
+#: lib/klass_hero_web/components/provider_components.ex:1688
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:407
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1264
+#: lib/klass_hero_web/components/provider_components.ex:1300
 #, elixir-autogen, elixir-format
 msgid "Save Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:975
+#: lib/klass_hero_web/components/provider_components.ex:1011
 #, elixir-autogen, elixir-format
 msgid "Schedule (optional)"
 msgstr ""
@@ -2770,7 +2775,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3321
+#: lib/klass_hero_web/components/provider_components.ex:3357
 #, elixir-autogen, elixir-format
 msgid "Select File"
 msgstr ""
@@ -2787,23 +2792,23 @@ msgstr ""
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2887
+#: lib/klass_hero_web/components/provider_components.ex:2923
 #: lib/klass_hero_web/live/admin/emails_live.ex:206
 #, elixir-autogen, elixir-format
 msgid "Sent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:760
+#: lib/klass_hero_web/components/provider_components.ex:796
 #, elixir-autogen, elixir-format
 msgid "Separate multiple qualifications with commas"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1057
+#: lib/klass_hero_web/components/provider_components.ex:1093
 #, elixir-autogen, elixir-format
 msgid "Set minimum and maximum enrollment for this program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:734
+#: lib/klass_hero_web/components/provider_components.ex:770
 #, elixir-autogen, elixir-format
 msgid "Specialties"
 msgstr ""
@@ -2821,12 +2826,12 @@ msgstr ""
 msgid "Staff member not found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1021
+#: lib/klass_hero_web/components/provider_components.ex:1057
 #, elixir-autogen, elixir-format
 msgid "Start Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1008
+#: lib/klass_hero_web/components/provider_components.ex:1044
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:184
 #, elixir-autogen, elixir-format
 msgid "Start Time"
@@ -2892,13 +2897,13 @@ msgstr ""
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:933
-#: lib/klass_hero_web/components/provider_components.ex:1940
+#: lib/klass_hero_web/components/provider_components.ex:969
+#: lib/klass_hero_web/components/provider_components.ex:1976
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3220
+#: lib/klass_hero_web/components/provider_components.ex:3256
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -2918,27 +2923,27 @@ msgstr ""
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2545
+#: lib/klass_hero_web/components/provider_components.ex:2581
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3367
+#: lib/klass_hero_web/components/provider_components.ex:3403
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3275
+#: lib/klass_hero_web/components/provider_components.ex:3311
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3223
+#: lib/klass_hero_web/components/provider_components.ex:3259
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3240
+#: lib/klass_hero_web/components/provider_components.ex:3276
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -2960,7 +2965,7 @@ msgstr ""
 msgid "Verifications"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:279
+#: lib/klass_hero_web/components/provider_components.ex:315
 #: lib/klass_hero_web/components/provider_layout_components.ex:217
 #: lib/klass_hero_web/components/ui_components.ex:1671
 #, elixir-autogen, elixir-format
@@ -2973,37 +2978,38 @@ msgid "We are Klass Hero — parents, brothers, and partners of educators — bu
 msgstr ""
 
 #: lib/klass_hero_web/live/admin/messages_live.ex:106
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:100
 #: lib/klass_hero_web/user_auth.ex:298
 #, elixir-autogen, elixir-format
 msgid "You don't have access to that page."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:714
+#: lib/klass_hero_web/components/provider_components.ex:750
 #, elixir-autogen, elixir-format
 msgid "e.g. Head Coach"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:705
+#: lib/klass_hero_web/components/provider_components.ex:741
 #, elixir-autogen, elixir-format
 msgid "e.g. Johnson"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:699
+#: lib/klass_hero_web/components/provider_components.ex:735
 #, elixir-autogen, elixir-format
 msgid "e.g. Mike"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:720
+#: lib/klass_hero_web/components/provider_components.ex:756
 #, elixir-autogen, elixir-format
 msgid "e.g. mike@example.com"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:934
+#: lib/klass_hero_web/components/provider_components.ex:970
 #, elixir-autogen, elixir-format
 msgid "e.g., Art Adventures"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:970
+#: lib/klass_hero_web/components/provider_components.ex:1006
 #, elixir-autogen, elixir-format
 msgid "e.g., Community Center, Main St"
 msgstr ""
@@ -3029,7 +3035,7 @@ msgid "Child Safeguarding Training"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1507
-#: lib/klass_hero_web/components/provider_components.ex:3596
+#: lib/klass_hero_web/components/provider_components.ex:3632
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr ""
@@ -3180,7 +3186,7 @@ msgid "Vetted with Care"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1491
-#: lib/klass_hero_web/components/provider_components.ex:3374
+#: lib/klass_hero_web/components/provider_components.ex:3410
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr ""
@@ -3354,7 +3360,7 @@ msgstr ""
 msgid "Checked Out"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2746
+#: lib/klass_hero_web/components/provider_components.ex:2782
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Child"
@@ -3400,7 +3406,7 @@ msgstr ""
 msgid "Download monthly statements for taxes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2461
+#: lib/klass_hero_web/components/provider_components.ex:2497
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:504
 #, elixir-autogen, elixir-format
 msgid "Enrollment not confirmed"
@@ -3473,7 +3479,7 @@ msgstr ""
 msgid "No chasing payments or sending invoices"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1675
+#: lib/klass_hero_web/components/provider_components.ex:1711
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:428
 #, elixir-autogen, elixir-format
 msgid "No enrolled parents"
@@ -3496,7 +3502,7 @@ msgstr ""
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2460
+#: lib/klass_hero_web/components/provider_components.ex:2496
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:503
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -3746,7 +3752,7 @@ msgstr ""
 msgid "Back to emails"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:732
+#: lib/klass_hero_web/components/messaging_components.ex:754
 #, elixir-autogen, elixir-format
 msgid "Broadcast messages are one-way"
 msgstr ""
@@ -4107,7 +4113,7 @@ msgstr ""
 msgid "Please fill in all required fields"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2652
+#: lib/klass_hero_web/components/provider_components.ex:2688
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:24
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:299
@@ -4152,7 +4158,7 @@ msgstr ""
 msgid "Reply"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:743
+#: lib/klass_hero_web/components/messaging_components.ex:765
 #, elixir-autogen, elixir-format
 msgid "Reply privately"
 msgstr ""
@@ -4167,7 +4173,7 @@ msgstr ""
 msgid "Reply sent successfully"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:553
+#: lib/klass_hero_web/components/provider_components.ex:589
 #, elixir-autogen, elixir-format
 msgid "Resend"
 msgstr ""
@@ -4433,7 +4439,7 @@ msgstr ""
 msgid "Failed to upload files. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:818
+#: lib/klass_hero_web/components/messaging_components.ex:841
 #, elixir-autogen, elixir-format
 msgid "File is too large (max %{mb} MB)"
 msgstr ""
@@ -4443,7 +4449,7 @@ msgstr ""
 msgid "File is too large (max %{mb} MB)."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:821
+#: lib/klass_hero_web/components/messaging_components.ex:844
 #, elixir-autogen, elixir-format
 msgid "File type not accepted (images only)"
 msgstr ""
@@ -4463,8 +4469,8 @@ msgstr ""
 msgid "Only images are accepted (JPG, PNG, GIF, WebP)."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:803
-#: lib/klass_hero_web/components/messaging_components.ex:807
+#: lib/klass_hero_web/components/messaging_components.ex:826
+#: lib/klass_hero_web/components/messaging_components.ex:830
 #, elixir-autogen, elixir-format
 msgid "Photo"
 msgstr ""
@@ -4484,8 +4490,8 @@ msgstr ""
 msgid "Provider not found"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:281
-#: lib/klass_hero_web/components/messaging_components.ex:352
+#: lib/klass_hero_web/components/messaging_components.ex:294
+#: lib/klass_hero_web/components/messaging_components.ex:365
 #, elixir-autogen, elixir-format
 msgid "Remove attachment"
 msgstr ""
@@ -4504,7 +4510,7 @@ msgstr ""
 msgid "Tell parents about your organization and what makes you unique..."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:825
+#: lib/klass_hero_web/components/messaging_components.ex:848
 #, elixir-autogen, elixir-format
 msgid "Too many files (max %{max})"
 msgstr ""
@@ -4514,12 +4520,12 @@ msgstr ""
 msgid "Too many files (max %{max})."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:829
+#: lib/klass_hero_web/components/messaging_components.ex:852
 #, elixir-autogen, elixir-format
 msgid "Upload error"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:828
+#: lib/klass_hero_web/components/messaging_components.ex:851
 #, elixir-autogen, elixir-format
 msgid "Upload failed"
 msgstr ""
@@ -4540,47 +4546,47 @@ msgstr ""
 msgid "Your profile is already complete."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:90
+#: lib/klass_hero_web/components/messaging_components.ex:96
 #: lib/klass_hero_web/live/messaging_live_helper.ex:397
 #, elixir-autogen, elixir-format
 msgid "for"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1799
+#: lib/klass_hero_web/components/provider_components.ex:1835
 #, elixir-autogen, elixir-format
 msgid "Assigned staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1800
+#: lib/klass_hero_web/components/provider_components.ex:1836
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1783
-#: lib/klass_hero_web/components/provider_components.ex:1868
-#: lib/klass_hero_web/components/provider_components.ex:2016
-#: lib/klass_hero_web/components/provider_components.ex:2165
+#: lib/klass_hero_web/components/provider_components.ex:1819
+#: lib/klass_hero_web/components/provider_components.ex:1904
+#: lib/klass_hero_web/components/provider_components.ex:2052
+#: lib/klass_hero_web/components/provider_components.ex:2201
 #: lib/klass_hero_web/live/provider/overview_live.ex:403
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1798
+#: lib/klass_hero_web/components/provider_components.ex:1834
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1792
+#: lib/klass_hero_web/components/provider_components.ex:1828
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1781
+#: lib/klass_hero_web/components/provider_components.ex:1817
 #, elixir-autogen, elixir-format
 msgid "Sessions — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1486
+#: lib/klass_hero_web/components/provider_components.ex:1522
 #, elixir-autogen, elixir-format
 msgid "View sessions"
 msgstr ""
@@ -4612,17 +4618,17 @@ msgstr ""
 msgid "Failed to update record"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2810
+#: lib/klass_hero_web/components/provider_components.ex:2846
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2483
+#: lib/klass_hero_web/components/provider_components.ex:2519
 #, elixir-autogen, elixir-format
 msgid "Invite mode"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2502
+#: lib/klass_hero_web/components/provider_components.ex:2538
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr ""
@@ -4637,12 +4643,12 @@ msgstr ""
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2823
+#: lib/klass_hero_web/components/provider_components.ex:2859
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2829
+#: lib/klass_hero_web/components/provider_components.ex:2865
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr ""
@@ -4653,17 +4659,17 @@ msgstr ""
 msgid "Nothing to update"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2831
+#: lib/klass_hero_web/components/provider_components.ex:2867
 #, elixir-autogen, elixir-format
 msgid "Nut allergy"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2835
+#: lib/klass_hero_web/components/provider_components.ex:2871
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2840
+#: lib/klass_hero_web/components/provider_components.ex:2876
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr ""
@@ -4673,7 +4679,7 @@ msgstr ""
 msgid "Present"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2767
+#: lib/klass_hero_web/components/provider_components.ex:2803
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr ""
@@ -4700,22 +4706,22 @@ msgstr ""
 msgid "Save changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2804
+#: lib/klass_hero_web/components/provider_components.ex:2840
 #, elixir-autogen, elixir-format
 msgid "School (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2814
+#: lib/klass_hero_web/components/provider_components.ex:2850
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2788
+#: lib/klass_hero_web/components/provider_components.ex:2824
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2857
+#: lib/klass_hero_web/components/provider_components.ex:2893
 #, elixir-autogen, elixir-format
 msgid "Send invite"
 msgstr ""
@@ -4725,7 +4731,7 @@ msgstr ""
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2520
+#: lib/klass_hero_web/components/provider_components.ex:2556
 #, elixir-autogen, elixir-format
 msgid "Upload a list"
 msgstr ""
@@ -4760,7 +4766,7 @@ msgstr ""
 msgid "High"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:787
+#: lib/klass_hero_web/components/provider_components.ex:823
 #, elixir-autogen, elixir-format
 msgid "Hourly"
 msgstr ""
@@ -4785,22 +4791,22 @@ msgstr ""
 msgid "Medium"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:777
+#: lib/klass_hero_web/components/provider_components.ex:813
 #, elixir-autogen, elixir-format
 msgid "None"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:766
+#: lib/klass_hero_web/components/provider_components.ex:802
 #, elixir-autogen, elixir-format
 msgid "Pay Rate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:528
+#: lib/klass_hero_web/components/provider_components.ex:564
 #, elixir-autogen, elixir-format
 msgid "Pay rate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:797
+#: lib/klass_hero_web/components/provider_components.ex:833
 #, elixir-autogen, elixir-format
 msgid "Per Session"
 msgstr ""
@@ -4825,7 +4831,7 @@ msgstr ""
 msgid "Property Damage"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1523
+#: lib/klass_hero_web/components/provider_components.ex:1559
 #, elixir-autogen, elixir-format
 msgid "Report Incident"
 msgstr ""
@@ -5000,7 +5006,7 @@ msgstr ""
 msgid "At Klass Hero, trust isn't a feature — it's the foundation of everything we do. We connect families, schools, and organizations with qualified, vetted, and safety-verified educators."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:302
+#: lib/klass_hero_web/components/messaging_components.ex:315
 #, elixir-autogen, elixir-format
 msgid "Attach photo"
 msgstr ""
@@ -5160,7 +5166,7 @@ msgstr ""
 msgid "Coming soon — track your family's weekly attendance."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/messages_live/index.ex:19
+#: lib/klass_hero_web/live/provider/messages_live/index.ex:20
 #, elixir-autogen, elixir-format
 msgid "Comms"
 msgstr ""
@@ -5493,7 +5499,7 @@ msgstr[1] ""
 msgid "In 2025, Shane connected with his friend"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1532
+#: lib/klass_hero_web/components/provider_components.ex:1568
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:43
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:72
 #, elixir-autogen, elixir-format
@@ -5563,7 +5569,7 @@ msgstr ""
 msgid "Last 8 weeks"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1245
+#: lib/klass_hero_web/components/provider_components.ex:1281
 #: lib/klass_hero_web/presenters/hero_cards_presenter.ex:27
 #, elixir-autogen, elixir-format
 msgid "Lead Instructor"
@@ -5905,7 +5911,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:812
 #: lib/klass_hero_web/components/marketing_components.ex:859
-#: lib/klass_hero_web/live/privacy_policy_live.ex:240
+#: lib/klass_hero_web/live/privacy_policy_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr ""
@@ -6002,17 +6008,17 @@ msgstr ""
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2896
+#: lib/klass_hero_web/components/provider_components.ex:2932
 #, elixir-autogen, elixir-format
 msgid "Row %{row}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2896
+#: lib/klass_hero_web/components/provider_components.ex:2932
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2597
+#: lib/klass_hero_web/components/provider_components.ex:2633
 #, elixir-autogen, elixir-format
 msgid "Rows with errors"
 msgstr ""
@@ -6742,12 +6748,12 @@ msgstr ""
 msgid "Experience validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3404
+#: lib/klass_hero_web/components/provider_components.ex:3440
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3377
+#: lib/klass_hero_web/components/provider_components.ex:3413
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
@@ -6757,12 +6763,12 @@ msgstr ""
 msgid "Safeguarding certificate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3401
+#: lib/klass_hero_web/components/provider_components.ex:3437
 #, elixir-autogen, elixir-format
 msgid "Select Video"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3447
+#: lib/klass_hero_web/components/provider_components.ex:3483
 #, elixir-autogen, elixir-format
 msgid "Upload Video"
 msgstr ""
@@ -6772,7 +6778,7 @@ msgstr ""
 msgid "Your browser does not support video playback."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3600
+#: lib/klass_hero_web/components/provider_components.ex:3636
 #, elixir-autogen, elixir-format
 msgid "Confirm agreement"
 msgstr ""
@@ -6782,12 +6788,12 @@ msgstr ""
 msgid "Couldn't record your agreement. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3623
+#: lib/klass_hero_web/components/provider_components.ex:3659
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3599
+#: lib/klass_hero_web/components/provider_components.ex:3635
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr ""
@@ -6797,7 +6803,7 @@ msgstr ""
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3502
+#: lib/klass_hero_web/components/provider_components.ex:3538
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr ""
@@ -6807,17 +6813,17 @@ msgstr ""
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3608
+#: lib/klass_hero_web/components/provider_components.ex:3644
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3597
+#: lib/klass_hero_web/components/provider_components.ex:3633
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3598
+#: lib/klass_hero_web/components/provider_components.ex:3634
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
@@ -7086,12 +7092,12 @@ msgstr ""
 msgid "Your insurance is verified."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3546
+#: lib/klass_hero_web/components/provider_components.ex:3582
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3655
+#: lib/klass_hero_web/components/provider_components.ex:3691
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr ""
@@ -7101,7 +7107,7 @@ msgstr ""
 msgid "Couldn't record your declaration. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3661
+#: lib/klass_hero_web/components/provider_components.ex:3697
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr ""
@@ -7111,17 +7117,17 @@ msgstr ""
 msgid "Please confirm the declaration before signing."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3686
+#: lib/klass_hero_web/components/provider_components.ex:3722
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3665
+#: lib/klass_hero_web/components/provider_components.ex:3701
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3653
+#: lib/klass_hero_web/components/provider_components.ex:3689
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr ""
@@ -7131,12 +7137,12 @@ msgstr ""
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3673
+#: lib/klass_hero_web/components/provider_components.ex:3709
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3659
+#: lib/klass_hero_web/components/provider_components.ex:3695
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
@@ -7203,15 +7209,15 @@ msgstr ""
 msgid "Undelivered Events"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2110
-#: lib/klass_hero_web/components/provider_components.ex:2288
+#: lib/klass_hero_web/components/provider_components.ex:2146
+#: lib/klass_hero_web/components/provider_components.ex:2324
 #: lib/klass_hero_web/live/user_live/settings.ex:273
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2038
-#: lib/klass_hero_web/components/provider_components.ex:2219
+#: lib/klass_hero_web/components/provider_components.ex:2074
+#: lib/klass_hero_web/components/provider_components.ex:2255
 #, elixir-autogen, elixir-format
 msgid "Lead"
 msgstr ""
@@ -7221,17 +7227,17 @@ msgstr ""
 msgid "Lead instructor updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2050
+#: lib/klass_hero_web/components/provider_components.ex:2086
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1500
+#: lib/klass_hero_web/components/provider_components.ex:1536
 #, elixir-autogen, elixir-format
 msgid "Manage Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2079
+#: lib/klass_hero_web/components/provider_components.ex:2115
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this program yet."
 msgstr ""
@@ -7242,19 +7248,19 @@ msgstr ""
 msgid "Pick a staff member to add."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2062
-#: lib/klass_hero_web/components/provider_components.ex:2327
+#: lib/klass_hero_web/components/provider_components.ex:2098
+#: lib/klass_hero_web/components/provider_components.ex:2363
 #, elixir-autogen, elixir-format
 msgid "Reassign the lead before removing them"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2063
+#: lib/klass_hero_web/components/provider_components.ex:2099
 #, elixir-autogen, elixir-format
 msgid "Remove from program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2098
-#: lib/klass_hero_web/components/provider_components.ex:2275
+#: lib/klass_hero_web/components/provider_components.ex:2134
+#: lib/klass_hero_web/components/provider_components.ex:2311
 #, elixir-autogen, elixir-format
 msgid "Select a staff member…"
 msgstr ""
@@ -7269,12 +7275,12 @@ msgstr ""
 msgid "Staff member removed from the program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2115
+#: lib/klass_hero_web/components/provider_components.ex:2151
 #, elixir-autogen, elixir-format
 msgid "Staff you add can read and reply to this program's parent conversations."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2014
+#: lib/klass_hero_web/components/provider_components.ex:2050
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{title}"
 msgstr ""
@@ -7294,19 +7300,19 @@ msgstr ""
 msgid "This person is the lead instructor. Make someone else lead before removing them."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1444
+#: lib/klass_hero_web/components/provider_components.ex:1480
 #, elixir-autogen, elixir-format
 msgid "%{count} staff member · no lead"
 msgid_plural "%{count} staff · no lead"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/components/provider_components.ex:563
+#: lib/klass_hero_web/components/provider_components.ex:599
 #, elixir-autogen, elixir-format
 msgid "%{name} will be unassigned from every program and removed from those conversations. Their history is kept and you can add them back later."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:639
+#: lib/klass_hero_web/components/provider_components.ex:675
 #, elixir-autogen, elixir-format
 msgid "Add back to team"
 msgstr ""
@@ -7316,7 +7322,7 @@ msgstr ""
 msgid "Could not bring this team member back. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:601
+#: lib/klass_hero_web/components/provider_components.ex:637
 #, elixir-autogen, elixir-format
 msgid "Delete entry"
 msgstr ""
@@ -7326,7 +7332,7 @@ msgstr ""
 msgid "Former team members"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:575
+#: lib/klass_hero_web/components/provider_components.ex:611
 #, elixir-autogen, elixir-format
 msgid "Remove from team"
 msgstr ""
@@ -7341,7 +7347,7 @@ msgstr ""
 msgid "Team member removed from the team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:591
+#: lib/klass_hero_web/components/provider_components.ex:627
 #, elixir-autogen, elixir-format
 msgid "This deletes %{name} permanently — there's nothing to undo. Use it only for an entry added by mistake."
 msgstr ""
@@ -7366,24 +7372,24 @@ msgstr ""
 msgid "Program updated, but the enrollment capacity was rejected. The previous limits still apply."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:876
+#: lib/klass_hero_web/components/provider_components.ex:912
 #, elixir-autogen, elixir-format
 msgid "%{count} child is already enrolled. Confirm you want this program to have no capacity limit."
 msgid_plural "%{count} children are already enrolled. Confirm you want this program to have no capacity limit."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1087
+#: lib/klass_hero_web/components/provider_components.ex:1123
 #, elixir-autogen, elixir-format
 msgid "Anyone will be able to book a place until you set a new maximum."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1092
+#: lib/klass_hero_web/components/provider_components.ex:1128
 #, elixir-autogen, elixir-format
 msgid "I understand this program will have no capacity limit."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2315
+#: lib/klass_hero_web/components/provider_components.ex:2351
 #, elixir-autogen, elixir-format
 msgid "Go back to the program's usual team"
 msgstr ""
@@ -7393,17 +7399,17 @@ msgstr ""
 msgid "Lead instructor for this session updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2234
+#: lib/klass_hero_web/components/provider_components.ex:2270
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor for this session"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2256
+#: lib/klass_hero_web/components/provider_components.ex:2292
 #, elixir-autogen, elixir-format
 msgid "Nobody is working this session yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2332
+#: lib/klass_hero_web/components/provider_components.ex:2368
 #, elixir-autogen, elixir-format
 msgid "Remove from this session"
 msgstr ""
@@ -7423,7 +7429,7 @@ msgstr ""
 msgid "Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2158
+#: lib/klass_hero_web/components/provider_components.ex:2194
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{date}"
 msgstr ""
@@ -7453,22 +7459,22 @@ msgstr ""
 msgid "A session needs at least one person. Use “Go back to the program's usual team” to drop this session's own roster."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2330
+#: lib/klass_hero_web/components/provider_components.ex:2366
 #, elixir-autogen, elixir-format
 msgid "A session needs someone — use “Go back to the program's usual team” instead"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2297
+#: lib/klass_hero_web/components/provider_components.ex:2333
 #, elixir-autogen, elixir-format
 msgid "Everyone on your team is already working this session."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2190
+#: lib/klass_hero_web/components/provider_components.ex:2226
 #, elixir-autogen, elixir-format
 msgid "Staffed just for this session. Changes here do not touch the program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2192
+#: lib/klass_hero_web/components/provider_components.ex:2228
 #, elixir-autogen, elixir-format
 msgid "Using the program's usual team. The first change here copies them onto this session, so later program changes stop reaching it."
 msgstr ""
@@ -7478,12 +7484,12 @@ msgstr ""
 msgid "(optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1933
+#: lib/klass_hero_web/components/provider_components.ex:1969
 #, elixir-autogen, elixir-format
 msgid "Add a waiver"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1965
+#: lib/klass_hero_web/components/provider_components.ex:2001
 #, elixir-autogen, elixir-format
 msgid "Add waiver"
 msgstr ""
@@ -7505,22 +7511,22 @@ msgstr ""
 msgid "I have read and agree to %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1947
+#: lib/klass_hero_web/components/provider_components.ex:1983
 #, elixir-autogen, elixir-format
 msgid "Legal text"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1507
+#: lib/klass_hero_web/components/provider_components.ex:1543
 #, elixir-autogen, elixir-format
 msgid "Manage Waivers"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1875
+#: lib/klass_hero_web/components/provider_components.ex:1911
 #, elixir-autogen, elixir-format
 msgid "No waivers yet. Parents enrol without signing anything."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1954
+#: lib/klass_hero_web/components/provider_components.ex:1990
 #, elixir-autogen, elixir-format
 msgid "Parents must sign this before enrolling"
 msgstr ""
@@ -7540,17 +7546,17 @@ msgstr ""
 msgid "Please tick a waiver to sign it."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1932
+#: lib/klass_hero_web/components/provider_components.ex:1968
 #, elixir-autogen, elixir-format
 msgid "Publish a new version"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1965
+#: lib/klass_hero_web/components/provider_components.ex:2001
 #, elixir-autogen, elixir-format
 msgid "Publish version"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1958
+#: lib/klass_hero_web/components/provider_components.ex:1994
 #, elixir-autogen, elixir-format
 msgid "Publishing keeps every earlier version on record; signatures already given stay bound to the wording they were shown."
 msgstr ""
@@ -7560,12 +7566,12 @@ msgstr ""
 msgid "Required"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1909
+#: lib/klass_hero_web/components/provider_components.ex:1945
 #, elixir-autogen, elixir-format
 msgid "Retire this waiver"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1900
+#: lib/klass_hero_web/components/provider_components.ex:1936
 #, elixir-autogen, elixir-format
 msgid "Revise text"
 msgstr ""
@@ -7580,7 +7586,7 @@ msgstr ""
 msgid "Sign waivers"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2410
+#: lib/klass_hero_web/components/provider_components.ex:2446
 #: lib/klass_hero_web/live/enrollment_waivers_live.ex:149
 #, elixir-autogen, elixir-format
 msgid "Signed"
@@ -7596,12 +7602,12 @@ msgstr ""
 msgid "There is nothing to sign for this enrollment."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2410
+#: lib/klass_hero_web/components/provider_components.ex:2446
 #, elixir-autogen, elixir-format
 msgid "Unsigned"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1892
+#: lib/klass_hero_web/components/provider_components.ex:1928
 #, elixir-autogen, elixir-format
 msgid "Version %{number}"
 msgstr ""
@@ -7611,7 +7617,7 @@ msgstr ""
 msgid "Waiver not found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2378
+#: lib/klass_hero_web/components/provider_components.ex:2414
 #: lib/klass_hero_web/live/booking_live.ex:447
 #: lib/klass_hero_web/live/enrollment_waivers_live.ex:33
 #: lib/klass_hero_web/live/enrollment_waivers_live.ex:105
@@ -7624,7 +7630,7 @@ msgstr ""
 msgid "Waivers waiting for your signature"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1866
+#: lib/klass_hero_web/components/provider_components.ex:1902
 #, elixir-autogen, elixir-format
 msgid "Waivers — %{title}"
 msgstr ""
@@ -7639,7 +7645,7 @@ msgstr ""
 msgid "New version published. It applies to future enrolments."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1913
+#: lib/klass_hero_web/components/provider_components.ex:1949
 #, elixir-autogen, elixir-format
 msgid "Retire \"%{title}\"? Parents will no longer be asked to sign it. Signatures already collected are kept."
 msgstr ""
@@ -7659,7 +7665,7 @@ msgstr ""
 msgid "You are not assigned to this session"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:430
+#: lib/klass_hero_web/components/provider_components.ex:466
 #, elixir-autogen, elixir-format
 msgid "Complete verification to create programs."
 msgstr ""
@@ -7690,7 +7696,7 @@ msgstr ""
 msgid "Provider Name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:208
+#: lib/klass_hero_web/components/provider_components.ex:244
 #, elixir-autogen, elixir-format
 msgid "Provider Profile"
 msgstr ""
@@ -7710,17 +7716,17 @@ msgstr ""
 msgid "This invitation has expired. Please ask your provider to resend it."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:211
+#: lib/klass_hero_web/components/provider_components.ex:247
 #, elixir-autogen, elixir-format
 msgid "This is your main provider identity. Verification is required to list programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3243
+#: lib/klass_hero_web/components/provider_components.ex:3279
 #, elixir-autogen, elixir-format
 msgid "Upload documents to be verified. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:403
+#: lib/klass_hero_web/components/provider_components.ex:439
 #, elixir-autogen, elixir-format
 msgid "Verified Provider"
 msgstr ""
@@ -7859,8 +7865,8 @@ msgstr ""
 msgid "Review invitations"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2673
-#: lib/klass_hero_web/components/provider_components.ex:2680
+#: lib/klass_hero_web/components/provider_components.ex:2709
+#: lib/klass_hero_web/components/provider_components.ex:2716
 #, elixir-autogen, elixir-format
 msgid "Unknown program"
 msgstr ""
@@ -7885,12 +7891,12 @@ msgstr ""
 msgid "This program has closed. Its sessions are no longer available."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:384
+#: lib/klass_hero_web/components/messaging_components.ex:397
 #, elixir-autogen, elixir-format
 msgid "Attach files"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:408
+#: lib/klass_hero_web/components/messaging_components.ex:421
 #, elixir-autogen, elixir-format
 msgid "Send message"
 msgstr ""
@@ -7905,12 +7911,12 @@ msgstr ""
 msgid "You can't start a conversation with this person"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:952
+#: lib/klass_hero_web/components/provider_components.ex:988
 #, elixir-autogen, elixir-format
 msgid "Subtitle"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:953
+#: lib/klass_hero_web/components/provider_components.ex:989
 #, elixir-autogen, elixir-format
 msgid "e.g., For beginners, no experience needed"
 msgstr ""
@@ -7925,17 +7931,17 @@ msgstr ""
 msgid "N/A"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3151
+#: lib/klass_hero_web/components/provider_components.ex:3187
 #, elixir-autogen, elixir-format
 msgid "A short line that sums you up"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3140
+#: lib/klass_hero_web/components/provider_components.ex:3176
 #, elixir-autogen, elixir-format
 msgid "Branding & Presence"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3164
+#: lib/klass_hero_web/components/provider_components.ex:3200
 #, elixir-autogen, elixir-format
 msgid "Choose Cover Image"
 msgstr ""
@@ -7945,17 +7951,17 @@ msgstr ""
 msgid "Cover image upload failed. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3165
+#: lib/klass_hero_web/components/provider_components.ex:3201
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 5MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3143
+#: lib/klass_hero_web/components/provider_components.ex:3179
 #, elixir-autogen, elixir-format
 msgid "Shown on your public profile page."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3150
+#: lib/klass_hero_web/components/provider_components.ex:3186
 #, elixir-autogen, elixir-format
 msgid "Tagline"
 msgstr ""
@@ -8001,7 +8007,7 @@ msgstr ""
 msgid "Klass Hero on %{network}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3222
+#: lib/klass_hero_web/components/provider_components.ex:3258
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr ""
@@ -8041,7 +8047,7 @@ msgstr ""
 msgid "A newly chosen cover or logo appears here after you save."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3195
+#: lib/klass_hero_web/components/provider_components.ex:3231
 #, elixir-autogen, elixir-format
 msgid "Add %{network}"
 msgstr ""
@@ -8061,7 +8067,7 @@ msgstr ""
 msgid "Show preview"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3182
+#: lib/klass_hero_web/components/provider_components.ex:3218
 #, elixir-autogen, elixir-format
 msgid "e.g. %{example}"
 msgstr ""
@@ -8074,6 +8080,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/klass_hero_web/live/admin/messages_live.ex:75
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:77
 #, elixir-autogen, elixir-format
 msgid "Conversation not found."
 msgstr ""
@@ -8084,6 +8091,7 @@ msgid "Direct"
 msgstr ""
 
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:70
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr ""
@@ -8094,6 +8102,7 @@ msgid "No conversations found."
 msgstr ""
 
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:102
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:74
 #, elixir-autogen, elixir-format
 msgid "No messages in this conversation."
 msgstr ""
@@ -8123,7 +8132,44 @@ msgstr ""
 msgid "← Back to messages"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:711
+#: lib/klass_hero_web/components/messaging_components.ex:733
 #, elixir-autogen, elixir-format
 msgid "Messages here may be reviewed by the activity provider and by Klass Hero staff, to keep children safe."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:56
+#, elixir-autogen, elixir-format
+msgid "Back to staff conversations"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:15
+#, elixir-autogen, elixir-format
+msgid "Conversations your staff have with parents. Read-only — opening a thread here does not mark anything as read."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:178
+#, elixir-autogen, elixir-format
+msgid "My conversations"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:34
+#, elixir-autogen, elixir-format
+msgid "No staff conversations yet. Threads your team starts will appear here."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:65
+#, elixir-autogen, elixir-format
+msgid "Read-only. You are viewing this as the business owner, not as a participant — nothing is marked as read."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:185
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:45
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:62
+#, elixir-autogen, elixir-format
+msgid "Staff conversations"
+msgstr ""
+
+#: lib/klass_hero_web/components/messaging_components.ex:103
+#, elixir-autogen, elixir-format
+msgid "via"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -1486,11 +1486,11 @@ msgstr ""
 msgid "Unassigned"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:794
+#: lib/klass_hero_web/components/messaging_components.ex:832
 #: lib/klass_hero_web/components/provider_components.ex:52
 #: lib/klass_hero_web/components/provider_components.ex:1589
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:110
-#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:82
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:79
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:455
 #: lib/klass_hero_web/presenters/provider_presenter.ex:172
 #, elixir-autogen, elixir-format
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "%{age} years old"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:815
+#: lib/klass_hero_web/components/messaging_components.ex:853
 #, elixir-autogen, elixir-format
 msgid "%{n}m ago"
 msgstr ""
@@ -1601,7 +1601,7 @@ msgstr ""
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:80
 #: lib/klass_hero_web/live/dashboard_live.ex:175
 #: lib/klass_hero_web/live/messaging_live_helper.ex:413
-#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:72
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:73
 #: lib/klass_hero_web/live/provider/staff_conversations_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "Conversation"
@@ -1709,14 +1709,14 @@ msgstr ""
 
 #: lib/klass_hero_web/components/layouts/admin.html.heex:90
 #: lib/klass_hero_web/components/layouts/app.html.heex:214
-#: lib/klass_hero_web/components/messaging_components.ex:527
-#: lib/klass_hero_web/components/messaging_components.ex:550
+#: lib/klass_hero_web/components/messaging_components.ex:565
+#: lib/klass_hero_web/components/messaging_components.ex:588
 #: lib/klass_hero_web/live/admin/messages_live.ex:37
 #: lib/klass_hero_web/live/admin/messages_live.ex:56
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:5
 #: lib/klass_hero_web/live/messages_live/index.ex:19
 #: lib/klass_hero_web/live/messaging_live_helper.ex:365
-#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:6
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:5
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr ""
@@ -1733,7 +1733,7 @@ msgid "No conversations yet"
 msgstr ""
 
 #: lib/klass_hero_web/components/messaging_components.ex:458
-#: lib/klass_hero_web/components/messaging_components.ex:837
+#: lib/klass_hero_web/components/messaging_components.ex:875
 #, elixir-autogen, elixir-format
 msgid "No messages yet"
 msgstr ""
@@ -1765,7 +1765,7 @@ msgstr ""
 msgid "Note resubmitted for review"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:814
+#: lib/klass_hero_web/components/messaging_components.ex:852
 #, elixir-autogen, elixir-format
 msgid "Now"
 msgstr ""
@@ -1805,7 +1805,7 @@ msgstr ""
 msgid "Please set up your parent profile to manage children."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:787
+#: lib/klass_hero_web/components/messaging_components.ex:825
 #: lib/klass_hero_web/live/messaging_live_helper.ex:409
 #, elixir-autogen, elixir-format
 msgid "Program Broadcast"
@@ -2104,7 +2104,7 @@ msgstr ""
 msgid "Confirmed"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:889
+#: lib/klass_hero_web/components/messaging_components.ex:927
 #, elixir-autogen, elixir-format
 msgid "Contact Provider"
 msgstr ""
@@ -3752,7 +3752,7 @@ msgstr ""
 msgid "Back to emails"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:754
+#: lib/klass_hero_web/components/messaging_components.ex:792
 #, elixir-autogen, elixir-format
 msgid "Broadcast messages are one-way"
 msgstr ""
@@ -4158,7 +4158,7 @@ msgstr ""
 msgid "Reply"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:765
+#: lib/klass_hero_web/components/messaging_components.ex:803
 #, elixir-autogen, elixir-format
 msgid "Reply privately"
 msgstr ""
@@ -4439,7 +4439,7 @@ msgstr ""
 msgid "Failed to upload files. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:841
+#: lib/klass_hero_web/components/messaging_components.ex:879
 #, elixir-autogen, elixir-format
 msgid "File is too large (max %{mb} MB)"
 msgstr ""
@@ -4449,7 +4449,7 @@ msgstr ""
 msgid "File is too large (max %{mb} MB)."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:844
+#: lib/klass_hero_web/components/messaging_components.ex:882
 #, elixir-autogen, elixir-format
 msgid "File type not accepted (images only)"
 msgstr ""
@@ -4469,8 +4469,8 @@ msgstr ""
 msgid "Only images are accepted (JPG, PNG, GIF, WebP)."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:826
-#: lib/klass_hero_web/components/messaging_components.ex:830
+#: lib/klass_hero_web/components/messaging_components.ex:864
+#: lib/klass_hero_web/components/messaging_components.ex:868
 #, elixir-autogen, elixir-format
 msgid "Photo"
 msgstr ""
@@ -4510,7 +4510,7 @@ msgstr ""
 msgid "Tell parents about your organization and what makes you unique..."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:848
+#: lib/klass_hero_web/components/messaging_components.ex:886
 #, elixir-autogen, elixir-format
 msgid "Too many files (max %{max})"
 msgstr ""
@@ -4520,12 +4520,12 @@ msgstr ""
 msgid "Too many files (max %{max})."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:852
+#: lib/klass_hero_web/components/messaging_components.ex:890
 #, elixir-autogen, elixir-format
 msgid "Upload error"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:851
+#: lib/klass_hero_web/components/messaging_components.ex:889
 #, elixir-autogen, elixir-format
 msgid "Upload failed"
 msgstr ""
@@ -8080,7 +8080,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/klass_hero_web/live/admin/messages_live.ex:75
-#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:77
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:78
 #, elixir-autogen, elixir-format
 msgid "Conversation not found."
 msgstr ""
@@ -8091,7 +8091,7 @@ msgid "Direct"
 msgstr ""
 
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:70
-#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:46
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Load more"
 msgstr ""
@@ -8102,7 +8102,7 @@ msgid "No conversations found."
 msgstr ""
 
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:102
-#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:74
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:71
 #, elixir-autogen, elixir-format
 msgid "No messages in this conversation."
 msgstr ""
@@ -8132,17 +8132,17 @@ msgstr ""
 msgid "← Back to messages"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:733
+#: lib/klass_hero_web/components/messaging_components.ex:771
 #, elixir-autogen, elixir-format
 msgid "Messages here may be reviewed by the activity provider and by Klass Hero staff, to keep children safe."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:56
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "Back to staff conversations"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:15
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Conversations your staff have with parents. Read-only — opening a thread here does not mark anything as read."
 msgstr ""
@@ -8152,19 +8152,19 @@ msgstr ""
 msgid "My conversations"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:34
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:29
 #, elixir-autogen, elixir-format
 msgid "No staff conversations yet. Threads your team starts will appear here."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:65
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:62
 #, elixir-autogen, elixir-format
 msgid "Read-only. You are viewing this as the business owner, not as a participant — nothing is marked as read."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:185
-#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:45
-#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:62
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:47
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:63
 #, elixir-autogen, elixir-format
 msgid "Staff conversations"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -1545,7 +1545,6 @@ msgstr ""
 
 #: lib/klass_hero_web/components/messaging_components.ex:166
 #: lib/klass_hero_web/live/admin/messages_live.ex:147
-#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:113
 #, elixir-autogen, elixir-format
 msgid "Broadcast"
 msgstr ""
@@ -1601,8 +1600,7 @@ msgstr ""
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:80
 #: lib/klass_hero_web/live/dashboard_live.ex:175
 #: lib/klass_hero_web/live/messaging_live_helper.ex:413
-#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:73
-#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:114
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:79
 #, elixir-autogen, elixir-format
 msgid "Conversation"
 msgstr ""
@@ -2978,7 +2976,7 @@ msgid "We are Klass Hero — parents, brothers, and partners of educators — bu
 msgstr ""
 
 #: lib/klass_hero_web/live/admin/messages_live.ex:106
-#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:100
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:106
 #: lib/klass_hero_web/user_auth.ex:298
 #, elixir-autogen, elixir-format
 msgid "You don't have access to that page."
@@ -8080,7 +8078,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/klass_hero_web/live/admin/messages_live.ex:75
-#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:78
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:84
 #, elixir-autogen, elixir-format
 msgid "Conversation not found."
 msgstr ""
@@ -8163,8 +8161,8 @@ msgid "Read-only. You are viewing this as the business owner, not as a participa
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:185
-#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:47
-#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:63
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:53
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:69
 #, elixir-autogen, elixir-format
 msgid "Staff conversations"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -1545,7 +1545,6 @@ msgstr ""
 
 #: lib/klass_hero_web/components/messaging_components.ex:166
 #: lib/klass_hero_web/live/admin/messages_live.ex:147
-#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:113
 #, elixir-autogen, elixir-format
 msgid "Broadcast"
 msgstr ""
@@ -1601,8 +1600,7 @@ msgstr ""
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:80
 #: lib/klass_hero_web/live/dashboard_live.ex:175
 #: lib/klass_hero_web/live/messaging_live_helper.ex:413
-#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:73
-#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:114
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:79
 #, elixir-autogen, elixir-format
 msgid "Conversation"
 msgstr ""
@@ -2978,7 +2976,7 @@ msgid "We are Klass Hero — parents, brothers, and partners of educators — bu
 msgstr ""
 
 #: lib/klass_hero_web/live/admin/messages_live.ex:106
-#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:100
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:106
 #: lib/klass_hero_web/user_auth.ex:298
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You don't have access to that page."
@@ -8080,7 +8078,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/klass_hero_web/live/admin/messages_live.ex:75
-#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:78
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:84
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Conversation not found."
 msgstr ""
@@ -8163,8 +8161,8 @@ msgid "Read-only. You are viewing this as the business owner, not as a participa
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:185
-#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:47
-#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:63
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:53
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:69
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Staff conversations"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -45,7 +45,7 @@ msgstr ""
 #: lib/klass_hero_web/components/layouts/app.html.heex:131
 #: lib/klass_hero_web/components/layouts/app.html.heex:206
 #: lib/klass_hero_web/components/layouts/app.html.heex:231
-#: lib/klass_hero_web/components/provider_components.ex:392
+#: lib/klass_hero_web/components/provider_components.ex:428
 #: lib/klass_hero_web/components/ui_components.ex:277
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
@@ -136,7 +136,7 @@ msgid "Your Data"
 msgstr ""
 
 #: lib/klass_hero_web/components/core_components.ex:71
-#: lib/klass_hero_web/components/provider_components.ex:1682
+#: lib/klass_hero_web/components/provider_components.ex:1718
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr ""
@@ -231,7 +231,7 @@ msgstr ""
 msgid "Enroll Now - %{price}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1401
+#: lib/klass_hero_web/components/provider_components.ex:1437
 #: lib/klass_hero_web/live/booking_live.ex:317
 #, elixir-autogen, elixir-format
 msgid "Enrollment"
@@ -456,7 +456,7 @@ msgstr ""
 msgid "Changes to Terms"
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:207
+#: lib/klass_hero_web/live/privacy_policy_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "Changes to This Policy"
 msgstr ""
@@ -476,7 +476,7 @@ msgstr ""
 msgid "Child checked out successfully"
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:155
+#: lib/klass_hero_web/live/privacy_policy_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "Children's Privacy"
 msgstr ""
@@ -515,12 +515,12 @@ msgstr ""
 #: lib/klass_hero_web/components/composite_components.ex:472
 #: lib/klass_hero_web/live/contact_live.ex:16
 #: lib/klass_hero_web/live/contact_live.ex:107
-#: lib/klass_hero_web/live/privacy_policy_live.ex:223
+#: lib/klass_hero_web/live/privacy_policy_live.ex:224
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Contact Us"
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:176
+#: lib/klass_hero_web/live/privacy_policy_live.ex:177
 #, elixir-autogen, elixir-format
 msgid "Cookies & Tracking"
 msgstr ""
@@ -541,12 +541,12 @@ msgstr ""
 msgid "Creating account..."
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:192
+#: lib/klass_hero_web/live/privacy_policy_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "Data Retention"
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:138
+#: lib/klass_hero_web/live/privacy_policy_live.ex:139
 #, elixir-autogen, elixir-format
 msgid "Data Security"
 msgstr ""
@@ -576,9 +576,9 @@ msgstr ""
 msgid "Dispute Resolution"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:719
-#: lib/klass_hero_web/components/provider_components.ex:2774
-#: lib/klass_hero_web/components/provider_components.ex:2792
+#: lib/klass_hero_web/components/provider_components.ex:755
+#: lib/klass_hero_web/components/provider_components.ex:2810
+#: lib/klass_hero_web/components/provider_components.ex:2828
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:61
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Magic link is invalid or it has expired."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:391
+#: lib/klass_hero_web/components/messaging_components.ex:404
 #: lib/klass_hero_web/live/contact_live.ex:176
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:181
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:205
@@ -821,7 +821,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/composite_components.ex:358
 #: lib/klass_hero_web/live/privacy_policy_live.ex:11
-#: lib/klass_hero_web/live/privacy_policy_live.ex:241
+#: lib/klass_hero_web/live/privacy_policy_live.ex:242
 #, elixir-autogen, elixir-format
 msgid "Privacy Policy"
 msgstr ""
@@ -836,7 +836,7 @@ msgstr ""
 msgid "Program Question"
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:245
+#: lib/klass_hero_web/live/privacy_policy_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "Questions About Privacy?"
 msgstr ""
@@ -881,9 +881,9 @@ msgstr ""
 msgid "Select one or both options"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2424
-#: lib/klass_hero_web/components/provider_components.ex:2425
-#: lib/klass_hero_web/components/provider_components.ex:2462
+#: lib/klass_hero_web/components/provider_components.ex:2460
+#: lib/klass_hero_web/components/provider_components.ex:2461
+#: lib/klass_hero_web/components/provider_components.ex:2498
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:468
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:469
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:505
@@ -971,7 +971,7 @@ msgstr ""
 msgid "We're here to clarify any questions you may have."
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:246
+#: lib/klass_hero_web/live/privacy_policy_live.ex:247
 #, elixir-autogen, elixir-format
 msgid "We're here to help with any privacy-related concerns."
 msgstr ""
@@ -1012,7 +1012,7 @@ msgstr ""
 msgid "You need to reauthenticate to perform sensitive actions on your account."
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:116
+#: lib/klass_hero_web/live/privacy_policy_live.ex:117
 #, elixir-autogen, elixir-format
 msgid "Your Privacy Rights"
 msgstr ""
@@ -1022,7 +1022,7 @@ msgstr ""
 msgid "Your account has been deleted."
 msgstr ""
 
-#: lib/klass_hero_web/live/privacy_policy_live.ex:242
+#: lib/klass_hero_web/live/privacy_policy_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "Your privacy matters to us"
 msgstr ""
@@ -1210,7 +1210,7 @@ msgstr ""
 msgid "Music"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:755
+#: lib/klass_hero_web/components/provider_components.ex:791
 #: lib/klass_hero_web/live/for_providers_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "Qualifications"
@@ -1332,19 +1332,19 @@ msgstr ""
 msgid "Quick Navigation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1404
-#: lib/klass_hero_web/components/provider_components.ex:2384
-#: lib/klass_hero_web/components/provider_components.ex:2661
+#: lib/klass_hero_web/components/provider_components.ex:1440
+#: lib/klass_hero_web/components/provider_components.ex:2420
+#: lib/klass_hero_web/components/provider_components.ex:2697
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1550
+#: lib/klass_hero_web/components/provider_components.ex:1586
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Active"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:672
+#: lib/klass_hero_web/components/provider_components.ex:708
 #: lib/klass_hero_web/live/provider/team_live.ex:627
 #, elixir-autogen, elixir-format
 msgid "Add Team Member"
@@ -1355,7 +1355,7 @@ msgstr ""
 msgid "All Staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1395
+#: lib/klass_hero_web/components/provider_components.ex:1431
 #, elixir-autogen, elixir-format
 msgid "Assigned Staff"
 msgstr ""
@@ -1377,8 +1377,8 @@ msgstr ""
 msgid "Create profiles for your staff. These will be visible to parents when assigned to programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:543
-#: lib/klass_hero_web/components/provider_components.ex:1513
+#: lib/klass_hero_web/components/provider_components.ex:579
+#: lib/klass_hero_web/components/provider_components.ex:1549
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:65
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:92
 #: lib/klass_hero_web/live/settings/children_live.ex:413
@@ -1388,14 +1388,14 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:226
+#: lib/klass_hero_web/components/provider_components.ex:262
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:34
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "Edit Profile"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1552
+#: lib/klass_hero_web/components/provider_components.ex:1588
 #, elixir-autogen, elixir-format
 msgid "Inactive"
 msgstr ""
@@ -1406,8 +1406,8 @@ msgstr ""
 msgid "My Programs"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:418
-#: lib/klass_hero_web/components/provider_components.ex:910
+#: lib/klass_hero_web/components/provider_components.ex:454
+#: lib/klass_hero_web/components/provider_components.ex:946
 #, elixir-autogen, elixir-format, fuzzy
 msgid "New Program"
 msgstr ""
@@ -1419,26 +1419,26 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:49
 #: lib/klass_hero_web/components/provider_components.ex:75
-#: lib/klass_hero_web/components/provider_components.ex:1551
-#: lib/klass_hero_web/components/provider_components.ex:2868
-#: lib/klass_hero_web/components/provider_components.ex:2886
+#: lib/klass_hero_web/components/provider_components.ex:1587
+#: lib/klass_hero_web/components/provider_components.ex:2904
+#: lib/klass_hero_web/components/provider_components.ex:2922
 #: lib/klass_hero_web/live/admin/sessions_live.ex:293
 #: lib/klass_hero_web/live/admin/verifications_live.ex:202
 #, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1482
+#: lib/klass_hero_web/components/provider_components.ex:1518
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1335
+#: lib/klass_hero_web/components/provider_components.ex:1371
 #, elixir-autogen, elixir-format
 msgid "Program Inventory"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1392
+#: lib/klass_hero_web/components/provider_components.ex:1428
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program Name"
 msgstr ""
@@ -1453,15 +1453,15 @@ msgstr ""
 msgid "Save for Later"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1352
+#: lib/klass_hero_web/components/provider_components.ex:1388
 #, elixir-autogen, elixir-format
 msgid "Search by name..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1398
-#: lib/klass_hero_web/components/provider_components.ex:1801
-#: lib/klass_hero_web/components/provider_components.ex:2375
-#: lib/klass_hero_web/components/provider_components.ex:2658
+#: lib/klass_hero_web/components/provider_components.ex:1434
+#: lib/klass_hero_web/components/provider_components.ex:1837
+#: lib/klass_hero_web/components/provider_components.ex:2411
+#: lib/klass_hero_web/components/provider_components.ex:2694
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1480,23 +1480,24 @@ msgstr ""
 msgid "Team & Provider Profiles"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1455
-#: lib/klass_hero_web/components/provider_components.ex:1816
+#: lib/klass_hero_web/components/provider_components.ex:1491
+#: lib/klass_hero_web/components/provider_components.ex:1852
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:772
+#: lib/klass_hero_web/components/messaging_components.ex:794
 #: lib/klass_hero_web/components/provider_components.ex:52
-#: lib/klass_hero_web/components/provider_components.ex:1553
+#: lib/klass_hero_web/components/provider_components.ex:1589
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:110
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:82
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:455
 #: lib/klass_hero_web/presenters/provider_presenter.ex:172
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1493
+#: lib/klass_hero_web/components/provider_components.ex:1529
 #, elixir-autogen, elixir-format
 msgid "View Roster"
 msgstr ""
@@ -1506,7 +1507,7 @@ msgstr ""
 msgid "%{age} years old"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:792
+#: lib/klass_hero_web/components/messaging_components.ex:815
 #, elixir-autogen, elixir-format
 msgid "%{n}m ago"
 msgstr ""
@@ -1542,8 +1543,9 @@ msgstr ""
 msgid "Back to Settings"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:153
+#: lib/klass_hero_web/components/messaging_components.ex:166
 #: lib/klass_hero_web/live/admin/messages_live.ex:147
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:113
 #, elixir-autogen, elixir-format
 msgid "Broadcast"
 msgstr ""
@@ -1557,10 +1559,10 @@ msgstr ""
 #: lib/klass_hero_web/components/participation_components.ex:346
 #: lib/klass_hero_web/components/participation_components.ex:571
 #: lib/klass_hero_web/components/participation_components.ex:662
-#: lib/klass_hero_web/components/provider_components.ex:847
-#: lib/klass_hero_web/components/provider_components.ex:1261
-#: lib/klass_hero_web/components/provider_components.ex:1974
-#: lib/klass_hero_web/components/provider_components.ex:2566
+#: lib/klass_hero_web/components/provider_components.ex:883
+#: lib/klass_hero_web/components/provider_components.ex:1297
+#: lib/klass_hero_web/components/provider_components.ex:2010
+#: lib/klass_hero_web/components/provider_components.ex:2602
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:489
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
@@ -1599,6 +1601,8 @@ msgstr ""
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:80
 #: lib/klass_hero_web/live/dashboard_live.ex:175
 #: lib/klass_hero_web/live/messaging_live_helper.ex:413
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:72
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "Conversation"
 msgstr ""
@@ -1618,7 +1622,7 @@ msgstr ""
 msgid "Data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2755
+#: lib/klass_hero_web/components/provider_components.ex:2791
 #: lib/klass_hero_web/live/settings/children_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1666,17 +1670,17 @@ msgstr ""
 msgid "Failed to submit note"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2749
-#: lib/klass_hero_web/components/provider_components.ex:2778
-#: lib/klass_hero_web/components/provider_components.ex:2794
+#: lib/klass_hero_web/components/provider_components.ex:2785
+#: lib/klass_hero_web/components/provider_components.ex:2814
+#: lib/klass_hero_web/components/provider_components.ex:2830
 #: lib/klass_hero_web/live/settings/children_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2750
-#: lib/klass_hero_web/components/provider_components.ex:2779
-#: lib/klass_hero_web/components/provider_components.ex:2795
+#: lib/klass_hero_web/components/provider_components.ex:2786
+#: lib/klass_hero_web/components/provider_components.ex:2815
+#: lib/klass_hero_web/components/provider_components.ex:2831
 #: lib/klass_hero_web/live/settings/children_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -1705,13 +1709,14 @@ msgstr ""
 
 #: lib/klass_hero_web/components/layouts/admin.html.heex:90
 #: lib/klass_hero_web/components/layouts/app.html.heex:214
-#: lib/klass_hero_web/components/messaging_components.ex:506
-#: lib/klass_hero_web/components/messaging_components.ex:529
+#: lib/klass_hero_web/components/messaging_components.ex:527
+#: lib/klass_hero_web/components/messaging_components.ex:550
 #: lib/klass_hero_web/live/admin/messages_live.ex:37
 #: lib/klass_hero_web/live/admin/messages_live.ex:56
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:5
 #: lib/klass_hero_web/live/messages_live/index.ex:19
 #: lib/klass_hero_web/live/messaging_live_helper.ex:365
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:6
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Messages"
 msgstr ""
@@ -1722,13 +1727,13 @@ msgstr ""
 msgid "No children yet"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:476
+#: lib/klass_hero_web/components/messaging_components.ex:489
 #, elixir-autogen, elixir-format
 msgid "No conversations yet"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:445
-#: lib/klass_hero_web/components/messaging_components.ex:814
+#: lib/klass_hero_web/components/messaging_components.ex:458
+#: lib/klass_hero_web/components/messaging_components.ex:837
 #, elixir-autogen, elixir-format
 msgid "No messages yet"
 msgstr ""
@@ -1760,7 +1765,7 @@ msgstr ""
 msgid "Note resubmitted for review"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:791
+#: lib/klass_hero_web/components/messaging_components.ex:814
 #, elixir-autogen, elixir-format
 msgid "Now"
 msgstr ""
@@ -1800,7 +1805,7 @@ msgstr ""
 msgid "Please set up your parent profile to manage children."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:765
+#: lib/klass_hero_web/components/messaging_components.ex:787
 #: lib/klass_hero_web/live/messaging_live_helper.ex:409
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program Broadcast"
@@ -1811,15 +1816,15 @@ msgstr ""
 msgid "Provider data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:832
+#: lib/klass_hero_web/components/provider_components.ex:868
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:307
 #: lib/klass_hero_web/live/settings/children_live.ex:719
 #, elixir-autogen, elixir-format
 msgid "Save Changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1660
-#: lib/klass_hero_web/components/provider_components.ex:1661
+#: lib/klass_hero_web/components/provider_components.ex:1696
+#: lib/klass_hero_web/components/provider_components.ex:1697
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:43
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:151
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:252
@@ -1832,12 +1837,12 @@ msgstr ""
 msgid "Send Broadcast"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:448
+#: lib/klass_hero_web/components/messaging_components.ex:461
 #, elixir-autogen, elixir-format
 msgid "Send a message to start the conversation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2849
+#: lib/klass_hero_web/components/provider_components.ex:2885
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:249
 #, elixir-autogen, elixir-format, fuzzy
@@ -1856,7 +1861,7 @@ msgstr ""
 msgid "This message will be sent to all parents with active enrollments in this program."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:398
+#: lib/klass_hero_web/components/messaging_components.ex:411
 #, elixir-autogen, elixir-format
 msgid "Type a message..."
 msgstr ""
@@ -1893,12 +1898,12 @@ msgstr ""
 msgid "You don't have permission to edit this child."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:485
+#: lib/klass_hero_web/components/messaging_components.ex:498
 #, elixir-autogen, elixir-format
 msgid "Your conversations with parents will appear here"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:487
+#: lib/klass_hero_web/components/messaging_components.ex:500
 #, elixir-autogen, elixir-format
 msgid "Your conversations with providers will appear here"
 msgstr ""
@@ -1943,12 +1948,12 @@ msgstr[1] ""
 msgid "%{gender} only"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:311
+#: lib/klass_hero_web/components/provider_components.ex:347
 #, elixir-autogen, elixir-format
 msgid "Action Required"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:834
+#: lib/klass_hero_web/components/provider_components.ex:870
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add Member"
 msgstr ""
@@ -1968,12 +1973,12 @@ msgstr ""
 msgid "Ages %{min}+"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1162
+#: lib/klass_hero_web/components/provider_components.ex:1198
 #, elixir-autogen, elixir-format
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2908
+#: lib/klass_hero_web/components/provider_components.ex:2944
 #, elixir-autogen, elixir-format, fuzzy
 msgid "An unexpected error occurred during import."
 msgstr ""
@@ -2016,7 +2021,7 @@ msgstr ""
 msgid "Back to verifications"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:728
+#: lib/klass_hero_web/components/provider_components.ex:764
 #, elixir-autogen, elixir-format
 msgid "Bio"
 msgstr ""
@@ -2026,7 +2031,7 @@ msgstr ""
 msgid "Book a Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:729
+#: lib/klass_hero_web/components/provider_components.ex:765
 #, elixir-autogen, elixir-format
 msgid "Brief description of experience and specialties..."
 msgstr ""
@@ -2041,19 +2046,19 @@ msgstr ""
 msgid "Business"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:940
+#: lib/klass_hero_web/components/provider_components.ex:976
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "Category"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1111
+#: lib/klass_hero_web/components/provider_components.ex:1147
 #, elixir-autogen, elixir-format
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2372
-#: lib/klass_hero_web/components/provider_components.ex:2644
+#: lib/klass_hero_web/components/provider_components.ex:2408
+#: lib/klass_hero_web/components/provider_components.ex:2680
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2068,7 +2073,7 @@ msgstr ""
 msgid "Child meets all program requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1234
+#: lib/klass_hero_web/components/provider_components.ex:1270
 #, elixir-autogen, elixir-format
 msgid "Choose Image"
 msgstr ""
@@ -2079,12 +2084,12 @@ msgstr ""
 msgid "Choose Logo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:823
+#: lib/klass_hero_web/components/provider_components.ex:859
 #, elixir-autogen, elixir-format
 msgid "Choose Photo"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:942
+#: lib/klass_hero_web/components/provider_components.ex:978
 #, elixir-autogen, elixir-format
 msgid "Choose a category"
 msgstr ""
@@ -2094,12 +2099,12 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2869
+#: lib/klass_hero_web/components/provider_components.ex:2905
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:866
+#: lib/klass_hero_web/components/messaging_components.ex:889
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Contact Provider"
 msgstr ""
@@ -2114,23 +2119,23 @@ msgstr ""
 msgid "Could not remove invite."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1228
-#: lib/klass_hero_web/components/provider_components.ex:3157
+#: lib/klass_hero_web/components/provider_components.ex:1264
+#: lib/klass_hero_web/components/provider_components.ex:3193
 #, elixir-autogen, elixir-format
 msgid "Cover Image"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1105
+#: lib/klass_hero_web/components/provider_components.ex:1141
 #, elixir-autogen, elixir-format
 msgid "Define age, gender, or grade restrictions for eligible participants."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1221
+#: lib/klass_hero_web/components/provider_components.ex:1257
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Describe your program..."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1220
+#: lib/klass_hero_web/components/provider_components.ex:1256
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:325
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:300
 #, elixir-autogen, elixir-format
@@ -2138,13 +2143,13 @@ msgid "Description"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:696
-#: lib/klass_hero_web/components/provider_components.ex:1173
+#: lib/klass_hero_web/components/provider_components.ex:1209
 #: lib/klass_hero_web/live/settings/children_live.ex:635
 #, elixir-autogen, elixir-format
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3286
+#: lib/klass_hero_web/components/provider_components.ex:3322
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2178,7 +2183,7 @@ msgstr ""
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2585
+#: lib/klass_hero_web/components/provider_components.ex:2621
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
@@ -2188,40 +2193,40 @@ msgstr ""
 msgid "Download document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:908
+#: lib/klass_hero_web/components/provider_components.ex:944
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:670
+#: lib/klass_hero_web/components/provider_components.ex:706
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit Team Member"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1026
+#: lib/klass_hero_web/components/provider_components.ex:1062
 #, elixir-autogen, elixir-format
 msgid "End Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1013
+#: lib/klass_hero_web/components/provider_components.ex:1049
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:185
 #, elixir-autogen, elixir-format
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2381
-#: lib/klass_hero_web/components/provider_components.ex:2889
+#: lib/klass_hero_web/components/provider_components.ex:2417
+#: lib/klass_hero_web/components/provider_components.ex:2925
 #: lib/klass_hero_web/components/provider_layout_components.ex:612
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrolled"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1706
+#: lib/klass_hero_web/components/provider_components.ex:1742
 #, elixir-autogen, elixir-format
 msgid "Enrolled (%{count})"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1054
+#: lib/klass_hero_web/components/provider_components.ex:1090
 #, elixir-autogen, elixir-format
 msgid "Enrollment Capacity (optional)"
 msgstr ""
@@ -2232,7 +2237,7 @@ msgid "Explain why this document is being rejected..."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:73
-#: lib/klass_hero_web/components/provider_components.ex:2890
+#: lib/klass_hero_web/components/provider_components.ex:2926
 #: lib/klass_hero_web/live/admin/emails_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2265,7 +2270,7 @@ msgid "Family Programs"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:694
-#: lib/klass_hero_web/components/provider_components.ex:1172
+#: lib/klass_hero_web/components/provider_components.ex:1208
 #: lib/klass_hero_web/live/settings/children_live.ex:634
 #, elixir-autogen, elixir-format
 msgid "Female"
@@ -2276,22 +2281,22 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3219
+#: lib/klass_hero_web/components/provider_components.ex:3255
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3221
+#: lib/klass_hero_web/components/provider_components.ex:3257
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:756
+#: lib/klass_hero_web/components/provider_components.ex:792
 #, elixir-autogen, elixir-format
 msgid "First Aid, UEFA B License, Child Care Cert"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:698
+#: lib/klass_hero_web/components/provider_components.ex:734
 #, elixir-autogen, elixir-format, fuzzy
 msgid "First Name"
 msgstr ""
@@ -2316,12 +2321,12 @@ msgstr ""
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2655
+#: lib/klass_hero_web/components/provider_components.ex:2691
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:817
+#: lib/klass_hero_web/components/provider_components.ex:853
 #, elixir-autogen, elixir-format
 msgid "Headshot Photo"
 msgstr ""
@@ -2331,7 +2336,7 @@ msgstr ""
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2558
+#: lib/klass_hero_web/components/provider_components.ex:2594
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import"
 msgstr ""
@@ -2356,17 +2361,17 @@ msgstr ""
 msgid "Invite resent successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1723
+#: lib/klass_hero_web/components/provider_components.ex:1759
 #, elixir-autogen, elixir-format
 msgid "Invites (%{count})"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:824
+#: lib/klass_hero_web/components/provider_components.ex:860
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 1MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1235
+#: lib/klass_hero_web/components/provider_components.ex:1271
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:276
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:366
 #, elixir-autogen, elixir-format
@@ -2383,22 +2388,22 @@ msgstr ""
 msgid "Klasse %{n}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:704
+#: lib/klass_hero_web/components/provider_components.ex:740
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Last Name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1036
+#: lib/klass_hero_web/components/provider_components.ex:1072
 #, elixir-autogen, elixir-format
 msgid "Leave blank for open registration at any time."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1165
+#: lib/klass_hero_web/components/provider_components.ex:1201
 #, elixir-autogen, elixir-format
 msgid "Leave unchecked to allow all genders."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:969
+#: lib/klass_hero_web/components/provider_components.ex:1005
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:191
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Location"
@@ -2411,43 +2416,43 @@ msgid "Logo upload failed. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:695
-#: lib/klass_hero_web/components/provider_components.ex:1171
+#: lib/klass_hero_web/components/provider_components.ex:1207
 #: lib/klass_hero_web/live/settings/children_live.ex:633
 #, elixir-autogen, elixir-format
 msgid "Male"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1155
+#: lib/klass_hero_web/components/provider_components.ex:1191
 #, elixir-autogen, elixir-format
 msgid "Maximum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1069
+#: lib/klass_hero_web/components/provider_components.ex:1105
 #, elixir-autogen, elixir-format
 msgid "Maximum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1210
+#: lib/klass_hero_web/components/provider_components.ex:1246
 #, elixir-autogen, elixir-format
 msgid "Maximum Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:978
+#: lib/klass_hero_web/components/provider_components.ex:1014
 #, elixir-autogen, elixir-format
 msgid "Meeting Days"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1149
+#: lib/klass_hero_web/components/provider_components.ex:1185
 #, elixir-autogen, elixir-format
 msgid "Minimum Age (months)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1063
+#: lib/klass_hero_web/components/provider_components.ex:1099
 #, elixir-autogen, elixir-format
 msgid "Minimum Enrollment"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1203
+#: lib/klass_hero_web/components/provider_components.ex:1239
 #, elixir-autogen, elixir-format
 msgid "Minimum Grade"
 msgstr ""
@@ -2457,12 +2462,12 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3248
+#: lib/klass_hero_web/components/provider_components.ex:3284
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2365
+#: lib/klass_hero_web/components/provider_components.ex:2401
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
@@ -2478,17 +2483,17 @@ msgstr ""
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2609
+#: lib/klass_hero_web/components/provider_components.ex:2645
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1212
+#: lib/klass_hero_web/components/provider_components.ex:1248
 #, elixir-autogen, elixir-format
 msgid "No maximum"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1205
+#: lib/klass_hero_web/components/provider_components.ex:1241
 #, elixir-autogen, elixir-format
 msgid "No minimum"
 msgstr ""
@@ -2519,18 +2524,18 @@ msgstr ""
 msgid "No verification documents found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1247
+#: lib/klass_hero_web/components/provider_components.ex:1283
 #, elixir-autogen, elixir-format
 msgid "None (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:327
+#: lib/klass_hero_web/components/provider_components.ex:363
 #, elixir-autogen, elixir-format
 msgid "Not Verified"
 msgstr ""
 
 #: lib/klass_hero_web/components/program_components.ex:697
-#: lib/klass_hero_web/components/provider_components.ex:1174
+#: lib/klass_hero_web/components/provider_components.ex:1210
 #: lib/klass_hero_web/live/settings/children_live.ex:632
 #, elixir-autogen, elixir-format
 msgid "Not specified"
@@ -2541,7 +2546,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3324
+#: lib/klass_hero_web/components/provider_components.ex:3360
 #: lib/klass_hero_web/live/provider/verification_live.ex:707
 #: lib/klass_hero_web/live/provider/verification_live.ex:781
 #, elixir-autogen, elixir-format
@@ -2553,13 +2558,13 @@ msgstr ""
 msgid "Participant Requirements"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1102
+#: lib/klass_hero_web/components/provider_components.ex:1138
 #, elixir-autogen, elixir-format
 msgid "Participant Restrictions (optional)"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:770
-#: lib/klass_hero_web/components/provider_components.ex:295
+#: lib/klass_hero_web/components/provider_components.ex:331
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Pending Review"
 msgstr ""
@@ -2587,7 +2592,7 @@ msgstr ""
 msgid "Preview not available for this file type."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:960
+#: lib/klass_hero_web/components/provider_components.ex:996
 #, elixir-autogen, elixir-format
 msgid "Price (EUR)"
 msgstr ""
@@ -2597,7 +2602,7 @@ msgstr ""
 msgid "Profile updated successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1140
+#: lib/klass_hero_web/components/provider_components.ex:1176
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program Start"
 msgstr ""
@@ -2641,13 +2646,13 @@ msgid "Read our founding story →"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:750
-#: lib/klass_hero_web/components/provider_components.ex:2888
+#: lib/klass_hero_web/components/provider_components.ex:2924
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registered"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1127
+#: lib/klass_hero_web/components/provider_components.ex:1163
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration"
 msgstr ""
@@ -2657,7 +2662,7 @@ msgstr ""
 msgid "Registration Closed"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1047
+#: lib/klass_hero_web/components/provider_components.ex:1083
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration Closes"
 msgstr ""
@@ -2667,12 +2672,12 @@ msgstr ""
 msgid "Registration Not Open Yet"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1042
+#: lib/klass_hero_web/components/provider_components.ex:1078
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registration Opens"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1033
+#: lib/klass_hero_web/components/provider_components.ex:1069
 #, elixir-autogen, elixir-format
 msgid "Registration Period (optional)"
 msgstr ""
@@ -2721,15 +2726,15 @@ msgstr ""
 msgid "Rejection reason"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2711
-#: lib/klass_hero_web/components/provider_components.ex:3075
-#: lib/klass_hero_web/components/provider_components.ex:3343
-#: lib/klass_hero_web/components/provider_components.ex:3423
+#: lib/klass_hero_web/components/provider_components.ex:2747
+#: lib/klass_hero_web/components/provider_components.ex:3111
+#: lib/klass_hero_web/components/provider_components.ex:3379
+#: lib/klass_hero_web/components/provider_components.ex:3459
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2704
+#: lib/klass_hero_web/components/provider_components.ex:2740
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -2739,23 +2744,23 @@ msgstr ""
 msgid "Reviewed"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:713
+#: lib/klass_hero_web/components/provider_components.ex:749
 #, elixir-autogen, elixir-format
 msgid "Role"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1652
+#: lib/klass_hero_web/components/provider_components.ex:1688
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:407
 #, elixir-autogen, elixir-format
 msgid "Roster: %{name}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1264
+#: lib/klass_hero_web/components/provider_components.ex:1300
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Save Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:975
+#: lib/klass_hero_web/components/provider_components.ex:1011
 #, elixir-autogen, elixir-format
 msgid "Schedule (optional)"
 msgstr ""
@@ -2770,7 +2775,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3321
+#: lib/klass_hero_web/components/provider_components.ex:3357
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select File"
 msgstr ""
@@ -2787,23 +2792,23 @@ msgstr ""
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2887
+#: lib/klass_hero_web/components/provider_components.ex:2923
 #: lib/klass_hero_web/live/admin/emails_live.ex:206
 #, elixir-autogen, elixir-format
 msgid "Sent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:760
+#: lib/klass_hero_web/components/provider_components.ex:796
 #, elixir-autogen, elixir-format
 msgid "Separate multiple qualifications with commas"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1057
+#: lib/klass_hero_web/components/provider_components.ex:1093
 #, elixir-autogen, elixir-format
 msgid "Set minimum and maximum enrollment for this program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:734
+#: lib/klass_hero_web/components/provider_components.ex:770
 #, elixir-autogen, elixir-format
 msgid "Specialties"
 msgstr ""
@@ -2821,12 +2826,12 @@ msgstr ""
 msgid "Staff member not found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1021
+#: lib/klass_hero_web/components/provider_components.ex:1057
 #, elixir-autogen, elixir-format
 msgid "Start Date"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1008
+#: lib/klass_hero_web/components/provider_components.ex:1044
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:184
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Start Time"
@@ -2892,13 +2897,13 @@ msgstr ""
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:933
-#: lib/klass_hero_web/components/provider_components.ex:1940
+#: lib/klass_hero_web/components/provider_components.ex:969
+#: lib/klass_hero_web/components/provider_components.ex:1976
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3220
+#: lib/klass_hero_web/components/provider_components.ex:3256
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -2918,27 +2923,27 @@ msgstr ""
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2545
+#: lib/klass_hero_web/components/provider_components.ex:2581
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3367
+#: lib/klass_hero_web/components/provider_components.ex:3403
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3275
+#: lib/klass_hero_web/components/provider_components.ex:3311
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3223
+#: lib/klass_hero_web/components/provider_components.ex:3259
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3240
+#: lib/klass_hero_web/components/provider_components.ex:3276
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -2960,7 +2965,7 @@ msgstr ""
 msgid "Verifications"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:279
+#: lib/klass_hero_web/components/provider_components.ex:315
 #: lib/klass_hero_web/components/provider_layout_components.ex:217
 #: lib/klass_hero_web/components/ui_components.ex:1671
 #, elixir-autogen, elixir-format, fuzzy
@@ -2973,37 +2978,38 @@ msgid "We are Klass Hero — parents, brothers, and partners of educators — bu
 msgstr ""
 
 #: lib/klass_hero_web/live/admin/messages_live.ex:106
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:100
 #: lib/klass_hero_web/user_auth.ex:298
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You don't have access to that page."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:714
+#: lib/klass_hero_web/components/provider_components.ex:750
 #, elixir-autogen, elixir-format, fuzzy
 msgid "e.g. Head Coach"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:705
+#: lib/klass_hero_web/components/provider_components.ex:741
 #, elixir-autogen, elixir-format
 msgid "e.g. Johnson"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:699
+#: lib/klass_hero_web/components/provider_components.ex:735
 #, elixir-autogen, elixir-format
 msgid "e.g. Mike"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:720
+#: lib/klass_hero_web/components/provider_components.ex:756
 #, elixir-autogen, elixir-format
 msgid "e.g. mike@example.com"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:934
+#: lib/klass_hero_web/components/provider_components.ex:970
 #, elixir-autogen, elixir-format
 msgid "e.g., Art Adventures"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:970
+#: lib/klass_hero_web/components/provider_components.ex:1006
 #, elixir-autogen, elixir-format
 msgid "e.g., Community Center, Main St"
 msgstr ""
@@ -3029,7 +3035,7 @@ msgid "Child Safeguarding Training"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1507
-#: lib/klass_hero_web/components/provider_components.ex:3596
+#: lib/klass_hero_web/components/provider_components.ex:3632
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr ""
@@ -3180,7 +3186,7 @@ msgid "Vetted with Care"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1491
-#: lib/klass_hero_web/components/provider_components.ex:3374
+#: lib/klass_hero_web/components/provider_components.ex:3410
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr ""
@@ -3354,7 +3360,7 @@ msgstr ""
 msgid "Checked Out"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2746
+#: lib/klass_hero_web/components/provider_components.ex:2782
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Child"
@@ -3400,7 +3406,7 @@ msgstr ""
 msgid "Download monthly statements for taxes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2461
+#: lib/klass_hero_web/components/provider_components.ex:2497
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:504
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrollment not confirmed"
@@ -3473,7 +3479,7 @@ msgstr ""
 msgid "No chasing payments or sending invoices"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1675
+#: lib/klass_hero_web/components/provider_components.ex:1711
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:428
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No enrolled parents"
@@ -3496,7 +3502,7 @@ msgstr ""
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2460
+#: lib/klass_hero_web/components/provider_components.ex:2496
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:503
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -3746,7 +3752,7 @@ msgstr ""
 msgid "Back to emails"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:732
+#: lib/klass_hero_web/components/messaging_components.ex:754
 #, elixir-autogen, elixir-format
 msgid "Broadcast messages are one-way"
 msgstr ""
@@ -4107,7 +4113,7 @@ msgstr ""
 msgid "Please fill in all required fields"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2652
+#: lib/klass_hero_web/components/provider_components.ex:2688
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:24
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:299
@@ -4152,7 +4158,7 @@ msgstr ""
 msgid "Reply"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:743
+#: lib/klass_hero_web/components/messaging_components.ex:765
 #, elixir-autogen, elixir-format
 msgid "Reply privately"
 msgstr ""
@@ -4167,7 +4173,7 @@ msgstr ""
 msgid "Reply sent successfully"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:553
+#: lib/klass_hero_web/components/provider_components.ex:589
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Resend"
 msgstr ""
@@ -4433,7 +4439,7 @@ msgstr ""
 msgid "Failed to upload files. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:818
+#: lib/klass_hero_web/components/messaging_components.ex:841
 #, elixir-autogen, elixir-format, fuzzy
 msgid "File is too large (max %{mb} MB)"
 msgstr ""
@@ -4443,7 +4449,7 @@ msgstr ""
 msgid "File is too large (max %{mb} MB)."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:821
+#: lib/klass_hero_web/components/messaging_components.ex:844
 #, elixir-autogen, elixir-format, fuzzy
 msgid "File type not accepted (images only)"
 msgstr ""
@@ -4463,8 +4469,8 @@ msgstr ""
 msgid "Only images are accepted (JPG, PNG, GIF, WebP)."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:803
-#: lib/klass_hero_web/components/messaging_components.ex:807
+#: lib/klass_hero_web/components/messaging_components.ex:826
+#: lib/klass_hero_web/components/messaging_components.ex:830
 #, elixir-autogen, elixir-format
 msgid "Photo"
 msgstr ""
@@ -4484,8 +4490,8 @@ msgstr ""
 msgid "Provider not found"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:281
-#: lib/klass_hero_web/components/messaging_components.ex:352
+#: lib/klass_hero_web/components/messaging_components.ex:294
+#: lib/klass_hero_web/components/messaging_components.ex:365
 #, elixir-autogen, elixir-format
 msgid "Remove attachment"
 msgstr ""
@@ -4504,7 +4510,7 @@ msgstr ""
 msgid "Tell parents about your organization and what makes you unique..."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:825
+#: lib/klass_hero_web/components/messaging_components.ex:848
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Too many files (max %{max})"
 msgstr ""
@@ -4514,12 +4520,12 @@ msgstr ""
 msgid "Too many files (max %{max})."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:829
+#: lib/klass_hero_web/components/messaging_components.ex:852
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload error"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:828
+#: lib/klass_hero_web/components/messaging_components.ex:851
 #, elixir-autogen, elixir-format
 msgid "Upload failed"
 msgstr ""
@@ -4540,47 +4546,47 @@ msgstr ""
 msgid "Your profile is already complete."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:90
+#: lib/klass_hero_web/components/messaging_components.ex:96
 #: lib/klass_hero_web/live/messaging_live_helper.ex:397
 #, elixir-autogen, elixir-format, fuzzy
 msgid "for"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1799
+#: lib/klass_hero_web/components/provider_components.ex:1835
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assigned staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1800
+#: lib/klass_hero_web/components/provider_components.ex:1836
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1783
-#: lib/klass_hero_web/components/provider_components.ex:1868
-#: lib/klass_hero_web/components/provider_components.ex:2016
-#: lib/klass_hero_web/components/provider_components.ex:2165
+#: lib/klass_hero_web/components/provider_components.ex:1819
+#: lib/klass_hero_web/components/provider_components.ex:1904
+#: lib/klass_hero_web/components/provider_components.ex:2052
+#: lib/klass_hero_web/components/provider_components.ex:2201
 #: lib/klass_hero_web/live/provider/overview_live.ex:403
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Close"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1798
+#: lib/klass_hero_web/components/provider_components.ex:1834
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1792
+#: lib/klass_hero_web/components/provider_components.ex:1828
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No sessions scheduled yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1781
+#: lib/klass_hero_web/components/provider_components.ex:1817
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sessions — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1486
+#: lib/klass_hero_web/components/provider_components.ex:1522
 #, elixir-autogen, elixir-format
 msgid "View sessions"
 msgstr ""
@@ -4612,17 +4618,17 @@ msgstr ""
 msgid "Failed to update record"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2810
+#: lib/klass_hero_web/components/provider_components.ex:2846
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2483
+#: lib/klass_hero_web/components/provider_components.ex:2519
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invite mode"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2502
+#: lib/klass_hero_web/components/provider_components.ex:2538
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr ""
@@ -4637,12 +4643,12 @@ msgstr ""
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2823
+#: lib/klass_hero_web/components/provider_components.ex:2859
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2829
+#: lib/klass_hero_web/components/provider_components.ex:2865
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr ""
@@ -4653,17 +4659,17 @@ msgstr ""
 msgid "Nothing to update"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2831
+#: lib/klass_hero_web/components/provider_components.ex:2867
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nut allergy"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2835
+#: lib/klass_hero_web/components/provider_components.ex:2871
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2840
+#: lib/klass_hero_web/components/provider_components.ex:2876
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr ""
@@ -4673,7 +4679,7 @@ msgstr ""
 msgid "Present"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2767
+#: lib/klass_hero_web/components/provider_components.ex:2803
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr ""
@@ -4700,22 +4706,22 @@ msgstr ""
 msgid "Save changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2804
+#: lib/klass_hero_web/components/provider_components.ex:2840
 #, elixir-autogen, elixir-format, fuzzy
 msgid "School (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2814
+#: lib/klass_hero_web/components/provider_components.ex:2850
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2788
+#: lib/klass_hero_web/components/provider_components.ex:2824
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2857
+#: lib/klass_hero_web/components/provider_components.ex:2893
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Send invite"
 msgstr ""
@@ -4725,7 +4731,7 @@ msgstr ""
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2520
+#: lib/klass_hero_web/components/provider_components.ex:2556
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload a list"
 msgstr ""
@@ -4760,7 +4766,7 @@ msgstr ""
 msgid "High"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:787
+#: lib/klass_hero_web/components/provider_components.ex:823
 #, elixir-autogen, elixir-format
 msgid "Hourly"
 msgstr ""
@@ -4785,22 +4791,22 @@ msgstr ""
 msgid "Medium"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:777
+#: lib/klass_hero_web/components/provider_components.ex:813
 #, elixir-autogen, elixir-format
 msgid "None"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:766
+#: lib/klass_hero_web/components/provider_components.ex:802
 #, elixir-autogen, elixir-format
 msgid "Pay Rate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:528
+#: lib/klass_hero_web/components/provider_components.ex:564
 #, elixir-autogen, elixir-format
 msgid "Pay rate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:797
+#: lib/klass_hero_web/components/provider_components.ex:833
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Per Session"
 msgstr ""
@@ -4825,7 +4831,7 @@ msgstr ""
 msgid "Property Damage"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1523
+#: lib/klass_hero_web/components/provider_components.ex:1559
 #, elixir-autogen, elixir-format
 msgid "Report Incident"
 msgstr ""
@@ -5000,7 +5006,7 @@ msgstr ""
 msgid "At Klass Hero, trust isn't a feature — it's the foundation of everything we do. We connect families, schools, and organizations with qualified, vetted, and safety-verified educators."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:302
+#: lib/klass_hero_web/components/messaging_components.ex:315
 #, elixir-autogen, elixir-format
 msgid "Attach photo"
 msgstr ""
@@ -5160,7 +5166,7 @@ msgstr ""
 msgid "Coming soon — track your family's weekly attendance."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/messages_live/index.ex:19
+#: lib/klass_hero_web/live/provider/messages_live/index.ex:20
 #, elixir-autogen, elixir-format
 msgid "Comms"
 msgstr ""
@@ -5493,7 +5499,7 @@ msgstr[1] ""
 msgid "In 2025, Shane connected with his friend"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1532
+#: lib/klass_hero_web/components/provider_components.ex:1568
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:43
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:72
 #, elixir-autogen, elixir-format
@@ -5563,7 +5569,7 @@ msgstr ""
 msgid "Last 8 weeks"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1245
+#: lib/klass_hero_web/components/provider_components.ex:1281
 #: lib/klass_hero_web/presenters/hero_cards_presenter.ex:27
 #, elixir-autogen, elixir-format
 msgid "Lead Instructor"
@@ -5905,7 +5911,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:812
 #: lib/klass_hero_web/components/marketing_components.ex:859
-#: lib/klass_hero_web/live/privacy_policy_live.ex:240
+#: lib/klass_hero_web/live/privacy_policy_live.ex:241
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Privacy"
 msgstr ""
@@ -6002,17 +6008,17 @@ msgstr ""
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2896
+#: lib/klass_hero_web/components/provider_components.ex:2932
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Row %{row}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2896
+#: lib/klass_hero_web/components/provider_components.ex:2932
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2597
+#: lib/klass_hero_web/components/provider_components.ex:2633
 #, elixir-autogen, elixir-format
 msgid "Rows with errors"
 msgstr ""
@@ -6742,12 +6748,12 @@ msgstr ""
 msgid "Experience validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3404
+#: lib/klass_hero_web/components/provider_components.ex:3440
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3377
+#: lib/klass_hero_web/components/provider_components.ex:3413
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
@@ -6757,12 +6763,12 @@ msgstr ""
 msgid "Safeguarding certificate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3401
+#: lib/klass_hero_web/components/provider_components.ex:3437
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select Video"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3447
+#: lib/klass_hero_web/components/provider_components.ex:3483
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload Video"
 msgstr ""
@@ -6772,7 +6778,7 @@ msgstr ""
 msgid "Your browser does not support video playback."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3600
+#: lib/klass_hero_web/components/provider_components.ex:3636
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Confirm agreement"
 msgstr ""
@@ -6782,12 +6788,12 @@ msgstr ""
 msgid "Couldn't record your agreement. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3623
+#: lib/klass_hero_web/components/provider_components.ex:3659
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3599
+#: lib/klass_hero_web/components/provider_components.ex:3635
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr ""
@@ -6797,7 +6803,7 @@ msgstr ""
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3502
+#: lib/klass_hero_web/components/provider_components.ex:3538
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr ""
@@ -6807,17 +6813,17 @@ msgstr ""
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3608
+#: lib/klass_hero_web/components/provider_components.ex:3644
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3597
+#: lib/klass_hero_web/components/provider_components.ex:3633
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3598
+#: lib/klass_hero_web/components/provider_components.ex:3634
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
@@ -7086,12 +7092,12 @@ msgstr ""
 msgid "Your insurance is verified."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3546
+#: lib/klass_hero_web/components/provider_components.ex:3582
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3655
+#: lib/klass_hero_web/components/provider_components.ex:3691
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr ""
@@ -7101,7 +7107,7 @@ msgstr ""
 msgid "Couldn't record your declaration. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3661
+#: lib/klass_hero_web/components/provider_components.ex:3697
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr ""
@@ -7111,17 +7117,17 @@ msgstr ""
 msgid "Please confirm the declaration before signing."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3686
+#: lib/klass_hero_web/components/provider_components.ex:3722
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3665
+#: lib/klass_hero_web/components/provider_components.ex:3701
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3653
+#: lib/klass_hero_web/components/provider_components.ex:3689
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr ""
@@ -7131,12 +7137,12 @@ msgstr ""
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3673
+#: lib/klass_hero_web/components/provider_components.ex:3709
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3659
+#: lib/klass_hero_web/components/provider_components.ex:3695
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
@@ -7203,15 +7209,15 @@ msgstr ""
 msgid "Undelivered Events"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2110
-#: lib/klass_hero_web/components/provider_components.ex:2288
+#: lib/klass_hero_web/components/provider_components.ex:2146
+#: lib/klass_hero_web/components/provider_components.ex:2324
 #: lib/klass_hero_web/live/user_live/settings.ex:273
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2038
-#: lib/klass_hero_web/components/provider_components.ex:2219
+#: lib/klass_hero_web/components/provider_components.ex:2074
+#: lib/klass_hero_web/components/provider_components.ex:2255
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Lead"
 msgstr ""
@@ -7221,17 +7227,17 @@ msgstr ""
 msgid "Lead instructor updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2050
+#: lib/klass_hero_web/components/provider_components.ex:2086
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1500
+#: lib/klass_hero_web/components/provider_components.ex:1536
 #, elixir-autogen, elixir-format
 msgid "Manage Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2079
+#: lib/klass_hero_web/components/provider_components.ex:2115
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this program yet."
 msgstr ""
@@ -7242,19 +7248,19 @@ msgstr ""
 msgid "Pick a staff member to add."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2062
-#: lib/klass_hero_web/components/provider_components.ex:2327
+#: lib/klass_hero_web/components/provider_components.ex:2098
+#: lib/klass_hero_web/components/provider_components.ex:2363
 #, elixir-autogen, elixir-format
 msgid "Reassign the lead before removing them"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2063
+#: lib/klass_hero_web/components/provider_components.ex:2099
 #, elixir-autogen, elixir-format
 msgid "Remove from program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2098
-#: lib/klass_hero_web/components/provider_components.ex:2275
+#: lib/klass_hero_web/components/provider_components.ex:2134
+#: lib/klass_hero_web/components/provider_components.ex:2311
 #, elixir-autogen, elixir-format
 msgid "Select a staff member…"
 msgstr ""
@@ -7269,12 +7275,12 @@ msgstr ""
 msgid "Staff member removed from the program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2115
+#: lib/klass_hero_web/components/provider_components.ex:2151
 #, elixir-autogen, elixir-format
 msgid "Staff you add can read and reply to this program's parent conversations."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2014
+#: lib/klass_hero_web/components/provider_components.ex:2050
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Staffing — %{title}"
 msgstr ""
@@ -7294,19 +7300,19 @@ msgstr ""
 msgid "This person is the lead instructor. Make someone else lead before removing them."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1444
+#: lib/klass_hero_web/components/provider_components.ex:1480
 #, elixir-autogen, elixir-format
 msgid "%{count} staff member · no lead"
 msgid_plural "%{count} staff · no lead"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/components/provider_components.ex:563
+#: lib/klass_hero_web/components/provider_components.ex:599
 #, elixir-autogen, elixir-format
 msgid "%{name} will be unassigned from every program and removed from those conversations. Their history is kept and you can add them back later."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:639
+#: lib/klass_hero_web/components/provider_components.ex:675
 #, elixir-autogen, elixir-format
 msgid "Add back to team"
 msgstr ""
@@ -7316,7 +7322,7 @@ msgstr ""
 msgid "Could not bring this team member back. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:601
+#: lib/klass_hero_web/components/provider_components.ex:637
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Delete entry"
 msgstr ""
@@ -7326,7 +7332,7 @@ msgstr ""
 msgid "Former team members"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:575
+#: lib/klass_hero_web/components/provider_components.ex:611
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove from team"
 msgstr ""
@@ -7341,7 +7347,7 @@ msgstr ""
 msgid "Team member removed from the team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:591
+#: lib/klass_hero_web/components/provider_components.ex:627
 #, elixir-autogen, elixir-format
 msgid "This deletes %{name} permanently — there's nothing to undo. Use it only for an entry added by mistake."
 msgstr ""
@@ -7366,24 +7372,24 @@ msgstr ""
 msgid "Program updated, but the enrollment capacity was rejected. The previous limits still apply."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:876
+#: lib/klass_hero_web/components/provider_components.ex:912
 #, elixir-autogen, elixir-format
 msgid "%{count} child is already enrolled. Confirm you want this program to have no capacity limit."
 msgid_plural "%{count} children are already enrolled. Confirm you want this program to have no capacity limit."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1087
+#: lib/klass_hero_web/components/provider_components.ex:1123
 #, elixir-autogen, elixir-format
 msgid "Anyone will be able to book a place until you set a new maximum."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1092
+#: lib/klass_hero_web/components/provider_components.ex:1128
 #, elixir-autogen, elixir-format
 msgid "I understand this program will have no capacity limit."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2315
+#: lib/klass_hero_web/components/provider_components.ex:2351
 #, elixir-autogen, elixir-format
 msgid "Go back to the program's usual team"
 msgstr ""
@@ -7393,17 +7399,17 @@ msgstr ""
 msgid "Lead instructor for this session updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2234
+#: lib/klass_hero_web/components/provider_components.ex:2270
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Make lead instructor for this session"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2256
+#: lib/klass_hero_web/components/provider_components.ex:2292
 #, elixir-autogen, elixir-format
 msgid "Nobody is working this session yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2332
+#: lib/klass_hero_web/components/provider_components.ex:2368
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove from this session"
 msgstr ""
@@ -7423,7 +7429,7 @@ msgstr ""
 msgid "Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2158
+#: lib/klass_hero_web/components/provider_components.ex:2194
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Staffing — %{date}"
 msgstr ""
@@ -7453,22 +7459,22 @@ msgstr ""
 msgid "A session needs at least one person. Use “Go back to the program's usual team” to drop this session's own roster."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2330
+#: lib/klass_hero_web/components/provider_components.ex:2366
 #, elixir-autogen, elixir-format
 msgid "A session needs someone — use “Go back to the program's usual team” instead"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2297
+#: lib/klass_hero_web/components/provider_components.ex:2333
 #, elixir-autogen, elixir-format
 msgid "Everyone on your team is already working this session."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2190
+#: lib/klass_hero_web/components/provider_components.ex:2226
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Staffed just for this session. Changes here do not touch the program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2192
+#: lib/klass_hero_web/components/provider_components.ex:2228
 #, elixir-autogen, elixir-format
 msgid "Using the program's usual team. The first change here copies them onto this session, so later program changes stop reaching it."
 msgstr ""
@@ -7478,12 +7484,12 @@ msgstr ""
 msgid "(optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1933
+#: lib/klass_hero_web/components/provider_components.ex:1969
 #, elixir-autogen, elixir-format
 msgid "Add a waiver"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1965
+#: lib/klass_hero_web/components/provider_components.ex:2001
 #, elixir-autogen, elixir-format
 msgid "Add waiver"
 msgstr ""
@@ -7505,22 +7511,22 @@ msgstr ""
 msgid "I have read and agree to %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1947
+#: lib/klass_hero_web/components/provider_components.ex:1983
 #, elixir-autogen, elixir-format
 msgid "Legal text"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1507
+#: lib/klass_hero_web/components/provider_components.ex:1543
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Manage Waivers"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1875
+#: lib/klass_hero_web/components/provider_components.ex:1911
 #, elixir-autogen, elixir-format
 msgid "No waivers yet. Parents enrol without signing anything."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1954
+#: lib/klass_hero_web/components/provider_components.ex:1990
 #, elixir-autogen, elixir-format
 msgid "Parents must sign this before enrolling"
 msgstr ""
@@ -7540,17 +7546,17 @@ msgstr ""
 msgid "Please tick a waiver to sign it."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1932
+#: lib/klass_hero_web/components/provider_components.ex:1968
 #, elixir-autogen, elixir-format
 msgid "Publish a new version"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1965
+#: lib/klass_hero_web/components/provider_components.ex:2001
 #, elixir-autogen, elixir-format
 msgid "Publish version"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1958
+#: lib/klass_hero_web/components/provider_components.ex:1994
 #, elixir-autogen, elixir-format
 msgid "Publishing keeps every earlier version on record; signatures already given stay bound to the wording they were shown."
 msgstr ""
@@ -7560,12 +7566,12 @@ msgstr ""
 msgid "Required"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1909
+#: lib/klass_hero_web/components/provider_components.ex:1945
 #, elixir-autogen, elixir-format
 msgid "Retire this waiver"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1900
+#: lib/klass_hero_web/components/provider_components.ex:1936
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Revise text"
 msgstr ""
@@ -7580,7 +7586,7 @@ msgstr ""
 msgid "Sign waivers"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2410
+#: lib/klass_hero_web/components/provider_components.ex:2446
 #: lib/klass_hero_web/live/enrollment_waivers_live.ex:149
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Signed"
@@ -7596,12 +7602,12 @@ msgstr ""
 msgid "There is nothing to sign for this enrollment."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2410
+#: lib/klass_hero_web/components/provider_components.ex:2446
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Unsigned"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1892
+#: lib/klass_hero_web/components/provider_components.ex:1928
 #, elixir-autogen, elixir-format
 msgid "Version %{number}"
 msgstr ""
@@ -7611,7 +7617,7 @@ msgstr ""
 msgid "Waiver not found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2378
+#: lib/klass_hero_web/components/provider_components.ex:2414
 #: lib/klass_hero_web/live/booking_live.ex:447
 #: lib/klass_hero_web/live/enrollment_waivers_live.ex:33
 #: lib/klass_hero_web/live/enrollment_waivers_live.ex:105
@@ -7624,7 +7630,7 @@ msgstr ""
 msgid "Waivers waiting for your signature"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1866
+#: lib/klass_hero_web/components/provider_components.ex:1902
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Waivers — %{title}"
 msgstr ""
@@ -7639,7 +7645,7 @@ msgstr ""
 msgid "New version published. It applies to future enrolments."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1913
+#: lib/klass_hero_web/components/provider_components.ex:1949
 #, elixir-autogen, elixir-format
 msgid "Retire \"%{title}\"? Parents will no longer be asked to sign it. Signatures already collected are kept."
 msgstr ""
@@ -7659,7 +7665,7 @@ msgstr ""
 msgid "You are not assigned to this session"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:430
+#: lib/klass_hero_web/components/provider_components.ex:466
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Complete verification to create programs."
 msgstr ""
@@ -7690,7 +7696,7 @@ msgstr ""
 msgid "Provider Name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:208
+#: lib/klass_hero_web/components/provider_components.ex:244
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Provider Profile"
 msgstr ""
@@ -7710,17 +7716,17 @@ msgstr ""
 msgid "This invitation has expired. Please ask your provider to resend it."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:211
+#: lib/klass_hero_web/components/provider_components.ex:247
 #, elixir-autogen, elixir-format, fuzzy
 msgid "This is your main provider identity. Verification is required to list programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3243
+#: lib/klass_hero_web/components/provider_components.ex:3279
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload documents to be verified. Documents are reviewed by our team."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:403
+#: lib/klass_hero_web/components/provider_components.ex:439
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Verified Provider"
 msgstr ""
@@ -7859,8 +7865,8 @@ msgstr ""
 msgid "Review invitations"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2673
-#: lib/klass_hero_web/components/provider_components.ex:2680
+#: lib/klass_hero_web/components/provider_components.ex:2709
+#: lib/klass_hero_web/components/provider_components.ex:2716
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Unknown program"
 msgstr ""
@@ -7885,12 +7891,12 @@ msgstr ""
 msgid "This program has closed. Its sessions are no longer available."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:384
+#: lib/klass_hero_web/components/messaging_components.ex:397
 #, elixir-autogen, elixir-format
 msgid "Attach files"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:408
+#: lib/klass_hero_web/components/messaging_components.ex:421
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Send message"
 msgstr ""
@@ -7905,12 +7911,12 @@ msgstr ""
 msgid "You can't start a conversation with this person"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:952
+#: lib/klass_hero_web/components/provider_components.ex:988
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Subtitle"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:953
+#: lib/klass_hero_web/components/provider_components.ex:989
 #, elixir-autogen, elixir-format
 msgid "e.g., For beginners, no experience needed"
 msgstr ""
@@ -7925,17 +7931,17 @@ msgstr ""
 msgid "N/A"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3151
+#: lib/klass_hero_web/components/provider_components.ex:3187
 #, elixir-autogen, elixir-format
 msgid "A short line that sums you up"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3140
+#: lib/klass_hero_web/components/provider_components.ex:3176
 #, elixir-autogen, elixir-format
 msgid "Branding & Presence"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3164
+#: lib/klass_hero_web/components/provider_components.ex:3200
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Choose Cover Image"
 msgstr ""
@@ -7945,17 +7951,17 @@ msgstr ""
 msgid "Cover image upload failed. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3165
+#: lib/klass_hero_web/components/provider_components.ex:3201
 #, elixir-autogen, elixir-format, fuzzy
 msgid "JPG, PNG or WebP. Max 5MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3143
+#: lib/klass_hero_web/components/provider_components.ex:3179
 #, elixir-autogen, elixir-format
 msgid "Shown on your public profile page."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3150
+#: lib/klass_hero_web/components/provider_components.ex:3186
 #, elixir-autogen, elixir-format
 msgid "Tagline"
 msgstr ""
@@ -8001,7 +8007,7 @@ msgstr ""
 msgid "Klass Hero on %{network}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3222
+#: lib/klass_hero_web/components/provider_components.ex:3258
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr ""
@@ -8041,7 +8047,7 @@ msgstr ""
 msgid "A newly chosen cover or logo appears here after you save."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3195
+#: lib/klass_hero_web/components/provider_components.ex:3231
 #, elixir-autogen, elixir-format
 msgid "Add %{network}"
 msgstr ""
@@ -8061,7 +8067,7 @@ msgstr ""
 msgid "Show preview"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3182
+#: lib/klass_hero_web/components/provider_components.ex:3218
 #, elixir-autogen, elixir-format
 msgid "e.g. %{example}"
 msgstr ""
@@ -8074,6 +8080,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/klass_hero_web/live/admin/messages_live.ex:75
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:77
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Conversation not found."
 msgstr ""
@@ -8084,6 +8091,7 @@ msgid "Direct"
 msgstr ""
 
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:70
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:46
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Load more"
 msgstr ""
@@ -8094,6 +8102,7 @@ msgid "No conversations found."
 msgstr ""
 
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:102
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:74
 #, elixir-autogen, elixir-format
 msgid "No messages in this conversation."
 msgstr ""
@@ -8123,7 +8132,44 @@ msgstr ""
 msgid "← Back to messages"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:711
+#: lib/klass_hero_web/components/messaging_components.ex:733
 #, elixir-autogen, elixir-format
 msgid "Messages here may be reviewed by the activity provider and by Klass Hero staff, to keep children safe."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:56
+#, elixir-autogen, elixir-format
+msgid "Back to staff conversations"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:15
+#, elixir-autogen, elixir-format
+msgid "Conversations your staff have with parents. Read-only — opening a thread here does not mark anything as read."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:178
+#, elixir-autogen, elixir-format, fuzzy
+msgid "My conversations"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:34
+#, elixir-autogen, elixir-format
+msgid "No staff conversations yet. Threads your team starts will appear here."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:65
+#, elixir-autogen, elixir-format
+msgid "Read-only. You are viewing this as the business owner, not as a participant — nothing is marked as read."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:185
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:45
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:62
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Staff conversations"
+msgstr ""
+
+#: lib/klass_hero_web/components/messaging_components.ex:103
+#, elixir-autogen, elixir-format
+msgid "via"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -1486,11 +1486,11 @@ msgstr ""
 msgid "Unassigned"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:794
+#: lib/klass_hero_web/components/messaging_components.ex:832
 #: lib/klass_hero_web/components/provider_components.ex:52
 #: lib/klass_hero_web/components/provider_components.ex:1589
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:110
-#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:82
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:79
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:455
 #: lib/klass_hero_web/presenters/provider_presenter.ex:172
 #, elixir-autogen, elixir-format
@@ -1507,7 +1507,7 @@ msgstr ""
 msgid "%{age} years old"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:815
+#: lib/klass_hero_web/components/messaging_components.ex:853
 #, elixir-autogen, elixir-format
 msgid "%{n}m ago"
 msgstr ""
@@ -1601,7 +1601,7 @@ msgstr ""
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:80
 #: lib/klass_hero_web/live/dashboard_live.ex:175
 #: lib/klass_hero_web/live/messaging_live_helper.ex:413
-#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:72
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:73
 #: lib/klass_hero_web/live/provider/staff_conversations_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "Conversation"
@@ -1709,14 +1709,14 @@ msgstr ""
 
 #: lib/klass_hero_web/components/layouts/admin.html.heex:90
 #: lib/klass_hero_web/components/layouts/app.html.heex:214
-#: lib/klass_hero_web/components/messaging_components.ex:527
-#: lib/klass_hero_web/components/messaging_components.ex:550
+#: lib/klass_hero_web/components/messaging_components.ex:565
+#: lib/klass_hero_web/components/messaging_components.ex:588
 #: lib/klass_hero_web/live/admin/messages_live.ex:37
 #: lib/klass_hero_web/live/admin/messages_live.ex:56
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:5
 #: lib/klass_hero_web/live/messages_live/index.ex:19
 #: lib/klass_hero_web/live/messaging_live_helper.ex:365
-#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:6
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:5
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Messages"
 msgstr ""
@@ -1733,7 +1733,7 @@ msgid "No conversations yet"
 msgstr ""
 
 #: lib/klass_hero_web/components/messaging_components.ex:458
-#: lib/klass_hero_web/components/messaging_components.ex:837
+#: lib/klass_hero_web/components/messaging_components.ex:875
 #, elixir-autogen, elixir-format
 msgid "No messages yet"
 msgstr ""
@@ -1765,7 +1765,7 @@ msgstr ""
 msgid "Note resubmitted for review"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:814
+#: lib/klass_hero_web/components/messaging_components.ex:852
 #, elixir-autogen, elixir-format
 msgid "Now"
 msgstr ""
@@ -1805,7 +1805,7 @@ msgstr ""
 msgid "Please set up your parent profile to manage children."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:787
+#: lib/klass_hero_web/components/messaging_components.ex:825
 #: lib/klass_hero_web/live/messaging_live_helper.ex:409
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program Broadcast"
@@ -2104,7 +2104,7 @@ msgstr ""
 msgid "Confirmed"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:889
+#: lib/klass_hero_web/components/messaging_components.ex:927
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Contact Provider"
 msgstr ""
@@ -3752,7 +3752,7 @@ msgstr ""
 msgid "Back to emails"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:754
+#: lib/klass_hero_web/components/messaging_components.ex:792
 #, elixir-autogen, elixir-format
 msgid "Broadcast messages are one-way"
 msgstr ""
@@ -4158,7 +4158,7 @@ msgstr ""
 msgid "Reply"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:765
+#: lib/klass_hero_web/components/messaging_components.ex:803
 #, elixir-autogen, elixir-format
 msgid "Reply privately"
 msgstr ""
@@ -4439,7 +4439,7 @@ msgstr ""
 msgid "Failed to upload files. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:841
+#: lib/klass_hero_web/components/messaging_components.ex:879
 #, elixir-autogen, elixir-format, fuzzy
 msgid "File is too large (max %{mb} MB)"
 msgstr ""
@@ -4449,7 +4449,7 @@ msgstr ""
 msgid "File is too large (max %{mb} MB)."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:844
+#: lib/klass_hero_web/components/messaging_components.ex:882
 #, elixir-autogen, elixir-format, fuzzy
 msgid "File type not accepted (images only)"
 msgstr ""
@@ -4469,8 +4469,8 @@ msgstr ""
 msgid "Only images are accepted (JPG, PNG, GIF, WebP)."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:826
-#: lib/klass_hero_web/components/messaging_components.ex:830
+#: lib/klass_hero_web/components/messaging_components.ex:864
+#: lib/klass_hero_web/components/messaging_components.ex:868
 #, elixir-autogen, elixir-format
 msgid "Photo"
 msgstr ""
@@ -4510,7 +4510,7 @@ msgstr ""
 msgid "Tell parents about your organization and what makes you unique..."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:848
+#: lib/klass_hero_web/components/messaging_components.ex:886
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Too many files (max %{max})"
 msgstr ""
@@ -4520,12 +4520,12 @@ msgstr ""
 msgid "Too many files (max %{max})."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:852
+#: lib/klass_hero_web/components/messaging_components.ex:890
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload error"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:851
+#: lib/klass_hero_web/components/messaging_components.ex:889
 #, elixir-autogen, elixir-format
 msgid "Upload failed"
 msgstr ""
@@ -8080,7 +8080,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/klass_hero_web/live/admin/messages_live.ex:75
-#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:77
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:78
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Conversation not found."
 msgstr ""
@@ -8091,7 +8091,7 @@ msgid "Direct"
 msgstr ""
 
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:70
-#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:46
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:41
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Load more"
 msgstr ""
@@ -8102,7 +8102,7 @@ msgid "No conversations found."
 msgstr ""
 
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:102
-#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:74
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:71
 #, elixir-autogen, elixir-format
 msgid "No messages in this conversation."
 msgstr ""
@@ -8132,17 +8132,17 @@ msgstr ""
 msgid "← Back to messages"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:733
+#: lib/klass_hero_web/components/messaging_components.ex:771
 #, elixir-autogen, elixir-format
 msgid "Messages here may be reviewed by the activity provider and by Klass Hero staff, to keep children safe."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:56
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "Back to staff conversations"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:15
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:14
 #, elixir-autogen, elixir-format
 msgid "Conversations your staff have with parents. Read-only — opening a thread here does not mark anything as read."
 msgstr ""
@@ -8152,19 +8152,19 @@ msgstr ""
 msgid "My conversations"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:34
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:29
 #, elixir-autogen, elixir-format
 msgid "No staff conversations yet. Threads your team starts will appear here."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:65
+#: lib/klass_hero_web/live/provider/staff_conversations_live.html.heex:62
 #, elixir-autogen, elixir-format
 msgid "Read-only. You are viewing this as the business owner, not as a participant — nothing is marked as read."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:185
-#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:45
-#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:62
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:47
+#: lib/klass_hero_web/live/provider/staff_conversations_live.ex:63
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Staff conversations"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/en/LC_MESSAGES/enrollment.po
@@ -11,95 +11,95 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:2990
-#: lib/klass_hero_web/components/provider_components.ex:3007
+#: lib/klass_hero_web/components/provider_components.ex:3026
+#: lib/klass_hero_web/components/provider_components.ex:3043
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2991
-#: lib/klass_hero_web/components/provider_components.ex:3008
+#: lib/klass_hero_web/components/provider_components.ex:3027
+#: lib/klass_hero_web/components/provider_components.ex:3044
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2992
-#: lib/klass_hero_web/components/provider_components.ex:3009
+#: lib/klass_hero_web/components/provider_components.ex:3028
+#: lib/klass_hero_web/components/provider_components.ex:3045
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3003
+#: lib/klass_hero_web/components/provider_components.ex:3039
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2993
+#: lib/klass_hero_web/components/provider_components.ex:3029
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2994
+#: lib/klass_hero_web/components/provider_components.ex:3030
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2995
+#: lib/klass_hero_web/components/provider_components.ex:3031
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3002
+#: lib/klass_hero_web/components/provider_components.ex:3038
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3004
+#: lib/klass_hero_web/components/provider_components.ex:3040
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2996
+#: lib/klass_hero_web/components/provider_components.ex:3032
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2998
+#: lib/klass_hero_web/components/provider_components.ex:3034
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3000
+#: lib/klass_hero_web/components/provider_components.ex:3036
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2930
+#: lib/klass_hero_web/components/provider_components.ex:2966
 #, elixir-autogen, elixir-format
 msgid "Date of birth \"%{value}\" is not a valid date. Please correct it and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2924
+#: lib/klass_hero_web/components/provider_components.ex:2960
 #, elixir-autogen, elixir-format
 msgid "Invite link could not be generated (no token). Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2938
+#: lib/klass_hero_web/components/provider_components.ex:2974
 #, elixir-autogen, elixir-format
 msgid "The invitation email could not be delivered. Please check the address and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2927
+#: lib/klass_hero_web/components/provider_components.ex:2963
 #, elixir-autogen, elixir-format
 msgid "The program is full, so this child could not be enrolled."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2941
+#: lib/klass_hero_web/components/provider_components.ex:2977
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed and no retries remain. Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2950
+#: lib/klass_hero_web/components/provider_components.ex:2986
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed. Please resend."
 msgstr ""

--- a/priv/gettext/enrollment.pot
+++ b/priv/gettext/enrollment.pot
@@ -11,95 +11,95 @@
 msgid ""
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2990
-#: lib/klass_hero_web/components/provider_components.ex:3007
+#: lib/klass_hero_web/components/provider_components.ex:3026
+#: lib/klass_hero_web/components/provider_components.ex:3043
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2991
-#: lib/klass_hero_web/components/provider_components.ex:3008
+#: lib/klass_hero_web/components/provider_components.ex:3027
+#: lib/klass_hero_web/components/provider_components.ex:3044
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2992
-#: lib/klass_hero_web/components/provider_components.ex:3009
+#: lib/klass_hero_web/components/provider_components.ex:3028
+#: lib/klass_hero_web/components/provider_components.ex:3045
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3003
+#: lib/klass_hero_web/components/provider_components.ex:3039
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2993
+#: lib/klass_hero_web/components/provider_components.ex:3029
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2994
+#: lib/klass_hero_web/components/provider_components.ex:3030
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2995
+#: lib/klass_hero_web/components/provider_components.ex:3031
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3002
+#: lib/klass_hero_web/components/provider_components.ex:3038
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3004
+#: lib/klass_hero_web/components/provider_components.ex:3040
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2996
+#: lib/klass_hero_web/components/provider_components.ex:3032
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2998
+#: lib/klass_hero_web/components/provider_components.ex:3034
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3000
+#: lib/klass_hero_web/components/provider_components.ex:3036
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2930
+#: lib/klass_hero_web/components/provider_components.ex:2966
 #, elixir-autogen, elixir-format
 msgid "Date of birth \"%{value}\" is not a valid date. Please correct it and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2924
+#: lib/klass_hero_web/components/provider_components.ex:2960
 #, elixir-autogen, elixir-format
 msgid "Invite link could not be generated (no token). Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2938
+#: lib/klass_hero_web/components/provider_components.ex:2974
 #, elixir-autogen, elixir-format
 msgid "The invitation email could not be delivered. Please check the address and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2927
+#: lib/klass_hero_web/components/provider_components.ex:2963
 #, elixir-autogen, elixir-format
 msgid "The program is full, so this child could not be enrolled."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2941
+#: lib/klass_hero_web/components/provider_components.ex:2977
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed and no retries remain. Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2950
+#: lib/klass_hero_web/components/provider_components.ex:2986
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed. Please resend."
 msgstr ""

--- a/test/flows/provider_staff_conversations_test.exs
+++ b/test/flows/provider_staff_conversations_test.exs
@@ -1,0 +1,202 @@
+defmodule KlassHeroWeb.Flows.ProviderStaffConversationsTest do
+  @moduledoc """
+  Flow tests for a provider owner reading the threads their staff conduct (#746).
+
+  The load-bearing assertions here are the negative ones, for the same reason they
+  are on the admin monitoring surface. "Read-only" is not a property of the context
+  alone — it is a property of what the page renders. If a future change reuses
+  `conversation_show/1` or the `MessagingLiveHelper, :show` macro here, the composer
+  comes back with it, and `refute_has("#message-input")` is what notices.
+
+  The other assertion worth its keep is that a *staff* member cannot reach this
+  surface. Oversight is the owner's, not the team's; the whole point is that one
+  staffer must not read another's private threads with a parent.
+  """
+
+  use KlassHeroWeb.FlowCase, async: false
+
+  alias KlassHero.Accounts.Scope
+  alias KlassHero.Messaging
+
+  setup do
+    owner_user = user_fixture(%{intended_roles: [:provider]})
+
+    provider =
+      insert(:provider_profile_schema, identity_id: owner_user.id, business_name: "Bouldering Bees")
+
+    staff_user = user_fixture(%{name: "Sam Staff", intended_roles: [:staff]})
+    insert(:staff_member_schema, provider_id: provider.id, user_id: staff_user.id)
+
+    parent_user = user_fixture(%{name: "Pat Parent", intended_roles: [:parent]})
+    insert(:parent_profile_schema, identity_id: parent_user.id)
+
+    staff_scope = staff_user |> Scope.for_user() |> Scope.resolve_roles()
+
+    # Created by the staff member, exactly as the app would: the owner is seated
+    # nowhere, which is the whole gap #746 closes.
+    conversation =
+      with_real_outbox(fn ->
+        {:ok, conversation, _message} =
+          Messaging.start_conversation_with_message(
+            staff_scope,
+            provider.id,
+            parent_user.id,
+            "Pickup will be five minutes late today"
+          )
+
+        conversation
+      end)
+
+    refute Messaging.participant?(conversation.id, owner_user.id)
+
+    %{
+      owner_user: owner_user,
+      staff_user: staff_user,
+      parent_user: parent_user,
+      provider: provider,
+      conversation: conversation
+    }
+  end
+
+  describe "access" do
+    test "a staff member cannot reach the staff-conversations index", %{staff_user: staff_user} do
+      build_conn()
+      |> log_in_user(staff_user)
+      |> visit(~p"/provider/messages/staff")
+      |> refute_has("#staff-conversations")
+    end
+
+    test "a parent cannot reach a thread through this surface", %{
+      parent_user: parent_user,
+      conversation: conversation
+    } do
+      build_conn()
+      |> log_in_user(parent_user)
+      |> visit(~p"/provider/messages/staff/#{conversation.id}")
+      |> refute_has("[data-role=read-only-note]")
+    end
+
+    test "another provider's owner is bounced off a thread that is not theirs", %{
+      conversation: conversation
+    } do
+      stranger = user_fixture(%{intended_roles: [:provider]})
+      insert(:provider_profile_schema, identity_id: stranger.id, business_name: "Rival Rock")
+
+      build_conn()
+      |> log_in_user(stranger)
+      |> visit(~p"/provider/messages/staff/#{conversation.id}")
+      |> assert_path(~p"/provider/messages/staff")
+    end
+  end
+
+  describe "the index" do
+    test "lists the thread the staff member started, with their name attached", %{
+      owner_user: owner_user
+    } do
+      build_conn()
+      |> log_in_user(owner_user)
+      |> visit(~p"/provider/messages/staff")
+      |> assert_has("[data-role=conversation-card]")
+      |> assert_has("[data-role=staff-attribution]", text: "Sam Staff")
+      |> assert_has("[data-role=conversation-card]", text: "Pat Parent")
+    end
+
+    # A *different* parent on purpose. `find_direct_conversation/2` keys on provider +
+    # parent only, so reusing the setup's parent would hand the owner back the staff's
+    # existing thread rather than opening one of their own — see the follow-up issue
+    # filed alongside #746.
+    test "the owner's own threads stay on their own tab", %{
+      owner_user: owner_user,
+      provider: provider
+    } do
+      other_parent = user_fixture(%{name: "Robin Other", intended_roles: [:parent]})
+      insert(:parent_profile_schema, identity_id: other_parent.id)
+
+      owner_scope = owner_user |> Scope.for_user() |> Scope.resolve_roles()
+
+      mine =
+        with_real_outbox(fn ->
+          {:ok, conversation, _} =
+            Messaging.start_conversation_with_message(
+              owner_scope,
+              provider.id,
+              other_parent.id,
+              "Following up myself"
+            )
+
+          conversation
+        end)
+
+      assert Messaging.participant?(mine.id, owner_user.id)
+
+      build_conn()
+      |> log_in_user(owner_user)
+      |> visit(~p"/provider/messages/staff")
+      |> refute_has("#staff-conversations-#{mine.id}")
+      |> assert_has("[data-role=conversation-card]")
+    end
+
+    test "both tabs are reachable from the inbox", %{owner_user: owner_user} do
+      build_conn()
+      |> log_in_user(owner_user)
+      |> visit(~p"/provider/messages")
+      |> assert_has("[data-role=provider-message-tabs]")
+      |> click_link("Staff conversations")
+      |> assert_path(~p"/provider/messages/staff")
+    end
+  end
+
+  describe "the thread" do
+    test "renders the messages the owner was never party to", %{
+      owner_user: owner_user,
+      conversation: conversation
+    } do
+      build_conn()
+      |> log_in_user(owner_user)
+      |> visit(~p"/provider/messages/staff/#{conversation.id}")
+      |> assert_has("#conversation-thread")
+      |> assert_has("[data-role=message]", text: "Pickup will be five minutes late today")
+      |> assert_has("[data-role=read-only-note]")
+    end
+
+    test "offers no way to write into it", %{owner_user: owner_user, conversation: conversation} do
+      build_conn()
+      |> log_in_user(owner_user)
+      |> visit(~p"/provider/messages/staff/#{conversation.id}")
+      |> refute_has("#message-input")
+      |> refute_has("[data-role=send-message-btn]")
+      |> refute_has("textarea")
+    end
+
+    test "seats nobody and moves no read receipt", %{
+      owner_user: owner_user,
+      conversation: conversation
+    } do
+      before = Messaging.get_conversation_by_id(conversation.id, preload: [:participants])
+
+      build_conn()
+      |> log_in_user(owner_user)
+      |> visit(~p"/provider/messages/staff/#{conversation.id}")
+      |> assert_has("#conversation-thread")
+
+      refute Messaging.participant?(conversation.id, owner_user.id)
+
+      assert {:ok, %{participants: participants_before}} = before
+
+      assert {:ok, %{participants: participants_after}} =
+               Messaging.get_conversation_by_id(conversation.id, preload: [:participants])
+
+      assert Enum.map(participants_before, & &1.last_read_at) ==
+               Enum.map(participants_after, & &1.last_read_at)
+
+      assert length(participants_after) == length(participants_before)
+    end
+
+    test "a malformed id lands back on the index", %{owner_user: owner_user} do
+      build_conn()
+      |> log_in_user(owner_user)
+      |> visit(~p"/provider/messages/staff/not-a-uuid")
+      |> assert_path(~p"/provider/messages/staff")
+    end
+  end
+end

--- a/test/klass_hero/messaging/authorization_test.exs
+++ b/test/klass_hero/messaging/authorization_test.exs
@@ -3,7 +3,9 @@ defmodule KlassHero.Messaging.AuthorizationTest do
 
   import KlassHero.AccountsFixtures
 
+  alias KlassHero.Accounts.Scope
   alias KlassHero.Messaging.Authorization
+  alias KlassHero.ProviderFixtures
 
   describe "authorize_admin/1" do
     test "authorizes a platform admin" do
@@ -12,6 +14,32 @@ defmodule KlassHero.Messaging.AuthorizationTest do
 
     test "refuses a non-admin scope" do
       assert {:error, :unauthorized} = Authorization.authorize_admin(user_scope_fixture())
+    end
+  end
+
+  describe "authorize_provider_owner/1" do
+    test "authorizes an owner and hands back the provider it resolved" do
+      provider = ProviderFixtures.provider_profile_fixture()
+      scope = %Scope{user: user_fixture(), provider: provider}
+
+      assert {:ok, provider_id} = Authorization.authorize_provider_owner(scope)
+      assert provider_id == provider.id
+    end
+
+    # The gate that separates this from `resolve_acting_provider/2`, which accepts a
+    # staff scope on purpose. Accepting one here would let a staff member read their
+    # coworkers' private threads with parents.
+    test "refuses a staff scope of the very provider it works for" do
+      provider = ProviderFixtures.provider_profile_fixture()
+      user = user_fixture(intended_roles: [:staff])
+      staff = ProviderFixtures.staff_member_fixture(provider_id: provider.id, user_id: user.id)
+
+      assert {:error, :unauthorized} =
+               Authorization.authorize_provider_owner(%Scope{user: user, staff_member: staff})
+    end
+
+    test "refuses a scope carrying neither profile" do
+      assert {:error, :unauthorized} = Authorization.authorize_provider_owner(user_scope_fixture())
     end
   end
 end

--- a/test/klass_hero/messaging/get_staff_conversation_test.exs
+++ b/test/klass_hero/messaging/get_staff_conversation_test.exs
@@ -47,9 +47,12 @@ defmodule KlassHero.Messaging.GetStaffConversationTest do
     conversation
   end
 
+  setup do
+    business()
+  end
+
   describe "execute/3 authorization" do
-    test "refuses a staff scope of the very provider that owns the thread" do
-      ctx = business()
+    test "refuses a staff scope of the very provider that owns the thread", ctx do
       conversation = staff_thread(ctx)
 
       assert {:error, :unauthorized} =
@@ -59,8 +62,7 @@ defmodule KlassHero.Messaging.GetStaffConversationTest do
                )
     end
 
-    test "refuses a scope with no provider profile" do
-      ctx = business()
+    test "refuses a scope with no provider profile", ctx do
       conversation = staff_thread(ctx)
 
       assert {:error, :unauthorized} =
@@ -73,8 +75,7 @@ defmodule KlassHero.Messaging.GetStaffConversationTest do
     # Owner authorization proves the scope owns *a* provider, never that it owns *this*
     # conversation — unlike `is_admin`, which grants blanket visibility. Both answers
     # must be identical, or a UUID becomes an oracle for another business's threads.
-    test "a different provider's owner cannot tell a real thread from a missing one" do
-      ctx = business()
+    test "a different provider's owner cannot tell a real thread from a missing one", ctx do
       conversation = staff_thread(ctx)
 
       stranger = business()
@@ -87,8 +88,7 @@ defmodule KlassHero.Messaging.GetStaffConversationTest do
   end
 
   describe "execute/3 reading" do
-    test "returns the thread with its messages and sender names" do
-      ctx = business()
+    test "returns the thread with its messages and sender names", ctx do
       conversation = staff_thread(ctx)
 
       assert {:ok, result} = GetStaffConversation.execute(ctx.scope, conversation.id)
@@ -101,8 +101,7 @@ defmodule KlassHero.Messaging.GetStaffConversationTest do
   end
 
   describe "execute/3 is strictly read-only" do
-    test "seats no participant for the owner" do
-      ctx = business()
+    test "seats no participant for the owner", ctx do
       conversation = staff_thread(ctx)
 
       assert {:ok, _} = GetStaffConversation.execute(ctx.scope, conversation.id)
@@ -115,13 +114,28 @@ defmodule KlassHero.Messaging.GetStaffConversationTest do
              ) == 2
     end
 
-    test "moves nobody's read receipt" do
-      ctx = business()
+    test "moves nobody's read receipt", ctx do
       conversation = staff_thread(ctx)
+
+      # Stamped first, on purpose. Left at their initial `nil` the assertion would
+      # still catch a mark-as-read — a DateTime is not nil — but nothing else: code
+      # that *cleared* an existing receipt would compare `[nil, nil] == [nil, nil]`
+      # and pass. A non-nil value pins the state in both directions.
+      read_at = ~U[2026-01-01 09:00:00Z]
+
+      {1, _} =
+        Repo.update_all(
+          from(p in Participant,
+            where: p.conversation_id == ^conversation.id and p.user_id == ^ctx.parent.id
+          ),
+          set: [last_read_at: read_at]
+        )
 
       before =
         Repo.all(from(p in Participant, where: p.conversation_id == ^conversation.id))
         |> Enum.map(& &1.last_read_at)
+
+      assert read_at in before
 
       assert {:ok, _} = GetStaffConversation.execute(ctx.scope, conversation.id)
 
@@ -137,8 +151,7 @@ defmodule KlassHero.Messaging.GetStaffConversationTest do
   # admin branch". Read-only here is structural: there is no owner clause in
   # SendMessage to bypass, and this test is what keeps it that way.
   describe "the write path gained no owner branch" do
-    test "an owner who is not a participant still cannot send a message" do
-      ctx = business()
+    test "an owner who is not a participant still cannot send a message", ctx do
       conversation = staff_thread(ctx)
 
       assert {:error, :not_participant} =

--- a/test/klass_hero/messaging/get_staff_conversation_test.exs
+++ b/test/klass_hero/messaging/get_staff_conversation_test.exs
@@ -1,0 +1,148 @@
+defmodule KlassHero.Messaging.GetStaffConversationTest do
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+
+  alias KlassHero.Accounts.Scope
+  alias KlassHero.AccountsFixtures
+  alias KlassHero.Messaging
+  alias KlassHero.Messaging.GetStaffConversation
+  alias KlassHero.Messaging.Participant
+  alias KlassHero.ProviderFixtures
+
+  defp business do
+    owner = AccountsFixtures.user_fixture(name: "Olive Owner", intended_roles: [:provider])
+    provider = ProviderFixtures.provider_profile_fixture(identity_id: owner.id)
+
+    staff_user = AccountsFixtures.user_fixture(name: "Sam Staff", intended_roles: [:staff])
+
+    staff =
+      ProviderFixtures.staff_member_fixture(provider_id: provider.id, user_id: staff_user.id)
+
+    parent = AccountsFixtures.user_fixture(name: "Pat Parent")
+
+    %{
+      owner: owner,
+      provider: provider,
+      staff: staff,
+      staff_user: staff_user,
+      parent: parent,
+      scope: %Scope{user: owner, provider: provider}
+    }
+  end
+
+  defp staff_thread(ctx) do
+    conversation = insert(:conversation_schema, provider_id: ctx.provider.id)
+
+    insert(:participant_schema, conversation_id: conversation.id, user_id: ctx.staff_user.id)
+    insert(:participant_schema, conversation_id: conversation.id, user_id: ctx.parent.id)
+
+    {:ok, _} =
+      Messaging.create_message(%{
+        conversation_id: conversation.id,
+        sender_id: ctx.parent.id,
+        content: "Is pickup still at four?"
+      })
+
+    conversation
+  end
+
+  describe "execute/3 authorization" do
+    test "refuses a staff scope of the very provider that owns the thread" do
+      ctx = business()
+      conversation = staff_thread(ctx)
+
+      assert {:error, :unauthorized} =
+               GetStaffConversation.execute(
+                 %Scope{user: ctx.staff_user, staff_member: ctx.staff},
+                 conversation.id
+               )
+    end
+
+    test "refuses a scope with no provider profile" do
+      ctx = business()
+      conversation = staff_thread(ctx)
+
+      assert {:error, :unauthorized} =
+               GetStaffConversation.execute(
+                 AccountsFixtures.user_scope_fixture(),
+                 conversation.id
+               )
+    end
+
+    # Owner authorization proves the scope owns *a* provider, never that it owns *this*
+    # conversation — unlike `is_admin`, which grants blanket visibility. Both answers
+    # must be identical, or a UUID becomes an oracle for another business's threads.
+    test "a different provider's owner cannot tell a real thread from a missing one" do
+      ctx = business()
+      conversation = staff_thread(ctx)
+
+      stranger = business()
+
+      assert GetStaffConversation.execute(stranger.scope, conversation.id) ==
+               GetStaffConversation.execute(stranger.scope, Ecto.UUID.generate())
+
+      assert {:error, :not_found} = GetStaffConversation.execute(stranger.scope, conversation.id)
+    end
+  end
+
+  describe "execute/3 reading" do
+    test "returns the thread with its messages and sender names" do
+      ctx = business()
+      conversation = staff_thread(ctx)
+
+      assert {:ok, result} = GetStaffConversation.execute(ctx.scope, conversation.id)
+      assert result.conversation.id == conversation.id
+      assert [message] = result.messages
+      assert message.content == "Is pickup still at four?"
+      assert result.sender_names[ctx.parent.id] == "Pat Parent"
+      refute result.has_more
+    end
+  end
+
+  describe "execute/3 is strictly read-only" do
+    test "seats no participant for the owner" do
+      ctx = business()
+      conversation = staff_thread(ctx)
+
+      assert {:ok, _} = GetStaffConversation.execute(ctx.scope, conversation.id)
+
+      refute Messaging.participant?(conversation.id, ctx.owner.id)
+
+      assert Repo.aggregate(
+               from(p in Participant, where: p.conversation_id == ^conversation.id),
+               :count
+             ) == 2
+    end
+
+    test "moves nobody's read receipt" do
+      ctx = business()
+      conversation = staff_thread(ctx)
+
+      before =
+        Repo.all(from(p in Participant, where: p.conversation_id == ^conversation.id))
+        |> Enum.map(& &1.last_read_at)
+
+      assert {:ok, _} = GetStaffConversation.execute(ctx.scope, conversation.id)
+
+      after_read =
+        Repo.all(from(p in Participant, where: p.conversation_id == ^conversation.id))
+        |> Enum.map(& &1.last_read_at)
+
+      assert before == after_read
+    end
+  end
+
+  # The mirror of `get_monitored_conversation_test.exs`'s "the write path gained no
+  # admin branch". Read-only here is structural: there is no owner clause in
+  # SendMessage to bypass, and this test is what keeps it that way.
+  describe "the write path gained no owner branch" do
+    test "an owner who is not a participant still cannot send a message" do
+      ctx = business()
+      conversation = staff_thread(ctx)
+
+      assert {:error, :not_participant} =
+               Messaging.send_message(conversation.id, ctx.owner.id, "Let me step in here")
+    end
+  end
+end

--- a/test/klass_hero/messaging/list_staff_conversations_test.exs
+++ b/test/klass_hero/messaging/list_staff_conversations_test.exs
@@ -53,9 +53,12 @@ defmodule KlassHero.Messaging.ListStaffConversationsTest do
     message
   end
 
+  setup do
+    business()
+  end
+
   describe "execute/2 authorization" do
-    test "refuses a staff scope of the very provider it works for" do
-      ctx = business()
+    test "refuses a staff scope of the very provider it works for", ctx do
       staff_thread(ctx)
 
       assert {:error, :unauthorized} =
@@ -72,8 +75,7 @@ defmodule KlassHero.Messaging.ListStaffConversationsTest do
   end
 
   describe "execute/2 listing" do
-    test "lists a thread the owner's staff conducts without them" do
-      ctx = business()
+    test "lists a thread the owner's staff conducts without them", ctx do
       conversation = staff_thread(ctx)
 
       assert {:ok, [row], false} = ListStaffConversations.execute(ctx.scope)
@@ -85,8 +87,7 @@ defmodule KlassHero.Messaging.ListStaffConversationsTest do
     # The one behavioural difference from MonitorConversations: the owner's own threads
     # already render as rich cards in their inbox, so listing them here would show them
     # twice across the two tabs.
-    test "excludes a thread the owner is already a participant of" do
-      ctx = business()
+    test "excludes a thread the owner is already a participant of", ctx do
       mine = staff_thread(ctx)
       insert(:participant_schema, conversation_id: mine.id, user_id: ctx.owner.id)
 
@@ -96,8 +97,7 @@ defmodule KlassHero.Messaging.ListStaffConversationsTest do
       assert row.conversation_id == theirs.id
     end
 
-    test "excludes another provider's conversations" do
-      ctx = business()
+    test "excludes another provider's conversations", ctx do
       mine = staff_thread(ctx)
       insert(:conversation_schema)
 
@@ -105,8 +105,7 @@ defmodule KlassHero.Messaging.ListStaffConversationsTest do
       assert row.conversation_id == mine.id
     end
 
-    test "excludes archived conversations" do
-      ctx = business()
+    test "excludes archived conversations", ctx do
       staff_thread(ctx, archived_at: DateTime.utc_now() |> DateTime.truncate(:second))
 
       assert {:ok, [], false} = ListStaffConversations.execute(ctx.scope)
@@ -114,8 +113,7 @@ defmodule KlassHero.Messaging.ListStaffConversationsTest do
   end
 
   describe "execute/2 row contents" do
-    test "names the non-staff party and the staff members in the thread" do
-      ctx = business()
+    test "names the non-staff party and the staff members in the thread", ctx do
       staff_thread(ctx)
 
       assert {:ok, [row], false} = ListStaffConversations.execute(ctx.scope)
@@ -123,8 +121,7 @@ defmodule KlassHero.Messaging.ListStaffConversationsTest do
       assert row.staff_member_names == ["Sam Staff"]
     end
 
-    test "carries the latest message and its timestamp" do
-      ctx = business()
+    test "carries the latest message and its timestamp", ctx do
       conversation = staff_thread(ctx)
       say(conversation, ctx.parent, "First")
       latest = say(conversation, ctx.staff_user, "Second")
@@ -135,8 +132,7 @@ defmodule KlassHero.Messaging.ListStaffConversationsTest do
       refute row.has_attachments
     end
 
-    test "resolves the program title for a broadcast, and nothing for a direct thread" do
-      ctx = business()
+    test "resolves the program title for a broadcast, and nothing for a direct thread", ctx do
       program = insert(:program_schema, provider_id: ctx.provider.id, title: "Tuesday Judo")
 
       staff_thread(ctx, type: :program_broadcast, program_id: program.id)
@@ -152,8 +148,7 @@ defmodule KlassHero.Messaging.ListStaffConversationsTest do
       assert broadcast.program_name == "Tuesday Judo"
     end
 
-    test "pins the fields that exist only so the shared card renders" do
-      ctx = business()
+    test "pins the fields that exist only so the shared card renders", ctx do
       staff_thread(ctx)
 
       assert {:ok, [row], false} = ListStaffConversations.execute(ctx.scope)
@@ -195,9 +190,7 @@ defmodule KlassHero.Messaging.ListStaffConversationsTest do
   describe "execute/2 batching" do
     # The claim the enriched read model is worth its code: cost is flat in page size.
     # An N+1 regression here would be invisible to every other test in this file.
-    test "issues the same number of queries however many rows are on the page" do
-      ctx = business()
-
+    test "issues the same number of queries however many rows are on the page", ctx do
       for _ <- 1..2, do: staff_thread(ctx)
       two_rows = count_queries(fn -> ListStaffConversations.execute(ctx.scope) end)
 
@@ -216,8 +209,7 @@ defmodule KlassHero.Messaging.ListStaffConversationsTest do
     # of those carry attachments. A broadcast adds the program-title lookup; a page of
     # threads with no messages at all spends less, because the attachment and title
     # lookups both short-circuit on an empty list rather than querying for nothing.
-    test "spends a fixed query budget, plus one only when a broadcast is on the page" do
-      ctx = business()
+    test "spends a fixed query budget, plus one only when a broadcast is on the page", ctx do
       direct = staff_thread(ctx)
       say(direct, ctx.parent, "Is pickup still at four?")
 
@@ -232,8 +224,7 @@ defmodule KlassHero.Messaging.ListStaffConversationsTest do
   end
 
   describe "execute/2 pagination" do
-    test "reports has_more when more rows exist than the limit" do
-      ctx = business()
+    test "reports has_more when more rows exist than the limit", ctx do
       for _ <- 1..3, do: staff_thread(ctx)
 
       assert {:ok, listed, true} = ListStaffConversations.execute(ctx.scope, limit: 2)
@@ -243,8 +234,7 @@ defmodule KlassHero.Messaging.ListStaffConversationsTest do
     # Timestamps are pinned a month apart on purpose. `paginate/2`'s cursor is
     # exclusive on `inserted_at` alone, so rows sharing a second cannot be walked
     # apart — the same shape `MonitorConversationsTest` pins.
-    test "newest first, and :before walks to the older page" do
-      ctx = business()
+    test "newest first, and :before walks to the older page", ctx do
       older = staff_thread(ctx, inserted_at: ~N[2026-01-01 10:00:00])
       newer = staff_thread(ctx, inserted_at: ~N[2026-02-01 10:00:00])
 

--- a/test/klass_hero/messaging/list_staff_conversations_test.exs
+++ b/test/klass_hero/messaging/list_staff_conversations_test.exs
@@ -1,0 +1,261 @@
+defmodule KlassHero.Messaging.ListStaffConversationsTest do
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+
+  alias KlassHero.Accounts.Scope
+  alias KlassHero.AccountsFixtures
+  alias KlassHero.Messaging
+  alias KlassHero.Messaging.ListStaffConversations
+  alias KlassHero.Messaging.StaffConversation
+  alias KlassHero.ProviderFixtures
+
+  # An owner, a staffer they employ, and a parent — the cast every test here needs.
+  defp business do
+    owner = AccountsFixtures.user_fixture(name: "Olive Owner", intended_roles: [:provider])
+    provider = ProviderFixtures.provider_profile_fixture(identity_id: owner.id)
+
+    staff_user = AccountsFixtures.user_fixture(name: "Sam Staff", intended_roles: [:staff])
+
+    staff =
+      ProviderFixtures.staff_member_fixture(provider_id: provider.id, user_id: staff_user.id)
+
+    parent = AccountsFixtures.user_fixture(name: "Pat Parent")
+
+    %{
+      owner: owner,
+      provider: provider,
+      staff: staff,
+      staff_user: staff_user,
+      parent: parent,
+      scope: %Scope{user: owner, provider: provider}
+    }
+  end
+
+  defp staff_thread(ctx, attrs \\ []) do
+    conversation =
+      insert(:conversation_schema, Keyword.merge([provider_id: ctx.provider.id], attrs))
+
+    insert(:participant_schema, conversation_id: conversation.id, user_id: ctx.staff_user.id)
+    insert(:participant_schema, conversation_id: conversation.id, user_id: ctx.parent.id)
+
+    conversation
+  end
+
+  defp say(conversation, sender, content) do
+    {:ok, message} =
+      Messaging.create_message(%{
+        conversation_id: conversation.id,
+        sender_id: sender.id,
+        content: content
+      })
+
+    message
+  end
+
+  describe "execute/2 authorization" do
+    test "refuses a staff scope of the very provider it works for" do
+      ctx = business()
+      staff_thread(ctx)
+
+      assert {:error, :unauthorized} =
+               ListStaffConversations.execute(%Scope{
+                 user: ctx.staff_user,
+                 staff_member: ctx.staff
+               })
+    end
+
+    test "refuses a scope with no provider profile, even when nothing exists to list" do
+      assert {:error, :unauthorized} =
+               ListStaffConversations.execute(AccountsFixtures.user_scope_fixture())
+    end
+  end
+
+  describe "execute/2 listing" do
+    test "lists a thread the owner's staff conducts without them" do
+      ctx = business()
+      conversation = staff_thread(ctx)
+
+      assert {:ok, [row], false} = ListStaffConversations.execute(ctx.scope)
+      assert %StaffConversation{} = row
+      assert row.conversation_id == conversation.id
+      refute Messaging.participant?(conversation.id, ctx.owner.id)
+    end
+
+    # The one behavioural difference from MonitorConversations: the owner's own threads
+    # already render as rich cards in their inbox, so listing them here would show them
+    # twice across the two tabs.
+    test "excludes a thread the owner is already a participant of" do
+      ctx = business()
+      mine = staff_thread(ctx)
+      insert(:participant_schema, conversation_id: mine.id, user_id: ctx.owner.id)
+
+      theirs = staff_thread(ctx)
+
+      assert {:ok, [row], false} = ListStaffConversations.execute(ctx.scope)
+      assert row.conversation_id == theirs.id
+    end
+
+    test "excludes another provider's conversations" do
+      ctx = business()
+      mine = staff_thread(ctx)
+      insert(:conversation_schema)
+
+      assert {:ok, [row], false} = ListStaffConversations.execute(ctx.scope)
+      assert row.conversation_id == mine.id
+    end
+
+    test "excludes archived conversations" do
+      ctx = business()
+      staff_thread(ctx, archived_at: DateTime.utc_now() |> DateTime.truncate(:second))
+
+      assert {:ok, [], false} = ListStaffConversations.execute(ctx.scope)
+    end
+  end
+
+  describe "execute/2 row contents" do
+    test "names the non-staff party and the staff members in the thread" do
+      ctx = business()
+      staff_thread(ctx)
+
+      assert {:ok, [row], false} = ListStaffConversations.execute(ctx.scope)
+      assert row.other_participant_name == "Pat Parent"
+      assert row.staff_member_names == ["Sam Staff"]
+    end
+
+    test "carries the latest message and its timestamp" do
+      ctx = business()
+      conversation = staff_thread(ctx)
+      say(conversation, ctx.parent, "First")
+      latest = say(conversation, ctx.staff_user, "Second")
+
+      assert {:ok, [row], false} = ListStaffConversations.execute(ctx.scope)
+      assert row.latest_message_content == "Second"
+      assert row.latest_message_at == latest.inserted_at
+      refute row.has_attachments
+    end
+
+    test "resolves the program title for a broadcast, and nothing for a direct thread" do
+      ctx = business()
+      program = insert(:program_schema, provider_id: ctx.provider.id, title: "Tuesday Judo")
+
+      staff_thread(ctx, type: :program_broadcast, program_id: program.id)
+      direct = staff_thread(ctx)
+
+      assert {:ok, rows, false} = ListStaffConversations.execute(ctx.scope)
+      by_id = Map.new(rows, &{&1.conversation_id, &1})
+
+      assert by_id[direct.id].program_name == nil
+      assert by_id[direct.id].conversation_type == :direct
+
+      broadcast = Enum.find(rows, &(&1.conversation_type == :program_broadcast))
+      assert broadcast.program_name == "Tuesday Judo"
+    end
+
+    test "pins the fields that exist only so the shared card renders" do
+      ctx = business()
+      staff_thread(ctx)
+
+      assert {:ok, [row], false} = ListStaffConversations.execute(ctx.scope)
+      assert row.unread_count == 0
+      assert row.enrolled_child_names == []
+    end
+  end
+
+  # Handlers run in the process that emitted the event, and the reads here all happen
+  # inline in the test process — so filtering on `self()` keeps this honest under
+  # `async: true`, where other tests are querying the same repo concurrently.
+  defp count_queries(fun) do
+    ref = make_ref()
+    test_pid = self()
+
+    :telemetry.attach(
+      {__MODULE__, ref},
+      [:klass_hero, :repo, :query],
+      fn _event, _measurements, _metadata, _config ->
+        if self() == test_pid, do: send(test_pid, {ref, :query})
+      end,
+      nil
+    )
+
+    fun.()
+    :telemetry.detach({__MODULE__, ref})
+
+    drain(ref, 0)
+  end
+
+  defp drain(ref, acc) do
+    receive do
+      {^ref, :query} -> drain(ref, acc + 1)
+    after
+      0 -> acc
+    end
+  end
+
+  describe "execute/2 batching" do
+    # The claim the enriched read model is worth its code: cost is flat in page size.
+    # An N+1 regression here would be invisible to every other test in this file.
+    test "issues the same number of queries however many rows are on the page" do
+      ctx = business()
+
+      for _ <- 1..2, do: staff_thread(ctx)
+      two_rows = count_queries(fn -> ListStaffConversations.execute(ctx.scope) end)
+
+      for _ <- 1..8, do: staff_thread(ctx)
+      ten_rows = count_queries(fn -> ListStaffConversations.execute(ctx.scope) end)
+
+      assert {:ok, rows, false} = ListStaffConversations.execute(ctx.scope)
+      assert length(rows) == 10
+
+      assert two_rows == ten_rows,
+             "query count grew with page size: #{two_rows} for 2 rows, #{ten_rows} for 10"
+    end
+
+    # The budget, spelled out. Six is: conversations, their participants, display
+    # names, the provider's staff ids, the latest message per conversation, and which
+    # of those carry attachments. A broadcast adds the program-title lookup; a page of
+    # threads with no messages at all spends less, because the attachment and title
+    # lookups both short-circuit on an empty list rather than querying for nothing.
+    test "spends a fixed query budget, plus one only when a broadcast is on the page" do
+      ctx = business()
+      direct = staff_thread(ctx)
+      say(direct, ctx.parent, "Is pickup still at four?")
+
+      assert count_queries(fn -> ListStaffConversations.execute(ctx.scope) end) == 6
+
+      program = insert(:program_schema, provider_id: ctx.provider.id, title: "Tuesday Judo")
+      broadcast = staff_thread(ctx, type: :program_broadcast, program_id: program.id)
+      say(broadcast, ctx.staff_user, "Class is cancelled today")
+
+      assert count_queries(fn -> ListStaffConversations.execute(ctx.scope) end) == 7
+    end
+  end
+
+  describe "execute/2 pagination" do
+    test "reports has_more when more rows exist than the limit" do
+      ctx = business()
+      for _ <- 1..3, do: staff_thread(ctx)
+
+      assert {:ok, listed, true} = ListStaffConversations.execute(ctx.scope, limit: 2)
+      assert length(listed) == 2
+    end
+
+    # Timestamps are pinned a month apart on purpose. `paginate/2`'s cursor is
+    # exclusive on `inserted_at` alone, so rows sharing a second cannot be walked
+    # apart — the same shape `MonitorConversationsTest` pins.
+    test "newest first, and :before walks to the older page" do
+      ctx = business()
+      older = staff_thread(ctx, inserted_at: ~N[2026-01-01 10:00:00])
+      newer = staff_thread(ctx, inserted_at: ~N[2026-02-01 10:00:00])
+
+      assert {:ok, [first, second], false} = ListStaffConversations.execute(ctx.scope)
+      assert first.conversation_id == newer.id
+      assert second.conversation_id == older.id
+
+      assert {:ok, [only], false} =
+               ListStaffConversations.execute(ctx.scope, before: newer.inserted_at)
+
+      assert only.conversation_id == older.id
+    end
+  end
+end

--- a/test/klass_hero_web/components/messaging_components_test.exs
+++ b/test/klass_hero_web/components/messaging_components_test.exs
@@ -4,6 +4,7 @@ defmodule KlassHeroWeb.MessagingComponentsTest do
   import KlassHero.Factory
   import Phoenix.LiveViewTest
 
+  alias KlassHero.Messaging.StaffConversation
   alias KlassHeroWeb.MessagingComponents
 
   defp render_card(summary_attrs, opts \\ []) do
@@ -111,6 +112,86 @@ defmodule KlassHeroWeb.MessagingComponentsTest do
       assert LazyHTML.attribute(button, "phx-value-program-id") == ["prog-42"]
       assert LazyHTML.attribute(button, "phx-value-provider-id") == ["prov-7"]
       assert LazyHTML.text(button) =~ "Contact Provider"
+    end
+  end
+
+  # The card is duck-typed on purpose (#746): it matches field names, never a struct
+  # name, so the owner's staff-conversations list renders through the very same card
+  # as the participant inbox and the two cannot drift apart. These tests are what stop
+  # someone reintroducing a struct-name match and silently breaking that.
+  describe "conversation_card/1 renders a StaffConversation" do
+    defp staff_row(attrs) do
+      struct!(
+        %StaffConversation{
+          conversation_id: "conv-1",
+          conversation_type: :direct,
+          provider_id: "prov-1",
+          inserted_at: DateTime.utc_now()
+        },
+        attrs
+      )
+    end
+
+    defp render_staff_card(attrs \\ []) do
+      render_component(&MessagingComponents.conversation_card/1, %{
+        id: "conv-test",
+        summary: staff_row(attrs),
+        user_type: :provider,
+        navigate: "/provider/messages/staff/conv-1"
+      })
+    end
+
+    test "reads the same display and preview fields it reads off a summary" do
+      html =
+        render_staff_card(
+          other_participant_name: "Pat Parent",
+          latest_message_content: "Is pickup still at four?"
+        )
+
+      assert html =~ "Pat Parent"
+      assert html =~ "Is pickup still at four?"
+    end
+
+    test "falls back to the no-messages preview when the thread is empty" do
+      assert render_staff_card() =~ "No messages yet"
+    end
+
+    test "shows the staff attribution only when the row carries names" do
+      with_names = render_staff_card(staff_member_names: ["Sam Staff"])
+      assert with_names =~ "Sam Staff"
+
+      assert with_names
+             |> LazyHTML.from_fragment()
+             |> LazyHTML.query(~s([data-role="staff-attribution"]))
+             |> Enum.count() == 1
+
+      assert render_staff_card()
+             |> LazyHTML.from_fragment()
+             |> LazyHTML.query(~s([data-role="staff-attribution"]))
+             |> Enum.empty?()
+    end
+
+    # A ConversationSummary has no such field at all — the card must omit the line
+    # rather than raise, which is exactly what makes the shared-card reuse safe.
+    test "omits the attribution for a summary row that has no such field" do
+      assert render_card([], user_type: :provider)
+             |> LazyHTML.from_fragment()
+             |> LazyHTML.query(~s([data-role="staff-attribution"]))
+             |> Enum.empty?()
+    end
+
+    test "hides the unread badge, which a non-participant can never have" do
+      # Paired with a positive case on purpose: asserting only the absence would pass
+      # just as happily against a mistyped selector.
+      assert render_card([unread_count: 3], user_type: :provider)
+             |> LazyHTML.from_fragment()
+             |> LazyHTML.query(~s([data-role="unread-count"]))
+             |> Enum.count() == 1
+
+      assert render_staff_card()
+             |> LazyHTML.from_fragment()
+             |> LazyHTML.query(~s([data-role="unread-count"]))
+             |> Enum.empty?()
     end
   end
 end


### PR DESCRIPTION
Closes #746.

## Summary

A provider owner could not see the conversations their staff conduct with parents. `CreateDirectConversation` seats only the initiator, the target and program-assigned staff; `BroadcastToProgram` seats the sender and enrolled parents. Neither seats the owner, and every Messaging read is gated on a `Participant` row — so a staff-initiated thread was invisible to the person accountable for it.

Parent-initiated *program* threads were the exception; they already seat the owner. The gap was specifically staff-initiated direct threads and staff-sent broadcasts.

**The disclosure had already shipped ahead of the capability.** The notice added in #1516 tells parents their messages "may be reviewed by the activity provider and by Klass Hero staff" — true of Klass Hero staff, not yet true of the provider. This makes the shipped sentence honest.

## Design

Adds a second non-participant read gate beside the admin one, and **amends ADR-0021**, which reserved `authorize_admin/1` to monitoring and required an amendment before any further non-participant read.

**Owner-only, and pointedly not staff.** `Authorization.authorize_provider_owner/1` matches `%Scope{provider: %{id: id}}` only. The tempting reuse was `resolve_acting_provider/2`, which already binds a scope to a provider — but it accepts a staff scope *on purpose* for the write path, and honouring that hint here would let one staff member read a colleague's private threads with a parent.

**It returns the provider id, not `:ok`.** Unlike `is_admin`, provider ownership grants no blanket visibility: it proves the scope owns *a* provider, never *this* conversation. So the id is the read predicate, and `GetStaffConversation` carries it into the fetch — a thread belonging to another business is indistinguishable from one that never existed. Without that second predicate a pasted UUID would read a competitor's threads.

**The predicate is `conversations.provider_id`, not a staff join.** The issue proposed listing conversations whose participants are active staff. Rejected: `get_provider_staff_user_ids/1` already documents that ever-employed staff lists "must never gate access". Keying oversight on *current* employment would hide the threads an owner remains accountable for the moment a staffer is deactivated. Every conversation already carries `provider_id` as a required field — the fact is stored, not derived.

**Read-only is structural, not a flag.** No send path exists in the use cases; the LiveView does not `use MessagingLiveHelper` (which injects `send_message` and marks threads read on mount); `message_input/1` never enters scope. `GetStaffConversation` has no `:mark_as_read` option at all.

## Review focus

- **`conversation_summaries.ex` is an event-critical projection.** Its two private latest-message helpers moved into `MessageQueries` and the projection now calls them, so this feature and the inbox cannot drift on what "latest message" means. The extraction preserves the deliberate absence of a `deleted_at` filter and both empty-collection guards. Its existing tests are the regression proof.
- **`conversation_card/1` is now explicitly duck-typed.** It always matched on field names; the one nominal coupling (`ConversationSummary.has_latest_message?/1`) is inlined as a local predicate so a `StaffConversation` renders through the identical card. That is what stops the two inbox surfaces drifting apart visually.
- **Route ordering** — `/messages/staff` must precede `/messages/:id` or it is captured as an id.

## Test plan

- `mix precommit` green: **5247 passed**, credo `--strict` clean, translations complete (DE shipped).
- Query budget is pinned by test: **6 queries per page, 7 with a broadcast**, flat regardless of page size.
- Flow test mirrors `admin_conversation_monitoring_test.exs`, including `refute_has("#message-input")` / `textarea`, and that a *staff* member cannot reach the surface.
- A write-path guard asserts a non-participant owner still gets `{:error, :not_participant}` from `send_message/4`.
- Verified live against dev data via Tidewave and the browser: owner reads the thread; staff of that same provider → `:unauthorized`; another provider's owner → `:not_found`, identical to a bogus UUID; owner cannot send; no participant row seated and no `last_read_at` moved after two browser visits. Checked at 375px.

## Follow-ups filed separately

Two pre-existing issues surfaced while building this; neither is fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
