### PR TITLE
feat: add "Meet the Heroes" to the provider profile

### DIFF
--- a/lib/klass_hero/provider.ex
+++ b/lib/klass_hero/provider.ex
@@ -265,6 +265,9 @@ defmodule KlassHero.Provider do
   @doc "Lists active staff members for a provider."
   defdelegate list_active_staff_members(provider_id), to: Staff
 
+  @doc "The provider's staff safe to name publicly: employed, and claimed."
+  defdelegate list_public_staff(provider_id), to: Staff
+
   @doc "Returns the full name of a staff member."
   defdelegate staff_member_full_name(staff), to: Staff
 
@@ -319,6 +322,9 @@ defmodule KlassHero.Provider do
 
   @doc "Lists active staff members assigned to a program."
   defdelegate list_active_staff_for_program(program_id), to: Assignments
+
+  @doc "A program's staff safe to name publicly: assigned, employed, and claimed."
+  defdelegate list_public_staff_for_program(program_id), to: Assignments
 
   @doc "Lists the user IDs of claimed, active staff assigned to a program."
   defdelegate list_active_staff_user_ids_for_program(program_id), to: Assignments

--- a/lib/klass_hero/provider/assignments.ex
+++ b/lib/klass_hero/provider/assignments.ex
@@ -478,6 +478,28 @@ defmodule KlassHero.Provider.Assignments do
   end
 
   @doc """
+  As `list_active_staff_for_program/1`, for the public `/programs/:id` page:
+  additionally drops staff who have not claimed their seat.
+
+  A sibling rather than a narrowing of the original, and not a narrowing of
+  `active_staffing_query/0` either. Both feed provider-facing surfaces — the
+  staffing modal and the programs table — which must keep showing people whose
+  invitations are still outstanding. Narrowing the shared base is precisely the
+  shape of #1310, where an over-filtered read made staffed programs read as
+  "Unassigned" and their staff unfindable.
+
+  Skips `StaffMember.load_pay_rate/1`: no public surface reads a pay rate.
+  """
+  @spec list_public_staff_for_program(String.t()) :: [StaffMember.t()]
+  def list_public_staff_for_program(program_id) when is_binary(program_id) do
+    active_staffing_query()
+    |> StaffMember.claimed()
+    |> where([assignment: a], a.program_id == ^program_id)
+    |> select([staff: s], s)
+    |> Repo.all()
+  end
+
+  @doc """
   Lists the *user* IDs of staff currently active on a program.
 
   The membership set Messaging needs to answer "does this user act for the

--- a/lib/klass_hero/provider/staff.ex
+++ b/lib/klass_hero/provider/staff.ex
@@ -460,6 +460,28 @@ defmodule KlassHero.Provider.Staff do
     {:ok, members}
   end
 
+  @doc """
+  The provider's staff safe to name on a public page: employed, and claimed.
+
+  Narrower than `list_active_staff_members/1` by exactly one gate, and that gate
+  is why this is a separate function rather than an option: the sibling feeds the
+  provider's own team screens, which must keep showing the people they invited
+  while those invitations are still outstanding.
+
+  Returns a bare list, and skips `StaffMember.load_pay_rate/1` — no public
+  surface reads a pay rate, and an anonymous request is the wrong place to
+  hydrate one.
+  """
+  @spec list_public_staff(String.t()) :: [StaffMember.t()]
+  def list_public_staff(provider_id) when is_binary(provider_id) do
+    provider_id
+    |> StaffMember.owned_by()
+    |> StaffMember.active()
+    |> StaffMember.claimed()
+    |> order_by([s], asc: s.inserted_at)
+    |> Repo.all()
+  end
+
   @doc "Returns the full name of a staff member."
   @spec staff_member_full_name(StaffMember.t()) :: String.t()
   def staff_member_full_name(%StaffMember{} = staff) do

--- a/lib/klass_hero/provider/staff_member.ex
+++ b/lib/klass_hero/provider/staff_member.ex
@@ -393,6 +393,28 @@ defmodule KlassHero.Provider.StaffMember do
     from s in query, where: s.active == true
   end
 
+  @doc """
+  Narrows a query to staff who have claimed their seat — a `User` is attached,
+  so there is a real person to name.
+
+  A third question again, separate for the same reason `active/1` is separate
+  from `owned_by/2`: tenancy, employment and identity are independent. A row can
+  be owned and live and still be nothing but a name a provider typed into an
+  invitation nobody accepted.
+
+  `user_id`, not `invitation_status`, is the predicate: founder self-staffing
+  mints a row already linked and `:accepted` with no invitation token at all
+  (ADR-0005), so keying on the status would work while keying on the token
+  would silently hide every owner who teaches.
+
+  Compose it on **public** reads only. A provider must still see the people they
+  invited, so management surfaces deliberately do not narrow by this.
+  """
+  @spec claimed(Ecto.Queryable.t()) :: Ecto.Query.t()
+  def claimed(query \\ __MODULE__) do
+    from s in query, where: not is_nil(s.user_id)
+  end
+
   # ── Functional core (ported domain validator + helpers) ──────────────────
 
   @doc """

--- a/lib/klass_hero_web/live/program_detail_live.ex
+++ b/lib/klass_hero_web/live/program_detail_live.ex
@@ -108,7 +108,7 @@ defmodule KlassHeroWeb.ProgramDetailLive do
   end
 
   defp load_team_members(program_id) when is_binary(program_id) do
-    staff = Provider.list_active_staff_for_program(program_id)
+    staff = Provider.list_public_staff_for_program(program_id)
 
     lead_id =
       case Provider.get_lead_instructor(program_id) do

--- a/lib/klass_hero_web/live/provider_profile_live.ex
+++ b/lib/klass_hero_web/live/provider_profile_live.ex
@@ -11,10 +11,15 @@ defmodule KlassHeroWeb.ProviderProfileLive do
 
   import KlassHeroWeb.CompositeComponents
   import KlassHeroWeb.MarketingComponents
+  # Only the card. The section chrome around it differs from the program page's
+  # by design — there a bordered panel inside a column, here a full-width band.
+  import KlassHeroWeb.ProgramComponents, only: [hero_card: 1]
 
   alias KlassHero.ProgramCatalog
+  alias KlassHero.Provider
   alias KlassHeroWeb.Helpers.ProviderDisplay
   alias KlassHeroWeb.Presenters.ProgramPresenter
+  alias KlassHeroWeb.Presenters.StaffMemberPresenter
   alias KlassHeroWeb.Theme
 
   @impl true
@@ -42,10 +47,20 @@ defmodule KlassHeroWeb.ProviderProfileLive do
       # page it is on, once per card.
       |> Enum.map(&ProgramPresenter.to_card_view/1)
 
+    # No lead instructor at this scope: the flag lives on a program assignment,
+    # so a person can lead one programme and not another (ADR-0016). There is no
+    # provider-wide lead to badge, which is why this skips HeroCardsPresenter and
+    # goes straight to the card shape.
+    hero_cards =
+      provider_id
+      |> Provider.list_public_staff()
+      |> StaffMemberPresenter.to_hero_card_list()
+
     socket
     |> assign(:page_title, provider.business_name)
     |> assign(:provider, provider)
     |> assign(:programs_empty?, programs == [])
+    |> assign(:hero_cards, hero_cards)
     |> stream(:programs, programs)
   end
 
@@ -147,6 +162,24 @@ defmodule KlassHeroWeb.ProviderProfileLive do
           id={dom_id}
           program={program}
         />
+      </div>
+    </.profile_section>
+
+    <%!-- Hidden rather than empty-stated: this is a footnote to the programs
+          above, and a second "nothing here" block would read as a second
+          failure. Cream also keeps the bands alternating — Programs is white
+          and the CTA below is the base fade. --%>
+    <.profile_section
+      :if={@hero_cards != []}
+      id="provider-heroes"
+      background="bg-hero-cream-100"
+    >
+      <h2 class={[Theme.typography(:section_title), Theme.text_color(:heading), "mb-6"]}>
+        {ngettext("Meet the Hero", "Meet the Heroes", length(@hero_cards))}
+      </h2>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-6">
+        <.hero_card :for={card <- @hero_cards} {card} />
       </div>
     </.profile_section>
 

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -94,7 +94,7 @@ msgstr "Anmelden"
 #: lib/klass_hero_web/components/layouts/app.html.heex:36
 #: lib/klass_hero_web/components/layouts/app.html.heex:198
 #: lib/klass_hero_web/components/marketing_components.ex:202
-#: lib/klass_hero_web/live/provider_profile_live.ex:129
+#: lib/klass_hero_web/live/provider_profile_live.ex:144
 #, elixir-autogen, elixir-format
 msgid "Programs"
 msgstr "Programme"
@@ -284,6 +284,7 @@ msgid "Loading..."
 msgstr "Laden..."
 
 #: lib/klass_hero_web/live/program_detail_live.ex:408
+#: lib/klass_hero_web/live/provider_profile_live.ex:178
 #, elixir-autogen, elixir-format
 msgid "Meet the Hero"
 msgid_plural "Meet the Heroes"
@@ -416,7 +417,7 @@ msgstr "Kontobeendigung"
 
 #: lib/klass_hero_web/live/contact_live.ex:85
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:326
-#: lib/klass_hero_web/live/provider_profile_live.ex:107
+#: lib/klass_hero_web/live/provider_profile_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "Address"
 msgstr "Adresse"
@@ -815,7 +816,7 @@ msgstr "Zahlungsbedingungen"
 
 #: lib/klass_hero_web/live/contact_live.ex:78
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:311
-#: lib/klass_hero_web/live/provider_profile_live.ex:113
+#: lib/klass_hero_web/live/provider_profile_live.ex:128
 #, elixir-autogen, elixir-format
 msgid "Phone"
 msgstr "Telefon"
@@ -4394,7 +4395,7 @@ msgid "+1234567890"
 msgstr "+1234567890"
 
 #: lib/klass_hero_web/components/composite_components.ex:516
-#: lib/klass_hero_web/live/provider_profile_live.ex:93
+#: lib/klass_hero_web/live/provider_profile_live.ex:108
 #, elixir-autogen, elixir-format
 msgid "About the Provider"
 msgstr "Über den Anbieter"
@@ -4537,7 +4538,7 @@ msgid "View your assignments"
 msgstr "Ihre Zuweisungen anzeigen"
 
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:318
-#: lib/klass_hero_web/live/provider_profile_live.ex:120
+#: lib/klass_hero_web/live/provider_profile_live.ex:135
 #, elixir-autogen, elixir-format
 msgid "Website"
 msgstr "Website"
@@ -5430,7 +5431,7 @@ msgstr "Handverlesene Programme diese Woche in ganz Berlin."
 msgid "Hand-picked, vetted programs across Berlin — filter by category, age, or schedule."
 msgstr "Handverlesene, geprüfte Programme in ganz Berlin — filtern Sie nach Kategorie, Alter oder Zeitplan."
 
-#: lib/klass_hero_web/live/provider_profile_live.ex:155
+#: lib/klass_hero_web/live/provider_profile_live.ex:188
 #: lib/klass_hero_web/live/trust_safety_live.ex:103
 #, elixir-autogen, elixir-format
 msgid "Have questions?"
@@ -8032,27 +8033,27 @@ msgstr "Klass Hero auf %{network}"
 msgid "Upload failed."
 msgstr "Hochladen fehlgeschlagen."
 
-#: lib/klass_hero_web/live/provider_profile_live.ex:157
+#: lib/klass_hero_web/live/provider_profile_live.ex:190
 #, elixir-autogen, elixir-format
 msgid "Message %{provider} directly about their programs."
 msgstr "Schreiben Sie %{provider} direkt zu den Programmen."
 
-#: lib/klass_hero_web/live/provider_profile_live.ex:169
+#: lib/klass_hero_web/live/provider_profile_live.ex:202
 #, elixir-autogen, elixir-format
 msgid "Message this provider"
 msgstr "Anbieter kontaktieren"
 
-#: lib/klass_hero_web/live/provider_profile_live.ex:135
+#: lib/klass_hero_web/live/provider_profile_live.ex:150
 #, elixir-autogen, elixir-format
 msgid "No programs running right now"
 msgstr "Zurzeit keine laufenden Programme"
 
-#: lib/klass_hero_web/live/provider_profile_live.ex:28
+#: lib/klass_hero_web/live/provider_profile_live.ex:33
 #, elixir-autogen, elixir-format
 msgid "Provider not found. They may have been removed or are no longer listed."
 msgstr "Anbieter nicht gefunden. Möglicherweise wurde er entfernt oder ist nicht mehr gelistet."
 
-#: lib/klass_hero_web/live/provider_profile_live.ex:136
+#: lib/klass_hero_web/live/provider_profile_live.ex:151
 #, elixir-autogen, elixir-format
 msgid "This provider has no open programs at the moment. Check back soon."
 msgstr "Dieser Anbieter hat derzeit keine offenen Programme. Schauen Sie bald wieder vorbei."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -94,7 +94,7 @@ msgstr ""
 #: lib/klass_hero_web/components/layouts/app.html.heex:36
 #: lib/klass_hero_web/components/layouts/app.html.heex:198
 #: lib/klass_hero_web/components/marketing_components.ex:202
-#: lib/klass_hero_web/live/provider_profile_live.ex:129
+#: lib/klass_hero_web/live/provider_profile_live.ex:144
 #, elixir-autogen, elixir-format
 msgid "Programs"
 msgstr ""
@@ -284,6 +284,7 @@ msgid "Loading..."
 msgstr ""
 
 #: lib/klass_hero_web/live/program_detail_live.ex:408
+#: lib/klass_hero_web/live/provider_profile_live.ex:178
 #, elixir-autogen, elixir-format
 msgid "Meet the Hero"
 msgid_plural "Meet the Heroes"
@@ -416,7 +417,7 @@ msgstr ""
 
 #: lib/klass_hero_web/live/contact_live.ex:85
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:326
-#: lib/klass_hero_web/live/provider_profile_live.ex:107
+#: lib/klass_hero_web/live/provider_profile_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "Address"
 msgstr ""
@@ -815,7 +816,7 @@ msgstr ""
 
 #: lib/klass_hero_web/live/contact_live.ex:78
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:311
-#: lib/klass_hero_web/live/provider_profile_live.ex:113
+#: lib/klass_hero_web/live/provider_profile_live.ex:128
 #, elixir-autogen, elixir-format
 msgid "Phone"
 msgstr ""
@@ -4394,7 +4395,7 @@ msgid "+1234567890"
 msgstr ""
 
 #: lib/klass_hero_web/components/composite_components.ex:516
-#: lib/klass_hero_web/live/provider_profile_live.ex:93
+#: lib/klass_hero_web/live/provider_profile_live.ex:108
 #, elixir-autogen, elixir-format
 msgid "About the Provider"
 msgstr ""
@@ -4537,7 +4538,7 @@ msgid "View your assignments"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:318
-#: lib/klass_hero_web/live/provider_profile_live.ex:120
+#: lib/klass_hero_web/live/provider_profile_live.ex:135
 #, elixir-autogen, elixir-format
 msgid "Website"
 msgstr ""
@@ -5430,7 +5431,7 @@ msgstr ""
 msgid "Hand-picked, vetted programs across Berlin — filter by category, age, or schedule."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider_profile_live.ex:155
+#: lib/klass_hero_web/live/provider_profile_live.ex:188
 #: lib/klass_hero_web/live/trust_safety_live.ex:103
 #, elixir-autogen, elixir-format
 msgid "Have questions?"
@@ -8014,27 +8015,27 @@ msgstr ""
 msgid "Upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider_profile_live.ex:157
+#: lib/klass_hero_web/live/provider_profile_live.ex:190
 #, elixir-autogen, elixir-format
 msgid "Message %{provider} directly about their programs."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider_profile_live.ex:169
+#: lib/klass_hero_web/live/provider_profile_live.ex:202
 #, elixir-autogen, elixir-format
 msgid "Message this provider"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider_profile_live.ex:135
+#: lib/klass_hero_web/live/provider_profile_live.ex:150
 #, elixir-autogen, elixir-format
 msgid "No programs running right now"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider_profile_live.ex:28
+#: lib/klass_hero_web/live/provider_profile_live.ex:33
 #, elixir-autogen, elixir-format
 msgid "Provider not found. They may have been removed or are no longer listed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider_profile_live.ex:136
+#: lib/klass_hero_web/live/provider_profile_live.ex:151
 #, elixir-autogen, elixir-format
 msgid "This provider has no open programs at the moment. Check back soon."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -94,7 +94,7 @@ msgstr ""
 #: lib/klass_hero_web/components/layouts/app.html.heex:36
 #: lib/klass_hero_web/components/layouts/app.html.heex:198
 #: lib/klass_hero_web/components/marketing_components.ex:202
-#: lib/klass_hero_web/live/provider_profile_live.ex:129
+#: lib/klass_hero_web/live/provider_profile_live.ex:144
 #, elixir-autogen, elixir-format
 msgid "Programs"
 msgstr ""
@@ -284,6 +284,7 @@ msgid "Loading..."
 msgstr ""
 
 #: lib/klass_hero_web/live/program_detail_live.ex:408
+#: lib/klass_hero_web/live/provider_profile_live.ex:178
 #, elixir-autogen, elixir-format
 msgid "Meet the Hero"
 msgid_plural "Meet the Heroes"
@@ -416,7 +417,7 @@ msgstr ""
 
 #: lib/klass_hero_web/live/contact_live.ex:85
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:326
-#: lib/klass_hero_web/live/provider_profile_live.ex:107
+#: lib/klass_hero_web/live/provider_profile_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "Address"
 msgstr ""
@@ -815,7 +816,7 @@ msgstr ""
 
 #: lib/klass_hero_web/live/contact_live.ex:78
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:311
-#: lib/klass_hero_web/live/provider_profile_live.ex:113
+#: lib/klass_hero_web/live/provider_profile_live.ex:128
 #, elixir-autogen, elixir-format
 msgid "Phone"
 msgstr ""
@@ -4394,7 +4395,7 @@ msgid "+1234567890"
 msgstr ""
 
 #: lib/klass_hero_web/components/composite_components.ex:516
-#: lib/klass_hero_web/live/provider_profile_live.ex:93
+#: lib/klass_hero_web/live/provider_profile_live.ex:108
 #, elixir-autogen, elixir-format
 msgid "About the Provider"
 msgstr ""
@@ -4537,7 +4538,7 @@ msgid "View your assignments"
 msgstr ""
 
 #: lib/klass_hero_web/live/provider/profile_completion_live.ex:318
-#: lib/klass_hero_web/live/provider_profile_live.ex:120
+#: lib/klass_hero_web/live/provider_profile_live.ex:135
 #, elixir-autogen, elixir-format
 msgid "Website"
 msgstr ""
@@ -5430,7 +5431,7 @@ msgstr ""
 msgid "Hand-picked, vetted programs across Berlin — filter by category, age, or schedule."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider_profile_live.ex:155
+#: lib/klass_hero_web/live/provider_profile_live.ex:188
 #: lib/klass_hero_web/live/trust_safety_live.ex:103
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Have questions?"
@@ -8014,27 +8015,27 @@ msgstr ""
 msgid "Upload failed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider_profile_live.ex:157
+#: lib/klass_hero_web/live/provider_profile_live.ex:190
 #, elixir-autogen, elixir-format
 msgid "Message %{provider} directly about their programs."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider_profile_live.ex:169
+#: lib/klass_hero_web/live/provider_profile_live.ex:202
 #, elixir-autogen, elixir-format
 msgid "Message this provider"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider_profile_live.ex:135
+#: lib/klass_hero_web/live/provider_profile_live.ex:150
 #, elixir-autogen, elixir-format
 msgid "No programs running right now"
 msgstr ""
 
-#: lib/klass_hero_web/live/provider_profile_live.ex:28
+#: lib/klass_hero_web/live/provider_profile_live.ex:33
 #, elixir-autogen, elixir-format
 msgid "Provider not found. They may have been removed or are no longer listed."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider_profile_live.ex:136
+#: lib/klass_hero_web/live/provider_profile_live.ex:151
 #, elixir-autogen, elixir-format
 msgid "This provider has no open programs at the moment. Check back soon."
 msgstr ""

--- a/test/klass_hero/provider/assignments/list_public_staff_for_program_test.exs
+++ b/test/klass_hero/provider/assignments/list_public_staff_for_program_test.exs
@@ -1,0 +1,97 @@
+defmodule KlassHero.Provider.Assignments.ListPublicStaffForProgramTest do
+  @moduledoc """
+  The roster behind the public `/programs/:id` "Meet the Heroes" section.
+
+  Same assignment rules as `list_active_staff_for_program/1`, plus one: the seat
+  must be claimed. The two functions exist side by side rather than as one
+  narrowed query because the unnarrowed one feeds the provider's staffing modal,
+  which has to keep showing people whose invitations are still outstanding.
+  """
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+
+  alias KlassHero.AccountsFixtures
+  alias KlassHero.Provider
+
+  setup do
+    provider = insert(:provider_profile_schema)
+    program = insert(:program_schema, provider_id: provider.id)
+
+    shown = claimed_staff(provider.id)
+    unclaimed = insert(:staff_member_schema, provider_id: provider.id, user_id: nil)
+    deactivated = claimed_staff(provider.id)
+    released = claimed_staff(provider.id)
+    unassigned = claimed_staff(provider.id)
+
+    for staff <- [shown, unclaimed, deactivated, released] do
+      assign!(provider.id, program.id, staff.id)
+    end
+
+    {:ok, deactivated} = Provider.deactivate_staff_member(deactivated)
+    {:ok, _} = Provider.unassign_staff_from_program(program.id, released.id, provider.id)
+
+    %{
+      provider: provider,
+      program: program,
+      shown: shown,
+      unclaimed: unclaimed,
+      deactivated: deactivated,
+      released: released,
+      unassigned: unassigned
+    }
+  end
+
+  describe "list_public_staff_for_program/1" do
+    test "returns exactly the claimed, active, currently-assigned staff", ctx do
+      assert [%{id: id}] = Provider.list_public_staff_for_program(ctx.program.id)
+      assert id == ctx.shown.id
+    end
+
+    test "excludes every shape a public page must not name", ctx do
+      ids = ids_for(ctx.program)
+
+      for {reason, excluded} <- [
+            {"an invitation nobody claimed", ctx.unclaimed},
+            {"an employment that ended", ctx.deactivated},
+            {"an assignment that was released", ctx.released},
+            {"a colleague never assigned to this program", ctx.unassigned}
+          ] do
+        refute excluded.id in ids, "#{reason} leaked onto the public program page"
+      end
+    end
+
+    # The narrowing is the ONLY difference. Pinning it as a set difference means
+    # a drift in the shared assignment rules shows here as well as in the
+    # sibling's own tests, rather than the two quietly diverging.
+    test "differs from the management read by the unclaimed staff alone", ctx do
+      managed = ctx.program.id |> Provider.list_active_staff_for_program() |> Enum.map(& &1.id)
+
+      assert MapSet.difference(MapSet.new(managed), MapSet.new(ids_for(ctx.program))) ==
+               MapSet.new([ctx.unclaimed.id])
+    end
+  end
+
+  defp ids_for(program) do
+    program.id |> Provider.list_public_staff_for_program() |> Enum.map(& &1.id)
+  end
+
+  defp claimed_staff(provider_id) do
+    insert(:staff_member_schema,
+      provider_id: provider_id,
+      user_id: AccountsFixtures.user_fixture().id,
+      invitation_status: :accepted
+    )
+  end
+
+  defp assign!(provider_id, program_id, staff_member_id) do
+    {:ok, assignment} =
+      Provider.assign_staff_to_program(%{
+        provider_id: provider_id,
+        program_id: program_id,
+        staff_member_id: staff_member_id
+      })
+
+    assignment
+  end
+end

--- a/test/klass_hero/provider/staff/list_public_staff_test.exs
+++ b/test/klass_hero/provider/staff/list_public_staff_test.exs
@@ -1,0 +1,77 @@
+defmodule KlassHero.Provider.Staff.ListPublicStaffTest do
+  @moduledoc """
+  The roster behind the public provider profile's "Meet the Heroes" section.
+
+  "Public" is two independent gates and both must hold: the employment is live
+  (`active`), and someone has actually claimed the seat (`user_id`) — so the
+  page names a real person rather than a name a provider typed into an
+  invitation nobody ever accepted.
+  """
+  use KlassHero.DataCase, async: true
+
+  import KlassHero.Factory
+
+  alias KlassHero.AccountsFixtures
+  alias KlassHero.Provider
+
+  # One fixture carrying every exclusion at once, so a regression in any single
+  # rule shows as a diff on one id set rather than passing quietly elsewhere.
+  setup do
+    provider = insert(:provider_profile_schema)
+    other_provider = insert(:provider_profile_schema)
+
+    %{
+      provider: provider,
+      shown: claimed_staff(provider),
+      unclaimed: insert(:staff_member_schema, provider_id: provider.id, user_id: nil),
+      deactivated: claimed_staff(provider, active: false),
+      foreign: claimed_staff(other_provider)
+    }
+  end
+
+  defp claimed_staff(provider, attrs \\ []) do
+    [
+      provider_id: provider.id,
+      user_id: AccountsFixtures.user_fixture().id,
+      invitation_status: :accepted
+    ]
+    |> Keyword.merge(attrs)
+    |> then(&insert(:staff_member_schema, &1))
+  end
+
+  describe "list_public_staff/1" do
+    test "returns the provider's claimed, active staff", ctx do
+      assert [%{id: id}] = Provider.list_public_staff(ctx.provider.id)
+      assert id == ctx.shown.id
+    end
+
+    test "excludes every kind of staff a public page must not name", ctx do
+      ids = ctx.provider.id |> Provider.list_public_staff() |> Enum.map(& &1.id)
+
+      for {reason, excluded} <- [
+            {"an invitation nobody claimed", ctx.unclaimed},
+            {"an employment that ended", ctx.deactivated},
+            {"another provider's staff", ctx.foreign}
+          ] do
+        refute excluded.id in ids, "#{reason} leaked onto the public roster"
+      end
+    end
+
+    test "orders by when the employment started", ctx do
+      newest = claimed_staff(ctx.provider, inserted_at: ~U[2026-06-01 09:00:00.000000Z])
+      oldest = claimed_staff(ctx.provider, inserted_at: ~U[2026-01-01 09:00:00.000000Z])
+
+      ids = ctx.provider.id |> Provider.list_public_staff() |> Enum.map(& &1.id)
+
+      assert Enum.find_index(ids, &(&1 == oldest.id)) <
+               Enum.find_index(ids, &(&1 == newest.id))
+    end
+
+    test "returns an empty list rather than raising when nobody qualifies" do
+      provider = insert(:provider_profile_schema)
+      insert(:staff_member_schema, provider_id: provider.id, user_id: nil)
+
+      assert Provider.list_public_staff(provider.id) == []
+    end
+  end
+end

--- a/test/klass_hero_web/live/program_detail_live_test.exs
+++ b/test/klass_hero_web/live/program_detail_live_test.exs
@@ -203,7 +203,7 @@ defmodule KlassHeroWeb.ProgramDetailLiveTest do
         insert(:program_schema, provider_id: provider.id, title: "Soccer Academy")
 
       staff =
-        staff_member_fixture(
+        claimed_staff_fixture(
           provider_id: provider.id,
           first_name: "Coach",
           last_name: "Smith",
@@ -231,7 +231,7 @@ defmodule KlassHeroWeb.ProgramDetailLiveTest do
         insert(:program_schema, provider_id: provider.id, title: "STEM Camp")
 
       alice =
-        staff_member_fixture(
+        claimed_staff_fixture(
           provider_id: provider.id,
           first_name: "Alice",
           last_name: "Johnson",
@@ -239,7 +239,7 @@ defmodule KlassHeroWeb.ProgramDetailLiveTest do
         )
 
       bob =
-        staff_member_fixture(
+        claimed_staff_fixture(
           provider_id: provider.id,
           first_name: "Bob",
           last_name: "Williams",
@@ -264,7 +264,7 @@ defmodule KlassHeroWeb.ProgramDetailLiveTest do
       provider = provider_profile_fixture()
 
       instructor =
-        staff_member_fixture(
+        claimed_staff_fixture(
           provider_id: provider.id,
           first_name: "Dr.",
           last_name: "Strange"
@@ -293,10 +293,10 @@ defmodule KlassHeroWeb.ProgramDetailLiveTest do
       provider = provider_profile_fixture()
 
       lead =
-        staff_member_fixture(provider_id: provider.id, first_name: "Marie", last_name: "Curie")
+        claimed_staff_fixture(provider_id: provider.id, first_name: "Marie", last_name: "Curie")
 
       assistant =
-        staff_member_fixture(
+        claimed_staff_fixture(
           provider_id: provider.id,
           first_name: "Coach",
           last_name: "Smith",
@@ -338,7 +338,7 @@ defmodule KlassHeroWeb.ProgramDetailLiveTest do
       provider = provider_profile_fixture()
 
       lead =
-        staff_member_fixture(
+        claimed_staff_fixture(
           provider_id: provider.id,
           first_name: "Alice",
           last_name: "Lead",
@@ -380,7 +380,7 @@ defmodule KlassHeroWeb.ProgramDetailLiveTest do
       program = insert(:program_schema, provider_id: provider.id)
 
       staff =
-        staff_member_fixture(
+        claimed_staff_fixture(
           provider_id: provider.id,
           first_name: "Jane",
           last_name: "Doe",
@@ -404,13 +404,13 @@ defmodule KlassHeroWeb.ProgramDetailLiveTest do
       program = insert(:program_schema, provider_id: provider.id)
 
       assigned =
-        staff_member_fixture(
+        claimed_staff_fixture(
           provider_id: provider.id,
           first_name: "Assigned",
           last_name: "Coach"
         )
 
-      staff_member_fixture(
+      claimed_staff_fixture(
         provider_id: provider.id,
         first_name: "Unassigned",
         last_name: "Bystander"
@@ -426,6 +426,63 @@ defmodule KlassHeroWeb.ProgramDetailLiveTest do
 
       assert html =~ "Assigned Coach"
       refute html =~ "Unassigned Bystander"
+    end
+
+    test "hides a staff member who has not claimed their invite", %{conn: conn} do
+      provider = provider_profile_fixture()
+      program = insert(:program_schema, provider_id: provider.id)
+
+      unclaimed =
+        staff_member_fixture(
+          provider_id: provider.id,
+          first_name: "Never",
+          last_name: "Onboarded"
+        )
+
+      insert(:program_staff_assignment_schema,
+        provider_id: provider.id,
+        program_id: program.id,
+        staff_member_id: unclaimed.id
+      )
+
+      {:ok, view, html} = live(conn, ~p"/programs/#{program.id}")
+
+      refute has_element?(view, "#hero-card-staff-#{unclaimed.id}")
+      refute html =~ "Never Onboarded"
+    end
+
+    # The lead flag lives on the assignment, so it survives the staff member
+    # being filtered out. HeroCardsPresenter matches the lead by id against the
+    # roster, so an absent lead simply matches nothing — the badge disappears
+    # with the card rather than orphaning itself onto someone else's.
+    test "an unclaimed lead takes its badge with it", %{conn: conn} do
+      provider = provider_profile_fixture()
+      program = insert(:program_schema, provider_id: provider.id)
+
+      unclaimed_lead =
+        staff_member_fixture(provider_id: provider.id, first_name: "Ghost", last_name: "Lead")
+
+      colleague =
+        claimed_staff_fixture(provider_id: provider.id, first_name: "Real", last_name: "Coach")
+
+      insert(:program_staff_assignment_schema,
+        provider_id: provider.id,
+        program_id: program.id,
+        staff_member_id: unclaimed_lead.id,
+        is_lead_instructor: true
+      )
+
+      insert(:program_staff_assignment_schema,
+        provider_id: provider.id,
+        program_id: program.id,
+        staff_member_id: colleague.id
+      )
+
+      {:ok, view, html} = live(conn, ~p"/programs/#{program.id}")
+
+      assert has_element?(view, "#hero-card-staff-#{colleague.id}")
+      refute has_element?(view, "#hero-card-staff-#{unclaimed_lead.id}")
+      refute html =~ "Lead Instructor"
     end
   end
 
@@ -518,5 +575,17 @@ defmodule KlassHeroWeb.ProgramDetailLiveTest do
 
       assert has_element?(view, "#enroll-bottom-cta", "Enroll Now - €149.99")
     end
+  end
+
+  # Every staff member on this public page must have claimed their seat, so the
+  # fixture says so out loud. Before #1509 these tests all used the bare
+  # `staff_member_fixture/1`, which leaves `user_id` nil — so the suite was
+  # pinning "unclaimed staff render" by accident, in eight places, and nowhere
+  # on purpose.
+  defp claimed_staff_fixture(attrs) do
+    attrs
+    |> Keyword.put_new(:user_id, KlassHero.AccountsFixtures.user_fixture().id)
+    |> Keyword.put_new(:invitation_status, :accepted)
+    |> staff_member_fixture()
   end
 end

--- a/test/klass_hero_web/live/provider_profile_live_test.exs
+++ b/test/klass_hero_web/live/provider_profile_live_test.exs
@@ -135,6 +135,89 @@ defmodule KlassHeroWeb.ProviderProfileLiveTest do
     end
   end
 
+  describe "heroes" do
+    test "lists the provider's claimed, active staff", %{conn: conn} do
+      provider = active_provider()
+
+      staff =
+        claimed_staff(provider,
+          first_name: "Marie",
+          last_name: "Curie",
+          role: "Head Coach",
+          bio: "Two Nobel prizes, one whistle."
+        )
+
+      {:ok, view, html} = live(conn, ~p"/providers/#{provider.id}")
+
+      assert has_element?(view, "#provider-heroes")
+      assert has_element?(view, "#hero-card-staff-#{staff.id}")
+      assert html =~ "Marie Curie"
+      assert html =~ "Head Coach"
+      assert html =~ "Two Nobel prizes, one whistle."
+    end
+
+    test "pluralises the heading with the roster size", %{conn: conn} do
+      provider = active_provider()
+
+      for name <- ["Ada", "Grace"], do: claimed_staff(provider, first_name: name)
+
+      {:ok, view, _html} = live(conn, ~p"/providers/#{provider.id}")
+
+      assert has_element?(view, "#provider-heroes h2", "Meet the Heroes")
+    end
+
+    test "names nobody who has not claimed their seat", %{conn: conn} do
+      provider = active_provider()
+
+      unclaimed =
+        staff_member_fixture(
+          provider_id: provider.id,
+          first_name: "Never",
+          last_name: "Onboarded"
+        )
+
+      {:ok, view, html} = live(conn, ~p"/providers/#{provider.id}")
+
+      refute has_element?(view, "#hero-card-staff-#{unclaimed.id}")
+      refute html =~ "Never Onboarded"
+    end
+
+    test "drops a staff member whose employment has ended", %{conn: conn} do
+      provider = active_provider()
+      departed = claimed_staff(provider, first_name: "Gone", last_name: "Away")
+
+      {:ok, _} = KlassHero.Provider.deactivate_staff_member(departed)
+
+      {:ok, view, html} = live(conn, ~p"/providers/#{provider.id}")
+
+      refute has_element?(view, "#hero-card-staff-#{departed.id}")
+      refute html =~ "Gone Away"
+    end
+
+    # A roster nobody qualifies for is an absent section, not an empty one. The
+    # page already carries a "no programs" empty state, and two would read as
+    # two failures rather than one quiet footnote.
+    test "omits the section entirely when nobody qualifies", %{conn: conn} do
+      provider = active_provider()
+      staff_member_fixture(provider_id: provider.id)
+
+      {:ok, view, html} = live(conn, ~p"/providers/#{provider.id}")
+
+      refute has_element?(view, "#provider-heroes")
+      refute html =~ "Meet the Hero"
+    end
+
+    test "never exposes a staff member's email", %{conn: conn} do
+      provider = active_provider()
+      staff = claimed_staff(provider, email: "private@example.com")
+
+      {:ok, view, html} = live(conn, ~p"/providers/#{provider.id}")
+
+      assert has_element?(view, "#hero-card-staff-#{staff.id}")
+      refute html =~ "private@example.com"
+    end
+  end
+
   describe "message CTA" do
     test "points at compose for this provider", %{conn: conn} do
       provider = active_provider()
@@ -166,5 +249,18 @@ defmodule KlassHeroWeb.ProviderProfileLiveTest do
   defp elem_view(conn, provider) do
     {:ok, view, _html} = live(conn, ~p"/providers/#{provider.id}")
     view
+  end
+
+  # A seat someone actually took. The bare `staff_member_fixture/1` leaves
+  # `user_id` nil, which is the unclaimed case this page must not name — so the
+  # tests above spell out which of the two they mean rather than inheriting one.
+  defp claimed_staff(provider, attrs) do
+    attrs
+    |> Keyword.merge(
+      provider_id: provider.id,
+      user_id: KlassHero.AccountsFixtures.user_fixture().id,
+      invitation_status: :accepted
+    )
+    |> staff_member_fixture()
   end
 end


### PR DESCRIPTION
## Summary

The public provider profile showed identity, about and programs but never said **who works there**. This adds the roster after Programs, reusing `<.hero_card>` and `StaffMemberPresenter.to_hero_card_list/1` unchanged — no new component, no new presenter.

Three of the four things the issue budgeted for already existed. The only genuinely new code is one query scope and two public-read queries.

## Only claimed staff are named

A provider can type a name into an invitation nobody ever accepts. Those rows are employment records, not people you can point a parent at, so public surfaces now require a claimed seat.

`user_id`, **not** `invitation_status`, is the predicate. Founder self-staffing mints a row already linked and `:accepted` with no invitation token at all (ADR-0005), so keying on the token would have silently hidden every owner who teaches. Every existing claimed-check in the codebase already reads `user_id` (`staff.ex:520`, `assignments.ex:489`, `staff_member_presenter.ex:95`); this adds the scope those had all been inlining.

The same rule now applies to the public `/programs/:id` page, so the two public surfaces agree on who they will name.

## Review focus — why this is three new functions and not three edits

**The rule must not reach management surfaces.** A provider has to keep seeing the people they invited. Every query that looked like the obvious place to narrow is shared with such a surface:

| Query | Also feeds | Action |
|---|---|---|
| `active_staffing_query/0` (private base) | provider programs table + filter | untouched |
| `list_active_staff_for_program/1` | staffing modal (`programs_live.ex:1026`) | untouched; public sibling added |
| `get_lead_instructor/1` | staffing modal, program creation | **untouched** |

Narrowing the shared base is the exact shape of #1310, where an over-filtered read made staffed programs display "Unassigned" and their staff unfindable in the table filter. Its doc says so, which is why the narrowing went into siblings instead.

**`get_lead_instructor/1` needed no change at all.** `HeroCardsPresenter.for_program/2` matches the lead by **id against the roster** rather than trusting `lead_id` on its own, so a filtered-out lead matches nothing and the badge leaves with the card. Had the presenter looked the lead up independently, this change would have orphaned a "Lead Instructor" badge onto whoever sorted first. Pinned by *"an unclaimed lead takes its badge with it"*.

Dev seeds happen to contain that exact case — an unclaimed lead on Children's Choir — and it was verified live:

| Surface | Sees the unclaimed lead |
|---|---|
| Staffing modal | yes — unchanged |
| Programs table (`member_count`) | 3 — unchanged |
| `get_lead_instructor/1` | yes — unchanged |
| Public program page | excluded, and no badge appears |

**No lead badge at provider scope.** `is_lead_instructor` lives on a program assignment, so a person can lead one programme and not another (ADR-0016). There is no provider-wide lead to badge, which is why the profile skips `HeroCardsPresenter` entirely rather than passing it a `nil`.

## The test change is the load-bearing part of this diff

All eight tests in `program_detail_live_test.exs`'s `staff member display` were pinning **"unclaimed staff render"** — by accident. Every one built its fixture with `staff_member_fixture/1`, which leaves `user_id` nil, and none of them said so. They were the reason this behaviour was invisible.

They now claim their seats explicitly through a named `claimed_staff_fixture/1`, and two new tests pin the exclusion **on purpose** — including the unclaimed-lead badge case, which no test could previously observe.

## Notes

- `list_public_staff/1` returns a bare list and skips `load_pay_rate/1`: no public surface reads a pay rate, and an anonymous request is the wrong place to hydrate one.
- The section is hidden when empty rather than empty-stated — it is a footnote to the programs above, and `mk_empty_state` hard-codes `id="mk-empty"`, so a second one would emit a duplicate DOM id.
- Cream background keeps the bands alternating (Programs is white, the CTA below is the base fade).
- No new gettext strings; both msgids were already translated. The `.po`/`.pot` diff is reference lines only — `0 new messages`.

## Test plan

- `mix precommit` green: credo `--strict` clean, **5405 tests passed**.
- New: `list_public_staff_test.exs` (4), `list_public_staff_for_program_test.exs` (3, including a set-difference test asserting the public and management reads differ by the unclaimed staff *alone*).
- Verified in the browser at 375px and 1280px: section renders after Programs, hides the unclaimed member, and is omitted entirely for a provider whose staff are all unclaimed. No console errors.

Closes #1509
