### PR TITLE
feat: show a session's capacity on its roster and flag overflow

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -57,6 +57,10 @@ _Avoid_: Capacity as a noun for the row itself ("the capacity" is the number), L
 The set of children expected at a given **Session**, seeded from the Program's active **Enrollments**. A roster belongs to one Session.
 _Avoid_: Attendance list, Class list, Sign-in sheet
 
+**Session Capacity**:
+The most children one **Session** can hold — the room, or what the staffing on that date can supervise. Optional, and set only on manually-created Sessions; a schedule-generated one has none, because a Program carries no per-date number to derive it from. Distinct from the **Enrollment Policy**'s *cap*, which bounds bookings across the whole Program: the cap is a gate Enrollment enforces before a place is taken, while Session Capacity is checked by nothing. A **Roster** may exceed it, and does — the Roster is seeded from Enrollments that were already accepted, so by the time a child reaches a Session the place is paid for and cannot be refused. Exceeding it is therefore shown to the Provider to act on, never prevented.
+_Avoid_: bare "Capacity" (ambiguous with the Program's cap), Limit, Quota, Max
+
 **Participation Record**:
 One child's row on one Session's Roster, tracking presence through `registered → checked_in → checked_out`, or `absent`. `registered` here means "on the roster, not yet arrived" — it is not the **Enrollment**.
 _Avoid_: Attendance record, Booking

--- a/lib/klass_hero/participation/program_session.ex
+++ b/lib/klass_hero/participation/program_session.ex
@@ -144,6 +144,30 @@ defmodule KlassHero.Participation.ProgramSession do
   def in_progress?(%__MODULE__{status: :in_progress}), do: true
   def in_progress?(%__MODULE__{}), do: false
 
+  @doc """
+  How a roster of `count` children sits against this Session's Session Capacity.
+
+  A Session with no Session Capacity is `:uncapped` — never `:within`, because
+  "inside a limit" is a different claim from "there is no limit".
+
+  Matches on the field rather than on `%__MODULE__{}` deliberately.
+  `Participation.get_session_with_roster_enriched/1` hands the roster detail pages
+  a `Map.from_struct`'d session so presentation fields can be merged onto it, so
+  half the callers ask this about a plain map.
+
+  A map carrying no `:max_capacity` at all still raises — answering `:uncapped`
+  for something which is not a session would be a fabricated reassurance. That
+  case has no test on purpose: the type checker proves such a map matches no
+  clause and warns at the call site, so `--warnings-as-errors` fails the build
+  before any test could run, and pinning it at runtime means defeating the
+  analysis that provides the stronger guarantee.
+  """
+  @spec occupancy(t() | map(), non_neg_integer()) :: :uncapped | :within | :full | :over
+  def occupancy(%{max_capacity: nil}, _count), do: :uncapped
+  def occupancy(%{max_capacity: cap}, count) when count > cap, do: :over
+  def occupancy(%{max_capacity: cap}, count) when count == cap, do: :full
+  def occupancy(%{max_capacity: _}, _count), do: :within
+
   @doc "Returns the duration of the session in minutes."
   @spec duration_minutes(t()) :: non_neg_integer()
   def duration_minutes(%__MODULE__{start_time: start_time, end_time: end_time}) do

--- a/lib/klass_hero_web/components/participation_components.ex
+++ b/lib/klass_hero_web/components/participation_components.ex
@@ -9,6 +9,7 @@ defmodule KlassHeroWeb.ParticipationComponents do
   import KlassHeroWeb.UIComponents
 
   alias KlassHero.Participation.Domain.Services.ParticipationCollection
+  alias KlassHero.Participation.ProgramSession
   alias KlassHeroWeb.Theme
   alias Phoenix.HTML.Form
 
@@ -85,13 +86,26 @@ defmodule KlassHeroWeb.ParticipationComponents do
         </div>
 
         <%= if @role in [:provider, :staff] && @attendance do %>
-          <div class="flex items-center gap-2 text-sm text-hero-black-100">
+          <%!-- `flex-wrap` because the occupancy mark is a third element on this
+                line: at 375px a two-digit "12 of 10" plus the German "Überbelegt"
+                would otherwise have to fit beside the icon and the count. --%>
+          <div class="flex items-center flex-wrap gap-2 text-sm text-hero-black-100">
             <.icon name="hero-user-group" class="w-4 h-4 text-hero-grey-400" />
             <span>
               <%= if @session.status == :scheduled do %>
-                {ngettext("%{count} child enrolled", "%{count} children enrolled", @attendance.roster,
-                  count: @attendance.roster
-                )}
+                <%= if @session.max_capacity do %>
+                  {gettext("%{roster} of %{capacity}",
+                    roster: @attendance.roster,
+                    capacity: @session.max_capacity
+                  )}
+                <% else %>
+                  {ngettext(
+                    "%{count} child enrolled",
+                    "%{count} children enrolled",
+                    @attendance.roster,
+                    count: @attendance.roster
+                  )}
+                <% end %>
               <% else %>
                 {gettext("%{checked_in} of %{roster} checked in",
                   checked_in: @attendance.checked_in,
@@ -99,6 +113,7 @@ defmodule KlassHeroWeb.ParticipationComponents do
                 )}
               <% end %>
             </span>
+            <.occupancy_mark state={ProgramSession.occupancy(@session, @attendance.roster)} />
           </div>
         <% end %>
       </div>
@@ -156,6 +171,37 @@ defmodule KlassHeroWeb.ParticipationComponents do
     </span>
     """
   end
+
+  @doc """
+  Marks a Session whose Roster has outgrown its Session Capacity.
+
+  Only `:over` renders anything. `:uncapped` is the common case — most Sessions
+  carry no Session Capacity at all — and `:within`/`:full` are unremarkable, so
+  each returns empty rather than a reassurance nobody asked for.
+
+  Colours come from `Theme.status_badge/1` rather than `kh_pill`'s tones, which
+  measure below WCAG AA for text this size — the same reason `kh_trust_mark/1`
+  takes them from there.
+  """
+  attr :state, :atom, required: true, values: [:uncapped, :within, :full, :over]
+
+  def occupancy_mark(%{state: :over} = assigns) do
+    ~H"""
+    <.kh_pill
+      tone={:none}
+      size={:xs}
+      class={Theme.status_badge(:full)}
+      data-testid="session-occupancy-mark"
+      data-occupancy="over"
+      title={gettext("More children are on this session's roster than its capacity allows")}
+    >
+      <.icon name="hero-exclamation-triangle-mini" class="w-3.5 h-3.5" />
+      <span>{gettext("Over capacity")}</span>
+    </.kh_pill>
+    """
+  end
+
+  def occupancy_mark(assigns), do: ~H""
 
   @doc """
   Renders a session roster list with participation status.

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -1556,9 +1556,9 @@ msgstr "Rundnachricht"
 msgid "Broadcast sent to %{count} parents"
 msgstr "Rundnachricht an %{count} Eltern gesendet"
 
-#: lib/klass_hero_web/components/participation_components.ex:346
-#: lib/klass_hero_web/components/participation_components.ex:571
-#: lib/klass_hero_web/components/participation_components.ex:662
+#: lib/klass_hero_web/components/participation_components.ex:392
+#: lib/klass_hero_web/components/participation_components.ex:617
+#: lib/klass_hero_web/components/participation_components.ex:708
 #: lib/klass_hero_web/components/provider_components.ex:909
 #: lib/klass_hero_web/components/provider_components.ex:1323
 #: lib/klass_hero_web/components/provider_components.ex:2036
@@ -1990,7 +1990,7 @@ msgstr "Beim Import ist ein unerwarteter Fehler aufgetreten."
 msgid "Approve"
 msgstr "Genehmigen"
 
-#: lib/klass_hero_web/components/participation_components.ex:771
+#: lib/klass_hero_web/components/participation_components.ex:817
 #: lib/klass_hero_web/components/provider_components.ex:51
 #: lib/klass_hero_web/live/admin/sessions_live.ex:290
 #: lib/klass_hero_web/live/admin/verifications_live.ex:207
@@ -2563,7 +2563,7 @@ msgstr "Teilnahmevoraussetzungen"
 msgid "Participant Restrictions (optional)"
 msgstr "Teilnahmebeschränkungen (optional)"
 
-#: lib/klass_hero_web/components/participation_components.ex:770
+#: lib/klass_hero_web/components/participation_components.ex:816
 #: lib/klass_hero_web/components/provider_components.ex:332
 #, elixir-autogen, elixir-format
 msgid "Pending Review"
@@ -2645,7 +2645,7 @@ msgstr "Anbieterprofil nicht gefunden."
 msgid "Read our founding story →"
 msgstr "Lesen Sie unsere Gründungsgeschichte →"
 
-#: lib/klass_hero_web/components/participation_components.ex:750
+#: lib/klass_hero_web/components/participation_components.ex:796
 #: lib/klass_hero_web/components/provider_components.ex:2982
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
@@ -2713,7 +2713,7 @@ msgstr "Anmeldung öffnet am %{date}"
 msgid "Reject"
 msgstr "Ablehnen"
 
-#: lib/klass_hero_web/components/participation_components.ex:772
+#: lib/klass_hero_web/components/participation_components.ex:818
 #: lib/klass_hero_web/components/provider_components.ex:52
 #: lib/klass_hero_web/live/admin/verifications_live.ex:212
 #, elixir-autogen, elixir-format
@@ -3241,7 +3241,7 @@ msgstr "Diese Löschanfrage ist abgelaufen. Bitte versuchen Sie es erneut."
 msgid "A reason is required for corrections"
 msgstr "Ein Grund für die Korrektur ist erforderlich"
 
-#: lib/klass_hero_web/components/participation_components.ex:756
+#: lib/klass_hero_web/components/participation_components.ex:802
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:201
 #, elixir-autogen, elixir-format
 msgid "Absent"
@@ -3371,7 +3371,7 @@ msgstr "Kind"
 msgid "Coming soon! Sign up for our newsletter to be notified when gift vouchers launch."
 msgstr "Demnächst verfügbar! Melden Sie sich für unseren Newsletter an, um benachrichtigt zu werden, sobald Geschenkgutscheine verfügbar sind."
 
-#: lib/klass_hero_web/components/participation_components.ex:753
+#: lib/klass_hero_web/components/participation_components.ex:799
 #, elixir-autogen, elixir-format
 msgid "Completed"
 msgstr "Abgeschlossen"
@@ -3437,7 +3437,7 @@ msgstr "So werden Sie bezahlt:"
 msgid "How does the booking system work?"
 msgstr "Wie funktioniert das Buchungssystem?"
 
-#: lib/klass_hero_web/components/participation_components.ex:752
+#: lib/klass_hero_web/components/participation_components.ex:798
 #: lib/klass_hero_web/live/admin/sessions_live.ex:271
 #, elixir-autogen, elixir-format
 msgid "In Progress"
@@ -3490,7 +3490,7 @@ msgstr "Keine angemeldeten Eltern"
 msgid "No risk of non-payment"
 msgstr "Kein Risiko von Zahlungsausfällen"
 
-#: lib/klass_hero_web/components/participation_components.ex:775
+#: lib/klass_hero_web/components/participation_components.ex:821
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:155
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:197
 #, elixir-autogen, elixir-format
@@ -3579,7 +3579,7 @@ msgstr "SEPA-Lastschrift"
 msgid "Save Correction"
 msgstr "Korrektur speichern"
 
-#: lib/klass_hero_web/components/participation_components.ex:751
+#: lib/klass_hero_web/components/participation_components.ex:797
 #, elixir-autogen, elixir-format
 msgid "Scheduled"
 msgstr "Geplant"
@@ -3675,7 +3675,7 @@ msgstr "Sie werden bezahlt, BEVOR Sie das Programm durchführen (kein Warten)"
 msgid "You receive instant email with booking details and parent contact info"
 msgstr "Sie erhalten sofort eine E-Mail mit den Buchungsdetails und den Kontaktdaten der Eltern"
 
-#: lib/klass_hero_web/components/participation_components.ex:225
+#: lib/klass_hero_web/components/participation_components.ex:271
 #, elixir-autogen, elixir-format
 msgid "%{checked_in} / %{total} checked in"
 msgstr "%{checked_in} / %{total} eingecheckt"
@@ -3720,7 +3720,7 @@ msgstr "Alle Programme"
 msgid "All providers"
 msgstr "Alle Anbieter"
 
-#: lib/klass_hero_web/components/participation_components.ex:682
+#: lib/klass_hero_web/components/participation_components.ex:728
 #, elixir-autogen, elixir-format
 msgid "Allergies: %{details}"
 msgstr "Allergien: %{details}"
@@ -3768,17 +3768,17 @@ msgstr "Einchecken"
 msgid "Check-in time must be before check-out time"
 msgstr "Die Eincheckzeit muss vor der Auscheckzeit liegen"
 
-#: lib/klass_hero_web/components/participation_components.ex:266
+#: lib/klass_hero_web/components/participation_components.ex:312
 #, elixir-autogen, elixir-format
 msgid "Check-in:"
 msgstr "Einchecken:"
 
-#: lib/klass_hero_web/components/participation_components.ex:318
+#: lib/klass_hero_web/components/participation_components.ex:364
 #, elixir-autogen, elixir-format
 msgid "Check-out notes (optional)"
 msgstr "Auschecken-Notizen (optional)"
 
-#: lib/klass_hero_web/components/participation_components.ex:272
+#: lib/klass_hero_web/components/participation_components.ex:318
 #, elixir-autogen, elixir-format
 msgid "Check-out:"
 msgstr "Auschecken:"
@@ -3811,7 +3811,7 @@ msgstr "Registrierung abschließen"
 msgid "Complete Session"
 msgstr "Sitzung abschließen"
 
-#: lib/klass_hero_web/components/participation_components.ex:333
+#: lib/klass_hero_web/components/participation_components.ex:379
 #, elixir-autogen, elixir-format
 msgid "Confirm Check Out"
 msgstr "Auschecken bestätigen"
@@ -3864,7 +3864,7 @@ msgstr "Datum"
 msgid "Date is required"
 msgstr "Datum ist erforderlich"
 
-#: lib/klass_hero_web/components/participation_components.ex:319
+#: lib/klass_hero_web/components/participation_components.ex:365
 #, elixir-autogen, elixir-format
 msgid "E.g., picked up by parent, gave medication reminder..."
 msgstr "Z.B. von Eltern abgeholt, Medikamentenerinnerung gegeben..."
@@ -3897,7 +3897,7 @@ msgstr "E-Mail nicht gefunden"
 msgid "Emails"
 msgstr "E-Mails"
 
-#: lib/klass_hero_web/components/participation_components.ex:694
+#: lib/klass_hero_web/components/participation_components.ex:740
 #, elixir-autogen, elixir-format
 msgid "Emergency: %{details}"
 msgstr "Notfall: %{details}"
@@ -3907,7 +3907,7 @@ msgstr "Notfall: %{details}"
 msgid "End time must be after start time"
 msgstr "Die Endzeit muss nach der Startzeit liegen"
 
-#: lib/klass_hero_web/components/participation_components.ex:757
+#: lib/klass_hero_web/components/participation_components.ex:803
 #, elixir-autogen, elixir-format
 msgid "Expected"
 msgstr "Erwartet"
@@ -3963,7 +3963,7 @@ msgstr "Von:"
 msgid "Go to Home"
 msgstr "Zur Startseite"
 
-#: lib/klass_hero_web/components/participation_components.ex:251
+#: lib/klass_hero_web/components/participation_components.ex:297
 #, elixir-autogen, elixir-format
 msgid "In: %{time}"
 msgstr "Ein: %{time}"
@@ -4015,7 +4015,7 @@ msgstr "Beigetreten"
 msgid "Load images"
 msgstr "Bilder laden"
 
-#: lib/klass_hero_web/components/participation_components.ex:84
+#: lib/klass_hero_web/components/participation_components.ex:85
 #, elixir-autogen, elixir-format
 msgid "Location TBD"
 msgstr "Ort noch offen"
@@ -4041,7 +4041,7 @@ msgstr "Maximale Kapazität"
 msgid "No actions available"
 msgstr "Keine Aktionen verfügbar"
 
-#: lib/klass_hero_web/components/participation_components.ex:363
+#: lib/klass_hero_web/components/participation_components.ex:409
 #, elixir-autogen, elixir-format
 msgid "No children enrolled in this session"
 msgstr "Keine Kinder in dieser Sitzung angemeldet"
@@ -4077,17 +4077,17 @@ msgstr "Keine Sitzungen für die ausgewählten Filter gefunden."
 msgid "No sessions scheduled"
 msgstr "Keine Sitzungen geplant"
 
-#: lib/klass_hero_web/components/participation_components.ex:598
+#: lib/klass_hero_web/components/participation_components.ex:644
 #, elixir-autogen, elixir-format
 msgid "Note:"
 msgstr "Notiz:"
 
-#: lib/klass_hero_web/components/participation_components.ex:425
+#: lib/klass_hero_web/components/participation_components.ex:471
 #, elixir-autogen, elixir-format
 msgid "Observation about the child's participation..."
 msgstr "Beobachtung zur Teilnahme des Kindes..."
 
-#: lib/klass_hero_web/components/participation_components.ex:257
+#: lib/klass_hero_web/components/participation_components.ex:303
 #, elixir-autogen, elixir-format
 msgid "Out: %{time}"
 msgstr "Aus: %{time}"
@@ -4183,7 +4183,7 @@ msgstr "Erneut senden"
 msgid "Reset to today"
 msgstr "Auf heute zurücksetzen"
 
-#: lib/klass_hero_web/components/participation_components.ex:456
+#: lib/klass_hero_web/components/participation_components.ex:502
 #, elixir-autogen, elixir-format
 msgid "Resubmit Note"
 msgstr "Notiz erneut einreichen"
@@ -4193,7 +4193,7 @@ msgstr "Notiz erneut einreichen"
 msgid "Retry"
 msgstr "Erneut versuchen"
 
-#: lib/klass_hero_web/components/participation_components.ex:454
+#: lib/klass_hero_web/components/participation_components.ex:500
 #, elixir-autogen, elixir-format
 msgid "Revised Note"
 msgstr "Überarbeitete Notiz"
@@ -4213,7 +4213,7 @@ msgstr "Antwort senden"
 msgid "Sending"
 msgstr "Wird gesendet"
 
-#: lib/klass_hero_web/components/participation_components.ex:70
+#: lib/klass_hero_web/components/participation_components.ex:71
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:16
 #: lib/klass_hero_web/live/provider/sessions_live.ex:415
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:16
@@ -4221,7 +4221,7 @@ msgstr "Wird gesendet"
 msgid "Session"
 msgstr "Sitzung"
 
-#: lib/klass_hero_web/components/participation_components.ex:222
+#: lib/klass_hero_web/components/participation_components.ex:268
 #, elixir-autogen, elixir-format
 msgid "Session Roster"
 msgstr "Teilnehmerliste"
@@ -4242,12 +4242,12 @@ msgstr "Mitarbeiter-Dashboard"
 msgid "Start Session"
 msgstr "Sitzung starten"
 
-#: lib/klass_hero_web/components/participation_components.ex:426
+#: lib/klass_hero_web/components/participation_components.ex:472
 #, elixir-autogen, elixir-format
 msgid "Submit Note"
 msgstr "Notiz absenden"
 
-#: lib/klass_hero_web/components/participation_components.ex:688
+#: lib/klass_hero_web/components/participation_components.ex:734
 #, elixir-autogen, elixir-format
 msgid "Support: %{details}"
 msgstr "Unterstützung: %{details}"
@@ -4302,7 +4302,7 @@ msgstr "Nicht autorisiert"
 msgid "Unread"
 msgstr "Ungelesen"
 
-#: lib/klass_hero_web/components/participation_components.ex:455
+#: lib/klass_hero_web/components/participation_components.ex:501
 #, elixir-autogen, elixir-format
 msgid "Update your observation..."
 msgstr "Aktualisieren Sie Ihre Beobachtung..."
@@ -4403,7 +4403,7 @@ msgstr "Über den Anbieter"
 msgid "Built for the Berlin international community. Integrated secure encrypted messaging to connect with local families and trusted educators nearby."
 msgstr "Entwickelt für die internationale Berliner Gemeinschaft. Integriertes sicheres verschlüsseltes Messaging, um sich mit lokalen Familien und vertrauenswürdigen Pädagogen in Ihrer Nähe zu verbinden."
 
-#: lib/klass_hero_web/components/participation_components.ex:758
+#: lib/klass_hero_web/components/participation_components.ex:804
 #, elixir-autogen, elixir-format
 msgid "Cancelled"
 msgstr "Abgesagt"
@@ -4596,12 +4596,12 @@ msgstr "Sessions anzeigen"
 msgid "Create a program before inviting participants."
 msgstr "Erstellen Sie zuerst ein Programm, bevor Sie Teilnehmer einladen."
 
-#: lib/klass_hero_web/components/participation_components.ex:755
+#: lib/klass_hero_web/components/participation_components.ex:801
 #, elixir-autogen, elixir-format
 msgid "Departed"
 msgstr "Abgereist"
 
-#: lib/klass_hero_web/components/participation_components.ex:774
+#: lib/klass_hero_web/components/participation_components.ex:820
 #, elixir-autogen, elixir-format
 msgid "Departure notes"
 msgstr "Notizen zur Abreise"
@@ -4638,7 +4638,7 @@ msgstr "Einzelperson einladen"
 msgid "Invite sent."
 msgstr "Einladung verschickt."
 
-#: lib/klass_hero_web/components/participation_components.ex:544
+#: lib/klass_hero_web/components/participation_components.ex:590
 #, elixir-autogen, elixir-format
 msgid "Leave blank to keep this child marked as present."
 msgstr "Leer lassen, um dieses Kind als anwesend markiert zu lassen."
@@ -4674,7 +4674,7 @@ msgstr "Fotos dürfen in Marketingmaterialien verwendet werden"
 msgid "Photos may appear on social media"
 msgstr "Fotos dürfen in sozialen Medien erscheinen"
 
-#: lib/klass_hero_web/components/participation_components.ex:754
+#: lib/klass_hero_web/components/participation_components.ex:800
 #, elixir-autogen, elixir-format
 msgid "Present"
 msgstr "Anwesend"
@@ -4690,7 +4690,7 @@ msgstr "Hauptansprechpartner"
 msgid "Record departure"
 msgstr "Abreise erfassen"
 
-#: lib/klass_hero_web/components/participation_components.ex:541
+#: lib/klass_hero_web/components/participation_components.ex:587
 #, elixir-autogen, elixir-format
 msgid "Record departure time (optional)"
 msgstr "Abreisezeit erfassen (optional)"
@@ -4701,7 +4701,7 @@ msgstr "Abreisezeit erfassen (optional)"
 msgid "Record updated"
 msgstr "Datensatz aktualisiert"
 
-#: lib/klass_hero_web/components/participation_components.ex:558
+#: lib/klass_hero_web/components/participation_components.ex:604
 #, elixir-autogen, elixir-format
 msgid "Save changes"
 msgstr "Änderungen speichern"
@@ -4726,7 +4726,7 @@ msgstr "Zweiter Ansprechpartner (optional)"
 msgid "Send invite"
 msgstr "Einladung senden"
 
-#: lib/klass_hero_web/components/participation_components.ex:533
+#: lib/klass_hero_web/components/participation_components.ex:579
 #, elixir-autogen, elixir-format
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr "Aktualisieren Sie die Notiz für dieses Kind (z. B. um zu klären, was passiert ist)"
@@ -5676,7 +5676,7 @@ msgstr "Weniger verwalten."
 msgid "Mandatory child-protection course before going live."
 msgstr "Verpflichtender Kinderschutzkurs vor der Freischaltung."
 
-#: lib/klass_hero_web/components/participation_components.ex:490
+#: lib/klass_hero_web/components/participation_components.ex:536
 #: lib/klass_hero_web/components/provider_layout_components.ex:578
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:141
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:141
@@ -7147,7 +7147,7 @@ msgstr "Die Erklärung zur Mitarbeiter-Compliance wurde seit deiner letzten Unte
 msgid "You have signed the Staff Compliance Declaration."
 msgstr "Du hast die Erklärung zur Mitarbeiter-Compliance unterzeichnet."
 
-#: lib/klass_hero_web/components/participation_components.ex:424
+#: lib/klass_hero_web/components/participation_components.ex:470
 #, elixir-autogen, elixir-format
 msgid "Session Note"
 msgstr "Sitzungsnotiz"
@@ -7172,12 +7172,12 @@ msgstr "Wird geladen…"
 msgid "Incidents"
 msgstr "Vorfälle"
 
-#: lib/klass_hero_web/components/participation_components.ex:96
+#: lib/klass_hero_web/components/participation_components.ex:110
 #, elixir-autogen, elixir-format
 msgid "%{checked_in} of %{roster} checked in"
 msgstr "%{checked_in} von %{roster} eingecheckt"
 
-#: lib/klass_hero_web/components/participation_components.ex:92
+#: lib/klass_hero_web/components/participation_components.ex:102
 #, elixir-autogen, elixir-format
 msgid "%{count} child enrolled"
 msgid_plural "%{count} children enrolled"
@@ -7984,7 +7984,7 @@ msgstr "Erscheint auf eurer öffentlichen Profilseite."
 msgid "Tagline"
 msgstr "Slogan"
 
-#: lib/klass_hero_web/components/participation_components.ex:289
+#: lib/klass_hero_web/components/participation_components.ex:335
 #, elixir-autogen, elixir-format
 msgid "Absent:"
 msgstr "Abwesend:"
@@ -8005,12 +8005,12 @@ msgstr "Kind als abwesend markiert"
 msgid "Failed to mark absent: %{reason}"
 msgstr "Kind konnte nicht als abwesend markiert werden: %{reason}"
 
-#: lib/klass_hero_web/components/participation_components.ex:488
+#: lib/klass_hero_web/components/participation_components.ex:534
 #, elixir-autogen, elixir-format
 msgid "Reason for absence (optional)"
 msgstr "Grund für die Abwesenheit (optional)"
 
-#: lib/klass_hero_web/components/participation_components.ex:489
+#: lib/klass_hero_web/components/participation_components.ex:535
 #, elixir-autogen, elixir-format
 msgid "e.g. Mum called — off sick today"
 msgstr "z. B. Mutter hat angerufen — heute krank"
@@ -8216,3 +8216,18 @@ msgstr "Benachrichtigen Sie mich per E-Mail, wenn ich eine neue Nachricht erhalt
 #, elixir-autogen, elixir-format
 msgid "Email notifications"
 msgstr "E-Mail-Benachrichtigungen"
+
+#: lib/klass_hero_web/components/participation_components.ex:97
+#, elixir-autogen, elixir-format
+msgid "%{roster} of %{capacity}"
+msgstr "%{roster} von %{capacity}"
+
+#: lib/klass_hero_web/components/participation_components.ex:196
+#, elixir-autogen, elixir-format
+msgid "More children are on this session's roster than its capacity allows"
+msgstr "Auf der Teilnehmerliste dieser Sitzung stehen mehr Kinder, als die Kapazität zulässt"
+
+#: lib/klass_hero_web/components/participation_components.ex:199
+#, elixir-autogen, elixir-format
+msgid "Over capacity"
+msgstr "Überbelegt"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -1556,9 +1556,9 @@ msgstr ""
 msgid "Broadcast sent to %{count} parents"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:346
-#: lib/klass_hero_web/components/participation_components.ex:571
-#: lib/klass_hero_web/components/participation_components.ex:662
+#: lib/klass_hero_web/components/participation_components.ex:392
+#: lib/klass_hero_web/components/participation_components.ex:617
+#: lib/klass_hero_web/components/participation_components.ex:708
 #: lib/klass_hero_web/components/provider_components.ex:909
 #: lib/klass_hero_web/components/provider_components.ex:1323
 #: lib/klass_hero_web/components/provider_components.ex:2036
@@ -1990,7 +1990,7 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:771
+#: lib/klass_hero_web/components/participation_components.ex:817
 #: lib/klass_hero_web/components/provider_components.ex:51
 #: lib/klass_hero_web/live/admin/sessions_live.ex:290
 #: lib/klass_hero_web/live/admin/verifications_live.ex:207
@@ -2563,7 +2563,7 @@ msgstr ""
 msgid "Participant Restrictions (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:770
+#: lib/klass_hero_web/components/participation_components.ex:816
 #: lib/klass_hero_web/components/provider_components.ex:332
 #, elixir-autogen, elixir-format
 msgid "Pending Review"
@@ -2645,7 +2645,7 @@ msgstr ""
 msgid "Read our founding story →"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:750
+#: lib/klass_hero_web/components/participation_components.ex:796
 #: lib/klass_hero_web/components/provider_components.ex:2982
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
@@ -2713,7 +2713,7 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:772
+#: lib/klass_hero_web/components/participation_components.ex:818
 #: lib/klass_hero_web/components/provider_components.ex:52
 #: lib/klass_hero_web/live/admin/verifications_live.ex:212
 #, elixir-autogen, elixir-format
@@ -3241,7 +3241,7 @@ msgstr ""
 msgid "A reason is required for corrections"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:756
+#: lib/klass_hero_web/components/participation_components.ex:802
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:201
 #, elixir-autogen, elixir-format
 msgid "Absent"
@@ -3371,7 +3371,7 @@ msgstr ""
 msgid "Coming soon! Sign up for our newsletter to be notified when gift vouchers launch."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:753
+#: lib/klass_hero_web/components/participation_components.ex:799
 #, elixir-autogen, elixir-format
 msgid "Completed"
 msgstr ""
@@ -3437,7 +3437,7 @@ msgstr ""
 msgid "How does the booking system work?"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:752
+#: lib/klass_hero_web/components/participation_components.ex:798
 #: lib/klass_hero_web/live/admin/sessions_live.ex:271
 #, elixir-autogen, elixir-format
 msgid "In Progress"
@@ -3490,7 +3490,7 @@ msgstr ""
 msgid "No risk of non-payment"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:775
+#: lib/klass_hero_web/components/participation_components.ex:821
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:155
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:197
 #, elixir-autogen, elixir-format
@@ -3579,7 +3579,7 @@ msgstr ""
 msgid "Save Correction"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:751
+#: lib/klass_hero_web/components/participation_components.ex:797
 #, elixir-autogen, elixir-format
 msgid "Scheduled"
 msgstr ""
@@ -3675,7 +3675,7 @@ msgstr ""
 msgid "You receive instant email with booking details and parent contact info"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:225
+#: lib/klass_hero_web/components/participation_components.ex:271
 #, elixir-autogen, elixir-format
 msgid "%{checked_in} / %{total} checked in"
 msgstr ""
@@ -3720,7 +3720,7 @@ msgstr ""
 msgid "All providers"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:682
+#: lib/klass_hero_web/components/participation_components.ex:728
 #, elixir-autogen, elixir-format
 msgid "Allergies: %{details}"
 msgstr ""
@@ -3768,17 +3768,17 @@ msgstr ""
 msgid "Check-in time must be before check-out time"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:266
+#: lib/klass_hero_web/components/participation_components.ex:312
 #, elixir-autogen, elixir-format
 msgid "Check-in:"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:318
+#: lib/klass_hero_web/components/participation_components.ex:364
 #, elixir-autogen, elixir-format
 msgid "Check-out notes (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:272
+#: lib/klass_hero_web/components/participation_components.ex:318
 #, elixir-autogen, elixir-format
 msgid "Check-out:"
 msgstr ""
@@ -3811,7 +3811,7 @@ msgstr ""
 msgid "Complete Session"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:333
+#: lib/klass_hero_web/components/participation_components.ex:379
 #, elixir-autogen, elixir-format
 msgid "Confirm Check Out"
 msgstr ""
@@ -3864,7 +3864,7 @@ msgstr ""
 msgid "Date is required"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:319
+#: lib/klass_hero_web/components/participation_components.ex:365
 #, elixir-autogen, elixir-format
 msgid "E.g., picked up by parent, gave medication reminder..."
 msgstr ""
@@ -3897,7 +3897,7 @@ msgstr ""
 msgid "Emails"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:694
+#: lib/klass_hero_web/components/participation_components.ex:740
 #, elixir-autogen, elixir-format
 msgid "Emergency: %{details}"
 msgstr ""
@@ -3907,7 +3907,7 @@ msgstr ""
 msgid "End time must be after start time"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:757
+#: lib/klass_hero_web/components/participation_components.ex:803
 #, elixir-autogen, elixir-format
 msgid "Expected"
 msgstr ""
@@ -3963,7 +3963,7 @@ msgstr ""
 msgid "Go to Home"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:251
+#: lib/klass_hero_web/components/participation_components.ex:297
 #, elixir-autogen, elixir-format
 msgid "In: %{time}"
 msgstr ""
@@ -4015,7 +4015,7 @@ msgstr ""
 msgid "Load images"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:84
+#: lib/klass_hero_web/components/participation_components.ex:85
 #, elixir-autogen, elixir-format
 msgid "Location TBD"
 msgstr ""
@@ -4041,7 +4041,7 @@ msgstr ""
 msgid "No actions available"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:363
+#: lib/klass_hero_web/components/participation_components.ex:409
 #, elixir-autogen, elixir-format
 msgid "No children enrolled in this session"
 msgstr ""
@@ -4077,17 +4077,17 @@ msgstr ""
 msgid "No sessions scheduled"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:598
+#: lib/klass_hero_web/components/participation_components.ex:644
 #, elixir-autogen, elixir-format
 msgid "Note:"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:425
+#: lib/klass_hero_web/components/participation_components.ex:471
 #, elixir-autogen, elixir-format
 msgid "Observation about the child's participation..."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:257
+#: lib/klass_hero_web/components/participation_components.ex:303
 #, elixir-autogen, elixir-format
 msgid "Out: %{time}"
 msgstr ""
@@ -4183,7 +4183,7 @@ msgstr ""
 msgid "Reset to today"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:456
+#: lib/klass_hero_web/components/participation_components.ex:502
 #, elixir-autogen, elixir-format
 msgid "Resubmit Note"
 msgstr ""
@@ -4193,7 +4193,7 @@ msgstr ""
 msgid "Retry"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:454
+#: lib/klass_hero_web/components/participation_components.ex:500
 #, elixir-autogen, elixir-format
 msgid "Revised Note"
 msgstr ""
@@ -4213,7 +4213,7 @@ msgstr ""
 msgid "Sending"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:70
+#: lib/klass_hero_web/components/participation_components.ex:71
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:16
 #: lib/klass_hero_web/live/provider/sessions_live.ex:415
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:16
@@ -4221,7 +4221,7 @@ msgstr ""
 msgid "Session"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:222
+#: lib/klass_hero_web/components/participation_components.ex:268
 #, elixir-autogen, elixir-format
 msgid "Session Roster"
 msgstr ""
@@ -4242,12 +4242,12 @@ msgstr ""
 msgid "Start Session"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:426
+#: lib/klass_hero_web/components/participation_components.ex:472
 #, elixir-autogen, elixir-format
 msgid "Submit Note"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:688
+#: lib/klass_hero_web/components/participation_components.ex:734
 #, elixir-autogen, elixir-format
 msgid "Support: %{details}"
 msgstr ""
@@ -4302,7 +4302,7 @@ msgstr ""
 msgid "Unread"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:455
+#: lib/klass_hero_web/components/participation_components.ex:501
 #, elixir-autogen, elixir-format
 msgid "Update your observation..."
 msgstr ""
@@ -4403,7 +4403,7 @@ msgstr ""
 msgid "Built for the Berlin international community. Integrated secure encrypted messaging to connect with local families and trusted educators nearby."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:758
+#: lib/klass_hero_web/components/participation_components.ex:804
 #, elixir-autogen, elixir-format
 msgid "Cancelled"
 msgstr ""
@@ -4596,12 +4596,12 @@ msgstr ""
 msgid "Create a program before inviting participants."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:755
+#: lib/klass_hero_web/components/participation_components.ex:801
 #, elixir-autogen, elixir-format
 msgid "Departed"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:774
+#: lib/klass_hero_web/components/participation_components.ex:820
 #, elixir-autogen, elixir-format
 msgid "Departure notes"
 msgstr ""
@@ -4638,7 +4638,7 @@ msgstr ""
 msgid "Invite sent."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:544
+#: lib/klass_hero_web/components/participation_components.ex:590
 #, elixir-autogen, elixir-format
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
@@ -4674,7 +4674,7 @@ msgstr ""
 msgid "Photos may appear on social media"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:754
+#: lib/klass_hero_web/components/participation_components.ex:800
 #, elixir-autogen, elixir-format
 msgid "Present"
 msgstr ""
@@ -4690,7 +4690,7 @@ msgstr ""
 msgid "Record departure"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:541
+#: lib/klass_hero_web/components/participation_components.ex:587
 #, elixir-autogen, elixir-format
 msgid "Record departure time (optional)"
 msgstr ""
@@ -4701,7 +4701,7 @@ msgstr ""
 msgid "Record updated"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:558
+#: lib/klass_hero_web/components/participation_components.ex:604
 #, elixir-autogen, elixir-format
 msgid "Save changes"
 msgstr ""
@@ -4726,7 +4726,7 @@ msgstr ""
 msgid "Send invite"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:533
+#: lib/klass_hero_web/components/participation_components.ex:579
 #, elixir-autogen, elixir-format
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr ""
@@ -5676,7 +5676,7 @@ msgstr ""
 msgid "Mandatory child-protection course before going live."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:490
+#: lib/klass_hero_web/components/participation_components.ex:536
 #: lib/klass_hero_web/components/provider_layout_components.ex:578
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:141
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:141
@@ -7147,7 +7147,7 @@ msgstr ""
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:424
+#: lib/klass_hero_web/components/participation_components.ex:470
 #, elixir-autogen, elixir-format
 msgid "Session Note"
 msgstr ""
@@ -7172,12 +7172,12 @@ msgstr ""
 msgid "Incidents"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:96
+#: lib/klass_hero_web/components/participation_components.ex:110
 #, elixir-autogen, elixir-format
 msgid "%{checked_in} of %{roster} checked in"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:92
+#: lib/klass_hero_web/components/participation_components.ex:102
 #, elixir-autogen, elixir-format
 msgid "%{count} child enrolled"
 msgid_plural "%{count} children enrolled"
@@ -7966,7 +7966,7 @@ msgstr ""
 msgid "Tagline"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:289
+#: lib/klass_hero_web/components/participation_components.ex:335
 #, elixir-autogen, elixir-format
 msgid "Absent:"
 msgstr ""
@@ -7987,12 +7987,12 @@ msgstr ""
 msgid "Failed to mark absent: %{reason}"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:488
+#: lib/klass_hero_web/components/participation_components.ex:534
 #, elixir-autogen, elixir-format
 msgid "Reason for absence (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:489
+#: lib/klass_hero_web/components/participation_components.ex:535
 #, elixir-autogen, elixir-format
 msgid "e.g. Mum called — off sick today"
 msgstr ""
@@ -8197,4 +8197,19 @@ msgstr ""
 #: lib/klass_hero_web/live/user_live/settings.ex:207
 #, elixir-autogen, elixir-format
 msgid "Email notifications"
+msgstr ""
+
+#: lib/klass_hero_web/components/participation_components.ex:97
+#, elixir-autogen, elixir-format
+msgid "%{roster} of %{capacity}"
+msgstr ""
+
+#: lib/klass_hero_web/components/participation_components.ex:196
+#, elixir-autogen, elixir-format
+msgid "More children are on this session's roster than its capacity allows"
+msgstr ""
+
+#: lib/klass_hero_web/components/participation_components.ex:199
+#, elixir-autogen, elixir-format
+msgid "Over capacity"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -1556,9 +1556,9 @@ msgstr ""
 msgid "Broadcast sent to %{count} parents"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:346
-#: lib/klass_hero_web/components/participation_components.ex:571
-#: lib/klass_hero_web/components/participation_components.ex:662
+#: lib/klass_hero_web/components/participation_components.ex:392
+#: lib/klass_hero_web/components/participation_components.ex:617
+#: lib/klass_hero_web/components/participation_components.ex:708
 #: lib/klass_hero_web/components/provider_components.ex:909
 #: lib/klass_hero_web/components/provider_components.ex:1323
 #: lib/klass_hero_web/components/provider_components.ex:2036
@@ -1990,7 +1990,7 @@ msgstr ""
 msgid "Approve"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:771
+#: lib/klass_hero_web/components/participation_components.ex:817
 #: lib/klass_hero_web/components/provider_components.ex:51
 #: lib/klass_hero_web/live/admin/sessions_live.ex:290
 #: lib/klass_hero_web/live/admin/verifications_live.ex:207
@@ -2563,7 +2563,7 @@ msgstr ""
 msgid "Participant Restrictions (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:770
+#: lib/klass_hero_web/components/participation_components.ex:816
 #: lib/klass_hero_web/components/provider_components.ex:332
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Pending Review"
@@ -2645,7 +2645,7 @@ msgstr ""
 msgid "Read our founding story →"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:750
+#: lib/klass_hero_web/components/participation_components.ex:796
 #: lib/klass_hero_web/components/provider_components.ex:2982
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format, fuzzy
@@ -2713,7 +2713,7 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:772
+#: lib/klass_hero_web/components/participation_components.ex:818
 #: lib/klass_hero_web/components/provider_components.ex:52
 #: lib/klass_hero_web/live/admin/verifications_live.ex:212
 #, elixir-autogen, elixir-format
@@ -3241,7 +3241,7 @@ msgstr ""
 msgid "A reason is required for corrections"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:756
+#: lib/klass_hero_web/components/participation_components.ex:802
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:201
 #, elixir-autogen, elixir-format
 msgid "Absent"
@@ -3371,7 +3371,7 @@ msgstr ""
 msgid "Coming soon! Sign up for our newsletter to be notified when gift vouchers launch."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:753
+#: lib/klass_hero_web/components/participation_components.ex:799
 #, elixir-autogen, elixir-format
 msgid "Completed"
 msgstr ""
@@ -3437,7 +3437,7 @@ msgstr ""
 msgid "How does the booking system work?"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:752
+#: lib/klass_hero_web/components/participation_components.ex:798
 #: lib/klass_hero_web/live/admin/sessions_live.ex:271
 #, elixir-autogen, elixir-format, fuzzy
 msgid "In Progress"
@@ -3490,7 +3490,7 @@ msgstr ""
 msgid "No risk of non-payment"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:775
+#: lib/klass_hero_web/components/participation_components.ex:821
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:155
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:197
 #, elixir-autogen, elixir-format
@@ -3579,7 +3579,7 @@ msgstr ""
 msgid "Save Correction"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:751
+#: lib/klass_hero_web/components/participation_components.ex:797
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Scheduled"
 msgstr ""
@@ -3675,7 +3675,7 @@ msgstr ""
 msgid "You receive instant email with booking details and parent contact info"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:225
+#: lib/klass_hero_web/components/participation_components.ex:271
 #, elixir-autogen, elixir-format
 msgid "%{checked_in} / %{total} checked in"
 msgstr ""
@@ -3720,7 +3720,7 @@ msgstr ""
 msgid "All providers"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:682
+#: lib/klass_hero_web/components/participation_components.ex:728
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Allergies: %{details}"
 msgstr ""
@@ -3768,17 +3768,17 @@ msgstr ""
 msgid "Check-in time must be before check-out time"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:266
+#: lib/klass_hero_web/components/participation_components.ex:312
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Check-in:"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:318
+#: lib/klass_hero_web/components/participation_components.ex:364
 #, elixir-autogen, elixir-format
 msgid "Check-out notes (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:272
+#: lib/klass_hero_web/components/participation_components.ex:318
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Check-out:"
 msgstr ""
@@ -3811,7 +3811,7 @@ msgstr ""
 msgid "Complete Session"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:333
+#: lib/klass_hero_web/components/participation_components.ex:379
 #, elixir-autogen, elixir-format
 msgid "Confirm Check Out"
 msgstr ""
@@ -3864,7 +3864,7 @@ msgstr ""
 msgid "Date is required"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:319
+#: lib/klass_hero_web/components/participation_components.ex:365
 #, elixir-autogen, elixir-format
 msgid "E.g., picked up by parent, gave medication reminder..."
 msgstr ""
@@ -3897,7 +3897,7 @@ msgstr ""
 msgid "Emails"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:694
+#: lib/klass_hero_web/components/participation_components.ex:740
 #, elixir-autogen, elixir-format
 msgid "Emergency: %{details}"
 msgstr ""
@@ -3907,7 +3907,7 @@ msgstr ""
 msgid "End time must be after start time"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:757
+#: lib/klass_hero_web/components/participation_components.ex:803
 #, elixir-autogen, elixir-format
 msgid "Expected"
 msgstr ""
@@ -3963,7 +3963,7 @@ msgstr ""
 msgid "Go to Home"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:251
+#: lib/klass_hero_web/components/participation_components.ex:297
 #, elixir-autogen, elixir-format
 msgid "In: %{time}"
 msgstr ""
@@ -4015,7 +4015,7 @@ msgstr ""
 msgid "Load images"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:84
+#: lib/klass_hero_web/components/participation_components.ex:85
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Location TBD"
 msgstr ""
@@ -4041,7 +4041,7 @@ msgstr ""
 msgid "No actions available"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:363
+#: lib/klass_hero_web/components/participation_components.ex:409
 #, elixir-autogen, elixir-format
 msgid "No children enrolled in this session"
 msgstr ""
@@ -4077,17 +4077,17 @@ msgstr ""
 msgid "No sessions scheduled"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:598
+#: lib/klass_hero_web/components/participation_components.ex:644
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Note:"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:425
+#: lib/klass_hero_web/components/participation_components.ex:471
 #, elixir-autogen, elixir-format
 msgid "Observation about the child's participation..."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:257
+#: lib/klass_hero_web/components/participation_components.ex:303
 #, elixir-autogen, elixir-format
 msgid "Out: %{time}"
 msgstr ""
@@ -4183,7 +4183,7 @@ msgstr ""
 msgid "Reset to today"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:456
+#: lib/klass_hero_web/components/participation_components.ex:502
 #, elixir-autogen, elixir-format
 msgid "Resubmit Note"
 msgstr ""
@@ -4193,7 +4193,7 @@ msgstr ""
 msgid "Retry"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:454
+#: lib/klass_hero_web/components/participation_components.ex:500
 #, elixir-autogen, elixir-format
 msgid "Revised Note"
 msgstr ""
@@ -4213,7 +4213,7 @@ msgstr ""
 msgid "Sending"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:70
+#: lib/klass_hero_web/components/participation_components.ex:71
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:16
 #: lib/klass_hero_web/live/provider/sessions_live.ex:415
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:16
@@ -4221,7 +4221,7 @@ msgstr ""
 msgid "Session"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:222
+#: lib/klass_hero_web/components/participation_components.ex:268
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Session Roster"
 msgstr ""
@@ -4242,12 +4242,12 @@ msgstr ""
 msgid "Start Session"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:426
+#: lib/klass_hero_web/components/participation_components.ex:472
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Submit Note"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:688
+#: lib/klass_hero_web/components/participation_components.ex:734
 #, elixir-autogen, elixir-format
 msgid "Support: %{details}"
 msgstr ""
@@ -4302,7 +4302,7 @@ msgstr ""
 msgid "Unread"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:455
+#: lib/klass_hero_web/components/participation_components.ex:501
 #, elixir-autogen, elixir-format
 msgid "Update your observation..."
 msgstr ""
@@ -4403,7 +4403,7 @@ msgstr ""
 msgid "Built for the Berlin international community. Integrated secure encrypted messaging to connect with local families and trusted educators nearby."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:758
+#: lib/klass_hero_web/components/participation_components.ex:804
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cancelled"
 msgstr ""
@@ -4596,12 +4596,12 @@ msgstr ""
 msgid "Create a program before inviting participants."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:755
+#: lib/klass_hero_web/components/participation_components.ex:801
 #, elixir-autogen, elixir-format
 msgid "Departed"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:774
+#: lib/klass_hero_web/components/participation_components.ex:820
 #, elixir-autogen, elixir-format
 msgid "Departure notes"
 msgstr ""
@@ -4638,7 +4638,7 @@ msgstr ""
 msgid "Invite sent."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:544
+#: lib/klass_hero_web/components/participation_components.ex:590
 #, elixir-autogen, elixir-format
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
@@ -4674,7 +4674,7 @@ msgstr ""
 msgid "Photos may appear on social media"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:754
+#: lib/klass_hero_web/components/participation_components.ex:800
 #, elixir-autogen, elixir-format
 msgid "Present"
 msgstr ""
@@ -4690,7 +4690,7 @@ msgstr ""
 msgid "Record departure"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:541
+#: lib/klass_hero_web/components/participation_components.ex:587
 #, elixir-autogen, elixir-format
 msgid "Record departure time (optional)"
 msgstr ""
@@ -4701,7 +4701,7 @@ msgstr ""
 msgid "Record updated"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:558
+#: lib/klass_hero_web/components/participation_components.ex:604
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Save changes"
 msgstr ""
@@ -4726,7 +4726,7 @@ msgstr ""
 msgid "Send invite"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:533
+#: lib/klass_hero_web/components/participation_components.ex:579
 #, elixir-autogen, elixir-format
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr ""
@@ -5676,7 +5676,7 @@ msgstr ""
 msgid "Mandatory child-protection course before going live."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:490
+#: lib/klass_hero_web/components/participation_components.ex:536
 #: lib/klass_hero_web/components/provider_layout_components.ex:578
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:141
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:141
@@ -7147,7 +7147,7 @@ msgstr ""
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:424
+#: lib/klass_hero_web/components/participation_components.ex:470
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Session Note"
 msgstr ""
@@ -7172,12 +7172,12 @@ msgstr ""
 msgid "Incidents"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:96
+#: lib/klass_hero_web/components/participation_components.ex:110
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{checked_in} of %{roster} checked in"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:92
+#: lib/klass_hero_web/components/participation_components.ex:102
 #, elixir-autogen, elixir-format
 msgid "%{count} child enrolled"
 msgid_plural "%{count} children enrolled"
@@ -7966,7 +7966,7 @@ msgstr ""
 msgid "Tagline"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:289
+#: lib/klass_hero_web/components/participation_components.ex:335
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Absent:"
 msgstr ""
@@ -7987,12 +7987,12 @@ msgstr ""
 msgid "Failed to mark absent: %{reason}"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:488
+#: lib/klass_hero_web/components/participation_components.ex:534
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Reason for absence (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/participation_components.ex:489
+#: lib/klass_hero_web/components/participation_components.ex:535
 #, elixir-autogen, elixir-format
 msgid "e.g. Mum called — off sick today"
 msgstr ""
@@ -8197,4 +8197,19 @@ msgstr ""
 #: lib/klass_hero_web/live/user_live/settings.ex:207
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Email notifications"
+msgstr ""
+
+#: lib/klass_hero_web/components/participation_components.ex:97
+#, elixir-autogen, elixir-format
+msgid "%{roster} of %{capacity}"
+msgstr ""
+
+#: lib/klass_hero_web/components/participation_components.ex:196
+#, elixir-autogen, elixir-format
+msgid "More children are on this session's roster than its capacity allows"
+msgstr ""
+
+#: lib/klass_hero_web/components/participation_components.ex:199
+#, elixir-autogen, elixir-format
+msgid "Over capacity"
 msgstr ""

--- a/test/klass_hero/participation/program_session_test.exs
+++ b/test/klass_hero/participation/program_session_test.exs
@@ -283,4 +283,40 @@ defmodule KlassHero.Participation.ProgramSessionTest do
       assert length(statuses) == 4
     end
   end
+
+  describe "occupancy/2" do
+    # {Session Capacity, roster count, expected}. The 5/6 row is the shape live in
+    # production: four completed sessions hold six children on a capacity of five.
+    @occupancy_cases [
+      {nil, 0, :uncapped},
+      {nil, 99, :uncapped},
+      {5, 4, :within},
+      {5, 5, :full},
+      {5, 6, :over},
+      {12, 0, :within}
+    ]
+
+    # `get_session_with_roster_enriched/1` hands the card a `Map.from_struct`'d
+    # session so presentation fields can be merged onto it, so the roster detail
+    # pages ask this question about a plain map, never a `%ProgramSession{}`.
+    test "answers for the enriched plain map the roster detail pages carry" do
+      enriched =
+        :program_session
+        |> build(max_capacity: 5)
+        |> Map.from_struct()
+        |> Map.put(:program_name, "After-School Club")
+
+      assert ProgramSession.occupancy(enriched, 6) == :over
+    end
+
+    for {capacity, count, expected} <- @occupancy_cases do
+      test "capacity #{inspect(capacity)} with #{count} on the roster is #{inspect(expected)}" do
+        session = build(:program_session, max_capacity: unquote(capacity))
+
+        assert ProgramSession.occupancy(session, unquote(count)) == unquote(expected),
+               "expected a roster of #{unquote(count)} against a Session Capacity of " <>
+                 "#{inspect(unquote(capacity))} to read #{inspect(unquote(expected))}"
+      end
+    end
+  end
 end

--- a/test/klass_hero_web/components/participation_components_test.exs
+++ b/test/klass_hero_web/components/participation_components_test.exs
@@ -18,4 +18,62 @@ defmodule KlassHeroWeb.ParticipationComponentsTest do
       assert html =~ "Cancelled"
     end
   end
+
+  describe "participation_card/1 — Session Capacity" do
+    setup do
+      %{
+        session:
+          KlassHero.Factory.build(:program_session,
+            status: :scheduled,
+            max_capacity: nil
+          )
+      }
+    end
+
+    test "shows the roster against the Session Capacity when one is set", %{session: session} do
+      html =
+        render_component(&ParticipationComponents.participation_card/1,
+          session: %{session | max_capacity: 5},
+          role: :provider,
+          attendance: %{roster: 4, checked_in: 0}
+        )
+
+      assert html =~ "4 of 5"
+    end
+
+    test "renders the plain count when the session is uncapped", %{session: session} do
+      html =
+        render_component(&ParticipationComponents.participation_card/1,
+          session: session,
+          role: :provider,
+          attendance: %{roster: 4, checked_in: 0}
+        )
+
+      assert html =~ "4 children enrolled"
+      refute html =~ "data-occupancy"
+    end
+
+    test "marks a session whose roster exceeds its Session Capacity", %{session: session} do
+      html =
+        render_component(&ParticipationComponents.participation_card/1,
+          session: %{session | max_capacity: 5},
+          role: :provider,
+          attendance: %{roster: 6, checked_in: 0}
+        )
+
+      assert html =~ ~s(data-occupancy="over")
+      assert html =~ "Over capacity"
+    end
+
+    test "does not mark a session sitting exactly at its Session Capacity", %{session: session} do
+      html =
+        render_component(&ParticipationComponents.participation_card/1,
+          session: %{session | max_capacity: 5},
+          role: :provider,
+          attendance: %{roster: 5, checked_in: 0}
+        )
+
+      refute html =~ "Over capacity"
+    end
+  end
 end

--- a/test/klass_hero_web/live/provider/sessions_live_test.exs
+++ b/test/klass_hero_web/live/provider/sessions_live_test.exs
@@ -94,11 +94,15 @@ defmodule KlassHeroWeb.Provider.SessionsLiveTest do
       program = insert(:program_schema, provider_id: provider.id, title: "Junior Choir")
       insert(:program_listing_schema, id: program.id, provider_id: provider.id, title: "Junior Choir")
 
+      # Explicitly uncapped, overriding the factory's default Session Capacity:
+      # this pins the plain-count wording, which is what most sessions in
+      # production render. The staff mirror covers the capped "N of M" branch.
       session =
         insert(:program_session_schema,
           program_id: program.id,
           session_date: Date.utc_today(),
-          status: :scheduled
+          status: :scheduled,
+          max_capacity: nil
         )
 
       for _ <- 1..2 do

--- a/test/klass_hero_web/live/staff/staff_sessions_live_test.exs
+++ b/test/klass_hero_web/live/staff/staff_sessions_live_test.exs
@@ -102,7 +102,10 @@ defmodule KlassHeroWeb.Staff.StaffSessionsLiveTest do
       {:ok, view, _html} = live(conn, ~p"/staff/sessions")
 
       assert has_element?(view, "h3", "Soccer Training")
-      assert has_element?(view, "span", "1 child enrolled")
+      # The factory gives every session a Session Capacity, so the headcount reads
+      # against it. `participation_components_test.exs` pins the uncapped wording.
+      assert has_element?(view, "span", "1 of 20")
+      refute has_element?(view, "[data-occupancy]")
     end
 
     test "an event for another date does not inject that session into today's list",


### PR DESCRIPTION
Closes #1538.

## Summary

A provider could set **Max Capacity** on a session and nothing ever read it back — no query, changeset, projection or handler counted a roster against it, and no screen displayed it. The value round-tripped from the create form into the column and was never seen again.

The comment sitting exactly where a check would go claimed capacity was *"an enrollment-time concern, not a roster gate"*. That holds only while a session's capacity is never narrower than its program's. In production it routinely is:

| Session cap | Program `max_enrollment` | Sessions |
|---|---|---|
| 5 | 14 | 7 |
| 6 | 14 | 3 |
| 8 | 12 | 2 |
| 10 | 12 | 5 |
| 12 | 12 | 12 |

25 of the 47 capped sessions sit below their program's cap, so `EnrollmentPolicy`'s gate — the one capacity that *is* enforced — structurally cannot protect them. Four sessions have already overflowed, and two scheduled ones currently sit exactly at capacity.

## Why this surfaces rather than blocks

Both roster writes — `seed_session_roster/2` and `backfill_roster_for_enrollment/2` — run from an Oban job *after* the enrollment transaction has committed. There is nothing left to refuse: the family is enrolled and has paid. Skipping the row would be worse, since the child would then be missing from the register the instructor takes attendance on.

So the roster always seats, and the overflow is shown to the provider to act on — move a child, raise the cap, or split the session. Gating at enrollment time is the only place a refusal could be honoured, and that is a different product decision, deliberately not taken here.

## Review Focus

- **`ProgramSession.occupancy/2`** (`lib/klass_hero/participation/program_session.ex`) — the pure core, four states, living beside the status state machine. The card *asks* it rather than comparing inline, so the template holds no `>` and no nil check.
- **It matches on `:max_capacity`, not on `%ProgramSession{}`.** `get_session_with_roster_enriched/1` hands the detail pages a `Map.from_struct`'d session, so half the callers ask this about a plain map. Architecture review flagged this and proposed precomputing the atom during that flattening instead; I declined, because occupancy depends on a roster count that arrives from a *separate* query, so stashing a derived atom on the session would create a second source of truth able to disagree with `@attendance.roster`.
- **`occupancy_mark/1` renders only for `:over`** — `:uncapped`, `:within` and `:full` all return `~H""`, so the 86 uncapped sessions emit byte-identical markup. Modelled on `kh_trust_mark/1`; colours come from `Theme.status_badge/1` (≈6.8:1) rather than `kh_pill`'s own tones, which fall below AA at this size.
- **The mark shows for every session status, `:cancelled` included.** For `:completed` that is intended — the four production overflows should be visible, not corrected, since their attendance is already recorded. For `:cancelled` it is arguably noise. Happy to suppress it there; it is a one-line guard.

## Test Plan

- `ProgramSession.occupancy/2` — a six-row table covering uncapped, within, full and over, plus the enriched-plain-map shape the detail pages carry. The 5/6 row is the shape live in production.
- `participation_card/1` — capped display, the uncapped regression guard, the over-capacity mark, and the boundary case that a session exactly *at* capacity is not marked.
- Two LiveView tests needed splitting: `program_session_factory` defaults `max_capacity: 20`, so every fixture was capped while most real sessions are not. They now pin one branch each rather than inheriting an invisible default. This inversion is why a minority-case display change initially broke 54 tests.
- `mix precommit` green: 5328 passed, credo clean, `lint_typography` / `lint_hero_colors` / `lint_translations` all pass.
- Verified against live data through Tidewave: a real session with a roster of 3 against a capacity of 2 renders "3 of 2" plus the mark.

**Not visually verified at 375px** — the Chrome MCP profile was held by another session. `flex-wrap` was added to the headcount row defensively, per design review, since the mark is now a third element on that line alongside the German "Überbelegt". Worth an eyes-on pass.

## Also

- `CONTEXT.md` gains a **Session Capacity** entry. The glossary reserved "cap" for the Enrollment Policy maximum and had no term for the per-session number, which is what let the two concepts blur in the first place.
- Follow-up worth filing: schedule-generated sessions (86 of 133, and the growing share) carry no capacity at all, so nothing here covers them. Whether a generated session should inherit one is an open question the issue records.
