### PR TITLE
feat: warn against off-platform contact on both provider-contact surfaces

### DIFF
--- a/lib/klass_hero_web/components/marketing_components.ex
+++ b/lib/klass_hero_web/components/marketing_components.ex
@@ -1347,12 +1347,22 @@ defmodule KlassHeroWeb.MarketingComponents do
   Generic peach CTA closer used by Trust & Safety (and reusable by About /
   Contact follow-ups). H2 + lede + primary CTA via slot, with an optional
   tagline + sub-tagline rendered below a horizontal rule.
+
+  `:footnote` is small print under the button, opt-in per caller so the closers
+  that want no small print keep rendering exactly as before. Plain text rather
+  than a slot: every other string here is an attr, and no caller needs markup in
+  it yet.
   """
   attr :id, :string, default: "mk-cta"
   attr :title, :string, required: true
   attr :lede, :string, default: nil
   attr :tagline, :string, default: nil
   attr :sub_tagline, :string, default: nil
+
+  attr :footnote, :string,
+    default: nil,
+    doc: "caption-size small print under the CTA — subordinate to it, never competing"
+
   slot :cta, required: true
 
   def mk_cta_section(assigns) do
@@ -1367,6 +1377,17 @@ defmodule KlassHeroWeb.MarketingComponents do
         <div class="mt-8">
           {render_slot(@cta)}
         </div>
+
+        <p
+          :if={@footnote}
+          id={"#{@id}-footnote"}
+          class={[
+            Theme.typography(:caption),
+            "mt-4 max-w-md mx-auto text-[var(--fg-muted-on-light)]"
+          ]}
+        >
+          {@footnote}
+        </p>
 
         <div :if={@tagline} class="mt-14 pt-10 border-t border-[var(--border-light)]">
           <%!-- typography-lint-ignore: display-font tagline is an intentional non-heading brand callout --%>

--- a/lib/klass_hero_web/components/messaging_components.ex
+++ b/lib/klass_hero_web/components/messaging_components.ex
@@ -856,11 +856,11 @@ defmodule KlassHeroWeb.MessagingComponents do
       <p class={Theme.typography(:caption)}>
         <%= if @variant == :provider do %>
           {gettext(
-            "Keep conversations with families on Klass Hero. Messages sent here can be reviewed if something goes wrong. Messages moved to WhatsApp, email or text cannot."
+            "Keep conversations with families on Klass Hero. Messages moved to WhatsApp, email or text cannot be reviewed if something goes wrong."
           )}
         <% else %>
           {gettext(
-            "Keep this conversation on Klass Hero. Messages sent here can be reviewed if something goes wrong. Messages moved to WhatsApp, email or text cannot."
+            "Keep this conversation on Klass Hero. Messages moved to WhatsApp, email or text cannot be reviewed if something goes wrong."
           )}
         <% end %>
       </p>

--- a/lib/klass_hero_web/components/messaging_components.ex
+++ b/lib/klass_hero_web/components/messaging_components.ex
@@ -726,6 +726,7 @@ defmodule KlassHeroWeb.MessagingComponents do
       </div>
       <.messages_empty_state :if={@messages_empty?} />
     </div>
+    <.safety_notice variant={@variant} />
     <%= cond do %>
       <% @variant == :provider -> %>
         <.message_input form={@form} uploads={@uploads} />
@@ -793,6 +794,73 @@ defmodule KlassHeroWeb.MessagingComponents do
         <% else %>
           {gettext(
             "Messages here may be reviewed by the activity provider and by Klass Hero staff, to keep children safe."
+          )}
+        <% end %>
+      </p>
+    </div>
+    """
+  end
+
+  @doc """
+  Renders the standing off-platform safety notice, above the composer.
+
+  A banner rather than a `:system` message, for the same three reasons
+  `monitoring_notice/1` is one: no write on any conversation-creation path, it
+  covers threads that already exist without a backfill, and being rendered rather
+  than stored it cannot be deleted.
+
+  Placed *below* `#messages-container` and *above* the composer, where
+  `monitoring_notice/1` sits above the stream. Both are outside the scrollable
+  region, so both are permanently visible — the property that notice's docstring
+  argues for. Stacking a second strip on top of the first would cost ~90px above
+  the first message on a phone; here it costs nothing and lands next to the box
+  the reader is about to type into, which is where off-platform steering is
+  answered.
+
+  It renders on the broadcast path too, where the composer is replaced by
+  `broadcast_reply_bar/1`. A broadcast is one-way, but "reply privately" opens a
+  direct thread with the provider — the same exposure, so the same notice.
+
+  Two wordings, split on who is being addressed rather than on who is at risk.
+  Both sides are: a parent can be asked to pay off-platform, and a provider can be
+  asked to accept it. Airbnb warns hosts as well as guests for this reason.
+
+  Deliberately says nothing about payment. Klass Hero cannot take one — there is
+  no Billing context (#1165), and #1171 records that cash or bank transfer paid
+  directly to the provider is the *current* booking flow. "Always pay through
+  Klass Hero" would name a rail that does not exist and promise a protection that
+  does not follow from it. What is true today is the record: a thread here can be
+  reviewed. Add the payment sentence when Billing lands.
+
+  > This wording is PROVISIONAL and must not ship before legal review, on the same
+  > footing as `monitoring_notice/1`'s.
+  """
+  attr :variant, :atom,
+    required: true,
+    values: [:parent, :provider],
+    doc: "who is being addressed — `:provider` also covers a provider's staff"
+
+  def safety_notice(assigns) do
+    ~H"""
+    <div
+      id="safety-notice"
+      data-role="safety-notice"
+      class={[
+        "flex items-start gap-2 px-4 py-2.5 border-t",
+        Theme.bg(:light),
+        Theme.border_color(:light),
+        Theme.text_color(:muted)
+      ]}
+    >
+      <.icon name="hero-shield-check" class="w-4 h-4 shrink-0 mt-0.5" />
+      <p class={Theme.typography(:caption)}>
+        <%= if @variant == :provider do %>
+          {gettext(
+            "Keep conversations with families on Klass Hero. Messages sent here can be reviewed if something goes wrong. Messages moved to WhatsApp, email or text cannot."
+          )}
+        <% else %>
+          {gettext(
+            "Keep this conversation on Klass Hero. Messages sent here can be reviewed if something goes wrong. Messages moved to WhatsApp, email or text cannot."
           )}
         <% end %>
       </p>

--- a/lib/klass_hero_web/live/provider_profile_live.ex
+++ b/lib/klass_hero_web/live/provider_profile_live.ex
@@ -191,6 +191,7 @@ defmodule KlassHeroWeb.ProviderProfileLive do
           provider: @provider.business_name
         )
       }
+      footnote={gettext("Messages sent through Klass Hero can be reviewed if something goes wrong.")}
     >
       <:cta>
         <%!-- A link, not a gated button. Messaging.build_compose_target/3 owns who may

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -1488,7 +1488,7 @@ msgstr "Team- & Anbieterprofile"
 msgid "Unassigned"
 msgstr "Nicht zugewiesen"
 
-#: lib/klass_hero_web/components/messaging_components.ex:856
+#: lib/klass_hero_web/components/messaging_components.ex:924
 #: lib/klass_hero_web/components/provider_components.ex:53
 #: lib/klass_hero_web/components/provider_components.ex:1632
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:110
@@ -1509,7 +1509,7 @@ msgstr "Teilnehmerliste"
 msgid "%{age} years old"
 msgstr "%{age} Jahre alt"
 
-#: lib/klass_hero_web/components/messaging_components.ex:877
+#: lib/klass_hero_web/components/messaging_components.ex:945
 #, elixir-autogen, elixir-format
 msgid "%{n}m ago"
 msgstr "vor %{n} Min."
@@ -1734,7 +1734,7 @@ msgid "No conversations yet"
 msgstr "Noch keine Unterhaltungen"
 
 #: lib/klass_hero_web/components/messaging_components.ex:458
-#: lib/klass_hero_web/components/messaging_components.ex:899
+#: lib/klass_hero_web/components/messaging_components.ex:967
 #, elixir-autogen, elixir-format
 msgid "No messages yet"
 msgstr "Noch keine Nachrichten"
@@ -1766,7 +1766,7 @@ msgstr "Notiz abgelehnt"
 msgid "Note resubmitted for review"
 msgstr "Notiz erneut zur Überprüfung eingereicht"
 
-#: lib/klass_hero_web/components/messaging_components.ex:876
+#: lib/klass_hero_web/components/messaging_components.ex:944
 #, elixir-autogen, elixir-format
 msgid "Now"
 msgstr "Jetzt"
@@ -1806,7 +1806,7 @@ msgstr "Bitte authentifizieren Sie sich erneut, um Ihr Konto zu löschen."
 msgid "Please set up your parent profile to manage children."
 msgstr "Bitte richten Sie Ihr Elternprofil ein, um Kinder zu verwalten."
 
-#: lib/klass_hero_web/components/messaging_components.ex:849
+#: lib/klass_hero_web/components/messaging_components.ex:917
 #: lib/klass_hero_web/live/messaging_live_helper.ex:414
 #, elixir-autogen, elixir-format
 msgid "Program Broadcast"
@@ -2105,7 +2105,7 @@ msgstr "Ablehnung bestätigen"
 msgid "Confirmed"
 msgstr "Bestätigt"
 
-#: lib/klass_hero_web/components/messaging_components.ex:951
+#: lib/klass_hero_web/components/messaging_components.ex:1019
 #, elixir-autogen, elixir-format
 msgid "Contact Provider"
 msgstr "Anbieter kontaktieren"
@@ -3015,12 +3015,12 @@ msgstr "z. B. Art Adventures"
 msgid "e.g., Community Center, Main St"
 msgstr "z. B. Gemeindezentrum, Hauptstraße"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1501
+#: lib/klass_hero_web/components/marketing_components.ex:1522
 #, elixir-autogen, elixir-format
 msgid "All Heroes must hold or complete a recognized child safeguarding course, ensuring up-to-date knowledge."
 msgstr "Alle Heroes müssen einen anerkannten Kinderschutzkurs absolviert haben oder absolvieren, um stets aktuelles Wissen sicherzustellen."
 
-#: lib/klass_hero_web/components/marketing_components.ex:1469
+#: lib/klass_hero_web/components/marketing_components.ex:1490
 #, elixir-autogen, elixir-format
 msgid "All providers must be 18 years or older, ensuring legal accountability and professional responsibility."
 msgstr "Alle Anbieter müssen mindestens 18 Jahre alt sein, um rechtliche Verantwortlichkeit und professionelle Verlässlichkeit zu gewährleisten."
@@ -3030,12 +3030,12 @@ msgstr "Alle Anbieter müssen mindestens 18 Jahre alt sein, um rechtliche Verant
 msgid "And at Klass Hero, both come standard."
 msgstr "Und bei Klass Hero sind beide selbstverständlich."
 
-#: lib/klass_hero_web/components/marketing_components.ex:1499
+#: lib/klass_hero_web/components/marketing_components.ex:1520
 #, elixir-autogen, elixir-format
 msgid "Child Safeguarding Training"
 msgstr "Kinderschutzschulung"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1507
+#: lib/klass_hero_web/components/marketing_components.ex:1528
 #: lib/klass_hero_web/components/provider_components.ex:3887
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
@@ -3046,7 +3046,7 @@ msgstr "Vereinbarung zu Community-Standards"
 msgid "Create long-term trust across our community"
 msgstr "Langfristiges Vertrauen in unserer Community aufbauen"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1485
+#: lib/klass_hero_web/components/marketing_components.ex:1506
 #, elixir-autogen, elixir-format
 msgid "Each provider submits an extended police background check, confirming their eligibility to work safely with minors."
 msgstr "Jeder Anbieter reicht ein erweitertes polizeiliches Führungszeugnis ein, das seine Eignung bestätigt, sicher mit Minderjährigen zu arbeiten."
@@ -3056,17 +3056,17 @@ msgstr "Jeder Anbieter reicht ein erweitertes polizeiliches Führungszeugnis ein
 msgid "Enforcing platform standards and guidelines"
 msgstr "Durchsetzung von Plattformstandards und -richtlinien"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1509
+#: lib/klass_hero_web/components/marketing_components.ex:1530
 #, elixir-autogen, elixir-format
 msgid "Every provider agrees to follow our Community Guidelines, defining expectations around professionalism."
 msgstr "Jeder Anbieter verpflichtet sich, unsere Community-Richtlinien einzuhalten, die die Erwartungen an Professionalität festlegen."
 
-#: lib/klass_hero_web/components/marketing_components.ex:1475
+#: lib/klass_hero_web/components/marketing_components.ex:1496
 #, elixir-autogen, elixir-format
 msgid "Experience Validation"
 msgstr "Erfahrungsprüfung"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1483
+#: lib/klass_hero_web/components/marketing_components.ex:1504
 #, elixir-autogen, elixir-format
 msgid "Extended Background Checks"
 msgstr "Erweiterte Führungszeugnisprüfungen"
@@ -3076,12 +3076,12 @@ msgstr "Erweiterte Führungszeugnisprüfungen"
 msgid "From academic tutoring to sports, arts, and enrichment programs, every provider on Klass Hero is carefully reviewed to ensure they meet our high standards for child safety, professionalism, and educational quality."
 msgstr "Von akademischer Nachhilfe über Sport und Kunst bis hin zu Förderprogrammen wird jeder Anbieter auf Klass Hero sorgfältig geprüft, um sicherzustellen, dass er unseren hohen Standards für Kindersicherheit, Professionalität und pädagogische Qualität entspricht."
 
-#: lib/klass_hero_web/components/marketing_components.ex:1529
+#: lib/klass_hero_web/components/marketing_components.ex:1550
 #, elixir-autogen, elixir-format
 msgid "How We Verify Providers"
 msgstr "Wie wir Anbieter verifizieren"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1467
+#: lib/klass_hero_web/components/marketing_components.ex:1488
 #, elixir-autogen, elixir-format
 msgid "Identity & Age Verification"
 msgstr "Identitäts- und Altersverifizierung"
@@ -3116,7 +3116,7 @@ msgstr "Programm gespeichert, aber der Upload des Titelbilds ist fehlgeschlagen.
 msgid "Protect children and families"
 msgstr "Kinder und Familien schützen"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1477
+#: lib/klass_hero_web/components/marketing_components.ex:1498
 #, elixir-autogen, elixir-format
 msgid "Providers must demonstrate at least one year of experience working with children in their area of expertise."
 msgstr "Anbieter müssen mindestens ein Jahr Erfahrung in der Arbeit mit Kindern in ihrem Fachgebiet nachweisen."
@@ -3181,12 +3181,12 @@ msgstr "Vertrauen muss man sich verdienen. Sicherheit ist nicht verhandelbar."
 msgid "Uphold professional and ethical teaching practices"
 msgstr "Professionelle und ethische Lehrpraktiken einhalten"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1426
+#: lib/klass_hero_web/components/marketing_components.ex:1447
 #, elixir-autogen, elixir-format
 msgid "Vetted with Care"
 msgstr "Mit Sorgfalt geprüft"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1491
+#: lib/klass_hero_web/components/marketing_components.ex:1512
 #: lib/klass_hero_web/components/provider_components.ex:3665
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
@@ -3753,7 +3753,7 @@ msgstr "Zurück zu Sitzungen"
 msgid "Back to emails"
 msgstr "Zurück zu E-Mails"
 
-#: lib/klass_hero_web/components/messaging_components.ex:816
+#: lib/klass_hero_web/components/messaging_components.ex:884
 #, elixir-autogen, elixir-format
 msgid "Broadcast messages are one-way"
 msgstr "Broadcast-Nachrichten sind einseitig"
@@ -4159,7 +4159,7 @@ msgstr "Grund für die Ablehnung (optional)"
 msgid "Reply"
 msgstr "Antworten"
 
-#: lib/klass_hero_web/components/messaging_components.ex:827
+#: lib/klass_hero_web/components/messaging_components.ex:895
 #, elixir-autogen, elixir-format
 msgid "Reply privately"
 msgstr "Privat antworten"
@@ -4441,7 +4441,7 @@ msgstr "Vervollständigen Sie Ihr Anbieterprofil"
 msgid "Failed to upload files. Please try again."
 msgstr "Hochladen der Dateien fehlgeschlagen. Bitte versuchen Sie es erneut."
 
-#: lib/klass_hero_web/components/messaging_components.ex:903
+#: lib/klass_hero_web/components/messaging_components.ex:971
 #, elixir-autogen, elixir-format
 msgid "File is too large (max %{mb} MB)"
 msgstr "Datei ist zu groß (max. %{mb} MB)"
@@ -4451,7 +4451,7 @@ msgstr "Datei ist zu groß (max. %{mb} MB)"
 msgid "File is too large (max %{mb} MB)."
 msgstr "Datei ist zu groß (max. %{mb} MB)."
 
-#: lib/klass_hero_web/components/messaging_components.ex:906
+#: lib/klass_hero_web/components/messaging_components.ex:974
 #, elixir-autogen, elixir-format
 msgid "File type not accepted (images only)"
 msgstr "Dateityp nicht akzeptiert (nur Bilder)"
@@ -4471,8 +4471,8 @@ msgstr "Geben Sie Ihre Unternehmensdaten ein. Ihr Profil wird von Klass Hero gep
 msgid "Only images are accepted (JPG, PNG, GIF, WebP)."
 msgstr "Nur Bilder werden akzeptiert (JPG, PNG, GIF, WebP)."
 
-#: lib/klass_hero_web/components/messaging_components.ex:888
-#: lib/klass_hero_web/components/messaging_components.ex:892
+#: lib/klass_hero_web/components/messaging_components.ex:956
+#: lib/klass_hero_web/components/messaging_components.ex:960
 #, elixir-autogen, elixir-format
 msgid "Photo"
 msgstr "Foto"
@@ -4512,7 +4512,7 @@ msgstr "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut."
 msgid "Tell parents about your organization and what makes you unique..."
 msgstr "Erzählen Sie Eltern von Ihrer Organisation und was Sie einzigartig macht..."
 
-#: lib/klass_hero_web/components/messaging_components.ex:910
+#: lib/klass_hero_web/components/messaging_components.ex:978
 #, elixir-autogen, elixir-format
 msgid "Too many files (max %{max})"
 msgstr "Zu viele Dateien (max. %{max})"
@@ -4522,12 +4522,12 @@ msgstr "Zu viele Dateien (max. %{max})"
 msgid "Too many files (max %{max})."
 msgstr "Zu viele Dateien (max. %{max})."
 
-#: lib/klass_hero_web/components/messaging_components.ex:914
+#: lib/klass_hero_web/components/messaging_components.ex:982
 #, elixir-autogen, elixir-format
 msgid "Upload error"
 msgstr "Upload-Fehler"
 
-#: lib/klass_hero_web/components/messaging_components.ex:913
+#: lib/klass_hero_web/components/messaging_components.ex:981
 #, elixir-autogen, elixir-format
 msgid "Upload failed"
 msgstr "Hochladen fehlgeschlagen"
@@ -5804,7 +5804,7 @@ msgstr "Bieten Sie Ihre eigenen Programme auf Klass Hero an — zusätzlich zu I
 msgid "Once your listing is live and you've completed Hero verification (typically 3–5 business days), parents can book immediately. Most providers receive their first inquiry within the first week."
 msgstr "Sobald Ihr Eintrag live ist und Sie die Hero-Verifizierung abgeschlossen haben (in der Regel 3–5 Werktage), können Eltern sofort buchen. Die meisten Anbieter erhalten ihre erste Anfrage innerhalb der ersten Woche."
 
-#: lib/klass_hero_web/components/marketing_components.ex:1577
+#: lib/klass_hero_web/components/marketing_components.ex:1598
 #, elixir-autogen, elixir-format
 msgid "Ongoing Quality"
 msgstr "Laufende Qualität"
@@ -5829,7 +5829,7 @@ msgstr "Posteingang öffnen"
 msgid "Open menu"
 msgstr "Menü öffnen"
 
-#: lib/klass_hero_web/components/marketing_components.ex:1405
+#: lib/klass_hero_web/components/marketing_components.ex:1426
 #, elixir-autogen, elixir-format
 msgid "Our Commitment"
 msgstr "Unser Engagement"
@@ -6830,7 +6830,7 @@ msgstr "Der letzte Schritt: Lies die Klass Hero Community-Richtlinien und stimme
 msgid "You have agreed to the Community Guidelines."
 msgstr "Du hast den Community-Richtlinien zugestimmt."
 
-#: lib/klass_hero_web/components/marketing_components.ex:1493
+#: lib/klass_hero_web/components/marketing_components.ex:1514
 #, elixir-autogen, elixir-format
 msgid "Applicants submit a short recorded video (max 2 minutes) so we can assess communication skills and alignment with our values before approving their profile."
 msgstr "Bewerber reichen ein kurzes aufgezeichnetes Video (max. 2 Minuten) ein, damit wir vor der Freigabe ihres Profils Kommunikationsfähigkeiten und die Übereinstimmung mit unseren Werten beurteilen können."
@@ -8038,7 +8038,7 @@ msgstr "Hochladen fehlgeschlagen."
 msgid "Message %{provider} directly about their programs."
 msgstr "Schreiben Sie %{provider} direkt zu den Programmen."
 
-#: lib/klass_hero_web/live/provider_profile_live.ex:202
+#: lib/klass_hero_web/live/provider_profile_live.ex:203
 #, elixir-autogen, elixir-format
 msgid "Message this provider"
 msgstr "Anbieter kontaktieren"
@@ -8153,7 +8153,7 @@ msgstr "Unbekannter Anbieter"
 msgid "← Back to messages"
 msgstr "← Zurück zu den Nachrichten"
 
-#: lib/klass_hero_web/components/messaging_components.ex:794
+#: lib/klass_hero_web/components/messaging_components.ex:795
 #, elixir-autogen, elixir-format
 msgid "Messages here may be reviewed by the activity provider and by Klass Hero staff, to keep children safe."
 msgstr "Nachrichten hier können vom Anbieter und von Klass Hero-Mitarbeitenden eingesehen werden, um Kinder zu schützen."
@@ -8195,7 +8195,7 @@ msgstr "Unterhaltungen des Teams"
 msgid "via"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:792
+#: lib/klass_hero_web/components/messaging_components.ex:793
 #, elixir-autogen, elixir-format
 msgid "Messages here may be reviewed by Klass Hero staff."
 msgstr "Nachrichten hier können von Klass Hero-Mitarbeitenden eingesehen werden."
@@ -8285,3 +8285,18 @@ msgstr "Wie viele Kinder in eine Sitzung passen. Gilt für Sitzungen, die aus di
 #, elixir-autogen, elixir-format
 msgid "Usual capacity per session"
 msgstr "Übliche Kapazität pro Sitzung"
+
+#: lib/klass_hero_web/components/messaging_components.ex:858
+#, elixir-autogen, elixir-format
+msgid "Keep conversations with families on Klass Hero. Messages sent here can be reviewed if something goes wrong. Messages moved to WhatsApp, email or text cannot."
+msgstr "Gespräche mit Familien sollten auf Klass Hero bleiben. Nachrichten hier können bei Problemen eingesehen werden. Nachrichten über WhatsApp, E-Mail oder SMS nicht."
+
+#: lib/klass_hero_web/components/messaging_components.ex:862
+#, elixir-autogen, elixir-format
+msgid "Keep this conversation on Klass Hero. Messages sent here can be reviewed if something goes wrong. Messages moved to WhatsApp, email or text cannot."
+msgstr "Dieses Gespräch sollte auf Klass Hero bleiben. Nachrichten hier können bei Problemen eingesehen werden. Nachrichten über WhatsApp, E-Mail oder SMS nicht."
+
+#: lib/klass_hero_web/live/provider_profile_live.ex:194
+#, elixir-autogen, elixir-format
+msgid "Messages sent through Klass Hero can be reviewed if something goes wrong."
+msgstr "Nachrichten über Klass Hero können bei Problemen eingesehen werden."

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -8286,17 +8286,17 @@ msgstr "Wie viele Kinder in eine Sitzung passen. Gilt für Sitzungen, die aus di
 msgid "Usual capacity per session"
 msgstr "Übliche Kapazität pro Sitzung"
 
-#: lib/klass_hero_web/components/messaging_components.ex:858
-#, elixir-autogen, elixir-format
-msgid "Keep conversations with families on Klass Hero. Messages sent here can be reviewed if something goes wrong. Messages moved to WhatsApp, email or text cannot."
-msgstr "Gespräche mit Familien sollten auf Klass Hero bleiben. Nachrichten hier können bei Problemen eingesehen werden. Nachrichten über WhatsApp, E-Mail oder SMS nicht."
-
-#: lib/klass_hero_web/components/messaging_components.ex:862
-#, elixir-autogen, elixir-format
-msgid "Keep this conversation on Klass Hero. Messages sent here can be reviewed if something goes wrong. Messages moved to WhatsApp, email or text cannot."
-msgstr "Dieses Gespräch sollte auf Klass Hero bleiben. Nachrichten hier können bei Problemen eingesehen werden. Nachrichten über WhatsApp, E-Mail oder SMS nicht."
-
 #: lib/klass_hero_web/live/provider_profile_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "Messages sent through Klass Hero can be reviewed if something goes wrong."
 msgstr "Nachrichten über Klass Hero können bei Problemen eingesehen werden."
+
+#: lib/klass_hero_web/components/messaging_components.ex:858
+#, elixir-autogen, elixir-format
+msgid "Keep conversations with families on Klass Hero. Messages moved to WhatsApp, email or text cannot be reviewed if something goes wrong."
+msgstr "Gespräche mit Familien sollten auf Klass Hero bleiben. Nachrichten über WhatsApp, E-Mail oder SMS können bei Problemen nicht eingesehen werden."
+
+#: lib/klass_hero_web/components/messaging_components.ex:862
+#, elixir-autogen, elixir-format
+msgid "Keep this conversation on Klass Hero. Messages moved to WhatsApp, email or text cannot be reviewed if something goes wrong."
+msgstr "Dieses Gespräch sollte auf Klass Hero bleiben. Nachrichten über WhatsApp, E-Mail oder SMS können bei Problemen nicht eingesehen werden."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -8268,17 +8268,17 @@ msgstr ""
 msgid "Usual capacity per session"
 msgstr ""
 
+#: lib/klass_hero_web/live/provider_profile_live.ex:194
+#, elixir-autogen, elixir-format
+msgid "Messages sent through Klass Hero can be reviewed if something goes wrong."
+msgstr ""
+
 #: lib/klass_hero_web/components/messaging_components.ex:858
 #, elixir-autogen, elixir-format
-msgid "Keep conversations with families on Klass Hero. Messages sent here can be reviewed if something goes wrong. Messages moved to WhatsApp, email or text cannot."
+msgid "Keep conversations with families on Klass Hero. Messages moved to WhatsApp, email or text cannot be reviewed if something goes wrong."
 msgstr ""
 
 #: lib/klass_hero_web/components/messaging_components.ex:862
 #, elixir-autogen, elixir-format
-msgid "Keep this conversation on Klass Hero. Messages sent here can be reviewed if something goes wrong. Messages moved to WhatsApp, email or text cannot."
-msgstr ""
-
-#: lib/klass_hero_web/live/provider_profile_live.ex:194
-#, elixir-autogen, elixir-format
-msgid "Messages sent through Klass Hero can be reviewed if something goes wrong."
+msgid "Keep this conversation on Klass Hero. Messages moved to WhatsApp, email or text cannot be reviewed if something goes wrong."
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -1488,7 +1488,7 @@ msgstr ""
 msgid "Unassigned"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:856
+#: lib/klass_hero_web/components/messaging_components.ex:924
 #: lib/klass_hero_web/components/provider_components.ex:53
 #: lib/klass_hero_web/components/provider_components.ex:1632
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:110
@@ -1509,7 +1509,7 @@ msgstr ""
 msgid "%{age} years old"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:877
+#: lib/klass_hero_web/components/messaging_components.ex:945
 #, elixir-autogen, elixir-format
 msgid "%{n}m ago"
 msgstr ""
@@ -1734,7 +1734,7 @@ msgid "No conversations yet"
 msgstr ""
 
 #: lib/klass_hero_web/components/messaging_components.ex:458
-#: lib/klass_hero_web/components/messaging_components.ex:899
+#: lib/klass_hero_web/components/messaging_components.ex:967
 #, elixir-autogen, elixir-format
 msgid "No messages yet"
 msgstr ""
@@ -1766,7 +1766,7 @@ msgstr ""
 msgid "Note resubmitted for review"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:876
+#: lib/klass_hero_web/components/messaging_components.ex:944
 #, elixir-autogen, elixir-format
 msgid "Now"
 msgstr ""
@@ -1806,7 +1806,7 @@ msgstr ""
 msgid "Please set up your parent profile to manage children."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:849
+#: lib/klass_hero_web/components/messaging_components.ex:917
 #: lib/klass_hero_web/live/messaging_live_helper.ex:414
 #, elixir-autogen, elixir-format
 msgid "Program Broadcast"
@@ -2105,7 +2105,7 @@ msgstr ""
 msgid "Confirmed"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:951
+#: lib/klass_hero_web/components/messaging_components.ex:1019
 #, elixir-autogen, elixir-format
 msgid "Contact Provider"
 msgstr ""
@@ -3015,12 +3015,12 @@ msgstr ""
 msgid "e.g., Community Center, Main St"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1501
+#: lib/klass_hero_web/components/marketing_components.ex:1522
 #, elixir-autogen, elixir-format
 msgid "All Heroes must hold or complete a recognized child safeguarding course, ensuring up-to-date knowledge."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1469
+#: lib/klass_hero_web/components/marketing_components.ex:1490
 #, elixir-autogen, elixir-format
 msgid "All providers must be 18 years or older, ensuring legal accountability and professional responsibility."
 msgstr ""
@@ -3030,12 +3030,12 @@ msgstr ""
 msgid "And at Klass Hero, both come standard."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1499
+#: lib/klass_hero_web/components/marketing_components.ex:1520
 #, elixir-autogen, elixir-format
 msgid "Child Safeguarding Training"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1507
+#: lib/klass_hero_web/components/marketing_components.ex:1528
 #: lib/klass_hero_web/components/provider_components.ex:3887
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
@@ -3046,7 +3046,7 @@ msgstr ""
 msgid "Create long-term trust across our community"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1485
+#: lib/klass_hero_web/components/marketing_components.ex:1506
 #, elixir-autogen, elixir-format
 msgid "Each provider submits an extended police background check, confirming their eligibility to work safely with minors."
 msgstr ""
@@ -3056,17 +3056,17 @@ msgstr ""
 msgid "Enforcing platform standards and guidelines"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1509
+#: lib/klass_hero_web/components/marketing_components.ex:1530
 #, elixir-autogen, elixir-format
 msgid "Every provider agrees to follow our Community Guidelines, defining expectations around professionalism."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1475
+#: lib/klass_hero_web/components/marketing_components.ex:1496
 #, elixir-autogen, elixir-format
 msgid "Experience Validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1483
+#: lib/klass_hero_web/components/marketing_components.ex:1504
 #, elixir-autogen, elixir-format
 msgid "Extended Background Checks"
 msgstr ""
@@ -3076,12 +3076,12 @@ msgstr ""
 msgid "From academic tutoring to sports, arts, and enrichment programs, every provider on Klass Hero is carefully reviewed to ensure they meet our high standards for child safety, professionalism, and educational quality."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1529
+#: lib/klass_hero_web/components/marketing_components.ex:1550
 #, elixir-autogen, elixir-format
 msgid "How We Verify Providers"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1467
+#: lib/klass_hero_web/components/marketing_components.ex:1488
 #, elixir-autogen, elixir-format
 msgid "Identity & Age Verification"
 msgstr ""
@@ -3116,7 +3116,7 @@ msgstr ""
 msgid "Protect children and families"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1477
+#: lib/klass_hero_web/components/marketing_components.ex:1498
 #, elixir-autogen, elixir-format
 msgid "Providers must demonstrate at least one year of experience working with children in their area of expertise."
 msgstr ""
@@ -3181,12 +3181,12 @@ msgstr ""
 msgid "Uphold professional and ethical teaching practices"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1426
+#: lib/klass_hero_web/components/marketing_components.ex:1447
 #, elixir-autogen, elixir-format
 msgid "Vetted with Care"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1491
+#: lib/klass_hero_web/components/marketing_components.ex:1512
 #: lib/klass_hero_web/components/provider_components.ex:3665
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
@@ -3753,7 +3753,7 @@ msgstr ""
 msgid "Back to emails"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:816
+#: lib/klass_hero_web/components/messaging_components.ex:884
 #, elixir-autogen, elixir-format
 msgid "Broadcast messages are one-way"
 msgstr ""
@@ -4159,7 +4159,7 @@ msgstr ""
 msgid "Reply"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:827
+#: lib/klass_hero_web/components/messaging_components.ex:895
 #, elixir-autogen, elixir-format
 msgid "Reply privately"
 msgstr ""
@@ -4441,7 +4441,7 @@ msgstr ""
 msgid "Failed to upload files. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:903
+#: lib/klass_hero_web/components/messaging_components.ex:971
 #, elixir-autogen, elixir-format
 msgid "File is too large (max %{mb} MB)"
 msgstr ""
@@ -4451,7 +4451,7 @@ msgstr ""
 msgid "File is too large (max %{mb} MB)."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:906
+#: lib/klass_hero_web/components/messaging_components.ex:974
 #, elixir-autogen, elixir-format
 msgid "File type not accepted (images only)"
 msgstr ""
@@ -4471,8 +4471,8 @@ msgstr ""
 msgid "Only images are accepted (JPG, PNG, GIF, WebP)."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:888
-#: lib/klass_hero_web/components/messaging_components.ex:892
+#: lib/klass_hero_web/components/messaging_components.ex:956
+#: lib/klass_hero_web/components/messaging_components.ex:960
 #, elixir-autogen, elixir-format
 msgid "Photo"
 msgstr ""
@@ -4512,7 +4512,7 @@ msgstr ""
 msgid "Tell parents about your organization and what makes you unique..."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:910
+#: lib/klass_hero_web/components/messaging_components.ex:978
 #, elixir-autogen, elixir-format
 msgid "Too many files (max %{max})"
 msgstr ""
@@ -4522,12 +4522,12 @@ msgstr ""
 msgid "Too many files (max %{max})."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:914
+#: lib/klass_hero_web/components/messaging_components.ex:982
 #, elixir-autogen, elixir-format
 msgid "Upload error"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:913
+#: lib/klass_hero_web/components/messaging_components.ex:981
 #, elixir-autogen, elixir-format
 msgid "Upload failed"
 msgstr ""
@@ -5804,7 +5804,7 @@ msgstr ""
 msgid "Once your listing is live and you've completed Hero verification (typically 3–5 business days), parents can book immediately. Most providers receive their first inquiry within the first week."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1577
+#: lib/klass_hero_web/components/marketing_components.ex:1598
 #, elixir-autogen, elixir-format
 msgid "Ongoing Quality"
 msgstr ""
@@ -5829,7 +5829,7 @@ msgstr ""
 msgid "Open menu"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1405
+#: lib/klass_hero_web/components/marketing_components.ex:1426
 #, elixir-autogen, elixir-format
 msgid "Our Commitment"
 msgstr ""
@@ -6830,7 +6830,7 @@ msgstr ""
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1493
+#: lib/klass_hero_web/components/marketing_components.ex:1514
 #, elixir-autogen, elixir-format
 msgid "Applicants submit a short recorded video (max 2 minutes) so we can assess communication skills and alignment with our values before approving their profile."
 msgstr ""
@@ -8020,7 +8020,7 @@ msgstr ""
 msgid "Message %{provider} directly about their programs."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider_profile_live.ex:202
+#: lib/klass_hero_web/live/provider_profile_live.ex:203
 #, elixir-autogen, elixir-format
 msgid "Message this provider"
 msgstr ""
@@ -8135,7 +8135,7 @@ msgstr ""
 msgid "← Back to messages"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:794
+#: lib/klass_hero_web/components/messaging_components.ex:795
 #, elixir-autogen, elixir-format
 msgid "Messages here may be reviewed by the activity provider and by Klass Hero staff, to keep children safe."
 msgstr ""
@@ -8177,7 +8177,7 @@ msgstr ""
 msgid "via"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:792
+#: lib/klass_hero_web/components/messaging_components.ex:793
 #, elixir-autogen, elixir-format
 msgid "Messages here may be reviewed by Klass Hero staff."
 msgstr ""
@@ -8266,4 +8266,19 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:1100
 #, elixir-autogen, elixir-format
 msgid "Usual capacity per session"
+msgstr ""
+
+#: lib/klass_hero_web/components/messaging_components.ex:858
+#, elixir-autogen, elixir-format
+msgid "Keep conversations with families on Klass Hero. Messages sent here can be reviewed if something goes wrong. Messages moved to WhatsApp, email or text cannot."
+msgstr ""
+
+#: lib/klass_hero_web/components/messaging_components.ex:862
+#, elixir-autogen, elixir-format
+msgid "Keep this conversation on Klass Hero. Messages sent here can be reviewed if something goes wrong. Messages moved to WhatsApp, email or text cannot."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider_profile_live.ex:194
+#, elixir-autogen, elixir-format
+msgid "Messages sent through Klass Hero can be reviewed if something goes wrong."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -1488,7 +1488,7 @@ msgstr ""
 msgid "Unassigned"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:856
+#: lib/klass_hero_web/components/messaging_components.ex:924
 #: lib/klass_hero_web/components/provider_components.ex:53
 #: lib/klass_hero_web/components/provider_components.ex:1632
 #: lib/klass_hero_web/live/admin/messages_live.html.heex:110
@@ -1509,7 +1509,7 @@ msgstr ""
 msgid "%{age} years old"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:877
+#: lib/klass_hero_web/components/messaging_components.ex:945
 #, elixir-autogen, elixir-format
 msgid "%{n}m ago"
 msgstr ""
@@ -1734,7 +1734,7 @@ msgid "No conversations yet"
 msgstr ""
 
 #: lib/klass_hero_web/components/messaging_components.ex:458
-#: lib/klass_hero_web/components/messaging_components.ex:899
+#: lib/klass_hero_web/components/messaging_components.ex:967
 #, elixir-autogen, elixir-format
 msgid "No messages yet"
 msgstr ""
@@ -1766,7 +1766,7 @@ msgstr ""
 msgid "Note resubmitted for review"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:876
+#: lib/klass_hero_web/components/messaging_components.ex:944
 #, elixir-autogen, elixir-format
 msgid "Now"
 msgstr ""
@@ -1806,7 +1806,7 @@ msgstr ""
 msgid "Please set up your parent profile to manage children."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:849
+#: lib/klass_hero_web/components/messaging_components.ex:917
 #: lib/klass_hero_web/live/messaging_live_helper.ex:414
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Program Broadcast"
@@ -2105,7 +2105,7 @@ msgstr ""
 msgid "Confirmed"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:951
+#: lib/klass_hero_web/components/messaging_components.ex:1019
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Contact Provider"
 msgstr ""
@@ -3015,12 +3015,12 @@ msgstr ""
 msgid "e.g., Community Center, Main St"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1501
+#: lib/klass_hero_web/components/marketing_components.ex:1522
 #, elixir-autogen, elixir-format
 msgid "All Heroes must hold or complete a recognized child safeguarding course, ensuring up-to-date knowledge."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1469
+#: lib/klass_hero_web/components/marketing_components.ex:1490
 #, elixir-autogen, elixir-format
 msgid "All providers must be 18 years or older, ensuring legal accountability and professional responsibility."
 msgstr ""
@@ -3030,12 +3030,12 @@ msgstr ""
 msgid "And at Klass Hero, both come standard."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1499
+#: lib/klass_hero_web/components/marketing_components.ex:1520
 #, elixir-autogen, elixir-format
 msgid "Child Safeguarding Training"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1507
+#: lib/klass_hero_web/components/marketing_components.ex:1528
 #: lib/klass_hero_web/components/provider_components.ex:3887
 #, elixir-autogen, elixir-format
 msgid "Community Standards Agreement"
@@ -3046,7 +3046,7 @@ msgstr ""
 msgid "Create long-term trust across our community"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1485
+#: lib/klass_hero_web/components/marketing_components.ex:1506
 #, elixir-autogen, elixir-format
 msgid "Each provider submits an extended police background check, confirming their eligibility to work safely with minors."
 msgstr ""
@@ -3056,17 +3056,17 @@ msgstr ""
 msgid "Enforcing platform standards and guidelines"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1509
+#: lib/klass_hero_web/components/marketing_components.ex:1530
 #, elixir-autogen, elixir-format
 msgid "Every provider agrees to follow our Community Guidelines, defining expectations around professionalism."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1475
+#: lib/klass_hero_web/components/marketing_components.ex:1496
 #, elixir-autogen, elixir-format
 msgid "Experience Validation"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1483
+#: lib/klass_hero_web/components/marketing_components.ex:1504
 #, elixir-autogen, elixir-format
 msgid "Extended Background Checks"
 msgstr ""
@@ -3076,12 +3076,12 @@ msgstr ""
 msgid "From academic tutoring to sports, arts, and enrichment programs, every provider on Klass Hero is carefully reviewed to ensure they meet our high standards for child safety, professionalism, and educational quality."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1529
+#: lib/klass_hero_web/components/marketing_components.ex:1550
 #, elixir-autogen, elixir-format
 msgid "How We Verify Providers"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1467
+#: lib/klass_hero_web/components/marketing_components.ex:1488
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Identity & Age Verification"
 msgstr ""
@@ -3116,7 +3116,7 @@ msgstr ""
 msgid "Protect children and families"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1477
+#: lib/klass_hero_web/components/marketing_components.ex:1498
 #, elixir-autogen, elixir-format
 msgid "Providers must demonstrate at least one year of experience working with children in their area of expertise."
 msgstr ""
@@ -3181,12 +3181,12 @@ msgstr ""
 msgid "Uphold professional and ethical teaching practices"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1426
+#: lib/klass_hero_web/components/marketing_components.ex:1447
 #, elixir-autogen, elixir-format
 msgid "Vetted with Care"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1491
+#: lib/klass_hero_web/components/marketing_components.ex:1512
 #: lib/klass_hero_web/components/provider_components.ex:3665
 #, elixir-autogen, elixir-format
 msgid "Video Screening"
@@ -3753,7 +3753,7 @@ msgstr ""
 msgid "Back to emails"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:816
+#: lib/klass_hero_web/components/messaging_components.ex:884
 #, elixir-autogen, elixir-format
 msgid "Broadcast messages are one-way"
 msgstr ""
@@ -4159,7 +4159,7 @@ msgstr ""
 msgid "Reply"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:827
+#: lib/klass_hero_web/components/messaging_components.ex:895
 #, elixir-autogen, elixir-format
 msgid "Reply privately"
 msgstr ""
@@ -4441,7 +4441,7 @@ msgstr ""
 msgid "Failed to upload files. Please try again."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:903
+#: lib/klass_hero_web/components/messaging_components.ex:971
 #, elixir-autogen, elixir-format, fuzzy
 msgid "File is too large (max %{mb} MB)"
 msgstr ""
@@ -4451,7 +4451,7 @@ msgstr ""
 msgid "File is too large (max %{mb} MB)."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:906
+#: lib/klass_hero_web/components/messaging_components.ex:974
 #, elixir-autogen, elixir-format, fuzzy
 msgid "File type not accepted (images only)"
 msgstr ""
@@ -4471,8 +4471,8 @@ msgstr ""
 msgid "Only images are accepted (JPG, PNG, GIF, WebP)."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:888
-#: lib/klass_hero_web/components/messaging_components.ex:892
+#: lib/klass_hero_web/components/messaging_components.ex:956
+#: lib/klass_hero_web/components/messaging_components.ex:960
 #, elixir-autogen, elixir-format
 msgid "Photo"
 msgstr ""
@@ -4512,7 +4512,7 @@ msgstr ""
 msgid "Tell parents about your organization and what makes you unique..."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:910
+#: lib/klass_hero_web/components/messaging_components.ex:978
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Too many files (max %{max})"
 msgstr ""
@@ -4522,12 +4522,12 @@ msgstr ""
 msgid "Too many files (max %{max})."
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:914
+#: lib/klass_hero_web/components/messaging_components.ex:982
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Upload error"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:913
+#: lib/klass_hero_web/components/messaging_components.ex:981
 #, elixir-autogen, elixir-format
 msgid "Upload failed"
 msgstr ""
@@ -5804,7 +5804,7 @@ msgstr ""
 msgid "Once your listing is live and you've completed Hero verification (typically 3–5 business days), parents can book immediately. Most providers receive their first inquiry within the first week."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1577
+#: lib/klass_hero_web/components/marketing_components.ex:1598
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Ongoing Quality"
 msgstr ""
@@ -5829,7 +5829,7 @@ msgstr ""
 msgid "Open menu"
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1405
+#: lib/klass_hero_web/components/marketing_components.ex:1426
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Our Commitment"
 msgstr ""
@@ -6830,7 +6830,7 @@ msgstr ""
 msgid "You have agreed to the Community Guidelines."
 msgstr ""
 
-#: lib/klass_hero_web/components/marketing_components.ex:1493
+#: lib/klass_hero_web/components/marketing_components.ex:1514
 #, elixir-autogen, elixir-format
 msgid "Applicants submit a short recorded video (max 2 minutes) so we can assess communication skills and alignment with our values before approving their profile."
 msgstr ""
@@ -8020,7 +8020,7 @@ msgstr ""
 msgid "Message %{provider} directly about their programs."
 msgstr ""
 
-#: lib/klass_hero_web/live/provider_profile_live.ex:202
+#: lib/klass_hero_web/live/provider_profile_live.ex:203
 #, elixir-autogen, elixir-format
 msgid "Message this provider"
 msgstr ""
@@ -8135,7 +8135,7 @@ msgstr ""
 msgid "← Back to messages"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:794
+#: lib/klass_hero_web/components/messaging_components.ex:795
 #, elixir-autogen, elixir-format
 msgid "Messages here may be reviewed by the activity provider and by Klass Hero staff, to keep children safe."
 msgstr ""
@@ -8177,7 +8177,7 @@ msgstr ""
 msgid "via"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:792
+#: lib/klass_hero_web/components/messaging_components.ex:793
 #, elixir-autogen, elixir-format
 msgid "Messages here may be reviewed by Klass Hero staff."
 msgstr ""
@@ -8266,4 +8266,19 @@ msgstr ""
 #: lib/klass_hero_web/components/provider_components.ex:1100
 #, elixir-autogen, elixir-format
 msgid "Usual capacity per session"
+msgstr ""
+
+#: lib/klass_hero_web/components/messaging_components.ex:858
+#, elixir-autogen, elixir-format
+msgid "Keep conversations with families on Klass Hero. Messages sent here can be reviewed if something goes wrong. Messages moved to WhatsApp, email or text cannot."
+msgstr ""
+
+#: lib/klass_hero_web/components/messaging_components.ex:862
+#, elixir-autogen, elixir-format
+msgid "Keep this conversation on Klass Hero. Messages sent here can be reviewed if something goes wrong. Messages moved to WhatsApp, email or text cannot."
+msgstr ""
+
+#: lib/klass_hero_web/live/provider_profile_live.ex:194
+#, elixir-autogen, elixir-format
+msgid "Messages sent through Klass Hero can be reviewed if something goes wrong."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -8268,17 +8268,17 @@ msgstr ""
 msgid "Usual capacity per session"
 msgstr ""
 
-#: lib/klass_hero_web/components/messaging_components.ex:858
-#, elixir-autogen, elixir-format
-msgid "Keep conversations with families on Klass Hero. Messages sent here can be reviewed if something goes wrong. Messages moved to WhatsApp, email or text cannot."
-msgstr ""
-
-#: lib/klass_hero_web/components/messaging_components.ex:862
-#, elixir-autogen, elixir-format
-msgid "Keep this conversation on Klass Hero. Messages sent here can be reviewed if something goes wrong. Messages moved to WhatsApp, email or text cannot."
-msgstr ""
-
 #: lib/klass_hero_web/live/provider_profile_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "Messages sent through Klass Hero can be reviewed if something goes wrong."
+msgstr ""
+
+#: lib/klass_hero_web/components/messaging_components.ex:858
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Keep conversations with families on Klass Hero. Messages moved to WhatsApp, email or text cannot be reviewed if something goes wrong."
+msgstr ""
+
+#: lib/klass_hero_web/components/messaging_components.ex:862
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Keep this conversation on Klass Hero. Messages moved to WhatsApp, email or text cannot be reviewed if something goes wrong."
 msgstr ""

--- a/test/klass_hero_web/live/messages_live/show_test.exs
+++ b/test/klass_hero_web/live/messages_live/show_test.exs
@@ -73,6 +73,19 @@ defmodule KlassHeroWeb.MessagesLive.ShowTest do
       assert has_element?(view, "h3", "No messages yet")
     end
 
+    test "renders the off-platform safety notice", %{conn: conn, user: user} do
+      conversation = insert(:conversation_schema)
+
+      insert(:participant_schema,
+        conversation_id: conversation.id,
+        user_id: user.id
+      )
+
+      {:ok, view, _html} = live(conn, ~p"/messages/#{conversation.id}")
+
+      assert has_element?(view, "[data-role='safety-notice']")
+    end
+
     test "renders back navigation link", %{conn: conn, user: user} do
       conversation = insert(:conversation_schema)
 
@@ -211,6 +224,26 @@ defmodule KlassHeroWeb.MessagesLive.ShowTest do
       assert has_element?(view, "#broadcast-reply-bar")
       refute has_element?(view, "#message-form")
       assert has_element?(view, "button", "Reply privately")
+    end
+
+    test "renders the safety notice even though there is no composer", %{
+      conn: conn,
+      user: user
+    } do
+      # A broadcast swaps the composer for the reply-privately bar. That reply is
+      # a private thread with the provider — the same place off-platform steering
+      # happens — so the notice must survive the swap.
+      conversation = insert(:broadcast_conversation_schema)
+
+      insert(:participant_schema,
+        conversation_id: conversation.id,
+        user_id: user.id
+      )
+
+      {:ok, view, _html} = live(conn, ~p"/messages/#{conversation.id}")
+
+      assert has_element?(view, "#broadcast-reply-bar")
+      assert has_element?(view, "[data-role='safety-notice']")
     end
 
     test "shows message form for direct conversations", %{conn: conn, user: user} do

--- a/test/klass_hero_web/live/provider/messages_live/show_test.exs
+++ b/test/klass_hero_web/live/provider/messages_live/show_test.exs
@@ -85,6 +85,22 @@ defmodule KlassHeroWeb.Provider.MessagesLive.ShowTest do
       assert has_element?(view, "h3", "No messages yet")
     end
 
+    test "renders the off-platform safety notice with provider wording", %{
+      conn: conn,
+      user: user
+    } do
+      conversation = insert(:conversation_schema)
+
+      insert(:participant_schema,
+        conversation_id: conversation.id,
+        user_id: user.id
+      )
+
+      {:ok, view, _html} = live(conn, ~p"/provider/messages/#{conversation.id}")
+
+      assert has_element?(view, "[data-role='safety-notice']", "conversations with families")
+    end
+
     test "renders back navigation to provider messages", %{conn: conn, user: user} do
       conversation = insert(:conversation_schema)
 

--- a/test/klass_hero_web/live/provider_profile_live_test.exs
+++ b/test/klass_hero_web/live/provider_profile_live_test.exs
@@ -244,6 +244,14 @@ defmodule KlassHeroWeb.ProviderProfileLiveTest do
 
       assert message =~ "log in"
     end
+
+    test "carries the off-platform safety footnote", %{conn: conn} do
+      provider = active_provider()
+
+      {:ok, view, _html} = live(conn, ~p"/providers/#{provider.id}")
+
+      assert has_element?(view, "#provider-cta-footnote")
+    end
   end
 
   defp elem_view(conn, provider) do

--- a/test/klass_hero_web/live/trust_safety_live_test.exs
+++ b/test/klass_hero_web/live/trust_safety_live_test.exs
@@ -58,6 +58,14 @@ defmodule KlassHeroWeb.TrustSafetyLiveTest do
       assert html =~ "And at Klass Hero, both come standard."
     end
 
+    test "carries no footnote, since this caller does not opt in", %{conn: conn} do
+      # mk_cta_section/1's :footnote is opt-in per caller (#1510). This is the
+      # guard that adding it for the provider profile left the other callers alone.
+      {:ok, view, _html} = live(conn, ~p"/trust-safety")
+
+      refute has_element?(view, "#mk-trust-cta-footnote")
+    end
+
     test "renders under :marketing chrome (sticky header + dark footer)", %{conn: conn} do
       {:ok, view, html} = live(conn, ~p"/trust-safety")
 


### PR DESCRIPTION
Closes #1510 — widened during assessment to cover both surfaces, per discussion.

## Summary

A parent can be steered off-platform at two moments. #1510 covered one of them.

- **Provider profile** — `mk_cta_section/1` gains an opt-in `:footnote` attr, used by the "Have questions?" closer (the original scope).
- **Message thread** — a new `safety_notice/1` between the message list and the composer, shown on parent *and* provider/staff threads (the widening).

## Why the thread placement

A provider asks a parent to move to WhatsApp **inside a conversation**, not while they browse a profile. By then a profile-only notice is off-screen and out of memory — correct content, wrong moment.

`message_area/1` renders `monitoring_notice` → `#messages-container` (`overflow-y-auto`) → composer as three siblings. Putting the new strip before the composer keeps it *outside* the scroll container, so it inherits the permanent visibility that `monitoring_notice/1`'s docstring argues for — but at the point of action, instead of stacking a second grey band above the first message.

It renders on broadcast threads too, where the composer is swapped for `broadcast_reply_bar/1`: "reply privately" opens a direct thread with the provider, which is the same exposure.

## Why both sides

A parent can be asked to pay off-platform; a provider can be asked to accept it. Airbnb warns hosts as well as guests for exactly this reason. Two wordings, no suppression — consistent with the monitoring notice's principle that every thread carries a disclosure.

## Why there is no payment sentence

#1510 proposed *"To protect your payment, always use Klass Hero to send money…"*. **Klass Hero cannot take a payment today.**

- No Billing context — #1165 is open, and `lib/klass_hero/` has no payment/invoice/billing module.
- #1171 records the live behaviour: *"Parents can currently choose 'Cash / Bank Transfer', and the provider confirms the enrollment out of band."*

That sentence would name a rail that does not exist and promise a protection that does not follow from it. It would also break the app's documented hedged register — `trust_safety_live.ex:37-39` carries a deliberate product call to show a bare "Reporting" stat *"to avoid implying 24/7 staffed support"*.

What is true today is the record: a thread here can be reviewed. The payment sentence follows when Billing lands (follow-up filed).

## Review focus

- **Copy is provisional**, on the same footing as `monitoring_notice/1`'s — whose docstring says its wordings *"must not ship before legal review (#745)"*, and #745 is closed with that box unticked. Pre-existing, but new safety copy inherits it.
- **Two strips per thread.** Measured at 375px: 69px + 69px = 21% of viewport, messages get 397px. An earlier three-sentence draft was 85px/23%; the second commit tightens it.
- `:footnote` is opt-in, so About / Trust & Safety / legal-page closers render byte-identical. Guarded by a `refute` test on Trust & Safety.

## Test plan

- `mix precommit` green — 5375 passed, credo clean, `lint_translations` passed.
- Five new tests: parent thread, broadcast thread (no composer), provider thread, profile footnote present, Trust & Safety footnote absent.
- Browser-verified at `375x667x2,mobile,touch`: profile footnote contrast **8.45:1** (passes AA at 12px), German renders with correct umlauts, provider thread screenshot confirms placement above the composer.