### PR TITLE
feat: email participants when a new message arrives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,11 +92,8 @@ jobs:
       - name: Check for unused dependencies
         run: mix deps.unlock --check-unused
 
-      # Keeps a runtime dependency from silently becoming a compile-time one, which
-      # balloons recompiles across a 7-context app. Threshold is the count at the time
-      # this landed — see the note in mix.exs's precommit alias.
       - name: No new compile-time coupling
-        run: mix xref graph --label compile-connected --fail-above 32
+        run: mix lint_compile_coupling
 
       - name: Credo
         run: mix credo --strict

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -195,7 +195,7 @@ A thread between specific **Users** — typically a **Parent** and the **Provide
 _Avoid_: DM, Private message
 
 **Broadcast** (`program_broadcast`):
-A Provider's one-to-many announcement thread scoped to a single **Program**. At most one active Broadcast exists per Program. Its audience is *derived*, not hand-added: the **Parents**/guardians of the children **Enrolled** in that Program, plus the Program's assigned **Staff Members**. Recipients are not **Participants**.
+A Provider's one-to-many announcement thread scoped to a single **Program**. At most one active Broadcast exists per Program. Its audience is *derived*, not hand-picked: the **Parents**/guardians of the children **Enrolled** in that Program, plus the Program's assigned **Staff Members**. Derived, but then **seated**: each of them becomes a **Participant**, so a Broadcast carries read receipts like any other Conversation, and a late enrollee is seated when they enrol.
 _Avoid_: Announcement, Bulletin, Newsletter, Channel
 
 **Message**:
@@ -210,8 +210,8 @@ A file attached to a **Message** — a photo or document with a filename, conten
 _Avoid_: Upload, File, Media, Document (that's a **Verification Document**, unrelated)
 
 **Participant** (Messaging):
-A **User**'s membership in a **Direct Conversation** — tracks join/leave and read receipts. Applies to Direct Conversations only; a **Broadcast** has a derived audience, not Participants. This is the *only* meaning of "Participant" in the system; it is **not** a child attending a Session. An **Admin** reading a Conversation under **Monitoring** is not a Participant either: reading it seats nobody and moves no read receipt.
-_Avoid_: using "Participant" for a child on a **Roster** (that's a **Participation Record**), or for a **Broadcast** recipient
+A **User**'s membership in a **Conversation** — tracks join/leave and read receipts. Applies to both kinds: a **Direct Conversation**'s membership is chosen, a **Broadcast**'s is derived from enrolment and assignment, but both are seated as Participants and both carry read receipts. This is the *only* meaning of "Participant" in the system; it is **not** a child attending a Session. An **Admin** reading a Conversation under **Monitoring** is not a Participant: reading it seats nobody and moves no read receipt.
+_Avoid_: using "Participant" for a child on a **Roster** (that's a **Participation Record**)
 
 **Archival**:
 The automatic retirement of a **Conversation** once its **Program** has ended (after a grace window). Archiving starts the **Retention Period**; it deletes nothing yet. A **Direct Conversation** with no Program is never archived — it lives indefinitely.

--- a/config/config.exs
+++ b/config/config.exs
@@ -20,6 +20,7 @@ alias KlassHero.Messaging.ConversationSummaries
 alias KlassHero.Messaging.EnrolledChildren
 alias KlassHero.Messaging.EnrollmentParticipationHandler
 alias KlassHero.Messaging.MessagingEventHandler
+alias KlassHero.Messaging.NewMessageEmailHandler
 alias KlassHero.Messaging.StaffAssignmentHandler
 alias KlassHero.Messaging.Workers.FetchEmailContentWorker
 alias KlassHero.Messaging.Workers.MessageCleanupWorker
@@ -149,10 +150,23 @@ config :klass_hero, Oban,
        {"*/5 * * * *", CompensationSweepWorker}
      ]}
   ],
-  # email: 1 — serialized to stay under Resend's 2 req/sec rate limit (per-node;
-  #   add a rate limiter if scaling to multiple Oban nodes)
+  # email: 5 — raised from 1 when new-message notifications landed (#1071). One
+  #   program broadcast is a single message to every enrolled family, so it can
+  #   enqueue hundreds of jobs at once, and at concurrency 1 that queue is also
+  #   what staff invites and email replies wait in.
+  #
+  #   Concurrency is not the upstream ceiling: this was 1 to stay under Resend's
+  #   documented 2 req/sec default, and raising it does not raise that. What
+  #   absorbs the difference is `RateLimitedEmailWorker`'s 429-aware backoff plus
+  #   max_attempts: 5 on every worker here — three attempts left only two
+  #   retries, which a sustained burst can exhaust on rate limits alone, losing
+  #   a real email rather than merely delaying it.
+  #
+  #   UNVERIFIED: whether this account's actual Resend limit is above 2 req/sec.
+  #   If it is not, 5 trades queue latency for 429 churn rather than winning
+  #   throughput. Confirm and rewrite this comment with the real number.
   # events: 5 — every event goes here; since ADR-0014 there is no other kind.
-  queues: [default: 10, messaging: 5, cleanup: 2, email: 1, family: 1, events: 5]
+  queues: [default: 10, messaging: 5, cleanup: 2, email: 5, family: 1, events: 5]
 
 # Base URL for constructing links in emails and event handlers
 # (avoids boundary violations from referencing KlassHeroWeb.Endpoint in domain code)
@@ -338,8 +352,12 @@ config :klass_hero, :event_consumers, %{
     {ConversationSummaries, :project},
     {EnrolledChildren, :project}
   ],
+  # Order is not load-bearing here: NewMessageEmailHandler deliberately reads
+  # conversation_participants rather than the unread_count ConversationSummaries
+  # maintains, so it cannot observe whether that projection has run yet.
   "integration:messaging:message_sent" => [
-    {ConversationSummaries, :project}
+    {ConversationSummaries, :project},
+    {NewMessageEmailHandler, :handle_event}
   ],
   "integration:messaging:messages_read" => [
     {ConversationSummaries, :project}

--- a/docs/adr/0022-notification-emails-dispatch-from-the-outbox-gated-in-accounts.md
+++ b/docs/adr/0022-notification-emails-dispatch-from-the-outbox-gated-in-accounts.md
@@ -120,6 +120,36 @@ notifier is about to be written.
 
 ## Alternatives considered
 
+**Enqueuing the job directly from `SendMessage`, with no consumer.** This is the
+codebase's existing idiom for an email that follows a write:
+`Provider.SubmitIncidentReport` enqueues `NotifyIncidentReportedWorker` inside
+its own `Repo.transaction` ("Row insert and email-job insert commit together via
+ACID"), and `Enrollment.EnqueueInviteEmails` bulk-inserts inside one too. It was
+raised in review as the obvious alternative, and it is the first thing a reader
+should expect. It was rejected for a reason specific to this producer.
+
+Those two producers stage **no event at all** — `SubmitIncidentReport` does not
+touch the outbox, and `integration:provider:incident_reported` has no entry in
+`:event_consumers`, so `Outbox.stage/2` would drop it. A direct enqueue was
+their only option.
+
+`message_sent` is not in that position. It is already staged and already
+delivered, because `ConversationSummaries` consumes it — so the
+`EventDeliveryWorker` hop runs on every message send whether or not this feature
+exists. Registering a second consumer therefore adds **N** jobs (the emails).
+Enqueuing a separate resolver job instead would add **N + 1**, because the
+delivery job still runs for the projection. The direct route is the extra
+indirection here, not the saving.
+
+Two honest costs of the route taken. This is the first same-context,
+non-projection consumer in the codebase, so it widens what `ForHandlingEvents`
+is used for. And two consumers on one topic raised the ordering question that
+`NewMessageEmailHandler`'s moduledoc has to answer — resolved by reading the
+write side, which is independently the more robust choice, but the question only
+arose because both consumers sit on the same event.
+
+
+
 **Preference on `Family.ParentProfile`**, as #1071 originally specified. Its
 `notification_preferences` map is dead scaffolding — nullable `jsonb`, no
 default, no key schema, cast wholesale — and `KlassHero.Family` has no update

--- a/docs/adr/0022-notification-emails-dispatch-from-the-outbox-gated-in-accounts.md
+++ b/docs/adr/0022-notification-emails-dispatch-from-the-outbox-gated-in-accounts.md
@@ -1,0 +1,133 @@
+# 22. Notification emails dispatch from the outbox, gated in Accounts
+
+Date: 2026-08-26
+
+## Status
+
+Accepted
+
+## Context
+
+#1071 added the first email the platform sends *because of a preference* rather
+than because of a transaction. Three more are queued behind it — #829
+(enrollment confirmation), #798 (incident-report parent notification), #742
+(incident_reported owner + admin escalation) — and #742 asks the question
+outright: "New driving event handler in some context (Provider?
+Notifications?)".
+
+Before #1071 there were three email notifier modules, in three contexts
+(`Accounts.UserNotifier`, `Enrollment…InviteEmailNotifier`,
+`Provider.IncidentReportedEmailNotifier`). None consulted any preference. Two
+shared only `Shared.EmailHtml`. Whatever #1071 did was going to be copied three
+times, so the shape mattered more than the feature.
+
+Two questions had to be answered together: **where does the dispatch live**, and
+**where does the gate live**.
+
+## Decision
+
+### 1. A notification email is dispatched by an event consumer in the context that owns the event
+
+Not by a call inside the producing use case.
+
+`domain-architecture.md` says a same-context reaction is an ordinary function
+call made inside the producer's transaction, "so the write and its consequence
+commit together". Read literally, Messaging consuming its own `message_sent`
+violates that. It does not, because the rule's justification is about
+**database** writes.
+
+An email cannot be rolled back. If it is sent inside the producing transaction
+and that transaction then fails, the mail is already gone. So it must happen
+*after* commit, at-least-once, with retry — which is precisely the transactional
+outbox from ADR-0014. Two further consequences of sending inline decided it:
+
+- A user-facing write would carry a participants query, an Accounts query, and
+  up to N job inserts. A program broadcast is one message to every enrolled
+  family, so N is routinely in the hundreds.
+- A person's message would fail to send because Resend was briefly unavailable.
+
+It must be a **handler**, not a projection. `Shared.Projection.project/1`
+discards its callback's return value and always answers `:ok`, so a projection
+would swallow every dispatch failure — no retry, no compensation, no
+dead-letter. A `ForHandlingEvents` consumer propagates `{:error, reason}` back
+to `EventDeliveryWorker`.
+
+### 2. The user-preference gate is one contract, owned by Accounts
+
+`users.disabled_email_notifications` is a `{:array, Ecto.Enum}` of the kinds a
+user has switched **off**. Absence means enabled, which is what gives every
+existing row — and every kind added later — a default of ON with no backfill and
+no three-way nil/false/missing ambiguity.
+
+Producing contexts never touch the column. They ask:
+
+- `Accounts.email_notification_enabled?(user_or_id, kind)` — one recipient;
+- `Accounts.notifiable_recipients(user_ids, kind)` — bulk, shaped like the
+  existing `Accounts.get_display_names/1`.
+
+Adding a user-togglable notification is one atom in the field's `values:` and
+one checkbox in the settings card.
+
+### 3. A gate that is not a user preference stays in its own context
+
+This is the half that keeps the contract honest. Of the three queued issues,
+**none** is gated by a user preference:
+
+- #798's gate is a per-report toggle the provider sets at submission time.
+- #742's gate is the report's severity.
+- #829 is transactional confirmation of an action the user just took.
+
+So they must **not** route through `Accounts.notifiable_recipients/2`. Doing it
+"for consistency" would let a parent's *message* preference silently veto an
+*incident* email — the wrong axis entirely.
+
+### 4. No shared dispatcher
+
+Three designs were generated for #1071, including a full registry (config map +
+behaviour + generic dispatcher + generic worker). It was rejected: it builds a
+second dispatch system beside `ForHandlingEvents` before a second notification
+exists in code, and it carries two vocabularies nothing keeps in sync.
+
+What is genuinely shared is already shared: `Shared.RateLimitedEmailWorker`,
+`Shared.EmailHtml`, `KlassHero.Mailer`, and now the Accounts gate. Each feature
+writes its own consumer, worker and notifier — roughly 25–40 lines of
+recognisable scaffolding.
+
+Per `workflow.md`'s "Second Occurrence Escalates", revisit when either: a second
+genuine **user-level** preference is requested, or a **fourth** bespoke email
+notifier is about to be written.
+
+## Consequences
+
+- Adding a notification means: a consumer in the owning context, a worker, a
+  notifier, one registry line in `:event_consumers`, and — only if it is
+  user-togglable — one atom and one checkbox.
+- `test/klass_hero/event_consumer_wiring_test.exs` already guards the registry
+  line, bidirectionally, so a consumer that declares an event it is not routed
+  fails the build.
+- The `:email` queue went from concurrency 1 to 5 to absorb broadcast fan-out.
+  Concurrency is not the upstream ceiling, so every worker on that queue also
+  went to `max_attempts: 5`: at 3, a sustained 429 burst can spend the whole
+  budget on backoff and **discard** a real email rather than delay it. Those two
+  numbers are one decision and are asserted together in
+  `test/klass_hero/email_queue_capacity_test.exs`.
+- Job args carry ids only. An address in `oban_jobs.args` outlives the send by
+  the Pruner's retention, and one changed between enqueue and delivery would
+  send to the old mailbox. The worker re-checks the preference and fetches the
+  address itself.
+- Notification emails carry a link, never content. For #1071 this is a
+  deliberate omission: the `message_sent` payload does include `content`.
+
+## Alternatives considered
+
+**Preference on `Family.ParentProfile`**, as #1071 originally specified. Its
+`notification_preferences` map is dead scaffolding — nullable `jsonb`, no
+default, no key schema, cast wholesale — and `KlassHero.Family` has no update
+path at all, so that route had to invent a Family mutation anyway. It would also
+have made the feature structurally parent-only while the toggle sits beside
+`locale`, a user-level column, in the same settings card.
+
+**A `Notifications` bounded context.** Rejected: `domain-architecture.md` is
+explicit that "service"-style catch-alls sort modules by having no category, and
+the existing convention is that consumers live in the context that consumes the
+event.

--- a/lib/klass_hero/accounts.ex
+++ b/lib/klass_hero/accounts.ex
@@ -431,14 +431,6 @@ defmodule KlassHero.Accounts do
   end
 
   @doc """
-  Changeset for the settings form's notification preferences section.
-  """
-  @spec change_user_email_notification_preferences(User.t(), map()) :: Ecto.Changeset.t()
-  def change_user_email_notification_preferences(user, attrs \\ %{}) do
-    User.email_notification_preferences_changeset(user, attrs)
-  end
-
-  @doc """
   Remembers the surface this user last chose to work in (ADR-0005).
 
   A preference, not a grant: the caller is responsible for having checked that

--- a/lib/klass_hero/accounts.ex
+++ b/lib/klass_hero/accounts.ex
@@ -13,6 +13,7 @@ defmodule KlassHero.Accounts do
   alias KlassHero.Provider
   alias KlassHero.Provider.StaffMember
   alias KlassHero.Repo
+  alias KlassHero.Shared.Adapters.Driven.Persistence.RepositoryHelpers
   alias KlassHero.Shared.Outbox
 
   require Logger
@@ -363,6 +364,78 @@ defmodule KlassHero.Accounts do
       |> User.locale_changeset(attrs)
       |> Repo.update()
     end
+  end
+
+  @doc """
+  Whether `user_or_id` currently wants `kind` emailed to them.
+
+  The gate every producing context asks before sending. Answers `false` for a
+  user that cannot be found: a notification worker holding an id whose account
+  has since gone should skip, not send and not raise.
+
+  Callers speak in "enabled?"; that the column stores the *disabled* kinds is
+  this context's business alone.
+  """
+  @spec email_notification_enabled?(User.t() | String.t(), atom()) :: boolean()
+  def email_notification_enabled?(%User{disabled_email_notifications: disabled}, kind) do
+    kind not in (disabled || [])
+  end
+
+  def email_notification_enabled?(user_id, kind) when is_binary(user_id) do
+    case RepositoryHelpers.get_schema_by_uuid(User, user_id) do
+      {:ok, user} -> email_notification_enabled?(user, kind)
+      {:error, :not_found} -> false
+    end
+  end
+
+  @doc """
+  Narrows `user_ids` to those who want `kind`, as `%{user_id => %{email:, name:}}`.
+
+  Bulk counterpart to `email_notification_enabled?/2`, shaped like
+  `get_display_names/1`: ids that match no user are simply absent, so a caller
+  building a recipient list from a participants query never has to pre-validate
+  them.
+  """
+  @spec notifiable_recipients([String.t()], atom()) :: %{String.t() => %{email: String.t(), name: String.t()}}
+  def notifiable_recipients([], _kind), do: %{}
+
+  def notifiable_recipients(user_ids, kind) when is_list(user_ids) do
+    kind_string = Atom.to_string(kind)
+
+    from(u in User,
+      where: u.id in ^user_ids and ^kind_string not in u.disabled_email_notifications,
+      select: {u.id, %{email: u.email, name: u.name}}
+    )
+    |> Repo.all()
+    |> Map.new()
+  end
+
+  @doc """
+  Switches one email notification on or off for a user.
+
+  Owns the disabled-list inversion so no caller sees it, and is idempotent in
+  both directions — opting out twice stores one entry, opting in when already
+  enabled writes nothing.
+  """
+  @spec update_user_email_notification_preference(User.t(), atom(), boolean()) ::
+          {:ok, User.t()} | {:error, Ecto.Changeset.t()}
+  def update_user_email_notification_preference(%User{} = user, kind, enabled?) do
+    context_span entity: "user" do
+      current = user.disabled_email_notifications || []
+      next = if enabled?, do: List.delete(current, kind), else: Enum.uniq([kind | current])
+
+      user
+      |> User.email_notification_preferences_changeset(%{disabled_email_notifications: next})
+      |> Repo.update()
+    end
+  end
+
+  @doc """
+  Changeset for the settings form's notification preferences section.
+  """
+  @spec change_user_email_notification_preferences(User.t(), map()) :: Ecto.Changeset.t()
+  def change_user_email_notification_preferences(user, attrs \\ %{}) do
+    User.email_notification_preferences_changeset(user, attrs)
   end
 
   @doc """

--- a/lib/klass_hero/accounts.ex
+++ b/lib/klass_hero/accounts.ex
@@ -13,7 +13,6 @@ defmodule KlassHero.Accounts do
   alias KlassHero.Provider
   alias KlassHero.Provider.StaffMember
   alias KlassHero.Repo
-  alias KlassHero.Shared.Adapters.Driven.Persistence.RepositoryHelpers
   alias KlassHero.Shared.Outbox
 
   require Logger
@@ -367,25 +366,19 @@ defmodule KlassHero.Accounts do
   end
 
   @doc """
-  Whether `user_or_id` currently wants `kind` emailed to them.
+  Whether `user` currently wants `kind` emailed to them.
 
-  The gate every producing context asks before sending. Answers `false` for a
-  user that cannot be found: a notification worker holding an id whose account
-  has since gone should skip, not send and not raise.
+  The gate every producing context asks before sending. Callers speak in
+  "enabled?"; that the column stores the *disabled* kinds is this context's
+  business alone.
 
-  Callers speak in "enabled?"; that the column stores the *disabled* kinds is
-  this context's business alone.
+  Takes a loaded user because that is what every caller has. Working from an id
+  is `notifiable_recipients/2`'s job — it answers for a list of them in one
+  query, and an id matching no user is simply absent from the result.
   """
-  @spec email_notification_enabled?(User.t() | String.t(), atom()) :: boolean()
+  @spec email_notification_enabled?(User.t(), atom()) :: boolean()
   def email_notification_enabled?(%User{disabled_email_notifications: disabled}, kind) do
     kind not in (disabled || [])
-  end
-
-  def email_notification_enabled?(user_id, kind) when is_binary(user_id) do
-    case RepositoryHelpers.get_schema_by_uuid(User, user_id) do
-      {:ok, user} -> email_notification_enabled?(user, kind)
-      {:error, :not_found} -> false
-    end
   end
 
   @doc """
@@ -416,11 +409,19 @@ defmodule KlassHero.Accounts do
   Owns the disabled-list inversion so no caller sees it, and is idempotent in
   both directions — opting out twice stores one entry, opting in when already
   enabled writes nothing.
+
+  The other kinds are read back from the row rather than taken from the passed
+  struct, which is the whole reason this reloads. One column holds every kind,
+  so a list computed from a stale struct silently re-enables whatever changed
+  since it was loaded — and the settings page holds a user in `@current_scope`
+  that nothing refreshes in place. Harmless while one kind exists; a lost update
+  the moment there are two.
   """
   @spec update_user_email_notification_preference(User.t(), atom(), boolean()) ::
           {:ok, User.t()} | {:error, Ecto.Changeset.t()}
   def update_user_email_notification_preference(%User{} = user, kind, enabled?) do
     context_span entity: "user" do
+      user = Repo.reload!(user)
       current = user.disabled_email_notifications || []
       next = if enabled?, do: List.delete(current, kind), else: Enum.uniq([kind | current])
 

--- a/lib/klass_hero/accounts/user.ex
+++ b/lib/klass_hero/accounts/user.ex
@@ -34,6 +34,7 @@ defmodule KlassHero.Accounts.User do
     field :locale, :string, default: "en"
     field :active_persona, Ecto.Enum, values: UserRole.valid_roles()
     field :is_admin, :boolean, default: false
+    field :disabled_email_notifications, {:array, Ecto.Enum}, values: [:new_message_email], default: []
 
     has_one :parent_profile, ParentProfile, foreign_key: :identity_id
     has_one :provider_profile, ProviderProfile, foreign_key: :identity_id
@@ -253,6 +254,29 @@ defmodule KlassHero.Accounts.User do
     |> cast(attrs, [:locale])
     |> validate_required([:locale])
     |> validate_inclusion(:locale, Locales.supported())
+  end
+
+  @doc """
+  Every email notification a user can switch off.
+
+  Derived from the field's own `Ecto.Enum` values rather than restated, so the
+  vocabulary the UI offers and the vocabulary the changeset accepts cannot drift.
+  """
+  @spec email_notification_kinds() :: [atom()]
+  def email_notification_kinds, do: Ecto.Enum.values(__MODULE__, :disabled_email_notifications)
+
+  @doc """
+  A user changeset for the email notification preferences.
+
+  The column stores what is **disabled**. Absence therefore means enabled, which
+  is what gives every existing row — and every kind added later — a default of
+  ON with no backfill. `[]` is the ordinary starting state and stays valid; `nil`
+  does not, because the column is `null: false`.
+  """
+  def email_notification_preferences_changeset(user, attrs) do
+    user
+    |> cast(attrs, [:disabled_email_notifications])
+    |> validate_required([:disabled_email_notifications])
   end
 
   @doc """

--- a/lib/klass_hero/enrollment/adapters/driving/workers/send_invite_email_worker.ex
+++ b/lib/klass_hero/enrollment/adapters/driving/workers/send_invite_email_worker.ex
@@ -6,7 +6,7 @@ defmodule KlassHero.Enrollment.Adapters.Driving.Workers.SendInviteEmailWorker do
   and transitions the invite status from `pending` to `invite_sent`.
   """
 
-  use KlassHero.Shared.RateLimitedEmailWorker, queue: :email, max_attempts: 3
+  use KlassHero.Shared.RateLimitedEmailWorker, queue: :email, max_attempts: 5
 
   alias KlassHero.Enrollment
   alias KlassHero.Enrollment.Adapters.Driven.Notifications.InviteEmailNotifier

--- a/lib/klass_hero/family/parent_profile.ex
+++ b/lib/klass_hero/family/parent_profile.ex
@@ -21,7 +21,6 @@ defmodule KlassHero.Family.ParentProfile do
     field :display_name, :string
     field :phone, :string
     field :location, :string
-    field :notification_preferences, :map
 
     timestamps()
   end
@@ -39,8 +38,7 @@ defmodule KlassHero.Family.ParentProfile do
       :identity_id,
       :display_name,
       :phone,
-      :location,
-      :notification_preferences
+      :location
     ])
     |> validate_required([:identity_id])
     |> validate_length(:display_name, min: 1, max: 100)
@@ -52,19 +50,12 @@ defmodule KlassHero.Family.ParentProfile do
     )
   end
 
-  @doc "Whether the profile has any notification preferences configured."
-  def has_notification_preferences?(%__MODULE__{notification_preferences: prefs})
-      when is_map(prefs) and map_size(prefs) > 0, do: true
-
-  def has_notification_preferences?(%__MODULE__{}), do: false
-
   @type t :: %__MODULE__{
           id: binary() | nil,
           identity_id: binary() | nil,
           display_name: String.t() | nil,
           phone: String.t() | nil,
           location: String.t() | nil,
-          notification_preferences: map() | nil,
           inserted_at: DateTime.t() | nil,
           updated_at: DateTime.t() | nil
         }

--- a/lib/klass_hero/messaging/new_message_email_handler.ex
+++ b/lib/klass_hero/messaging/new_message_email_handler.ex
@@ -68,6 +68,11 @@ defmodule KlassHero.Messaging.NewMessageEmailHandler do
   # Active participants with nothing else outstanding in this conversation.
   # Someone already sitting on unread mail has been told; a second email says
   # nothing new and is what turns a busy thread into a mute.
+  #
+  # The `is_nil(last_read_at) or inserted_at > last_read_at` half is the same
+  # "has this participant caught up" rule as `ConversationQueries.total_unread_count/1`
+  # and `MessageQueries.count_unread/2` — three expressions of one rule, which is
+  # why a change to any of them has to visit the others. See #1531.
   defp caught_up_user_ids(conversation_id, message_id) do
     from(p in Participant,
       where: p.conversation_id == ^conversation_id and is_nil(p.left_at),

--- a/lib/klass_hero/messaging/new_message_email_handler.ex
+++ b/lib/klass_hero/messaging/new_message_email_handler.ex
@@ -1,0 +1,107 @@
+defmodule KlassHero.Messaging.NewMessageEmailHandler do
+  @moduledoc """
+  Turns one `message_sent` event into one email job per participant who should
+  hear about it.
+
+  ## Why a consumer and not a call inside `SendMessage`
+
+  `domain-architecture.md` says a same-context reaction is an ordinary function
+  call made inside the producer's transaction, "so the write and its consequence
+  commit together". That reasoning is about **database** writes. An email cannot
+  be rolled back, so it must happen *after* commit, at-least-once, with retry —
+  which is what the outbox is for. Sending inline would also drag a participants
+  query, an Accounts query and up to N job inserts into a user-facing write, and
+  would fail a person's message send because Resend was briefly unavailable.
+
+  A handler, not a projection: `Shared.Projection.project/1` discards its
+  callback's return and always answers `:ok`, which would swallow every dispatch
+  failure. A `ForHandlingEvents` consumer propagates `{:error, reason}` back to
+  `EventDeliveryWorker` for retry and compensation.
+
+  ## Why the read-up filter queries the write side
+
+  Consumers of one event run **sequentially**, and `ConversationSummaries` is
+  also registered on `message_sent`. Filtering on its `unread_count` would mean
+  reading a number that consumer may or may not have already incremented,
+  depending on registry order — and if it ran first, every recipient would look
+  "already unread" and no email would ever send. So the filter reads
+  `conversation_participants.last_read_at` against `messages` instead, which no
+  consumer mutates.
+  """
+
+  @behaviour KlassHero.Shared.ForHandlingEvents
+
+  import Ecto.Query
+
+  alias KlassHero.Accounts
+  alias KlassHero.Messaging.Message
+  alias KlassHero.Messaging.Participant
+  alias KlassHero.Messaging.Workers.NewMessageEmailWorker
+  alias KlassHero.Repo
+  alias KlassHero.Shared.Tracing.Context
+
+  @kind :new_message_email
+
+  @impl true
+  def subscribed_events, do: [:message_sent]
+
+  @impl true
+  # A system message is written by the platform, not typed by a person — today
+  # only ReplyPrivatelyToBroadcast's "[broadcast:…]" context marker. Emailing on
+  # it would notify the provider twice for one parent action, once for a line
+  # the parent never wrote.
+  def handle_event(%{event_type: :message_sent, payload: %{message_type: :system}}), do: :ok
+
+  def handle_event(%{event_type: :message_sent, payload: payload}) do
+    %{conversation_id: conversation_id, message_id: message_id, sender_id: sender_id} = payload
+
+    conversation_id
+    |> caught_up_user_ids(message_id)
+    |> Enum.reject(&(&1 == sender_id))
+    |> Accounts.notifiable_recipients(@kind)
+    |> Map.keys()
+    |> enqueue(conversation_id)
+  end
+
+  def handle_event(_event), do: :ignore
+
+  # Active participants with nothing else outstanding in this conversation.
+  # Someone already sitting on unread mail has been told; a second email says
+  # nothing new and is what turns a busy thread into a mute.
+  defp caught_up_user_ids(conversation_id, message_id) do
+    from(p in Participant,
+      where: p.conversation_id == ^conversation_id and is_nil(p.left_at),
+      left_join: m in Message,
+      on:
+        m.conversation_id == p.conversation_id and
+          m.id != ^message_id and
+          is_nil(m.deleted_at) and
+          (is_nil(p.last_read_at) or m.inserted_at > p.last_read_at),
+      group_by: p.user_id,
+      having: count(m.id) == 0,
+      select: p.user_id
+    )
+    |> Repo.all()
+  end
+
+  defp enqueue([], _conversation_id), do: :ok
+
+  defp enqueue(user_ids, conversation_id) do
+    # One insert_all rather than a job-at-a-time insert: a program broadcast is
+    # a single message to every enrolled family, so this list is routinely in
+    # the hundreds. Stamping inserted_at from one clock keeps the batch ordered
+    # together (see Enrollment.EnqueueInviteEmails, #1339).
+    enqueued_at = DateTime.utc_now()
+
+    jobs =
+      Enum.map(user_ids, fn user_id ->
+        %{"conversation_id" => conversation_id, "recipient_user_id" => user_id}
+        |> Context.inject_into_args()
+        |> NewMessageEmailWorker.new(inserted_at: enqueued_at)
+      end)
+
+    Oban.insert_all(jobs)
+
+    :ok
+  end
+end

--- a/lib/klass_hero/messaging/new_message_email_notifier.ex
+++ b/lib/klass_hero/messaging/new_message_email_notifier.ex
@@ -1,0 +1,79 @@
+defmodule KlassHero.Messaging.NewMessageEmailNotifier do
+  @moduledoc """
+  Swoosh adapter telling someone they have a new message.
+
+  Carries a link and nothing else. The message body never reaches this module —
+  not because it is unavailable (the `message_sent` payload does carry
+  `content`), but because an inbox notification that quotes the message would
+  put private conversation text into an unencrypted mailbox and into every mail
+  provider's logs. The recipient reads it in the app.
+  """
+
+  use KlassHero.Shared.Interaction
+
+  import Swoosh.Email
+
+  alias KlassHero.Mailer
+  alias KlassHero.Shared.EmailHtml
+
+  @from Application.compile_env!(:klass_hero, [:mailer_defaults, :from])
+
+  @doc """
+  Emails `recipient` that `conversation_id` has a new message waiting.
+
+  `recipient` is `%{email: String.t(), name: String.t() | nil}`.
+  """
+  @spec send_new_message_notice(map(), String.t()) ::
+          {:ok, Swoosh.Email.t()} | {:error, term()}
+  def send_new_message_notice(recipient, conversation_id) do
+    email_interaction operation: :send_new_message_notice do
+      url = conversation_url(conversation_id)
+      name = recipient.name || recipient.email
+
+      email =
+        new()
+        |> to({name, recipient.email})
+        |> from(@from)
+        |> subject("You have a new message on Klass Hero")
+        |> text_body(text_body(url))
+        |> html_body(html_body(url))
+
+      with {:ok, _metadata} <- Mailer.deliver(email) do
+        {:ok, email}
+      end
+    end
+  end
+
+  # /messages/:id sits in the :authenticated live_session, so one URL shape is
+  # correct for a parent, a staff member and a provider alike.
+  defp conversation_url(conversation_id) do
+    base = Application.get_env(:klass_hero, :app_base_url, "http://localhost:4000")
+
+    "#{base}/messages/#{conversation_id}"
+  end
+
+  defp text_body(url) do
+    """
+    You have a new message waiting for you on Klass Hero.
+
+    Read it here: #{url}
+
+    We don't include message content in emails — open the conversation to read it.
+    """
+  end
+
+  defp html_body(url) do
+    EmailHtml.wrap(~s|
+      <p style="font-size: 16px;">You have a new message waiting for you on Klass Hero.</p>
+      <p style="margin: 30px 0;">
+        <a href="#{EmailHtml.esc(url)}"
+           style="background: #4F46E5; color: #fff; padding: 12px 24px; border-radius: 8px; text-decoration: none; font-weight: 600;">
+          Read your message
+        </a>
+      </p>
+      <p style="color: #666; font-size: 14px;">
+        We don't include message content in emails — open the conversation to read it.
+      </p>
+    |)
+  end
+end

--- a/lib/klass_hero/messaging/new_message_email_notifier.ex
+++ b/lib/klass_hero/messaging/new_message_email_notifier.ex
@@ -62,12 +62,14 @@ defmodule KlassHero.Messaging.NewMessageEmailNotifier do
     """
   end
 
+  # The button repeats Enrollment's invite-email values on purpose — the two
+  # should look alike. A shared `EmailHtml.button/2` waits for a third caller.
   defp html_body(url) do
     EmailHtml.wrap(~s|
       <p style="font-size: 16px;">You have a new message waiting for you on Klass Hero.</p>
       <p style="margin: 30px 0;">
         <a href="#{EmailHtml.esc(url)}"
-           style="background: #4F46E5; color: #fff; padding: 12px 24px; border-radius: 8px; text-decoration: none; font-weight: 600;">
+           style="background-color: #4F46E5; color: white; padding: 12px 30px; text-decoration: none; border-radius: 6px; font-weight: 600; display: inline-block;">
           Read your message
         </a>
       </p>

--- a/lib/klass_hero/messaging/workers/fetch_email_content_worker.ex
+++ b/lib/klass_hero/messaging/workers/fetch_email_content_worker.ex
@@ -6,7 +6,7 @@ defmodule KlassHero.Messaging.Workers.FetchEmailContentWorker do
   body_html, body_text, headers, and sets content_status to fetched/failed.
   """
 
-  use KlassHero.Shared.RateLimitedEmailWorker, queue: :email, max_attempts: 3
+  use KlassHero.Shared.RateLimitedEmailWorker, queue: :email, max_attempts: 5
 
   alias KlassHero.Messaging
   alias KlassHero.Messaging.ResendEmailContentAdapter

--- a/lib/klass_hero/messaging/workers/new_message_email_worker.ex
+++ b/lib/klass_hero/messaging/workers/new_message_email_worker.ex
@@ -1,0 +1,54 @@
+defmodule KlassHero.Messaging.Workers.NewMessageEmailWorker do
+  @moduledoc """
+  Delivers one "you have a new message" email.
+
+  Args carry ids only. The address is fetched here rather than passed in for
+  two reasons: an address in `oban_jobs.args` outlives the send by the Pruner's
+  retention, and one changed between enqueue and delivery would send to the old
+  mailbox.
+
+  The preference is re-checked here too. `NewMessageEmailHandler` already
+  filtered at enqueue — that keeps pointless jobs off a shared, rate-limited
+  queue — but a broadcast's jobs can sit for a while, and someone who opts out
+  in that window should not still receive the backlog.
+  """
+
+  use KlassHero.Shared.RateLimitedEmailWorker, queue: :email, max_attempts: 5
+
+  alias KlassHero.Accounts
+  alias KlassHero.Messaging.NewMessageEmailNotifier
+
+  require Logger
+
+  @kind :new_message_email
+
+  @impl true
+  def execute(%Oban.Job{args: %{"conversation_id" => conversation_id, "recipient_user_id" => user_id}})
+      when is_binary(conversation_id) and is_binary(user_id) do
+    case Accounts.notifiable_recipients([user_id], @kind) do
+      %{^user_id => recipient} ->
+        deliver(recipient, conversation_id, user_id)
+
+      # Opted out after enqueue, or the account is gone. Neither is an error and
+      # neither is fixable by retrying, so this is a completed job with no send.
+      %{} ->
+        :ok
+    end
+  end
+
+  defp deliver(recipient, conversation_id, user_id) do
+    case NewMessageEmailNotifier.send_new_message_notice(recipient, conversation_id) do
+      {:ok, _email} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.error("New-message email failed",
+          conversation_id: conversation_id,
+          user_id: user_id,
+          reason: inspect(reason)
+        )
+
+        {:error, reason}
+    end
+  end
+end

--- a/lib/klass_hero/messaging/workers/send_email_reply_worker.ex
+++ b/lib/klass_hero/messaging/workers/send_email_reply_worker.ex
@@ -6,7 +6,7 @@ defmodule KlassHero.Messaging.Workers.SendEmailReplyWorker do
   with proper threading headers, delivers, and updates reply status.
   """
 
-  use KlassHero.Shared.RateLimitedEmailWorker, queue: :email, max_attempts: 3
+  use KlassHero.Shared.RateLimitedEmailWorker, queue: :email, max_attempts: 5
   use KlassHero.Shared.Interaction
 
   alias KlassHero.Messaging

--- a/lib/klass_hero/provider/notify_incident_reported_worker.ex
+++ b/lib/klass_hero/provider/notify_incident_reported_worker.ex
@@ -2,9 +2,11 @@ defmodule KlassHero.Provider.NotifyIncidentReportedWorker do
   @moduledoc """
   Oban worker that delivers the incident-report email for a single report.
 
-  Runs on the `:email` queue (concurrency 1) so Resend rate limits are
-  respected globally. Delegates the actual orchestration to the
-  `NotifyIncidentReported` use case.
+  Runs on the shared `:email` queue, whose concurrency and retry budget are one
+  decision documented in `config/config.exs` — not restated here, because this
+  file said "concurrency 1" for a while after that stopped being true. Rate
+  limiting is `RateLimitedEmailWorker`'s 429-aware backoff, not the queue width.
+  Delegates the actual orchestration to the `NotifyIncidentReported` use case.
   """
 
   use KlassHero.Shared.RateLimitedEmailWorker, queue: :email, max_attempts: 5

--- a/lib/klass_hero/provider/notify_incident_reported_worker.ex
+++ b/lib/klass_hero/provider/notify_incident_reported_worker.ex
@@ -7,7 +7,7 @@ defmodule KlassHero.Provider.NotifyIncidentReportedWorker do
   `NotifyIncidentReported` use case.
   """
 
-  use KlassHero.Shared.RateLimitedEmailWorker, queue: :email, max_attempts: 3
+  use KlassHero.Shared.RateLimitedEmailWorker, queue: :email, max_attempts: 5
 
   alias KlassHero.Provider.NotifyIncidentReported
 

--- a/lib/klass_hero_web/live/user_live/settings.ex
+++ b/lib/klass_hero_web/live/user_live/settings.ex
@@ -202,6 +202,25 @@ defmodule KlassHeroWeb.UserLive.Settings do
                 </div>
               </.form>
             </div>
+            <div class="p-5 border-t border-[var(--border-light)]">
+              <h3 class="text-sm font-semibold mb-3 text-hero-black">
+                {gettext("Email notifications")}
+              </h3>
+              <p class="text-sm mb-4 text-[var(--fg-muted)]">
+                {gettext("Choose which emails you want us to send you")}
+              </p>
+              <.form
+                for={@notification_form}
+                id="notification_preferences_form"
+                phx-change="update_notification_preferences"
+              >
+                <.input
+                  field={@notification_form[:new_message_email]}
+                  type="checkbox"
+                  label={gettext("Email me when I receive a new message")}
+                />
+              </.form>
+            </div>
           </.kh_card>
 
           <%!-- Profiles --%>
@@ -433,6 +452,7 @@ defmodule KlassHeroWeb.UserLive.Settings do
       |> assign(:email_form, to_form(email_changeset))
       |> assign(:password_form, to_form(password_changeset))
       |> assign(:locale_form, to_form(locale_changeset))
+      |> assign_notification_form(user)
       |> assign(:delete_form, to_form(%{"password" => ""}, as: :delete))
       |> assign(:trigger_submit, false)
       |> assign(:user_initials, get_user_initials(user.email))
@@ -457,6 +477,17 @@ defmodule KlassHeroWeb.UserLive.Settings do
   # Only these two are self-grantable. :staff is an employment link to someone
   # else's business (ADR-0005) — a provider adds themselves to their own team
   # from the team page, and nobody can hire themselves into another's.
+  # One boolean per notification kind, keyed the way the checkbox reads: on
+  # means "send me this". The stored column is the inverse — that inversion is
+  # Accounts' business, and nothing here should learn it.
+  defp assign_notification_form(socket, user) do
+    params = %{
+      "new_message_email" => Accounts.email_notification_enabled?(user, :new_message_email)
+    }
+
+    assign(socket, :notification_form, to_form(params, as: :notifications))
+  end
+
   @self_grantable [:parent, :provider]
 
   defp addable_personas(scope), do: @self_grantable -- Persona.available(scope)
@@ -644,6 +675,23 @@ defmodule KlassHeroWeb.UserLive.Settings do
   # first, and only its redirect re-renders the root layout's <html lang>.
   def handle_event("update_locale", %{"user" => %{"locale" => locale}}, socket) do
     {:noreply, redirect(socket, to: ~p"/locale/#{locale}?return_to=/users/settings")}
+  end
+
+  # Unlike update_locale above, this persists in place — there is no session to
+  # write, so nothing forces a redirect. The form renders from its own assign
+  # rather than @current_scope.user, which no handler on this page refreshes.
+  def handle_event("update_notification_preferences", %{"notifications" => %{"new_message_email" => enabled}}, socket) do
+    case Accounts.update_user_email_notification_preference(
+           socket.assigns.current_scope.user,
+           :new_message_email,
+           enabled == "true"
+         ) do
+      {:ok, user} ->
+        {:noreply, assign_notification_form(socket, user)}
+
+      {:error, %Ecto.Changeset{}} ->
+        {:noreply, put_flash(socket, :error, gettext("Could not update your notification preferences."))}
+    end
   end
 
   def handle_event("delete_account", %{"delete" => %{"password" => password}}, socket) do

--- a/lib/mix/tasks/lint_compile_coupling.ex
+++ b/lib/mix/tasks/lint_compile_coupling.ex
@@ -1,0 +1,64 @@
+defmodule Mix.Tasks.LintCompileCoupling do
+  @shortdoc "Fail if compile-time coupling grows beyond the recorded ceiling"
+  @moduledoc """
+  Wraps `mix xref graph --label compile-connected` with a ceiling on the count.
+
+  Keeps a runtime dependency from silently becoming a compile-time one, which
+  balloons recompiles across a seven-context app.
+
+  ## Why this is a task and not a line in two places
+
+  The ceiling used to be written twice — in `mix.exs`'s `precommit` alias and in
+  `.github/workflows/ci.yml` — and the two drifted the first time it moved:
+  `precommit` passed locally at the new number while CI still failed at the old
+  one. Every other check in that CI job is a `mix lint_*` task for exactly this
+  reason. One number, one place, both callers.
+
+  ## The ceiling is a ratchet, not an aspiration
+
+  It is the count the tree had when the gate landed, and nearly all of it is
+  inherent `use`-macro coupling: Backpex admin LiveViews to their schemas,
+  messaging LiveViews to their shared helper, Oban workers to `TracedWorker`.
+  Driving it to zero is not the goal; noticing the next one is. Lower it whenever
+  a refactor earns it, and raise it only after reading the printed graph and
+  confirming the new edge is that same inherent kind.
+
+  ## Usage
+
+      mix lint_compile_coupling
+  """
+  use Mix.Task
+
+  # 34 as of #1071: NewMessageEmailWorker -> RateLimitedEmailWorker/TracedWorker
+  # and NewMessageEmailNotifier -> Shared.Interaction. Both are the inherent kind
+  # above, identical to the four email workers already counted — no runtime
+  # dependency was converted into a compile-time one.
+  @ceiling 34
+
+  @impl true
+  def run(_args) do
+    # Runs xref in a subprocess so its stdout can be swallowed: the full graph is
+    # printed even on success, which is ~60 lines of noise in every CI log. The
+    # failure message goes to stderr and is left alone, so it still surfaces.
+    {_graph, status} =
+      System.cmd(
+        "mix",
+        ["xref", "graph", "--label", "compile-connected", "--fail-above", to_string(@ceiling)],
+        into: "",
+        stderr_to_stdout: false
+      )
+
+    if status == 0 do
+      Mix.shell().info("Compile coupling lint passed — at or below #{@ceiling} references.")
+    else
+      Mix.raise("""
+      Compile-time coupling grew past #{@ceiling}.
+
+      Run `mix xref graph --label compile-connected` to see what is connected. If
+      the new edge is inherent `use`-macro coupling, raise @ceiling in
+      lib/mix/tasks/lint_compile_coupling.ex and record why. If a runtime
+      dependency became compile-time, fix that instead of the number.
+      """)
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -161,18 +161,9 @@ defmodule KlassHero.MixProject do
       precommit: [
         "compile --warnings-as-errors",
         "deps.unlock --unused",
-        # Ratchet, not an aspiration: 32 is what the tree had when this gate landed, and
-        # nearly all of it is inherent `use`-macro coupling (Backpex admin LiveViews ->
-        # schemas, messaging LiveViews -> their shared helper, workers -> TracedWorker).
-        # Driving it to 0 is not the goal; noticing the 33rd is. Lower the number whenever
-        # a refactor earns it.
-        # 34 since #1071: NewMessageEmailWorker -> RateLimitedEmailWorker/TracedWorker and
-        # NewMessageEmailNotifier -> Shared.Interaction. Both are the inherent kind above,
-        # identical to the four email workers already counted — no runtime dependency was
-        # converted into a compile-time one. The gate did its job: it made someone check.
-        # stdout is the full graph even on success, which is 60 lines of noise here; the
-        # failure message goes to stderr and survives. Re-run without the redirect to see it.
-        "cmd bash -c 'mix xref graph --label compile-connected --fail-above 34 >/dev/null'",
+        # The ceiling lives in the task, not here — it was written in both places
+        # once, and they drifted the first time it moved (#1529).
+        "lint_compile_coupling",
         "format",
         "lint_typography",
         "lint_hero_colors",

--- a/mix.exs
+++ b/mix.exs
@@ -166,9 +166,13 @@ defmodule KlassHero.MixProject do
         # schemas, messaging LiveViews -> their shared helper, workers -> TracedWorker).
         # Driving it to 0 is not the goal; noticing the 33rd is. Lower the number whenever
         # a refactor earns it.
+        # 34 since #1071: NewMessageEmailWorker -> RateLimitedEmailWorker/TracedWorker and
+        # NewMessageEmailNotifier -> Shared.Interaction. Both are the inherent kind above,
+        # identical to the four email workers already counted — no runtime dependency was
+        # converted into a compile-time one. The gate did its job: it made someone check.
         # stdout is the full graph even on success, which is 60 lines of noise here; the
         # failure message goes to stderr and survives. Re-run without the redirect to see it.
-        "cmd bash -c 'mix xref graph --label compile-connected --fail-above 32 >/dev/null'",
+        "cmd bash -c 'mix xref graph --label compile-connected --fail-above 34 >/dev/null'",
         "format",
         "lint_typography",
         "lint_hero_colors",

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -51,12 +51,12 @@ msgstr "Kontakt"
 msgid "Dashboard"
 msgstr "Dashboard"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:328
+#: lib/klass_hero_web/live/user_live/settings.ex:347
 #, elixir-autogen, elixir-format
 msgid "Download My Data"
 msgstr "Meine Daten herunterladen"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:324
+#: lib/klass_hero_web/live/user_live/settings.ex:343
 #, elixir-autogen, elixir-format
 msgid "Download a copy of all your personal data"
 msgstr "Laden Sie eine Kopie aller Ihrer persönlichen Daten herunter"
@@ -102,7 +102,7 @@ msgstr "Programme"
 #: lib/klass_hero_web/components/layouts/app.html.heex:115
 #: lib/klass_hero_web/components/layouts/app.html.heex:223
 #: lib/klass_hero_web/components/ui_components.ex:205
-#: lib/klass_hero_web/live/user_live/settings.ex:430
+#: lib/klass_hero_web/live/user_live/settings.ex:449
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr "Einstellungen"
@@ -130,7 +130,7 @@ msgstr "Etwas ist schief gelaufen!"
 msgid "We can't find the internet"
 msgstr "Keine Internetverbindung gefunden"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:322
+#: lib/klass_hero_web/live/user_live/settings.ex:341
 #, elixir-autogen, elixir-format
 msgid "Your Data"
 msgstr "Ihre Daten"
@@ -398,7 +398,7 @@ msgstr "Alle Programme ansehen →"
 msgid "✓ No hidden fees"
 msgstr "✓ Keine versteckten Gebühren"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:596
+#: lib/klass_hero_web/live/user_live/settings.ex:627
 #, elixir-autogen, elixir-format
 msgid "A link to confirm your email change has been sent to the new address."
 msgstr "Ein Bestätigungslink wurde an Ihre neue E-Mail-Adresse gesendet."
@@ -556,17 +556,17 @@ msgstr "Datensicherheit"
 msgid "Data Sharing"
 msgstr "Datenweitergabe"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:343
+#: lib/klass_hero_web/live/user_live/settings.ex:362
 #, elixir-autogen, elixir-format
 msgid "Delete Account"
 msgstr "Konto löschen"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:376
+#: lib/klass_hero_web/live/user_live/settings.ex:395
 #, elixir-autogen, elixir-format
 msgid "Delete My Account"
 msgstr "Mein Konto löschen"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:366
+#: lib/klass_hero_web/live/user_live/settings.ex:385
 #, elixir-autogen, elixir-format
 msgid "Deleting..."
 msgstr "Wird gelöscht..."
@@ -590,12 +590,12 @@ msgstr "Streitbeilegung"
 msgid "Email"
 msgstr "E-Mail"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:414
+#: lib/klass_hero_web/live/user_live/settings.ex:433
 #, elixir-autogen, elixir-format
 msgid "Email change link is invalid or it has expired."
 msgstr "Der Link zur E-Mail-Änderung ist ungültig oder abgelaufen."
 
-#: lib/klass_hero_web/live/user_live/settings.ex:411
+#: lib/klass_hero_web/live/user_live/settings.ex:430
 #, elixir-autogen, elixir-format
 msgid "Email changed successfully."
 msgstr "E-Mail erfolgreich geändert."
@@ -605,7 +605,7 @@ msgstr "E-Mail erfolgreich geändert."
 msgid "Enroll children in programs"
 msgstr "Kinder für Programme anmelden"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:360
+#: lib/klass_hero_web/live/user_live/settings.ex:379
 #, elixir-autogen, elixir-format
 msgid "Enter your password to confirm"
 msgstr "Geben Sie Ihr Passwort zur Bestätigung ein"
@@ -627,7 +627,7 @@ msgstr "Auschecken fehlgeschlagen: %{reason}"
 msgid "Failed to complete session: %{reason}"
 msgstr "Sitzung konnte nicht abgeschlossen werden: %{reason}"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:674
+#: lib/klass_hero_web/live/user_live/settings.ex:722
 #, elixir-autogen, elixir-format
 msgid "Failed to delete account. Please try again."
 msgstr "Konto konnte nicht gelöscht werden. Bitte versuchen Sie es erneut."
@@ -690,7 +690,7 @@ msgstr "Einleitung"
 msgid "Invalid date format"
 msgstr "Ungültiges Datumsformat"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:668
+#: lib/klass_hero_web/live/user_live/settings.ex:716
 #, elixir-autogen, elixir-format
 msgid "Invalid password."
 msgstr "Ungültiges Passwort."
@@ -937,7 +937,7 @@ msgstr "Technisches Problem"
 msgid "Terms of Service"
 msgstr "Nutzungsbedingungen"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:346
+#: lib/klass_hero_web/live/user_live/settings.ex:365
 #, elixir-autogen, elixir-format
 msgid "This action cannot be undone. Your account data will be anonymized and you will be logged out."
 msgstr "Diese Aktion kann nicht rückgängig gemacht werden. Ihre Kontodaten werden anonymisiert und Sie werden abgemeldet."
@@ -1018,7 +1018,7 @@ msgstr "Sie müssen sich erneut authentifizieren, um sensible Aktionen auf Ihrem
 msgid "Your Privacy Rights"
 msgstr "Ihre Datenschutzrechte"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:656
+#: lib/klass_hero_web/live/user_live/settings.ex:704
 #, elixir-autogen, elixir-format
 msgid "Your account has been deleted."
 msgstr "Ihr Konto wurde gelöscht."
@@ -1075,7 +1075,7 @@ msgstr "Sommercamps"
 
 #: lib/klass_hero_web/live/settings/children_live.ex:23
 #: lib/klass_hero_web/live/settings/children_live.ex:313
-#: lib/klass_hero_web/live/user_live/settings.ex:300
+#: lib/klass_hero_web/live/user_live/settings.ex:319
 #, elixir-autogen, elixir-format
 msgid "Children Profiles"
 msgstr "Kinderprofile"
@@ -1090,7 +1090,7 @@ msgstr "Ungültige E-Mail oder Passwort"
 msgid "Logged out successfully."
 msgstr "Erfolgreich abgemeldet."
 
-#: lib/klass_hero_web/live/user_live/settings.ex:286
+#: lib/klass_hero_web/live/user_live/settings.ex:305
 #, elixir-autogen, elixir-format
 msgid "My Family"
 msgstr "Meine Familie"
@@ -1287,17 +1287,17 @@ msgstr "Kontosicherheit"
 msgid "Customize your experience"
 msgstr "Passen Sie Ihre Erfahrung an"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:336
+#: lib/klass_hero_web/live/user_live/settings.ex:355
 #, elixir-autogen, elixir-format
 msgid "Danger Zone"
 msgstr "Gefahrenzone"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:314
+#: lib/klass_hero_web/live/user_live/settings.ex:333
 #, elixir-autogen, elixir-format
 msgid "Data & Privacy"
 msgstr "Daten & Datenschutz"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:316
+#: lib/klass_hero_web/live/user_live/settings.ex:335
 #, elixir-autogen, elixir-format
 msgid "Download your data or delete your account"
 msgstr "Daten herunterladen oder Konto löschen"
@@ -1695,7 +1695,7 @@ msgstr "Bekannte Allergien auflisten..."
 msgid "Manage your children's information and consents"
 msgstr "Informationen und Einwilligungen Ihrer Kinder verwalten"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:288
+#: lib/klass_hero_web/live/user_live/settings.ex:307
 #, elixir-autogen, elixir-format
 msgid "Manage your children's profiles"
 msgstr "Verwalten Sie die Profile Ihrer Kinder"
@@ -1784,17 +1784,17 @@ msgstr "Bitte überprüfen Sie das Formular auf Fehler."
 msgid "Please complete your profile before making a booking."
 msgstr "Bitte vervollständigen Sie Ihr Profil, bevor Sie eine Buchung vornehmen."
 
-#: lib/klass_hero_web/live/user_live/settings.ex:605
+#: lib/klass_hero_web/live/user_live/settings.ex:636
 #, elixir-autogen, elixir-format
 msgid "Please re-authenticate to change your email."
 msgstr "Bitte authentifizieren Sie sich erneut, um Ihre E-Mail-Adresse zu ändern."
 
-#: lib/klass_hero_web/live/user_live/settings.ex:637
+#: lib/klass_hero_web/live/user_live/settings.ex:668
 #, elixir-autogen, elixir-format
 msgid "Please re-authenticate to change your password."
 msgstr "Bitte authentifizieren Sie sich erneut, um Ihr Passwort zu ändern."
 
-#: lib/klass_hero_web/live/user_live/settings.ex:662
+#: lib/klass_hero_web/live/user_live/settings.ex:710
 #, elixir-autogen, elixir-format
 msgid "Please re-authenticate to delete your account."
 msgstr "Bitte authentifizieren Sie sich erneut, um Ihr Konto zu löschen."
@@ -4499,7 +4499,7 @@ msgstr "Anhang entfernen"
 #: lib/klass_hero_web/live/messaging_live_helper.ex:535
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:132
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:118
-#: lib/klass_hero_web/live/user_live/settings.ex:513
+#: lib/klass_hero_web/live/user_live/settings.ex:544
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Please try again."
 msgstr "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut."
@@ -5786,7 +5786,7 @@ msgid "Not allowed to approve this enrollment"
 msgstr "Nicht berechtigt, diese Anmeldung zu genehmigen"
 
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:290
-#: lib/klass_hero_web/live/user_live/settings.ex:245
+#: lib/klass_hero_web/live/user_live/settings.ex:264
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr "Nicht jetzt"
@@ -6093,7 +6093,7 @@ msgid "Send us a message"
 msgstr "Schreiben Sie uns eine Nachricht"
 
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:279
-#: lib/klass_hero_web/live/user_live/settings.ex:235
+#: lib/klass_hero_web/live/user_live/settings.ex:254
 #, elixir-autogen, elixir-format
 msgid "Setting up..."
 msgstr "Wird eingerichtet..."
@@ -6406,7 +6406,7 @@ msgid "Yes. You can run unlimited programs, each with its own schedule and venue
 msgstr "Ja. Sie können unbegrenzt viele Programme mit jeweils eigenem Zeitplan und Veranstaltungsort betreiben und beliebig viele Teammitglieder hinzufügen, um die Verwaltung auf Ihre Kursleitungen zu verteilen."
 
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:83
-#: lib/klass_hero_web/live/user_live/settings.ex:491
+#: lib/klass_hero_web/live/user_live/settings.ex:522
 #, elixir-autogen, elixir-format
 msgid "You already have a provider profile."
 msgstr "Sie haben bereits ein Anbieterprofil."
@@ -7210,7 +7210,7 @@ msgstr "Nicht zugestellte Ereignisse"
 
 #: lib/klass_hero_web/components/provider_components.ex:2171
 #: lib/klass_hero_web/components/provider_components.ex:2349
-#: lib/klass_hero_web/live/user_live/settings.ex:273
+#: lib/klass_hero_web/live/user_live/settings.ex:292
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr "Hinzufügen"
@@ -7746,7 +7746,7 @@ msgid "Verified Provider"
 msgstr "Verifizierter Anbieter"
 
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:75
-#: lib/klass_hero_web/live/user_live/settings.ex:486
+#: lib/klass_hero_web/live/user_live/settings.ex:517
 #, elixir-autogen, elixir-format
 msgid "Welcome aboard! Let's set up your provider profile."
 msgstr "Willkommen an Bord! Lassen Sie uns Ihr Anbieterprofil einrichten."
@@ -7776,47 +7776,47 @@ msgstr "Profil konnte nicht gewechselt werden."
 msgid "You don't have that profile."
 msgstr "Sie haben dieses Profil nicht."
 
-#: lib/klass_hero_web/live/user_live/settings.ex:519
+#: lib/klass_hero_web/live/user_live/settings.ex:550
 #, elixir-autogen, elixir-format
 msgid "Add a family profile"
 msgstr "Familienprofil hinzufügen"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:520
+#: lib/klass_hero_web/live/user_live/settings.ex:551
 #, elixir-autogen, elixir-format
 msgid "Add a provider profile"
 msgstr "Anbieterprofil hinzufügen"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:536
+#: lib/klass_hero_web/live/user_live/settings.ex:567
 #, elixir-autogen, elixir-format
 msgid "Add family profile"
 msgstr "Familienprofil hinzufügen"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:537
+#: lib/klass_hero_web/live/user_live/settings.ex:568
 #, elixir-autogen, elixir-format
 msgid "Add provider profile"
 msgstr "Anbieterprofil hinzufügen"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:522
+#: lib/klass_hero_web/live/user_live/settings.ex:553
 #, elixir-autogen, elixir-format
 msgid "Book activities and manage your children's places."
 msgstr "Kurse buchen und die Plätze Ihrer Kinder verwalten."
 
-#: lib/klass_hero_web/live/user_live/settings.ex:468
+#: lib/klass_hero_web/live/user_live/settings.ex:499
 #, elixir-autogen, elixir-format
 msgid "Family profile added. You can add your children now."
 msgstr "Familienprofil hinzugefügt. Sie können jetzt Ihre Kinder anlegen."
 
-#: lib/klass_hero_web/live/user_live/settings.ex:524
+#: lib/klass_hero_web/live/user_live/settings.ex:555
 #, elixir-autogen, elixir-format
 msgid "List your own activities and take bookings."
 msgstr "Eigene Kurse anbieten und Buchungen annehmen."
 
-#: lib/klass_hero_web/live/user_live/settings.ex:431
+#: lib/klass_hero_web/live/user_live/settings.ex:450
 #, elixir-autogen, elixir-format
 msgid "Manage your account, preferences, and privacy."
 msgstr "Verwalten Sie Ihr Konto, Ihre Einstellungen und Ihren Datenschutz."
 
-#: lib/klass_hero_web/live/user_live/settings.ex:214
+#: lib/klass_hero_web/live/user_live/settings.ex:233
 #, elixir-autogen, elixir-format
 msgid "One account can be both a family and a provider."
 msgstr "Ein Konto kann Familie und Anbieter zugleich sein."
@@ -7827,7 +7827,7 @@ msgid "Parent"
 msgstr "Eltern"
 
 #: lib/klass_hero_web/live/user_live/settings.ex:40
-#: lib/klass_hero_web/live/user_live/settings.ex:212
+#: lib/klass_hero_web/live/user_live/settings.ex:231
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr "Profile"
@@ -7847,17 +7847,17 @@ msgstr "Zu %{persona} wechseln"
 msgid "Viewing as %{persona}"
 msgstr "Angezeigt als %{persona}"
 
-#: lib/klass_hero_web/live/user_live/settings.ex:474
+#: lib/klass_hero_web/live/user_live/settings.ex:505
 #, elixir-autogen, elixir-format
 msgid "You already have a family profile."
 msgstr "Sie haben bereits ein Familienprofil."
 
-#: lib/klass_hero_web/live/user_live/settings.ex:528
+#: lib/klass_hero_web/live/user_live/settings.ex:559
 #, elixir-autogen, elixir-format
 msgid "You'll be able to add your children and book activities. Your provider account stays exactly as it is."
 msgstr "Sie können dann Ihre Kinder anlegen und Kurse buchen. Ihr Anbieterkonto bleibt unverändert."
 
-#: lib/klass_hero_web/live/user_live/settings.ex:532
+#: lib/klass_hero_web/live/user_live/settings.ex:563
 #, elixir-autogen, elixir-format
 msgid "You'll get a provider profile to fill in, and a dashboard for your activities. Your family account stays exactly as it is."
 msgstr "Sie erhalten ein Anbieterprofil zum Ausfüllen und ein Dashboard für Ihre Kurse. Ihr Familienkonto bleibt unverändert."
@@ -8195,3 +8195,23 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "Messages here may be reviewed by Klass Hero staff."
 msgstr "Nachrichten hier können von Klass Hero-Mitarbeitenden eingesehen werden."
+
+#: lib/klass_hero_web/live/user_live/settings.ex:210
+#, elixir-autogen, elixir-format
+msgid "Choose which emails you want us to send you"
+msgstr "Wählen Sie, welche E-Mails wir Ihnen senden sollen"
+
+#: lib/klass_hero_web/live/user_live/settings.ex:693
+#, elixir-autogen, elixir-format
+msgid "Could not update your notification preferences."
+msgstr "Ihre Benachrichtigungseinstellungen konnten nicht aktualisiert werden."
+
+#: lib/klass_hero_web/live/user_live/settings.ex:220
+#, elixir-autogen, elixir-format
+msgid "Email me when I receive a new message"
+msgstr "Benachrichtigen Sie mich per E-Mail, wenn ich eine neue Nachricht erhalte"
+
+#: lib/klass_hero_web/live/user_live/settings.ex:207
+#, elixir-autogen, elixir-format
+msgid "Email notifications"
+msgstr "E-Mail-Benachrichtigungen"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -51,12 +51,12 @@ msgstr ""
 msgid "Dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:328
+#: lib/klass_hero_web/live/user_live/settings.ex:347
 #, elixir-autogen, elixir-format
 msgid "Download My Data"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:324
+#: lib/klass_hero_web/live/user_live/settings.ex:343
 #, elixir-autogen, elixir-format
 msgid "Download a copy of all your personal data"
 msgstr ""
@@ -102,7 +102,7 @@ msgstr ""
 #: lib/klass_hero_web/components/layouts/app.html.heex:115
 #: lib/klass_hero_web/components/layouts/app.html.heex:223
 #: lib/klass_hero_web/components/ui_components.ex:205
-#: lib/klass_hero_web/live/user_live/settings.ex:430
+#: lib/klass_hero_web/live/user_live/settings.ex:449
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr ""
@@ -130,7 +130,7 @@ msgstr ""
 msgid "We can't find the internet"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:322
+#: lib/klass_hero_web/live/user_live/settings.ex:341
 #, elixir-autogen, elixir-format
 msgid "Your Data"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "✓ No hidden fees"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:596
+#: lib/klass_hero_web/live/user_live/settings.ex:627
 #, elixir-autogen, elixir-format
 msgid "A link to confirm your email change has been sent to the new address."
 msgstr ""
@@ -556,17 +556,17 @@ msgstr ""
 msgid "Data Sharing"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:343
+#: lib/klass_hero_web/live/user_live/settings.ex:362
 #, elixir-autogen, elixir-format
 msgid "Delete Account"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:376
+#: lib/klass_hero_web/live/user_live/settings.ex:395
 #, elixir-autogen, elixir-format
 msgid "Delete My Account"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:366
+#: lib/klass_hero_web/live/user_live/settings.ex:385
 #, elixir-autogen, elixir-format
 msgid "Deleting..."
 msgstr ""
@@ -590,12 +590,12 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:414
+#: lib/klass_hero_web/live/user_live/settings.ex:433
 #, elixir-autogen, elixir-format
 msgid "Email change link is invalid or it has expired."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:411
+#: lib/klass_hero_web/live/user_live/settings.ex:430
 #, elixir-autogen, elixir-format
 msgid "Email changed successfully."
 msgstr ""
@@ -605,7 +605,7 @@ msgstr ""
 msgid "Enroll children in programs"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:360
+#: lib/klass_hero_web/live/user_live/settings.ex:379
 #, elixir-autogen, elixir-format
 msgid "Enter your password to confirm"
 msgstr ""
@@ -627,7 +627,7 @@ msgstr ""
 msgid "Failed to complete session: %{reason}"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:674
+#: lib/klass_hero_web/live/user_live/settings.ex:722
 #, elixir-autogen, elixir-format
 msgid "Failed to delete account. Please try again."
 msgstr ""
@@ -690,7 +690,7 @@ msgstr ""
 msgid "Invalid date format"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:668
+#: lib/klass_hero_web/live/user_live/settings.ex:716
 #, elixir-autogen, elixir-format
 msgid "Invalid password."
 msgstr ""
@@ -937,7 +937,7 @@ msgstr ""
 msgid "Terms of Service"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:346
+#: lib/klass_hero_web/live/user_live/settings.ex:365
 #, elixir-autogen, elixir-format
 msgid "This action cannot be undone. Your account data will be anonymized and you will be logged out."
 msgstr ""
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "Your Privacy Rights"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:656
+#: lib/klass_hero_web/live/user_live/settings.ex:704
 #, elixir-autogen, elixir-format
 msgid "Your account has been deleted."
 msgstr ""
@@ -1075,7 +1075,7 @@ msgstr ""
 
 #: lib/klass_hero_web/live/settings/children_live.ex:23
 #: lib/klass_hero_web/live/settings/children_live.ex:313
-#: lib/klass_hero_web/live/user_live/settings.ex:300
+#: lib/klass_hero_web/live/user_live/settings.ex:319
 #, elixir-autogen, elixir-format
 msgid "Children Profiles"
 msgstr ""
@@ -1090,7 +1090,7 @@ msgstr ""
 msgid "Logged out successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:286
+#: lib/klass_hero_web/live/user_live/settings.ex:305
 #, elixir-autogen, elixir-format
 msgid "My Family"
 msgstr ""
@@ -1287,17 +1287,17 @@ msgstr ""
 msgid "Customize your experience"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:336
+#: lib/klass_hero_web/live/user_live/settings.ex:355
 #, elixir-autogen, elixir-format
 msgid "Danger Zone"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:314
+#: lib/klass_hero_web/live/user_live/settings.ex:333
 #, elixir-autogen, elixir-format
 msgid "Data & Privacy"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:316
+#: lib/klass_hero_web/live/user_live/settings.ex:335
 #, elixir-autogen, elixir-format
 msgid "Download your data or delete your account"
 msgstr ""
@@ -1695,7 +1695,7 @@ msgstr ""
 msgid "Manage your children's information and consents"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:288
+#: lib/klass_hero_web/live/user_live/settings.ex:307
 #, elixir-autogen, elixir-format
 msgid "Manage your children's profiles"
 msgstr ""
@@ -1784,17 +1784,17 @@ msgstr ""
 msgid "Please complete your profile before making a booking."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:605
+#: lib/klass_hero_web/live/user_live/settings.ex:636
 #, elixir-autogen, elixir-format
 msgid "Please re-authenticate to change your email."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:637
+#: lib/klass_hero_web/live/user_live/settings.ex:668
 #, elixir-autogen, elixir-format
 msgid "Please re-authenticate to change your password."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:662
+#: lib/klass_hero_web/live/user_live/settings.ex:710
 #, elixir-autogen, elixir-format
 msgid "Please re-authenticate to delete your account."
 msgstr ""
@@ -4499,7 +4499,7 @@ msgstr ""
 #: lib/klass_hero_web/live/messaging_live_helper.ex:535
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:132
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:118
-#: lib/klass_hero_web/live/user_live/settings.ex:513
+#: lib/klass_hero_web/live/user_live/settings.ex:544
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Please try again."
 msgstr ""
@@ -5786,7 +5786,7 @@ msgid "Not allowed to approve this enrollment"
 msgstr ""
 
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:290
-#: lib/klass_hero_web/live/user_live/settings.ex:245
+#: lib/klass_hero_web/live/user_live/settings.ex:264
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr ""
@@ -6093,7 +6093,7 @@ msgid "Send us a message"
 msgstr ""
 
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:279
-#: lib/klass_hero_web/live/user_live/settings.ex:235
+#: lib/klass_hero_web/live/user_live/settings.ex:254
 #, elixir-autogen, elixir-format
 msgid "Setting up..."
 msgstr ""
@@ -6406,7 +6406,7 @@ msgid "Yes. You can run unlimited programs, each with its own schedule and venue
 msgstr ""
 
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:83
-#: lib/klass_hero_web/live/user_live/settings.ex:491
+#: lib/klass_hero_web/live/user_live/settings.ex:522
 #, elixir-autogen, elixir-format
 msgid "You already have a provider profile."
 msgstr ""
@@ -7210,7 +7210,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:2171
 #: lib/klass_hero_web/components/provider_components.ex:2349
-#: lib/klass_hero_web/live/user_live/settings.ex:273
+#: lib/klass_hero_web/live/user_live/settings.ex:292
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr ""
@@ -7731,7 +7731,7 @@ msgid "Verified Provider"
 msgstr ""
 
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:75
-#: lib/klass_hero_web/live/user_live/settings.ex:486
+#: lib/klass_hero_web/live/user_live/settings.ex:517
 #, elixir-autogen, elixir-format
 msgid "Welcome aboard! Let's set up your provider profile."
 msgstr ""
@@ -7761,47 +7761,47 @@ msgstr ""
 msgid "You don't have that profile."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:519
+#: lib/klass_hero_web/live/user_live/settings.ex:550
 #, elixir-autogen, elixir-format
 msgid "Add a family profile"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:520
+#: lib/klass_hero_web/live/user_live/settings.ex:551
 #, elixir-autogen, elixir-format
 msgid "Add a provider profile"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:536
+#: lib/klass_hero_web/live/user_live/settings.ex:567
 #, elixir-autogen, elixir-format
 msgid "Add family profile"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:537
+#: lib/klass_hero_web/live/user_live/settings.ex:568
 #, elixir-autogen, elixir-format
 msgid "Add provider profile"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:522
+#: lib/klass_hero_web/live/user_live/settings.ex:553
 #, elixir-autogen, elixir-format
 msgid "Book activities and manage your children's places."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:468
+#: lib/klass_hero_web/live/user_live/settings.ex:499
 #, elixir-autogen, elixir-format
 msgid "Family profile added. You can add your children now."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:524
+#: lib/klass_hero_web/live/user_live/settings.ex:555
 #, elixir-autogen, elixir-format
 msgid "List your own activities and take bookings."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:431
+#: lib/klass_hero_web/live/user_live/settings.ex:450
 #, elixir-autogen, elixir-format
 msgid "Manage your account, preferences, and privacy."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:214
+#: lib/klass_hero_web/live/user_live/settings.ex:233
 #, elixir-autogen, elixir-format
 msgid "One account can be both a family and a provider."
 msgstr ""
@@ -7812,7 +7812,7 @@ msgid "Parent"
 msgstr ""
 
 #: lib/klass_hero_web/live/user_live/settings.ex:40
-#: lib/klass_hero_web/live/user_live/settings.ex:212
+#: lib/klass_hero_web/live/user_live/settings.ex:231
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
@@ -7832,17 +7832,17 @@ msgstr ""
 msgid "Viewing as %{persona}"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:474
+#: lib/klass_hero_web/live/user_live/settings.ex:505
 #, elixir-autogen, elixir-format
 msgid "You already have a family profile."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:528
+#: lib/klass_hero_web/live/user_live/settings.ex:559
 #, elixir-autogen, elixir-format
 msgid "You'll be able to add your children and book activities. Your provider account stays exactly as it is."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:532
+#: lib/klass_hero_web/live/user_live/settings.ex:563
 #, elixir-autogen, elixir-format
 msgid "You'll get a provider profile to fill in, and a dashboard for your activities. Your family account stays exactly as it is."
 msgstr ""
@@ -8176,4 +8176,24 @@ msgstr ""
 #: lib/klass_hero_web/components/messaging_components.ex:792
 #, elixir-autogen, elixir-format
 msgid "Messages here may be reviewed by Klass Hero staff."
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/settings.ex:210
+#, elixir-autogen, elixir-format
+msgid "Choose which emails you want us to send you"
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/settings.ex:693
+#, elixir-autogen, elixir-format
+msgid "Could not update your notification preferences."
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/settings.ex:220
+#, elixir-autogen, elixir-format
+msgid "Email me when I receive a new message"
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/settings.ex:207
+#, elixir-autogen, elixir-format
+msgid "Email notifications"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -51,12 +51,12 @@ msgstr ""
 msgid "Dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:328
+#: lib/klass_hero_web/live/user_live/settings.ex:347
 #, elixir-autogen, elixir-format
 msgid "Download My Data"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:324
+#: lib/klass_hero_web/live/user_live/settings.ex:343
 #, elixir-autogen, elixir-format
 msgid "Download a copy of all your personal data"
 msgstr ""
@@ -102,7 +102,7 @@ msgstr ""
 #: lib/klass_hero_web/components/layouts/app.html.heex:115
 #: lib/klass_hero_web/components/layouts/app.html.heex:223
 #: lib/klass_hero_web/components/ui_components.ex:205
-#: lib/klass_hero_web/live/user_live/settings.ex:430
+#: lib/klass_hero_web/live/user_live/settings.ex:449
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr ""
@@ -130,7 +130,7 @@ msgstr ""
 msgid "We can't find the internet"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:322
+#: lib/klass_hero_web/live/user_live/settings.ex:341
 #, elixir-autogen, elixir-format
 msgid "Your Data"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr ""
 msgid "✓ No hidden fees"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:596
+#: lib/klass_hero_web/live/user_live/settings.ex:627
 #, elixir-autogen, elixir-format
 msgid "A link to confirm your email change has been sent to the new address."
 msgstr ""
@@ -556,17 +556,17 @@ msgstr ""
 msgid "Data Sharing"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:343
+#: lib/klass_hero_web/live/user_live/settings.ex:362
 #, elixir-autogen, elixir-format
 msgid "Delete Account"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:376
+#: lib/klass_hero_web/live/user_live/settings.ex:395
 #, elixir-autogen, elixir-format
 msgid "Delete My Account"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:366
+#: lib/klass_hero_web/live/user_live/settings.ex:385
 #, elixir-autogen, elixir-format
 msgid "Deleting..."
 msgstr ""
@@ -590,12 +590,12 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:414
+#: lib/klass_hero_web/live/user_live/settings.ex:433
 #, elixir-autogen, elixir-format
 msgid "Email change link is invalid or it has expired."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:411
+#: lib/klass_hero_web/live/user_live/settings.ex:430
 #, elixir-autogen, elixir-format
 msgid "Email changed successfully."
 msgstr ""
@@ -605,7 +605,7 @@ msgstr ""
 msgid "Enroll children in programs"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:360
+#: lib/klass_hero_web/live/user_live/settings.ex:379
 #, elixir-autogen, elixir-format
 msgid "Enter your password to confirm"
 msgstr ""
@@ -627,7 +627,7 @@ msgstr ""
 msgid "Failed to complete session: %{reason}"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:674
+#: lib/klass_hero_web/live/user_live/settings.ex:722
 #, elixir-autogen, elixir-format
 msgid "Failed to delete account. Please try again."
 msgstr ""
@@ -690,7 +690,7 @@ msgstr ""
 msgid "Invalid date format"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:668
+#: lib/klass_hero_web/live/user_live/settings.ex:716
 #, elixir-autogen, elixir-format
 msgid "Invalid password."
 msgstr ""
@@ -937,7 +937,7 @@ msgstr ""
 msgid "Terms of Service"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:346
+#: lib/klass_hero_web/live/user_live/settings.ex:365
 #, elixir-autogen, elixir-format
 msgid "This action cannot be undone. Your account data will be anonymized and you will be logged out."
 msgstr ""
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "Your Privacy Rights"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:656
+#: lib/klass_hero_web/live/user_live/settings.ex:704
 #, elixir-autogen, elixir-format
 msgid "Your account has been deleted."
 msgstr ""
@@ -1075,7 +1075,7 @@ msgstr ""
 
 #: lib/klass_hero_web/live/settings/children_live.ex:23
 #: lib/klass_hero_web/live/settings/children_live.ex:313
-#: lib/klass_hero_web/live/user_live/settings.ex:300
+#: lib/klass_hero_web/live/user_live/settings.ex:319
 #, elixir-autogen, elixir-format
 msgid "Children Profiles"
 msgstr ""
@@ -1090,7 +1090,7 @@ msgstr ""
 msgid "Logged out successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:286
+#: lib/klass_hero_web/live/user_live/settings.ex:305
 #, elixir-autogen, elixir-format
 msgid "My Family"
 msgstr ""
@@ -1287,17 +1287,17 @@ msgstr ""
 msgid "Customize your experience"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:336
+#: lib/klass_hero_web/live/user_live/settings.ex:355
 #, elixir-autogen, elixir-format
 msgid "Danger Zone"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:314
+#: lib/klass_hero_web/live/user_live/settings.ex:333
 #, elixir-autogen, elixir-format
 msgid "Data & Privacy"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:316
+#: lib/klass_hero_web/live/user_live/settings.ex:335
 #, elixir-autogen, elixir-format
 msgid "Download your data or delete your account"
 msgstr ""
@@ -1695,7 +1695,7 @@ msgstr ""
 msgid "Manage your children's information and consents"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:288
+#: lib/klass_hero_web/live/user_live/settings.ex:307
 #, elixir-autogen, elixir-format
 msgid "Manage your children's profiles"
 msgstr ""
@@ -1784,17 +1784,17 @@ msgstr ""
 msgid "Please complete your profile before making a booking."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:605
+#: lib/klass_hero_web/live/user_live/settings.ex:636
 #, elixir-autogen, elixir-format
 msgid "Please re-authenticate to change your email."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:637
+#: lib/klass_hero_web/live/user_live/settings.ex:668
 #, elixir-autogen, elixir-format
 msgid "Please re-authenticate to change your password."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:662
+#: lib/klass_hero_web/live/user_live/settings.ex:710
 #, elixir-autogen, elixir-format
 msgid "Please re-authenticate to delete your account."
 msgstr ""
@@ -4499,7 +4499,7 @@ msgstr ""
 #: lib/klass_hero_web/live/messaging_live_helper.ex:535
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:132
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:118
-#: lib/klass_hero_web/live/user_live/settings.ex:513
+#: lib/klass_hero_web/live/user_live/settings.ex:544
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Something went wrong. Please try again."
 msgstr ""
@@ -5786,7 +5786,7 @@ msgid "Not allowed to approve this enrollment"
 msgstr ""
 
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:290
-#: lib/klass_hero_web/live/user_live/settings.ex:245
+#: lib/klass_hero_web/live/user_live/settings.ex:264
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr ""
@@ -6093,7 +6093,7 @@ msgid "Send us a message"
 msgstr ""
 
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:279
-#: lib/klass_hero_web/live/user_live/settings.ex:235
+#: lib/klass_hero_web/live/user_live/settings.ex:254
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Setting up..."
 msgstr ""
@@ -6406,7 +6406,7 @@ msgid "Yes. You can run unlimited programs, each with its own schedule and venue
 msgstr ""
 
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:83
-#: lib/klass_hero_web/live/user_live/settings.ex:491
+#: lib/klass_hero_web/live/user_live/settings.ex:522
 #, elixir-autogen, elixir-format
 msgid "You already have a provider profile."
 msgstr ""
@@ -7210,7 +7210,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:2171
 #: lib/klass_hero_web/components/provider_components.ex:2349
-#: lib/klass_hero_web/live/user_live/settings.ex:273
+#: lib/klass_hero_web/live/user_live/settings.ex:292
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add"
 msgstr ""
@@ -7731,7 +7731,7 @@ msgid "Verified Provider"
 msgstr ""
 
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:75
-#: lib/klass_hero_web/live/user_live/settings.ex:486
+#: lib/klass_hero_web/live/user_live/settings.ex:517
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Welcome aboard! Let's set up your provider profile."
 msgstr ""
@@ -7761,47 +7761,47 @@ msgstr ""
 msgid "You don't have that profile."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:519
+#: lib/klass_hero_web/live/user_live/settings.ex:550
 #, elixir-autogen, elixir-format
 msgid "Add a family profile"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:520
+#: lib/klass_hero_web/live/user_live/settings.ex:551
 #, elixir-autogen, elixir-format
 msgid "Add a provider profile"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:536
+#: lib/klass_hero_web/live/user_live/settings.ex:567
 #, elixir-autogen, elixir-format
 msgid "Add family profile"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:537
+#: lib/klass_hero_web/live/user_live/settings.ex:568
 #, elixir-autogen, elixir-format
 msgid "Add provider profile"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:522
+#: lib/klass_hero_web/live/user_live/settings.ex:553
 #, elixir-autogen, elixir-format
 msgid "Book activities and manage your children's places."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:468
+#: lib/klass_hero_web/live/user_live/settings.ex:499
 #, elixir-autogen, elixir-format
 msgid "Family profile added. You can add your children now."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:524
+#: lib/klass_hero_web/live/user_live/settings.ex:555
 #, elixir-autogen, elixir-format
 msgid "List your own activities and take bookings."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:431
+#: lib/klass_hero_web/live/user_live/settings.ex:450
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Manage your account, preferences, and privacy."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:214
+#: lib/klass_hero_web/live/user_live/settings.ex:233
 #, elixir-autogen, elixir-format
 msgid "One account can be both a family and a provider."
 msgstr ""
@@ -7812,7 +7812,7 @@ msgid "Parent"
 msgstr ""
 
 #: lib/klass_hero_web/live/user_live/settings.ex:40
-#: lib/klass_hero_web/live/user_live/settings.ex:212
+#: lib/klass_hero_web/live/user_live/settings.ex:231
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Profiles"
 msgstr ""
@@ -7832,17 +7832,17 @@ msgstr ""
 msgid "Viewing as %{persona}"
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:474
+#: lib/klass_hero_web/live/user_live/settings.ex:505
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You already have a family profile."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:528
+#: lib/klass_hero_web/live/user_live/settings.ex:559
 #, elixir-autogen, elixir-format
 msgid "You'll be able to add your children and book activities. Your provider account stays exactly as it is."
 msgstr ""
 
-#: lib/klass_hero_web/live/user_live/settings.ex:532
+#: lib/klass_hero_web/live/user_live/settings.ex:563
 #, elixir-autogen, elixir-format
 msgid "You'll get a provider profile to fill in, and a dashboard for your activities. Your family account stays exactly as it is."
 msgstr ""
@@ -8176,4 +8176,24 @@ msgstr ""
 #: lib/klass_hero_web/components/messaging_components.ex:792
 #, elixir-autogen, elixir-format
 msgid "Messages here may be reviewed by Klass Hero staff."
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/settings.ex:210
+#, elixir-autogen, elixir-format
+msgid "Choose which emails you want us to send you"
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/settings.ex:693
+#, elixir-autogen, elixir-format
+msgid "Could not update your notification preferences."
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/settings.ex:220
+#, elixir-autogen, elixir-format
+msgid "Email me when I receive a new message"
+msgstr ""
+
+#: lib/klass_hero_web/live/user_live/settings.ex:207
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Email notifications"
 msgstr ""

--- a/priv/repo/migrations/20260826093414_add_disabled_email_notifications_to_users.exs
+++ b/priv/repo/migrations/20260826093414_add_disabled_email_notifications_to_users.exs
@@ -1,0 +1,13 @@
+defmodule KlassHero.Repo.Migrations.AddDisabledEmailNotificationsToUsers do
+  use Ecto.Migration
+
+  # Stores what a user has switched OFF, not what they have on. Absence is
+  # therefore "enabled", so every existing row defaults to receiving
+  # notifications with no backfill, and a kind added later is on for everyone
+  # until they opt out.
+  def change do
+    alter table(:users) do
+      add :disabled_email_notifications, {:array, :string}, null: false, default: []
+    end
+  end
+end

--- a/priv/repo/migrations/20260826130921_drop_parent_notification_preferences.exs
+++ b/priv/repo/migrations/20260826130921_drop_parent_notification_preferences.exs
@@ -1,0 +1,22 @@
+defmodule KlassHero.Repo.Migrations.DropParentNotificationPreferences do
+  use Ecto.Migration
+
+  # DEPLOY ORDERING: the release before this one still carries
+  # `field :notification_preferences, :map` on ParentProfile, so its queries name
+  # the column. Fly runs migrations while that release is still serving, and
+  # `Accounts.Scope.resolve_roles/1` loads a parent profile on every authenticated
+  # LiveView mount — so between this statement committing and the new machines
+  # taking traffic, those mounts fail with `column does not exist`.
+  #
+  # Reversible without data loss: the column was castable but no caller ever
+  # passed it (every `Family.create_parent_profile/1` call site sends
+  # `identity_id` alone), so it is NULL in every row. Rolling back re-adds it
+  # with the same type and nullability — last in ordinal position rather than
+  # where it was, which nothing depends on because Ecto names every field it
+  # selects. See ADR 0022 for why it was dead in the first place.
+  def change do
+    alter table(:parents) do
+      remove :notification_preferences, :map
+    end
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -88,7 +88,15 @@ parent_user_data = [
   %{name: "Michael Wagner", email: "michael.wagner@example.com"},
   %{name: "Julia Hoffmann", email: "julia.hoffmann@example.com"},
   %{name: "Stefan Schäfer", email: "stefan.schaefer@example.com"},
-  %{name: "Monika Koch", email: "monika.koch@example.com"},
+  # Opted out of the new-message notification, so /users/settings shows the
+  # toggle already off and the preference gate is demonstrable on its own. She is
+  # caught up in every thread she is in, so nothing else can be the reason she is
+  # skipped.
+  %{
+    name: "Monika Koch",
+    email: "monika.koch@example.com",
+    disabled_email_notifications: [:new_message_email]
+  },
   %{name: "Andreas Bauer", email: "andreas.bauer@example.com"}
 ]
 
@@ -100,7 +108,8 @@ parent_users =
       email: data.email,
       hashed_password: hashed_pw,
       confirmed_at: now,
-      intended_roles: [:parent]
+      intended_roles: [:parent],
+      disabled_email_notifications: Map.get(data, :disabled_email_notifications, [])
     })
     |> Repo.insert!()
   end)
@@ -1496,6 +1505,32 @@ Logger.info("Created #{length(all_conversations)} conversations (3 direct, 2 bro
 
 Logger.info("Seeding conversation participants and messages...")
 
+# Read state has to be stamped *after* the messages exist. Participants are
+# inserted first, so a last_read_at written at insert time would still predate
+# every message and leave everyone permanently "behind" — which is what seeded
+# data used to do, showing every thread unread for every user and suppressing the
+# new-message notification for almost all of them.
+mark_caught_up = fn participants, msgs ->
+  # The real maximum, not the last inserted: :utc_datetime truncates to the
+  # second, so "caught up" should hold by construction rather than by luck of
+  # insertion order.
+  caught_up_at = msgs |> Enum.map(& &1.inserted_at) |> Enum.max(DateTime)
+
+  for participant <- participants do
+    participant
+    |> Participant.mark_read_changeset(%{last_read_at: caught_up_at})
+    |> Repo.update!()
+  end
+end
+
+# Left at last_read_at: nil in the broadcast conversations only — "seated but
+# never opened it", which is a state a real broadcast participant reaches. Keeps
+# one unread badge in the seeded inbox, exercises the is_nil branch of
+# NewMessageEmailHandler's read-up filter, and stays caught up in his own direct
+# thread so the suppression is visibly per-conversation. Deliberate: do not
+# "tidy" this into the uniform case.
+behind_in_broadcasts = Enum.at(parent_users, 7)
+
 participant_count = 0
 message_count = 0
 
@@ -1513,19 +1548,15 @@ message_count = 0
       end
 
     # Add both participants
-    Participant.create_changeset(%{
-      conversation_id: convo.id,
-      user_id: provider_user.id,
-      joined_at: now
-    })
-    |> Repo.insert!()
-
-    Participant.create_changeset(%{
-      conversation_id: convo.id,
-      user_id: data.parent_user.id,
-      joined_at: now
-    })
-    |> Repo.insert!()
+    participants =
+      for user_id <- [provider_user.id, data.parent_user.id] do
+        Participant.create_changeset(%{
+          conversation_id: convo.id,
+          user_id: user_id,
+          joined_at: now
+        })
+        |> Repo.insert!()
+      end
 
     # Generate 4-6 messages alternating between participants
     msg_count = 4 + :rand.uniform(3) - 1
@@ -1551,6 +1582,8 @@ message_count = 0
         |> Repo.insert!()
       end)
 
+    mark_caught_up.(participants, msgs)
+
     {pc + 2, mc + length(msgs)}
   end)
 
@@ -1566,12 +1599,13 @@ message_count = 0
       end
 
     # Provider is always a participant in broadcasts
-    Participant.create_changeset(%{
-      conversation_id: convo.id,
-      user_id: provider_user.id,
-      joined_at: now
-    })
-    |> Repo.insert!()
+    provider_participant =
+      Participant.create_changeset(%{
+        conversation_id: convo.id,
+        user_id: provider_user.id,
+        joined_at: now
+      })
+      |> Repo.insert!()
 
     # Add 2-3 parent users as participants
     broadcast_parent_users = Enum.take(Enum.drop(parent_users, 6), 3)
@@ -1623,6 +1657,10 @@ message_count = 0
         })
         |> Repo.insert!()
       end)
+
+    ([provider_participant] ++ added_parents ++ added_staff)
+    |> Enum.reject(&(&1.user_id == behind_in_broadcasts.id))
+    |> mark_caught_up.(msgs)
 
     {pc + 1 + length(added_parents) + length(added_staff), mc + length(msgs)}
   end)

--- a/test/klass_hero/accounts/email_notification_gate_test.exs
+++ b/test/klass_hero/accounts/email_notification_gate_test.exs
@@ -107,15 +107,4 @@ defmodule KlassHero.Accounts.EmailNotificationGateTest do
       assert Accounts.notifiable_recipients([], @kind) == %{}
     end
   end
-
-  describe "change_user_email_notification_preferences/2" do
-    test "builds a changeset the settings form can render" do
-      user = user_fixture()
-
-      changeset = Accounts.change_user_email_notification_preferences(user)
-
-      assert %Ecto.Changeset{} = changeset
-      assert Ecto.Changeset.get_field(changeset, :disabled_email_notifications) == []
-    end
-  end
 end

--- a/test/klass_hero/accounts/email_notification_gate_test.exs
+++ b/test/klass_hero/accounts/email_notification_gate_test.exs
@@ -20,7 +20,6 @@ defmodule KlassHero.Accounts.EmailNotificationGateTest do
 
       assert user.disabled_email_notifications == []
       assert Accounts.email_notification_enabled?(user, @kind)
-      assert Accounts.email_notification_enabled?(user.id, @kind)
     end
 
     test "is off once the user opts out" do
@@ -28,17 +27,6 @@ defmodule KlassHero.Accounts.EmailNotificationGateTest do
       {:ok, user} = Accounts.update_user_email_notification_preference(user, @kind, false)
 
       refute Accounts.email_notification_enabled?(user, @kind)
-      refute Accounts.email_notification_enabled?(user.id, @kind)
-    end
-
-    # Fail closed: a gate that answers "yes" for an id it cannot find would have
-    # a worker email a deleted account.
-    test "is off for a user that does not exist" do
-      refute Accounts.email_notification_enabled?(Ecto.UUID.generate(), @kind)
-    end
-
-    test "is off for a malformed id rather than raising" do
-      refute Accounts.email_notification_enabled?("not-a-uuid", @kind)
     end
   end
 
@@ -62,6 +50,24 @@ defmodule KlassHero.Accounts.EmailNotificationGateTest do
       {:ok, twice} = Accounts.update_user_email_notification_preference(once, @kind, false)
 
       assert twice.disabled_email_notifications == [@kind]
+    end
+
+    # The column holds every kind at once, so a list computed from a struct that
+    # predates someone else's write silently re-enables whatever changed since.
+    # One kind cannot show that directly — both branches produce the same list —
+    # so this probes the reload itself, through a field the caller staled.
+    test "computes the next list from the stored row, not the caller's struct" do
+      user = user_fixture()
+      {:ok, _} = Accounts.update_user_email_notification_preference(user, @kind, false)
+
+      stale = %{user | name: "only in this struct"}
+
+      {:ok, updated} = Accounts.update_user_email_notification_preference(stale, @kind, false)
+
+      assert updated.disabled_email_notifications == [@kind]
+
+      refute updated.name == "only in this struct",
+             "the write was computed from the caller's struct rather than the stored row"
     end
 
     test "opting in when already enabled is a no-op" do

--- a/test/klass_hero/accounts/email_notification_gate_test.exs
+++ b/test/klass_hero/accounts/email_notification_gate_test.exs
@@ -1,0 +1,121 @@
+defmodule KlassHero.Accounts.EmailNotificationGateTest do
+  @moduledoc """
+  The contract every context asks before emailing someone.
+
+  Accounts owns the vocabulary and the answer; a producing context asks and
+  never touches the column. The stored list is what is *disabled*, and this is
+  the only module allowed to know that — callers speak in "enabled?".
+  """
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.AccountsFixtures
+
+  alias KlassHero.Accounts
+
+  @kind :new_message_email
+
+  describe "email_notification_enabled?/2" do
+    test "defaults to on for a user who has never touched the setting" do
+      user = user_fixture()
+
+      assert user.disabled_email_notifications == []
+      assert Accounts.email_notification_enabled?(user, @kind)
+      assert Accounts.email_notification_enabled?(user.id, @kind)
+    end
+
+    test "is off once the user opts out" do
+      user = user_fixture()
+      {:ok, user} = Accounts.update_user_email_notification_preference(user, @kind, false)
+
+      refute Accounts.email_notification_enabled?(user, @kind)
+      refute Accounts.email_notification_enabled?(user.id, @kind)
+    end
+
+    # Fail closed: a gate that answers "yes" for an id it cannot find would have
+    # a worker email a deleted account.
+    test "is off for a user that does not exist" do
+      refute Accounts.email_notification_enabled?(Ecto.UUID.generate(), @kind)
+    end
+
+    test "is off for a malformed id rather than raising" do
+      refute Accounts.email_notification_enabled?("not-a-uuid", @kind)
+    end
+  end
+
+  describe "update_user_email_notification_preference/3" do
+    test "opting out then back in returns to the enabled state" do
+      user = user_fixture()
+
+      {:ok, disabled} = Accounts.update_user_email_notification_preference(user, @kind, false)
+      # Pin the intermediate state: without this, the final assertion below
+      # would pass even if neither call did anything.
+      assert disabled.disabled_email_notifications == [@kind]
+
+      {:ok, enabled} = Accounts.update_user_email_notification_preference(disabled, @kind, true)
+      assert enabled.disabled_email_notifications == []
+    end
+
+    test "opting out twice does not duplicate the entry" do
+      user = user_fixture()
+
+      {:ok, once} = Accounts.update_user_email_notification_preference(user, @kind, false)
+      {:ok, twice} = Accounts.update_user_email_notification_preference(once, @kind, false)
+
+      assert twice.disabled_email_notifications == [@kind]
+    end
+
+    test "opting in when already enabled is a no-op" do
+      user = user_fixture()
+
+      {:ok, updated} = Accounts.update_user_email_notification_preference(user, @kind, true)
+
+      assert updated.disabled_email_notifications == []
+    end
+  end
+
+  describe "notifiable_recipients/2" do
+    test "returns address and name for users who want the notification" do
+      user = user_fixture()
+
+      recipients = Accounts.notifiable_recipients([user.id], @kind)
+
+      assert %{email: email, name: name} = Map.fetch!(recipients, user.id)
+      assert email == user.email
+      assert name == user.name
+    end
+
+    test "omits users who opted out" do
+      wants = user_fixture()
+      declines = user_fixture()
+      {:ok, declines} = Accounts.update_user_email_notification_preference(declines, @kind, false)
+
+      recipients = Accounts.notifiable_recipients([wants.id, declines.id], @kind)
+
+      assert Map.has_key?(recipients, wants.id)
+      refute Map.has_key?(recipients, declines.id)
+    end
+
+    test "omits ids that match no user instead of raising" do
+      user = user_fixture()
+
+      recipients = Accounts.notifiable_recipients([user.id, Ecto.UUID.generate()], @kind)
+
+      assert Map.keys(recipients) == [user.id]
+    end
+
+    test "short-circuits on an empty list" do
+      assert Accounts.notifiable_recipients([], @kind) == %{}
+    end
+  end
+
+  describe "change_user_email_notification_preferences/2" do
+    test "builds a changeset the settings form can render" do
+      user = user_fixture()
+
+      changeset = Accounts.change_user_email_notification_preferences(user)
+
+      assert %Ecto.Changeset{} = changeset
+      assert Ecto.Changeset.get_field(changeset, :disabled_email_notifications) == []
+    end
+  end
+end

--- a/test/klass_hero/accounts/user_email_notification_preferences_test.exs
+++ b/test/klass_hero/accounts/user_email_notification_preferences_test.exs
@@ -1,0 +1,87 @@
+defmodule KlassHero.Accounts.UserEmailNotificationPreferencesTest do
+  @moduledoc """
+  The changeset that decides which email notifications a user has switched off.
+
+  The column stores what is *disabled*, so absence means enabled. That inversion
+  is why `[]` must stay valid — it is the state every user starts in — while
+  `nil` must not, because the column is `null: false` and a nil would only ever
+  reach it through a bug.
+  """
+  use ExUnit.Case, async: true
+
+  alias Ecto.Changeset
+  alias KlassHero.Accounts.User
+
+  describe "email_notification_preferences_changeset/2" do
+    test "accepts every kind the app claims to support" do
+      # Without this the loop below is vacuous: an empty vocabulary would pass
+      # every assertion in this file by never running one.
+      refute Enum.empty?(User.email_notification_kinds()),
+             "email_notification_kinds/0 is empty — every test here would be vacuous"
+
+      for kind <- User.email_notification_kinds() do
+        changeset =
+          User.email_notification_preferences_changeset(%User{}, %{
+            disabled_email_notifications: [kind]
+          })
+
+        assert changeset.valid?,
+               "#{kind} is in email_notification_kinds/0 but the changeset rejects it: " <>
+                 inspect(changeset.errors)
+
+        assert Changeset.get_field(changeset, :disabled_email_notifications) == [kind]
+      end
+    end
+
+    # Deliberately not plausible-looking kinds: adding one of these for real
+    # would make the fixture wrong rather than making the test fail loudly.
+    @never_kinds [:new_message_sms, :marketing_digest, :not_a_kind]
+
+    test "rejects anything outside that set" do
+      assert Enum.all?(@never_kinds, &(&1 not in User.email_notification_kinds())),
+             "fixture overlaps email_notification_kinds/0 — this test would be vacuous"
+
+      for kind <- @never_kinds do
+        changeset =
+          User.email_notification_preferences_changeset(%User{}, %{
+            disabled_email_notifications: [kind]
+          })
+
+        refute changeset.valid?, "#{inspect(kind)} was accepted as a notification kind"
+        assert Keyword.has_key?(changeset.errors, :disabled_email_notifications)
+      end
+    end
+
+    test "accepts the empty list — that is the everything-enabled state" do
+      changeset =
+        User.email_notification_preferences_changeset(%User{}, %{
+          disabled_email_notifications: []
+        })
+
+      assert changeset.valid?
+      assert Changeset.get_field(changeset, :disabled_email_notifications) == []
+    end
+
+    test "rejects nil rather than writing it to a null: false column" do
+      changeset =
+        User.email_notification_preferences_changeset(
+          %User{disabled_email_notifications: [:new_message_email]},
+          %{disabled_email_notifications: nil}
+        )
+
+      refute changeset.valid?
+      assert {"can't be blank", _meta} = changeset.errors[:disabled_email_notifications]
+    end
+
+    test "casts nothing but the preference field" do
+      changeset =
+        User.email_notification_preferences_changeset(%User{}, %{
+          disabled_email_notifications: [],
+          email: "attacker@example.com",
+          is_admin: true
+        })
+
+      assert changeset.changes == %{}
+    end
+  end
+end

--- a/test/klass_hero/email_queue_capacity_test.exs
+++ b/test/klass_hero/email_queue_capacity_test.exs
@@ -1,0 +1,55 @@
+defmodule KlassHero.EmailQueueCapacityTest do
+  @moduledoc """
+  The `:email` queue's concurrency and its workers' retry budget are one
+  decision, not two.
+
+  Concurrency was raised from 1 to 5 so a program broadcast's fan-out stops
+  head-of-line blocking staff invites and email replies. That makes 429s from
+  Resend more likely, not less — the upstream limit did not move. What keeps a
+  rate-limited job from being *discarded* instead of merely delayed is the
+  retry budget, because `RateLimitedEmailWorker` spends attempts on 429 backoff
+  (30s → 60s → 120s …).
+
+  So lowering either half in isolation silently converts "this email is late"
+  into "this email is gone". Asserted together, in one test, because checking
+  either alone would go green on a broken pair.
+  """
+  use ExUnit.Case, async: true
+
+  alias KlassHero.Enrollment.Adapters.Driving.Workers.SendInviteEmailWorker
+  alias KlassHero.Messaging.Workers.FetchEmailContentWorker
+  alias KlassHero.Messaging.Workers.NewMessageEmailWorker
+  alias KlassHero.Messaging.Workers.SendEmailReplyWorker
+  alias KlassHero.Provider.NotifyIncidentReportedWorker
+
+  @email_workers [
+    SendInviteEmailWorker,
+    FetchEmailContentWorker,
+    NewMessageEmailWorker,
+    SendEmailReplyWorker,
+    NotifyIncidentReportedWorker
+  ]
+
+  test "concurrency above one is paid for by a retry budget that outlasts a 429 burst" do
+    concurrency =
+      :klass_hero
+      |> Application.fetch_env!(Oban)
+      |> Keyword.fetch!(:queues)
+      |> Keyword.fetch!(:email)
+
+    assert concurrency >= 5,
+           "the :email queue is back to #{concurrency} — a broadcast's fan-out will " <>
+             "block staff invites and email replies behind it"
+
+    for worker <- @email_workers do
+      opts = worker.__opts__()
+
+      assert Keyword.fetch!(opts, :queue) == :email,
+             "#{inspect(worker)} is listed here but is not on the :email queue"
+
+      assert Keyword.fetch!(opts, :max_attempts) >= 5,
+             "#{inspect(worker)} has too small a retry budget: a sustained 429 burst " <>
+               "would exhaust it on backoff alone and discard a real email"
+    end
+  end
+end

--- a/test/klass_hero/family/parent_profile_test.exs
+++ b/test/klass_hero/family/parent_profile_test.exs
@@ -26,8 +26,7 @@ defmodule KlassHero.Family.ParentProfileTest do
         valid_attrs(%{
           display_name: "John Doe",
           phone: "+1234567890",
-          location: "Berlin",
-          notification_preferences: %{email: true}
+          location: "Berlin"
         })
 
       assert ParentProfile.changeset(%ParentProfile{}, attrs).valid?
@@ -48,17 +47,6 @@ defmodule KlassHero.Family.ParentProfileTest do
 
       refute changeset.valid?
       assert %{display_name: [_]} = errors_on(changeset)
-    end
-  end
-
-  describe "has_notification_preferences?/1" do
-    test "true when preferences are present" do
-      assert ParentProfile.has_notification_preferences?(%ParentProfile{notification_preferences: %{email: true}})
-    end
-
-    test "false when nil or empty" do
-      refute ParentProfile.has_notification_preferences?(%ParentProfile{notification_preferences: nil})
-      refute ParentProfile.has_notification_preferences?(%ParentProfile{notification_preferences: %{}})
     end
   end
 end

--- a/test/klass_hero/family/parent_profiles_test.exs
+++ b/test/klass_hero/family/parent_profiles_test.exs
@@ -20,8 +20,7 @@ defmodule KlassHero.Family.ParentProfilesTest do
         identity_id: identity_id(),
         display_name: "John Doe",
         phone: "+1234567890",
-        location: "Berlin",
-        notification_preferences: %{email: true, sms: false}
+        location: "Berlin"
       }
 
       assert {:ok, %ParentProfile{} = profile} = Family.create_parent_profile(attrs)

--- a/test/klass_hero/messaging/new_message_email_delivery_test.exs
+++ b/test/klass_hero/messaging/new_message_email_delivery_test.exs
@@ -43,18 +43,19 @@ defmodule KlassHero.Messaging.NewMessageEmailDeliveryTest do
   test "a sent message reaches the other participant's mailbox as a link", ctx do
     send_and_deliver(ctx.conversation.id, ctx.sender.id)
 
-    # assert_email_sent/1 asserts on this callback's return value, and ExUnit's
-    # refute/2 returns false when it passes — so the last expression here has to
-    # be an assert, or the whole assertion fails whatever the email says.
-    assert_email_sent(fn email ->
-      assert [{_name, address}] = email.to
-      assert address == ctx.recipient.email
+    # Bound directly rather than through assert_email_sent/1, which asserts on
+    # its callback's *return value* — and ExUnit's refute/2 returns false when it
+    # passes, so a callback ending on a refute fails whatever the email says.
+    assert_received {:email, email}
 
-      refute email.text_body =~ "the actual message text",
-             "the notification quoted the message body"
+    assert [{_name, address}] = email.to
+    assert address == ctx.recipient.email
 
-      assert email.text_body =~ "/messages/#{ctx.conversation.id}"
-    end)
+    assert email.text_body =~ "/messages/#{ctx.conversation.id}",
+           "the notification carried no link back to the conversation"
+
+    refute email.text_body =~ "the actual message text",
+           "the notification quoted the message body"
   end
 
   test "nothing is sent to someone who switched the notification off", ctx do

--- a/test/klass_hero/messaging/new_message_email_delivery_test.exs
+++ b/test/klass_hero/messaging/new_message_email_delivery_test.exs
@@ -1,0 +1,100 @@
+defmodule KlassHero.Messaging.NewMessageEmailDeliveryTest do
+  @moduledoc """
+  The whole path, once: sending a message stages `message_sent` in the same
+  transaction as the write, the delivery job routes it to
+  `NewMessageEmailHandler`, and the email job that handler enqueues actually
+  reaches a mailbox.
+
+  The rest of the messaging suite runs against `TestOutbox`, which records what
+  a producer staged but never runs a consumer — so nothing else in the suite
+  would notice if this consumer were unregistered, or if the handler and the
+  real payload disagreed about a key. This swaps in the real `ObanOutbox` for
+  the length of one send, following `archive_conversations_delivery_test.exs`.
+  """
+  use KlassHero.DataCase, async: false
+
+  import KlassHero.EmailTestHelper
+  import KlassHero.Factory
+  import Swoosh.TestAssertions
+
+  alias KlassHero.Accounts
+  alias KlassHero.AccountsFixtures
+  alias KlassHero.Messaging
+  alias KlassHero.Shared.Adapters.Driven.Events.ObanOutbox
+
+  setup do
+    provider = insert(:provider_profile_schema)
+    conversation = insert(:conversation_schema, provider_id: provider.id)
+
+    sender = AccountsFixtures.user_fixture()
+    recipient = AccountsFixtures.user_fixture()
+
+    for user <- [sender, recipient] do
+      insert(:participant_schema,
+        conversation_id: conversation.id,
+        user_id: user.id,
+        last_read_at: DateTime.utc_now()
+      )
+    end
+
+    %{conversation: conversation, sender: sender, recipient: recipient}
+  end
+
+  test "a sent message reaches the other participant's mailbox as a link", ctx do
+    send_and_deliver(ctx.conversation.id, ctx.sender.id)
+
+    # assert_email_sent/1 asserts on this callback's return value, and ExUnit's
+    # refute/2 returns false when it passes — so the last expression here has to
+    # be an assert, or the whole assertion fails whatever the email says.
+    assert_email_sent(fn email ->
+      assert [{_name, address}] = email.to
+      assert address == ctx.recipient.email
+
+      refute email.text_body =~ "the actual message text",
+             "the notification quoted the message body"
+
+      assert email.text_body =~ "/messages/#{ctx.conversation.id}"
+    end)
+  end
+
+  test "nothing is sent to someone who switched the notification off", ctx do
+    {:ok, _} =
+      Accounts.update_user_email_notification_preference(
+        ctx.recipient,
+        :new_message_email,
+        false
+      )
+
+    send_and_deliver(ctx.conversation.id, ctx.sender.id)
+
+    assert_no_email_sent()
+  end
+
+  # The real outbox is swapped in around the act alone: under ObanOutbox the
+  # user fixtures would also deliver their own user_registered, which creates a
+  # provider profile that collides with the factory's.
+  #
+  # Manual mode then drain, because `testing: :inline` would run the delivery
+  # job at insert — inside SendMessage's own transaction, which is a sequencing
+  # production never has.
+  defp send_and_deliver(conversation_id, sender_id) do
+    original_outbox = Application.get_env(:klass_hero, :outbox)
+    Application.put_env(:klass_hero, :outbox, module: ObanOutbox)
+
+    # Drain before the act, not only after: the fixtures above staged jobs of
+    # their own, and leaving them queued lets them replay into this assertion.
+    flush_emails()
+
+    try do
+      {:ok, _message} =
+        Oban.Testing.with_testing_mode(:manual, fn ->
+          Messaging.send_message(conversation_id, sender_id, "the actual message text")
+        end)
+    after
+      Application.put_env(:klass_hero, :outbox, original_outbox)
+    end
+
+    Oban.drain_queue(queue: :events, with_recursion: true)
+    Oban.drain_queue(queue: :email, with_recursion: true)
+  end
+end

--- a/test/klass_hero/messaging/new_message_email_handler_test.exs
+++ b/test/klass_hero/messaging/new_message_email_handler_test.exs
@@ -8,6 +8,7 @@ defmodule KlassHero.Messaging.NewMessageEmailHandlerTest do
   passing against a fixture that no producer emits.
   """
   use KlassHero.DataCase, async: true
+  use Oban.Testing, repo: KlassHero.Repo
 
   import KlassHero.Factory
 
@@ -58,9 +59,8 @@ defmodule KlassHero.Messaging.NewMessageEmailHandlerTest do
   end
 
   defp enqueued_recipient_ids do
-    Oban.Job
-    |> KlassHero.Repo.all()
-    |> Enum.filter(&(&1.worker == Oban.Worker.to_string(NewMessageEmailWorker)))
+    [worker: NewMessageEmailWorker]
+    |> all_enqueued()
     |> Enum.map(& &1.args["recipient_user_id"])
     |> Enum.sort()
   end
@@ -169,10 +169,7 @@ defmodule KlassHero.Messaging.NewMessageEmailHandlerTest do
       message = message(conversation, sender, content: "a private medical detail")
       assert :ok = message |> event() |> handle()
 
-      [job] =
-        Oban.Job
-        |> KlassHero.Repo.all()
-        |> Enum.filter(&(&1.worker == Oban.Worker.to_string(NewMessageEmailWorker)))
+      [job] = all_enqueued(worker: NewMessageEmailWorker)
 
       assert job.args["conversation_id"] == conversation.id
       assert job.args["recipient_user_id"] == recipient.id

--- a/test/klass_hero/messaging/new_message_email_handler_test.exs
+++ b/test/klass_hero/messaging/new_message_email_handler_test.exs
@@ -1,0 +1,195 @@
+defmodule KlassHero.Messaging.NewMessageEmailHandlerTest do
+  @moduledoc """
+  Turns one `message_sent` event into one email job per participant who should
+  get one.
+
+  Events are built through `Messaging.Events.message_sent/7` rather than
+  hand-rolled maps, so a change to the real payload shape fails here instead of
+  passing against a fixture that no producer emits.
+  """
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+
+  alias KlassHero.Accounts
+  alias KlassHero.AccountsFixtures
+  alias KlassHero.Messaging.Events
+  alias KlassHero.Messaging.NewMessageEmailHandler
+  alias KlassHero.Messaging.Workers.NewMessageEmailWorker
+
+  defp participant(conversation, opts \\ []) do
+    user = AccountsFixtures.user_fixture()
+
+    insert(
+      :participant_schema,
+      Keyword.merge(
+        [conversation_id: conversation.id, user_id: user.id, last_read_at: DateTime.utc_now()],
+        opts
+      )
+    )
+
+    user
+  end
+
+  defp message(conversation, sender, opts \\ []) do
+    insert(
+      :message_schema,
+      Keyword.merge(
+        [conversation_id: conversation.id, sender_id: sender.id, content: "hello"],
+        opts
+      )
+    )
+  end
+
+  defp event(message, opts \\ []) do
+    Events.message_sent(
+      message.conversation_id,
+      message.id,
+      message.sender_id,
+      Keyword.get(opts, :content, message.content),
+      Keyword.get(opts, :message_type, :text),
+      message.inserted_at,
+      []
+    )
+  end
+
+  defp handle(event) do
+    Oban.Testing.with_testing_mode(:manual, fn -> NewMessageEmailHandler.handle_event(event) end)
+  end
+
+  defp enqueued_recipient_ids do
+    Oban.Job
+    |> KlassHero.Repo.all()
+    |> Enum.filter(&(&1.worker == Oban.Worker.to_string(NewMessageEmailWorker)))
+    |> Enum.map(& &1.args["recipient_user_id"])
+    |> Enum.sort()
+  end
+
+  describe "handle_event/1 — who gets a job" do
+    test "one per active participant, excluding the sender" do
+      conversation = insert(:conversation_schema)
+      sender = participant(conversation)
+      recipient_a = participant(conversation)
+      recipient_b = participant(conversation)
+
+      assert :ok = conversation |> message(sender) |> event() |> handle()
+
+      assert enqueued_recipient_ids() == Enum.sort([recipient_a.id, recipient_b.id])
+    end
+
+    test "nobody who has opted out" do
+      conversation = insert(:conversation_schema)
+      sender = participant(conversation)
+      wants = participant(conversation)
+      declines = participant(conversation)
+
+      {:ok, _} =
+        Accounts.update_user_email_notification_preference(declines, :new_message_email, false)
+
+      assert :ok = conversation |> message(sender) |> event() |> handle()
+
+      assert enqueued_recipient_ids() == [wants.id]
+    end
+
+    test "nobody who has left the conversation" do
+      conversation = insert(:conversation_schema)
+      sender = participant(conversation)
+      stayed = participant(conversation)
+      _left = participant(conversation, left_at: DateTime.utc_now())
+
+      assert :ok = conversation |> message(sender) |> event() |> handle()
+
+      assert enqueued_recipient_ids() == [stayed.id]
+    end
+
+    # A "[broadcast:…] Re: …" marker is written by ReplyPrivatelyToBroadcast
+    # through the same send path, so it stages a real message_sent. Emailing on
+    # it would notify the provider twice for one parent action.
+    test "nothing at all for a system message" do
+      conversation = insert(:conversation_schema)
+      sender = participant(conversation)
+      _recipient = participant(conversation)
+
+      message = message(conversation, sender, message_type: :system)
+
+      assert :ok = message |> event(message_type: :system) |> handle()
+
+      assert enqueued_recipient_ids() == []
+    end
+  end
+
+  describe "handle_event/1 — already-unread suppression" do
+    test "skips a participant who has not caught up on this conversation" do
+      conversation = insert(:conversation_schema)
+      sender = participant(conversation)
+      caught_up = participant(conversation)
+      _behind = participant(conversation, last_read_at: ~U[2020-01-01 00:00:00Z])
+
+      # An earlier message that `behind` has not read and `caught_up` has.
+      message(conversation, sender, inserted_at: ~U[2021-01-01 00:00:00Z])
+
+      assert :ok = conversation |> message(sender) |> event() |> handle()
+
+      assert enqueued_recipient_ids() == [caught_up.id],
+             "a participant already sitting on unread mail was emailed again"
+    end
+
+    test "still notifies someone who has never read but has no earlier messages" do
+      conversation = insert(:conversation_schema)
+      sender = participant(conversation)
+      newcomer = participant(conversation, last_read_at: nil)
+
+      assert :ok = conversation |> message(sender) |> event() |> handle()
+
+      assert enqueued_recipient_ids() == [newcomer.id]
+    end
+
+    test "a soft-deleted earlier message does not count as unread" do
+      conversation = insert(:conversation_schema)
+      sender = participant(conversation)
+      recipient = participant(conversation, last_read_at: ~U[2020-01-01 00:00:00Z])
+
+      message(conversation, sender,
+        inserted_at: ~U[2021-01-01 00:00:00Z],
+        deleted_at: ~U[2021-01-02 00:00:00Z]
+      )
+
+      assert :ok = conversation |> message(sender) |> event() |> handle()
+
+      assert enqueued_recipient_ids() == [recipient.id]
+    end
+  end
+
+  describe "handle_event/1 — job args" do
+    test "carry ids only, never the message body or an address" do
+      conversation = insert(:conversation_schema)
+      sender = participant(conversation)
+      recipient = participant(conversation)
+
+      message = message(conversation, sender, content: "a private medical detail")
+      assert :ok = message |> event() |> handle()
+
+      [job] =
+        Oban.Job
+        |> KlassHero.Repo.all()
+        |> Enum.filter(&(&1.worker == Oban.Worker.to_string(NewMessageEmailWorker)))
+
+      assert job.args["conversation_id"] == conversation.id
+      assert job.args["recipient_user_id"] == recipient.id
+
+      encoded = Jason.encode!(job.args)
+      refute encoded =~ "a private medical detail"
+      refute encoded =~ recipient.email
+    end
+  end
+
+  describe "wiring" do
+    test "declares the event the registry routes to it" do
+      assert NewMessageEmailHandler.subscribed_events() == [:message_sent]
+    end
+
+    test "ignores anything else" do
+      assert :ignore = NewMessageEmailHandler.handle_event(%{event_type: :conversation_created})
+    end
+  end
+end

--- a/test/klass_hero/messaging/workers/new_message_email_worker_test.exs
+++ b/test/klass_hero/messaging/workers/new_message_email_worker_test.exs
@@ -1,0 +1,77 @@
+defmodule KlassHero.Messaging.Workers.NewMessageEmailWorkerTest do
+  @moduledoc """
+  Delivery of one new-message notice.
+
+  The worker re-checks the preference rather than trusting the enqueue, so the
+  interesting cases here are the ones where the world changed between the two.
+  """
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.EmailTestHelper
+  import Swoosh.TestAssertions
+
+  alias KlassHero.Accounts
+  alias KlassHero.AccountsFixtures
+  alias KlassHero.Messaging.Workers.NewMessageEmailWorker
+  alias KlassHero.Test.StubMailerAdapter
+
+  setup do
+    # user_fixture/1 delivers a magic-link email as a side effect; without this
+    # the assertions below would match that one instead.
+    on_exit(&StubMailerAdapter.deliver_normally/0)
+    :ok
+  end
+
+  defp job(user_id, conversation_id \\ Ecto.UUID.generate()) do
+    %Oban.Job{
+      args: %{"conversation_id" => conversation_id, "recipient_user_id" => user_id}
+    }
+  end
+
+  describe "execute/1" do
+    test "emails a link, and never the conversation's content" do
+      user = AccountsFixtures.user_fixture()
+      conversation_id = Ecto.UUID.generate()
+      flush_emails()
+
+      assert :ok = NewMessageEmailWorker.execute(job(user.id, conversation_id))
+
+      assert_email_sent(fn email ->
+        assert {_name, address} = email.to |> List.first()
+        assert address == user.email
+        assert email.subject =~ "new message"
+        assert email.text_body =~ "/messages/#{conversation_id}"
+        assert email.html_body =~ "/messages/#{conversation_id}"
+      end)
+    end
+
+    # The enqueue already filtered, but a broadcast's jobs can sit on a
+    # rate-limited queue long enough for someone to change their mind.
+    test "sends nothing when the user opted out after the job was enqueued" do
+      user = AccountsFixtures.user_fixture()
+      {:ok, _} = Accounts.update_user_email_notification_preference(user, :new_message_email, false)
+      flush_emails()
+
+      assert :ok = NewMessageEmailWorker.execute(job(user.id))
+
+      assert_no_email_sent()
+    end
+
+    # Completed, not failed: retrying cannot make a deleted account exist.
+    test "sends nothing when the recipient no longer exists" do
+      flush_emails()
+
+      assert :ok = NewMessageEmailWorker.execute(job(Ecto.UUID.generate()))
+
+      assert_no_email_sent()
+    end
+
+    test "reports an error when delivery fails, so Oban retries" do
+      user = AccountsFixtures.user_fixture()
+      flush_emails()
+      StubMailerAdapter.fail_with({:network, :timeout})
+
+      assert {:error, _reason} = NewMessageEmailWorker.execute(job(user.id))
+    end
+  end
+end

--- a/test/klass_hero_web/live/user_live/settings_test.exs
+++ b/test/klass_hero_web/live/user_live/settings_test.exs
@@ -377,13 +377,13 @@ defmodule KlassHeroWeb.UserLive.SettingsTest do
     test "the rendered state follows the change without a reload", %{conn: conn} do
       {:ok, lv, _html} = live(conn, ~p"/users/settings")
 
-      html =
-        lv
-        |> form("#notification_preferences_form", notifications: %{new_message_email: "false"})
-        |> render_change()
+      assert has_element?(lv, "#notifications_new_message_email[checked]")
 
-      refute html =~
-               ~s(id="notifications_new_message_email" name="notifications[new_message_email]" value="true" checked)
+      lv
+      |> form("#notification_preferences_form", notifications: %{new_message_email: "false"})
+      |> render_change()
+
+      refute has_element?(lv, "#notifications_new_message_email[checked]")
     end
 
     test "switching it back on clears the opt-out", %{conn: conn, user: user} do

--- a/test/klass_hero_web/live/user_live/settings_test.exs
+++ b/test/klass_hero_web/live/user_live/settings_test.exs
@@ -343,4 +343,68 @@ defmodule KlassHeroWeb.UserLive.SettingsTest do
       assert KlassHero.Repo.reload!(user).locale == "de"
     end
   end
+
+  describe "email notification preferences" do
+    setup %{conn: conn} do
+      user = user_fixture()
+
+      %{conn: log_in_user(conn, user), user: user}
+    end
+
+    test "renders the toggle on, because the preference defaults on", %{conn: conn} do
+      {:ok, lv, _html} = live(conn, ~p"/users/settings")
+
+      assert has_element?(lv, "#notification_preferences_form")
+      assert has_element?(lv, "#notifications_new_message_email[checked]")
+    end
+
+    test "switching it off persists the opt-out", %{conn: conn, user: user} do
+      {:ok, lv, _html} = live(conn, ~p"/users/settings")
+
+      lv
+      |> form("#notification_preferences_form", notifications: %{new_message_email: "false"})
+      |> render_change()
+
+      refute KlassHero.Accounts.email_notification_enabled?(
+               KlassHero.Repo.reload!(user),
+               :new_message_email
+             )
+    end
+
+    # The toggle renders from its own assign rather than @current_scope.user,
+    # because nothing on this page refreshes the scope in place. If it ever
+    # reads the scope again, this goes stale-but-green until a remount.
+    test "the rendered state follows the change without a reload", %{conn: conn} do
+      {:ok, lv, _html} = live(conn, ~p"/users/settings")
+
+      html =
+        lv
+        |> form("#notification_preferences_form", notifications: %{new_message_email: "false"})
+        |> render_change()
+
+      refute html =~
+               ~s(id="notifications_new_message_email" name="notifications[new_message_email]" value="true" checked)
+    end
+
+    test "switching it back on clears the opt-out", %{conn: conn, user: user} do
+      {:ok, _} =
+        KlassHero.Accounts.update_user_email_notification_preference(
+          user,
+          :new_message_email,
+          false
+        )
+
+      {:ok, lv, _html} = live(conn, ~p"/users/settings")
+      refute has_element?(lv, "#notifications_new_message_email[checked]")
+
+      lv
+      |> form("#notification_preferences_form", notifications: %{new_message_email: "true"})
+      |> render_change()
+
+      assert KlassHero.Accounts.email_notification_enabled?(
+               KlassHero.Repo.reload!(user),
+               :new_message_email
+             )
+    end
+  end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -266,7 +266,6 @@ defmodule KlassHero.Factory do
       display_name: sequence(:parent_display_name, &"Test Parent #{&1}"),
       phone: "+1234567890",
       location: "New York, NY",
-      notification_preferences: %{email: true, sms: false},
       inserted_at: ~U[2025-01-01 12:00:00Z],
       updated_at: ~U[2025-01-01 12:00:00Z]
     }
@@ -293,8 +292,7 @@ defmodule KlassHero.Factory do
       identity_id: user.id,
       display_name: sequence(:parent_schema_display_name, &"Test Parent #{&1}"),
       phone: "+1234567890",
-      location: "New York, NY",
-      notification_preferences: %{email: true, sms: false}
+      location: "New York, NY"
     }
   end
 

--- a/test/support/flow_case.ex
+++ b/test/support/flow_case.ex
@@ -20,6 +20,21 @@ defmodule KlassHeroWeb.FlowCase do
   be caught at compile time here — `ExUnit.CaseTemplate` applies the caller's opts
   before this template's `using` block runs, so a nested `use ConnCase, async: false`
   is inert — so the `setup` below raises on it instead.
+
+  ## Email delivery is pinned to the test process
+
+  Swoosh's test adapter delivers by sending `{:email, _}` to `self()` and to every
+  pid in `$callers`. A flow test runs the real outbox, and `Oban, testing: :inline`
+  executes a job *at insert, in the calling process* — so a LiveView event that
+  ends in an email runs that whole chain inside the LiveView process, and the
+  `{:email, _}` message lands in **its** mailbox. A LiveView whose `handle_info/2`
+  does not expect that message then crashes, which leaves `with_real_outbox/1`'s
+  global swap unrestored and takes several hundred unrelated tests down behind it.
+
+  `:shared_test_process` is Swoosh's own escape hatch for exactly this — its docs
+  name "feature, browser, and E2E tests where the email is delivered from
+  request-handling or LiveView processes". Safe as a global because flow tests are
+  already `async: false`.
   """
 
   use ExUnit.CaseTemplate
@@ -45,6 +60,9 @@ defmodule KlassHeroWeb.FlowCase do
       events concurrently.
       """
     end
+
+    Application.put_env(:swoosh, :shared_test_process, self())
+    on_exit(fn -> Application.delete_env(:swoosh, :shared_test_process) end)
 
     {:ok, conn: Phoenix.ConnTest.build_conn()}
   end


### PR DESCRIPTION
Closes #1071

Parents got no signal when a message landed in their Klass Hero inbox — they only found out by opening the app. This adds an email notification with a per-user toggle, defaulting on.

## What the issue asked for vs what shipped

#1071 was filed 2026-07-11, before the Family/Messaging flattens and before ADR-0014. Every path in its Code References section is dead, so the feature was assessed and the spec discarded.

The one substantive divergence: the issue said to reuse `notification_preferences` on `Family.ParentProfile`. That map was dead scaffolding — nullable `jsonb`, no default, no key schema, cast wholesale — and `KlassHero.Family` has no update path at all, so that route had to invent a Family mutation anyway. It would also have made the feature structurally parent-only while the toggle sits beside `locale`, a user-level column, in the same settings card.

The preference is on `Accounts.User` instead, typed:

```elixir
field :disabled_email_notifications, {:array, Ecto.Enum},
  values: [:new_message_email], default: []
```

Storing what is **disabled** makes "default on" fall out of absence — no backfill, no three-way nil/false/missing ambiguity, and a kind added later is on for everyone by default.

## Shape

An event consumer, not a call inside `SendMessage`. `domain-architecture.md` says a same-context reaction is an ordinary function call inside the producer's transaction "so the write and its consequence commit together" — but that reasoning is about database writes. An email cannot be rolled back, so it must happen after commit, at-least-once, with retry, which is what the outbox is for. Sending inline would also drag a participants query, an Accounts query and up to N job inserts into a user-facing write, and would fail a person's message send because Resend was briefly unavailable.

A handler rather than a projection: `Shared.Projection.project/1` discards its callback's return and always answers `:ok`, which would swallow every dispatch failure.

`message_sent` is already staged and delivered for `ConversationSummaries`, so the `EventDeliveryWorker` hop runs on every send regardless — a second consumer adds N jobs, where a separate resolver job would add N+1.

ADR 0022 records all of this, including why the three queued notification issues (#829, #798, #742) must **not** route through the Accounts gate: none of them is gated by a user preference. #798's gate is a per-report toggle, #742's is severity, #829 is transactional confirmation.

## Three filters, each for a reason

- **The sender**, obviously.
- **`message_type: :system`.** The only producer is `ReplyPrivatelyToBroadcast`, which writes a `[broadcast:<id>] Re: <subject>` marker through the same send path — so it stages a real `message_sent`. Unfiltered, one "reply privately" action emails the provider twice for one parent action, once for a line the parent never wrote.
- **Anyone already sitting on unread mail in that conversation.** One email per thread until you read it, not one per message. The filter reads `conversation_participants.last_read_at` against `messages` rather than the projection's `unread_count`, because consumers of one event run sequentially and `ConversationSummaries` is on the same topic — reading its counter would depend on invisible registry ordering, and if it ran first, nobody would ever be emailed.

## Email queue capacity

`:email` went from concurrency 1 to 5 so a broadcast's fan-out stops head-of-line blocking staff invites and email replies. That makes 429s more likely, not less — the upstream limit did not move — so every worker on that queue also went to `max_attempts: 5`. At 3, a sustained 429 burst can spend the whole budget on `RateLimitedEmailWorker`'s backoff and **discard** a real email rather than delay it. The two numbers are one decision and are asserted together in `test/klass_hero/email_queue_capacity_test.exs`.

**Open:** whether this account's actual Resend limit is above 2 req/sec. `config/config.exs` carries an explicit `UNVERIFIED:` note. If it is still 2/s, 5 trades queue latency for 429 churn rather than winning throughput.

## Two things worth a reviewer's attention

**A destructive migration ships here.** `parents.notification_preferences` is dropped. The release before this one still names the column in `ParentProfile`, and `Accounts.Scope.resolve_roles/1` loads a parent profile on every authenticated LiveView mount — so between the migration committing and the new machines taking traffic, those mounts fail with `column does not exist`. The migration file carries this note. It is reversible without data loss: no caller ever passed the field (every `create_parent_profile/1` call site sends `identity_id` alone), so it is NULL in every row. If the window is unwelcome, the migration is self-contained and can be lifted into a follow-up PR merged after this one deploys.

**Seeded read state was broken independently of this feature.** `seeds.exs` inserted participants before their messages and never stamped `last_read_at`, leaving everyone permanently "never opened this thread" — which showed every thread unread for every user, and made the new notification suppress 14 of 16 participants. Fixed by stamping after the messages exist, with two hand-picked exceptions so each suppression rule stays demonstrable on its own: one parent left unread in the broadcast conversations only, one parent with the notification switched off.

## Verification

`mix precommit` green — 5282 tests. Beyond that, driven against a freshly seeded dev database: sending into a broadcast emails 3 of 6 participants, with the sender, the behind one and the opted-out one each skipped for a different reason, while the behind parent is still emailed in his own direct thread. Real mail landed in `/dev/mailbox`, link-only, correct deep link. Settings toggle exercised in the browser at 390px in both locales.

Also corrected two stale `CONTEXT.md` entries the work disproved: a Broadcast's recipients *are* Participants, and Participant is not Direct-only.
