### PR TITLE
chore: add campsite pass and phx routing to build-elixir skill

### DIFF
--- a/.claude/skills/build-elixir/SKILL.md
+++ b/.claude/skills/build-elixir/SKILL.md
@@ -3,7 +3,8 @@ name: build-elixir
 description: >-
   Deliberate TDD-first, design-heavy workflow for building an Elixir/Phoenix
   change end-to-end — surface rival designs, pick one, drive red→green, keep the
-  test suite lean. Invoke with: /build-elixir <what you're building>
+  test suite lean, leave the code better than you found it. Invoke with:
+  /build-elixir <what you're building>
 disable-model-invocation: true
 ---
 
@@ -16,7 +17,8 @@ completion criterion; do not advance until it is met.
 The spine is the red→green **loop**, entered only *after* a design **gate** the
 human owns. Leading words used throughout: **seam** (the interface under change),
 **gate** (the human design decision), **red** (the failing test that drives a
-cycle), **fold** (collapsing many tests into one).
+cycle), **fold** (collapsing many tests into one), **campsite** (leave the code
+you touched cleaner than you found it).
 
 ## Phase 1 — Orient the seam
 
@@ -26,13 +28,32 @@ your vocabulary matches the project's domain language. Then name, in writing, th
 what is its *interface* (every fact a caller must know), where does the *seam*
 sit, is there a real *adapter* or a hypothetical one.
 
-**Done when:** the seam and its interface are written down and confirmed with the
-user.
+Then map the **blast radius** — every caller and dependent of that seam. It is
+also the **campsite** boundary: touched files plus what they directly reach.
+
+- CodeGraph first (`codegraph_explore`), per CLAUDE.md.
+- `/phx:trace` for a call tree from entry points before a signature change.
+- `phx:xref-analyzer` for module coupling and compile-connected edges.
+
+**Done when:** the seam, its interface, and its blast radius are written down and
+confirmed with the user.
 
 ## Phase 2 — Design gate (mandatory, human-owned)
 
-Run `/design-an-interface` to generate **≥2–3 radically different** designs for the
-seam from Phase 1. This gate is never skipped for a non-trivial change, and the
+First spawn, in parallel, whichever phx specialist matches the surface, and feed
+its findings **into** the design generation as input:
+
+| Surface | Agent |
+|---|---|
+| schema, migration, query shape | `phx:ecto-schema-designer` |
+| process, state, concurrency | `phx:otp-advisor` |
+| interactive surface | `phx:liveview-architect` |
+| background job | `phx:oban-specialist` |
+
+They **advise**. They never author the comparison table and never make the pick.
+
+Then run `/design-an-interface` to generate **≥2–3 radically different** designs for
+the seam from Phase 1. This gate is never skipped for a non-trivial change, and the
 **user makes the final call** — no implementation code is written before the pick.
 
 Surface the designs like this:
@@ -70,7 +91,9 @@ skip and said so.
 `/tdd` drives. First agree the **seams under test** with the user (no test at an
 unconfirmed seam). Then cycle in vertical slices: one failing test (**red**) →
 the minimal code to pass it → repeat, each test a tracer bullet shaped by what the
-last cycle taught. Refactoring is **not** part of the loop — it belongs to Phase 6.
+last cycle taught. Refactoring is **not** part of the loop — it belongs to Phase 7.
+
+Note **campsite** candidates as you meet them — write them down, edit nothing.
 
 **Done when:** the chosen design is implemented and every slice's test is green.
 
@@ -96,34 +119,59 @@ Obey `.claude/rules/liveview.md` (streams for collections, `<.link navigate/patc
 `to_form/2` + `<.input>`, no LiveComponents without cause) and
 `.claude/rules/frontend.md` (mobile-first, `Theme.typography(:variant)`). Test with
 `exunit-testing`'s `liveview-testing.md` conventions (assert on element IDs, never
-raw text).
+raw text). Run `/phx:assigns-audit` when the LiveView carries collections — it
+catches assign bloat and missing `temporary_assigns`.
 
 **Done when:** UI tests are green and the LiveView rules are satisfied.
 
-## Phase 7 — Idioms & Iron Laws (adhere, don't restate)
+## Phase 7 — Campsite pass
 
-These load automatically — do not copy them into your reasoning, just comply:
+Apply every **campsite** candidate noted in Phases 1–6, bounded to the blast radius
+from Phase 1. Each one is behaviour-preserving and covered by a green test — if it
+isn't covered, write the test first.
 
-- The `inject-iron-laws.sh` hook feeds the Elixir/Phoenix Iron Laws into every
-  subagent.
-- The plugin's `elixir-idioms`, `ecto-patterns`, `security`, `oban`,
-  `phoenix-contexts` auto-attach by context.
-- `.claude/rules/elixir-style.md` and `domain-architecture.md` are always loaded
-  (generic idioms + the project's DDD modeling idioms live there).
+- **`/simplify`** whenever the change touched more than one module — reuse,
+  simplification, efficiency, altitude.
+- **Performance:** `/phx:n1-check` when the change added queries; `/phx:perf` on a
+  hot path.
+- **File an issue instead of fixing** only when the refactor would need its own
+  design **gate** — a call the user owns. Everything else gets fixed here.
+- A **second occurrence** of a class is fixed here *and* earns a rule or `lint_*`
+  task — see CLAUDE.md's "Second Occurrence Escalates".
+- Ship campsite work as its own `refactor:` commits, so review reads the cleanup
+  apart from the feature.
+
+**Done when:** every noted candidate is applied or filed with its reason, and
+`/simplify` has run (or the change touched exactly one module).
 
 ## Phase 8 — Verify
 
 Run `mix precommit` (or `/phx:verify` for a tool-discovering loop). Then a review
 pass: `/phx:review` (spawns `iron-law-judge`) for general changes, or
-`/review-architecture` for bounded-context / structural changes.
+`/review-architecture` for bounded-context / structural changes. When the work came
+from a GitHub issue or a `/phx:plan` file, add `phx:requirements-verifier` to
+cross-check the implementation against what was actually asked for.
 
 **Done when:** precommit is green and the review pass reports no blockers.
+
+## Standing context (adhere, don't restate)
+
+These load automatically — do not copy them into your reasoning, just comply: the
+`inject-iron-laws.sh` hook feeds the Iron Laws into every subagent, and the plugin's
+`elixir-idioms`, `ecto-patterns`, `security`, `oban`, `phoenix-contexts` auto-attach
+by context.
+
+`.claude/rules/elixir-style.md` and `domain-architecture.md` are always loaded —
+generic idioms and the project's domain modeling idioms live there.
 
 ## Rules
 
 - The **gate** (Phase 2) is never skipped for a non-trivial change, and the **user
   picks** the design — never auto-select.
 - Never restate the Iron Laws or idioms; name their source and comply.
-- Never refactor inside the red→green loop; that is Phase 6/8 work.
+- Never refactor inside the red→green loop; that is Phase 7 work, and campsite
+  fixes ship as their own commits.
+- The phx specialists advise; `/design-an-interface`, `/tdd` and `exunit-testing`
+  decide.
 - Route to the named skills; do not improvise a manual substitute for `/tdd`,
   `/design-an-interface`, or `exunit-testing` — composing them is the whole point.

--- a/mix.exs
+++ b/mix.exs
@@ -96,6 +96,17 @@ defmodule KlassHero.MixProject do
       {:bandit, "~> 1.5"},
       {:tz, "~> 0.28"},
       {:tidewave, "~> 0.5", only: :dev},
+      # NOT unused, despite no `mix igniter.*` invocation anywhere — do not prune it again.
+      # A dozen deps ship an installer Mix task guarded by `if Code.ensure_loaded?(Igniter)`
+      # (oban, jump_credo_checks, backpex, error_tracker, tidewave, ...). Those guards read
+      # the code path, and #1548 removed this line believing usage_rules kept igniter "in
+      # the tree" — usage_rules is `only: [:dev]`, so igniter reached dev and nothing else.
+      # A restored dep cache still holding _build/test/lib/igniter then makes the guard
+      # answer *true* and the module compile, right up until Mix prunes that now-stale
+      # directory mid-run: "struct Igniter.Mix.Task.Info is undefined (the module was also
+      # only available but may have been removed during compilation)". Which dep trips
+      # first is partition-dependent, so removing one victim just moves the failure.
+      {:igniter, "~> 0.8", only: [:dev, :test]},
       {:quokka, "~> 2.11", only: [:dev, :test], runtime: false},
       {:sobelow, "~> 0.13", only: [:dev, :test], runtime: false},
       {:mix_audit, "~> 2.1", only: [:dev, :test], runtime: false},


### PR DESCRIPTION
## Summary

`/build-elixir` only built what the ticket asked, never invoked `/simplify`, and routed to just three phx skills. Its Rule 3 also sent refactoring to "Phase 6/8" — but Phase 6 is the UI branch and Phase 8 is Verify, so no refactor phase existed for it to point at.

This adds a **campsite** pass (leave the code cleaner than you found it), wires in the phx plugin's stack-specific specialists as *advisors*, and repairs the dangling rule.

## Changes

| Section | Change |
|---|---|
| Header | **campsite** registered as a leading word |
| Phase 1 | Maps the blast radius (CodeGraph → `/phx:trace` → `phx:xref-analyzer`), which doubles as the campsite boundary |
| Phase 2 | Spawns the matching design specialist (`phx:ecto-schema-designer` / `otp-advisor` / `liveview-architect` / `oban-specialist`) as input to `/design-an-interface`; they advise, they never pick |
| Phase 4 | Log campsite candidates, edit nothing |
| Phase 6 | `/phx:assigns-audit` for collection-carrying LiveViews |
| **Phase 7 (new)** | Campsite pass — apply noted candidates, `/simplify` on multi-module changes, `/phx:n1-check` + `/phx:perf`, own `refactor:` commits |
| Phase 7 (old) → reference | Iron Laws/idioms demoted out of a phase slot to `## Standing context` |
| Phase 8 | `phx:requirements-verifier` when the work came from an issue or plan |
| Rules | "Phase 6/8" → **Phase 7**; two new rules |

## Review Focus

- **The file-vs-fix boundary.** A campsite candidate is filed as an issue only when the refactor would need its own design gate — reusing Phase 2's existing concept rather than inventing a severity scale. A second occurrence of a class is still fixed here *and* earns a rule or `lint_*` task per CLAUDE.md.
- **Campsite scope** is bounded to Phase 1's blast radius (touched files + what they directly reach), so PRs don't grow without limit.
- **Matt Pocock skills stay in the driver's seat** — the phx specialists feed `/design-an-interface`, `/tdd` and `exunit-testing`, never replace them.

## Test Plan

- [x] `mix lint_doc_refs` green — every cited path and module resolves
- [x] All 8 `Phase N` references resolve to real headings (the bug being fixed)
- [x] Every added skill/agent name verified against the live roster
- [ ] Dry-run `/build-elixir` on a small change: names the blast radius in Phase 1, logs rather than applies a candidate mid-loop, reaches Phase 7 and runs `/simplify` on 2+ modules

---

## Also fixes: the red `deps / Dependencies` job

Unrelated to the skill change, but folded in here because `main` is red and every open PR inherits it. `mix deps.compile` under `MIX_ENV=test` has failed on **every** run since #1548 merged:

```
error: struct Igniter.Mix.Task.Info is undefined (the module was also
only available but may have been removed during compilation)
== Type checking failed with errors ==
```

**Root cause.** #1548 removed `{:igniter, "~> 0.6", only: [:dev, :test]}`, reasoning that *"usage_rules hard-depends on it, so it stays in the tree."* That premise is env-scoped and doesn't hold — `usage_rules` is `only: [:dev]`, so igniter reached dev and nothing else.

**Why a guarded module still fails.** Roughly a dozen deps wrap their installer Mix task in `if Code.ensure_loaded?(Igniter) do` — oban, jump_credo_checks, backpex, error_tracker and tidewave all do. That guard reads the code path, so it should cleanly skip in an env without igniter. What turns it into a hard error is the restored dependency cache: it still holds `_build/test/lib/igniter` from before #1548, so the guard answers `true` and the module starts compiling — then Mix prunes that now-stale directory, since igniter is no longer a dep of the env. The module loses its dependency mid-compile, which is precisely what *"may have been removed during compilation"* is reporting.

**Which dep trips first is partition-dependent** (CI runs `MIX_OS_DEPS_COMPILE_PARTITION_COUNT=4`). `jump_credo_checks` failed in partition 3; an earlier revision of this PR narrowed that one dep to `only: [:dev]` and the identical failure simply moved to `oban` in partition 1. Restoring the declaration fixes the class rather than one victim.

**Verified:**

| Check | Result |
|---|---|
| `Code.ensure_loaded?(Igniter.Mix.Task.Info)` on the test code path | `false` → `true` |
| `MIX_OS_DEPS_COMPILE_PARTITION_COUNT=4 MIX_ENV=test mix deps.compile` (CI's exact partitioning) | exit 0 |
| `mix precommit` | green, 5390 tests |

`mix.lock` is untouched — igniter 0.8.3 was already locked, since `usage_rules` hard-depends on it.

### Follow-up after merge (not in this PR)

`main` has no dependency cache at the current `mix.lock` key, since the run that would have written it is the one that failed. PRs still restore via the `restore-keys` prefix fallback, so nothing is broken — they just pay a delta recompile. `deps-cache.yml`'s `push` trigger fires only on `mix.lock` / workflow changes, and this fix touches neither, so merging won't re-seed it. Trigger the workflow manually on main (`workflow_dispatch` is already declared) to restore a warm cache.
