### PR TITLE
feat: make the Program Inventory sessions popup a management surface

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -317,6 +317,10 @@ config :klass_hero, :event_consumers, %{
     {SeedSessionRosterHandler, :handle_event},
     {ProviderSessionDetails, :project}
   ],
+  # No roster handler: an edit moves a session that already has one.
+  "integration:participation:session_updated" => [
+    {ProviderSessionDetails, :project}
+  ],
   "integration:participation:sessions_generated" => [
     {SeedSessionRosterHandler, :handle_event},
     {ProviderSessionDetails, :project}

--- a/lib/klass_hero/participation.ex
+++ b/lib/klass_hero/participation.ex
@@ -197,6 +197,82 @@ defmodule KlassHero.Participation do
     end
   end
 
+  @doc """
+  Edits an existing session on behalf of `scope`.
+
+  Accepts `session_date`, `start_time`, `end_time`, `location`, `notes` and
+  `max_capacity`. Before #1074 none of this was possible: there was no command,
+  and `update_changeset/2` could not cast a date or a time, so a session typed
+  with the wrong hour stayed wrong.
+
+  **The schedule freezes once the session leaves `:scheduled`.** Attendance
+  records are keyed to the session, so moving a completed one rewrites history
+  its roster cannot follow. Details stay editable at every status — a wrong
+  location on a session that already ran is still worth fixing. A schedule key
+  submitted with its current value is not a change, so re-submitting an unchanged
+  form is allowed rather than refused on the shape of the params.
+
+  Staff are refused even when assigned, matching `create_session/2`: assignment is
+  permission to run a session, not to move it.
+
+  Returns `{:ok, session}`, `{:error, :not_found}`, `{:error, :unauthorized}`,
+  `{:error, :session_started}`, `{:error, :invalid_time_range}`, or
+  `{:error, :duplicate_session}`.
+  """
+  @spec update_session(Scope.t(), String.t(), map()) ::
+          {:ok, ProgramSession.t()}
+          | {:error, :not_found | :unauthorized | :session_started | :invalid_time_range | :duplicate_session}
+  def update_session(%Scope{} = scope, session_id, attrs) when is_binary(session_id) and is_map(attrs) do
+    context_span entity: "session" do
+      with {:ok, session} <- fetch_session(session_id),
+           {:ok, _role} <- authorize_session_edit(scope, session),
+           :ok <- allow_schedule_change?(session, attrs),
+           {:ok, {persisted, events}} <- persist_session_update(session, attrs) do
+        Notifications.notify_all(events)
+        {:ok, persisted}
+      end
+    end
+  end
+
+  # `authorize_lifecycle/2` grants :staff on an assigned session; editing does not.
+  defp authorize_session_edit(scope, session) do
+    case SessionAuthorization.authorize_lifecycle(scope, session) do
+      {:ok, :staff} -> {:error, :unauthorized}
+      {:ok, role} -> {:ok, role}
+      {:error, _reason} -> {:error, :unauthorized}
+    end
+  end
+
+  @schedule_fields [:session_date, :start_time, :end_time]
+
+  defp allow_schedule_change?(%ProgramSession{status: :scheduled}, _attrs), do: :ok
+
+  defp allow_schedule_change?(%ProgramSession{} = session, attrs) do
+    changed? = Enum.any?(@schedule_fields, &(Map.has_key?(attrs, &1) and Map.get(attrs, &1) != Map.get(session, &1)))
+
+    if changed?, do: {:error, :session_started}, else: :ok
+  end
+
+  defp persist_session_update(session, attrs) do
+    Outbox.transact_with_events(@context, fn ->
+      session
+      |> ProgramSession.update_changeset(attrs)
+      |> Repo.update()
+      |> case do
+        {:ok, persisted} -> {:ok, persisted, [ParticipationEvents.session_updated(persisted)]}
+        {:error, changeset} -> {:error, update_refusal(changeset)}
+      end
+    end)
+  end
+
+  defp update_refusal(%Ecto.Changeset{errors: errors}) do
+    cond do
+      Keyword.has_key?(errors, :program_id) -> :duplicate_session
+      Keyword.has_key?(errors, :end_time) -> :invalid_time_range
+      true -> :invalid_session
+    end
+  end
+
   @doc "Lists sessions, optionally filtered by `program_id` or `date`."
   def list_sessions(params \\ %{})
 

--- a/lib/klass_hero/participation.ex
+++ b/lib/klass_hero/participation.ex
@@ -60,26 +60,46 @@ defmodule KlassHero.Participation do
   # ============================================================================
 
   @doc """
-  Creates a new program session.
+  Schedules a new session on `params.program_id`, on behalf of `scope`.
 
   Required params: `program_id`, `session_date`, `start_time`, `end_time`.
 
-  Returns `{:ok, session}`, `{:error, :invalid_time_range}`, or `{:error, :duplicate_session}`.
+  Gated like `start_session/2` and `complete_session/2`, and for the same reason
+  (#1373, ADR-0019): this took bare params until #1074, with the ownership check
+  spelled out in `SessionsLive` as a `provider_program_ids` MapSet test. A second
+  create surface in Program Inventory would have been a second copy of that rule,
+  and a rule respelled per surface is one a surface eventually omits.
+
+  Authorization runs before validation, so a caller with no standing on the
+  program learns nothing about whether their params would have been accepted.
+
+  Returns `{:ok, session}`, `{:error, :unauthorized}`, `{:error, :invalid_time_range}`,
+  or `{:error, :duplicate_session}`.
   """
-  def create_session(params) when is_map(params) do
+  @spec create_session(Scope.t(), map()) ::
+          {:ok, ProgramSession.t()} | {:error, :unauthorized | :invalid_time_range | :duplicate_session}
+  def create_session(%Scope{} = scope, params) when is_map(params) do
     context_span entity: "session" do
       session_attrs =
         params
         |> Map.put(:id, Ecto.UUID.generate())
         |> Map.put(:status, :scheduled)
 
-      with {:ok, session} <- ProgramSession.new(session_attrs),
+      with {:ok, _role} <- authorize_creation(scope, params),
+           {:ok, session} <- ProgramSession.new(session_attrs),
            {:ok, {persisted, events}} <- insert_session_with_event(session) do
         Notifications.notify_all(events)
         {:ok, persisted}
       end
     end
   end
+
+  # A missing program_id can never be owned, so it refuses here rather than
+  # reaching the changeset's `validate_required` — same reasoning as above.
+  defp authorize_creation(scope, %{program_id: program_id}) when is_binary(program_id),
+    do: SessionAuthorization.authorize_creation(scope, program_id)
+
+  defp authorize_creation(_scope, _params), do: {:error, :unauthorized}
 
   @doc """
   Brings a program's generated sessions into agreement with its recurring schedule.

--- a/lib/klass_hero/participation/domain/events/participation_events.ex
+++ b/lib/klass_hero/participation/domain/events/participation_events.ex
@@ -29,6 +29,7 @@ defmodule KlassHero.Participation.Domain.Events.ParticipationEvents do
   # call site, so a new factory cannot invent one.
   @event_entities %{
     session_created: :session,
+    session_updated: :session,
     sessions_generated: :program,
     session_started: :session,
     session_completed: :session,
@@ -61,6 +62,29 @@ defmodule KlassHero.Participation.Domain.Events.ParticipationEvents do
     }
 
     new_event(:session_created, session.id, payload, opts)
+  end
+
+  @doc """
+  Creates a session_updated event.
+
+  Carries the same full snapshot as `session_created/2` rather than a diff, and
+  is built from the same fields for the same reason: two builders of one shape
+  drift, and when #1450 let them, the catalog showed €0.00 for months. A consumer
+  can therefore project an update with the clause it already has for a create.
+  """
+  @spec session_updated(ProgramSession.t(), keyword()) :: Event.t()
+  def session_updated(%ProgramSession{} = session, opts \\ []) do
+    payload = %{
+      session_id: session.id,
+      program_id: session.program_id,
+      session_date: session.session_date,
+      start_time: session.start_time,
+      end_time: session.end_time,
+      location: session.location,
+      max_capacity: session.max_capacity
+    }
+
+    new_event(:session_updated, session.id, payload, opts)
   end
 
   @doc """

--- a/lib/klass_hero/participation/notifications.ex
+++ b/lib/klass_hero/participation/notifications.ex
@@ -39,7 +39,18 @@ defmodule KlassHero.Participation.Notifications do
 
   require Logger
 
-  @session_events [:session_created, :session_started, :session_completed, :session_cancelled, :roster_seeded]
+  # A session event missing from this list is not a smaller broadcast — it is no
+  # broadcast at all: `message/1` falls through to the catch-all `nil` and `notify/1`
+  # returns `:ok` having told nobody. The write lands, the projection lands, and
+  # every already-mounted LiveView keeps rendering the old row (#1074).
+  @session_events [
+    :session_created,
+    :session_updated,
+    :session_started,
+    :session_completed,
+    :session_cancelled,
+    :roster_seeded
+  ]
 
   @attendance_kinds %{
     child_checked_in: :checked_in,

--- a/lib/klass_hero/participation/program_session.ex
+++ b/lib/klass_hero/participation/program_session.ex
@@ -64,12 +64,26 @@ defmodule KlassHero.Participation.ProgramSession do
     |> optimistic_lock(:lock_version)
   end
 
-  @doc "Creates a changeset for updating an existing session."
+  @doc """
+  Creates a changeset for updating an existing session.
+
+  The schedule fields are castable here as of #1074. They were not before, which
+  is why rescheduling was impossible by construction rather than by rule — and why
+  `validate_time_range/1` and the slot `unique_constraint` had to come with them:
+  a reschedule can invert the times, and it can land on a slot a sibling session
+  already holds. Without the constraint declared, that collision raises
+  `Ecto.ConstraintError` instead of returning a changeset the provider can fix.
+  """
   def update_changeset(session, attrs) do
     session
-    |> cast(attrs, @optional_fields ++ [:status])
+    |> cast(attrs, @optional_fields ++ [:status, :session_date, :start_time, :end_time])
     |> validate_inclusion(:status, @valid_statuses)
     |> validate_number(:max_capacity, greater_than: 0)
+    |> validate_time_range()
+    |> unique_constraint([:program_id, :session_date, :start_time],
+      name: :program_sessions_program_id_session_date_start_time_index,
+      message: "session already exists at this time"
+    )
     |> optimistic_lock(:lock_version)
   end
 

--- a/lib/klass_hero/participation/session_authorization.ex
+++ b/lib/klass_hero/participation/session_authorization.ex
@@ -120,6 +120,32 @@ defmodule KlassHero.Participation.SessionAuthorization do
   @spec authorize_lifecycle(Scope.t(), ProgramSession.t()) :: {:ok, role()} | {:error, refusal()}
   def authorize_lifecycle(%Scope{} = scope, %ProgramSession{} = session), do: resolve(scope, session)
 
+  @doc """
+  Who may schedule a **new** session on `program_id`.
+
+  Asked at program grain because there is no session yet to ask about, which is
+  also why it cannot go through `resolve/2`: two of that function's three
+  branches read a session.
+
+  Staff are refused even when assigned. The staff rule elsewhere answers "are you
+  on this session", and a session that does not exist has nobody on it; assignment
+  to the program is permission to *run* sessions, not to add them to the calendar.
+  A refused staff member is `:unauthorized` like any other — creation has no
+  closure case to distinguish, since a closed program is one you should not be
+  adding sessions to either.
+
+  An unknown `program_id` refuses rather than raising: `provider_owns?/2` compares
+  against a resolver result, so a program that resolves to nothing matches no one.
+  """
+  @spec authorize_creation(Scope.t(), String.t()) :: {:ok, :provider | :admin} | {:error, :unauthorized}
+  def authorize_creation(%Scope{} = scope, program_id) when is_binary(program_id) do
+    if provider_owns?(scope, program_id) do
+      {:ok, :provider}
+    else
+      admin_or_refuse(scope)
+    end
+  end
+
   # The one place a scope's standing on a session is decided.
   defp resolve(%Scope{} = scope, %ProgramSession{} = session) do
     cond do

--- a/lib/klass_hero/provider/projections/provider_session_details.ex
+++ b/lib/klass_hero/provider/projections/provider_session_details.ex
@@ -57,6 +57,7 @@ defmodule KlassHero.Provider.Projections.ProviderSessionDetails do
   use KlassHero.Shared.Projection,
     topics: [
       "integration:participation:session_created",
+      "integration:participation:session_updated",
       "integration:participation:sessions_generated",
       "integration:participation:session_started",
       "integration:participation:session_completed",
@@ -101,6 +102,24 @@ defmodule KlassHero.Provider.Projections.ProviderSessionDetails do
   # rather than once per session as the per-session clause above does.
   def handle_event(:sessions_generated, %Event{payload: %{program_id: program_id, sessions: sessions}}) do
     Enum.each(sessions, &project_session_created(Map.put(&1, :program_id, program_id)))
+  end
+
+  # The schedule, and only the schedule. Status, staffing and the attendance
+  # counters are each owned by their own event, and re-deriving them from an edit
+  # would let a stale field in the payload overwrite a fresher one projected since.
+  def handle_event(:session_updated, %Event{payload: payload} = event) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    from(d in SessionDetail, where: d.session_id == ^event.entity_id)
+    |> Repo.update_all(
+      set: [
+        session_date: payload.session_date,
+        start_time: payload.start_time,
+        end_time: payload.end_time,
+        updated_at: now
+      ]
+    )
+    |> warn_if_missing("session update", session_id: event.entity_id)
   end
 
   def handle_event(:session_started, %Event{} = event) do

--- a/lib/klass_hero_web/components/provider_components.ex
+++ b/lib/klass_hero_web/components/provider_components.ex
@@ -1864,26 +1864,51 @@ defmodule KlassHeroWeb.ProviderComponents do
                 </tr>
               </thead>
               <tbody>
-                <tr :for={s <- @modal.sessions} class="border-t">
-                  <td class="px-4 py-3">
-                    {Calendar.strftime(s.session_date, "%a, %d %b")}
-                    <span class="text-[var(--fg-muted)]">
-                      · {Calendar.strftime(s.start_time, "%H:%M")}–{Calendar.strftime(
-                        s.end_time,
-                        "%H:%M"
-                      )}
-                    </span>
+                <%!-- The link wraps each cell, not the row: an <a> around <td>s is invalid
+                HTML, and LiveView's DOM patcher reparents it on the next update. --%>
+                <tr
+                  :for={s <- @modal.sessions}
+                  class={["border-t hover:bg-hero-grey-50", Theme.transition(:normal)]}
+                >
+                  <td class="p-0">
+                    <.link
+                      navigate={~p"/provider/participation/#{s.session_id}"}
+                      class="block px-4 py-3"
+                    >
+                      {Calendar.strftime(s.session_date, "%a, %d %b")}
+                      <span class="text-[var(--fg-muted)]">
+                        · {Calendar.strftime(s.start_time, "%H:%M")}–{Calendar.strftime(
+                          s.end_time,
+                          "%H:%M"
+                        )}
+                      </span>
+                    </.link>
                   </td>
-                  <td class="px-4 py-3">
-                    {s.current_assigned_staff_name || gettext("Unassigned")}
+                  <td class="p-0">
+                    <.link
+                      navigate={~p"/provider/participation/#{s.session_id}"}
+                      class="block px-4 py-3"
+                    >
+                      {s.current_assigned_staff_name || gettext("Unassigned")}
+                    </.link>
                   </td>
-                  <td class="px-4 py-3">
-                    <span :if={s.status != :cancelled}>
-                      {s.checked_in_count} / {s.total_count}
-                    </span>
+                  <td class="p-0">
+                    <.link
+                      navigate={~p"/provider/participation/#{s.session_id}"}
+                      class="block px-4 py-3"
+                    >
+                      <span :if={s.status != :cancelled}>
+                        {s.checked_in_count} / {s.total_count}
+                      </span>
+                    </.link>
                   </td>
-                  <td class="px-4 py-3">
-                    <.participation_status status={s.status} size={:sm} />
+                  <td class="p-0">
+                    <.link
+                      navigate={~p"/provider/participation/#{s.session_id}"}
+                      class="block px-4 py-3"
+                    >
+                      <.participation_status status={s.status} size={:sm} />
+                    </.link>
                   </td>
                 </tr>
               </tbody>

--- a/lib/klass_hero_web/components/provider_components.ex
+++ b/lib/klass_hero_web/components/provider_components.ex
@@ -1831,6 +1831,17 @@ defmodule KlassHeroWeb.ProviderComponents do
   attr :program_locked?, :boolean, default: false
   attr :program_title, :string, default: nil
   attr :cancel_event, :string, required: true
+  attr :submit_label, :string, default: nil
+
+  attr :schedule_locked?, :boolean,
+    default: false,
+    doc: """
+    makes date and time read-only once the session has started — see
+    `KlassHero.Participation.update_session/3`. `readonly`, deliberately not
+    `disabled`: a disabled input is not submitted, so locking the schedule that
+    way would strip the date and time from the payload and make even a *details*
+    edit fail coercion.
+    """
 
   def session_form(assigns) do
     ~H"""
@@ -1860,12 +1871,36 @@ defmodule KlassHeroWeb.ProviderComponents do
         />
       <% end %>
 
-      <.input field={@form[:session_date]} type="date" label={gettext("Date")} required />
+      <.input
+        field={@form[:session_date]}
+        type="date"
+        label={gettext("Date")}
+        required
+        readonly={@schedule_locked?}
+      />
 
       <div class="grid grid-cols-2 gap-4">
-        <.input field={@form[:start_time]} type="time" label={gettext("Start Time")} required />
-        <.input field={@form[:end_time]} type="time" label={gettext("End Time")} required />
+        <.input
+          field={@form[:start_time]}
+          type="time"
+          label={gettext("Start Time")}
+          required
+          readonly={@schedule_locked?}
+        />
+        <.input
+          field={@form[:end_time]}
+          type="time"
+          label={gettext("End Time")}
+          required
+          readonly={@schedule_locked?}
+        />
       </div>
+
+      <p :if={@schedule_locked?} class="text-xs text-[var(--fg-muted)]">
+        {gettext(
+          "The date and time are fixed once a session has started — its attendance records are keyed to it."
+        )}
+      </p>
 
       <.input field={@form[:location]} type="text" label={gettext("Location")} phx-debounce="blur" />
       <.input field={@form[:notes]} type="textarea" label={gettext("Notes")} phx-debounce="blur" />
@@ -1889,7 +1924,7 @@ defmodule KlassHeroWeb.ProviderComponents do
             Theme.rounded(:lg)
           ]}
         >
-          {gettext("Create Session")}
+          {@submit_label || gettext("Create Session")}
         </button>
       </div>
     </.form>

--- a/lib/klass_hero_web/components/provider_components.ex
+++ b/lib/klass_hero_web/components/provider_components.ex
@@ -1811,11 +1811,102 @@ defmodule KlassHeroWeb.ProviderComponents do
   end
 
   @doc """
+  Renders the create-session form.
+
+  The *form* is what the surfaces share; the modal chrome around it is not, so
+  each caller supplies its own and this renders only what is genuinely common.
+
+  When `program_locked?` is true the program `<select>` is replaced by static text
+  and a hidden input. The Sessions popup opens from one program's row, so asking
+  again would be a step that answers a question already answered — and the hidden
+  field is not the guard: `Participation.create_session/2` authorizes the program
+  id whatever the client sends.
+
+  ## Example
+
+      <.session_form form={@form} programs={@provider_programs} cancel_event="close_new_session" />
+  """
+  attr :form, :any, required: true
+  attr :programs, :list, default: []
+  attr :program_locked?, :boolean, default: false
+  attr :program_title, :string, default: nil
+  attr :cancel_event, :string, required: true
+
+  def session_form(assigns) do
+    ~H"""
+    <.form
+      for={@form}
+      id="create-session-form"
+      phx-change="validate_session"
+      phx-submit="save_session"
+      class="space-y-4"
+    >
+      <%= if @program_locked? do %>
+        <div>
+          <p class={["mb-1 block text-sm font-semibold", Theme.text_color(:heading)]}>
+            {gettext("Program")}
+          </p>
+          <p class="text-sm text-[var(--fg-muted)]">{@program_title}</p>
+        </div>
+        <input type="hidden" name={@form[:program_id].name} value={@form[:program_id].value} />
+      <% else %>
+        <.input
+          field={@form[:program_id]}
+          type="select"
+          label={gettext("Program")}
+          prompt={gettext("Select a program...")}
+          options={Enum.map(@programs, &{&1.title, &1.id})}
+          required
+        />
+      <% end %>
+
+      <.input field={@form[:session_date]} type="date" label={gettext("Date")} required />
+
+      <div class="grid grid-cols-2 gap-4">
+        <.input field={@form[:start_time]} type="time" label={gettext("Start Time")} required />
+        <.input field={@form[:end_time]} type="time" label={gettext("End Time")} required />
+      </div>
+
+      <.input field={@form[:location]} type="text" label={gettext("Location")} phx-debounce="blur" />
+      <.input field={@form[:notes]} type="textarea" label={gettext("Notes")} phx-debounce="blur" />
+      <.input field={@form[:max_capacity]} type="number" label={gettext("Max Capacity")} />
+
+      <div class="flex justify-end gap-3 pt-2">
+        <button
+          type="button"
+          phx-click={@cancel_event}
+          class={[
+            "px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-50",
+            Theme.rounded(:lg)
+          ]}
+        >
+          {gettext("Cancel")}
+        </button>
+        <button
+          type="submit"
+          class={[
+            "px-4 py-2 text-sm font-medium text-white bg-hero-blue-600 hover:bg-hero-blue-700",
+            Theme.rounded(:lg)
+          ]}
+        >
+          {gettext("Create Session")}
+        </button>
+      </div>
+    </.form>
+    """
+  end
+
+  @doc """
   Renders a modal listing every session of a program with date/time, assigned
   staff, attendance count, and status.
 
   "Assigned staff" is the session's *effective* staffing: its own override roster
   where the provider set one, the program roster otherwise (#782).
+
+  Since #1074 this is a management surface, not a read-only summary: rows navigate
+  into a session, and `modal.form` swaps the body for the create-session form.
+  The form replaces the list rather than stacking a second modal on top of this
+  one — nesting dialogs is how a flash ends up behind its own overlay.
 
   ## Example
 
@@ -1838,16 +1929,45 @@ defmodule KlassHeroWeb.ProviderComponents do
         class="bg-white rounded-lg shadow-xl max-w-4xl w-full max-h-[80vh] overflow-hidden flex flex-col"
         phx-click-away="close_sessions"
       >
-        <div class="flex items-center justify-between px-6 py-4 border-b">
+        <div class="flex items-center justify-between gap-3 px-6 py-4 border-b">
           <h2 id="sessions-modal-title" class={Theme.typography(:section_title)}>
-            {gettext("Sessions — %{title}", title: @modal.program_title)}
+            <%= if @modal.form do %>
+              {gettext("New session — %{title}", title: @modal.program_title)}
+            <% else %>
+              {gettext("Sessions — %{title}", title: @modal.program_title)}
+            <% end %>
           </h2>
-          <button type="button" phx-click="close_sessions" aria-label={gettext("Close")}>
-            <.icon name="hero-x-mark" class="w-5 h-5" />
-          </button>
+          <div class="flex items-center gap-3">
+            <button
+              :if={!@modal.form}
+              type="button"
+              id="new-session-button"
+              phx-click="new_session"
+              class={[
+                "px-3 py-2 text-sm font-medium text-white bg-hero-blue-600 hover:bg-hero-blue-700",
+                Theme.rounded(:lg),
+                Theme.transition(:normal)
+              ]}
+            >
+              <.icon name="hero-plus" class="w-4 h-4 mr-1 inline" />
+              {gettext("Create Session")}
+            </button>
+            <button type="button" phx-click="close_sessions" aria-label={gettext("Close")}>
+              <.icon name="hero-x-mark" class="w-5 h-5" />
+            </button>
+          </div>
         </div>
 
-        <div class="flex-1 overflow-y-auto">
+        <div :if={@modal.form} class="flex-1 overflow-y-auto p-6">
+          <.session_form
+            form={@modal.form}
+            program_locked?={true}
+            program_title={@modal.program_title}
+            cancel_event="close_new_session"
+          />
+        </div>
+
+        <div :if={!@modal.form} class="flex-1 overflow-y-auto">
           <%= if @modal.sessions == [] do %>
             <div class="text-center py-12">
               <.icon name="hero-calendar-days" class="w-12 h-12 text-hero-grey-300 mx-auto" />

--- a/lib/klass_hero_web/helpers/session_form_handlers.ex
+++ b/lib/klass_hero_web/helpers/session_form_handlers.ex
@@ -1,0 +1,173 @@
+defmodule KlassHeroWeb.Helpers.SessionFormHandlers do
+  @moduledoc """
+  The create-session form's non-visual half, shared by every surface that offers it.
+
+  Until #1074 this lived inside `SessionsLive` — its form markup, its param
+  coercion, and its ownership check all local to the one LiveView that rendered
+  it. Program Inventory's Sessions popup then needed the same form, and #1501
+  deletes `SessionsLive` outright, so copying it would have meant maintaining two
+  and losing the original.
+
+  The split is deliberate: this module *decides*, the caller *navigates*. Every
+  function returns a value rather than a socket, because the two surfaces differ
+  in exactly one respect — where they go afterwards — and threading a
+  `push_patch` target through here would put that difference in the shared code.
+
+  Failures are atoms, never sentences, all the way out: coercion and the context
+  both refuse in the same currency, so a caller can ask `user_correctable?/1`
+  before deciding whether to log. Rendering them is `humanize_error/1`'s job and
+  happens once, which is what keeps the two surfaces saying the same thing about
+  the same refusal.
+
+  Authorization is **not** here. `KlassHero.Participation.create_session/2` asks
+  `SessionAuthorization` itself, which is the whole point of moving it out of the
+  web layer; a guard restated in a form helper would be the same mistake one
+  level down.
+  """
+
+  use Gettext, backend: KlassHeroWeb.Gettext
+
+  alias KlassHero.Accounts.Scope
+  alias KlassHero.Participation
+
+  @type form_data :: %{String.t() => String.t()}
+  @type refusal ::
+          :date_required
+          | :invalid_date
+          | :time_required
+          | :invalid_time
+          | :invalid_time_range
+          | :duplicate_session
+          | :unauthorized
+
+  # Everything a provider can fix by editing the form in front of them. Anything
+  # else is ours, and gets logged rather than shown raw.
+  @correctable [
+    :date_required,
+    :invalid_date,
+    :time_required,
+    :invalid_time,
+    :invalid_time_range,
+    :duplicate_session,
+    :unauthorized
+  ]
+
+  @doc """
+  Blank form params for a new session.
+
+  `program_id` is pre-set when the surface already knows the program — the
+  Sessions popup opens from one program's row, so re-asking would be a step that
+  answers a question the user has already answered.
+  """
+  @spec blank_form(Date.t(), String.t()) :: form_data()
+  def blank_form(%Date{} = date, program_id \\ "") do
+    %{
+      "program_id" => program_id,
+      "session_date" => Date.to_iso8601(date),
+      "start_time" => "",
+      "end_time" => "",
+      "location" => "",
+      "notes" => "",
+      "max_capacity" => ""
+    }
+  end
+
+  @doc """
+  Fills time and location from the chosen program's defaults, leaving anything the
+  provider has already typed alone.
+  """
+  @spec prefill_from_program(form_data(), [struct()]) :: form_data()
+  def prefill_from_program(params, programs) do
+    case Enum.find(programs, &(&1.id == params["program_id"])) do
+      nil ->
+        params
+
+      program ->
+        params
+        |> maybe_set_default("start_time", format_time(program.meeting_start_time))
+        |> maybe_set_default("end_time", format_time(program.meeting_end_time))
+        |> maybe_set_default("location", program.location || "")
+    end
+  end
+
+  @doc "Coerces the form's strings and creates the session on behalf of `scope`."
+  @spec submit(Scope.t(), form_data()) :: {:ok, Participation.ProgramSession.t()} | {:error, refusal() | atom()}
+  def submit(%Scope{} = scope, params) do
+    with {:ok, coerced} <- coerce_params(params) do
+      Participation.create_session(scope, coerced)
+    end
+  end
+
+  @doc "Whether a refusal is the provider's to correct, or ours to log."
+  @spec user_correctable?(atom()) :: boolean()
+  def user_correctable?(reason), do: reason in @correctable
+
+  @doc "The one place a refusal becomes a sentence."
+  @spec humanize_error(atom()) :: String.t()
+  def humanize_error(:date_required), do: gettext("Date is required")
+  def humanize_error(:invalid_date), do: gettext("Invalid date format")
+  def humanize_error(:time_required), do: gettext("Time is required")
+  def humanize_error(:invalid_time), do: gettext("Invalid time format")
+  def humanize_error(:invalid_time_range), do: gettext("End time must be after start time")
+  def humanize_error(:duplicate_session), do: gettext("A session already exists at this time")
+  def humanize_error(:unauthorized), do: gettext("Unauthorized")
+  def humanize_error(:missing_required_fields), do: gettext("Please fill in all required fields")
+  def humanize_error(reason), do: gettext("Failed to create session: %{reason}", reason: inspect(reason))
+
+  defp coerce_params(params) do
+    with {:ok, date} <- parse_date(params["session_date"]),
+         {:ok, start_time} <- parse_time(params["start_time"]),
+         {:ok, end_time} <- parse_time(params["end_time"]) do
+      attrs = %{
+        program_id: params["program_id"],
+        session_date: date,
+        start_time: start_time,
+        end_time: end_time
+      }
+
+      {:ok,
+       attrs
+       |> put_present(:location, params["location"])
+       |> put_present(:notes, params["notes"])
+       |> put_capacity(params["max_capacity"])}
+    end
+  end
+
+  defp put_present(attrs, _key, value) when value in [nil, ""], do: attrs
+  defp put_present(attrs, key, value), do: Map.put(attrs, key, value)
+
+  defp put_capacity(attrs, raw) do
+    case Integer.parse(raw || "") do
+      {value, ""} when value > 0 -> Map.put(attrs, :max_capacity, value)
+      _other -> attrs
+    end
+  end
+
+  defp maybe_set_default(params, key, default) do
+    if params[key] in [nil, ""], do: Map.put(params, key, default), else: params
+  end
+
+  defp format_time(nil), do: ""
+  defp format_time(%Time{} = time), do: Calendar.strftime(time, "%H:%M")
+
+  defp parse_date(value) when value in [nil, ""], do: {:error, :date_required}
+
+  defp parse_date(date_string) do
+    case Date.from_iso8601(date_string) do
+      {:ok, _date} = ok -> ok
+      {:error, _reason} -> {:error, :invalid_date}
+    end
+  end
+
+  defp parse_time(value) when value in [nil, ""], do: {:error, :time_required}
+
+  defp parse_time(time_string) do
+    # HTML time inputs produce "HH:MM"; Time.from_iso8601/1 requires "HH:MM:SS".
+    normalized = if byte_size(time_string) == 5, do: time_string <> ":00", else: time_string
+
+    case Time.from_iso8601(normalized) do
+      {:ok, _time} = ok -> ok
+      {:error, _reason} -> {:error, :invalid_time}
+    end
+  end
+end

--- a/lib/klass_hero_web/helpers/session_form_handlers.ex
+++ b/lib/klass_hero_web/helpers/session_form_handlers.ex
@@ -139,7 +139,7 @@ defmodule KlassHeroWeb.Helpers.SessionFormHandlers do
         |> Map.delete(:program_id)
         |> Map.put(:location, blank_to_nil(params["location"]))
         |> Map.put(:notes, blank_to_nil(params["notes"]))
-        |> clear_blank_capacity(params["max_capacity"])
+        |> clear_blank_capacity(params)
 
       Participation.update_session(scope, session_id, attrs)
     end
@@ -149,8 +149,16 @@ defmodule KlassHeroWeb.Helpers.SessionFormHandlers do
   # create is right — there is nothing to clear — but on an edit makes a blanked
   # capacity silently keep its old value. Blank clears; garbage still omits, so a
   # typo does not wipe a real limit.
-  defp clear_blank_capacity(attrs, raw) when raw in [nil, ""], do: Map.put(attrs, :max_capacity, nil)
-  defp clear_blank_capacity(attrs, _raw), do: attrs
+  #
+  # `Map.fetch/2` rather than `params["max_capacity"]`, so an *absent* key is not
+  # read as a blank one: a surface that does not render the input at all must
+  # leave the stored capacity alone, not null it.
+  defp clear_blank_capacity(attrs, params) do
+    case Map.fetch(params, "max_capacity") do
+      {:ok, raw} when raw in [nil, ""] -> Map.put(attrs, :max_capacity, nil)
+      _present_or_absent -> attrs
+    end
+  end
 
   defp blank_to_nil(value) when value in [nil, ""], do: nil
   defp blank_to_nil(value), do: value

--- a/lib/klass_hero_web/helpers/session_form_handlers.ex
+++ b/lib/klass_hero_web/helpers/session_form_handlers.ex
@@ -139,10 +139,18 @@ defmodule KlassHeroWeb.Helpers.SessionFormHandlers do
         |> Map.delete(:program_id)
         |> Map.put(:location, blank_to_nil(params["location"]))
         |> Map.put(:notes, blank_to_nil(params["notes"]))
+        |> clear_blank_capacity(params["max_capacity"])
 
       Participation.update_session(scope, session_id, attrs)
     end
   end
+
+  # `put_capacity/2` omits the key whenever `Integer.parse` fails, which on a
+  # create is right — there is nothing to clear — but on an edit makes a blanked
+  # capacity silently keep its old value. Blank clears; garbage still omits, so a
+  # typo does not wipe a real limit.
+  defp clear_blank_capacity(attrs, raw) when raw in [nil, ""], do: Map.put(attrs, :max_capacity, nil)
+  defp clear_blank_capacity(attrs, _raw), do: attrs
 
   defp blank_to_nil(value) when value in [nil, ""], do: nil
   defp blank_to_nil(value), do: value

--- a/lib/klass_hero_web/helpers/session_form_handlers.ex
+++ b/lib/klass_hero_web/helpers/session_form_handlers.ex
@@ -49,7 +49,10 @@ defmodule KlassHeroWeb.Helpers.SessionFormHandlers do
     :invalid_time,
     :invalid_time_range,
     :duplicate_session,
-    :unauthorized
+    :unauthorized,
+    :session_started,
+    :invalid_session,
+    :not_found
   ]
 
   @doc """
@@ -98,6 +101,52 @@ defmodule KlassHeroWeb.Helpers.SessionFormHandlers do
     end
   end
 
+  @doc """
+  Form params for editing an existing session.
+
+  Takes the enriched map `Participation.get_session_with_roster_enriched/1`
+  returns, not a struct — that path has already been through `Map.from_struct/1`.
+  """
+  @spec form_from_session(map()) :: form_data()
+  def form_from_session(session) do
+    %{
+      "program_id" => session.program_id,
+      "session_date" => Date.to_iso8601(session.session_date),
+      "start_time" => format_time(session.start_time),
+      "end_time" => format_time(session.end_time),
+      "location" => session.location || "",
+      "notes" => session.notes || "",
+      "max_capacity" => to_string(session.max_capacity || "")
+    }
+  end
+
+  @doc """
+  Coerces the form's strings and edits `session_id` on behalf of `scope`.
+
+  Unlike creation, a blank optional field here means *clear it*, not *omit it*:
+  on a create there is nothing to clear, but a provider editing a session must be
+  able to remove a location they typed by mistake.
+
+  `program_id` is dropped — a session cannot change programs, and passing it would
+  invite `update_changeset/2` to start casting it.
+  """
+  @spec submit_update(Scope.t(), String.t(), form_data()) ::
+          {:ok, Participation.ProgramSession.t()} | {:error, refusal() | atom()}
+  def submit_update(%Scope{} = scope, session_id, params) do
+    with {:ok, coerced} <- coerce_params(params) do
+      attrs =
+        coerced
+        |> Map.delete(:program_id)
+        |> Map.put(:location, blank_to_nil(params["location"]))
+        |> Map.put(:notes, blank_to_nil(params["notes"]))
+
+      Participation.update_session(scope, session_id, attrs)
+    end
+  end
+
+  defp blank_to_nil(value) when value in [nil, ""], do: nil
+  defp blank_to_nil(value), do: value
+
   @doc "Whether a refusal is the provider's to correct, or ours to log."
   @spec user_correctable?(atom()) :: boolean()
   def user_correctable?(reason), do: reason in @correctable
@@ -112,6 +161,11 @@ defmodule KlassHeroWeb.Helpers.SessionFormHandlers do
   def humanize_error(:duplicate_session), do: gettext("A session already exists at this time")
   def humanize_error(:unauthorized), do: gettext("Unauthorized")
   def humanize_error(:missing_required_fields), do: gettext("Please fill in all required fields")
+  def humanize_error(:not_found), do: gettext("That session could not be found.")
+  def humanize_error(:invalid_session), do: gettext("That session could not be saved.")
+
+  def humanize_error(:session_started), do: gettext("The date and time are fixed once a session has started.")
+
   def humanize_error(reason), do: gettext("Failed to create session: %{reason}", reason: inspect(reason))
 
   defp coerce_params(params) do

--- a/lib/klass_hero_web/live/provider/participation_live.ex
+++ b/lib/klass_hero_web/live/provider/participation_live.ex
@@ -9,10 +9,13 @@ defmodule KlassHeroWeb.Provider.ParticipationLive do
       find_participation_record: 2
     ]
 
+  import KlassHeroWeb.ProviderComponents, only: [session_form: 1]
+
   alias KlassHero.Participation
   alias KlassHero.ProgramCatalog
   alias KlassHeroWeb.Helpers.ParticipationEditHelpers
   alias KlassHeroWeb.Helpers.ParticipationLiveHandlers
+  alias KlassHeroWeb.Helpers.SessionFormHandlers
   alias KlassHeroWeb.Theme
 
   require Logger
@@ -44,6 +47,7 @@ defmodule KlassHeroWeb.Provider.ParticipationLive do
       |> assign(:edit_forms, %{})
       |> assign(:provider_notes, %{})
       |> assign(:record_note_map, %{})
+      |> assign(:session_form, nil)
 
     if connected?(socket) do
       # One topic for everything this provider does — attendance and session notes
@@ -65,6 +69,52 @@ defmodule KlassHeroWeb.Provider.ParticipationLive do
   @impl true
   def handle_event("complete_session", _params, socket) do
     ParticipationLiveHandlers.complete_session(socket, &load_session_data/1)
+  end
+
+  # --- Session editing (#1074) --------------------------------------------
+  #
+  # The session id comes from the socket, not the client, and
+  # `Participation.update_session/3` authorizes it again regardless.
+
+  @impl true
+  def handle_event("edit_session", _params, socket) do
+    form = socket.assigns.session |> SessionFormHandlers.form_from_session() |> to_form(as: :session)
+
+    {:noreply, assign(socket, :session_form, form)}
+  end
+
+  @impl true
+  def handle_event("cancel_edit_session", _params, socket) do
+    {:noreply, assign(socket, :session_form, nil)}
+  end
+
+  @impl true
+  def handle_event("validate_session", %{"session" => params}, socket) do
+    {:noreply, assign(socket, :session_form, to_form(params, as: :session))}
+  end
+
+  @impl true
+  def handle_event("save_session", %{"session" => params}, socket) do
+    case SessionFormHandlers.submit_update(socket.assigns.current_scope, socket.assigns.session_id, params) do
+      {:ok, _session} ->
+        {:noreply,
+         socket
+         |> assign(:session_form, nil)
+         |> put_flash(:info, gettext("Session updated"))
+         |> load_session_data()}
+
+      {:error, reason} ->
+        if !SessionFormHandlers.user_correctable?(reason) do
+          Logger.error(
+            "[ParticipationLive.save_session] Failed to update session",
+            session_id: socket.assigns.session_id,
+            reason: inspect(reason),
+            provider_id: socket.assigns.provider_id
+          )
+        end
+
+        {:noreply, put_flash(socket, :error, SessionFormHandlers.humanize_error(reason))}
+    end
   end
 
   @impl true

--- a/lib/klass_hero_web/live/provider/participation_live.html.heex
+++ b/lib/klass_hero_web/live/provider/participation_live.html.heex
@@ -32,8 +32,31 @@
           >
             {gettext("Complete Session")}
           </.kh_button>
+          <.kh_button
+            :if={!@session_form}
+            id="edit-session-btn"
+            variant={:secondary}
+            phx-click="edit_session"
+          >
+            {gettext("Edit Session")}
+          </.kh_button>
         </:actions>
       </.participation_card>
+    </div>
+
+    <%!-- Schedule fields lock once the session leaves :scheduled; the details do
+    not. Participation.update_session/3 enforces the same rule, so disabling here
+    is the affordance rather than the guard. --%>
+    <div :if={@session_form} id="edit-session-panel" class="mb-6 rounded-lg border p-4">
+      <h2 class={["mb-4", Theme.typography(:card_title)]}>{gettext("Edit Session")}</h2>
+      <.session_form
+        form={@session_form}
+        program_locked?={true}
+        program_title={Map.get(@session, :program_name, gettext("Session"))}
+        schedule_locked?={@session.status != :scheduled}
+        submit_label={gettext("Save Session")}
+        cancel_event="cancel_edit_session"
+      />
     </div>
 
     <div class="mt-6">

--- a/lib/klass_hero_web/live/provider/programs_live.ex
+++ b/lib/klass_hero_web/live/provider/programs_live.ex
@@ -24,6 +24,7 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
   alias KlassHero.ProgramCatalog
   alias KlassHero.Provider
   alias KlassHero.Provider.ReadModels.ProgramStaffing
+  alias KlassHeroWeb.Helpers.SessionFormHandlers
   alias KlassHeroWeb.Presenters.ProgramPresenter
   alias KlassHeroWeb.Presenters.ProgramStaffingPresenter
   alias KlassHeroWeb.Presenters.StaffMemberPresenter
@@ -230,13 +231,72 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
      assign(socket, :sessions_modal, %{
        program_id: program_id,
        program_title: program_title,
-       sessions: sessions
+       sessions: sessions,
+       form: nil
      })}
   end
 
   @impl true
   def handle_event("close_sessions", _params, socket) do
     {:noreply, assign(socket, :sessions_modal, nil)}
+  end
+
+  # The popup already names one program, so the form opens with it filled in and
+  # the select replaced by static text. `get_program_for_provider/2` is the
+  # tenancy-safe getter, which is also what makes the program's meeting times
+  # available to pre-fill — the `provider_programs` projection carries only a name.
+  @impl true
+  def handle_event("new_session", _params, socket) do
+    %{program_id: program_id} = socket.assigns.sessions_modal
+    provider_id = socket.assigns.current_scope.provider.id
+
+    case ProgramCatalog.get_program_for_provider(provider_id, program_id) do
+      {:ok, program} ->
+        form =
+          Date.utc_today()
+          |> SessionFormHandlers.blank_form(program_id)
+          |> SessionFormHandlers.prefill_from_program([program])
+          |> to_form(as: :session)
+
+        {:noreply, assign_sessions_modal(socket, form: form)}
+
+      {:error, :not_found} ->
+        {:noreply, put_flash(socket, :error, gettext("That program could not be found."))}
+    end
+  end
+
+  @impl true
+  def handle_event("close_new_session", _params, socket) do
+    {:noreply, assign_sessions_modal(socket, form: nil)}
+  end
+
+  @impl true
+  def handle_event("validate_session", %{"session" => params}, socket) do
+    # No re-prefill: the program cannot change here, so its defaults were applied
+    # once when the form opened and re-applying would fight the provider's edits.
+    {:noreply, assign_sessions_modal(socket, form: to_form(params, as: :session))}
+  end
+
+  @impl true
+  def handle_event("save_session", %{"session" => params}, socket) do
+    case SessionFormHandlers.submit(socket.assigns.current_scope, params) do
+      {:ok, _session} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, gettext("Session created successfully"))
+         |> reload_sessions_modal()}
+
+      {:error, reason} ->
+        if !SessionFormHandlers.user_correctable?(reason) do
+          Logger.error(
+            "[ProgramsLive.save_session] Failed to create session",
+            reason: inspect(reason),
+            provider_id: socket.assigns.current_scope.provider.id
+          )
+        end
+
+        {:noreply, put_flash(socket, :error, SessionFormHandlers.humanize_error(reason))}
+    end
   end
 
   @impl true
@@ -933,6 +993,25 @@ defmodule KlassHeroWeb.Provider.ProgramsLive do
 
   defp waiver_form_errors(%Ecto.Changeset{} = changeset), do: changeset.errors
   defp waiver_form_errors(_reason), do: []
+
+  defp assign_sessions_modal(socket, updates) do
+    assign(socket, :sessions_modal, Enum.into(updates, socket.assigns.sessions_modal))
+  end
+
+  # The new row reaches `provider_session_details` through session_created and an
+  # Oban job, so this re-read can legitimately come back without it. That is the
+  # projection's normal lag, not a failure — the row appears on the next open. An
+  # optimistic insert here would be a second writer to a read table the projection
+  # owns, which is the drift #1321 deleted.
+  defp reload_sessions_modal(socket) do
+    %{program_id: program_id} = socket.assigns.sessions_modal
+    provider_id = socket.assigns.current_scope.provider.id
+
+    assign_sessions_modal(socket,
+      form: nil,
+      sessions: Provider.list_program_sessions(provider_id, program_id)
+    )
+  end
 
   defp build_staffing_modal(program_id, program_name, provider_id) do
     lead_id =

--- a/lib/klass_hero_web/live/provider/sessions_live.ex
+++ b/lib/klass_hero_web/live/provider/sessions_live.ex
@@ -8,6 +8,7 @@ defmodule KlassHeroWeb.Provider.SessionsLive do
   alias KlassHero.Provider
   alias KlassHero.Provider.ReadModels.SessionStaffing
   alias KlassHeroWeb.Helpers.ParticipationLiveHandlers
+  alias KlassHeroWeb.Helpers.SessionFormHandlers
   alias KlassHeroWeb.Helpers.TaskHelpers
   alias KlassHeroWeb.Presenters.ProgramStaffingPresenter
   alias KlassHeroWeb.Presenters.ProviderPresenter
@@ -93,7 +94,7 @@ defmodule KlassHeroWeb.Provider.SessionsLive do
   end
 
   defp apply_action(socket, :new, _params) do
-    form_data = build_initial_form_data(socket.assigns.selected_date)
+    form_data = SessionFormHandlers.blank_form(socket.assigns.selected_date)
 
     assign(socket, :form, to_form(form_data, as: :session))
   end
@@ -168,10 +169,9 @@ defmodule KlassHeroWeb.Provider.SessionsLive do
 
   @impl true
   def handle_event("validate_session", %{"session" => params}, socket) do
-    params = maybe_prefill_from_program(params, socket.assigns.provider_programs)
-    form = to_form(params, as: :session)
+    params = SessionFormHandlers.prefill_from_program(params, socket.assigns.provider_programs)
 
-    {:noreply, assign(socket, :form, form)}
+    {:noreply, assign(socket, :form, to_form(params, as: :session))}
   end
 
   @impl true
@@ -184,6 +184,11 @@ defmodule KlassHeroWeb.Provider.SessionsLive do
     else
       do_create_session(params, socket)
     end
+  end
+
+  @impl true
+  def handle_event("close_new_session", _params, socket) do
+    {:noreply, push_patch(socket, to: ~p"/provider/sessions")}
   end
 
   # --- Session staffing panel (#782) ---------------------------------------
@@ -422,18 +427,6 @@ defmodule KlassHeroWeb.Provider.SessionsLive do
     |> put_flash(:error, gettext("That session could not be found."))
   end
 
-  defp build_initial_form_data(selected_date) do
-    %{
-      "program_id" => "",
-      "session_date" => Date.to_iso8601(selected_date),
-      "start_time" => "",
-      "end_time" => "",
-      "location" => "",
-      "notes" => "",
-      "max_capacity" => ""
-    }
-  end
-
   defp load_sessions(socket) do
     result =
       Participation.list_provider_sessions(
@@ -461,129 +454,26 @@ defmodule KlassHeroWeb.Provider.SessionsLive do
     assign(socket, :sessions_error, reason)
   end
 
-  defp maybe_prefill_from_program(params, programs) do
-    program_id = params["program_id"]
-
-    case Enum.find(programs, &(&1.id == program_id)) do
-      nil ->
-        params
-
-      program ->
-        # Pre-fill time/location from program defaults; provider can still override any value.
-        params
-        |> maybe_set_default("start_time", format_time(program.meeting_start_time))
-        |> maybe_set_default("end_time", format_time(program.meeting_end_time))
-        |> maybe_set_default("location", program.location || "")
-    end
-  end
-
-  # Don't overwrite values the provider has already typed.
-  defp maybe_set_default(params, key, default) do
-    if params[key] in [nil, ""] do
-      Map.put(params, key, default)
-    else
-      params
-    end
-  end
-
-  defp format_time(nil), do: ""
-  defp format_time(%Time{} = time), do: Calendar.strftime(time, "%H:%M")
-
   defp do_create_session(params, socket) do
-    case coerce_session_params(params) do
-      {:ok, coerced} ->
-        case Participation.create_session(socket.assigns.current_scope, coerced) do
-          {:ok, _session} ->
-            {:noreply,
-             socket
-             |> put_flash(:info, gettext("Session created successfully"))
-             |> push_patch(to: ~p"/provider/sessions")}
+    case SessionFormHandlers.submit(socket.assigns.current_scope, params) do
+      {:ok, _session} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, gettext("Session created successfully"))
+         |> push_patch(to: ~p"/provider/sessions")}
 
-          {:error, reason} when reason in [:invalid_time_range, :duplicate_session, :unauthorized] ->
-            # User-correctable domain error: show humanized message without "Failed" prefix.
-            {:noreply, put_flash(socket, :error, humanize_error(reason))}
-
-          {:error, reason} ->
-            Logger.error(
-              "[SessionsLive.save_session] Failed to create session",
-              reason: inspect(reason),
-              provider_id: socket.assigns.provider_id
-            )
-
-            {:noreply,
-             put_flash(
-               socket,
-               :error,
-               gettext("Failed to create session: %{reason}", reason: humanize_error(reason))
-             )}
+      {:error, reason} ->
+        if !SessionFormHandlers.user_correctable?(reason) do
+          Logger.error(
+            "[SessionsLive.save_session] Failed to create session",
+            reason: inspect(reason),
+            provider_id: socket.assigns.provider_id
+          )
         end
 
-      {:error, message} ->
-        {:noreply, put_flash(socket, :error, message)}
+        {:noreply, put_flash(socket, :error, SessionFormHandlers.humanize_error(reason))}
     end
   end
-
-  defp coerce_session_params(params) do
-    with {:ok, date} <- parse_date(params["session_date"]),
-         {:ok, start_time} <- parse_time(params["start_time"]),
-         {:ok, end_time} <- parse_time(params["end_time"]) do
-      coerced = %{
-        program_id: params["program_id"],
-        session_date: date,
-        start_time: start_time,
-        end_time: end_time
-      }
-
-      coerced =
-        if params["location"] in [nil, ""],
-          do: coerced,
-          else: Map.put(coerced, :location, params["location"])
-
-      coerced =
-        if params["notes"] in [nil, ""],
-          do: coerced,
-          else: Map.put(coerced, :notes, params["notes"])
-
-      coerced =
-        case Integer.parse(params["max_capacity"] || "") do
-          {value, ""} when value > 0 -> Map.put(coerced, :max_capacity, value)
-          _ -> coerced
-        end
-
-      {:ok, coerced}
-    end
-  end
-
-  defp parse_date(nil), do: {:error, gettext("Date is required")}
-  defp parse_date(""), do: {:error, gettext("Date is required")}
-
-  defp parse_date(date_string) do
-    case Date.from_iso8601(date_string) do
-      {:ok, _date} = ok -> ok
-      {:error, _} -> {:error, gettext("Invalid date format")}
-    end
-  end
-
-  defp parse_time(nil), do: {:error, gettext("Time is required")}
-  defp parse_time(""), do: {:error, gettext("Time is required")}
-
-  defp parse_time(time_string) do
-    # HTML time inputs produce "HH:MM"; Time.from_iso8601/1 requires "HH:MM:SS".
-    normalized = if byte_size(time_string) == 5, do: time_string <> ":00", else: time_string
-
-    case Time.from_iso8601(normalized) do
-      {:ok, _time} = ok -> ok
-      {:error, _} -> {:error, gettext("Invalid time format")}
-    end
-  end
-
-  defp humanize_error(:invalid_time_range), do: gettext("End time must be after start time")
-  defp humanize_error(:duplicate_session), do: gettext("A session already exists at this time")
-  defp humanize_error(:unauthorized), do: gettext("Unauthorized")
-
-  defp humanize_error(:missing_required_fields), do: gettext("Please fill in all required fields")
-
-  defp humanize_error(reason), do: inspect(reason)
 
   defp update_session_in_stream(socket, session_id) do
     case Participation.get_session_with_roster(session_id) do

--- a/lib/klass_hero_web/live/provider/sessions_live.ex
+++ b/lib/klass_hero_web/live/provider/sessions_live.ex
@@ -491,7 +491,10 @@ defmodule KlassHeroWeb.Provider.SessionsLive do
           )
           |> stream_insert(:sessions, session)
         else
-          socket
+          # It moved off the day on screen. Before #1074 nothing could move a
+          # session's date, so falling through here was harmless; now a reschedule
+          # can, and leaving the row would show it under a day it is no longer on.
+          stream_delete(socket, :sessions, session)
         end
 
       {:error, reason} ->

--- a/lib/klass_hero_web/live/provider/sessions_live.ex
+++ b/lib/klass_hero_web/live/provider/sessions_live.ex
@@ -40,8 +40,6 @@ defmodule KlassHeroWeb.Provider.SessionsLive do
     provider_programs =
       TaskHelpers.safe_await(programs_task, [], label: "SessionsLive.programs")
 
-    provider_program_ids = MapSet.new(provider_programs, & &1.id)
-
     docs = unwrap(TaskHelpers.safe_await(docs_task, {:ok, []}, label: "SessionsLive.docs"))
 
     business = build_business_view(provider, docs)
@@ -53,7 +51,6 @@ defmodule KlassHeroWeb.Provider.SessionsLive do
       |> assign(:provider_id, provider_id)
       |> assign(:selected_date, selected_date)
       |> assign(:provider_programs, provider_programs)
-      |> assign(:provider_program_ids, provider_program_ids)
       |> assign(:program_names, program_names(provider_programs))
       |> assign(:business, business)
       |> assign(:form, nil)
@@ -178,19 +175,14 @@ defmodule KlassHeroWeb.Provider.SessionsLive do
   end
 
   @impl true
+  # Ownership is no longer checked here. `Participation.create_session/2` asks
+  # `SessionAuthorization` itself (#1074), so a tampered program_id is refused for
+  # every caller rather than for whichever surface remembered to look.
   def handle_event("save_session", %{"session" => params}, socket) do
-    program_id = params["program_id"]
-
-    cond do
-      program_id in [nil, ""] ->
-        {:noreply, put_flash(socket, :error, gettext("Program is required"))}
-
-      not MapSet.member?(socket.assigns.provider_program_ids, program_id) ->
-        # Verify ownership server-side — the dropdown only shows their programs but form data can be tampered.
-        {:noreply, put_flash(socket, :error, gettext("Unauthorized"))}
-
-      true ->
-        do_create_session(params, socket)
+    if params["program_id"] in [nil, ""] do
+      {:noreply, put_flash(socket, :error, gettext("Program is required"))}
+    else
+      do_create_session(params, socket)
     end
   end
 
@@ -338,7 +330,6 @@ defmodule KlassHeroWeb.Provider.SessionsLive do
     socket =
       socket
       |> assign(:provider_programs, programs)
-      |> assign(:provider_program_ids, MapSet.new(programs, & &1.id))
       |> assign(:program_names, program_names(programs))
       |> load_sessions()
 
@@ -501,14 +492,14 @@ defmodule KlassHeroWeb.Provider.SessionsLive do
   defp do_create_session(params, socket) do
     case coerce_session_params(params) do
       {:ok, coerced} ->
-        case Participation.create_session(coerced) do
+        case Participation.create_session(socket.assigns.current_scope, coerced) do
           {:ok, _session} ->
             {:noreply,
              socket
              |> put_flash(:info, gettext("Session created successfully"))
              |> push_patch(to: ~p"/provider/sessions")}
 
-          {:error, reason} when reason in [:invalid_time_range, :duplicate_session] ->
+          {:error, reason} when reason in [:invalid_time_range, :duplicate_session, :unauthorized] ->
             # User-correctable domain error: show humanized message without "Failed" prefix.
             {:noreply, put_flash(socket, :error, humanize_error(reason))}
 
@@ -588,6 +579,7 @@ defmodule KlassHeroWeb.Provider.SessionsLive do
 
   defp humanize_error(:invalid_time_range), do: gettext("End time must be after start time")
   defp humanize_error(:duplicate_session), do: gettext("A session already exists at this time")
+  defp humanize_error(:unauthorized), do: gettext("Unauthorized")
 
   defp humanize_error(:missing_required_fields), do: gettext("Please fill in all required fields")
 

--- a/lib/klass_hero_web/live/provider/sessions_live.html.heex
+++ b/lib/klass_hero_web/live/provider/sessions_live.html.heex
@@ -1,22 +1,12 @@
 <.pv_dashboard_chrome business={@business} current_tab={:sessions}>
-  <div class="flex flex-wrap items-end justify-between gap-3 mb-6">
-    <div>
-      <h2 class={["mb-1", Theme.typography(:section_title)]}>{gettext("My Sessions")}</h2>
-      <p class="text-sm text-[var(--fg-muted)]">
-        {gettext("Manage your scheduled sessions and attendance")}
-      </p>
-    </div>
-    <.link
-      patch={~p"/provider/sessions/new"}
-      class={[
-        "px-4 py-2 text-sm font-medium text-white bg-hero-blue-600 hover:bg-hero-blue-700 focus:outline-none focus:ring-2 focus:ring-[var(--focus-ring)] focus:ring-offset-2",
-        Theme.rounded(:lg),
-        Theme.transition(:normal)
-      ]}
-    >
-      <.icon name="hero-plus" class="w-4 h-4 mr-1 inline" />
-      {gettext("Create Session")}
-    </.link>
+  <%!-- Sessions are created from Program Inventory's Sessions popup as of #1074:
+  creation belongs where a program is already in hand, and #1501 turns this page
+  into a read-only Schedule. The /new route stays reachable by URL until then. --%>
+  <div class="mb-6">
+    <h2 class={["mb-1", Theme.typography(:section_title)]}>{gettext("My Sessions")}</h2>
+    <p class="text-sm text-[var(--fg-muted)]">
+      {gettext("Manage your scheduled sessions and attendance")}
+    </p>
   </div>
 
   <div class="mb-6">
@@ -162,64 +152,11 @@
       </div>
 
       <div class="p-4">
-        <.form
-          for={@form}
-          id="create-session-form"
-          phx-change="validate_session"
-          phx-submit="save_session"
-          class="space-y-4"
-        >
-          <.input
-            field={@form[:program_id]}
-            type="select"
-            label={gettext("Program")}
-            prompt={gettext("Select a program...")}
-            options={Enum.map(@provider_programs, &{&1.title, &1.id})}
-            required
-          />
-
-          <.input field={@form[:session_date]} type="date" label={gettext("Date")} required />
-
-          <div class="grid grid-cols-2 gap-4">
-            <.input field={@form[:start_time]} type="time" label={gettext("Start Time")} required />
-            <.input field={@form[:end_time]} type="time" label={gettext("End Time")} required />
-          </div>
-
-          <.input
-            field={@form[:location]}
-            type="text"
-            label={gettext("Location")}
-            phx-debounce="blur"
-          />
-          <.input
-            field={@form[:notes]}
-            type="textarea"
-            label={gettext("Notes")}
-            phx-debounce="blur"
-          />
-          <.input field={@form[:max_capacity]} type="number" label={gettext("Max Capacity")} />
-
-          <div class="flex justify-end gap-3 pt-2">
-            <.link
-              patch={~p"/provider/sessions"}
-              class={[
-                "px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-50",
-                Theme.rounded(:lg)
-              ]}
-            >
-              {gettext("Cancel")}
-            </.link>
-            <button
-              type="submit"
-              class={[
-                "px-4 py-2 text-sm font-medium text-white bg-hero-blue-600 hover:bg-hero-blue-700",
-                Theme.rounded(:lg)
-              ]}
-            >
-              {gettext("Create Session")}
-            </button>
-          </div>
-        </.form>
+        <.session_form
+          form={@form}
+          programs={@provider_programs}
+          cancel_event="close_new_session"
+        />
       </div>
     </div>
   <% end %>

--- a/lib/klass_hero_web/live/staff/staff_sessions_live.ex
+++ b/lib/klass_hero_web/live/staff/staff_sessions_live.ex
@@ -191,16 +191,24 @@ defmodule KlassHeroWeb.Staff.StaffSessionsLive do
         # `staffs_session?/2` costs a round trip, and this topic carries every
         # participation message for the provider, not only the ones this view
         # renders. `and` short-circuits, so an off-date message never queries.
-        if session.session_date == socket.assigns.selected_date and
-             staffs_session?(socket, session.id) do
-          socket
-          |> assign(
-            :attendance,
-            Map.put(socket.assigns.attendance, session.id, Participation.attendance_from_roster(roster))
-          )
-          |> stream_insert(:sessions, session)
-        else
-          socket
+        cond do
+          session.session_date != socket.assigns.selected_date ->
+            # It moved off the day on screen. Before #1074 nothing could move a
+            # session's date, so falling through was harmless; a reschedule can
+            # now, and the row would otherwise sit under a day it is not on.
+            # A delete for a row never inserted (an unstaffed session) is a no-op.
+            stream_delete(socket, :sessions, session)
+
+          staffs_session?(socket, session.id) ->
+            socket
+            |> assign(
+              :attendance,
+              Map.put(socket.assigns.attendance, session.id, Participation.attendance_from_roster(roster))
+            )
+            |> stream_insert(:sessions, session)
+
+          true ->
+            socket
         end
 
       {:error, reason} ->

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -577,8 +577,8 @@ msgid "Dispute Resolution"
 msgstr "Streitbeilegung"
 
 #: lib/klass_hero_web/components/provider_components.ex:781
-#: lib/klass_hero_web/components/provider_components.ex:2859
-#: lib/klass_hero_web/components/provider_components.ex:2877
+#: lib/klass_hero_web/components/provider_components.ex:3039
+#: lib/klass_hero_web/components/provider_components.ex:3057
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:61
@@ -621,7 +621,7 @@ msgid "Failed to check out: %{reason}"
 msgstr "Auschecken fehlgeschlagen: %{reason}"
 
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:202
-#: lib/klass_hero_web/live/provider/sessions_live.ex:167
+#: lib/klass_hero_web/live/provider/sessions_live.ex:165
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:117
 #, elixir-autogen, elixir-format
 msgid "Failed to complete session: %{reason}"
@@ -632,7 +632,7 @@ msgstr "Sitzung konnte nicht abgeschlossen werden: %{reason}"
 msgid "Failed to delete account. Please try again."
 msgstr "Konto konnte nicht gelöscht werden. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:141
+#: lib/klass_hero_web/live/provider/sessions_live.ex:139
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:91
 #, elixir-autogen, elixir-format
 msgid "Failed to start session: %{reason}"
@@ -683,8 +683,8 @@ msgstr "Geistiges Eigentum"
 msgid "Introduction"
 msgstr "Einleitung"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:116
-#: lib/klass_hero_web/live/provider/sessions_live.ex:572
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:157
+#: lib/klass_hero_web/live/provider/sessions_live.ex:114
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:66
 #, elixir-autogen, elixir-format
 msgid "Invalid date format"
@@ -758,8 +758,8 @@ msgstr "Nachricht"
 msgid "Message sent successfully!"
 msgstr "Nachricht erfolgreich gesendet!"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:51
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:4
+#: lib/klass_hero_web/live/provider/sessions_live.ex:50
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:6
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:21
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:223
 #, elixir-autogen, elixir-format
@@ -852,8 +852,8 @@ msgstr "Fragen zu diesen Bedingungen?"
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:107
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:139
 #: lib/klass_hero_web/live/admin/sessions_live.ex:247
-#: lib/klass_hero_web/live/provider/participation_live.ex:199
-#: lib/klass_hero_web/live/provider/participation_live.ex:245
+#: lib/klass_hero_web/live/provider/participation_live.ex:249
+#: lib/klass_hero_web/live/provider/participation_live.ex:295
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:139
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:185
 #, elixir-autogen, elixir-format
@@ -882,9 +882,9 @@ msgstr "Speichern..."
 msgid "Select one or both options"
 msgstr "Wählen Sie eine oder beide Optionen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2508
-#: lib/klass_hero_web/components/provider_components.ex:2509
-#: lib/klass_hero_web/components/provider_components.ex:2547
+#: lib/klass_hero_web/components/provider_components.ex:2688
+#: lib/klass_hero_web/components/provider_components.ex:2689
+#: lib/klass_hero_web/components/provider_components.ex:2727
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:468
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:469
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:505
@@ -893,7 +893,7 @@ msgid "Send Message"
 msgstr "Nachricht senden"
 
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:190
-#: lib/klass_hero_web/live/provider/sessions_live.ex:150
+#: lib/klass_hero_web/live/provider/sessions_live.ex:148
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:100
 #, elixir-autogen, elixir-format
 msgid "Session completed successfully"
@@ -901,13 +901,13 @@ msgstr "Sitzung erfolgreich abgeschlossen"
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:62
 #: lib/klass_hero_web/live/admin/sessions_live.ex:68
-#: lib/klass_hero_web/live/provider/participation_live.ex:315
+#: lib/klass_hero_web/live/provider/participation_live.ex:365
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:270
 #, elixir-autogen, elixir-format
 msgid "Session not found"
 msgstr "Sitzung nicht gefunden"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:124
+#: lib/klass_hero_web/live/provider/sessions_live.ex:122
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:74
 #, elixir-autogen, elixir-format
 msgid "Session started successfully"
@@ -1135,8 +1135,8 @@ msgstr "Willkommen zurück"
 msgid "Failed to load participation history"
 msgstr "Teilnahmeverlauf konnte nicht geladen werden"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:27
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:65
+#: lib/klass_hero_web/live/provider/participation_live.ex:30
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:55
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:27
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:271
 #, elixir-autogen, elixir-format
@@ -1334,8 +1334,8 @@ msgid "Quick Navigation"
 msgstr "Schnellnavigation"
 
 #: lib/klass_hero_web/components/provider_components.ex:1466
-#: lib/klass_hero_web/components/provider_components.ex:2453
-#: lib/klass_hero_web/components/provider_components.ex:2746
+#: lib/klass_hero_web/components/provider_components.ex:2633
+#: lib/klass_hero_web/components/provider_components.ex:2926
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr "Aktionen"
@@ -1351,7 +1351,7 @@ msgstr "Aktiv"
 msgid "Add Team Member"
 msgstr "Teammitglied hinzufügen"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:49
+#: lib/klass_hero_web/live/provider/programs_live.ex:50
 #, elixir-autogen, elixir-format
 msgid "All Staff"
 msgstr "Alle Mitarbeiter"
@@ -1380,8 +1380,8 @@ msgstr "Erstellen Sie Profile für Ihr Personal. Diese werden für Eltern sichtb
 
 #: lib/klass_hero_web/components/provider_components.ex:586
 #: lib/klass_hero_web/components/provider_components.ex:1575
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:65
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:92
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:88
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:115
 #: lib/klass_hero_web/live/settings/children_live.ex:413
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:65
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:92
@@ -1402,7 +1402,7 @@ msgid "Inactive"
 msgstr "Inaktiv"
 
 #: lib/klass_hero_web/components/provider_components.ex:116
-#: lib/klass_hero_web/live/provider/programs_live.ex:55
+#: lib/klass_hero_web/live/provider/programs_live.ex:56
 #, elixir-autogen, elixir-format
 msgid "My Programs"
 msgstr "Meine Programme"
@@ -1421,8 +1421,8 @@ msgstr "Übersicht"
 #: lib/klass_hero_web/components/provider_components.ex:50
 #: lib/klass_hero_web/components/provider_components.ex:76
 #: lib/klass_hero_web/components/provider_components.ex:1613
-#: lib/klass_hero_web/components/provider_components.ex:2953
-#: lib/klass_hero_web/components/provider_components.ex:2980
+#: lib/klass_hero_web/components/provider_components.ex:3133
+#: lib/klass_hero_web/components/provider_components.ex:3160
 #: lib/klass_hero_web/live/admin/sessions_live.ex:293
 #: lib/klass_hero_web/live/admin/verifications_live.ex:202
 #, elixir-autogen, elixir-format
@@ -1460,9 +1460,9 @@ msgid "Search by name..."
 msgstr "Nach Namen suchen..."
 
 #: lib/klass_hero_web/components/provider_components.ex:1460
-#: lib/klass_hero_web/components/provider_components.ex:1863
-#: lib/klass_hero_web/components/provider_components.ex:2444
-#: lib/klass_hero_web/components/provider_components.ex:2743
+#: lib/klass_hero_web/components/provider_components.ex:2018
+#: lib/klass_hero_web/components/provider_components.ex:2624
+#: lib/klass_hero_web/components/provider_components.ex:2923
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1482,7 +1482,7 @@ msgid "Team & Provider Profiles"
 msgstr "Team- & Anbieterprofile"
 
 #: lib/klass_hero_web/components/provider_components.ex:1517
-#: lib/klass_hero_web/components/provider_components.ex:1878
+#: lib/klass_hero_web/components/provider_components.ex:2047
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr "Nicht zugewiesen"
@@ -1561,14 +1561,14 @@ msgstr "Rundnachricht an %{count} Eltern gesendet"
 #: lib/klass_hero_web/components/participation_components.ex:708
 #: lib/klass_hero_web/components/provider_components.ex:909
 #: lib/klass_hero_web/components/provider_components.ex:1323
-#: lib/klass_hero_web/components/provider_components.ex:2036
-#: lib/klass_hero_web/components/provider_components.ex:2651
+#: lib/klass_hero_web/components/provider_components.ex:1918
+#: lib/klass_hero_web/components/provider_components.ex:2216
+#: lib/klass_hero_web/components/provider_components.ex:2831
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:489
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:222
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:361
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:210
 #: lib/klass_hero_web/live/settings/children_live.ex:544
 #: lib/klass_hero_web/live/settings/children_live.ex:703
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:237
@@ -1621,8 +1621,8 @@ msgstr "Kind konnte nicht entfernt werden. Bitte versuchen Sie es erneut."
 msgid "Data sharing consent"
 msgstr "Einwilligung zur Datenweitergabe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2441
-#: lib/klass_hero_web/components/provider_components.ex:2840
+#: lib/klass_hero_web/components/provider_components.ex:2621
+#: lib/klass_hero_web/components/provider_components.ex:3020
 #: lib/klass_hero_web/live/settings/children_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1654,7 +1654,7 @@ msgstr "Notiz konnte nicht genehmigt werden"
 msgid "Failed to reject note"
 msgstr "Notiz konnte nicht abgelehnt werden"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:191
+#: lib/klass_hero_web/live/provider/participation_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "Failed to resubmit note"
 msgstr "Notiz konnte nicht erneut eingereicht werden"
@@ -1670,17 +1670,17 @@ msgstr "Rundnachricht konnte nicht gesendet werden"
 msgid "Failed to submit note"
 msgstr "Notiz konnte nicht eingereicht werden"
 
-#: lib/klass_hero_web/components/provider_components.ex:2834
-#: lib/klass_hero_web/components/provider_components.ex:2863
-#: lib/klass_hero_web/components/provider_components.ex:2879
+#: lib/klass_hero_web/components/provider_components.ex:3014
+#: lib/klass_hero_web/components/provider_components.ex:3043
+#: lib/klass_hero_web/components/provider_components.ex:3059
 #: lib/klass_hero_web/live/settings/children_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr "Vorname"
 
-#: lib/klass_hero_web/components/provider_components.ex:2835
-#: lib/klass_hero_web/components/provider_components.ex:2864
-#: lib/klass_hero_web/components/provider_components.ex:2880
+#: lib/klass_hero_web/components/provider_components.ex:3015
+#: lib/klass_hero_web/components/provider_components.ex:3044
+#: lib/klass_hero_web/components/provider_components.ex:3060
 #: lib/klass_hero_web/live/settings/children_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -1750,7 +1750,7 @@ msgid "Note approved"
 msgstr "Notiz genehmigt"
 
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:157
-#: lib/klass_hero_web/live/provider/participation_live.ex:183
+#: lib/klass_hero_web/live/provider/participation_live.ex:233
 #, elixir-autogen, elixir-format
 msgid "Note content cannot be blank"
 msgstr "Notizinhalt darf nicht leer sein"
@@ -1760,7 +1760,7 @@ msgstr "Notizinhalt darf nicht leer sein"
 msgid "Note rejected"
 msgstr "Notiz abgelehnt"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:177
+#: lib/klass_hero_web/live/provider/participation_live.ex:227
 #, elixir-autogen, elixir-format
 msgid "Note resubmitted for review"
 msgstr "Notiz erneut zur Überprüfung eingereicht"
@@ -1842,7 +1842,7 @@ msgstr "Rundnachricht senden"
 msgid "Send a message to start the conversation"
 msgstr "Senden Sie eine Nachricht, um die Unterhaltung zu beginnen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2934
+#: lib/klass_hero_web/components/provider_components.ex:3114
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:249
 #, elixir-autogen, elixir-format
@@ -1866,7 +1866,7 @@ msgstr "Diese Nachricht wird an alle Eltern mit aktiven Anmeldungen in diesem Pr
 msgid "Type a message..."
 msgstr "Nachricht eingeben..."
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:335
+#: lib/klass_hero_web/live/provider/participation_live.ex:385
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:290
 #, elixir-autogen, elixir-format
 msgid "Unable to refresh roster. Please reload."
@@ -1978,7 +1978,7 @@ msgstr "Alter %{min}+"
 msgid "Allowed Genders"
 msgstr "Zulässige Geschlechter"
 
-#: lib/klass_hero_web/components/provider_components.ex:3002
+#: lib/klass_hero_web/components/provider_components.ex:3182
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred during import."
 msgstr "Beim Import ist ein unerwarteter Fehler aufgetreten."
@@ -2057,8 +2057,8 @@ msgstr "Kategorie"
 msgid "Check eligibility at"
 msgstr "Berechtigung prüfen unter"
 
-#: lib/klass_hero_web/components/provider_components.ex:2435
-#: lib/klass_hero_web/components/provider_components.ex:2729
+#: lib/klass_hero_web/components/provider_components.ex:2615
+#: lib/klass_hero_web/components/provider_components.ex:2909
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr "Name des Kindes"
@@ -2099,7 +2099,7 @@ msgstr "Kategorie auswählen"
 msgid "Confirm rejection"
 msgstr "Ablehnung bestätigen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2954
+#: lib/klass_hero_web/components/provider_components.ex:3134
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr "Bestätigt"
@@ -2109,7 +2109,7 @@ msgstr "Bestätigt"
 msgid "Contact Provider"
 msgstr "Anbieter kontaktieren"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:510
+#: lib/klass_hero_web/live/provider/programs_live.ex:570
 #, elixir-autogen, elixir-format
 msgid "Could not read the uploaded file."
 msgstr "Die hochgeladene Datei konnte nicht gelesen werden."
@@ -2120,7 +2120,7 @@ msgid "Could not remove invite."
 msgstr "Einladung konnte nicht entfernt werden."
 
 #: lib/klass_hero_web/components/provider_components.ex:1290
-#: lib/klass_hero_web/components/provider_components.ex:3251
+#: lib/klass_hero_web/components/provider_components.ex:3431
 #, elixir-autogen, elixir-format
 msgid "Cover Image"
 msgstr "Titelbild"
@@ -2149,7 +2149,7 @@ msgstr "Beschreibung"
 msgid "Diverse"
 msgstr "Divers"
 
-#: lib/klass_hero_web/components/provider_components.ex:3380
+#: lib/klass_hero_web/components/provider_components.ex:3560
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr "Dokumenttyp"
@@ -2183,7 +2183,7 @@ msgstr "Dokument abgelehnt."
 msgid "Document uploaded successfully."
 msgstr "Dokument erfolgreich hochgeladen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2670
+#: lib/klass_hero_web/components/provider_components.ex:2850
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr "Vorlage herunterladen"
@@ -2209,13 +2209,13 @@ msgid "End Date"
 msgstr "Enddatum"
 
 #: lib/klass_hero_web/components/provider_components.ex:1075
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:185
+#: lib/klass_hero_web/components/provider_components.ex:1893
 #, elixir-autogen, elixir-format
 msgid "End Time"
 msgstr "Endzeit"
 
-#: lib/klass_hero_web/components/provider_components.ex:2450
-#: lib/klass_hero_web/components/provider_components.ex:2983
+#: lib/klass_hero_web/components/provider_components.ex:2630
+#: lib/klass_hero_web/components/provider_components.ex:3163
 #: lib/klass_hero_web/components/provider_layout_components.ex:612
 #, elixir-autogen, elixir-format
 msgid "Enrolled"
@@ -2237,7 +2237,7 @@ msgid "Explain why this document is being rejected..."
 msgstr "Erklären Sie, warum dieses Dokument abgelehnt wird..."
 
 #: lib/klass_hero_web/components/provider_components.ex:74
-#: lib/klass_hero_web/components/provider_components.ex:2984
+#: lib/klass_hero_web/components/provider_components.ex:3164
 #: lib/klass_hero_web/live/admin/emails_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2281,12 +2281,12 @@ msgstr "Weiblich"
 msgid "File"
 msgstr "Datei"
 
-#: lib/klass_hero_web/components/provider_components.ex:3313
+#: lib/klass_hero_web/components/provider_components.ex:3493
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr "Die Datei ist zu groß."
 
-#: lib/klass_hero_web/components/provider_components.ex:3315
+#: lib/klass_hero_web/components/provider_components.ex:3495
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr "Dateityp wird nicht akzeptiert."
@@ -2321,7 +2321,7 @@ msgstr "Klassenstufe %{min}+"
 msgid "Grades %{min} – %{max}"
 msgstr "Klassenstufen %{min} – %{max}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2740
+#: lib/klass_hero_web/components/provider_components.ex:2920
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr "E-Mail des Erziehungsberechtigten"
@@ -2336,7 +2336,7 @@ msgstr "Porträtfoto"
 msgid "ID Document"
 msgstr "Ausweisdokument"
 
-#: lib/klass_hero_web/components/provider_components.ex:2643
+#: lib/klass_hero_web/components/provider_components.ex:2823
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Importieren"
@@ -2404,7 +2404,7 @@ msgid "Leave unchecked to allow all genders."
 msgstr "Nicht markiert lassen, um alle Geschlechter zuzulassen."
 
 #: lib/klass_hero_web/components/provider_components.ex:1031
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:191
+#: lib/klass_hero_web/components/provider_components.ex:1905
 #, elixir-autogen, elixir-format
 msgid "Location"
 msgstr "Ort"
@@ -2462,18 +2462,18 @@ msgstr "Niedrigste Klassenstufe"
 msgid "No approved documents."
 msgstr "Keine genehmigten Dokumente."
 
-#: lib/klass_hero_web/components/provider_components.ex:3342
+#: lib/klass_hero_web/components/provider_components.ex:3522
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr "Noch keine Dokumente hochgeladen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2427
+#: lib/klass_hero_web/components/provider_components.ex:2607
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
 msgstr "Noch keine Anmeldungen."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:506
+#: lib/klass_hero_web/live/provider/programs_live.ex:566
 #, elixir-autogen, elixir-format
 msgid "No file selected."
 msgstr "Keine Datei ausgewählt."
@@ -2483,7 +2483,7 @@ msgstr "Keine Datei ausgewählt."
 msgid "No grade"
 msgstr "Keine Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2694
+#: lib/klass_hero_web/components/provider_components.ex:2874
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr "Noch keine Einladungen. Laden Sie eine CSV-Datei hoch, um Familien einzuladen."
@@ -2546,7 +2546,7 @@ msgstr "Nicht angegeben"
 msgid "Our Story"
 msgstr "Unsere Geschichte"
 
-#: lib/klass_hero_web/components/provider_components.ex:3418
+#: lib/klass_hero_web/components/provider_components.ex:3598
 #: lib/klass_hero_web/live/provider/verification_live.ex:707
 #: lib/klass_hero_web/live/provider/verification_live.ex:781
 #, elixir-autogen, elixir-format
@@ -2573,8 +2573,8 @@ msgstr "Ausstehende Überprüfung"
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:111
-#: lib/klass_hero_web/live/provider/programs_live.ex:750
-#: lib/klass_hero_web/live/provider/programs_live.ex:819
+#: lib/klass_hero_web/live/provider/programs_live.ex:810
+#: lib/klass_hero_web/live/provider/programs_live.ex:879
 #: lib/klass_hero_web/live/provider/team_live.ex:314
 #: lib/klass_hero_web/live/provider/team_live.ex:357
 #: lib/klass_hero_web/live/provider/team_live.ex:476
@@ -2607,28 +2607,28 @@ msgstr "Profil erfolgreich aktualisiert."
 msgid "Program Start"
 msgstr "Programmbeginn"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1319
+#: lib/klass_hero_web/live/provider/programs_live.ex:1398
 #, elixir-autogen, elixir-format
 msgid "Program created successfully."
 msgstr "Programm erfolgreich erstellt."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1323
+#: lib/klass_hero_web/live/provider/programs_live.ex:1402
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr "Programm erstellt, aber die Anmeldekapazität konnte nicht gespeichert werden. Bearbeiten Sie das Programm, um es erneut zu versuchen."
 
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:52
-#: lib/klass_hero_web/live/provider/programs_live.ex:157
-#: lib/klass_hero_web/live/provider/programs_live.ex:194
-#: lib/klass_hero_web/live/provider/programs_live.ex:258
-#: lib/klass_hero_web/live/provider/programs_live.ex:282
-#: lib/klass_hero_web/live/provider/programs_live.ex:794
-#: lib/klass_hero_web/live/provider/programs_live.ex:926
+#: lib/klass_hero_web/live/provider/programs_live.ex:158
+#: lib/klass_hero_web/live/provider/programs_live.ex:195
+#: lib/klass_hero_web/live/provider/programs_live.ex:318
+#: lib/klass_hero_web/live/provider/programs_live.ex:342
+#: lib/klass_hero_web/live/provider/programs_live.ex:854
+#: lib/klass_hero_web/live/provider/programs_live.ex:986
 #, elixir-autogen, elixir-format
 msgid "Program not found."
 msgstr "Programm nicht gefunden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1320
+#: lib/klass_hero_web/live/provider/programs_live.ex:1399
 #, elixir-autogen, elixir-format
 msgid "Program updated successfully."
 msgstr "Programm erfolgreich aktualisiert."
@@ -2647,6 +2647,8 @@ msgstr "Lesen Sie unsere Gründungsgeschichte →"
 
 #: lib/klass_hero_web/components/participation_components.ex:796
 #: lib/klass_hero_web/components/provider_components.ex:2982
+#: lib/klass_hero_web/components/participation_components.ex:750
+#: lib/klass_hero_web/components/provider_components.ex:3162
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Registered"
@@ -2726,15 +2728,15 @@ msgstr "Abgelehnt"
 msgid "Rejection reason"
 msgstr "Ablehnungsgrund"
 
-#: lib/klass_hero_web/components/provider_components.ex:2796
-#: lib/klass_hero_web/components/provider_components.ex:3169
-#: lib/klass_hero_web/components/provider_components.ex:3437
-#: lib/klass_hero_web/components/provider_components.ex:3517
+#: lib/klass_hero_web/components/provider_components.ex:2976
+#: lib/klass_hero_web/components/provider_components.ex:3349
+#: lib/klass_hero_web/components/provider_components.ex:3617
+#: lib/klass_hero_web/components/provider_components.ex:3697
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr "Entfernen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2789
+#: lib/klass_hero_web/components/provider_components.ex:2969
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr "Einladung erneut senden"
@@ -2775,7 +2777,7 @@ msgstr "Zeitplan noch offen"
 msgid "School Grade (optional)"
 msgstr "Klassenstufe (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:3415
+#: lib/klass_hero_web/components/provider_components.ex:3595
 #, elixir-autogen, elixir-format
 msgid "Select File"
 msgstr "Datei auswählen"
@@ -2786,13 +2788,13 @@ msgstr "Datei auswählen"
 msgid "Selected child does not meet the program requirements."
 msgstr "Das ausgewählte Kind erfüllt die Programmanforderungen nicht."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:740
-#: lib/klass_hero_web/live/provider/programs_live.ex:809
+#: lib/klass_hero_web/live/provider/programs_live.ex:800
+#: lib/klass_hero_web/live/provider/programs_live.ex:869
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr "Der ausgewählte Kursleiter konnte nicht gefunden werden. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:2981
+#: lib/klass_hero_web/components/provider_components.ex:3161
 #: lib/klass_hero_web/live/admin/emails_live.ex:206
 #, elixir-autogen, elixir-format
 msgid "Sent"
@@ -2832,7 +2834,7 @@ msgid "Start Date"
 msgstr "Startdatum"
 
 #: lib/klass_hero_web/components/provider_components.ex:1070
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:184
+#: lib/klass_hero_web/components/provider_components.ex:1886
 #, elixir-autogen, elixir-format
 msgid "Start Time"
 msgstr "Startzeit"
@@ -2892,18 +2894,18 @@ msgstr "Die Geschichte von Klass Hero"
 msgid "This invite cannot be resent."
 msgstr "Diese Einladung kann nicht erneut gesendet werden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:801
+#: lib/klass_hero_web/live/provider/programs_live.ex:861
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr "Dieses Programm wurde von jemand anderem geändert. Bitte schließen Sie es und versuchen Sie es erneut."
 
 #: lib/klass_hero_web/components/provider_components.ex:995
-#: lib/klass_hero_web/components/provider_components.ex:2002
+#: lib/klass_hero_web/components/provider_components.ex:2182
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr "Titel"
 
-#: lib/klass_hero_web/components/provider_components.ex:3314
+#: lib/klass_hero_web/components/provider_components.ex:3494
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr "Zu viele Dateien."
@@ -2923,27 +2925,27 @@ msgstr "Bis zu %{max}"
 msgid "Up to Grade %{max}"
 msgstr "Bis Klassenstufe %{max}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2630
+#: lib/klass_hero_web/components/provider_components.ex:2810
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr "CSV hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3461
+#: lib/klass_hero_web/components/provider_components.ex:3641
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr "Dokument hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3369
+#: lib/klass_hero_web/components/provider_components.ex:3549
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr "Neues Dokument hochladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3317
+#: lib/klass_hero_web/components/provider_components.ex:3497
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr "Upload-Fehler."
 
-#: lib/klass_hero_web/components/provider_components.ex:3334
+#: lib/klass_hero_web/components/provider_components.ex:3514
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr "Verifizierungsdokumente"
@@ -3035,7 +3037,7 @@ msgid "Child Safeguarding Training"
 msgstr "Kinderschutzschulung"
 
 #: lib/klass_hero_web/components/marketing_components.ex:1507
-#: lib/klass_hero_web/components/provider_components.ex:3690
+#: lib/klass_hero_web/components/provider_components.ex:3870
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr "Vereinbarung zu Community-Standards"
@@ -3105,7 +3107,7 @@ msgstr "Zahlung per Bargeld oder Banküberweisung"
 msgid "Program fee:"
 msgstr "Programmgebühr:"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1096
+#: lib/klass_hero_web/live/provider/programs_live.ex:1175
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr "Programm gespeichert, aber der Upload des Titelbilds ist fehlgeschlagen. Sie können es erneut hochladen, indem Sie das Programm bearbeiten."
@@ -3186,7 +3188,7 @@ msgid "Vetted with Care"
 msgstr "Mit Sorgfalt geprüft"
 
 #: lib/klass_hero_web/components/marketing_components.ex:1491
-#: lib/klass_hero_web/components/provider_components.ex:3468
+#: lib/klass_hero_web/components/provider_components.ex:3648
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr "Video-Überprüfung"
@@ -3322,7 +3324,7 @@ msgstr "Kann ich meine Programme auf Klass Hero listen und was kostet das?"
 msgid "Cannot check out without a check-in"
 msgstr "Auschecken ohne Einchecken nicht möglich"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:453
+#: lib/klass_hero_web/live/provider/programs_live.ex:513
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:155
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
@@ -3360,7 +3362,7 @@ msgstr "Eingecheckt"
 msgid "Checked Out"
 msgstr "Ausgecheckt"
 
-#: lib/klass_hero_web/components/provider_components.ex:2831
+#: lib/klass_hero_web/components/provider_components.ex:3011
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Child"
@@ -3406,7 +3408,7 @@ msgstr "Benötige ich ein Konto, um zu buchen?"
 msgid "Download monthly statements for taxes"
 msgstr "Monatliche Abrechnungen für die Steuer herunterladen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2546
+#: lib/klass_hero_web/components/provider_components.ex:2726
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:504
 #, elixir-autogen, elixir-format
 msgid "Enrollment not confirmed"
@@ -3491,8 +3493,9 @@ msgid "No risk of non-payment"
 msgstr "Kein Risiko von Zahlungsausfällen"
 
 #: lib/klass_hero_web/components/participation_components.ex:821
+#: lib/klass_hero_web/components/participation_components.ex:775
+#: lib/klass_hero_web/components/provider_components.ex:1906
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:155
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:197
 #, elixir-autogen, elixir-format
 msgid "Notes"
 msgstr "Notizen"
@@ -3502,7 +3505,7 @@ msgstr "Notizen"
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr "Oder: Jederzeit eine Sofortauszahlung anfordern (mindestens 50 €)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2545
+#: lib/klass_hero_web/components/provider_components.ex:2725
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:503
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -3685,7 +3688,7 @@ msgstr "%{checked_in} / %{total} eingecheckt"
 msgid "%{count} unread"
 msgstr "%{count} ungelesen"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:590
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:161
 #, elixir-autogen, elixir-format
 msgid "A session already exists at this time"
 msgstr "Zu dieser Zeit existiert bereits eine Sitzung"
@@ -3695,7 +3698,7 @@ msgstr "Zu dieser Zeit existiert bereits eine Sitzung"
 msgid "Account created! Check your email to confirm and log in."
 msgstr "Konto erstellt! Überprüfen Sie Ihre E-Mails, um zu bestätigen und sich anzumelden."
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:160
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:183
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:160
 #, elixir-autogen, elixir-format
 msgid "Add Note"
@@ -3757,7 +3760,7 @@ msgstr "Zurück zu E-Mails"
 msgid "Broadcast messages are one-way"
 msgstr "Broadcast-Nachrichten sind einseitig"
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:128
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:151
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "Check In"
@@ -3804,7 +3807,7 @@ msgid "Complete Registration"
 msgstr "Registrierung abschließen"
 
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:33
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:76
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:66
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:33
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:282
 #, elixir-autogen, elixir-format
@@ -3846,20 +3849,19 @@ msgstr "Inhalt wird abgerufen..."
 msgid "Could not start private conversation"
 msgstr "Private Unterhaltung konnte nicht gestartet werden"
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:18
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:154
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:219
+#: lib/klass_hero_web/components/provider_components.ex:1927
+#: lib/klass_hero_web/components/provider_components.ex:1988
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "Create Session"
 msgstr "Sitzung erstellen"
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:181
+#: lib/klass_hero_web/components/provider_components.ex:1877
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr "Datum"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:566
-#: lib/klass_hero_web/live/provider/sessions_live.ex:567
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:156
 #, elixir-autogen, elixir-format
 msgid "Date is required"
 msgstr "Datum ist erforderlich"
@@ -3869,7 +3871,7 @@ msgstr "Datum ist erforderlich"
 msgid "E.g., picked up by parent, gave medication reminder..."
 msgstr "Z.B. von Eltern abgeholt, Medikamentenerinnerung gegeben..."
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:189
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:212
 #, elixir-autogen, elixir-format
 msgid "Edit & Resubmit"
 msgstr "Bearbeiten & erneut einreichen"
@@ -3902,7 +3904,7 @@ msgstr "E-Mails"
 msgid "Emergency: %{details}"
 msgstr "Notfall: %{details}"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:589
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:160
 #, elixir-autogen, elixir-format
 msgid "End time must be after start time"
 msgstr "Die Endzeit muss nach der Startzeit liegen"
@@ -3917,7 +3919,7 @@ msgstr "Erwartet"
 msgid "Failed to archive email"
 msgstr "E-Mail konnte nicht archiviert werden"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:526
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:169
 #, elixir-autogen, elixir-format
 msgid "Failed to create session: %{reason}"
 msgstr "Sitzung konnte nicht erstellt werden: %{reason}"
@@ -3973,8 +3975,8 @@ msgstr "Ein: %{time}"
 msgid "Invalid Invitation"
 msgstr "Ungültige Einladung"
 
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:159
 #: lib/klass_hero_web/live/admin/sessions_live.ex:255
-#: lib/klass_hero_web/live/provider/sessions_live.ex:585
 #, elixir-autogen, elixir-format
 msgid "Invalid time format"
 msgstr "Ungültiges Zeitformat"
@@ -4020,7 +4022,7 @@ msgstr "Bilder laden"
 msgid "Location TBD"
 msgstr "Ort noch offen"
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:6
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Manage your scheduled sessions and attendance"
 msgstr "Verwalten Sie Ihre geplanten Sitzungen und die Anwesenheit"
@@ -4030,12 +4032,12 @@ msgstr "Verwalten Sie Ihre geplanten Sitzungen und die Anwesenheit"
 msgid "Mark Unread"
 msgstr "Als ungelesen markieren"
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:200
+#: lib/klass_hero_web/components/provider_components.ex:1907
 #, elixir-autogen, elixir-format
 msgid "Max Capacity"
 msgstr "Maximale Kapazität"
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:90
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:80
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "No actions available"
@@ -4071,7 +4073,7 @@ msgstr "Keine Ergebnisse"
 msgid "No sessions found for the selected filters."
 msgstr "Keine Sitzungen für die ausgewählten Filter gefunden."
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:122
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:112
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled"
@@ -4092,7 +4094,7 @@ msgstr "Beobachtung zur Teilnahme des Kindes..."
 msgid "Out: %{time}"
 msgstr "Aus: %{time}"
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:41
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:64
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Participation Management"
@@ -4108,23 +4110,24 @@ msgstr "Ausstehende Überprüfungen"
 msgid "Please explain why you're rejecting this note..."
 msgstr "Bitte erklären Sie, warum Sie diese Notiz ablehnen..."
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:592
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:163
 #, elixir-autogen, elixir-format
 msgid "Please fill in all required fields"
 msgstr "Bitte füllen Sie alle erforderlichen Felder aus"
 
-#: lib/klass_hero_web/components/provider_components.ex:2737
+#: lib/klass_hero_web/components/provider_components.ex:1858
+#: lib/klass_hero_web/components/provider_components.ex:1867
+#: lib/klass_hero_web/components/provider_components.ex:2917
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:24
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:299
-#: lib/klass_hero_web/live/provider/programs_live.ex:226
-#: lib/klass_hero_web/live/provider/sessions_live.ex:388
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:175
+#: lib/klass_hero_web/live/provider/programs_live.ex:227
+#: lib/klass_hero_web/live/provider/sessions_live.ex:384
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr "Programm"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:186
+#: lib/klass_hero_web/live/provider/sessions_live.ex:183
 #, elixir-autogen, elixir-format
 msgid "Program is required"
 msgstr "Programm ist erforderlich"
@@ -4198,7 +4201,7 @@ msgstr "Erneut versuchen"
 msgid "Revised Note"
 msgstr "Überarbeitete Notiz"
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:176
+#: lib/klass_hero_web/components/provider_components.ex:1868
 #, elixir-autogen, elixir-format
 msgid "Select a program..."
 msgstr "Programm auswählen..."
@@ -4215,7 +4218,8 @@ msgstr "Wird gesendet"
 
 #: lib/klass_hero_web/components/participation_components.ex:71
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:16
-#: lib/klass_hero_web/live/provider/sessions_live.ex:415
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:55
+#: lib/klass_hero_web/live/provider/sessions_live.ex:411
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:16
 #, elixir-autogen, elixir-format
 msgid "Session"
@@ -4226,7 +4230,8 @@ msgstr "Sitzung"
 msgid "Session Roster"
 msgstr "Teilnehmerliste"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:508
+#: lib/klass_hero_web/live/provider/programs_live.ex:286
+#: lib/klass_hero_web/live/provider/sessions_live.ex:462
 #, elixir-autogen, elixir-format
 msgid "Session created successfully"
 msgstr "Sitzung erfolgreich erstellt"
@@ -4236,7 +4241,7 @@ msgstr "Sitzung erfolgreich erstellt"
 msgid "Staff Dashboard"
 msgstr "Mitarbeiter-Dashboard"
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:54
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:44
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "Start Session"
@@ -4272,8 +4277,7 @@ msgstr "Diese Einladung wurde bereits verwendet."
 msgid "This invite link is invalid or has expired."
 msgstr "Dieser Einladungslink ist ungültig oder abgelaufen."
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:576
-#: lib/klass_hero_web/live/provider/sessions_live.ex:577
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:158
 #, elixir-autogen, elixir-format
 msgid "Time is required"
 msgstr "Uhrzeit ist erforderlich"
@@ -4289,7 +4293,7 @@ msgid "Type your reply..."
 msgstr "Ihre Antwort eingeben..."
 
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:227
-#: lib/klass_hero_web/live/provider/sessions_live.ex:190
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:162
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:126
 #, elixir-autogen, elixir-format
 msgid "Unauthorized"
@@ -4308,7 +4312,7 @@ msgid "Update your observation..."
 msgstr "Aktualisieren Sie Ihre Beobachtung..."
 
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:166
-#: lib/klass_hero_web/live/provider/programs_live.ex:503
+#: lib/klass_hero_web/live/provider/programs_live.ex:563
 #: lib/klass_hero_web/live/provider/verification_live.ex:247
 #: lib/klass_hero_web/live/provider/verification_live.ex:564
 #: lib/klass_hero_web/live/provider/verification_live.ex:602
@@ -4316,7 +4320,7 @@ msgstr "Aktualisieren Sie Ihre Beobachtung..."
 msgid "Upload connection lost. Please try again."
 msgstr "Upload-Verbindung unterbrochen. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:87
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:77
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:293
 #, elixir-autogen, elixir-format
 msgid "View Participation"
@@ -4337,7 +4341,7 @@ msgstr "Willkommen, %{name}"
 msgid "You already have an account. Log in to see your new enrollment."
 msgstr "Sie haben bereits ein Konto. Melden Sie sich an, um Ihre neue Anmeldung zu sehen."
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:125
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:115
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:314
 #, elixir-autogen, elixir-format
 msgid "You have no sessions scheduled for %{date}"
@@ -4381,7 +4385,7 @@ msgstr "Ihre zugewiesenen Sitzungen anzeigen und verwalten"
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:52
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:86
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:120
-#: lib/klass_hero_web/live/provider/participation_live.ex:304
+#: lib/klass_hero_web/live/provider/participation_live.ex:354
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:53
 #, elixir-autogen, elixir-format
 msgid "You are not assigned to this program"
@@ -4552,36 +4556,36 @@ msgstr "Ihr Profil ist bereits vollständig."
 msgid "for"
 msgstr "für"
 
-#: lib/klass_hero_web/components/provider_components.ex:1861
+#: lib/klass_hero_web/components/provider_components.ex:2016
 #, elixir-autogen, elixir-format
 msgid "Assigned staff"
 msgstr "Zugewiesenes Personal"
 
-#: lib/klass_hero_web/components/provider_components.ex:1862
+#: lib/klass_hero_web/components/provider_components.ex:2017
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr "Anwesenheit"
 
-#: lib/klass_hero_web/components/provider_components.ex:1845
-#: lib/klass_hero_web/components/provider_components.ex:1930
-#: lib/klass_hero_web/components/provider_components.ex:2078
-#: lib/klass_hero_web/components/provider_components.ex:2227
+#: lib/klass_hero_web/components/provider_components.ex:1990
+#: lib/klass_hero_web/components/provider_components.ex:2110
+#: lib/klass_hero_web/components/provider_components.ex:2258
+#: lib/klass_hero_web/components/provider_components.ex:2407
 #: lib/klass_hero_web/live/provider/overview_live.ex:403
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr "Schließen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1860
+#: lib/klass_hero_web/components/provider_components.ex:2015
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr "Datum / Uhrzeit"
 
-#: lib/klass_hero_web/components/provider_components.ex:1854
+#: lib/klass_hero_web/components/provider_components.ex:2009
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled yet."
 msgstr "Noch keine Sessions geplant."
 
-#: lib/klass_hero_web/components/provider_components.ex:1843
+#: lib/klass_hero_web/components/provider_components.ex:1972
 #, elixir-autogen, elixir-format
 msgid "Sessions — %{title}"
 msgstr "Sessions — %{title}"
@@ -4591,7 +4595,7 @@ msgstr "Sessions — %{title}"
 msgid "View sessions"
 msgstr "Sessions anzeigen"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:594
+#: lib/klass_hero_web/live/provider/programs_live.ex:654
 #, elixir-autogen, elixir-format
 msgid "Create a program before inviting participants."
 msgstr "Erstellen Sie zuerst ein Programm, bevor Sie Teilnehmer einladen."
@@ -4606,34 +4610,34 @@ msgstr "Abgereist"
 msgid "Departure notes"
 msgstr "Notizen zur Abreise"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:248
+#: lib/klass_hero_web/live/provider/participation_live.ex:298
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:188
 #, elixir-autogen, elixir-format
 msgid "Departure time is not a valid date and time"
 msgstr "Abreisezeit ist kein gültiges Datum oder keine gültige Uhrzeit"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:259
+#: lib/klass_hero_web/live/provider/participation_live.ex:309
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:199
 #, elixir-autogen, elixir-format
 msgid "Failed to update record"
 msgstr "Aktualisieren des Datensatzes fehlgeschlagen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2895
+#: lib/klass_hero_web/components/provider_components.ex:3075
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr "Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:2568
+#: lib/klass_hero_web/components/provider_components.ex:2748
 #, elixir-autogen, elixir-format
 msgid "Invite mode"
 msgstr "Einladungsmodus"
 
-#: lib/klass_hero_web/components/provider_components.ex:2587
+#: lib/klass_hero_web/components/provider_components.ex:2767
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr "Einzelperson einladen"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:590
+#: lib/klass_hero_web/live/provider/programs_live.ex:650
 #, elixir-autogen, elixir-format
 msgid "Invite sent."
 msgstr "Einladung verschickt."
@@ -4643,33 +4647,33 @@ msgstr "Einladung verschickt."
 msgid "Leave blank to keep this child marked as present."
 msgstr "Leer lassen, um dieses Kind als anwesend markiert zu lassen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2908
+#: lib/klass_hero_web/components/provider_components.ex:3088
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr "Gesundheit & Einwilligungen (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2914
+#: lib/klass_hero_web/components/provider_components.ex:3094
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr "Gesundheitliche Besonderheiten"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:251
+#: lib/klass_hero_web/live/provider/participation_live.ex:301
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:191
 #, elixir-autogen, elixir-format
 msgid "Nothing to update"
 msgstr "Nichts zu aktualisieren"
 
-#: lib/klass_hero_web/components/provider_components.ex:2916
+#: lib/klass_hero_web/components/provider_components.ex:3096
 #, elixir-autogen, elixir-format
 msgid "Nut allergy"
 msgstr "Nussallergie"
 
-#: lib/klass_hero_web/components/provider_components.ex:2920
+#: lib/klass_hero_web/components/provider_components.ex:3100
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr "Fotos dürfen in Marketingmaterialien verwendet werden"
 
-#: lib/klass_hero_web/components/provider_components.ex:2925
+#: lib/klass_hero_web/components/provider_components.ex:3105
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr "Fotos dürfen in sozialen Medien erscheinen"
@@ -4679,12 +4683,12 @@ msgstr "Fotos dürfen in sozialen Medien erscheinen"
 msgid "Present"
 msgstr "Anwesend"
 
-#: lib/klass_hero_web/components/provider_components.ex:2852
+#: lib/klass_hero_web/components/provider_components.ex:3032
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr "Hauptansprechpartner"
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:77
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:100
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:77
 #, elixir-autogen, elixir-format
 msgid "Record departure"
@@ -4695,7 +4699,7 @@ msgstr "Abreise erfassen"
 msgid "Record departure time (optional)"
 msgstr "Abreisezeit erfassen (optional)"
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:239
+#: lib/klass_hero_web/live/provider/participation_live.ex:289
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "Record updated"
@@ -4706,22 +4710,22 @@ msgstr "Datensatz aktualisiert"
 msgid "Save changes"
 msgstr "Änderungen speichern"
 
-#: lib/klass_hero_web/components/provider_components.ex:2889
+#: lib/klass_hero_web/components/provider_components.ex:3069
 #, elixir-autogen, elixir-format
 msgid "School (optional)"
 msgstr "Schule (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2899
+#: lib/klass_hero_web/components/provider_components.ex:3079
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr "Schulname"
 
-#: lib/klass_hero_web/components/provider_components.ex:2873
+#: lib/klass_hero_web/components/provider_components.ex:3053
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr "Zweiter Ansprechpartner (optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2942
+#: lib/klass_hero_web/components/provider_components.ex:3122
 #, elixir-autogen, elixir-format
 msgid "Send invite"
 msgstr "Einladung senden"
@@ -4731,12 +4735,12 @@ msgstr "Einladung senden"
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr "Aktualisieren Sie die Notiz für dieses Kind (z. B. um zu klären, was passiert ist)"
 
-#: lib/klass_hero_web/components/provider_components.ex:2605
+#: lib/klass_hero_web/components/provider_components.ex:2785
 #, elixir-autogen, elixir-format
 msgid "Upload a list"
 msgstr "Liste hochladen"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:601
+#: lib/klass_hero_web/live/provider/programs_live.ex:661
 #, elixir-autogen, elixir-format
 msgid "An invite for this child and program already exists."
 msgstr "Für dieses Kind und Programm existiert bereits eine Einladung."
@@ -4913,7 +4917,7 @@ msgstr "Ihre Woche mit den Kindern"
 msgid "Go to dashboard"
 msgstr "Zum Dashboard"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:546
+#: lib/klass_hero_web/live/provider/programs_live.ex:606
 #, elixir-autogen, elixir-format
 msgid "%{count} row could not be processed."
 msgid_plural "%{count} rows could not be processed."
@@ -5486,8 +5490,8 @@ msgstr "Wie wir Anbieter überprüfen"
 msgid "I'll be teaching"
 msgstr "Ich werde unterrichten"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:521
-#: lib/klass_hero_web/live/provider/programs_live.ex:543
+#: lib/klass_hero_web/live/provider/programs_live.ex:581
+#: lib/klass_hero_web/live/provider/programs_live.ex:603
 #, elixir-autogen, elixir-format
 msgid "Imported %{count} family."
 msgid_plural "Imported %{count} families."
@@ -5678,7 +5682,7 @@ msgstr "Verpflichtender Kinderschutzkurs vor der Freischaltung."
 
 #: lib/klass_hero_web/components/participation_components.ex:536
 #: lib/klass_hero_web/components/provider_layout_components.ex:578
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:141
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:164
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:141
 #, elixir-autogen, elixir-format
 msgid "Mark absent"
@@ -5769,7 +5773,7 @@ msgstr "Noch keine Programme — fügen Sie Ihr erstes über den Tab „Programm
 msgid "No registered children for this session."
 msgstr "Keine Kinder in dieser Sitzung angemeldet."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:530
+#: lib/klass_hero_web/live/provider/programs_live.ex:590
 #, elixir-autogen, elixir-format
 msgid "No rows imported. %{count} row could not be processed."
 msgid_plural "No rows imported. %{count} rows could not be processed."
@@ -6008,17 +6012,17 @@ msgstr "Umsatz (diese Woche)"
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr "Strenge Überprüfung, damit Familien immer wissen, wer die Gruppe leitet."
 
-#: lib/klass_hero_web/components/provider_components.ex:2990
+#: lib/klass_hero_web/components/provider_components.ex:3170
 #, elixir-autogen, elixir-format
 msgid "Row %{row}"
 msgstr "Zeile %{row}"
 
-#: lib/klass_hero_web/components/provider_components.ex:2990
+#: lib/klass_hero_web/components/provider_components.ex:3170
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr "Zeile —"
 
-#: lib/klass_hero_web/components/provider_components.ex:2682
+#: lib/klass_hero_web/components/provider_components.ex:2862
 #, elixir-autogen, elixir-format
 msgid "Rows with errors"
 msgstr "Zeilen mit Fehlern"
@@ -6748,12 +6752,12 @@ msgstr "Deine Identität ist verifiziert."
 msgid "Experience validation"
 msgstr "Erfahrungsnachweis"
 
-#: lib/klass_hero_web/components/provider_components.ex:3498
+#: lib/klass_hero_web/components/provider_components.ex:3678
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr "MP4, MOV oder WEBM. Max. 100 MB."
 
-#: lib/klass_hero_web/components/provider_components.ex:3471
+#: lib/klass_hero_web/components/provider_components.ex:3651
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr "Nimm ein kurzes Video auf, in dem du dich vorstellst. Unser Team prüft es, um Kommunikationsfähigkeit und Übereinstimmung mit unseren Werten einzuschätzen."
@@ -6763,12 +6767,12 @@ msgstr "Nimm ein kurzes Video auf, in dem du dich vorstellst. Unser Team prüft 
 msgid "Safeguarding certificate"
 msgstr "Kinderschutz-Zertifikat"
 
-#: lib/klass_hero_web/components/provider_components.ex:3495
+#: lib/klass_hero_web/components/provider_components.ex:3675
 #, elixir-autogen, elixir-format
 msgid "Select Video"
 msgstr "Video auswählen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3541
+#: lib/klass_hero_web/components/provider_components.ex:3721
 #, elixir-autogen, elixir-format
 msgid "Upload Video"
 msgstr "Video hochladen"
@@ -6778,7 +6782,7 @@ msgstr "Video hochladen"
 msgid "Your browser does not support video playback."
 msgstr "Dein Browser unterstützt keine Videowiedergabe."
 
-#: lib/klass_hero_web/components/provider_components.ex:3694
+#: lib/klass_hero_web/components/provider_components.ex:3874
 #, elixir-autogen, elixir-format
 msgid "Confirm agreement"
 msgstr "Zustimmung bestätigen"
@@ -6788,12 +6792,12 @@ msgstr "Zustimmung bestätigen"
 msgid "Couldn't record your agreement. Please try again."
 msgstr "Deine Zustimmung konnte nicht gespeichert werden. Bitte versuche es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:3717
+#: lib/klass_hero_web/components/provider_components.ex:3897
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr "Vereinbarung herunterladen (PDF)"
 
-#: lib/klass_hero_web/components/provider_components.ex:3693
+#: lib/klass_hero_web/components/provider_components.ex:3873
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr "Ich habe die Klass Hero Community-Richtlinien gelesen und stimme ihnen zu."
@@ -6803,7 +6807,7 @@ msgstr "Ich habe die Klass Hero Community-Richtlinien gelesen und stimme ihnen z
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr "Bitte bestätige, dass du die Community-Richtlinien gelesen hast und ihnen zustimmst."
 
-#: lib/klass_hero_web/components/provider_components.ex:3596
+#: lib/klass_hero_web/components/provider_components.ex:3776
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr "Unterzeichnet von %{name} am %{date} (v%{version})."
@@ -6813,17 +6817,17 @@ msgstr "Unterzeichnet von %{name} am %{date} (v%{version})."
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr "Danke – deine Zustimmung zu den Community-Richtlinien wurde gespeichert."
 
-#: lib/klass_hero_web/components/provider_components.ex:3702
+#: lib/klass_hero_web/components/provider_components.ex:3882
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr "Die Community-Richtlinien wurden seit deiner letzten Zustimmung aktualisiert (v%{old}). Bitte lies sie erneut und stimme erneut zu."
 
-#: lib/klass_hero_web/components/provider_components.ex:3691
+#: lib/klass_hero_web/components/provider_components.ex:3871
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr "Der letzte Schritt: Lies die Klass Hero Community-Richtlinien und stimme ihnen zu."
 
-#: lib/klass_hero_web/components/provider_components.ex:3692
+#: lib/klass_hero_web/components/provider_components.ex:3872
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr "Du hast den Community-Richtlinien zugestimmt."
@@ -7092,12 +7096,12 @@ msgstr "Ihre Versicherungsbescheinigung wird geprüft."
 msgid "Your insurance is verified."
 msgstr "Ihre Versicherung ist verifiziert."
 
-#: lib/klass_hero_web/components/provider_components.ex:3640
+#: lib/klass_hero_web/components/provider_components.ex:3820
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr "Unterzeichnung durch %{name} im Namen des Unternehmens."
 
-#: lib/klass_hero_web/components/provider_components.ex:3749
+#: lib/klass_hero_web/components/provider_components.ex:3929
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr "Bestätige im Namen deines Unternehmens, dass alle Mitarbeitenden gemäß dem deutschen Kinderschutzrecht überprüft sind."
@@ -7107,7 +7111,7 @@ msgstr "Bestätige im Namen deines Unternehmens, dass alle Mitarbeitenden gemä�
 msgid "Couldn't record your declaration. Please try again."
 msgstr "Deine Erklärung konnte nicht gespeichert werden. Bitte versuche es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:3755
+#: lib/klass_hero_web/components/provider_components.ex:3935
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr "Ich bestätige im Namen des Unternehmens, dass die obige Erklärung zutrifft und ich zu ihrer Unterzeichnung berechtigt bin."
@@ -7117,17 +7121,17 @@ msgstr "Ich bestätige im Namen des Unternehmens, dass die obige Erklärung zutr
 msgid "Please confirm the declaration before signing."
 msgstr "Bitte bestätige die Erklärung vor der Unterzeichnung."
 
-#: lib/klass_hero_web/components/provider_components.ex:3780
+#: lib/klass_hero_web/components/provider_components.ex:3960
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr "Vorläufiger Text — vor der Freischaltung noch von einer in Deutschland zugelassenen Anwältin bzw. einem Anwalt zu prüfen."
 
-#: lib/klass_hero_web/components/provider_components.ex:3759
+#: lib/klass_hero_web/components/provider_components.ex:3939
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr "Erklärung unterzeichnen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3747
+#: lib/klass_hero_web/components/provider_components.ex:3927
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr "Erklärung zur Mitarbeiter-Compliance"
@@ -7137,12 +7141,12 @@ msgstr "Erklärung zur Mitarbeiter-Compliance"
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr "Danke — deine Erklärung zur Mitarbeiter-Compliance wurde erfasst."
 
-#: lib/klass_hero_web/components/provider_components.ex:3767
+#: lib/klass_hero_web/components/provider_components.ex:3947
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr "Die Erklärung zur Mitarbeiter-Compliance wurde seit deiner letzten Unterzeichnung aktualisiert (v%{old}). Bitte prüfe sie und unterzeichne erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:3753
+#: lib/klass_hero_web/components/provider_components.ex:3933
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr "Du hast die Erklärung zur Mitarbeiter-Compliance unterzeichnet."
@@ -7209,25 +7213,25 @@ msgstr "In Prüfung"
 msgid "Undelivered Events"
 msgstr "Nicht zugestellte Ereignisse"
 
-#: lib/klass_hero_web/components/provider_components.ex:2172
-#: lib/klass_hero_web/components/provider_components.ex:2350
+#: lib/klass_hero_web/components/provider_components.ex:2352
+#: lib/klass_hero_web/components/provider_components.ex:2530
 #: lib/klass_hero_web/live/user_live/settings.ex:292
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2100
-#: lib/klass_hero_web/components/provider_components.ex:2281
+#: lib/klass_hero_web/components/provider_components.ex:2280
+#: lib/klass_hero_web/components/provider_components.ex:2461
 #, elixir-autogen, elixir-format
 msgid "Lead"
 msgstr "Leitung"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:432
+#: lib/klass_hero_web/live/provider/programs_live.ex:492
 #, elixir-autogen, elixir-format
 msgid "Lead instructor updated."
 msgstr "Leitender Kursleiter aktualisiert."
 
-#: lib/klass_hero_web/components/provider_components.ex:2112
+#: lib/klass_hero_web/components/provider_components.ex:2292
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor"
 msgstr "Als leitenden Kursleiter festlegen"
@@ -7237,67 +7241,67 @@ msgstr "Als leitenden Kursleiter festlegen"
 msgid "Manage Staffing"
 msgstr "Programmteam verwalten"
 
-#: lib/klass_hero_web/components/provider_components.ex:2141
+#: lib/klass_hero_web/components/provider_components.ex:2321
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this program yet."
 msgstr "Diesem Programm ist noch niemand zugewiesen."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:362
-#: lib/klass_hero_web/live/provider/sessions_live.ex:220
+#: lib/klass_hero_web/live/provider/programs_live.ex:422
+#: lib/klass_hero_web/live/provider/sessions_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "Pick a staff member to add."
 msgstr "Bitte ein Teammitglied zum Hinzufügen auswählen."
 
-#: lib/klass_hero_web/components/provider_components.ex:2124
-#: lib/klass_hero_web/components/provider_components.ex:2389
+#: lib/klass_hero_web/components/provider_components.ex:2304
+#: lib/klass_hero_web/components/provider_components.ex:2569
 #, elixir-autogen, elixir-format
 msgid "Reassign the lead before removing them"
 msgstr "Vor dem Entfernen einen anderen leitenden Kursleiter festlegen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2125
+#: lib/klass_hero_web/components/provider_components.ex:2305
 #, elixir-autogen, elixir-format
 msgid "Remove from program"
 msgstr "Aus dem Programm entfernen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2160
-#: lib/klass_hero_web/components/provider_components.ex:2337
+#: lib/klass_hero_web/components/provider_components.ex:2340
+#: lib/klass_hero_web/components/provider_components.ex:2517
 #, elixir-autogen, elixir-format
 msgid "Select a staff member…"
 msgstr "Teammitglied auswählen …"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:377
+#: lib/klass_hero_web/live/provider/programs_live.ex:437
 #, elixir-autogen, elixir-format
 msgid "Staff member added to the program."
 msgstr "Teammitglied zum Programm hinzugefügt."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:403
+#: lib/klass_hero_web/live/provider/programs_live.ex:463
 #, elixir-autogen, elixir-format
 msgid "Staff member removed from the program."
 msgstr "Teammitglied aus dem Programm entfernt."
 
-#: lib/klass_hero_web/components/provider_components.ex:2177
+#: lib/klass_hero_web/components/provider_components.ex:2357
 #, elixir-autogen, elixir-format
 msgid "Staff you add can read and reply to this program's parent conversations."
 msgstr ""
 "Hinzugefügte Teammitglieder können die Elterngespräche dieses Programms lesen "
 "und beantworten."
 
-#: lib/klass_hero_web/components/provider_components.ex:2076
+#: lib/klass_hero_web/components/provider_components.ex:2256
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{title}"
 msgstr "Programmteam — %{title}"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1055
+#: lib/klass_hero_web/live/provider/programs_live.ex:1134
 #, elixir-autogen, elixir-format
 msgid "That staff member could not be found."
 msgstr "Dieses Teammitglied wurde nicht gefunden."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:385
+#: lib/klass_hero_web/live/provider/programs_live.ex:445
 #, elixir-autogen, elixir-format
 msgid "They are already on this program."
 msgstr "Diese Person ist bereits in diesem Programm."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:411
+#: lib/klass_hero_web/live/provider/programs_live.ex:471
 #, elixir-autogen, elixir-format
 msgid "This person is the lead instructor. Make someone else lead before removing them."
 msgstr ""
@@ -7361,21 +7365,21 @@ msgstr "Damit wird %{name} endgültig gelöscht – das lässt sich nicht rückg
 msgid "This person has a history here now — use 'Remove from team' instead."
 msgstr "Diese Person hat inzwischen eine Historie – nutze stattdessen „Aus dem Team entfernen“."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1333
+#: lib/klass_hero_web/live/provider/programs_live.ex:1412
 #, elixir-autogen, elixir-format
 msgid "Program created, but some settings could not be saved. Please review the program's limits."
 msgstr ""
 "Programm erstellt, aber einige Einstellungen konnten nicht gespeichert werden. "
 "Bitte überprüfen Sie die Grenzwerte des Programms."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1337
+#: lib/klass_hero_web/live/provider/programs_live.ex:1416
 #, elixir-autogen, elixir-format
 msgid "Program updated, but some settings could not be saved. Please review the program's limits."
 msgstr ""
 "Programm aktualisiert, aber einige Einstellungen konnten nicht gespeichert "
 "werden. Bitte überprüfen Sie die Grenzwerte des Programms."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1327
+#: lib/klass_hero_web/live/provider/programs_live.ex:1406
 #, elixir-autogen, elixir-format
 msgid "Program updated, but the enrollment capacity was rejected. The previous limits still apply."
 msgstr ""
@@ -7404,92 +7408,93 @@ msgstr ""
 msgid "I understand this program will have no capacity limit."
 msgstr "Ich verstehe, dass dieses Programm keine Teilnehmerbegrenzung haben wird."
 
-#: lib/klass_hero_web/components/provider_components.ex:2377
+#: lib/klass_hero_web/components/provider_components.ex:2557
 #, elixir-autogen, elixir-format
 msgid "Go back to the program's usual team"
 msgstr "Zurück zum üblichen Programmteam"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:302
+#: lib/klass_hero_web/live/provider/sessions_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "Lead instructor for this session updated."
 msgstr "Leitung für diesen Termin aktualisiert."
 
-#: lib/klass_hero_web/components/provider_components.ex:2296
+#: lib/klass_hero_web/components/provider_components.ex:2476
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor for this session"
 msgstr "Als Leitung für diesen Termin festlegen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2318
+#: lib/klass_hero_web/components/provider_components.ex:2498
 #, elixir-autogen, elixir-format
 msgid "Nobody is working this session yet."
 msgstr "Für diesen Termin ist noch niemand eingeteilt."
 
-#: lib/klass_hero_web/components/provider_components.ex:2394
+#: lib/klass_hero_web/components/provider_components.ex:2574
 #, elixir-autogen, elixir-format
 msgid "Remove from this session"
 msgstr "Von diesem Termin entfernen"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:238
+#: lib/klass_hero_web/live/provider/sessions_live.ex:235
 #, elixir-autogen, elixir-format
 msgid "Staff member added to this session."
 msgstr "Teammitglied zu diesem Termin hinzugefügt."
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:262
+#: lib/klass_hero_web/live/provider/sessions_live.ex:259
 #, elixir-autogen, elixir-format
 msgid "Staff member removed from this session."
 msgstr "Teammitglied von diesem Termin entfernt."
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:107
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Staffing"
 msgstr "Team"
 
-#: lib/klass_hero_web/components/provider_components.ex:2220
+#: lib/klass_hero_web/components/provider_components.ex:2400
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{date}"
 msgstr "Team — %{date}"
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:431
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:164
+#: lib/klass_hero_web/live/provider/sessions_live.ex:427
 #, elixir-autogen, elixir-format
 msgid "That session could not be found."
 msgstr "Dieser Termin konnte nicht gefunden werden."
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:246
+#: lib/klass_hero_web/live/provider/sessions_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "They are already working this session."
 msgstr "Diese Person ist bereits für diesen Termin eingeteilt."
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:270
+#: lib/klass_hero_web/live/provider/sessions_live.ex:267
 #, elixir-autogen, elixir-format
 msgid "This person leads the session. Make someone else lead before removing them."
 msgstr "Diese Person leitet den Termin. Bitte zuerst eine andere Person als Leitung festlegen."
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:318
+#: lib/klass_hero_web/live/provider/sessions_live.ex:315
 #, elixir-autogen, elixir-format
 msgid "This session is back on the program's usual team."
 msgstr "Dieser Termin nutzt wieder das übliche Programmteam."
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:281
+#: lib/klass_hero_web/live/provider/sessions_live.ex:278
 #, elixir-autogen, elixir-format
 msgid "A session needs at least one person. Use “Go back to the program's usual team” to drop this session's own roster."
 msgstr "Ein Termin braucht mindestens eine Person. Nutze „Zurück zum üblichen Programmteam“, um die eigene Besetzung dieses Termins aufzuheben."
 
-#: lib/klass_hero_web/components/provider_components.ex:2392
+#: lib/klass_hero_web/components/provider_components.ex:2572
 #, elixir-autogen, elixir-format
 msgid "A session needs someone — use “Go back to the program's usual team” instead"
 msgstr "Ein Termin braucht jemanden — nutze stattdessen „Zurück zum üblichen Programmteam“"
 
-#: lib/klass_hero_web/components/provider_components.ex:2359
+#: lib/klass_hero_web/components/provider_components.ex:2539
 #, elixir-autogen, elixir-format
 msgid "Everyone on your team is already working this session."
 msgstr "Alle aus deinem Team arbeiten bereits bei diesem Termin."
 
-#: lib/klass_hero_web/components/provider_components.ex:2252
+#: lib/klass_hero_web/components/provider_components.ex:2432
 #, elixir-autogen, elixir-format
 msgid "Staffed just for this session. Changes here do not touch the program."
 msgstr "Nur für diesen Termin eingeteilt. Änderungen hier wirken sich nicht auf das Programm aus."
 
-#: lib/klass_hero_web/components/provider_components.ex:2254
+#: lib/klass_hero_web/components/provider_components.ex:2434
 #, elixir-autogen, elixir-format
 msgid "Using the program's usual team. The first change here copies them onto this session, so later program changes stop reaching it."
 msgstr "Es gilt das übliche Programmteam. Die erste Änderung hier übernimmt das Team in diesen Termin — spätere Änderungen am Programm greifen dann nicht mehr."
@@ -7499,17 +7504,17 @@ msgstr "Es gilt das übliche Programmteam. Die erste Änderung hier übernimmt d
 msgid "(optional)"
 msgstr "(optional)"
 
-#: lib/klass_hero_web/components/provider_components.ex:1995
+#: lib/klass_hero_web/components/provider_components.ex:2175
 #, elixir-autogen, elixir-format
 msgid "Add a waiver"
 msgstr "Verzichtserklärung hinzufügen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2027
+#: lib/klass_hero_web/components/provider_components.ex:2207
 #, elixir-autogen, elixir-format
 msgid "Add waiver"
 msgstr "Hinzufügen"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:927
+#: lib/klass_hero_web/live/provider/programs_live.ex:987
 #, elixir-autogen, elixir-format
 msgid "Check the waiver details and try again."
 msgstr "Bitte prüfe die Angaben zur Verzichtserklärung und versuche es erneut."
@@ -7526,7 +7531,7 @@ msgstr "Anmeldung nicht gefunden."
 msgid "I have read and agree to %{title}"
 msgstr "Ich habe %{title} gelesen und stimme zu"
 
-#: lib/klass_hero_web/components/provider_components.ex:2009
+#: lib/klass_hero_web/components/provider_components.ex:2189
 #, elixir-autogen, elixir-format
 msgid "Legal text"
 msgstr "Rechtstext"
@@ -7536,12 +7541,12 @@ msgstr "Rechtstext"
 msgid "Manage Waivers"
 msgstr "Verzichtserklärungen verwalten"
 
-#: lib/klass_hero_web/components/provider_components.ex:1937
+#: lib/klass_hero_web/components/provider_components.ex:2117
 #, elixir-autogen, elixir-format
 msgid "No waivers yet. Parents enrol without signing anything."
 msgstr "Noch keine Verzichtserklärungen. Eltern melden sich ohne Unterschrift an."
 
-#: lib/klass_hero_web/components/provider_components.ex:2016
+#: lib/klass_hero_web/components/provider_components.ex:2196
 #, elixir-autogen, elixir-format
 msgid "Parents must sign this before enrolling"
 msgstr "Eltern müssen dies vor der Anmeldung unterschreiben"
@@ -7561,17 +7566,17 @@ msgstr "Bitte lies und unterschreibe diese, bevor %{program} beginnt."
 msgid "Please tick a waiver to sign it."
 msgstr "Bitte wähle eine Verzichtserklärung aus, um sie zu unterschreiben."
 
-#: lib/klass_hero_web/components/provider_components.ex:1994
+#: lib/klass_hero_web/components/provider_components.ex:2174
 #, elixir-autogen, elixir-format
 msgid "Publish a new version"
 msgstr "Neue Version veröffentlichen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2027
+#: lib/klass_hero_web/components/provider_components.ex:2207
 #, elixir-autogen, elixir-format
 msgid "Publish version"
 msgstr "Version veröffentlichen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2020
+#: lib/klass_hero_web/components/provider_components.ex:2200
 #, elixir-autogen, elixir-format
 msgid "Publishing keeps every earlier version on record; signatures already given stay bound to the wording they were shown."
 msgstr "Beim Veröffentlichen bleibt jede frühere Version erhalten; bereits geleistete Unterschriften bleiben an den damals gezeigten Wortlaut gebunden."
@@ -7581,12 +7586,12 @@ msgstr "Beim Veröffentlichen bleibt jede frühere Version erhalten; bereits gel
 msgid "Required"
 msgstr "Erforderlich"
 
-#: lib/klass_hero_web/components/provider_components.ex:1971
+#: lib/klass_hero_web/components/provider_components.ex:2151
 #, elixir-autogen, elixir-format
 msgid "Retire this waiver"
 msgstr "Diese Verzichtserklärung zurückziehen"
 
-#: lib/klass_hero_web/components/provider_components.ex:1962
+#: lib/klass_hero_web/components/provider_components.ex:2142
 #, elixir-autogen, elixir-format
 msgid "Revise text"
 msgstr "Text überarbeiten"
@@ -7601,7 +7606,7 @@ msgstr "Verzichtserklärungen für %{program} unterschreiben"
 msgid "Sign waivers"
 msgstr "Verzichtserklärungen unterschreiben"
 
-#: lib/klass_hero_web/components/provider_components.ex:2494
+#: lib/klass_hero_web/components/provider_components.ex:2674
 #: lib/klass_hero_web/live/enrollment_waivers_live.ex:149
 #, elixir-autogen, elixir-format
 msgid "Signed"
@@ -7617,22 +7622,22 @@ msgstr "Danke — deine Verzichtserklärungen sind erfasst."
 msgid "There is nothing to sign for this enrollment."
 msgstr "Für diese Anmeldung gibt es nichts zu unterschreiben."
 
-#: lib/klass_hero_web/components/provider_components.ex:2494
+#: lib/klass_hero_web/components/provider_components.ex:2674
 #, elixir-autogen, elixir-format
 msgid "Unsigned"
 msgstr "Nicht unterschrieben"
 
-#: lib/klass_hero_web/components/provider_components.ex:1954
+#: lib/klass_hero_web/components/provider_components.ex:2134
 #, elixir-autogen, elixir-format
 msgid "Version %{number}"
 msgstr "Version %{number}"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:356
+#: lib/klass_hero_web/live/provider/programs_live.ex:416
 #, elixir-autogen, elixir-format
 msgid "Waiver not found."
 msgstr "Verzichtserklärung nicht gefunden."
 
-#: lib/klass_hero_web/components/provider_components.ex:2447
+#: lib/klass_hero_web/components/provider_components.ex:2627
 #: lib/klass_hero_web/live/booking_live.ex:447
 #: lib/klass_hero_web/live/enrollment_waivers_live.ex:33
 #: lib/klass_hero_web/live/enrollment_waivers_live.ex:105
@@ -7645,7 +7650,7 @@ msgstr "Verzichtserklärungen"
 msgid "Waivers waiting for your signature"
 msgstr "Verzichtserklärungen warten auf deine Unterschrift"
 
-#: lib/klass_hero_web/components/provider_components.ex:1928
+#: lib/klass_hero_web/components/provider_components.ex:2108
 #, elixir-autogen, elixir-format
 msgid "Waivers — %{title}"
 msgstr "Verzichtserklärungen — %{title}"
@@ -7655,22 +7660,22 @@ msgstr "Verzichtserklärungen — %{title}"
 msgid "this program"
 msgstr "dieses Programm"
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:924
+#: lib/klass_hero_web/live/provider/programs_live.ex:984
 #, elixir-autogen, elixir-format
 msgid "New version published. It applies to future enrolments."
 msgstr "Neue Fassung veröffentlicht. Sie gilt für künftige Anmeldungen."
 
-#: lib/klass_hero_web/components/provider_components.ex:1975
+#: lib/klass_hero_web/components/provider_components.ex:2155
 #, elixir-autogen, elixir-format
 msgid "Retire \"%{title}\"? Parents will no longer be asked to sign it. Signatures already collected are kept."
 msgstr "\"%{title}\" zurückziehen? Eltern werden nicht mehr um eine Unterschrift gebeten. Bereits erteilte Unterschriften bleiben erhalten."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:923
+#: lib/klass_hero_web/live/provider/programs_live.ex:983
 #, elixir-autogen, elixir-format
 msgid "Waiver added."
 msgstr "Einverständniserklärung hinzugefügt."
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:353
+#: lib/klass_hero_web/live/provider/programs_live.ex:413
 #, elixir-autogen, elixir-format
 msgid "Waiver retired. Signatures already collected are kept."
 msgstr "Einverständniserklärung zurückgezogen. Bereits erteilte Unterschriften bleiben erhalten."
@@ -7736,7 +7741,7 @@ msgstr "Diese Einladung ist abgelaufen. Bitte bitten Sie Ihren Anbieter, sie ern
 msgid "This is your main provider identity. Verification is required to list programs."
 msgstr "Dies ist Ihr Hauptprofil als Anbieter. Eine Verifizierung ist erforderlich, um Programme anzubieten."
 
-#: lib/klass_hero_web/components/provider_components.ex:3337
+#: lib/klass_hero_web/components/provider_components.ex:3517
 #, elixir-autogen, elixir-format
 msgid "Upload documents to be verified. Documents are reviewed by our team."
 msgstr "Laden Sie Dokumente hoch, um verifiziert zu werden. Die Dokumente werden von unserem Team überprüft."
@@ -7880,8 +7885,8 @@ msgstr "Einladungen ohne Antwort"
 msgid "Review invitations"
 msgstr "Einladungen prüfen"
 
-#: lib/klass_hero_web/components/provider_components.ex:2758
-#: lib/klass_hero_web/components/provider_components.ex:2765
+#: lib/klass_hero_web/components/provider_components.ex:2938
+#: lib/klass_hero_web/components/provider_components.ex:2945
 #, elixir-autogen, elixir-format
 msgid "Unknown program"
 msgstr "Unbekanntes Programm"
@@ -7949,17 +7954,17 @@ msgstr "Kostenlos"
 msgid "N/A"
 msgstr "k. A."
 
-#: lib/klass_hero_web/components/provider_components.ex:3245
+#: lib/klass_hero_web/components/provider_components.ex:3425
 #, elixir-autogen, elixir-format
 msgid "A short line that sums you up"
 msgstr "Ein kurzer Satz, der euch beschreibt"
 
-#: lib/klass_hero_web/components/provider_components.ex:3234
+#: lib/klass_hero_web/components/provider_components.ex:3414
 #, elixir-autogen, elixir-format
 msgid "Branding & Presence"
 msgstr "Marke & Auftritt"
 
-#: lib/klass_hero_web/components/provider_components.ex:3258
+#: lib/klass_hero_web/components/provider_components.ex:3438
 #, elixir-autogen, elixir-format
 msgid "Choose Cover Image"
 msgstr "Titelbild auswählen"
@@ -7969,17 +7974,17 @@ msgstr "Titelbild auswählen"
 msgid "Cover image upload failed. Please try again."
 msgstr "Titelbild konnte nicht hochgeladen werden. Bitte versucht es erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:3259
+#: lib/klass_hero_web/components/provider_components.ex:3439
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 5MB."
 msgstr "JPG, PNG oder WebP. Max. 5 MB."
 
-#: lib/klass_hero_web/components/provider_components.ex:3237
+#: lib/klass_hero_web/components/provider_components.ex:3417
 #, elixir-autogen, elixir-format
 msgid "Shown on your public profile page."
 msgstr "Erscheint auf eurer öffentlichen Profilseite."
 
-#: lib/klass_hero_web/components/provider_components.ex:3244
+#: lib/klass_hero_web/components/provider_components.ex:3424
 #, elixir-autogen, elixir-format
 msgid "Tagline"
 msgstr "Slogan"
@@ -7989,7 +7994,7 @@ msgstr "Slogan"
 msgid "Absent:"
 msgstr "Abwesend:"
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:115
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:138
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:115
 #, elixir-autogen, elixir-format
 msgid "Arrived late"
@@ -8025,7 +8030,7 @@ msgstr "%{business} auf %{network}"
 msgid "Klass Hero on %{network}"
 msgstr "Klass Hero auf %{network}"
 
-#: lib/klass_hero_web/components/provider_components.ex:3316
+#: lib/klass_hero_web/components/provider_components.ex:3496
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr "Hochladen fehlgeschlagen."
@@ -8065,7 +8070,7 @@ msgstr "Allgemein"
 msgid "A newly chosen cover or logo appears here after you save."
 msgstr "Ein neu gewähltes Titelbild oder Logo erscheint hier nach dem Speichern."
 
-#: lib/klass_hero_web/components/provider_components.ex:3289
+#: lib/klass_hero_web/components/provider_components.ex:3469
 #, elixir-autogen, elixir-format
 msgid "Add %{network}"
 msgstr "%{network} hinzufügen"
@@ -8085,7 +8090,7 @@ msgstr "Vorschau des öffentlichen Profils"
 msgid "Show preview"
 msgstr "Vorschau anzeigen"
 
-#: lib/klass_hero_web/components/provider_components.ex:3276
+#: lib/klass_hero_web/components/provider_components.ex:3456
 #, elixir-autogen, elixir-format
 msgid "e.g. %{example}"
 msgstr "z. B. %{example}"
@@ -8231,3 +8236,43 @@ msgstr "Auf der Teilnehmerliste dieser Sitzung stehen mehr Kinder, als die Kapaz
 #, elixir-autogen, elixir-format
 msgid "Over capacity"
 msgstr "Überbelegt"
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:41
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:51
+#, elixir-autogen, elixir-format
+msgid "Edit Session"
+msgstr "Sitzung bearbeiten"
+
+#: lib/klass_hero_web/components/provider_components.ex:1970
+#, elixir-autogen, elixir-format
+msgid "New session — %{title}"
+msgstr "Neue Sitzung — %{title}"
+
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:57
+#, elixir-autogen, elixir-format
+msgid "Save Session"
+msgstr "Sitzung speichern"
+
+#: lib/klass_hero_web/live/provider/participation_live.ex:103
+#, elixir-autogen, elixir-format
+msgid "Session updated"
+msgstr "Sitzung aktualisiert"
+
+#: lib/klass_hero_web/live/provider/programs_live.ex:264
+#, elixir-autogen, elixir-format
+msgid "That program could not be found."
+msgstr "Dieses Programm konnte nicht gefunden werden."
+
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:165
+#, elixir-autogen, elixir-format
+msgid "That session could not be saved."
+msgstr "Diese Sitzung konnte nicht gespeichert werden."
+
+#: lib/klass_hero_web/components/provider_components.ex:1900
+#, elixir-autogen, elixir-format
+msgid "The date and time are fixed once a session has started — its attendance records are keyed to it."
+msgstr "Datum und Uhrzeit stehen fest, sobald eine Sitzung begonnen hat — die Anwesenheitseinträge sind daran gebunden."
+
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:167
+#, elixir-autogen, elixir-format
+msgid "The date and time are fixed once a session has started."
+msgstr "Datum und Uhrzeit stehen fest, sobald eine Sitzung begonnen hat."

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -683,7 +683,7 @@ msgstr "Geistiges Eigentum"
 msgid "Introduction"
 msgstr "Einleitung"
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:157
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:165
 #: lib/klass_hero_web/live/provider/sessions_live.ex:114
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:66
 #, elixir-autogen, elixir-format
@@ -761,7 +761,7 @@ msgstr "Nachricht erfolgreich gesendet!"
 #: lib/klass_hero_web/live/provider/sessions_live.ex:50
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:6
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:21
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:223
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:231
 #, elixir-autogen, elixir-format
 msgid "My Sessions"
 msgstr "Meine Sitzungen"
@@ -1138,7 +1138,7 @@ msgstr "Teilnahmeverlauf konnte nicht geladen werden"
 #: lib/klass_hero_web/live/provider/participation_live.ex:30
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:55
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:27
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:271
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:279
 #, elixir-autogen, elixir-format
 msgid "Manage Participation"
 msgstr "Teilnahme verwalten"
@@ -3688,7 +3688,7 @@ msgstr "%{checked_in} / %{total} eingecheckt"
 msgid "%{count} unread"
 msgstr "%{count} ungelesen"
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:161
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:169
 #, elixir-autogen, elixir-format
 msgid "A session already exists at this time"
 msgstr "Zu dieser Zeit existiert bereits eine Sitzung"
@@ -3809,7 +3809,7 @@ msgstr "Registrierung abschließen"
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:33
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:66
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:33
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:282
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:290
 #, elixir-autogen, elixir-format
 msgid "Complete Session"
 msgstr "Sitzung abschließen"
@@ -3861,7 +3861,7 @@ msgstr "Sitzung erstellen"
 msgid "Date"
 msgstr "Datum"
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:156
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:164
 #, elixir-autogen, elixir-format
 msgid "Date is required"
 msgstr "Datum ist erforderlich"
@@ -3904,7 +3904,7 @@ msgstr "E-Mails"
 msgid "Emergency: %{details}"
 msgstr "Notfall: %{details}"
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:160
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:168
 #, elixir-autogen, elixir-format
 msgid "End time must be after start time"
 msgstr "Die Endzeit muss nach der Startzeit liegen"
@@ -3919,7 +3919,7 @@ msgstr "Erwartet"
 msgid "Failed to archive email"
 msgstr "E-Mail konnte nicht archiviert werden"
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:169
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:177
 #, elixir-autogen, elixir-format
 msgid "Failed to create session: %{reason}"
 msgstr "Sitzung konnte nicht erstellt werden: %{reason}"
@@ -3975,7 +3975,7 @@ msgstr "Ein: %{time}"
 msgid "Invalid Invitation"
 msgstr "Ungültige Einladung"
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:159
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:167
 #: lib/klass_hero_web/live/admin/sessions_live.ex:255
 #, elixir-autogen, elixir-format
 msgid "Invalid time format"
@@ -4038,7 +4038,7 @@ msgid "Max Capacity"
 msgstr "Maximale Kapazität"
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:80
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:296
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:304
 #, elixir-autogen, elixir-format
 msgid "No actions available"
 msgstr "Keine Aktionen verfügbar"
@@ -4074,7 +4074,7 @@ msgid "No sessions found for the selected filters."
 msgstr "Keine Sitzungen für die ausgewählten Filter gefunden."
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:112
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:311
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:319
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled"
 msgstr "Keine Sitzungen geplant"
@@ -4110,7 +4110,7 @@ msgstr "Ausstehende Überprüfungen"
 msgid "Please explain why you're rejecting this note..."
 msgstr "Bitte erklären Sie, warum Sie diese Notiz ablehnen..."
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:163
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:171
 #, elixir-autogen, elixir-format
 msgid "Please fill in all required fields"
 msgstr "Bitte füllen Sie alle erforderlichen Felder aus"
@@ -4242,7 +4242,7 @@ msgid "Staff Dashboard"
 msgstr "Mitarbeiter-Dashboard"
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:44
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:260
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "Start Session"
 msgstr "Sitzung starten"
@@ -4277,7 +4277,7 @@ msgstr "Diese Einladung wurde bereits verwendet."
 msgid "This invite link is invalid or has expired."
 msgstr "Dieser Einladungslink ist ungültig oder abgelaufen."
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:158
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:166
 #, elixir-autogen, elixir-format
 msgid "Time is required"
 msgstr "Uhrzeit ist erforderlich"
@@ -4293,7 +4293,7 @@ msgid "Type your reply..."
 msgstr "Ihre Antwort eingeben..."
 
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:227
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:162
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:170
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:126
 #, elixir-autogen, elixir-format
 msgid "Unauthorized"
@@ -4321,7 +4321,7 @@ msgid "Upload connection lost. Please try again."
 msgstr "Upload-Verbindung unterbrochen. Bitte versuchen Sie es erneut."
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:77
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:293
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:301
 #, elixir-autogen, elixir-format
 msgid "View Participation"
 msgstr "Teilnahme anzeigen"
@@ -4342,7 +4342,7 @@ msgid "You already have an account. Log in to see your new enrollment."
 msgstr "Sie haben bereits ein Konto. Melden Sie sich an, um Ihre neue Anmeldung zu sehen."
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:115
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:314
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:322
 #, elixir-autogen, elixir-format
 msgid "You have no sessions scheduled for %{date}"
 msgstr "Sie haben keine Sitzungen geplant für %{date}"
@@ -4377,7 +4377,7 @@ msgstr "Teilnehmerliste"
 msgid "Unlimited team seats"
 msgstr "Unbegrenzte Team-Plätze"
 
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:224
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:232
 #, elixir-autogen, elixir-format
 msgid "View and manage your assigned sessions"
 msgstr "Ihre zugewiesenen Sitzungen anzeigen und verwalten"
@@ -7453,7 +7453,7 @@ msgstr "Team"
 msgid "Staffing — %{date}"
 msgstr "Team — %{date}"
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:164
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:172
 #: lib/klass_hero_web/live/provider/sessions_live.ex:427
 #, elixir-autogen, elixir-format
 msgid "That session could not be found."
@@ -8262,7 +8262,7 @@ msgstr "Sitzung aktualisiert"
 msgid "That program could not be found."
 msgstr "Dieses Programm konnte nicht gefunden werden."
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:165
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:173
 #, elixir-autogen, elixir-format
 msgid "That session could not be saved."
 msgstr "Diese Sitzung konnte nicht gespeichert werden."
@@ -8272,7 +8272,7 @@ msgstr "Diese Sitzung konnte nicht gespeichert werden."
 msgid "The date and time are fixed once a session has started — its attendance records are keyed to it."
 msgstr "Datum und Uhrzeit stehen fest, sobald eine Sitzung begonnen hat — die Anwesenheitseinträge sind daran gebunden."
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:167
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:175
 #, elixir-autogen, elixir-format
 msgid "The date and time are fixed once a session has started."
 msgstr "Datum und Uhrzeit stehen fest, sobald eine Sitzung begonnen hat."

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -2646,8 +2646,6 @@ msgid "Read our founding story →"
 msgstr "Lesen Sie unsere Gründungsgeschichte →"
 
 #: lib/klass_hero_web/components/participation_components.ex:796
-#: lib/klass_hero_web/components/provider_components.ex:2982
-#: lib/klass_hero_web/components/participation_components.ex:750
 #: lib/klass_hero_web/components/provider_components.ex:3162
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
@@ -3493,7 +3491,6 @@ msgid "No risk of non-payment"
 msgstr "Kein Risiko von Zahlungsausfällen"
 
 #: lib/klass_hero_web/components/participation_components.ex:821
-#: lib/klass_hero_web/components/participation_components.ex:775
 #: lib/klass_hero_web/components/provider_components.ex:1906
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:155
 #, elixir-autogen, elixir-format
@@ -8236,6 +8233,7 @@ msgstr "Auf der Teilnehmerliste dieser Sitzung stehen mehr Kinder, als die Kapaz
 #, elixir-autogen, elixir-format
 msgid "Over capacity"
 msgstr "Überbelegt"
+
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:41
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:51
 #, elixir-autogen, elixir-format

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -683,7 +683,7 @@ msgstr "Geistiges Eigentum"
 msgid "Introduction"
 msgstr "Einleitung"
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:165
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:173
 #: lib/klass_hero_web/live/provider/sessions_live.ex:114
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:66
 #, elixir-autogen, elixir-format
@@ -3688,7 +3688,7 @@ msgstr "%{checked_in} / %{total} eingecheckt"
 msgid "%{count} unread"
 msgstr "%{count} ungelesen"
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:169
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:177
 #, elixir-autogen, elixir-format
 msgid "A session already exists at this time"
 msgstr "Zu dieser Zeit existiert bereits eine Sitzung"
@@ -3861,7 +3861,7 @@ msgstr "Sitzung erstellen"
 msgid "Date"
 msgstr "Datum"
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:164
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:172
 #, elixir-autogen, elixir-format
 msgid "Date is required"
 msgstr "Datum ist erforderlich"
@@ -3904,7 +3904,7 @@ msgstr "E-Mails"
 msgid "Emergency: %{details}"
 msgstr "Notfall: %{details}"
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:168
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:176
 #, elixir-autogen, elixir-format
 msgid "End time must be after start time"
 msgstr "Die Endzeit muss nach der Startzeit liegen"
@@ -3919,7 +3919,7 @@ msgstr "Erwartet"
 msgid "Failed to archive email"
 msgstr "E-Mail konnte nicht archiviert werden"
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:177
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:185
 #, elixir-autogen, elixir-format
 msgid "Failed to create session: %{reason}"
 msgstr "Sitzung konnte nicht erstellt werden: %{reason}"
@@ -3975,7 +3975,7 @@ msgstr "Ein: %{time}"
 msgid "Invalid Invitation"
 msgstr "Ungültige Einladung"
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:167
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:175
 #: lib/klass_hero_web/live/admin/sessions_live.ex:255
 #, elixir-autogen, elixir-format
 msgid "Invalid time format"
@@ -4110,7 +4110,7 @@ msgstr "Ausstehende Überprüfungen"
 msgid "Please explain why you're rejecting this note..."
 msgstr "Bitte erklären Sie, warum Sie diese Notiz ablehnen..."
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:171
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:179
 #, elixir-autogen, elixir-format
 msgid "Please fill in all required fields"
 msgstr "Bitte füllen Sie alle erforderlichen Felder aus"
@@ -4277,7 +4277,7 @@ msgstr "Diese Einladung wurde bereits verwendet."
 msgid "This invite link is invalid or has expired."
 msgstr "Dieser Einladungslink ist ungültig oder abgelaufen."
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:166
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:174
 #, elixir-autogen, elixir-format
 msgid "Time is required"
 msgstr "Uhrzeit ist erforderlich"
@@ -4293,7 +4293,7 @@ msgid "Type your reply..."
 msgstr "Ihre Antwort eingeben..."
 
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:227
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:170
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:178
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:126
 #, elixir-autogen, elixir-format
 msgid "Unauthorized"
@@ -7453,7 +7453,7 @@ msgstr "Team"
 msgid "Staffing — %{date}"
 msgstr "Team — %{date}"
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:172
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:180
 #: lib/klass_hero_web/live/provider/sessions_live.ex:427
 #, elixir-autogen, elixir-format
 msgid "That session could not be found."
@@ -8262,7 +8262,7 @@ msgstr "Sitzung aktualisiert"
 msgid "That program could not be found."
 msgstr "Dieses Programm konnte nicht gefunden werden."
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:173
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:181
 #, elixir-autogen, elixir-format
 msgid "That session could not be saved."
 msgstr "Diese Sitzung konnte nicht gespeichert werden."
@@ -8272,7 +8272,7 @@ msgstr "Diese Sitzung konnte nicht gespeichert werden."
 msgid "The date and time are fixed once a session has started — its attendance records are keyed to it."
 msgstr "Datum und Uhrzeit stehen fest, sobald eine Sitzung begonnen hat — die Anwesenheitseinträge sind daran gebunden."
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:175
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:183
 #, elixir-autogen, elixir-format
 msgid "The date and time are fixed once a session has started."
 msgstr "Datum und Uhrzeit stehen fest, sobald eine Sitzung begonnen hat."

--- a/priv/gettext/de/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/de/LC_MESSAGES/enrollment.po
@@ -11,105 +11,105 @@ msgstr ""
 "Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:3084
-#: lib/klass_hero_web/components/provider_components.ex:3101
+#: lib/klass_hero_web/components/provider_components.ex:3264
+#: lib/klass_hero_web/components/provider_components.ex:3281
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr "Vorname des Kindes"
 
-#: lib/klass_hero_web/components/provider_components.ex:3085
-#: lib/klass_hero_web/components/provider_components.ex:3102
+#: lib/klass_hero_web/components/provider_components.ex:3265
+#: lib/klass_hero_web/components/provider_components.ex:3282
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr "Nachname des Kindes"
 
-#: lib/klass_hero_web/components/provider_components.ex:3086
-#: lib/klass_hero_web/components/provider_components.ex:3103
+#: lib/klass_hero_web/components/provider_components.ex:3266
+#: lib/klass_hero_web/components/provider_components.ex:3283
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr "Geburtsdatum"
 
-#: lib/klass_hero_web/components/provider_components.ex:3097
+#: lib/klass_hero_web/components/provider_components.ex:3277
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr "Klassenstufe"
 
-#: lib/klass_hero_web/components/provider_components.ex:3087
+#: lib/klass_hero_web/components/provider_components.ex:3267
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr "E-Mail des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:3088
+#: lib/klass_hero_web/components/provider_components.ex:3268
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr "Vorname des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:3089
+#: lib/klass_hero_web/components/provider_components.ex:3269
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr "Nachname des Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:3096
+#: lib/klass_hero_web/components/provider_components.ex:3276
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr "Programm"
 
-#: lib/klass_hero_web/components/provider_components.ex:3098
+#: lib/klass_hero_web/components/provider_components.ex:3278
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr "Schule"
 
-#: lib/klass_hero_web/components/provider_components.ex:3090
+#: lib/klass_hero_web/components/provider_components.ex:3270
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr "E-Mail des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:3092
+#: lib/klass_hero_web/components/provider_components.ex:3272
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr "Vorname des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:3094
+#: lib/klass_hero_web/components/provider_components.ex:3274
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr "Nachname des zweiten Erziehungsberechtigten"
 
-#: lib/klass_hero_web/components/provider_components.ex:3024
+#: lib/klass_hero_web/components/provider_components.ex:3204
 #, elixir-autogen, elixir-format
 msgid "Date of birth \"%{value}\" is not a valid date. Please correct it and resend."
 msgstr ""
 "Das Geburtsdatum „%{value}“ ist kein gültiges Datum. Bitte korrigieren Sie es "
 "und senden Sie die Einladung erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:3018
+#: lib/klass_hero_web/components/provider_components.ex:3198
 #, elixir-autogen, elixir-format
 msgid "Invite link could not be generated (no token). Please resend."
 msgstr ""
 "Der Einladungslink konnte nicht erzeugt werden (kein Token). Bitte erneut "
 "senden."
 
-#: lib/klass_hero_web/components/provider_components.ex:3032
+#: lib/klass_hero_web/components/provider_components.ex:3212
 #, elixir-autogen, elixir-format
 msgid "The invitation email could not be delivered. Please check the address and resend."
 msgstr ""
 "Die Einladungs-E-Mail konnte nicht zugestellt werden. Bitte prüfen Sie die "
 "Adresse und senden Sie die Einladung erneut."
 
-#: lib/klass_hero_web/components/provider_components.ex:3021
+#: lib/klass_hero_web/components/provider_components.ex:3201
 #, elixir-autogen, elixir-format
 msgid "The program is full, so this child could not be enrolled."
 msgstr ""
 "Das Programm ist ausgebucht, daher konnte dieses Kind nicht angemeldet "
 "werden."
 
-#: lib/klass_hero_web/components/provider_components.ex:3035
+#: lib/klass_hero_web/components/provider_components.ex:3215
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed and no retries remain. Please resend."
 msgstr ""
 "Diese Einladung konnte nicht abgeschlossen werden und es sind keine weiteren "
 "Versuche möglich. Bitte erneut senden."
 
-#: lib/klass_hero_web/components/provider_components.ex:3044
+#: lib/klass_hero_web/components/provider_components.ex:3224
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed. Please resend."
 msgstr "Diese Einladung konnte nicht abgeschlossen werden. Bitte erneut senden."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -2646,8 +2646,6 @@ msgid "Read our founding story →"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:796
-#: lib/klass_hero_web/components/provider_components.ex:2982
-#: lib/klass_hero_web/components/participation_components.ex:750
 #: lib/klass_hero_web/components/provider_components.ex:3162
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
@@ -3493,7 +3491,6 @@ msgid "No risk of non-payment"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:821
-#: lib/klass_hero_web/components/participation_components.ex:775
 #: lib/klass_hero_web/components/provider_components.ex:1906
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:155
 #, elixir-autogen, elixir-format

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -683,7 +683,7 @@ msgstr ""
 msgid "Introduction"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:165
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:173
 #: lib/klass_hero_web/live/provider/sessions_live.ex:114
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:66
 #, elixir-autogen, elixir-format
@@ -3688,7 +3688,7 @@ msgstr ""
 msgid "%{count} unread"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:169
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:177
 #, elixir-autogen, elixir-format
 msgid "A session already exists at this time"
 msgstr ""
@@ -3861,7 +3861,7 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:164
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:172
 #, elixir-autogen, elixir-format
 msgid "Date is required"
 msgstr ""
@@ -3904,7 +3904,7 @@ msgstr ""
 msgid "Emergency: %{details}"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:168
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:176
 #, elixir-autogen, elixir-format
 msgid "End time must be after start time"
 msgstr ""
@@ -3919,7 +3919,7 @@ msgstr ""
 msgid "Failed to archive email"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:177
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:185
 #, elixir-autogen, elixir-format
 msgid "Failed to create session: %{reason}"
 msgstr ""
@@ -3975,7 +3975,7 @@ msgstr ""
 msgid "Invalid Invitation"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:167
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:175
 #: lib/klass_hero_web/live/admin/sessions_live.ex:255
 #, elixir-autogen, elixir-format
 msgid "Invalid time format"
@@ -4110,7 +4110,7 @@ msgstr ""
 msgid "Please explain why you're rejecting this note..."
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:171
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:179
 #, elixir-autogen, elixir-format
 msgid "Please fill in all required fields"
 msgstr ""
@@ -4277,7 +4277,7 @@ msgstr ""
 msgid "This invite link is invalid or has expired."
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:166
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:174
 #, elixir-autogen, elixir-format
 msgid "Time is required"
 msgstr ""
@@ -4293,7 +4293,7 @@ msgid "Type your reply..."
 msgstr ""
 
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:227
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:170
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:178
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:126
 #, elixir-autogen, elixir-format
 msgid "Unauthorized"
@@ -7438,7 +7438,7 @@ msgstr ""
 msgid "Staffing — %{date}"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:172
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:180
 #: lib/klass_hero_web/live/provider/sessions_live.ex:427
 #, elixir-autogen, elixir-format
 msgid "That session could not be found."
@@ -8245,7 +8245,7 @@ msgstr ""
 msgid "That program could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:173
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:181
 #, elixir-autogen, elixir-format
 msgid "That session could not be saved."
 msgstr ""
@@ -8255,7 +8255,7 @@ msgstr ""
 msgid "The date and time are fixed once a session has started — its attendance records are keyed to it."
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:175
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:183
 #, elixir-autogen, elixir-format
 msgid "The date and time are fixed once a session has started."
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -577,8 +577,8 @@ msgid "Dispute Resolution"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:781
-#: lib/klass_hero_web/components/provider_components.ex:2859
-#: lib/klass_hero_web/components/provider_components.ex:2877
+#: lib/klass_hero_web/components/provider_components.ex:3039
+#: lib/klass_hero_web/components/provider_components.ex:3057
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:61
@@ -621,7 +621,7 @@ msgid "Failed to check out: %{reason}"
 msgstr ""
 
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:202
-#: lib/klass_hero_web/live/provider/sessions_live.ex:167
+#: lib/klass_hero_web/live/provider/sessions_live.ex:165
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:117
 #, elixir-autogen, elixir-format
 msgid "Failed to complete session: %{reason}"
@@ -632,7 +632,7 @@ msgstr ""
 msgid "Failed to delete account. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:141
+#: lib/klass_hero_web/live/provider/sessions_live.ex:139
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:91
 #, elixir-autogen, elixir-format
 msgid "Failed to start session: %{reason}"
@@ -683,8 +683,8 @@ msgstr ""
 msgid "Introduction"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:116
-#: lib/klass_hero_web/live/provider/sessions_live.ex:572
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:157
+#: lib/klass_hero_web/live/provider/sessions_live.ex:114
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:66
 #, elixir-autogen, elixir-format
 msgid "Invalid date format"
@@ -758,8 +758,8 @@ msgstr ""
 msgid "Message sent successfully!"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:51
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:4
+#: lib/klass_hero_web/live/provider/sessions_live.ex:50
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:6
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:21
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:223
 #, elixir-autogen, elixir-format
@@ -852,8 +852,8 @@ msgstr ""
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:107
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:139
 #: lib/klass_hero_web/live/admin/sessions_live.ex:247
-#: lib/klass_hero_web/live/provider/participation_live.ex:199
-#: lib/klass_hero_web/live/provider/participation_live.ex:245
+#: lib/klass_hero_web/live/provider/participation_live.ex:249
+#: lib/klass_hero_web/live/provider/participation_live.ex:295
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:139
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:185
 #, elixir-autogen, elixir-format
@@ -882,9 +882,9 @@ msgstr ""
 msgid "Select one or both options"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2508
-#: lib/klass_hero_web/components/provider_components.ex:2509
-#: lib/klass_hero_web/components/provider_components.ex:2547
+#: lib/klass_hero_web/components/provider_components.ex:2688
+#: lib/klass_hero_web/components/provider_components.ex:2689
+#: lib/klass_hero_web/components/provider_components.ex:2727
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:468
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:469
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:505
@@ -893,7 +893,7 @@ msgid "Send Message"
 msgstr ""
 
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:190
-#: lib/klass_hero_web/live/provider/sessions_live.ex:150
+#: lib/klass_hero_web/live/provider/sessions_live.ex:148
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:100
 #, elixir-autogen, elixir-format
 msgid "Session completed successfully"
@@ -901,13 +901,13 @@ msgstr ""
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:62
 #: lib/klass_hero_web/live/admin/sessions_live.ex:68
-#: lib/klass_hero_web/live/provider/participation_live.ex:315
+#: lib/klass_hero_web/live/provider/participation_live.ex:365
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:270
 #, elixir-autogen, elixir-format
 msgid "Session not found"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:124
+#: lib/klass_hero_web/live/provider/sessions_live.ex:122
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:74
 #, elixir-autogen, elixir-format
 msgid "Session started successfully"
@@ -1135,8 +1135,8 @@ msgstr ""
 msgid "Failed to load participation history"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:27
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:65
+#: lib/klass_hero_web/live/provider/participation_live.ex:30
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:55
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:27
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:271
 #, elixir-autogen, elixir-format
@@ -1334,8 +1334,8 @@ msgid "Quick Navigation"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1466
-#: lib/klass_hero_web/components/provider_components.ex:2453
-#: lib/klass_hero_web/components/provider_components.ex:2746
+#: lib/klass_hero_web/components/provider_components.ex:2633
+#: lib/klass_hero_web/components/provider_components.ex:2926
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
@@ -1351,7 +1351,7 @@ msgstr ""
 msgid "Add Team Member"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:49
+#: lib/klass_hero_web/live/provider/programs_live.ex:50
 #, elixir-autogen, elixir-format
 msgid "All Staff"
 msgstr ""
@@ -1380,8 +1380,8 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:586
 #: lib/klass_hero_web/components/provider_components.ex:1575
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:65
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:92
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:88
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:115
 #: lib/klass_hero_web/live/settings/children_live.ex:413
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:65
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:92
@@ -1402,7 +1402,7 @@ msgid "Inactive"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:116
-#: lib/klass_hero_web/live/provider/programs_live.ex:55
+#: lib/klass_hero_web/live/provider/programs_live.ex:56
 #, elixir-autogen, elixir-format
 msgid "My Programs"
 msgstr ""
@@ -1421,8 +1421,8 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:50
 #: lib/klass_hero_web/components/provider_components.ex:76
 #: lib/klass_hero_web/components/provider_components.ex:1613
-#: lib/klass_hero_web/components/provider_components.ex:2953
-#: lib/klass_hero_web/components/provider_components.ex:2980
+#: lib/klass_hero_web/components/provider_components.ex:3133
+#: lib/klass_hero_web/components/provider_components.ex:3160
 #: lib/klass_hero_web/live/admin/sessions_live.ex:293
 #: lib/klass_hero_web/live/admin/verifications_live.ex:202
 #, elixir-autogen, elixir-format
@@ -1460,9 +1460,9 @@ msgid "Search by name..."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1460
-#: lib/klass_hero_web/components/provider_components.ex:1863
-#: lib/klass_hero_web/components/provider_components.ex:2444
-#: lib/klass_hero_web/components/provider_components.ex:2743
+#: lib/klass_hero_web/components/provider_components.ex:2018
+#: lib/klass_hero_web/components/provider_components.ex:2624
+#: lib/klass_hero_web/components/provider_components.ex:2923
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1482,7 +1482,7 @@ msgid "Team & Provider Profiles"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1517
-#: lib/klass_hero_web/components/provider_components.ex:1878
+#: lib/klass_hero_web/components/provider_components.ex:2047
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr ""
@@ -1561,14 +1561,14 @@ msgstr ""
 #: lib/klass_hero_web/components/participation_components.ex:708
 #: lib/klass_hero_web/components/provider_components.ex:909
 #: lib/klass_hero_web/components/provider_components.ex:1323
-#: lib/klass_hero_web/components/provider_components.ex:2036
-#: lib/klass_hero_web/components/provider_components.ex:2651
+#: lib/klass_hero_web/components/provider_components.ex:1918
+#: lib/klass_hero_web/components/provider_components.ex:2216
+#: lib/klass_hero_web/components/provider_components.ex:2831
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:489
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:222
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:361
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:210
 #: lib/klass_hero_web/live/settings/children_live.ex:544
 #: lib/klass_hero_web/live/settings/children_live.ex:703
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:237
@@ -1621,8 +1621,8 @@ msgstr ""
 msgid "Data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2441
-#: lib/klass_hero_web/components/provider_components.ex:2840
+#: lib/klass_hero_web/components/provider_components.ex:2621
+#: lib/klass_hero_web/components/provider_components.ex:3020
 #: lib/klass_hero_web/live/settings/children_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1654,7 +1654,7 @@ msgstr ""
 msgid "Failed to reject note"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:191
+#: lib/klass_hero_web/live/provider/participation_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "Failed to resubmit note"
 msgstr ""
@@ -1670,17 +1670,17 @@ msgstr ""
 msgid "Failed to submit note"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2834
-#: lib/klass_hero_web/components/provider_components.ex:2863
-#: lib/klass_hero_web/components/provider_components.ex:2879
+#: lib/klass_hero_web/components/provider_components.ex:3014
+#: lib/klass_hero_web/components/provider_components.ex:3043
+#: lib/klass_hero_web/components/provider_components.ex:3059
 #: lib/klass_hero_web/live/settings/children_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2835
-#: lib/klass_hero_web/components/provider_components.ex:2864
-#: lib/klass_hero_web/components/provider_components.ex:2880
+#: lib/klass_hero_web/components/provider_components.ex:3015
+#: lib/klass_hero_web/components/provider_components.ex:3044
+#: lib/klass_hero_web/components/provider_components.ex:3060
 #: lib/klass_hero_web/live/settings/children_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -1750,7 +1750,7 @@ msgid "Note approved"
 msgstr ""
 
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:157
-#: lib/klass_hero_web/live/provider/participation_live.ex:183
+#: lib/klass_hero_web/live/provider/participation_live.ex:233
 #, elixir-autogen, elixir-format
 msgid "Note content cannot be blank"
 msgstr ""
@@ -1760,7 +1760,7 @@ msgstr ""
 msgid "Note rejected"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:177
+#: lib/klass_hero_web/live/provider/participation_live.ex:227
 #, elixir-autogen, elixir-format
 msgid "Note resubmitted for review"
 msgstr ""
@@ -1842,7 +1842,7 @@ msgstr ""
 msgid "Send a message to start the conversation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2934
+#: lib/klass_hero_web/components/provider_components.ex:3114
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:249
 #, elixir-autogen, elixir-format
@@ -1866,7 +1866,7 @@ msgstr ""
 msgid "Type a message..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:335
+#: lib/klass_hero_web/live/provider/participation_live.ex:385
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:290
 #, elixir-autogen, elixir-format
 msgid "Unable to refresh roster. Please reload."
@@ -1978,7 +1978,7 @@ msgstr ""
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3002
+#: lib/klass_hero_web/components/provider_components.ex:3182
 #, elixir-autogen, elixir-format
 msgid "An unexpected error occurred during import."
 msgstr ""
@@ -2057,8 +2057,8 @@ msgstr ""
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2435
-#: lib/klass_hero_web/components/provider_components.ex:2729
+#: lib/klass_hero_web/components/provider_components.ex:2615
+#: lib/klass_hero_web/components/provider_components.ex:2909
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2954
+#: lib/klass_hero_web/components/provider_components.ex:3134
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
@@ -2109,7 +2109,7 @@ msgstr ""
 msgid "Contact Provider"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:510
+#: lib/klass_hero_web/live/provider/programs_live.ex:570
 #, elixir-autogen, elixir-format
 msgid "Could not read the uploaded file."
 msgstr ""
@@ -2120,7 +2120,7 @@ msgid "Could not remove invite."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1290
-#: lib/klass_hero_web/components/provider_components.ex:3251
+#: lib/klass_hero_web/components/provider_components.ex:3431
 #, elixir-autogen, elixir-format
 msgid "Cover Image"
 msgstr ""
@@ -2149,7 +2149,7 @@ msgstr ""
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3380
+#: lib/klass_hero_web/components/provider_components.ex:3560
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2183,7 +2183,7 @@ msgstr ""
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2670
+#: lib/klass_hero_web/components/provider_components.ex:2850
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
@@ -2209,13 +2209,13 @@ msgid "End Date"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1075
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:185
+#: lib/klass_hero_web/components/provider_components.ex:1893
 #, elixir-autogen, elixir-format
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2450
-#: lib/klass_hero_web/components/provider_components.ex:2983
+#: lib/klass_hero_web/components/provider_components.ex:2630
+#: lib/klass_hero_web/components/provider_components.ex:3163
 #: lib/klass_hero_web/components/provider_layout_components.ex:612
 #, elixir-autogen, elixir-format
 msgid "Enrolled"
@@ -2237,7 +2237,7 @@ msgid "Explain why this document is being rejected..."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:74
-#: lib/klass_hero_web/components/provider_components.ex:2984
+#: lib/klass_hero_web/components/provider_components.ex:3164
 #: lib/klass_hero_web/live/admin/emails_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2281,12 +2281,12 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3313
+#: lib/klass_hero_web/components/provider_components.ex:3493
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3315
+#: lib/klass_hero_web/components/provider_components.ex:3495
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
@@ -2321,7 +2321,7 @@ msgstr ""
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2740
+#: lib/klass_hero_web/components/provider_components.ex:2920
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
@@ -2336,7 +2336,7 @@ msgstr ""
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2643
+#: lib/klass_hero_web/components/provider_components.ex:2823
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
@@ -2404,7 +2404,7 @@ msgid "Leave unchecked to allow all genders."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1031
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:191
+#: lib/klass_hero_web/components/provider_components.ex:1905
 #, elixir-autogen, elixir-format
 msgid "Location"
 msgstr ""
@@ -2462,18 +2462,18 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3342
+#: lib/klass_hero_web/components/provider_components.ex:3522
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2427
+#: lib/klass_hero_web/components/provider_components.ex:2607
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:506
+#: lib/klass_hero_web/live/provider/programs_live.ex:566
 #, elixir-autogen, elixir-format
 msgid "No file selected."
 msgstr ""
@@ -2483,7 +2483,7 @@ msgstr ""
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2694
+#: lib/klass_hero_web/components/provider_components.ex:2874
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
@@ -2546,7 +2546,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3418
+#: lib/klass_hero_web/components/provider_components.ex:3598
 #: lib/klass_hero_web/live/provider/verification_live.ex:707
 #: lib/klass_hero_web/live/provider/verification_live.ex:781
 #, elixir-autogen, elixir-format
@@ -2573,8 +2573,8 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:111
-#: lib/klass_hero_web/live/provider/programs_live.ex:750
-#: lib/klass_hero_web/live/provider/programs_live.ex:819
+#: lib/klass_hero_web/live/provider/programs_live.ex:810
+#: lib/klass_hero_web/live/provider/programs_live.ex:879
 #: lib/klass_hero_web/live/provider/team_live.ex:314
 #: lib/klass_hero_web/live/provider/team_live.ex:357
 #: lib/klass_hero_web/live/provider/team_live.ex:476
@@ -2607,28 +2607,28 @@ msgstr ""
 msgid "Program Start"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1319
+#: lib/klass_hero_web/live/provider/programs_live.ex:1398
 #, elixir-autogen, elixir-format
 msgid "Program created successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1323
+#: lib/klass_hero_web/live/provider/programs_live.ex:1402
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:52
-#: lib/klass_hero_web/live/provider/programs_live.ex:157
-#: lib/klass_hero_web/live/provider/programs_live.ex:194
-#: lib/klass_hero_web/live/provider/programs_live.ex:258
-#: lib/klass_hero_web/live/provider/programs_live.ex:282
-#: lib/klass_hero_web/live/provider/programs_live.ex:794
-#: lib/klass_hero_web/live/provider/programs_live.ex:926
+#: lib/klass_hero_web/live/provider/programs_live.ex:158
+#: lib/klass_hero_web/live/provider/programs_live.ex:195
+#: lib/klass_hero_web/live/provider/programs_live.ex:318
+#: lib/klass_hero_web/live/provider/programs_live.ex:342
+#: lib/klass_hero_web/live/provider/programs_live.ex:854
+#: lib/klass_hero_web/live/provider/programs_live.ex:986
 #, elixir-autogen, elixir-format
 msgid "Program not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1320
+#: lib/klass_hero_web/live/provider/programs_live.ex:1399
 #, elixir-autogen, elixir-format
 msgid "Program updated successfully."
 msgstr ""
@@ -2647,6 +2647,8 @@ msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:796
 #: lib/klass_hero_web/components/provider_components.ex:2982
+#: lib/klass_hero_web/components/participation_components.ex:750
+#: lib/klass_hero_web/components/provider_components.ex:3162
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Registered"
@@ -2726,15 +2728,15 @@ msgstr ""
 msgid "Rejection reason"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2796
-#: lib/klass_hero_web/components/provider_components.ex:3169
-#: lib/klass_hero_web/components/provider_components.ex:3437
-#: lib/klass_hero_web/components/provider_components.ex:3517
+#: lib/klass_hero_web/components/provider_components.ex:2976
+#: lib/klass_hero_web/components/provider_components.ex:3349
+#: lib/klass_hero_web/components/provider_components.ex:3617
+#: lib/klass_hero_web/components/provider_components.ex:3697
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2789
+#: lib/klass_hero_web/components/provider_components.ex:2969
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -2775,7 +2777,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3415
+#: lib/klass_hero_web/components/provider_components.ex:3595
 #, elixir-autogen, elixir-format
 msgid "Select File"
 msgstr ""
@@ -2786,13 +2788,13 @@ msgstr ""
 msgid "Selected child does not meet the program requirements."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:740
-#: lib/klass_hero_web/live/provider/programs_live.ex:809
+#: lib/klass_hero_web/live/provider/programs_live.ex:800
+#: lib/klass_hero_web/live/provider/programs_live.ex:869
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2981
+#: lib/klass_hero_web/components/provider_components.ex:3161
 #: lib/klass_hero_web/live/admin/emails_live.ex:206
 #, elixir-autogen, elixir-format
 msgid "Sent"
@@ -2832,7 +2834,7 @@ msgid "Start Date"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1070
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:184
+#: lib/klass_hero_web/components/provider_components.ex:1886
 #, elixir-autogen, elixir-format
 msgid "Start Time"
 msgstr ""
@@ -2892,18 +2894,18 @@ msgstr ""
 msgid "This invite cannot be resent."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:801
+#: lib/klass_hero_web/live/provider/programs_live.ex:861
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:995
-#: lib/klass_hero_web/components/provider_components.ex:2002
+#: lib/klass_hero_web/components/provider_components.ex:2182
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3314
+#: lib/klass_hero_web/components/provider_components.ex:3494
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -2923,27 +2925,27 @@ msgstr ""
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2630
+#: lib/klass_hero_web/components/provider_components.ex:2810
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3461
+#: lib/klass_hero_web/components/provider_components.ex:3641
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3369
+#: lib/klass_hero_web/components/provider_components.ex:3549
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3317
+#: lib/klass_hero_web/components/provider_components.ex:3497
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3334
+#: lib/klass_hero_web/components/provider_components.ex:3514
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -3035,7 +3037,7 @@ msgid "Child Safeguarding Training"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1507
-#: lib/klass_hero_web/components/provider_components.ex:3690
+#: lib/klass_hero_web/components/provider_components.ex:3870
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr ""
@@ -3105,7 +3107,7 @@ msgstr ""
 msgid "Program fee:"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1096
+#: lib/klass_hero_web/live/provider/programs_live.ex:1175
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr ""
@@ -3186,7 +3188,7 @@ msgid "Vetted with Care"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1491
-#: lib/klass_hero_web/components/provider_components.ex:3468
+#: lib/klass_hero_web/components/provider_components.ex:3648
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr ""
@@ -3322,7 +3324,7 @@ msgstr ""
 msgid "Cannot check out without a check-in"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:453
+#: lib/klass_hero_web/live/provider/programs_live.ex:513
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:155
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
@@ -3360,7 +3362,7 @@ msgstr ""
 msgid "Checked Out"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2831
+#: lib/klass_hero_web/components/provider_components.ex:3011
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Child"
@@ -3406,7 +3408,7 @@ msgstr ""
 msgid "Download monthly statements for taxes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2546
+#: lib/klass_hero_web/components/provider_components.ex:2726
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:504
 #, elixir-autogen, elixir-format
 msgid "Enrollment not confirmed"
@@ -3491,8 +3493,9 @@ msgid "No risk of non-payment"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:821
+#: lib/klass_hero_web/components/participation_components.ex:775
+#: lib/klass_hero_web/components/provider_components.ex:1906
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:155
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:197
 #, elixir-autogen, elixir-format
 msgid "Notes"
 msgstr ""
@@ -3502,7 +3505,7 @@ msgstr ""
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2545
+#: lib/klass_hero_web/components/provider_components.ex:2725
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:503
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -3685,7 +3688,7 @@ msgstr ""
 msgid "%{count} unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:590
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:161
 #, elixir-autogen, elixir-format
 msgid "A session already exists at this time"
 msgstr ""
@@ -3695,7 +3698,7 @@ msgstr ""
 msgid "Account created! Check your email to confirm and log in."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:160
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:183
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:160
 #, elixir-autogen, elixir-format
 msgid "Add Note"
@@ -3757,7 +3760,7 @@ msgstr ""
 msgid "Broadcast messages are one-way"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:128
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:151
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:128
 #, elixir-autogen, elixir-format
 msgid "Check In"
@@ -3804,7 +3807,7 @@ msgid "Complete Registration"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:33
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:76
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:66
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:33
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:282
 #, elixir-autogen, elixir-format
@@ -3846,20 +3849,19 @@ msgstr ""
 msgid "Could not start private conversation"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:18
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:154
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:219
+#: lib/klass_hero_web/components/provider_components.ex:1927
+#: lib/klass_hero_web/components/provider_components.ex:1988
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "Create Session"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:181
+#: lib/klass_hero_web/components/provider_components.ex:1877
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:566
-#: lib/klass_hero_web/live/provider/sessions_live.ex:567
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:156
 #, elixir-autogen, elixir-format
 msgid "Date is required"
 msgstr ""
@@ -3869,7 +3871,7 @@ msgstr ""
 msgid "E.g., picked up by parent, gave medication reminder..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:189
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:212
 #, elixir-autogen, elixir-format
 msgid "Edit & Resubmit"
 msgstr ""
@@ -3902,7 +3904,7 @@ msgstr ""
 msgid "Emergency: %{details}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:589
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:160
 #, elixir-autogen, elixir-format
 msgid "End time must be after start time"
 msgstr ""
@@ -3917,7 +3919,7 @@ msgstr ""
 msgid "Failed to archive email"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:526
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:169
 #, elixir-autogen, elixir-format
 msgid "Failed to create session: %{reason}"
 msgstr ""
@@ -3973,8 +3975,8 @@ msgstr ""
 msgid "Invalid Invitation"
 msgstr ""
 
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:159
 #: lib/klass_hero_web/live/admin/sessions_live.ex:255
-#: lib/klass_hero_web/live/provider/sessions_live.ex:585
 #, elixir-autogen, elixir-format
 msgid "Invalid time format"
 msgstr ""
@@ -4020,7 +4022,7 @@ msgstr ""
 msgid "Location TBD"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:6
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Manage your scheduled sessions and attendance"
 msgstr ""
@@ -4030,12 +4032,12 @@ msgstr ""
 msgid "Mark Unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:200
+#: lib/klass_hero_web/components/provider_components.ex:1907
 #, elixir-autogen, elixir-format
 msgid "Max Capacity"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:90
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:80
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "No actions available"
@@ -4071,7 +4073,7 @@ msgstr ""
 msgid "No sessions found for the selected filters."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:122
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:112
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled"
@@ -4092,7 +4094,7 @@ msgstr ""
 msgid "Out: %{time}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:41
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:64
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Participation Management"
@@ -4108,23 +4110,24 @@ msgstr ""
 msgid "Please explain why you're rejecting this note..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:592
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:163
 #, elixir-autogen, elixir-format
 msgid "Please fill in all required fields"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2737
+#: lib/klass_hero_web/components/provider_components.ex:1858
+#: lib/klass_hero_web/components/provider_components.ex:1867
+#: lib/klass_hero_web/components/provider_components.ex:2917
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:24
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:299
-#: lib/klass_hero_web/live/provider/programs_live.ex:226
-#: lib/klass_hero_web/live/provider/sessions_live.ex:388
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:175
+#: lib/klass_hero_web/live/provider/programs_live.ex:227
+#: lib/klass_hero_web/live/provider/sessions_live.ex:384
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:186
+#: lib/klass_hero_web/live/provider/sessions_live.ex:183
 #, elixir-autogen, elixir-format
 msgid "Program is required"
 msgstr ""
@@ -4198,7 +4201,7 @@ msgstr ""
 msgid "Revised Note"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:176
+#: lib/klass_hero_web/components/provider_components.ex:1868
 #, elixir-autogen, elixir-format
 msgid "Select a program..."
 msgstr ""
@@ -4215,7 +4218,8 @@ msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:71
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:16
-#: lib/klass_hero_web/live/provider/sessions_live.ex:415
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:55
+#: lib/klass_hero_web/live/provider/sessions_live.ex:411
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:16
 #, elixir-autogen, elixir-format
 msgid "Session"
@@ -4226,7 +4230,8 @@ msgstr ""
 msgid "Session Roster"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:508
+#: lib/klass_hero_web/live/provider/programs_live.ex:286
+#: lib/klass_hero_web/live/provider/sessions_live.ex:462
 #, elixir-autogen, elixir-format
 msgid "Session created successfully"
 msgstr ""
@@ -4236,7 +4241,7 @@ msgstr ""
 msgid "Staff Dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:54
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:44
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "Start Session"
@@ -4272,8 +4277,7 @@ msgstr ""
 msgid "This invite link is invalid or has expired."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:576
-#: lib/klass_hero_web/live/provider/sessions_live.ex:577
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:158
 #, elixir-autogen, elixir-format
 msgid "Time is required"
 msgstr ""
@@ -4289,7 +4293,7 @@ msgid "Type your reply..."
 msgstr ""
 
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:227
-#: lib/klass_hero_web/live/provider/sessions_live.ex:190
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:162
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:126
 #, elixir-autogen, elixir-format
 msgid "Unauthorized"
@@ -4308,7 +4312,7 @@ msgid "Update your observation..."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:166
-#: lib/klass_hero_web/live/provider/programs_live.ex:503
+#: lib/klass_hero_web/live/provider/programs_live.ex:563
 #: lib/klass_hero_web/live/provider/verification_live.ex:247
 #: lib/klass_hero_web/live/provider/verification_live.ex:564
 #: lib/klass_hero_web/live/provider/verification_live.ex:602
@@ -4316,7 +4320,7 @@ msgstr ""
 msgid "Upload connection lost. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:87
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:77
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:293
 #, elixir-autogen, elixir-format
 msgid "View Participation"
@@ -4337,7 +4341,7 @@ msgstr ""
 msgid "You already have an account. Log in to see your new enrollment."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:125
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:115
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:314
 #, elixir-autogen, elixir-format
 msgid "You have no sessions scheduled for %{date}"
@@ -4381,7 +4385,7 @@ msgstr ""
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:52
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:86
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:120
-#: lib/klass_hero_web/live/provider/participation_live.ex:304
+#: lib/klass_hero_web/live/provider/participation_live.ex:354
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:53
 #, elixir-autogen, elixir-format
 msgid "You are not assigned to this program"
@@ -4552,36 +4556,36 @@ msgstr ""
 msgid "for"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1861
+#: lib/klass_hero_web/components/provider_components.ex:2016
 #, elixir-autogen, elixir-format
 msgid "Assigned staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1862
+#: lib/klass_hero_web/components/provider_components.ex:2017
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1845
-#: lib/klass_hero_web/components/provider_components.ex:1930
-#: lib/klass_hero_web/components/provider_components.ex:2078
-#: lib/klass_hero_web/components/provider_components.ex:2227
+#: lib/klass_hero_web/components/provider_components.ex:1990
+#: lib/klass_hero_web/components/provider_components.ex:2110
+#: lib/klass_hero_web/components/provider_components.ex:2258
+#: lib/klass_hero_web/components/provider_components.ex:2407
 #: lib/klass_hero_web/live/provider/overview_live.ex:403
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1860
+#: lib/klass_hero_web/components/provider_components.ex:2015
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1854
+#: lib/klass_hero_web/components/provider_components.ex:2009
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1843
+#: lib/klass_hero_web/components/provider_components.ex:1972
 #, elixir-autogen, elixir-format
 msgid "Sessions — %{title}"
 msgstr ""
@@ -4591,7 +4595,7 @@ msgstr ""
 msgid "View sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:594
+#: lib/klass_hero_web/live/provider/programs_live.ex:654
 #, elixir-autogen, elixir-format
 msgid "Create a program before inviting participants."
 msgstr ""
@@ -4606,34 +4610,34 @@ msgstr ""
 msgid "Departure notes"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:248
+#: lib/klass_hero_web/live/provider/participation_live.ex:298
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:188
 #, elixir-autogen, elixir-format
 msgid "Departure time is not a valid date and time"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:259
+#: lib/klass_hero_web/live/provider/participation_live.ex:309
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:199
 #, elixir-autogen, elixir-format
 msgid "Failed to update record"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2895
+#: lib/klass_hero_web/components/provider_components.ex:3075
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2568
+#: lib/klass_hero_web/components/provider_components.ex:2748
 #, elixir-autogen, elixir-format
 msgid "Invite mode"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2587
+#: lib/klass_hero_web/components/provider_components.ex:2767
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:590
+#: lib/klass_hero_web/live/provider/programs_live.ex:650
 #, elixir-autogen, elixir-format
 msgid "Invite sent."
 msgstr ""
@@ -4643,33 +4647,33 @@ msgstr ""
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2908
+#: lib/klass_hero_web/components/provider_components.ex:3088
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2914
+#: lib/klass_hero_web/components/provider_components.ex:3094
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:251
+#: lib/klass_hero_web/live/provider/participation_live.ex:301
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:191
 #, elixir-autogen, elixir-format
 msgid "Nothing to update"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2916
+#: lib/klass_hero_web/components/provider_components.ex:3096
 #, elixir-autogen, elixir-format
 msgid "Nut allergy"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2920
+#: lib/klass_hero_web/components/provider_components.ex:3100
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2925
+#: lib/klass_hero_web/components/provider_components.ex:3105
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr ""
@@ -4679,12 +4683,12 @@ msgstr ""
 msgid "Present"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2852
+#: lib/klass_hero_web/components/provider_components.ex:3032
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:77
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:100
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:77
 #, elixir-autogen, elixir-format
 msgid "Record departure"
@@ -4695,7 +4699,7 @@ msgstr ""
 msgid "Record departure time (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:239
+#: lib/klass_hero_web/live/provider/participation_live.ex:289
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "Record updated"
@@ -4706,22 +4710,22 @@ msgstr ""
 msgid "Save changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2889
+#: lib/klass_hero_web/components/provider_components.ex:3069
 #, elixir-autogen, elixir-format
 msgid "School (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2899
+#: lib/klass_hero_web/components/provider_components.ex:3079
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2873
+#: lib/klass_hero_web/components/provider_components.ex:3053
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2942
+#: lib/klass_hero_web/components/provider_components.ex:3122
 #, elixir-autogen, elixir-format
 msgid "Send invite"
 msgstr ""
@@ -4731,12 +4735,12 @@ msgstr ""
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2605
+#: lib/klass_hero_web/components/provider_components.ex:2785
 #, elixir-autogen, elixir-format
 msgid "Upload a list"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:601
+#: lib/klass_hero_web/live/provider/programs_live.ex:661
 #, elixir-autogen, elixir-format
 msgid "An invite for this child and program already exists."
 msgstr ""
@@ -4913,7 +4917,7 @@ msgstr ""
 msgid "Go to dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:546
+#: lib/klass_hero_web/live/provider/programs_live.ex:606
 #, elixir-autogen, elixir-format
 msgid "%{count} row could not be processed."
 msgid_plural "%{count} rows could not be processed."
@@ -5486,8 +5490,8 @@ msgstr ""
 msgid "I'll be teaching"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:521
-#: lib/klass_hero_web/live/provider/programs_live.ex:543
+#: lib/klass_hero_web/live/provider/programs_live.ex:581
+#: lib/klass_hero_web/live/provider/programs_live.ex:603
 #, elixir-autogen, elixir-format
 msgid "Imported %{count} family."
 msgid_plural "Imported %{count} families."
@@ -5678,7 +5682,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:536
 #: lib/klass_hero_web/components/provider_layout_components.ex:578
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:141
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:164
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:141
 #, elixir-autogen, elixir-format
 msgid "Mark absent"
@@ -5769,7 +5773,7 @@ msgstr ""
 msgid "No registered children for this session."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:530
+#: lib/klass_hero_web/live/provider/programs_live.ex:590
 #, elixir-autogen, elixir-format
 msgid "No rows imported. %{count} row could not be processed."
 msgid_plural "No rows imported. %{count} rows could not be processed."
@@ -6008,17 +6012,17 @@ msgstr ""
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2990
+#: lib/klass_hero_web/components/provider_components.ex:3170
 #, elixir-autogen, elixir-format
 msgid "Row %{row}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2990
+#: lib/klass_hero_web/components/provider_components.ex:3170
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2682
+#: lib/klass_hero_web/components/provider_components.ex:2862
 #, elixir-autogen, elixir-format
 msgid "Rows with errors"
 msgstr ""
@@ -6748,12 +6752,12 @@ msgstr ""
 msgid "Experience validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3498
+#: lib/klass_hero_web/components/provider_components.ex:3678
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3471
+#: lib/klass_hero_web/components/provider_components.ex:3651
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
@@ -6763,12 +6767,12 @@ msgstr ""
 msgid "Safeguarding certificate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3495
+#: lib/klass_hero_web/components/provider_components.ex:3675
 #, elixir-autogen, elixir-format
 msgid "Select Video"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3541
+#: lib/klass_hero_web/components/provider_components.ex:3721
 #, elixir-autogen, elixir-format
 msgid "Upload Video"
 msgstr ""
@@ -6778,7 +6782,7 @@ msgstr ""
 msgid "Your browser does not support video playback."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3694
+#: lib/klass_hero_web/components/provider_components.ex:3874
 #, elixir-autogen, elixir-format
 msgid "Confirm agreement"
 msgstr ""
@@ -6788,12 +6792,12 @@ msgstr ""
 msgid "Couldn't record your agreement. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3717
+#: lib/klass_hero_web/components/provider_components.ex:3897
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3693
+#: lib/klass_hero_web/components/provider_components.ex:3873
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr ""
@@ -6803,7 +6807,7 @@ msgstr ""
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3596
+#: lib/klass_hero_web/components/provider_components.ex:3776
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr ""
@@ -6813,17 +6817,17 @@ msgstr ""
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3702
+#: lib/klass_hero_web/components/provider_components.ex:3882
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3691
+#: lib/klass_hero_web/components/provider_components.ex:3871
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3692
+#: lib/klass_hero_web/components/provider_components.ex:3872
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
@@ -7092,12 +7096,12 @@ msgstr ""
 msgid "Your insurance is verified."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3640
+#: lib/klass_hero_web/components/provider_components.ex:3820
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3749
+#: lib/klass_hero_web/components/provider_components.ex:3929
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr ""
@@ -7107,7 +7111,7 @@ msgstr ""
 msgid "Couldn't record your declaration. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3755
+#: lib/klass_hero_web/components/provider_components.ex:3935
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr ""
@@ -7117,17 +7121,17 @@ msgstr ""
 msgid "Please confirm the declaration before signing."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3780
+#: lib/klass_hero_web/components/provider_components.ex:3960
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3759
+#: lib/klass_hero_web/components/provider_components.ex:3939
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3747
+#: lib/klass_hero_web/components/provider_components.ex:3927
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr ""
@@ -7137,12 +7141,12 @@ msgstr ""
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3767
+#: lib/klass_hero_web/components/provider_components.ex:3947
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3753
+#: lib/klass_hero_web/components/provider_components.ex:3933
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
@@ -7209,25 +7213,25 @@ msgstr ""
 msgid "Undelivered Events"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2172
-#: lib/klass_hero_web/components/provider_components.ex:2350
+#: lib/klass_hero_web/components/provider_components.ex:2352
+#: lib/klass_hero_web/components/provider_components.ex:2530
 #: lib/klass_hero_web/live/user_live/settings.ex:292
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2100
-#: lib/klass_hero_web/components/provider_components.ex:2281
+#: lib/klass_hero_web/components/provider_components.ex:2280
+#: lib/klass_hero_web/components/provider_components.ex:2461
 #, elixir-autogen, elixir-format
 msgid "Lead"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:432
+#: lib/klass_hero_web/live/provider/programs_live.ex:492
 #, elixir-autogen, elixir-format
 msgid "Lead instructor updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2112
+#: lib/klass_hero_web/components/provider_components.ex:2292
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor"
 msgstr ""
@@ -7237,65 +7241,65 @@ msgstr ""
 msgid "Manage Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2141
+#: lib/klass_hero_web/components/provider_components.ex:2321
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this program yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:362
-#: lib/klass_hero_web/live/provider/sessions_live.ex:220
+#: lib/klass_hero_web/live/provider/programs_live.ex:422
+#: lib/klass_hero_web/live/provider/sessions_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "Pick a staff member to add."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2124
-#: lib/klass_hero_web/components/provider_components.ex:2389
+#: lib/klass_hero_web/components/provider_components.ex:2304
+#: lib/klass_hero_web/components/provider_components.ex:2569
 #, elixir-autogen, elixir-format
 msgid "Reassign the lead before removing them"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2125
+#: lib/klass_hero_web/components/provider_components.ex:2305
 #, elixir-autogen, elixir-format
 msgid "Remove from program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2160
-#: lib/klass_hero_web/components/provider_components.ex:2337
+#: lib/klass_hero_web/components/provider_components.ex:2340
+#: lib/klass_hero_web/components/provider_components.ex:2517
 #, elixir-autogen, elixir-format
 msgid "Select a staff member…"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:377
+#: lib/klass_hero_web/live/provider/programs_live.ex:437
 #, elixir-autogen, elixir-format
 msgid "Staff member added to the program."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:403
+#: lib/klass_hero_web/live/provider/programs_live.ex:463
 #, elixir-autogen, elixir-format
 msgid "Staff member removed from the program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2177
+#: lib/klass_hero_web/components/provider_components.ex:2357
 #, elixir-autogen, elixir-format
 msgid "Staff you add can read and reply to this program's parent conversations."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2076
+#: lib/klass_hero_web/components/provider_components.ex:2256
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1055
+#: lib/klass_hero_web/live/provider/programs_live.ex:1134
 #, elixir-autogen, elixir-format
 msgid "That staff member could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:385
+#: lib/klass_hero_web/live/provider/programs_live.ex:445
 #, elixir-autogen, elixir-format
 msgid "They are already on this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:411
+#: lib/klass_hero_web/live/provider/programs_live.ex:471
 #, elixir-autogen, elixir-format
 msgid "This person is the lead instructor. Make someone else lead before removing them."
 msgstr ""
@@ -7357,17 +7361,17 @@ msgstr ""
 msgid "This person has a history here now — use 'Remove from team' instead."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1333
+#: lib/klass_hero_web/live/provider/programs_live.ex:1412
 #, elixir-autogen, elixir-format
 msgid "Program created, but some settings could not be saved. Please review the program's limits."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1337
+#: lib/klass_hero_web/live/provider/programs_live.ex:1416
 #, elixir-autogen, elixir-format
 msgid "Program updated, but some settings could not be saved. Please review the program's limits."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1327
+#: lib/klass_hero_web/live/provider/programs_live.ex:1406
 #, elixir-autogen, elixir-format
 msgid "Program updated, but the enrollment capacity was rejected. The previous limits still apply."
 msgstr ""
@@ -7389,92 +7393,93 @@ msgstr ""
 msgid "I understand this program will have no capacity limit."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2377
+#: lib/klass_hero_web/components/provider_components.ex:2557
 #, elixir-autogen, elixir-format
 msgid "Go back to the program's usual team"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:302
+#: lib/klass_hero_web/live/provider/sessions_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "Lead instructor for this session updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2296
+#: lib/klass_hero_web/components/provider_components.ex:2476
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor for this session"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2318
+#: lib/klass_hero_web/components/provider_components.ex:2498
 #, elixir-autogen, elixir-format
 msgid "Nobody is working this session yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2394
+#: lib/klass_hero_web/components/provider_components.ex:2574
 #, elixir-autogen, elixir-format
 msgid "Remove from this session"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:238
+#: lib/klass_hero_web/live/provider/sessions_live.ex:235
 #, elixir-autogen, elixir-format
 msgid "Staff member added to this session."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:262
+#: lib/klass_hero_web/live/provider/sessions_live.ex:259
 #, elixir-autogen, elixir-format
 msgid "Staff member removed from this session."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:107
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2220
+#: lib/klass_hero_web/components/provider_components.ex:2400
 #, elixir-autogen, elixir-format
 msgid "Staffing — %{date}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:431
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:164
+#: lib/klass_hero_web/live/provider/sessions_live.ex:427
 #, elixir-autogen, elixir-format
 msgid "That session could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:246
+#: lib/klass_hero_web/live/provider/sessions_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "They are already working this session."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:270
+#: lib/klass_hero_web/live/provider/sessions_live.ex:267
 #, elixir-autogen, elixir-format
 msgid "This person leads the session. Make someone else lead before removing them."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:318
+#: lib/klass_hero_web/live/provider/sessions_live.ex:315
 #, elixir-autogen, elixir-format
 msgid "This session is back on the program's usual team."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:281
+#: lib/klass_hero_web/live/provider/sessions_live.ex:278
 #, elixir-autogen, elixir-format
 msgid "A session needs at least one person. Use “Go back to the program's usual team” to drop this session's own roster."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2392
+#: lib/klass_hero_web/components/provider_components.ex:2572
 #, elixir-autogen, elixir-format
 msgid "A session needs someone — use “Go back to the program's usual team” instead"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2359
+#: lib/klass_hero_web/components/provider_components.ex:2539
 #, elixir-autogen, elixir-format
 msgid "Everyone on your team is already working this session."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2252
+#: lib/klass_hero_web/components/provider_components.ex:2432
 #, elixir-autogen, elixir-format
 msgid "Staffed just for this session. Changes here do not touch the program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2254
+#: lib/klass_hero_web/components/provider_components.ex:2434
 #, elixir-autogen, elixir-format
 msgid "Using the program's usual team. The first change here copies them onto this session, so later program changes stop reaching it."
 msgstr ""
@@ -7484,17 +7489,17 @@ msgstr ""
 msgid "(optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1995
+#: lib/klass_hero_web/components/provider_components.ex:2175
 #, elixir-autogen, elixir-format
 msgid "Add a waiver"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2027
+#: lib/klass_hero_web/components/provider_components.ex:2207
 #, elixir-autogen, elixir-format
 msgid "Add waiver"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:927
+#: lib/klass_hero_web/live/provider/programs_live.ex:987
 #, elixir-autogen, elixir-format
 msgid "Check the waiver details and try again."
 msgstr ""
@@ -7511,7 +7516,7 @@ msgstr ""
 msgid "I have read and agree to %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2009
+#: lib/klass_hero_web/components/provider_components.ex:2189
 #, elixir-autogen, elixir-format
 msgid "Legal text"
 msgstr ""
@@ -7521,12 +7526,12 @@ msgstr ""
 msgid "Manage Waivers"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1937
+#: lib/klass_hero_web/components/provider_components.ex:2117
 #, elixir-autogen, elixir-format
 msgid "No waivers yet. Parents enrol without signing anything."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2016
+#: lib/klass_hero_web/components/provider_components.ex:2196
 #, elixir-autogen, elixir-format
 msgid "Parents must sign this before enrolling"
 msgstr ""
@@ -7546,17 +7551,17 @@ msgstr ""
 msgid "Please tick a waiver to sign it."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1994
+#: lib/klass_hero_web/components/provider_components.ex:2174
 #, elixir-autogen, elixir-format
 msgid "Publish a new version"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2027
+#: lib/klass_hero_web/components/provider_components.ex:2207
 #, elixir-autogen, elixir-format
 msgid "Publish version"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2020
+#: lib/klass_hero_web/components/provider_components.ex:2200
 #, elixir-autogen, elixir-format
 msgid "Publishing keeps every earlier version on record; signatures already given stay bound to the wording they were shown."
 msgstr ""
@@ -7566,12 +7571,12 @@ msgstr ""
 msgid "Required"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1971
+#: lib/klass_hero_web/components/provider_components.ex:2151
 #, elixir-autogen, elixir-format
 msgid "Retire this waiver"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1962
+#: lib/klass_hero_web/components/provider_components.ex:2142
 #, elixir-autogen, elixir-format
 msgid "Revise text"
 msgstr ""
@@ -7586,7 +7591,7 @@ msgstr ""
 msgid "Sign waivers"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2494
+#: lib/klass_hero_web/components/provider_components.ex:2674
 #: lib/klass_hero_web/live/enrollment_waivers_live.ex:149
 #, elixir-autogen, elixir-format
 msgid "Signed"
@@ -7602,22 +7607,22 @@ msgstr ""
 msgid "There is nothing to sign for this enrollment."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2494
+#: lib/klass_hero_web/components/provider_components.ex:2674
 #, elixir-autogen, elixir-format
 msgid "Unsigned"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1954
+#: lib/klass_hero_web/components/provider_components.ex:2134
 #, elixir-autogen, elixir-format
 msgid "Version %{number}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:356
+#: lib/klass_hero_web/live/provider/programs_live.ex:416
 #, elixir-autogen, elixir-format
 msgid "Waiver not found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2447
+#: lib/klass_hero_web/components/provider_components.ex:2627
 #: lib/klass_hero_web/live/booking_live.ex:447
 #: lib/klass_hero_web/live/enrollment_waivers_live.ex:33
 #: lib/klass_hero_web/live/enrollment_waivers_live.ex:105
@@ -7630,7 +7635,7 @@ msgstr ""
 msgid "Waivers waiting for your signature"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1928
+#: lib/klass_hero_web/components/provider_components.ex:2108
 #, elixir-autogen, elixir-format
 msgid "Waivers — %{title}"
 msgstr ""
@@ -7640,22 +7645,22 @@ msgstr ""
 msgid "this program"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:924
+#: lib/klass_hero_web/live/provider/programs_live.ex:984
 #, elixir-autogen, elixir-format
 msgid "New version published. It applies to future enrolments."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1975
+#: lib/klass_hero_web/components/provider_components.ex:2155
 #, elixir-autogen, elixir-format
 msgid "Retire \"%{title}\"? Parents will no longer be asked to sign it. Signatures already collected are kept."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:923
+#: lib/klass_hero_web/live/provider/programs_live.ex:983
 #, elixir-autogen, elixir-format
 msgid "Waiver added."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:353
+#: lib/klass_hero_web/live/provider/programs_live.ex:413
 #, elixir-autogen, elixir-format
 msgid "Waiver retired. Signatures already collected are kept."
 msgstr ""
@@ -7721,7 +7726,7 @@ msgstr ""
 msgid "This is your main provider identity. Verification is required to list programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3337
+#: lib/klass_hero_web/components/provider_components.ex:3517
 #, elixir-autogen, elixir-format
 msgid "Upload documents to be verified. Documents are reviewed by our team."
 msgstr ""
@@ -7865,8 +7870,8 @@ msgstr ""
 msgid "Review invitations"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2758
-#: lib/klass_hero_web/components/provider_components.ex:2765
+#: lib/klass_hero_web/components/provider_components.ex:2938
+#: lib/klass_hero_web/components/provider_components.ex:2945
 #, elixir-autogen, elixir-format
 msgid "Unknown program"
 msgstr ""
@@ -7931,17 +7936,17 @@ msgstr ""
 msgid "N/A"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3245
+#: lib/klass_hero_web/components/provider_components.ex:3425
 #, elixir-autogen, elixir-format
 msgid "A short line that sums you up"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3234
+#: lib/klass_hero_web/components/provider_components.ex:3414
 #, elixir-autogen, elixir-format
 msgid "Branding & Presence"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3258
+#: lib/klass_hero_web/components/provider_components.ex:3438
 #, elixir-autogen, elixir-format
 msgid "Choose Cover Image"
 msgstr ""
@@ -7951,17 +7956,17 @@ msgstr ""
 msgid "Cover image upload failed. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3259
+#: lib/klass_hero_web/components/provider_components.ex:3439
 #, elixir-autogen, elixir-format
 msgid "JPG, PNG or WebP. Max 5MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3237
+#: lib/klass_hero_web/components/provider_components.ex:3417
 #, elixir-autogen, elixir-format
 msgid "Shown on your public profile page."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3244
+#: lib/klass_hero_web/components/provider_components.ex:3424
 #, elixir-autogen, elixir-format
 msgid "Tagline"
 msgstr ""
@@ -7971,7 +7976,7 @@ msgstr ""
 msgid "Absent:"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:115
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:138
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:115
 #, elixir-autogen, elixir-format
 msgid "Arrived late"
@@ -8007,7 +8012,7 @@ msgstr ""
 msgid "Klass Hero on %{network}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3316
+#: lib/klass_hero_web/components/provider_components.ex:3496
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr ""
@@ -8047,7 +8052,7 @@ msgstr ""
 msgid "A newly chosen cover or logo appears here after you save."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3289
+#: lib/klass_hero_web/components/provider_components.ex:3469
 #, elixir-autogen, elixir-format
 msgid "Add %{network}"
 msgstr ""
@@ -8067,7 +8072,7 @@ msgstr ""
 msgid "Show preview"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3276
+#: lib/klass_hero_web/components/provider_components.ex:3456
 #, elixir-autogen, elixir-format
 msgid "e.g. %{example}"
 msgstr ""
@@ -8212,4 +8217,45 @@ msgstr ""
 #: lib/klass_hero_web/components/participation_components.ex:199
 #, elixir-autogen, elixir-format
 msgid "Over capacity"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:41
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:51
+#, elixir-autogen, elixir-format
+msgid "Edit Session"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1970
+#, elixir-autogen, elixir-format
+msgid "New session — %{title}"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:57
+#, elixir-autogen, elixir-format
+msgid "Save Session"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/participation_live.ex:103
+#, elixir-autogen, elixir-format
+msgid "Session updated"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/programs_live.ex:264
+#, elixir-autogen, elixir-format
+msgid "That program could not be found."
+msgstr ""
+
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:165
+#, elixir-autogen, elixir-format
+msgid "That session could not be saved."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1900
+#, elixir-autogen, elixir-format
+msgid "The date and time are fixed once a session has started — its attendance records are keyed to it."
+msgstr ""
+
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:167
+#, elixir-autogen, elixir-format
+msgid "The date and time are fixed once a session has started."
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -683,7 +683,7 @@ msgstr ""
 msgid "Introduction"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:157
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:165
 #: lib/klass_hero_web/live/provider/sessions_live.ex:114
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:66
 #, elixir-autogen, elixir-format
@@ -761,7 +761,7 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/sessions_live.ex:50
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:6
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:21
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:223
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:231
 #, elixir-autogen, elixir-format
 msgid "My Sessions"
 msgstr ""
@@ -1138,7 +1138,7 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/participation_live.ex:30
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:55
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:27
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:271
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:279
 #, elixir-autogen, elixir-format
 msgid "Manage Participation"
 msgstr ""
@@ -3688,7 +3688,7 @@ msgstr ""
 msgid "%{count} unread"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:161
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:169
 #, elixir-autogen, elixir-format
 msgid "A session already exists at this time"
 msgstr ""
@@ -3809,7 +3809,7 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:33
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:66
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:33
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:282
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:290
 #, elixir-autogen, elixir-format
 msgid "Complete Session"
 msgstr ""
@@ -3861,7 +3861,7 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:156
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:164
 #, elixir-autogen, elixir-format
 msgid "Date is required"
 msgstr ""
@@ -3904,7 +3904,7 @@ msgstr ""
 msgid "Emergency: %{details}"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:160
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:168
 #, elixir-autogen, elixir-format
 msgid "End time must be after start time"
 msgstr ""
@@ -3919,7 +3919,7 @@ msgstr ""
 msgid "Failed to archive email"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:169
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:177
 #, elixir-autogen, elixir-format
 msgid "Failed to create session: %{reason}"
 msgstr ""
@@ -3975,7 +3975,7 @@ msgstr ""
 msgid "Invalid Invitation"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:159
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:167
 #: lib/klass_hero_web/live/admin/sessions_live.ex:255
 #, elixir-autogen, elixir-format
 msgid "Invalid time format"
@@ -4038,7 +4038,7 @@ msgid "Max Capacity"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:80
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:296
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:304
 #, elixir-autogen, elixir-format
 msgid "No actions available"
 msgstr ""
@@ -4074,7 +4074,7 @@ msgid "No sessions found for the selected filters."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:112
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:311
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:319
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled"
 msgstr ""
@@ -4110,7 +4110,7 @@ msgstr ""
 msgid "Please explain why you're rejecting this note..."
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:163
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:171
 #, elixir-autogen, elixir-format
 msgid "Please fill in all required fields"
 msgstr ""
@@ -4242,7 +4242,7 @@ msgid "Staff Dashboard"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:44
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:260
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "Start Session"
 msgstr ""
@@ -4277,7 +4277,7 @@ msgstr ""
 msgid "This invite link is invalid or has expired."
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:158
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:166
 #, elixir-autogen, elixir-format
 msgid "Time is required"
 msgstr ""
@@ -4293,7 +4293,7 @@ msgid "Type your reply..."
 msgstr ""
 
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:227
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:162
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:170
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:126
 #, elixir-autogen, elixir-format
 msgid "Unauthorized"
@@ -4321,7 +4321,7 @@ msgid "Upload connection lost. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:77
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:293
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:301
 #, elixir-autogen, elixir-format
 msgid "View Participation"
 msgstr ""
@@ -4342,7 +4342,7 @@ msgid "You already have an account. Log in to see your new enrollment."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:115
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:314
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:322
 #, elixir-autogen, elixir-format
 msgid "You have no sessions scheduled for %{date}"
 msgstr ""
@@ -4377,7 +4377,7 @@ msgstr ""
 msgid "Unlimited team seats"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:224
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:232
 #, elixir-autogen, elixir-format
 msgid "View and manage your assigned sessions"
 msgstr ""
@@ -7438,7 +7438,7 @@ msgstr ""
 msgid "Staffing — %{date}"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:164
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:172
 #: lib/klass_hero_web/live/provider/sessions_live.ex:427
 #, elixir-autogen, elixir-format
 msgid "That session could not be found."
@@ -8245,7 +8245,7 @@ msgstr ""
 msgid "That program could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:165
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:173
 #, elixir-autogen, elixir-format
 msgid "That session could not be saved."
 msgstr ""
@@ -8255,7 +8255,7 @@ msgstr ""
 msgid "The date and time are fixed once a session has started — its attendance records are keyed to it."
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:167
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:175
 #, elixir-autogen, elixir-format
 msgid "The date and time are fixed once a session has started."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -683,7 +683,7 @@ msgstr ""
 msgid "Introduction"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:165
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:173
 #: lib/klass_hero_web/live/provider/sessions_live.ex:114
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:66
 #, elixir-autogen, elixir-format
@@ -3688,7 +3688,7 @@ msgstr ""
 msgid "%{count} unread"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:169
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:177
 #, elixir-autogen, elixir-format
 msgid "A session already exists at this time"
 msgstr ""
@@ -3861,7 +3861,7 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:164
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:172
 #, elixir-autogen, elixir-format
 msgid "Date is required"
 msgstr ""
@@ -3904,7 +3904,7 @@ msgstr ""
 msgid "Emergency: %{details}"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:168
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:176
 #, elixir-autogen, elixir-format
 msgid "End time must be after start time"
 msgstr ""
@@ -3919,7 +3919,7 @@ msgstr ""
 msgid "Failed to archive email"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:177
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:185
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to create session: %{reason}"
 msgstr ""
@@ -3975,7 +3975,7 @@ msgstr ""
 msgid "Invalid Invitation"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:167
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:175
 #: lib/klass_hero_web/live/admin/sessions_live.ex:255
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invalid time format"
@@ -4110,7 +4110,7 @@ msgstr ""
 msgid "Please explain why you're rejecting this note..."
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:171
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:179
 #, elixir-autogen, elixir-format
 msgid "Please fill in all required fields"
 msgstr ""
@@ -4277,7 +4277,7 @@ msgstr ""
 msgid "This invite link is invalid or has expired."
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:166
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:174
 #, elixir-autogen, elixir-format
 msgid "Time is required"
 msgstr ""
@@ -4293,7 +4293,7 @@ msgid "Type your reply..."
 msgstr ""
 
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:227
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:170
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:178
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:126
 #, elixir-autogen, elixir-format
 msgid "Unauthorized"
@@ -7438,7 +7438,7 @@ msgstr ""
 msgid "Staffing — %{date}"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:172
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:180
 #: lib/klass_hero_web/live/provider/sessions_live.ex:427
 #, elixir-autogen, elixir-format
 msgid "That session could not be found."
@@ -8245,7 +8245,7 @@ msgstr ""
 msgid "That program could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:173
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:181
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That session could not be saved."
 msgstr ""
@@ -8255,7 +8255,7 @@ msgstr ""
 msgid "The date and time are fixed once a session has started — its attendance records are keyed to it."
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:175
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:183
 #, elixir-autogen, elixir-format
 msgid "The date and time are fixed once a session has started."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -683,7 +683,7 @@ msgstr ""
 msgid "Introduction"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:157
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:165
 #: lib/klass_hero_web/live/provider/sessions_live.ex:114
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:66
 #, elixir-autogen, elixir-format
@@ -761,7 +761,7 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/sessions_live.ex:50
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:6
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:21
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:223
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:231
 #, elixir-autogen, elixir-format
 msgid "My Sessions"
 msgstr ""
@@ -1138,7 +1138,7 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/participation_live.ex:30
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:55
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:27
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:271
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:279
 #, elixir-autogen, elixir-format
 msgid "Manage Participation"
 msgstr ""
@@ -3688,7 +3688,7 @@ msgstr ""
 msgid "%{count} unread"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:161
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:169
 #, elixir-autogen, elixir-format
 msgid "A session already exists at this time"
 msgstr ""
@@ -3809,7 +3809,7 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:33
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:66
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:33
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:282
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:290
 #, elixir-autogen, elixir-format
 msgid "Complete Session"
 msgstr ""
@@ -3861,7 +3861,7 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:156
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:164
 #, elixir-autogen, elixir-format
 msgid "Date is required"
 msgstr ""
@@ -3904,7 +3904,7 @@ msgstr ""
 msgid "Emergency: %{details}"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:160
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:168
 #, elixir-autogen, elixir-format
 msgid "End time must be after start time"
 msgstr ""
@@ -3919,7 +3919,7 @@ msgstr ""
 msgid "Failed to archive email"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:169
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:177
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to create session: %{reason}"
 msgstr ""
@@ -3975,7 +3975,7 @@ msgstr ""
 msgid "Invalid Invitation"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:159
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:167
 #: lib/klass_hero_web/live/admin/sessions_live.ex:255
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invalid time format"
@@ -4038,7 +4038,7 @@ msgid "Max Capacity"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:80
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:296
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:304
 #, elixir-autogen, elixir-format
 msgid "No actions available"
 msgstr ""
@@ -4074,7 +4074,7 @@ msgid "No sessions found for the selected filters."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:112
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:311
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:319
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled"
 msgstr ""
@@ -4110,7 +4110,7 @@ msgstr ""
 msgid "Please explain why you're rejecting this note..."
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:163
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:171
 #, elixir-autogen, elixir-format
 msgid "Please fill in all required fields"
 msgstr ""
@@ -4242,7 +4242,7 @@ msgid "Staff Dashboard"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:44
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:260
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:268
 #, elixir-autogen, elixir-format
 msgid "Start Session"
 msgstr ""
@@ -4277,7 +4277,7 @@ msgstr ""
 msgid "This invite link is invalid or has expired."
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:158
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:166
 #, elixir-autogen, elixir-format
 msgid "Time is required"
 msgstr ""
@@ -4293,7 +4293,7 @@ msgid "Type your reply..."
 msgstr ""
 
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:227
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:162
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:170
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:126
 #, elixir-autogen, elixir-format
 msgid "Unauthorized"
@@ -4321,7 +4321,7 @@ msgid "Upload connection lost. Please try again."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:77
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:293
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:301
 #, elixir-autogen, elixir-format
 msgid "View Participation"
 msgstr ""
@@ -4342,7 +4342,7 @@ msgid "You already have an account. Log in to see your new enrollment."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/sessions_live.html.heex:115
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:314
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:322
 #, elixir-autogen, elixir-format
 msgid "You have no sessions scheduled for %{date}"
 msgstr ""
@@ -4377,7 +4377,7 @@ msgstr ""
 msgid "Unlimited team seats"
 msgstr ""
 
-#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:224
+#: lib/klass_hero_web/live/staff/staff_sessions_live.ex:232
 #, elixir-autogen, elixir-format
 msgid "View and manage your assigned sessions"
 msgstr ""
@@ -7438,7 +7438,7 @@ msgstr ""
 msgid "Staffing — %{date}"
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:164
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:172
 #: lib/klass_hero_web/live/provider/sessions_live.ex:427
 #, elixir-autogen, elixir-format
 msgid "That session could not be found."
@@ -8245,7 +8245,7 @@ msgstr ""
 msgid "That program could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:165
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:173
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That session could not be saved."
 msgstr ""
@@ -8255,7 +8255,7 @@ msgstr ""
 msgid "The date and time are fixed once a session has started — its attendance records are keyed to it."
 msgstr ""
 
-#: lib/klass_hero_web/helpers/session_form_handlers.ex:167
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:175
 #, elixir-autogen, elixir-format
 msgid "The date and time are fixed once a session has started."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -577,8 +577,8 @@ msgid "Dispute Resolution"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:781
-#: lib/klass_hero_web/components/provider_components.ex:2859
-#: lib/klass_hero_web/components/provider_components.ex:2877
+#: lib/klass_hero_web/components/provider_components.ex:3039
+#: lib/klass_hero_web/components/provider_components.ex:3057
 #: lib/klass_hero_web/live/contact_live.ex:71
 #: lib/klass_hero_web/live/contact_live.ex:160
 #: lib/klass_hero_web/live/user_live/login.ex:61
@@ -621,7 +621,7 @@ msgid "Failed to check out: %{reason}"
 msgstr ""
 
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:202
-#: lib/klass_hero_web/live/provider/sessions_live.ex:167
+#: lib/klass_hero_web/live/provider/sessions_live.ex:165
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:117
 #, elixir-autogen, elixir-format
 msgid "Failed to complete session: %{reason}"
@@ -632,7 +632,7 @@ msgstr ""
 msgid "Failed to delete account. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:141
+#: lib/klass_hero_web/live/provider/sessions_live.ex:139
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:91
 #, elixir-autogen, elixir-format
 msgid "Failed to start session: %{reason}"
@@ -683,8 +683,8 @@ msgstr ""
 msgid "Introduction"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:116
-#: lib/klass_hero_web/live/provider/sessions_live.ex:572
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:157
+#: lib/klass_hero_web/live/provider/sessions_live.ex:114
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:66
 #, elixir-autogen, elixir-format
 msgid "Invalid date format"
@@ -758,8 +758,8 @@ msgstr ""
 msgid "Message sent successfully!"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:51
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:4
+#: lib/klass_hero_web/live/provider/sessions_live.ex:50
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:6
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:21
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:223
 #, elixir-autogen, elixir-format
@@ -852,8 +852,8 @@ msgstr ""
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:107
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:139
 #: lib/klass_hero_web/live/admin/sessions_live.ex:247
-#: lib/klass_hero_web/live/provider/participation_live.ex:199
-#: lib/klass_hero_web/live/provider/participation_live.ex:245
+#: lib/klass_hero_web/live/provider/participation_live.ex:249
+#: lib/klass_hero_web/live/provider/participation_live.ex:295
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:139
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:185
 #, elixir-autogen, elixir-format
@@ -882,9 +882,9 @@ msgstr ""
 msgid "Select one or both options"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2508
-#: lib/klass_hero_web/components/provider_components.ex:2509
-#: lib/klass_hero_web/components/provider_components.ex:2547
+#: lib/klass_hero_web/components/provider_components.ex:2688
+#: lib/klass_hero_web/components/provider_components.ex:2689
+#: lib/klass_hero_web/components/provider_components.ex:2727
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:468
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:469
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:505
@@ -893,7 +893,7 @@ msgid "Send Message"
 msgstr ""
 
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:190
-#: lib/klass_hero_web/live/provider/sessions_live.ex:150
+#: lib/klass_hero_web/live/provider/sessions_live.ex:148
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:100
 #, elixir-autogen, elixir-format
 msgid "Session completed successfully"
@@ -901,13 +901,13 @@ msgstr ""
 
 #: lib/klass_hero_web/live/admin/sessions_live.ex:62
 #: lib/klass_hero_web/live/admin/sessions_live.ex:68
-#: lib/klass_hero_web/live/provider/participation_live.ex:315
+#: lib/klass_hero_web/live/provider/participation_live.ex:365
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:270
 #, elixir-autogen, elixir-format
 msgid "Session not found"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:124
+#: lib/klass_hero_web/live/provider/sessions_live.ex:122
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:74
 #, elixir-autogen, elixir-format
 msgid "Session started successfully"
@@ -1135,8 +1135,8 @@ msgstr ""
 msgid "Failed to load participation history"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:27
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:65
+#: lib/klass_hero_web/live/provider/participation_live.ex:30
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:55
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:27
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:271
 #, elixir-autogen, elixir-format
@@ -1334,8 +1334,8 @@ msgid "Quick Navigation"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1466
-#: lib/klass_hero_web/components/provider_components.ex:2453
-#: lib/klass_hero_web/components/provider_components.ex:2746
+#: lib/klass_hero_web/components/provider_components.ex:2633
+#: lib/klass_hero_web/components/provider_components.ex:2926
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
@@ -1351,7 +1351,7 @@ msgstr ""
 msgid "Add Team Member"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:49
+#: lib/klass_hero_web/live/provider/programs_live.ex:50
 #, elixir-autogen, elixir-format
 msgid "All Staff"
 msgstr ""
@@ -1380,8 +1380,8 @@ msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:586
 #: lib/klass_hero_web/components/provider_components.ex:1575
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:65
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:92
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:88
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:115
 #: lib/klass_hero_web/live/settings/children_live.ex:413
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:65
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:92
@@ -1402,7 +1402,7 @@ msgid "Inactive"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:116
-#: lib/klass_hero_web/live/provider/programs_live.ex:55
+#: lib/klass_hero_web/live/provider/programs_live.ex:56
 #, elixir-autogen, elixir-format, fuzzy
 msgid "My Programs"
 msgstr ""
@@ -1421,8 +1421,8 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:50
 #: lib/klass_hero_web/components/provider_components.ex:76
 #: lib/klass_hero_web/components/provider_components.ex:1613
-#: lib/klass_hero_web/components/provider_components.ex:2953
-#: lib/klass_hero_web/components/provider_components.ex:2980
+#: lib/klass_hero_web/components/provider_components.ex:3133
+#: lib/klass_hero_web/components/provider_components.ex:3160
 #: lib/klass_hero_web/live/admin/sessions_live.ex:293
 #: lib/klass_hero_web/live/admin/verifications_live.ex:202
 #, elixir-autogen, elixir-format
@@ -1460,9 +1460,9 @@ msgid "Search by name..."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1460
-#: lib/klass_hero_web/components/provider_components.ex:1863
-#: lib/klass_hero_web/components/provider_components.ex:2444
-#: lib/klass_hero_web/components/provider_components.ex:2743
+#: lib/klass_hero_web/components/provider_components.ex:2018
+#: lib/klass_hero_web/components/provider_components.ex:2624
+#: lib/klass_hero_web/components/provider_components.ex:2923
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:70
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:152
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:195
@@ -1482,7 +1482,7 @@ msgid "Team & Provider Profiles"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1517
-#: lib/klass_hero_web/components/provider_components.ex:1878
+#: lib/klass_hero_web/components/provider_components.ex:2047
 #, elixir-autogen, elixir-format
 msgid "Unassigned"
 msgstr ""
@@ -1561,14 +1561,14 @@ msgstr ""
 #: lib/klass_hero_web/components/participation_components.ex:708
 #: lib/klass_hero_web/components/provider_components.ex:909
 #: lib/klass_hero_web/components/provider_components.ex:1323
-#: lib/klass_hero_web/components/provider_components.ex:2036
-#: lib/klass_hero_web/components/provider_components.ex:2651
+#: lib/klass_hero_web/components/provider_components.ex:1918
+#: lib/klass_hero_web/components/provider_components.ex:2216
+#: lib/klass_hero_web/components/provider_components.ex:2831
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:241
 #: lib/klass_hero_web/live/admin/verifications_live.ex:489
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:111
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:222
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:361
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:210
 #: lib/klass_hero_web/live/settings/children_live.ex:544
 #: lib/klass_hero_web/live/settings/children_live.ex:703
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:237
@@ -1621,8 +1621,8 @@ msgstr ""
 msgid "Data sharing consent"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2441
-#: lib/klass_hero_web/components/provider_components.ex:2840
+#: lib/klass_hero_web/components/provider_components.ex:2621
+#: lib/klass_hero_web/components/provider_components.ex:3020
 #: lib/klass_hero_web/live/settings/children_live.ex:622
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
@@ -1654,7 +1654,7 @@ msgstr ""
 msgid "Failed to reject note"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:191
+#: lib/klass_hero_web/live/provider/participation_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "Failed to resubmit note"
 msgstr ""
@@ -1670,17 +1670,17 @@ msgstr ""
 msgid "Failed to submit note"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2834
-#: lib/klass_hero_web/components/provider_components.ex:2863
-#: lib/klass_hero_web/components/provider_components.ex:2879
+#: lib/klass_hero_web/components/provider_components.ex:3014
+#: lib/klass_hero_web/components/provider_components.ex:3043
+#: lib/klass_hero_web/components/provider_components.ex:3059
 #: lib/klass_hero_web/live/settings/children_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "First name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2835
-#: lib/klass_hero_web/components/provider_components.ex:2864
-#: lib/klass_hero_web/components/provider_components.ex:2880
+#: lib/klass_hero_web/components/provider_components.ex:3015
+#: lib/klass_hero_web/components/provider_components.ex:3044
+#: lib/klass_hero_web/components/provider_components.ex:3060
 #: lib/klass_hero_web/live/settings/children_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Last name"
@@ -1750,7 +1750,7 @@ msgid "Note approved"
 msgstr ""
 
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:157
-#: lib/klass_hero_web/live/provider/participation_live.ex:183
+#: lib/klass_hero_web/live/provider/participation_live.ex:233
 #, elixir-autogen, elixir-format
 msgid "Note content cannot be blank"
 msgstr ""
@@ -1760,7 +1760,7 @@ msgstr ""
 msgid "Note rejected"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:177
+#: lib/klass_hero_web/live/provider/participation_live.ex:227
 #, elixir-autogen, elixir-format
 msgid "Note resubmitted for review"
 msgstr ""
@@ -1842,7 +1842,7 @@ msgstr ""
 msgid "Send a message to start the conversation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2934
+#: lib/klass_hero_web/components/provider_components.ex:3114
 #: lib/klass_hero_web/live/provider/broadcast_live.ex:251
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:249
 #, elixir-autogen, elixir-format, fuzzy
@@ -1866,7 +1866,7 @@ msgstr ""
 msgid "Type a message..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:335
+#: lib/klass_hero_web/live/provider/participation_live.ex:385
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:290
 #, elixir-autogen, elixir-format
 msgid "Unable to refresh roster. Please reload."
@@ -1978,7 +1978,7 @@ msgstr ""
 msgid "Allowed Genders"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3002
+#: lib/klass_hero_web/components/provider_components.ex:3182
 #, elixir-autogen, elixir-format, fuzzy
 msgid "An unexpected error occurred during import."
 msgstr ""
@@ -2057,8 +2057,8 @@ msgstr ""
 msgid "Check eligibility at"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2435
-#: lib/klass_hero_web/components/provider_components.ex:2729
+#: lib/klass_hero_web/components/provider_components.ex:2615
+#: lib/klass_hero_web/components/provider_components.ex:2909
 #, elixir-autogen, elixir-format
 msgid "Child Name"
 msgstr ""
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "Confirm rejection"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2954
+#: lib/klass_hero_web/components/provider_components.ex:3134
 #, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
@@ -2109,7 +2109,7 @@ msgstr ""
 msgid "Contact Provider"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:510
+#: lib/klass_hero_web/live/provider/programs_live.ex:570
 #, elixir-autogen, elixir-format
 msgid "Could not read the uploaded file."
 msgstr ""
@@ -2120,7 +2120,7 @@ msgid "Could not remove invite."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1290
-#: lib/klass_hero_web/components/provider_components.ex:3251
+#: lib/klass_hero_web/components/provider_components.ex:3431
 #, elixir-autogen, elixir-format
 msgid "Cover Image"
 msgstr ""
@@ -2149,7 +2149,7 @@ msgstr ""
 msgid "Diverse"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3380
+#: lib/klass_hero_web/components/provider_components.ex:3560
 #, elixir-autogen, elixir-format
 msgid "Document Type"
 msgstr ""
@@ -2183,7 +2183,7 @@ msgstr ""
 msgid "Document uploaded successfully."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2670
+#: lib/klass_hero_web/components/provider_components.ex:2850
 #, elixir-autogen, elixir-format
 msgid "Download Template"
 msgstr ""
@@ -2209,13 +2209,13 @@ msgid "End Date"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1075
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:185
+#: lib/klass_hero_web/components/provider_components.ex:1893
 #, elixir-autogen, elixir-format
 msgid "End Time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2450
-#: lib/klass_hero_web/components/provider_components.ex:2983
+#: lib/klass_hero_web/components/provider_components.ex:2630
+#: lib/klass_hero_web/components/provider_components.ex:3163
 #: lib/klass_hero_web/components/provider_layout_components.ex:612
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrolled"
@@ -2237,7 +2237,7 @@ msgid "Explain why this document is being rejected..."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:74
-#: lib/klass_hero_web/components/provider_components.ex:2984
+#: lib/klass_hero_web/components/provider_components.ex:3164
 #: lib/klass_hero_web/live/admin/emails_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Failed"
@@ -2281,12 +2281,12 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3313
+#: lib/klass_hero_web/components/provider_components.ex:3493
 #, elixir-autogen, elixir-format
 msgid "File is too large."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3315
+#: lib/klass_hero_web/components/provider_components.ex:3495
 #, elixir-autogen, elixir-format
 msgid "File type not accepted."
 msgstr ""
@@ -2321,7 +2321,7 @@ msgstr ""
 msgid "Grades %{min} – %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2740
+#: lib/klass_hero_web/components/provider_components.ex:2920
 #, elixir-autogen, elixir-format
 msgid "Guardian Email"
 msgstr ""
@@ -2336,7 +2336,7 @@ msgstr ""
 msgid "ID Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2643
+#: lib/klass_hero_web/components/provider_components.ex:2823
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import"
 msgstr ""
@@ -2404,7 +2404,7 @@ msgid "Leave unchecked to allow all genders."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1031
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:191
+#: lib/klass_hero_web/components/provider_components.ex:1905
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Location"
 msgstr ""
@@ -2462,18 +2462,18 @@ msgstr ""
 msgid "No approved documents."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3342
+#: lib/klass_hero_web/components/provider_components.ex:3522
 #, elixir-autogen, elixir-format
 msgid "No documents uploaded yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2427
+#: lib/klass_hero_web/components/provider_components.ex:2607
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:447
 #, elixir-autogen, elixir-format
 msgid "No enrollments yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:506
+#: lib/klass_hero_web/live/provider/programs_live.ex:566
 #, elixir-autogen, elixir-format
 msgid "No file selected."
 msgstr ""
@@ -2483,7 +2483,7 @@ msgstr ""
 msgid "No grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2694
+#: lib/klass_hero_web/components/provider_components.ex:2874
 #, elixir-autogen, elixir-format
 msgid "No invites yet. Upload a CSV to invite families."
 msgstr ""
@@ -2546,7 +2546,7 @@ msgstr ""
 msgid "Our Story"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3418
+#: lib/klass_hero_web/components/provider_components.ex:3598
 #: lib/klass_hero_web/live/provider/verification_live.ex:707
 #: lib/klass_hero_web/live/provider/verification_live.ex:781
 #, elixir-autogen, elixir-format
@@ -2573,8 +2573,8 @@ msgstr ""
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:121
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:127
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:111
-#: lib/klass_hero_web/live/provider/programs_live.ex:750
-#: lib/klass_hero_web/live/provider/programs_live.ex:819
+#: lib/klass_hero_web/live/provider/programs_live.ex:810
+#: lib/klass_hero_web/live/provider/programs_live.ex:879
 #: lib/klass_hero_web/live/provider/team_live.ex:314
 #: lib/klass_hero_web/live/provider/team_live.ex:357
 #: lib/klass_hero_web/live/provider/team_live.ex:476
@@ -2607,28 +2607,28 @@ msgstr ""
 msgid "Program Start"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1319
+#: lib/klass_hero_web/live/provider/programs_live.ex:1398
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program created successfully."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1323
+#: lib/klass_hero_web/live/provider/programs_live.ex:1402
 #, elixir-autogen, elixir-format
 msgid "Program created, but enrollment capacity could not be saved. Edit the program to retry."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/incident_reports_live.ex:52
-#: lib/klass_hero_web/live/provider/programs_live.ex:157
-#: lib/klass_hero_web/live/provider/programs_live.ex:194
-#: lib/klass_hero_web/live/provider/programs_live.ex:258
-#: lib/klass_hero_web/live/provider/programs_live.ex:282
-#: lib/klass_hero_web/live/provider/programs_live.ex:794
-#: lib/klass_hero_web/live/provider/programs_live.ex:926
+#: lib/klass_hero_web/live/provider/programs_live.ex:158
+#: lib/klass_hero_web/live/provider/programs_live.ex:195
+#: lib/klass_hero_web/live/provider/programs_live.ex:318
+#: lib/klass_hero_web/live/provider/programs_live.ex:342
+#: lib/klass_hero_web/live/provider/programs_live.ex:854
+#: lib/klass_hero_web/live/provider/programs_live.ex:986
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program not found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1320
+#: lib/klass_hero_web/live/provider/programs_live.ex:1399
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program updated successfully."
 msgstr ""
@@ -2647,6 +2647,8 @@ msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:796
 #: lib/klass_hero_web/components/provider_components.ex:2982
+#: lib/klass_hero_web/components/participation_components.ex:750
+#: lib/klass_hero_web/components/provider_components.ex:3162
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Registered"
@@ -2726,15 +2728,15 @@ msgstr ""
 msgid "Rejection reason"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2796
-#: lib/klass_hero_web/components/provider_components.ex:3169
-#: lib/klass_hero_web/components/provider_components.ex:3437
-#: lib/klass_hero_web/components/provider_components.ex:3517
+#: lib/klass_hero_web/components/provider_components.ex:2976
+#: lib/klass_hero_web/components/provider_components.ex:3349
+#: lib/klass_hero_web/components/provider_components.ex:3617
+#: lib/klass_hero_web/components/provider_components.ex:3697
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2789
+#: lib/klass_hero_web/components/provider_components.ex:2969
 #, elixir-autogen, elixir-format
 msgid "Resend Invite"
 msgstr ""
@@ -2775,7 +2777,7 @@ msgstr ""
 msgid "School Grade (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3415
+#: lib/klass_hero_web/components/provider_components.ex:3595
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select File"
 msgstr ""
@@ -2786,13 +2788,13 @@ msgstr ""
 msgid "Selected child does not meet the program requirements."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:740
-#: lib/klass_hero_web/live/provider/programs_live.ex:809
+#: lib/klass_hero_web/live/provider/programs_live.ex:800
+#: lib/klass_hero_web/live/provider/programs_live.ex:869
 #, elixir-autogen, elixir-format
 msgid "Selected instructor could not be found. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2981
+#: lib/klass_hero_web/components/provider_components.ex:3161
 #: lib/klass_hero_web/live/admin/emails_live.ex:206
 #, elixir-autogen, elixir-format
 msgid "Sent"
@@ -2832,7 +2834,7 @@ msgid "Start Date"
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:1070
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:184
+#: lib/klass_hero_web/components/provider_components.ex:1886
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Start Time"
 msgstr ""
@@ -2892,18 +2894,18 @@ msgstr ""
 msgid "This invite cannot be resent."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:801
+#: lib/klass_hero_web/live/provider/programs_live.ex:861
 #, elixir-autogen, elixir-format
 msgid "This program was modified by someone else. Please close and try again."
 msgstr ""
 
 #: lib/klass_hero_web/components/provider_components.ex:995
-#: lib/klass_hero_web/components/provider_components.ex:2002
+#: lib/klass_hero_web/components/provider_components.ex:2182
 #, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3314
+#: lib/klass_hero_web/components/provider_components.ex:3494
 #, elixir-autogen, elixir-format
 msgid "Too many files."
 msgstr ""
@@ -2923,27 +2925,27 @@ msgstr ""
 msgid "Up to Grade %{max}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2630
+#: lib/klass_hero_web/components/provider_components.ex:2810
 #, elixir-autogen, elixir-format
 msgid "Upload CSV"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3461
+#: lib/klass_hero_web/components/provider_components.ex:3641
 #, elixir-autogen, elixir-format
 msgid "Upload Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3369
+#: lib/klass_hero_web/components/provider_components.ex:3549
 #, elixir-autogen, elixir-format
 msgid "Upload New Document"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3317
+#: lib/klass_hero_web/components/provider_components.ex:3497
 #, elixir-autogen, elixir-format
 msgid "Upload error."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3334
+#: lib/klass_hero_web/components/provider_components.ex:3514
 #, elixir-autogen, elixir-format
 msgid "Verification Documents"
 msgstr ""
@@ -3035,7 +3037,7 @@ msgid "Child Safeguarding Training"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1507
-#: lib/klass_hero_web/components/provider_components.ex:3690
+#: lib/klass_hero_web/components/provider_components.ex:3870
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
 msgstr ""
@@ -3105,7 +3107,7 @@ msgstr ""
 msgid "Program fee:"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1096
+#: lib/klass_hero_web/live/provider/programs_live.ex:1175
 #, elixir-autogen, elixir-format
 msgid "Program saved, but the cover image upload failed. You can re-upload it by editing the program."
 msgstr ""
@@ -3186,7 +3188,7 @@ msgid "Vetted with Care"
 msgstr ""
 
 #: lib/klass_hero_web/components/marketing_components.ex:1491
-#: lib/klass_hero_web/components/provider_components.ex:3468
+#: lib/klass_hero_web/components/provider_components.ex:3648
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
 msgstr ""
@@ -3322,7 +3324,7 @@ msgstr ""
 msgid "Cannot check out without a check-in"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:453
+#: lib/klass_hero_web/live/provider/programs_live.ex:513
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:155
 #, elixir-autogen, elixir-format
 msgid "Cannot message this parent."
@@ -3360,7 +3362,7 @@ msgstr ""
 msgid "Checked Out"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2831
+#: lib/klass_hero_web/components/provider_components.ex:3011
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:151
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Child"
@@ -3406,7 +3408,7 @@ msgstr ""
 msgid "Download monthly statements for taxes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2546
+#: lib/klass_hero_web/components/provider_components.ex:2726
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:504
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Enrollment not confirmed"
@@ -3491,8 +3493,9 @@ msgid "No risk of non-payment"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:821
+#: lib/klass_hero_web/components/participation_components.ex:775
+#: lib/klass_hero_web/components/provider_components.ex:1906
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:155
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:197
 #, elixir-autogen, elixir-format
 msgid "Notes"
 msgstr ""
@@ -3502,7 +3505,7 @@ msgstr ""
 msgid "Or: Request instant payout anytime (minimum €50)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2545
+#: lib/klass_hero_web/components/provider_components.ex:2725
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:503
 #, elixir-autogen, elixir-format
 msgid "Parent account not available"
@@ -3685,7 +3688,7 @@ msgstr ""
 msgid "%{count} unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:590
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:161
 #, elixir-autogen, elixir-format
 msgid "A session already exists at this time"
 msgstr ""
@@ -3695,7 +3698,7 @@ msgstr ""
 msgid "Account created! Check your email to confirm and log in."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:160
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:183
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:160
 #, elixir-autogen, elixir-format
 msgid "Add Note"
@@ -3757,7 +3760,7 @@ msgstr ""
 msgid "Broadcast messages are one-way"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:128
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:151
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:128
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Check In"
@@ -3804,7 +3807,7 @@ msgid "Complete Registration"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:33
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:76
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:66
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:33
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:282
 #, elixir-autogen, elixir-format
@@ -3846,20 +3849,19 @@ msgstr ""
 msgid "Could not start private conversation"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:18
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:154
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:219
+#: lib/klass_hero_web/components/provider_components.ex:1927
+#: lib/klass_hero_web/components/provider_components.ex:1988
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:144
 #, elixir-autogen, elixir-format
 msgid "Create Session"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:181
+#: lib/klass_hero_web/components/provider_components.ex:1877
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:566
-#: lib/klass_hero_web/live/provider/sessions_live.ex:567
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:156
 #, elixir-autogen, elixir-format
 msgid "Date is required"
 msgstr ""
@@ -3869,7 +3871,7 @@ msgstr ""
 msgid "E.g., picked up by parent, gave medication reminder..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:189
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:212
 #, elixir-autogen, elixir-format
 msgid "Edit & Resubmit"
 msgstr ""
@@ -3902,7 +3904,7 @@ msgstr ""
 msgid "Emergency: %{details}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:589
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:160
 #, elixir-autogen, elixir-format
 msgid "End time must be after start time"
 msgstr ""
@@ -3917,7 +3919,7 @@ msgstr ""
 msgid "Failed to archive email"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:526
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:169
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to create session: %{reason}"
 msgstr ""
@@ -3973,8 +3975,8 @@ msgstr ""
 msgid "Invalid Invitation"
 msgstr ""
 
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:159
 #: lib/klass_hero_web/live/admin/sessions_live.ex:255
-#: lib/klass_hero_web/live/provider/sessions_live.ex:585
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invalid time format"
 msgstr ""
@@ -4020,7 +4022,7 @@ msgstr ""
 msgid "Location TBD"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:6
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Manage your scheduled sessions and attendance"
 msgstr ""
@@ -4030,12 +4032,12 @@ msgstr ""
 msgid "Mark Unread"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:200
+#: lib/klass_hero_web/components/provider_components.ex:1907
 #, elixir-autogen, elixir-format
 msgid "Max Capacity"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:90
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:80
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "No actions available"
@@ -4071,7 +4073,7 @@ msgstr ""
 msgid "No sessions found for the selected filters."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:122
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:112
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:311
 #, elixir-autogen, elixir-format
 msgid "No sessions scheduled"
@@ -4092,7 +4094,7 @@ msgstr ""
 msgid "Out: %{time}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:41
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:64
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:41
 #, elixir-autogen, elixir-format
 msgid "Participation Management"
@@ -4108,23 +4110,24 @@ msgstr ""
 msgid "Please explain why you're rejecting this note..."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:592
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:163
 #, elixir-autogen, elixir-format
 msgid "Please fill in all required fields"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2737
+#: lib/klass_hero_web/components/provider_components.ex:1858
+#: lib/klass_hero_web/components/provider_components.ex:1867
+#: lib/klass_hero_web/components/provider_components.ex:2917
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:24
 #: lib/klass_hero_web/live/parent/participation_history_live.html.heex:136
 #: lib/klass_hero_web/live/provider/incident_report_live.ex:299
-#: lib/klass_hero_web/live/provider/programs_live.ex:226
-#: lib/klass_hero_web/live/provider/sessions_live.ex:388
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:175
+#: lib/klass_hero_web/live/provider/programs_live.ex:227
+#: lib/klass_hero_web/live/provider/sessions_live.ex:384
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:186
+#: lib/klass_hero_web/live/provider/sessions_live.ex:183
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program is required"
 msgstr ""
@@ -4198,7 +4201,7 @@ msgstr ""
 msgid "Revised Note"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:176
+#: lib/klass_hero_web/components/provider_components.ex:1868
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select a program..."
 msgstr ""
@@ -4215,7 +4218,8 @@ msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:71
 #: lib/klass_hero_web/live/provider/participation_live.html.heex:16
-#: lib/klass_hero_web/live/provider/sessions_live.ex:415
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:55
+#: lib/klass_hero_web/live/provider/sessions_live.ex:411
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:16
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Session"
@@ -4226,7 +4230,8 @@ msgstr ""
 msgid "Session Roster"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:508
+#: lib/klass_hero_web/live/provider/programs_live.ex:286
+#: lib/klass_hero_web/live/provider/sessions_live.ex:462
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Session created successfully"
 msgstr ""
@@ -4236,7 +4241,7 @@ msgstr ""
 msgid "Staff Dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:54
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:44
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "Start Session"
@@ -4272,8 +4277,7 @@ msgstr ""
 msgid "This invite link is invalid or has expired."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:576
-#: lib/klass_hero_web/live/provider/sessions_live.ex:577
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:158
 #, elixir-autogen, elixir-format
 msgid "Time is required"
 msgstr ""
@@ -4289,7 +4293,7 @@ msgid "Type your reply..."
 msgstr ""
 
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:227
-#: lib/klass_hero_web/live/provider/sessions_live.ex:190
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:162
 #: lib/klass_hero_web/live/staff/staff_dashboard_live.ex:126
 #, elixir-autogen, elixir-format
 msgid "Unauthorized"
@@ -4308,7 +4312,7 @@ msgid "Update your observation..."
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/edit_profile_live.ex:166
-#: lib/klass_hero_web/live/provider/programs_live.ex:503
+#: lib/klass_hero_web/live/provider/programs_live.ex:563
 #: lib/klass_hero_web/live/provider/verification_live.ex:247
 #: lib/klass_hero_web/live/provider/verification_live.ex:564
 #: lib/klass_hero_web/live/provider/verification_live.ex:602
@@ -4316,7 +4320,7 @@ msgstr ""
 msgid "Upload connection lost. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:87
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:77
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:293
 #, elixir-autogen, elixir-format
 msgid "View Participation"
@@ -4337,7 +4341,7 @@ msgstr ""
 msgid "You already have an account. Log in to see your new enrollment."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:125
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:115
 #: lib/klass_hero_web/live/staff/staff_sessions_live.ex:314
 #, elixir-autogen, elixir-format
 msgid "You have no sessions scheduled for %{date}"
@@ -4381,7 +4385,7 @@ msgstr ""
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:52
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:86
 #: lib/klass_hero_web/helpers/participation_live_handlers.ex:120
-#: lib/klass_hero_web/live/provider/participation_live.ex:304
+#: lib/klass_hero_web/live/provider/participation_live.ex:354
 #: lib/klass_hero_web/live/staff/staff_broadcast_live.ex:53
 #, elixir-autogen, elixir-format
 msgid "You are not assigned to this program"
@@ -4552,36 +4556,36 @@ msgstr ""
 msgid "for"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1861
+#: lib/klass_hero_web/components/provider_components.ex:2016
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assigned staff"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1862
+#: lib/klass_hero_web/components/provider_components.ex:2017
 #, elixir-autogen, elixir-format
 msgid "Attendance"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1845
-#: lib/klass_hero_web/components/provider_components.ex:1930
-#: lib/klass_hero_web/components/provider_components.ex:2078
-#: lib/klass_hero_web/components/provider_components.ex:2227
+#: lib/klass_hero_web/components/provider_components.ex:1990
+#: lib/klass_hero_web/components/provider_components.ex:2110
+#: lib/klass_hero_web/components/provider_components.ex:2258
+#: lib/klass_hero_web/components/provider_components.ex:2407
 #: lib/klass_hero_web/live/provider/overview_live.ex:403
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Close"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1860
+#: lib/klass_hero_web/components/provider_components.ex:2015
 #, elixir-autogen, elixir-format
 msgid "Date / time"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1854
+#: lib/klass_hero_web/components/provider_components.ex:2009
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No sessions scheduled yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1843
+#: lib/klass_hero_web/components/provider_components.ex:1972
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sessions — %{title}"
 msgstr ""
@@ -4591,7 +4595,7 @@ msgstr ""
 msgid "View sessions"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:594
+#: lib/klass_hero_web/live/provider/programs_live.ex:654
 #, elixir-autogen, elixir-format
 msgid "Create a program before inviting participants."
 msgstr ""
@@ -4606,34 +4610,34 @@ msgstr ""
 msgid "Departure notes"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:248
+#: lib/klass_hero_web/live/provider/participation_live.ex:298
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:188
 #, elixir-autogen, elixir-format
 msgid "Departure time is not a valid date and time"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:259
+#: lib/klass_hero_web/live/provider/participation_live.ex:309
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:199
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to update record"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2895
+#: lib/klass_hero_web/components/provider_components.ex:3075
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2568
+#: lib/klass_hero_web/components/provider_components.ex:2748
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invite mode"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2587
+#: lib/klass_hero_web/components/provider_components.ex:2767
 #, elixir-autogen, elixir-format
 msgid "Invite one person"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:590
+#: lib/klass_hero_web/live/provider/programs_live.ex:650
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invite sent."
 msgstr ""
@@ -4643,33 +4647,33 @@ msgstr ""
 msgid "Leave blank to keep this child marked as present."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2908
+#: lib/klass_hero_web/components/provider_components.ex:3088
 #, elixir-autogen, elixir-format
 msgid "Medical & consents (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2914
+#: lib/klass_hero_web/components/provider_components.ex:3094
 #, elixir-autogen, elixir-format
 msgid "Medical conditions"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:251
+#: lib/klass_hero_web/live/provider/participation_live.ex:301
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:191
 #, elixir-autogen, elixir-format
 msgid "Nothing to update"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2916
+#: lib/klass_hero_web/components/provider_components.ex:3096
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nut allergy"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2920
+#: lib/klass_hero_web/components/provider_components.ex:3100
 #, elixir-autogen, elixir-format
 msgid "Photos may appear in marketing materials"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2925
+#: lib/klass_hero_web/components/provider_components.ex:3105
 #, elixir-autogen, elixir-format
 msgid "Photos may appear on social media"
 msgstr ""
@@ -4679,12 +4683,12 @@ msgstr ""
 msgid "Present"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2852
+#: lib/klass_hero_web/components/provider_components.ex:3032
 #, elixir-autogen, elixir-format
 msgid "Primary guardian"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:77
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:100
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:77
 #, elixir-autogen, elixir-format
 msgid "Record departure"
@@ -4695,7 +4699,7 @@ msgstr ""
 msgid "Record departure time (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.ex:239
+#: lib/klass_hero_web/live/provider/participation_live.ex:289
 #: lib/klass_hero_web/live/staff/staff_participation_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "Record updated"
@@ -4706,22 +4710,22 @@ msgstr ""
 msgid "Save changes"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2889
+#: lib/klass_hero_web/components/provider_components.ex:3069
 #, elixir-autogen, elixir-format, fuzzy
 msgid "School (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2899
+#: lib/klass_hero_web/components/provider_components.ex:3079
 #, elixir-autogen, elixir-format
 msgid "School name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2873
+#: lib/klass_hero_web/components/provider_components.ex:3053
 #, elixir-autogen, elixir-format
 msgid "Second guardian (optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2942
+#: lib/klass_hero_web/components/provider_components.ex:3122
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Send invite"
 msgstr ""
@@ -4731,12 +4735,12 @@ msgstr ""
 msgid "Update the note for this child (e.g. clarify what happened)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2605
+#: lib/klass_hero_web/components/provider_components.ex:2785
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload a list"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:601
+#: lib/klass_hero_web/live/provider/programs_live.ex:661
 #, elixir-autogen, elixir-format
 msgid "An invite for this child and program already exists."
 msgstr ""
@@ -4913,7 +4917,7 @@ msgstr ""
 msgid "Go to dashboard"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:546
+#: lib/klass_hero_web/live/provider/programs_live.ex:606
 #, elixir-autogen, elixir-format
 msgid "%{count} row could not be processed."
 msgid_plural "%{count} rows could not be processed."
@@ -5486,8 +5490,8 @@ msgstr ""
 msgid "I'll be teaching"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:521
-#: lib/klass_hero_web/live/provider/programs_live.ex:543
+#: lib/klass_hero_web/live/provider/programs_live.ex:581
+#: lib/klass_hero_web/live/provider/programs_live.ex:603
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Imported %{count} family."
 msgid_plural "Imported %{count} families."
@@ -5678,7 +5682,7 @@ msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:536
 #: lib/klass_hero_web/components/provider_layout_components.ex:578
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:141
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:164
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:141
 #, elixir-autogen, elixir-format
 msgid "Mark absent"
@@ -5769,7 +5773,7 @@ msgstr ""
 msgid "No registered children for this session."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:530
+#: lib/klass_hero_web/live/provider/programs_live.ex:590
 #, elixir-autogen, elixir-format
 msgid "No rows imported. %{count} row could not be processed."
 msgid_plural "No rows imported. %{count} rows could not be processed."
@@ -6008,17 +6012,17 @@ msgstr ""
 msgid "Rigorous screening so families never wonder who's leading the room."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2990
+#: lib/klass_hero_web/components/provider_components.ex:3170
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Row %{row}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2990
+#: lib/klass_hero_web/components/provider_components.ex:3170
 #, elixir-autogen, elixir-format
 msgid "Row —"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2682
+#: lib/klass_hero_web/components/provider_components.ex:2862
 #, elixir-autogen, elixir-format
 msgid "Rows with errors"
 msgstr ""
@@ -6748,12 +6752,12 @@ msgstr ""
 msgid "Experience validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3498
+#: lib/klass_hero_web/components/provider_components.ex:3678
 #, elixir-autogen, elixir-format
 msgid "MP4, MOV or WEBM. Max 100MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3471
+#: lib/klass_hero_web/components/provider_components.ex:3651
 #, elixir-autogen, elixir-format
 msgid "Record a short video introducing yourself. Our team reviews it to assess communication skills and alignment with our values."
 msgstr ""
@@ -6763,12 +6767,12 @@ msgstr ""
 msgid "Safeguarding certificate"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3495
+#: lib/klass_hero_web/components/provider_components.ex:3675
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select Video"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3541
+#: lib/klass_hero_web/components/provider_components.ex:3721
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload Video"
 msgstr ""
@@ -6778,7 +6782,7 @@ msgstr ""
 msgid "Your browser does not support video playback."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3694
+#: lib/klass_hero_web/components/provider_components.ex:3874
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Confirm agreement"
 msgstr ""
@@ -6788,12 +6792,12 @@ msgstr ""
 msgid "Couldn't record your agreement. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3717
+#: lib/klass_hero_web/components/provider_components.ex:3897
 #, elixir-autogen, elixir-format
 msgid "Download the agreement (PDF)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3693
+#: lib/klass_hero_web/components/provider_components.ex:3873
 #, elixir-autogen, elixir-format
 msgid "I have read and agree to the Klass Hero Community Guidelines."
 msgstr ""
@@ -6803,7 +6807,7 @@ msgstr ""
 msgid "Please confirm you have read and agree to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3596
+#: lib/klass_hero_web/components/provider_components.ex:3776
 #, elixir-autogen, elixir-format
 msgid "Signed by %{name} on %{date} (v%{version})."
 msgstr ""
@@ -6813,17 +6817,17 @@ msgstr ""
 msgid "Thanks — your agreement to the Community Guidelines has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3702
+#: lib/klass_hero_web/components/provider_components.ex:3882
 #, elixir-autogen, elixir-format
 msgid "The Community Guidelines have been updated since you last agreed (v%{old}). Please review and re-agree."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3691
+#: lib/klass_hero_web/components/provider_components.ex:3871
 #, elixir-autogen, elixir-format
 msgid "The final step: read and agree to the Klass Hero Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3692
+#: lib/klass_hero_web/components/provider_components.ex:3872
 #, elixir-autogen, elixir-format
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
@@ -7092,12 +7096,12 @@ msgstr ""
 msgid "Your insurance is verified."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3640
+#: lib/klass_hero_web/components/provider_components.ex:3820
 #, elixir-autogen, elixir-format
 msgid "Signing as %{name} on behalf of the business."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3749
+#: lib/klass_hero_web/components/provider_components.ex:3929
 #, elixir-autogen, elixir-format
 msgid "Confirm, on behalf of your business, that all staff are vetted per German child-safety law."
 msgstr ""
@@ -7107,7 +7111,7 @@ msgstr ""
 msgid "Couldn't record your declaration. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3755
+#: lib/klass_hero_web/components/provider_components.ex:3935
 #, elixir-autogen, elixir-format
 msgid "I confirm, on behalf of the business, that the above declaration is true and I am authorised to sign it."
 msgstr ""
@@ -7117,17 +7121,17 @@ msgstr ""
 msgid "Please confirm the declaration before signing."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3780
+#: lib/klass_hero_web/components/provider_components.ex:3960
 #, elixir-autogen, elixir-format
 msgid "Provisional text — pending review by a German-qualified lawyer before go-live."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3759
+#: lib/klass_hero_web/components/provider_components.ex:3939
 #, elixir-autogen, elixir-format
 msgid "Sign the declaration"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3747
+#: lib/klass_hero_web/components/provider_components.ex:3927
 #, elixir-autogen, elixir-format
 msgid "Staff Compliance Declaration"
 msgstr ""
@@ -7137,12 +7141,12 @@ msgstr ""
 msgid "Thanks — your Staff Compliance Declaration has been recorded."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3767
+#: lib/klass_hero_web/components/provider_components.ex:3947
 #, elixir-autogen, elixir-format
 msgid "The Staff Compliance Declaration has been updated since you last signed (v%{old}). Please review and re-sign."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3753
+#: lib/klass_hero_web/components/provider_components.ex:3933
 #, elixir-autogen, elixir-format
 msgid "You have signed the Staff Compliance Declaration."
 msgstr ""
@@ -7209,25 +7213,25 @@ msgstr ""
 msgid "Undelivered Events"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2172
-#: lib/klass_hero_web/components/provider_components.ex:2350
+#: lib/klass_hero_web/components/provider_components.ex:2352
+#: lib/klass_hero_web/components/provider_components.ex:2530
 #: lib/klass_hero_web/live/user_live/settings.ex:292
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2100
-#: lib/klass_hero_web/components/provider_components.ex:2281
+#: lib/klass_hero_web/components/provider_components.ex:2280
+#: lib/klass_hero_web/components/provider_components.ex:2461
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Lead"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:432
+#: lib/klass_hero_web/live/provider/programs_live.ex:492
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Lead instructor updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2112
+#: lib/klass_hero_web/components/provider_components.ex:2292
 #, elixir-autogen, elixir-format
 msgid "Make lead instructor"
 msgstr ""
@@ -7237,65 +7241,65 @@ msgstr ""
 msgid "Manage Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2141
+#: lib/klass_hero_web/components/provider_components.ex:2321
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this program yet."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:362
-#: lib/klass_hero_web/live/provider/sessions_live.ex:220
+#: lib/klass_hero_web/live/provider/programs_live.ex:422
+#: lib/klass_hero_web/live/provider/sessions_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "Pick a staff member to add."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2124
-#: lib/klass_hero_web/components/provider_components.ex:2389
+#: lib/klass_hero_web/components/provider_components.ex:2304
+#: lib/klass_hero_web/components/provider_components.ex:2569
 #, elixir-autogen, elixir-format
 msgid "Reassign the lead before removing them"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2125
+#: lib/klass_hero_web/components/provider_components.ex:2305
 #, elixir-autogen, elixir-format
 msgid "Remove from program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2160
-#: lib/klass_hero_web/components/provider_components.ex:2337
+#: lib/klass_hero_web/components/provider_components.ex:2340
+#: lib/klass_hero_web/components/provider_components.ex:2517
 #, elixir-autogen, elixir-format
 msgid "Select a staff member…"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:377
+#: lib/klass_hero_web/live/provider/programs_live.ex:437
 #, elixir-autogen, elixir-format
 msgid "Staff member added to the program."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:403
+#: lib/klass_hero_web/live/provider/programs_live.ex:463
 #, elixir-autogen, elixir-format
 msgid "Staff member removed from the program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2177
+#: lib/klass_hero_web/components/provider_components.ex:2357
 #, elixir-autogen, elixir-format
 msgid "Staff you add can read and reply to this program's parent conversations."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2076
+#: lib/klass_hero_web/components/provider_components.ex:2256
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Staffing — %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1055
+#: lib/klass_hero_web/live/provider/programs_live.ex:1134
 #, elixir-autogen, elixir-format
 msgid "That staff member could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:385
+#: lib/klass_hero_web/live/provider/programs_live.ex:445
 #, elixir-autogen, elixir-format
 msgid "They are already on this program."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:411
+#: lib/klass_hero_web/live/provider/programs_live.ex:471
 #, elixir-autogen, elixir-format
 msgid "This person is the lead instructor. Make someone else lead before removing them."
 msgstr ""
@@ -7357,17 +7361,17 @@ msgstr ""
 msgid "This person has a history here now — use 'Remove from team' instead."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1333
+#: lib/klass_hero_web/live/provider/programs_live.ex:1412
 #, elixir-autogen, elixir-format
 msgid "Program created, but some settings could not be saved. Please review the program's limits."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1337
+#: lib/klass_hero_web/live/provider/programs_live.ex:1416
 #, elixir-autogen, elixir-format
 msgid "Program updated, but some settings could not be saved. Please review the program's limits."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:1327
+#: lib/klass_hero_web/live/provider/programs_live.ex:1406
 #, elixir-autogen, elixir-format
 msgid "Program updated, but the enrollment capacity was rejected. The previous limits still apply."
 msgstr ""
@@ -7389,92 +7393,93 @@ msgstr ""
 msgid "I understand this program will have no capacity limit."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2377
+#: lib/klass_hero_web/components/provider_components.ex:2557
 #, elixir-autogen, elixir-format
 msgid "Go back to the program's usual team"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:302
+#: lib/klass_hero_web/live/provider/sessions_live.ex:299
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Lead instructor for this session updated."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2296
+#: lib/klass_hero_web/components/provider_components.ex:2476
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Make lead instructor for this session"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2318
+#: lib/klass_hero_web/components/provider_components.ex:2498
 #, elixir-autogen, elixir-format
 msgid "Nobody is working this session yet."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2394
+#: lib/klass_hero_web/components/provider_components.ex:2574
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove from this session"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:238
+#: lib/klass_hero_web/live/provider/sessions_live.ex:235
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Staff member added to this session."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:262
+#: lib/klass_hero_web/live/provider/sessions_live.ex:259
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Staff member removed from this session."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.html.heex:107
+#: lib/klass_hero_web/live/provider/sessions_live.html.heex:97
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Staffing"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2220
+#: lib/klass_hero_web/components/provider_components.ex:2400
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Staffing — %{date}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:431
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:164
+#: lib/klass_hero_web/live/provider/sessions_live.ex:427
 #, elixir-autogen, elixir-format
 msgid "That session could not be found."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:246
+#: lib/klass_hero_web/live/provider/sessions_live.ex:243
 #, elixir-autogen, elixir-format, fuzzy
 msgid "They are already working this session."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:270
+#: lib/klass_hero_web/live/provider/sessions_live.ex:267
 #, elixir-autogen, elixir-format, fuzzy
 msgid "This person leads the session. Make someone else lead before removing them."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:318
+#: lib/klass_hero_web/live/provider/sessions_live.ex:315
 #, elixir-autogen, elixir-format
 msgid "This session is back on the program's usual team."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/sessions_live.ex:281
+#: lib/klass_hero_web/live/provider/sessions_live.ex:278
 #, elixir-autogen, elixir-format
 msgid "A session needs at least one person. Use “Go back to the program's usual team” to drop this session's own roster."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2392
+#: lib/klass_hero_web/components/provider_components.ex:2572
 #, elixir-autogen, elixir-format
 msgid "A session needs someone — use “Go back to the program's usual team” instead"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2359
+#: lib/klass_hero_web/components/provider_components.ex:2539
 #, elixir-autogen, elixir-format
 msgid "Everyone on your team is already working this session."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2252
+#: lib/klass_hero_web/components/provider_components.ex:2432
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Staffed just for this session. Changes here do not touch the program."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2254
+#: lib/klass_hero_web/components/provider_components.ex:2434
 #, elixir-autogen, elixir-format
 msgid "Using the program's usual team. The first change here copies them onto this session, so later program changes stop reaching it."
 msgstr ""
@@ -7484,17 +7489,17 @@ msgstr ""
 msgid "(optional)"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1995
+#: lib/klass_hero_web/components/provider_components.ex:2175
 #, elixir-autogen, elixir-format
 msgid "Add a waiver"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2027
+#: lib/klass_hero_web/components/provider_components.ex:2207
 #, elixir-autogen, elixir-format
 msgid "Add waiver"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:927
+#: lib/klass_hero_web/live/provider/programs_live.ex:987
 #, elixir-autogen, elixir-format
 msgid "Check the waiver details and try again."
 msgstr ""
@@ -7511,7 +7516,7 @@ msgstr ""
 msgid "I have read and agree to %{title}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2009
+#: lib/klass_hero_web/components/provider_components.ex:2189
 #, elixir-autogen, elixir-format
 msgid "Legal text"
 msgstr ""
@@ -7521,12 +7526,12 @@ msgstr ""
 msgid "Manage Waivers"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1937
+#: lib/klass_hero_web/components/provider_components.ex:2117
 #, elixir-autogen, elixir-format
 msgid "No waivers yet. Parents enrol without signing anything."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2016
+#: lib/klass_hero_web/components/provider_components.ex:2196
 #, elixir-autogen, elixir-format
 msgid "Parents must sign this before enrolling"
 msgstr ""
@@ -7546,17 +7551,17 @@ msgstr ""
 msgid "Please tick a waiver to sign it."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1994
+#: lib/klass_hero_web/components/provider_components.ex:2174
 #, elixir-autogen, elixir-format
 msgid "Publish a new version"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2027
+#: lib/klass_hero_web/components/provider_components.ex:2207
 #, elixir-autogen, elixir-format
 msgid "Publish version"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2020
+#: lib/klass_hero_web/components/provider_components.ex:2200
 #, elixir-autogen, elixir-format
 msgid "Publishing keeps every earlier version on record; signatures already given stay bound to the wording they were shown."
 msgstr ""
@@ -7566,12 +7571,12 @@ msgstr ""
 msgid "Required"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1971
+#: lib/klass_hero_web/components/provider_components.ex:2151
 #, elixir-autogen, elixir-format
 msgid "Retire this waiver"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1962
+#: lib/klass_hero_web/components/provider_components.ex:2142
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Revise text"
 msgstr ""
@@ -7586,7 +7591,7 @@ msgstr ""
 msgid "Sign waivers"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2494
+#: lib/klass_hero_web/components/provider_components.ex:2674
 #: lib/klass_hero_web/live/enrollment_waivers_live.ex:149
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Signed"
@@ -7602,22 +7607,22 @@ msgstr ""
 msgid "There is nothing to sign for this enrollment."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2494
+#: lib/klass_hero_web/components/provider_components.ex:2674
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Unsigned"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1954
+#: lib/klass_hero_web/components/provider_components.ex:2134
 #, elixir-autogen, elixir-format
 msgid "Version %{number}"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:356
+#: lib/klass_hero_web/live/provider/programs_live.ex:416
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Waiver not found."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2447
+#: lib/klass_hero_web/components/provider_components.ex:2627
 #: lib/klass_hero_web/live/booking_live.ex:447
 #: lib/klass_hero_web/live/enrollment_waivers_live.ex:33
 #: lib/klass_hero_web/live/enrollment_waivers_live.ex:105
@@ -7630,7 +7635,7 @@ msgstr ""
 msgid "Waivers waiting for your signature"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1928
+#: lib/klass_hero_web/components/provider_components.ex:2108
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Waivers — %{title}"
 msgstr ""
@@ -7640,22 +7645,22 @@ msgstr ""
 msgid "this program"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:924
+#: lib/klass_hero_web/live/provider/programs_live.ex:984
 #, elixir-autogen, elixir-format
 msgid "New version published. It applies to future enrolments."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:1975
+#: lib/klass_hero_web/components/provider_components.ex:2155
 #, elixir-autogen, elixir-format
 msgid "Retire \"%{title}\"? Parents will no longer be asked to sign it. Signatures already collected are kept."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:923
+#: lib/klass_hero_web/live/provider/programs_live.ex:983
 #, elixir-autogen, elixir-format
 msgid "Waiver added."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/programs_live.ex:353
+#: lib/klass_hero_web/live/provider/programs_live.ex:413
 #, elixir-autogen, elixir-format
 msgid "Waiver retired. Signatures already collected are kept."
 msgstr ""
@@ -7721,7 +7726,7 @@ msgstr ""
 msgid "This is your main provider identity. Verification is required to list programs."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3337
+#: lib/klass_hero_web/components/provider_components.ex:3517
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload documents to be verified. Documents are reviewed by our team."
 msgstr ""
@@ -7865,8 +7870,8 @@ msgstr ""
 msgid "Review invitations"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:2758
-#: lib/klass_hero_web/components/provider_components.ex:2765
+#: lib/klass_hero_web/components/provider_components.ex:2938
+#: lib/klass_hero_web/components/provider_components.ex:2945
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Unknown program"
 msgstr ""
@@ -7931,17 +7936,17 @@ msgstr ""
 msgid "N/A"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3245
+#: lib/klass_hero_web/components/provider_components.ex:3425
 #, elixir-autogen, elixir-format
 msgid "A short line that sums you up"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3234
+#: lib/klass_hero_web/components/provider_components.ex:3414
 #, elixir-autogen, elixir-format
 msgid "Branding & Presence"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3258
+#: lib/klass_hero_web/components/provider_components.ex:3438
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Choose Cover Image"
 msgstr ""
@@ -7951,17 +7956,17 @@ msgstr ""
 msgid "Cover image upload failed. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3259
+#: lib/klass_hero_web/components/provider_components.ex:3439
 #, elixir-autogen, elixir-format, fuzzy
 msgid "JPG, PNG or WebP. Max 5MB."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3237
+#: lib/klass_hero_web/components/provider_components.ex:3417
 #, elixir-autogen, elixir-format
 msgid "Shown on your public profile page."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3244
+#: lib/klass_hero_web/components/provider_components.ex:3424
 #, elixir-autogen, elixir-format
 msgid "Tagline"
 msgstr ""
@@ -7971,7 +7976,7 @@ msgstr ""
 msgid "Absent:"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider/participation_live.html.heex:115
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:138
 #: lib/klass_hero_web/live/staff/staff_participation_live.html.heex:115
 #, elixir-autogen, elixir-format
 msgid "Arrived late"
@@ -8007,7 +8012,7 @@ msgstr ""
 msgid "Klass Hero on %{network}"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3316
+#: lib/klass_hero_web/components/provider_components.ex:3496
 #, elixir-autogen, elixir-format
 msgid "Upload failed."
 msgstr ""
@@ -8047,7 +8052,7 @@ msgstr ""
 msgid "A newly chosen cover or logo appears here after you save."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3289
+#: lib/klass_hero_web/components/provider_components.ex:3469
 #, elixir-autogen, elixir-format
 msgid "Add %{network}"
 msgstr ""
@@ -8067,7 +8072,7 @@ msgstr ""
 msgid "Show preview"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3276
+#: lib/klass_hero_web/components/provider_components.ex:3456
 #, elixir-autogen, elixir-format
 msgid "e.g. %{example}"
 msgstr ""
@@ -8212,4 +8217,45 @@ msgstr ""
 #: lib/klass_hero_web/components/participation_components.ex:199
 #, elixir-autogen, elixir-format
 msgid "Over capacity"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:41
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:51
+#, elixir-autogen, elixir-format
+msgid "Edit Session"
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1970
+#, elixir-autogen, elixir-format, fuzzy
+msgid "New session — %{title}"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/participation_live.html.heex:57
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Save Session"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/participation_live.ex:103
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Session updated"
+msgstr ""
+
+#: lib/klass_hero_web/live/provider/programs_live.ex:264
+#, elixir-autogen, elixir-format
+msgid "That program could not be found."
+msgstr ""
+
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:165
+#, elixir-autogen, elixir-format, fuzzy
+msgid "That session could not be saved."
+msgstr ""
+
+#: lib/klass_hero_web/components/provider_components.ex:1900
+#, elixir-autogen, elixir-format
+msgid "The date and time are fixed once a session has started — its attendance records are keyed to it."
+msgstr ""
+
+#: lib/klass_hero_web/helpers/session_form_handlers.ex:167
+#, elixir-autogen, elixir-format
+msgid "The date and time are fixed once a session has started."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -2646,8 +2646,6 @@ msgid "Read our founding story →"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:796
-#: lib/klass_hero_web/components/provider_components.ex:2982
-#: lib/klass_hero_web/components/participation_components.ex:750
 #: lib/klass_hero_web/components/provider_components.ex:3162
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:198
 #, elixir-autogen, elixir-format, fuzzy
@@ -3493,7 +3491,6 @@ msgid "No risk of non-payment"
 msgstr ""
 
 #: lib/klass_hero_web/components/participation_components.ex:821
-#: lib/klass_hero_web/components/participation_components.ex:775
 #: lib/klass_hero_web/components/provider_components.ex:1906
 #: lib/klass_hero_web/live/admin/sessions_live.html.heex:155
 #, elixir-autogen, elixir-format

--- a/priv/gettext/en/LC_MESSAGES/enrollment.po
+++ b/priv/gettext/en/LC_MESSAGES/enrollment.po
@@ -11,95 +11,95 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/klass_hero_web/components/provider_components.ex:3084
-#: lib/klass_hero_web/components/provider_components.ex:3101
+#: lib/klass_hero_web/components/provider_components.ex:3264
+#: lib/klass_hero_web/components/provider_components.ex:3281
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3085
-#: lib/klass_hero_web/components/provider_components.ex:3102
+#: lib/klass_hero_web/components/provider_components.ex:3265
+#: lib/klass_hero_web/components/provider_components.ex:3282
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3086
-#: lib/klass_hero_web/components/provider_components.ex:3103
+#: lib/klass_hero_web/components/provider_components.ex:3266
+#: lib/klass_hero_web/components/provider_components.ex:3283
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3097
+#: lib/klass_hero_web/components/provider_components.ex:3277
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3087
+#: lib/klass_hero_web/components/provider_components.ex:3267
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3088
+#: lib/klass_hero_web/components/provider_components.ex:3268
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3089
+#: lib/klass_hero_web/components/provider_components.ex:3269
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3096
+#: lib/klass_hero_web/components/provider_components.ex:3276
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3098
+#: lib/klass_hero_web/components/provider_components.ex:3278
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3090
+#: lib/klass_hero_web/components/provider_components.ex:3270
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3092
+#: lib/klass_hero_web/components/provider_components.ex:3272
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3094
+#: lib/klass_hero_web/components/provider_components.ex:3274
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3024
+#: lib/klass_hero_web/components/provider_components.ex:3204
 #, elixir-autogen, elixir-format
 msgid "Date of birth \"%{value}\" is not a valid date. Please correct it and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3018
+#: lib/klass_hero_web/components/provider_components.ex:3198
 #, elixir-autogen, elixir-format
 msgid "Invite link could not be generated (no token). Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3032
+#: lib/klass_hero_web/components/provider_components.ex:3212
 #, elixir-autogen, elixir-format
 msgid "The invitation email could not be delivered. Please check the address and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3021
+#: lib/klass_hero_web/components/provider_components.ex:3201
 #, elixir-autogen, elixir-format
 msgid "The program is full, so this child could not be enrolled."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3035
+#: lib/klass_hero_web/components/provider_components.ex:3215
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed and no retries remain. Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3044
+#: lib/klass_hero_web/components/provider_components.ex:3224
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed. Please resend."
 msgstr ""

--- a/priv/gettext/enrollment.pot
+++ b/priv/gettext/enrollment.pot
@@ -11,95 +11,95 @@
 msgid ""
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3084
-#: lib/klass_hero_web/components/provider_components.ex:3101
+#: lib/klass_hero_web/components/provider_components.ex:3264
+#: lib/klass_hero_web/components/provider_components.ex:3281
 #, elixir-autogen, elixir-format
 msgid "Child first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3085
-#: lib/klass_hero_web/components/provider_components.ex:3102
+#: lib/klass_hero_web/components/provider_components.ex:3265
+#: lib/klass_hero_web/components/provider_components.ex:3282
 #, elixir-autogen, elixir-format
 msgid "Child last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3086
-#: lib/klass_hero_web/components/provider_components.ex:3103
+#: lib/klass_hero_web/components/provider_components.ex:3266
+#: lib/klass_hero_web/components/provider_components.ex:3283
 #, elixir-autogen, elixir-format
 msgid "Date of birth"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3097
+#: lib/klass_hero_web/components/provider_components.ex:3277
 #, elixir-autogen, elixir-format
 msgid "Grade"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3087
+#: lib/klass_hero_web/components/provider_components.ex:3267
 #, elixir-autogen, elixir-format
 msgid "Guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3088
+#: lib/klass_hero_web/components/provider_components.ex:3268
 #, elixir-autogen, elixir-format
 msgid "Guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3089
+#: lib/klass_hero_web/components/provider_components.ex:3269
 #, elixir-autogen, elixir-format
 msgid "Guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3096
+#: lib/klass_hero_web/components/provider_components.ex:3276
 #, elixir-autogen, elixir-format
 msgid "Program"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3098
+#: lib/klass_hero_web/components/provider_components.ex:3278
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3090
+#: lib/klass_hero_web/components/provider_components.ex:3270
 #, elixir-autogen, elixir-format
 msgid "Second guardian email"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3092
+#: lib/klass_hero_web/components/provider_components.ex:3272
 #, elixir-autogen, elixir-format
 msgid "Second guardian first name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3094
+#: lib/klass_hero_web/components/provider_components.ex:3274
 #, elixir-autogen, elixir-format
 msgid "Second guardian last name"
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3024
+#: lib/klass_hero_web/components/provider_components.ex:3204
 #, elixir-autogen, elixir-format
 msgid "Date of birth \"%{value}\" is not a valid date. Please correct it and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3018
+#: lib/klass_hero_web/components/provider_components.ex:3198
 #, elixir-autogen, elixir-format
 msgid "Invite link could not be generated (no token). Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3032
+#: lib/klass_hero_web/components/provider_components.ex:3212
 #, elixir-autogen, elixir-format
 msgid "The invitation email could not be delivered. Please check the address and resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3021
+#: lib/klass_hero_web/components/provider_components.ex:3201
 #, elixir-autogen, elixir-format
 msgid "The program is full, so this child could not be enrolled."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3035
+#: lib/klass_hero_web/components/provider_components.ex:3215
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed and no retries remain. Please resend."
 msgstr ""
 
-#: lib/klass_hero_web/components/provider_components.ex:3044
+#: lib/klass_hero_web/components/provider_components.ex:3224
 #, elixir-autogen, elixir-format
 msgid "This invite could not be completed. Please resend."
 msgstr ""

--- a/test/klass_hero/participation/backfill_roster_for_enrollment_test.exs
+++ b/test/klass_hero/participation/backfill_roster_for_enrollment_test.exs
@@ -21,7 +21,7 @@ defmodule KlassHero.Participation.BackfillRosterForEnrollmentTest do
       {child, _parent} = insert_child_with_guardian()
 
       {:ok, session} =
-        Participation.create_session(%{
+        Participation.create_session(admin_scope(), %{
           program_id: program.id,
           session_date: Date.add(Date.utc_today(), 7),
           start_time: ~T[15:00:00],
@@ -46,7 +46,7 @@ defmodule KlassHero.Participation.BackfillRosterForEnrollmentTest do
       {child, _parent} = insert_child_with_guardian()
 
       {:ok, session} =
-        Participation.create_session(%{
+        Participation.create_session(admin_scope(), %{
           program_id: program.id,
           session_date: Date.add(Date.utc_today(), 7),
           start_time: ~T[15:00:00],
@@ -67,7 +67,7 @@ defmodule KlassHero.Participation.BackfillRosterForEnrollmentTest do
       {child, _parent} = insert_child_with_guardian()
 
       {:ok, past_session} =
-        Participation.create_session(%{
+        Participation.create_session(admin_scope(), %{
           program_id: program.id,
           session_date: Date.add(Date.utc_today(), -7),
           start_time: ~T[15:00:00],
@@ -82,4 +82,8 @@ defmodule KlassHero.Participation.BackfillRosterForEnrollmentTest do
       assert {:ok, %{roster: []}} = Participation.get_session_with_roster(past_session.id)
     end
   end
+
+  # An admin is authorized everywhere, so the scope stays out of a test whose
+  # subject is not authorization.
+  defp admin_scope, do: KlassHero.AccountsFixtures.admin_scope_fixture()
 end

--- a/test/klass_hero/participation/create_session_test.exs
+++ b/test/klass_hero/participation/create_session_test.exs
@@ -9,14 +9,16 @@ defmodule KlassHero.Participation.CreateSessionTest do
 
   import KlassHero.Factory
 
+  alias KlassHero.Accounts.Scope
   alias KlassHero.Participation.ProgramSession
+  alias KlassHero.Provider.ProviderProfile
 
   describe "execute/1" do
     test "successfully creates a session with valid attributes" do
       program = insert(:program_schema)
 
       assert {:ok, session} =
-               KlassHero.Participation.create_session(%{
+               KlassHero.Participation.create_session(owner_scope(program), %{
                  program_id: program.id,
                  session_date: ~D[2025-02-15],
                  start_time: ~T[09:00:00],
@@ -39,7 +41,7 @@ defmodule KlassHero.Participation.CreateSessionTest do
       program = insert(:program_schema)
 
       assert {:ok, session} =
-               KlassHero.Participation.create_session(%{
+               KlassHero.Participation.create_session(owner_scope(program), %{
                  program_id: program.id,
                  session_date: ~D[2025-02-15],
                  start_time: ~T[09:00:00],
@@ -54,7 +56,7 @@ defmodule KlassHero.Participation.CreateSessionTest do
       program = insert(:program_schema)
 
       assert {:ok, session} =
-               KlassHero.Participation.create_session(%{
+               KlassHero.Participation.create_session(owner_scope(program), %{
                  program_id: program.id,
                  session_date: ~D[2025-02-15],
                  start_time: ~T[09:00:00],
@@ -70,7 +72,7 @@ defmodule KlassHero.Participation.CreateSessionTest do
       program = insert(:program_schema)
 
       assert {:error, reason} =
-               KlassHero.Participation.create_session(%{
+               KlassHero.Participation.create_session(owner_scope(program), %{
                  program_id: program.id,
                  session_date: ~D[2025-02-15],
                  start_time: ~T[14:00:00],
@@ -85,7 +87,7 @@ defmodule KlassHero.Participation.CreateSessionTest do
       program = insert(:program_schema)
 
       assert {:ok, _session1} =
-               KlassHero.Participation.create_session(%{
+               KlassHero.Participation.create_session(owner_scope(program), %{
                  program_id: program.id,
                  session_date: ~D[2025-02-15],
                  start_time: ~T[09:00:00],
@@ -94,7 +96,7 @@ defmodule KlassHero.Participation.CreateSessionTest do
                })
 
       assert {:ok, session2} =
-               KlassHero.Participation.create_session(%{
+               KlassHero.Participation.create_session(owner_scope(program), %{
                  program_id: program.id,
                  session_date: ~D[2025-02-16],
                  start_time: ~T[09:00:00],
@@ -109,7 +111,7 @@ defmodule KlassHero.Participation.CreateSessionTest do
       program = insert(:program_schema)
 
       assert {:ok, _session1} =
-               KlassHero.Participation.create_session(%{
+               KlassHero.Participation.create_session(owner_scope(program), %{
                  program_id: program.id,
                  session_date: ~D[2025-02-15],
                  start_time: ~T[09:00:00],
@@ -118,7 +120,7 @@ defmodule KlassHero.Participation.CreateSessionTest do
                })
 
       assert {:ok, session2} =
-               KlassHero.Participation.create_session(%{
+               KlassHero.Participation.create_session(owner_scope(program), %{
                  program_id: program.id,
                  session_date: ~D[2025-02-15],
                  start_time: ~T[14:00:00],
@@ -128,5 +130,59 @@ defmodule KlassHero.Participation.CreateSessionTest do
 
       assert session2.start_time == ~T[14:00:00]
     end
+  end
+
+  # The guard used to live in SessionsLive as a `provider_program_ids` MapSet test,
+  # so a caller reaching the context directly had none. #1074 added a second create
+  # surface, which is exactly the shape ADR-0019 warns about — hence these assert
+  # the refusal *at the context*, not at a LiveView.
+  describe "authorization" do
+    test "refuses a provider who does not own the program" do
+      program = insert(:program_schema)
+      foreign = %Scope{provider: %ProviderProfile{id: Ecto.UUID.generate()}}
+
+      assert {:error, :unauthorized} =
+               KlassHero.Participation.create_session(foreign, %{
+                 program_id: program.id,
+                 session_date: ~D[2025-02-15],
+                 start_time: ~T[09:00:00],
+                 end_time: ~T[12:00:00],
+                 max_capacity: 20
+               })
+    end
+
+    test "refuses before validating, so an unauthorized caller learns nothing about the params" do
+      program = insert(:program_schema)
+      foreign = %Scope{provider: %ProviderProfile{id: Ecto.UUID.generate()}}
+
+      # end_time before start_time would be :invalid_time_range if it got that far.
+      assert {:error, :unauthorized} =
+               KlassHero.Participation.create_session(foreign, %{
+                 program_id: program.id,
+                 session_date: ~D[2025-02-15],
+                 start_time: ~T[14:00:00],
+                 end_time: ~T[09:00:00],
+                 max_capacity: 20
+               })
+    end
+
+    test "refuses a scope holding no persona at all" do
+      program = insert(:program_schema)
+
+      assert {:error, :unauthorized} =
+               KlassHero.Participation.create_session(%Scope{}, %{
+                 program_id: program.id,
+                 session_date: ~D[2025-02-15],
+                 start_time: ~T[09:00:00],
+                 end_time: ~T[12:00:00],
+                 max_capacity: 20
+               })
+    end
+  end
+
+  # Only `provider.id` is read on this path, so the profile need not be a real row —
+  # `provider_owns?/2` compares it against what the resolver reads from `programs`.
+  defp owner_scope(program) do
+    %Scope{provider: %ProviderProfile{id: program.provider_id}}
   end
 end

--- a/test/klass_hero/participation/notifications_test.exs
+++ b/test/klass_hero/participation/notifications_test.exs
@@ -6,8 +6,20 @@ defmodule KlassHero.Participation.NotificationsTest do
   alias KlassHero.Shared.Domain.Events.Event
 
   # Every session-lifecycle event says the same thing to a LiveView — "this session
-  # is not what you rendered" — so they collapse to one message rather than nine.
-  @session_events [:session_created, :session_started, :session_completed, :session_cancelled, :roster_seeded]
+  # is not what you rendered" — so they collapse to one message rather than one each.
+  #
+  # This list is a deliberate second copy of `Notifications`' own `@session_events`.
+  # A new session event added there and not here is untested; added here and not
+  # there, this test fails — which is the direction that matters, and is how
+  # `:session_updated` was caught shipping mute in #1074.
+  @session_events [
+    :session_created,
+    :session_updated,
+    :session_started,
+    :session_completed,
+    :session_cancelled,
+    :roster_seeded
+  ]
 
   @attendance_kinds %{
     child_checked_in: :checked_in,

--- a/test/klass_hero/participation/outbox_staging_test.exs
+++ b/test/klass_hero/participation/outbox_staging_test.exs
@@ -56,6 +56,21 @@ defmodule KlassHero.Participation.OutboxStagingTest do
     assert entity_id == session.id
   end
 
+  # `Outbox.stage/2` drops an event with no `:event_consumers` entry, so this
+  # fails loudly if the registry line is ever removed — the failure mode that is
+  # otherwise a silently unmaintained read table.
+  test "update_session stages session_updated", %{program: program} do
+    session = create_session(program)
+    TestOutbox.setup()
+
+    {:ok, _updated} =
+      Participation.update_session(owner_scope(program), session.id, %{session_date: ~D[2026-12-01]})
+
+    assert [:session_updated] = staged_types()
+    assert [%{entity_id: entity_id}] = TestOutbox.staged()
+    assert entity_id == session.id
+  end
+
   test "start_session stages session_started", %{program: program} do
     session = create_session(program)
     # Built before the outbox is armed: the fixture creates a User, and user

--- a/test/klass_hero/participation/outbox_staging_test.exs
+++ b/test/klass_hero/participation/outbox_staging_test.exs
@@ -15,6 +15,7 @@ defmodule KlassHero.Participation.OutboxStagingTest do
   alias KlassHero.Accounts.Scope
   alias KlassHero.AccountsFixtures
   alias KlassHero.Participation
+  alias KlassHero.Provider.ProviderProfile
   alias KlassHero.Shared.Adapters.Driven.Events.TestOutbox
 
   setup do
@@ -30,9 +31,14 @@ defmodule KlassHero.Participation.OutboxStagingTest do
 
   defp staged_types, do: Enum.map(TestOutbox.staged(), & &1.event_type)
 
+  # A bare struct, not `admin_scope()`: this runs *after* the outbox is armed, and
+  # the admin fixture creates a User, which stages user_registered/user_confirmed of
+  # its own. Only `provider.id` is read on the creation path, so no row is needed.
+  defp owner_scope(program), do: %Scope{provider: %ProviderProfile{id: program.provider_id}}
+
   defp create_session(program) do
     {:ok, session} =
-      Participation.create_session(%{
+      Participation.create_session(owner_scope(program), %{
         program_id: program.id,
         session_date: Date.utc_today(),
         start_time: ~T[09:00:00],

--- a/test/klass_hero/participation/program_session_test.exs
+++ b/test/klass_hero/participation/program_session_test.exs
@@ -319,4 +319,75 @@ defmodule KlassHero.Participation.ProgramSessionTest do
       end
     end
   end
+
+  # Until #1074 this changeset cast only the optional fields plus :status, so
+  # rescheduling was impossible by construction — there was no command to do it
+  # and no changeset that would have accepted it.
+  describe "update_changeset/2" do
+    test "casts the schedule fields" do
+      changeset =
+        ProgramSession.update_changeset(%ProgramSession{}, %{
+          session_date: ~D[2026-09-02],
+          start_time: ~T[10:00:00],
+          end_time: ~T[11:30:00]
+        })
+
+      assert changeset.valid?
+      assert Ecto.Changeset.get_change(changeset, :session_date) == ~D[2026-09-02]
+      assert Ecto.Changeset.get_change(changeset, :start_time) == ~T[10:00:00]
+      assert Ecto.Changeset.get_change(changeset, :end_time) == ~T[11:30:00]
+    end
+
+    test "rejects an end time at or before the start time" do
+      session = %ProgramSession{start_time: ~T[09:00:00], end_time: ~T[10:00:00]}
+
+      changeset = ProgramSession.update_changeset(session, %{end_time: ~T[08:00:00]})
+
+      refute changeset.valid?
+      assert %{end_time: ["must be after start time"]} = errors_on(changeset)
+    end
+
+    # The half a partial edit gets wrong: changing only the start time has to be
+    # compared against the *stored* end time, not against nothing.
+    test "compares a changed start time against the session's existing end time" do
+      session = %ProgramSession{start_time: ~T[09:00:00], end_time: ~T[10:00:00]}
+
+      changeset = ProgramSession.update_changeset(session, %{start_time: ~T[11:00:00]})
+
+      refute changeset.valid?
+    end
+
+    test "still rejects a non-positive capacity" do
+      changeset = ProgramSession.update_changeset(%ProgramSession{}, %{max_capacity: 0})
+
+      refute changeset.valid?
+    end
+
+    # A reschedule can land on a slot another session already holds. Without the
+    # constraint declared here that surfaces as an Ecto.ConstraintError — a 500,
+    # not a form error the provider can act on.
+    test "declares the slot uniqueness constraint so a collision is an error tuple" do
+      program = insert(:program_schema)
+
+      insert(:program_session_schema,
+        program_id: program.id,
+        session_date: ~D[2026-09-03],
+        start_time: ~T[09:00:00]
+      )
+
+      clash =
+        insert(:program_session_schema,
+          program_id: program.id,
+          session_date: ~D[2026-09-04],
+          start_time: ~T[09:00:00]
+        )
+
+      assert {:error, changeset} =
+               clash
+               |> ProgramSession.update_changeset(%{session_date: ~D[2026-09-03]})
+               |> Repo.update()
+
+      assert %{program_id: ["session already exists at this time"]} = errors_on(changeset)
+    end
+  end
 end

--- a/test/klass_hero/participation/session_authorization_test.exs
+++ b/test/klass_hero/participation/session_authorization_test.exs
@@ -294,6 +294,50 @@ defmodule KlassHero.Participation.SessionAuthorizationTest do
     end
   end
 
+  # Creation is asked at *program* grain: there is no session yet to ask about.
+  # Staff are refused outright — scheduling is an owner concern, and staff have
+  # never had a create-session surface (#1074).
+  describe "authorize_creation/2" do
+    test "a provider owning the program is authorized as :provider" do
+      %{provider: provider, program: program} = provider_with_program()
+      scope = scope_for(provider_profile: provider)
+
+      assert {:ok, :provider} = SessionAuthorization.authorize_creation(scope, program.id)
+    end
+
+    test "a provider is refused on another provider's program" do
+      %{provider: provider} = provider_with_program()
+      %{program: foreign_program} = provider_with_program()
+      scope = scope_for(provider_profile: provider)
+
+      assert {:error, :unauthorized} =
+               SessionAuthorization.authorize_creation(scope, foreign_program.id)
+    end
+
+    test "a platform admin is authorized as :admin" do
+      %{program: program} = provider_with_program()
+      scope = scope_for(user: AccountsFixtures.user_fixture(is_admin: true))
+
+      assert {:ok, :admin} = SessionAuthorization.authorize_creation(scope, program.id)
+    end
+
+    test "a staff member assigned to the program is still refused" do
+      %{provider: provider, program: program} = provider_with_program()
+      staff = assigned_staff(provider, program)
+      scope = scope_for(staff_member: staff)
+
+      assert {:error, :unauthorized} =
+               SessionAuthorization.authorize_creation(scope, program.id)
+    end
+
+    test "an unknown program id is refused, not raised" do
+      scope = scope_for(provider_profile: ProviderFixtures.provider_profile_fixture())
+
+      assert {:error, :unauthorized} =
+               SessionAuthorization.authorize_creation(scope, Ecto.UUID.generate())
+    end
+  end
+
   defp provider_with_program do
     provider = ProviderFixtures.provider_profile_fixture()
     program = insert(:program_schema, provider_id: provider.id)

--- a/test/klass_hero/participation/sync_sessions_for_program_test.exs
+++ b/test/klass_hero/participation/sync_sessions_for_program_test.exs
@@ -108,7 +108,7 @@ defmodule KlassHero.Participation.SyncSessionsForProgramTest do
       program = fortnightly_program()
 
       {:ok, manual} =
-        Participation.create_session(%{
+        Participation.create_session(admin_scope(), %{
           program_id: program.id,
           session_date: Date.add(Date.utc_today(), 3),
           start_time: ~T[09:00:00],

--- a/test/klass_hero/participation/update_session_test.exs
+++ b/test/klass_hero/participation/update_session_test.exs
@@ -136,6 +136,28 @@ defmodule KlassHero.Participation.UpdateSessionTest do
                })
     end
 
+    # Guards the asymmetry `SessionFormHandlers.clear_blank_capacity/2` relies on:
+    # a submitted-blank capacity clears, an omitted one must not. Today only one
+    # surface calls it and that surface always renders the input, so this pins the
+    # contract for the next one.
+    test "leaves max_capacity alone when the attr is absent" do
+      %{scope: scope, session: session} = provider_with_session()
+      {:ok, _} = Participation.update_session(scope, session.id, %{max_capacity: 25})
+
+      assert {:ok, updated} = Participation.update_session(scope, session.id, %{location: "Gym B"})
+
+      assert updated.max_capacity == 25
+    end
+
+    test "clears max_capacity when the attr is present and nil" do
+      %{scope: scope, session: session} = provider_with_session()
+      {:ok, _} = Participation.update_session(scope, session.id, %{max_capacity: 25})
+
+      assert {:ok, updated} = Participation.update_session(scope, session.id, %{max_capacity: nil})
+
+      assert is_nil(updated.max_capacity)
+    end
+
     test "rejects an end time before the start time" do
       %{scope: scope, session: session} = provider_with_session()
 

--- a/test/klass_hero/participation/update_session_test.exs
+++ b/test/klass_hero/participation/update_session_test.exs
@@ -1,0 +1,170 @@
+defmodule KlassHero.Participation.UpdateSessionTest do
+  @moduledoc """
+  Editing an existing session's schedule and details (#1074).
+
+  Until this command there was no way to correct a session at all: the facade had
+  `create`, `start` and `complete`, and `update_changeset/2` could not cast a date
+  or a time. So a provider who typed the wrong hour had a wrong session forever.
+
+  Two rules carry most of the weight here. Rescheduling stops at `:scheduled`,
+  because attendance records are keyed to the session and moving a completed one
+  rewrites history its roster cannot follow. And staff are refused, matching
+  creation: assignment is permission to *run* a session, not to move it.
+  """
+
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+
+  alias KlassHero.Accounts.Scope
+  alias KlassHero.AccountsFixtures
+  alias KlassHero.Participation
+  alias KlassHero.Participation.ProgramSession
+  alias KlassHero.Provider.ProviderProfile
+  alias KlassHero.ProviderFixtures
+
+  describe "update_session/3" do
+    test "reschedules a scheduled session" do
+      %{scope: scope, session: session} = provider_with_session()
+
+      assert {:ok, %ProgramSession{} = updated} =
+               Participation.update_session(scope, session.id, %{
+                 session_date: ~D[2026-09-09],
+                 start_time: ~T[10:00:00],
+                 end_time: ~T[11:30:00]
+               })
+
+      assert updated.session_date == ~D[2026-09-09]
+      assert updated.start_time == ~T[10:00:00]
+      assert updated.end_time == ~T[11:30:00]
+    end
+
+    test "edits the details without touching the schedule" do
+      %{scope: scope, session: session} = provider_with_session()
+
+      assert {:ok, updated} =
+               Participation.update_session(scope, session.id, %{
+                 location: "Gym B",
+                 notes: "Bring water",
+                 max_capacity: 12
+               })
+
+      assert updated.location == "Gym B"
+      assert updated.notes == "Bring water"
+      assert updated.max_capacity == 12
+      assert updated.session_date == session.session_date
+    end
+
+    test "returns :not_found for an unknown session" do
+      %{scope: scope} = provider_with_session()
+
+      assert {:error, :not_found} =
+               Participation.update_session(scope, Ecto.UUID.generate(), %{location: "Gym B"})
+    end
+
+    test "refuses a provider who does not own the program" do
+      %{session: session} = provider_with_session()
+      foreign = %Scope{provider: %ProviderProfile{id: Ecto.UUID.generate()}}
+
+      assert {:error, :unauthorized} =
+               Participation.update_session(foreign, session.id, %{location: "Gym B"})
+    end
+
+    test "refuses a staff member assigned to the program" do
+      %{provider: provider, program: program, session: session} = provider_with_session()
+      staff = ProviderFixtures.staff_member_fixture(%{provider_id: provider.id})
+
+      ProviderFixtures.program_assignment_fixture(%{
+        provider_id: provider.id,
+        staff_member_id: staff.id,
+        program_id: program.id
+      })
+
+      scope = %Scope{user: AccountsFixtures.unconfirmed_user_fixture(), staff_member: staff}
+
+      assert {:error, :unauthorized} =
+               Participation.update_session(scope, session.id, %{location: "Gym B"})
+    end
+
+    # Assumption 1 in the plan: the schedule freezes once the session has started,
+    # the details do not.
+    for status <- [:in_progress, :completed, :cancelled] do
+      test "refuses a schedule change on a #{status} session" do
+        %{scope: scope, session: session} = provider_with_session(status: unquote(status))
+
+        assert {:error, :session_started} =
+                 Participation.update_session(scope, session.id, %{session_date: ~D[2026-09-09]})
+      end
+
+      test "still allows a detail edit on a #{status} session" do
+        %{scope: scope, session: session} = provider_with_session(status: unquote(status))
+
+        assert {:ok, updated} = Participation.update_session(scope, session.id, %{location: "Gym B"})
+        assert updated.location == "Gym B"
+      end
+    end
+
+    # A no-op reschedule is not a reschedule: re-submitting the form unchanged
+    # must not be refused just because the keys are present.
+    test "allows a submitted-but-unchanged schedule on a completed session" do
+      %{scope: scope, session: session} = provider_with_session(status: :completed)
+
+      assert {:ok, _updated} =
+               Participation.update_session(scope, session.id, %{
+                 session_date: session.session_date,
+                 start_time: session.start_time,
+                 location: "Gym B"
+               })
+    end
+
+    test "returns an error tuple when the new slot is already taken" do
+      %{scope: scope, program: program, session: session} = provider_with_session()
+
+      insert(:program_session_schema,
+        program_id: program.id,
+        session_date: ~D[2026-09-09],
+        start_time: ~T[10:00:00]
+      )
+
+      # End time moves with the start: leaving it at the stored 10:00 would invert
+      # the range and trip that validation first, never reaching the constraint.
+      assert {:error, :duplicate_session} =
+               Participation.update_session(scope, session.id, %{
+                 session_date: ~D[2026-09-09],
+                 start_time: ~T[10:00:00],
+                 end_time: ~T[11:30:00]
+               })
+    end
+
+    test "rejects an end time before the start time" do
+      %{scope: scope, session: session} = provider_with_session()
+
+      assert {:error, :invalid_time_range} =
+               Participation.update_session(scope, session.id, %{
+                 start_time: ~T[14:00:00],
+                 end_time: ~T[09:00:00]
+               })
+    end
+  end
+
+  defp provider_with_session(opts \\ []) do
+    provider = ProviderFixtures.provider_profile_fixture()
+    program = insert(:program_schema, provider_id: provider.id)
+
+    session =
+      insert(:program_session_schema,
+        program_id: program.id,
+        session_date: ~D[2026-09-01],
+        start_time: ~T[09:00:00],
+        end_time: ~T[10:00:00],
+        status: Keyword.get(opts, :status, :scheduled)
+      )
+
+    %{
+      provider: provider,
+      program: program,
+      session: session,
+      scope: %Scope{provider: provider}
+    }
+  end
+end

--- a/test/klass_hero/participation/update_session_unboxed_test.exs
+++ b/test/klass_hero/participation/update_session_unboxed_test.exs
@@ -1,0 +1,114 @@
+defmodule KlassHero.Participation.UpdateSessionUnboxedTest do
+  @moduledoc """
+  The one `update_session/3` test that runs *outside* the SQL sandbox.
+
+  `update_session/3` rescheduling can land on a slot a sibling session already
+  holds. Its `Repo.update/1` runs inside `Outbox.transact_with_events/2`, so
+  turning that collision into `{:error, :duplicate_session}` rather than a raised
+  `Postgrex.Error` depends on `mode: :savepoint` — Ecto only converts a constraint
+  violation into a changeset error when the statement can be rolled back to a
+  savepoint, and inside a transaction it cannot unless asked.
+
+  Under the sandbox this is invisible: `Ecto.Adapters.SQL.Sandbox.Connection`
+  proxies every statement and injects `mode: :savepoint` of its own accord, so the
+  sandboxed test passes whether or not the production code asks for it. That is
+  precisely how #1322 shipped green in the other direction.
+
+  Consequences, all deliberate — see `KlassHero.Family.ConsentsUnboxedTest` for
+  the same reasoning at length: `async: false`, no `DataCase`, fixtures built
+  inside the block, and nothing rolls back so the block cleans up after itself.
+  """
+
+  use ExUnit.Case, async: false
+
+  import Ecto.Query
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias KlassHero.Accounts.Scope
+  alias KlassHero.Accounts.User
+  alias KlassHero.Participation
+  alias KlassHero.Participation.ProgramSession
+  alias KlassHero.ProgramCatalog.Program
+  alias KlassHero.Provider.ProviderProfile
+  alias KlassHero.Repo
+
+  test "a reschedule onto an occupied slot refuses instead of raising" do
+    Sandbox.unboxed_run(Repo, fn ->
+      # Pins the precondition: inside a transaction the sandbox would supply the
+      # savepoint itself and the test would prove nothing.
+      refute Repo.in_transaction?()
+
+      {provider, program, moving, _blocker} = insert_fixtures()
+
+      try do
+        assert {:error, :duplicate_session} =
+                 Participation.update_session(%Scope{provider: provider}, moving.id, %{
+                   session_date: ~D[2027-03-02],
+                   start_time: ~T[09:00:00],
+                   end_time: ~T[10:30:00]
+                 })
+      after
+        cleanup(provider, program)
+      end
+    end)
+  end
+
+  defp insert_fixtures do
+    user =
+      Repo.insert!(%User{
+        email: "reschedule-unboxed-#{System.unique_integer([:positive])}@example.com",
+        name: "Unboxed Test User"
+      })
+
+    provider =
+      Repo.insert!(%ProviderProfile{
+        identity_id: user.id,
+        business_name: "Unboxed Provider #{System.unique_integer([:positive])}"
+      })
+
+    program =
+      Repo.insert!(%Program{
+        provider_id: provider.id,
+        title: "Unboxed Program",
+        description: "A program used only by the unboxed reschedule test",
+        category: "education",
+        age_range: "6-10 years",
+        price: Decimal.new("0.00"),
+        pricing_period: "per month"
+      })
+
+    blocker =
+      Repo.insert!(%ProgramSession{
+        program_id: program.id,
+        session_date: ~D[2027-03-02],
+        start_time: ~T[09:00:00],
+        end_time: ~T[10:30:00],
+        status: :scheduled
+      })
+
+    moving =
+      Repo.insert!(%ProgramSession{
+        program_id: program.id,
+        session_date: ~D[2027-03-03],
+        start_time: ~T[09:00:00],
+        end_time: ~T[10:30:00],
+        status: :scheduled
+      })
+
+    {provider, program, moving, blocker}
+  end
+
+  # Nothing rolls back here, so every row this test made must go — the `users` row
+  # included. Leaving it behind is not a tidiness problem: `AccountsTest` asserts
+  # on `Repo.update_all(User, ...)` across the whole table, so one leaked user
+  # fails a test in another file with no visible connection to this one.
+  #
+  # FK order: sessions reference programs, programs reference providers, providers
+  # reference users.
+  defp cleanup(provider, program) do
+    Repo.delete_all(from(s in ProgramSession, where: s.program_id == ^program.id))
+    Repo.delete_all(from(p in Program, where: p.id == ^program.id))
+    Repo.delete_all(from(p in ProviderProfile, where: p.id == ^provider.id))
+    Repo.delete_all(from(u in User, where: u.id == ^provider.identity_id))
+  end
+end

--- a/test/klass_hero/provider/projections/provider_session_details_test.exs
+++ b/test/klass_hero/provider/projections/provider_session_details_test.exs
@@ -234,6 +234,70 @@ defmodule KlassHero.Provider.Projections.ProviderSessionDetailsTest do
     end
   end
 
+  # The popup reads this table, so an edit that never lands here shows the old
+  # date forever. Both halves matter: the topic in `use Projection` and the clause
+  # below — either alone is the silent no-op from #1481.
+  describe "session_updated" do
+    setup :insert_seed_session
+
+    test "reprojects the schedule", %{session_id: session_id} do
+      broadcast(:session_updated, session_id, %{
+        session_id: session_id,
+        program_id: "prog",
+        session_date: ~D[2026-11-11],
+        start_time: ~T[16:30:00],
+        end_time: ~T[18:00:00],
+        location: "Gym B",
+        max_capacity: 12
+      })
+
+      assert %{
+               session_date: ~D[2026-11-11],
+               start_time: ~T[16:30:00],
+               end_time: ~T[18:00:00]
+             } = reload(session_id)
+    end
+
+    # Status, staffing and the counters each have their own event. Re-deriving
+    # them from an edit would let a stale payload overwrite a fresher projection.
+    test "leaves status and the attendance counters alone", %{session_id: session_id} do
+      broadcast(:session_started, session_id, %{session_id: session_id, program_id: "prog"})
+      broadcast(:roster_seeded, session_id, %{session_id: session_id, seeded_count: 3})
+
+      broadcast(:session_updated, session_id, %{
+        session_id: session_id,
+        program_id: "prog",
+        session_date: ~D[2026-11-11],
+        start_time: ~T[16:30:00],
+        end_time: ~T[18:00:00],
+        location: nil,
+        max_capacity: nil
+      })
+
+      assert %{status: :in_progress, total_count: 3} = reload(session_id)
+    end
+
+    test "logs a warning when the session row is missing" do
+      unknown_id = Ecto.UUID.generate()
+
+      log =
+        capture_log(fn ->
+          broadcast(:session_updated, unknown_id, %{
+            session_id: unknown_id,
+            program_id: "prog",
+            session_date: ~D[2026-11-11],
+            start_time: ~T[16:30:00],
+            end_time: ~T[18:00:00],
+            location: nil,
+            max_capacity: nil
+          })
+        end)
+
+      assert log =~ "session update skipped"
+      assert log =~ unknown_id
+    end
+  end
+
   describe "roster_seeded" do
     setup :insert_seed_session
 

--- a/test/klass_hero_web/components/provider_components_test.exs
+++ b/test/klass_hero_web/components/provider_components_test.exs
@@ -158,7 +158,8 @@ defmodule KlassHeroWeb.ProviderComponentsTest do
             checked_in_count: 0,
             total_count: 0
           }
-        ]
+        ],
+        form: nil
       }
 
       html = render_component(&KlassHeroWeb.ProviderComponents.sessions_modal/1, modal: modal)
@@ -172,7 +173,7 @@ defmodule KlassHeroWeb.ProviderComponentsTest do
     end
 
     test "shows empty state when sessions is []" do
-      modal = %{program_id: "p", program_title: "T", sessions: []}
+      modal = %{program_id: "p", program_title: "T", sessions: [], form: nil}
       html = render_component(&KlassHeroWeb.ProviderComponents.sessions_modal/1, modal: modal)
       assert html =~ "No sessions scheduled yet"
     end
@@ -184,7 +185,8 @@ defmodule KlassHeroWeb.ProviderComponentsTest do
         modal = %{
           program_id: "prog-1",
           program_title: "Judo",
-          sessions: [session_detail(session_id: "s-42", status: unquote(status))]
+          sessions: [session_detail(session_id: "s-42", status: unquote(status))],
+          form: nil
         }
 
         html = render_component(&KlassHeroWeb.ProviderComponents.sessions_modal/1, modal: modal)

--- a/test/klass_hero_web/components/provider_components_test.exs
+++ b/test/klass_hero_web/components/provider_components_test.exs
@@ -176,6 +176,48 @@ defmodule KlassHeroWeb.ProviderComponentsTest do
       html = render_component(&KlassHeroWeb.ProviderComponents.sessions_modal/1, modal: modal)
       assert html =~ "No sessions scheduled yet"
     end
+
+    # Every status navigates, cancelled included: a cancelled session still has a
+    # roster worth reading, and hiding the way in was the whole complaint in #1074.
+    for status <- [:scheduled, :in_progress, :completed, :cancelled] do
+      test "a #{status} row links every cell to the session detail page" do
+        modal = %{
+          program_id: "prog-1",
+          program_title: "Judo",
+          sessions: [session_detail(session_id: "s-42", status: unquote(status))]
+        }
+
+        html = render_component(&KlassHeroWeb.ProviderComponents.sessions_modal/1, modal: modal)
+
+        hrefs =
+          html
+          |> LazyHTML.from_fragment()
+          |> LazyHTML.query("tbody a")
+          |> LazyHTML.attribute("href")
+
+        # One per cell, not one per row: an <a> wrapping <td>s is invalid HTML.
+        assert hrefs == List.duplicate("/provider/participation/s-42", 4)
+      end
+    end
+  end
+
+  defp session_detail(overrides) do
+    struct!(
+      %SessionDetail{
+        session_id: "s-1",
+        program_id: "prog-1",
+        provider_id: "prv-1",
+        session_date: ~D[2026-05-01],
+        start_time: ~T[15:00:00],
+        end_time: ~T[16:00:00],
+        status: :scheduled,
+        program_title: "Judo",
+        current_assigned_staff_name: "Alice",
+        checked_in_count: 0,
+        total_count: 0
+      },
+      overrides
+    )
   end
 
   describe "invite_table/1" do

--- a/test/klass_hero_web/live/provider/participation_live_test.exs
+++ b/test/klass_hero_web/live/provider/participation_live_test.exs
@@ -43,6 +43,78 @@ defmodule KlassHeroWeb.Provider.ParticipationLiveTest do
     %{session: session, parent: parent, child: child, record: record, scope: scope}
   end
 
+  # This is what makes the Sessions popup a management surface rather than a
+  # list: the row leads here, and here the session can actually be corrected.
+  describe "editing the session" do
+    setup [:create_session_with_child]
+
+    test "the form opens seeded from the session", %{conn: conn, session: session} do
+      {:ok, view, _html} = live(conn, ~p"/provider/participation/#{session.id}")
+
+      refute has_element?(view, "#edit-session-panel")
+
+      view |> element("#edit-session-btn") |> render_click()
+
+      assert has_element?(view, "#edit-session-panel")
+      assert has_element?(view, "#create-session-form")
+    end
+
+    test "saving a detail edit persists it", %{conn: conn, session: session} do
+      {:ok, view, _html} = live(conn, ~p"/provider/participation/#{session.id}")
+
+      view |> element("#edit-session-btn") |> render_click()
+
+      # The session is :in_progress, so its schedule must round-trip unchanged —
+      # submitting different times would be a reschedule and get refused.
+      view
+      |> form("#create-session-form", %{
+        "session" => %{
+          "session_date" => Date.to_iso8601(session.session_date),
+          "start_time" => Calendar.strftime(session.start_time, "%H:%M"),
+          "end_time" => Calendar.strftime(session.end_time, "%H:%M"),
+          "location" => "Gym B",
+          "notes" => "",
+          "max_capacity" => "15"
+        }
+      })
+      |> render_submit()
+
+      assert {:ok, updated} = Participation.get_session(session.id)
+      assert updated.location == "Gym B"
+      assert updated.max_capacity == 15
+
+      # Panel closes on success rather than leaving a submitted form on screen.
+      refute has_element?(view, "#edit-session-panel")
+    end
+
+    # The fixture session is :in_progress, so the schedule is frozen. Disabling
+    # the inputs is the affordance; the context is the guard, and this asserts the
+    # guard by submitting the change the disabled input would have prevented.
+    test "refuses a schedule change on a started session", %{conn: conn, session: session} do
+      {:ok, view, _html} = live(conn, ~p"/provider/participation/#{session.id}")
+
+      view |> element("#edit-session-btn") |> render_click()
+
+      html =
+        view
+        |> form("#create-session-form", %{
+          "session" => %{
+            "session_date" => "2027-01-01",
+            "start_time" => "09:00",
+            "end_time" => "11:00",
+            "location" => "",
+            "notes" => "",
+            "max_capacity" => ""
+          }
+        })
+        |> render_submit()
+
+      assert html =~ "fixed once a session has started"
+      assert {:ok, unchanged} = Participation.get_session(session.id)
+      assert unchanged.session_date == session.session_date
+    end
+  end
+
   describe "cross-provider authorization" do
     test "redirects when the session belongs to another provider (IDOR guard)", %{conn: conn} do
       foreign_provider = insert(:provider_profile_schema)

--- a/test/klass_hero_web/live/provider/participation_live_test.exs
+++ b/test/klass_hero_web/live/provider/participation_live_test.exs
@@ -87,6 +87,32 @@ defmodule KlassHeroWeb.Provider.ParticipationLiveTest do
       refute has_element?(view, "#edit-session-panel")
     end
 
+    # The moduledoc promises a blank optional field clears it. `put_capacity/2`
+    # omits the key whenever Integer.parse fails, which made that false for
+    # max_capacity alone — it silently kept its old value.
+    test "blanking max capacity clears it", %{conn: conn, session: session} do
+      {:ok, view, _html} = live(conn, ~p"/provider/participation/#{session.id}")
+
+      view |> element("#edit-session-btn") |> render_click()
+
+      view
+      |> form("#create-session-form", %{
+        "session" => %{
+          "session_date" => Date.to_iso8601(session.session_date),
+          "start_time" => Calendar.strftime(session.start_time, "%H:%M"),
+          "end_time" => Calendar.strftime(session.end_time, "%H:%M"),
+          "location" => "",
+          "notes" => "",
+          "max_capacity" => ""
+        }
+      })
+      |> render_submit()
+
+      assert {:ok, updated} = Participation.get_session(session.id)
+      assert is_nil(updated.max_capacity)
+      assert is_nil(updated.location)
+    end
+
     # The fixture session is :in_progress, so the schedule is frozen. Disabling
     # the inputs is the affordance; the context is the guard, and this asserts the
     # guard by submitting the change the disabled input would have prevented.

--- a/test/klass_hero_web/live/provider/provider_dashboard_test.exs
+++ b/test/klass_hero_web/live/provider/provider_dashboard_test.exs
@@ -68,13 +68,14 @@ defmodule KlassHeroWeb.Provider.ProviderDashboardTest do
 
     program = insert_program_with_listing(provider_id: provider.id, title: title)
 
-    KlassHero.Factory.insert(:program_session_schema,
-      program_id: program.id,
-      session_date: ~D[2026-05-01],
-      start_time: ~T[15:00:00],
-      end_time: ~T[16:00:00],
-      status: "scheduled"
-    )
+    session =
+      KlassHero.Factory.insert(:program_session_schema,
+        program_id: program.id,
+        session_date: ~D[2026-05-01],
+        start_time: ~T[15:00:00],
+        end_time: ~T[16:00:00],
+        status: "scheduled"
+      )
 
     name = :"provider_session_details_#{System.unique_integer([:positive])}"
     pid = start_supervised!({ProviderSessionDetails, name: name})
@@ -90,7 +91,7 @@ defmodule KlassHeroWeb.Provider.ProviderDashboardTest do
     :ok = Sandbox.allow(Repo, self(), pid)
     :ok = ProviderSessionDetails.rebuild(name)
 
-    program
+    {program, session}
   end
 
   describe "overview section" do
@@ -885,7 +886,7 @@ defmodule KlassHeroWeb.Provider.ProviderDashboardTest do
       conn: conn,
       provider: provider
     } do
-      program = seed_program_with_session!(provider, title: "Judo")
+      {program, _session} = seed_program_with_session!(provider, title: "Judo")
 
       {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
 
@@ -898,6 +899,26 @@ defmodule KlassHeroWeb.Provider.ProviderDashboardTest do
 
       view |> element("#sessions-modal button[phx-click='close_sessions']") |> render_click()
       refute has_element?(view, "#sessions-modal")
+    end
+
+    test "a session row is a working entry point into that session's detail page", %{
+      conn: conn,
+      provider: provider
+    } do
+      {program, session} = seed_program_with_session!(provider, title: "Judo")
+
+      {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+
+      view
+      |> element(~s|button[phx-click="view_sessions"][phx-value-program-id="#{program.id}"]|)
+      |> render_click()
+
+      assert has_element?(view, ~s|#sessions-modal a[href="/provider/participation/#{session.id}"]|)
+
+      # Following it must actually land: ParticipationLive re-guards ownership at
+      # mount and push_navigates away on refusal, so a redirect here would fail
+      # this match rather than pass quietly.
+      assert {:ok, _detail, _html} = live(conn, ~p"/provider/participation/#{session.id}")
     end
   end
 

--- a/test/klass_hero_web/live/provider/provider_dashboard_test.exs
+++ b/test/klass_hero_web/live/provider/provider_dashboard_test.exs
@@ -920,6 +920,70 @@ defmodule KlassHeroWeb.Provider.ProviderDashboardTest do
       # this match rather than pass quietly.
       assert {:ok, _detail, _html} = live(conn, ~p"/provider/participation/#{session.id}")
     end
+
+    test "Create Session opens the form with this popup's program locked in", %{
+      conn: conn,
+      provider: provider
+    } do
+      {program, _session} = seed_program_with_session!(provider, title: "Judo")
+
+      view = open_sessions_popup(conn, program)
+
+      view |> element("#new-session-button") |> render_click()
+
+      assert has_element?(view, "#create-session-form")
+      # No program picker: the popup opened from one program, so the id rides a
+      # hidden field instead of a question the provider already answered.
+      refute has_element?(view, "#create-session-form select[name='session[program_id]']")
+
+      program_id = program.id
+
+      assert [^program_id] =
+               view
+               |> render()
+               |> LazyHTML.from_fragment()
+               |> LazyHTML.query(~s|input[name="session[program_id]"]|)
+               |> LazyHTML.attribute("value")
+    end
+
+    test "submitting the popup form creates a session for that program", %{
+      conn: conn,
+      provider: provider
+    } do
+      {program, _session} = seed_program_with_session!(provider, title: "Judo")
+
+      view = open_sessions_popup(conn, program)
+      view |> element("#new-session-button") |> render_click()
+
+      view
+      |> form("#create-session-form", %{
+        "session" => %{
+          "program_id" => program.id,
+          "session_date" => "2026-09-01",
+          "start_time" => "09:00",
+          "end_time" => "11:00"
+        }
+      })
+      |> render_submit()
+
+      assert Enum.any?(
+               KlassHero.Participation.list_sessions(%{program_id: program.id}),
+               &(&1.session_date == ~D[2026-09-01] and &1.start_time == ~T[09:00:00])
+             )
+
+      # Back to the list, not left on a form the provider has already submitted.
+      refute has_element?(view, "#create-session-form")
+    end
+  end
+
+  defp open_sessions_popup(conn, program) do
+    {:ok, view, _html} = live(conn, ~p"/provider/dashboard/programs")
+
+    view
+    |> element(~s|button[phx-click="view_sessions"][phx-value-program-id="#{program.id}"]|)
+    |> render_click()
+
+    view
   end
 
   describe "invite error paths" do

--- a/test/klass_hero_web/live/provider/sessions_live_test.exs
+++ b/test/klass_hero_web/live/provider/sessions_live_test.exs
@@ -258,6 +258,36 @@ defmodule KlassHeroWeb.Provider.SessionsLiveTest do
       # Session still present in the stream afterwards (no crash)
       assert has_element?(view, "button", "Start Session")
     end
+
+    # Before #1074 a session's date could not change, so a `:session_changed` for
+    # another day was correctly ignored. A reschedule can move one now, and an
+    # ignored message would leave the row rendered under a day it is not on.
+    test "removes a session from the stream once it is rescheduled off the day on screen", %{
+      conn: conn,
+      provider: provider,
+      scope: scope
+    } do
+      program = insert(:program_schema, provider_id: provider.id)
+      _listing = insert(:program_listing_schema, id: program.id, provider_id: provider.id)
+
+      session =
+        insert(:program_session_schema,
+          program_id: program.id,
+          session_date: Date.utc_today(),
+          status: :scheduled
+        )
+
+      {:ok, view, _html} = live(conn, ~p"/provider/sessions")
+
+      assert has_element?(view, "button", "Start Session")
+
+      {:ok, _moved} =
+        Participation.update_session(scope, session.id, %{session_date: Date.add(Date.utc_today(), 3)})
+
+      send(view.pid, {:session_changed, session.id})
+
+      refute has_element?(view, "button", "Start Session")
+    end
   end
 
   describe "create session modal" do

--- a/test/klass_hero_web/live/provider/sessions_live_test.exs
+++ b/test/klass_hero_web/live/provider/sessions_live_test.exs
@@ -580,10 +580,21 @@ defmodule KlassHeroWeb.Provider.SessionsLiveTest do
   describe "Create Session button" do
     setup :register_and_log_in_provider
 
-    test "shows 'Create Session' button on sessions page", %{conn: conn} do
+    # Moved to Program Inventory's Sessions popup (#1074), where a program is
+    # already in hand. This page becomes the read-only Schedule in #1501, so the
+    # CTA had to leave before the page does.
+    test "no longer offers session creation from My Sessions", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/provider/sessions")
 
-      assert has_element?(view, ~s(a[href="/provider/sessions/new"]), "Create Session")
+      refute has_element?(view, ~s(a[href="/provider/sessions/new"]))
+    end
+
+    # The route survives the button: #1501 owns removing it, and a URL that 500s
+    # in the meantime would be a worse regression than an unlinked page.
+    test "the /new route still renders for anyone holding the URL", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/provider/sessions/new")
+
+      assert has_element?(view, "#create-session-form")
     end
   end
 

--- a/test/klass_hero_web/live/staff/staff_sessions_live_test.exs
+++ b/test/klass_hero_web/live/staff/staff_sessions_live_test.exs
@@ -4,6 +4,7 @@ defmodule KlassHeroWeb.Staff.StaffSessionsLiveTest do
   import KlassHero.Factory
   import Phoenix.LiveViewTest
 
+  alias KlassHero.Accounts.Scope
   alias KlassHero.Participation
   alias KlassHero.ProviderFixtures
 
@@ -121,6 +122,31 @@ defmodule KlassHeroWeb.Staff.StaffSessionsLiveTest do
       send(view.pid, {:session_changed, future.id})
 
       refute has_element?(view, "button[phx-value-session_id='#{future.id}']")
+    end
+
+    # The sibling case, and the one that actually regressed: a session this staff
+    # member *is* on, rendered on today's list, then rescheduled away. The test
+    # above only ever covered a session that was never inserted, so the off-date
+    # branch could return the socket unchanged and still look correct (#1074).
+    # `SessionsLive` has the same test — this pair has drifted before (#921).
+    test "removes a rendered session once it is rescheduled off the day on screen",
+         %{conn: conn} = ctx do
+      program = assigned_program(ctx, title: "Soccer Training")
+      session = session_on(program, Date.utc_today(), :scheduled)
+
+      {:ok, view, _html} = live(conn, ~p"/staff/sessions")
+      assert has_element?(view, "button[phx-value-session_id='#{session.id}']")
+
+      {:ok, _moved} =
+        Participation.update_session(
+          %Scope{provider: ctx.provider},
+          session.id,
+          %{session_date: Date.add(Date.utc_today(), 4)}
+        )
+
+      send(view.pid, {:session_changed, session.id})
+
+      refute has_element?(view, "button[phx-value-session_id='#{session.id}']")
     end
 
     test "shows sessions of assigned programs only, whatever the staff member's Specialties",


### PR DESCRIPTION
## Summary

Makes the Program Inventory Sessions popup a real management surface for its program, in three independent slices.

The issue's original ACs were unbuildable as written: they asked to "reuse the existing create-session flow at `/provider/sessions/new`", but that is a `patch` action *inside* `SessionsLive` rendering a modal over My Sessions — not a linkable flow — and #1501 deletes that route and LiveView. #1074's body has been rewritten to match what actually shipped.

**Slice 1 — rows navigate.** Each cell in `sessions_modal` links to `/provider/participation/:session_id`, for every status. Per-cell rather than per-row, because an `<a>` wrapping `<td>`s is invalid HTML and LiveView's DOM patcher reparents it.

**Slice 2 — create from the popup.** The create-session form's logic moves to `KlassHeroWeb.Helpers.SessionFormHandlers` and its markup to a `session_form` component, so both surfaces render one form instead of two copies. The popup passes `program_locked?`, replacing the select with static text.

The point of this slice is not the button. `create_session/1` took bare params with the ownership check spelled out in `SessionsLive` as a `provider_program_ids` MapSet test. A second create surface would have made that rule a per-surface copy — the shape ADR-0019 names as one a surface eventually omits (#1323). `create_session/2` now takes a `Scope` and asks `SessionAuthorization.authorize_creation/2`, a program-grain question because there is no session yet to ask about. Staff are refused: assignment is permission to *run* sessions, not to add them.

Create Session is removed from My Sessions (AC5). The `/new` route stays until #1501 removes it, with a test pinning that it still renders.

**Slice 3 — edit a session.** There was no way to correct a session at all: `Participation` had create/start/complete, and `update_changeset/2` could not cast a date or a time, so a session typed with the wrong hour stayed wrong.

`update_session/3` adds the command. Rescheduling stops at `:scheduled` — attendance records are keyed to the session, so moving a completed one rewrites history its roster cannot follow — while details stay editable at every status. The edit ships with a `session_updated` event, its `ProviderSessionDetails` clause, the topic, and the `:event_consumers` entry; without that entry `Outbox.stage/2` drops the event and the popup would show the old date forever.

## Review focus

- **`ProgramSession.update_changeset/2` gained schedule fields, `validate_time_range` and a slot `unique_constraint`.** That changeset has other callers (`start_session/2`, `complete_session/2`, and the bulk cancel/revive in `sync_sessions_for_program/1`). The added validation only fires on a change, but this is the highest-risk edit in the PR.
- **Locked schedule inputs are `readonly`, not `disabled`.** A disabled input is not submitted, so disabling them would strip date and time from the payload and make even a *details* edit fail coercion. Caught by a test, not by review.
- **`submit_update/3` treats a blank `location`/`notes` as "clear it"** where `submit/2` omits them — a create has nothing to clear, an edit does.
- **`SessionFormHandlers` refuses in atoms, never sentences**, so a caller can ask `user_correctable?/1` before logging; `humanize_error/1` renders them once.

## Test plan

`mix precommit` — green, 5360 passed, 2 skipped.

New coverage:

| Area | Tests |
|---|---|
| Row links | 4 statuses × per-cell hrefs; a LiveView case that follows the link and lands |
| `authorize_creation/2` | provider ✓, admin ✓, assigned staff ✗, foreign provider ✗, unknown program refuses rather than raises |
| `create_session/2` | refuses **at the context**, and refuses before validating so an unauthorized caller learns nothing about the params |
| Popup create | program pre-locked with no select; submitting persists |
| `update_session/3` | reschedule, detail edit, not_found, foreign provider, assigned staff, schedule frozen on each non-scheduled status, details still editable there, unchanged-schedule re-submit allowed, slot collision, inverted range |
| `update_changeset/2` | casts schedule fields, partial edit compared against stored values, constraint declared |
| Projection | reprojects the schedule; leaves status and counters alone; warns on a missing row |
| Outbox | `session_updated` is staged — fails loudly if the registry line is removed |

**`update_session_unboxed_test.exs` runs outside the SQL sandbox.** The sandbox savepoints every statement, so a constraint violation inside a transaction looks harmless in tests and can abort the transaction in production (#1322). This pins that the slot collision returns an error tuple on a real, idle connection. Its cleanup deletes the `users` row it creates — leaving one behind fails `AccountsTest`, which asserts on `Repo.update_all(User, ...)` across the whole table.

Verified end-to-end against the running dev server (Tidewave), which is what catches a missing consumer-registry entry that no unit test sees:

- edit → event staged → Oban delivered (`success: 1, discard: 0`) → projection moved `2026-09-03 16:00–17:30` to `2026-09-10 16:45–18:15`, with status and counters untouched
- create as owner ✓, foreign provider `:unauthorized`, no persona `:unauthorized`, duplicate slot `:duplicate_session`; the new row landed in the projection with its program title

**Not verified:** the visual/responsive pass. Both browser channels were unavailable — the Chrome DevTools profile is held by another session, and the Claude extension is not connected. The UI wiring is covered by LiveView tests, but a mobile check of the popup's new header (title + Create Session + close, three items where there were two) is still owed.

Closes #1074
